### PR TITLE
Introduce Randoms bench

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/RandomBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/RandomBench.scala
@@ -1,0 +1,73 @@
+package kyo.bench
+
+class RandomBench extends Bench.SyncAndFork[Unit]:
+
+    val depth = 10000
+
+    def kyoBench() =
+        import kyo.*
+
+        def rand() =
+            for
+                _ <- Randoms.nextInt
+                _ <- Randoms.nextLong
+                _ <- Randoms.nextBoolean
+                _ <- Randoms.nextFloat
+            yield ()
+
+        def loop(i: Int): Unit < IOs =
+            if i > depth then
+                ()
+            else
+                rand().flatMap { _ =>
+                    loop(i + 1)
+                }
+        loop(0)
+    end kyoBench
+
+    def catsBench() =
+        import cats.effect.*
+        import cats.effect.std.Random
+        import cats.effect.unsafe.implicits.global
+
+        val random = Random.javaUtilRandom[IO](new java.util.Random).unsafeRunSync()
+
+        def rand() =
+            for
+                _ <- random.nextInt
+                _ <- random.nextLong
+                _ <- random.nextBoolean
+                _ <- random.nextFloat
+            yield ()
+
+        def loop(i: Int): IO[Unit] =
+            if i > depth then
+                IO.unit
+            else
+                rand().flatMap { _ =>
+                    loop(i + 1)
+                }
+        loop(0)
+    end catsBench
+
+    def zioBench() =
+        import zio.*
+
+        def rand() =
+            for
+                _ <- Random.nextInt
+                _ <- Random.nextLong
+                _ <- Random.nextBoolean
+                _ <- Random.nextFloat
+            yield ()
+
+        def loop(i: Int): UIO[Unit] =
+            if i > depth then
+                ZIO.unit
+            else
+                rand().flatMap { _ =>
+                    loop(i + 1)
+                }
+        loop(0)
+    end zioBench
+end RandomBench

--- a/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
@@ -143,4 +143,8 @@ class BenchTest extends AsyncFreeSpec with Assertions:
         given [T]: CanEqual[T, T] = CanEqual.derived
         test(FailureBench(), Left(Ex2))
     }
+
+    "RandomBench" - {
+        test(RandomBench(), ())
+    }
 end BenchTest


### PR DESCRIPTION
```kyo/clean;jmh:clean;jmh:run -wi 10 -i 5 -r 1 -w 1 -t 1 -rf json -foe true -prof gc RandomsBench```

```
[info] Benchmark                                  Mode  Cnt        Score      Error   Units
[info] RandomsBench.forkCats                     thrpt    5      523.631 ±    6.182   ops/s
[info] RandomsBench.forkCats:gc.alloc.rate       thrpt    5     4075.822 ±   47.943  MB/sec
[info] RandomsBench.forkCats:gc.alloc.rate.norm  thrpt    5  8163050.052 ±   40.221    B/op
[info] RandomsBench.forkCats:gc.count            thrpt    5       78.000             counts
[info] RandomsBench.forkCats:gc.time             thrpt    5       47.000                 ms
[info] RandomsBench.forkKyo                      thrpt    5      656.814 ±  340.748   ops/s
[info] RandomsBench.forkKyo:gc.alloc.rate        thrpt    5     3557.825 ± 1845.904  MB/sec
[info] RandomsBench.forkKyo:gc.alloc.rate.norm   thrpt    5  5680906.667 ±   15.861    B/op
[info] RandomsBench.forkKyo:gc.count             thrpt    5       62.000             counts
[info] RandomsBench.forkKyo:gc.time              thrpt    5       61.000                 ms
[info] RandomsBench.forkZio                      thrpt    5      529.947 ±   23.776   ops/s
[info] RandomsBench.forkZio:gc.alloc.rate        thrpt    5     4528.665 ±  203.510  MB/sec
[info] RandomsBench.forkZio:gc.alloc.rate.norm   thrpt    5  8961942.200 ±  312.305    B/op
[info] RandomsBench.forkZio:gc.count             thrpt    5       83.000             counts
[info] RandomsBench.forkZio:gc.time              thrpt    5       54.000                 ms
[info] RandomsBench.syncCats                     thrpt    5      525.629 ±   12.856   ops/s
[info] RandomsBench.syncCats:gc.alloc.rate       thrpt    5     4091.215 ±   99.822  MB/sec
[info] RandomsBench.syncCats:gc.alloc.rate.norm  thrpt    5  8162753.583 ±   37.048    B/op
[info] RandomsBench.syncCats:gc.count            thrpt    5       78.000             counts
[info] RandomsBench.syncCats:gc.time             thrpt    5       49.000                 ms
[info] RandomsBench.syncKyo                      thrpt    5      747.653 ±    3.414   ops/s
[info] RandomsBench.syncKyo:gc.alloc.rate        thrpt    5     4049.756 ±   18.372  MB/sec
[info] RandomsBench.syncKyo:gc.alloc.rate.norm   thrpt    5  5680577.214 ±    0.065    B/op
[info] RandomsBench.syncKyo:gc.count             thrpt    5       93.000             counts
[info] RandomsBench.syncKyo:gc.time              thrpt    5       52.000                 ms
[info] RandomsBench.syncZio                      thrpt    5      568.111 ±    6.009   ops/s
[info] RandomsBench.syncZio:gc.alloc.rate        thrpt    5     4854.334 ±   51.382  MB/sec
[info] RandomsBench.syncZio:gc.alloc.rate.norm   thrpt    5  8961397.752 ±  168.846    B/op
[info] RandomsBench.syncZio:gc.count             thrpt    5       87.000             counts
[info] RandomsBench.syncZio:gc.time              thrpt    5       52.000                 ms
```