### PR TITLE
Tag optimizations

### DIFF
--- a/kyo-tag/shared/src/test/scala/kyoTest/tagsTest.scala
+++ b/kyo-tag/shared/src/test/scala/kyoTest/tagsTest.scala
@@ -205,6 +205,13 @@ class tagsTest extends AsyncFreeSpec with NonImplicitAssertions:
 
     "show" - {
 
+        "compact" in {
+            assert(Tag[Object].show == "java.lang.Object")
+            assert(Tag[Matchable].show == "scala.Matchable")
+            assert(Tag[Any].show == "scala.Any")
+            assert(Tag[String].show == "java.lang.String")
+        }
+
         "no type params" in {
             assert(Tag[Int].show == "scala.Int")
             assert(Tag[Thread].show == "java.lang.Thread")

--- a/kyo-tag/shared/src/test/scala/kyoTest/tagsTest.scala
+++ b/kyo-tag/shared/src/test/scala/kyoTest/tagsTest.scala
@@ -217,4 +217,13 @@ class tagsTest extends AsyncFreeSpec with NonImplicitAssertions:
         }
     }
 
+    "type with large name" in pendingUntilFixed {
+        assertCompiles(
+            """
+            class A0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
+            Tag[A0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789]
+            """
+        )
+    }
+
 end tagsTest


### PR DESCRIPTION
I'm working on reimplementing `Aborts` and `Envs` based on the new `Tag` but there's a performance regression. This PR introduces optimizations to address it:

1. Each type in a segment is now prefixed with its size encoded as `char`, which avoids scans to find the next element.
2. A hash of the type name is also encoded as a `char` after the length, which enables fast mismatches. For example, when checking `scala.Int` against `scala.Double`, the previous implementation would first compare `scala.` to then find out the type doesn't match. Hash conflicts aren't a concern since, in case of match, the entire type string is checked for equality.
3. Introduces a mechanism to compact the representation of common types.

This change introduces a restriction: type names with more than 94 characters aren't supported. I had some trouble with encoding arbitrary char values into strings because the UTF-8/Latin string encodings produce garbage in some cases since there are control characters. I decided to use the ASCII range of printable chars, which should be the same regardless of the string encoding. It seems a reasonable tradeoff, especially since the issue is detected at compile time.

Benchmark:

![image](https://github.com/getkyo/kyo/assets/831175/297de9d2-604b-4c15-be7a-9d9d56ab74a7)
https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/fwbrasil/6614ae6cf60bccdc5aa52eebc5196213/raw/785a7a001111974fb986eed4cfe7f77079f1dba3/jmh-result-baseline.json,https://gist.githubusercontent.com/fwbrasil/6614ae6cf60bccdc5aa52eebc5196213/raw/785a7a001111974fb986eed4cfe7f77079f1dba3/jmh-result-candidate.json