### PR TITLE
introduce kyo-pure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
 
     - name: Build JVM
       run: |
-        sbt 'kyo-bench/test' 'kyo-cache/test' '+kyo-scheduler/test' 'kyo-core/test' 'kyo-direct/test' 'kyo-test/test' 'kyo-examples/test' 'kyo-os-lib/test' 'kyo-stats-otel/test' 'kyo-sttp/test' 'kyo-tapir/test'
+        sbt 'kyo-pure/test' '+kyo-scheduler/test' 'kyo-core/test' 'kyo-direct/test' 'kyo-test/test' 'kyo-bench/test' 'kyo-cache/test' 'kyo-examples/test' 'kyo-os-lib/test' 'kyo-stats-otel/test' 'kyo-sttp/test' 'kyo-tapir/test'
 
     - name: Build JS
       run: |
-        sbt '+kyo-schedulerJS/test' 'kyo-coreJS/test' 'kyo-directJS/test' 'kyo-sttpJS/test' 'kyo-testJS/test'
+        sbt 'kyo-pureJS/test' '+kyo-schedulerJS/test' 'kyo-coreJS/test' 'kyo-directJS/test' 'kyo-sttpJS/test' 'kyo-testJS/test'

--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,21 @@ lazy val `kyo-scheduler` =
         )
         .jsSettings(`js-settings`)
 
+lazy val `kyo-pure` =
+    crossProject(JSPlatform, JVMPlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-pure"))
+        .settings(
+            `kyo-settings`,
+            libraryDependencies += "dev.zio"       %%% "izumi-reflect"   % "2.3.8",
+            libraryDependencies += "dev.zio"       %%% "zio-laws-laws"   % "1.0.0-RC23" % Test,
+            libraryDependencies += "dev.zio"       %%% "zio-test-sbt"    % "2.1.0-RC3"  % Test,
+            libraryDependencies += "org.scalatest" %%% "scalatest"       % "3.2.16"     % Test,
+            libraryDependencies += "javassist"       % "javassist"       % "3.12.1.GA"  % Test,
+        )
+        .jsSettings(`js-settings`)
+
 lazy val `kyo-core` =
     crossProject(JSPlatform, JVMPlatform)
         .withoutSuffixFor(JVMPlatform)

--- a/kyo-pure/js/src/test/scala/kyoTest/Platform.scala
+++ b/kyo-pure/js/src/test/scala/kyoTest/Platform.scala
@@ -1,0 +1,8 @@
+package kyoTest
+
+object Platform:
+    def executionContext        = scala.scalajs.concurrent.JSExecutionContext.queue
+    def isJVM: Boolean          = false
+    def isJS: Boolean           = true
+    def isDebugEnabled: Boolean = false
+end Platform

--- a/kyo-pure/jvm/src/test/scala/kyoTest/MonadLawsTest.scala
+++ b/kyo-pure/jvm/src/test/scala/kyoTest/MonadLawsTest.scala
@@ -1,0 +1,45 @@
+package kyoTest
+
+import kyo.*
+import kyo.Flat.unsafe.bypass
+import zio.Trace
+import zio.prelude.Equal
+import zio.prelude.coherent.CovariantDeriveEqual
+import zio.prelude.coherent.CovariantDeriveEqualIdentityFlatten
+import zio.prelude.laws.*
+import zio.test.*
+import zio.test.laws.*
+
+object MonadLawsTest extends ZIOSpecDefault:
+
+    case class Myo[+T](v: T < Defers)
+
+    val listGenF: GenF[Any, Myo] =
+        new GenF[Any, Myo]:
+            def apply[R, A](gen: Gen[R, A])(using trace: Trace) =
+                Gen.oneOf(
+                    gen.map(v => (v: A < Defers)),
+                    gen.map(v => Defers(v))
+                ).map(Myo(_))
+
+    given CovariantDeriveEqualIdentityFlatten[Myo] =
+        new CovariantDeriveEqualIdentityFlatten[Myo]:
+            override def flatten[A](ffa: Myo[Myo[A]]): Myo[A] =
+                Myo(ffa.v.flatMap(_.v))
+            override def any: Myo[Any] =
+                Myo(())
+            override def map[A, B](f: A => B): Myo[A] => Myo[B] =
+                m => Myo[B](m.v.map(f))
+            override def derive[A: Equal]: Equal[Myo[A]] =
+                new Equal[Myo[A]]:
+                    protected def checkEqual(l: Myo[A], r: Myo[A]): Boolean =
+                        def run(m: Myo[A]): A = Defers.run(m.v).pure
+                        summon[Equal[A]].equal(run(l), run(r))
+
+    def spec = suite("MonadLawsTest")(
+        test("covariant")(checkAllLaws(CovariantLaws)(listGenF, Gen.int)),
+        test("identityFlatten")(
+            checkAllLaws(IdentityFlattenLaws)(listGenF, Gen.int)
+        )
+    )
+end MonadLawsTest

--- a/kyo-pure/jvm/src/test/scala/kyoTest/Platform.scala
+++ b/kyo-pure/jvm/src/test/scala/kyoTest/Platform.scala
@@ -1,0 +1,12 @@
+package kyoTest
+
+object Platform:
+    def executionContext = scala.concurrent.ExecutionContext.global
+    def isJVM: Boolean   = true
+    def isJS: Boolean    = false
+    def isDebugEnabled: Boolean =
+        java.lang.management.ManagementFactory
+            .getRuntimeMXBean()
+            .getInputArguments()
+            .toString.contains("jdwp")
+end Platform

--- a/kyo-pure/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
+++ b/kyo-pure/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
@@ -1,0 +1,65 @@
+package kyoTest
+
+import kyo.*
+import scala.reflect.ClassTag
+
+class coreBytecodeSizeTest extends KyoPureTest:
+
+    import kyo.core.*
+
+    object TestEffect extends Effect[TestEffect.type]:
+        type Command[T] = T
+
+    object TestHandler extends Handler[Id, TestEffect.type, Any]:
+        def resume[T, U: Flat, S](command: T, k: T => U < (TestEffect.type & S)) =
+            Resume((), k(command))
+
+    class TestSuspend:
+        def test(e: TestEffect.type) = suspend(e)(42)
+
+    class TestTransform:
+        def test(v: Int < TestEffect.type) = transform(v)(_ + 1)
+
+    class TestHandle:
+        def test(h: TestHandler.type, v: Int < TestEffect.type) = TestEffect.handle(h)((), v)
+
+    "suspend" in runJVM {
+        val map = methodBytecodeSize[TestSuspend]
+        assert(map == Map("test" -> 14))
+    }
+
+    "transform" in runJVM {
+        val map = methodBytecodeSize[TestTransform]
+        assert(map == Map("test" -> 16, "anonfun" -> 6, "transformLoop" -> 42))
+    }
+
+    "handle" in runJVM {
+        val map = methodBytecodeSize[TestHandle]
+        assert(map == Map(
+            "test"        -> 28,
+            "resultLoop"  -> 94,
+            "handleLoop"  -> 280,
+            "_handleLoop" -> 12
+        ))
+    }
+
+    def methodBytecodeSize[T](using ct: ClassTag[T]): Map[String, Int] =
+        import javassist.*
+        val classpath = System.getProperty("java.class.path")
+        val classPool = ClassPool.getDefault
+        classpath.split(":").foreach { path =>
+            classPool.insertClassPath(path)
+        }
+        val ctClass = classPool.get(ct.runtimeClass.getName())
+        val methods = ctClass.getDeclaredMethods
+        methods.map(m =>
+            normalizeMethodName(m.getName()) -> m.getMethodInfo.getCodeAttribute.getCodeLength
+        ).toMap.filter(!_._1.isEmpty())
+    end methodBytecodeSize
+
+    def normalizeMethodName(methodName: String): String =
+        val simpleMethodName = methodName.split("\\$\\$").last
+        val normalizedName   = simpleMethodName.stripPrefix("_$")
+        normalizedName.split("\\$").head
+    end normalizeMethodName
+end coreBytecodeSizeTest

--- a/kyo-pure/shared/src/main/scala/kyo/Flat.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/Flat.scala
@@ -1,0 +1,20 @@
+package kyo
+
+import internal.FlatImplicits
+
+sealed trait Flat[-T]
+
+object Flat extends FlatImplicits:
+
+    inline def derive[T: Flat, S]: Flat[T < S] = Flat.unsafe.bypass
+
+    private val cached = new Flat[Any] {}
+
+    given unit[S]: Flat[Unit < S] = unsafe.bypass[Unit < S]
+
+    object unsafe:
+
+        inline given bypass[T]: Flat[T] =
+            cached.asInstanceOf[Flat[T]]
+    end unsafe
+end Flat

--- a/kyo-pure/shared/src/main/scala/kyo/KyoPureApp.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/KyoPureApp.scala
@@ -1,0 +1,45 @@
+package kyo
+
+import scala.collection.mutable.ListBuffer
+
+abstract class KyoPureApp extends KyoPureApp.Base[KyoPureApp.Effects]:
+
+    override protected def handle[T](v: T < KyoPureApp.Effects)(implicit
+        f: Flat[T < KyoPureApp.Effects]
+    ): Unit =
+        println(KyoPureApp.run(v))
+
+end KyoPureApp
+
+object KyoPureApp:
+
+    abstract class Base[S]:
+
+        protected def handle[T](v: T < S)(using f: Flat[T < S]): Unit
+
+        final protected def args: Array[String] = _args
+
+        private var _args: Array[String] = null
+
+        private val initCode = new ListBuffer[() => Unit]
+
+        final def main(args: Array[String]) =
+            this._args = args
+            for proc <- initCode do proc()
+
+        protected def run[T](v: => T < S)(
+            using f: Flat[T < S]
+        ): Unit =
+            initCode += (() => handle(v))
+    end Base
+
+    type Effects = Defers & Aborts[Throwable]
+
+    def run[T](v: T < Effects)(
+        using f: Flat[T < Effects]
+    ): T =
+        Defers.run(Aborts.run[Throwable](v)).pure match
+            case Left(ex)     => throw ex
+            case Right(value) => value
+
+end KyoPureApp

--- a/kyo-pure/shared/src/main/scala/kyo/aborts.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/aborts.scala
@@ -1,0 +1,80 @@
+package kyo
+
+import kyo.core.*
+import scala.reflect.ClassTag
+
+// Can't use an opaque type because
+// kyo-direct tests crash the compiler.
+type Aborts[-V] //= DoAbort
+
+object Aborts:
+
+    import internal.*
+
+    def fail[V](v: V): Nothing < Aborts[V] =
+        DoAbort.suspend(v).asInstanceOf[Nothing < Aborts[V]]
+
+    def when[V](b: Boolean)(value: => V): Unit < Aborts[V] =
+        if b then fail(value)
+        else ()
+
+    def get[V, T](e: Either[V, T]): T < Aborts[V] =
+        e match
+            case Right(v) => v
+            case Left(v)  => fail(v)
+
+    class RunDsl[V]:
+        def apply[V0 <: V, T: Flat, S, VS, VR](v: T < (Aborts[VS] & S))(
+            using
+            h: HasAborts[V0, VS] { type Remainder = VR },
+            ct: ClassTag[V0]
+        ): Either[V, T] < (VR & S) =
+            DoAbort.handle(handler)(ct, v).asInstanceOf[Either[V, T] < (VR & S)]
+    end RunDsl
+
+    def run[V]: RunDsl[V] = RunDsl[V]
+
+    private object internal:
+
+        val handler =
+            new ResultHandler[ClassTag[?], Const[Any], DoAbort, [T] =>> Either[Any, T], Any]:
+                def done[T](st: ClassTag[?], v: T) = Right(v)
+
+                override def accepts[T](st: ClassTag[?], command: Any) =
+                    type V
+                    given ClassTag[V] = st.asInstanceOf[ClassTag[V]]
+                    command match
+                        case v: V => true
+                        case _    => false
+                end accepts
+
+                def resume[T, U: Flat, S2](st: ClassTag[?], command: Any, k: T => U < (DoAbort & S2)) =
+                    Left(command)
+        end handler
+
+        class DoAbort extends Effect[DoAbort]:
+            type Command[T] = Any
+        object DoAbort extends DoAbort
+
+        /** An effect `Aborts[VS]` includes a failure type `V`, and once `V` has been handled, `Aborts[VS]` should be replaced by `Out`
+          *
+          * @tparam V
+          *   the failure type included in `VS`
+          * @tparam VS
+          *   all of the `Aborts` failure types represented by type union
+          */
+        sealed trait HasAborts[V, VS]:
+            /** Remaining effect type, once failures of type `V` have been handled
+              */
+            type Remainder
+        end HasAborts
+
+        trait LowPriorityHasAborts:
+            given hasAborts[V, VR]: HasAborts[V, V | VR] with
+                type Remainder = Aborts[VR]
+
+        object HasAborts extends LowPriorityHasAborts:
+            given isAborts[V]: HasAborts[V, V] with
+                type Remainder = Any
+    end internal
+end Aborts

--- a/kyo-pure/shared/src/main/scala/kyo/aspects.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/aspects.scala
@@ -1,0 +1,65 @@
+package kyo
+
+object Aspects:
+
+    private[kyo] val local = Locals.init(Map.empty[Aspect[?, ?, ?], Cut[?, ?, ?]])
+
+    def init[T, U, S]: Aspect[T, U, S] =
+        init(new Cut[T, U, S]:
+            def apply[S2](v: T < S2)(f: T => U < (Defers & S)) =
+                v.map(f)
+        )
+
+    def init[T, U, S](default: Cut[T, U, S]): Aspect[T, U, S] =
+        new Aspect[T, U, S](default)
+
+    def chain[T, U, S](head: Cut[T, U, S], tail: Seq[Cut[T, U, S]]) =
+        tail.foldLeft(head)(_.andThen(_))
+end Aspects
+
+import Aspects.*
+
+abstract class Cut[T, U, S]:
+    def apply[S2](v: T < S2)(f: T => U < (Defers & S)): U < (Defers & S & S2)
+
+    def andThen(other: Cut[T, U, S]): Cut[T, U, S] =
+        new Cut[T, U, S]:
+            def apply[S2](v: T < S2)(f: T => U < (Defers & S)) =
+                Cut.this(v)(other(_)(f))
+end Cut
+
+final class Aspect[T, U, S] private[kyo] (default: Cut[T, U, S]) extends Cut[T, U, S]:
+
+    def apply[S2](v: T < S2)(f: T => U < (Defers & S)) =
+        local.use { map =>
+            map.get(this) match
+                case Some(a: Cut[T, U, S] @unchecked) =>
+                    local.let(map - this) {
+                        a(v)(f)
+                    }
+                case _ =>
+                    default(v)(f)
+        }
+
+    def sandbox[S](v: T < S): T < (Defers & S) =
+        local.use { map =>
+            map.get(this) match
+                case Some(a: Cut[T, U, S] @unchecked) =>
+                    local.let(map - this) {
+                        v
+                    }
+                case _ =>
+                    v
+        }
+
+    def let[V, S2](a: Cut[T, U, S])(v: V < (Defers & S2)): V < (Defers & S & S2) =
+        local.use { map =>
+            val cut =
+                map.get(this) match
+                    case Some(b: Cut[T, U, S] @unchecked) =>
+                        b.andThen(a)
+                    case _ =>
+                        a
+            local.let(map + (this -> cut))(v)
+        }
+end Aspect

--- a/kyo-pure/shared/src/main/scala/kyo/choices.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/choices.scala
@@ -1,0 +1,37 @@
+package kyo
+
+import kyo.core.*
+
+class Choices extends Effect[Choices]:
+    type Command[T] = Seq[T]
+
+object Choices extends Choices:
+
+    def run[T: Flat, S](v: T < (Choices & S)): Seq[T] < S =
+        this.handle(handler)((), v)
+
+    def get[T](v: Seq[T]): T < Choices =
+        this.suspend(v)
+
+    def eval[T, U, S](v: Seq[T])(f: T => U < S): U < (Choices & S) =
+        v match
+            case Seq(head) => f(head)
+            case v         => this.suspend(v, f)
+
+    def filter[S](v: Boolean < S): Unit < (Choices & S) =
+        v.map {
+            case true =>
+                ()
+            case false =>
+                drop
+        }
+
+    val drop: Nothing < Choices =
+        suspend(this)(Seq.empty)
+
+    private val handler =
+        new ResultHandler[Unit, Seq, Choices, Seq, Any]:
+            def done[T](st: Unit, v: T) = Seq(v)
+            def resume[T, U: Flat, S](st: Unit, v: Seq[T], f: T => U < (Choices & S)): (Seq[U] | Resume[U, S]) < (Any & S) =
+                Seqs.collect(v.map(e => Choices.run(f(e)))).map(_.flatten)
+end Choices

--- a/kyo-pure/shared/src/main/scala/kyo/chunks.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/chunks.scala
@@ -1,0 +1,467 @@
+package kyo
+
+import Chunks.Indexed
+import scala.annotation.tailrec
+import scala.reflect.ClassTag
+
+sealed abstract class Chunk[T] derives CanEqual:
+
+    import Chunks.internal.*
+
+    //////////////////
+    // O(1) methods //
+    //////////////////
+
+    def size: Int
+
+    final def isEmpty: Boolean = size == 0
+
+    final def take(n: Int): Chunk[T] =
+        dropLeftAndRight(0, size - Math.min(Math.max(0, n), size))
+
+    final def dropLeft(n: Int): Chunk[T] =
+        dropLeftAndRight(Math.min(size, Math.max(0, n)), 0)
+
+    final def dropRight(n: Int): Chunk[T] =
+        dropLeftAndRight(0, Math.min(size, Math.max(0, n)))
+
+    final def slice(from: Int, until: Int): Chunk[T] =
+        dropLeftAndRight(Math.max(0, from), size - Math.min(size, until))
+
+    final def dropLeftAndRight(left: Int, right: Int): Chunk[T] =
+        @tailrec def loop(c: Chunk[T], left: Int, right: Int): Chunk[T] =
+            val size = c.size - left - right
+            if size <= 0 then Chunks.init
+            else
+                c match
+                    case Drop(chunk, dropLeft, dropRight, _) =>
+                        Drop(chunk, left + dropLeft, right + dropRight, size)
+                    case Append(chunk, value, size) if right > 0 =>
+                        loop(chunk, left, right - 1)
+                    case _ =>
+                        Drop(c, left, right, size)
+            end if
+        end loop
+        loop(this, left, right)
+    end dropLeftAndRight
+
+    final def append(v: T): Chunk[T] =
+        Append(this, v, size + 1)
+
+    final def last: T =
+        @tailrec def loop(c: Chunk[T], index: Int): T =
+            c match
+                case c if index >= c.size || index < 0 =>
+                    throw new NoSuchElementException
+                case c: Append[T] =>
+                    if index == c.size - 1 then
+                        c.value
+                    else
+                        loop(c.chunk, index)
+                case c: Drop[T] =>
+                    loop(c.chunk, index + c.dropLeft)
+                case c: Indexed[T] =>
+                    c(index)
+        loop(this, this.size - 1)
+    end last
+
+    //////////////////
+    // O(n) methods //
+    //////////////////
+
+    final def concat(other: Chunk[T]): Chunk[T] =
+        if isEmpty then other
+        else if other.isEmpty then this
+        else
+            val s     = size
+            val array = new Array[T](s + other.size)(using ClassTag(classOf[Any]))
+            this.copyTo(array, 0)
+            other.copyTo(array, s)
+            Compact(array)
+        end if
+    end concat
+
+    final def map[U, S](f: T => U < S): Chunk[U] < S =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(Chunks.init[U]) { (idx, acc) =>
+                if idx < size then
+                    f(indexed(idx)).map(u => Loops.continue(acc.append(u)))
+                else
+                    Loops.done(acc)
+            }
+    end map
+
+    final def filter[S](f: T => Boolean < S): Chunk[T] < S =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(Chunks.init[T]) { (idx, acc) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    f(v).map {
+                        case true  => Loops.continue(acc.append(v))
+                        case false => Loops.continue(acc)
+                    }
+                else
+                    Loops.done(acc)
+            }
+    end filter
+
+    final def takeWhile[S](f: T => Boolean < S): Chunk[T] < S =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(Chunks.init[T]) { (idx, acc) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    f(v).map {
+                        case true  => Loops.continue(acc.append(v))
+                        case false => Loops.done(acc)
+                    }
+                else
+                    Loops.done(acc)
+            }
+
+    final def dropWhile[S](f: T => Boolean < S): Chunk[T] < S =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(()) { (idx, _) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    f(v).map {
+                        case true  => Loops.continue
+                        case false => Loops.done(indexed.dropLeft(idx))
+                    }
+                else
+                    Loops.done(Chunks.init)
+            }
+
+    final def changes: Chunk[T] =
+        changes(null)
+
+    final def changes(first: T | Null): Chunk[T] =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            @tailrec def loop(idx: Int, prev: T | Null, acc: Chunk[T]): Chunk[T] =
+                if idx < size then
+                    val v = indexed(idx)
+                    if v.equals(prev) then
+                        loop(idx + 1, prev, acc)
+                    else
+                        loop(idx + 1, v, acc.append(v))
+                    end if
+                else
+                    acc
+            loop(0, null, Chunks.init)
+    end changes
+
+    final def collect[U, S](pf: PartialFunction[T, U < S]): Chunk[U] < S =
+        if isEmpty then Chunks.init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(Chunks.init[U]) { (idx, acc) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    if pf.isDefinedAt(v) then
+                        pf(v).map { u =>
+                            Loops.continue(acc.append(u))
+                        }
+                    else
+                        Loops.continue(acc)
+                    end if
+                else
+                    Loops.done(acc)
+            }
+
+    final def collectUnit[U, S](pf: PartialFunction[T, Unit < S]): Unit < S =
+        if isEmpty then ()
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(()) { (idx, _) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    if pf.isDefinedAt(v) then
+                        pf(v).andThen {
+                            Loops.continue
+                        }
+                    else
+                        Loops.continue
+                    end if
+                else
+                    Loops.done
+            }
+
+    final def foreach[S](f: T => Unit < S): Unit < S =
+        if isEmpty then ()
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(()) { (idx, _) =>
+                if idx < size then
+                    val v = indexed(idx)
+                    f(v).andThen(Loops.continue)
+                else
+                    Loops.done
+            }
+    end foreach
+
+    final def foldLeft[S, U: Flat](init: U)(f: (U, T) => U < S): U < S =
+        if isEmpty then init
+        else
+            val size    = this.size
+            val indexed = this.toIndexed
+            Loops.indexed(init) { (idx, acc) =>
+                if idx < size then
+                    f(acc, indexed(idx)).map(nacc => Loops.continue(nacc))
+                else
+                    Loops.done(acc)
+            }
+    end foldLeft
+
+    final def toSeq: IndexedSeq[T] =
+        if isEmpty then IndexedSeq.empty
+        else
+            this match
+                case c: FromSeq[T] => c.seq
+                case _             => toArrayInternal.toIndexedSeq
+
+    final def toIndexed: Chunks.Indexed[T] =
+        if isEmpty then cachedEmpty.asInstanceOf[Chunks.Indexed[T]]
+        else
+            this match
+                case c: Chunks.Indexed[T] => c
+                case _                    => Compact(toArrayInternal)
+
+    final def flatten[U](using ev: T =:= Chunk[U]): Chunk[U] =
+        if isEmpty then Chunks.init
+        else
+            val nested = this.toArrayInternal
+
+            @tailrec def totalSize(idx: Int = 0, acc: Int = 0): Int =
+                if idx < nested.length then
+                    val chunk = nested(idx).asInstanceOf[Chunk[U]]
+                    totalSize(idx + 1, acc + chunk.size)
+                else
+                    acc
+
+            val unnested = new Array[U](totalSize())(using ClassTag(classOf[Any]))
+
+            @tailrec def copy(idx: Int = 0, offset: Int = 0): Unit =
+                if idx < nested.length then
+                    val chunk = nested(idx).asInstanceOf[Chunk[U]]
+                    chunk.copyTo(unnested, offset)
+                    copy(idx + 1, offset + chunk.size)
+            copy()
+
+            Compact(unnested)
+    end flatten
+
+    final def copyTo(array: Array[T], start: Int): Unit =
+        copyTo(array, start, size)
+
+    final def copyTo(array: Array[T], start: Int, elements: Int): Unit =
+        @tailrec def loop(c: Chunk[T], end: Int, dropLeft: Int, dropRight: Int): Unit =
+            c match
+                case c: Append[T] =>
+                    if dropRight > 0 then
+                        loop(c.chunk, end, dropLeft, dropRight - 1)
+                    else if end > 0 then
+                        array(end - 1) = c.value
+                        loop(c.chunk, end - 1, dropLeft, dropRight)
+                case c: Drop[T] =>
+                    loop(c.chunk, end, dropLeft + c.dropLeft, dropRight + c.dropRight)
+                case c: Tail[T] =>
+                    loop(c.chunk, end, dropLeft + c.offset, dropRight)
+                case c: Compact[T] =>
+                    val l = c.array.length
+                    if l > 0 then
+                        System.arraycopy(c.array, dropLeft, array, start, l - dropRight - dropLeft)
+                case c: FromSeq[T] =>
+                    val seq  = c.seq
+                    val size = Math.min(end, c.seq.size - dropLeft - dropRight)
+                    @tailrec def loop(index: Int): Unit =
+                        if index < size then
+                            array(start + index) = seq(index + dropLeft)
+                            loop(index + 1)
+                    loop(0)
+        if !isEmpty then
+            loop(this, elements, 0, 0)
+    end copyTo
+
+    final def toArray(using ClassTag[T]): Array[T] =
+        val array = new Array[T](size)
+        copyTo(array, 0)
+        array
+    end toArray
+
+    final private def toArrayInternal: Array[T] =
+        this match
+            case c if c.isEmpty =>
+                cachedEmpty.array.asInstanceOf[Array[T]]
+            case c: Compact[T] =>
+                c.array
+            case c =>
+                c.toArray(using ClassTag(classOf[Any]))
+
+    override def equals(other: Any) =
+        (this eq other.asInstanceOf[Object]) || {
+            other match
+                case other: Chunk[?] =>
+                    (this.isEmpty && other.isEmpty) ||
+                    (this.size == other.size && {
+                        val s = this.size
+                        val a = this.toIndexed
+                        val b = other.toIndexed
+                        @tailrec def loop(idx: Int = 0): Boolean =
+                            if idx < s then
+                                inline given CanEqual[Any, Any] = CanEqual.derived
+                                a(idx) == b(idx) && loop(idx + 1)
+                            else
+                                true
+                        loop()
+                    })
+                case _ =>
+                    false
+        }
+
+    override def hashCode(): Int =
+        if isEmpty then
+            1
+        else
+            val s = this.size
+            val a = this.toIndexed
+            @tailrec def loop(idx: Int = 0, acc: Int = 1): Int =
+                if idx < s then
+                    loop(idx + 1, 31 * acc + a(idx).hashCode())
+                else
+                    acc
+            loop()
+end Chunk
+
+object Chunk:
+    def empty[T]: Chunk[T] = Chunks.init[T]
+
+object Chunks:
+
+    import internal.*
+
+    sealed abstract class Indexed[T] extends Chunk[T]:
+
+        //////////////////
+        // O(1) methods //
+        //////////////////
+
+        def apply(i: Int): T
+
+        final def head: T =
+            if isEmpty then
+                throw new NoSuchElementException
+            else
+                apply(0)
+
+        final def tail: Indexed[T] =
+            if size <= 1 then cachedEmpty.asInstanceOf[Indexed[T]]
+            else
+                this match
+                    case Tail(chunk, offset, size) =>
+                        Tail(chunk, offset + 1, size - 1)
+                    case c =>
+                        Tail(c, 1, size - 1)
+    end Indexed
+
+    def init[T]: Chunk[T] =
+        cachedEmpty.asInstanceOf[Chunk[T]]
+
+    def init[T](values: T*): Chunk[T] =
+        initSeq(values)
+
+    def initSeq[T](values: Seq[T]): Chunk[T] =
+        if values.isEmpty then init[T]
+        else
+            values match
+                case seq: IndexedSeq[T] => FromSeq(seq)
+                case _                  => Compact(values.toArray(using ClassTag(classOf[Any])))
+
+    def fill[T](n: Int)(v: T): Chunk[T] =
+        if n <= 0 then Chunks.init
+        else
+            val array = (new Array[Any](n)).asInstanceOf[Array[T]]
+            @tailrec def loop(idx: Int = 0): Unit =
+                if idx < n then
+                    array(idx) = v
+                    loop(idx + 1)
+            loop()
+            Compact(array)
+    end fill
+
+    def collect[T: Flat, S](c: Chunk[T < S]): Chunk[T] < S =
+        c.map(identity)
+
+    private[kyo] object internal:
+
+        val cachedEmpty = Compact(new Array[Any](0))
+
+        case class FromSeq[T](
+            seq: IndexedSeq[T]
+        ) extends Indexed[T]:
+            def size = seq.size
+            def apply(i: Int) =
+                if i >= size || i < 0 then
+                    throw new NoSuchElementException
+                else
+                    seq(i)
+
+            override def toString = s"Chunk.Indexed(${seq.mkString(", ")})"
+        end FromSeq
+
+        case class Compact[T](
+            array: Array[T]
+        ) extends Indexed[T]:
+            def size = array.length
+            def apply(i: Int) =
+                if i >= size || i < 0 then
+                    throw new NoSuchElementException
+                else
+                    array(i)
+
+            override def toString = s"Chunk.Indexed(${array.mkString(", ")})"
+        end Compact
+
+        case class Tail[T](
+            chunk: Indexed[T],
+            offset: Int,
+            size: Int
+        ) extends Indexed[T]:
+            def apply(i: Int): T  = chunk(i + offset)
+            override def toString = s"Chunk(${toSeq.mkString(", ")})"
+        end Tail
+
+        case class Drop[T](
+            chunk: Chunk[T],
+            dropLeft: Int,
+            dropRight: Int,
+            size: Int
+        ) extends Chunk[T]:
+            override def toString = s"Chunk(${toSeq.mkString(", ")})"
+        end Drop
+
+        case class Append[T](
+            chunk: Chunk[T],
+            value: T,
+            size: Int
+        ) extends Chunk[T]:
+            override def toString = s"Chunk(${toSeq.mkString(", ")})"
+        end Append
+    end internal
+end Chunks

--- a/kyo-pure/shared/src/main/scala/kyo/core.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/core.scala
@@ -1,0 +1,214 @@
+package kyo
+
+import kyo.Locals.State
+import scala.annotation.tailrec
+
+object core:
+
+    import internal.*
+
+    type Id[T]    = T
+    type Const[T] = [U] =>> T
+
+    opaque type <[+T, -S] >: T = T | internal.Kyo[T, S]
+
+    trait Effect[+E]:
+        type Command[_]
+
+    extension [E <: Effect[E]](e: E)
+
+        inline def suspend[T](inline cmd: e.Command[T])(
+            using inline _tag: Tag[E]
+        ): T < E =
+            new Suspend[e.Command, T, T, E]:
+                def command = cmd
+                def tag     = _tag.asInstanceOf[Tag[Any]]
+                def apply(v: T, s: Safepoint[E], l: State) =
+                    v
+
+        inline def suspend[T, U, S](inline cmd: e.Command[T], inline f: T => U < S)(
+            using inline _tag: Tag[E]
+        ): U < (E & S) =
+            new Suspend[e.Command, T, U, S]:
+                def command = cmd
+                def tag     = _tag.asInstanceOf[Tag[Any]]
+                def apply(v: T, s: Safepoint[S], l: State) =
+                    f(v)
+    end extension
+
+    inline def eval[T, S, S2](v: T < S)(inline f: (Safepoint[S & S2], () => T < S) => T < (S & S2)): T < (S & S2) =
+        def evalLoop(s: Safepoint[S & S2], v: T < (S & S2)): T < (S & S2) =
+            v match
+                case kyo: Suspend[MX, Any, T, S] @unchecked =>
+                    new Continue[MX, Any, T, S & S2](kyo):
+                        def apply(v: Any, s: Safepoint[S & S2], l: Locals.State) =
+                            evalLoop(s, f(s, () => kyo(v, s.asInstanceOf[Safepoint[S]], l)))
+                        end apply
+                case v =>
+                    f(s, () => v.asInstanceOf[T])
+        evalLoop(Safepoint.noop, v)
+    end eval
+
+    inline def transform[T, S, U, S2](v: T < S)(inline k: T => (U < S2)): U < (S & S2) =
+        def transformLoop(v: T < S): U < (S & S2) =
+            v match
+                case kyo: Suspend[MX, Any, T, S] @unchecked =>
+                    new Continue[MX, Any, U, S & S2](kyo):
+                        def apply(v: Any, s: Safepoint[S & S2], l: Locals.State) =
+                            val r = kyo(v, s.asInstanceOf[Safepoint[S]], l)
+                            if s.preempt() then
+                                s.suspend(transformLoop(r))
+                            else
+                                transformLoop(r)
+                            end if
+                        end apply
+                case v =>
+                    k(v.asInstanceOf[T])
+        transformLoop(v)
+    end transform
+
+    extension [E <: Effect[E]](e: E)
+        inline def handle[State, Result[_], T, S, S2](
+            handler: ResultHandler[State, e.Command, E, Result, S]
+        )(
+            state: State,
+            value: T < (E & S2)
+        )(using inline tag: Tag[E], inline flat: Flat[T < (E & S)]): Result[T] < (S & S2) =
+            def _handleLoop(st: State, value: T < (E & S & S2)): Result[T] < (S & S2) =
+                handleLoop(st, value)
+            @tailrec def handleLoop(st: State, value: T < (E & S & S2)): Result[T] < (S & S2) =
+                value match
+                    case kyo: Suspend[e.Command, Any, T, S2] @unchecked
+                        if tag == kyo.tag && handler.accepts(st, kyo.command) =>
+                        handler.resume(st, kyo.command, kyo) match
+                            case r: handler.Resume[T, S & S2] @unchecked =>
+                                handleLoop(r.st, r.v)
+                            case kyo: Kyo[Result[T] | handler.Resume[T, S2], S & S2] @unchecked =>
+                                resultLoop(kyo)
+                            case r =>
+                                r.asInstanceOf[Result[T]]
+                        end match
+                    case kyo: Suspend[MX, Any, T, E & S & S2] @unchecked =>
+                        new Continue[MX, Any, Result[T], S & S2](kyo):
+                            def apply(v: Any, s: Safepoint[S & S2], l: Locals.State) =
+                                _handleLoop(st, kyo(v, s, l))
+                    case v =>
+                        handler.done(st, v.asInstanceOf[T])
+            def resultLoop(v: (Result[T] | handler.Resume[T, S2]) < (S & S2)): Result[T] < (S & S2) =
+                v match
+                    case r: handler.Resume[T, S & S2] @unchecked =>
+                        _handleLoop(r.st, r.v)
+                    case kyo: Suspend[MX, Any, Result[T] | handler.Resume[T, S2], S & S2] @unchecked =>
+                        new Continue[MX, Any, Result[T], S & S2](kyo):
+                            def apply(
+                                v: Any,
+                                s: Safepoint[S & S2],
+                                l: Locals.State
+                            ) =
+                                resultLoop(kyo(v, s, l))
+                    case r =>
+                        r.asInstanceOf[Result[T]]
+            handleLoop(state, value)
+        end handle
+    end extension
+
+    abstract class ResultHandler[State, Command[_], E <: Effect[E], Result[_], S]:
+
+        case class Resume[U, S2](st: State, v: U < (E & S & S2))
+
+        def accepts[T](st: State, command: Command[T]): Boolean =
+            true
+
+        def done[T](st: State, v: T): Result[T] < S
+
+        def resume[T, U: Flat, S2](
+            st: State,
+            command: Command[T],
+            k: T => U < (E & S2)
+        ): (Result[U] | Resume[U, S2]) < (S & S2)
+
+    end ResultHandler
+
+    abstract class Handler[Command[_], E <: Effect[E], S]
+        extends ResultHandler[Unit, Command, E, Id, S]:
+        inline def done[T](st: Unit, v: T) =
+            done(v)
+        inline def resume[T, U: Flat, S2](
+            st: Unit,
+            command: Command[T],
+            k: T => U < (E & S2)
+        ): (U | Resume[U, S2]) < (S & S2) =
+            resume(command, k)
+
+        def done[T](v: T): T < S = v
+
+        def resume[T, U: Flat, S2](
+            command: Command[T],
+            k: T => U < (E & S2)
+        ): (U | Resume[U, S2]) < (S & S2)
+    end Handler
+
+    trait Safepoint[-E]:
+        def preempt(): Boolean
+        def suspend[T, S](v: => T < S): T < (E & S)
+
+    object Safepoint:
+        private val _noop = new Safepoint[?]:
+            def preempt()                  = false
+            def suspend[T, S](v: => T < S) = v
+        inline def noop[S]: Safepoint[S] =
+            _noop.asInstanceOf[Safepoint[S]]
+    end Safepoint
+
+    private[kyo] object internal:
+
+        type MX[T] = Any
+        type EX <: Effect[EX]
+
+        abstract class DeepHandler[Command[_], E, S]:
+            def done[T: Flat](v: T): Command[T]
+            def resume[T, U: Flat](command: Command[T], k: T => Command[U] < S): Command[U] < S
+
+        def deepHandle[Command[_], E <: Effect[E], S, T](
+            handler: DeepHandler[Command, E, S],
+            v: T < E
+        )(using
+            tag: Tag[E],
+            flat: Flat[T < E]
+        ): Command[T] < S =
+            def deepHandleLoop(v: T < (E & S)): Command[T] < S =
+                v match
+                    case kyo: Suspend[Command, Any, T, E] @unchecked =>
+                        bug.checkTag(kyo.tag, tag)
+                        handler.resume(
+                            kyo.command,
+                            (v: Any) => deepHandleLoop(kyo(v))
+                        )
+                    case _ =>
+                        handler.done(v.asInstanceOf[T])
+            if isNull(v) then
+                throw new NullPointerException
+            deepHandleLoop(v)
+        end deepHandle
+
+        sealed abstract class Kyo[+T, -S]
+
+        abstract class Suspend[Command[_], T, U, S] extends Kyo[U, S]
+            with Function1[T, U < S]:
+            def command: Command[T]
+            def tag: Tag[Any]
+            inline def apply(v: T) = apply(v, Safepoint.noop, Locals.State.empty)
+            def apply(v: T, s: Safepoint[S], l: Locals.State): U < S
+        end Suspend
+
+        abstract class Continue[Command[_], T, U, S](
+            s: Suspend[Command, T, ?, ?]
+        ) extends Suspend[Command, T, U, S]:
+            val command = s.command
+            val tag     = s.tag
+        end Continue
+
+        implicit inline def fromKyo[T, S](v: Kyo[T, S]): T < S =
+            v.asInstanceOf[T < S]
+    end internal
+end core

--- a/kyo-pure/shared/src/main/scala/kyo/defers.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/defers.scala
@@ -1,0 +1,25 @@
+package kyo
+
+import kyo.core.*
+import kyo.core.internal.*
+
+abstract private[kyo] class Defer[T, S] extends Suspend[Const[Unit], Unit, T, S & Defers]:
+    final def command = ()
+    final def tag     = Tag[Defers].asInstanceOf[Tag[Any]]
+
+class Defers extends Effect[Defers]:
+    type Command[T] = Unit
+
+object Defers extends Defers:
+
+    inline def apply[T, S](inline v: => T < S): T < (S & Defers) =
+        new Defer[T, S]:
+            def apply(ign: Unit, s: Safepoint[S & Defers], l: Locals.State): T < S = v
+
+    def run[T: Flat, S](v: T < (Defers & S)): T < S =
+        this.handle(handler)((), v)
+
+    private val handler = new Handler[Const[Unit], Defers, Any]:
+        def resume[T, U: Flat, S2](command: Command[T], k: T => U < (Defers & S2)) =
+            Resume((), k(().asInstanceOf[T]))
+end Defers

--- a/kyo-pure/shared/src/main/scala/kyo/envs.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/envs.scala
@@ -1,0 +1,66 @@
+package kyo
+
+import kyo.core.*
+
+class Envs[+V] extends Effect[Envs[V]]:
+    type Command[T] = Unit
+
+object Envs:
+    private case object envs extends Envs[Any]
+    private def envs[V]: Envs[V] = envs.asInstanceOf[Envs[V]]
+
+    def get[V](using Tag[Envs[V]]): V < Envs[V] =
+        envs[V].suspend[V](())
+
+    class UseDsl[V]:
+        inline def apply[T, S](inline f: V => T < S)(
+            using inline tag: Tag[Envs[V]]
+        ): T < (Envs[V] & S) =
+            envs[V].suspend[V, T, S]((), f)
+    end UseDsl
+
+    def use[V >: Nothing]: UseDsl[V] =
+        new UseDsl[V]
+
+    class RunDsl[V]:
+        def apply[T: Flat, S, VS, VR](env: V)(value: T < (Envs[VS] & S))(
+            using
+            HasEnvs[V, VS] { type Remainder = VR },
+            Tag[Envs[V]]
+        ): T < (S & VR) =
+            envs[V].handle(handler[V])(env, value).asInstanceOf[T < (S & VR)]
+    end RunDsl
+
+    def run[V >: Nothing]: RunDsl[V] =
+        new RunDsl[V]
+
+    private def handler[V]: ResultHandler[V, Const[Unit], Envs[V], Id, Any] =
+        cachedHandler.asInstanceOf[ResultHandler[V, Const[Unit], Envs[V], Id, Any]]
+
+    private val cachedHandler =
+        new ResultHandler[Any, Const[Unit], Envs[Any], Id, Any]:
+            def done[T](st: Any, v: T) = v
+            def resume[T, U: Flat, S2](st: Any, command: Unit, k: T => U < (Envs[Any] & S2)) =
+                Resume(st, k(st.asInstanceOf[T]))
+
+    /** An effect `Envs[VS]` includes a dependency on `V`, and once `V` has been handled, `Envs[VS]` should be replaced by `Out`
+      *
+      * @tparam V
+      *   the dependency included in `VS`
+      * @tparam VS
+      *   all of the `Envs` dependencies represented by type intersection
+      */
+    sealed trait HasEnvs[V, VS]:
+        /** Remaining effect type, once the `V` dependency has been provided
+          */
+        type Remainder
+    end HasEnvs
+
+    trait LowPriorityHasEnvs:
+        given hasEnvs[V, VR]: HasEnvs[V, V & VR] with
+            type Remainder = Envs[VR]
+
+    object HasEnvs extends LowPriorityHasEnvs:
+        given isEnvs[V]: HasEnvs[V, V] with
+            type Remainder = Any
+end Envs

--- a/kyo-pure/shared/src/main/scala/kyo/internal/FileImplicits.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/internal/FileImplicits.scala
@@ -1,0 +1,20 @@
+package kyo.internal
+
+import scala.quoted.*
+
+opaque type Position <: String = String
+object Position:
+    def apply(value: String): Position = value
+    inline given derive: Position      = ${ Macros.fileNameWithLine }
+end Position
+
+object Macros:
+    def fileNameWithLine(using Quotes): Expr[Position] =
+        val expansion = quotes.reflect.Position.ofMacroExpansion
+        val name      = expansion.sourceFile.name
+        val line      = expansion.startLine + 1
+
+        Expr(Position(s"$name:$line"))
+    end fileNameWithLine
+
+end Macros

--- a/kyo-pure/shared/src/main/scala/kyo/internal/FlatImplicits.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/internal/FlatImplicits.scala
@@ -1,0 +1,90 @@
+package kyo.internal
+
+import kyo.*
+import scala.quoted.*
+
+trait FlatImplicits0:
+    inline given infer[T]: Flat[T] =
+        ${ FlatImplicits.inferMacro[T] }
+
+trait FlatImplicits1 extends FlatImplicits0:
+    given product[T <: Product]: Flat[T] =
+        Flat.unsafe.bypass[T]
+
+trait FlatImplicits extends FlatImplicits1:
+    given anyVal[T <: AnyVal]: Flat[T] =
+        Flat.unsafe.bypass[T]
+
+object FlatImplicits:
+
+    def inferMacro[T: Type](using Quotes): Expr[Flat[T]] =
+        import quotes.reflect.*
+
+        val t = TypeRepr.of[T].dealias
+
+        object Kyo:
+            def unapply(tpe: TypeRepr): Option[(TypeRepr, TypeRepr)] =
+                tpe match
+                    case AppliedType(_, List(t, u))
+                        if (tpe.typeSymbol eq TypeRepr.of[<].typeSymbol) =>
+                        Some((t.dealias, u.dealias))
+                    case _ => None
+        end Kyo
+
+        def code(str: String) =
+            s"${scala.Console.YELLOW}'$str'${scala.Console.RESET}"
+
+        def print(t: TypeRepr): String =
+            t match
+                case Kyo(t, s) =>
+                    s"${print(t)} < ${print(s)}"
+                case _ => t.show
+
+        def fail(msg: String) =
+            report.errorAndAbort(s"Method doesn't accept nested Kyo computations.\n$msg")
+
+        def canDerive(t: TypeRepr): Boolean =
+            t.dealias match
+                case OrType(left, right) =>
+                    canDerive(left) && canDerive(right)
+                case tpe =>
+                    tpe.asType match
+                        case '[nt] => Expr.summon[Flat[nt]] match
+                                case Some(_) => true
+                                case None    => false
+
+        def isAny(t: TypeRepr) =
+            t.typeSymbol eq TypeRepr.of[Any].typeSymbol
+
+        def isConcrete(t: TypeRepr) =
+            t.typeSymbol.isClassDef
+
+        def check(t: TypeRepr): Expr[Flat[T]] =
+            if isAny(t) || !isConcrete(t.dealias) then
+                canDerive(t) match
+                    case true =>
+                        '{ Flat.unsafe.bypass[T] }
+                    case false =>
+                        fail(
+                            s"Cannot prove ${code(print(t))} isn't nested. Provide an implicit evidence ${code(s"kyo.Flat[${print(t)}]")}."
+                        )
+            else
+                '{ Flat.unsafe.bypass[T] }
+
+        t match
+            case Kyo(Kyo(nt, s1), s2) =>
+                val mismatch =
+                    if print(s1) != print(s2) then
+                        s"\nPossible pending effects mismatch: Expected ${code(print(s2))}, found ${code(print(s1))}."
+                    else
+                        ""
+                fail(
+                    s"Detected: ${code(print(t))}. Consider using ${code("flatten")} to resolve. " + mismatch
+                )
+            case Kyo(nt, s) =>
+                check(nt)
+            case t =>
+                check(t)
+        end match
+    end inferMacro
+end FlatImplicits

--- a/kyo-pure/shared/src/main/scala/kyo/locals.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/locals.scala
@@ -1,0 +1,82 @@
+package kyo
+
+import core.*
+import core.internal.*
+
+abstract class Local[T]:
+
+    import Locals.*
+
+    def default: T
+
+    val get: T < Defers =
+        new Defer[T, Any]:
+            def apply(v: Unit, s: Safepoint[Defers], l: State) =
+                get(l)
+
+    def let[U, S](f: T)(v: U < S): U < (S & Defers) =
+        def letLoop(f: T, v: U < S): U < S =
+            v match
+                case kyo: Suspend[MX, Any, U, S] @unchecked =>
+                    new Continue[MX, Any, U, S](kyo):
+                        def apply(v2: Any < S, s: Safepoint[S], l: Locals.State) =
+                            letLoop(f, kyo(v2, s, l.updated(Local.this, f)))
+                case _ =>
+                    v
+        letLoop(f, v)
+    end let
+
+    inline def use[U, S](inline f: T => U < S): U < (S & Defers) =
+        new Defer[U, S]:
+            def apply(v: Unit, s: Safepoint[S & Defers], l: State) =
+                f(get(l))
+
+    def update[U, S](f: T => T)(v: U < S): U < (S & Defers) =
+        def updateLoop(f: T => T, v: U < S): U < S =
+            v match
+                case kyo: Suspend[MX, Any, U, S] @unchecked =>
+                    new Continue[MX, Any, U, S](kyo):
+                        def apply(v2: Any < S, s: Safepoint[S], l: Locals.State) =
+                            updateLoop(f, kyo(v2, s, l.updated(Local.this, f(get(l)))))
+                case _ =>
+                    v
+        updateLoop(f, v)
+    end update
+
+    private def get(l: Locals.State) =
+        l.getOrElse(Local.this, default).asInstanceOf[T]
+end Local
+
+object Locals:
+
+    type State = Map[Local[?], Any]
+
+    object State:
+        inline def empty: State = Map.empty
+
+    def init[T](defaultValue: => T): Local[T] =
+        new Local[T]:
+            def default = defaultValue
+
+    val save: State < Defers =
+        new Defer[State, Any]:
+            def apply(v: Unit, s: Safepoint[Defers], l: Locals.State) =
+                l
+
+    inline def save[U, S](inline f: State => U < S): U < (Defers & S) =
+        new Defer[U, S]:
+            def apply(v: Unit, s: Safepoint[Defers & S], l: Locals.State) =
+                f(l)
+
+    def restore[T, S](st: State)(f: T < S): T < (Defers & S) =
+        def loop(f: T < S): T < S =
+            f match
+                case kyo: Suspend[MX, Any, T, S] @unchecked =>
+                    new Continue[MX, Any, T, S](kyo):
+                        def apply(v2: Any < S, s: Safepoint[S], l: Locals.State) =
+                            loop(kyo(v2, s, l ++ st))
+                case _ =>
+                    f
+        loop(f)
+    end restore
+end Locals

--- a/kyo-pure/shared/src/main/scala/kyo/loops.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/loops.scala
@@ -1,0 +1,223 @@
+package kyo
+
+import kyo.core.internal.Kyo
+import scala.annotation.tailrec
+import scala.util.NotGiven
+
+object Loops:
+
+    private case class Continue[Input](input: Input)
+    private case class Continue2[Input1, Input2](input1: Input1, input2: Input2)
+    private case class Continue3[Input1, Input2, Input3](input1: Input1, input2: Input2, input3: Input3)
+
+    opaque type Result[Input, Output]                   = Output | Continue[Input]
+    opaque type Result2[Input1, Input2, Output]         = Output | Continue2[Input1, Input2]
+    opaque type Result3[Input1, Input2, Input3, Output] = Output | Continue3[Input1, Input2, Input3]
+
+    private val _continueUnit = Continue[Unit](())
+
+    inline def continue[T]: Result[Unit, T] = _continueUnit
+    inline def done[T]: Result[T, Unit]     = ()
+
+    inline def done[Input, Output](v: Output): Result[Input, Output]       = v
+    inline def continue[Input, Output, S](v: Input): Result[Input, Output] = Continue(v)
+
+    inline def done[Input1, Input2, Output](v: Output): Result2[Input1, Input2, Output] = v
+    inline def continue[Input1, Input2, Output](
+        v1: Input1,
+        v2: Input2
+    ): Result2[Input1, Input2, Output] = Continue2(v1, v2)
+
+    inline def done[Input1, Input2, Input3, Output](v: Output): Result3[Input1, Input2, Input3, Output] = v
+    inline def continue[Input1, Input2, Input3, Output](
+        v1: Input1,
+        v2: Input2,
+        v3: Input3
+    ): Result3[Input1, Input2, Input3, Output] = Continue3(v1, v2, v3)
+
+    inline def transform[Input, Output: Flat, S](
+        input: Input
+    )(
+        inline run: Input => Result[Input, Output] < S
+    ): Output < S =
+        def _loop(input: Input): Output < S =
+            loop(input)
+        @tailrec def loop(input: Input): Output < S =
+            run(input) match
+                case next: Continue[Input] @unchecked =>
+                    loop(next.input)
+                case kyo: Kyo[Output | Continue[Input], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue[Input] =>
+                            _loop(next.input)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(input)
+    end transform
+
+    inline def transform[Input1, Input2, Output: Flat, S](
+        input1: Input1,
+        input2: Input2
+    )(
+        inline run: (Input1, Input2) => Result2[Input1, Input2, Output] < S
+    ): Output < S =
+        def _loop(input1: Input1, input2: Input2): Output < S =
+            loop(input1, input2)
+        @tailrec def loop(input1: Input1, input2: Input2): Output < S =
+            run(input1, input2) match
+                case next: Continue2[Input1, Input2] @unchecked =>
+                    loop(next.input1, next.input2)
+                case kyo: Kyo[Output | Continue2[Input1, Input2], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue2[Input1, Input2] @unchecked =>
+                            _loop(next.input1, next.input2)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(input1, input2)
+    end transform
+
+    inline def transform[Input1, Input2, Input3, Output: Flat, S](
+        input1: Input1,
+        input2: Input2,
+        input3: Input3
+    )(
+        inline run: (Input1, Input2, Input3) => Result3[Input1, Input2, Input3, Output] < S
+    ): Output < S =
+        def _loop(input1: Input1, input2: Input2, input3: Input3): Output < S =
+            loop(input1, input2, input3)
+        @tailrec def loop(input1: Input1, input2: Input2, input3: Input3): Output < S =
+            run(input1, input2, input3) match
+                case next: Continue3[Input1, Input2, Input3] @unchecked =>
+                    loop(next.input1, next.input2, next.input3)
+                case kyo: Kyo[Output | Continue3[Input1, Input2, Input3], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue3[Input1, Input2, Input3] =>
+                            _loop(next.input1, next.input2, next.input3)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(input1, input2, input3)
+    end transform
+
+    inline def indexed[Output: Flat, S](
+        inline run: Int => Result[Unit, Output] < S
+    ): Output < S =
+        def _loop(idx: Int): Output < S =
+            loop(idx)
+        @tailrec def loop(idx: Int): Output < S =
+            run(idx) match
+                case next: Continue[Unit] @unchecked =>
+                    loop(idx + 1)
+                case kyo: Kyo[Output | Continue[Unit], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue[Unit] @unchecked =>
+                            _loop(idx + 1)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(0)
+    end indexed
+
+    inline def indexed[Input, Output: Flat, S](
+        input: Input
+    )(
+        inline run: (Int, Input) => Result[Input, Output] < S
+    ): Output < S =
+        def _loop(idx: Int, input: Input): Output < S =
+            loop(idx, input)
+        @tailrec def loop(idx: Int, input: Input): Output < S =
+            run(idx, input) match
+                case next: Continue[Input] @unchecked =>
+                    loop(idx + 1, next.input)
+                case kyo: Kyo[Output | Continue[Input], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue[Input] @unchecked =>
+                            _loop(idx + 1, next.input)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(0, input)
+    end indexed
+
+    inline def indexed[Input1, Input2, Output: Flat, S](
+        input1: Input1,
+        input2: Input2
+    )(
+        inline run: (Int, Input1, Input2) => Result2[Input1, Input2, Output] < S
+    ): Output < S =
+        def _loop(idx: Int, input1: Input1, input2: Input2): Output < S =
+            loop(idx, input1, input2)
+        @tailrec def loop(idx: Int, input1: Input1, input2: Input2): Output < S =
+            run(idx, input1, input2) match
+                case next: Continue2[Input1, Input2] @unchecked =>
+                    loop(idx + 1, next.input1, next.input2)
+                case kyo: Kyo[Output | Continue2[Input1, Input2], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue2[Input1, Input2] =>
+                            _loop(idx + 1, next.input1, next.input2)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(0, input1, input2)
+    end indexed
+
+    inline def indexed[Input1, Input2, Input3, Output: Flat, S](
+        input1: Input1,
+        input2: Input2,
+        input3: Input3
+    )(
+        inline run: (Int, Input1, Input2, Input3) => Result3[Input1, Input2, Input3, Output] < S
+    ): Output < S =
+        def _loop(idx: Int, input1: Input1, input2: Input2, input3: Input3): Output < S =
+            loop(idx, input1, input2, input3)
+        @tailrec def loop(idx: Int, input1: Input1, input2: Input2, input3: Input3): Output < S =
+            run(idx, input1, input2, input3) match
+                case next: Continue3[Input1, Input2, Input3] @unchecked =>
+                    loop(idx + 1, next.input1, next.input2, next.input3)
+                case kyo: Kyo[Output | Continue3[Input1, Input2, Input3], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue3[Input1, Input2, Input3] =>
+                            _loop(idx + 1, next.input1, next.input2, next.input3)
+                        case res =>
+                            res.asInstanceOf[Output]
+                    }
+                case res =>
+                    res.asInstanceOf[Output]
+        loop(0, input1, input2, input3)
+    end indexed
+
+    inline def foreach[S](
+        inline run: => Result[Unit, Unit] < S
+    ): Unit < S =
+        def _loop(): Unit < S =
+            loop()
+        @tailrec def loop(): Unit < S =
+            run match
+                case next: Continue[Unit] @unchecked =>
+                    loop()
+                case kyo: Kyo[Unit | Continue[Unit], S] @unchecked =>
+                    kyo.map {
+                        case next: Continue[Unit] =>
+                            _loop()
+                        case res =>
+                            ()
+                    }
+                case res =>
+                    ()
+        loop()
+    end foreach
+end Loops

--- a/kyo-pure/shared/src/main/scala/kyo/options.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/options.scala
@@ -1,0 +1,43 @@
+package kyo
+
+type Options = Aborts[None.type]
+
+object Options:
+
+    val empty: Nothing < Options =
+        Aborts.fail(None)
+
+    def apply[T](v: T): T < Options =
+        if isNull(v) then
+            empty
+        else
+            v
+
+    def get[T, S](v: Option[T] < S): T < (Options & S) =
+        v.map {
+            case Some(v) => v
+            case None    => empty
+        }
+
+    def getOrElse[T, S1, S2](v: Option[T] < S1, default: => T < S2): T < (S1 & S2) =
+        v.map {
+            case None    => default
+            case Some(v) => v
+        }
+
+    def run[T: Flat, S](v: T < (Options & S)): Option[T] < S =
+        Aborts.run(v).map {
+            case Left(e)  => None
+            case Right(v) => Some(v)
+        }
+
+    def orElse[T: Flat, S](l: (T < (Options & S))*): T < (Options & S) =
+        l.toList match
+            case Nil => Options.empty
+            case h :: t =>
+                run[T, S](h).map {
+                    case None => orElse[T, S](t*)
+                    case v    => get(v)
+                }
+
+end Options

--- a/kyo-pure/shared/src/main/scala/kyo/package.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/package.scala
@@ -1,0 +1,96 @@
+import scala.util.NotGiven
+
+package object kyo:
+
+    export core.<
+
+    extension [T, S](v: T < S)(using NotGiven[Any => S])
+
+        inline def flatMap[U, S2](inline f: T => U < S2): U < (S & S2) =
+            if isNull(v) then
+                throw new NullPointerException
+            kyo.core.transform(v)(f)
+        end flatMap
+
+        inline def map[U, S2](inline f: T => U < S2): U < (S & S2) =
+            flatMap(f)
+
+        def unit: Unit < S =
+            map(_ => ())
+
+        def withFilter(p: T => Boolean): T < S =
+            map(v => if !p(v) then throw new MatchError(v) else v)
+
+        def flatten[U, S2](using ev: T => U < S2): U < (S & S2) =
+            flatMap(ev)
+
+        inline def andThen[U, S2](inline f: => U < S2)(using ev: T => Unit): U < (S & S2) =
+            flatMap(_ => f)
+
+        def repeat(i: Int)(using ev: T => Unit): Unit < S =
+            if i <= 0 then () else andThen(repeat(i - 1))
+
+        private[kyo] def isPure: Boolean =
+            !v.isInstanceOf[core.internal.Kyo[?, ?]]
+
+    end extension
+
+    extension [T](v: T < Any)(using Flat[T < Any])
+        def pure: T =
+            v match
+                case kyo: kyo.core.internal.Suspend[?, ?, ?, ?] =>
+                    bug.failTag(kyo.tag)
+                case v =>
+                    v.asInstanceOf[T]
+    end extension
+
+    def zip[T1, T2, S](v1: T1 < S, v2: T2 < S): (T1, T2) < S =
+        v1.map(t1 => v2.map(t2 => (t1, t2)))
+
+    def zip[T1, T2, T3, S](v1: T1 < S, v2: T2 < S, v3: T3 < S): (T1, T2, T3) < S =
+        v1.map(t1 => v2.map(t2 => v3.map(t3 => (t1, t2, t3))))
+
+    def zip[T1, T2, T3, T4, S](
+        v1: T1 < S,
+        v2: T2 < S,
+        v3: T3 < S,
+        v4: T4 < S
+    ): (T1, T2, T3, T4) < S =
+        v1.map(t1 => v2.map(t2 => v3.map(t3 => v4.map(t4 => (t1, t2, t3, t4)))))
+
+    inline def discard[T](v: T): Unit =
+        val _ = v
+        ()
+
+    private[kyo] inline def isNull[T](v: T): Boolean =
+        v.asInstanceOf[AnyRef] == null
+
+    private[kyo] object bug:
+
+        case class KyoBugException(msg: String) extends Exception(msg)
+
+        inline def failTag[T, U](
+            inline actual: Tag[U]
+        ): Nothing =
+            bug(s"Unexpected effect '${actual.parse}' found in 'pure'.")
+
+        inline def failTag[T, U](
+            inline actual: Tag[U],
+            inline expected: Tag[T]
+        ): Nothing =
+            bug(s"Unexpected effect '${actual.parse}' found while handling '${expected.parse}'.")
+
+        inline def checkTag[T, U](
+            inline actual: Tag[U],
+            inline expected: Tag[T]
+        ): Unit =
+            if actual != expected then
+                failTag(actual, expected)
+
+        def when(cond: Boolean)(msg: String): Unit =
+            if cond then bug(msg)
+
+        def apply(msg: String): Nothing =
+            throw KyoBugException(msg + " Please file a ticket.")
+    end bug
+end kyo

--- a/kyo-pure/shared/src/main/scala/kyo/seqs.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/seqs.scala
@@ -1,0 +1,128 @@
+package kyo
+
+import kyo.core.*
+
+object Seqs:
+
+    def map[T, U, S, S2](seq: Seq[T])(f: T => U < S2): Seq[U] < (S & S2) =
+        seq.size match
+            case 0 => Seq.empty
+            case 1 => f(seq(0)).map(Seq(_))
+            case size =>
+                seq match
+                    case seq: IndexedSeq[T] =>
+                        Loops.indexed(Chunks.init[U]) { (idx, acc) =>
+                            if idx == size then Loops.done(acc.toSeq)
+                            else f(seq(idx)).map(u => Loops.continue(acc.append(u)))
+                        }
+                    case seq: List[T] =>
+                        Loops.transform(seq, Chunks.init[U]) { (seq, acc) =>
+                            seq match
+                                case Nil          => Loops.done(acc.toSeq)
+                                case head :: tail => f(head).map(u => Loops.continue(tail, acc.append(u)))
+                        }
+                    case seq =>
+                        Chunks.initSeq(seq).map(f).map(_.toSeq)
+                end match
+
+    def foreach[T, U, S](seq: Seq[T])(f: T => Unit < S): Unit < S =
+        seq.size match
+            case 0 =>
+            case 1 => f(seq(0))
+            case size =>
+                seq match
+                    case seq: IndexedSeq[T] =>
+                        Loops.indexed { idx =>
+                            if idx == size then Loops.done
+                            else f(seq(idx)).andThen(Loops.continue)
+                        }
+                    case seq: List[T] =>
+                        Loops.transform(seq) {
+                            case Nil          => Loops.done
+                            case head :: tail => f(head).andThen(Loops.continue(tail))
+                        }
+                    case seq =>
+                        Chunks.initSeq(seq).foreach(f)
+                end match
+        end match
+    end foreach
+
+    def foldLeft[T, U: Flat, S](seq: Seq[T])(acc: U)(f: (U, T) => U < S): U < S =
+        seq.size match
+            case 0 => acc
+            case 1 => f(acc, seq(0))
+            case size =>
+                seq match
+                    case seq: IndexedSeq[T] =>
+                        Loops.indexed(acc) { (idx, acc) =>
+                            if idx == size then Loops.done(acc)
+                            else f(acc, seq(idx)).map(Loops.continue)
+                        }
+                    case seq: List[T] =>
+                        Loops.transform(seq, acc) { (seq, acc) =>
+                            seq match
+                                case Nil          => Loops.done(acc)
+                                case head :: tail => f(acc, head).map(Loops.continue(tail, _))
+                        }
+                    case seq =>
+                        Chunks.initSeq(seq).foldLeft(acc)(f)
+                end match
+        end match
+    end foldLeft
+
+    def collect[T, S](seq: Seq[T < S]): Seq[T] < S =
+        seq.size match
+            case 0 => Seq.empty
+            case 1 => seq(0).map(Seq(_))
+            case size =>
+                seq match
+                    case seq: IndexedSeq[T < S] =>
+                        Loops.indexed(Chunks.init[T]) { (idx, acc) =>
+                            if idx == size then Loops.done(acc.toSeq)
+                            else seq(idx).map(u => Loops.continue(acc.append(u)))
+                        }
+                    case seq: List[T < S] =>
+                        Loops.transform(seq, Chunks.init[T]) { (seq, acc) =>
+                            seq match
+                                case Nil          => Loops.done(acc.toSeq)
+                                case head :: tail => head.map(u => Loops.continue(tail, acc.append(u)))
+                        }
+                    case seq =>
+                        Chunks.initSeq(seq).map(identity).map(_.toSeq)
+                end match
+
+    def collectUnit[T, S](seq: Seq[Unit < S]): Unit < S =
+        seq.size match
+            case 0 =>
+            case 1 => seq(0)
+            case size =>
+                seq match
+                    case seq: IndexedSeq[Unit < S] =>
+                        Loops.indexed { idx =>
+                            if idx == size then Loops.done
+                            else seq(idx).map(u => Loops.continue)
+                        }
+                    case seq: List[Unit < S] =>
+                        Loops.transform(seq) { seq =>
+                            seq match
+                                case Nil          => Loops.done
+                                case head :: tail => head.andThen(Loops.continue(tail))
+                        }
+                    case seq =>
+                        Chunks.initSeq(seq).foreach(identity)
+                end match
+    end collectUnit
+
+    def fill[T, S](n: Int)(v: => T < S): Seq[T] < S =
+        Loops.indexed(Chunks.init[T]) { (idx, acc) =>
+            if idx == n then Loops.done(acc.toSeq)
+            else v.map(t => Loops.continue(acc.append(t)))
+        }
+
+    def repeat[S](n: Int)(v: => Unit < S): Unit < S =
+        Loops.indexed {
+            case `n` => Loops.done
+            case _ =>
+                v.andThen(Loops.continue)
+        }
+end Seqs

--- a/kyo-pure/shared/src/main/scala/kyo/streams.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/streams.scala
@@ -1,0 +1,265 @@
+package kyo
+
+import kyo.*
+import kyo.core.*
+import kyo.core.internal.*
+import scala.annotation.tailrec
+
+opaque type Stream[+T, V, -S] = T < (Streams[V] & S)
+
+object Stream:
+
+    import internal.*
+
+    class Done
+    object Done extends Done
+
+    extension [T: Flat, V: Flat, S](s: Stream[T, V, S])(using tag: Tag[Streams[V]])
+        def get: T < (Streams[V] & S) =
+            s
+
+        def take(n: Int): Stream[T, V, S] =
+            if n <= 0 then
+                runDiscard
+            else
+                val handler =
+                    new ResultHandler[Int, Const[Chunk[V]], Streams[V], Id, Streams[V]]:
+                        def done[T](st: Int, v: T) = v
+                        def resume[T, U: Flat, S2](
+                            st: Int,
+                            command: Chunk[V],
+                            k: T => U < (Streams[V] & S2)
+                        ) =
+                            if st == 0 then
+                                Resume(0, k(().asInstanceOf[T]))
+                            else
+                                val t: Chunk[V] = command.take(st)
+                                Streams.emitChunkAndThen(t) {
+                                    Resume(st - t.size, k(().asInstanceOf[T]))
+                                }
+                Streams[V].handle(handler)(n, s)
+        end take
+
+        def drop(n: Int): Stream[T, V, S] =
+            if n <= 0 then
+                s
+            else
+                val handler =
+                    new ResultHandler[Int, Const[Chunk[V]], Streams[V], Id, Streams[V]]:
+                        def done[T](st: Int, v: T) = v
+                        def resume[T, U: Flat, S2](
+                            st: Int,
+                            command: Chunk[V],
+                            k: T => U < (Streams[V] & S2)
+                        ) =
+                            if st == 0 then
+                                Streams.emitChunkAndThen(command) {
+                                    k(().asInstanceOf[T])
+                                }
+                            else
+                                Streams.emitChunkAndThen(command.dropLeft(st)) {
+                                    Resume(st - Math.min(command.size, st), k(().asInstanceOf[T]))
+                                }
+                Streams[V].handle(handler)(n, s)
+        end drop
+
+        def takeWhile[S2](f: V => Boolean < S2): Stream[T, V, S & S2] =
+            val handler =
+                new ResultHandler[Boolean, Const[Chunk[V]], Streams[V], Id, Streams[V] & S & S2]:
+                    def done[T](st: Boolean, v: T) = v
+                    def resume[T, U: Flat, S3](
+                        st: Boolean,
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S3)
+                    ) =
+                        if st then
+                            command.takeWhile(f).map { c =>
+                                Streams.emitChunkAndThen(c) {
+                                    Resume(command.size == c.size, k(().asInstanceOf[T]))
+                                }
+                            }
+                        else
+                            Resume(false, k(().asInstanceOf[T]))
+            Streams[V].handle(handler)(true, s)
+        end takeWhile
+
+        def dropWhile[S2](f: V => Boolean < S2): Stream[T, V, S & S2] =
+            val handler =
+                new Handler[Const[Chunk[V]], Streams[V], Streams[V] & S & S2]:
+                    def resume[T, U: Flat, S3](
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S3)
+                    ) =
+                        command.dropWhile(f).map { c =>
+                            Streams.emitChunkAndThen(c) {
+                                if c.isEmpty || command.isEmpty then
+                                    Resume((), k(().asInstanceOf[T]))
+                                else
+                                    k(().asInstanceOf[T])
+                            }
+                        }
+            Streams[V].handle(handler)((), s)
+        end dropWhile
+
+        def filter[S2](f: V => Boolean < S2): Stream[T, V, S & S2] =
+            val handler = new Handler[Const[Chunk[V]], Streams[V], Streams[V] & S & S2]:
+                def resume[T, U: Flat, S3](
+                    command: Chunk[V],
+                    k: T => U < (Streams[V] & S3)
+                ) =
+                    command.filter(f).map { c =>
+                        Streams.emitChunkAndThen(c) {
+                            Resume((), k(().asInstanceOf[T]))
+                        }
+                    }
+                end resume
+            Streams[V].handle(handler)((), s)
+        end filter
+
+        def changes: Stream[T, V, S] =
+            val handler =
+                new ResultHandler[V | Null, Const[Chunk[V]], Streams[V], Id, Streams[V] & S]:
+                    def done[T](st: V | Null, v: T) = v
+                    def resume[T, U: Flat, S3](
+                        st: V | Null,
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S3)
+                    ): (U | Resume[U, S3]) < (Streams[V] & S & S3) =
+                        val c = command.changes(st)
+                        Streams.emitChunkAndThen(c) {
+                            val nst = if c.isEmpty then st else c.last
+                            Resume(nst, k(().asInstanceOf[T]))
+                        }
+                    end resume
+            Streams[V].handle(handler)(null, s)
+        end changes
+
+        def collect[S2, V2: Flat](
+            pf: PartialFunction[V, Unit < (Streams[V2] & S2)]
+        )(using tag2: Tag[Streams[V2]]): Stream[T, V2, S & S2] =
+            val handler =
+                new Handler[Const[Chunk[V]], Streams[V], Streams[V2] & S & S2]:
+                    def resume[T, U: Flat, S3](
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S3)
+                    ) =
+                        command.collectUnit(pf).andThen {
+                            Streams.emitChunkAndThen(Chunks.init[V2]) {
+                                Resume((), k(().asInstanceOf[T]))
+                            }
+                        }
+            Streams[V].handle(handler)((), s)
+        end collect
+
+        def transform[V2: Flat, S2](f: V => V2 < S2)(
+            using tag2: Tag[Streams[V2]]
+        ): Stream[T, V2, S & S2] =
+            val handler =
+                new Handler[Const[Chunk[V]], Streams[V], Streams[V2] & S & S2]:
+                    def resume[T, U: Flat, S3](
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S3)
+                    ): (U | Resume[U, S3]) < (Streams[V2] & S & S2 & S3) =
+                        command.map(f).map { c =>
+                            Streams.emitChunkAndThen(c) {
+                                Resume((), k(().asInstanceOf[T]))
+                            }
+                        }
+                    end resume
+            Streams[V].handle(handler)((), s)
+        end transform
+
+        def concat[T2: Flat, S2](
+            s2: Stream[T2, V, S2]
+        ): Stream[(T, T2), V, S & S2] =
+            s.map(t => s2.map((t, _)))
+
+        def runFold[A: Flat, S2](acc: A)(f: (A, V) => A < S2): (A, T) < (S & S2) =
+            val handler =
+                new ResultHandler[A, Const[Chunk[V]], Streams[V], [T] =>> (A, T), S & S2]:
+                    def done[T](st: A, v: T) = (st, v)
+                    def resume[T, U: Flat, S2](
+                        st: A,
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S2)
+                    ) =
+                        command.foldLeft(st)(f).map { r =>
+                            Resume(r, k(().asInstanceOf[T]))
+                        }
+                    end resume
+            Streams[V].handle(handler)(acc, s)
+        end runFold
+
+        def runDiscard: T < S =
+            Streams[V].handle(discardHandler[V])((), s)
+
+        def runChunk: (Chunk[V], T) < S =
+            val handler =
+                new ResultHandler[Chunk[Chunk[V]], Const[Chunk[V]], Streams[V], [T] =>> (Chunk[V], T), S]:
+                    def done[T](st: Chunk[Chunk[V]], v: T) = (st.flatten, v)
+                    def resume[T, U: Flat, S2](
+                        st: Chunk[Chunk[V]],
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S2)
+                    ) =
+                        Resume(st.append(command), k(().asInstanceOf[T]))
+            Streams[V].handle(handler)(Chunks.init, s)
+        end runChunk
+
+        def runSeq: (IndexedSeq[V], T) < S =
+            runChunk.map((c, v) => (c.toSeq, v))
+
+    end extension
+
+    private[kyo] inline def source[T, V, S](s: T < (Streams[V] & S)): Stream[T, V, S] =
+        s
+
+    private object internal:
+        private val discard = new Handler[Const[Chunk[Any]], Streams[Any], Any]:
+            def resume[T, U: Flat, S](command: Chunk[Any], k: T => U < (Streams[Any] & S)) =
+                Resume((), k(().asInstanceOf[T]))
+
+        def discardHandler[V]: Handler[Const[Chunk[V]], Streams[V], Any] =
+            discard.asInstanceOf[Handler[Const[Chunk[V]], Streams[V], Any]]
+    end internal
+
+end Stream
+
+class Streams[V] extends Effect[Streams[V]]:
+    type Command[T] = Chunk[V]
+
+object Streams:
+
+    import internal.*
+
+    def initSource[V]: InitSourceDsl[V] = new InitSourceDsl[V]
+
+    def initSeq[V](c: Seq[V])(using Tag[Streams[V]]): Stream[Unit, V, Any] =
+        initSource(emitSeq(c))
+
+    def initChunk[V](c: Chunk[V])(using Tag[Streams[V]]): Stream[Unit, V, Any] =
+        initSource(emitChunk(c))
+
+    def emitSeq[V](s: Seq[V])(using Tag[Streams[V]]): Unit < Streams[V] =
+        if s.isEmpty then
+            ()
+        else
+            emitChunk(Chunks.initSeq(s))
+
+    inline def emitChunk[V](c: Chunk[V])(using inline tag: Tag[Streams[V]]): Unit < Streams[V] =
+        if c.isEmpty then
+            ()
+        else
+            Streams[V].suspend[Unit](c)
+
+    inline def emitChunkAndThen[V, U, S](c: Chunk[V])(inline f: => U < S)(using
+        inline tag: Tag[Streams[V]]
+    ): U < (S & Streams[V]) =
+        Streams[V].suspend[Unit, U, S](c, _ => f)
+
+    object internal:
+        class InitSourceDsl[V]:
+            def apply[T, S](v: T < (Streams[V] & S)): Stream[T, V, S] =
+                Stream.source(v)
+    end internal
+end Streams

--- a/kyo-pure/shared/src/main/scala/kyo/sums.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/sums.scala
@@ -1,0 +1,31 @@
+package kyo
+
+import kyo.core.*
+
+class Sums[V] extends Effect[Sums[V]]:
+    type Command[T] = V
+
+    private val handler =
+        new ResultHandler[Chunk[V], Const[V], Sums[V], [T] =>> (Chunk[V], T), Any]:
+            def done[T](st: Chunk[V], v: T) = (st, v)
+            def resume[T, U: Flat, S](st: Chunk[V], command: V, k: T => U < (Sums[V] & S)) =
+                Resume(st.append(command), k(().asInstanceOf[T]))
+end Sums
+
+object Sums:
+    private object sums extends Sums[Any]
+    private def sums[V]: Sums[V] = sums.asInstanceOf[Sums[V]]
+
+    def add[V](v: V)(using Tag[Sums[V]]): Unit < Sums[V] =
+        sums[V].suspend[Unit](v)
+
+    class RunDsl[V]:
+        def apply[T: Flat, S](v: T < (Sums[V] & S))(
+            using Tag[Sums[V]]
+        ): (Chunk[V], T) < S =
+            sums[V].handle(sums[V].handler)(Chunks.init, v)
+    end RunDsl
+
+    def run[V >: Nothing]: RunDsl[V] = new RunDsl[V]
+
+end Sums

--- a/kyo-pure/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/tags.scala
@@ -1,0 +1,41 @@
+package kyo
+
+import izumi.reflect.dottyreflection.TypeInspections
+import izumi.reflect.macrortti.LightTypeTag
+import scala.quoted.*
+
+opaque type Tag[T] = String
+
+object Tag:
+
+    given canEqual[T, U]: CanEqual[Tag[T], Tag[U]] = CanEqual.derived
+
+    extension [T](t: Tag[T])
+        def parse: LightTypeTag =
+            val arr = t.split('|')
+            LightTypeTag.parse(arr(0).toInt, arr(1), arr(2), arr(3).toInt)
+    end extension
+
+    inline given apply[T]: Tag[T] = ${ tagImpl[T] }
+
+    private def tagImpl[T: Type](using Quotes): Expr[Tag[T]] =
+        import quotes.reflect.*
+        if TypeRepr.of[T] =:= TypeRepr.of[Nothing] then
+            report.errorAndAbort("Can't infer a Tag[Nothing]")
+        if TypeRepr.of[T] =:= TypeRepr.of[Any] then
+            report.errorAndAbort("Can't infer a Tag[Any]")
+        if TypeRepr.of[T] =:= TypeRepr.of[Object] then
+            report.errorAndAbort("Can't infer a Tag[Object]")
+        val ref         = TypeInspections.apply[T]
+        val fullDb      = TypeInspections.fullDb[T]
+        val nameDb      = TypeInspections.unappliedDb[T]
+        val ltt         = LightTypeTag(ref, fullDb, nameDb)
+        val serialized  = ltt.serialize()
+        val hashCodeRef = serialized.hash
+        val strRef      = serialized.ref
+        val strDBs      = serialized.databases
+        val version     = LightTypeTag.currentBinaryFormatVersion
+        val tagStr      = s"$hashCodeRef|$strRef|$strDBs|$version"
+        Expr(tagStr)
+    end tagImpl
+end Tag

--- a/kyo-pure/shared/src/main/scala/kyo/vars.scala
+++ b/kyo-pure/shared/src/main/scala/kyo/vars.scala
@@ -1,0 +1,56 @@
+package kyo
+
+import Vars.internal.*
+import kyo.core.*
+
+class Vars[V] extends Effect[Vars[V]]:
+    type Command[T] = Op[V]
+
+    private val handler =
+        new ResultHandler[V, Const[Op[V]], Vars[V], Id, Any]:
+            def done[T](st: V, v: T) = v
+            def resume[T, U: Flat, S2](st: V, op: Op[V], k: T => U < (Vars[V] & S2)) =
+                op match
+                    case _: Get.type =>
+                        Resume(st, k(st.asInstanceOf[T]))
+                    case Set(v) =>
+                        Resume(v, k(().asInstanceOf[T]))
+                    case Update(f) =>
+                        Resume(f(st), k(().asInstanceOf[T]))
+end Vars
+
+object Vars:
+    private case object vars extends Vars[Any]
+    private def vars[V]: Vars[V] = vars.asInstanceOf[Vars[V]]
+    object internal:
+        case object Get
+        case class Set[V](v: V)
+        case class Update[V](f: V => V)
+        type Op[V] = Get.type | Set[V] | Update[V]
+    end internal
+
+    def get[V](using Tag[Vars[V]]): V < Vars[V] =
+        vars[V].suspend[V](Get)
+
+    class UseDsl[V]:
+        inline def apply[T, S](inline f: V => T < S)(using inline tag: Tag[Vars[V]]): T < (Vars[V] & S) =
+            vars[V].suspend[V, T, S](Get, f)
+
+    def use[V >: Nothing]: UseDsl[V] = new UseDsl[V]
+
+    def set[V](value: V)(using Tag[Vars[V]]): Unit < Vars[V] =
+        vars[V].suspend[Unit](Set(value))
+
+    def update[V](f: V => V)(using Tag[Vars[V]]): Unit < Vars[V] =
+        vars[V].suspend[Unit](Update(f))
+
+    class RunDsl[V]:
+        def apply[T: Flat, S2](state: V)(value: T < (Vars[V] & S2))(
+            using Tag[Vars[V]]
+        ): T < S2 =
+            vars[V].handle(vars[V].handler)(state, value)
+    end RunDsl
+
+    def run[V >: Nothing]: RunDsl[V] = new RunDsl[V]
+
+end Vars

--- a/kyo-pure/shared/src/test/scala/kyoTest/KyoPureTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/KyoPureTest.scala
@@ -1,0 +1,63 @@
+package kyoTest
+
+import kyo.*
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.compatible.Assertion
+import org.scalatest.concurrent.ScalaFutures.*
+import org.scalatest.freespec.AsyncFreeSpec
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.*
+import scala.util.Try
+import scala.util.control.NonFatal
+
+class KyoPureTest extends AsyncFreeSpec with NonImplicitAssertions:
+
+    override given executionContext: ExecutionContext = Platform.executionContext
+
+    given tryCanEqual[T]: CanEqual[Try[T], Try[T]]                   = CanEqual.derived
+    given eitherCanEqual[T, U]: CanEqual[Either[T, U], Either[T, U]] = CanEqual.derived
+    given throwableCanEqual: CanEqual[Throwable, Throwable]          = CanEqual.derived
+
+    def retry[S](f: => Boolean < S): Boolean < S =
+        def loop(): Boolean < S =
+            f.map {
+                case true  => true
+                case false => loop()
+            }
+        loop()
+    end retry
+
+    def timeout =
+        if Platform.isDebugEnabled then
+            Duration.Inf
+        else
+            5.seconds
+
+    implicit def toFuture(a: Assertion): Future[Assertion] = Future.successful(a)
+
+    def runJVM(
+        v: => Assertion < KyoPureApp.Effects
+    ): Future[Assertion] =
+        if Platform.isJVM then
+            run(v)
+        else
+            Future.successful(succeed)
+
+    def runJS(
+        v: => Assertion < KyoPureApp.Effects
+    ): Future[Assertion] =
+        if Platform.isJS then
+            run(v)
+        else
+            Future.successful(succeed)
+
+    def run(
+        v: => Assertion < KyoPureApp.Effects
+    ): Future[Assertion] =
+        try Future.successful(KyoPureApp.run(v))
+        catch
+            case ex if NonFatal(ex) =>
+                Future.failed(ex)
+
+end KyoPureTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/abortsTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/abortsTest.scala
@@ -1,0 +1,243 @@
+package kyoTest
+
+import kyo.*
+
+class abortsTest extends KyoPureTest:
+
+    case class Ex1() extends RuntimeException derives CanEqual
+    case class Ex2() derives CanEqual
+
+    val ex1 = new Ex1
+    val ex2 = new Ex2
+
+    "pure" - {
+        "handle" in {
+            assert(
+                Aborts.run[Ex1](Aborts.get(Right(1))).pure ==
+                    Right(1)
+            )
+        }
+        "handle + transform" in {
+            assert(
+                Aborts.run[Ex1](Aborts.get(Right(1)).map(_ + 1)).pure ==
+                    Right(2)
+            )
+        }
+        "handle + effectful transform" in {
+            assert(
+                Aborts.run[Ex1](Aborts.get(Right(1)).map(i =>
+                    Aborts.get(Right(i + 1))
+                )).pure ==
+                    Right(2)
+            )
+        }
+        "handle + transform + effectful transform" in {
+            assert(
+                Aborts.run[Ex1](Aborts.get(Right(1)).map(_ + 1).map(i =>
+                    Aborts.get(Right(i + 1))
+                )).pure ==
+                    Right(3)
+            )
+        }
+        "handle + transform + failed effectful transform" in {
+            val fail = Left[Ex1, Int](ex1)
+            assert(
+                Aborts.run[Ex1](Aborts.get(Right(1)).map(_ + 1).map(_ =>
+                    Aborts.get(fail)
+                )).pure ==
+                    fail
+            )
+        }
+        "union tags" - {
+            "in suspend 1" in {
+                val effect1: Int < Aborts[String | Boolean] =
+                    Aborts.fail("failure")
+                val handled1: Either[String, Int] < Aborts[Boolean] =
+                    Aborts.run[String](effect1)
+                val handled2: Either[Boolean, Either[String, Int]] =
+                    Aborts.run[Boolean](handled1).pure
+                assert(handled2 == Right(Left("failure")))
+            }
+            "in suspend 2" in {
+                val effect1: Int < Aborts[String | Boolean] =
+                    Aborts.fail("failure")
+                val handled1: Either[Boolean, Int] < Aborts[String] =
+                    Aborts.run[Boolean](effect1)
+                val handled2: Either[String, Either[Boolean, Int]] =
+                    Aborts.run[String](handled1).pure
+                assert(handled2 == Left("failure"))
+            }
+            "in handle" in {
+                val effect: Int < Aborts[String | Boolean] =
+                    Aborts.fail("failure")
+                val handled: Either[String | Boolean, Int] =
+                    Aborts.run[String | Boolean](effect).pure
+                assert(handled == Left("failure"))
+            }
+        }
+    }
+
+    "effectful" - {
+        "success" - {
+            val v = Aborts.get[Ex1, Int](Right(1))
+            "handle" in {
+                assert(
+                    Aborts.run[Ex1](v).pure ==
+                        Right(1)
+                )
+            }
+            "handle + transform" in {
+                assert(
+                    Aborts.run[Ex1](v.map(_ + 1)).pure ==
+                        Right(2)
+                )
+            }
+            "handle + effectful transform" in {
+                assert(
+                    Aborts.run[Ex1](v.map(i => Aborts.get(Right(i + 1)))).pure ==
+                        Right(2)
+                )
+            }
+            "handle + transform + effectful transform" in {
+                assert(
+                    Aborts.run[Ex1](v.map(_ + 1).map(i => Aborts.get(Right(i + 1)))).pure ==
+                        Right(3)
+                )
+            }
+            "handle + transform + failed effectful transform" in {
+                val fail = Left[Ex1, Int](ex1)
+                assert(
+                    Aborts.run[Ex1](v.map(_ + 1).map(_ => Aborts.get(fail))).pure ==
+                        fail
+                )
+            }
+        }
+        "failure" - {
+            val v: Int < Aborts[Ex1] = Aborts.get(Left(ex1))
+            "handle" in {
+                assert(
+                    Aborts.run[Ex1](v).pure ==
+                        Left(ex1)
+                )
+            }
+            "handle + transform" in {
+                assert(
+                    Aborts.run[Ex1](v.map(_ + 1)).pure ==
+                        Left(ex1)
+                )
+            }
+            "handle + effectful transform" in {
+                assert(
+                    Aborts.run[Ex1](v.map(i => Aborts.get(Right(i + 1)))).pure ==
+                        Left(ex1)
+                )
+            }
+            "handle + transform + effectful transform" in {
+                assert(
+                    Aborts.run[Ex1](v.map(_ + 1).map(i => Aborts.get(Right(i + 1)))).pure ==
+                        Left(ex1)
+                )
+            }
+            "handle + transform + failed effectful transform" in {
+                val fail = Left[Ex1, Int](ex1)
+                assert(
+                    Aborts.run[Ex1](v.map(_ + 1).map(_ => Aborts.get(fail))).pure ==
+                        Left(ex1)
+                )
+            }
+        }
+    }
+
+    "Aborts" - {
+        def test(v: Int): Int < Aborts[Ex1] =
+            v match
+                case 0 => Aborts.fail(ex1)
+                case i => 10 / i
+        "run" - {
+            "success" in {
+                assert(
+                    Aborts.run[Ex1](test(2)).pure ==
+                        Right(5)
+                )
+            }
+            "failure" in {
+                assert(
+                    Aborts.run[Ex1](test(0)).pure ==
+                        Left(ex1)
+                )
+            }
+            "inference" in {
+                def t1(v: Int < Aborts[Int | String]) =
+                    Aborts.run[Int](v)
+                val _: Either[Int, Int] < Aborts[String] =
+                    t1(42)
+                def t2(v: Int < (Aborts[Int] & Aborts[String])) =
+                    Aborts.run[String](v)
+                val _: Either[String, Int] < Aborts[Int] =
+                    t2(42)
+                def t3(v: Int < Aborts[Int]) =
+                    Aborts.run[Int](v).pure
+                val _: Either[Int, Int] =
+                    t3(42)
+                succeed
+            }
+            "super" in {
+                val ex                         = new Exception
+                val a: Int < Aborts[Exception] = Aborts.fail(ex)
+                val b: Either[Throwable, Int]  = Aborts.run[Throwable](a).pure
+                assert(b == Left(ex))
+            }
+            "super success" in {
+                val a: Int < Aborts[Exception] = 24
+                val b: Either[Throwable, Int]  = Aborts.run[Throwable](a).pure
+                assert(b == Right(24))
+            }
+            "reduce large union incrementally" in {
+                val t1: Int < Aborts[Int | String | Boolean | Float | Char | Double] =
+                    18
+                val t2 = Aborts.run[Int](t1)
+                val t3 = Aborts.run[String](t2)
+                val t4 = Aborts.run[Boolean](t3)
+                val t5 = Aborts.run[Float](t4)
+                val t6 = Aborts.run[Char](t5)
+                val t7 = Aborts.run[Double](t6).pure
+                assert(t7.pure == Right(Right(Right(Right(Right(Right(18)))))))
+            }
+            "reduce large union in a single expression" in {
+                val t: Int < Aborts[Int | String | Boolean | Float | Char | Double] = 18
+                // NB: Adding type annotation leads to compilation error
+                val res =
+                    Aborts.run[Double](
+                        Aborts.run[Char](
+                            Aborts.run[Float](
+                                Aborts.run[Boolean](
+                                    Aborts.run[String](
+                                        Aborts.run[Int](t)
+                                    )
+                                )
+                            )
+                        )
+                    ).pure
+                val expected: Either[Double, Either[Char, Either[Float, Either[Boolean, Either[String, Either[Int, Int]]]]]] =
+                    Right(Right(Right(Right(Right(Right(18))))))
+                assert(res == expected)
+            }
+        }
+        "fail" in {
+            val ex: Throwable = new Exception("throwable failure")
+            val a             = Aborts.fail(ex)
+            assert(Aborts.run[Throwable](a).pure == Left(ex))
+        }
+        "fail inferred" in {
+            val e = "test"
+            val f = Aborts.fail(e)
+            assert(Aborts.run(f).pure == Left(e))
+        }
+        "when" in {
+            def abort(b: Boolean) = Aborts.run[String](Aborts.when(b)("FAIL!")).pure
+
+            assert(abort(true) == Left("FAIL!"))
+            assert(abort(false) == Right(()))
+        }
+    }
+end abortsTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/aspectsTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/aspectsTest.scala
@@ -1,0 +1,93 @@
+package kyoTest
+
+import kyo.*
+import org.scalatest.compatible.Assertion
+
+class aspectsTest extends KyoPureTest:
+
+    "one aspect" - {
+        val aspect       = Aspects.init[Int, Int, Defers]
+        def test(v: Int) = aspect(v)(_ + 1)
+
+        "default" in run {
+            test(1).map(v => assert(v == 2))
+        }
+
+        "with cut" in run {
+            val cut = new Cut[Int, Int, Defers]:
+                def apply[S](v: Int < S)(f: Int => Int < Defers) =
+                    v.map(v => f(v + 1))
+            aspect.let[Assertion, Defers](cut) {
+                test(1).map(v => assert(v == 3))
+            }
+        }
+
+        "sandboxed" in run {
+            val cut = new Cut[Int, Int, Defers]:
+                def apply[S](v: Int < S)(f: Int => Int < Defers) =
+                    v.map(v => f(v + 1))
+            aspect.let[Assertion, Defers](cut) {
+                aspect.sandbox {
+                    test(1)
+                }.map(v => assert(v == 2))
+            }
+        }
+
+        "nested cuts" in run {
+            val cut1 = new Cut[Int, Int, Defers]:
+                def apply[S](v: Int < S)(f: Int => Int < Defers) =
+                    v.map(v => f(v * 3))
+            val cut2 = new Cut[Int, Int, Defers]:
+                def apply[S](v: Int < S)(f: Int => Int < Defers) =
+                    v.map(v => f(v + 5))
+            aspect.let[Assertion, Defers](cut1) {
+                aspect.let[Assertion, Defers](cut2) {
+                    test(2).map(v => assert(v == 2 * 3 + 5 + 1))
+                }
+            }
+        }
+    }
+
+    "multiple aspects" in run {
+        val aspect1 = Aspects.init[Int, Int, Defers]
+        val aspect2 = Aspects.init[Int, Int, Defers]
+
+        def test(v: Int) =
+            for
+                v1 <- aspect1(v)(_ + 1)
+                v2 <- aspect2(v)(_ + 1)
+            yield (v1, v2)
+
+        val cut1 = new Cut[Int, Int, Defers]:
+            def apply[S](v: Int < S)(f: Int => Int < Defers) =
+                v.map(v => f(v * 3))
+        val cut2 = new Cut[Int, Int, Defers]:
+            def apply[S](v: Int < S)(f: Int => Int < Defers) =
+                v.map(v => f(v + 5))
+        aspect1.let[Assertion, Defers](cut1) {
+            aspect2.let[Assertion, Defers](cut2) {
+                test(2).map(v => assert(v == (2 * 3 + 1, 2 + 5 + 1)))
+            }
+        }
+    }
+
+    "use aspect as a cut" in run {
+        val aspect1 = Aspects.init[Int, Int, Defers]
+        val aspect2 = Aspects.init[Int, Int, Defers]
+
+        def test(v: Int) =
+            for
+                v1 <- aspect1(v)(_ + 1)
+                v2 <- aspect2(v)(_ + 1)
+            yield (v1, v2)
+
+        val cut = new Cut[Int, Int, Defers]:
+            def apply[S](v: Int < S)(f: Int => Int < Defers) =
+                v.map(v => f(v * 3))
+        aspect1.let[Assertion, Defers](cut) {
+            aspect2.let[Assertion, Defers](aspect1) {
+                test(2).map(v => assert(v == (2 * 3 + 1, 2 * 3 + 1)))
+            }
+        }
+    }
+end aspectsTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/choicesTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/choicesTest.scala
@@ -1,0 +1,98 @@
+package kyoTest
+import kyo.*
+
+class choicesTest extends KyoPureTest:
+    "eval with a single choice" in {
+        assert(
+            Choices.run(Choices.eval(Seq(1))(i => (i + 1))).pure == Seq(2)
+        )
+    }
+
+    "eval with multiple choices" in {
+        assert(
+            Choices.run(Choices.eval(Seq(1, 2, 3))(i => (i + 1))).pure == Seq(2, 3, 4)
+        )
+    }
+
+    "nested eval" in {
+        assert(
+            Choices.run(Choices.eval(Seq(1, 2, 3))(i =>
+                Choices.get(Seq(i * 10, i * 100))
+            )).pure == Seq(10, 100, 20, 200, 30, 300)
+        )
+    }
+
+    "drop" in {
+        assert(
+            Choices.run(Choices.eval(Seq(1, 2, 3))(i =>
+                if i < 2 then Choices.drop else Choices.get(Seq(i * 10, i * 100))
+            )).pure == Seq(20, 200, 30, 300)
+        )
+    }
+
+    "filter" in {
+        assert(
+            Choices.run(Choices.eval(Seq(1, 2, 3))(i =>
+                Choices.filter(i >= 2).map(_ => Choices.get(Seq(i * 10, i * 100)))
+            )).pure == Seq(20, 200, 30, 300)
+        )
+    }
+
+    "empty choices" in {
+        assert(
+            Choices.run(Choices.eval(Seq.empty[Int])(_ => 42)).pure == Seq.empty[Int]
+        )
+    }
+
+    "nested drop" in {
+        assert(
+            Choices.run(
+                Choices.eval(Seq(1, 2, 3))(i =>
+                    Choices.eval(Seq(i * 10, i * 100))(j =>
+                        if j > 100 then Choices.drop else j
+                    )
+                )
+            ).pure == Seq(10, 100, 20, 30)
+        )
+    }
+
+    "nested filter" in {
+        assert(
+            Choices.run(
+                Choices.eval(Seq(1, 2, 3))(i =>
+                    Choices.filter(i % 2 == 0).map(_ =>
+                        Choices.eval(Seq(i * 10, i * 100))(j =>
+                            Choices.filter(j < 300).map(_ => j)
+                        )
+                    )
+                )
+            ).pure == Seq(20, 200)
+        )
+    }
+
+    "large number of choices" in {
+        val largeChoices = Seq.range(0, 100000)
+        try
+            assert(
+                Choices.run(Choices.get(largeChoices)).pure == largeChoices
+            )
+        catch
+            case ex: StackOverflowError => fail()
+        end try
+    }
+
+    "large number of suspensions" in pendingUntilFixed {
+        // https://github.com/getkyo/kyo/issues/208
+        var v = Choices.get(Seq(1))
+        for _ <- 0 until 100000 do
+            v = v.map(_ => Choices.get(Seq(1)))
+        try
+            assert(
+                Choices.run(v).pure == Seq(1)
+            )
+        catch
+            case ex: StackOverflowError => fail()
+        end try
+        ()
+    }
+end choicesTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/chunksTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/chunksTest.scala
@@ -1,0 +1,849 @@
+package kyoTest
+import kyo.*
+import scala.util.Try
+
+class chunksTest extends KyoPureTest:
+
+    "append" - {
+        "appends a value to an empty chunk" in {
+            val chunk = Chunks.init[Int].append(1)
+            assert(chunk == Chunks.init(1))
+        }
+
+        "appends a value to a non-empty chunk" in {
+            val chunk = Chunks.init(1, 2, 3).append(4)
+            assert(chunk == Chunks.init(1, 2, 3, 4))
+        }
+    }
+
+    "head" - {
+        "returns the first element of a non-empty chunk" in {
+            val chunk = Chunks.init(1, 2, 3).toIndexed
+            assert(chunk.head == 1)
+        }
+
+        "throws NoSuchElementException for an empty chunk" in {
+            val chunk = Chunks.init[Int].toIndexed
+            assert(Try(chunk.head).isFailure)
+        }
+    }
+
+    "tail" - {
+        "returns the tail of a non-empty chunk" in {
+            val chunk = Chunks.init(1, 2, 3).toIndexed
+            assert(chunk.tail == Chunks.init(2, 3))
+        }
+
+        "returns an empty chunk for a chunk with a single element" in {
+            val chunk = Chunks.init(1).toIndexed
+            assert(chunk.tail.isEmpty)
+        }
+
+        "returns an empty chunk for an empty chunk" in {
+            val chunk = Chunks.init[Int].toIndexed
+            assert(chunk.tail.isEmpty)
+        }
+
+        "returns the correct tail for a Drop chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropLeft(2).toIndexed
+            assert(chunk.tail == Chunks.init(4, 5))
+        }
+
+        "of appends" in {
+            val chunk = Chunks.init[Int].append(1).append(2).append(3).toIndexed
+            assert(chunk.tail == Chunks.init(2, 3))
+            assert(chunk.tail.tail == Chunks.init(3))
+        }
+    }
+
+    "take" - {
+        "returns the first n elements of a chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.take(3) == Chunks.init(1, 2, 3))
+        }
+
+        "returns the entire chunk if n is greater than the chunk size" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.take(5) == Chunks.init(1, 2, 3))
+        }
+
+        "returns an empty chunk if n is zero or negative" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.take(0).isEmpty)
+            assert(chunk.take(-1).isEmpty)
+        }
+    }
+
+    "dropLeft" - {
+        "drops the first n elements of a chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.dropLeft(2) == Chunks.init(3, 4, 5))
+        }
+
+        "returns an empty chunk if n is greater than or equal to the chunk size" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.dropLeft(3).isEmpty)
+            assert(chunk.dropLeft(4).isEmpty)
+        }
+
+        "returns the entire chunk if n is zero or negative" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.dropLeft(0) == Chunks.init(1, 2, 3))
+            assert(chunk.dropLeft(-1) == Chunks.init(1, 2, 3))
+        }
+    }
+
+    "dropRight" - {
+        "drops the last n elements of a chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.dropRight(2) == Chunks.init(1, 2, 3))
+        }
+
+        "returns an empty chunk if n is greater than or equal to the chunk size" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.dropRight(3).isEmpty)
+            assert(chunk.dropRight(4).isEmpty)
+        }
+
+        "returns the entire chunk if n is zero or negative" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.dropRight(0) == Chunks.init(1, 2, 3))
+            assert(chunk.dropRight(-1) == Chunks.init(1, 2, 3))
+        }
+    }
+
+    "slice" - {
+        "returns a slice of a chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.slice(1, 4) == Chunks.init(2, 3, 4))
+        }
+
+        "returns an empty chunk if from is greater than or equal to until" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.slice(2, 2).isEmpty)
+            assert(chunk.slice(3, 2).isEmpty)
+        }
+
+        "returns an empty chunk if the chunk is empty" in {
+            val chunk = Chunks.init[Int]
+            assert(chunk.slice(0, 1).isEmpty)
+        }
+
+        "returns the full chunk if `from` is negative and `until` is greater than the size" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.slice(-1, 6) == Chunks.init(1, 2, 3, 4, 5))
+        }
+
+        "returns the full chunk if `from` is 0 and `until` is greater than the size" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.slice(0, 5) == Chunks.init(1, 2, 3))
+        }
+
+        "returns the correct slice when multiple slice operations are chained" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            val result = chunk.slice(2, 8).slice(1, 5).slice(1, 3)
+            assert(result == Chunks.init(5, 6))
+        }
+    }
+
+    "map" - {
+        "with a pure function" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.map(_ * 2)
+            assert(result.pure == Chunks.init(2, 4, 6, 8, 10))
+        }
+
+        "with a function using Defers" in {
+            val chunk    = Chunks.init(1, 2, 3, 4, 5)
+            val result   = chunk.map(n => Defers(n * 2))
+            val expected = Chunks.init(2, 4, 6, 8, 10)
+            assert(Defers.run(result).pure == expected)
+        }
+
+        "with a function returning pure values and effectful computations" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.map { n =>
+                if n % 2 == 0 then Defers(n * 2) else n * 2
+            }
+            val expected = Chunks.init(2, 4, 6, 8, 10)
+            assert(Defers.run(result).pure == expected)
+        }
+
+        "with an empty chunk" in {
+            val chunk  = Chunks.init[Int]
+            val result = chunk.map(_ * 2)
+            assert(result.pure.isEmpty)
+        }
+    }
+
+    "filter" - {
+        "with a pure predicate" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.filter(_ % 2 == 0)
+            assert(result.pure == Chunks.init(2, 4))
+        }
+
+        "with a predicate using Defers" in {
+            val chunk    = Chunks.init(1, 2, 3, 4, 5)
+            val result   = chunk.filter(n => Defers(n % 2 == 0))
+            val expected = Chunks.init(2, 4)
+            assert(Defers.run(result).pure == expected)
+        }
+
+        "with a predicate returning pure values and effectful computations" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.filter { n =>
+                if n % 2 == 0 then Defers(true) else false
+            }
+            val expected = Chunks.init(2, 4)
+            assert(Defers.run(result).pure == expected)
+        }
+
+        "with a predicate that filters out all elements" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.filter(_ => Defers(false))
+            assert(Defers.run(result).pure.isEmpty)
+        }
+    }
+
+    "foldLeft" - {
+        "with a pure function" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.foldLeft(0)(_ + _)
+            assert(result.pure == 15)
+        }
+
+        "with a function using Defers" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.foldLeft(0)((acc, n) => Defers(acc + n))
+            assert(Defers.run(result).pure == 15)
+        }
+
+        "with a function returning pure values and effectful computations" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.foldLeft(0) { (acc, n) =>
+                if n % 2 == 0 then Defers(acc + n) else acc + n
+            }
+            assert(Defers.run(result).pure == 15)
+        }
+
+        "with an empty chunk" in {
+            val chunk  = Chunks.init[Int]
+            val result = chunk.foldLeft(0)(_ + _)
+            assert(result.pure == 0)
+        }
+    }
+
+    "toSeq" - {
+        "converts a Chunk to an IndexedSeq" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.toSeq == IndexedSeq(1, 2, 3, 4, 5))
+        }
+
+        "converts an empty Chunk to an empty IndexedSeq" in {
+            val chunk = Chunks.init[Int]
+            assert(chunk.toSeq.isEmpty)
+        }
+    }
+
+    "mixed" - {
+        "chained operations" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5).toIndexed
+            val result = chunk.append(6).toIndexed.tail.take(3).dropLeft(1)
+            assert(result == Chunks.init(3, 4))
+        }
+
+        "empty chunk operations" in {
+            val chunk = Chunks.init[Int]
+            assert(chunk.append(1).toIndexed.head == 1)
+            assert(chunk.toIndexed.tail.isEmpty)
+            assert(chunk.take(2).isEmpty)
+            assert(chunk.dropLeft(1).isEmpty)
+            assert(chunk.slice(0, 1).isEmpty)
+        }
+
+        "single element chunk operations" in {
+            val chunk = Chunks.init(1)
+            assert(chunk.append(2) == Chunks.init(1, 2))
+            assert(chunk.toIndexed.tail.isEmpty)
+            assert(chunk.take(1) == Chunks.init(1))
+            assert(chunk.dropLeft(1).isEmpty)
+            assert(chunk.slice(0, 1) == Chunks.init(1))
+        }
+
+        "out of bounds indexing" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.dropLeft(5).isEmpty)
+            assert(chunk.take(5) == Chunks.init(1, 2, 3))
+            assert(chunk.slice(1, 5) == Chunks.init(2, 3))
+            assert(chunk.slice(5, 6).isEmpty)
+        }
+
+        "negative indexing" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.dropLeft(-1) == Chunks.init(1, 2, 3, 4, 5))
+            assert(chunk.take(-1).isEmpty)
+            assert(chunk.slice(-2, 3) == Chunks.init(1, 2, 3))
+            assert(chunk.slice(2, -1).isEmpty)
+        }
+
+        "chained append operations" in {
+            val chunk = Chunks.init[Int].append(1).append(2).append(3)
+            assert(chunk == Chunks.init(1, 2, 3))
+        }
+
+        "chained slice operations" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.slice(1, 4).slice(1, 2) == Chunks.init(3))
+        }
+
+        "slice beyond chunk size" in {
+            val chunk = Chunks.init(1, 2, 3)
+            assert(chunk.slice(1, 10) == Chunks.init(2, 3))
+            assert(chunk.slice(5, 10).isEmpty)
+        }
+
+        "mapping and filtering an empty chunk" in {
+            val chunk = Chunks.init[Int]
+            val result = chunk
+                .map(_ * 2).pure
+                .filter(_ % 2 == 0)
+            assert(result.pure.isEmpty)
+        }
+
+        "filter and map" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5, 6)
+            val result = chunk
+                .filter(_ % 2 == 0).pure
+                .map(_ + 1).pure
+            assert(result == Chunks.init(3, 5, 7))
+        }
+
+        "multiple appends followed by head and tail" - {
+            "returns the correct elements when calling head and tail repeatedly" in {
+                val chunk = Chunks.init[Int]
+                    .append(1)
+                    .append(2)
+
+                assert(chunk.toIndexed.head == 1)
+                assert(chunk.toIndexed.tail.head == 2)
+                assert(chunk.toIndexed.tail.tail.isEmpty)
+            }
+
+            "returns the correct elements when calling head and tail in a loop" in {
+                val chunk = Chunks.init[Int]
+                    .append(1)
+                    .append(2)
+                    .append(3)
+                    .append(4)
+                    .append(5)
+
+                var current = chunk.toIndexed
+                val result  = collection.mutable.ListBuffer[Int]()
+
+                while !current.isEmpty do
+                    result += current.head
+                    current = current.tail
+
+                assert(result.toList == List(1, 2, 3, 4, 5))
+            }
+
+            "handles empty chunks when calling head and tail" in {
+                val chunk = Chunks.init[Int]
+                    .append(1)
+                    .append(2)
+                    .toIndexed
+                    .tail
+                    .tail
+
+                assert(chunk.isEmpty)
+                assert(Try(chunk.head).isFailure)
+                assert(chunk.tail.isEmpty)
+            }
+        }
+        "handles nested Drop chunks" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+                .dropLeft(2)
+                .dropLeft(1)
+                .toIndexed
+
+            assert(chunk == Chunks.init(4, 5))
+            assert(chunk.tail == Chunks.init(5))
+            assert(chunk.tail.tail.isEmpty)
+        }
+
+        "chained take, dropLeft, and dropRight operations" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            assert(chunk.take(7).dropLeft(2).dropRight(2) == Chunks.init(3, 4, 5))
+        }
+
+        "empty chunk with take, dropLeft, and dropRight" in {
+            val chunk = Chunks.init[Int]
+            assert(chunk.take(5).isEmpty)
+            assert(chunk.dropLeft(2).isEmpty)
+            assert(chunk.dropRight(3).isEmpty)
+        }
+
+        "single element chunk with take, dropLeft, and dropRight" in {
+            val chunk = Chunks.init(1)
+            assert(chunk.take(1) == Chunks.init(1))
+            assert(chunk.take(2) == Chunks.init(1))
+            assert(chunk.dropLeft(0) == Chunks.init(1))
+            assert(chunk.dropLeft(1).isEmpty)
+            assert(chunk.dropRight(0) == Chunks.init(1))
+            assert(chunk.dropRight(1).isEmpty)
+        }
+    }
+
+    "flatten" - {
+        "flattens a chunk of chunks in original order" in {
+            val chunk: Chunk[Chunk[Int]] = Chunks.init(Chunks.init(1, 2), Chunks.init(3, 4, 5), Chunks.init(6, 7, 8, 9))
+            assert(chunk.flatten == Chunks.init(1, 2, 3, 4, 5, 6, 7, 8, 9))
+        }
+
+        "returns an empty chunk when flattening an empty chunk of chunks" in {
+            val chunk = Chunks.init[Chunk[Int]]
+            assert(chunk.flatten.isEmpty)
+        }
+
+        "returns an empty chunk when flattening a chunk of empty chunks" in {
+            val chunk = Chunks.init(Chunks.init[Int], Chunks.init[Int])
+            assert(chunk.flatten.isEmpty)
+        }
+
+        "preserves the order of elements within each chunk" in {
+            val chunk = Chunks.init(Chunks.init(1, 2, 3), Chunks.init(4, 5, 6))
+            assert(chunk.flatten == Chunks.init(1, 2, 3, 4, 5, 6))
+        }
+
+        "handles a chunk containing a single chunk" in {
+            val chunk = Chunks.init(Chunks.init(1, 2, 3))
+            assert(chunk.flatten == Chunks.init(1, 2, 3))
+        }
+
+        "handles chunks of different sizes" in {
+            val chunk = Chunks.init(Chunks.init(1), Chunks.init(2, 3), Chunks.init(4, 5, 6, 7))
+            assert(chunk.flatten == Chunks.init(1, 2, 3, 4, 5, 6, 7))
+        }
+    }
+
+    "toArray" - {
+        "returns an array with the elements of a Chunk.Compact" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val array = chunk.toArray
+            assert(array.toSeq == Seq(1, 2, 3, 4, 5))
+        }
+
+        "returns an array with the elements of a Chunk.FromSeq" in {
+            val chunk = Chunks.initSeq(IndexedSeq(1, 2, 3))
+            val array = chunk.toArray
+            assert(array.toSeq == Seq(1, 2, 3))
+        }
+
+        "returns an array with the elements of a Chunk.Drop" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropLeft(2)
+            val array = chunk.toArray
+            assert(array.toSeq == Seq(3, 4, 5))
+        }
+
+        "returns an array with the elements of a Chunk.Append" in {
+            val chunk = Chunks.init(1, 2, 3).append(4).append(5)
+            val array = chunk.toArray
+            assert(array.toSeq == Seq(1, 2, 3, 4, 5))
+        }
+
+        "returns an empty array for an empty Chunk" in {
+            val chunk = Chunks.init[Int]
+            val array = chunk.toArray
+            assert(array.isEmpty)
+        }
+
+        "returns a new array instance for each call" in {
+            val chunk  = Chunks.init(1, 2, 3)
+            val array1 = chunk.toArray
+            val array2 = chunk.toArray
+            assert(array1 ne array2)
+        }
+    }
+
+    "copyTo" - {
+        "copies elements to an array" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val array = new Array[Int](5)
+            chunk.copyTo(array, 0)
+            assert(array.toSeq == Seq(1, 2, 3, 4, 5))
+        }
+
+        "copies elements to a specific position in the array" in {
+            val chunk = Chunks.init(1, 2, 3)
+            val array = new Array[Int](5)
+            chunk.copyTo(array, 2)
+            assert(array.toSeq == Seq(0, 0, 1, 2, 3))
+        }
+
+        "copies elements from a Chunk.Compact" in {
+            val chunk = Chunks.init(1, 2, 3)
+            val array = new Array[Int](3)
+            chunk.copyTo(array, 0)
+            assert(array.toSeq == Seq(1, 2, 3))
+        }
+
+        "copies elements from a Chunk.FromSeq" in {
+            val chunk = Chunks.initSeq(IndexedSeq(1, 2, 3))
+            val array = new Array[Int](3)
+            chunk.copyTo(array, 0)
+            assert(array.toSeq == Seq(1, 2, 3))
+        }
+
+        "copies elements from a Chunk.Drop" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropLeft(2)
+            val array = new Array[Int](3)
+            chunk.copyTo(array, 0)
+            assert(array.toSeq == Seq(3, 4, 5))
+        }
+
+        "copies elements from a Chunk.Append" in {
+            val chunk = Chunks.init(1, 2, 3).append(4)
+            val array = new Array[Int](4)
+            chunk.copyTo(array, 0)
+            assert(array.toSeq == Seq(1, 2, 3, 4))
+        }
+    }
+
+    "copyTo with size" - {
+        "copies a specified number of elements to an array" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val array = new Array[Int](3)
+            chunk.copyTo(array, 0, 3)
+            assert(array.toSeq == Seq(1, 2, 3))
+        }
+
+        "copies elements from a specific position and size" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val array = new Array[Int](2)
+            chunk.copyTo(array, 0, 2)
+            assert(array.toSeq == Seq(1, 2))
+        }
+
+        "copies elements from a Chunk.Compact with size limit" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            val array = new Array[Int](3)
+            chunk.copyTo(array, 0, 3)
+            assert(array.toSeq == Seq(1, 2, 3))
+        }
+    }
+
+    "last" - {
+        "returns the last element of a non-empty chunk" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.last == 5)
+        }
+
+        "throws NoSuchElementException for an empty chunk" in {
+            val chunk = Chunks.init[Int]
+            assert(Try(chunk.last).isFailure)
+        }
+
+        "returns the last element after appending" in {
+            val chunk = Chunks.init(1, 2, 3).append(4)
+            assert(chunk.last == 4)
+        }
+
+        "returns the correct last element for a Drop chunk with dropRight" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropRight(2)
+            assert(chunk.last == 3)
+        }
+
+        "throws NoSuchElementException for a Drop chunk with dropRight equal to size" in {
+            val chunk = Chunks.init(1, 2, 3).dropRight(3)
+            assert(Try(chunk.last).isFailure)
+        }
+
+        "returns the correct last element for a Drop chunk with both dropLeft and dropRight" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropLeft(1).dropRight(2)
+            assert(chunk.last == 3)
+        }
+        "one element" in {
+            val chunk = Chunks.init(1)
+            assert(chunk.last == 1)
+        }
+    }
+
+    "concat" - {
+        "concatenates two non-empty chunks" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init(4, 5, 6)
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(1, 2, 3, 4, 5, 6))
+        }
+
+        "concatenates a non-empty chunk with an empty chunk" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init[Int]
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(1, 2, 3))
+        }
+
+        "concatenates an empty chunk with a non-empty chunk" in {
+            val chunk1 = Chunks.init[Int]
+            val chunk2 = Chunks.init(1, 2, 3)
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(1, 2, 3))
+        }
+
+        "returns an empty chunk when concatenating two empty chunks" in {
+            val chunk1 = Chunks.init[Int]
+            val chunk2 = Chunks.init[Int]
+            val result = chunk1.concat(chunk2)
+            assert(result.isEmpty)
+        }
+
+        "handles chunks of different types" in {
+            val chunk1 = Chunks.init("a", "b", "c")
+            val chunk2 = Chunks.init("d", "e", "f")
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init("a", "b", "c", "d", "e", "f"))
+        }
+
+        "handles multiple concatenations" in {
+            val chunk1 = Chunks.init(1, 2)
+            val chunk2 = Chunks.init(3, 4)
+            val chunk3 = Chunks.init(5, 6)
+            val chunk4 = Chunks.init(7, 8)
+            val result = chunk1.concat(chunk2).concat(chunk3).concat(chunk4)
+            assert(result == Chunks.init(1, 2, 3, 4, 5, 6, 7, 8))
+        }
+
+        "concatenates a Chunk.Compact with a Chunk.FromSeq" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.initSeq(IndexedSeq(4, 5, 6))
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(1, 2, 3, 4, 5, 6))
+        }
+
+        "concatenates a Chunk.FromSeq with a Chunk.Compact" in {
+            val chunk1 = Chunks.initSeq(IndexedSeq(1, 2, 3))
+            val chunk2 = Chunks.init(4, 5, 6)
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(1, 2, 3, 4, 5, 6))
+        }
+
+        "concatenates a Chunk.Drop with a Chunk.Compact" in {
+            val chunk1 = Chunks.init(1, 2, 3, 4, 5).dropLeft(2)
+            val chunk2 = Chunks.init(6, 7, 8)
+            val result = chunk1.concat(chunk2)
+            assert(result == Chunks.init(3, 4, 5, 6, 7, 8))
+        }
+    }
+
+    "takeWhile" - {
+        "returns elements while the predicate is true" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.takeWhile(_ < 4).pure
+            assert(result == Chunks.init(1, 2, 3))
+        }
+
+        "returns all elements if the predicate is always true" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.takeWhile(_ => true).pure
+            assert(result == Chunks.init(1, 2, 3, 4, 5))
+        }
+
+        "returns an empty chunk if the predicate is always false" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.takeWhile(_ => false).pure
+            assert(result.isEmpty)
+        }
+
+        "handles effectful predicates" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.takeWhile(n => Defers(n < 4))
+            assert(Defers.run(result).pure == Chunks.init(1, 2, 3))
+        }
+    }
+
+    "dropWhile" - {
+        "drops elements while the predicate is true" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.dropWhile(_ < 3).pure
+            assert(result == Chunks.init(3, 4, 5))
+        }
+
+        "drops all elements if the predicate is always true" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.dropWhile(_ => true).pure
+            assert(result.isEmpty)
+        }
+
+        "drops no elements if the predicate is always false" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.dropWhile(_ => false).pure
+            assert(result == Chunks.init(1, 2, 3, 4, 5))
+        }
+
+        "handles effectful predicates" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.dropWhile(n => Defers(n < 3))
+            assert(Defers.run(result).pure == Chunks.init(3, 4, 5))
+        }
+    }
+
+    "changes" - {
+        "returns a chunk with consecutive duplicates removed" in {
+            val chunk = Chunks.init(1, 1, 2, 3, 3, 3, 4, 4, 5)
+            assert(chunk.changes == Chunks.init(1, 2, 3, 4, 5))
+        }
+
+        "returns the original chunk if there are no consecutive duplicates" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            assert(chunk.changes == Chunks.init(1, 2, 3, 4, 5))
+        }
+
+        "returns an empty chunk for an empty input chunk" in {
+            val chunk = Chunks.init[Int]
+            assert(chunk.changes.isEmpty)
+        }
+
+        "handles a single element chunk" in {
+            val chunk = Chunks.init(1)
+            assert(chunk.changes == Chunks.init(1))
+        }
+
+        "handles a chunk with all duplicate elements" in {
+            val chunk = Chunks.init(1, 1, 1, 1, 1)
+            assert(chunk.changes == Chunks.init(1))
+        }
+    }
+
+    "collect" - {
+        "with a partial function" in {
+            val chunk  = Chunks.init(1, 2, 3, 4, 5)
+            val result = chunk.collect { case x if x % 2 == 0 => x * 2 }.pure
+            assert(result == Chunks.init(4, 8))
+        }
+
+        "with an empty chunk" in {
+            val chunk  = Chunks.init[Int]
+            val result = chunk.collect { case x if x % 2 == 0 => x * 2 }.pure
+            assert(result.isEmpty)
+        }
+    }
+
+    "collectUnit" - {
+        "with a partial function" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            var sum   = 0
+            Defers.run(chunk.collectUnit { case x if x % 2 == 0 => Defers(sum += x) })
+            assert(sum == 6)
+        }
+
+        "with an empty chunk" in {
+            val chunk = Chunks.init[Int]
+            var sum   = 0
+            Defers.run(chunk.collectUnit { case x if x % 2 == 0 => Defers(sum += x) })
+            assert(sum == 0)
+        }
+    }
+
+    "foreach" - {
+        "with a pure function" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            var sum   = 0
+            chunk.foreach(x => sum += x).pure
+            assert(sum == 15)
+        }
+
+        "with a function using Defers" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5)
+            var sum   = 0
+            Defers.run(chunk.foreach(x => Defers(sum += x)))
+            assert(sum == 15)
+        }
+
+        "with an empty chunk" in {
+            val chunk = Chunks.init[Int]
+            var sum   = 0
+            chunk.foreach(x => sum += x).pure
+            assert(sum == 0)
+        }
+    }
+
+    "hashCode and equals" - {
+        "equal chunks have the same hashCode" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init(1, 2, 3)
+            assert(chunk1.hashCode() == chunk2.hashCode())
+        }
+
+        "equal chunks are equal" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init(1, 2, 3)
+            assert(chunk1 == chunk2)
+        }
+
+        "different chunks have different hashCodes" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init(3, 2, 1)
+            assert(chunk1.hashCode() != chunk2.hashCode())
+        }
+
+        "different chunks are not equal" in {
+            val chunk1 = Chunks.init(1, 2, 3)
+            val chunk2 = Chunks.init(3, 2, 1)
+            assert(chunk1 != chunk2)
+        }
+
+        "empty chunks have the same hashCode" in {
+            val chunk1 = Chunks.init[Int]
+            val chunk2 = Chunks.init[Int]
+            assert(chunk1.hashCode() == chunk2.hashCode())
+        }
+
+        "empty chunks are equal" in {
+            val chunk1 = Chunks.init[Int]
+            val chunk2 = Chunks.init[Int]
+            assert(chunk1 == chunk2)
+        }
+    }
+
+    "Chunk.empty" in {
+        assert(Chunk.empty[Int].toSeq.isEmpty)
+    }
+
+    "Chunks.collect" - {
+        "collects elements from a chunk of effectful computations" in {
+            val chunk  = Chunks.init(Defers(1), Defers(2), Defers(3))
+            val result = Chunks.collect(chunk)
+            assert(Defers.run(result).pure == Chunks.init(1, 2, 3))
+        }
+
+        "collects elements from a chunk of effectful computations with different effect types" in {
+            val chunk  = Chunks.init(Defers(1), Options.get(Some(2)), Options.get(Some(3)))
+            val result = Chunks.collect(chunk)
+            assert(Defers.run(Options.run(result)).pure == Some(Chunks.init(1, 2, 3)))
+        }
+    }
+
+    "toString" - {
+        "prints the elements of a Chunk.Compact" in {
+            val chunk = Chunks.init[Int].append(1).append(2).append(3).toIndexed
+            assert(chunk.toString == "Chunk.Indexed(1, 2, 3)")
+        }
+
+        "prints the elements of a Chunk.FromSeq" in {
+            val chunk = Chunks.initSeq(IndexedSeq(1, 2, 3))
+            assert(chunk.toString == "Chunk.Indexed(1, 2, 3)")
+        }
+
+        "prints the elements of a Chunk.Drop" in {
+            val chunk = Chunks.init(1, 2, 3, 4, 5).dropLeft(2)
+            assert(chunk.toString == "Chunk(3, 4, 5)")
+        }
+
+        "prints the elements of a Chunk.Append" in {
+            val chunk = Chunks.init(1, 2, 3).append(4)
+            assert(chunk.toString == "Chunk(1, 2, 3, 4)")
+        }
+    }
+
+end chunksTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/envsTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/envsTest.scala
@@ -1,0 +1,223 @@
+package kyoTest
+
+import kyo.*
+
+class envsTest extends KyoPureTest:
+
+    "value" in {
+        val v1 =
+            Envs.get[Int].map(_ + 1)
+        val v2: Int < Envs[Int] = v1
+        assert(
+            Envs.run(1)(v2).pure ==
+                2
+        )
+    }
+
+    "use" in {
+        val v1 =
+            Envs.use[Int](_ + 1)
+        val v2: Int < Envs[Int] = v1
+        assert(
+            Envs.run(1)(v2).pure ==
+                2
+        )
+    }
+
+    "passing subclass" in {
+        trait Super:
+            def i = 42
+        case class Sub() extends Super
+        assert(Envs.run[Super](Sub())(Envs.use[Super](_.i)).pure == 42)
+    }
+
+    "inference" in {
+        def t1(v: Int < Envs[Int & String]) =
+            Envs.run(1)(v)
+        val _: Int < Envs[String] =
+            t1(42)
+        def t2(v: Int < (Envs[Int] & Envs[String])) =
+            Envs.run("s")(v)
+        val _: Int < Envs[Int] =
+            t2(42)
+        def t3(v: Int < Envs[String]) =
+            Envs.run("a")(v)
+        val _: Int < Any =
+            t3(42)
+        succeed
+    }
+
+    "intersection type env" - {
+        "explicit" in pendingUntilFixed {
+            val a = Envs.run(1)(Envs.get[Int & Double])
+            val b = Envs.run(1.2d)(a)
+            assert(b.pure == 1)
+            ()
+        }
+        "method inference" in pendingUntilFixed {
+            def test[T](v: T < (Envs[Int] & Envs[Double])) =
+                v
+            val a                                = test(Envs.get)
+            val b: (Int & Double) < Envs[Double] = Envs.run(1)(a)
+            val c: (Int & Double) < Any          = Envs.run(1.2d)(b)
+            assert(c.pure == 1)
+            ()
+        }
+    }
+
+    "reduce large intersection incrementally" in {
+        val t1: Int < Envs[Int & String & Boolean & Float & Char & Double] = 18
+        val t2                                                             = Envs.run(42)(t1)
+        val t3                                                             = Envs.run("a")(t2)
+        val t4                                                             = Envs.run(false)(t3)
+        val t5                                                             = Envs.run(0.23f)(t4)
+        val t6                                                             = Envs.run('a')(t5)
+        val t7                                                             = Envs.run(0.23d)(t6)
+        assert(t7.pure == 18)
+    }
+
+    "reduce large intersection in single expression" in {
+        val t: Int < Envs[Int & String & Boolean & Float & Char & Double] = 18
+        // NB: Adding a type annotation here leads to compilation error!
+        val res =
+            Envs.run(0.23d)(
+                Envs.run('a')(
+                    Envs.run(0.23f)(
+                        Envs.run(false)(
+                            Envs.run("a")(
+                                Envs.run(42)(t)
+                            )
+                        )
+                    )
+                )
+            )
+        assert(res.pure == 18)
+    }
+
+    "invalid inference" in {
+        assertDoesNotCompile("""
+            def t1(v: Int < Envs[Int & String]) =
+                Envs[Int].run[Int, Any, Nothing](1)(v)
+            val _: Int < Any = t1(42)
+        """)
+    }
+
+    "no transformations" in {
+        assert(Envs.run(1)(Envs.get[Int]).pure == 1)
+    }
+
+    "pure services" - {
+
+        trait Service1:
+            def apply(i: Int): Int
+        trait Service2:
+            def apply(i: Int): Int
+
+        val service1 = new Service1:
+            def apply(i: Int) = i + 1
+        val service2 = new Service2:
+            def apply(i: Int) = i + 2
+
+        "one service" in {
+            val a =
+                Envs.get[Service1].map(_(1))
+            assert(
+                Envs.run(service1)(a).pure ==
+                    2
+            )
+        }
+        "two services" - {
+            val a =
+                Envs.get[Service1].map(_(1)).map { i =>
+                    Envs.get[Service2].map(_(i))
+                }
+            val v: Int < (Envs[Service1] & Envs[Service2]) = a
+            "same handling order" in {
+                assert(
+                    Envs.run(service1)(Envs.run(service2)(v)).pure ==
+                        4
+                )
+            }
+            "reverse handling order" in {
+                assert(
+                    Envs.run(service2)(Envs.run(service1)(v)).pure ==
+                        4
+                )
+            }
+            "dependent services" in {
+                val v1 =
+                    Envs.run(service1)(v)
+                assert(
+                    Envs.run(service2)(v1).pure ==
+                        4
+                )
+            }
+        }
+    }
+
+    "effectful services" - {
+
+        trait Service1:
+            def apply(i: Int): Int < Options
+        trait Service2:
+            def apply(i: Int): Int < Options
+
+        val service1 = new Service1:
+            def apply(i: Int) = i match
+                case 0 => Options.get(Option.empty[Int])
+                case i => i + 1
+        val service2 = new Service2:
+            def apply(i: Int) = i match
+                case 0 => Options.get(Some(1))
+                case i => i + 1
+
+        "one service" - {
+            "continue" in {
+                val a =
+                    Envs.get[Service1].map(_(1))
+                assert(
+                    Options.run(Envs.run(service1)(a)).pure ==
+                        Some(2)
+                )
+            }
+            "short circuit" in {
+                val a =
+                    Envs.get[Service1].map(_(0))
+                assert(
+                    Options.run(Envs.run(service1)(a)).pure ==
+                        None
+                )
+            }
+        }
+        "two services" - {
+            "continue" - {
+                val a =
+                    Envs.get[Service1].map(_(1)).map { i =>
+                        Envs.get[Service2].map(_(i))
+                    }
+                val v: Int < (Envs[Service1] & Envs[Service2] & Options) = a
+                "same handling order" in {
+                    val b = Envs.run(service2)(v)
+                    val c = Envs.run(service1)(b)
+                    assert(
+                        Options.run(c).pure == Option(3)
+                    )
+                }
+                "reverse handling order" in {
+                    val b = Envs.run(service1)(v)
+                    val c = Envs.run(service2)(b)
+                    assert(
+                        Options.run(c).pure == Option(3)
+                    )
+                }
+                "dependent services" in {
+                    val v2: Int < (Envs[Service2] & Options) = Envs.run(service1)(v)
+                    assert(
+                        Options.run(Envs.run(service2)(v2)).pure ==
+                            Some(3)
+                    )
+                }
+            }
+        }
+    }
+end envsTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/localsTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/localsTest.scala
@@ -1,0 +1,299 @@
+package kyoTest
+
+import kyo.*
+
+class localsTest extends KyoPureTest:
+
+    "default" - {
+        "method" in {
+            val l = Locals.init(10)
+            assert(l.default == 10)
+        }
+        "get" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(l.get).pure ==
+                    10
+            )
+        }
+        "effect + get" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(Options.run(Options(1).map(_ => l.get))).pure ==
+                    Some(10)
+            )
+        }
+        "effect + get + effect" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(Options.run(Options(1).map(_ => l.get).map(Options(_)))).pure ==
+                    Some(10)
+            )
+        }
+        "multiple" in {
+            val l1 = Locals.init(10)
+            val l2 = Locals.init(20)
+            assert(
+                Defers.run(zip(l1.get, l2.get)).pure ==
+                    (10, 20)
+            )
+        }
+    }
+
+    "let" - {
+        "get" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(l.let(20)(l.get)).pure ==
+                    20
+            )
+        }
+        "effect + get" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(Options.run(Options(1).map(_ => l.let(20)(l.get)))).pure ==
+                    Some(20)
+            )
+        }
+        "effect + get + effect" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(
+                    Options.run(Options(1).map(_ => l.let(20)(l.get).map(Options(_))))
+                ).pure ==
+                    Some(20)
+            )
+        }
+        "multiple" in {
+            val l1 = Locals.init(10)
+            val l2 = Locals.init(20)
+            assert(
+                Defers.run(zip(l1.let(30)(l1.get), l2.let(40)(l2.get))).pure ==
+                    (30, 40)
+            )
+        }
+    }
+
+    "update" - {
+        "get" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(l.update(_ + 10)(l.get)).pure ==
+                    20
+            )
+        }
+        "effect + get" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(Options.run(Options(1).map(_ => l.update(_ + 10)(l.get)))).pure ==
+                    Some(20)
+            )
+        }
+        "effect + get + effect" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(
+                    Options.run(Options(1).map(_ => l.update(_ + 10)(l.get).map(Options(_))))
+                ).pure ==
+                    Some(20)
+            )
+        }
+        "multiple" in {
+            val l1 = Locals.init(10)
+            val l2 = Locals.init(20)
+            assert(
+                Defers.run(zip(l1.update(_ + 10)(l1.get), l2.update(_ + 10)(l2.get))).pure ==
+                    (20, 30)
+            )
+        }
+    }
+
+    given CanEqual[Locals.State, Map[Local[Int], Int]] = CanEqual.derived
+
+    "save" - {
+        "let + save" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(l.let(20)(Locals.save)).pure ==
+                    Map(l -> 20)
+            )
+        }
+        "let + effect + save" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(Options.run(l.let(20)(Options(1).map(_ =>
+                    Locals.save
+                )))).pure ==
+                    Some(Map(l -> 20))
+            )
+        }
+        "effect + let + save" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(Options.run(Options(1).map(_ =>
+                    l.let(20)(Locals.save)
+                ))).pure ==
+                    Some(Map(l -> 20))
+            )
+        }
+        "effect + let + save + effect" in {
+            val l = Locals.init(10)
+            assert(
+                Defers.run(Options.run(Options(1).map(_ =>
+                    l.let(20)(Locals.save).map(Options(_))
+                ))).pure ==
+                    Some(Map(l -> 20))
+            )
+        }
+        "nested" in {
+            val l1 = Locals.init(10)
+            val l2 = Locals.init(20)
+            assert(
+                Defers.run(
+                    l1.let(30)(
+                        l2.let(40)(
+                            Locals.save
+                        )
+                    )
+                ).pure ==
+                    Map(l1 -> 30, l2 -> 40)
+            )
+        }
+        "nested + effect" in {
+            val l1 = Locals.init(10)
+            val l2 = Locals.init(20)
+            assert(
+                Defers.run(
+                    Options.run(
+                        l1.let(30)(
+                            l2.let(40)(
+                                Options(1).map(_ => Locals.save)
+                            )
+                        )
+                    )
+                ).pure ==
+                    Some(Map(l1 -> 30, l2 -> 40))
+            )
+        }
+        "nested + effects" in {
+            val l1 = Locals.init(10)
+            val l2 = Locals.init(20)
+            assert(
+                Defers.run(
+                    Options.run(
+                        l1.let(30)(
+                            l2.let(40)(
+                                Options(1).map(_ => Locals.save).map(Options(_))
+                            ).map(Options(_))
+                        ).map(Options(_))
+                    )
+                ).pure ==
+                    Some(Map(l1 -> 30, l2 -> 40))
+            )
+        }
+        "multiple" in {
+            val l1 = Locals.init(0)
+            val l2 = Locals.init(0)
+            val l3 = Locals.init(0)
+            assert(
+                Defers.run(
+                    l3.let(20) {
+                        zip(
+                            l1.let(30)(Locals.save),
+                            l2.let(40)(Locals.save)
+                        )
+                    }
+                ).pure ==
+                    (Map(l3 -> 20, l1 -> 30), Map(l3 -> 20, l2 -> 40))
+            )
+        }
+        "multiple + effect" in {
+            val l1 = Locals.init(0)
+            val l2 = Locals.init(0)
+            val l3 = Locals.init(0)
+            assert(
+                Defers.run(
+                    Options.run(
+                        l3.let(20) {
+                            Options(1).map(_ =>
+                                zip(
+                                    l1.let(30)(Locals.save).map(Options(_)),
+                                    l2.let(40)(Locals.save)
+                                )
+                            )
+                        }
+                    )
+                ).pure ==
+                    Some((Map(l3 -> 20, l1 -> 30), Map(l3 -> 20, l2 -> 40)))
+            )
+        }
+    }
+
+    "restore" - {
+        val l1 = Locals.init(0)
+        val l2 = Locals.init(0)
+        val l3 = Locals.init(0)
+        val state: Locals.State =
+            Defers.run {
+                l1.let(10) {
+                    l2.let(20) {
+                        l3.let(30) {
+                            Locals.save
+                        }
+                    }
+                }
+            }.pure
+        "get" in {
+            assert(
+                Defers.run(Locals.restore(state)(l1.get)).pure ==
+                    10
+            )
+        }
+        "effect + get" in {
+            assert(
+                Defers.run(
+                    Options.run(Locals.restore[Int, Options & Defers](state)(Options(1).map(_ =>
+                        l1.get
+                    )))
+                ).pure ==
+                    Some(10)
+            )
+        }
+        "effect + get + effect" in {
+            assert(
+                Defers.run(
+                    Options.run(Locals.restore[Int, Options & Defers](state)(
+                        Options(1).map(_ => l1.get).map(Options(_))
+                    ))
+                ).pure ==
+                    Some(10)
+            )
+        }
+        "multiple" in {
+            assert(
+                Defers.run(Locals.restore(state)(zip(l1.get, l2.get))).pure ==
+                    (10, 20)
+            )
+        }
+        "multiple + effect" in {
+            assert(
+                Defers.run(
+                    Options.run(Locals.restore[(Int, Int), Options & Defers](state)(Options(1).map(_ =>
+                        zip(l1.get, l2.get)
+                    )))
+                ).pure ==
+                    Some((10, 20))
+            )
+        }
+        "nested" in {
+            assert(
+                Defers.run(
+                    l1.let(30) {
+                        Locals.restore(state)(zip(l1.get, l2.get))
+                    }
+                ).pure ==
+                    (10, 20)
+            )
+        }
+    }
+end localsTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/loopsTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/loopsTest.scala
@@ -1,0 +1,538 @@
+package kyoTest
+
+import kyo.*
+
+class loopsTest extends KyoPureTest:
+
+    "transform" - {
+        "with a single iteration" in {
+            assert(
+                Loops.transform(1)(i => if i < 5 then Loops.continue(i + 1) else Loops.done(i)).pure == 5
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.transform(1)(i => if i < 5 then Loops.continue(i + 1) else Loops.done(i)).pure == 5
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.transform(5)(i => if i < 5 then Loops.continue(i + 1) else Loops.done(i)).pure == 5
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+            def test[T](v: T) = Loops.transform(0)(i => Loops.done(v))
+          """)
+        }
+
+        "accumulate results in a List" in {
+            val result = Loops.transform((0, List.empty[Int])) { case (i, acc) =>
+                if i < 5 then
+                    Loops.continue((i + 1, i :: acc))
+                else
+                    Loops.done(acc.reverse)
+            }
+            assert(result.pure == List(0, 1, 2, 3, 4))
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.transform(1)(i => if i < largeNumber then Loops.continue(i + 1) else Loops.done(i)).pure == largeNumber
+            )
+        }
+
+        "stack safety with nested loops" in {
+            val outerLoopIterations = 1000
+            val innerLoopIterations = 1000
+
+            assert(
+                Loops.transform(0)(i =>
+                    if i < outerLoopIterations then
+                        Loops.continue(Loops.transform(0)(j =>
+                            if j < innerLoopIterations then Loops.continue(j + 1) else Loops.done(j)
+                        ).pure)
+                    else
+                        Loops.done(i)
+                ).pure == outerLoopIterations
+            )
+        }
+
+        "stack safety with multiple levels of nested loops" in {
+            val level1Iterations = 100
+            val level2Iterations = 100
+            val level3Iterations = 100
+
+            assert(
+                Loops.transform(0)(i =>
+                    if i < level1Iterations then
+                        Loops.continue(
+                            Loops.transform(0)(j =>
+                                if j < level2Iterations then
+                                    Loops.continue(
+                                        Loops.transform(0)(k => if k < level3Iterations then Loops.continue(k + 1) else Loops.done(k)).pure
+                                    )
+                                else
+                                    Loops.done(j)
+                            ).pure
+                        )
+                    else
+                        Loops.done(i)
+                ).pure == level1Iterations
+            )
+        }
+
+        "suspend with Defers at the beginning" in {
+            val result = Loops.transform(1)(i =>
+                Defers {
+                    if i < 5 then Loops.continue(i + 1) else Loops.done(i)
+                }
+            )
+            assert(Defers.run(result).pure == 5)
+        }
+
+        "suspend with Defers in the middle" in {
+            val result = Loops.transform(1)(i =>
+                if i < 3 then
+                    Defers(Loops.continue(i + 1))
+                else if i < 5 then
+                    Loops.continue(i + 1)
+                else
+                    Loops.done(i)
+            )
+            assert(Defers.run(result).pure == 5)
+        }
+
+        "suspend with Defers at the end" in {
+            val result = Loops.transform(1)(i =>
+                if i < 5 then
+                    Loops.continue(i + 1)
+                else
+                    Defers(Loops.done(i))
+            )
+            assert(Defers.run(result).pure == 5)
+        }
+    }
+
+    "transform2" - {
+        "with a single iteration" in {
+            assert(
+                Loops.transform(1, 1)((i, j) => if i + j < 5 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 6
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.transform(1, 1)((i, j) => if i + j < 10 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 10
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.transform(5, 5)((i, j) => if i + j < 10 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 10
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+            def test[T](v: T) = Loops.transform2(0, 0)((i, j) => Loops.done(v))
+          """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.transform(1, 1)((i, j) =>
+                    if i + j < largeNumber then Loops.continue(i + 1, j + 1)
+                    else Loops.done(i + j)
+                ).pure == largeNumber
+            )
+        }
+
+        "stack safety with nested loops" in {
+            val outerLoopIterations = 1000
+            val innerLoopIterations = 1000
+            assert(
+                Loops.transform(0, 0)((i, j) =>
+                    if i < outerLoopIterations then
+                        Loops.continue(
+                            i + 1,
+                            Loops.transform(0)(k =>
+                                if k < innerLoopIterations then Loops.continue(k + 1)
+                                else Loops.done(k)
+                            ).pure
+                        )
+                    else Loops.done(j)
+                ).pure == innerLoopIterations
+            )
+        }
+
+        "stack safety with interleaved iterations" in {
+            val iterations = 100000
+            assert(
+                Loops.transform(0, 0)((i, j) =>
+                    if i + j < iterations then
+                        if i % 2 == 0 then Loops.continue(i + 1, j)
+                        else Loops.continue(i, j + 1)
+                    else Loops.done(i + j)
+                ).pure == iterations
+            )
+        }
+
+        "suspend with Defers at the beginning" in {
+            val result = Loops.transform(1, 1)((i, j) =>
+                Defers {
+                    if i + j < 5 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)
+                }
+            )
+            assert(Defers.run(result).pure == 6)
+        }
+
+        "suspend with Defers in the middle" in {
+            val result = Loops.transform(1, 1)((i, j) =>
+                if i + j < 3 then
+                    Defers(Loops.continue(i + 1, j + 1))
+                else if i + j < 5 then
+                    Loops.continue(i + 1, j + 1)
+                else
+                    Loops.done(i + j)
+            )
+            assert(Defers.run(result).pure == 6)
+        }
+
+        "suspend with Defers at the end" in {
+            val result = Loops.transform(1, 1)((i, j) =>
+                if i + j < 5 then
+                    Loops.continue(i + 1, j + 1)
+                else
+                    Defers(Loops.done(i + j))
+            )
+            assert(Defers.run(result).pure == 6)
+        }
+    }
+
+    "transform3" - {
+        "with a single iteration" in {
+            assert(
+                Loops.transform(1, 1, 1)((i, j, k) =>
+                    if i + j + k < 5 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 6
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.transform(1, 1, 1)((i, j, k) =>
+                    if i + j + k < 10 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 12
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.transform(5, 5, 5)((i, j, k) =>
+                    if i + j + k < 10 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 15
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+            def test[T](v: T) = Loops.transform3(0, 0, 0)((i, j, j) => Loops.done(v))
+          """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.transform(1, 1, 1)((i, j, k) =>
+                    if i + j + k < largeNumber then Loops.continue(i + 1, j + 1, k + 1)
+                    else Loops.done(i + j + k)
+                ).pure == largeNumber + 2
+            )
+        }
+
+        "stack safety with interleaved iterations" in {
+            val iterations = 100000
+            assert(
+                Loops.transform(0, 0, 0)((i, j, k) =>
+                    if i + j + k < iterations then
+                        if i % 3 == 0 then Loops.continue(i + 1, j, k)
+                        else if i % 3 == 1 then Loops.continue(i, j + 1, k)
+                        else Loops.continue(i, j, k + 1)
+                    else Loops.done(i + j + k)
+                ).pure == iterations
+            )
+        }
+
+        "suspend with Defers at the beginning" in {
+            val result = Loops.transform(1, 1, 1)((i, j, k) =>
+                Defers {
+                    if i + j + k < 5 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                }
+            )
+            assert(Defers.run(result).pure == 6)
+        }
+
+        "suspend with Defers in the middle" in {
+            val result = Loops.transform(1, 1, 1)((i, j, k) =>
+                if i + j + k < 3 then
+                    Defers(Loops.continue(i + 1, j + 1, k + 1))
+                else if i + j + k < 5 then
+                    Loops.continue(i + 1, j + 1, k + 1)
+                else
+                    Loops.done(i + j + k)
+            )
+            assert(Defers.run(result).pure == 6)
+        }
+
+        "suspend with Defers at the end" in {
+            val result = Loops.transform(1, 1, 1)((i, j, k) =>
+                if i + j + k < 5 then
+                    Loops.continue(i + 1, j + 1, k + 1)
+                else
+                    Defers(Loops.done(i + j + k))
+            )
+            assert(Defers.run(result).pure == 6)
+        }
+    }
+
+    "indexed without input" - {
+        "with a single iteration" in {
+            assert(
+                Loops.indexed(idx => if idx < 1 then Loops.continue(()) else Loops.done(idx)).pure == 1
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.indexed(idx => if idx < 5 then Loops.continue(()) else Loops.done(idx)).pure == 5
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.indexed(idx => if idx < 0 then Loops.continue(()) else Loops.done(idx)).pure == 0
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+            def test[T](v: T) = Loops.indexed(idx => Loops.done(v))
+            """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.indexed(idx => if idx < largeNumber then Loops.continue(()) else Loops.done(idx)).pure == largeNumber
+            )
+        }
+
+        "suspend with Defers" in {
+            val result = Loops.indexed(idx =>
+                if idx < 5 then
+                    Defers(Loops.continue(()))
+                else
+                    Defers(Loops.done(idx))
+            )
+            assert(Defers.run(result).pure == 5)
+        }
+    }
+
+    "indexed" - {
+        "with a single iteration" in {
+            assert(
+                Loops.indexed(1)((idx, i) => if idx < 5 then Loops.continue(i + 1) else Loops.done(i)).pure == 6
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.indexed(1)((idx, i) => if idx < 10 then Loops.continue(i + 1) else Loops.done(i)).pure == 11
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.indexed(1)((idx, i) => if idx < 0 then Loops.continue(i + 1) else Loops.done(i)).pure == 1
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+        def test[T](v: T) = Loops.indexed(0)((idx, i) => Loops.done(v))
+        """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.indexed(1)((idx, i) => if idx < largeNumber then Loops.continue(i + 1) else Loops.done(i)).pure == largeNumber + 1
+            )
+        }
+
+        "suspend with Defers" in {
+            val result = Loops.indexed(1)((idx, i) =>
+                if idx < 5 then
+                    Defers(Loops.continue(i + 1))
+                else
+                    Defers(Loops.done(i))
+            )
+            assert(Defers.run(result).pure == 6)
+        }
+    }
+
+    "indexed2" - {
+        "with a single iteration" in {
+            assert(
+                Loops.indexed(1, 1)((idx, i, j) => if idx < 5 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 12
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.indexed(1, 1)((idx, i, j) => if idx < 10 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 22
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.indexed(1, 1)((idx, i, j) => if idx < 0 then Loops.continue(i + 1, j + 1) else Loops.done(i + j)).pure == 2
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+        def test[T](v: T) = Loops.indexed2(0, 0)((idx, i, j) => Loops.done(v))
+        """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.indexed(1, 1)((idx, i, j) =>
+                    if idx < largeNumber then Loops.continue(i + 1, j + 1) else Loops.done(i + j)
+                ).pure == 2 * largeNumber + 2
+            )
+        }
+
+        "suspend with Defers" in {
+            val result = Loops.indexed(1, 1)((idx, i, j) =>
+                if idx < 5 then
+                    Defers(Loops.continue(i + 1, j + 1))
+                else
+                    Defers(Loops.done(i + j))
+            )
+            assert(Defers.run(result).pure == 12)
+        }
+    }
+
+    "indexed3" - {
+        "with a single iteration" in {
+            assert(
+                Loops.indexed(1, 1, 1)((idx, i, j, k) =>
+                    if idx < 5 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 18
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loops.indexed(1, 1, 1)((idx, i, j, k) =>
+                    if idx < 10 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 33
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loops.indexed(1, 1, 1)((idx, i, j, k) =>
+                    if idx < 0 then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 3
+            )
+        }
+
+        "output must be flat" in {
+            assertDoesNotCompile("""
+        def test[T](v: T) = Loops.indexed3(0, 0, 0)((idx, i, j, k) => Loops.done(v))
+        """)
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loops.indexed(1, 1, 1)((idx, i, j, k) =>
+                    if idx < largeNumber then Loops.continue(i + 1, j + 1, k + 1) else Loops.done(i + j + k)
+                ).pure == 3 * largeNumber + 3
+            )
+        }
+
+        "suspend with Defers" in {
+            val result = Loops.indexed(1, 1, 1)((idx, i, j, k) =>
+                if idx < 5 then
+                    Defers(Loops.continue(i + 1, j + 1, k + 1))
+                else
+                    Defers(Loops.done(i + j + k))
+            )
+            assert(Defers.run(result).pure == 18)
+        }
+    }
+
+    "foreach" - {
+        "with a single iteration" in {
+            var counter = 0
+            Loops.foreach {
+                counter += 1
+                if counter < 1 then Loops.continue(()) else Loops.done(())
+            }.pure
+            assert(counter == 1)
+        }
+
+        "with multiple iterations" in {
+            var sum = 0
+            Loops.foreach {
+                sum += 1
+                if sum < 10 then Loops.continue(()) else Loops.done(())
+            }.pure
+            assert(sum == 10)
+        }
+
+        "with no iterations" in {
+            var entered = false
+            Loops.foreach {
+                entered = true
+                Loops.done(())
+            }.pure
+            assert(entered)
+        }
+
+        "stack safety" in {
+            var counter     = 0
+            val largeNumber = 100000
+            Loops.foreach {
+                counter += 1
+                if counter < largeNumber then Loops.continue(()) else Loops.done(())
+            }.pure
+            assert(counter == largeNumber)
+        }
+
+        "suspend with Defers" in {
+            var effect = ""
+            val result = Loops.foreach {
+                effect += "A"
+                if effect.length < 3 then
+                    Defers(Loops.continue(()))
+                else
+                    Defers(Loops.done(()))
+                end if
+            }
+            Defers.run(result).pure
+            assert(effect == "AAA")
+        }
+    }
+end loopsTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/optionsTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/optionsTest.scala
@@ -1,0 +1,199 @@
+package kyoTest
+
+import kyo.*
+
+class optionsTest extends KyoPureTest:
+
+    "apply" - {
+        "null" in {
+            assert(Options.run(Options(null: String)).pure == None)
+            assert(
+                Options.run(Options(null: String)).pure ==
+                    None
+            )
+        }
+        "value" in {
+            assert(
+                Options.run(Options("hi")).pure ==
+                    Option("hi")
+            )
+        }
+    }
+
+    "pure" - {
+        "handle" in {
+            assert(
+                Options.run(1: Int < Options).pure ==
+                    Option(1)
+            )
+        }
+        "handle + transform" in {
+            assert(
+                Options.run((1: Int < Options).map(_ + 1)).pure ==
+                    Option(2)
+            )
+        }
+        "handle + effectful transform" in {
+            assert(
+                Options.run((1: Int < Options).map(i => Options.get(Option(i + 1)))).pure ==
+                    Option(2)
+            )
+        }
+        "handle + transform + effectful transform" in {
+            assert(
+                Options.run(
+                    (1: Int < Options).map(_ + 1).map(i => Options.get(Option(i + 1)))
+                ).pure ==
+                    Option(3)
+            )
+        }
+    }
+
+    "effectful" - {
+        "handle" in {
+            assert(
+                Options.run(Options.get(Option(1))).pure ==
+                    Option(1)
+            )
+        }
+        "handle + transform" in {
+            assert(
+                Options.run(Options.get(Option(1)).map(_ + 1)).pure ==
+                    Option(2)
+            )
+        }
+        "handle + effectful transform" in {
+            assert(
+                Options.run(Options.get(Option(1)).map(i => Options.get(Option(i + 1)))).pure ==
+                    Option(2)
+            )
+        }
+        "handle + transform + effectful transform" in {
+            assert(
+                Options.run(
+                    Options.get(Option(1)).map(_ + 1).map(i => Options.get(Option(i + 1)))
+                ).pure ==
+                    Option(3)
+            )
+        }
+    }
+
+    "Options.run" - {
+        "pure" in {
+            assert(
+                Options.run(1: Int < Options).pure ==
+                    Option(1)
+            )
+        }
+        "not empty" in {
+            assert(
+                Options.run(Options.get(Option(1))).pure ==
+                    Option(1)
+            )
+        }
+        "empty" in {
+            assert(
+                Options.run(Options.get(Option.empty[Int])).pure ==
+                    None
+            )
+        }
+    }
+
+    "orElse" - {
+        "empty" in {
+            assert(
+                Options.run(Options.orElse[Int, Any]()).pure ==
+                    None
+            )
+        }
+        "not empty" in {
+            assert(
+                Options.run(Options.orElse(Options.get(Option(1)))).pure ==
+                    Option(1)
+            )
+        }
+        "not empty + empty" in {
+            assert(
+                Options.run(
+                    Options.orElse(Options.get(Option(1)), Options.get(Option.empty[Int]))
+                ).pure ==
+                    Option(1)
+            )
+        }
+        "empty + not empty" in {
+            assert(
+                Options.run(
+                    Options.orElse(Options.get(Option.empty[Int]), Options.get(Option(1)))
+                ).pure ==
+                    Option(1)
+            )
+        }
+        "empty + empty" in {
+            assert(
+                Options.run(Options.orElse(
+                    Options.get(Option.empty[Int]),
+                    Options.get(Option.empty[Int])
+                )).pure ==
+                    None
+            )
+        }
+        "not empty + not empty" in {
+            assert(
+                Options.run(Options.orElse(Options.get(Option(1)), Options.get(Option(2)))).pure ==
+                    Option(1)
+            )
+        }
+        "not empty + not empty + not empty" in {
+            assert(
+                Options.run(Options.orElse(
+                    Options.get(Option(1)),
+                    Options.get(Option(2)),
+                    Options.get(Option(3))
+                )).pure ==
+                    Option(1)
+            )
+        }
+        "not empty + not empty + not empty + not empty" in {
+            assert(
+                Options.run(
+                    Options.orElse(
+                        Options.get(Option(1)),
+                        Options.get(Option(2)),
+                        Options.get(Option(3)),
+                        Options.get(Option(4))
+                    )
+                ).pure ==
+                    Option(1)
+            )
+        }
+        "not empty + not empty + not empty + not empty + not empty" in {
+            assert(
+                Options.run(
+                    Options.orElse(
+                        Options.get(Option(1)),
+                        Options.get(Option(2)),
+                        Options.get(Option(3)),
+                        Options.get(Option(4)),
+                        Options.get(Option(5))
+                    )
+                ).pure ==
+                    Option(1)
+            )
+        }
+    }
+
+    "getOrElse" - {
+        "empty" in {
+            assert(
+                Options.getOrElse(Option.empty[Int], 1).pure ==
+                    1
+            )
+        }
+        "not empty" in {
+            assert(
+                Options.getOrElse(Some(2), 1).pure ==
+                    2
+            )
+        }
+    }
+end optionsTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/seqsTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/seqsTest.scala
@@ -1,0 +1,129 @@
+package kyoTest
+
+import kyo.*
+
+class seqsTest extends KyoPureTest:
+    "collect" in {
+        assert(Seqs.collect(Seq.empty).pure == Seq.empty)
+        assert(Seqs.collect(Seq(1)).pure == Seq(1))
+        assert(Seqs.collect(Seq(1, 2)).pure == Seq(1, 2))
+        assert(Seqs.collect(Seq.fill(100)(1)).pure == Seq.fill(100)(1))
+        assert(Seqs.collect(List(1, 2, 3)).pure == List(1, 2, 3))
+        assert(Seqs.collect(Vector(1, 2, 3)).pure == Vector(1, 2, 3))
+    }
+
+    "collectUnit" in {
+        var count = 0
+        val io    = Defers(count += 1)
+        Defers.run(Seqs.collectUnit(Seq.empty))
+        assert(count == 0)
+        Defers.run(Seqs.collectUnit(Seq(io)))
+        assert(count == 1)
+        Defers.run(Seqs.collectUnit(List.fill(42)(io)))
+        assert(count == 43)
+        Defers.run(Seqs.collectUnit(Vector.fill(10)(io)))
+        assert(count == 53)
+    }
+
+    "map" in {
+        assert(Seqs.map(Seq.empty[Int])(_ + 1).pure == Seq.empty)
+        assert(Seqs.map(Seq(1))(_ + 1).pure == Seq(2))
+        assert(Seqs.map(Seq(1, 2))(_ + 1).pure == Seq(2, 3))
+        assert(Seqs.map(Seq.fill(100)(1))(_ + 1).pure == Seq.fill(100)(2))
+        assert(Seqs.map(List(1, 2, 3))(_ + 1).pure == List(2, 3, 4))
+        assert(Seqs.map(Vector(1, 2, 3))(_ + 1).pure == Vector(2, 3, 4))
+    }
+
+    "foreach" in {
+        var acc = Seq.empty[Int]
+        Defers.run(Seqs.foreach(Seq.empty[Int])(v => Defers(acc :+= v)))
+        assert(acc == Seq.empty)
+        acc = Seq.empty[Int]
+        Defers.run(Seqs.foreach(Seq(1))(v => Defers(acc :+= v)))
+        assert(acc == Seq(1))
+        acc = Seq.empty[Int]
+        Defers.run(Seqs.foreach(Seq(1, 2))(v => Defers(acc :+= v)))
+        assert(acc == Seq(1, 2))
+        acc = Seq.empty[Int]
+        Defers.run(Seqs.foreach(Seq.fill(100)(1))(v => Defers(acc :+= v)))
+        assert(acc == Seq.fill(100)(1))
+        acc = Seq.empty[Int]
+        Defers.run(Seqs.foreach(List(1, 2, 3))(v => Defers(acc :+= v)))
+        assert(acc == List(1, 2, 3))
+        acc = Seq.empty[Int]
+        Defers.run(Seqs.foreach(Vector(1, 2, 3))(v => Defers(acc :+= v)))
+        assert(acc == Vector(1, 2, 3))
+    }
+
+    "foldLeft" in {
+        assert(Seqs.foldLeft(Seq.empty[Int])(0)(_ + _).pure == 0)
+        assert(Seqs.foldLeft(Seq(1))(0)(_ + _).pure == 1)
+        assert(Seqs.foldLeft(Seq(1, 2, 3))(0)(_ + _).pure == 6)
+        assert(Seqs.foldLeft(Seq.fill(100)(1))(0)(_ + _).pure == 100)
+        assert(Seqs.foldLeft(List(1, 2, 3))(0)(_ + _).pure == 6)
+        assert(Seqs.foldLeft(Vector(1, 2, 3))(0)(_ + _).pure == 6)
+    }
+
+    "fill" in {
+        assert(Defers.run(Seqs.fill(0)(Defers(1))).pure == Seq.empty)
+        assert(Defers.run(Seqs.fill(1)(Defers(1))).pure == Seq(1))
+        assert(Defers.run(Seqs.fill(3)(Defers(1))).pure == Seq(1, 1, 1))
+        assert(Defers.run(Seqs.fill(100)(Defers(1))).pure == Seq.fill(100)(1))
+    }
+
+    "repeat" in {
+        var count = 0
+        val io    = Defers(count += 1)
+
+        Defers.run(Seqs.repeat(0)(io))
+        assert(count == 0)
+
+        count = 0
+        Defers.run(Seqs.repeat(1)(io))
+        assert(count == 1)
+
+        count = 0
+        Defers.run(Seqs.repeat(100)(io))
+        assert(count == 100)
+
+        count = 0
+        Defers.run(Seqs.repeat(10000)(io))
+        assert(count == 10000)
+    }
+
+    "stack safety" - {
+        val n = 10000
+
+        "collect" in {
+            val largeSeq = Seq.fill(n)(1)
+            assert(Seqs.collect(largeSeq).pure == largeSeq)
+        }
+
+        "collectUnit" in {
+            var count = 0
+            val io    = Defers(count += 1)
+            Defers.run(Seqs.collectUnit(Seq.fill(n)(io)))
+            assert(count == n)
+        }
+
+        "map" in {
+            val largeSeq = Seq.fill(n)(1)
+            assert(Seqs.map(largeSeq)(_ + 1).pure == Seq.fill(n)(2))
+        }
+
+        "foreach" in {
+            var acc = Seq.empty[Int]
+            Defers.run(Seqs.foreach(Seq.fill(n)(1))(v => Defers(acc :+= v)))
+            assert(acc == Seq.fill(n)(1))
+        }
+
+        "foldLeft" in {
+            val largeSeq = Seq.fill(n)(1)
+            assert(Seqs.foldLeft(largeSeq)(0)(_ + _).pure == n)
+        }
+
+        "fill" in {
+            assert(Defers.run(Seqs.fill(n)(Defers(1))).pure == Seq.fill(n)(1))
+        }
+    }
+end seqsTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/streamsTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/streamsTest.scala
@@ -1,0 +1,403 @@
+package kyoTest
+
+import kyo.*
+
+class streamsTest extends KyoPureTest:
+
+    val n = 10000
+
+    "initSeq" - {
+        "empty" in {
+            assert(
+                Streams.initSeq(Seq()).runSeq.pure == (Seq.empty, ())
+            )
+        }
+
+        "non-empty" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).runSeq.pure == (Seq(1, 2, 3), ())
+            )
+        }
+    }
+
+    "emitSeq" - {
+        "empty" in {
+            assert(
+                Streams.initSource(Streams.emitSeq(Seq.empty[Int])).runSeq.pure == (Seq.empty, ())
+            )
+        }
+
+        "non-empty" in {
+            assert(
+                Streams.initSource(Streams.emitSeq(Seq(1, 2, 3))).runSeq.pure == (Seq(1, 2, 3), ())
+            )
+        }
+    }
+
+    "take" - {
+        "zero" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).take(0).runSeq.pure == (Seq.empty, ())
+            )
+        }
+
+        "negative" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).take(-1).runSeq.pure == (Seq.empty, ())
+            )
+        }
+
+        "two" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).take(2).runSeq.pure == (Seq(1, 2), ())
+            )
+        }
+
+        "more than available" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).take(5).runSeq.pure == (Seq(1, 2, 3), ())
+            )
+        }
+
+        "stack safety" in {
+            assert(
+                Streams.initSeq(Seq.fill(100000)(1)).take(5).runSeq.pure ==
+                    (Seq.fill(5)(1), ())
+            )
+        }
+    }
+
+    "drop" - {
+        "zero" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).drop(0).runSeq.pure == (Seq(1, 2, 3), ())
+            )
+        }
+
+        "negative" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).drop(-1).runSeq.pure == (Seq(1, 2, 3), ())
+            )
+        }
+
+        "two" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).drop(2).runSeq.pure == (Seq(3), ())
+            )
+        }
+
+        "more than available" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).drop(5).runSeq.pure == (Seq.empty, ())
+            )
+        }
+
+        "stack safety" in {
+            assert(
+                Streams.initSeq(Seq.fill(n)(1)).drop(5).runSeq.pure._1.size == n - 5
+            )
+        }
+    }
+
+    "takeWhile" - {
+        "take none" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).takeWhile(_ < 0).runSeq.pure == (Seq.empty, ())
+            )
+        }
+
+        "take some" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3, 4, 5)).takeWhile(_ < 4).runSeq.pure == (Seq(
+                    1,
+                    2,
+                    3
+                ), ())
+            )
+        }
+
+        "take all" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).takeWhile(_ < 10).runSeq.pure ==
+                    (Seq(1, 2, 3), ())
+            )
+        }
+
+        "empty stream" in {
+            assert(
+                Streams.initSeq(Seq.empty[Int]).takeWhile(_ => true).runSeq.pure ==
+                    (Seq.empty, ())
+            )
+        }
+
+        "with effects" in {
+            var count  = 0
+            val stream = Streams.initSeq(Seq(1, 2, 3, 4, 5))
+            val taken = stream.takeWhile { v =>
+                Defers { count += 1; count < 4 }
+            }.runSeq
+            assert(Defers.run(taken).pure == (Seq(1, 2, 3), ()))
+        }
+
+        "stack safety" in {
+            assert(
+                Streams.initSeq(Seq.fill(n)(1)).takeWhile(_ == 1).runSeq.pure ==
+                    (Seq.fill(n)(1), ())
+            )
+        }
+    }
+
+    "dropWhile" - {
+        "drop none" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).dropWhile(_ < 0).runSeq.pure ==
+                    (Seq(1, 2, 3), ())
+            )
+        }
+
+        "drop some" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3, 4, 5)).dropWhile(_ < 4).runSeq.pure ==
+                    (Seq(4, 5), ())
+            )
+        }
+
+        "drop all" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).dropWhile(_ < 10).runSeq.pure ==
+                    (Seq.empty, ())
+            )
+        }
+
+        "empty stream" in {
+            assert(
+                Streams.initSeq(Seq.empty[Int]).dropWhile(_ => false).runSeq.pure ==
+                    (Seq.empty, ())
+            )
+        }
+
+        "with effects" in {
+            var count  = 0
+            val stream = Streams.initSeq(Seq(1, 2, 3, 4, 5))
+            val dropped = stream.dropWhile { v =>
+                Defers { count += 1; count < 3 }
+            }.runSeq
+            assert(Defers.run(dropped).pure == (Seq(3, 4, 5), ()))
+        }
+
+        "stack safety" in {
+            assert(
+                Streams.initSeq(Seq.fill(n)(1) ++ Seq(2)).dropWhile(_ == 1).runSeq.pure ==
+                    (Seq(2), ())
+            )
+        }
+    }
+
+    "filter" - {
+        "non-empty" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).filter(_ % 2 == 0).runSeq.pure ==
+                    (Seq(2), ())
+            )
+        }
+
+        "all in" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).filter(_ => true).runSeq.pure ==
+                    (Seq(1, 2, 3), ())
+            )
+        }
+
+        "all out" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).filter(_ => false).runSeq.pure ==
+                    (Seq.empty, ())
+            )
+        }
+
+        "stack safety" in {
+            assert(
+                Streams.initSeq(1 to n).filter(_ % 2 == 0).runSeq.pure._1.size ==
+                    n / 2
+            )
+        }
+    }
+
+    "changes" - {
+        "no duplicates" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).changes.runSeq.pure ==
+                    (Seq(1, 2, 3), ())
+            )
+        }
+
+        "with duplicates" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 2, 3, 2, 3, 3)).changes.runSeq.pure ==
+                    (Seq(1, 2, 3, 2, 3), ())
+            )
+        }
+
+        "empty stream" in {
+            assert(
+                Streams.initSeq(Seq.empty[Int]).changes.runSeq.pure ==
+                    (Seq.empty, ())
+            )
+        }
+
+        "stack safety" in {
+            assert(
+                Streams.initSeq(Seq.fill(n)(1)).changes.runSeq.pure ==
+                    (Seq(1), ())
+            )
+        }
+    }
+
+    "collect" - {
+        "to string" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).collect {
+                    case v if v % 2 == 0 => Streams.emitSeq(Seq(s"even: $v"))
+                }.runSeq.pure == (Seq("even: 2"), ())
+            )
+        }
+
+        "none" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).collect {
+                    case v if false => ???
+                }.runSeq.pure == (Seq.empty, ())
+            )
+        }
+
+        "with effects" in {
+            val stream = Streams.initSeq(Seq(1, 2, 3, 4, 5))
+            val collected = stream.collect {
+                case v if v % 2 == 0 =>
+                    Defers(println(s"Even: $v")).andThen(Streams.emitSeq(Seq(v)))
+            }.runSeq
+            assert(Defers.run(collected).pure == (Seq(2, 4), ()))
+        }
+
+        "stack safety" in {
+            assert(
+                Streams.initSeq(1 to n).collect {
+                    case v if v % 2 == 0 => Streams.emitSeq(Seq(v))
+                }.runSeq.pure._1.size == n / 2
+            )
+        }
+    }
+
+    "transform" - {
+        "double" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).transform(_ * 2).runSeq.pure == (Seq(2, 4, 6), ())
+            )
+        }
+
+        "to string" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).transform(_.toString).runSeq.pure ==
+                    (Seq("1", "2", "3"), ())
+            )
+        }
+
+        "with effects" in {
+            val stream      = Streams.initSeq(Seq(1, 2, 3))
+            val transformed = stream.transform(v => Defers(v * 2)).runSeq
+            assert(Defers.run(transformed).pure == (Seq(2, 4, 6), ()))
+        }
+
+        "stack safety" in {
+            assert(
+                Streams.initSeq(Seq.fill(n)(1)).transform(_ + 1).runSeq.pure ==
+                    (Seq.fill(n)(2), ())
+            )
+        }
+    }
+
+    "concat" - {
+        "non-empty streams" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3))
+                    .concat(Streams.initSeq(Seq(4, 5, 6)))
+                    .runSeq.pure == (Seq(1, 2, 3, 4, 5, 6), ((), ()))
+            )
+        }
+
+        "empty left stream" in {
+            assert(
+                Streams.initSeq(Seq.empty[Int])
+                    .concat(Streams.initSeq(Seq(1, 2, 3)))
+                    .runSeq.pure == (Seq(1, 2, 3), ((), ()))
+            )
+        }
+
+        "empty right stream" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3))
+                    .concat(Streams.initSeq(Seq.empty[Int]))
+                    .runSeq.pure == (Seq(1, 2, 3), ((), ()))
+            )
+        }
+
+        "both streams empty" in {
+            assert(
+                Streams.initSeq(Seq.empty[Int])
+                    .concat(Streams.initSeq(Seq.empty[Int]))
+                    .runSeq.pure == (Seq.empty, ((), ()))
+            )
+        }
+
+        "stack safety" in {
+            assert(
+                Streams.initSeq(1 to n)
+                    .concat(Streams.initSeq(n + 1 to 2 * n))
+                    .runSeq.pure == ((1 to (2 * n)).toSeq, ((), ()))
+            )
+        }
+    }
+
+    "runDiscard" - {
+        "non-empty stream" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).runDiscard.pure == ()
+            )
+        }
+
+        "empty stream" in {
+            assert(
+                Streams.initSeq(Seq.empty[Int]).runDiscard.pure == ()
+            )
+        }
+    }
+
+    "runFold" - {
+        "sum" in {
+            assert(
+                Streams.initSeq(Seq(1, 2, 3)).runFold(0)(_ + _).pure == (6, ())
+            )
+        }
+
+        "concat" in {
+            assert(
+                Streams.initSeq(Seq("a", "b", "c")).runFold("")(_ + _).pure == ("abc", ())
+            )
+        }
+
+        "early termination" in {
+            val stream = Streams.initSeq(Seq(1, 2, 3, 4, 5))
+            val folded = stream.runFold(0) { (acc, v) =>
+                if acc < 6 then acc + v else Aborts.fail(())
+            }
+            assert(Aborts.run[Unit](folded).pure.fold(_ => true, _ => false))
+        }
+
+        "stack safety" in {
+            assert(
+                Streams.initSeq(Seq.fill(n)(1)).runFold(0)(_ + _).pure == (n, ())
+            )
+        }
+    }
+
+end streamsTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/sumsTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/sumsTest.scala
@@ -1,0 +1,72 @@
+package kyoTest
+
+import kyo.*
+
+class sumsTest extends KyoPureTest:
+
+    "int" in {
+        val v: String < Sums[Int] =
+            for
+                _ <- Sums.add(1)
+                _ <- Sums.add(1)
+                _ <- Sums.add(1)
+            yield "a"
+
+        assert(Sums.run(v).pure == (Chunks.init(1, 1, 1), "a"))
+    }
+    "string" in {
+        val v: String < Sums[String] =
+            for
+                _ <- Sums.add("1")
+                _ <- Sums.add("2")
+                _ <- Sums.add("3")
+            yield "a"
+        val res = Sums.run(v)
+        assert(res.pure == (Chunks.init("1", "2", "3"), "a"))
+    }
+    "int and string" in {
+        val v: String < (Sums[Int] & Sums[String]) =
+            for
+                _ <- Sums.add(3)
+                _ <- Sums.add("1")
+                _ <- Sums.add(2)
+                _ <- Sums.add("2")
+                _ <- Sums.add(1)
+                _ <- Sums.add("3")
+            yield "a"
+        val res: (Chunk[String], (Chunk[Int], String)) =
+            Sums.run(Sums.run[Int](v)).pure
+        assert(res == (Chunks.init("1", "2", "3"), (Chunks.init(3, 2, 1), "a")))
+    }
+
+    "no values" in {
+        val t = Sums.run[Int]("a").pure
+        assert(t == (Chunks.init, "a"))
+
+        val t2 = Sums.run[String](42).pure
+        assert(t2 == (Chunks.init, 42))
+    }
+
+    "List" in {
+        val v =
+            for
+                _ <- Sums.add(List(1))
+                _ <- Sums.add(List(2))
+                _ <- Sums.add(List(3))
+            yield "a"
+        val res = Sums.run(v)
+        assert(res.pure == (Chunks.init(List(1), List(2), List(3)), "a"))
+    }
+
+    "Set" in {
+        val v =
+            for
+                _ <- Sums.add(Set(1))
+                _ <- Sums.add(Set(2))
+                _ <- Sums.add(Set(3))
+            yield "a"
+        val res = Sums.run(v)
+        assert(res.pure == (Chunks.init(Set(1), Set(2), Set(3)), "a"))
+    }
+
+end sumsTest

--- a/kyo-pure/shared/src/test/scala/kyoTest/varsTest.scala
+++ b/kyo-pure/shared/src/test/scala/kyoTest/varsTest.scala
@@ -1,0 +1,77 @@
+package kyoTest
+
+import kyo.*
+
+class varsTest extends KyoPureTest:
+
+    "get" in {
+        val r = Vars.run(1)(Vars.get[Int].map(_ + 1)).pure
+        assert(r == 2)
+    }
+
+    "use" in {
+        val r = Vars.run(1)(Vars.use[Int](_ + 1)).pure
+        assert(r == 2)
+    }
+
+    "set, get" in {
+        val r = Vars.run(1)(Vars.set(2).andThen(Vars.get[Int])).pure
+        assert(r == 2)
+    }
+
+    "get, set, get" in {
+        val r = Vars.run(1)(
+            Vars.get[Int].map(i => Vars.set[Int](i + 1)).andThen(Vars.get[Int])
+        ).pure
+        assert(r == 2)
+    }
+
+    "update" in {
+        val r = Vars.run(1)(Vars.update[Int](_ + 1).andThen(Vars.get[Int])).pure
+        assert(r == 2)
+    }
+
+    "nested let" in {
+        assert(
+            Defers.run {
+                Vars.run(1) {
+                    Defers {
+                        Vars.run(2) {
+                            Vars.get[Int].map { innerValue =>
+                                assert(innerValue == 2)
+                            }
+                        }
+                    }.unit.andThen(Vars.get[Int])
+                }
+            }.pure == 1
+        )
+    }
+
+    "string value" in {
+        val result = Vars.run("a")(Vars.set("b").andThen(Vars.get[String])).pure
+        assert(result == "b")
+    }
+
+    "side effect" in {
+        var calls = 0
+        val result =
+            Vars.run(1) {
+                for
+                    _ <- Vars.update[Int] { value =>
+                        calls += 1
+                        value + 1
+                    }
+                    result <- Vars.get[Int]
+                yield result
+            }.pure
+        assert(result == 2 && calls == 1)
+    }
+
+    "inference" in {
+        val a: Int < Vars[Int]                   = Vars.get[Int]
+        val b: Unit < (Vars[Int] & Vars[String]) = a.map(i => Vars.set(i.toString()))
+        val c: Unit < Vars[String]               = Vars.run(1)(b)
+        val d: Unit < Any                        = Vars.run("t")(c)
+        assert(d.pure == ())
+    }
+end varsTest


### PR DESCRIPTION
I've been considering the long-term maintenance of the library and something that worries me is the lack of a clear separation between 100% pure effects from those that rely on `IOs`. Ideally, the library should evolve to have as much as possible of its code not depending on `IOs`, which should help keep the code quality and maintainability.

Additionally, some users might want to use Kyo in the same kind of scope which `zio-pure` is currently used for. This new module would be Kyo's equivalent to it.

This initial PR only creates the new module and copies all pure effects to it. Some effects like `Streams` has a few `IOs`-based methods to handle `Channel`s. I've removed these methods and am planning to reintroduce them in `kyo-core` via extension methods.

After this change, I'm planning follow up with a new PR changing `kyo-core` to depend on `kyo-pure` and removing the duplicate effects that were moved to `kyo-pure`.