### PR TITLE
core: reduce bytecode size by avoiding type checks

### DIFF
--- a/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
@@ -37,8 +37,8 @@ class coreBytecodeSizeTest extends KyoTest:
         val map = methodBytecodeSize[TestHandle]
         assert(map == Map(
             "test"        -> 28,
-            "resultLoop"  -> 112,
-            "handleLoop"  -> 294,
+            "resultLoop"  -> 94,
+            "handleLoop"  -> 280,
             "_handleLoop" -> 12
         ))
     }

--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -86,8 +86,8 @@ object core:
                                             handler.failed(st, ex)
                                 _handleLoop(st, r)
                             end apply
-                    case v: T @unchecked =>
-                        handler.done(st, v)
+                    case v =>
+                        handler.done(st, v.asInstanceOf[T])
             def resultLoop(v: (Result[T] | handler.Resume[T, S2]) < (S & S2)): Result[T] < (S & S2) =
                 v match
                     case r: handler.Resume[T, S & S2] @unchecked =>
@@ -100,8 +100,8 @@ object core:
                                 l: Locals.State
                             ) =
                                 resultLoop(kyo(v, s, l))
-                    case r: Result[T] @unchecked =>
-                        r
+                    case r =>
+                        r.asInstanceOf[Result[T]]
             handleLoop(state, value)
         end handle
     end extension


### PR DESCRIPTION
There's no need to check the type at the last case of the match, especially considering that it uses `@unchecked`.