### PR TITLE
Vars effect

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/vars.scala
+++ b/kyo-core/shared/src/main/scala/kyo/vars.scala
@@ -1,0 +1,65 @@
+package kyo
+
+import Vars.*
+import izumi.reflect.Tag
+import kyo.core.*
+
+class Vars[-V](private val tag: Tag[?]) extends Effect[[T] =>> State[V, T], Vars[V]]:
+    override def accepts[M2[_], E2 <: Effect[M2, E2]](other: Effect[M2, E2]) =
+        other match
+            case other: Vars[?] =>
+                other.tag.tag == tag.tag
+            case _ =>
+                false
+end Vars
+
+object Vars:
+
+    opaque type State[-V, +T] = T | Op[V, T]
+
+    sealed private trait Op[-V, +T]
+    private case object Get         extends Op[Any, Any]
+    private case class Set[V](v: V) extends Op[V, Unit]
+
+    private def vars[T](using t: Tag[T]): Vars[T] = Vars(t)
+
+    def get[V: Tag]: V < Vars[V] =
+        vars[V].suspend(Get.asInstanceOf[Op[V, V]])
+
+    def set[V: Tag](v: V): Unit < Vars[V] =
+        vars[V].suspend(Set[V](v))
+
+    def update[V: Tag](f: V => V): Unit < Vars[V] =
+        get[V].map(f).map(set[V])
+
+    def run[T, S](v: T < (Vars[Nothing] & S))(using Flat[T < (Vars[Nothing] & S)]): T < S =
+        v.asInstanceOf[T < S]
+
+    def let[V: Tag, T: Flat, S, V1, V2](init: V)(v: T < (Vars[V1] & S))(
+        using V1 => V | V2
+    ): T < (Vars[V2] & S) =
+        var curr = init
+        given Handler[[T] =>> State[V, T], Vars[V], Any] with
+            def pure[T: Flat](v: T) = v
+            def apply[T, U: Flat, S2](m: State[V, T], f: T => U < (Vars[V] & S2)) =
+                m match
+                    case Get =>
+                        f(curr.asInstanceOf[T])
+                    case Set(v) =>
+                        curr = v.asInstanceOf[V]
+                        f(().asInstanceOf[T])
+                    case v =>
+                        f(v.asInstanceOf[T])
+                end match
+            end apply
+        end given
+
+        vars[V]
+            .handle[T, Vars[V2] & S, Any](v.asInstanceOf[T < (Vars[V] & Vars[V2] & S)])
+            .map {
+                case Get    => curr.asInstanceOf[T]
+                case Set(v) => ().asInstanceOf[T]
+                case v      => v.asInstanceOf[T]
+            }
+    end let
+end Vars

--- a/kyo-core/shared/src/test/scala/kyoTest/varsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/varsTest.scala
@@ -1,0 +1,105 @@
+package kyoTest
+
+import kyo.*
+
+class varsTest extends KyoTest:
+
+    // workaround for inference issues
+    override def convertToEqualizer[T](left: T): Equalizer[T] = super.convertToEqualizer(left)
+
+    "get" in run {
+        Vars.run {
+            Vars.let(1)(Vars.get[Int].map(_ + 1)).map { r =>
+                assert(r == 2)
+            }
+        }
+    }
+
+    "set, get" in run {
+        Vars.run {
+            Vars.let(1)(Vars.set(2).andThen(Vars.get[Int])).map { r =>
+                assert(r == 2)
+            }
+        }
+    }
+
+    "get, set, get" in run {
+        Vars.run {
+            Vars.let(1)(Vars.get[Int].map(i => Vars.set(i + 1)).andThen(Vars.get[Int])).map { r =>
+                assert(r == 2)
+            }
+        }
+    }
+
+    "update" in run {
+        Vars.run {
+            Vars.let(1)(Vars.update[Int](_ + 1).andThen(Vars.get[Int])).map { r =>
+                assert(r == 2)
+            }
+        }
+    }
+
+    "nested let" in run {
+        Vars.run {
+            Vars.let(1) {
+                Vars.let(2) {
+                    Vars.get[Int].map { innerValue =>
+                        assert(innerValue == 2)
+                    }
+                }.unit.andThen(Vars.get[Int])
+                    .map { outerValue =>
+                        assert(outerValue == 1)
+                    }
+            }
+        }
+    }
+
+    "string value" in run {
+        Vars.run {
+            Vars.let("a") {
+                for
+                    _      <- Vars.set("b")
+                    result <- Vars.get[String]
+                yield assert(result == "b")
+            }
+        }
+    }
+
+    "side effect" in run {
+        var sideEffectCounter = 0
+        Vars.run {
+            Vars.let(1) {
+                for
+                    _ <- Vars.update[Int] { value =>
+                        sideEffectCounter += 1
+                        value + 1
+                    }
+                    result <- Vars.get[Int]
+                yield assert(result == 2 && sideEffectCounter == 1)
+            }
+        }
+    }
+
+    "with ios" in run {
+        Vars.run {
+            IOs {
+                Vars.let(1)(
+                    IOs(Vars.get[Int]).map(i =>
+                        IOs(Vars.update[Int](_ + i + 1)).andThen(Vars.get[Int])
+                    )
+                ).map { r =>
+                    assert(r == 3)
+                }
+            }
+        }
+    }
+
+    "inference" in {
+        val a: Int < Vars[Int]           = Vars.get[Int]
+        val b: Unit < Vars[Int | String] = a.map(i => Vars.set(i.toString()))
+        val c: Unit < Vars[String]       = Vars.let(1)(b)
+        val d: Unit < Vars[Nothing]      = Vars.let("t")(c)
+        val e: Unit < Any                = Vars.run(d)
+        assert(e.pure == ())
+    }
+end varsTest


### PR DESCRIPTION
## Problem

As @ghostdogpr described in https://github.com/getkyo/kyo/issues/195, Kyo doesn't have an effect equivalent to `State` yet. The [Sums](https://github.com/getkyo/kyo/blob/c1ef74632d171bc619db1b37da7c8c4f251ef8b9/kyo-core/shared/src/main/scala/kyo/sums.scala#L8) effect provides similar functionality but I decided not to document it because I'm not happy with its design since it bundles both `State` and `Writer` in the same effect.

## Solution

Introduce the new `Vars` effect.

## Notes

- I think the name is more intuitive than `State` for newcomers but I'm open to suggestions.
- This effect is similar to other effects like `Envs` but I decided to try a new encoding to avoid having multiple `Vars` in the pending effect set. For example, if a computation uses `String` and `Int` vars, it can be declared as `T < Vars[String | Int]`. We should try the same for other effects as suggested by @johnhungerford in https://github.com/getkyo/kyo/issues/156.
- Unfortunately, I couldn't find a way for Scala to automatically remove the `Vars[Nothing]` once all required vars are provided via `let` (which ideally should be called `run`), so users have to use an additional `Vars.run` to remove it.
- I'll follow up to remove the `State`-like methods from `Sums` and document both `Vars` and `Sums`.
