### PR TITLE
Loops: Stack-Safe Recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ val d: Int < IOs =
   )
 
 // Mixing 'Consoles' with 'Loops'
-val d: Int < Consoles = 
+val e: Int < Consoles = 
   Loops.transform(1)(i => 
     if i < 5 then 
       Consoles.println(s"Iteration: $i").map(_ => Loops.continue(i + 1))

--- a/README.md
+++ b/README.md
@@ -693,6 +693,15 @@ val d: Int < IOs =
     else
       Loops.done(i)
   )
+
+// Mixing 'Consoles' with 'Loops'
+val d: Int < Consoles = 
+  Loops.transform(1)(i => 
+    if i < 5 then 
+      Consoles.println(s"Iteration: $i").map(_ => Loops.continue(i + 1))
+    else
+      Loops.done(i)
+  )
 ```
 
 The `transform` method takes an initial input value and a function that accepts this value. The function should return either `Loops.continue` with the next input value or `Loops.done` with the final result. The computation continues until `Loops.done` is returned. Similarly, `transform2` and `transform3` allow transformations with multiple input values. These methods also ensure stack safety even for a large number of iterations, without the need for explicit effect suspensions.

--- a/README.md
+++ b/README.md
@@ -673,16 +673,9 @@ val a: Int < Any =
 
 // Transform with multiple input values
 val b: Int < Any =
-  Loops.transform2(1, 1)((i, j) => 
+  Loops.transform(1, 1)((i, j) => 
     if i + j < 5 then Loops.continue(i + 1, j + 1) 
     else Loops.done(i + j)
-  )
-
-// Transform with three input values
-val c: Int < Any = 
-  Loops.transform3(1, 1, 1)((i, j, k) => 
-    if i + j + k < 5 then Loops.continue(i + 1, j + 1, k + 1)
-    else Loops.done(i + j + k)
   )
 
 // Mixing 'IOs' with 'Loops'
@@ -729,11 +722,43 @@ def recursiveLoop(i: Int = 0, sum: Int = 0): Int =
 
 // Version 3: Using Loops
 def loopsVersion: Int < Any =
-  Loops.transform2(0, 0)((i, sum) => 
+  Loops.transform(0, 0)((i, sum) => 
     if i < 10 then 
       Loops.continue(i + 1, sum + i)
     else 
       Loops.done(sum)
+  )
+```
+
+In addition to the transform methods, Loops also provides indexed variants that pass the current iteration index to the transformation function. This can be useful when the logic of the loop depends on the iteration count, such as performing an action every nth iteration or terminating the loop after a certain number of iterations. The indexed methods are available with one, two, or three input values.
+
+```scala
+import kyo._
+
+// Print a message every 3 iterations
+val a: Int < Consoles = 
+  Loops.indexed(1)((idx, i) => 
+    if idx < 10 then
+      if idx % 3 == 0 then
+        Consoles.println(s"Iteration $idx").map(_ => Loops.continue(i + 1))
+      else
+        Loops.continue(i + 1)
+    else 
+      Loops.done(i)
+  )
+
+// Terminate the loop after 5 iterations
+val b: Int < Any =
+  Loops.indexed(1, 1)((idx, i, j) => 
+    if idx < 5 then Loops.continue(i + 1, j + 1) 
+    else Loops.done(i + j)
+  )
+
+// Use the index to calculate the next value
+val c: Int < Any =
+  Loops.indexed(1, 1, 1)((idx, i, j, k) => 
+    if idx < 5 then Loops.continue(i + idx, j + idx, k + idx)
+    else Loops.done(i + j + k)
   )
 ```
 

--- a/kyo-core/shared/src/main/scala/kyo/loops.scala
+++ b/kyo-core/shared/src/main/scala/kyo/loops.scala
@@ -1,0 +1,104 @@
+package kyo
+
+import kyo.core.internal.Kyo
+import scala.annotation.tailrec
+import scala.util.NotGiven
+
+object Loops:
+
+    private case class Continue[Input](input: Input)
+    private case class Continue2[Input1, Input2](input1: Input1, input2: Input2)
+    private case class Continue3[Input1, Input2, Input3](input1: Input1, input2: Input2, input3: Input3)
+
+    opaque type Result[Input, Output]                   = Output | Continue[Input]
+    opaque type Result2[Input1, Input2, Output]         = Output | Continue2[Input1, Input2]
+    opaque type Result3[Input1, Input2, Input3, Output] = Output | Continue3[Input1, Input2, Input3]
+
+    inline def done[Input, Output](v: Output): Result[Input, Output]       = v
+    inline def continue[Input, Output, S](v: Input): Result[Input, Output] = Continue(v)
+
+    inline def done[Input1, Input2, Output](v: Output): Result2[Input1, Input2, Output] = v
+    inline def continue[Input1, Input2, Output](
+        v1: Input1,
+        v2: Input2
+    ): Result2[Input1, Input2, Output] = Continue2(v1, v2)
+
+    inline def done[Input1, Input2, Input3, Output](v: Output): Result3[Input1, Input2, Input3, Output] = v
+    inline def continue[Input1, Input2, Input3, Output](
+        v1: Input1,
+        v2: Input2,
+        v3: Input3
+    ): Result3[Input1, Input2, Input3, Output] = Continue3(v1, v2, v3)
+
+    inline def transform[Input, Output: Flat, S](
+        input: Input
+    )(
+        inline run: Input => Result[Input, Output] < S
+    ): Output < S =
+        def _loop(input: Input): Output < S =
+            loop(input)
+        @tailrec def loop(input: Input): Output < S =
+            run(input) match
+                case next: Continue[Input] @unchecked =>
+                    loop(next.input)
+                case kyo: Kyo[Output | Continue[Input], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue[Input] =>
+                            _loop(next.input)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(input)
+    end transform
+
+    inline def transform2[Input1, Input2, Output: Flat, S](
+        input1: Input1,
+        input2: Input2
+    )(
+        inline run: (Input1, Input2) => Result2[Input1, Input2, Output] < S
+    ): Output < S =
+        def _loop(input1: Input1, input2: Input2): Output < S =
+            loop(input1, input2)
+        @tailrec def loop(input1: Input1, input2: Input2): Output < S =
+            run(input1, input2) match
+                case next: Continue2[Input1, Input2] @unchecked =>
+                    loop(next.input1, next.input2)
+                case kyo: Kyo[Output | Continue2[Input1, Input2], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue2[Input1, Input2] =>
+                            _loop(next.input1, next.input2)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(input1, input2)
+    end transform2
+
+    inline def transform3[Input1, Input2, Input3, Output: Flat, S](
+        input1: Input1,
+        input2: Input2,
+        input3: Input3
+    )(
+        inline run: (Input1, Input2, Input3) => Result3[Input1, Input2, Input3, Output] < S
+    ): Output < S =
+        def _loop(input1: Input1, input2: Input2, input3: Input3): Output < S =
+            loop(input1, input2, input3)
+        @tailrec def loop(input1: Input1, input2: Input2, input3: Input3): Output < S =
+            run(input1, input2, input3) match
+                case next: Continue3[Input1, Input2, Input3] @unchecked =>
+                    loop(next.input1, next.input2, next.input3)
+                case kyo: Kyo[Output | Continue3[Input1, Input2, Input3], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue3[Input1, Input2, Input3] =>
+                            _loop(next.input1, next.input2, next.input3)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(input1, input2, input3)
+    end transform3
+end Loops

--- a/kyo-core/shared/src/main/scala/kyo/loops.scala
+++ b/kyo-core/shared/src/main/scala/kyo/loops.scala
@@ -53,7 +53,7 @@ object Loops:
         loop(input)
     end transform
 
-    inline def transform2[Input1, Input2, Output: Flat, S](
+    inline def transform[Input1, Input2, Output: Flat, S](
         input1: Input1,
         input2: Input2
     )(
@@ -75,9 +75,9 @@ object Loops:
                 case res =>
                     res.asInstanceOf[Output]
         loop(input1, input2)
-    end transform2
+    end transform
 
-    inline def transform3[Input1, Input2, Input3, Output: Flat, S](
+    inline def transform[Input1, Input2, Input3, Output: Flat, S](
         input1: Input1,
         input2: Input2,
         input3: Input3
@@ -100,5 +100,77 @@ object Loops:
                 case res =>
                     res.asInstanceOf[Output]
         loop(input1, input2, input3)
-    end transform3
+    end transform
+
+    inline def indexed[Input, Output: Flat, S](
+        input: Input
+    )(
+        inline run: (Int, Input) => Result[Input, Output] < S
+    ): Output < S =
+        def _loop(idx: Int, input: Input): Output < S =
+            loop(idx, input)
+        @tailrec def loop(idx: Int, input: Input): Output < S =
+            run(idx, input) match
+                case next: Continue[Input] @unchecked =>
+                    loop(idx + 1, next.input)
+                case kyo: Kyo[Output | Continue[Input], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue[Input] =>
+                            _loop(idx + 1, next.input)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(0, input)
+    end indexed
+
+    inline def indexed[Input1, Input2, Output: Flat, S](
+        input1: Input1,
+        input2: Input2
+    )(
+        inline run: (Int, Input1, Input2) => Result2[Input1, Input2, Output] < S
+    ): Output < S =
+        def _loop(idx: Int, input1: Input1, input2: Input2): Output < S =
+            loop(idx, input1, input2)
+        @tailrec def loop(idx: Int, input1: Input1, input2: Input2): Output < S =
+            run(idx, input1, input2) match
+                case next: Continue2[Input1, Input2] @unchecked =>
+                    loop(idx + 1, next.input1, next.input2)
+                case kyo: Kyo[Output | Continue2[Input1, Input2], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue2[Input1, Input2] =>
+                            _loop(idx + 1, next.input1, next.input2)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(0, input1, input2)
+    end indexed
+
+    inline def indexed[Input1, Input2, Input3, Output: Flat, S](
+        input1: Input1,
+        input2: Input2,
+        input3: Input3
+    )(
+        inline run: (Int, Input1, Input2, Input3) => Result3[Input1, Input2, Input3, Output] < S
+    ): Output < S =
+        def _loop(idx: Int, input1: Input1, input2: Input2, input3: Input3): Output < S =
+            loop(idx, input1, input2, input3)
+        @tailrec def loop(idx: Int, input1: Input1, input2: Input2, input3: Input3): Output < S =
+            run(idx, input1, input2, input3) match
+                case next: Continue3[Input1, Input2, Input3] @unchecked =>
+                    loop(idx + 1, next.input1, next.input2, next.input3)
+                case kyo: Kyo[Output | Continue3[Input1, Input2, Input3], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue3[Input1, Input2, Input3] =>
+                            _loop(idx + 1, next.input1, next.input2, next.input3)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(0, input1, input2, input3)
+    end indexed
 end Loops

--- a/kyo-core/shared/src/test/scala/kyoTest/loopsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/loopsTest.scala
@@ -29,6 +29,16 @@ class loopsTest extends KyoTest:
           """)
         }
 
+        "accumulate results in a List" in {
+            val result = Loops.transform((0, List.empty[Int])) { case (i, acc) =>
+                if i < 5 then
+                    Loops.continue((i + 1, i :: acc))
+                else
+                    Loops.done(acc.reverse)
+            }
+            assert(result.pure == List(0, 1, 2, 3, 4))
+        }
+
         "stack safety" in {
             val largeNumber = 100000
             assert(
@@ -136,7 +146,7 @@ class loopsTest extends KyoTest:
         "stack safety" in {
             val largeNumber = 100000
             assert(
-                Loops.transform2(1, 1)((i, j) =>
+                Loops.transform(1, 1)((i, j) =>
                     if i + j < largeNumber then Loops.continue(i + 1, j + 1)
                     else Loops.done(i + j)
                 ).pure == largeNumber
@@ -147,7 +157,7 @@ class loopsTest extends KyoTest:
             val outerLoopIterations = 1000
             val innerLoopIterations = 1000
             assert(
-                Loops.transform2(0, 0)((i, j) =>
+                Loops.transform(0, 0)((i, j) =>
                     if i < outerLoopIterations then
                         Loops.continue(
                             i + 1,
@@ -164,7 +174,7 @@ class loopsTest extends KyoTest:
         "stack safety with interleaved iterations" in {
             val iterations = 100000
             assert(
-                Loops.transform2(0, 0)((i, j) =>
+                Loops.transform(0, 0)((i, j) =>
                     if i + j < iterations then
                         if i % 2 == 0 then Loops.continue(i + 1, j)
                         else Loops.continue(i, j + 1)
@@ -174,7 +184,7 @@ class loopsTest extends KyoTest:
         }
 
         "suspend with IOs at the beginning" in {
-            val result = Loops.transform2(1, 1)((i, j) =>
+            val result = Loops.transform(1, 1)((i, j) =>
                 IOs {
                     if i + j < 5 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)
                 }
@@ -183,7 +193,7 @@ class loopsTest extends KyoTest:
         }
 
         "suspend with IOs in the middle" in {
-            val result = Loops.transform2(1, 1)((i, j) =>
+            val result = Loops.transform(1, 1)((i, j) =>
                 if i + j < 3 then
                     IOs(Loops.continue(i + 1, j + 1))
                 else if i + j < 5 then
@@ -195,7 +205,7 @@ class loopsTest extends KyoTest:
         }
 
         "suspend with IOs at the end" in {
-            val result = Loops.transform2(1, 1)((i, j) =>
+            val result = Loops.transform(1, 1)((i, j) =>
                 if i + j < 5 then
                     Loops.continue(i + 1, j + 1)
                 else
@@ -208,7 +218,7 @@ class loopsTest extends KyoTest:
     "transform3" - {
         "with a single iteration" in {
             assert(
-                Loops.transform3(1, 1, 1)((i, j, k) =>
+                Loops.transform(1, 1, 1)((i, j, k) =>
                     if i + j + k < 5 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
                 ).pure == 6
             )
@@ -216,7 +226,7 @@ class loopsTest extends KyoTest:
 
         "with multiple iterations" in {
             assert(
-                Loops.transform3(1, 1, 1)((i, j, k) =>
+                Loops.transform(1, 1, 1)((i, j, k) =>
                     if i + j + k < 10 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
                 ).pure == 12
             )
@@ -224,7 +234,7 @@ class loopsTest extends KyoTest:
 
         "with no iterations" in {
             assert(
-                Loops.transform3(5, 5, 5)((i, j, k) =>
+                Loops.transform(5, 5, 5)((i, j, k) =>
                     if i + j + k < 10 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
                 ).pure == 15
             )
@@ -239,7 +249,7 @@ class loopsTest extends KyoTest:
         "stack safety" in {
             val largeNumber = 100000
             assert(
-                Loops.transform3(1, 1, 1)((i, j, k) =>
+                Loops.transform(1, 1, 1)((i, j, k) =>
                     if i + j + k < largeNumber then Loops.continue(i + 1, j + 1, k + 1)
                     else Loops.done(i + j + k)
                 ).pure == largeNumber + 2
@@ -249,7 +259,7 @@ class loopsTest extends KyoTest:
         "stack safety with interleaved iterations" in {
             val iterations = 100000
             assert(
-                Loops.transform3(0, 0, 0)((i, j, k) =>
+                Loops.transform(0, 0, 0)((i, j, k) =>
                     if i + j + k < iterations then
                         if i % 3 == 0 then Loops.continue(i + 1, j, k)
                         else if i % 3 == 1 then Loops.continue(i, j + 1, k)
@@ -260,7 +270,7 @@ class loopsTest extends KyoTest:
         }
 
         "suspend with IOs at the beginning" in {
-            val result = Loops.transform3(1, 1, 1)((i, j, k) =>
+            val result = Loops.transform(1, 1, 1)((i, j, k) =>
                 IOs {
                     if i + j + k < 5 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
                 }
@@ -269,7 +279,7 @@ class loopsTest extends KyoTest:
         }
 
         "suspend with IOs in the middle" in {
-            val result = Loops.transform3(1, 1, 1)((i, j, k) =>
+            val result = Loops.transform(1, 1, 1)((i, j, k) =>
                 if i + j + k < 3 then
                     IOs(Loops.continue(i + 1, j + 1, k + 1))
                 else if i + j + k < 5 then
@@ -281,13 +291,152 @@ class loopsTest extends KyoTest:
         }
 
         "suspend with IOs at the end" in {
-            val result = Loops.transform3(1, 1, 1)((i, j, k) =>
+            val result = Loops.transform(1, 1, 1)((i, j, k) =>
                 if i + j + k < 5 then
                     Loops.continue(i + 1, j + 1, k + 1)
                 else
                     IOs(Loops.done(i + j + k))
             )
             assert(IOs.run(result).pure == 6)
+        }
+    }
+
+    "indexed" - {
+        "with a single iteration" in {
+            assert(
+                Loops.indexed(1)((idx, i) => if idx < 5 then Loops.continue(i + 1) else Loops.done(i)).pure == 6
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.indexed(1)((idx, i) => if idx < 10 then Loops.continue(i + 1) else Loops.done(i)).pure == 11
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.indexed(1)((idx, i) => if idx < 0 then Loops.continue(i + 1) else Loops.done(i)).pure == 1
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+        def test[T](v: T) = Loops.indexed(0)((idx, i) => Loops.done(v))
+        """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.indexed(1)((idx, i) => if idx < largeNumber then Loops.continue(i + 1) else Loops.done(i)).pure == largeNumber + 1
+            )
+        }
+
+        "suspend with IOs" in {
+            val result = Loops.indexed(1)((idx, i) =>
+                if idx < 5 then
+                    IOs(Loops.continue(i + 1))
+                else
+                    IOs(Loops.done(i))
+            )
+            assert(IOs.run(result).pure == 6)
+        }
+    }
+
+    "indexed2" - {
+        "with a single iteration" in {
+            assert(
+                Loops.indexed(1, 1)((idx, i, j) => if idx < 5 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 12
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.indexed(1, 1)((idx, i, j) => if idx < 10 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 22
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.indexed(1, 1)((idx, i, j) => if idx < 0 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 2
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+        def test[T](v: T) = Loops.indexed2(0, 0)((idx, i, j) => Loops.done(v))
+        """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.indexed(1, 1)((idx, i, j) =>
+                    if idx < largeNumber then Loops.continue(i + 1, j + 1) else Loops.done(i + j)
+                ).pure == 2 * largeNumber + 2
+            )
+        }
+
+        "suspend with IOs" in {
+            val result = Loops.indexed(1, 1)((idx, i, j) =>
+                if idx < 5 then
+                    IOs(Loops.continue(i + 1, j + 1))
+                else
+                    IOs(Loops.done(i + j))
+            )
+            assert(IOs.run(result).pure == 12)
+        }
+    }
+
+    "indexed3" - {
+        "with a single iteration" in {
+            assert(
+                Loops.indexed(1, 1, 1)((idx, i, j, k) =>
+                    if idx < 5 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 18
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.indexed(1, 1, 1)((idx, i, j, k) =>
+                    if idx < 10 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 33
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.indexed(1, 1, 1)((idx, i, j, k) =>
+                    if idx < 0 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 3
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+        def test[T](v: T) = Loops.indexed3(0, 0, 0)((idx, i, j, k) => Loops.done(v))
+        """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.indexed(1, 1, 1)((idx, i, j, k) =>
+                    if idx < largeNumber then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 3 * largeNumber + 3
+            )
+        }
+
+        "suspend with IOs" in {
+            val result = Loops.indexed(1, 1, 1)((idx, i, j, k) =>
+                if idx < 5 then
+                    IOs(Loops.continue(i + 1, j + 1, k + 1))
+                else
+                    IOs(Loops.done(i + j + k))
+            )
+            assert(IOs.run(result).pure == 18)
         }
     }
 end loopsTest

--- a/kyo-core/shared/src/test/scala/kyoTest/loopsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/loopsTest.scala
@@ -1,0 +1,293 @@
+package kyoTest
+
+import kyo.*
+
+class loopsTest extends KyoTest:
+
+    "transform" - {
+        "with a single iteration" in {
+            assert(
+                Loops.transform(1)(i => if i < 5 then Loops.continue(i + 1) else Loops.done(i)).pure == 5
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.transform(1)(i => if i < 5 then Loops.continue(i + 1) else Loops.done(i)).pure == 5
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.transform(5)(i => if i < 5 then Loops.continue(i + 1) else Loops.done(i)).pure == 5
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+            def test[T](v: T) = Loops.transform(0)(i => Loops.done(v))
+          """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.transform(1)(i => if i < largeNumber then Loops.continue(i + 1) else Loops.done(i)).pure == largeNumber
+            )
+        }
+
+        "stack safety with nested loops" in {
+            val outerLoopIterations = 1000
+            val innerLoopIterations = 1000
+
+            assert(
+                Loops.transform(0)(i =>
+                    if i < outerLoopIterations then
+                        Loops.continue(Loops.transform(0)(j =>
+                            if j < innerLoopIterations then Loops.continue(j + 1) else Loops.done(j)
+                        ).pure)
+                    else
+                        Loops.done(i)
+                ).pure == outerLoopIterations
+            )
+        }
+
+        "stack safety with multiple levels of nested loops" in {
+            val level1Iterations = 100
+            val level2Iterations = 100
+            val level3Iterations = 100
+
+            assert(
+                Loops.transform(0)(i =>
+                    if i < level1Iterations then
+                        Loops.continue(
+                            Loops.transform(0)(j =>
+                                if j < level2Iterations then
+                                    Loops.continue(
+                                        Loops.transform(0)(k => if k < level3Iterations then Loops.continue(k + 1) else Loops.done(k)).pure
+                                    )
+                                else
+                                    Loops.done(j)
+                            ).pure
+                        )
+                    else
+                        Loops.done(i)
+                ).pure == level1Iterations
+            )
+        }
+
+        "suspend with IOs at the beginning" in {
+            val result = Loops.transform(1)(i =>
+                IOs {
+                    if i < 5 then Loops.continue(i + 1) else Loops.done(i)
+                }
+            )
+            assert(IOs.run(result).pure == 5)
+        }
+
+        "suspend with IOs in the middle" in {
+            val result = Loops.transform(1)(i =>
+                if i < 3 then
+                    IOs(Loops.continue(i + 1))
+                else if i < 5 then
+                    Loops.continue(i + 1)
+                else
+                    Loops.done(i)
+            )
+            assert(IOs.run(result).pure == 5)
+        }
+
+        "suspend with IOs at the end" in {
+            val result = Loops.transform(1)(i =>
+                if i < 5 then
+                    Loops.continue(i + 1)
+                else
+                    IOs(Loops.done(i))
+            )
+            assert(IOs.run(result).pure == 5)
+        }
+    }
+
+    "transform2" - {
+        "with a single iteration" in {
+            assert(
+                Loops.transform(1, 1)((i, j) => if i + j < 5 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 6
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.transform(1, 1)((i, j) => if i + j < 10 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 10
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.transform(5, 5)((i, j) => if i + j < 10 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 10
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+            def test[T](v: T) = Loops.transform2(0, 0)((i, j) => Loops.done(v))
+          """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.transform2(1, 1)((i, j) =>
+                    if i + j < largeNumber then Loops.continue(i + 1, j + 1)
+                    else Loops.done(i + j)
+                ).pure == largeNumber
+            )
+        }
+
+        "stack safety with nested loops" in {
+            val outerLoopIterations = 1000
+            val innerLoopIterations = 1000
+            assert(
+                Loops.transform2(0, 0)((i, j) =>
+                    if i < outerLoopIterations then
+                        Loops.continue(
+                            i + 1,
+                            Loops.transform(0)(k =>
+                                if k < innerLoopIterations then Loops.continue(k + 1)
+                                else Loops.done(k)
+                            ).pure
+                        )
+                    else Loops.done(j)
+                ).pure == innerLoopIterations
+            )
+        }
+
+        "stack safety with interleaved iterations" in {
+            val iterations = 100000
+            assert(
+                Loops.transform2(0, 0)((i, j) =>
+                    if i + j < iterations then
+                        if i % 2 == 0 then Loops.continue(i + 1, j)
+                        else Loops.continue(i, j + 1)
+                    else Loops.done(i + j)
+                ).pure == iterations
+            )
+        }
+
+        "suspend with IOs at the beginning" in {
+            val result = Loops.transform2(1, 1)((i, j) =>
+                IOs {
+                    if i + j < 5 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)
+                }
+            )
+            assert(IOs.run(result).pure == 6)
+        }
+
+        "suspend with IOs in the middle" in {
+            val result = Loops.transform2(1, 1)((i, j) =>
+                if i + j < 3 then
+                    IOs(Loops.continue(i + 1, j + 1))
+                else if i + j < 5 then
+                    Loops.continue(i + 1, j + 1)
+                else
+                    Loops.done(i + j)
+            )
+            assert(IOs.run(result).pure == 6)
+        }
+
+        "suspend with IOs at the end" in {
+            val result = Loops.transform2(1, 1)((i, j) =>
+                if i + j < 5 then
+                    Loops.continue(i + 1, j + 1)
+                else
+                    IOs(Loops.done(i + j))
+            )
+            assert(IOs.run(result).pure == 6)
+        }
+    }
+
+    "transform3" - {
+        "with a single iteration" in {
+            assert(
+                Loops.transform3(1, 1, 1)((i, j, k) =>
+                    if i + j + k < 5 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 6
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.transform3(1, 1, 1)((i, j, k) =>
+                    if i + j + k < 10 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 12
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.transform3(5, 5, 5)((i, j, k) =>
+                    if i + j + k < 10 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 15
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+            def test[T](v: T) = Loops.transform3(0, 0, 0)((i, j, j) => Loops.done(v))
+          """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.transform3(1, 1, 1)((i, j, k) =>
+                    if i + j + k < largeNumber then Loops.continue(i + 1, j + 1, k + 1)
+                    else Loops.done(i + j + k)
+                ).pure == largeNumber + 2
+            )
+        }
+
+        "stack safety with interleaved iterations" in {
+            val iterations = 100000
+            assert(
+                Loops.transform3(0, 0, 0)((i, j, k) =>
+                    if i + j + k < iterations then
+                        if i % 3 == 0 then Loops.continue(i + 1, j, k)
+                        else if i % 3 == 1 then Loops.continue(i, j + 1, k)
+                        else Loops.continue(i, j, k + 1)
+                    else Loops.done(i + j + k)
+                ).pure == iterations
+            )
+        }
+
+        "suspend with IOs at the beginning" in {
+            val result = Loops.transform3(1, 1, 1)((i, j, k) =>
+                IOs {
+                    if i + j + k < 5 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                }
+            )
+            assert(IOs.run(result).pure == 6)
+        }
+
+        "suspend with IOs in the middle" in {
+            val result = Loops.transform3(1, 1, 1)((i, j, k) =>
+                if i + j + k < 3 then
+                    IOs(Loops.continue(i + 1, j + 1, k + 1))
+                else if i + j + k < 5 then
+                    Loops.continue(i + 1, j + 1, k + 1)
+                else
+                    Loops.done(i + j + k)
+            )
+            assert(IOs.run(result).pure == 6)
+        }
+
+        "suspend with IOs at the end" in {
+            val result = Loops.transform3(1, 1, 1)((i, j, k) =>
+                if i + j + k < 5 then
+                    Loops.continue(i + 1, j + 1, k + 1)
+                else
+                    IOs(Loops.done(i + j + k))
+            )
+            assert(IOs.run(result).pure == 6)
+        }
+    }
+end loopsTest


### PR DESCRIPTION
Kyo's execution model evaluates pure code strictly as [described in the readme](https://github.com/getkyo/kyo/blob/457d9f5958afb6af8b847245164d85de3362e439/README.md?plain=1#L1741), which makes recursive computations without effect suspensions not stack safe by default. The current recommendation is introducing an effect suspension like `IOs` to achieve stack safety.

Although introducing an effect suspension can be convenient in some cases, it can become problematic in code that doesn't have a reasonable way to introduce suspensions. For example, I've been working on the `Streams` effect and adding `IOs` to its execution just to ensure stack safety doesn't seem reasonable. I could emit an empty chunk but that would introduce unnecessary overhead and doesn't feel like a proper solution.

This PR introduces `Loops`, which provides generic stack-safe recursion using a technique identified as part of https://github.com/getkyo/kyo/pull/253 that is currently [used in Kyo's core](https://github.com/getkyo/kyo/blob/457d9f5958afb6af8b847245164d85de3362e439/kyo-core/shared/src/main/scala/kyo/core.scala#L72). The technique reflects on the result of the computation to determine if it can continue the loop immediately (using @tailrec) or if the loop should suspend (using `map`).