### PR TITLE
introduce fork/join benchmark

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/ForkJoinBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForkJoinBench.scala
@@ -1,0 +1,47 @@
+package kyo.bench
+
+import org.openjdk.jmh.annotations.*
+
+class ForkJoinBench extends Bench.ForkOnly[Unit]:
+
+    val depth = 10000
+    val range = (0 until depth).toList
+
+    def catsBench() =
+        import cats.*
+        import cats.effect.*
+
+        val forkFiber     = IO.unit.start
+        val forkAllFibers = Traverse[List].traverse(range)(_ => forkFiber)
+
+        forkAllFibers.flatMap(fibers => Traverse[List].traverse(fibers)(_.join).void)
+    end catsBench
+
+    override def kyoBenchFiber() =
+        import kyo.*
+
+        val forkFiber     = Fibers.init(())
+        val forkAllFibers = Seqs.map(range)(_ => forkFiber)
+
+        forkAllFibers.flatMap(fibers => Seqs.map(fibers)(_.get).unit)
+    end kyoBenchFiber
+
+    def zioBench() =
+        import zio.*
+
+        val forkFiber     = ZIO.unit.forkDaemon
+        val forkAllFibers = ZIO.yieldNow *> ZIO.foreach(range)(_ => forkFiber)
+        forkAllFibers.flatMap(fibers => ZIO.foreach(fibers)(_.await).unit)
+    end zioBench
+
+    @Benchmark
+    def forkOx() =
+        import ox.*
+        scoped {
+            val forkAllFibers =
+                for (_ <- range) yield fork(())
+            for fiber <- forkAllFibers do
+                fiber.join()
+        }
+    end forkOx
+end ForkJoinBench

--- a/kyo-bench/src/main/scala/kyo/bench/ForkJoinBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForkJoinBench.scala
@@ -30,7 +30,7 @@ class ForkJoinBench extends Bench.ForkOnly[Unit]:
         import zio.*
 
         val forkFiber     = ZIO.unit.forkDaemon
-        val forkAllFibers = ZIO.yieldNow *> ZIO.foreach(range)(_ => forkFiber)
+        val forkAllFibers = ZIO.foreach(range)(_ => forkFiber)
         forkAllFibers.flatMap(fibers => ZIO.foreach(fibers)(_.await).unit)
     end zioBench
 

--- a/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
@@ -147,4 +147,8 @@ class BenchTest extends AsyncFreeSpec with Assertions:
     "RandomBench" - {
         test(RandomBench(), ())
     }
+
+    "ForkJoinBench" - {
+        test(ForkJoinBench(), ())
+    }
 end BenchTest


### PR DESCRIPTION
Port of ZIO's benchmark: https://github.com/zio/zio/blob/b84b12892e8b6c329e5ace56f4c4ecc2d21ce094/benchmarks/src/main/scala/zio/ForkJoinBenchmark.scala#L1

Results with M2 Max:

https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fwbrasil/ea9fcff9a00b6f79a1799b3342d625d7/raw/5d4876a9257176924c8bd19a63c48da4769b3821/jmh-result.json