### PR TITLE
kyo-sttp: backend meter

### DIFF
--- a/kyo-sttp/shared/src/main/scala/kyo/requests.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/requests.scala
@@ -8,7 +8,15 @@ opaque type Requests <: Fibers = Fibers
 object Requests:
 
     abstract class Backend:
+        self =>
+
         def send[T](r: Request[T, Any]): Response[T] < Fibers
+
+        def withMeter(m: Meter): Backend =
+            new Backend:
+                def send[T](r: Request[T, Any]) =
+                    m.run(self.send(r))
+    end Backend
 
     private val local = Locals.init[Backend](PlatformBackend.default)
 

--- a/kyo-sttp/shared/src/test/scala/kyoTest/requestsTest.scala
+++ b/kyo-sttp/shared/src/test/scala/kyoTest/requestsTest.scala
@@ -47,4 +47,23 @@ class requestsTest extends KyoTest:
             }.map(_.get)
         }
     }
+    "with meter" in run {
+        var calls = 0
+        val meter = new Meter:
+            def available                 = ???
+            def tryRun[T, S](v: => T < S) = ???
+            def run[T, S](v: => T < S) =
+                calls += 1
+                v
+        val backend = (new TestBackend).withMeter(meter)
+        Requests.run(backend) {
+            Fibers.init {
+                for
+                    r <- Requests[String](_.get(uri"https://httpbin.org/get"))
+                yield
+                    assert(r == "mocked")
+                    assert(calls == 1)
+            }.map(_.get)
+        }
+    }
 end requestsTest


### PR DESCRIPTION
Provides an API to limit the use of the backend with a `Meter`. I need this feature because Kyo is overloading the test http server in benchmarks with the latest optimizations.