### PR TITLE
aborts: improve support for union types (fixes #244)

### DIFF
--- a/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
@@ -38,7 +38,7 @@ class coreBytecodeSizeTest extends KyoTest:
         assert(map == Map(
             "test"        -> 28,
             "resultLoop"  -> 112,
-            "handleLoop"  -> 280,
+            "handleLoop"  -> 264,
             "_handleLoop" -> 12
         ))
     }

--- a/kyo-core/shared/src/main/scala/kyo/aborts.scala
+++ b/kyo-core/shared/src/main/scala/kyo/aborts.scala
@@ -13,8 +13,8 @@ object Aborts:
 
     extension [V](self: Aborts[V])
 
-        def fail[T](value: T)(using ev: T => V, t: Tag[Aborts[V]]): Nothing < Aborts[V] =
-            self.suspend[Nothing](Left(ev(value)))
+        def fail[T <: V](value: T)(using t: Tag[Aborts[T]]): Nothing < Aborts[T] =
+            self.suspend[Nothing](Left(value))
 
         def when(b: Boolean)(value: V)(using Tag[Aborts[V]]): Unit < Aborts[V] =
             if b then fail(value)
@@ -46,6 +46,9 @@ object Aborts:
         private def handler(using ClassTag[V], Tag[Aborts[V]]) =
             new ResultHandler[Unit, self.Command, Aborts[V], [T] =>> Either[V, T], Any]:
                 def done[T](st: Unit, v: T) = Right(v)
+
+                override inline def accepts[T, U](self: Tag[T], other: Tag[U]): Boolean =
+                    self == other || self.parse <:< other.parse
 
                 override def failed(st: Unit, ex: Throwable) =
                     ex match

--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -67,7 +67,7 @@ object core:
             @tailrec def handleLoop(st: State, value: T < (E & S & S2)): Result[T] < (S & S2) =
                 value match
                     case kyo: Suspend[e.Command, Any, T, S2] @unchecked
-                        if kyo.tag == tag =>
+                        if handler.accepts(tag, kyo.tag) =>
                         handler.resume(st, kyo.command, kyo) match
                             case r: handler.Resume[T, S & S2] @unchecked =>
                                 handleLoop(r.st, r.v)
@@ -109,6 +109,9 @@ object core:
     abstract class ResultHandler[State, Command[_], E <: Effect[E], Result[_], S]:
 
         case class Resume[U, S2](st: State, v: U < (E & S & S2))
+
+        def accepts[T, U](self: Tag[T], other: Tag[U]): Boolean =
+            self == other
 
         def done[T](st: State, v: T): Result[T] < S
 


### PR DESCRIPTION
Kyo currently only checks effect tags for equality, which isn't enough for effects like `Aborts`. See https://github.com/getkyo/kyo/issues/244 for more background.

This PR introduces a new method to `Handler` called `accepts`, which can be overriden with custom tag matching logic. I've added the override to `Aborts` to consider sub-typing for it and it seems to fix the issue.

I noticed another issue with the API not enabling handling of a super class and added a pending test for it. I think we'd need to add variance to `HasAborts` to fix it.