### PR TITLE
workaround to declare effects as opaque

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/aborts.scala
+++ b/kyo-core/shared/src/main/scala/kyo/aborts.scala
@@ -4,13 +4,13 @@ import kyo.core.*
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
-// Can't use an opaque type because
-// kyo-direct tests crash the compiler.
-type Aborts[-V] //= DoAbort
+type Aborts[-V] >: Aborts.Effects[V] <: Aborts.Effects[V]
 
 object Aborts:
 
     import internal.*
+
+    opaque type Effects[-V] = DoAbort
 
     def fail[V](v: V): Nothing < Aborts[V] =
         DoAbort.suspend(v).asInstanceOf[Nothing < Aborts[V]]


### PR DESCRIPTION
As mentioned in https://github.com/getkyo/kyo/pull/360, I've identified an encoding that allows us to declare effects as `opaque` without breaking the direct syntax. It's not ideal but at least unblocks https://github.com/getkyo/kyo/pull/335.