### PR TITLE
simplify Flat usage

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/Bench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/Bench.scala
@@ -33,7 +33,7 @@ object Bench:
     end Base
 
     @nowarn
-    abstract class Fork[T](using f: Flat[T]) extends Base[T]:
+    abstract class Fork[T: Flat] extends Base[T]:
         @Benchmark
         def forkKyo(): T = IOs.run(Fibers.init(kyoBenchFiber()).flatMap(_.block(Duration.Inf)))
 
@@ -46,10 +46,10 @@ object Bench:
         )
     end Fork
 
-    abstract class ForkOnly[T](using f: Flat[T]) extends Fork[T]:
+    abstract class ForkOnly[T: Flat] extends Fork[T]:
         def kyoBench() = ???
 
-    abstract class SyncAndFork[T](using f: Flat[T]) extends Fork[T]:
+    abstract class SyncAndFork[T: Flat] extends Fork[T]:
 
         @Benchmark
         def syncKyo(): T = IOs.run(kyoBench())

--- a/kyo-core/shared/src/main/scala/kyo/aborts.scala
+++ b/kyo-core/shared/src/main/scala/kyo/aborts.scala
@@ -41,12 +41,11 @@ object Aborts:
                     fail(ex.asInstanceOf[V])
             }
 
-        def run[T, S, VS, VR](v: T < (Aborts[VS] & S))(
+        def run[T: Flat, S, VS, VR](v: T < (Aborts[VS] & S))(
             using
             HasAborts[V, VS] { type Remainder = VR },
             Tag[Aborts[V]],
-            ClassTag[V],
-            Flat[T < (Aborts[V] & S)]
+            ClassTag[V]
         ): Either[V, T] < (S & VR) =
             handle(handler, v).asInstanceOf[Either[V, T] < (S & VR)]
 

--- a/kyo-core/shared/src/main/scala/kyo/envs.scala
+++ b/kyo-core/shared/src/main/scala/kyo/envs.scala
@@ -17,11 +17,10 @@ object Envs:
         def use[T, S](f: V => T < S)(using Tag[Envs[V]]): T < (Envs[V] & S) =
             get.map(f)
 
-        def run[T, S, VS, VR](env: V)(value: T < (Envs[VS] & S))(
+        def run[T: Flat, S, VS, VR](env: V)(value: T < (Envs[VS] & S))(
             using
             HasEnvs[V, VS] { type Remainder = VR },
-            Tag[Envs[V]],
-            Flat[T < (Envs[VS] & S)]
+            Tag[Envs[V]]
         ): T < (S & VR) =
             val handler = new Handler[Const[Unit], Envs[V], Any]:
                 def resume[T2, U: Flat, S1](

--- a/kyo-core/shared/src/main/scala/kyo/hubs.scala
+++ b/kyo-core/shared/src/main/scala/kyo/hubs.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.CopyOnWriteArraySet
 
 object Hubs:
     private[kyo] val closed = IOs.fail("Hub closed!")
-    def init[T](capacity: Int)(using f: Flat[T]): Hub[T] < IOs =
+    def init[T: Flat](capacity: Int): Hub[T] < IOs =
         Channels.init[T](capacity).map { ch =>
             IOs {
                 val listeners = new CopyOnWriteArraySet[Channel[T]]
@@ -49,11 +49,11 @@ end Hubs
 
 import Hubs.*
 
-class Hub[T] private[kyo] (
+class Hub[T: Flat] private[kyo] (
     ch: Channel[T],
     fiber: Fiber[Unit],
     listeners: CopyOnWriteArraySet[Channel[T]]
-)(using f: Flat[T]):
+):
 
     def size: Int < IOs = ch.size
 

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -97,7 +97,7 @@ sealed trait IOs extends Effect[IOs]:
         runLoop(v)
     end run
 
-    def runLazy[T, S](v: T < (IOs & S))(using f: Flat[T < (IOs & S)]): T < S =
+    def runLazy[T: Flat, S](v: T < (IOs & S)): T < S =
         def runLazyLoop(v: T < (IOs & S)): T < S =
             val safepoint = Safepoint.noop[IOs]
             v match

--- a/kyo-core/shared/src/main/scala/kyo/options.scala
+++ b/kyo-core/shared/src/main/scala/kyo/options.scala
@@ -27,15 +27,13 @@ object Options:
             case Some(v) => v
         }
 
-    def run[T, S](v: T < (Options & S))(using f: Flat[T < (Options & S)]): Option[T] < S =
+    def run[T: Flat, S](v: T < (Options & S)): Option[T] < S =
         options.run(v).map {
             case Left(e)  => None
             case Right(v) => Some(v)
         }
 
-    def orElse[T, S](l: (T < (Options & S))*)(implicit
-        f: Flat[T < (Options & S)]
-    ): T < (Options & S) =
+    def orElse[T: Flat, S](l: (T < (Options & S))*): T < (Options & S) =
         l.toList match
             case Nil => Options.empty
             case h :: t =>

--- a/kyo-core/shared/src/main/scala/kyo/package.scala
+++ b/kyo-core/shared/src/main/scala/kyo/package.scala
@@ -31,7 +31,7 @@ package object kyo:
             if i <= 0 then () else andThen(repeat(i - 1))
     end extension
 
-    extension [T, S](v: T < Any)(using Any => S, Flat[T < Any])
+    extension [T](v: T < Any)(using Flat[T < Any])
         def pure: T =
             v match
                 case v: kyo.core.internal.Suspend[?, ?, ?, ?] =>

--- a/kyo-core/shared/src/main/scala/kyo/retries.scala
+++ b/kyo-core/shared/src/main/scala/kyo/retries.scala
@@ -23,14 +23,10 @@ object Retries:
     object Policy:
         val default = Policy(_ => Duration.Zero, 3)
 
-    def apply[T, S](policy: Policy)(v: => T < S)(
-        using f: Flat[T < S]
-    ): T < (Fibers & S) =
+    def apply[T: Flat, S](policy: Policy)(v: => T < S): T < (Fibers & S) =
         apply(_ => policy)(v)
 
-    def apply[T, S](builder: Policy => Policy)(v: => T < S)(
-        using f: Flat[T < S]
-    ): T < (Fibers & S) =
+    def apply[T: Flat, S](builder: Policy => Policy)(v: => T < S): T < (Fibers & S) =
         val b = builder(Policy.default)
         def loop(attempt: Int): T < (Fibers & S) =
             IOs.attempt[T, S](v).map {

--- a/kyo-core/shared/src/main/scala/kyo/seqs.scala
+++ b/kyo-core/shared/src/main/scala/kyo/seqs.scala
@@ -7,7 +7,7 @@ class Seqs extends Effect[Seqs]:
 
 object Seqs extends Seqs:
 
-    def run[T, S](v: T < (Seqs & S))(using f: Flat[T < (Seqs & S)]): Seq[T] < S =
+    def run[T: Flat, S](v: T < (Seqs & S)): Seq[T] < S =
         handle(handler, v)
 
     def repeat(n: Int): Unit < Seqs =

--- a/kyo-core/shared/src/main/scala/kyo/sums.scala
+++ b/kyo-core/shared/src/main/scala/kyo/sums.scala
@@ -12,18 +12,16 @@ class Sums[V] extends Effect[Sums[V]]:
     def add(v: V)(using Tag[Sums[V]]): Unit < Sums[V] =
         suspend(Sums[V])(v)
 
-    def run[T, S](v: T < (Sums[V] & S))(
+    def run[T: Flat, S](v: T < (Sums[V] & S))(
         using
         g: Summer[V],
-        f: Flat[T < (Sums[V] & S)],
         t: Tag[Sums[V]]
     ): (V, T) < S =
         run(g.init)(v)
 
-    def run[T, S](init: V)(v: T < (Sums[V] & S))(
+    def run[T: Flat, S](init: V)(v: T < (Sums[V] & S))(
         using
         g: Summer[V],
-        f: Flat[T < (Sums[V] & S)],
         t: Tag[Sums[V]]
     ): (V, T) < S =
         handle[Const[V], [T] =>> (V, T), Sums[V], T, Any, S](handler(init), v)

--- a/kyo-core/shared/src/main/scala/kyo/vars.scala
+++ b/kyo-core/shared/src/main/scala/kyo/vars.scala
@@ -27,10 +27,8 @@ class Vars[V] extends Effect[Vars[V]]:
     def update(f: V => V)(using Tag[Vars[V]]): Unit < Vars[V] =
         suspend(this)(Op.Update(f))
 
-    def run[T, S2](state: V)(value: T < (Vars[V] & S2))(
-        using
-        Flat[T < (Vars[V] & S2)],
-        Tag[Vars[V]]
+    def run[T: Flat, S2](state: V)(value: T < (Vars[V] & S2))(
+        using Tag[Vars[V]]
     ): T < S2 =
         handle(handler(state), value)
 

--- a/kyo-direct/src/main/scala/kyo/TestSupport.scala
+++ b/kyo-direct/src/main/scala/kyo/TestSupport.scala
@@ -5,9 +5,7 @@ import language.higherKinds
 import scala.language.experimental.macros
 
 object TestSupport:
-    transparent inline def runLiftTest[T, U](inline expected: T)(inline body: U)(implicit
-        f: Flat[U < Any]
-    ) =
+    transparent inline def runLiftTest[T: Flat, U](inline expected: T)(inline body: U) =
         val actual: U = IOs.run(defer(body).asInstanceOf[U < IOs])
         if expected != actual then
             throw new AssertionError("Expected " + expected + " but got " + actual)


### PR DESCRIPTION
Scala has a behavior that when there's a method with a restricted set of effects, it automatically lifts the parameter into a nested computation in case the pending set of the provided parameter doesn't match:

```scala
def test1[T](v: T < IOs) = ...

def test2(v: Int < Fibers): Int < Fibers < IOs =
    test1(v)
```

The `Flat` check is able to detect this issue and produce a better error message.

```scala
def test1[T](v: T < IOs)(using Flat[T < IOs]) = ...

def test2(v: Int < Fibers) =
    test1(v) // compilation failure with details of the effect mismatch
```

Several methods use an implicit `Flat` with the full expected type for this reason but we don't need the full type in case the pending set isn't restricted since Scala won't attempt to do the automatic lifting. We can define the implicit inline with the type parameter:

```scala
def test1[T: Flat, S](v: T < S) = ...
```