### PR TITLE
Improve error messages in case of bugs + reproduce #244

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -136,7 +136,7 @@ object core:
             def deepHandleLoop(v: T < (E & S)): Command[T] < S =
                 v match
                     case kyo: Suspend[Command, Any, T, E] @unchecked =>
-                        require(kyo.tag == tag, "Unhandled effect: " + kyo.tag)
+                        bug(kyo.tag != tag, "Unhandled effect: " + kyo.tag.parse)
                         handler.resume(
                             kyo.command,
                             (v: Any) => deepHandleLoop(kyo(v))

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -89,7 +89,7 @@ sealed trait IOs extends Effect[IOs]:
         @tailrec def runLoop(v: T < IOs): T =
             v match
                 case kyo: Suspend[IO, Unit, T, IOs] @unchecked =>
-                    require(kyo.tag == tag, "Unhandled effect: " + kyo.tag)
+                    bug(kyo.tag != tag, "Unhandled effect: " + kyo.tag.parse)
                     runLoop(kyo(()))
                 case _ =>
                     v.asInstanceOf[T]

--- a/kyo-core/shared/src/main/scala/kyo/package.scala
+++ b/kyo-core/shared/src/main/scala/kyo/package.scala
@@ -34,8 +34,8 @@ package object kyo:
     extension [T](v: T < Any)(using Flat[T < Any])
         def pure: T =
             v match
-                case v: kyo.core.internal.Suspend[?, ?, ?, ?] =>
-                    throw new IllegalStateException("Unhandled effect: " + v.tag)
+                case kyo: kyo.core.internal.Suspend[?, ?, ?, ?] =>
+                    bug("Unhandled effect: " + kyo.tag.parse)
                 case v =>
                     v.asInstanceOf[T]
     end extension
@@ -58,6 +58,10 @@ package object kyo:
         val _ = v
         ()
 
+    case class KyoBugException(msg: String) extends Exception(msg)
+
+    private[kyo] def bug(cond: Boolean, msg: String): Unit =
+        if cond then bug(msg)
     private[kyo] def bug(msg: String): Nothing =
-        throw new IllegalStateException("Kyo bug, please file a ticket: " + msg)
+        throw KyoBugException(msg + ". Please file a ticket.")
 end kyo

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -70,7 +70,7 @@ private[kyo] class IOTask[T](
                                 )
                         end match
                     else
-                        IOs.fail("Unhandled effect: " + kyo.tag)
+                        IOs(bug("Unhandled effect: " + kyo.tag.parse))
                 case _ =>
                     complete(curr.asInstanceOf[T < IOs])
                     finalize()

--- a/kyo-core/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-core/shared/src/main/scala/kyo/tags.scala
@@ -10,7 +10,7 @@ object Tag:
 
     extension [T](t: Tag[T])
         def parse: LightTypeTag =
-            val arr = t.split("|")
+            val arr = t.split('|')
             LightTypeTag.parse(arr(0).toInt, arr(1), arr(2), arr(3).toInt)
     end extension
 

--- a/kyo-core/shared/src/test/scala/kyoTest/abortsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/abortsTest.scala
@@ -48,6 +48,16 @@ class abortsTest extends KyoTest:
                     fail
             )
         }
+        "union tags" in pendingUntilFixed {
+            val effect1: Int < Aborts[String | Boolean] =
+                Aborts[String | Boolean].fail("failure")
+            val handled1: Either[String, Int] < Aborts[Boolean] =
+                Aborts[String].run(effect1)
+            val handled2: Either[Boolean, Either[String, Int]] < Any =
+                Aborts[Boolean].run(handled1)
+            handled2.pure
+            succeed
+        }
     }
 
     "effectful" - {


### PR DESCRIPTION
Kyo uses a custom tag mechanism based on Izumi that is designed to avoid allocations. The macro generates a string at compile time that becomes a constant in the class pool, so tags can be obtained and compared for equality without any runtime allocations.

That's the reason the error message in #244 is so cryptic. I've fixed the error messages to parse the `Tag` string into a regular Izumi tag to provide a better string representation. With this change, the error message in #244 becomes:

```
[info] - union tags *** FAILED *** (8 milliseconds)
[info]   kyo.package$KyoBugException: Unhandled effect: Aborts[-{String | Boolean}]. Please file a ticket.
[info]   at kyo.package$KyoBugException$.apply(package.scala:61)
[info]   at kyo.package$.bug(package.scala:66)
[info]   at kyo.package$.pure(package.scala:38)
[info]   at kyoTest.abortsTest.$init$$$anonfun$1$$anonfun$6(abortsTest.scala:58)
```

I've also fixed a bug in `tag.parse` when splitting the string payload.