### PR TITLE
scheduler: minor optimizations

### DIFF
--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -176,7 +176,11 @@ final class Scheduler(
 
     private def ensureWorkers() =
         for (idx <- allocatedWorkers until currentWorkers) {
-            workers(idx) = new Worker(idx, _ >= currentWorkers, pool, schedule, steal, () => cycles, clock)
+            workers(idx) =
+                new Worker(idx, pool, schedule, steal, clock) {
+                    def shouldStop(): Boolean   = idx >= currentWorkers
+                    def getCurrentCycle(): Long = cycles
+                }
             allocatedWorkers += 1
         }
 

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Worker.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Worker.scala
@@ -8,17 +8,18 @@ import java.util.concurrent.atomic.LongAdder
 import kyo.stats.internal.MetricReceiver
 import scala.util.control.NonFatal
 
-final private class Worker(
+abstract private class Worker(
     id: Int,
-    stop: Int => Boolean,
     exec: Executor,
     scheduleTask: (Task, Worker) => Unit,
     stealTask: Worker => Task,
-    getCurrentCycle: () => Long,
     clock: InternalClock
 ) extends Runnable {
 
     import Worker.internal.*
+
+    protected def shouldStop(): Boolean
+    protected def getCurrentCycle(): Long
 
     val a1, a2, a3, a4, a5, a6, a7 = 0L // padding
 
@@ -138,7 +139,7 @@ final private class Worker(
                     return
                 }
             }
-            if (stop(id)) {
+            if (shouldStop()) {
                 running = false
                 if (task != null) schedule(task)
                 drain()

--- a/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/WorkerTest.scala
+++ b/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/WorkerTest.scala
@@ -22,10 +22,13 @@ class WorkerTest extends AnyFreeSpec with NonImplicitAssertions {
         scheduleTask: (Task, Worker) => Unit = (_, _) => ???,
         stop: () => Boolean = () => false,
         stealTask: Worker => Task = _ => null,
-        getCurrentCycle: () => Long = () => 0
+        currentCycle: () => Long = () => 0
     ): Worker = {
         val clock = InternalClock(executor)
-        new Worker(0, _ => stop(), executor, scheduleTask, stealTask, getCurrentCycle, clock)
+        new Worker(0, executor, scheduleTask, stealTask, clock) {
+            def getCurrentCycle() = currentCycle()
+            def shouldStop()      = stop()
+        }
     }
 
     "enqueue" - {
@@ -170,7 +173,7 @@ class WorkerTest extends AnyFreeSpec with NonImplicitAssertions {
         }
 
         "executing a task that gets preempted" in {
-            val worker      = createWorker(getCurrentCycle = () => 1)
+            val worker      = createWorker(currentCycle = () => 1)
             var preemptions = 0
             val task = TestTask(
                 _run = () =>


### PR DESCRIPTION
I'm working on tracking down the regression in ZIO's benchmarks when I enable the option use Kyo's scheduler and noticed a couple of minor optimization opportunities. There isn't a significant change in benchmark results but I think it's worth it since things can change over time.