### PR TITLE
Update `>` to `<` in `Flat` implicit error

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/internal/FlatImplicits.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/FlatImplicits.scala
@@ -37,7 +37,7 @@ object FlatImplicits:
         def print(t: TypeRepr): String =
             t match
                 case Kyo(t, s) =>
-                    s"${print(t)} > ${print(s)}"
+                    s"${print(t)} < ${print(s)}"
                 case _ => t.show
 
         def fail(msg: String) =


### PR DESCRIPTION
I've been exploring the codebase to try to get a grasp on some of the magic (simultaneously scouring the _Do Be Do Be Do_ paper and attempting to build a toy replica) 🤩 It's such a cool library, @fwbrasil! 

Back in the day, I was a huge fan of Haskell's [Polysemy](https://github.com/polysemy-research/polysemy#readme)—an extensible effects library with some really great ergonomics. When I switched to Scala, I sought out something similar. And after flailing about the Cats ecosystem for a time (trying and failing to enjoy `Eff`), I finally gave ZIO a try. Of course, ZIO has a completely different implementation, but it provided an even better experience than Polysemy, whereas I'd found the Cats ecosystem to be significantly more verbose than Haskell (all those required type annotations 😭).

It's extremely cool to see that original extensible-effects-ish model return with a vengeance 🤘 (that is, with ZIO-like ergonomics + crazy performance).

---

Anyhow, while exploring the code, I did notice that perhaps this error message didn't get updated along with the change from `>` to `<` as the Pending symbol. So here's a one-line—nay, one-character—MR to go along with my accolades 😜.