### PR TITLE
move effect command from member type to type parameter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ val compilerOptions = Seq(
     "-feature",
     "-unchecked",
     "-deprecation",
+    "-Ykind-projector",
     "-language:implicitConversions",
     "-Wvalue-discard",
     "-Wunused:all",
@@ -85,7 +86,8 @@ lazy val `kyo-scheduler` =
             scalacOptions --= Seq(
                 "-Wvalue-discard",
                 "-Wunused:all",
-                "-language:strictEquality"
+                "-language:strictEquality",
+                "-Ykind-projector"
             ),
             scalacOptions += "-Xsource:3",
             crossScalaVersions                      := List(scala3Version, scala212Version, scala213Version),

--- a/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
@@ -7,8 +7,7 @@ class coreBytecodeSizeTest extends KyoTest:
 
     import kyo.core.*
 
-    object TestEffect extends Effect[TestEffect.type]:
-        type Command[T] = T
+    object TestEffect extends Effect[Id, TestEffect.type]
 
     object TestHandler extends Handler[Id, TestEffect.type, Any]:
         def resume[T, U: Flat, S](command: T, k: T => U < (TestEffect.type & S)) =

--- a/kyo-core/shared/src/main/scala/kyo/aborts.scala
+++ b/kyo-core/shared/src/main/scala/kyo/aborts.scala
@@ -72,8 +72,7 @@ object Aborts:
                     Left(command)
         end handler
 
-        class DoAbort extends Effect[DoAbort]:
-            type Command[T] = Any
+        class DoAbort  extends Effect[Const[Any], DoAbort]
         object DoAbort extends DoAbort
     end internal
 

--- a/kyo-core/shared/src/main/scala/kyo/choices.scala
+++ b/kyo-core/shared/src/main/scala/kyo/choices.scala
@@ -2,8 +2,7 @@ package kyo
 
 import kyo.core.*
 
-class Choices extends Effect[Choices]:
-    type Command[T] = Seq[T]
+class Choices extends Effect[Seq, Choices]
 
 object Choices extends Choices:
 

--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -13,24 +13,23 @@ object core:
 
     opaque type <[+T, -S] >: T = T | internal.Kyo[T, S]
 
-    trait Effect[+E]:
-        type Command[_]
+    trait Effect[Command[_], +E]
 
-    extension [E <: Effect[E]](e: E)
+    extension [Command[_], E <: Effect[Command, E]](e: E)
 
-        inline def suspend[T](inline cmd: e.Command[T])(
+        inline def suspend[T](inline cmd: Command[T])(
             using inline _tag: Tag[E]
         ): T < E =
-            new Suspend[e.Command, T, T, E]:
+            new Suspend[Command, T, T, E]:
                 def command = cmd
                 def tag     = _tag.asInstanceOf[Tag[Any]]
                 def apply(v: T, s: Safepoint[E], l: State) =
                     v
 
-        inline def suspend[T, U, S](inline cmd: e.Command[T], inline f: T => U < S)(
+        inline def suspend[T, U, S](inline cmd: Command[T], inline f: T => U < S)(
             using inline _tag: Tag[E]
         ): U < (E & S) =
-            new Suspend[e.Command, T, U, S]:
+            new Suspend[Command, T, U, S]:
                 def command = cmd
                 def tag     = _tag.asInstanceOf[Tag[Any]]
                 def apply(v: T, s: Safepoint[S], l: State) =
@@ -55,9 +54,9 @@ object core:
         transformLoop(v)
     end transform
 
-    extension [E <: Effect[E]](e: E)
+    extension [Command[_], E <: Effect[Command, E]](e: E)
         inline def handle[State, Result[_], T, S, S2](
-            handler: ResultHandler[State, e.Command, E, Result, S]
+            handler: ResultHandler[State, Command, E, Result, S]
         )(
             state: State,
             value: T < (E & S2)
@@ -66,7 +65,7 @@ object core:
                 handleLoop(st, value)
             @tailrec def handleLoop(st: State, value: T < (E & S & S2)): Result[T] < (S & S2) =
                 value match
-                    case kyo: Suspend[e.Command, Any, T, S2] @unchecked
+                    case kyo: Suspend[Command, Any, T, S2] @unchecked
                         if tag =:= kyo.tag && handler.accepts(st, kyo.command) =>
                         handler.resume(st, kyo.command, kyo) match
                             case r: handler.Resume[T, S & S2] @unchecked =>
@@ -123,7 +122,7 @@ object core:
         evalLoop(s, suspend(resume(s, () => v)))
     end eval
 
-    abstract class ResultHandler[State, Command[_], E <: Effect[E], Result[_], S]:
+    abstract class ResultHandler[State, Command[_], E <: Effect[Command, E], Result[_], S]:
 
         case class Resume[U, S2](st: State, v: U < (E & S & S2))
 
@@ -142,7 +141,7 @@ object core:
 
     end ResultHandler
 
-    abstract class Handler[Command[_], E <: Effect[E], S]
+    abstract class Handler[Command[_], E <: Effect[Command, E], S]
         extends ResultHandler[Unit, Command, E, Id, S]:
         inline def done[T](st: Unit, v: T) =
             done(v)
@@ -176,13 +175,13 @@ object core:
     private[kyo] object internal:
 
         type MX[T] = Any
-        type EX <: Effect[EX]
+        type EX <: Effect[MX, EX]
 
         abstract class DeepHandler[Command[_], E, S]:
             def done[T: Flat](v: T): Command[T]
             def resume[T, U: Flat](command: Command[T], k: T => Command[U] < S): Command[U] < S
 
-        def deepHandle[Command[_], E <: Effect[E], S, T: Flat](
+        def deepHandle[Command[_], E <: Effect[Command, E], S, T: Flat](
             handler: DeepHandler[Command, E, S],
             v: T < E
         )(using tag: Tag[E]): Command[T] < S =

--- a/kyo-core/shared/src/main/scala/kyo/defers.scala
+++ b/kyo-core/shared/src/main/scala/kyo/defers.scala
@@ -7,8 +7,7 @@ abstract private[kyo] class Defer[T, S] extends Suspend[Const[Unit], Unit, T, S 
     final def command = ()
     final def tag     = Tag[Defers].asInstanceOf[Tag[Any]]
 
-class Defers extends Effect[Defers]:
-    type Command[T] = Unit
+class Defers extends Effect[Const[Unit], Defers]
 
 object Defers extends Defers:
 
@@ -20,6 +19,6 @@ object Defers extends Defers:
         this.handle(handler)((), v)
 
     private val handler = new Handler[Const[Unit], Defers, Any]:
-        def resume[T, U: Flat, S2](command: Command[T], k: T => U < (Defers & S2)) =
+        def resume[T, U: Flat, S2](command: Unit, k: T => U < (Defers & S2)) =
             Resume((), k(().asInstanceOf[T]))
 end Defers

--- a/kyo-core/shared/src/main/scala/kyo/envs.scala
+++ b/kyo-core/shared/src/main/scala/kyo/envs.scala
@@ -2,8 +2,7 @@ package kyo
 
 import kyo.core.*
 
-class Envs[+V] extends Effect[Envs[V]]:
-    type Command[T] = Unit
+class Envs[+V] extends Effect[Const[Unit], Envs[V]]
 
 object Envs:
     private case object envs extends Envs[Any]

--- a/kyo-core/shared/src/main/scala/kyo/fibers.scala
+++ b/kyo-core/shared/src/main/scala/kyo/fibers.scala
@@ -315,8 +315,7 @@ object fibersInternal:
             result.map(t)
     end Done
 
-    class FiberGets extends Effect[FiberGets]:
-        type Command[T] = Fiber[T]
+    class FiberGets extends Effect[Fiber, FiberGets]
 
     object FiberGets extends FiberGets:
         type Command[T] = Fiber[T]

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -8,7 +8,7 @@ import scala.annotation.tailrec
 import scala.util.*
 import scala.util.control.NonFatal
 
-sealed trait IOs extends Effect[IOs]:
+sealed trait IOs extends Effect[Const[Unit], IOs]:
 
     private val tag = Tag[IOs]
 

--- a/kyo-core/shared/src/main/scala/kyo/streams.scala
+++ b/kyo-core/shared/src/main/scala/kyo/streams.scala
@@ -248,8 +248,7 @@ object Stream:
 
 end Stream
 
-class Streams[V] extends Effect[Streams[V]]:
-    type Command[T] = Chunk[V]
+class Streams[V] extends Effect[Const[Chunk[V]], Streams[V]]
 
 object Streams:
 

--- a/kyo-core/shared/src/main/scala/kyo/sums.scala
+++ b/kyo-core/shared/src/main/scala/kyo/sums.scala
@@ -2,8 +2,7 @@ package kyo
 
 import kyo.core.*
 
-class Sums[V] extends Effect[Sums[V]]:
-    type Command[T] = V
+class Sums[V] extends Effect[Const[V], Sums[V]]:
 
     private val handler =
         new ResultHandler[Chunk[V], Const[V], Sums[V], [T] =>> (Chunk[V], T), Any]:

--- a/kyo-core/shared/src/main/scala/kyo/vars.scala
+++ b/kyo-core/shared/src/main/scala/kyo/vars.scala
@@ -1,48 +1,43 @@
 package kyo
 
-import Vars.internal.*
 import kyo.core.*
+import varsInternal.*
 
-class Vars[V] extends Effect[Vars[V]]:
-    type Command[T] = Op[V]
+class Vars[V] extends Effect[Op[V, *], Vars[V]]:
+
+    private[Vars] val get = Op.Get[V]()
 
     private val handler =
-        new ResultHandler[V, Const[Op[V]], Vars[V], Id, Any]:
+        new ResultHandler[V, [T] =>> Op[V, T], Vars[V], Id, Any]:
             def done[T](st: V, v: T) = v
-            def resume[T, U: Flat, S2](st: V, op: Op[V], k: T => U < (Vars[V] & S2)) =
+            def resume[T, U: Flat, S2](st: V, op: Op[V, T], k: T => U < (Vars[V] & S2)) =
                 op match
-                    case _: Get.type =>
+                    case _: Op.Get[V] @unchecked =>
                         Resume(st, k(st.asInstanceOf[T]))
-                    case Set(v) =>
+                    case Op.Set(v: V @unchecked) =>
                         Resume(v, k(().asInstanceOf[T]))
-                    case Update(f) =>
+                    case Op.Update(f: (V => V) @unchecked) =>
                         Resume(f(st), k(().asInstanceOf[T]))
 end Vars
 
 object Vars:
     private case object vars extends Vars[Any]
     private def vars[V]: Vars[V] = vars.asInstanceOf[Vars[V]]
-    object internal:
-        case object Get
-        case class Set[V](v: V)
-        case class Update[V](f: V => V)
-        type Op[V] = Get.type | Set[V] | Update[V]
-    end internal
 
     def get[V](using Tag[Vars[V]]): V < Vars[V] =
-        vars[V].suspend[V](Get)
+        vars[V].suspend[V](vars[V].get)
 
     class UseDsl[V]:
         inline def apply[T, S](inline f: V => T < S)(using inline tag: Tag[Vars[V]]): T < (Vars[V] & S) =
-            vars[V].suspend[V, T, S](Get, f)
+            vars[V].suspend[V, T, S](vars[V].get, f)
 
     def use[V >: Nothing]: UseDsl[V] = new UseDsl[V]
 
     def set[V](value: V)(using Tag[Vars[V]]): Unit < Vars[V] =
-        vars[V].suspend[Unit](Set(value))
+        vars[V].suspend[Unit](Op.Set[V](value))
 
     def update[V](f: V => V)(using Tag[Vars[V]]): Unit < Vars[V] =
-        vars[V].suspend[Unit](Update(f))
+        vars[V].suspend[Unit](Op.Update[V](f))
 
     class RunDsl[V]:
         def apply[T: Flat, S2](state: V)(value: T < (Vars[V] & S2))(
@@ -54,3 +49,12 @@ object Vars:
     def run[V >: Nothing]: RunDsl[V] = new RunDsl[V]
 
 end Vars
+
+// Moving to Vars.internal crashes the compiler
+object varsInternal:
+    enum Op[-V, +T]:
+        case Get[V]()             extends Op[V, V]
+        case Set[V](v: V)         extends Op[V, Unit]
+        case Update[V](f: V => V) extends Op[V, Unit]
+    end Op
+end varsInternal

--- a/kyo-zio/shared/src/main/scala/kyo/zios.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/zios.scala
@@ -61,8 +61,7 @@ object ZIOs:
     end run
 
     private[kyo] object internal:
-        class Tasks extends Effect[Tasks]:
-            type Command[T] = Task[T]
+        class Tasks  extends Effect[Task, Tasks]
         object Tasks extends Tasks
     end internal
 end ZIOs


### PR DESCRIPTION
I'm working on a follow up of https://github.com/getkyo/kyo/pull/348 to rely on the new `Tag` in `Aborts`. Something that has been challenging when developing effects is dealing with variance and the `Command` defined as type member:

```scala
class Aborts[-V] extends Effect[Aborts[V]]:
    type Command[T] = Left[V, ?] // compilation error because V is contravariant
```

This fails to compile because `V` is contravariant and type members are invariant. It's possible to work it around by making `Command` opaque but then it's necessary to provide bridge methods.

This PR changes the encoding of effects to use a type parameter for the command instead of a type member, which solves this encoding issue with variance.