### PR TITLE
fix io task runtime tracking

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -49,7 +49,7 @@ private[kyo] class IOTask[T](
                         k.command match
                             case Promise(p) =>
                                 this.interrupts(p)
-                                val runtime = (clock.currentMillis() - startMillis).toInt
+                                val runtime = (clock.currentMillis() - startMillis + this.runtime()).toInt
                                 p.onComplete { (v: Any < IOs) =>
                                     val io = IOs(k(
                                         v,

--- a/kyo-scheduler/js/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/js/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -12,7 +12,7 @@ class Scheduler {
 
     def schedule(t: Task): Unit = {
         JSExecutionContext.queue.execute { () =>
-            if (t.run(0, clock) == Task.Preempted)
+            if (t.run(clock.currentMillis(), clock) == Task.Preempted)
                 schedule(t)
         }
     }

--- a/kyo-scheduler/shared/src/main/scala/kyo/scheduler/Task.scala
+++ b/kyo-scheduler/shared/src/main/scala/kyo/scheduler/Task.scala
@@ -15,7 +15,7 @@ trait Task {
 
     def run(startMillis: Long, clock: InternalClock): Task.Result
 
-    private def runtime(): Int = {
+    protected def runtime(): Int = {
         val state = this.state
         if (state < 0) -state
         else state


### PR DESCRIPTION
This is a bug introduced by https://github.com/getkyo/kyo/pull/278. I noticed it while testing the new scheduler under stress. I'm not sure how to introduce an automated test for this given that it's a performance issue and this code isn't very testable in isolation. I've tried designing a benchmark to measure preemption performance a few times unsuccessfully.