### PR TITLE
automatically derive Flat from Tag

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/internal/FlatImplicits.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/FlatImplicits.scala
@@ -41,6 +41,11 @@ object FlatImplicits:
         def isConcrete(t: TypeRepr) =
             t.typeSymbol.isClassDef
 
+        def hasTag(t: TypeRepr): Boolean =
+            t.asType match
+                case '[t] =>
+                    Expr.summon[Tag[t]].isDefined
+
         def check(t: TypeRepr): Unit =
             t match
                 case OrType(a, b) =>
@@ -50,7 +55,7 @@ object FlatImplicits:
                     check(a)
                     check(b)
                 case _ =>
-                    if isAny(t) || !isConcrete(t.dealias) then
+                    if isAny(t) || (!isConcrete(t.dealias) && !hasTag(t)) then
                         fail(
                             s"Cannot prove ${code(print(t))} isn't nested. " +
                                 s"This error can be reported an unsupported pending effect is passed to a method. " +

--- a/kyo-core/shared/src/test/scala/kyoTest/FlatTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/FlatTest.scala
@@ -15,6 +15,12 @@ class FlatTest extends KyoTest:
             implicitly[Flat[Fiber[Int]]]
             succeed
         }
+        "derived from Tag" in {
+            def test[T: Tag] =
+                implicitly[Flat[T]]
+                succeed
+            test[Int]
+        }
     }
 
     "nok" - {


### PR DESCRIPTION
A `Flat` instance can now be derived from `Tag` since its new implementation restricts tags to concrete types, which doesn't include Kyo's pending type.

This change introduces automatic derivation so users don't need to provide implicits for both `Flat` and `Tag` for the same type.