### PR TITLE
flat check fixes

### DIFF
--- a/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
@@ -36,10 +36,10 @@ class coreBytecodeSizeTest extends KyoTest:
     "handle" in runJVM {
         val map = methodBytecodeSize[TestHandle]
         assert(map == Map(
-            "test"        -> 28,
-            "resultLoop"  -> 94,
-            "handleLoop"  -> 280,
-            "_handleLoop" -> 12
+            "test"        -> 27,
+            "resultLoop"  -> 91,
+            "handleLoop"  -> 276,
+            "_handleLoop" -> 10
         ))
     }
 

--- a/kyo-core/shared/src/main/scala/kyo/Flat.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Flat.scala
@@ -2,19 +2,10 @@ package kyo
 
 import internal.FlatImplicits
 
-sealed trait Flat[-T]
+opaque type Flat[T] = Null
 
 object Flat extends FlatImplicits:
-
-    inline def derive[T: Flat, S]: Flat[T < S] = Flat.unsafe.bypass
-
-    private val cached = new Flat[Any] {}
-
-    given unit[S]: Flat[Unit < S] = unsafe.bypass[Unit < S]
-
     object unsafe:
-
-        inline given bypass[T]: Flat[T] =
-            cached.asInstanceOf[Flat[T]]
+        inline given bypass[T]: Flat[T] = null
     end unsafe
 end Flat

--- a/kyo-core/shared/src/main/scala/kyo/Joins.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Joins.scala
@@ -2,71 +2,56 @@ package kyo
 
 trait Joins[E]:
 
-    def race[T](l: Seq[T < E])(using f: Flat[T < E]): T < E
+    def race[T: Flat](l: Seq[T < E]): T < E
 
-    def parallel[T](l: Seq[T < E])(using f: Flat[T < E]): Seq[T] < E
+    def parallel[T: Flat](l: Seq[T < E]): Seq[T] < E
 
-    def parallelTraverse[T, U](v: Seq[T] < E)(f: T => U < E)(using flat: Flat[U < E]): Seq[U] < E =
+    def parallelTraverse[T, U: Flat](v: Seq[T] < E)(f: T => U < E): Seq[U] < E =
         v.map(_.map(f)).map(parallel[U](_))
 
-    def race[T](
+    def race[T: Flat](
         v1: => T < E,
         v2: => T < E
-    )(using f: Flat[T < E]): T < E =
+    ): T < E =
         race(List(v1, v2))
 
-    def race[T](
+    def race[T: Flat](
         v1: => T < E,
         v2: => T < E,
         v3: => T < E
-    )(using f: Flat[T < E]): T < E =
+    ): T < E =
         race(List(v1, v2, v3))
 
-    def race[T](
+    def race[T: Flat](
         v1: => T < E,
         v2: => T < E,
         v3: => T < E,
         v4: => T < E
-    )(using f: Flat[T < E]): T < E =
+    ): T < E =
         race(List(v1, v2, v3, v4))
 
     def parallel[T1: Flat, T2: Flat](
         v1: => T1 < E,
         v2: => T2 < E
-    )(
-        using
-        f1: Flat[T1 < E],
-        f2: Flat[T2 < E]
     ): (T1, T2) < E =
         parallel(List(v1, v2))(using Flat.unsafe.bypass).map(s =>
             (s(0).asInstanceOf[T1], s(1).asInstanceOf[T2])
         )
 
-    def parallel[T1, T2, T3](
+    def parallel[T1: Flat, T2: Flat, T3: Flat](
         v1: => T1 < E,
         v2: => T2 < E,
         v3: => T3 < E
-    )(
-        using
-        f1: Flat[T1 < E],
-        f2: Flat[T2 < E],
-        f3: Flat[T3 < E]
     ): (T1, T2, T3) < E =
         parallel(List(v1, v2, v3))(using Flat.unsafe.bypass).map(s =>
             (s(0).asInstanceOf[T1], s(1).asInstanceOf[T2], s(2).asInstanceOf[T3])
         )
 
-    def parallel[T1, T2, T3, T4](
+    def parallel[T1: Flat, T2: Flat, T3: Flat, T4: Flat](
         v1: => T1 < E,
         v2: => T2 < E,
         v3: => T3 < E,
         v4: => T4 < E
-    )(
-        using
-        f1: Flat[T1 < E],
-        f2: Flat[T2 < E],
-        f3: Flat[T3 < E],
-        f4: Flat[T4 < E]
     ): (T1, T2, T3, T4) < E =
         parallel(List(v1, v2, v3, v4))(using Flat.unsafe.bypass).map(s =>
             (

--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -61,7 +61,7 @@ object core:
         )(
             state: State,
             value: T < (E & S2)
-        )(using inline tag: Tag[E], inline flat: Flat[T < (E & S)]): Result[T] < (S & S2) =
+        )(using inline tag: Tag[E], inline flat: Flat[T]): Result[T] < (S & S2) =
             def _handleLoop(st: State, value: T < (E & S & S2)): Result[T] < (S & S2) =
                 handleLoop(st, value)
             @tailrec def handleLoop(st: State, value: T < (E & S & S2)): Result[T] < (S & S2) =
@@ -182,13 +182,10 @@ object core:
             def done[T: Flat](v: T): Command[T]
             def resume[T, U: Flat](command: Command[T], k: T => Command[U] < S): Command[U] < S
 
-        def deepHandle[Command[_], E <: Effect[E], S, T](
+        def deepHandle[Command[_], E <: Effect[E], S, T: Flat](
             handler: DeepHandler[Command, E, S],
             v: T < E
-        )(using
-            tag: Tag[E],
-            flat: Flat[T < E]
-        ): Command[T] < S =
+        )(using tag: Tag[E]): Command[T] < S =
             def deepHandleLoop(v: T < (E & S)): Command[T] < S =
                 v match
                     case kyo: Suspend[Command, Any, T, E] @unchecked =>

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -53,7 +53,7 @@ sealed trait IOs extends Effect[IOs]:
                     pf(ex)
         )
 
-    def run[T](v: T < IOs)(using f: Flat[T < IOs]): T =
+    def run[T: Flat](v: T < IOs): T =
         @tailrec def runLoop(v: T < IOs): T =
             v match
                 case kyo: Suspend[IO, Unit, T, IOs] @unchecked =>

--- a/kyo-core/shared/src/main/scala/kyo/package.scala
+++ b/kyo-core/shared/src/main/scala/kyo/package.scala
@@ -35,7 +35,7 @@ package object kyo:
 
     end extension
 
-    extension [T](v: T < Any)(using Flat[T < Any])
+    extension [T: Flat](v: T < Any)
         def pure: T =
             v match
                 case kyo: kyo.core.internal.Suspend[?, ?, ?, ?] =>

--- a/kyo-core/shared/src/test/scala/kyoTest/FlatTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/FlatTest.scala
@@ -7,38 +7,23 @@ class FlatTest extends KyoTest:
     "ok" - {
         "concrete" in {
             implicitly[Flat[Int]]
-            implicitly[Flat[Int < Any]]
-            implicitly[Flat[Int < Options]]
-            implicitly[Flat[Int < Nothing]]
+            implicitly[Flat[String]]
+            implicitly[Flat[Thread]]
             succeed
         }
         "fiber" in {
-            implicitly[Flat[Fiber[Int] < Options]]
-            succeed
-        }
-        "by evidence" in {
-            def test1[T: Flat] =
-                implicitly[Flat[T < IOs]]
-                implicitly[Flat[T < Options]]
-                implicitly[Flat[T < Any]]
-            end test1
-            test1[Int]
-            succeed
-        }
-        "derived" in {
-            def test2[T](using f: Flat[T < IOs]) =
-                val _: Flat[T < Options] = Flat.derive[T, Options]
-                implicitly[Flat[T]]
-                implicitly[Flat[T < Options]]
-                implicitly[Flat[T < Any]]
-                implicitly[Flat[T | Int]]
-            end test2
-            test2[Int]
+            implicitly[Flat[Fiber[Int]]]
             succeed
         }
     }
 
     "nok" - {
+
+        "pending type" in {
+            assertDoesNotCompile("implicitly[Flat[Int < Any]]")
+            assertDoesNotCompile("implicitly[Flat[Int < Options]]")
+            assertDoesNotCompile("implicitly[Flat[Int < Nothing]]")
+        }
 
         "nested" in {
             assertDoesNotCompile("implicitly[Flat[Int < IOs < IOs]]")
@@ -62,13 +47,13 @@ class FlatTest extends KyoTest:
         }
 
         "effect mismatch" in {
-            def test[T](v: T < Fibers)(using Flat[T < Fibers]): T < Fibers = v
+            def test[T: Flat](v: T < Fibers): T < Fibers = v
             test(1)
             test(1: Int < Fibers)
             assertDoesNotCompile("test(1: Int < Options)")
         }
 
-        "flat flat" in pendingUntilFixed {
+        "flat flat" in {
             def test[T](v: T < Fibers)(using Flat[T]): T < Fibers = v
             test(1)
             test(1: Int < Fibers)

--- a/kyo-core/shared/src/test/scala/kyoTest/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/KyoAppTest.scala
@@ -62,7 +62,7 @@ class KyoAppTest extends KyoTest:
         """)
     }
 
-    "indirect effect mismatch" taggedAs jvmOnly in pendingUntilFixed {
+    "indirect effect mismatch" taggedAs jvmOnly in {
         assertDoesNotCompile("""
             new KyoApp:
                 run(Choices.run(1: Int < Options))

--- a/kyo-test/shared/src/main/scala/kyo/test/KyoSpecAbstract.scala
+++ b/kyo-test/shared/src/main/scala/kyo/test/KyoSpecAbstract.scala
@@ -21,10 +21,9 @@ abstract class KyoSpecAbstract[S] extends ZIOSpecAbstract:
 
     def spec: Spec[Environment, Any]
 
-    def run[In](v: => In < S)(using Flat[In < S]): ZIO[Environment, Throwable, In]
+    def run[In: Flat](v: => In < S): ZIO[Environment, Throwable, In]
 
-    def test[In <: TestResult](label: String)(assertion: => In < S)(using
-        fl: Flat[In < S],
+    def test[In <: TestResult: Flat](label: String)(assertion: => In < S)(using
         sl: SourceLocation,
         tr: Trace
     ): Spec[Any, Throwable] =

--- a/kyo-test/shared/src/main/scala/kyo/test/KyoSpecDefault.scala
+++ b/kyo-test/shared/src/main/scala/kyo/test/KyoSpecDefault.scala
@@ -6,7 +6,7 @@ import zio.ZIO
 import zio.test.Spec
 
 abstract class KyoSpecDefault extends KyoSpecAbstract[KyoApp.Effects]:
-    final override def run[In](v: => In < KyoApp.Effects)(using Flat[In < KyoApp.Effects]): ZIO[Environment, Throwable, In] =
+    final override def run[In: Flat](v: => In < KyoApp.Effects): ZIO[Environment, Throwable, In] =
         ZIO.fromKyoFiber(KyoApp.runFiber(timeout)(v)).flatMap(ZIO.fromTry)
 
     def timeout: Duration = Duration.Infinity

--- a/kyo-test/shared/src/main/scala/kyo/test/interop/zio.scala
+++ b/kyo-test/shared/src/main/scala/kyo/test/interop/zio.scala
@@ -5,7 +5,7 @@ import zio.Trace
 import zio.ZIO
 
 extension (capture: ZIO.type)
-    private[kyo] def fromKyoFiber[A](fiber: Fiber[A])(using Flat[A], Trace): ZIO[Any, Throwable, A] =
+    private[kyo] def fromKyoFiber[A: Flat](fiber: Fiber[A])(using Trace): ZIO[Any, Throwable, A] =
         ZIO.asyncInterrupt[Any, Throwable, A] { cb =>
             val async: ZIO[Any, Throwable, A] = ZIO.fromFuture(_ => IOs.run(fiber.toFuture))
             cb(async)


### PR DESCRIPTION
Fixes https://github.com/getkyo/kyo/issues/327.

Kyo's `Flat` check was designed to have a complex derivation mechanism to provide better error messages in case of a mismatch between the effects a method supports vs the pending effects of its parameters. This derivation mechanism is unsound. This PR removes it.

This results in a regression in usability since error messages don't explicitly show where the mismatch is anymore. It seems a reasonable tradeoff that we can address later.