### PR TITLE
kyo-benchs: migrate TestHttpServer to Vert.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -291,6 +291,8 @@ lazy val `kyo-bench` =
             libraryDependencies += "org.http4s"          %% "http4s-ember-client" % "0.23.27",
             libraryDependencies += "org.http4s"          %% "http4s-dsl"          % "0.23.27",
             libraryDependencies += "dev.zio"             %% "zio-http"            % "3.0.0-RC6",
+            libraryDependencies += "io.vertx"             % "vertx-core"          % "4.5.7",
+            libraryDependencies += "io.vertx"             % "vertx-web"           % "4.5.7",
             libraryDependencies += "org.scalatest"       %% "scalatest"           % "3.2.16" % Test
         )
 

--- a/kyo-bench/src/main/scala/kyo/bench/HttpClientBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/HttpClientBench.scala
@@ -4,8 +4,7 @@ import org.http4s.ember.client.EmberClientBuilder
 
 class HttpClientBench extends Bench.ForkOnly("pong"):
 
-    val port = 9999
-    val url  = TestHttpServer.start(port)
+    val url = TestHttpServer.start(1)
 
     lazy val catsClient =
         import cats.effect.*

--- a/kyo-bench/src/main/scala/kyo/bench/HttpClientContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/HttpClientContentionBench.scala
@@ -5,9 +5,8 @@ import org.http4s.ember.client.EmberClientBuilder
 class HttpClientContentionBench
     extends Bench.ForkOnly(Seq.fill(Runtime.getRuntime().availableProcessors())("pong")):
 
-    val port        = 9999
     val concurrency = Runtime.getRuntime().availableProcessors()
-    val url         = TestHttpServer.start(port)
+    val url         = TestHttpServer.start(concurrency)
 
     lazy val catsClient =
         import cats.effect.*

--- a/kyo-bench/src/main/scala/kyo/bench/HttpClientRaceContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/HttpClientRaceContentionBench.scala
@@ -5,9 +5,8 @@ import org.http4s.ember.client.EmberClientBuilder
 class HttpClientRaceContentionBench
     extends Bench.ForkOnly("pong"):
 
-    val port        = 9999
     val concurrency = 100
-    val url         = TestHttpServer.start(port)
+    val url         = TestHttpServer.start(concurrency)
 
     lazy val catsClient =
         import cats.effect.*
@@ -55,7 +54,7 @@ class HttpClientRaceContentionBench
     override def kyoBenchFiber() =
         import kyo.*
 
-        Fibers.race(Seq.fill(concurrency)(Requests.run(Requests[String](_.get(kyoUrl)))))
+        Fibers.race(Seq.fill(concurrency)(Requests.run(kyoClient)(Requests[String](_.get(kyoUrl)))))
     end kyoBenchFiber
 
     val zioUrl =

--- a/kyo-bench/src/main/scala/kyo/bench/TestHttpServer.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TestHttpServer.scala
@@ -1,64 +1,113 @@
 package kyo.bench
 
-import com.sun.net.httpserver.HttpExchange
-import com.sun.net.httpserver.HttpHandler
-import com.sun.net.httpserver.HttpServer
-import java.io.OutputStream
-import java.net.InetSocketAddress
-import java.util.concurrent.locks.LockSupport
+import io.vertx.core.AbstractVerticle
+import io.vertx.core.DeploymentOptions
+import io.vertx.core.Vertx
+import io.vertx.core.http.HttpServer
+import io.vertx.core.http.HttpServerOptions
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.PrintStream
+import java.io.PrintWriter
+import scala.util.control.NonFatal
 
 object TestHttpServer:
+    val port = 8888
 
     trait StopServer:
         def apply(): Unit
 
-    def log(port: Int, msg: String) =
-        println(s"TestHttpServer(port=$port): $msg")
+    def log(port: Int, msg: String) = println(s"TestHttpServer(port=$port): $msg")
 
-    def start(port: Int): String =
+    def start(concurrency: Int): String =
         val javaBin   = System.getProperty("java.home") + "/bin/java"
         val classpath = System.getProperty("java.class.path")
-        val command   = List(javaBin, "-cp", classpath, "kyo.bench.TestHttpServer", port.toString)
+        val command   = List(javaBin, "-cp", classpath, "kyo.bench.TestHttpServer", concurrency.toString)
         val builder   = new ProcessBuilder(command*)
-        builder.redirectOutput(ProcessBuilder.Redirect.INHERIT)
-        builder.redirectError(ProcessBuilder.Redirect.INHERIT)
-        builder.redirectErrorStream(true)
         try
             log(port, "forking")
             val process = builder.start()
-            val stopServer: StopServer =
-                () =>
-                    log(port, "stopping")
-                    process.destroy()
+            val stopServer: StopServer = () =>
+                log(port, "stopping")
+                process.destroy()
             Runtime.getRuntime().addShutdownHook(new Thread:
-                override def run(): Unit =
-                    stopServer()
+                override def run(): Unit = stopServer()
             )
+            redirect(process.getInputStream, System.out)
+            redirect(process.getErrorStream, System.err)
             s"http://localhost:$port/ping"
         finally
             log(port, "forked")
         end try
     end start
 
-    def main(args: Array[String]): Unit =
-        val port = if args.isEmpty then 9999 else args(0).toInt
-        log(port, "starting")
-        val server = HttpServer.create(new InetSocketAddress("0.0.0.0", port), 0)
-        server.createContext(
-            "/ping",
-            new HttpHandler:
-                val response = "pong".getBytes()
-                override def handle(exchange: HttpExchange): Unit =
-                    exchange.sendResponseHeaders(200, response.length)
-                    val os: OutputStream = exchange.getResponseBody
-                    os.write(response)
-                    os.close()
-                end handle
+    def redirect(inputStream: InputStream, outputStream: PrintStream): Unit =
+        val thread = new Thread(new Runnable:
+            def run(): Unit =
+                val reader       = new BufferedReader(new InputStreamReader(inputStream))
+                val writer       = new PrintWriter(outputStream)
+                var line: String = null
+                while { line = reader.readLine(); line != null } do
+                    writer.println(s"[TestHttpServer] $line")
+                    writer.flush()
+            end run
         )
-        server.setExecutor(null)
-        server.start()
-        log(port, "started")
-        try LockSupport.park()
-        finally log(port, "stopped")
+        thread.setDaemon(true)
+        thread.start()
+    end redirect
+
+    class PingVerticle extends AbstractVerticle:
+        override def start(): Unit =
+            val serverOptions = new HttpServerOptions()
+                .setMaxInitialLineLength(8192)
+                .setMaxHeaderSize(8192)
+                .setMaxChunkSize(8192)
+                .setIdleTimeout(0)
+                .setTcpKeepAlive(true)
+
+            val server: HttpServer = vertx.createHttpServer(serverOptions)
+            server.requestHandler { request =>
+                val response = request.response()
+                try
+                    response.setStatusCode(200)
+                    response.putHeader("Content-Type", "text/plain")
+                    response.end("pong")
+                catch
+                    case ex if NonFatal(ex) =>
+                        log(port, s"Error handling request: ${ex.getClass}")
+                        try
+                            response.reset(500)
+                        catch
+                            case e if NonFatal(e) =>
+                                log(port, s"Error closing response: ${e.getClass}")
+                        end try
+                end try
+                ()
+            }.listen(port).andThen { result =>
+                if !result.succeeded then
+                    log(port, s"Failed to start server: ${result.cause}")
+            }
+            ()
+        end start
+    end PingVerticle
+
+    def main(args: Array[String]): Unit =
+        val concurrency = args(0).toInt
+        log(port, "starting")
+        val vertx   = Vertx.vertx()
+        val options = new DeploymentOptions().setInstances(concurrency)
+        vertx.deployVerticle(classOf[PingVerticle], options).andThen { result =>
+            if result.succeeded then
+                log(port, s"Deployed ${result.result}")
+            else
+                log(port, s"Deployment failed: ${result.cause}")
+        }
+        try
+            java.util.concurrent.locks.LockSupport.park()
+        finally
+            log(port, "stopped")
+        end try
     end main
+
 end TestHttpServer


### PR DESCRIPTION
The Java server became a bottleneck in the http contention benchmarks. This PR migrates it to Vert.x since it's highly optimized. We can't use `kyo-tapir` since it'd be difficult to distinguish between performance changes in the client vs server.