### PR TITLE
kyo-scheduler-zio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Build JVM
       run: |
-        sbt 'kyo-bench/test' 'kyo-cache/test' '+kyo-scheduler/test' 'kyo-core/test' 'kyo-direct/test' 'kyo-test/test' 'kyo-zio/test' 'kyo-examples/test' 'kyo-os-lib/test' 'kyo-stats-otel/test' 'kyo-sttp/test' 'kyo-tapir/test'
+        sbt 'kyo-bench/test' 'kyo-cache/test' '+kyo-scheduler/test' '+kyo-scheduler-zio/test' 'kyo-core/test' 'kyo-direct/test' 'kyo-test/test' 'kyo-zio/test' 'kyo-examples/test' 'kyo-os-lib/test' 'kyo-stats-otel/test' 'kyo-sttp/test' 'kyo-tapir/test'
 
     - name: Build JS
       run: |

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -17,7 +17,7 @@ indent.main = 4
 indent.callSite = 4
 newlines.source = keep
 fileOverride {
-  "glob:**/kyo-scheduler/**" {
+  "glob:**/kyo-scheduler*/**" {
     runner.dialect = scala212source3
   }
 } 

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val kyo =
             `kyo-settings`
         ).aggregate(
             `kyo-scheduler`,
+            `kyo-scheduler-zio`,
             `kyo-tag`,
             `kyo-core`,
             `kyo-direct`,
@@ -94,6 +95,25 @@ lazy val `kyo-scheduler` =
             libraryDependencies += "ch.qos.logback"  % "logback-classic" % "1.5.5"  % Test
         )
         .jsSettings(`js-settings`)
+
+lazy val `kyo-scheduler-zio` =
+    crossProject(JVMPlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-scheduler-zio"))
+        .dependsOn(`kyo-scheduler`)
+        .settings(
+            `kyo-settings`,
+            scalacOptions --= Seq(
+                "-Wvalue-discard",
+                "-Wunused:all",
+                "-language:strictEquality"
+            ),
+            scalacOptions += "-Xsource:3",
+            libraryDependencies += "dev.zio"       %%% "zio"       % "2.1.1",
+            libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.16" % Test,
+            crossScalaVersions                      := List(scala3Version, scala212Version, scala213Version)
+        )
 
 lazy val `kyo-tag` =
     crossProject(JSPlatform, JVMPlatform)
@@ -252,6 +272,7 @@ lazy val `kyo-bench` =
         .enablePlugins(JmhPlugin)
         .dependsOn(`kyo-core`)
         .dependsOn(`kyo-sttp`)
+        .dependsOn(`kyo-scheduler-zio`)
         .settings(
             `kyo-settings`,
             // Forks each test suite individually

--- a/kyo-scheduler-zio/jvm/src/main/scala/kyo/KyoSchedulerRuntime.scala
+++ b/kyo-scheduler-zio/jvm/src/main/scala/kyo/KyoSchedulerRuntime.scala
@@ -1,0 +1,31 @@
+package kyo
+
+import kyo.scheduler.*
+import zio.*
+import zio.internal.ExecutionMetrics
+import zio.internal.FiberRuntime
+
+object KyoSchedulerRuntime {
+
+    lazy val default: Runtime[Any] = {
+        val exec =
+            new Executor {
+                val scheduler =
+                    kyo.scheduler.Scheduler.get
+                def metrics(implicit unsafe: Unsafe): Option[ExecutionMetrics] = None
+                def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean = {
+                    scheduler.schedule(kyo.scheduler.Task(runnable.run()))
+                    true
+                }
+            }
+        Unsafe.unsafe { implicit u =>
+            Runtime.default.unsafe.run {
+                for {
+                    scope   <- Scope.make
+                    env     <- (Runtime.setExecutor(exec) ++ Runtime.setBlockingExecutor(exec)).build(scope)
+                    runtime <- ZIO.runtime[Any].provideEnvironment(env)
+                } yield runtime
+            }.getOrThrowFiberFailure()
+        }
+    }
+}

--- a/kyo-scheduler-zio/jvm/src/test/scala/kyo/KyoSchedulerRuntimeTest.scala
+++ b/kyo-scheduler-zio/jvm/src/test/scala/kyo/KyoSchedulerRuntimeTest.scala
@@ -1,0 +1,15 @@
+package kyo
+
+import org.scalatest.freespec.AsyncFreeSpec
+import zio.*
+
+class KyoSchedulerRuntimeTest extends AsyncFreeSpec {
+
+    "run" in {
+        Unsafe.unsafe { implicit u =>
+            val io     = ZIO.succeed(Thread.currentThread().getName()).fork.flatMap(_.join)
+            val thread = KyoSchedulerRuntime.default.unsafe.run(io).getOrThrow()
+            assert(thread.contains("kyo"))
+        }
+    }
+}


### PR DESCRIPTION
Provides a module integrating Kyo's scheduler as an alternative for `ZScheduler` in ZIO applications.