### PR TITLE
benchs: detect runtime leaks

### DIFF
--- a/kyo-bench/src/test/scala/kyo/bench/CatsBenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/bench/CatsBenchTest.scala
@@ -1,0 +1,9 @@
+package kyo.bench
+
+class CatsBenchTest extends BenchTest:
+
+    def target                                 = Target.Cats
+    def runFork[T](b: Bench.Fork[T]): T        = b.forkCats()
+    def runSync[T](b: Bench.SyncAndFork[T]): T = b.syncCats()
+
+end CatsBenchTest

--- a/kyo-bench/src/test/scala/kyo/bench/KyoBenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/bench/KyoBenchTest.scala
@@ -1,0 +1,9 @@
+package kyo.bench
+
+class KyoBenchTest extends BenchTest:
+
+    def target                                 = Target.Kyo
+    def runFork[T](b: Bench.Fork[T]): T        = b.forkKyo()
+    def runSync[T](b: Bench.SyncAndFork[T]): T = b.syncKyo()
+
+end KyoBenchTest

--- a/kyo-bench/src/test/scala/kyo/bench/ZioBenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/bench/ZioBenchTest.scala
@@ -1,0 +1,9 @@
+package kyo.bench
+
+class ZioBenchTest extends BenchTest:
+
+    def target                                 = Target.Zio
+    def runFork[T](b: Bench.Fork[T]): T        = b.forkZio()
+    def runSync[T](b: Bench.SyncAndFork[T]): T = b.syncZio()
+
+end ZioBenchTest


### PR DESCRIPTION
It's easy to make mistakes in benchmarks that end up initializing targets other than the one being tested. For example, if `Bench.zioRuntime` were a `val` instead of `lazy val`, all benchmarks would run with ZIO's runtime initialized, including its threads. This kind of mistake can introduce significant noise in the benchmarks. 