### PR TITLE
Use sys.env and sys.props instead of Java equivalents

### DIFF
--- a/kyo-llm/shared/src/main/scala/kyo/llm/configs.scala
+++ b/kyo-llm/shared/src/main/scala/kyo/llm/configs.scala
@@ -55,11 +55,8 @@ object Config:
     val default =
         val apiKeyProp = "OPENAI_API_KEY"
         val apiOrgProp = "OPENAI_API_ORG"
-        val apiKey =
-            Option(System.getenv(apiKeyProp))
-                .orElse(Option(System.getProperty(apiKeyProp)))
-        val apiOrg =
-            Option(System.getenv(apiOrgProp))
+        val apiKey     = sys.env.get(apiKeyProp).orElse(sys.props.get(apiKeyProp))
+        val apiOrg     = sys.env.get(apiOrgProp)
         Config(
             "https://api.openai.com/v1",
             apiKey,

--- a/kyo-llm/shared/src/main/scala/kyo/llm/tools/BraveSearch.scala
+++ b/kyo-llm/shared/src/main/scala/kyo/llm/tools/BraveSearch.scala
@@ -35,8 +35,7 @@ object BraveSearch extends Tool:
     object apiKey:
         private val local = Locals.init[Option[String]] {
             val apiKeyProp = "BRAVE_SEARCH_API_KEY"
-            Option(System.getenv(apiKeyProp))
-                .orElse(Option(System.getProperty(apiKeyProp)))
+            sys.env.get(apiKeyProp).orElse(sys.props.get(apiKeyProp))
         }
 
         val get: String < AIs =


### PR DESCRIPTION
Just a minor improvement: Scala has nice built-in ways to handle environment variables and system properties 😃 