### PR TITLE
http race contention bench: use a meter to avoid overloading the http server

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/HttpClientRaceContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/HttpClientRaceContentionBench.scala
@@ -45,7 +45,7 @@ class HttpClientRaceContentionBench
 
     lazy val kyoClient =
         import kyo.*
-        PlatformBackend.default
+        IOs.run(Meters.initSemaphore(5).map(PlatformBackend.default.withMeter))
 
     val kyoUrl =
         import sttp.client3.*


### PR DESCRIPTION
Fixes https://github.com/getkyo/kyo/issues/347.

This is the last PR to fix the regression we identified in the last release. [Benchmark results](https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fwbrasil/27c8abec86e947e9719d41a859deb5d2/raw/814ca4ebb3a1294f8dd7bbec9b54ea0957b92434/jmh-result.json):

![image](https://github.com/getkyo/kyo/assets/831175/af276b25-0e3c-422e-9a72-eb1f7c3596b4)

@hearnadam EasyRacer might also need a meter to avoid overloading the server.
