### PR TITLE
fork/join contention benchmark improvement

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/ForkJoinContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForkJoinContentionBench.scala
@@ -37,7 +37,7 @@ class ForkJoinContentionBench extends Bench.ForkOnly[Unit]:
         val forkAllFibers     = ZIO.foreach(range)(_ => forkFiber)
         val forkJoinAllFibers = forkAllFibers.flatMap(fibers => ZIO.foreach(fibers)(_.await).unit)
 
-        ZIO.collectAllPar(Seq.fill(parallism)(forkJoinAllFibers)).unit
+        ZIO.collectAll(Seq.fill(parallism)(forkJoinAllFibers.forkDaemon)).flatMap(ZIO.foreach(_)(_.join)).unit
     end zioBench
 
     @Benchmark


### PR DESCRIPTION
ZIO's `collectAllPar` is getting [optimized](https://github.com/zio/zio/issues/8813). This PR changes the benchmark to manually fork and join fibers as a workaround for now. 

@kyri-petrou Thank you for sharing this suggestion! 🙏