### PR TITLE
ensure the preemption signal is dispatched to all workers

### DIFF
--- a/kyo-core/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -126,7 +126,7 @@ private[kyo] object Scheduler:
 
     def cycle(curr: Long): Unit =
         var i = 0
-        while i < maxConcurrency do
+        while i < allocatedWorkers do
             val w = workers(i)
             if w != null then
                 w.cycle(curr)


### PR DESCRIPTION
@hearnadam I was finally able to reproduce using another machine. The issue actually isn't related to the preemption flag directly but with the scheduler not even sending the preemption signal. Could you check again in your machine?

Kyo's scheduler uses a dynamic policy for the number of threads that can reduce the worker count (maxConcurrency) but it's possible an existing worker with index greater than `maxConcurrency` is still running. This PR changes the scheduler to cycle all allocated workers, regardless if they're accepting workload.

The scheduler's code isn't very testable so I don't see an easy way to introduce a test for the bug. I'll follow up with a separate PR moving the scheduler to a new module and refactoring the code to introduce tests.