### PR TITLE
better support for other effects in Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,20 +585,20 @@ class Database extends Closeable {
 
 // The `acquire` method accepts any object that 
 // implements Java's `Closeable` interface
-val db: Database < (Resources & IOs) = 
+val db: Database < Resources = 
   Resources.acquire(new Database)
 
 // Use `run` to handle the effect, while also 
 // closing the resources utilized by the 
 // computationation
-val b: Int < IOs = 
+val b: Int < Fibers = 
   Resources.run(db.map(_.count))
 
 // The `ensure` method provides a low-level API to handle the finalization of 
 // resources directly. The `acquire` method is implemented in terms of `ensure`.
 
 // Example method to execute a function on a database
-def withDb[T](f: Database => T < IOs): T < (IOs & Resources) =
+def withDb[T](f: Database => T < Fibers): T < Resources =
   // Initializes the database ('new Database' is a placeholder)
   IOs(new Database).map { db =>
     // Registers `db.close` to be finalized
@@ -609,11 +609,11 @@ def withDb[T](f: Database => T < IOs): T < (IOs & Resources) =
   }
 
 // Execute a function
-val c: Int < (IOs & Resources) =
+val c: Int < Resources =
   withDb(_.count)
 
 // Close resources
-val d: Int < IOs = 
+val d: Int < Fibers = 
   Resources.run(c)
 ```
 

--- a/kyo-core/shared/src/test/scala/kyoTest/fibersTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/fibersTest.scala
@@ -369,7 +369,7 @@ class fibersTest extends KyoTest:
             def loop(ref: AtomicInt): Unit < IOs =
                 ref.incrementAndGet.map(_ => loop(ref))
 
-            def task(l: Latch): Unit < IOs =
+            def task(l: Latch): Unit < Fibers =
                 Resources.run[Unit, IOs] {
                     Resources.ensure(l.release).map { _ =>
                         Atomics.initInt(0).map(loop)


### PR DESCRIPTION
Fixes https://github.com/getkyo/kyo/issues/353.

The `Resources` effect isn't very flexible in what effects it allows in its APIs. This PR reimplements the effect based on `Fibers`, which allows `Fibers` in any of its APIs in addition to `IOs`, and makes the `acquire` parameter of `acquireRelease` support any effect.