### PR TITLE
loops: repeat and forever

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/loops.scala
+++ b/kyo-core/shared/src/main/scala/kyo/loops.scala
@@ -220,4 +220,30 @@ object Loops:
                     ()
         loop()
     end foreach
+
+    inline def repeat[S](n: Int)(inline run: => Unit < S): Unit < S =
+        def _loop(i: Int): Unit < S =
+            loop(i)
+        @tailrec def loop(i: Int = 0): Unit < S =
+            if i == n then ()
+            else
+                run match
+                    case kyo: Kyo[Unit, S] @unchecked =>
+                        kyo.andThen(_loop(i + 1))
+                    case _ =>
+                        loop(i + 1)
+        loop()
+    end repeat
+
+    inline def forever[S](inline run: Unit < S): Unit < S =
+        def _loop(): Unit < S =
+            loop()
+        @tailrec def loop(): Unit < S =
+            run match
+                case kyo: Kyo[Unit, S] @unchecked =>
+                    kyo.andThen(_loop())
+                case _ =>
+                    loop()
+        loop()
+    end forever
 end Loops

--- a/kyo-core/shared/src/main/scala/kyo/seqs.scala
+++ b/kyo-core/shared/src/main/scala/kyo/seqs.scala
@@ -118,11 +118,4 @@ object Seqs:
             if idx == n then Loops.done(acc.toSeq)
             else v.map(t => Loops.continue(acc.append(t)))
         }
-
-    def repeat[S](n: Int)(v: => Unit < S): Unit < S =
-        Loops.indexed {
-            case `n` => Loops.done
-            case _ =>
-                v.andThen(Loops.continue)
-        }
 end Seqs

--- a/kyo-core/shared/src/test/scala/kyoTest/loopsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/loopsTest.scala
@@ -535,4 +535,33 @@ class loopsTest extends KyoTest:
             assert(effect == "AAA")
         }
     }
+
+    "repeat" in {
+        var count = 0
+        val io    = IOs(count += 1)
+
+        IOs.run(Loops.repeat(0)(io))
+        assert(count == 0)
+
+        count = 0
+        IOs.run(Loops.repeat(1)(io))
+        assert(count == 1)
+
+        count = 0
+        IOs.run(Loops.repeat(100)(io))
+        assert(count == 100)
+
+        count = 0
+        IOs.run(Loops.repeat(10000)(io))
+        assert(count == 10000)
+    }
+
+    "forever" in runJVM {
+        for
+            p <- Fibers.initPromise[Unit]
+            f <- Fibers.init(Loops.forever(p.complete(()).unit))
+            _ <- p.get
+            _ <- f.interrupt
+        yield succeed
+    }
 end loopsTest

--- a/kyo-core/shared/src/test/scala/kyoTest/seqsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/seqsTest.scala
@@ -71,26 +71,6 @@ class seqsTest extends KyoTest:
         assert(IOs.run(Seqs.fill(100)(IOs(1))) == Seq.fill(100)(1))
     }
 
-    "repeat" in {
-        var count = 0
-        val io    = IOs(count += 1)
-
-        IOs.run(Seqs.repeat(0)(io))
-        assert(count == 0)
-
-        count = 0
-        IOs.run(Seqs.repeat(1)(io))
-        assert(count == 1)
-
-        count = 0
-        IOs.run(Seqs.repeat(100)(io))
-        assert(count == 100)
-
-        count = 0
-        IOs.run(Seqs.repeat(10000)(io))
-        assert(count == 10000)
-    }
-
     "stack safety" - {
         val n = 10000
 


### PR DESCRIPTION
Moves `repeat` from `Seqs` to `Loops` and introduces a new `forever` method to loop indefinitely. 