### PR TITLE
http client benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -238,19 +238,24 @@ lazy val `kyo-bench` =
         .in(file("kyo-bench"))
         .enablePlugins(JmhPlugin)
         .dependsOn(`kyo-core`)
+        .dependsOn(`kyo-sttp`)
         .settings(
             `kyo-settings`,
-            libraryDependencies += "org.typelevel"       %% "cats-effect"        % "3.5.4",
-            libraryDependencies += "org.typelevel"       %% "log4cats-core"      % "2.7.0",
-            libraryDependencies += "org.typelevel"       %% "log4cats-slf4j"     % "2.7.0",
-            libraryDependencies += "dev.zio"             %% "zio-logging"        % "2.2.3",
-            libraryDependencies += "dev.zio"             %% "zio-logging-slf4j2" % "2.2.3",
-            libraryDependencies += "dev.zio"             %% "zio"                % "2.1.0-RC5",
-            libraryDependencies += "dev.zio"             %% "zio-concurrent"     % "2.1.0-RC5",
-            libraryDependencies += "dev.zio"             %% "zio-prelude"        % "1.0.0-RC23",
-            libraryDependencies += "com.softwaremill.ox" %% "core"               % "0.0.25",
-            libraryDependencies += "co.fs2"              %% "fs2-core"           % "3.10.2",
-            libraryDependencies += "org.scalatest"       %% "scalatest"          % "3.2.16" % Test
+            Test / parallelExecution := false,
+            libraryDependencies += "org.typelevel"       %% "cats-effect"         % "3.5.4",
+            libraryDependencies += "org.typelevel"       %% "log4cats-core"       % "2.7.0",
+            libraryDependencies += "org.typelevel"       %% "log4cats-slf4j"      % "2.7.0",
+            libraryDependencies += "dev.zio"             %% "zio-logging"         % "2.2.3",
+            libraryDependencies += "dev.zio"             %% "zio-logging-slf4j2"  % "2.2.3",
+            libraryDependencies += "dev.zio"             %% "zio"                 % "2.1.0-RC5",
+            libraryDependencies += "dev.zio"             %% "zio-concurrent"      % "2.1.0-RC5",
+            libraryDependencies += "dev.zio"             %% "zio-prelude"         % "1.0.0-RC23",
+            libraryDependencies += "com.softwaremill.ox" %% "core"                % "0.0.25",
+            libraryDependencies += "co.fs2"              %% "fs2-core"            % "3.10.2",
+            libraryDependencies += "org.http4s"          %% "http4s-ember-client" % "0.23.26",
+            libraryDependencies += "org.http4s"          %% "http4s-dsl"          % "0.23.26",
+            libraryDependencies += "dev.zio"             %% "zio-http"            % "3.0.0-RC6",
+            libraryDependencies += "org.scalatest"       %% "scalatest"           % "3.2.16" % Test
         )
 
 lazy val rewriteReadmeFile = taskKey[Unit]("Rewrite README file")

--- a/kyo-bench/src/main/scala/kyo/bench/HttpClientBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/HttpClientBench.scala
@@ -1,0 +1,53 @@
+package kyo.bench
+
+import org.http4s.ember.client.EmberClientBuilder
+
+class HttpClientBench extends Bench.ForkOnly[String]:
+
+    val port = 9999
+    val url  = TestHttpServer.start(port)
+
+    lazy val catsClient =
+        import cats.effect.*
+        import cats.effect.unsafe.implicits.global
+        EmberClientBuilder.default[IO].build.allocated.unsafeRunSync()._1
+    end catsClient
+
+    val catsUrl =
+        import org.http4s.*
+        Uri.fromString(url).toOption.get
+
+    def catsBench() =
+        import cats.effect.*
+
+        catsClient.expect[String](catsUrl)
+    end catsBench
+
+    lazy val kyoClient =
+        import kyo.*
+        PlatformBackend.default
+
+    val kyoUrl =
+        import sttp.client3.*
+        uri"$url"
+
+    override def kyoBenchFiber() =
+        import kyo.*
+
+        Requests.run(Requests[String](_.get(kyoUrl)))
+    end kyoBenchFiber
+
+    val zioUrl =
+        import zio.http.*
+        URL.decode(this.url).toOption.get
+
+    // TODO: Initialize client once and reuse
+    def zioBench() =
+        import zio.*
+        // import zio.http.*
+
+        // ZIO.service[Client].flatMap(_.url(zioUrl).get("")).flatMap(_.body.asString).provide(Client.default, Scope.default).orDie
+        ZIO.succeed("pong")
+    end zioBench
+
+end HttpClientBench

--- a/kyo-bench/src/main/scala/kyo/bench/HttpClientContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/HttpClientContentionBench.scala
@@ -1,0 +1,56 @@
+package kyo.bench
+
+import org.http4s.ember.client.EmberClientBuilder
+
+class HttpClientContentionBench extends Bench.ForkOnly[Seq[String]]:
+
+    val port        = 9999
+    val concurrency = Runtime.getRuntime().availableProcessors()
+    val url         = TestHttpServer.start(port)
+
+    lazy val catsClient =
+        import cats.effect.*
+        import cats.effect.unsafe.implicits.global
+        EmberClientBuilder.default[IO].build.allocated.unsafeRunSync()._1
+    end catsClient
+
+    val catsUrl =
+        import org.http4s.*
+        Uri.fromString(url).toOption.get
+
+    def catsBench() =
+        import cats.effect.*
+        import cats.implicits.*
+
+        Seq.fill(concurrency)(catsClient.expect[String](catsUrl)).parSequence
+    end catsBench
+
+    lazy val kyoClient =
+        import kyo.*
+        PlatformBackend.default
+
+    val kyoUrl =
+        import sttp.client3.*
+        uri"$url"
+
+    override def kyoBenchFiber() =
+        import kyo.*
+
+        Fibers.parallel(Seq.fill(concurrency)(Requests.run(Requests[String](_.get(kyoUrl)))))
+    end kyoBenchFiber
+
+    val zioUrl =
+        import zio.http.*
+        URL.decode(this.url).toOption.get
+
+    // TODO: Initialize client once and reuse
+    def zioBench() =
+        import zio.*
+        // import zio.http.*
+
+        // val run = ZIO.service[Client].flatMap(_.url(zioUrl).get("")).flatMap(_.body.asString).provide(Client.default, Scope.default).orDie
+        // ZIO.collectAll(Seq.fill(concurrency)(run.forkDaemon)).flatMap(ZIO.foreach(_)(_.join))
+        ZIO.succeed(Seq.fill(concurrency)("pong"))
+    end zioBench
+
+end HttpClientContentionBench

--- a/kyo-bench/src/main/scala/kyo/bench/TestHttpServer.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TestHttpServer.scala
@@ -1,0 +1,64 @@
+package kyo.bench
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import java.io.OutputStream
+import java.net.InetSocketAddress
+import java.util.concurrent.locks.LockSupport
+
+object TestHttpServer:
+
+    trait StopServer:
+        def apply(): Unit
+
+    def log(port: Int, msg: String) =
+        println(s"TestHttpServer(port=$port): $msg")
+
+    def start(port: Int): String =
+        val javaBin   = System.getProperty("java.home") + "/bin/java"
+        val classpath = System.getProperty("java.class.path")
+        val command   = List(javaBin, "-cp", classpath, "kyo.bench.TestHttpServer", port.toString)
+        val builder   = new ProcessBuilder(command*)
+        builder.redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        builder.redirectError(ProcessBuilder.Redirect.INHERIT)
+        builder.redirectErrorStream(true)
+        try
+            log(port, "forking")
+            val process = builder.start()
+            val stopServer: StopServer =
+                () =>
+                    log(port, "stopping")
+                    process.destroy()
+            Runtime.getRuntime().addShutdownHook(new Thread:
+                override def run(): Unit =
+                    stopServer()
+            )
+            s"http://localhost:$port/ping"
+        finally
+            log(port, "forked")
+        end try
+    end start
+
+    def main(args: Array[String]): Unit =
+        val port = if args.isEmpty then 9999 else args(0).toInt
+        log(port, "starting")
+        val server = HttpServer.create(new InetSocketAddress("0.0.0.0", port), 0)
+        server.createContext(
+            "/ping",
+            new HttpHandler:
+                val response = "pong".getBytes()
+                override def handle(exchange: HttpExchange): Unit =
+                    exchange.sendResponseHeaders(200, response.length)
+                    val os: OutputStream = exchange.getResponseBody
+                    os.write(response)
+                    os.close()
+                end handle
+        )
+        server.setExecutor(null)
+        server.start()
+        log(port, "started")
+        try LockSupport.park()
+        finally log(port, "stopped")
+    end main
+end TestHttpServer

--- a/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/bench/BenchTest.scala
@@ -155,4 +155,12 @@ class BenchTest extends AsyncFreeSpec with Assertions:
     "ForkJoinContentionBench" - {
         test(ForkJoinContentionBench(), ())
     }
+
+    "HttpClientBench" - {
+        test(HttpClientBench(), "pong")
+    }
+
+    "HttpClientContentionBench" - {
+        test(HttpClientContentionBench(), Seq.fill(Runtime.getRuntime().availableProcessors())("pong"))
+    }
 end BenchTest


### PR DESCRIPTION
I'm working on the performance of `Requests`. I couldn't find a way to instantiate `zio-http`'s client once and reuse it so I've disabled the benchmark for ZIO by returning a constant. Please ignore ZIO's results for now.

![image](https://github.com/getkyo/kyo/assets/831175/9455e378-d89d-4ded-8868-833793457a26)
