### PR TITLE
Remove v1 from base url openai endpoint

### DIFF
--- a/kyo-llm/shared/src/main/scala/kyo/llm/completions.scala
+++ b/kyo-llm/shared/src/main/scala/kyo/llm/completions.scala
@@ -54,7 +54,7 @@ object Completions {
                       "Authorization" -> s"Bearer $key"
                   ) ++ cfg.apiOrg.map("OpenAI-Organization" -> _)
               )
-              .post(uri"${cfg.apiUrl}/v1/chat/completions")
+              .post(uri"${cfg.apiUrl}/chat/completions")
               .body(req)
               .readTimeout(Duration.Inf)
               .response(asJson[Response])


### PR DESCRIPTION
Follow the same convention in openai-python library where the `/v1` prefix is part of the baseUrl.

https://github.com/openai/openai-python?tab=readme-ov-file#configuring-the-http-client

This is mostly due to Azure endpoints do not have the `v1` path; it is straight `/chat/completions.`

Optionally, we could change the apiUrl to baseUrl to have the same nomenclature if it makes sense.