### PR TITLE
zio integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
 
     - name: Build JVM
       run: |
-        sbt 'kyo-bench/test' 'kyo-cache/test' '+kyo-scheduler/test' 'kyo-core/test' 'kyo-direct/test' 'kyo-test/test' 'kyo-examples/test' 'kyo-os-lib/test' 'kyo-stats-otel/test' 'kyo-sttp/test' 'kyo-tapir/test'
+        sbt 'kyo-bench/test' 'kyo-cache/test' '+kyo-scheduler/test' 'kyo-core/test' 'kyo-direct/test' 'kyo-test/test' 'kyo-zio/test' 'kyo-examples/test' 'kyo-os-lib/test' 'kyo-stats-otel/test' 'kyo-sttp/test' 'kyo-tapir/test'
 
     - name: Build JS
       run: |
-        sbt '+kyo-schedulerJS/test' 'kyo-coreJS/test' 'kyo-directJS/test' 'kyo-sttpJS/test' 'kyo-testJS/test'
+        sbt '+kyo-schedulerJS/test' 'kyo-coreJS/test' 'kyo-directJS/test' 'kyo-sttpJS/test' 'kyo-testJS/test' 'kyo-zioJS/test'

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,7 @@ lazy val kyo =
             `kyo-tapir`,
             `kyo-bench`,
             `kyo-test`,
+            `kyo-zio`,
             `kyo-examples`
         )
 
@@ -196,6 +197,21 @@ lazy val `kyo-test` =
             libraryDependencies += "dev.zio" %% "zio"          % "2.1.0-RC5",
             libraryDependencies += "dev.zio" %% "zio-test"     % "2.1.0-RC5",
             libraryDependencies += "dev.zio" %% "zio-test-sbt" % "2.1.0-RC5" % Test
+        ).jsSettings(
+            `js-settings`
+        )
+
+lazy val `kyo-zio` =
+    crossProject(JVMPlatform, JSPlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-zio"))
+        .dependsOn(`kyo-core` % "test->test;compile->compile")
+        .settings(
+            `kyo-settings`,
+            libraryDependencies += "dev.zio" %% "zio"          % "2.1.0-RC3",
+            libraryDependencies += "dev.zio" %% "zio-test"     % "2.1.0-RC3",
+            libraryDependencies += "dev.zio" %% "zio-test-sbt" % "2.1.0-RC3" % Test
         ).jsSettings(
             `js-settings`
         )

--- a/kyo-zio/shared/src/main/scala/kyo/zios.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/zios.scala
@@ -1,20 +1,29 @@
 package kyo
 
+import ZIOs.internal.*
 import core.*
 import core.internal.*
 import kyo.fibersInternal.*
 import scala.util.control.NonFatal
 import zio.Task
-import zio.ZEnvironment
 import zio.ZIO
 
-class ZIOs extends Effect[ZIOs]:
-    type Command[T] = Task[T]
+opaque type ZIOs <: Fibers = Tasks & Fibers
 
-object ZIOs extends ZIOs:
+object ZIOs:
 
-    def run[T: Flat](v: T < (Fibers & ZIOs)): Task[T] =
-        def loop(v: T < (Fibers & ZIOs)): Task[T] =
+    def get[E >: Nothing: Tag, A](v: ZIO[Any, E, A]): A < (Aborts[E] & ZIOs) =
+        val task = v.fold[A < Aborts[E]](e => Aborts.fail(e), a => a)
+        Tasks.suspend[A < Aborts[E], A, Aborts[E]](task, identity)
+
+    def get[A](v: ZIO[Any, Nothing, A]): A < ZIOs =
+        Tasks.suspend[A](v)
+
+    inline def get[R: zio.Tag, A](v: ZIO[R, ?, A])(using tag: Tag[Envs[R]]): A < (Envs[R] & ZIOs) =
+        compiletime.error("ZIO environments are not supported yet. Please handle them before calling this method.")
+
+    def run[T: Flat](v: T < ZIOs): Task[T] =
+        def loop(v: T < ZIOs): Task[T] =
             v match
                 case kyo: Suspend[?, ?, ?, ?] =>
                     try
@@ -32,7 +41,7 @@ object ZIOs extends ZIOs:
                                         Left(ZIO.succeed(p.interrupt()))
                                     }
                             end match
-                        else if kyo.tag == Tag[ZIOs] then
+                        else if kyo.tag == Tag[Tasks] then
                             val k = kyo.asInstanceOf[Suspend[Task, Any, T, ZIOs]]
                             k.command.flatMap(v => loop(k(v)))
                         else
@@ -48,14 +57,9 @@ object ZIOs extends ZIOs:
         loop(v)
     end run
 
-    // TODO: fix Envs with type intersections
-    private[kyo] def get[R: zio.Tag, E: Tag, A](v: ZIO[R, E, A])(using tag: Tag[Envs[R]]): A < (Envs[R] & Aborts[E] & ZIOs) =
-        Envs.get[R](using tag).map(r => get(v.provideEnvironment(ZEnvironment(r))))
-
-    def get[E >: Nothing: Tag, A](v: ZIO[Any, E, A]): A < (Aborts[E] & ZIOs) =
-        val task = v.fold[A < Aborts[E]](e => Aborts.fail(e), a => a)
-        this.suspend(task, identity)
-
-    def get[A](v: ZIO[Any, Nothing, A]): A < ZIOs =
-        this.suspend(v)
+    private[kyo] object internal:
+        class Tasks extends Effect[Tasks]:
+            type Command[T] = Task[T]
+        object Tasks extends Tasks
+    end internal
 end ZIOs

--- a/kyo-zio/shared/src/main/scala/kyo/zios.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/zios.scala
@@ -19,7 +19,7 @@ object ZIOs:
     def get[A](v: ZIO[Any, Nothing, A]): A < ZIOs =
         Tasks.suspend[A](v)
 
-    inline def get[R: zio.Tag, A](v: ZIO[R, ?, A])(using tag: Tag[Envs[R]]): A < (Envs[R] & ZIOs) =
+    inline def get[R: zio.Tag, E, A](v: ZIO[R, E, A])(using tag: Tag[Envs[R]]): A < (Envs[R] & ZIOs) =
         compiletime.error("ZIO environments are not supported yet. Please handle them before calling this method.")
 
     def run[T: Flat](v: T < (Aborts[Throwable] & ZIOs)): Task[T] =

--- a/kyo-zio/shared/src/main/scala/kyo/zios.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/zios.scala
@@ -1,0 +1,71 @@
+package kyo
+
+import core.*
+import core.internal.*
+import kyo.fibersInternal.*
+import scala.annotation.targetName
+import scala.util.control.NonFatal
+import zio.IO
+import zio.Task
+import zio.UIO
+import zio.URIO
+import zio.ZEnvironment
+import zio.ZIO
+
+class ZIOs extends Effect[ZIOs]:
+    type Command[T] = Task[T]
+
+object ZIOs extends ZIOs:
+
+    def run[T: Flat](v: T < (Fibers & ZIOs)): Task[T] =
+        def loop(v: T < (Fibers & ZIOs)): Task[T] =
+            v match
+                case kyo: Suspend[?, ?, ?, ?] =>
+                    try
+                        if kyo.tag == Tag[IOs] then
+                            val k = kyo.asInstanceOf[Suspend[?, Unit, T, Fibers]]
+                            ZIO.suspend(loop(k(())))
+                        else if kyo.tag == Tag[FiberGets] then
+                            val k = kyo.asInstanceOf[Suspend[Fiber, Any, T, FiberGets]]
+                            k.command match
+                                case Done(v) =>
+                                    ZIO.suspend(loop(k(v)))
+                                case Promise(p) =>
+                                    ZIO.asyncInterrupt[Any, Throwable, T] { cb =>
+                                        p.onComplete(v => cb(ZIO.suspend(loop(v.map(k)))))
+                                        Left(ZIO.succeed(p.interrupt()))
+                                    }
+                            end match
+                        else if kyo.tag == Tag[ZIOs] then
+                            val k = kyo.asInstanceOf[Suspend[Task, Any, T, ZIOs]]
+                            k.command.flatMap(v => loop(k(v)))
+                        else
+                            bug.failTag(kyo.tag, Tag[Fibers & ZIOs])
+                    catch
+                        case ex if NonFatal(ex) =>
+                            ZIO.fail(ex)
+                case v =>
+                    ZIO.succeed(v.asInstanceOf[T])
+            end match
+        end loop
+
+        loop(v)
+    end run
+
+    def get[R: zio.Tag, E: Tag, A](v: ZIO[R, E, A])(using tag: Tag[Envs[R]]): A < (Envs[R] & Aborts[E] & ZIOs) =
+        Envs.get[R](using tag).map(r => get(v.provideEnvironment(ZEnvironment(r))))
+
+    def get[R: zio.Tag, A](v: URIO[R, A])(using tag: Tag[Envs[R]]): A < (Envs[R] & ZIOs) =
+        Envs.get[R](using tag).map(r => get(v.provideEnvironment(ZEnvironment(r))))
+
+    def get[E: Tag, T](v: IO[E, T]): T < (Aborts[E] & ZIOs) =
+        val task = v.fold[T < Aborts[E]](Aborts.fail(_), v => v)
+        this.suspend(task, identity)
+
+    def get[T](v: UIO[T]): T < ZIOs =
+        this.suspend(v)
+
+    @targetName("getTask")
+    def get[T](v: Task[T]): T < ZIOs =
+        this.suspend[T](v)
+end ZIOs

--- a/kyo-zio/shared/src/main/scala/kyo/zios.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/zios.scala
@@ -22,27 +22,27 @@ object ZIOs:
     inline def get[R: zio.Tag, A](v: ZIO[R, ?, A])(using tag: Tag[Envs[R]]): A < (Envs[R] & ZIOs) =
         compiletime.error("ZIO environments are not supported yet. Please handle them before calling this method.")
 
-    def run[T: Flat](v: T < ZIOs): Task[T] =
-        def loop(v: T < ZIOs): Task[T] =
+    def run[T: Flat](v: T < (Aborts[Throwable] & ZIOs)): Task[T] =
+        def loop[U](v: U < ZIOs): Task[U] =
             v match
                 case kyo: Suspend[?, ?, ?, ?] =>
                     try
                         if kyo.tag == Tag[IOs] then
-                            val k = kyo.asInstanceOf[Suspend[?, Unit, T, Fibers]]
+                            val k = kyo.asInstanceOf[Suspend[?, Unit, U, Fibers]]
                             ZIO.suspend(loop(k(())))
                         else if kyo.tag == Tag[FiberGets] then
-                            val k = kyo.asInstanceOf[Suspend[Fiber, Any, T, FiberGets]]
+                            val k = kyo.asInstanceOf[Suspend[Fiber, Any, U, FiberGets]]
                             k.command match
                                 case Done(v) =>
                                     ZIO.suspend(loop(k(v)))
                                 case Promise(p) =>
-                                    ZIO.asyncInterrupt[Any, Throwable, T] { cb =>
+                                    ZIO.asyncInterrupt[Any, Throwable, U] { cb =>
                                         p.onComplete(v => cb(ZIO.suspend(loop(v.map(k)))))
                                         Left(ZIO.succeed(p.interrupt()))
                                     }
                             end match
                         else if kyo.tag == Tag[Tasks] then
-                            val k = kyo.asInstanceOf[Suspend[Task, Any, T, ZIOs]]
+                            val k = kyo.asInstanceOf[Suspend[Task, Any, U, ZIOs]]
                             k.command.flatMap(v => loop(k(v)))
                         else
                             bug.failTag(kyo.tag, Tag[Fibers & ZIOs])
@@ -50,11 +50,14 @@ object ZIOs:
                         case ex if NonFatal(ex) =>
                             ZIO.fail(ex)
                 case v =>
-                    ZIO.succeed(v.asInstanceOf[T])
+                    ZIO.succeed(v.asInstanceOf[U])
             end match
         end loop
 
-        loop(v)
+        loop(Aborts.run(v)).flatMap {
+            case Left(ex)     => ZIO.fail(ex)
+            case Right(value) => ZIO.succeed(value)
+        }
     end run
 
     private[kyo] object internal:

--- a/kyo-zio/shared/src/test/scala/kyo/ziosTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ziosTest.scala
@@ -24,7 +24,7 @@ class ziosTest extends KyoTest:
         Aborts.run(a).map(e => assert(e.isLeft))
     }
     "Aborts[Throwable]" in runKyo {
-        val a: Boolean < (Aborts[Throwable] & ZIOs) = ZIOs.get(ZIO.fail(new java.lang.RuntimeException).when(false).as(true))
+        val a: Boolean < (Aborts[Throwable] & ZIOs) = ZIOs.get(ZIO.fail(new RuntimeException).when(false).as(true))
         Aborts.run(a).map(e => assert(e.isRight))
     }
 
@@ -39,6 +39,18 @@ class ziosTest extends KyoTest:
         assertCompiles("""
             val a = ZIOs.get(ZIO.service[Int] *> ZIO.service[Double])
         """)
+    }
+
+    "A < ZIOs" in runKyo {
+        val a: Int < ZIOs = ZIOs.get(ZIO.succeed(10))
+        val b             = a.map(_ * 2)
+        b.map(i => assert(i == 20))
+    }
+
+    "nested" in runKyo {
+        val a: (String < ZIOs) < ZIOs = ZIOs.get(ZIO.succeed(ZIOs.get(ZIO.succeed("Nested"))))
+        val b: String < ZIOs          = a.flatten
+        b.map(s => assert(s == "Nested"))
     }
 
     "fibers" in runKyo {

--- a/kyo-zio/shared/src/test/scala/kyo/ziosTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ziosTest.scala
@@ -1,0 +1,94 @@
+package kyoTest
+
+import kyo.*
+import org.scalatest.compatible.Assertion
+import scala.concurrent.Future
+import zio.*
+
+class ziosTest extends KyoTest:
+
+    def runZIO[T](v: Task[T]): T =
+        zio.Unsafe.unsafe(implicit u =>
+            zio.Runtime.default.unsafe.run(v).getOrThrow()
+        )
+
+    def runKyo(v: => Assertion < (Fibers & ZIOs)): Future[Assertion] =
+        zio.Unsafe.unsafe(implicit u =>
+            zio.Runtime.default.unsafe.runToFuture(
+                ZIOs.run(v)
+            )
+        )
+
+    "aborts" in runKyo {
+        val a: Nothing < (Aborts[String] & ZIOs) = ZIOs.get(ZIO.fail("error"))
+        Aborts.run(a).map(e => assert(e.isLeft))
+    }
+
+    "env" in runKyo {
+        val a: Int < (Envs[Int] & ZIOs) = ZIOs.get(ZIO.service[Int])
+        val b: Int < ZIOs               = Envs.run(10)(a)
+        b.map(v => assert(v == 10))
+    }
+
+    "fibers" in runKyo {
+        for
+            v1 <- ZIOs.get(ZIO.succeed(1))
+            v2 <- Fibers.init(2).map(_.get)
+            v3 <- ZIOs.get(ZIO.succeed(3))
+        yield assert(v1 == 1 && v2 == 2 && v3 == 3)
+    }
+
+    "interrupts" - {
+
+        def kyoLoop(a: AtomicInt): Unit < IOs =
+            a.incrementAndGet.map(_ => kyoLoop(a))
+
+        def zioLoop(a: Ref[Int]): Task[Unit] =
+            a.update(_ + 1).flatMap(_ => zioLoop(a))
+
+        if Platform.isJVM then
+
+            "zio to kyo" in runZIO {
+                val v =
+                    for
+                        a <- Atomics.initInt(0)
+                        _ <- Fibers.init(kyoLoop(a)).map(_.get)
+                    yield ()
+                for
+                    f <- ZIOs.run(v).fork
+                    _ <- f.interrupt
+                    r <- f.await
+                yield assert(r.isFailure)
+                end for
+            }
+            // "kyo to zio" in run {
+            //     val v =
+            //         for
+            //             a <- Ref.make(0)
+            //             _ <- zioLoop(a)
+            //         yield ()
+            //     for
+            //         f <-
+            //         _ <- f.interrupt
+            //         r <- f.await
+            //     yield assert(r.isFailure)
+            //     end for
+            // }
+            // "both" in run {
+            //     val v =
+            //         for
+            //             a  <- ZIOs.get(Ref.make(0))
+            //             _  <- ZIOs.get(zioLoop(a))
+            //             a2 <- Atomics.initInt(0)
+            //             _  <- Fibers.fork(kyoLoop(a2))
+            //         yield ()
+            //     for
+            //         f <- ZiosApp.runTask(v).fork
+            //         _ <- f.interrupt
+            //         r <- f.await
+            //     yield assert(r.isFailure)
+            //     end for
+            // }
+        end if
+    }
+end ziosTest

--- a/kyo-zio/shared/src/test/scala/kyo/ziosTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ziosTest.scala
@@ -19,15 +19,26 @@ class ziosTest extends KyoTest:
             )
         )
 
-    "aborts" in runKyo {
+    "Aborts[String]" in runKyo {
         val a: Nothing < (Aborts[String] & ZIOs) = ZIOs.get(ZIO.fail("error"))
         Aborts.run(a).map(e => assert(e.isLeft))
     }
+    "Aborts[Throwable]" in runKyo {
+        val a: Boolean < (Aborts[Throwable] & ZIOs) = ZIOs.get(ZIO.fail(new java.lang.RuntimeException).when(false).as(true))
+        Aborts.run(a).map(e => assert(e.isRight))
+    }
 
-    "env" in runKyo {
-        val a: Int < (Envs[Int] & ZIOs) = ZIOs.get(ZIO.service[Int])
-        val b: Int < ZIOs               = Envs.run(10)(a)
-        b.map(v => assert(v == 10))
+    "Envs[Int]" in pendingUntilFixed {
+        assertCompiles("""
+            val a: Int < (Envs[Int] & ZIOs) = ZIOs.get(ZIO.service[Int])
+            val b: Int < ZIOs               = Envs.run(10)(a)
+            b.map(v => assert(v == 10))
+        """)
+    }
+    "Envs[Int & Double]" in pendingUntilFixed {
+        assertCompiles("""
+            val a = ZIOs.get(ZIO.service[Int] *> ZIO.service[Double])
+        """)
     }
 
     "fibers" in runKyo {

--- a/kyo-zio/shared/src/test/scala/kyo/ziosTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ziosTest.scala
@@ -82,10 +82,12 @@ class ziosTest extends KyoTest:
                     _ <- f.interrupt
                     r <- f.await
                 yield
+                    a.reset()
                     eventually {
                         for _ <- 0 until 5 do
                             Thread.sleep(1)
-                            assert(a.sumThenReset() == 0)
+                            assert(a.sum() == 0)
+                            a.reset()
                     }
                     assert(r.isFailure)
                 end for
@@ -98,10 +100,12 @@ class ziosTest extends KyoTest:
                     _ <- f.interrupt
                     r <- f.getTry
                 yield
+                    a.reset()
                     eventually {
                         for _ <- 0 until 5 do
                             Thread.sleep(1)
-                            assert(a.sumThenReset() == 0)
+                            assert(a.sum() == 0)
+                            a.reset()
                     }
                     assert(r.isFailure)
                 end for
@@ -121,15 +125,19 @@ class ziosTest extends KyoTest:
                     _ <- f.interrupt
                     r <- f.await
                 yield
+                    a.reset()
                     eventually {
                         for _ <- 0 until 5 do
                             Thread.sleep(1)
-                            assert(a.sumThenReset() == 0)
+                            assert(a.sum() == 0)
+                            a.reset()
                     }
+                    a2.reset()
                     eventually {
                         for _ <- 0 until 5 do
                             Thread.sleep(1)
-                            assert(a2.sumThenReset() == 0)
+                            assert(a2.sum() == 0)
+                            a2.reset()
                     }
                     assert(r.isFailure)
                 end for


### PR DESCRIPTION
I've recovered the ZIO integration and identified a way to handle both Kyo and ZIO computations by manually implementing the evaluation loop handling all effects at once, [similarly to `IOTask`](https://github.com/getkyo/kyo/blob/be752ed1e6d8477da28a42d9847fea8867922790/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala#L27). This approach doesn't require blocking threads and it seems it can handle async boundaries and propagate interrupts/failures correctly.