### PR TITLE
unison-inspired streams

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,7 @@ lazy val `kyo-bench` =
             libraryDependencies += "dev.zio"             %% "zio-concurrent"     % zioVersion,
             libraryDependencies += "dev.zio"             %% "zio-prelude"        % "1.0.0-RC23",
             libraryDependencies += "com.softwaremill.ox" %% "core"               % "0.0.24",
+            libraryDependencies += "co.fs2"              %% "fs2-core"           % "3.10.2",
             libraryDependencies += "org.scalatest"       %% "scalatest"          % "3.2.16" % Test
         )
 

--- a/kyo-bench/src/main/scala/kyo/bench/StreamBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/StreamBench.scala
@@ -1,0 +1,36 @@
+package kyo.bench
+
+class StreamBench extends Bench.SyncAndFork[Int]:
+
+    val seq = (0 until 10000).toList
+
+    def catsBench() =
+        import cats.effect.*
+        import fs2.*
+        Stream.emits(seq)
+            .filter(_ % 2 == 0)
+            .map(_ + 1)
+            .covary[IO]
+            .compile
+            .fold(0)(_ + _)
+    end catsBench
+
+    def kyoBench() =
+        import kyo.*
+        val a = Streams[Int].emit(seq)
+        val b = Streams[Int].filter(a)(_ % 2 == 0)
+        val c = Streams[Int].transform(b)(_ + 1)
+        val d = Streams[Int].runFold(c)(0)(_ + _)
+        d.pure._1
+    end kyoBench
+
+    def zioBench() =
+        import zio.*
+        import zio.stream.*
+        ZStream.fromIterable(seq)
+            .filter(_ % 2 == 0)
+            .map(_ + 1)
+            .runSum
+    end zioBench
+
+end StreamBench

--- a/kyo-core/shared/src/main/scala/kyo/channels.scala
+++ b/kyo-core/shared/src/main/scala/kyo/channels.scala
@@ -30,6 +30,8 @@ abstract class Channel[T]:
 
     def isClosed: Boolean < IOs
 
+    def drain: Seq[T] < IOs
+
     def close: Option[Seq[T]] < IOs
 end Channel
 
@@ -108,6 +110,8 @@ object Channels:
                         }
 
                     def isClosed = queue.isClosed
+
+                    def drain = queue.drain
 
                     def close =
                         IOs {

--- a/kyo-core/shared/src/main/scala/kyo/streams.scala
+++ b/kyo-core/shared/src/main/scala/kyo/streams.scala
@@ -1,0 +1,154 @@
+package kyo
+
+import kyo.*
+import kyo.core.*
+import kyo.core.internal.*
+
+class Streams[V] extends Effect[Streams[V]]:
+    type Command[T] = V
+
+end Streams
+
+object Streams:
+
+    import internal.*
+
+    class Done
+    object Done extends Done
+
+    private case object streams extends Streams[Any]
+    def apply[V]: Streams[V] = streams.asInstanceOf[Streams[V]]
+
+    extension [V](s: Streams[V])(using tag: Tag[Streams[V]], flat: Flat[V])
+
+        def emit(v: V): Unit < Streams[V] =
+            suspend(s)(v)
+
+        def emit(v: V, tail: V*): Unit < Streams[V] =
+            emit(v +: tail)
+
+        def emit(v: Seq[V]): Unit < Streams[V] =
+            if v.isEmpty then ()
+            else emit(v.head).andThen(emit(v.tail))
+
+        def buffer[T: Flat](size: Int)(v: T < Streams[V]): T < (Streams[V] & Fibers) =
+            Channels.init[V | Done](size).map { ch =>
+                Fibers.init(runChannel(ch)(v)).map(f => emit(ch).andThen(f.get))
+            }
+
+        def take[T: Flat, S](n: Int)(v: T < (Streams[V] & S)): T < (Streams[V] & S) =
+            Vars[TakeN].run(n) {
+                reemit(v) { v =>
+                    Vars[TakeN].get.map {
+                        case 0 =>
+                            ()
+                        case n =>
+                            Vars[TakeN].set(n - 1)
+                                .andThen(emit(v))
+                    }
+                }
+            }
+
+        def drop[T: Flat, S](n: Int)(v: T < (Streams[V] & S)): T < (Streams[V] & S) =
+            Vars[DropN].run(n) {
+                reemit(v) { v =>
+                    Vars[DropN].get.map {
+                        case 0 =>
+                            emit(v)
+                        case n =>
+                            Vars[DropN].set(n - 1)
+                    }
+                }
+            }
+
+        def filter[T: Flat, S](v: T < (Streams[V] & S))(
+            f: V => Boolean < S
+        ): T < (Streams[V] & S) =
+            reemit(v) { v =>
+                f(v).map {
+                    case false => ()
+                    case true  => emit(v)
+                }
+            }
+
+        def transform[T: Flat, V2: Flat, S, S2](v: T < (Streams[V] & S))(
+            f: V => V2 < (S & S2)
+        )(using Tag[Streams[V2]]): T < (Streams[V2] & S & S2) =
+            reemit(v) { v =>
+                f(v).map(Streams[V2].emit)
+            }
+
+        def collect[T: Flat, S, S2, V2: Flat](v: T < (Streams[V] & S))(
+            f: PartialFunction[V, Unit < (Streams[V2] & S2)]
+        ): T < (Streams[V2] & S & S2) =
+            reemit(v) { v =>
+                if f.isDefinedAt(v) then f(v)
+                else ()
+            }
+        end collect
+
+        private inline def reemit[T: Flat, S, S2, V2: Flat](v: T < (Streams[V] & S))(
+            inline f: V => Unit < (Streams[V2] & S2)
+        ): T < (Streams[V2] & S & S2) =
+            def loop[T2: Flat, S](v: T2 < (Streams[V] & S)): T2 < (Streams[V2] & S & S2) =
+                val handler = new Handler[Const[V], Streams[V], Streams[V2] & S2]:
+                    def resume[T3, U: Flat, S3](command: V, k: T3 => U < (Streams[V] & S3)) =
+                        f(command).andThen(loop(k(().asInstanceOf[T3])))
+                handle(handler, v)(using tag, Flat.derive)
+            end loop
+            loop[T, S](v)
+        end reemit
+
+        def runFold[T: Flat, S, A](v: T < (Streams[V] & S))(acc: A)(f: (A, V) => A)(
+            using Flat[V]
+        ): (A, T) < S =
+            def handler(acc: A): ResultHandler[Const[V], [T] =>> (A, T), Streams[V], S] =
+                new ResultHandler[Const[V], [T] =>> (A, T), Streams[V], S]:
+                    def pure[T](v: T) = (acc, v)
+                    def resume[T, U: Flat, S3](command: V, k: T => U < (Streams[V] & S3)) =
+                        handle(handler(f(acc, command)), k(().asInstanceOf[T]))
+            val a = handle(handler(acc), v)
+            a
+        end runFold
+
+        def runSeq[T: Flat, S](v: T < (Streams[V] & S))(
+            using Flat[V]
+        ): (Seq[V], T) < S =
+            def handler(acc: List[V])
+                : ResultHandler[Const[V], [T] =>> (Seq[V], T), Streams[V], Any] =
+                new ResultHandler[Const[V], [T] =>> (Seq[V], T), Streams[V], Any]:
+                    def pure[T](v: T) = (acc.reverse, v)
+                    def resume[T, U: Flat, S](command: V, k: T => U < (Streams[V] & S)) =
+                        handle(handler(command :: acc), k(().asInstanceOf[T]))
+            val a = handle(handler(Nil), v)
+            a
+        end runSeq
+
+        private def emit(ch: Channel[V | Done]): Unit < (Streams[V] & Fibers) =
+            ch.take.map {
+                case Done =>
+                    ()
+                case v: V =>
+                    emit(v).andThen(emit(ch))
+            }
+
+        private def runChannel[T: Flat, S](ch: Channel[V | Done])(
+            v: T < (Streams[V] & S)
+        ): T < (S & Fibers) =
+            handle(channelHandler(ch), v)
+
+    end extension
+
+    private object internal:
+        // used to isolate Vars usage via a separate tag
+        opaque type TakeN >: Int <: Int = Int
+        opaque type DropN >: Int <: Int = Int
+
+        def channelHandler[V](ch: Channel[V | Done]): Handler[Const[V], Streams[V], Fibers] =
+            new Handler[Const[V], Streams[V], Fibers]:
+                override def pure[T](v: T) = ch.put(Done).andThen(v)
+                def resume[T, U: Flat, S](command: V, k: T => U < (Streams[V] & S)) =
+                    handle(ch.put(command).map(_ => k(().asInstanceOf[T])))
+    end internal
+
+end Streams

--- a/kyo-core/shared/src/main/scala/kyo/streams.scala
+++ b/kyo-core/shared/src/main/scala/kyo/streams.scala
@@ -31,6 +31,14 @@ object Streams:
             if v.isEmpty then ()
             else emit(v.head).andThen(emit(v.tail))
 
+        def emit(ch: Channel[V | Done]): Unit < (Streams[V] & Fibers) =
+            ch.take.map {
+                case Done =>
+                    ()
+                case v: V =>
+                    emit(v).andThen(emit(ch))
+            }
+
         def buffer[T: Flat](size: Int)(v: T < Streams[V]): T < (Streams[V] & Fibers) =
             Channels.init[V | Done](size).map { ch =>
                 Fibers.init(runChannel(ch)(v)).map(f => emit(ch).andThen(f.get))
@@ -87,18 +95,6 @@ object Streams:
             }
         end collect
 
-        private inline def reemit[T: Flat, S, S2, V2: Flat](v: T < (Streams[V] & S))(
-            inline f: V => Unit < (Streams[V2] & S2)
-        ): T < (Streams[V2] & S & S2) =
-            def loop[T2: Flat, S](v: T2 < (Streams[V] & S)): T2 < (Streams[V2] & S & S2) =
-                val handler = new Handler[Const[V], Streams[V], Streams[V2] & S2]:
-                    def resume[T3, U: Flat, S3](command: V, k: T3 => U < (Streams[V] & S3)) =
-                        f(command).andThen(loop(k(().asInstanceOf[T3])))
-                handle(handler, v)(using tag, Flat.derive)
-            end loop
-            loop[T, S](v)
-        end reemit
-
         def runFold[T: Flat, S, A](v: T < (Streams[V] & S))(acc: A)(f: (A, V) => A)(
             using Flat[V]
         ): (A, T) < S =
@@ -124,31 +120,34 @@ object Streams:
             a
         end runSeq
 
-        private def emit(ch: Channel[V | Done]): Unit < (Streams[V] & Fibers) =
-            ch.take.map {
-                case Done =>
-                    ()
-                case v: V =>
-                    emit(v).andThen(emit(ch))
-            }
-
-        private def runChannel[T: Flat, S](ch: Channel[V | Done])(
+        def runChannel[T: Flat, S](ch: Channel[V | Done])(
             v: T < (Streams[V] & S)
         ): T < (S & Fibers) =
-            handle(channelHandler(ch), v)
+            val handler: Handler[Const[V], Streams[V], Fibers] =
+                new Handler[Const[V], Streams[V], Fibers]:
+                    override def pure[T](v: T) = ch.put(Done).andThen(v)
+                    def resume[T, U: Flat, S](command: V, k: T => U < (Streams[V] & S)) =
+                        handle(ch.put(command).map(_ => k(().asInstanceOf[T])))
+            handle(handler, v)
+        end runChannel
 
+        private inline def reemit[T: Flat, S, S2, V2: Flat](v: T < (Streams[V] & S))(
+            inline f: V => Unit < (Streams[V2] & S2)
+        ): T < (Streams[V2] & S & S2) =
+            def loop[T2: Flat, S](v: T2 < (Streams[V] & S)): T2 < (Streams[V2] & S & S2) =
+                val handler = new Handler[Const[V], Streams[V], Streams[V2] & S2]:
+                    def resume[T3, U: Flat, S3](command: V, k: T3 => U < (Streams[V] & S3)) =
+                        f(command).andThen(loop(k(().asInstanceOf[T3])))
+                handle(handler, v)(using tag, Flat.derive)
+            end loop
+            loop[T, S](v)
+        end reemit
     end extension
 
     private object internal:
         // used to isolate Vars usage via a separate tag
         opaque type TakeN >: Int <: Int = Int
         opaque type DropN >: Int <: Int = Int
-
-        def channelHandler[V](ch: Channel[V | Done]): Handler[Const[V], Streams[V], Fibers] =
-            new Handler[Const[V], Streams[V], Fibers]:
-                override def pure[T](v: T) = ch.put(Done).andThen(v)
-                def resume[T, U: Flat, S](command: V, k: T => U < (Streams[V] & S)) =
-                    handle(ch.put(command).map(_ => k(().asInstanceOf[T])))
     end internal
 
 end Streams

--- a/kyo-core/shared/src/test/scala/kyoTest/channelsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/channelsTest.scala
@@ -77,6 +77,22 @@ class channelsTest extends KyoTest:
             v  <- f.get
         yield assert(!d1 && d2 && v == 1)
     }
+    "drain" - {
+        "empty" in run {
+            for
+                c <- Channels.init[Int](2)
+                r <- c.drain
+            yield assert(r == Seq())
+        }
+        "non-empty" in run {
+            for
+                c <- Channels.init[Int](2)
+                _ <- c.put(1)
+                _ <- c.put(2)
+                r <- c.drain
+            yield assert(r == Seq(1, 2))
+        }
+    }
     "close" - {
         "empty" in runJVM {
             for

--- a/kyo-core/shared/src/test/scala/kyoTest/streamsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/streamsTest.scala
@@ -1,0 +1,174 @@
+package kyoTest
+
+import kyo.*
+
+class streamsTest extends KyoTest:
+
+    "emit" - {
+        "non-empty" in {
+            assert(
+                Streams[Int].runSeq(Streams[Int].emit(1).andThen(Streams[Int].emit(2))) == (Seq(
+                    1,
+                    2
+                ), ())
+            )
+        }
+
+        "empty" in {
+            assert(
+                Streams[Int].runSeq(()) == (Seq.empty, ())
+            )
+        }
+    }
+
+    "buffer" - {
+        "non-empty" in run {
+            Streams[Int].runSeq(
+                Streams[Int].buffer(2)(Streams[Int].emit(1, 2, 3))
+            ).map { r =>
+                assert(r == (Seq(1, 2, 3), ()))
+            }
+        }
+
+        "empty" in run {
+            Streams[Int].runSeq(
+                Streams[Int].buffer(2)(Streams[Int].emit(Seq.empty[Int]))
+            ).map { r =>
+                assert(r == (Seq.empty, ()))
+            }
+        }
+    }
+
+    "take" - {
+
+        "zero" in {
+            assert(
+                Streams[Int].runSeq(
+                    Streams[Int].take(0)(Streams[Int].emit(1, 2, 3))
+                ) == (Seq.empty, ())
+            )
+        }
+
+        "two" in {
+            assert(
+                Streams[Int].runSeq(
+                    Streams[Int].take(2)(Streams[Int].emit(1, 2, 3))
+                ) == (Seq(1, 2), ())
+            )
+        }
+
+        "more than available" in {
+            assert(
+                Streams[Int].runSeq(
+                    Streams[Int].take(5)(Streams[Int].emit(1, 2, 3))
+                ) == (Seq(1, 2, 3), ())
+            )
+        }
+    }
+
+    "drop" - {
+
+        "zero" in {
+            assert(
+                Streams[Int].runSeq(
+                    Streams[Int].drop(0)(Streams[Int].emit(1, 2, 3))
+                ) == (Seq(1, 2, 3), ())
+            )
+        }
+
+        "two" in {
+            assert(
+                Streams[Int].runSeq(
+                    Streams[Int].drop(2)(Streams[Int].emit(1, 2, 3))
+                ) == (Seq(3), ())
+            )
+        }
+
+        "more than available" in {
+            assert(
+                Streams[Int].runSeq(
+                    Streams[Int].drop(5)(Streams[Int].emit(1, 2, 3))
+                ) == (Seq.empty, ())
+            )
+        }
+    }
+
+    "filter" - {
+        "non-empty" in {
+            assert(
+                Streams[Int].runSeq(
+                    Streams[Int].filter(Streams[Int].emit(1, 2, 3))(_ % 2 == 0)
+                ) == (Seq(2), ())
+            )
+        }
+
+        "all in" in {
+            assert(
+                Streams[Int].runSeq(
+                    Streams[Int].filter(Streams[Int].emit(1, 2, 3))(_ => true)
+                ) == (Seq(1, 2, 3), ())
+            )
+        }
+
+        "all out" in {
+            assert(
+                Streams[Int].runSeq(
+                    Streams[Int].filter(Streams[Int].emit(1, 2, 3))(_ => false)
+                ) == (Seq.empty, ())
+            )
+        }
+    }
+
+    "collect" - {
+        "to string" in {
+            assert(
+                Streams[String].runSeq(Streams[Int].collect(Streams[Int].emit(1, 2, 3)) {
+                    case v if v % 2 == 0 => Streams[String].emit(s"even: $v")
+                }) == (Seq("even: 2"), ())
+            )
+        }
+
+        "none" in {
+            assert(
+                Streams[String].runSeq(Streams[Int].collect(Streams[Int].emit(1, 2, 3)) {
+                    case v if false => ???
+                }) == (Seq.empty, ())
+            )
+        }
+    }
+
+    "transform" - {
+        "double" in {
+            assert(
+                Streams[Int].runSeq(
+                    Streams[Int].transform(Streams[Int].emit(1, 2, 3))(_ * 2)
+                ) == (Seq(2, 4, 6), ())
+            )
+        }
+
+        "to string" in {
+            assert(
+                Streams[String].runSeq(
+                    Streams[Int].transform(Streams[Int].emit(1, 2, 3))(_.toString)
+                ) == (Seq("1", "2", "3"), ())
+            )
+        }
+    }
+
+    "runFold" - {
+        "sum" in {
+            assert(
+                Streams[Int].runFold(Streams[Int].emit(1, 2, 3))(0)(_ + _) == (6, ())
+            )
+        }
+
+        "concat" in {
+            assert(
+                Streams[String].runFold(Streams[String].emit("a", "b", "c"))("")(
+                    _ + _
+                ) == ("abc", ())
+            )
+        }
+    }
+
+end streamsTest


### PR DESCRIPTION
An initial implementation of the `Streams` effect with an encoding inspired by Unison's `Stream` [ability](https://exercism.org/tracks/unison/exercises/stream-ops). With this encoding, computations can emit multiple streams. For example: `Int < (Stream[Int] & Stream[String])` is a computation that will emit two streams and return an `Int`.

Although the encoding is elegant, I'm not sure about usability. Performing more complex operations on elements of the pending effect set is something other effects don't do and users might have trouble to understand the approach:

```scala
// Note how 'emit' returns a computation that
// produces 'Unit' and has the 'Streams[Int]' 
// pending effect indicating that it also produces 
// a stream of 'Int' values.
val a: Unit < Streams[Int] =
    Streams[Int].emit(Seq(1, 2, 3))

// It's possible to transform the computation freely
// and 'Streams[Int]' continues present indicating
// that the computation also produces a stream.
val b: Int < Streams[Int] =
    a.andThen(42)

// A computation can produce multiple streams.
val c: Int < (Streams[Int] & Streams[String]) =
    b.map(v => Streams[String].emit("42").andThen(v))

// It's possible to perform operations on the
// streams a computation produces. For example,
// it's possible to transform 'Stream[String]'
// to 'Stream[Int]'.
val d: Int < Streams[Int] =
    Streams[String].transform(c)(v => v.toInt)

// A great property of this encoding is how
// pure the effect is. Currently, the only exception is
// the 'buffer' method that uses 'Fibers' to provide
// backpressured processing with buffering via
// channels.
val e: Int < (Streams[Int] & Fibers) =
    Streams[Int].buffer(10)(d)

// It's possible to handle the 'Streams' effect,
// which returns a tuple with the stream contents
// and the result of the computation.
val f: (Seq[Int], Int) < Fibers =
    Streams[Int].runSeq(d)

// prints '(List(1, 2, 3, 42), 42)'
println(IOs.run(Fibers.run(f)))
```

I wonder if we could improve usability with a wrapper API. For example, maybe we could add a `type Stream[T, V, S] = T < (Streams[V] & S)` or `type Stream[V, S] = Unit < (Streams[V] & S)` with extension methods. 

Although the implementation isn't micro-optimized and is missing chunking, which is a major optimization, the initial benchmark [results](https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fwbrasil/bef1f4e507f05ee7dcc877f79d2da646/raw/21ddf4c2fb84c1db648ed872e4f7b2cfe5efd386/jmh-result.json) indicate the performance isn't too far from alternatives:

![image](https://github.com/getkyo/kyo/assets/831175/798846ac-56ac-485f-8af6-9f625cd6477c)
