### PR TITLE
cache stream handlers

### DIFF
--- a/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
@@ -11,7 +11,7 @@ class coreBytecodeSizeTest extends KyoTest:
         type Command[T] = T
 
     object TestHandler extends Handler[Id, TestEffect.type, Any]:
-        def resume[T, U: Flat, S](command: T, k: T => U < (TestEffect.type & S)) =
+        def resume[T, U: Flat, S](command: T, k: T => U < (TestEffect.type & S))(using Tag[TestEffect.type]) =
             Resume((), k(command))
 
     class TestSuspend:
@@ -38,7 +38,7 @@ class coreBytecodeSizeTest extends KyoTest:
         assert(map == Map(
             "test"        -> 27,
             "resultLoop"  -> 91,
-            "handleLoop"  -> 253,
+            "handleLoop"  -> 265,
             "_handleLoop" -> 10
         ))
     }

--- a/kyo-core/shared/src/main/scala/kyo/aborts.scala
+++ b/kyo-core/shared/src/main/scala/kyo/aborts.scala
@@ -50,9 +50,9 @@ object Aborts:
 
         val handler =
             new ResultHandler[ClassTag[?], Const[Any], DoAbort, [T] =>> Either[Any, T], Any]:
-                def done[T](st: ClassTag[?], v: T) = Right(v)
+                def done[T](st: ClassTag[?], v: T)(using Tag[DoAbort]) = Right(v)
 
-                override def failed(st: ClassTag[?], ex: Throwable) =
+                override def failed(st: ClassTag[?], ex: Throwable)(using Tag[DoAbort]) =
                     type V
                     given ClassTag[V] = st.asInstanceOf[ClassTag[V]]
                     ex match
@@ -68,7 +68,7 @@ object Aborts:
                         case _    => false
                 end accepts
 
-                def resume[T, U: Flat, S2](st: ClassTag[?], command: Any, k: T => U < (DoAbort & S2)) =
+                def resume[T, U: Flat, S2](st: ClassTag[?], command: Any, k: T => U < (DoAbort & S2))(using Tag[DoAbort]) =
                     Left(command)
         end handler
 

--- a/kyo-core/shared/src/main/scala/kyo/choices.scala
+++ b/kyo-core/shared/src/main/scala/kyo/choices.scala
@@ -31,7 +31,7 @@ object Choices extends Choices:
 
     private val handler =
         new ResultHandler[Unit, Seq, Choices, Seq, Any]:
-            def done[T](st: Unit, v: T) = Seq(v)
-            def resume[T, U: Flat, S](st: Unit, v: Seq[T], f: T => U < (Choices & S)): (Seq[U] | Resume[U, S]) < (Any & S) =
+            def done[T](st: Unit, v: T)(using Tag[Choices]) = Seq(v)
+            def resume[T, U: Flat, S](st: Unit, v: Seq[T], f: T => U < (Choices & S))(using Tag[Choices]) =
                 Seqs.collect(v.map(e => Choices.run(f(e)))).map(_.flatten)
 end Choices

--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -130,35 +130,35 @@ object core:
         def accepts[T](st: State, command: Command[T]): Boolean =
             true
 
-        def done[T](st: State, v: T): Result[T] < S
+        def done[T](st: State, v: T)(using Tag[E]): Result[T] < S
 
-        def failed(st: State, ex: Throwable): Nothing < (E & S) = throw ex
+        def failed(st: State, ex: Throwable)(using Tag[E]): Nothing < (E & S) = throw ex
 
         def resume[T, U: Flat, S2](
             st: State,
             command: Command[T],
             k: T => U < (E & S2)
-        ): (Result[U] | Resume[U, S2]) < (S & S2)
+        )(using Tag[E]): (Result[U] | Resume[U, S2]) < (S & S2)
 
     end ResultHandler
 
     abstract class Handler[Command[_], E <: Effect[E], S]
         extends ResultHandler[Unit, Command, E, Id, S]:
-        inline def done[T](st: Unit, v: T) =
+        inline def done[T](st: Unit, v: T)(using Tag[E]) =
             done(v)
         inline def resume[T, U: Flat, S2](
             st: Unit,
             command: Command[T],
             k: T => U < (E & S2)
-        ): (U | Resume[U, S2]) < (S & S2) =
+        )(using Tag[E]): (U | Resume[U, S2]) < (S & S2) =
             resume(command, k)
 
-        def done[T](v: T): T < S = v
+        def done[T](v: T)(using Tag[E]): T < S = v
 
         def resume[T, U: Flat, S2](
             command: Command[T],
             k: T => U < (E & S2)
-        ): (U | Resume[U, S2]) < (S & S2)
+        )(using Tag[E]): (U | Resume[U, S2]) < (S & S2)
     end Handler
 
     trait Safepoint[-E]:

--- a/kyo-core/shared/src/main/scala/kyo/defers.scala
+++ b/kyo-core/shared/src/main/scala/kyo/defers.scala
@@ -20,6 +20,6 @@ object Defers extends Defers:
         this.handle(handler)((), v)
 
     private val handler = new Handler[Const[Unit], Defers, Any]:
-        def resume[T, U: Flat, S2](command: Command[T], k: T => U < (Defers & S2)) =
+        def resume[T, U: Flat, S2](command: Command[T], k: T => U < (Defers & S2))(using Tag[Defers]) =
             Resume((), k(().asInstanceOf[T]))
 end Defers

--- a/kyo-core/shared/src/main/scala/kyo/envs.scala
+++ b/kyo-core/shared/src/main/scala/kyo/envs.scala
@@ -39,8 +39,8 @@ object Envs:
 
     private val cachedHandler =
         new ResultHandler[Any, Const[Unit], Envs[Any], Id, Any]:
-            def done[T](st: Any, v: T) = v
-            def resume[T, U: Flat, S2](st: Any, command: Unit, k: T => U < (Envs[Any] & S2)) =
+            def done[T](st: Any, v: T)(using Tag[Envs[Any]]) = v
+            def resume[T, U: Flat, S2](st: Any, command: Unit, k: T => U < (Envs[Any] & S2))(using Tag[Envs[Any]]) =
                 Resume(st, k(st.asInstanceOf[T]))
 
     /** An effect `Envs[VS]` includes a dependency on `V`, and once `V` has been handled, `Envs[VS]` should be replaced by `Out`

--- a/kyo-core/shared/src/main/scala/kyo/fibers.scala
+++ b/kyo-core/shared/src/main/scala/kyo/fibers.scala
@@ -344,7 +344,7 @@ object fibersInternal:
                         Long.MaxValue
                 val handler =
                     new Handler[Fiber, FiberGets, IOs]:
-                        def resume[T, U: Flat, S](m: Fiber[T], f: T => U < (FiberGets & S)) =
+                        def resume[T, U: Flat, S](m: Fiber[T], f: T => U < (FiberGets & S))(using Tag[FiberGets]) =
                             m match
                                 case Promise(p) =>
                                     Resume((), p.block(deadline).map(f))

--- a/kyo-core/shared/src/main/scala/kyo/streams.scala
+++ b/kyo-core/shared/src/main/scala/kyo/streams.scala
@@ -23,117 +23,25 @@ object Stream:
             if n <= 0 then
                 runDiscard
             else
-                val handler =
-                    new ResultHandler[Int, Const[Chunk[V]], Streams[V], Id, Streams[V]]:
-                        def done[T](st: Int, v: T) = v
-                        def resume[T, U: Flat, S2](
-                            st: Int,
-                            command: Chunk[V],
-                            k: T => U < (Streams[V] & S2)
-                        ) =
-                            if st == 0 then
-                                Resume(0, k(().asInstanceOf[T]))
-                            else
-                                val t: Chunk[V] = command.take(st)
-                                Streams.emitChunkAndThen(t) {
-                                    Resume(st - t.size, k(().asInstanceOf[T]))
-                                }
-                Streams[V].handle(handler)(n, s)
-        end take
+                Streams[V].handle(handlers[V, Any].takeHandler)(n, s)
 
         def drop(n: Int): Stream[T, V, S] =
             if n <= 0 then
                 s
             else
-                val handler =
-                    new ResultHandler[Int, Const[Chunk[V]], Streams[V], Id, Streams[V]]:
-                        def done[T](st: Int, v: T) = v
-                        def resume[T, U: Flat, S2](
-                            st: Int,
-                            command: Chunk[V],
-                            k: T => U < (Streams[V] & S2)
-                        ) =
-                            if st == 0 then
-                                Streams.emitChunkAndThen(command) {
-                                    k(().asInstanceOf[T])
-                                }
-                            else
-                                Streams.emitChunkAndThen(command.dropLeft(st)) {
-                                    Resume(st - Math.min(command.size, st), k(().asInstanceOf[T]))
-                                }
-                Streams[V].handle(handler)(n, s)
-        end drop
+                Streams[V].handle(handlers[V, Any].dropHandler)(n, s)
 
         def takeWhile[S2](f: V => Boolean < S2): Stream[T, V, S & S2] =
-            val handler =
-                new ResultHandler[Boolean, Const[Chunk[V]], Streams[V], Id, Streams[V] & S & S2]:
-                    def done[T](st: Boolean, v: T) = v
-                    def resume[T, U: Flat, S3](
-                        st: Boolean,
-                        command: Chunk[V],
-                        k: T => U < (Streams[V] & S3)
-                    ) =
-                        if st then
-                            command.takeWhile(f).map { c =>
-                                Streams.emitChunkAndThen(c) {
-                                    Resume(command.size == c.size, k(().asInstanceOf[T]))
-                                }
-                            }
-                        else
-                            Resume(false, k(().asInstanceOf[T]))
-            Streams[V].handle(handler)(true, s)
-        end takeWhile
+            Streams[V].handle(handlers[V, S & S2].takeWhile)(f, s)
 
         def dropWhile[S2](f: V => Boolean < S2): Stream[T, V, S & S2] =
-            val handler =
-                new Handler[Const[Chunk[V]], Streams[V], Streams[V] & S & S2]:
-                    def resume[T, U: Flat, S3](
-                        command: Chunk[V],
-                        k: T => U < (Streams[V] & S3)
-                    ) =
-                        command.dropWhile(f).map { c =>
-                            Streams.emitChunkAndThen(c) {
-                                if c.isEmpty || command.isEmpty then
-                                    Resume((), k(().asInstanceOf[T]))
-                                else
-                                    k(().asInstanceOf[T])
-                            }
-                        }
-            Streams[V].handle(handler)((), s)
-        end dropWhile
+            Streams[V].handle(handlers[V, S & S2].dropWhile)(f, s)
 
         def filter[S2](f: V => Boolean < S2): Stream[T, V, S & S2] =
-            val handler = new Handler[Const[Chunk[V]], Streams[V], Streams[V] & S & S2]:
-                def resume[T, U: Flat, S3](
-                    command: Chunk[V],
-                    k: T => U < (Streams[V] & S3)
-                ) =
-                    command.filter(f).map { c =>
-                        Streams.emitChunkAndThen(c) {
-                            Resume((), k(().asInstanceOf[T]))
-                        }
-                    }
-                end resume
-            Streams[V].handle(handler)((), s)
-        end filter
+            Streams[V].handle(handlers[V, S & S2].filter)(f, s)
 
         def changes: Stream[T, V, S] =
-            val handler =
-                new ResultHandler[V | Null, Const[Chunk[V]], Streams[V], Id, Streams[V] & S]:
-                    def done[T](st: V | Null, v: T) = v
-                    def resume[T, U: Flat, S3](
-                        st: V | Null,
-                        command: Chunk[V],
-                        k: T => U < (Streams[V] & S3)
-                    ): (U | Resume[U, S3]) < (Streams[V] & S & S3) =
-                        val c = command.changes(st)
-                        Streams.emitChunkAndThen(c) {
-                            val nst = if c.isEmpty then st else c.last
-                            Resume(nst, k(().asInstanceOf[T]))
-                        }
-                    end resume
-            Streams[V].handle(handler)(null, s)
-        end changes
+            Streams[V].handle(handlers[V, S].changes)(null, s)
 
         def collect[S2, V2: Flat](
             pf: PartialFunction[V, Unit < (Streams[V2] & S2)]
@@ -143,7 +51,7 @@ object Stream:
                     def resume[T, U: Flat, S3](
                         command: Chunk[V],
                         k: T => U < (Streams[V] & S3)
-                    ) =
+                    )(using Tag[Streams[V]]) =
                         command.collectUnit(pf).andThen {
                             Streams.emitChunkAndThen(Chunks.init[V2]) {
                                 Resume((), k(().asInstanceOf[T]))
@@ -160,7 +68,7 @@ object Stream:
                     def resume[T, U: Flat, S3](
                         command: Chunk[V],
                         k: T => U < (Streams[V] & S3)
-                    ): (U | Resume[U, S3]) < (Streams[V2] & S & S2 & S3) =
+                    )(using Tag[Streams[V]]): (U | Resume[U, S3]) < (Streams[V2] & S & S2 & S3) =
                         command.map(f).map { c =>
                             Streams.emitChunkAndThen(c) {
                                 Resume((), k(().asInstanceOf[T]))
@@ -191,12 +99,12 @@ object Stream:
         def runFold[A: Flat, S2](acc: A)(f: (A, V) => A < S2): (A, T) < (S & S2) =
             val handler =
                 new ResultHandler[A, Const[Chunk[V]], Streams[V], [T] =>> (A, T), S & S2]:
-                    def done[T](st: A, v: T) = (st, v)
+                    def done[T](st: A, v: T)(using Tag[Streams[V]]) = (st, v)
                     def resume[T, U: Flat, S2](
                         st: A,
                         command: Chunk[V],
                         k: T => U < (Streams[V] & S2)
-                    ) =
+                    )(using Tag[Streams[V]]) =
                         command.foldLeft(st)(f).map { r =>
                             Resume(r, k(().asInstanceOf[T]))
                         }
@@ -205,20 +113,10 @@ object Stream:
         end runFold
 
         def runDiscard: T < S =
-            Streams[V].handle(discardHandler[V])((), s)
+            Streams[V].handle(handlers[V, Any].discard)((), s)
 
         def runChunk: (Chunk[V], T) < S =
-            val handler =
-                new ResultHandler[Chunk[Chunk[V]], Const[Chunk[V]], Streams[V], [T] =>> (Chunk[V], T), S]:
-                    def done[T](st: Chunk[Chunk[V]], v: T) = (st.flatten, v)
-                    def resume[T, U: Flat, S2](
-                        st: Chunk[Chunk[V]],
-                        command: Chunk[V],
-                        k: T => U < (Streams[V] & S2)
-                    ) =
-                        Resume(st.append(command), k(().asInstanceOf[T]))
-            Streams[V].handle(handler)(Chunks.init, s)
-        end runChunk
+            Streams[V].handle(handlers[V, Any].runChunk)(Chunks.init, s)
 
         def runSeq: (IndexedSeq[V], T) < S =
             runChunk.map((c, v) => (c.toSeq, v))
@@ -226,8 +124,8 @@ object Stream:
         def runChannel(ch: Channel[Chunk[V] | Done]): T < (Fibers & S) =
             val handler =
                 new Handler[Const[Chunk[V]], Streams[V], Fibers]:
-                    override def done[T](v: T) = ch.put(Done).andThen(v)
-                    def resume[T, U: Flat, S](command: Chunk[V], k: T => U < (Streams[V] & S)) =
+                    override def done[T](v: T)(using Tag[Streams[V]]) = ch.put(Done).andThen(v)
+                    def resume[T, U: Flat, S](command: Chunk[V], k: T => U < (Streams[V] & S))(using Tag[Streams[V]]) =
                         ch.put(command).andThen(Resume((), k(().asInstanceOf[T])))
             Streams[V].handle(handler)((), s)
         end runChannel
@@ -238,12 +136,125 @@ object Stream:
         s
 
     private object internal:
-        private val discard = new Handler[Const[Chunk[Any]], Streams[Any], Any]:
-            def resume[T, U: Flat, S](command: Chunk[Any], k: T => U < (Streams[Any] & S)) =
-                Resume((), k(().asInstanceOf[T]))
 
-        def discardHandler[V]: Handler[Const[Chunk[V]], Streams[V], Any] =
-            discard.asInstanceOf[Handler[Const[Chunk[V]], Streams[V], Any]]
+        class Handlers[V, S]:
+            val takeHandler =
+                new ResultHandler[Int, Const[Chunk[V]], Streams[V], Id, Streams[V]]:
+                    def done[T](st: Int, v: T)(using Tag[Streams[V]]) = v
+                    def resume[T, U: Flat, S2](
+                        st: Int,
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S2)
+                    )(using Tag[Streams[V]]) =
+                        if st == 0 then
+                            Resume(0, k(().asInstanceOf[T]))
+                        else
+                            val t: Chunk[V] = command.take(st)
+                            Streams.emitChunkAndThen(t) {
+                                Resume(st - t.size, k(().asInstanceOf[T]))
+                            }
+            val dropHandler =
+                new ResultHandler[Int, Const[Chunk[V]], Streams[V], Id, Streams[V]]:
+                    def done[T](st: Int, v: T)(using Tag[Streams[V]]) = v
+                    def resume[T, U: Flat, S2](
+                        st: Int,
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S2)
+                    )(using Tag[Streams[V]]) =
+                        if st == 0 then
+                            Streams.emitChunkAndThen(command) {
+                                k(().asInstanceOf[T])
+                            }
+                        else
+                            Streams.emitChunkAndThen(command.dropLeft(st)) {
+                                Resume(st - Math.min(command.size, st), k(().asInstanceOf[T]))
+                            }
+
+            val takeWhile =
+                new ResultHandler[V => Boolean < S, Const[Chunk[V]], Streams[V], Id, Streams[V] & S]:
+                    private val stop = (_: V) => false
+
+                    def done[T](st: V => Boolean < S, v: T)(using Tag[Streams[V]]) = v
+                    def resume[T, U: Flat, S3](
+                        st: V => Boolean < S,
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S3)
+                    )(using Tag[Streams[V]]) =
+                        if st ne stop then
+                            command.takeWhile(st).map { c =>
+                                Streams.emitChunkAndThen(c) {
+                                    val nst =
+                                        if command.size == c.size then st
+                                        else stop
+                                    Resume(nst, k(().asInstanceOf[T]))
+                                }
+                            }
+                        else
+                            Resume(stop, k(().asInstanceOf[T]))
+
+            val dropWhile =
+                new ResultHandler[V => Boolean < S, Const[Chunk[V]], Streams[V], Id, Streams[V] & S]:
+                    def done[T](st: V => Boolean < S, v: T)(using Tag[Streams[V]]) = v
+                    def resume[T, U: Flat, S3](
+                        st: V => Boolean < S,
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S3)
+                    )(using Tag[Streams[V]]) =
+                        command.dropWhile(st).map { c =>
+                            Streams.emitChunkAndThen(c) {
+                                if c.isEmpty || command.isEmpty then
+                                    Resume(st, k(().asInstanceOf[T]))
+                                else
+                                    k(().asInstanceOf[T])
+                            }
+                        }
+            val filter =
+                new ResultHandler[V => Boolean < S, Const[Chunk[V]], Streams[V], Id, Streams[V] & S]:
+                    def done[T](st: V => Boolean < S, v: T)(using Tag[Streams[V]]) = v
+                    def resume[T, U: Flat, S3](
+                        st: V => Boolean < S,
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S3)
+                    )(using Tag[Streams[V]]) =
+                        command.filter(st).map { c =>
+                            Streams.emitChunkAndThen(c) {
+                                Resume(st, k(().asInstanceOf[T]))
+                            }
+                        }
+
+            val changes =
+                new ResultHandler[V | Null, Const[Chunk[V]], Streams[V], Id, Streams[V] & S]:
+                    def done[T](st: V | Null, v: T)(using Tag[Streams[V]]) = v
+                    def resume[T, U: Flat, S3](
+                        st: V | Null,
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S3)
+                    )(using Tag[Streams[V]]): (U | Resume[U, S3]) < (Streams[V] & S & S3) =
+                        val c = command.changes(st)
+                        Streams.emitChunkAndThen(c) {
+                            val nst = if c.isEmpty then st else c.last
+                            Resume(nst, k(().asInstanceOf[T]))
+                        }
+                    end resume
+
+            val runChunk =
+                new ResultHandler[Chunk[Chunk[V]], Const[Chunk[V]], Streams[V], [T] =>> (Chunk[V], T), S]:
+                    def done[T](st: Chunk[Chunk[V]], v: T)(using Tag[Streams[V]]) = (st.flatten, v)
+                    def resume[T, U: Flat, S2](
+                        st: Chunk[Chunk[V]],
+                        command: Chunk[V],
+                        k: T => U < (Streams[V] & S2)
+                    )(using Tag[Streams[V]]) =
+                        Resume(st.append(command), k(().asInstanceOf[T]))
+
+            val discard = new Handler[Const[Chunk[V]], Streams[V], Any]:
+                def resume[T, U: Flat, S](command: Chunk[V], k: T => U < (Streams[V] & S))(using Tag[Streams[V]]) =
+                    Resume((), k(().asInstanceOf[T]))
+        end Handlers
+
+        private val _handlers = new Handlers[Any, Any]
+
+        inline def handlers[V, S]: Handlers[V, S] = _handlers.asInstanceOf[Handlers[V, S]]
     end internal
 
 end Stream
@@ -296,6 +307,7 @@ object Streams:
         }
 
     object internal:
+
         class InitSourceDsl[V]:
             def apply[T, S](v: T < (Streams[V] & S)): Stream[T, V, S] =
                 Stream.source(v)

--- a/kyo-core/shared/src/main/scala/kyo/sums.scala
+++ b/kyo-core/shared/src/main/scala/kyo/sums.scala
@@ -7,8 +7,8 @@ class Sums[V] extends Effect[Sums[V]]:
 
     private val handler =
         new ResultHandler[Chunk[V], Const[V], Sums[V], [T] =>> (Chunk[V], T), Any]:
-            def done[T](st: Chunk[V], v: T) = (st, v)
-            def resume[T, U: Flat, S](st: Chunk[V], command: V, k: T => U < (Sums[V] & S)) =
+            def done[T](st: Chunk[V], v: T)(using Tag[Sums[V]]) = (st, v)
+            def resume[T, U: Flat, S](st: Chunk[V], command: V, k: T => U < (Sums[V] & S))(using Tag[Sums[V]]) =
                 Resume(st.append(command), k(().asInstanceOf[T]))
 end Sums
 

--- a/kyo-core/shared/src/main/scala/kyo/vars.scala
+++ b/kyo-core/shared/src/main/scala/kyo/vars.scala
@@ -8,8 +8,8 @@ class Vars[V] extends Effect[Vars[V]]:
 
     private val handler =
         new ResultHandler[V, Const[Op[V]], Vars[V], Id, Any]:
-            def done[T](st: V, v: T) = v
-            def resume[T, U: Flat, S2](st: V, op: Op[V], k: T => U < (Vars[V] & S2)) =
+            def done[T](st: V, v: T)(using Tag[Vars[V]]) = v
+            def resume[T, U: Flat, S2](st: V, op: Op[V], k: T => U < (Vars[V] & S2))(using Tag[Vars[V]]) =
                 op match
                     case _: Get.type =>
                         Resume(st, k(st.asInstanceOf[T]))


### PR DESCRIPTION
Avoids handler allocations in `Streams`. The benchmarks show no improvement but it's because the JIT is able to avoid the handler allocations. I think it's still worth making the change since that might not be the case in production code.

![image](https://github.com/getkyo/kyo/assets/831175/55110cf4-914e-46c0-b587-d604a59a83ac)
