### PR TITLE
avoid `core.eval` for error handling

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -36,10 +36,7 @@ sealed trait IOs extends Effect[IOs]:
         }
 
     def attempt[T, S](v: => T < S): Try[T] < S =
-        core.catching(v.map(Success(_): Try[T])) {
-            case ex if NonFatal(ex) =>
-                Failure(ex)
-        }
+        core.catching(v.map(Success(_): Try[T]))(Failure(_))
 
     def catching[T, S, U >: T, S2](v: => T < S)(
         pf: PartialFunction[Throwable, U < S2]

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -36,22 +36,15 @@ sealed trait IOs extends Effect[IOs]:
         }
 
     def attempt[T, S](v: => T < S): Try[T] < S =
-        eval(v.map(Success(_): Try[T]))((s, k) =>
-            try k()
-            catch
-                case ex if NonFatal(ex) =>
-                    Failure(ex)
-        )
+        core.catching(v.map(Success(_): Try[T])) {
+            case ex if NonFatal(ex) =>
+                Failure(ex)
+        }
 
     def catching[T, S, U >: T, S2](v: => T < S)(
         pf: PartialFunction[Throwable, U < S2]
     ): U < (S & S2) =
-        eval(v: U < (S & S2))((s, k) =>
-            try k()
-            catch
-                case ex if NonFatal(ex) && pf.isDefinedAt(ex) =>
-                    pf(ex)
-        )
+        core.catching(v)(pf)
 
     def run[T: Flat](v: T < IOs): T =
         @tailrec def runLoop(v: T < IOs): T =


### PR DESCRIPTION
This is the main cause of the regression in https://github.com/getkyo/kyo/issues/347. The `eval` method introduces much more overhead than the previous dedicated loop. The issue is that function applications don't get inlined and producing a thunk to provide to `resume` introduces more indirection, preventing JIT optimizations.

I'll post benchmark results tomorrow.