### PR TITLE
scheduler: top utility

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/Bench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/Bench.scala
@@ -12,7 +12,11 @@ import zio.UIO
     jvmArgs = Array(
         "-Dcats.effect.tracing.mode=DISABLED",
         "-XX:+UnlockExperimentalVMOptions",
-        "-XX:-DoJVMTIVirtualThreadTransitions"
+        "-XX:-DoJVMTIVirtualThreadTransitions",
+        "-Dcom.sun.management.jmxremote",
+        "-Dcom.sun.management.jmxremote.port=1099",
+        "-Dcom.sun.management.jmxremote.authenticate=false",
+        "-Dcom.sun.management.jmxremote.ssl=false"
     ),
     jvmArgsPrepend = Array(
         "--add-opens=java.base/java.lang=ALL-UNNAMED"

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -244,7 +244,7 @@ object Scheduler {
         allocatedWorkers: Int,
         loadAvg: Double,
         flushes: Long,
-        workers: Seq[Worker.WorkerStatus],
+        workers: Seq[WorkerStatus],
         admission: Admission.AdmissionStatus,
         concurrency: Concurrency.AdmissionStatus
     ) {

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Worker.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Worker.scala
@@ -1,8 +1,10 @@
 package kyo.scheduler
 
+import java.lang.StackWalker.StackFrame
 import java.lang.invoke.MethodHandles
 import java.lang.invoke.VarHandle
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.LongAdder
 import kyo.stats.internal.MetricReceiver
 import scala.util.control.NonFatal
 
@@ -34,6 +36,9 @@ final private class Worker(
     private var preemptions = 0L
     private var completions = 0L
     private var mounts      = 0L
+    private var stolenTasks = 0L
+
+    private val lostTasks = new LongAdder
 
     private val queue = new Queue[Task]()
 
@@ -59,8 +64,12 @@ final private class Worker(
         load
     }
 
-    def stealingBy(thief: Worker): Task =
-        queue.stealingBy(thief.queue)
+    def stealingBy(thief: Worker): Task = {
+        val task = queue.stealingBy(thief.queue)
+        if (task != null)
+            lostTasks.add(thief.queue.size() + 1)
+        task
+    }
 
     def drain(): Unit =
         if (!queue.isEmpty())
@@ -105,8 +114,11 @@ final private class Worker(
                 currentCycle = cycle
             if (task == null)
                 task = queue.poll()
-            if (task == null)
+            if (task == null) {
                 task = stealTask(this)
+                if (task != null)
+                    stolenTasks += queue.size() + 1
+            }
             if (task != null) {
                 executions += 1
                 if (runTask(task) == Task.Preempted) {
@@ -152,12 +164,82 @@ final private class Worker(
         receiver.gauge(scope, "queue_size")(queue.size())
         receiver.gauge(scope, "current_cycle")(currentCycle.toDouble)
         receiver.gauge(scope, "mounts")(mounts.toDouble)
+        receiver.gauge(scope, "stolen_tasks")(stolenTasks.toDouble)
+        receiver.gauge(scope, "lost_tasks")(lostTasks.sum().toDouble)
     }
     registerStats()
 
+    def status(): Worker.WorkerStatus = {
+        val taskStatus =
+            currentTask match {
+                case null => null
+                case task => task.status()
+            }
+        val (thread, frame) =
+            mount match {
+                case null =>
+                    (null, null)
+                case mount: Thread =>
+                    (mount.getName(), mount.getStackTrace().head.toString())
+            }
+        Worker.WorkerStatus(
+            id,
+            running,
+            thread,
+            isBlocked(),
+            isStalled(getCurrentCycle()),
+            frame,
+            executions,
+            preemptions,
+            completions,
+            stolenTasks,
+            lostTasks.sum(),
+            load(),
+            mounts,
+            currentCycle,
+            taskStatus
+        )
+    }
 }
 
 private object Worker {
+
+    case class WorkerStatus(
+        id: Int,
+        running: Boolean,
+        mount: String,
+        isBlocked: Boolean,
+        isStalled: Boolean,
+        frame: String,
+        executions: Long,
+        preemptions: Long,
+        completions: Long,
+        stolenTasks: Long,
+        lostTasks: Long,
+        load: Int,
+        mounts: Long,
+        currentCycle: Long,
+        currentTask: Task.Status
+    ) {
+        infix def -(other: WorkerStatus): WorkerStatus =
+            WorkerStatus(
+                id,
+                running,
+                mount,
+                isBlocked,
+                isStalled,
+                frame,
+                executions - other.executions,
+                preemptions - other.preemptions,
+                completions - other.completions,
+                stolenTasks - other.stolenTasks,
+                lostTasks - other.lostTasks,
+                load,
+                mounts - other.mounts,
+                currentCycle,
+                currentTask
+            )
+    }
 
     final class WorkerThread(init: Runnable) extends Thread(init) {
         var currentWorker: Worker = null

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Worker.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Worker.scala
@@ -169,7 +169,7 @@ final private class Worker(
     }
     registerStats()
 
-    def status(): Worker.WorkerStatus = {
+    def status(): WorkerStatus = {
         val taskStatus =
             currentTask match {
                 case null => null
@@ -182,7 +182,7 @@ final private class Worker(
                 case mount: Thread =>
                     (mount.getName(), mount.getStackTrace().head.toString())
             }
-        Worker.WorkerStatus(
+        WorkerStatus(
             id,
             running,
             thread,
@@ -202,44 +202,44 @@ final private class Worker(
     }
 }
 
-private object Worker {
+case class WorkerStatus(
+    id: Int,
+    running: Boolean,
+    mount: String,
+    isBlocked: Boolean,
+    isStalled: Boolean,
+    frame: String,
+    executions: Long,
+    preemptions: Long,
+    completions: Long,
+    stolenTasks: Long,
+    lostTasks: Long,
+    load: Int,
+    mounts: Long,
+    currentCycle: Long,
+    currentTask: Task.Status
+) {
+    infix def -(other: WorkerStatus): WorkerStatus =
+        WorkerStatus(
+            id,
+            running,
+            mount,
+            isBlocked,
+            isStalled,
+            frame,
+            executions - other.executions,
+            preemptions - other.preemptions,
+            completions - other.completions,
+            stolenTasks - other.stolenTasks,
+            lostTasks - other.lostTasks,
+            load,
+            mounts - other.mounts,
+            currentCycle,
+            currentTask
+        )
+}
 
-    case class WorkerStatus(
-        id: Int,
-        running: Boolean,
-        mount: String,
-        isBlocked: Boolean,
-        isStalled: Boolean,
-        frame: String,
-        executions: Long,
-        preemptions: Long,
-        completions: Long,
-        stolenTasks: Long,
-        lostTasks: Long,
-        load: Int,
-        mounts: Long,
-        currentCycle: Long,
-        currentTask: Task.Status
-    ) {
-        infix def -(other: WorkerStatus): WorkerStatus =
-            WorkerStatus(
-                id,
-                running,
-                mount,
-                isBlocked,
-                isStalled,
-                frame,
-                executions - other.executions,
-                preemptions - other.preemptions,
-                completions - other.completions,
-                stolenTasks - other.stolenTasks,
-                lostTasks - other.lostTasks,
-                load,
-                mounts - other.mounts,
-                currentCycle,
-                currentTask
-            )
-    }
+private object Worker {
 
     final class WorkerThread(init: Runnable) extends Thread(init) {
         var currentWorker: Worker = null

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Worker.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Worker.scala
@@ -178,7 +178,7 @@ final private class Worker(
         val (thread, frame) =
             mount match {
                 case null =>
-                    (null, null)
+                    ("", "")
                 case mount: Thread =>
                     (mount.getName(), mount.getStackTrace().head.toString())
             }
@@ -186,9 +186,9 @@ final private class Worker(
             id,
             running,
             thread,
+            frame,
             isBlocked(),
             isStalled(getCurrentCycle()),
-            frame,
             executions,
             preemptions,
             completions,
@@ -206,9 +206,9 @@ case class WorkerStatus(
     id: Int,
     running: Boolean,
     mount: String,
+    frame: String,
     isBlocked: Boolean,
     isStalled: Boolean,
-    frame: String,
     executions: Long,
     preemptions: Long,
     completions: Long,
@@ -224,9 +224,9 @@ case class WorkerStatus(
             id,
             running,
             mount,
+            frame,
             isBlocked,
             isStalled,
-            frame,
             executions - other.executions,
             preemptions - other.preemptions,
             completions - other.completions,

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Admission.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Admission.scala
@@ -1,10 +1,12 @@
 package kyo.scheduler.regulator
 
 import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.LongAdder
 import kyo.scheduler.*
 import kyo.scheduler.InternalTimer
 import kyo.scheduler.util.Flag
 import kyo.stats.internal.MetricReceiver
+import kyo.stats.internal.UnsafeGauge
 import scala.concurrent.duration.*
 import scala.util.hashing.MurmurHash3
 
@@ -18,13 +20,8 @@ final class Admission(
 
     @volatile private var admissionPercent = 100
 
-    final private class ProbeTask extends Task {
-        val start = nowMillis()
-        def run(startMillis: Long, clock: InternalClock) = {
-            measure(nowMillis() - start)
-            Task.Done
-        }
-    }
+    private val rejected = new LongAdder
+    private val allowed  = new LongAdder
 
     def percent(): Int = admissionPercent
 
@@ -37,9 +34,17 @@ final class Admission(
     def reject(key: Int): Boolean = {
         val r =
             (key.abs % 100) > admissionPercent
-        if (r) stats.rejected.inc()
-        else stats.allowed.inc()
+        if (r) rejected.increment()
+        else allowed.increment()
         r
+    }
+
+    final private class ProbeTask extends Task {
+        val start = nowMillis()
+        def run(startMillis: Long, clock: InternalClock) = {
+            measure(nowMillis() - start)
+            Task.Done
+        }
     }
 
     protected def probe() =
@@ -49,19 +54,45 @@ final class Admission(
         admissionPercent = Math.max(0, Math.min(100, admissionPercent + diff))
 
     override def stop(): Unit = {
-        stats.percent.close()
+        gauges.close()
         super.stop()
     }
 
-    private object stats {
+    private val gauges = {
         val receiver = MetricReceiver.get
-        val percent  = receiver.gauge(statsScope, "percent")(admissionPercent)
-        val allowed  = receiver.counter(statsScope, "allowed")
-        val rejected = receiver.counter(statsScope, "rejected")
+        UnsafeGauge.all(
+            receiver.gauge(statsScope, "percent")(admissionPercent),
+            receiver.gauge(statsScope, "allowed")(allowed.sum().toDouble),
+            receiver.gauge(statsScope, "rejected")(rejected.sum().toDouble)
+        )
     }
+
+    def status(): Admission.AdmissionStatus =
+        Admission.AdmissionStatus(
+            admissionPercent,
+            allowed.sum(),
+            rejected.sum(),
+            regulatorStatus()
+        )
 }
 
 object Admission {
+
+    case class AdmissionStatus(
+        admissionPercent: Int,
+        allowed: Long,
+        rejected: Long,
+        regulator: Regulator.Status
+    ) {
+        infix def -(other: AdmissionStatus): AdmissionStatus =
+            AdmissionStatus(
+                admissionPercent - other.admissionPercent,
+                allowed - other.allowed,
+                rejected - other.rejected,
+                regulator - other.regulator
+            )
+    }
+
     val defaultConfig: Config =
         Config(
             collectWindow = Flag("admission.collectWindow", 40),

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Concurrency.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Concurrency.scala
@@ -22,9 +22,21 @@ final class Concurrency(
     protected def update(diff: Int): Unit =
         updateConcurrency(diff)
 
+    def status(): Concurrency.AdmissionStatus =
+        Concurrency.AdmissionStatus(
+            regulatorStatus()
+        )
 }
 
 object Concurrency {
+
+    case class AdmissionStatus(
+        regulator: Regulator.Status
+    ) {
+        infix def -(other: AdmissionStatus): AdmissionStatus =
+            AdmissionStatus(regulator - other.regulator)
+    }
+
     val defaultConfig: Config = Config(
         collectWindow = Flag("concurrency.collectWindow", 200),
         collectInterval = Flag("concurrency.collectIntervalMs", 10).millis,

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Top.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Top.scala
@@ -1,6 +1,5 @@
 package kyo.scheduler.util
 
-import Top.*
 import java.lang.management.ManagementFactory
 import javax.management.Attribute
 import javax.management.MBeanServer
@@ -8,7 +7,8 @@ import javax.management.ObjectName
 import javax.management.StandardMBean
 import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
-import kyo.scheduler.*
+import kyo.scheduler.InternalTimer
+import kyo.scheduler.Scheduler
 import scala.annotation.nowarn
 import scala.concurrent.duration.*
 import scala.io.StdIn
@@ -40,20 +40,20 @@ class Top(
             mBeanServer.unregisterMBean(objectName)
 }
 
+trait TopMBean {
+    def getStatus(): Scheduler.Status
+}
+
 @nowarn
 object Top extends App {
-
-    trait TopMBean {
-        def getStatus(): Scheduler.Status
-    }
 
     lazy val (host, port) =
         args.toList match {
             case Nil =>
                 ("localhost", 1099)
-            case host :: Nil =>
+            case (host: String) :: Nil =>
                 (host, 1099)
-            case host :: port :: Nil =>
+            case (host: String) :: (port: String) :: Nil =>
                 (host, port.toInt)
             case args =>
                 throw new IllegalArgumentException("Expected host and port but got: " + args)

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Top.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Top.scala
@@ -97,8 +97,8 @@ object Top extends App {
         sb.append(f"Kyo Scheduler Status      | LoadAvg: ${status.loadAvg}%1.4f   | Flushes: ${status.flushes}\n\n")
         sb.append("==============================================================================================\n")
         // Worker table header
-        sb.append("Worker | Running | Blocked | Stalled | Load  | Exec  | Preempt | Done  | Stolen | Lost | Frame\n")
-        sb.append("==============================================================================================\n")
+        sb.append("Worker | Running | Blocked | Stalled | Load  | Exec  | Preempt | Done  | Stolen | Lost | Thread \n")
+        sb.append("================================================================================================\n")
 
         // Worker table rows
         status.workers.foreach { w =>
@@ -108,7 +108,7 @@ object Top extends App {
                 val stalled = if (w.isStalled) "   🐢  " else "   ⚫  "
 
                 sb.append(
-                    f"${w.id}%6d | $running | $blocked%-2s | $stalled%-2s | ${w.load}%5d | ${w.executions}%5d | ${w.preemptions}%7d | ${w.completions}%5d | ${w.stolenTasks}%6d | ${w.lostTasks}%4d | ${w.frame}\n"
+                    f"${w.id}%6d | $running | $blocked%-2s | $stalled%-2s | ${w.load}%5d | ${w.executions}%5d | ${w.preemptions}%7d | ${w.completions}%5d | ${w.stolenTasks}%6d | ${w.lostTasks}%4d | ${w.mount} ${w.frame}\n"
                 )
             }
         }
@@ -116,9 +116,9 @@ object Top extends App {
         sb.append("\n")
 
         // Regulator table header
-        sb.append("==============================================================================================\n")
+        sb.append("================================================================================================\n")
         sb.append("Regulator   |   % | Allow | Reject | Probes | Cmpl  | Adjmts | Updts |    Avg    |  Jitter\n")
-        sb.append("==============================================================================================\n")
+        sb.append("================================================================================================\n")
 
         // Admission regulator row
         val admission       = status.admission

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Top.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Top.scala
@@ -93,32 +93,13 @@ object Top extends App {
     private def print(status: Scheduler.Status): String = {
         val sb = new StringBuilder()
 
-        // Header
-        sb.append(f"Kyo Scheduler Status      | LoadAvg: ${status.loadAvg}%1.4f   | Flushes: ${status.flushes}\n\n")
-        sb.append("==============================================================================================\n")
-        // Worker table header
-        sb.append("Worker | Running | Blocked | Stalled | Load  | Exec  | Preempt | Done  | Stolen | Lost | Thread \n")
-        sb.append("================================================================================================\n")
-
-        // Worker table rows
-        status.workers.foreach { w =>
-            if (w != null) {
-                val running = if (w.running) "   🏃  " else "   ⚫  "
-                val blocked = if (w.isBlocked) "   🚧  " else "   ⚫  "
-                val stalled = if (w.isStalled) "   🐢  " else "   ⚫  "
-
-                sb.append(
-                    f"${w.id}%6d | $running | $blocked%-2s | $stalled%-2s | ${w.load}%5d | ${w.executions}%5d | ${w.preemptions}%7d | ${w.completions}%5d | ${w.stolenTasks}%6d | ${w.lostTasks}%4d | ${w.mount} ${w.frame}\n"
-                )
-            }
-        }
-
-        sb.append("\n")
-
-        // Regulator table header
-        sb.append("================================================================================================\n")
-        sb.append("Regulator   |   % | Allow | Reject | Probes | Cmpl  | Adjmts | Updts |    Avg    |  Jitter\n")
-        sb.append("================================================================================================\n")
+        sb.append(f"""
+            |===============================================================================================
+            |Kyo Scheduler Status      | LoadAvg: ${status.loadAvg}%1.4f   | Flushes: ${status.flushes}
+            |===============================================================================================
+            |Regulator   |   %% | Allow | Reject | Probes | Cmpl  | Adjmts | Updts |    Avg    |  Jitter
+            |-----------------------------------------------------------------------------------------------
+            |""".stripMargin)
 
         // Admission regulator row
         val admission       = status.admission
@@ -135,6 +116,30 @@ object Top extends App {
         sb.append(
             f"Concurrency |   - |     - |      - | ${concurrency.regulator.probesSent}%6d | ${concurrency.regulator.probesCompleted}%5d | ${concurrency.regulator.adjustments}%6d | ${concurrency.regulator.updates}%5d | $concurrencyAvg%9s | $concurrencyJitter%8s\n"
         )
+
+        sb.append(f"""
+            |===============================================================================================
+            |Worker | Running | Blocked | Stalled | Load  | Exec  | Preempt | Done  | Stolen | Lost | Thread
+            |-----------------------------------------------------------------------------------------------
+            |""".stripMargin)
+
+        // Worker table rows
+        status.workers.foreach { w =>
+            if (w ne null) {
+                val running = if (w.running) "   🏃  " else "   ⚫  "
+                val blocked = if (w.isBlocked) "   🚧  " else "   ⚫  "
+                val stalled = if (w.isStalled) "   🐢  " else "   ⚫  "
+
+                sb.append(
+                    f"${w.id}%6d | $running | $blocked%-2s | $stalled%-2s | ${w.load}%5d | ${w.executions}%5d | ${w.preemptions}%7d | ${w.completions}%5d | ${w.stolenTasks}%6d | ${w.lostTasks}%4d | ${w.mount} ${w.frame}\n"
+                )
+            }
+        }
+
+        sb.append("\n")
+
+        // Regulator table header
+        sb.append("================================================================================================\n")
 
         sb.toString()
     }

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Top.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Top.scala
@@ -1,0 +1,141 @@
+package kyo.scheduler.util
+
+import Top.*
+import java.lang.management.ManagementFactory
+import javax.management.Attribute
+import javax.management.MBeanServer
+import javax.management.ObjectName
+import javax.management.StandardMBean
+import javax.management.remote.JMXConnectorFactory
+import javax.management.remote.JMXServiceURL
+import kyo.scheduler.*
+import scala.annotation.nowarn
+import scala.concurrent.duration.*
+import scala.io.StdIn
+
+class Top(
+    status: () => Scheduler.Status,
+    enableTopJMX: Boolean,
+    enableTopConsoleMs: Int,
+    timer: InternalTimer
+) extends TopMBean {
+
+    private val mBeanServer: MBeanServer = ManagementFactory.getPlatformMBeanServer
+    private val objectName               = new ObjectName("kyo.scheduler:type=Top")
+
+    if (enableTopJMX) {
+        close()
+        mBeanServer.registerMBean(new StandardMBean(this, classOf[TopMBean]), objectName)
+    }
+
+    if (enableTopConsoleMs > 0)
+        timer.schedule(enableTopConsoleMs.millis) {
+            println(print(status()))
+        }
+
+    def getStatus() = status()
+
+    def close(): Unit =
+        if (mBeanServer.isRegistered(objectName))
+            mBeanServer.unregisterMBean(objectName)
+}
+
+@nowarn
+object Top extends App {
+
+    trait TopMBean {
+        def getStatus(): Scheduler.Status
+    }
+
+    lazy val (host, port) =
+        args.toList match {
+            case Nil =>
+                ("localhost", 1099)
+            case host :: Nil =>
+                (host, 1099)
+            case host :: port :: Nil =>
+                (host, port.toInt)
+            case args =>
+                throw new IllegalArgumentException("Expected host and port but got: " + args)
+        }
+
+    private lazy val jmxServiceURL         = new JMXServiceURL(s"service:jmx:rmi:///jndi/rmi://$host:$port/jmxrmi")
+    private lazy val jmxConnector          = JMXConnectorFactory.connect(jmxServiceURL)
+    private lazy val mBeanServerConnection = jmxConnector.getMBeanServerConnection
+
+    private lazy val objectName = new ObjectName("kyo.scheduler:type=Top")
+
+    private var lastStatus: Scheduler.Status = null
+
+    delayedInit {
+        try {
+            while (true) {
+
+                val currentStatus = mBeanServerConnection.getAttribute(objectName, "Status").asInstanceOf[Scheduler.Status]
+
+                if (lastStatus != null) {
+                    val diffStatus = currentStatus - lastStatus
+                    val clear      = "\u001b[2J\u001b[H"
+                    println(clear + "\n" + print(diffStatus))
+                }
+
+                lastStatus = currentStatus
+                Thread.sleep(1000) // Refresh every 1 second
+            }
+        } catch {
+            case e: Exception =>
+                e.printStackTrace()
+        } finally {
+            jmxConnector.close()
+        }
+    }
+
+    private def print(status: Scheduler.Status): String = {
+        val sb = new StringBuilder()
+
+        // Header
+        sb.append(f"Kyo Scheduler Status      | LoadAvg: ${status.loadAvg}%1.4f   | Flushes: ${status.flushes}\n\n")
+        sb.append("==============================================================================================\n")
+        // Worker table header
+        sb.append("Worker | Running | Blocked | Stalled | Load  | Exec  | Preempt | Done  | Stolen | Lost | Frame\n")
+        sb.append("==============================================================================================\n")
+
+        // Worker table rows
+        status.workers.foreach { w =>
+            if (w != null) {
+                val running = if (w.running) "   🏃  " else "   ⚫  "
+                val blocked = if (w.isBlocked) "   🚧  " else "   ⚫  "
+                val stalled = if (w.isStalled) "   🐢  " else "   ⚫  "
+
+                sb.append(
+                    f"${w.id}%6d | $running | $blocked%-2s | $stalled%-2s | ${w.load}%5d | ${w.executions}%5d | ${w.preemptions}%7d | ${w.completions}%5d | ${w.stolenTasks}%6d | ${w.lostTasks}%4d | ${w.frame}\n"
+                )
+            }
+        }
+
+        sb.append("\n")
+
+        // Regulator table header
+        sb.append("==============================================================================================\n")
+        sb.append("Regulator   |   % | Allow | Reject | Probes | Cmpl  | Adjmts | Updts |    Avg    |  Jitter\n")
+        sb.append("==============================================================================================\n")
+
+        // Admission regulator row
+        val admission       = status.admission
+        val admissionAvg    = f"${admission.regulator.measurementsAvg}%7.1f"
+        val admissionJitter = f"${admission.regulator.measurementsJitter}%7.2f"
+        sb.append(
+            f"Admission   | ${admission.admissionPercent}%3d | ${admission.allowed}%5d | ${admission.rejected}%6d | ${admission.regulator.probesSent}%6d | ${admission.regulator.probesCompleted}%5d | ${admission.regulator.adjustments}%6d | ${admission.regulator.updates}%5d | $admissionAvg%9s | $admissionJitter%8s\n"
+        )
+
+        // Concurrency regulator row
+        val concurrency       = status.concurrency
+        val concurrencyAvg    = f"${concurrency.regulator.measurementsAvg}%7.1f"
+        val concurrencyJitter = f"${concurrency.regulator.measurementsJitter}%7.2f"
+        sb.append(
+            f"Concurrency |   - |     - |      - | ${concurrency.regulator.probesSent}%6d | ${concurrency.regulator.probesCompleted}%5d | ${concurrency.regulator.adjustments}%6d | ${concurrency.regulator.updates}%5d | $concurrencyAvg%9s | $concurrencyJitter%8s\n"
+        )
+
+        sb.toString()
+    }
+}

--- a/kyo-scheduler/shared/src/main/scala/kyo/scheduler/Task.scala
+++ b/kyo-scheduler/shared/src/main/scala/kyo/scheduler/Task.scala
@@ -27,9 +27,20 @@ trait Task {
             if (state < 0) -state + v
             else state + v
     }
+
+    def status(): Task.Status =
+        Task.Status(
+            shouldPreempt(),
+            runtime()
+        )
 }
 
 object Task {
+
+    case class Status(
+        preempting: Boolean,
+        runtime: Int
+    )
 
     implicit val taskOrdering: Ordering[Task] =
         new Ordering[Task] {


### PR DESCRIPTION
I'm working on https://github.com/getkyo/kyo/issues/347 and need more visibility on the execution of the scheduler to debug. This PR introduces a `top` utility that can be used in two ways:

- **Console**: It's possible to print the information to the console periodically by setting `-Dscheduler.enableTopConsoleMs=<<interval>>`. Disabled by default.
- **JMX**: The functionality is exposed as an mbean and can be accessed the main class `kyo.scheduler.util.Top`. Enabled by default since there shouldn't be a significant performance penalty.

The utility is lightweight and designed to be used in production as well. Demo:

[![asciicast](https://asciinema.org/a/FFZUkfAuMy5cnb16Q0N8KSKBR.svg)](https://asciinema.org/a/FFZUkfAuMy5cnb16Q0N8KSKBR)