### PR TITLE
introduce failure benchmark

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/FailureBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/FailureBench.scala
@@ -1,0 +1,89 @@
+package kyo.bench
+
+class Ex1  extends Exception
+object Ex1 extends Ex1
+class Ex2  extends Exception
+object Ex2 extends Ex2
+class Ex3  extends Exception
+object Ex3 extends Ex3
+
+class FailureBench extends Bench.SyncAndFork[Either[Ex1 | Ex2, Int]]:
+
+    val depth = 100
+
+    def catsBench() =
+        import cats.effect.*
+
+        def loop(i: Int): IO[Either[Ex1, Either[Ex2, Int]]] =
+            if i > depth then IO.pure(Right(Right(i)))
+            else
+                (i % 4) match
+                    case 0 => loop(i + 1).map(_ => Left(Ex1))
+                    case 1 => loop(i + 1).map(_ => Right(Left(Ex2)))
+                    case 2 =>
+                        loop(i + 1).map {
+                            case Left(ex1) => Right(Left(Ex2))
+                            case r         => r
+                        }
+                    case 3 =>
+                        loop(i + 1).map {
+                            case Right(Left(ex2)) => Left(Ex1)
+                            case r                => r
+                        }
+                    case 4 => loop(i + 1)
+        end loop
+
+        loop(0).map {
+            case Right(Left(ex2)) => Left(ex2)
+            case Left(ex1)        => Left(ex1)
+            case Right(value)     => value
+        }
+    end catsBench
+
+    def kyoBench() =
+        import kyo.*
+
+        def loop(i: Int): Int < (IOs & Aborts[Ex1 | Ex2]) =
+            if i > depth then i
+            else
+                (i % 4) match
+                    case 0 => loop(i + 1).map(_ => Aborts[Ex1].fail(Ex1))
+                    case 1 => loop(i + 1).map(_ => Aborts[Ex2].fail(Ex2))
+                    case 2 =>
+                        Aborts[Ex1].run(loop(i + 1)).map {
+                            case Left(ex) => Aborts[Ex2].fail(Ex2)
+                            case Right(v) => v
+                        }
+                    case 3 =>
+                        Aborts[Ex2].run(loop(i + 1)).map {
+                            case Left(ex) => Aborts[Ex1].fail(Ex1)
+                            case Right(v) => v
+                        }
+                    case 4 => loop(i + 1)
+                end match
+
+        Aborts[Ex1 | Ex2].run(loop(0))
+    end kyoBench
+
+    def zioBench() =
+        import zio.*
+
+        def loop(i: Int): ZIO[Any, Ex1 | Ex2, Int] =
+            if i > depth then ZIO.succeed(i)
+            else
+                (i % 4) match
+                    case 0 => loop(i + 1).flatMap(_ => ZIO.fail(Ex1))
+                    case 1 => loop(i + 1).flatMap(_ => ZIO.fail(Ex2))
+                    case 2 =>
+                        loop(i + 1).catchSome {
+                            case ex1: Ex1 => ZIO.fail(Ex2)
+                        }
+                    case 3 =>
+                        loop(i + 1).catchSome {
+                            case ex2: Ex2 => ZIO.fail(Ex1)
+                        }
+                    case 4 => loop(i + 1)
+        end loop
+        loop(0).either
+    end zioBench
+end FailureBench

--- a/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
@@ -138,4 +138,9 @@ class BenchTest extends AsyncFreeSpec with Assertions:
     "StreamBufferBench" - {
         test(StreamBufferBench(), 25000000)
     }
+
+    "FailureBench" - {
+        given [T]: CanEqual[T, T] = CanEqual.derived
+        test(FailureBench(), Left(Ex1))
+    }
 end BenchTest

--- a/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
@@ -141,6 +141,6 @@ class BenchTest extends AsyncFreeSpec with Assertions:
 
     "FailureBench" - {
         given [T]: CanEqual[T, T] = CanEqual.derived
-        test(FailureBench(), Left(Ex1))
+        test(FailureBench(), Left(Ex2))
     }
 end BenchTest


### PR DESCRIPTION
This new benchmark is designed to reproduce https://github.com/getkyo/kyo/issues/275. Current results on my M2:

```
[info] Benchmark               Mode  Cnt        Score       Error  Units
[info] FailureBench.forkCats  thrpt    5   132505.248 ± 12212.895  ops/s
[info] FailureBench.forkKyo   thrpt    5    28640.191 ±  1648.773  ops/s
[info] FailureBench.forkZio   thrpt    5    92255.834 ± 11252.393  ops/s
[info] FailureBench.syncCats  thrpt    5   133276.418 ±  4492.660  ops/s
[info] FailureBench.syncKyo   thrpt    5    43961.788 ±  2972.598  ops/s
[info] FailureBench.syncZio   thrpt    5  1453020.306 ± 54500.737  ops/s
```

Kyo's profiling sessions are dominated by Izumi's parsing and subtype checking:

Allocations
![alloc](https://github.com/getkyo/kyo/assets/831175/de4ccbdc-e0fe-4e0f-be90-4d1b3d63a234)

CPU
![cpu](https://github.com/getkyo/kyo/assets/831175/d761bbb9-834f-4089-8a6d-48c11549461e)
