### PR TITLE
scheduler: ensure workers stop when inactivated

### DIFF
--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -176,7 +176,7 @@ final class Scheduler(
 
     private def ensureWorkers() =
         for (idx <- allocatedWorkers until currentWorkers) {
-            workers(idx) = new Worker(idx, pool, schedule, steal, () => cycles, clock)
+            workers(idx) = new Worker(idx, _ >= currentWorkers, pool, schedule, steal, () => cycles, clock)
             allocatedWorkers += 1
         }
 


### PR DESCRIPTION
Kyo's concurrency regulator can reduce concurrency and make workers inactive. Inactive workers are automatically drained in multiple code paths and don't receive new workload but, if a worker has a long-running task, it can continue running until it finishes. This change makes workers exit as soon as possible.