### PR TITLE
attempt to fix missed interrupt signals (#260)

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -139,9 +139,9 @@ sealed trait IOs extends Effect[IOs]:
                             ensureLoop(v2, np)
                         end apply
                 case _ =>
-                    p.remove(ensure)
                     IOs {
                         ensure()
+                        p.remove(ensure)
                         v
                     }
         ensureLoop(v, Preempt.never)


### PR DESCRIPTION
I'm not sure if this will fix #260 since I'm not able to reproduce it on my machine (M2). I noticed that the interrupt signal can get lost in the `IOTask` run loop when `state` is updated. I've updated the code to maintain the interrupt signal via a `VarHandle` and `compareAndSwap` to avoid an `AtomicInteger` allocation.

This code can use some refactoring but I think it's best to attempt to fix the issue before improving it. @hearnadam could you check if it fixes the issue for you?

