### PR TITLE
(almost) allocationless tags ⚡

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,6 @@ lazy val `kyo-core` =
         .in(file("kyo-core"))
         .settings(
             `kyo-settings`,
-            libraryDependencies += "dev.zio"       %%% "izumi-reflect"   % "2.3.9",
             libraryDependencies += "com.lihaoyi"   %%% "pprint"          % "0.9.0",
             libraryDependencies += "org.jctools"     % "jctools-core"    % "4.0.3",
             libraryDependencies += "org.slf4j"       % "slf4j-api"       % "2.0.13",
@@ -264,6 +263,7 @@ lazy val `kyo-bench` =
                     )
                 }
             },
+            libraryDependencies += "dev.zio"             %% "izumi-reflect"       % "2.3.9",
             libraryDependencies += "org.typelevel"       %% "cats-effect"         % "3.5.4",
             libraryDependencies += "org.typelevel"       %% "log4cats-core"       % "2.7.0",
             libraryDependencies += "org.typelevel"       %% "log4cats-slf4j"      % "2.7.0",

--- a/kyo-bench/src/main/scala/kyo/bench/TagsBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TagsBench.scala
@@ -33,7 +33,7 @@ class TagsBench extends Bench(()):
     end syncKyo
 
     @Benchmark
-    def syncZio() =
+    def syncIzumi() =
         import izumi.reflect.*
         Tag[String] =:= Tag[String]
         Tag[Int] <:< Tag[Any]
@@ -48,6 +48,6 @@ class TagsBench extends Bench(()):
         Tag[Test3[Test1[Sub1], Test2[Super]]] <:< Tag[Test3[Test1[Super], Test2[Sub1]]]
         Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]] =:=
             Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]]
-    end syncZio
+    end syncIzumi
 
 end TagsBench

--- a/kyo-bench/src/main/scala/kyo/bench/TagsBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TagsBench.scala
@@ -1,0 +1,53 @@
+package kyo.bench
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class TagsBench extends Bench(()):
+
+    class Super
+    class Sub1 extends Super
+    class Sub2 extends Super
+    class Test1[+T]
+    class Test2[-T]
+    class Test3[T, U]
+    class Test4[-T, -U]
+    class Test5[+T, U]
+    class Test6[T1, T2, T3, T4, T5]
+
+    @Benchmark
+    def syncKyo() =
+        import kyo.*
+        Tag[String] =:= Tag[String]
+        Tag[Int] <:< Tag[Any]
+        Tag[Sub1] <:< Tag[Super]
+        Tag[Super] <:< Tag[Sub2]
+        Tag[Test1[Sub1]] <:< Tag[Test1[Super]]
+        Tag[Test2[Super]] <:< Tag[Test2[Sub1]]
+        Tag[Test3[String, Int]] =:= Tag[Test3[String, Int]]
+        Tag[Test4[Super, Super]] <:< Tag[Test4[Sub1, Sub2]]
+        Tag[Test5[Sub1, String]] <:< Tag[Test5[Super, String]]
+        Tag[Test6[Int, String, Boolean, Double, Char]] =:= Tag[Test6[Int, String, Boolean, Double, Char]]
+        Tag[Test3[Test1[Sub1], Test2[Super]]] <:< Tag[Test3[Test1[Super], Test2[Sub1]]]
+        Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]] =:=
+            Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]]
+    end syncKyo
+
+    @Benchmark
+    def syncZio() =
+        import izumi.reflect.*
+        Tag[String] =:= Tag[String]
+        Tag[Int] <:< Tag[Any]
+        Tag[Sub1] <:< Tag[Super]
+        Tag[Super] <:< Tag[Sub2]
+        Tag[Test1[Sub1]] <:< Tag[Test1[Super]]
+        Tag[Test2[Super]] <:< Tag[Test2[Sub1]]
+        Tag[Test3[String, Int]] =:= Tag[Test3[String, Int]]
+        Tag[Test4[Super, Super]] <:< Tag[Test4[Sub1, Sub2]]
+        Tag[Test5[Sub1, String]] <:< Tag[Test5[Super, String]]
+        Tag[Test6[Int, String, Boolean, Double, Char]] =:= Tag[Test6[Int, String, Boolean, Double, Char]]
+        Tag[Test3[Test1[Sub1], Test2[Super]]] <:< Tag[Test3[Test1[Super], Test2[Sub1]]]
+        Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]] =:=
+            Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]]
+    end syncZio
+
+end TagsBench

--- a/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
@@ -36,17 +36,10 @@ class coreBytecodeSizeTest extends KyoTest:
     "handle" in runJVM {
         val map = methodBytecodeSize[TestHandle]
         assert(map == Map(
-<<<<<<< HEAD
             "test"        -> 27,
             "resultLoop"  -> 91,
-            "handleLoop"  -> 276,
+            "handleLoop"  -> 253,
             "_handleLoop" -> 10
-=======
-            "test"        -> 28,
-            "resultLoop"  -> 94,
-            "handleLoop"  -> 257,
-            "_handleLoop" -> 12
->>>>>>> d5847e0a ((almost) allocationless tags)
         ))
     }
 

--- a/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
@@ -36,10 +36,17 @@ class coreBytecodeSizeTest extends KyoTest:
     "handle" in runJVM {
         val map = methodBytecodeSize[TestHandle]
         assert(map == Map(
+<<<<<<< HEAD
             "test"        -> 27,
             "resultLoop"  -> 91,
             "handleLoop"  -> 276,
             "_handleLoop" -> 10
+=======
+            "test"        -> 28,
+            "resultLoop"  -> 94,
+            "handleLoop"  -> 257,
+            "_handleLoop" -> 12
+>>>>>>> d5847e0a ((almost) allocationless tags)
         ))
     }
 

--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -67,7 +67,7 @@ object core:
             @tailrec def handleLoop(st: State, value: T < (E & S & S2)): Result[T] < (S & S2) =
                 value match
                     case kyo: Suspend[e.Command, Any, T, S2] @unchecked
-                        if tag == kyo.tag && handler.accepts(st, kyo.command) =>
+                        if tag =:= kyo.tag && handler.accepts(st, kyo.command) =>
                         handler.resume(st, kyo.command, kyo) match
                             case r: handler.Resume[T, S & S2] @unchecked =>
                                 handleLoop(r.st, r.v)

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -68,7 +68,7 @@ sealed trait IOs extends Effect[IOs]:
         @tailrec def runLazyLoop(v: T < (IOs & S)): T < S =
             v match
                 case kyo: Suspend[?, ?, ?, ?] =>
-                    if kyo.tag == tag then
+                    if kyo.tag =:= tag then
                         val k = kyo.asInstanceOf[Suspend[IO, Unit, T, S & IOs]]
                         runLazyLoop(k(()))
                     else

--- a/kyo-core/shared/src/main/scala/kyo/package.scala
+++ b/kyo-core/shared/src/main/scala/kyo/package.scala
@@ -72,19 +72,19 @@ package object kyo:
         inline def failTag[T, U](
             inline actual: Tag[U]
         ): Nothing =
-            bug(s"Unexpected effect '${actual.parse}' found in 'pure'.")
+            bug(s"Unexpected effect '${actual.show}' found in 'pure'.")
 
-        inline def failTag[T, U](
-            inline actual: Tag[U],
-            inline expected: Tag[T]
+        inline def failTag(
+            inline actual: Tag[?],
+            inline expected: Tag[?]*
         ): Nothing =
-            bug(s"Unexpected effect '${actual.parse}' found while handling '${expected.parse}'.")
+            bug(s"Unexpected effect '${actual.show}' found while handling '${expected.map(_.show).mkString(" & ")}'.")
 
         inline def checkTag[T, U](
             inline actual: Tag[U],
             inline expected: Tag[T]
         ): Unit =
-            if actual != expected then
+            if actual =!= expected then
                 failTag(actual, expected)
 
         def when(cond: Boolean)(msg: String): Unit =

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -41,10 +41,10 @@ private[kyo] class IOTask[T](
         else
             curr match
                 case kyo: Suspend[?, ?, ?, ?] =>
-                    if kyo.tag == Tag[IOs] then
+                    if kyo.tag =:= Tag[IOs] then
                         val k = kyo.asInstanceOf[Suspend[IO, Unit, T, Fibers]]
                         eval(k((), this, locals), scheduler, startMillis, clock)
-                    else if kyo.tag == Tag[FiberGets] then
+                    else if kyo.tag =:= Tag[FiberGets] then
                         val k = kyo.asInstanceOf[Suspend[Fiber, Any, T, Fibers]]
                         k.command match
                             case Promise(p) =>
@@ -69,7 +69,7 @@ private[kyo] class IOTask[T](
                                 )
                         end match
                     else
-                        IOs(bug.failTag(kyo.tag, Tag[FiberGets & IOs]))
+                        IOs(bug.failTag(kyo.tag, Tag[FiberGets], Tag[IOs]))
                 case _ =>
                     complete(curr.asInstanceOf[T < IOs])
                     finalize()

--- a/kyo-core/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-core/shared/src/main/scala/kyo/tags.scala
@@ -154,9 +154,13 @@ object Tag:
 
             tpe.dealias match
                 case AndType(_, _) | OrType(_, _) =>
-                    report.errorAndAbort(s"Unsupported Tag type ${tpe.show}")
+                    report.errorAndAbort(
+                        s"Unsupported intersection or union type in Tag: ${tpe.show}. Only class types and type parameters are allowed."
+                    )
                 case tpe if tpe.typeSymbol.fullName == "scala.Nothing" =>
-                    report.errorAndAbort(s"Unsupported Tag type ${tpe.show}")
+                    report.errorAndAbort(
+                        s"Tag cannot be created for Nothing as it has no values. Use a different type or add explicit type parameters if needed."
+                    )
                 case tpe if tpe.typeSymbol.isClassDef =>
                     val sym  = tpe.typeSymbol
                     val path = tpe.dealias.baseClasses.map(_.fullName).mkString(";") + ";"
@@ -184,12 +188,12 @@ object Tag:
                             Expr.summon[Tag[tpe]] match
                                 case None =>
                                     report.errorAndAbort(
-                                        s"Please provide an implicit ${TypeRepr.of[Tag[tpe]].show}"
+                                        report.errorAndAbort(s"Please provide an implicit kyo.Flat[${TypeRepr.of[tpe].show}] parameter.")
                                     )
                                 case Some(value) =>
                                     '{ $value.tpe }
                         case _ =>
-                            report.errorAndAbort(s"Unsupported Tag type ${tpe.show}")
+                            report.errorAndAbort(s"Tag only supports class types and type parameters, but got: ${tpe.show}")
             end match
         end encodeType
 

--- a/kyo-core/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-core/shared/src/main/scala/kyo/tags.scala
@@ -16,16 +16,16 @@ object Tag:
         def show = t1.tpe.takeWhile(_ != ';')
 
         def <:<[U](t2: Tag[U]): Boolean =
-            t1.tpe == t2.tpe || isSubtype(t1, t2)
+            t1 =:= t2 || isSubtype(t1, t2)
 
         def =:=[U](t2: Tag[U]): Boolean =
-            t1.tpe == t2.tpe
+            (t1.tpe eq t2.tpe) || t1.tpe == t2.tpe
 
         def =!=[U](t2: Tag[U]): Boolean =
-            t1.tpe != t2.tpe
+            (t1.tpe ne t2.tpe) || t1.tpe != t2.tpe
 
         def >:>[U](t2: Tag[U]): Boolean =
-            t1.tpe == t2.tpe || isSubtype(t2, t1)
+            t1 =:= t2 || isSubtype(t2, t1)
 
     end extension
 

--- a/kyo-core/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-core/shared/src/main/scala/kyo/tags.scala
@@ -1,5 +1,6 @@
 package kyo
 
+import scala.annotation.switch
 import scala.annotation.tailrec
 import scala.quoted.*
 
@@ -74,7 +75,7 @@ object Tag:
             @tailrec def loop(idx: Int): Int =
                 if idx >= tag.length() then -1
                 else
-                    tag.charAt(idx) match
+                    (tag.charAt(idx): @switch) match
                         case ';'             => idx + 1
                         case '[' | ',' | ']' => -1
                         case _               => loop(idx + 1)
@@ -99,7 +100,7 @@ object Tag:
                 @tailrec def loop(subIdx: Int, superIdx: Int): Boolean =
                     val variance = subTag.charAt(subIdx)
                     variance == superTag.charAt(superIdx) && {
-                        variance match
+                        (variance: @switch) match
                             case '=' =>
                                 sameType(subTag, superTag, subIdx + 1, superIdx + 1)
                             case '+' =>
@@ -123,13 +124,18 @@ object Tag:
 
         def nextParam(tag: String, idx: Int): Int =
             @tailrec def loop(opens: Int, idx: Int): Int =
-                tag.charAt(idx) match
-                    case ',' if opens == 0 =>
-                        idx + 1
-                    case ']' if opens == 0 =>
-                        -1
+                (tag.charAt(idx): @switch) match
+                    case ',' =>
+                        if opens == 0 then
+                            idx + 1
+                        else
+                            loop(opens, idx + 1)
+                    case ']' =>
+                        if opens == 0 then
+                            -1
+                        else
+                            loop(opens - 1, idx + 1)
                     case '[' => loop(opens + 1, idx + 1)
-                    case ']' => loop(opens - 1, idx + 1)
                     case _   => loop(opens, idx + 1)
             loop(0, idx)
         end nextParam

--- a/kyo-core/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-core/shared/src/main/scala/kyo/tags.scala
@@ -9,7 +9,7 @@ object Tag:
 
     import internal.*
 
-    inline given apply[T >: Nothing]: Tag[T] = ${ tagImpl[T] }
+    inline given apply[T]: Tag[T] = ${ tagImpl[T] }
 
     extension [T](t1: Tag[T])
 
@@ -147,6 +147,10 @@ object Tag:
             import quotes.reflect.*
 
             tpe.dealias match
+                case AndType(_, _) | OrType(_, _) =>
+                    report.errorAndAbort(s"Unsupported Tag type ${tpe.show}")
+                case tpe if tpe.typeSymbol.fullName == "scala.Nothing" =>
+                    report.errorAndAbort(s"Unsupported Tag type ${tpe.show}")
                 case tpe if tpe.typeSymbol.isClassDef =>
                     val sym  = tpe.typeSymbol
                     val path = tpe.dealias.baseClasses.map(_.fullName).mkString(";") + ";"
@@ -168,8 +172,6 @@ object Tag:
                                     ) :+ Expr("]"))
                         )
                     end if
-                case AndType(_, _) | OrType(_, _) =>
-                    report.errorAndAbort(s"Unsupported Tag type ${tpe.show}")
                 case _ =>
                     tpe.asType match
                         case '[tpe] =>

--- a/kyo-core/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-core/shared/src/main/scala/kyo/tags.scala
@@ -1,41 +1,206 @@
 package kyo
 
-import izumi.reflect.dottyreflection.TypeInspections
-import izumi.reflect.macrortti.LightTypeTag
+import scala.annotation.tailrec
 import scala.quoted.*
 
-opaque type Tag[T] = String
+case class Tag[T](tpe: String) extends AnyVal
 
 object Tag:
 
-    given canEqual[T, U]: CanEqual[Tag[T], Tag[U]] = CanEqual.derived
+    import internal.*
 
-    extension [T](t: Tag[T])
-        def parse: LightTypeTag =
-            val arr = t.split('|')
-            LightTypeTag.parse(arr(0).toInt, arr(1), arr(2), arr(3).toInt)
+    inline given apply[T >: Nothing]: Tag[T] = ${ tagImpl[T] }
+
+    extension [T](t1: Tag[T])
+
+        def show = t1.tpe.takeWhile(_ != ';')
+
+        def <:<[U](t2: Tag[U]): Boolean =
+            t1.tpe == t2.tpe || isSubtype(t1, t2)
+
+        def =:=[U](t2: Tag[U]): Boolean =
+            t1.tpe == t2.tpe
+
+        def =!=[U](t2: Tag[U]): Boolean =
+            t1.tpe != t2.tpe
+
+        def >:>[U](t2: Tag[U]): Boolean =
+            t1.tpe == t2.tpe || isSubtype(t2, t1)
+
     end extension
 
-    inline given apply[T]: Tag[T] = ${ tagImpl[T] }
+    private[Tag] object internal:
 
-    private def tagImpl[T: Type](using Quotes): Expr[Tag[T]] =
-        import quotes.reflect.*
-        if TypeRepr.of[T] =:= TypeRepr.of[Nothing] then
-            report.errorAndAbort("Can't infer a Tag[Nothing]")
-        if TypeRepr.of[T] =:= TypeRepr.of[Any] then
-            report.errorAndAbort("Can't infer a Tag[Any]")
-        if TypeRepr.of[T] =:= TypeRepr.of[Object] then
-            report.errorAndAbort("Can't infer a Tag[Object]")
-        val ref         = TypeInspections.apply[T]
-        val fullDb      = TypeInspections.fullDb[T]
-        val nameDb      = TypeInspections.unappliedDb[T]
-        val ltt         = LightTypeTag(ref, fullDb, nameDb)
-        val serialized  = ltt.serialize()
-        val hashCodeRef = serialized.hash
-        val strRef      = serialized.ref
-        val strDBs      = serialized.databases
-        val version     = LightTypeTag.currentBinaryFormatVersion
-        val tagStr      = s"$hashCodeRef|$strRef|$strDBs|$version"
-        Expr(tagStr)
-    end tagImpl
+        // Example Tag
+        //
+        // class Super
+        // class Param1 extends Super
+        // class Param2 extends Super
+        // class Test[-T, +U]
+        //
+        // Tag[Test[Param1, Param2]]
+        //
+        // Test;Super;java.lang.Object;scala.Matchable;scala.Any;[-Param1;Super;java.lang.Object;scala.Matchable;scala.Any;,+Param2;Super;java.lang.Object;scala.Matchable;scala.Any;]
+        // |--------------------Test segment---------------------|-|-------------------Param1 segment----------------------|+|-------------------Param2 segment----------------------|
+        //                                                     variance                                                  variance
+
+        def isSubtype(subTag: Tag[?], superTag: Tag[?]): Boolean =
+            checkType(subTag.tpe, superTag.tpe, 0, 0)
+
+        def checkType(subTag: String, superTag: String, subIdx: Int, superIdx: Int): Boolean =
+            checkSegment(subTag, superTag, subIdx, superIdx) && checkParams(subTag, superTag, subIdx, superIdx)
+
+        def checkSegment(subTag: String, superTag: String, subIdx: Int, superIdx: Int): Boolean =
+            @tailrec def loop(subIdx: Int, superIdx: Int, superStart: Int): Boolean =
+                if subIdx >= subTag.length() || superIdx >= superTag.length() then false
+                else
+                    val subChar   = subTag.charAt(subIdx)
+                    val superChar = superTag.charAt(superIdx)
+                    (subChar == ';' && superChar == ';') || {
+                        if subChar == superChar then
+                            loop(subIdx + 1, superIdx + 1, superStart)
+                        else
+                            nextSegmentEntry(subTag, subIdx) match
+                                case -1  => false
+                                case idx => loop(idx, superStart, superStart)
+                        end if
+                    }
+                end if
+            end loop
+            loop(subIdx, superIdx, superIdx)
+        end checkSegment
+
+        def nextSegmentEntry(tag: String, idx: Int): Int =
+            @tailrec def loop(idx: Int): Int =
+                if idx >= tag.length() then -1
+                else
+                    tag.charAt(idx) match
+                        case ';'             => idx + 1
+                        case '[' | ',' | ']' => -1
+                        case _               => loop(idx + 1)
+            loop(idx)
+        end nextSegmentEntry
+
+        def sameType(subTag: String, superTag: String, subIdx: Int, superIdx: Int): Boolean =
+            @tailrec def loop(subIdx: Int, superIdx: Int): Boolean =
+                val subChar   = subTag.charAt(subIdx)
+                val superChar = superTag.charAt(superIdx)
+                subChar == superChar && (subChar == ';' || loop(subIdx + 1, superIdx + 1))
+            end loop
+            loop(subIdx, superIdx) && checkParams(subTag, superTag, subIdx, superIdx)
+        end sameType
+
+        def checkParams(subTag: String, superTag: String, subIdx: Int, superIdx: Int): Boolean =
+            val subStart   = subTag.indexOf('[', subIdx)
+            val superStart = subTag.indexOf('[', superIdx)
+            if subStart == -1 || superStart == -1 then
+                superStart == superStart
+            else
+                @tailrec def loop(subIdx: Int, superIdx: Int): Boolean =
+                    val variance = subTag.charAt(subIdx)
+                    variance == superTag.charAt(superIdx) && {
+                        variance match
+                            case '=' =>
+                                sameType(subTag, superTag, subIdx + 1, superIdx + 1)
+                            case '+' =>
+                                checkType(subTag, superTag, subIdx + 1, superIdx + 1)
+                            case '-' =>
+                                checkType(superTag, subTag, superIdx + 1, subIdx + 1)
+                        end match
+                    } && {
+                        val nextSubParam   = nextParam(subTag, subIdx + 1)
+                        val nextSuperParam = nextParam(superTag, superIdx + 1)
+                        if nextSubParam == -1 || nextSuperParam == -1 then
+                            nextSubParam == nextSuperParam
+                        else
+                            loop(nextSubParam, nextSuperParam)
+                        end if
+                    }
+                end loop
+                loop(subStart + 1, superStart + 1)
+            end if
+        end checkParams
+
+        def nextParam(tag: String, idx: Int): Int =
+            @tailrec def loop(opens: Int, idx: Int): Int =
+                tag.charAt(idx) match
+                    case ',' if opens == 0 =>
+                        idx + 1
+                    case ']' if opens == 0 =>
+                        -1
+                    case '[' => loop(opens + 1, idx + 1)
+                    case ']' => loop(opens - 1, idx + 1)
+                    case _   => loop(opens, idx + 1)
+            loop(0, idx)
+        end nextParam
+
+        // Macro methods
+
+        def tagImpl[T: Type](using Quotes): Expr[Tag[T]] =
+            import quotes.reflect.*
+
+            val encoded = encodeType(TypeRepr.of[T])
+            '{ new Tag($encoded) }
+        end tagImpl
+
+        def encodeType(using Quotes)(tpe: quotes.reflect.TypeRepr): Expr[String] =
+            import quotes.reflect.*
+
+            tpe.dealias match
+                case tpe if tpe.typeSymbol.isClassDef =>
+                    val sym  = tpe.typeSymbol
+                    val path = tpe.dealias.baseClasses.map(_.fullName).mkString(";") + ";"
+                    val variances = sym.typeMembers.flatMap { v =>
+                        if !v.isTypeParam then None
+                        else if v.flags.is(Flags.Contravariant) then Some("-")
+                        else if v.flags.is(Flags.Covariant) then Some("+")
+                        else Some("=")
+                    }
+                    val params = tpe.typeArgs.map(encodeType)
+                    if params.isEmpty then
+                        Expr(path)
+                    else
+                        concat(
+                            Expr(s"$path[") ::
+                                (variances.zip(params).map((v, p) => Expr(v) :: p :: Nil)
+                                    .reduce((a, b) =>
+                                        a ::: Expr(",") :: b
+                                    ) :+ Expr("]"))
+                        )
+                    end if
+                case AndType(_, _) | OrType(_, _) =>
+                    report.errorAndAbort(s"Unsupported Tag type ${tpe.show}")
+                case _ =>
+                    tpe.asType match
+                        case '[tpe] =>
+                            Expr.summon[Tag[tpe]] match
+                                case None =>
+                                    report.errorAndAbort(
+                                        s"Please provide an implicit ${TypeRepr.of[Tag[tpe]].show}"
+                                    )
+                                case Some(value) =>
+                                    '{ $value.tpe }
+                        case _ =>
+                            report.errorAndAbort(s"Unsupported Tag type ${tpe.show}")
+            end match
+        end encodeType
+
+        def concat(l: List[Expr[String]])(using Quotes): Expr[String] =
+            def loop(l: List[Expr[String]], acc: String, exprs: List[Expr[String]]): Expr[String] =
+                l match
+                    case Nil =>
+                        (Expr(acc) :: exprs).reverse match
+                            case Nil => Expr("")
+                            case exprs =>
+                                exprs.filter {
+                                    case Expr("") => false
+                                    case _        => true
+                                }.reduce((a, b) => '{ $a + $b })
+                    case Expr(s: String) :: next =>
+                        loop(next, acc + s, exprs)
+                    case head :: next =>
+                        loop(next, "", head :: Expr(acc) :: exprs)
+            loop(l, "", Nil)
+        end concat
+    end internal
 end Tag

--- a/kyo-core/shared/src/test/scala/kyoTest/envsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/envsTest.scala
@@ -47,22 +47,8 @@ class envsTest extends KyoTest:
         succeed
     }
 
-    "intersection type env" - {
-        "explicit" in pendingUntilFixed {
-            val a = Envs.run(1)(Envs.get[Int & Double])
-            val b = Envs.run(1.2d)(a)
-            assert(b.pure == 1)
-            ()
-        }
-        "method inference" in pendingUntilFixed {
-            def test[T](v: T < (Envs[Int] & Envs[Double])) =
-                v
-            val a                                = test(Envs.get)
-            val b: (Int & Double) < Envs[Double] = Envs.run(1)(a)
-            val c: (Int & Double) < Any          = Envs.run(1.2d)(b)
-            assert(c.pure == 1)
-            ()
-        }
+    "intersection type env" in {
+        assertDoesNotCompile("Envs.get[Int & Double]")
     }
 
     "reduce large intersection incrementally" in {

--- a/kyo-core/shared/src/test/scala/kyoTest/streamsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/streamsTest.scala
@@ -9,7 +9,7 @@ class streamsTest extends KyoTest:
     "initSeq" - {
         "empty" in {
             assert(
-                Streams.initSeq(Seq()).runSeq.pure == (Seq.empty, ())
+                Streams.initSeq(Seq[Int]()).runSeq.pure == (Seq.empty, ())
             )
         }
 
@@ -321,7 +321,7 @@ class streamsTest extends KyoTest:
         "none" in {
             assert(
                 Streams.initSeq(Seq(1, 2, 3)).collect {
-                    case v if false => ???
+                    case v if false => (): Unit < Streams[Int]
                 }.runSeq.pure == (Seq.empty, ())
             )
         }

--- a/kyo-core/shared/src/test/scala/kyoTest/tagsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/tagsTest.scala
@@ -2,7 +2,6 @@ package kyoTest
 
 import izumi.reflect.Tag as ITag
 import kyo.*
-import scala.reflect.ClassTag
 
 class TagsTest extends KyoTest:
 

--- a/kyo-core/shared/src/test/scala/kyoTest/tagsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/tagsTest.scala
@@ -192,6 +192,7 @@ class TagsTest extends KyoTest:
     val test = new UnsupportedTest {}
 
     "unsupported types" in {
+        assertDoesNotCompile("Tag[Nothing]")
         assertDoesNotCompile("Tag[UnsupportedTest#T]")
         assertDoesNotCompile("Tag[UnsupportedTest.T]")
         assertDoesNotCompile("Tag[String & Int]")

--- a/kyo-core/shared/src/test/scala/kyoTest/tagsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/tagsTest.scala
@@ -1,0 +1,201 @@
+package kyoTest
+
+import izumi.reflect.Tag as ITag
+import kyo.*
+
+class TagsTest extends KyoTest:
+
+    def test[T1: Tag: ITag, T2: Tag: ITag]: Unit =
+        "T1 <:< T2" in {
+            assert(
+                Tag[T1] <:< Tag[T2] == ITag[T1] <:< ITag[T2],
+                s"Tag[T1] <:< Tag[T2] is ${Tag[T1] <:< Tag[T2]} but ITag[T1] <:< ITag[T2] is ${ITag[T1] <:< ITag[T2]}"
+            )
+        }
+        "T2 <:< T1" in {
+            val kresult = Tag[T2] <:< Tag[T1]
+            val iresult = ITag[T2] <:< ITag[T1]
+            assert(
+                kresult == iresult,
+                s"Tag[T2] <:< Tag[T1] is $kresult but ITag[T2] <:< ITag[T1] is $iresult"
+            )
+        }
+        ()
+    end test
+
+    "without variance" - {
+        "equal tags" - {
+            class Test[T]
+            test[Test[Int], Test[Int]]
+        }
+
+        "not equal tags (different type parameters)" - {
+            class Test[T]
+            test[Test[String], Test[Int]]
+        }
+
+        "not equal tags (different classes)" - {
+            class Test1[T]
+            class Test2[T]
+            test[Test1[Int], Test2[Int]]
+        }
+
+        "not subtype (invariant)" - {
+            class Test[T]
+            test[Test[String], Test[Any]]
+        }
+
+        "not supertype (invariant)" - {
+            class Test[T]
+            test[Test[Any], Test[String]]
+        }
+
+        "not subtype or supertype (unrelated types)" - {
+            class Test[T]
+            test[Test[String], Test[Int]]
+        }
+    }
+
+    "with variance" - {
+        "contravariance" - {
+            class Test[-T]
+            test[Test[String], Test[Any]]
+        }
+
+        "covariance" - {
+            class Test[+T]
+            test[Test[String], Test[Any]]
+        }
+
+        "nested contravariance" - {
+            class Test[-T]
+            class NestedTest[-U]
+            test[Test[NestedTest[Any]], Test[NestedTest[String]]]
+        }
+
+        "nested covariance" - {
+            class Test[+T]
+            class NestedTest[+U]
+            test[Test[NestedTest[String]], Test[NestedTest[Any]]]
+        }
+
+        "mixed variances" - {
+            class Test[+T, -U]
+            test[Test[String, Any], Test[Any, String]]
+        }
+
+        "invariant type parameter" - {
+            class Test[T, +U]
+            test[Test[String, String], Test[String, Any]]
+        }
+
+        "complex variance scenario" - {
+            class Test[-T, +U]
+            class NestedTest[+V, -W]
+            test[Test[NestedTest[String, Any], Any], Test[NestedTest[Any, String], String]]
+        }
+    }
+
+    "with variance and inheritance" - {
+        class Super
+        class Sub extends Super
+
+        "contravariance with inheritance" - {
+            class Test[-T]
+            test[Test[Sub], Test[Super]]
+        }
+
+        "covariance with inheritance" - {
+            class Test[+T]
+            test[Test[Sub], Test[Super]]
+        }
+
+        "nested contravariance with inheritance" - {
+            class Test[-T]
+            class NestedTest[-U]
+            test[Test[NestedTest[Super]], Test[NestedTest[Sub]]]
+        }
+
+        "nested covariance with inheritance" - {
+            class Test[+T]
+            class NestedTest[+U]
+            test[Test[NestedTest[Sub]], Test[NestedTest[Super]]]
+        }
+
+        "mixed variances with inheritance" - {
+            class Test[+T, -U]
+            test[Test[Sub, Super], Test[Super, Sub]]
+        }
+
+        "invariant type parameter with inheritance" - {
+            class Test[T, +U]
+            test[Test[Sub, Sub], Test[Sub, Super]]
+        }
+
+        "complex variance scenario with inheritance" - {
+            class Test[-T, +U]
+            class NestedTest[+V, -W]
+            test[Test[NestedTest[Sub, Super], Super], Test[NestedTest[Super, Sub], Sub]]
+        }
+    }
+
+    opaque type Test  = String
+    opaque type Test1 = String
+    opaque type Test2 = Int
+
+    class Super
+    class Sub extends Super
+    opaque type OpaqueSub   = Sub
+    opaque type OpaqueSuper = Super
+
+    class Test3[+T]
+    opaque type OpaqueString = String
+    opaque type OpaqueAny    = Any
+
+    class TestContra[-T]
+
+    class TestNested[T]
+    opaque type OpaqueTest = TestNested[OpaqueString]
+
+    "with opaque types" - {
+        "equal opaque types" - {
+            test[Test, Test]
+        }
+
+        "not equal opaque types" - {
+            test[Test1, Test2]
+        }
+
+        "subtype with opaque type" - {
+            test[OpaqueSub, OpaqueSuper]
+        }
+
+        "not subtype with opaque type" - {
+            test[OpaqueSuper, OpaqueSub]
+        }
+
+        "opaque type with variance" - {
+            test[Test3[OpaqueString], Test3[OpaqueAny]]
+        }
+
+        "opaque type with contravariance" - {
+            test[TestContra[OpaqueAny], TestContra[OpaqueString]]
+        }
+
+        "nested opaque types" - {
+            test[OpaqueTest, TestNested[String]]
+        }
+    }
+
+    trait UnsupportedTest:
+        type T
+    val test = new UnsupportedTest {}
+
+    "unsupported types" in {
+        assertDoesNotCompile("Tag[UnsupportedTest#T]")
+        assertDoesNotCompile("Tag[UnsupportedTest.T]")
+        assertDoesNotCompile("Tag[String & Int]")
+        assertDoesNotCompile("Tag[String | Int]")
+    }
+
+end TagsTest

--- a/kyo-core/shared/src/test/scala/kyoTest/tagsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/tagsTest.scala
@@ -2,14 +2,17 @@ package kyoTest
 
 import izumi.reflect.Tag as ITag
 import kyo.*
+import scala.reflect.ClassTag
 
 class TagsTest extends KyoTest:
 
     def test[T1: Tag: ITag, T2: Tag: ITag]: Unit =
         "T1 <:< T2" in {
+            val kresult = Tag[T1] <:< Tag[T2]
+            val iresult = ITag[T1] <:< ITag[T2]
             assert(
-                Tag[T1] <:< Tag[T2] == ITag[T1] <:< ITag[T2],
-                s"Tag[T1] <:< Tag[T2] is ${Tag[T1] <:< Tag[T2]} but ITag[T1] <:< ITag[T2] is ${ITag[T1] <:< ITag[T2]}"
+                kresult == iresult,
+                s"Tag[T1] <:< Tag[T2] is $kresult but ITag[T1] <:< ITag[T2] is $iresult"
             )
         }
         "T2 <:< T1" in {
@@ -197,6 +200,20 @@ class TagsTest extends KyoTest:
         assertDoesNotCompile("Tag[UnsupportedTest.T]")
         assertDoesNotCompile("Tag[String & Int]")
         assertDoesNotCompile("Tag[String | Int]")
+    }
+
+    "show" - {
+
+        "no type params" in {
+            assert(Tag[Int].show == "scala.Int")
+            assert(Tag[Thread].show == "java.lang.Thread")
+        }
+
+        "type params" in pendingUntilFixed {
+            class Test[T]
+            assert(Tag[Test[Int]].show == s"${classOf[Test[?]].getName}[scala.Int]")
+            ()
+        }
     }
 
 end TagsTest

--- a/kyo-tapir/src/main/scala/kyo/routes.scala
+++ b/kyo-tapir/src/main/scala/kyo/routes.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import izumi.reflect.*
 import kyo.internal.KyoSttpMonad
 import kyo.internal.KyoSttpMonad.*
 import scala.reflect.ClassTag
@@ -9,7 +8,7 @@ import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.netty.NettyKyoServer
 import sttp.tapir.server.netty.NettyKyoServerBinding
 
-type Route = ServerEndpoint[Any, KyoSttpMonad.M]
+case class Route(endpoint: ServerEndpoint[Any, KyoSttpMonad.M]) extends AnyVal
 
 type Routes >: Routes.Effects <: Routes.Effects
 
@@ -22,19 +21,20 @@ object Routes:
 
     def run[T, S](server: NettyKyoServer)(v: Unit < (Routes & S)): NettyKyoServerBinding < (Fibers & S) =
         Sums.run[Route].apply[Unit, Fibers & S](v).map { (routes, _) =>
-            IOs(server.addEndpoints(routes.toSeq.toList).start()): NettyKyoServerBinding < (Fibers & S)
+            IOs(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Fibers & S)
         }
     end run
 
     def add[A: Tag, I, E: Tag: ClassTag, O: Flat](e: Endpoint[A, I, E, O, Any])(
         f: I => O < (Fibers & Envs[A] & Aborts[E])
     ): Unit < Routes =
-        Sums.add(List(
-            e.serverSecurityLogic[A, KyoSttpMonad.M](a => Right(a)).serverLogic(a =>
-                i => Aborts.run(Envs.run(a)(f(i)))
+        Sums.add(
+            Route(
+                e.serverSecurityLogic[A, KyoSttpMonad.M](a => Right(a)).serverLogic(a =>
+                    i => Aborts.run(Envs.run(a)(f(i)))
+                )
             )
-        )).unit
-    end add
+        ).unit
 
     def add[A: Tag, I, E: Tag: ClassTag, O: Flat](
         e: PublicEndpoint[Unit, Unit, Unit, Any] => Endpoint[A, I, E, O, Any]

--- a/kyo-zio/shared/src/main/scala/kyo/zios.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/zios.scala
@@ -27,10 +27,10 @@ object ZIOs:
             v match
                 case kyo: Suspend[?, ?, ?, ?] =>
                     try
-                        if kyo.tag == Tag[IOs] then
+                        if kyo.tag =:= Tag[IOs] then
                             val k = kyo.asInstanceOf[Suspend[?, Unit, U, Fibers]]
                             ZIO.suspend(loop(k(())))
-                        else if kyo.tag == Tag[FiberGets] then
+                        else if kyo.tag =:= Tag[FiberGets] then
                             val k = kyo.asInstanceOf[Suspend[Fiber, Any, U, FiberGets]]
                             k.command match
                                 case Done(v) =>
@@ -41,11 +41,11 @@ object ZIOs:
                                         Left(ZIO.succeed(p.interrupt()))
                                     }
                             end match
-                        else if kyo.tag == Tag[Tasks] then
+                        else if kyo.tag =:= Tag[Tasks] then
                             val k = kyo.asInstanceOf[Suspend[Task, Any, U, ZIOs]]
                             k.command.flatMap(v => loop(k(v)))
                         else
-                            bug.failTag(kyo.tag, Tag[Fibers & ZIOs])
+                            bug.failTag(kyo.tag, Tag[FiberGets], Tag[Tasks])
                     catch
                         case ex if NonFatal(ex) =>
                             ZIO.fail(ex)


### PR DESCRIPTION
Fixes #339.

Kyo uses tags for effect handling. Izumi's performance has been an important limitation, especially to provide sub-type checking it hot paths. This PR introduces a new `Tag` implementation that bundles the type information in a string format amenable to type comparisons without requiring allocations. Since the string is generated at compile-time, it becomes a constant in the class pool and doesn't require allocations.

The only scenario where this new `Tag` can allocate is when one of the type parameters has an implicit tag. For example:

```scala
def test[T: Tag] = Tag[List[T]]
```

In this case, the macro generates a tree that will concatenate the string representing `Tag[T]` into `Tag[List[T]]`. JIT compilers can many times avoid such allocation, though.

This change introduces an important restriction: only types with concrete class symbols (traits, classes, objects) are supported. We could extend the implementation to support intersection and union types as well but I think allowing these types can be confusing to users since they can be produced by inference when a user makes a mistake.

The performance is ~10x in comparison to Izumi:

![image](https://github.com/getkyo/kyo/assets/831175/a0bb1844-bf2c-4e2d-b19a-a4981722d023)

The main reason is **zero allocation**:

![image](https://github.com/getkyo/kyo/assets/831175/e016f891-956a-45fe-9770-20d8e0754997)

https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fwbrasil/7010fc054376ce94e3497de2fbeb3030/raw/0ba5e81e932185ef4b10c75201e0ace98aac4a33/jmh-result.json#details
