### PR TITLE
avoid `lazy val` to access `KyoSttpMonad`

### DIFF
--- a/kyo-sttp/jvm/src/main/scala/sttp/client3/HttpClientKyoBackend.scala
+++ b/kyo-sttp/jvm/src/main/scala/sttp/client3/HttpClientKyoBackend.scala
@@ -30,7 +30,7 @@ class HttpClientKyoBackend private (
     customEncodingHandler: InputStreamEncodingHandler
 ) extends HttpClientAsyncBackend[M, Nothing, WebSockets, InputStream, InputStream](
         client,
-        KyoSttpMonad.instance,
+        KyoSttpMonad,
         closeClient,
         customizeRequest,
         customEncodingHandler
@@ -41,16 +41,16 @@ class HttpClientKyoBackend private (
     override protected val bodyToHttpClient =
         new BodyToHttpClient[KyoSttpMonad.M, Nothing]:
             override val streams: NoStreams                  = NoStreams
-            override given monad: MonadError[KyoSttpMonad.M] = KyoSttpMonad.instance
+            override given monad: MonadError[KyoSttpMonad.M] = KyoSttpMonad
             override def streamToPublisher(stream: Nothing) =
                 stream
 
     override protected val bodyFromHttpClient =
         new InputStreamBodyFromHttpClient[KyoSttpMonad.M, Nothing]:
             override def inputStreamToStream(is: InputStream) =
-                KyoSttpMonad.instance.error(new IllegalStateException("Streaming is not supported"))
+                KyoSttpMonad.error(new IllegalStateException("Streaming is not supported"))
             override val streams: NoStreams                  = NoStreams
-            override given monad: MonadError[KyoSttpMonad.M] = KyoSttpMonad.instance
+            override given monad: MonadError[KyoSttpMonad.M] = KyoSttpMonad
             override def compileWebSocketPipe(
                 ws: WebSocket[KyoSttpMonad.M],
                 pipe: streams.Pipe[WebSocketFrame.Data[?], WebSocketFrame]
@@ -121,5 +121,5 @@ object HttpClientKyoBackend:
         )
 
     def stub: SttpBackendStub[KyoSttpMonad.M, WebSockets] =
-        SttpBackendStub(KyoSttpMonad.instance)
+        SttpBackendStub(KyoSttpMonad)
 end HttpClientKyoBackend

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -1,61 +1,65 @@
 package kyo.internal
 
+import KyoSttpMonad.M
 import kyo.*
+import kyo.core.internal.Kyo
 import sttp.monad.Canceler
 import sttp.monad.MonadAsyncError
 
-object KyoSttpMonad:
+class KyoSttpMonad extends MonadAsyncError[M]:
+
+    def map[T, T2](fa: T < Fibers)(f: T => T2): T2 < Fibers =
+        fa.map(f)
+
+    def flatMap[T, T2](fa: T < Fibers)(
+        f: T => T2 < Fibers
+    ): T2 < Fibers =
+        fa.flatMap(f)
+
+    protected def handleWrappedError[T](rt: T < Fibers)(
+        h: PartialFunction[Throwable, T < Fibers]
+    ) =
+        IOs.catching(rt) {
+            case ex if ex eq Fibers.Interrupted =>
+                Fibers.interrupted
+            case ex if h.isDefinedAt(ex) =>
+                h(ex)
+        }
+
+    override def handleError[T](rt: => T < Fibers)(h: PartialFunction[Throwable, T < Fibers]) =
+        handleWrappedError(rt)(h)
+
+    def ensure[T](f: T < Fibers, e: => Unit < Fibers) =
+        IOs.ensure(Fibers.run(e).unit)(f)
+
+    def error[T](t: Throwable) =
+        IOs.fail(t)
+
+    def unit[T](t: T) =
+        t
+
+    override def eval[T](t: => T) =
+        IOs[T, Fibers](t)
+
+    override def suspend[T](t: => M[T]) =
+        IOs[T, Fibers](t)
+
+    def async[T](register: (Either[Throwable, T] => Unit) => Canceler): M[T] =
+        Fibers.initPromise[T].map { p =>
+            val canceller =
+                register {
+                    case Left(t)  => discard(p.unsafeComplete(IOs.fail(t)))
+                    case Right(t) => discard(p.unsafeComplete(t))
+                }
+            p.onComplete { r =>
+                if r.equals(Fibers.interrupted) then
+                    canceller.cancel()
+            }.andThen(p.get)
+        }
+end KyoSttpMonad
+
+object KyoSttpMonad extends KyoSttpMonad:
     type M[T] = T < Fibers
 
-    given instance: MonadAsyncError[M] =
-        new MonadAsyncError[M]:
-
-            def map[T, T2](fa: T < Fibers)(f: T => T2): T2 < Fibers =
-                fa.map(f)
-
-            def flatMap[T, T2](fa: T < Fibers)(
-                f: T => T2 < Fibers
-            ): T2 < Fibers =
-                fa.flatMap(f)
-
-            protected def handleWrappedError[T](rt: T < Fibers)(
-                h: PartialFunction[Throwable, T < Fibers]
-            ) =
-                IOs.catching(rt) {
-                    case ex if ex eq Fibers.Interrupted =>
-                        Fibers.interrupted
-                    case ex if h.isDefinedAt(ex) =>
-                        h(ex)
-                }
-
-            override def handleError[T](rt: => T < Fibers)(h: PartialFunction[Throwable, T < Fibers]) =
-                handleWrappedError(rt)(h)
-
-            def ensure[T](f: T < Fibers, e: => Unit < Fibers) =
-                IOs.ensure(Fibers.run(e).unit)(f)
-
-            def error[T](t: Throwable) =
-                IOs.fail(t)
-
-            def unit[T](t: T) =
-                t
-
-            override def eval[T](t: => T) =
-                IOs[T, Fibers](t)
-
-            override def suspend[T](t: => M[T]) =
-                IOs[T, Fibers](t)
-
-            def async[T](register: (Either[Throwable, T] => Unit) => Canceler): M[T] =
-                Fibers.initPromise[T].map { p =>
-                    val canceller =
-                        register {
-                            case Left(t)  => discard(p.unsafeComplete(IOs.fail(t)))
-                            case Right(t) => discard(p.unsafeComplete(t))
-                        }
-                    p.onComplete { r =>
-                        if r.equals(Fibers.interrupted) then
-                            canceller.cancel()
-                    }.andThen(p.get)
-                }
+    inline given KyoSttpMonad = this
 end KyoSttpMonad

--- a/kyo-tapir/src/main/scala/kyo/server/NettyKyoServer.scala
+++ b/kyo-tapir/src/main/scala/kyo/server/NettyKyoServer.scala
@@ -93,7 +93,7 @@ case class NettyKyoServer(
     private def startUsingSocketOverride[SA <: SocketAddress](socketOverride: Option[SA])
         : KyoSttpMonad.M[(SA, () => KyoSttpMonad.M[Unit])] =
         val eventLoopGroup                           = config.eventLoopConfig.initEventLoopGroup()
-        given monadError: MonadError[KyoSttpMonad.M] = KyoSttpMonad.instance
+        given monadError: MonadError[KyoSttpMonad.M] = KyoSttpMonad
         val route                                    = Route.combine(routes)
         val eventExecutor                            = new DefaultEventExecutor()
         val channelGroup                             = new DefaultChannelGroup(eventExecutor) // thread safe

--- a/kyo-tapir/src/main/scala/kyo/server/NettyKyoServerInterpreter.scala
+++ b/kyo-tapir/src/main/scala/kyo/server/NettyKyoServerInterpreter.scala
@@ -21,7 +21,7 @@ trait NettyKyoServerInterpreter:
     def toRoute(
         ses: List[ServerEndpoint[Any, KyoSttpMonad.M]]
     ): Route[KyoSttpMonad.M] =
-        given monad: MonadAsyncError[KyoSttpMonad.M] = KyoSttpMonad.instance
+        given monad: MonadAsyncError[KyoSttpMonad.M] = KyoSttpMonad
         val runAsync                                 = KyoRunAsync(nettyServerOptions.forkExecution)
         NettyServerInterpreter.toRoute(
             ses,

--- a/kyo-tapir/src/main/scala/kyo/server/internal/NettyKyoRequestBody.scala
+++ b/kyo-tapir/src/main/scala/kyo/server/internal/NettyKyoRequestBody.scala
@@ -17,7 +17,7 @@ private[netty] class NettyKyoRequestBody(val createFile: ServerRequest => KyoStt
     extends NettyRequestBody[KyoSttpMonad.M, NoStreams]:
 
     override val streams: capabilities.Streams[NoStreams] = NoStreams
-    override given monad: MonadError[KyoSttpMonad.M]      = KyoSttpMonad.instance
+    override given monad: MonadError[KyoSttpMonad.M]      = KyoSttpMonad
 
     override def publisherToBytes(
         publisher: Publisher[HttpContent],


### PR DESCRIPTION
Scala 3 automatically uses a `lazy val` in the desugaring of `given` statements. This isn't a major optimization but it avoids the `lazy val` by using `inline`. 