### PR TITLE
requests: race 10k requests test

### DIFF
--- a/kyo-sttp/jvm/src/test/scala/kyoTest/requestsLiveTest.scala
+++ b/kyo-sttp/jvm/src/test/scala/kyoTest/requestsLiveTest.scala
@@ -24,6 +24,14 @@ class requestsLiveTest extends KyoTest:
                     yield assert(r.isFailure)
                 }
             }
+            "race" in run {
+                val n = 10000
+                for
+                    port <- startTestServer("/ping", Success("pong"))
+                    r    <- Fibers.race(Seq.fill(n)(Requests.run(Requests(_.get(uri"http://localhost:$port/ping")))))
+                yield assert(r == "pong")
+                end for
+            }
         }
     }
 


### PR DESCRIPTION
Reproduces a [scenario from EasyRacer](https://github.com/jamesward/easyracer/blob/a9aa01afefe00ab905af53a27bb2e2f005b0d00d/scala-kyo/src/main/scala/EasyRacerClient.scala#L27). I'm expecting this to fail in CI and pass once https://github.com/getkyo/kyo/pull/330 and https://github.com/getkyo/kyo/pull/331 are merged.