### PR TITLE
add type inferred Aborts API

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/aborts.scala
+++ b/kyo-core/shared/src/main/scala/kyo/aborts.scala
@@ -11,12 +11,22 @@ object Aborts:
     private case object aborts extends Aborts[Any]
     def apply[V]: Aborts[V] = aborts.asInstanceOf[Aborts[V]]
 
+    def fail[V](value: V)(using t: Tag[Aborts[V]]): Nothing < Aborts[V] =
+        Aborts[V].fail(value)
+
+    def when[V](b: Boolean)(value: => V)(using Tag[Aborts[V]]): Unit < Aborts[V] =
+        if b then fail(value)
+        else ()
+
+    def get[V, T](e: Either[V, T])(using Tag[Aborts[V]]): T < Aborts[V] =
+        Aborts[V].get(e)
+
     extension [V](self: Aborts[V])
 
         def fail[T <: V](value: T)(using t: Tag[Aborts[T]]): Nothing < Aborts[T] =
             self.suspend[Nothing](Left(value))
 
-        def when(b: Boolean)(value: V)(using Tag[Aborts[V]]): Unit < Aborts[V] =
+        def when(b: Boolean)(value: => V)(using Tag[Aborts[V]]): Unit < Aborts[V] =
             if b then fail(value)
             else ()
 

--- a/kyo-core/shared/src/test/scala/kyoTest/abortsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/abortsTest.scala
@@ -219,8 +219,14 @@ class abortsTest extends KyoTest:
         }
         "fail" in {
             val ex: Throwable = new Exception("throwable failure")
-            val a             = Aborts[Throwable].fail(ex)
+            val a             = Aborts.fail(ex)
             assert(Aborts[Throwable].run(a).pure == Left(ex))
+        }
+        "when" in {
+            def abort(b: Boolean) = Aborts[String].run(Aborts.when(b)("FAIL!")).pure
+
+            assert(abort(true) == Left("FAIL!"))
+            assert(abort(false) == Right(()))
         }
         "catching" - {
             "only effect" - {


### PR DESCRIPTION
- pass failure value for `Aborts.when` by name, potentially avoiding allocations
- add unit test for `Aborts.when`

I intentionally did not create an API for `run`/`catching` as it's unergonomic with type unions. I think followup work can be done there depending on how https://github.com/getkyo/kyo/issues/275 is resolved.

This massively improves the ux of Aborts in my opinion.