### PR TITLE
Interop Kyo Fiber & ZIO

### DIFF
--- a/kyo-test/shared/src/main/scala/kyo/test/KyoSpecDefault.scala
+++ b/kyo-test/shared/src/main/scala/kyo/test/KyoSpecDefault.scala
@@ -1,13 +1,14 @@
 package kyo.test
 
 import kyo.*
+import kyo.test.interop.*
 import scala.concurrent.duration.*
 import zio.ZIO
 import zio.test.Spec
 
 abstract class KyoSpecDefault extends KyoSpecAbstract[KyoApp.Effects]:
     final override def run[In](v: => In < KyoApp.Effects)(using Flat[In < KyoApp.Effects]): ZIO[Environment, Throwable, In] =
-        ZIO.fromFuture { implicit ec => IOs.run(KyoApp.runFiber(timeout)(v).toFuture).map(_.get) }
+        ZIO.fromKyoFiber(KyoApp.runFiber(timeout)(v)).flatMap(ZIO.fromTry)
 
     def timeout: Duration = Duration.Inf
 

--- a/kyo-test/shared/src/main/scala/kyo/test/interop/zio.scala
+++ b/kyo-test/shared/src/main/scala/kyo/test/interop/zio.scala
@@ -1,0 +1,15 @@
+package kyo.test.interop
+
+import kyo.*
+import zio.Trace
+import zio.ZIO
+
+extension (capture: ZIO.type)
+    private[kyo] def fromKyoFiber[A](fiber: Fiber[A])(using Flat[A], Trace): ZIO[Any, Throwable, A] =
+        ZIO.asyncInterrupt[Any, Throwable, A] { cb =>
+            val async: ZIO[Any, Throwable, A] = ZIO.fromFuture(_ => IOs.run(fiber.toFuture))
+            cb(async)
+
+            val interrupt: ZIO[Any, Nothing, Any] = ZIO.attempt(IOs.run(fiber.interrupt)).ignore
+            Left(interrupt)
+        }

--- a/kyo-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
+++ b/kyo-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
@@ -26,6 +26,6 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
                     Fibers.delay(Duration.Infinity.asScala)(assertCompletes)
                 } @@ TestAspect.timeout(Duration.Zero)
             ) @@ TestAspect.failing
-        )
+        ) @@ TestAspect.timed
 
 end KyoSpecDefaultSpec

--- a/kyo-test/shared/src/test/scala/kyo/test/interop/zioSpec.scala
+++ b/kyo-test/shared/src/test/scala/kyo/test/interop/zioSpec.scala
@@ -1,0 +1,45 @@
+package kyo.test.interop
+
+import kyo.*
+import scala.concurrent.duration.Duration
+import scala.language.postfixOps
+import zio.ZIO
+import zio.duration2DurationOps
+import zio.durationInt
+import zio.test.*
+
+object zioSpec extends ZIOSpecDefault:
+
+    case object TestFail extends Throwable("Fail!")
+    def spec = suite("ZIO.fromKyoFiber")(
+        test("ZIO.timeout") {
+            val kyoNever = ZIO.fromKyoFiber { IOs.run(Fibers.run(Fibers.sleep(Duration.Inf))) }
+            val message  = "Successful interrupt!"
+
+            for
+                result <- kyoNever.timeoutFail(TestTimeoutException(message))(10.millis).either
+            yield assertTrue(result.is(_.left).getMessage == message)
+        },
+        test("completes") {
+            for
+                result <- ZIO.fromKyoFiber {
+                    KyoApp.runFiber(Fibers.delay(10.millis.asScala)(Fibers.init(IOs(21 * 2)).map(_.get)))
+                }.flatMap(ZIO.fromTry)
+            yield assertTrue(result == 42)
+        },
+        test("Fiber.value") {
+            for
+                result <- ZIO.fromKyoFiber {
+                    Fiber.value(true)
+                }
+            yield assertTrue(result)
+        },
+        test("Fiber.fail") {
+            for
+                result <- ZIO.fromKyoFiber {
+                    Fiber.fail(TestFail)
+                }.either
+            yield assertTrue(result.is(_.left).getMessage == TestFail.getMessage)
+        }
+    ) @@ TestAspect.withLiveClock @@ TestAspect.timed
+end zioSpec


### PR DESCRIPTION
- Ensure interruptions work correctly
- migrate KyoSepcDefault