### PR TITLE
Locals and IOs based on Defers

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -27,13 +27,13 @@ object core:
                 def apply(v: T, s: Safepoint[E], l: State) =
                     v
 
-        inline def suspend[T, U, S](inline cmd: e.Command[T], inline f: T => U < S)(
+        inline def suspend[T, U, S](inline cmd: e.Command[T], inline f: T => U < (E & S))(
             using inline _tag: Tag[E]
         ): U < (E & S) =
-            new Suspend[e.Command, T, U, S]:
+            new Suspend[e.Command, T, U, E & S]:
                 def command = cmd
                 def tag     = _tag.asInstanceOf[Tag[Any]]
-                def apply(v: T, s: Safepoint[S], l: State) =
+                def apply(v: T, s: Safepoint[E & S], l: State) =
                     f(v)
     end extension
 

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -2,7 +2,6 @@ package kyo
 
 import IOs.internal.*
 import core.*
-import core.internal.*
 import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 import scala.util.*

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -24,10 +24,10 @@ object IOs:
     def runLazy[T: Flat, S](v: T < (IOs & S)): T < S =
         Defers.run(SideEffects.handle(handler)((), v))
 
-    def fail[T](ex: Throwable): T < IOs =
+    def fail(ex: Throwable): Nothing < IOs =
         IOs(throw ex)
 
-    def fail[T](msg: String): T < IOs =
+    def fail(msg: String): Nothing < IOs =
         fail(new Exception(msg))
 
     def fromTry[T, S](v: Try[T] < S): T < (IOs & S) =

--- a/kyo-core/shared/src/test/scala/kyoTest/fibersTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/fibersTest.scala
@@ -238,7 +238,7 @@ class fibersTest extends KyoTest:
             val ex = new Exception
             Fibers.race(
                 Fibers.sleep(1.millis).andThen(42),
-                IOs.fail[Int](ex)
+                IOs.fail(ex)
             ).map { r =>
                 assert(r == 42)
             }
@@ -248,8 +248,8 @@ class fibersTest extends KyoTest:
             val ex2 = new Exception
             IOs.attempt(
                 Fibers.race(
-                    Fibers.sleep(1.millis).andThen(IOs.fail[Int](ex1)),
-                    IOs.fail[Int](ex2)
+                    Fibers.sleep(1.millis).andThen(IOs.fail(ex1)),
+                    IOs.fail(ex2)
                 )
             ).map {
                 r =>

--- a/kyo-core/shared/src/test/scala/kyoTest/iosTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/iosTest.scala
@@ -114,6 +114,11 @@ class iosTest extends KyoTest:
         "doesn't accept other pending effects" in {
             assertDoesNotCompile("IOs.run[Int < Options](Options.get(Some(1)))")
         }
+        "Defers.run doesn't handle IOs" in {
+            val c            = Defers.run(IOs(42))
+            val _: Int < IOs = c
+            assertDoesNotCompile("Defers.run(IOs(42)).pure")
+        }
     }
 
     "ensure" - {

--- a/kyo-core/shared/src/test/scala/kyoTest/iosTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/iosTest.scala
@@ -10,7 +10,7 @@ import scala.util.Try
 class iosTest extends KyoTest:
 
     "lazyRun" - {
-        "execution" in run {
+        "execution" in {
             var called = false
             val v =
                 IOs {
@@ -21,7 +21,7 @@ class iosTest extends KyoTest:
             assert(IOs.runLazy(v).pure == 1)
             assert(called)
         }
-        "next handled effects can execute" in run {
+        "next handled effects can execute" in {
             var called = false
             val v =
                 Envs.get[Int].map { i =>
@@ -39,7 +39,7 @@ class iosTest extends KyoTest:
             )
             assert(called)
         }
-        "failure" in run {
+        "failure" in {
             val ex        = new Exception
             def fail: Int = throw ex
 
@@ -54,7 +54,7 @@ class iosTest extends KyoTest:
             }
             succeed
         }
-        "stack-safe" in run {
+        "stack-safe" in {
             val frames = 10000
             def loop(i: Int): Int < IOs =
                 IOs {
@@ -70,7 +70,7 @@ class iosTest extends KyoTest:
         }
     }
     "run" - {
-        "execution" in run {
+        "execution" in {
             var called = false
             val v: Int < IOs =
                 IOs {
@@ -84,7 +84,7 @@ class iosTest extends KyoTest:
             )
             assert(called)
         }
-        "stack-safe" in run {
+        "stack-safe" in {
             val frames = 100000
             def loop(i: Int): Assertion < IOs =
                 IOs {
@@ -93,9 +93,10 @@ class iosTest extends KyoTest:
                     else
                         succeed
                 }
-            loop(0)
+            val r = IOs.run(loop(0))
+            r
         }
-        "failure" in run {
+        "failure" in {
             val ex        = new Exception
             def fail: Int = throw ex
 

--- a/kyo-core/shared/src/test/scala/kyoTest/iosTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/iosTest.scala
@@ -177,7 +177,7 @@ class iosTest extends KyoTest:
 
     "fail" in {
         assert(
-            IOs.run(IOs.attempt(IOs.fail[Int](e))) ==
+            IOs.run(IOs.attempt(IOs.fail(e))) ==
                 Failure(e)
         )
     }

--- a/kyo-direct/src/main/scala/kyo/TestSupport.scala
+++ b/kyo-direct/src/main/scala/kyo/TestSupport.scala
@@ -6,7 +6,7 @@ import scala.language.experimental.macros
 
 object TestSupport:
     transparent inline def runLiftTest[T: Flat, U](inline expected: T)(inline body: U) =
-        val actual: U = IOs.run(defer(body).asInstanceOf[U < IOs])
+        val actual: U = Defers.run(defer(body).asInstanceOf[U < Defers]).pure
         if !expected.equals(actual) then
             throw new AssertionError("Expected " + expected + " but got " + actual)
     end runLiftTest

--- a/kyo-direct/src/test/scala/kyoTest/blockTest.scala
+++ b/kyo-direct/src/test/scala/kyoTest/blockTest.scala
@@ -9,29 +9,29 @@ class blockTest extends AnyFreeSpec with Assertions:
 
     "assigned run" - {
         "only" in {
-            val i = IOs(1)
+            val i = Defers(1)
             runLiftTest(1) {
                 val v = await(i)
                 v
             }
         }
         "followed by pure expression" in {
-            val i = IOs(1)
+            val i = Defers(1)
             runLiftTest(2) {
                 val v = await(i)
                 v + 1
             }
         }
         "followed by impure expression" in {
-            val i = IOs(1)
-            val j = IOs(2)
+            val i = Defers(1)
+            val j = Defers(2)
             runLiftTest(3) {
                 val v = await(i)
                 v + await(j)
             }
         }
         "nested" in {
-            val i = IOs(1)
+            val i = Defers(1)
             runLiftTest(3) {
                 val v =
                     val r = await(i)
@@ -42,21 +42,21 @@ class blockTest extends AnyFreeSpec with Assertions:
     }
     "unassigned run" - {
         "only" in {
-            val i = IOs(1)
+            val i = Defers(1)
             runLiftTest(1) {
                 await(i)
             }
         }
         "followed by pure expression" in {
-            val i = IOs(1)
+            val i = Defers(1)
             runLiftTest(2) {
                 await(i)
                 2
             }
         }
         "followed by impure expression" in {
-            val i = IOs(1)
-            val j = IOs(2)
+            val i = Defers(1)
+            val j = Defers(2)
             runLiftTest(2) {
                 await(i)
                 await(j)
@@ -77,7 +77,7 @@ class blockTest extends AnyFreeSpec with Assertions:
             }
         }
         "followed by impure expression" in {
-            val i = IOs(1)
+            val i = Defers(1)
             def a = 2
             runLiftTest(1) {
                 a
@@ -85,8 +85,8 @@ class blockTest extends AnyFreeSpec with Assertions:
             }
         }
         "using previous defers" in {
-            val i = IOs(1)
-            val j = IOs(2)
+            val i = Defers(1)
+            val j = Defers(2)
             runLiftTest(3) {
                 val v = await(i)
                 v + await(j)
@@ -95,14 +95,14 @@ class blockTest extends AnyFreeSpec with Assertions:
         "using external function" in {
             def a(i: Int, s: String) = i + s.toInt
             runLiftTest(4) {
-                await(IOs(a(1, "2"))) + a(0, "1")
+                await(Defers(a(1, "2"))) + a(0, "1")
             }
         }
     }
     "complex" - {
         "tuple val pattern" in {
             runLiftTest(3) {
-                val (a, b) = (await(IOs(1)), await(IOs(2)))
+                val (a, b) = (await(Defers(1)), await(Defers(2)))
                 a + b
             }
         }
@@ -110,11 +110,11 @@ class blockTest extends AnyFreeSpec with Assertions:
             runLiftTest((1, 2, 3)) {
                 val x = 1
                 (
-                    await(IOs(x)), {
-                        val a = await(IOs(2))
+                    await(Defers(x)), {
+                        val a = await(Defers(2))
                         a
                     },
-                    await(IOs(3))
+                    await(Defers(3))
                 )
             }
         }

--- a/kyo-direct/src/test/scala/kyoTest/booleanTest.scala
+++ b/kyo-direct/src/test/scala/kyoTest/booleanTest.scala
@@ -20,51 +20,51 @@ class booleanTest extends AnyFreeSpec with Assertions:
         "pure/impure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    True && await(IOs(True))
+                    True && await(Defers(True))
                 }
             }
             "True/False" - {
                 runLiftTest(False) {
-                    True && await(IOs(False))
+                    True && await(Defers(False))
                 }
             }
             "False/NotExpected" - {
                 runLiftTest(False) {
-                    False && await(IOs(NotExpected))
+                    False && await(Defers(NotExpected))
                 }
             }
         }
         "impure/pure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    await(IOs(True)) && True
+                    await(Defers(True)) && True
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    await(IOs(True)) && False
+                    await(Defers(True)) && False
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    await(IOs(False)) && NotExpected
+                    await(Defers(False)) && NotExpected
                 }
             }
         }
         "impure/impure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    await(IOs(True)) && await(IOs(True))
+                    await(Defers(True)) && await(Defers(True))
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    await(IOs(True)) && await(IOs(False))
+                    await(Defers(True)) && await(Defers(False))
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    await(IOs(False)) && await(IOs(NotExpected))
+                    await(Defers(False)) && await(Defers(NotExpected))
                 }
             }
         }
@@ -78,51 +78,51 @@ class booleanTest extends AnyFreeSpec with Assertions:
         "pure/impure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    False || await(IOs(False))
+                    False || await(Defers(False))
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    False || await(IOs(True))
+                    False || await(Defers(True))
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    True || await(IOs(NotExpected))
+                    True || await(Defers(NotExpected))
                 }
             }
         }
         "impure/pure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    await(IOs(False)) || False
+                    await(Defers(False)) || False
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    await(IOs(False)) || True
+                    await(Defers(False)) || True
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    await(IOs(True)) || NotExpected
+                    await(Defers(True)) || NotExpected
                 }
             }
         }
         "impure/impure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    await(IOs(False)) || await(IOs(False))
+                    await(Defers(False)) || await(Defers(False))
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    await(IOs(False)) || await(IOs(True))
+                    await(Defers(False)) || await(Defers(True))
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    await(IOs(True)) || await(IOs(NotExpected))
+                    await(Defers(True)) || await(Defers(NotExpected))
                 }
             }
         }

--- a/kyo-direct/src/test/scala/kyoTest/directTest.scala
+++ b/kyo-direct/src/test/scala/kyoTest/directTest.scala
@@ -1,7 +1,6 @@
 package kyoTest
 
 import kyo.*
-import scala.util.Try
 
 class directTest extends KyoTest:
 

--- a/kyo-direct/src/test/scala/kyoTest/hygieneTest.scala
+++ b/kyo-direct/src/test/scala/kyoTest/hygieneTest.scala
@@ -7,14 +7,14 @@ import org.scalatest.freespec.AnyFreeSpec
 class hygieneTest extends AnyFreeSpec with Assertions:
 
     "ok" in {
-        assert(IOs.run(IOs(1)) == 1)
+        assert(Defers.run(Defers(1)).pure == 1)
     }
 
     "use of var" in {
         assertDoesNotCompile("""
           defer {
             var willFail = 1
-            await(IOs(1))
+            await(Defers(1))
           }
         """)
     }
@@ -23,7 +23,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             return 42
-            await(IOs(1))
+            await(Defers(1))
           }
         """)
     }
@@ -32,7 +32,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             defer {
-              await(IOs(1))
+              await(Defers(1))
             }
           }
         """)
@@ -42,7 +42,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             lazy val x = 10
-            await(IOs(1))
+            await(Defers(1))
           }
         """)
     }
@@ -50,7 +50,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
     "function containing await" in {
         assertDoesNotCompile("""
           defer {
-            def foo() = await(IOs(1))
+            def foo() = await(Defers(1))
             foo()
           }
         """)
@@ -60,9 +60,9 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             try {
-              await(IOs(1))
+              await(Defers(1))
             } catch {
-              case _: Exception => await(IOs(2))
+              case _: Exception => await(Defers(2))
             }
           }
         """)
@@ -72,7 +72,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             class A(val x: Int)
-            await(IOs(1))
+            await(Defers(1))
           }
         """)
     }
@@ -81,7 +81,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             object A
-            await(IOs(1))
+            await(Defers(1))
           }
         """)
     }
@@ -90,7 +90,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             trait A
-            await(IOs(1))
+            await(Defers(1))
           }
         """)
     }
@@ -99,8 +99,8 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             for {
-              x <- await(IOs(1))
-              y <- await(IOs(2))
+              x <- await(Defers(1))
+              y <- await(Defers(2))
             } yield x + y
           }
         """)
@@ -110,7 +110,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
     //     assertDoesNotCompile("""
     //       defer {
     //         throw new RuntimeException("Error!")
-    //         await(IOs(1))
+    //         await(Defers(1))
     //       }
     //     """)
     // }
@@ -118,7 +118,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             try {
-              await(IOs(1))
+              await(Defers(1))
             }
           }
         """)
@@ -128,7 +128,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             try {
-              await(IOs(1))
+              await(Defers(1))
             } finally {
               println("Cleanup")
             }
@@ -140,7 +140,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
     //     assertDoesNotCompile("""
     //       defer {
     //           def foo(x: => Int) = x + 1
-    //           foo(await(IOs(1)))
+    //           foo(await(Defers(1)))
     //       }
     //     """)
     // }
@@ -149,7 +149,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             class A(x: => Int)
-            new A(await(IOs(1)))
+            new A(await(Defers(1)))
           }
         """)
     }
@@ -157,7 +157,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
     "match expression without cases" in {
         assertDoesNotCompile("""
           defer {
-            await(IOs(1)) match {}
+            await(Defers(1)) match {}
           }
         """)
     }
@@ -166,8 +166,8 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             for {
-              x <- await(IOs(1))
-              y <- await(IOs(2))
+              x <- await(Defers(1))
+              y <- await(Defers(2))
             } x + y
           }
         """)
@@ -177,7 +177,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
         assertDoesNotCompile("""
           defer {
             def outer() = {
-              def inner() = await(IOs(1))
+              def inner() = await(Defers(1))
               inner()
             }
             outer()
@@ -188,7 +188,7 @@ class hygieneTest extends AnyFreeSpec with Assertions:
     "lambdas with await" in {
         assertDoesNotCompile("""
           defer {
-            val f = (x: Int) => await(IOs(1)) + x
+            val f = (x: Int) => await(Defers(1)) + x
             f(10)
           }
         """)

--- a/kyo-direct/src/test/scala/kyoTest/ifTest.scala
+++ b/kyo-direct/src/test/scala/kyoTest/ifTest.scala
@@ -10,22 +10,22 @@ class ifTest extends AnyFreeSpec with Assertions:
     "unlifted condition / ifelse" - {
         "pure / pure" in {
             runLiftTest(2) {
-                if await(IOs(1)) == 1 then 2 else 3
+                if await(Defers(1)) == 1 then 2 else 3
             }
         }
         "pure / impure" in {
             runLiftTest(2) {
-                if await(IOs(1)) == 1 then await(IOs(2)) else 3
+                if await(Defers(1)) == 1 then await(Defers(2)) else 3
             }
         }
         "impure / pure" in {
             runLiftTest(1) {
-                await(IOs(1))
+                await(Defers(1))
             }
         }
         "impure / impure" in {
             runLiftTest(3) {
-                if await(IOs(1)) == 2 then await(IOs(2)) else await(IOs(3))
+                if await(Defers(1)) == 2 then await(Defers(2)) else await(Defers(3))
             }
         }
     }
@@ -37,17 +37,17 @@ class ifTest extends AnyFreeSpec with Assertions:
         }
         "pure / impure" in {
             runLiftTest(2) {
-                if 1 == 1 then await(IOs(2)) else 3
+                if 1 == 1 then await(Defers(2)) else 3
             }
         }
         "impure / pure" in {
             runLiftTest(2) {
-                if 1 == 1 then 2 else await(IOs(3))
+                if 1 == 1 then 2 else await(Defers(3))
             }
         }
         "impure / impure" in {
             runLiftTest(3) {
-                if 1 == 2 then await(IOs(2)) else await(IOs(3))
+                if 1 == 2 then await(Defers(2)) else await(Defers(3))
             }
         }
     }

--- a/kyo-direct/src/test/scala/kyoTest/patMatchTest.scala
+++ b/kyo-direct/src/test/scala/kyoTest/patMatchTest.scala
@@ -113,7 +113,7 @@ class patMatchTest extends AnyFreeSpec with Assertions:
     "misc" - {
         "val patmatch" in {
             runLiftTest(1) {
-                val Some(a) = await(IOs(Some(1)))
+                val Some(a) = await(Defers(Some(1)))
                 a
             }
         }

--- a/kyo-direct/src/test/scala/kyoTest/whileTest.scala
+++ b/kyo-direct/src/test/scala/kyoTest/whileTest.scala
@@ -8,15 +8,15 @@ import scala.collection.mutable.ArrayBuffer
 
 class whileTest extends AnyFreeSpec with Assertions:
 
-    "with atomic" in {
-        runLiftTest(3) {
-            val i = await(Atomics.initInt(0))
-            while await(i.get) < 3 do
-                await(i.incrementAndGet)
-                ()
-            await(i.get)
-        }
-    }
+    // "with atomic" in {
+    //     runLiftTest(3) {
+    //         val i = await(Atomics.initInt(0))
+    //         while await(i.get) < 3 do
+    //             await(i.incrementAndGet)
+    //             ()
+    //         await(i.get)
+    //     }
+    // }
     "double in tuple - strange case" in {
         var i     = 0
         val buff1 = new ArrayBuffer[Int]()
@@ -34,8 +34,8 @@ class whileTest extends AnyFreeSpec with Assertions:
         val out =
             defer {
                 while i < 3 do
-                    await(IOs(incrementA()))
-                    await(IOs(incrementB()))
+                    await(Defers(incrementA()))
+                    await(Defers(incrementB()))
                     ()
                 end while
                 i

--- a/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/api/Endpoints.scala
+++ b/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/api/Endpoints.scala
@@ -1,46 +1,46 @@
-package kyo.examples.ledger.api
+// package kyo.examples.ledger.api
 
-import java.time.Instant
-import kyo.*
-import kyo.examples.ledger.*
-import sttp.model.StatusCode
-import sttp.tapir.*
-import sttp.tapir.generic.auto.*
-import sttp.tapir.json.zio.*
-import zio.json.JsonEncoder
+// import java.time.Instant
+// import kyo.*
+// import kyo.examples.ledger.*
+// import sttp.model.StatusCode
+// import sttp.tapir.*
+// import sttp.tapir.generic.auto.*
+// import sttp.tapir.json.zio.*
+// import zio.json.JsonEncoder
 
-object Endpoints:
+// object Endpoints:
 
-    val init: Unit < (Envs[Handler] & Routes) = defer {
+//     val init: Unit < (Envs[Handler] & Routes) = defer {
 
-        val handler = await(Envs.get[Handler])
+//         val handler = await(Envs.get[Handler])
 
-        await {
-            Routes.add(
-                _.post
-                    .in("clientes" / path[Int]("id") / "transacoes")
-                    .errorOut(statusCode)
-                    .in(jsonBody[Transaction])
-                    .out(jsonBody[Processed])
-            )(handler.transaction)
-        }
+//         await {
+//             Routes.add(
+//                 _.post
+//                     .in("clientes" / path[Int]("id") / "transacoes")
+//                     .errorOut(statusCode)
+//                     .in(jsonBody[Transaction])
+//                     .out(jsonBody[Processed])
+//             )(handler.transaction)
+//         }
 
-        await {
-            Routes.add(
-                _.get
-                    .in("clientes" / path[Int]("id") / "extrato")
-                    .errorOut(statusCode)
-                    .out(jsonBody[Statement])
-            )(handler.statement)
-        }
+//         await {
+//             Routes.add(
+//                 _.get
+//                     .in("clientes" / path[Int]("id") / "extrato")
+//                     .errorOut(statusCode)
+//                     .out(jsonBody[Statement])
+//             )(handler.statement)
+//         }
 
-        await {
-            Routes.add(
-                _.get
-                    .in("health")
-                    .out(stringBody)
-            )(_ => "ok")
-        }
-    }
+//         await {
+//             Routes.add(
+//                 _.get
+//                     .in("health")
+//                     .out(stringBody)
+//             )(_ => "ok")
+//         }
+//     }
 
-end Endpoints
+// end Endpoints

--- a/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/api/Handler.scala
+++ b/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/api/Handler.scala
@@ -1,71 +1,71 @@
-package kyo.examples.ledger.api
+// package kyo.examples.ledger.api
 
-import kyo.*
-import kyo.examples.ledger.*
-import kyo.examples.ledger.db.DB
-import sttp.model.StatusCode
+// import kyo.*
+// import kyo.examples.ledger.*
+// import kyo.examples.ledger.db.DB
+// import sttp.model.StatusCode
 
-trait Handler:
+// trait Handler:
 
-    def transaction(
-        account: Int,
-        request: Transaction
-    ): Processed < (Aborts[StatusCode] & Fibers)
+//     def transaction(
+//         account: Int,
+//         request: Transaction
+//     ): Processed < (Aborts[StatusCode] & Fibers)
 
-    def statement(
-        account: Int
-    ): Statement < (Aborts[StatusCode] & IOs)
+//     def statement(
+//         account: Int
+//     ): Statement < (Aborts[StatusCode] & IOs)
 
-end Handler
+// end Handler
 
-object Handler:
+// object Handler:
 
-    val init: Handler < Envs[DB] = defer {
-        Live(await(Envs.get[DB]))
-    }
+//     val init: Handler < Envs[DB] = defer {
+//         Live(await(Envs.get[DB]))
+//     }
 
-    final class Live(db: DB) extends Handler:
+//     final class Live(db: DB) extends Handler:
 
-        private val notFound            = Aborts.fail[StatusCode](StatusCode.NotFound)
-        private val unprocessableEntity = Aborts.fail[StatusCode](StatusCode.UnprocessableEntity)
+//         private val notFound            = Aborts.fail[StatusCode](StatusCode.NotFound)
+//         private val unprocessableEntity = Aborts.fail[StatusCode](StatusCode.UnprocessableEntity)
 
-        def transaction(account: Int, request: Transaction) = defer {
-            import request.*
-            // validations
-            await {
-                if account < 0 || account > 5 then notFound
-                else if description.isEmpty || description.exists(d =>
-                        d.size > 10 || d.isEmpty()
-                    )
-                then unprocessableEntity
-                else if kind != "c" && kind != "d" then unprocessableEntity
-                else ()
-            }
+//         def transaction(account: Int, request: Transaction) = defer {
+//             import request.*
+//             // validations
+//             await {
+//                 if account < 0 || account > 5 then notFound
+//                 else if description.isEmpty || description.exists(d =>
+//                         d.size > 10 || d.isEmpty()
+//                     )
+//                 then unprocessableEntity
+//                 else if kind != "c" && kind != "d" then unprocessableEntity
+//                 else ()
+//             }
 
-            val desc  = description.get
-            val value = if kind == "c" then amount else -amount
+//             val desc  = description.get
+//             val value = if kind == "c" then amount else -amount
 
-            // perform transaction
-            val result =
-                await(db.transaction(account, value, desc))
+//             // perform transaction
+//             val result =
+//                 await(db.transaction(account, value, desc))
 
-            result match
-                case Denied         => await(unprocessableEntity)
-                case res: Processed => res
-            end match
-        }
+//             result match
+//                 case Denied         => await(unprocessableEntity)
+//                 case res: Processed => res
+//             end match
+//         }
 
-        def statement(account: Int) = defer {
-            // validations
-            await {
-                if account < 0 || account > 5 then notFound
-                else ()
-            }
+//         def statement(account: Int) = defer {
+//             // validations
+//             await {
+//                 if account < 0 || account > 5 then notFound
+//                 else ()
+//             }
 
-            // get statement
-            await(db.statement(account))
-        }
+//             // get statement
+//             await(db.statement(account))
+//         }
 
-    end Live
+//     end Live
 
-end Handler
+// end Handler

--- a/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/api/Server.scala
+++ b/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/api/Server.scala
@@ -1,54 +1,54 @@
-package kyo.examples.ledger.api
+// package kyo.examples.ledger.api
 
-import java.util.concurrent.Executors
-import kyo.*
-import kyo.examples.ledger.db.DB
-import sttp.tapir.server.netty.*
+// import java.util.concurrent.Executors
+// import kyo.*
+// import kyo.examples.ledger.db.DB
+// import sttp.tapir.server.netty.*
 
-object Server extends KyoApp:
+// object Server extends KyoApp:
 
-    def flag(name: String, default: String) =
-        Option(System.getenv(name))
-            .getOrElse(System.getProperty(name, default))
+//     def flag(name: String, default: String) =
+//         Option(System.getenv(name))
+//             .getOrElse(System.getProperty(name, default))
 
-    run {
+//     run {
 
-        val port = flag("PORT", "9999").toInt
+//         val port = flag("PORT", "9999").toInt
 
-        val dbConfig =
-            DB.Config(
-                flag("DB_PATH", "/tmp/"),
-                flag("flushInternalMs", "1000").toInt.millis
-            )
+//         val dbConfig =
+//             DB.Config(
+//                 flag("DB_PATH", "/tmp/"),
+//                 flag("flushInternalMs", "1000").toInt.millis
+//             )
 
-        val options =
-            NettyKyoServerOptions
-                .default(enableLogging = false)
-                .forkExecution(false)
+//         val options =
+//             NettyKyoServerOptions
+//                 .default(enableLogging = false)
+//                 .forkExecution(false)
 
-        val cfg =
-            NettyConfig.default
-                .withSocketKeepAlive
-                .copy(lingerTimeout = None)
+//         val cfg =
+//             NettyConfig.default
+//                 .withSocketKeepAlive
+//                 .copy(lingerTimeout = None)
 
-        val server =
-            NettyKyoServer(options, cfg)
-                .host("0.0.0.0")
-                .port(port)
+//         val server =
+//             NettyKyoServer(options, cfg)
+//                 .host("0.0.0.0")
+//                 .port(port)
 
-        val timer = Timer(Executors.newSingleThreadScheduledExecutor())
+//         val timer = Timer(Executors.newSingleThreadScheduledExecutor())
 
-        val init = defer {
-            val db      = await(Envs.run(dbConfig)(DB.init))
-            val handler = await(Envs.run(db)(Handler.init))
-            await(Envs.run(handler)(Endpoints.init))
-        }
+//         val init = defer {
+//             val db      = await(Envs.run(dbConfig)(DB.init))
+//             val handler = await(Envs.run(db)(Handler.init))
+//             await(Envs.run(handler)(Endpoints.init))
+//         }
 
-        defer {
-            await(Consoles.println(s"Server starting on port $port..."))
-            val binding = await(Routes.run(server)(Timers.let(timer)(init)))
-            await(Consoles.println(s"Server started: ${binding.localSocket}"))
-        }
-    }
+//         defer {
+//             await(Consoles.println(s"Server starting on port $port..."))
+//             val binding = await(Routes.run(server)(Timers.let(timer)(init)))
+//             await(Consoles.println(s"Server started: ${binding.localSocket}"))
+//         }
+//     }
 
-end Server
+// end Server

--- a/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/db/DB.scala
+++ b/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/db/DB.scala
@@ -1,46 +1,46 @@
-package kyo.examples.ledger.db
+// package kyo.examples.ledger.db
 
-import kyo.*
-import kyo.examples.ledger.*
+// import kyo.*
+// import kyo.examples.ledger.*
 
-trait DB:
+// trait DB:
 
-    def transaction(
-        account: Int,
-        amount: Int,
-        desc: String
-    ): Result < IOs
+//     def transaction(
+//         account: Int,
+//         amount: Int,
+//         desc: String
+//     ): Result < IOs
 
-    def statement(
-        account: Int
-    ): Statement < IOs
+//     def statement(
+//         account: Int
+//     ): Statement < IOs
 
-end DB
+// end DB
 
-object DB:
+// object DB:
 
-    case class Config(
-        workingDir: String,
-        flushInterval: Duration
-    )
+//     case class Config(
+//         workingDir: String,
+//         flushInterval: Duration
+//     )
 
-    val init: DB < (Envs[Config] & IOs) = defer {
-        val index = await(Index.init)
-        val log   = await(Log.init)
-        Live(index, log)
-    }
+//     val init: DB < (Envs[Config] & IOs) = defer {
+//         val index = await(Index.init)
+//         val log   = await(Log.init)
+//         Live(index, log)
+//     }
 
-    class Live(index: Index, log: Log) extends DB:
+//     class Live(index: Index, log: Log) extends DB:
 
-        def transaction(account: Int, amount: Int, desc: String): Result < IOs =
-            index.transaction(account, amount, desc).map {
-                case Denied => Denied
-                case result: Processed =>
-                    log.transaction(result.balance, account, amount, desc).andThen(result)
-            }
+//         def transaction(account: Int, amount: Int, desc: String): Result < IOs =
+//             index.transaction(account, amount, desc).map {
+//                 case Denied => Denied
+//                 case result: Processed =>
+//                     log.transaction(result.balance, account, amount, desc).andThen(result)
+//             }
 
-        def statement(account: Int): Statement < IOs =
-            index.statement(account)
+//         def statement(account: Int): Statement < IOs =
+//             index.statement(account)
 
-    end Live
-end DB
+//     end Live
+// end DB

--- a/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/db/Index.scala
+++ b/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/db/Index.scala
@@ -1,200 +1,200 @@
-package kyo.examples.ledger.db
+// package kyo.examples.ledger.db
 
-import Index.*
-import java.lang.reflect.Field
-import java.nio.channels.FileChannel
-import java.nio.channels.FileChannel.MapMode.READ_WRITE
-import java.nio.file.Paths
-import java.nio.file.StandardOpenOption
-import java.time.Instant
-import kyo.*
-import kyo.examples.ledger.*
-import sun.misc.Unsafe
+// import Index.*
+// import java.lang.reflect.Field
+// import java.nio.channels.FileChannel
+// import java.nio.channels.FileChannel.MapMode.READ_WRITE
+// import java.nio.file.Paths
+// import java.nio.file.StandardOpenOption
+// import java.time.Instant
+// import kyo.*
+// import kyo.examples.ledger.*
+// import sun.misc.Unsafe
 
-trait Index:
+// trait Index:
 
-    def transaction(
-        account: Int,
-        amount: Int,
-        desc: String
-    ): Result < IOs
+//     def transaction(
+//         account: Int,
+//         amount: Int,
+//         desc: String
+//     ): Result < IOs
 
-    def statement(
-        account: Int
-    ): Statement < IOs
+//     def statement(
+//         account: Int
+//     ): Statement < IOs
 
-end Index
+// end Index
 
-object Index:
+// object Index:
 
-    val init: Index < (Envs[DB.Config] & IOs) = defer {
-        val cfg  = await(Envs.get[DB.Config])
-        val file = await(open(cfg.workingDir + "/index.dat"))
-        await(IOs(Live(file)))
-    }
+//     val init: Index < (Envs[DB.Config] & IOs) = defer {
+//         val cfg  = await(Envs.get[DB.Config])
+//         val file = await(open(cfg.workingDir + "/index.dat"))
+//         await(IOs(Live(file)))
+//     }
 
-    final class Live(file: FileChannel) extends Index:
-        private val descSize           = 10
-        private val transactionSize    = 32
-        private val transactionHistory = 10
-        private val entrySize          = Integer.BYTES * 3 + transactionSize * transactionHistory
-        private val paddedEntrySize    = 1024
-        private val fileSize           = paddedEntrySize * limits.size
+//     final class Live(file: FileChannel) extends Index:
+//         private val descSize           = 10
+//         private val transactionSize    = 32
+//         private val transactionHistory = 10
+//         private val entrySize          = Integer.BYTES * 3 + transactionSize * transactionHistory
+//         private val paddedEntrySize    = 1024
+//         private val fileSize           = paddedEntrySize * limits.size
 
-        private val address: Long =
-            val buffer       = file.map(READ_WRITE, 0, fileSize)
-            val addressField = buffer.getClass().getDeclaredMethod("address");
-            addressField.invoke(buffer).asInstanceOf[Long];
-        end address
+//         private val address: Long =
+//             val buffer       = file.map(READ_WRITE, 0, fileSize)
+//             val addressField = buffer.getClass().getDeclaredMethod("address");
+//             addressField.invoke(buffer).asInstanceOf[Long];
+//         end address
 
-        private case class Buffers(
-            descChars: Array[Char] = new Array[Char](10),
-            statement: Array[Byte] = new Array[Byte](entrySize)
-        )
+//         private case class Buffers(
+//             descChars: Array[Char] = new Array[Char](10),
+//             statement: Array[Byte] = new Array[Byte](entrySize)
+//         )
 
-        private val buffers = ThreadLocal.withInitial(() => Buffers())
+//         private val buffers = ThreadLocal.withInitial(() => Buffers())
 
-        def transaction(account: Int, amount: Int, desc: String) =
-            IOs {
-                val descChars  = this.descChars(desc)
-                val limit      = limits(account)
-                val offset     = address + (account * paddedEntrySize)
-                val timestamp  = System.currentTimeMillis()
-                var newBalance = 0
-                while !unsafe.compareAndSwapInt(null, offset, 0, 1) do {} // busy wait
-                try
-                    val balance = unsafe.getInt(offset + 4)
-                    newBalance = balance + amount
-                    if newBalance >= -limit then
-                        unsafe.putInt(offset + 4, newBalance)
-                        val tail = unsafe.getInt(offset + 8)
-                        unsafe.putInt(offset + 8, tail + 1)
-                        val toffset = (offset + 12) + (tail % transactionHistory) * transactionSize
-                        unsafe.putLong(toffset, timestamp)
-                        unsafe.putInt(toffset + 8, amount)
-                        unsafe.copyMemory(
-                            descChars,
-                            Unsafe.ARRAY_CHAR_BASE_OFFSET,
-                            null,
-                            toffset + 12,
-                            Character.BYTES * descSize
-                        )
-                    end if
-                finally
-                    unsafe.putOrderedInt(null, offset, 0)
-                end try
-                if newBalance >= -limit then
-                    Processed(limit, newBalance)
-                else
-                    Denied
-                end if
-            }
+//         def transaction(account: Int, amount: Int, desc: String) =
+//             IOs {
+//                 val descChars  = this.descChars(desc)
+//                 val limit      = limits(account)
+//                 val offset     = address + (account * paddedEntrySize)
+//                 val timestamp  = System.currentTimeMillis()
+//                 var newBalance = 0
+//                 while !unsafe.compareAndSwapInt(null, offset, 0, 1) do {} // busy wait
+//                 try
+//                     val balance = unsafe.getInt(offset + 4)
+//                     newBalance = balance + amount
+//                     if newBalance >= -limit then
+//                         unsafe.putInt(offset + 4, newBalance)
+//                         val tail = unsafe.getInt(offset + 8)
+//                         unsafe.putInt(offset + 8, tail + 1)
+//                         val toffset = (offset + 12) + (tail % transactionHistory) * transactionSize
+//                         unsafe.putLong(toffset, timestamp)
+//                         unsafe.putInt(toffset + 8, amount)
+//                         unsafe.copyMemory(
+//                             descChars,
+//                             Unsafe.ARRAY_CHAR_BASE_OFFSET,
+//                             null,
+//                             toffset + 12,
+//                             Character.BYTES * descSize
+//                         )
+//                     end if
+//                 finally
+//                     unsafe.putOrderedInt(null, offset, 0)
+//                 end try
+//                 if newBalance >= -limit then
+//                     Processed(limit, newBalance)
+//                 else
+//                     Denied
+//                 end if
+//             }
 
-        private def descChars(desc: String): Array[Char] =
-            val b    = buffers.get().descChars
-            var i    = 0
-            val size = Math.min(10, desc.size)
-            while i < size do
-                b(i) = desc.charAt(i)
-                i += 1
-            while i < descSize do
-                b(i) = 0
-                i += 1
-            b
-        end descChars
+//         private def descChars(desc: String): Array[Char] =
+//             val b    = buffers.get().descChars
+//             var i    = 0
+//             val size = Math.min(10, desc.size)
+//             while i < size do
+//                 b(i) = desc.charAt(i)
+//                 i += 1
+//             while i < descSize do
+//                 b(i) = 0
+//                 i += 1
+//             b
+//         end descChars
 
-        def statement(account: Int) =
-            IOs {
-                val limit     = limits(account)
-                val offset    = address + (account * paddedEntrySize)
-                val statement = this.buffers.get().statement
-                while !unsafe.compareAndSwapInt(null, offset, 0, 1) do {} // busy wait
-                try
-                    unsafe.copyMemory(
-                        null,
-                        offset,
-                        statement,
-                        Unsafe.ARRAY_BYTE_BASE_OFFSET,
-                        entrySize
-                    )
-                finally
-                    unsafe.putOrderedInt(null, offset, 0)
-                end try
-                decode(limit, statement)
-            }
+//         def statement(account: Int) =
+//             IOs {
+//                 val limit     = limits(account)
+//                 val offset    = address + (account * paddedEntrySize)
+//                 val statement = this.buffers.get().statement
+//                 while !unsafe.compareAndSwapInt(null, offset, 0, 1) do {} // busy wait
+//                 try
+//                     unsafe.copyMemory(
+//                         null,
+//                         offset,
+//                         statement,
+//                         Unsafe.ARRAY_BYTE_BASE_OFFSET,
+//                         entrySize
+//                     )
+//                 finally
+//                     unsafe.putOrderedInt(null, offset, 0)
+//                 end try
+//                 decode(limit, statement)
+//             }
 
-        private def decode(limit: Int, statement: Array[Byte]) =
-            val offset       = Unsafe.ARRAY_BYTE_BASE_OFFSET
-            val balance      = unsafe.getInt(statement, offset + 4)
-            val tail         = unsafe.getInt(statement, offset + 8)
-            val size         = Math.min(tail, transactionHistory)
-            val transactions = new Array[Transaction](size)
-            if size > 0 then
-                var pos = (tail) % size
-                var i   = 0
-                while i < size do
-                    val toffset   = (offset + 12) + (pos * transactionSize)
-                    val timestamp = unsafe.getLong(statement, toffset)
-                    val amount    = unsafe.getInt(statement, toffset + 8)
-                    var descSize  = 0
-                    while unsafe.getChar(
-                            statement,
-                            toffset + 12 + (descSize * Character.BYTES)
-                        ) != 0
-                    do
-                        descSize += 1
-                    end while
-                    val descChars = new Array[Char](descSize)
-                    unsafe.copyMemory(
-                        statement,
-                        toffset + 12,
-                        descChars,
-                        Unsafe.ARRAY_CHAR_BASE_OFFSET,
-                        Character.BYTES * descSize
-                    )
-                    transactions(size - 1 - i) = new Transaction(
-                        amount.abs,
-                        if amount < 0 then "d" else "c",
-                        Some(new String(descChars)),
-                        Some(Instant.ofEpochMilli(timestamp))
-                    )
-                    pos = (pos + 1) % transactionHistory
-                    i += 1
-                end while
-            end if
-            Statement(
-                Balance(balance, Instant.now(), limit),
-                transactions.toIndexedSeq
-            )
-        end decode
+//         private def decode(limit: Int, statement: Array[Byte]) =
+//             val offset       = Unsafe.ARRAY_BYTE_BASE_OFFSET
+//             val balance      = unsafe.getInt(statement, offset + 4)
+//             val tail         = unsafe.getInt(statement, offset + 8)
+//             val size         = Math.min(tail, transactionHistory)
+//             val transactions = new Array[Transaction](size)
+//             if size > 0 then
+//                 var pos = (tail) % size
+//                 var i   = 0
+//                 while i < size do
+//                     val toffset   = (offset + 12) + (pos * transactionSize)
+//                     val timestamp = unsafe.getLong(statement, toffset)
+//                     val amount    = unsafe.getInt(statement, toffset + 8)
+//                     var descSize  = 0
+//                     while unsafe.getChar(
+//                             statement,
+//                             toffset + 12 + (descSize * Character.BYTES)
+//                         ) != 0
+//                     do
+//                         descSize += 1
+//                     end while
+//                     val descChars = new Array[Char](descSize)
+//                     unsafe.copyMemory(
+//                         statement,
+//                         toffset + 12,
+//                         descChars,
+//                         Unsafe.ARRAY_CHAR_BASE_OFFSET,
+//                         Character.BYTES * descSize
+//                     )
+//                     transactions(size - 1 - i) = new Transaction(
+//                         amount.abs,
+//                         if amount < 0 then "d" else "c",
+//                         Some(new String(descChars)),
+//                         Some(Instant.ofEpochMilli(timestamp))
+//                     )
+//                     pos = (pos + 1) % transactionHistory
+//                     i += 1
+//                 end while
+//             end if
+//             Statement(
+//                 Balance(balance, Instant.now(), limit),
+//                 transactions.toIndexedSeq
+//             )
+//         end decode
 
-    end Live
+//     end Live
 
-    private def open(filePath: String) =
-        IOs {
-            FileChannel
-                .open(
-                    Paths.get(filePath),
-                    StandardOpenOption.READ,
-                    StandardOpenOption.WRITE,
-                    StandardOpenOption.CREATE
-                )
-        }
+//     private def open(filePath: String) =
+//         IOs {
+//             FileChannel
+//                 .open(
+//                     Paths.get(filePath),
+//                     StandardOpenOption.READ,
+//                     StandardOpenOption.WRITE,
+//                     StandardOpenOption.CREATE
+//                 )
+//         }
 
-    private val unsafe: Unsafe =
-        val f: Field = classOf[Unsafe].getDeclaredField("theUnsafe")
-        f.setAccessible(true)
-        f.get(null).asInstanceOf[Unsafe]
-    end unsafe
+//     private val unsafe: Unsafe =
+//         val f: Field = classOf[Unsafe].getDeclaredField("theUnsafe")
+//         f.setAccessible(true)
+//         f.get(null).asInstanceOf[Unsafe]
+//     end unsafe
 
-    private val limits =
-        List(
-            Integer.MAX_VALUE, // warmup account
-            100000,
-            80000,
-            1000000,
-            10000000,
-            500000
-        ).toArray
+//     private val limits =
+//         List(
+//             Integer.MAX_VALUE, // warmup account
+//             100000,
+//             80000,
+//             1000000,
+//             10000000,
+//             500000
+//         ).toArray
 
-end Index
+// end Index

--- a/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/db/Log.scala
+++ b/kyo-examples/jvm/src/main/scala/kyo/examples/ledger/db/Log.scala
@@ -1,62 +1,62 @@
-package kyo.examples.ledger.db
+// package kyo.examples.ledger.db
 
-import java.io.FileWriter
-import kyo.*
-import scala.jdk.CollectionConverters.*
+// import java.io.FileWriter
+// import kyo.*
+// import scala.jdk.CollectionConverters.*
 
-trait Log:
+// trait Log:
 
-    def transaction(
-        balance: Int,
-        account: Int,
-        amount: Int,
-        desc: String
-    ): Unit < IOs
+//     def transaction(
+//         balance: Int,
+//         account: Int,
+//         amount: Int,
+//         desc: String
+//     ): Unit < IOs
 
-end Log
+// end Log
 
-object Log:
+// object Log:
 
-    case class Entry(balance: Int, account: Int, amount: Int, desc: String)
+//     case class Entry(balance: Int, account: Int, amount: Int, desc: String)
 
-    val init: Log < (Envs[DB.Config] & IOs) = defer {
-        val cfg = await(Envs.get[DB.Config])
-        val q   = await(Queues.initUnbounded[Entry](Access.Mpsc))
-        val log = await(IOs(Live(cfg.workingDir + "/log.dat", q)))
-        await(Fibers.init(log.flushLoop(cfg.flushInterval)))
-        log
-    }
+//     val init: Log < (Envs[DB.Config] & IOs) = defer {
+//         val cfg = await(Envs.get[DB.Config])
+//         val q   = await(Queues.initUnbounded[Entry](Access.Mpsc))
+//         val log = await(IOs(Live(cfg.workingDir + "/log.dat", q)))
+//         await(Fibers.init(log.flushLoop(cfg.flushInterval)))
+//         log
+//     }
 
-    class Live(filePath: String, q: Queues.Unbounded[Entry]) extends Log:
+//     class Live(filePath: String, q: Queues.Unbounded[Entry]) extends Log:
 
-        private val writer = new FileWriter(filePath, true)
+//         private val writer = new FileWriter(filePath, true)
 
-        def transaction(
-            balance: Int,
-            account: Int,
-            amount: Int,
-            desc: String
-        ): Unit < IOs =
-            q.add(Entry(balance, account, amount, desc))
+//         def transaction(
+//             balance: Int,
+//             account: Int,
+//             amount: Int,
+//             desc: String
+//         ): Unit < IOs =
+//             q.add(Entry(balance, account, amount, desc))
 
-        private[Log] def flushLoop(interval: Duration): Unit < Fibers = defer {
-            await(Fibers.sleep(interval))
-            val entries = await(q.drain)
-            await(append(entries))
-            await(flushLoop(interval))
-        }
+//         private[Log] def flushLoop(interval: Duration): Unit < Fibers = defer {
+//             await(Fibers.sleep(interval))
+//             val entries = await(q.drain)
+//             await(append(entries))
+//             await(flushLoop(interval))
+//         }
 
-        private def append(entries: Seq[Entry]) =
-            IOs {
-                if entries.nonEmpty then
-                    val str =
-                        entries.map { e =>
-                            s"${e.balance}|${e.account}|${e.amount}|${e.desc}"
-                        }.mkString("\n")
-                    writer.append(str + "\n")
-                    writer.flush()
-            }
+//         private def append(entries: Seq[Entry]) =
+//             IOs {
+//                 if entries.nonEmpty then
+//                     val str =
+//                         entries.map { e =>
+//                             s"${e.balance}|${e.account}|${e.amount}|${e.desc}"
+//                         }.mkString("\n")
+//                     writer.append(str + "\n")
+//                     writer.flush()
+//             }
 
-    end Live
+//     end Live
 
-end Log
+// end Log

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -35,7 +35,7 @@ object KyoSttpMonad:
             override def eval[T](t: => T) =
                 IOs[T, Fibers](t)
 
-            override def suspend[T](t: => M[T]) =
+            override def suspend[T](t: => M[T]): M[T] =
                 IOs[T, Fibers](t)
 
             def async[T](register: (Either[Throwable, T] => Unit) => Canceler): M[T] =

--- a/kyo-sttp/shared/src/main/scala/kyo/requests.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/requests.scala
@@ -35,9 +35,9 @@ object Requests:
         local.use(_.send(req)).map {
             _.body match
                 case Left(ex: Throwable) =>
-                    IOs.fail[T](ex)
+                    IOs.fail(ex)
                 case Left(ex) =>
-                    IOs.fail[T](new Exception("" + ex))
+                    IOs.fail(new Exception("" + ex))
                 case Right(value) =>
                     value
         }

--- a/kyo-zio/shared/src/main/scala/kyo/zios.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/zios.scala
@@ -3,6 +3,7 @@ package kyo
 import ZIOs.internal.*
 import core.*
 import core.internal.*
+import kyo.IOs.internal.*
 import kyo.fibersInternal.*
 import scala.util.control.NonFatal
 import zio.Task
@@ -27,7 +28,7 @@ object ZIOs:
             v match
                 case kyo: Suspend[?, ?, ?, ?] =>
                     try
-                        if kyo.tag =:= Tag[IOs] then
+                        if kyo.tag =:= Tag[SideEffects] || kyo.tag =:= Tag[Defers] then
                             val k = kyo.asInstanceOf[Suspend[?, Unit, U, Fibers]]
                             ZIO.suspend(loop(k(())))
                         else if kyo.tag =:= Tag[FiberGets] then


### PR DESCRIPTION
I'm working on isolating Kyo's core in preparation for the new `kyo-pure` module (see https://github.com/getkyo/kyo/pull/308 for more context). This PR integrates `Defers` into both `IOs` and `Locals`. Computations that use `IOs` can also perform `Defer` suspensions since the opaque type declares it contains `Defers`:

```scala
opaque type IOs <: Defers = Defers & SideEffects
```

This change also makes `Locals` a pure effect based on `Defers` instead of `IOs`.

**Important:** This change breaks any use of `IOs` in `kyo-direct`. Any effect declared as `opaque` crashes the compiler for `kyo-direct`. I've changed the majority of tests to use `Defers` instead of `IOs` and commented out some others. The example http server is also commented out. We'll need to fix this issue with opaque types in the direct syntax before the next release.