### PR TITLE
streams: usability improvements

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/StreamBufferBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/StreamBufferBench.scala
@@ -1,6 +1,6 @@
 package kyo.bench
 
-class StreamBench extends Bench.SyncAndFork[Int]:
+class StreamBufferBench extends Bench.ForkOnly[Int]:
 
     val seq = (0 until 10000).toList
 
@@ -9,28 +9,31 @@ class StreamBench extends Bench.SyncAndFork[Int]:
         import fs2.*
         Stream.emits(seq)
             .filter(_ % 2 == 0)
+            .buffer(10)
             .map(_ + 1)
             .covary[IO]
             .compile
             .fold(0)(_ + _)
     end catsBench
 
-    def kyoBench() =
+    override def kyoBenchFiber() =
         import kyo.*
         Streams.initSeq(seq)
             .filter(_ % 2 == 0)
+            .buffer(10)
             .transform(_ + 1)
             .runFold(0)(_ + _)
-            .pure._1
-    end kyoBench
+            .map(_._1)
+    end kyoBenchFiber
 
     def zioBench() =
         import zio.*
         import zio.stream.*
         ZStream.fromIterable(seq)
             .filter(_ % 2 == 0)
+            .buffer(10)
             .map(_ + 1)
             .runSum
     end zioBench
 
-end StreamBench
+end StreamBufferBench

--- a/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
@@ -130,4 +130,12 @@ class BenchTest extends AsyncFreeSpec with Assertions:
     "MtlBench" in {
         assert(MtlBench().syncKyo().isRight)
     }
+
+    "StreamBench" - {
+        test(StreamBench(), 25000000)
+    }
+
+    "StreamBufferBench" - {
+        test(StreamBufferBench(), 25000000)
+    }
 end BenchTest

--- a/kyo-core/shared/src/main/scala/kyo/streams.scala
+++ b/kyo-core/shared/src/main/scala/kyo/streams.scala
@@ -141,9 +141,7 @@ end Streams
 
 object Streams:
 
-    class InitSourceDsl[V]:
-        def apply[T, S](v: T < (Streams[V] & S)): Stream[T, V, S] =
-            Stream.source(v)
+    import internal.*
 
     def initSource[V]: InitSourceDsl[V] = new InitSourceDsl[V]
 
@@ -180,4 +178,10 @@ object Streams:
             case v: V =>
                 emitValue(v).andThen(emitChannel(ch))
         }
+
+    object internal:
+        class InitSourceDsl[V]:
+            def apply[T, S](v: T < (Streams[V] & S)): Stream[T, V, S] =
+                Stream.source(v)
+    end internal
 end Streams

--- a/kyo-core/shared/src/test/scala/kyoTest/streamsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/streamsTest.scala
@@ -4,41 +4,39 @@ import kyo.*
 
 class streamsTest extends KyoTest:
 
-    "emit" - {
+    "initValue" - {
+        "single value" in {
+            assert(
+                Streams.initValue(1).runSeq.pure == (Seq(1), ())
+            )
+        }
 
+        "multiple values" in {
+            assert(
+                Streams.initValue(1, 2, 3).runSeq.pure == (Seq(1, 2, 3), ())
+            )
+        }
+    }
+
+    "initSeq" - {
         "empty" in {
             assert(
-                Streams[Int].runSeq(()).pure == (Seq.empty, ())
+                Streams.initSeq(Seq()).runSeq.pure == (Seq.empty, ())
             )
         }
 
-        "value" in {
+        "non-empty" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].emit(1).andThen(Streams[Int].emit(2))
-                ).pure ==
-                    (Seq(1, 2), ())
+                Streams.initSeq(Seq(1, 2, 3)).runSeq.pure == (Seq(1, 2, 3), ())
             )
         }
+    }
 
-        "varargs" in {
-            assert(
-                Streams[Int].runSeq(Streams[Int].emit(1, 2)).pure ==
-                    (Seq(1, 2), ())
-            )
-        }
-
-        "seq" in {
-            assert(
-                Streams[Int].runSeq(Streams[Int].emit(Seq(1, 2))).pure ==
-                    (Seq(1, 2), ())
-            )
-        }
-
-        "channel" in run {
-            Channels.init[Int | Streams.Done](3).map { ch =>
-                ch.put(1).andThen(ch.put(2)).andThen(ch.put(Streams.Done)).map { _ =>
-                    Streams[Int].runSeq(Streams[Int].emit(ch)).map { result =>
+    "initChannel" - {
+        "non-empty channel" in run {
+            Channels.init[Int | Stream.Done](3).map { ch =>
+                ch.put(1).andThen(ch.put(2)).andThen(ch.put(Stream.Done)).map { _ =>
+                    Streams.initChannel(ch).runSeq.map { result =>
                         assert(result == (Seq(1, 2), ()))
                     }
                 }
@@ -46,101 +44,107 @@ class streamsTest extends KyoTest:
         }
 
         "empty channel" in run {
-            Channels.init[Int | Streams.Done](2).map { ch =>
-                ch.put(Streams.Done).andThen {
-                    Streams[Int].runSeq(Streams[Int].emit(ch)).map { result =>
+            Channels.init[Int | Stream.Done](2).map { ch =>
+                ch.put(Stream.Done).andThen {
+                    Streams.initChannel(ch).runSeq.map { result =>
                         assert(result == (Seq.empty, ()))
                     }
                 }
             }
         }
+    }
 
+    "emitValue" - {
+        "single value" in {
+            assert(
+                Streams.initSource(Streams.emitValue(1)).runSeq.pure == (Seq(1), ())
+            )
+        }
+
+        "multiple values" in {
+            assert(
+                Streams.initSource(Streams.emitValue(1, 2, 3)).runSeq.pure == (Seq(1, 2, 3), ())
+            )
+        }
+    }
+
+    "emitSeq" - {
+        "empty" in {
+            assert(
+                Streams.initSource(Streams.emitSeq(Seq())).runSeq.pure == (Seq.empty, ())
+            )
+        }
+
+        "non-empty" in {
+            assert(
+                Streams.initSource(Streams.emitSeq(Seq(1, 2, 3))).runSeq.pure == (Seq(1, 2, 3), ())
+            )
+        }
     }
 
     "buffer" - {
         "non-empty" in run {
-            Streams[Int].runSeq(
-                Streams[Int].buffer(2)(Streams[Int].emit(1, 2, 3))
-            ).map { r =>
+            Streams.initSeq(Seq(1, 2, 3)).buffer(2).runSeq.map { r =>
                 assert(r == (Seq(1, 2, 3), ()))
             }
         }
 
         "empty" in run {
-            Streams[Int].runSeq(
-                Streams[Int].buffer(2)(Streams[Int].emit(Seq.empty[Int]))
-            ).map { r =>
+            Streams.initSeq(Seq.empty[Int]).buffer(2).runSeq.map { r =>
                 assert(r == (Seq.empty, ()))
             }
         }
     }
 
     "take" - {
-
         "zero" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].take(0)(Streams[Int].emit(1, 2, 3))
-                ).pure == (Seq.empty, ())
+                Streams.initSeq(Seq(1, 2, 3)).take(0).runSeq.pure == (Seq.empty, ())
             )
         }
 
         "two" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].take(2)(Streams[Int].emit(1, 2, 3))
-                ).pure == (Seq(1, 2), ())
+                Streams.initSeq(Seq(1, 2, 3)).take(2).runSeq.pure == (Seq(1, 2), ())
             )
         }
 
         "more than available" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].take(5)(Streams[Int].emit(1, 2, 3))
-                ).pure == (Seq(1, 2, 3), ())
+                Streams.initSeq(Seq(1, 2, 3)).take(5).runSeq.pure == (Seq(1, 2, 3), ())
             )
         }
 
         "stack safety" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].take(5)(Streams[Int].emit(Seq.fill(100000)(1)))
-                ).pure == (Seq.fill(5)(1), ())
+                Streams.initSeq(Seq.fill(100000)(1)).take(5).runSeq.pure ==
+                    (Seq.fill(5)(1), ())
             )
         }
     }
 
     "drop" - {
-
         "zero" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].drop(0)(Streams[Int].emit(1, 2, 3))
-                ).pure == (Seq(1, 2, 3), ())
+                Streams.initSeq(Seq(1, 2, 3)).drop(0).runSeq.pure == (Seq(1, 2, 3), ())
             )
         }
 
         "two" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].drop(2)(Streams[Int].emit(1, 2, 3))
-                ).pure == (Seq(3), ())
+                Streams.initSeq(Seq(1, 2, 3)).drop(2).runSeq.pure == (Seq(3), ())
             )
         }
 
         "more than available" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].drop(5)(Streams[Int].emit(1, 2, 3))
-                ).pure == (Seq.empty, ())
+                Streams.initSeq(Seq(1, 2, 3)).drop(5).runSeq.pure == (Seq.empty, ())
             )
         }
 
         "stack safety" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].drop(5)(Streams[Int].emit(Seq.fill(100000)(1)))
-                ).pure._1.size == 100000 - 5
+                Streams.initSeq(Seq.fill(100000)(1)).drop(5).runSeq.pure._1.size == 100000 - 5
             )
         }
     }
@@ -148,33 +152,25 @@ class streamsTest extends KyoTest:
     "filter" - {
         "non-empty" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].filter(Streams[Int].emit(1, 2, 3))(_ % 2 == 0)
-                ).pure == (Seq(2), ())
+                Streams.initSeq(Seq(1, 2, 3)).filter(_ % 2 == 0).runSeq.pure == (Seq(2), ())
             )
         }
 
         "all in" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].filter(Streams[Int].emit(1, 2, 3))(_ => true)
-                ).pure == (Seq(1, 2, 3), ())
+                Streams.initSeq(Seq(1, 2, 3)).filter(_ => true).runSeq.pure == (Seq(1, 2, 3), ())
             )
         }
 
         "all out" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].filter(Streams[Int].emit(1, 2, 3))(_ => false)
-                ).pure == (Seq.empty, ())
+                Streams.initSeq(Seq(1, 2, 3)).filter(_ => false).runSeq.pure == (Seq.empty, ())
             )
         }
 
         "stack safety" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].filter(Streams[Int].emit(1 to 100000))(_ % 2 == 0)
-                ).pure._1.size == 100000 / 2
+                Streams.initSeq(1 to 100000).filter(_ % 2 == 0).runSeq.pure._1.size == 100000 / 2
             )
         }
     }
@@ -182,25 +178,25 @@ class streamsTest extends KyoTest:
     "collect" - {
         "to string" in {
             assert(
-                Streams[String].runSeq(Streams[Int].collect(Streams[Int].emit(1, 2, 3)) {
-                    case v if v % 2 == 0 => Streams[String].emit(s"even: $v")
-                }).pure == (Seq("even: 2"), ())
+                Streams.initSeq(Seq(1, 2, 3)).collect {
+                    case v if v % 2 == 0 => Streams.emitValue(s"even: $v")
+                }.runSeq.pure == (Seq("even: 2"), ())
             )
         }
 
         "none" in {
             assert(
-                Streams[String].runSeq(Streams[Int].collect(Streams[Int].emit(1, 2, 3)) {
+                Streams.initSeq(Seq(1, 2, 3)).collect {
                     case v if false => ???
-                }).pure == (Seq.empty, ())
+                }.runSeq.pure == (Seq.empty, ())
             )
         }
 
         "stack safety" in {
             assert(
-                Streams[Int].runSeq(Streams[Int].collect(Streams[Int].emit(1 to 100000)) {
-                    case v if v % 2 == 0 => Streams[Int].emit(v)
-                }).pure._1.size == 100000 / 2
+                Streams.initSeq(1 to 100000).collect {
+                    case v if v % 2 == 0 => Streams.emitValue(v)
+                }.runSeq.pure._1.size == 100000 / 2
             )
         }
     }
@@ -208,43 +204,29 @@ class streamsTest extends KyoTest:
     "transform" - {
         "double" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].transform(Streams[Int].emit(1, 2, 3))(_ * 2)
-                ).pure == (Seq(2, 4, 6), ())
+                Streams.initSeq(Seq(1, 2, 3)).transform(_ * 2).runSeq.pure == (Seq(2, 4, 6), ())
             )
         }
 
         "to string" in {
             assert(
-                Streams[String].runSeq(
-                    Streams[Int].transform(Streams[Int].emit(1, 2, 3))(_.toString)
-                ).pure == (Seq("1", "2", "3"), ())
-            )
-        }
-
-        "one stream to another" in {
-            assert(
-                Streams[Int].runSeq(
-                    Streams[String].transform(
-                        Streams[Int].emit(0).andThen(Streams[String].emit("1", "2", "3"))
-                    )(_.toInt)
-                ).pure == (Seq(0, 1, 2, 3), ())
+                Streams.initSeq(Seq(1, 2, 3)).transform(_.toString).runSeq.pure ==
+                    (Seq("1", "2", "3"), ())
             )
         }
 
         "stack safety" in {
             assert(
-                Streams[Int].runSeq(
-                    Streams[Int].transform(Streams[Int].emit(Seq.fill(100000)(1)))(_ + 1)
-                ).pure == (Seq.fill(100000)(2), ())
+                Streams.initSeq(Seq.fill(100000)(1)).transform(_ + 1).runSeq.pure ==
+                    (Seq.fill(100000)(2), ())
             )
         }
     }
 
     "runChannel" - {
         "non-empty stream" in runJVM {
-            Channels.init[Int | Streams.Done](3).map { ch =>
-                Streams[Int].runChannel(ch)(Streams[Int].emit(1, 2, 3)).map { _ =>
+            Channels.init[Int | Stream.Done](3).map { ch =>
+                Streams.initSeq(Seq(1, 2, 3)).runChannel(ch).map { _ =>
                     ch.take.map { v1 =>
                         assert(v1 == 1)
                         ch.take.map { v2 =>
@@ -252,7 +234,7 @@ class streamsTest extends KyoTest:
                             ch.take.map { v3 =>
                                 assert(v3 == 3)
                                 ch.take.map { done =>
-                                    assert(done == Streams.Done)
+                                    assert(done == Stream.Done)
                                 }
                             }
                         }
@@ -262,18 +244,18 @@ class streamsTest extends KyoTest:
         }
 
         "empty stream" in run {
-            Channels.init[Int | Streams.Done](2).map { ch =>
-                Streams[Int].runChannel(ch)(()).map { _ =>
+            Channels.init[Int | Stream.Done](2).map { ch =>
+                Streams.initSeq(Seq()).runChannel(ch).map { _ =>
                     ch.take.map { done =>
-                        assert(done == Streams.Done)
+                        assert(done == Stream.Done)
                     }
                 }
             }
         }
 
         "stack safety" in run {
-            Channels.init[Int | Streams.Done](100001).map { ch =>
-                Streams[Int].runChannel(ch)(Streams[Int].emit(Seq.fill(100000)(1))).andThen {
+            Channels.init[Int | Stream.Done](100001).map { ch =>
+                Streams.initSeq(Seq.fill(100000)(1)).runChannel(ch).andThen {
                     ch.drain.map { seq =>
                         assert(seq.size == 100001)
                     }
@@ -285,25 +267,19 @@ class streamsTest extends KyoTest:
     "runFold" - {
         "sum" in {
             assert(
-                Streams[Int].runFold(Streams[Int].emit(1, 2, 3))(0)(_ + _).pure ==
-                    (6, ())
+                Streams.initSeq(Seq(1, 2, 3)).runFold(0)(_ + _).pure == (6, ())
             )
         }
 
         "concat" in {
             assert(
-                Streams[String].runFold(
-                    Streams[String].emit("a", "b", "c")
-                )("")(_ + _).pure == ("abc", ())
+                Streams.initSeq(Seq("a", "b", "c")).runFold("")(_ + _).pure == ("abc", ())
             )
         }
 
         "stack safety" in {
             assert(
-                Streams[Int].runFold(
-                    Streams[Int].emit(Seq.fill(100000)(1))
-                )(0)(_ + _).pure ==
-                    (100000, ())
+                Streams.initSeq(Seq.fill(100000)(1)).runFold(0)(_ + _).pure == (100000, ())
             )
         }
     }


### PR DESCRIPTION
The `Streams` effect introduced by https://github.com/getkyo/kyo/pull/235 has an inconvenient API that doesn't allow users to chain stream transformations and operates at a high level of abstraction by transforming `Streams` in the pending effect set. This PR aims to restructure the API to provide better usability. The main idea is providing a `Stream` opaque type that makes it more convenient to use `Streams`:

```scala
// A Stream produces a final value 'T', 
// emits stream elements 'V' and can 
// have other pending effects 'S'.
opaque type Stream[+T, V, -S] = 
    T < (Streams[V] & S)

// The 'initSource' method takes a regular
// computation and transforms it into a
// 'Stream'.
def a(v: Int < (Streams[String] & IOs)): Stream[Int, String, IOs] =
    Streams.initSource[String](v)

// It's possible to freely "rotate" between
// a 'Stream' and its underlying computation
// using 'Streams.initSource' and 'stream.get'.
def b(v: Stream[Int, String, IOs]): Int < (Streams[String] & IOs) =
    v.get

// If a computation produces multiple streams,
// the 'initSource' type parameter allows users to
// select which 'Streams[V]' they want to work with.
def c(v: Int < (Streams[String] & Streams[Int])): Stream[Int, String, Streams[Int]] =
    Streams.initSource[String](v)

// It continues possible to emit elements as before
// without a 'Stream'.
val d: Unit < Streams[Int] = 
    Streams.emitValue(1)

// There are a few 'Streams.init*' methods and
// stream transformations can now only be performed
// on a 'Stream' type. Note how running a stream still
// produces a tuple since it produces the stream + a value.
val e: (Int, Unit) < Any =
    Streams.initSeq(0 until 1000)
            .filter(_ % 2 == 0)
            .transform(_ + 1)
            .runFold(0)(_ + _)
```

I wanted to avoid types with multiple parameters as much as possible but I think this case calls for it given the low usability without it. A simplification we could make is allowing only computations that return unit (`opaque type Stream[V, S] = Unit < (Streams[V] & S)`) but I think the restriction would degrade experience since users wouldn't be able to freely rotate between the `Stream` representation and regular computations.

This PR has some intersection with https://github.com/getkyo/kyo/issues/145. This new approach to encode effects could be a good technique to make Kyo's APIs more fluent.

I've also added a new benchmark that uses buffering. The performance is [still not far](https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fwbrasil/eb2856d3e66430bb115f03494d368ea6/raw/716940c109179009c08d6d772ac577375f5c7fcb/jmh-result.json) from alternatives even without chunking and micro-optimizations:

<img width="927" alt="image" src="https://github.com/getkyo/kyo/assets/831175/fb008f9c-d156-45a7-9461-9b6346a5fc41">



