### PR TITLE
Log the exception in logger

### DIFF
--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/package.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/package.scala
@@ -2,7 +2,7 @@ package kyo
 
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.logging.Logger
+import java.util.logging._
 
 package object scheduler {
 
@@ -12,13 +12,6 @@ package object scheduler {
         "kyo" :: "scheduler" :: path.toList
 
     private[scheduler] def bug(msg: String, ex: Throwable) =
-        log.severe(s"🙈 !!Kyo Scheduler Bug!! $msg \n Caused by: ${stackTrace(ex)}")
+        log.log(Level.SEVERE, s"🙈 !!Kyo Scheduler Bug!!", new Exception(msg, ex))
 
-    private def stackTrace(ex: Throwable) = {
-        val stackTrace = new StringWriter()
-        val writer     = new PrintWriter(stackTrace)
-        ex.printStackTrace(writer)
-        writer.flush()
-        s"${ex.getMessage()}\n$stackTrace"
-    }
 }

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/package.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/package.scala
@@ -2,7 +2,7 @@ package kyo
 
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.logging._
+import java.util.logging.*
 
 package object scheduler {
 


### PR DESCRIPTION
continuation of https://github.com/getkyo/kyo/pull/278#discussion_r1579100968

I think logging the exception itself should be more helpful, with better interop, etc.

But if there's a good reason to print it manually then no worries, feel free to close the PR.