### PR TITLE
scheduler: don't check the availability of a submitter worker

### DIFF
--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -82,9 +82,13 @@ final class Scheduler(
                 var minLoad        = Int.MaxValue
                 while (stride > 0 && minLoad != 0) {
                     val candidate = workers(position)
-                    if (candidate != null && candidate.checkAvailability(cycles)) {
+                    if (
+                        candidate != null &&
+                        (candidate ne submitter) &&
+                        candidate.checkAvailability(cycles)
+                    ) {
                         val l = candidate.load()
-                        if (l < minLoad && (candidate ne submitter)) {
+                        if (l < minLoad) {
                             minLoad = l
                             worker = candidate
                         }


### PR DESCRIPTION
While optimizing `Requests`, I noticed a thread stack with nested `worker.drain` frames, which doesn't make sense. The issue is that when a worker is draining, it'll try to reschedule tasks but then `Scheduler.schedule` might pick up the worker itself and call `checkAvailability` on it, which can trigger a nested `drain`.

This was an oversight and is something difficult to test in isolation. The new logic also matches `scheduler.steal`.