### PR TITLE
Introduce generalized ZLayer -> Runtime mechanism

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/HttpClientBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/HttpClientBench.scala
@@ -3,6 +3,7 @@ package kyo.bench
 import org.http4s.ember.client.EmberClientBuilder
 
 class HttpClientBench extends Bench.ForkOnly("pong"):
+    // override val runtimeLayer: zio.ZLayer[Any, Any, zio.http.Client] = zio.http.Client.default
 
     val port = 9999
     val url  = TestHttpServer.start(port)
@@ -46,7 +47,7 @@ class HttpClientBench extends Bench.ForkOnly("pong"):
         import zio.*
         // import zio.http.*
 
-        // ZIO.service[Client].flatMap(_.url(zioUrl).get("")).flatMap(_.body.asString).provide(Client.default, Scope.default).orDie
+        // ZIO.scoped[Client](ZIO.service[Client].flatMap(_.url(zioUrl).get("")).flatMap(_.body.asString)).orDie.asInstanceOf[UIO[String]]
         ZIO.succeed("pong")
     end zioBench
 

--- a/kyo-bench/src/main/scala/kyo/bench/RuntimeLayers.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/RuntimeLayers.scala
@@ -1,0 +1,26 @@
+package kyo.bench
+
+import zio.*
+
+object RuntimeLayers:
+    given Unsafe = Unsafe.unsafe(identity)
+
+    private val withoutFinalization = ZLayer.succeed(Scope.global)
+
+    private val kExecutor = new Executor:
+        val scheduler = kyo.scheduler.Scheduler.get
+
+        def metrics(using unsafe: Unsafe) = None
+
+        def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean =
+            scheduler.schedule(kyo.scheduler.Task(runnable.run()))
+            true
+
+    val kyoExecutor: ZLayer[Any, Nothing, Unit] =
+        Runtime.setExecutor(kExecutor) ++ Runtime.setBlockingExecutor(kExecutor)
+
+    def makeRuntime[A](layer: ZLayer[Any, Any, A]): Runtime[A] =
+        Runtime.default.unsafe.run {
+            layer.toRuntime.provideLayer(withoutFinalization)
+        }.getOrThrowFiberFailure()
+end RuntimeLayers


### PR DESCRIPTION
In an effort to resolve the issue with the zio-http benchmark, I decided to create a mechanism to convert ZLayers to Runtime.

To avoid casting, we will need to introduce an `R` type to all benchmarks...

I saw some weird errors when running the benchmark:
```
[info] Thread[#63,DestroyJavaVM,5,main]
[info] Thread[#49,KQueueEventLoopGroup-2-1,10,main]
[info]   at app//io.netty.channel.kqueue.Native.keventWait(Native Method)
[info]   at app//io.netty.channel.kqueue.Native.keventWait(Native.java:124)
[info]   at app//io.netty.channel.kqueue.KQueueEventLoop.kqueueWait(KQueueEventLoop.java:184)
[info]   at app//io.netty.channel.kqueue.KQueueEventLoop.kqueueWait(KQueueEventLoop.java:176)
[info]   at app//io.netty.channel.kqueue.KQueueEventLoop.run(KQueueEventLoop.java:245)
[info]   at app//io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
[info]   at app//io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
[info]   at app//io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
[info]   at java.base@21.0.2/java.lang.Thread.runWith(Thread.java:1596)
[info]   at java.base@21.0.2/java.lang.Thread.run(Thread.java:1583)
```