### PR TITLE
Avoid Tags in Aborts (fixes #275)

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/FailureBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/FailureBench.scala
@@ -49,22 +49,22 @@ class FailureBench extends Bench.SyncAndFork[Either[Ex1 | Ex2, Int]]:
             if i > depth then i
             else
                 (i % 5) match
-                    case 0 => loop(i + 1).map(_ => Aborts[Ex1].fail(Ex1))
-                    case 1 => loop(i + 1).map(_ => Aborts[Ex2].fail(Ex2))
+                    case 0 => loop(i + 1).map(_ => Aborts.fail(Ex1))
+                    case 1 => loop(i + 1).map(_ => Aborts.fail(Ex2))
                     case 2 =>
-                        Aborts[Ex1].run(loop(i + 1)).map {
-                            case Left(Ex1) => Aborts[Ex2].fail(Ex2)
+                        Aborts.run[Ex1](loop(i + 1)).map {
+                            case Left(Ex1) => Aborts.fail(Ex2)
                             case Right(v)  => v
                         }
                     case 3 =>
-                        Aborts[Ex2].run(loop(i + 1)).map {
-                            case Left(Ex2) => Aborts[Ex1].fail(Ex1)
+                        Aborts.run[Ex2](loop(i + 1)).map {
+                            case Left(Ex2) => Aborts.fail(Ex1)
                             case Right(v)  => v
                         }
                     case 4 => loop(i + 1)
                 end match
         end loop
-        Aborts[Ex1 | Ex2].run(loop(0))
+        Aborts.run[Ex1 | Ex2](loop(0))
     end kyoBench
 
     def zioBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/MtlBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/MtlBench.scala
@@ -21,7 +21,7 @@ class MtlBench extends Bench:
                     _    <- Vars[State].update(state => state.copy(value = state.value + 1))
                 yield ()
             )
-        Aborts[Throwable].run(
+        Aborts.run[Throwable](
             Vars[State].run(State(2))(
                 Sums[Event].run(
                     Envs[Env].run(Env("config"))(

--- a/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
@@ -38,7 +38,7 @@ class coreBytecodeSizeTest extends KyoTest:
         assert(map == Map(
             "test"        -> 28,
             "resultLoop"  -> 112,
-            "handleLoop"  -> 264,
+            "handleLoop"  -> 294,
             "_handleLoop" -> 12
         ))
     }

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -70,7 +70,7 @@ object KyoApp:
     def runFiber[T](timeout: Duration)(v: T < Effects)(
         using f: Flat[T < Effects]
     ): Fiber[Try[T]] =
-        def v0: Try[T] < (Fibers & Resources & Consoles) = Aborts[Throwable].run(v).map(_.toTry)
+        def v0: Try[T] < (Fibers & Resources & Consoles) = Aborts.run[Throwable](v).map(_.toTry)
         def v1: Try[T] < (Fibers & Resources)            = Consoles.run(v0)
         def v2: Try[T] < Fibers                          = Resources.run(v1)
         def v3: Try[T] < Fibers                          = IOs.attempt(v2).map(_.flatten)

--- a/kyo-core/shared/src/main/scala/kyo/aborts.scala
+++ b/kyo-core/shared/src/main/scala/kyo/aborts.scala
@@ -4,95 +4,97 @@ import kyo.core.*
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
-class Aborts[-V] extends Effect[Aborts[V]]:
-    opaque type Command[T] >: Left[V, Nothing] = Left[V, Nothing]
+// Can't use an opaque type because
+// kyo-direct tests crash the compiler.
+type Aborts[-V] //= DoAbort
 
 object Aborts:
-    private case object aborts extends Aborts[Any]
-    def apply[V]: Aborts[V] = aborts.asInstanceOf[Aborts[V]]
 
-    def fail[V](value: V)(using t: Tag[Aborts[V]]): Nothing < Aborts[V] =
-        Aborts[V].fail(value)
+    import internal.*
 
-    def when[V](b: Boolean)(value: => V)(using Tag[Aborts[V]]): Unit < Aborts[V] =
+    def fail[V](v: V): Nothing < Aborts[V] =
+        DoAbort.suspend(v).asInstanceOf[Nothing < Aborts[V]]
+
+    def when[V](b: Boolean)(value: => V): Unit < Aborts[V] =
         if b then fail(value)
         else ()
 
-    def get[V, T](e: Either[V, T])(using Tag[Aborts[V]]): T < Aborts[V] =
-        Aborts[V].get(e)
+    def get[V, T](e: Either[V, T]): T < Aborts[V] =
+        e match
+            case Right(v) => v
+            case Left(v)  => DoAbort.suspend(v).asInstanceOf[Nothing < Aborts[V]]
 
-    extension [V](self: Aborts[V])
-
-        def fail[T <: V](value: T)(using t: Tag[Aborts[T]]): Nothing < Aborts[T] =
-            self.suspend[Nothing](Left(value))
-
-        def when(b: Boolean)(value: => V)(using Tag[Aborts[V]]): Unit < Aborts[V] =
-            if b then fail(value)
-            else ()
-
-        def get[T](e: Either[V, T])(using Tag[Aborts[V]]): T < Aborts[V] =
-            e match
-                case Right(value) => value
-                case Left(e)      => fail(e)
-
-        def catching[T, S](v: => T < S)(
+    class RunDsl[V]():
+        def apply[T: Flat, S, VS, VR](v: T < (Aborts[VS] & S))(
             using
-            ClassTag[V],
-            Tag[Aborts[V]]
+            h: HasAborts[V, VS] { type Remainder = VR },
+            ct: ClassTag[V]
+        ): Either[V, T] < (VR & S) =
+            DoAbort.handle(handler)(ct, v).asInstanceOf[Either[V, T] < (VR & S)]
+    end RunDsl
+
+    def run[V]: RunDsl[V] = RunDsl()
+
+    class CatchingDsl[V]():
+        def apply[T: Flat, S](v: => T < S)(
+            using ct: ClassTag[V]
         ): T < (Aborts[V] & S) =
-            IOs.handle(v) {
-                case ex: V =>
-                    fail(ex.asInstanceOf[V])
+            IOs.catching(v) {
+                case ex: V => Aborts.fail(ex)
             }
+    end CatchingDsl
 
-        def run[T: Flat, S, VS, VR](v: T < (Aborts[VS] & S))(
-            using
-            HasAborts[V, VS] { type Remainder = VR },
-            Tag[Aborts[V]],
-            ClassTag[V]
-        ): Either[V, T] < (S & VR) =
-            self.handle(handler)((), v).asInstanceOf[Either[V, T] < (S & VR)]
+    def catching[V]: CatchingDsl[V] = CatchingDsl()
 
-        private def handler(using ClassTag[V], Tag[Aborts[V]]) =
-            new ResultHandler[Unit, self.Command, Aborts[V], [T] =>> Either[V, T], Any]:
-                def done[T](st: Unit, v: T) = Right(v)
+    private object internal:
 
-                override inline def accepts[T, U](self: Tag[T], other: Tag[U]): Boolean =
-                    self == other || self.parse <:< other.parse
+        val handler =
+            new ResultHandler[ClassTag[?], Const[Any], DoAbort, [T] =>> Either[Any, T], Any]:
+                def done[T](st: ClassTag[?], v: T) = Right(v)
 
-                override def failed(st: Unit, ex: Throwable) =
+                override def failed(st: ClassTag[?], ex: Throwable) =
+                    type V
+                    given ClassTag[V] = st.asInstanceOf[ClassTag[V]]
                     ex match
-                        case ex: V =>
-                            self.fail(ex)
-                        case _ =>
-                            throw ex
+                        case ex: V => DoAbort.suspend(ex)
+                        case _     => throw ex
+                end failed
 
-                def resume[T, U: Flat, S](
-                    st: Unit,
-                    command: self.Command[T],
-                    k: T => U < (Aborts[V] & S)
-                ) =
-                    command.asInstanceOf[Either[V, U]]
-    end extension
+                override def accepts[T](st: ClassTag[?], command: Any) =
+                    type V
+                    given ClassTag[V] = st.asInstanceOf[ClassTag[V]]
+                    command match
+                        case v: V => true
+                        case _    => false
+                end accepts
 
-    /** An effect `Aborts[VS]` includes a failure type `V`, and once `V` has been handled, `Aborts[VS]` should be replaced by `Out`
-      *
-      * @tparam V
-      *   the failure type included in `VS`
-      * @tparam VS
-      *   all of the `Aborts` failure types represented by type union
-      */
-    sealed trait HasAborts[V, VS]:
-        /** Remaining effect type, once failures of type `V` have been handled
+                def resume[T, U: Flat, S2](st: ClassTag[?], command: Any, k: T => U < (DoAbort & S2)) =
+                    Left(command)
+        end handler
+
+        class DoAbort extends Effect[DoAbort]:
+            type Command[T] = Any
+        object DoAbort extends DoAbort
+
+        /** An effect `Aborts[VS]` includes a failure type `V`, and once `V` has been handled, `Aborts[VS]` should be replaced by `Out`
+          *
+          * @tparam V
+          *   the failure type included in `VS`
+          * @tparam VS
+          *   all of the `Aborts` failure types represented by type union
           */
-        type Remainder
-    end HasAborts
+        sealed trait HasAborts[V, VS]:
+            /** Remaining effect type, once failures of type `V` have been handled
+              */
+            type Remainder
+        end HasAborts
 
-    trait LowPriorityHasAborts:
-        given hasAborts[V, VR]: HasAborts[V, V | VR] with
-            type Remainder = Aborts[VR]
+        trait LowPriorityHasAborts:
+            given hasAborts[V, VR]: HasAborts[V, V | VR] with
+                type Remainder = Aborts[VR]
 
-    object HasAborts extends LowPriorityHasAborts:
-        given isAborts[V]: HasAborts[V, V] with
-            type Remainder = Any
+        object HasAborts extends LowPriorityHasAborts:
+            given isAborts[V]: HasAborts[V, V] with
+                type Remainder = Any
+    end internal
 end Aborts

--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -67,7 +67,7 @@ object core:
             @tailrec def handleLoop(st: State, value: T < (E & S & S2)): Result[T] < (S & S2) =
                 value match
                     case kyo: Suspend[e.Command, Any, T, S2] @unchecked
-                        if handler.accepts(tag, kyo.tag) =>
+                        if tag == kyo.tag && handler.accepts(st, kyo.command) =>
                         handler.resume(st, kyo.command, kyo) match
                             case r: handler.Resume[T, S & S2] @unchecked =>
                                 handleLoop(r.st, r.v)
@@ -110,8 +110,8 @@ object core:
 
         case class Resume[U, S2](st: State, v: U < (E & S & S2))
 
-        def accepts[T, U](self: Tag[T], other: Tag[U]): Boolean =
-            self == other
+        def accepts[T](st: State, command: Command[T]): Boolean =
+            true
 
         def done[T](st: State, v: T): Result[T] < S
 

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -59,7 +59,7 @@ sealed trait IOs extends Effect[IOs]:
         end try
     end attempt
 
-    def handle[T, S, U >: T, S2](v: => T < S)(
+    def catching[T, S, U >: T, S2](v: => T < S)(
         pf: PartialFunction[Throwable, U < S2]
     ): U < (S & S2) =
         def handleLoop(v: U < (S & S2)): U < (S & S2) =
@@ -83,7 +83,7 @@ sealed trait IOs extends Effect[IOs]:
             case ex: Throwable if (NonFatal(ex) && pf.isDefinedAt(ex)) =>
                 pf(ex)
         end try
-    end handle
+    end catching
 
     def run[T](v: T < IOs)(using f: Flat[T < IOs]): T =
         @tailrec def runLoop(v: T < IOs): T =

--- a/kyo-core/shared/src/main/scala/kyo/options.scala
+++ b/kyo-core/shared/src/main/scala/kyo/options.scala
@@ -4,10 +4,8 @@ type Options = Aborts[None.type]
 
 object Options:
 
-    private val options = Aborts[None.type]
-
     val empty: Nothing < Options =
-        options.fail(None)
+        Aborts.fail(None)
 
     def apply[T](v: T): T < Options =
         if isNull(v) then
@@ -28,7 +26,7 @@ object Options:
         }
 
     def run[T: Flat, S](v: T < (Options & S)): Option[T] < S =
-        options.run(v).map {
+        Aborts.run(v).map {
             case Left(e)  => None
             case Right(v) => Some(v)
         }

--- a/kyo-core/shared/src/test/scala/kyoTest/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/KyoAppTest.scala
@@ -48,7 +48,7 @@ class KyoAppTest extends KyoTest:
             for
                 _ <- Clocks.now
                 _ <- Randoms.nextInt
-                _ <- Aborts[Throwable].fail(new RuntimeException("Aborts!"))
+                _ <- Aborts.fail(new RuntimeException("Aborts!"))
             yield ()
 
         KyoApp.attempt(Duration.Inf)(run) match

--- a/kyo-core/shared/src/test/scala/kyoTest/abortsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/abortsTest.scala
@@ -13,28 +13,28 @@ class abortsTest extends KyoTest:
     "pure" - {
         "handle" in {
             assert(
-                Aborts[Ex1].run(Aborts[Ex1].get(Right(1))).pure ==
+                Aborts.run[Ex1](Aborts.get(Right(1))).pure ==
                     Right(1)
             )
         }
         "handle + transform" in {
             assert(
-                Aborts[Ex1].run(Aborts[Ex1].get(Right(1)).map(_ + 1)).pure ==
+                Aborts.run[Ex1](Aborts.get(Right(1)).map(_ + 1)).pure ==
                     Right(2)
             )
         }
         "handle + effectful transform" in {
             assert(
-                Aborts[Ex1].run(Aborts[Ex1].get(Right(1)).map(i =>
-                    Aborts[Ex1].get(Right(i + 1))
+                Aborts.run[Ex1](Aborts.get(Right(1)).map(i =>
+                    Aborts.get(Right(i + 1))
                 )).pure ==
                     Right(2)
             )
         }
         "handle + transform + effectful transform" in {
             assert(
-                Aborts[Ex1].run(Aborts[Ex1].get(Right(1)).map(_ + 1).map(i =>
-                    Aborts[Ex1].get(Right(i + 1))
+                Aborts.run[Ex1](Aborts.get(Right(1)).map(_ + 1).map(i =>
+                    Aborts.get(Right(i + 1))
                 )).pure ==
                     Right(3)
             )
@@ -42,8 +42,8 @@ class abortsTest extends KyoTest:
         "handle + transform + failed effectful transform" in {
             val fail = Left[Ex1, Int](ex1)
             assert(
-                Aborts[Ex1].run(Aborts[Ex1].get(Right(1)).map(_ + 1).map(_ =>
-                    Aborts[Ex1].get(fail)
+                Aborts.run[Ex1](Aborts.get(Right(1)).map(_ + 1).map(_ =>
+                    Aborts.get(fail)
                 )).pure ==
                     fail
             )
@@ -51,98 +51,98 @@ class abortsTest extends KyoTest:
         "union tags" - {
             "in suspend 1" in {
                 val effect1: Int < Aborts[String | Boolean] =
-                    Aborts[String | Boolean].fail("failure")
+                    Aborts.fail("failure")
                 val handled1: Either[String, Int] < Aborts[Boolean] =
-                    Aborts[String].run(effect1)
-                val handled2: Either[Boolean, Either[String, Int]] < Any =
-                    Aborts[Boolean].run(handled1)
-                assert(handled2.pure == Right(Left("failure")))
+                    Aborts.run[String](effect1)
+                val handled2: Either[Boolean, Either[String, Int]] =
+                    Aborts.run[Boolean](handled1).pure
+                assert(handled2 == Right(Left("failure")))
             }
             "in suspend 2" in {
                 val effect1: Int < Aborts[String | Boolean] =
-                    Aborts[String | Boolean].fail("failure")
+                    Aborts.fail("failure")
                 val handled1: Either[Boolean, Int] < Aborts[String] =
-                    Aborts[Boolean].run(effect1)
-                val handled2: Either[String, Either[Boolean, Int]] < Any =
-                    Aborts[String].run(handled1)
-                assert(handled2.pure == Left("failure"))
+                    Aborts.run[Boolean](effect1)
+                val handled2: Either[String, Either[Boolean, Int]] =
+                    Aborts.run[String](handled1).pure
+                assert(handled2 == Left("failure"))
             }
             "in handle" in {
                 val effect: Int < Aborts[String | Boolean] =
-                    Aborts[String].fail("failure")
-                val handled: Either[String | Boolean, Int] < Any =
-                    Aborts[String | Boolean].run(effect)
-                assert(handled.pure == Left("failure"))
+                    Aborts.fail("failure")
+                val handled: Either[String | Boolean, Int] =
+                    Aborts.run[String | Boolean](effect).pure
+                assert(handled == Left("failure"))
             }
         }
     }
 
     "effectful" - {
         "success" - {
-            val v = Aborts[Ex1].get(Right(1))
+            val v = Aborts.get[Ex1, Int](Right(1))
             "handle" in {
                 assert(
-                    Aborts[Ex1].run(v).pure ==
+                    Aborts.run[Ex1](v).pure ==
                         Right(1)
                 )
             }
             "handle + transform" in {
                 assert(
-                    Aborts[Ex1].run(v.map(_ + 1)).pure ==
+                    Aborts.run[Ex1](v.map(_ + 1)).pure ==
                         Right(2)
                 )
             }
             "handle + effectful transform" in {
                 assert(
-                    Aborts[Ex1].run(v.map(i => Aborts[Ex1].get(Right(i + 1)))).pure ==
+                    Aborts.run[Ex1](v.map(i => Aborts.get(Right(i + 1)))).pure ==
                         Right(2)
                 )
             }
             "handle + transform + effectful transform" in {
                 assert(
-                    Aborts[Ex1].run(v.map(_ + 1).map(i => Aborts[Ex1].get(Right(i + 1)))).pure ==
+                    Aborts.run[Ex1](v.map(_ + 1).map(i => Aborts.get(Right(i + 1)))).pure ==
                         Right(3)
                 )
             }
             "handle + transform + failed effectful transform" in {
                 val fail = Left[Ex1, Int](ex1)
                 assert(
-                    Aborts[Ex1].run(v.map(_ + 1).map(_ => Aborts[Ex1].get(fail))).pure ==
+                    Aborts.run[Ex1](v.map(_ + 1).map(_ => Aborts.get(fail))).pure ==
                         fail
                 )
             }
         }
         "failure" - {
-            val v: Int < Aborts[Ex1] = Aborts[Ex1].get(Left(ex1))
+            val v: Int < Aborts[Ex1] = Aborts.get(Left(ex1))
             "handle" in {
                 assert(
-                    Aborts[Ex1].run(v).pure ==
+                    Aborts.run[Ex1](v).pure ==
                         Left(ex1)
                 )
             }
             "handle + transform" in {
                 assert(
-                    Aborts[Ex1].run(v.map(_ + 1)).pure ==
+                    Aborts.run[Ex1](v.map(_ + 1)).pure ==
                         Left(ex1)
                 )
             }
             "handle + effectful transform" in {
                 assert(
-                    Aborts[Ex1].run(v.map(i => Aborts[Ex1].get(Right(i + 1)))).pure ==
+                    Aborts.run[Ex1](v.map(i => Aborts.get(Right(i + 1)))).pure ==
                         Left(ex1)
                 )
             }
             "handle + transform + effectful transform" in {
                 assert(
-                    Aborts[Ex1].run(v.map(_ + 1).map(i => Aborts[Ex1].get(Right(i + 1)))).pure ==
+                    Aborts.run[Ex1](v.map(_ + 1).map(i => Aborts.get(Right(i + 1)))).pure ==
                         Left(ex1)
                 )
             }
             "handle + transform + failed effectful transform" in {
                 val fail = Left[Ex1, Int](ex1)
                 assert(
-                    Aborts[Ex1].run(v.map(_ + 1).map(_ => Aborts[Ex1].get(fail))).pure ==
-                        fail
+                    Aborts.run[Ex1](v.map(_ + 1).map(_ => Aborts.get(fail))).pure ==
+                        Left(ex1)
                 )
             }
         }
@@ -151,32 +151,32 @@ class abortsTest extends KyoTest:
     "Aborts" - {
         def test(v: Int): Int < Aborts[Ex1] =
             v match
-                case 0 => Aborts[Ex1].fail(ex1)
+                case 0 => Aborts.fail(ex1)
                 case i => 10 / i
         "run" - {
             "success" in {
                 assert(
-                    Aborts[Ex1].run(test(2)).pure ==
+                    Aborts.run[Ex1](test(2)).pure ==
                         Right(5)
                 )
             }
             "failure" in {
                 assert(
-                    Aborts[Ex1].run(test(0)).pure ==
+                    Aborts.run[Ex1](test(0)).pure ==
                         Left(ex1)
                 )
             }
             "inference" in {
                 def t1(v: Int < Aborts[Int | String]) =
-                    Aborts[Int].run(v)
+                    Aborts.run[Int](v)
                 val _: Either[Int, Int] < Aborts[String] =
                     t1(42)
                 def t2(v: Int < (Aborts[Int] & Aborts[String])) =
-                    Aborts[String].run(v)
+                    Aborts.run[String](v)
                 val _: Either[String, Int] < Aborts[Int] =
                     t2(42)
                 def t3(v: Int < Aborts[Int]) =
-                    Aborts[Int].run(v)
+                    Aborts.run[Int](v).pure
                 val _: Either[Int, Int] < Any =
                     t3(42)
                 succeed
@@ -184,46 +184,49 @@ class abortsTest extends KyoTest:
             "super" in pendingUntilFixed {
                 assertCompiles("""
                     val ex                              = new Exception
-                    val a: Int < Aborts[Exception]      = Aborts[Exception].fail(ex)
-                    val b: Either[Throwable, Int] < Any = Aborts[Throwable].run(a)
-                    assert(b.pure == Left(ex))
+                    val a: Int < Aborts[Exception]      = Aborts.fail(ex)
+                    val b: Either[Throwable, Int] < Any = Aborts.run[Throwable](a).pure  
+                    assert(b == Left(ex))
                 """)
             }
             "reduce large union incrementally" in {
-                val t1: Int < Aborts[Int | String | Boolean | Float | Char | Double] = 18
-                val t2                                                               = Aborts[Int].run(t1)
-                val t3                                                               = Aborts[String].run(t2)
-                val t4                                                               = Aborts[Boolean].run(t3)
-                val t5                                                               = Aborts[Float].run(t4)
-                val t6                                                               = Aborts[Char].run(t5)
-                val t7                                                               = Aborts[Double].run(t6)
+                val t1: Int < Aborts[Int | String | Boolean | Float | Char | Double] =
+                    18
+                val t2 = Aborts.run[Int](t1)
+                val t3 = Aborts.run[String](t2)
+                val t4 = Aborts.run[Boolean](t3)
+                val t5 = Aborts.run[Float](t4)
+                val t6 = Aborts.run[Char](t5)
+                val t7 = Aborts.run[Double](t6).pure
                 assert(t7.pure == Right(Right(Right(Right(Right(Right(18)))))))
             }
             "reduce large union in a single expression" in {
                 val t: Int < Aborts[Int | String | Boolean | Float | Char | Double] = 18
                 // NB: Adding type annotation leads to compilation error
                 val res =
-                    Aborts[Double].run(
-                        Aborts[Char].run(
-                            Aborts[Float].run(
-                                Aborts[Boolean].run(
-                                    Aborts[String].run(
-                                        Aborts[Int].run(t)
+                    Aborts.run[Double](
+                        Aborts.run[Char](
+                            Aborts.run[Float](
+                                Aborts.run[Boolean](
+                                    Aborts.run[String](
+                                        Aborts.run[Int](t)
                                     )
                                 )
                             )
                         )
-                    )
-                assert(res.pure == Right(Right(Right(Right(Right(Right(18)))))))
+                    ).pure
+                val expected: Either[Double, Either[Char, Either[Float, Either[Boolean, Either[String, Either[Int, Int]]]]]] =
+                    Right(Right(Right(Right(Right(Right(18))))))
+                assert(res == expected)
             }
         }
         "fail" in {
             val ex: Throwable = new Exception("throwable failure")
             val a             = Aborts.fail(ex)
-            assert(Aborts[Throwable].run(a).pure == Left(ex))
+            assert(Aborts.run[Throwable](a).pure == Left(ex))
         }
         "when" in {
-            def abort(b: Boolean) = Aborts[String].run(Aborts.when(b)("FAIL!")).pure
+            def abort(b: Boolean) = Aborts.run[String](Aborts.when(b)("FAIL!")).pure
 
             assert(abort(true) == Left("FAIL!"))
             assert(abort(false) == Right(()))
@@ -236,21 +239,19 @@ class abortsTest extends KyoTest:
                         case i => 10 / i
                 "success" in {
                     assert(
-                        Aborts[Ex1].run(Aborts[Ex1].catching(test(2))).pure ==
+                        Aborts.run[Ex1](Aborts.catching[Ex1](test(2))).pure ==
                             Right(5)
                     )
                 }
                 "failure" in {
                     assert(
-                        Aborts[Ex1].run(Aborts[Ex1].catching(test(0))).pure ==
+                        Aborts.run[Ex1](Aborts.catching[Ex1](test(0))).pure ==
                             Left(ex1)
                     )
                 }
                 "subclass" in {
                     assert(
-                        Aborts[RuntimeException].run(
-                            Aborts[RuntimeException].catching(test(0))
-                        ).pure ==
+                        Aborts.run[RuntimeException](Aborts.catching[RuntimeException](test(0))).pure ==
                             Left(ex1)
                     )
                 }
@@ -264,7 +265,7 @@ class abortsTest extends KyoTest:
                 "success" in {
                     assert(
                         Envs[Int].run(2)(
-                            Aborts[Ex1].run(Aborts[Ex1].catching(test(Envs[Int].get)))
+                            Aborts.run[Ex1](Aborts.catching[Ex1](test(Envs[Int].get)))
                         ).pure ==
                             Right(5)
                     )
@@ -272,7 +273,7 @@ class abortsTest extends KyoTest:
                 "failure" in {
                     assert(
                         Envs[Int].run(0)(
-                            Aborts[Ex1].run(Aborts[Ex1].catching(test(Envs[Int].get)))
+                            Aborts.run[Ex1](Aborts.catching[Ex1](test(Envs[Int].get)))
                         ).pure ==
                             Left(ex1)
                     )

--- a/kyo-core/shared/src/test/scala/kyoTest/streamsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/streamsTest.scala
@@ -367,8 +367,8 @@ class streamsTest extends KyoTest:
 
         "with failures" in {
             val stream      = Streams.initSeq(Seq("1", "2", "abc", "3"))
-            val transformed = stream.transform(v => Aborts[NumberFormatException].catching(v.toInt)).runSeq
-            assert(Aborts[NumberFormatException].run(transformed).pure.isLeft)
+            val transformed = stream.transform(v => Aborts.catching[NumberFormatException](v.toInt)).runSeq
+            assert(Aborts.run(transformed).pure.isLeft)
         }
 
         "stack safety" in {
@@ -488,9 +488,9 @@ class streamsTest extends KyoTest:
         "early termination" in {
             val stream = Streams.initSeq(Seq(1, 2, 3, 4, 5))
             val folded = stream.runFold(0) { (acc, v) =>
-                if acc < 6 then acc + v else Aborts[Unit].fail(())
+                if acc < 6 then acc + v else Aborts.fail(())
             }
-            assert(Aborts[Unit].run(folded).pure.fold(_ => true, _ => false))
+            assert(Aborts.run[Unit](folded).pure.fold(_ => true, _ => false))
         }
 
         "stack safety" in {

--- a/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/api/Handler.scala
+++ b/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/api/Handler.scala
@@ -26,8 +26,8 @@ object Handler:
 
     final class Live(db: DB) extends Handler:
 
-        private val notFound            = Aborts[StatusCode].fail(StatusCode.NotFound)
-        private val unprocessableEntity = Aborts[StatusCode].fail(StatusCode.UnprocessableEntity)
+        private val notFound            = Aborts.fail[StatusCode](StatusCode.NotFound)
+        private val unprocessableEntity = Aborts.fail[StatusCode](StatusCode.UnprocessableEntity)
 
         def transaction(account: Int, request: Transaction) = defer {
             import request.*

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -21,7 +21,7 @@ object KyoSttpMonad:
             protected def handleWrappedError[T](rt: T < Fibers)(
                 h: PartialFunction[Throwable, T < Fibers]
             ) =
-                IOs.handle(rt)(h)
+                IOs.catching(rt)(h)
 
             def ensure[T](f: T < Fibers, e: => Unit < Fibers) =
                 IOs.ensure(Fibers.run(e).unit)(f)

--- a/kyo-tapir/src/main/scala/kyo/routes.scala
+++ b/kyo-tapir/src/main/scala/kyo/routes.scala
@@ -31,7 +31,7 @@ object Routes:
     ): Unit < Routes =
         Sums[List[Route]].add(List(
             e.serverSecurityLogic[A, KyoSttpMonad.M](a => Right(a)).serverLogic(a =>
-                i => Aborts[E].run(Envs[A].run(a)(f(i)))
+                i => Aborts.run(Envs[A].run(a)(f(i)))
             )
         )).unit
     end add

--- a/kyo-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
+++ b/kyo-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
@@ -4,6 +4,7 @@ import kyo.*
 import zio.Duration
 import zio.duration2DurationOps
 import zio.test.*
+
 object KyoSpecDefaultSpec extends KyoSpecDefault:
     def spec: Spec[Any, Any] =
         suite("all")(
@@ -20,7 +21,7 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
                     IOs.fail("Fail!").map(_ => assertCompletes)
                 },
                 test("IOs Succeed") {
-                    Aborts[Throwable].fail(new RuntimeException("Abort!")).map(_ => assertCompletes)
+                    Aborts.fail[Throwable](new RuntimeException("Abort!")).map(_ => assertCompletes)
                 },
                 test("Fibers.delay") {
                     Fibers.delay(Duration.Infinity.asScala)(assertCompletes)


### PR DESCRIPTION
As discussed in #275, this PR changes `Aborts` to rely solely on regular reflection of aborted values instead of type tags. It's an approach similar to ZIO. The [benchmark results](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/fwbrasil/3964a7ff775d855268b809cfee7fab84/raw/31e8b5b5b1dab3f70ec6aee60ef12873ba68dd1b/jmh-result-baseline.json,https://gist.githubusercontent.com/fwbrasil/3964a7ff775d855268b809cfee7fab84/raw/31e8b5b5b1dab3f70ec6aee60ef12873ba68dd1b/jmh-result-candidate.json) confirm the fix of the bottleneck very well 🤣

![image](https://github.com/getkyo/kyo/assets/831175/8af3a56e-6582-445a-ab15-7582cb15a0af)
