### PR TITLE
introduce chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,12 +867,14 @@ val m: Int < Any = a.foldLeft(0)(_ + _)
 // Copying to arrays
 val n: Array[Int] = a.toArray
 
-// Other operations
-val o: Chunk[Int] = Chunks.init(a, b)
-  .flatten
-val p: Chunk[Int] = Chunks.init(1, 1, 2, 3, 3)
-  .changes
-val q: Chunks.Indexed[Int] = a.toIndexed
+// Flatten a nested chunk
+val o: Chunk[Int] = 
+  Chunks.init(a, b).flatten
+
+// Obtain sequentially distict elements.
+// Outputs: Chunk(1, 2, 3, 1)
+val p: Chunk[Int] = 
+  Chunks.init(1, 1, 2, 3, 3, 1, 1).changes
 ```
 
 ### Aspects: Aspect-Oriented Programming

--- a/README.md
+++ b/README.md
@@ -859,7 +859,8 @@ val j: Chunk[String] < Any = a.map(_.toString)
 val k: Chunk[Int] < Any = a.filter(_ % 2 == 0)
 
 // Effectful side effects
-val l: Unit < IOs = a.foreach(v => IOs(println(v)))
+val l: Unit < Consoles = 
+  a.foreach(v => Consoles.println(v))
 
 // Effectful fold
 val m: Int < Any = a.foldLeft(0)(_ + _)

--- a/README.md
+++ b/README.md
@@ -762,6 +762,119 @@ val c: Int < Any =
   )
 ```
 
+## Chunks: Efficient Sequences
+
+`Chunks` is an efficient mechanism for processing sequences of data in a purely functional manner. It offers a wide range of operations optimized for different scenarios, ensuring high performance without compromising functional programming principles.
+
+`Chunk` is designed as a lightweight wrapper around arrays, allowing for efficient random access and transformation operations. Its internal representation is carefully crafted to minimize memory allocation and ensure stack safety. Many of its operations have an algorithmic complexity of `O(1)`, making them highly performant for a variety of use cases.
+
+```scala
+import kyo._
+
+// Construct chunks
+val a: Chunk[Int] = Chunks.init(1, 2, 3)
+val b: Chunk[Int] = Chunks.initSeq(Seq(4, 5, 6))
+
+// Perform O(1) operations
+val c: Chunk[Int] = a.append(4)
+val d: Chunk[Int] = b.take(2)
+val e: Chunk[Int] = c.dropLeft(1)
+
+// Perform O(n) operations
+val f: Chunk[String] = d.map(_.toString).pure
+val g: Chunk[Int] = e.filter(_ % 2 == 0).pure
+```
+
+`Chunks` provides two main subtypes: `Chunk` for regular chunks and `Chunks.Indexed` for indexed chunks. The table below summarizes the time complexity of various operations for each type:
+
+| Description                | Operations                                           | Regular Chunk | Indexed Chunk |
+|----------------------------|------------------------------------------------------|---------------|---------------|
+| Creation                   | `Chunks.init`, `Chunks.initSeq`                      | O(n)          | O(n)          |
+| Size and emptiness         | `size`, `isEmpty`                                    | O(1)          | O(1)          |
+| Take and drop              | `take`, `dropLeft`, `dropRight`, `slice`             | O(1)          | O(1)          |
+| Append and last            | `append`, `last`                                     | O(1)          | O(1)          |
+| Element access             | `apply`, `head`, `tail`                              | N/A           | O(1)          |
+| Concatenation              | `concat`                                             | O(n)          | O(n)          |
+| Effectful map and filter   | `map`, `filter`, `collect`, `takeWhile`, `dropWhile` | O(n)          | O(n)          |
+| Effectful side effects     | `foreach`, `collectUnit`                             | O(n)          | O(n)          |
+| Effectful fold             | `foldLeft`                                           | O(n)          | O(n)          |
+| Copying to arrays          | `toArray`, `copyTo`                                  | O(n)          | O(n)          |
+| Other operations           | `flatten`, `changes`, `toSeq`, `toIndexed`           | O(n)          | O(n)          |
+
+When deciding between `Chunk` and `Chunks.Indexed`, consider the primary operations you'll be performing on the data. If you mainly need to `append` elements, `take` slices, or `drop` elements from the beginning or end of the sequence, `Chunk` is a good choice. Its `O(1)` complexity for these operations makes it efficient for such tasks.
+
+```scala
+import kyo._
+
+val a: Chunk[Int] = Chunks.init(1, 2, 3, 4, 5)
+
+// Efficient O(1) operations with Chunk
+val b: Chunk[Int] = a.append(6)
+val c: Chunk[Int] = a.take(3)
+val d: Chunk[Int] = a.dropLeft(2)
+```
+
+On the other hand, if you frequently need to access elements by index, `Chunks.Indexed` is the better option. It provides `O(1)` element access and supports `head` and `tail` operations, which are not available in `Chunk`.
+
+```scala
+import kyo._
+
+val a: Chunks.Indexed[Int] = 
+  Chunks.init(1, 2, 3, 4, 5).toIndexed
+
+// Efficient O(1) operations with Chunks.Indexed
+val b: Int = a(2)
+val c: Int = a.head
+val d: Chunks.Indexed[Int] = a.tail
+```
+
+Keep in mind that converting between `Chunk` and `Chunks.Indexed` is an `O(n)` operation, so it's best to choose the appropriate type upfront based on your usage patterns. However, calling `toIndexed` on a chunk that is already internally indexed is a no-op and does not incur any additional overhead.
+
+Here's an overview of the main APIs available in Chunk:
+
+```scala
+import kyo._
+
+// Creation
+val a: Chunk[Int] = Chunks.init(1, 2, 3)
+val b: Chunk[Int] = Chunks.initSeq(Seq(4, 5, 6))
+
+// Size and emptiness
+val c: Int = a.size
+val d: Boolean = a.isEmpty
+
+// Take and drop
+val e: Chunk[Int] = a.take(2)
+val f: Chunk[Int] = a.dropLeft(1)
+
+// Append and last
+val g: Chunk[Int] = a.append(4)
+val h: Int = a.last
+
+// Concatenation
+val i: Chunk[Int] = a.concat(b)
+
+// Effectful map and filter
+val j: Chunk[String] < Any = a.map(_.toString)
+val k: Chunk[Int] < Any = a.filter(_ % 2 == 0)
+
+// Effectful side effects
+val l: Unit < IOs = a.foreach(v => IOs(println(v)))
+
+// Effectful fold
+val m: Int < Any = a.foldLeft(0)(_ + _)
+
+// Copying to arrays
+val n: Array[Int] = a.toArray
+
+// Other operations
+val o: Chunk[Int] = Chunks.init(a, b)
+  .flatten
+val p: Chunk[Int] = Chunks.init(1, 1, 2, 3, 3)
+  .changes
+val q: Chunks.Indexed[Int] = a.toIndexed
+```
+
 ### Aspects: Aspect-Oriented Programming
 
 The `Aspects` effect in Kyo allows for high-level customization of behavior across your application. This is similar to how some frameworks use aspects for centralized control over diverse functionalities like database timeouts, authentication, authorization, and transaction management. You can modify these core operations without altering their individual codebases, streamlining how centralized logic is applied across different parts of an application. This makes `Aspects` ideal for implementing cross-cutting concerns in a clean and efficient manner.

--- a/kyo-bench/src/main/scala/kyo/bench/MtlBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/MtlBench.scala
@@ -13,17 +13,17 @@ class MtlBench extends Bench:
     @Benchmark
     def syncKyo() =
         import kyo.*
-        def testKyo: Unit < (Aborts[Throwable] & Envs[Env] & Vars[State] & Sums[List[Event]]) =
+        def testKyo: Unit < (Aborts[Throwable] & Envs[Env] & Vars[State] & Sums[Event]) =
             Seqs.traverseUnit(loops)(_ =>
                 for
                     conf <- Envs[Env].use(_.config)
-                    _    <- Sums[List[Event]].add(List(Event(s"Env = $conf")))
+                    _    <- Sums[Event].add(Event(s"Env = $conf"))
                     _    <- Vars[State].update(state => state.copy(value = state.value + 1))
                 yield ()
             )
         Aborts[Throwable].run(
             Vars[State].run(State(2))(
-                Sums[List[Event]].run(
+                Sums[Event].run(
                     Envs[Env].run(Env("config"))(
                         testKyo.andThen(Vars[State].get)
                     )

--- a/kyo-core/shared/src/main/scala/kyo/chunks.scala
+++ b/kyo-core/shared/src/main/scala/kyo/chunks.scala
@@ -136,7 +136,7 @@ sealed abstract class Chunk[T] derives CanEqual:
                 if idx < size then
                     val v = indexed(idx)
                     f(v).map {
-                        case true  => Loops.continue(())
+                        case true  => Loops.continueUnit
                         case false => Loops.done(indexed.dropLeft(idx))
                     }
                 else
@@ -193,13 +193,13 @@ sealed abstract class Chunk[T] derives CanEqual:
                     val v = indexed(idx)
                     if pf.isDefinedAt(v) then
                         pf(v).andThen {
-                            Loops.continue(())
+                            Loops.continueUnit
                         }
                     else
-                        Loops.continue(())
+                        Loops.continueUnit
                     end if
                 else
-                    Loops.done(())
+                    Loops.doneUnit
             }
 
     final def foreach[S](f: T => Unit < S): Unit < S =
@@ -210,9 +210,9 @@ sealed abstract class Chunk[T] derives CanEqual:
             Loops.indexed(()) { (idx, _) =>
                 if idx < size then
                     val v = indexed(idx)
-                    f(v).andThen(Loops.continue(()))
+                    f(v).andThen(Loops.continueUnit)
                 else
-                    Loops.done(())
+                    Loops.doneUnit
             }
     end foreach
 
@@ -349,6 +349,9 @@ sealed abstract class Chunk[T] derives CanEqual:
             loop()
 end Chunk
 
+object Chunk:
+    def empty[T]: Chunk[T] = Chunks.init[T]
+
 object Chunks:
 
     import internal.*
@@ -390,7 +393,7 @@ object Chunks:
                 case seq: IndexedSeq[T] => FromSeq(seq)
                 case _                  => Compact(values.toArray(using ClassTag(classOf[Any])))
 
-    def fill[T, S](n: Int)(v: T): Chunk[T] =
+    def fill[T](n: Int)(v: T): Chunk[T] =
         if n <= 0 then Chunks.init
         else
             val array = (new Array[Any](n)).asInstanceOf[Array[T]]

--- a/kyo-core/shared/src/main/scala/kyo/chunks.scala
+++ b/kyo-core/shared/src/main/scala/kyo/chunks.scala
@@ -1,0 +1,464 @@
+package kyo
+
+import Chunks.Indexed
+import scala.annotation.tailrec
+import scala.reflect.ClassTag
+
+sealed abstract class Chunk[T] derives CanEqual:
+
+    import Chunks.internal.*
+
+    //////////////////
+    // O(1) methods //
+    //////////////////
+
+    def size: Int
+
+    final def isEmpty: Boolean = size == 0
+
+    final def take(n: Int): Chunk[T] =
+        dropLeftAndRight(0, size - Math.min(Math.max(0, n), size))
+
+    final def dropLeft(n: Int): Chunk[T] =
+        dropLeftAndRight(Math.min(size, Math.max(0, n)), 0)
+
+    final def dropRight(n: Int): Chunk[T] =
+        dropLeftAndRight(0, Math.min(size, Math.max(0, n)))
+
+    final def slice(from: Int, until: Int): Chunk[T] =
+        dropLeftAndRight(Math.max(0, from), size - Math.min(size, until))
+
+    final def dropLeftAndRight(left: Int, right: Int): Chunk[T] =
+        @tailrec def loop(c: Chunk[T], left: Int, right: Int): Chunk[T] =
+            val size = c.size - left - right
+            if size <= 0 then Chunks.init
+            else
+                c match
+                    case Drop(chunk, dropLeft, dropRight, _) =>
+                        Drop(chunk, left + dropLeft, right + dropRight, size)
+                    case Append(chunk, value, size) if right > 0 =>
+                        loop(chunk, left, right - 1)
+                    case _ =>
+                        Drop(c, left, right, size)
+            end if
+        end loop
+        loop(this, left, right)
+    end dropLeftAndRight
+
+    final def append(v: T): Chunk[T] =
+        Append(this, v, size + 1)
+
+    final def last: T =
+        @tailrec def loop(c: Chunk[T], index: Int): T =
+            c match
+                case c if index >= c.size || index <= 0 =>
+                    throw new NoSuchElementException
+                case c: Append[T] =>
+                    if index == c.size - 1 then
+                        c.value
+                    else
+                        loop(c.chunk, index)
+                case c: Drop[T] =>
+                    loop(c.chunk, index + c.dropLeft)
+                case c: Indexed[T] =>
+                    c(index)
+        loop(this, this.size - 1)
+    end last
+
+    //////////////////
+    // O(n) methods //
+    //////////////////
+
+    final def concat(other: Chunk[T]): Chunk[T] =
+        if isEmpty then other
+        else if other.isEmpty then this
+        else
+            val s     = size
+            val array = new Array[T](s + other.size)(using ClassTag(classOf[Any]))
+            this.copyTo(array, 0)
+            other.copyTo(array, s)
+            Compact(array)
+        end if
+    end concat
+
+    final def map[U: Flat, S](f: T => U < S): Chunk[U] < S =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(Chunks.init[U]) { (idx, acc) =>
+                if idx < size then
+                    f(indexed(idx)).map(u => Loops.continue(acc.append(u)))
+                else
+                    Loops.done(acc)
+            }
+    end map
+
+    final def filter[S](f: T => Boolean < S): Chunk[T] < S =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(Chunks.init[T]) { (idx, acc) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    f(v).map {
+                        case true  => Loops.continue(acc.append(v))
+                        case false => Loops.continue(acc)
+                    }
+                else
+                    Loops.done(acc)
+            }
+    end filter
+
+    final def takeWhile[S](f: T => Boolean < S): Chunk[T] < S =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(Chunks.init[T]) { (idx, acc) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    f(v).map {
+                        case true  => Loops.continue(acc.append(v))
+                        case false => Loops.done(acc)
+                    }
+                else
+                    Loops.done(acc)
+            }
+
+    final def dropWhile[S](f: T => Boolean < S): Chunk[T] < S =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(()) { (idx, _) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    f(v).map {
+                        case true  => Loops.continue(())
+                        case false => Loops.done(indexed.dropLeft(idx))
+                    }
+                else
+                    Loops.done(Chunks.init)
+            }
+
+    final def changes: Chunk[T] =
+        changes(null)
+
+    final def changes(first: T | Null): Chunk[T] =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            @tailrec def loop(idx: Int, prev: T | Null, acc: Chunk[T]): Chunk[T] =
+                if idx < size then
+                    val v = indexed(idx)
+                    if v.equals(prev) then
+                        loop(idx + 1, prev, acc)
+                    else
+                        loop(idx + 1, v, acc.append(v))
+                    end if
+                else
+                    acc
+            loop(0, null, Chunks.init)
+    end changes
+
+    final def collect[U, S](pf: PartialFunction[T, U < S]): Chunk[U] < S =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(Chunks.init[U]) { (idx, acc) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    if pf.isDefinedAt(v) then
+                        pf(v).map { u =>
+                            Loops.continue(acc.append(u))
+                        }
+                    else
+                        Loops.continue(acc)
+                    end if
+                else
+                    Loops.done(acc)
+            }
+
+    final def collectUnit[U, S](pf: PartialFunction[T, Unit < S]): Unit < S =
+        if isEmpty then ()
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(()) { (idx, _) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    if pf.isDefinedAt(v) then
+                        pf(v).andThen {
+                            Loops.continue(())
+                        }
+                    else
+                        Loops.continue(())
+                    end if
+                else
+                    Loops.done(())
+            }
+
+    final def foreach[S](f: T => Unit < S): Unit < S =
+        if isEmpty then ()
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(()) { (idx, _) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    f(v).andThen(Loops.continue(()))
+                else
+                    Loops.done(())
+            }
+    end foreach
+
+    final def foldLeft[S, U: Flat](init: U)(f: (U, T) => U < S): U < S =
+        if isEmpty then init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(init) { (idx, acc) =>
+                if idx < size then
+                    f(acc, indexed(idx)).map(nacc => Loops.continue(nacc))
+                else
+                    Loops.done(acc)
+            }
+    end foldLeft
+
+    final def toSeq: IndexedSeq[T] =
+        if isEmpty then IndexedSeq.empty
+        else
+            this match
+                case c: FromSeq[T] => c.seq
+                case _             => toArrayInternal.toIndexedSeq
+
+    final def toIndexed: Chunks.Indexed[T] =
+        if isEmpty then cachedEmpty.asInstanceOf[Chunks.Indexed[T]]
+        else
+            this match
+                case c: Chunks.Indexed[T] => c
+                case _                    => Compact(toArrayInternal)
+
+    final def flatten[U](using ev: T =:= Chunk[U]): Chunk[U] =
+        if isEmpty then Chunks.init
+        else
+            val nested = this.toArrayInternal
+
+            @tailrec def totalSize(idx: Int = 0, acc: Int = 0): Int =
+                if idx < nested.length then
+                    val chunk = nested(idx).asInstanceOf[Chunk[U]]
+                    totalSize(idx + 1, acc + chunk.size)
+                else
+                    acc
+
+            val unnested = new Array[U](totalSize())(using ClassTag(classOf[Any]))
+
+            @tailrec def copy(idx: Int = 0, offset: Int = 0): Unit =
+                if idx < nested.length then
+                    val chunk = nested(idx).asInstanceOf[Chunk[U]]
+                    chunk.copyTo(unnested, offset)
+                    copy(idx + 1, offset + chunk.size)
+            copy()
+
+            Compact(unnested)
+    end flatten
+
+    final def copyTo(array: Array[T], start: Int): Unit =
+        copyTo(array, start, size)
+
+    final def copyTo(array: Array[T], start: Int, elements: Int): Unit =
+        @tailrec def loop(c: Chunk[T], end: Int, dropLeft: Int, dropRight: Int): Unit =
+            c match
+                case c: Append[T] =>
+                    if dropRight > 0 then
+                        loop(c.chunk, end, dropLeft, dropRight - 1)
+                    else if end > 0 then
+                        array(end - 1) = c.value
+                        loop(c.chunk, end - 1, dropLeft, dropRight)
+                case c: Drop[T] =>
+                    loop(c.chunk, end, dropLeft + c.dropLeft, dropRight + c.dropRight)
+                case c: Tail[T] =>
+                    loop(c.chunk, end, dropLeft + c.offset, dropRight)
+                case c: Compact[T] =>
+                    val l = c.array.length
+                    if l > 0 then
+                        System.arraycopy(c.array, dropLeft, array, start, l - dropRight - dropLeft)
+                case c: FromSeq[T] =>
+                    val seq  = c.seq
+                    val size = Math.min(end, c.seq.size - dropLeft - dropRight)
+                    @tailrec def loop(index: Int): Unit =
+                        if index < size then
+                            array(start + index) = seq(index + dropLeft)
+                            loop(index + 1)
+                    loop(0)
+        if !isEmpty then
+            loop(this, elements, 0, 0)
+    end copyTo
+
+    final def toArray(using ClassTag[T]): Array[T] =
+        val array = new Array[T](size)
+        copyTo(array, 0)
+        array
+    end toArray
+
+    final private def toArrayInternal: Array[T] =
+        this match
+            case c if c.isEmpty =>
+                cachedEmpty.array.asInstanceOf[Array[T]]
+            case c: Compact[T] =>
+                c.array
+            case c =>
+                c.toArray(using ClassTag(classOf[Any]))
+
+    override def equals(other: Any) =
+        (this eq other.asInstanceOf[Object]) || {
+            other match
+                case other: Chunk[?] =>
+                    (this.isEmpty && other.isEmpty) ||
+                    (this.size == other.size && {
+                        val s = this.size
+                        val a = this.toIndexed
+                        val b = other.toIndexed
+                        @tailrec def loop(idx: Int = 0): Boolean =
+                            if idx < s then
+                                inline given CanEqual[Any, Any] = CanEqual.derived
+                                a(idx) == b(idx) && loop(idx + 1)
+                            else
+                                true
+                        loop()
+                    })
+                case _ =>
+                    false
+        }
+
+    override def hashCode(): Int =
+        if isEmpty then
+            1
+        else
+            val s = this.size
+            val a = this.toIndexed
+            @tailrec def loop(idx: Int = 0, acc: Int = 1): Int =
+                if idx < s then
+                    loop(idx + 1, 31 * acc + a(idx).hashCode())
+                else
+                    acc
+            loop()
+end Chunk
+
+object Chunks:
+
+    import internal.*
+
+    sealed abstract class Indexed[T] extends Chunk[T]:
+
+        //////////////////
+        // O(1) methods //
+        //////////////////
+
+        def apply(i: Int): T
+
+        final def head: T =
+            if isEmpty then
+                throw new NoSuchElementException
+            else
+                apply(0)
+
+        final def tail: Indexed[T] =
+            if size <= 1 then cachedEmpty.asInstanceOf[Indexed[T]]
+            else
+                this match
+                    case Tail(chunk, offset, size) =>
+                        Tail(chunk, offset + 1, size - 1)
+                    case c =>
+                        Tail(c, 1, size - 1)
+    end Indexed
+
+    def init[T]: Chunk[T] =
+        cachedEmpty.asInstanceOf[Chunk[T]]
+
+    def init[T](values: T*): Chunk[T] =
+        initSeq(values)
+
+    def initSeq[T](values: Seq[T]): Chunk[T] =
+        if values.isEmpty then init[T]
+        else
+            values match
+                case seq: IndexedSeq[T] => FromSeq(seq)
+                case _                  => Compact(values.toArray(using ClassTag(classOf[Any])))
+
+    def fill[T, S](n: Int)(v: T): Chunk[T] =
+        if n <= 0 then Chunks.init
+        else
+            val array = (new Array[Any](n)).asInstanceOf[Array[T]]
+            @tailrec def loop(idx: Int = 0): Unit =
+                if idx < n then
+                    array(idx) = v
+                    loop(idx + 1)
+            loop()
+            Compact(array)
+    end fill
+
+    def collect[T: Flat, S](c: Chunk[T < S]): Chunk[T] < S =
+        c.map(identity)
+
+    private[kyo] object internal:
+
+        val cachedEmpty = Compact(new Array[Any](0))
+
+        case class FromSeq[T](
+            seq: IndexedSeq[T]
+        ) extends Indexed[T]:
+            def size = seq.size
+            def apply(i: Int) =
+                if i >= size || i < 0 then
+                    throw new NoSuchElementException
+                else
+                    seq(i)
+
+            override def toString = s"Chunk.Indexed(${seq.mkString(", ")})"
+        end FromSeq
+
+        case class Compact[T](
+            array: Array[T]
+        ) extends Indexed[T]:
+            def size = array.length
+            def apply(i: Int) =
+                if i >= size || i < 0 then
+                    throw new NoSuchElementException
+                else
+                    array(i)
+
+            override def toString = s"Chunk.Indexed(${array.mkString(", ")})"
+        end Compact
+
+        case class Tail[T](
+            chunk: Indexed[T],
+            offset: Int,
+            size: Int
+        ) extends Indexed[T]:
+            def apply(i: Int): T  = chunk(i + offset)
+            override def toString = s"Chunk(${toSeq.mkString(", ")})"
+        end Tail
+
+        case class Drop[T](
+            chunk: Chunk[T],
+            dropLeft: Int,
+            dropRight: Int,
+            size: Int
+        ) extends Chunk[T]:
+            override def toString = s"Chunk(${toSeq.mkString(", ")})"
+        end Drop
+
+        case class Append[T](
+            chunk: Chunk[T],
+            value: T,
+            size: Int
+        ) extends Chunk[T]:
+            override def toString = s"Chunk(${toSeq.mkString(", ")})"
+        end Append
+    end internal
+end Chunks

--- a/kyo-core/shared/src/main/scala/kyo/loops.scala
+++ b/kyo-core/shared/src/main/scala/kyo/loops.scala
@@ -14,6 +14,11 @@ object Loops:
     opaque type Result2[Input1, Input2, Output]         = Output | Continue2[Input1, Input2]
     opaque type Result3[Input1, Input2, Input3, Output] = Output | Continue3[Input1, Input2, Input3]
 
+    private val _continueUnit = Continue[Unit](())
+
+    inline def continueUnit[T]: Result[Unit, T] = _continueUnit
+    inline def doneUnit[T]: Result[T, Unit]     = ()
+
     inline def done[Input, Output](v: Output): Result[Input, Output]       = v
     inline def continue[Input, Output, S](v: Input): Result[Input, Output] = Continue(v)
 

--- a/kyo-core/shared/src/main/scala/kyo/sums.scala
+++ b/kyo-core/shared/src/main/scala/kyo/sums.scala
@@ -7,50 +7,19 @@ object Sums:
     def apply[V]: Sums[V] = sums.asInstanceOf[Sums[V]]
 
 class Sums[V] extends Effect[Sums[V]]:
-    type Command[T] = V
+    opaque type Command[T] = V
 
     def add(v: V)(using Tag[Sums[V]]): Unit < Sums[V] =
-        Sums[V].suspend[Unit](v)
+        this.suspend[Unit](v)
 
     def run[T: Flat, S](v: T < (Sums[V] & S))(
-        using
-        g: Summer[V],
-        t: Tag[Sums[V]]
-    ): (V, T) < S =
-        run(g.init)(v)
+        using Tag[Sums[V]]
+    ): (Chunk[V], T) < S =
+        this.handle(handler)(Chunks.init, v)
 
-    def run[T: Flat, S](init: V)(v: T < (Sums[V] & S))(
-        using
-        g: Summer[V],
-        t: Tag[Sums[V]]
-    ): (V, T) < S =
-        Sums[V].handle(g.handler)(init, v)
+    private val handler =
+        new ResultHandler[Chunk[V], Const[V], Sums[V], [T] =>> (Chunk[V], T), Any]:
+            def done[T](st: Chunk[V], v: T) = (st, v)
+            def resume[T, U: Flat, S](st: Chunk[V], command: V, k: T => U < (Sums[V] & S)) =
+                Resume(st.append(command), k(().asInstanceOf[T]))
 end Sums
-
-abstract class Summer[V]:
-    def init: V
-    def add(v1: V, v2: V): V
-    def result(v: V): V
-    val handler =
-        new ResultHandler[V, Const[V], Sums[V], [T] =>> (V, T), Any]:
-            def done[T](st: V, v: T) = (result(st), v)
-            def resume[T, U: Flat, S](st: V, command: V, k: T => U < (Sums[V] & S)) =
-                Resume(add(st, command), k(().asInstanceOf[T]))
-end Summer
-
-object Summer:
-    def apply[V](_init: V)(_add: (V, V) => V, _result: V => V): Summer[V] =
-        new Summer[V]:
-            def init              = _init
-            def add(v1: V, v2: V) = _add(v1, v2)
-            def result(v: V): V   = _result(v)
-
-    given intSummer: Summer[Int]             = Summer(0)(_ + _, identity)
-    given longSummer: Summer[Long]           = Summer(0L)(_ + _, identity)
-    given doubleSummer: Summer[Double]       = Summer(0d)(_ + _, identity)
-    given floatSummer: Summer[Float]         = Summer(0f)(_ + _, identity)
-    given stringSummer: Summer[String]       = Summer("")(_ + _, identity)
-    given listSummer[T]: Summer[List[T]]     = Summer(List.empty[T])((a, b) => b ++ a, _.reverse)
-    given setSummer[T]: Summer[Set[T]]       = Summer(Set.empty[T])(_ ++ _, identity)
-    given mapSummer[T, U]: Summer[Map[T, U]] = Summer(Map.empty[T, U])(_ ++ _, identity)
-end Summer

--- a/kyo-core/shared/src/test/scala/kyoTest/chunksTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/chunksTest.scala
@@ -802,6 +802,10 @@ class chunksTest extends KyoTest:
         }
     }
 
+    "Chunk.empty" in {
+        assert(Chunk.empty[Int].toSeq.isEmpty)
+    }
+
     "Chunks.collect" - {
         "collects elements from a chunk of effectful computations" in {
             val chunk  = Chunks.init(IOs(1), IOs(2), IOs(3))

--- a/kyo-core/shared/src/test/scala/kyoTest/chunksTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/chunksTest.scala
@@ -1,0 +1,841 @@
+package kyoTest
+import kyo.*
+import scala.util.Try
+
+class chunksTest extends KyoTest:
+
+    "append" - {
+        "appends a value to an empty chunk" in {
+            val chunk = Chunks.init[Int].append(1)
+            assert(chunk == Chunks.init(1))
+        }
+
+        "appends a value to a non-empty chunk" in {
+            val chunk = Chunks.init(1, 2, 3).append(4)
+            assert(chunk == Chunks.init(1, 2, 3, 4))
+        }
+    }
+
+    "head" - {
+        "returns the first element of a non-empty chunk" in {
+            val chunk = Chunks.init(1, 2, 3).toIndexed
+            assert(chunk.head == 1)
+        }
+
+        "throws NoSuchElementException for an empty chunk" in {
+            val chunk = Chunks.init[Int].toIndexed
+            assert(Try(chunk.head).isFailure)
+        }
+    }
+
+    "tail" - {
+        "returns the tail of a non-empty chunk" in {
+            val chunk = Chunks.init(1, 2, 3).toIndexed
+            assert(chunk.tail == Chunks.init(2, 3))
+        }
+
+        "returns an empty chunk for a chunk with a single element" in {
+            val chunk = Chunks.init(1).toIndexed
+            assert(chunk.tail.isEmpty)
+        }
+
+        "returns an empty chunk for an empty chunk" in {
+            val chunk = Chunks.init[Int].toIndexed
+            assert(chunk.tail.isEmpty)
+        }
+
+        "returns the correct tail for a Drop chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropLeft(2).toIndexed
+            assert(chunk.tail == Chunks.init(4, 5))
+        }
+
+        "of appends" in {
+            val chunk = Chunks.init[Int].append(1).append(2).append(3).toIndexed
+            assert(chunk.tail == Chunks.init(2, 3))
+            assert(chunk.tail.tail == Chunks.init(3))
+        }
+    }
+
+    "take" - {
+        "returns the first n elements of a chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.take(3) == Chunks.init(1, 2, 3))
+        }
+
+        "returns the entire chunk if n is greater than the chunk size" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.take(5) == Chunks.init(1, 2, 3))
+        }
+
+        "returns an empty chunk if n is zero or negative" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.take(0).isEmpty)
+            assert(chunk.take(-1).isEmpty)
+        }
+    }
+
+    "dropLeft" - {
+        "drops the first n elements of a chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.dropLeft(2) == Chunks.init(3, 4, 5))
+        }
+
+        "returns an empty chunk if n is greater than or equal to the chunk size" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.dropLeft(3).isEmpty)
+            assert(chunk.dropLeft(4).isEmpty)
+        }
+
+        "returns the entire chunk if n is zero or negative" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.dropLeft(0) == Chunks.init(1, 2, 3))
+            assert(chunk.dropLeft(-1) == Chunks.init(1, 2, 3))
+        }
+    }
+
+    "dropRight" - {
+        "drops the last n elements of a chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.dropRight(2) == Chunks.init(1, 2, 3))
+        }
+
+        "returns an empty chunk if n is greater than or equal to the chunk size" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.dropRight(3).isEmpty)
+            assert(chunk.dropRight(4).isEmpty)
+        }
+
+        "returns the entire chunk if n is zero or negative" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.dropRight(0) == Chunks.init(1, 2, 3))
+            assert(chunk.dropRight(-1) == Chunks.init(1, 2, 3))
+        }
+    }
+
+    "slice" - {
+        "returns a slice of a chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.slice(1, 4) == Chunks.init(2, 3, 4))
+        }
+
+        "returns an empty chunk if from is greater than or equal to until" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.slice(2, 2).isEmpty)
+            assert(chunk.slice(3, 2).isEmpty)
+        }
+
+        "returns an empty chunk if the chunk is empty" in {
+            val chunk = Chunks.init[Int]
+            assert(chunk.slice(0, 1).isEmpty)
+        }
+
+        "returns the full chunk if `from` is negative and `until` is greater than the size" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.slice(-1, 6) == Chunks.init(1, 2, 3, 4, 5))
+        }
+
+        "returns the full chunk if `from` is 0 and `until` is greater than the size" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.slice(0, 5) == Chunks.init(1, 2, 3))
+        }
+
+        "returns the correct slice when multiple slice operations are chained" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            val result = chunk.slice(2, 8).slice(1, 5).slice(1, 3)
+            assert(result == Chunks.init(5, 6))
+        }
+    }
+
+    "map" - {
+        "with a pure function" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.map(_ * 2)
+            assert(result.pure == Chunks.init(2, 4, 6, 8, 10))
+        }
+
+        "with a function using IOs" in {
+            val chunk    = Chunks.init(1, 2, 3, 4, 5)
+            val result   = chunk.map(n => IOs(n * 2))
+            val expected = Chunks.init(2, 4, 6, 8, 10)
+            assert(IOs.run(result).pure == expected)
+        }
+
+        "with a function returning pure values and effectful computations" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.map { n =>
+                if n % 2 == 0 then IOs(n * 2) else n * 2
+            }
+            val expected = Chunks.init(2, 4, 6, 8, 10)
+            assert(IOs.run(result).pure == expected)
+        }
+
+        "with an empty chunk" in {
+            val chunk  = Chunks.init[Int]
+            val result = chunk.map(_ * 2)
+            assert(result.pure.isEmpty)
+        }
+    }
+
+    "filter" - {
+        "with a pure predicate" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.filter(_ % 2 == 0)
+            assert(result.pure == Chunks.init(2, 4))
+        }
+
+        "with a predicate using IOs" in {
+            val chunk    = Chunks.init(1, 2, 3, 4, 5)
+            val result   = chunk.filter(n => IOs(n % 2 == 0))
+            val expected = Chunks.init(2, 4)
+            assert(IOs.run(result).pure == expected)
+        }
+
+        "with a predicate returning pure values and effectful computations" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.filter { n =>
+                if n % 2 == 0 then IOs(true) else false
+            }
+            val expected = Chunks.init(2, 4)
+            assert(IOs.run(result).pure == expected)
+        }
+
+        "with a predicate that filters out all elements" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.filter(_ => IOs(false))
+            assert(IOs.run(result).pure.isEmpty)
+        }
+    }
+
+    "foldLeft" - {
+        "with a pure function" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.foldLeft(0)(_ + _)
+            assert(result.pure == 15)
+        }
+
+        "with a function using IOs" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.foldLeft(0)((acc, n) => IOs(acc + n))
+            assert(IOs.run(result).pure == 15)
+        }
+
+        "with a function returning pure values and effectful computations" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.foldLeft(0) { (acc, n) =>
+                if n % 2 == 0 then IOs(acc + n) else acc + n
+            }
+            assert(IOs.run(result).pure == 15)
+        }
+
+        "with an empty chunk" in {
+            val chunk  = Chunks.init[Int]
+            val result = chunk.foldLeft(0)(_ + _)
+            assert(result.pure == 0)
+        }
+    }
+
+    "toSeq" - {
+        "converts a Chunk to an IndexedSeq" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.toSeq == IndexedSeq(1, 2, 3, 4, 5))
+        }
+
+        "converts an empty Chunk to an empty IndexedSeq" in {
+            val chunk = Chunks.init[Int]
+            assert(chunk.toSeq.isEmpty)
+        }
+    }
+
+    "mixed" - {
+        "chained operations" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5).toIndexed
+            val result = chunk.append(6).toIndexed.tail.take(3).dropLeft(1)
+            assert(result == Chunks.init(3, 4))
+        }
+
+        "empty chunk operations" in {
+            val chunk = Chunks.init[Int]
+            assert(chunk.append(1).toIndexed.head == 1)
+            assert(chunk.toIndexed.tail.isEmpty)
+            assert(chunk.take(2).isEmpty)
+            assert(chunk.dropLeft(1).isEmpty)
+            assert(chunk.slice(0, 1).isEmpty)
+        }
+
+        "single element chunk operations" in {
+            val chunk = Chunks.init(1)
+            assert(chunk.append(2) == Chunks.init(1, 2))
+            assert(chunk.toIndexed.tail.isEmpty)
+            assert(chunk.take(1) == Chunks.init(1))
+            assert(chunk.dropLeft(1).isEmpty)
+            assert(chunk.slice(0, 1) == Chunks.init(1))
+        }
+
+        "out of bounds indexing" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.dropLeft(5).isEmpty)
+            assert(chunk.take(5) == Chunks.init(1, 2, 3))
+            assert(chunk.slice(1, 5) == Chunks.init(2, 3))
+            assert(chunk.slice(5, 6).isEmpty)
+        }
+
+        "negative indexing" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.dropLeft(-1) == Chunks.init(1, 2, 3, 4, 5))
+            assert(chunk.take(-1).isEmpty)
+            assert(chunk.slice(-2, 3) == Chunks.init(1, 2, 3))
+            assert(chunk.slice(2, -1).isEmpty)
+        }
+
+        "chained append operations" in {
+            val chunk = Chunks.init[Int].append(1).append(2).append(3)
+            assert(chunk == Chunks.init(1, 2, 3))
+        }
+
+        "chained slice operations" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.slice(1, 4).slice(1, 2) == Chunks.init(3))
+        }
+
+        "slice beyond chunk size" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.slice(1, 10) == Chunks.init(2, 3))
+            assert(chunk.slice(5, 10).isEmpty)
+        }
+
+        "mapping and filtering an empty chunk" in {
+            val chunk = Chunks.init[Int]
+            val result = chunk
+                .map(_ * 2).pure
+                .filter(_ % 2 == 0)
+            assert(result.pure.isEmpty)
+        }
+
+        "filter and map" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5, 6)
+            val result = chunk
+                .filter(_ % 2 == 0).pure
+                .map(_ + 1).pure
+            assert(result == Chunks.init(3, 5, 7))
+        }
+
+        "multiple appends followed by head and tail" - {
+            "returns the correct elements when calling head and tail repeatedly" in {
+                val chunk = Chunks.init[Int]
+                    .append(1)
+                    .append(2)
+
+                assert(chunk.toIndexed.head == 1)
+                assert(chunk.toIndexed.tail.head == 2)
+                assert(chunk.toIndexed.tail.tail.isEmpty)
+            }
+
+            "returns the correct elements when calling head and tail in a loop" in {
+                val chunk = Chunks.init[Int]
+                    .append(1)
+                    .append(2)
+                    .append(3)
+                    .append(4)
+                    .append(5)
+
+                var current = chunk.toIndexed
+                val result  = collection.mutable.ListBuffer[Int]()
+
+                while !current.isEmpty do
+                    result += current.head
+                    current = current.tail
+
+                assert(result.toList == List(1, 2, 3, 4, 5))
+            }
+
+            "handles empty chunks when calling head and tail" in {
+                val chunk = Chunks.init[Int]
+                    .append(1)
+                    .append(2)
+                    .toIndexed
+                    .tail
+                    .tail
+
+                assert(chunk.isEmpty)
+                assert(Try(chunk.head).isFailure)
+                assert(chunk.tail.isEmpty)
+            }
+        }
+        "handles nested Drop chunks" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+                .dropLeft(2)
+                .dropLeft(1)
+                .toIndexed
+
+            assert(chunk == Chunks.init(4, 5))
+            assert(chunk.tail == Chunks.init(5))
+            assert(chunk.tail.tail.isEmpty)
+        }
+
+        "chained take, dropLeft, and dropRight operations" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            assert(chunk.take(7).dropLeft(2).dropRight(2) == Chunks.init(3, 4, 5))
+        }
+
+        "empty chunk with take, dropLeft, and dropRight" in {
+            val chunk = Chunks.init[Int]
+            assert(chunk.take(5).isEmpty)
+            assert(chunk.dropLeft(2).isEmpty)
+            assert(chunk.dropRight(3).isEmpty)
+        }
+
+        "single element chunk with take, dropLeft, and dropRight" in {
+            val chunk = Chunks.init(1)
+            assert(chunk.take(1) == Chunks.init(1))
+            assert(chunk.take(2) == Chunks.init(1))
+            assert(chunk.dropLeft(0) == Chunks.init(1))
+            assert(chunk.dropLeft(1).isEmpty)
+            assert(chunk.dropRight(0) == Chunks.init(1))
+            assert(chunk.dropRight(1).isEmpty)
+        }
+    }
+
+    "flatten" - {
+        "flattens a chunk of chunks in original order" in {
+            val chunk: Chunk[Chunk[Int]] = Chunks.init(Chunks.init(1, 2), Chunks.init(3, 4, 5), Chunks.init(6, 7, 8, 9))
+            assert(chunk.flatten == Chunks.init(1, 2, 3, 4, 5, 6, 7, 8, 9))
+        }
+
+        "returns an empty chunk when flattening an empty chunk of chunks" in {
+            val chunk = Chunks.init[Chunk[Int]]
+            assert(chunk.flatten.isEmpty)
+        }
+
+        "returns an empty chunk when flattening a chunk of empty chunks" in {
+            val chunk = Chunks.init(Chunks.init[Int], Chunks.init[Int])
+            assert(chunk.flatten.isEmpty)
+        }
+
+        "preserves the order of elements within each chunk" in {
+            val chunk = Chunks.init(Chunks.init(1, 2, 3), Chunks.init(4, 5, 6))
+            assert(chunk.flatten == Chunks.init(1, 2, 3, 4, 5, 6))
+        }
+
+        "handles a chunk containing a single chunk" in {
+            val chunk = Chunks.init(Chunks.init(1, 2, 3))
+            assert(chunk.flatten == Chunks.init(1, 2, 3))
+        }
+
+        "handles chunks of different sizes" in {
+            val chunk = Chunks.init(Chunks.init(1), Chunks.init(2, 3), Chunks.init(4, 5, 6, 7))
+            assert(chunk.flatten == Chunks.init(1, 2, 3, 4, 5, 6, 7))
+        }
+    }
+
+    "toArray" - {
+        "returns an array with the elements of a Chunk.Compact" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val array = chunk.toArray
+            assert(array.toSeq == Seq(1, 2, 3, 4, 5))
+        }
+
+        "returns an array with the elements of a Chunk.FromSeq" in {
+            val chunk = Chunks.initSeq(IndexedSeq(1, 2, 3))
+            val array = chunk.toArray
+            assert(array.toSeq == Seq(1, 2, 3))
+        }
+
+        "returns an array with the elements of a Chunk.Drop" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropLeft(2)
+            val array = chunk.toArray
+            assert(array.toSeq == Seq(3, 4, 5))
+        }
+
+        "returns an array with the elements of a Chunk.Append" in {
+            val chunk = Chunks.init(1, 2, 3).append(4).append(5)
+            val array = chunk.toArray
+            assert(array.toSeq == Seq(1, 2, 3, 4, 5))
+        }
+
+        "returns an empty array for an empty Chunk" in {
+            val chunk = Chunks.init[Int]
+            val array = chunk.toArray
+            assert(array.isEmpty)
+        }
+
+        "returns a new array instance for each call" in {
+            val chunk  = Chunks.init(1, 2, 3)
+            val array1 = chunk.toArray
+            val array2 = chunk.toArray
+            assert(array1 ne array2)
+        }
+    }
+
+    "copyTo" - {
+        "copies elements to an array" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val array = new Array[Int](5)
+            chunk.copyTo(array, 0)
+            assert(array.toSeq == Seq(1, 2, 3, 4, 5))
+        }
+
+        "copies elements to a specific position in the array" in {
+            val chunk = Chunks.init(1, 2, 3)
+            val array = new Array[Int](5)
+            chunk.copyTo(array, 2)
+            assert(array.toSeq == Seq(0, 0, 1, 2, 3))
+        }
+
+        "copies elements from a Chunk.Compact" in {
+            val chunk = Chunks.init(1, 2, 3)
+            val array = new Array[Int](3)
+            chunk.copyTo(array, 0)
+            assert(array.toSeq == Seq(1, 2, 3))
+        }
+
+        "copies elements from a Chunk.FromSeq" in {
+            val chunk = Chunks.initSeq(IndexedSeq(1, 2, 3))
+            val array = new Array[Int](3)
+            chunk.copyTo(array, 0)
+            assert(array.toSeq == Seq(1, 2, 3))
+        }
+
+        "copies elements from a Chunk.Drop" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropLeft(2)
+            val array = new Array[Int](3)
+            chunk.copyTo(array, 0)
+            assert(array.toSeq == Seq(3, 4, 5))
+        }
+
+        "copies elements from a Chunk.Append" in {
+            val chunk = Chunks.init(1, 2, 3).append(4)
+            val array = new Array[Int](4)
+            chunk.copyTo(array, 0)
+            assert(array.toSeq == Seq(1, 2, 3, 4))
+        }
+    }
+
+    "copyTo with size" - {
+        "copies a specified number of elements to an array" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val array = new Array[Int](3)
+            chunk.copyTo(array, 0, 3)
+            assert(array.toSeq == Seq(1, 2, 3))
+        }
+
+        "copies elements from a specific position and size" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val array = new Array[Int](2)
+            chunk.copyTo(array, 0, 2)
+            assert(array.toSeq == Seq(1, 2))
+        }
+
+        "copies elements from a Chunk.Compact with size limit" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val array = new Array[Int](3)
+            chunk.copyTo(array, 0, 3)
+            assert(array.toSeq == Seq(1, 2, 3))
+        }
+    }
+
+    "last" - {
+        "returns the last element of a non-empty chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.last == 5)
+        }
+
+        "throws NoSuchElementException for an empty chunk" in {
+            val chunk = Chunks.init[Int]
+            assert(Try(chunk.last).isFailure)
+        }
+
+        "returns the last element after appending" in {
+            val chunk = Chunks.init(1, 2, 3).append(4)
+            assert(chunk.last == 4)
+        }
+
+        "returns the correct last element for a Drop chunk with dropRight" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropRight(2)
+            assert(chunk.last == 3)
+        }
+
+        "throws NoSuchElementException for a Drop chunk with dropRight equal to size" in {
+            val chunk = Chunks.init(1, 2, 3).dropRight(3)
+            assert(Try(chunk.last).isFailure)
+        }
+
+        "returns the correct last element for a Drop chunk with both dropLeft and dropRight" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropLeft(1).dropRight(2)
+            assert(chunk.last == 3)
+        }
+    }
+
+    "concat" - {
+        "concatenates two non-empty chunks" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init(4, 5, 6)
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(1, 2, 3, 4, 5, 6))
+        }
+
+        "concatenates a non-empty chunk with an empty chunk" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init[Int]
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(1, 2, 3))
+        }
+
+        "concatenates an empty chunk with a non-empty chunk" in {
+            val chunk1 = Chunks.init[Int]
+            val chunk2 = Chunks.init(1, 2, 3)
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(1, 2, 3))
+        }
+
+        "returns an empty chunk when concatenating two empty chunks" in {
+            val chunk1 = Chunks.init[Int]
+            val chunk2 = Chunks.init[Int]
+            val result = chunk1.concat(chunk2)
+            assert(result.isEmpty)
+        }
+
+        "handles chunks of different types" in {
+            val chunk1 = Chunks.init("a", "b", "c")
+            val chunk2 = Chunks.init("d", "e", "f")
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init("a", "b", "c", "d", "e", "f"))
+        }
+
+        "handles multiple concatenations" in {
+            val chunk1 = Chunks.init(1, 2)
+            val chunk2 = Chunks.init(3, 4)
+            val chunk3 = Chunks.init(5, 6)
+            val chunk4 = Chunks.init(7, 8)
+            val result = chunk1.concat(chunk2).concat(chunk3).concat(chunk4)
+            assert(result == Chunks.init(1, 2, 3, 4, 5, 6, 7, 8))
+        }
+
+        "concatenates a Chunk.Compact with a Chunk.FromSeq" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.initSeq(IndexedSeq(4, 5, 6))
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(1, 2, 3, 4, 5, 6))
+        }
+
+        "concatenates a Chunk.FromSeq with a Chunk.Compact" in {
+            val chunk1 = Chunks.initSeq(IndexedSeq(1, 2, 3))
+            val chunk2 = Chunks.init(4, 5, 6)
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(1, 2, 3, 4, 5, 6))
+        }
+
+        "concatenates a Chunk.Drop with a Chunk.Compact" in {
+            val chunk1 = Chunks.init(1, 2, 3, 4, 5).dropLeft(2)
+            val chunk2 = Chunks.init(6, 7, 8)
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(3, 4, 5, 6, 7, 8))
+        }
+    }
+
+    "takeWhile" - {
+        "returns elements while the predicate is true" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.takeWhile(_ < 4).pure
+            assert(result == Chunks.init(1, 2, 3))
+        }
+
+        "returns all elements if the predicate is always true" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.takeWhile(_ => true).pure
+            assert(result == Chunks.init(1, 2, 3, 4, 5))
+        }
+
+        "returns an empty chunk if the predicate is always false" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.takeWhile(_ => false).pure
+            assert(result.isEmpty)
+        }
+
+        "handles effectful predicates" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.takeWhile(n => IOs(n < 4))
+            assert(IOs.run(result).pure == Chunks.init(1, 2, 3))
+        }
+    }
+
+    "dropWhile" - {
+        "drops elements while the predicate is true" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.dropWhile(_ < 3).pure
+            assert(result == Chunks.init(3, 4, 5))
+        }
+
+        "drops all elements if the predicate is always true" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.dropWhile(_ => true).pure
+            assert(result.isEmpty)
+        }
+
+        "drops no elements if the predicate is always false" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.dropWhile(_ => false).pure
+            assert(result == Chunks.init(1, 2, 3, 4, 5))
+        }
+
+        "handles effectful predicates" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.dropWhile(n => IOs(n < 3))
+            assert(IOs.run(result).pure == Chunks.init(3, 4, 5))
+        }
+    }
+
+    "changes" - {
+        "returns a chunk with consecutive duplicates removed" in {
+            val chunk = Chunks.init(1, 1, 2, 3, 3, 3, 4, 4, 5)
+            assert(chunk.changes == Chunks.init(1, 2, 3, 4, 5))
+        }
+
+        "returns the original chunk if there are no consecutive duplicates" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.changes == Chunks.init(1, 2, 3, 4, 5))
+        }
+
+        "returns an empty chunk for an empty input chunk" in {
+            val chunk = Chunks.init[Int]
+            assert(chunk.changes.isEmpty)
+        }
+
+        "handles a single element chunk" in {
+            val chunk = Chunks.init(1)
+            assert(chunk.changes == Chunks.init(1))
+        }
+
+        "handles a chunk with all duplicate elements" in {
+            val chunk = Chunks.init(1, 1, 1, 1, 1)
+            assert(chunk.changes == Chunks.init(1))
+        }
+    }
+
+    "collect" - {
+        "with a partial function" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.collect { case x if x % 2 == 0 => x * 2 }.pure
+            assert(result == Chunks.init(4, 8))
+        }
+
+        "with an empty chunk" in {
+            val chunk  = Chunks.init[Int]
+            val result = chunk.collect { case x if x % 2 == 0 => x * 2 }.pure
+            assert(result.isEmpty)
+        }
+    }
+
+    "collectUnit" - {
+        "with a partial function" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            var sum   = 0
+            IOs.run(chunk.collectUnit { case x if x % 2 == 0 => IOs(sum += x) })
+            assert(sum == 6)
+        }
+
+        "with an empty chunk" in {
+            val chunk = Chunks.init[Int]
+            var sum   = 0
+            IOs.run(chunk.collectUnit { case x if x % 2 == 0 => IOs(sum += x) })
+            assert(sum == 0)
+        }
+    }
+
+    "foreach" - {
+        "with a pure function" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            var sum   = 0
+            chunk.foreach(x => sum += x).pure
+            assert(sum == 15)
+        }
+
+        "with a function using IOs" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            var sum   = 0
+            IOs.run(chunk.foreach(x => IOs(sum += x)))
+            assert(sum == 15)
+        }
+
+        "with an empty chunk" in {
+            val chunk = Chunks.init[Int]
+            var sum   = 0
+            chunk.foreach(x => sum += x).pure
+            assert(sum == 0)
+        }
+    }
+
+    "hashCode and equals" - {
+        "equal chunks have the same hashCode" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init(1, 2, 3)
+            assert(chunk1.hashCode() == chunk2.hashCode())
+        }
+
+        "equal chunks are equal" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init(1, 2, 3)
+            assert(chunk1 == chunk2)
+        }
+
+        "different chunks have different hashCodes" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init(3, 2, 1)
+            assert(chunk1.hashCode() != chunk2.hashCode())
+        }
+
+        "different chunks are not equal" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init(3, 2, 1)
+            assert(chunk1 != chunk2)
+        }
+
+        "empty chunks have the same hashCode" in {
+            val chunk1 = Chunks.init[Int]
+            val chunk2 = Chunks.init[Int]
+            assert(chunk1.hashCode() == chunk2.hashCode())
+        }
+
+        "empty chunks are equal" in {
+            val chunk1 = Chunks.init[Int]
+            val chunk2 = Chunks.init[Int]
+            assert(chunk1 == chunk2)
+        }
+    }
+
+    "Chunks.collect" - {
+        "collects elements from a chunk of effectful computations" in {
+            val chunk  = Chunks.init(IOs(1), IOs(2), IOs(3))
+            val result = Chunks.collect(chunk)
+            assert(IOs.run(result).pure == Chunks.init(1, 2, 3))
+        }
+
+        "collects elements from a chunk of effectful computations with different effect types" in {
+            val chunk  = Chunks.init(IOs(1), Options.get(Some(2)), Options.get(Some(3)))
+            val result = Chunks.collect(chunk)
+            assert(IOs.run(Options.run(result)).pure == Some(Chunks.init(1, 2, 3)))
+        }
+    }
+
+    "toString" - {
+        "prints the elements of a Chunk.Compact" in {
+            val chunk = Chunks.init[Int].append(1).append(2).append(3).toIndexed
+            assert(chunk.toString == "Chunk.Indexed(1, 2, 3)")
+        }
+
+        "prints the elements of a Chunk.FromSeq" in {
+            val chunk = Chunks.initSeq(IndexedSeq(1, 2, 3))
+            assert(chunk.toString == "Chunk.Indexed(1, 2, 3)")
+        }
+
+        "prints the elements of a Chunk.Drop" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropLeft(2)
+            assert(chunk.toString == "Chunk(3, 4, 5)")
+        }
+
+        "prints the elements of a Chunk.Append" in {
+            val chunk = Chunks.init(1, 2, 3).append(4)
+            assert(chunk.toString == "Chunk(1, 2, 3, 4)")
+        }
+    }
+
+end chunksTest

--- a/kyo-core/shared/src/test/scala/kyoTest/sumsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/sumsTest.scala
@@ -12,7 +12,7 @@ class sumsTest extends KyoTest:
                 _ <- Sums[Int].add(1)
             yield "a"
 
-        assert(Sums[Int].run(v).pure == (3, "a"))
+        assert(Sums[Int].run(v).pure == (Chunks.init(1, 1, 1), "a"))
     }
     "string" in {
         val v: String < Sums[String] =
@@ -22,31 +22,29 @@ class sumsTest extends KyoTest:
                 _ <- Sums[String].add("3")
             yield "a"
         val res = Sums[String].run(v)
-        assert(res.pure == ("123", "a"))
+        assert(res.pure == (Chunks.init("1", "2", "3"), "a"))
     }
     "int and string" in {
         val v: String < (Sums[Int] & Sums[String]) =
             for
-                _ <- Sums[Int].add(1)
+                _ <- Sums[Int].add(3)
                 _ <- Sums[String].add("1")
-                _ <- Sums[Int].add(1)
+                _ <- Sums[Int].add(2)
                 _ <- Sums[String].add("2")
                 _ <- Sums[Int].add(1)
                 _ <- Sums[String].add("3")
             yield "a"
-        val res: (String, (Int, String)) =
+        val res: (Chunk[String], (Chunk[Int], String)) =
             Sums[String].run(Sums[Int].run(v)).pure
-        assert(res == ("123", (3, "a")))
+        assert(res == (Chunks.init("1", "2", "3"), (Chunks.init(3, 2, 1), "a")))
     }
 
-    "initial value" in {
-        val t =
-            Sums[Int].run("a").pure
-        assert(t == (0, "a"))
+    "no values" in {
+        val t = Sums[Int].run("a").pure
+        assert(t == (Chunks.init, "a"))
 
-        val t2 =
-            Sums[String].run(42).pure
-        assert(t2 == ("", 42))
+        val t2 = Sums[String].run(42).pure
+        assert(t2 == (Chunks.init, 42))
     }
 
     "List" in {
@@ -57,7 +55,7 @@ class sumsTest extends KyoTest:
                 _ <- Sums[List[Int]].add(List(3))
             yield "a"
         val res = Sums[List[Int]].run(v)
-        assert(res.pure == (List(1, 2, 3), "a"))
+        assert(res.pure == (Chunks.init(List(1), List(2), List(3)), "a"))
     }
 
     "Set" in {
@@ -68,6 +66,6 @@ class sumsTest extends KyoTest:
                 _ <- Sums[Set[Int]].add(Set(3))
             yield "a"
         val res = Sums[Set[Int]].run(v)
-        assert(res.pure == (Set(1, 2, 3), "a"))
+        assert(res.pure == (Chunks.init(Set(1), Set(2), Set(3)), "a"))
     }
 end sumsTest

--- a/kyo-tapir/src/main/scala/kyo/routes.scala
+++ b/kyo-tapir/src/main/scala/kyo/routes.scala
@@ -15,14 +15,14 @@ type Routes >: Routes.Effects <: Routes.Effects
 
 object Routes:
 
-    type Effects = Sums[List[Route]] & Fibers
+    type Effects = Sums[Route] & Fibers
 
     def run[T, S](v: Unit < (Routes & S)): NettyKyoServerBinding < (Fibers & S) =
         run[T, S](NettyKyoServer())(v)
 
     def run[T, S](server: NettyKyoServer)(v: Unit < (Routes & S)): NettyKyoServerBinding < (Fibers & S) =
-        Sums[List[Route]].run[Unit, Fibers & S](v).map { (routes, _) =>
-            IOs(server.addEndpoints(routes).start()): NettyKyoServerBinding < (Fibers & S)
+        Sums[Route].run[Unit, Fibers & S](v).map { (routes, _) =>
+            IOs(server.addEndpoints(routes.toSeq.toList).start()): NettyKyoServerBinding < (Fibers & S)
         }
     end run
 


### PR DESCRIPTION
Kyo provides stronger guarantees regarding the purity of its effects than other effect systems typically do. A common pattern in libraries like ZIO is to [leverage mutable iterators internally](https://github.com/zio/zio/blob/62173a1aad4be0a369a16cb234f43db5c896337b/core/shared/src/main/scala/zio/ZIO.scala#L3333-L3341) to process sequences:

```scala
  def foreach[R, E, A, B, Collection[+Element] <: Iterable[Element]](in: Collection[A])(
    f: A => ZIO[R, E, B]
  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZIO[R, E, Collection[B]] =
    ZIO.suspendSucceed {
      val iterator = in.iterator
      val builder  = bf.newBuilder(in)

      ZIO.whileLoop(iterator.hasNext)(f(iterator.next()))(builder += _).as(builder.result())
    }
```


This form of local mutability doesn't seem ideal but it's generally ok to do in a monad that has `IO` as its base effect. That's not the case in Kyo. Pure effects that don't include `IOs` suspensions can't leverage mutable state across transformations since they're meant to support multi-shot continuations and the provided continuations can be executed multiple times by a handler, which would produce invalid state if an iterator is used for example. This is currently an issue with `Seqs` in Kyo as well. I'll follow up later to fix it.

This PR introduces `Chunks` as a mechanism to provide efficient processing of data in a purely functional manner without leveraging mutable state across transformations. The data structure is designed to provide `O(1)` operations for the common needs of recursive computations. Please see the readme for more information and the use in [streams I've working on](https://github.com/getkyo/kyo/blob/efe4f4ce371c808179ed13ce70b4baf639b6752e/kyo-core/shared/src/main/scala/kyo/streams.scala).

I've also updated `Sums` to remove `Summer` and accumulate items in a `Chunk` instead. I'm noticing that's the pattern for the effect in other libraries like ZPure, it's a good simplification of the effect, and it provides better performance than working with collections like `List`.