### PR TITLE
requests: avoid switching to ForkJoinPool

### DIFF
--- a/kyo-sttp/jvm/src/main/scala/sttp/client3/HttpClientKyoBackend.scala
+++ b/kyo-sttp/jvm/src/main/scala/sttp/client3/HttpClientKyoBackend.scala
@@ -6,11 +6,13 @@ import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.net.http.HttpResponse.BodyHandlers
+import java.util.concurrent.Executor
 import java.util.zip.GZIPInputStream
 import java.util.zip.InflaterInputStream
 import kyo.*
 import kyo.internal.KyoSttpMonad
 import kyo.internal.KyoSttpMonad.*
+import kyo.scheduler.Scheduler
 import sttp.capabilities.WebSockets
 import sttp.client3.HttpClientBackend.EncodingHandler
 import sttp.client3.HttpClientFutureBackend.InputStreamEncodingHandler
@@ -97,10 +99,11 @@ object HttpClientKyoBackend:
     def apply(
         options: SttpBackendOptions = SttpBackendOptions.Default,
         customizeRequest: HttpRequest => HttpRequest = identity,
-        customEncodingHandler: InputStreamEncodingHandler = PartialFunction.empty
+        customEncodingHandler: InputStreamEncodingHandler = PartialFunction.empty,
+        executor: Option[Executor] = Some(r => r.run())
     ): SttpBackend[KyoSttpMonad.M, WebSockets] =
         HttpClientKyoBackend(
-            HttpClientBackend.defaultClient(options),
+            HttpClientBackend.defaultClient(options, executor),
             closeClient = false,
             customizeRequest,
             customEncodingHandler


### PR DESCRIPTION
Java's HTTP client switches execution to `ForkJoinPool` by default, which isn't necessary since STTP already shifts the execution to Kyo's scheduler to process the request. This PR makes the client use an "immediate" executor by default, flushing any `CompletionStage` transformations immediately.


![image](https://github.com/getkyo/kyo/assets/831175/bfa85f11-c199-49df-b3eb-8f4d2ed72b0f)
https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/fwbrasil/63f13c78df90063bf403a584b647ccd7/raw/7116437f81dc06cdb6c06fdc8f8a711614375314/jmh-result-baseline.json,https://gist.githubusercontent.com/fwbrasil/63f13c78df90063bf403a584b647ccd7/raw/7116437f81dc06cdb6c06fdc8f8a711614375314/jmh-result-candidate.json