### PR TITLE
Add ZPure and RWST to mtl benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -212,6 +212,7 @@ lazy val `kyo-bench` =
             libraryDependencies += "dev.zio"             %% "zio-logging-slf4j2" % "2.2.2",
             libraryDependencies += "dev.zio"             %% "zio"                % zioVersion,
             libraryDependencies += "dev.zio"             %% "zio-concurrent"     % zioVersion,
+            libraryDependencies += "dev.zio"             %% "zio-prelude"        % "1.0.0-RC23",
             libraryDependencies += "com.softwaremill.ox" %% "core"               % "0.0.21",
             libraryDependencies += "org.scalatest"       %% "scalatest"          % "3.2.16" % Test
         )

--- a/kyo-bench/src/main/scala/kyo/bench/MtlBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/MtlBench.scala
@@ -1,8 +1,12 @@
 package kyo.bench
 
-import cats.data.Chain
+import cats.data.*
+import cats.syntax.all.toFoldableOps
 import kyo.*
 import org.openjdk.jmh.annotations.*
+import zio.Chunk
+import zio.prelude.fx.Cause
+import zio.prelude.fx.ZPure
 
 case class Env(config: String)
 case class Event(name: String)
@@ -36,6 +40,38 @@ class MtlBench extends Bench:
                 conf <- Envs[Env].use(_.config)
                 _    <- Vars.update[Chain[Event]](_ :+ Event(s"Env = $conf"))
                 _    <- Vars.update[State](state => state.copy(value = state.value + 1))
+            yield ()
+        )
+
+    @Benchmark
+    def syncZPure(): (Chunk[Event], Either[Cause[Throwable], (State, Unit)]) =
+        testZPure.provideService(Env("config")).runAll(State(2))
+
+    def testZPure: ZPure[Event, State, State, Env, Throwable, Unit] =
+        ZPure.foreachDiscard(loops)(_ =>
+            for
+                conf <- ZPure.serviceWith[Env](_.config)
+                _    <- ZPure.log(Event(s"Env = $conf"))
+                _    <- ZPure.update[State, State](state => state.copy(value = state.value + 1))
+            yield ()
+        )
+
+    type F[A] = Either[Throwable, A]
+
+    @Benchmark
+    def syncRWST(): Either[Throwable, (Chain[Event], State, Unit)] =
+        testRWST.run(Env("config"), State(2))
+
+    def testRWST: IRWST[F, Env, Chain[Event], State, State, Unit] =
+        loops.traverse_(_ =>
+            for
+                conf <- IndexedReaderWriterStateT.ask[F, Env, Chain[Event], State].map(_.config)
+                _ <- IndexedReaderWriterStateT.tell[F, Env, Chain[Event], State](
+                    Chain(Event(s"Env = $conf"))
+                )
+                _ <- IndexedReaderWriterStateT.modify[F, Env, Chain[Event], State, State](state =>
+                    state.copy(value = state.value + 1)
+                )
             yield ()
         )
 end MtlBench


### PR DESCRIPTION
See https://github.com/getkyo/kyo/issues/195 (originally from https://github.com/ghostdogpr/mtl-benchmarks)

```
[info] Benchmark            Mode  Cnt     Score     Error  Units
[info] MtlBench.syncKyo    thrpt    5  2822.207 ±  66.487  ops/s
[info] MtlBench.syncRWST   thrpt    5  2574.217 ± 155.879  ops/s
[info] MtlBench.syncZPure  thrpt    5  9352.017 ± 303.491  ops/s
```