### PR TITLE
Experimental Aborts.fold handler

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/aborts.scala
+++ b/kyo-core/shared/src/main/scala/kyo/aborts.scala
@@ -35,7 +35,7 @@ object Aborts:
 
     def run[V]: RunDsl[V] = RunDsl[V]
 
-    def fold[T](default: T): Fold[T] = Fold[T](default)
+    def fold[V, T](default: T): Fold[V, T] = Fold[V, T](default)
 
     class CatchingDsl[V <: Throwable]:
         def apply[T: Flat, S](v: => T < S)(
@@ -52,10 +52,10 @@ object Aborts:
 
         // TODO: Can this extend AnyVal? Requires ResultHandler to be a `trait`
         // TODO: is this type safe?
-        class Fold[T](default: T) extends ResultHandler[ClassTag[?], DoAbort.Command, DoAbort, Const[Any], Any]:
-            def apply[V, S, VS, VR](v: T < (Aborts[VS] & S))(
+        class Fold[V, T](default: T) extends ResultHandler[ClassTag[?], DoAbort.Command, DoAbort, Const[Any], Any]:
+            def apply[S, VS, VR](v: (T | Nothing) < (Aborts[VS] & S))(
                 using
-                f: Flat[T],
+                f: Flat[T | Nothing],
                 h: HasAborts[V, VS] { type Remainder = VR },
                 ct: ClassTag[V]
             ): T < (VR & S) =

--- a/kyo-core/shared/src/main/scala/kyo/aborts.scala
+++ b/kyo-core/shared/src/main/scala/kyo/aborts.scala
@@ -52,10 +52,10 @@ object Aborts:
 
         // TODO: Can this extend AnyVal? Requires ResultHandler to be a `trait`
         // TODO: is this type safe?
-        class Fold[T](default: T) extends ResultHandler[ClassTag[?], Const[Any], DoAbort, Const[Any], Any]:
+        class Fold[T](default: T) extends ResultHandler[ClassTag[?], DoAbort.Command, DoAbort, Const[Any], Any]:
             def apply[V, S, VS, VR](v: T < (Aborts[VS] & S))(
                 using
-                ev: Flat[T],
+                f: Flat[T],
                 h: HasAborts[V, VS] { type Remainder = VR },
                 ct: ClassTag[V]
             ): T < (VR & S) =
@@ -66,13 +66,13 @@ object Aborts:
                 type V
                 given ClassTag[V] = st.asInstanceOf[ClassTag[V]]
                 command match
-                    case v: V => true
+                    case _: V => true
                     case _    => false
                 end match
             end accepts
 
             def resume[T0, U: Flat, S2](st: ClassTag[?], command: Any, k: T0 => U < (DoAbort & S2))(using Tag[DoAbort]) =
-                default.asInstanceOf[T0]
+                default
         end Fold
 
         val handler =

--- a/kyo-core/shared/src/test/scala/kyoTest/abortsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/abortsTest.scala
@@ -257,6 +257,21 @@ class abortsTest extends KyoTest:
                 assert(Aborts.fold("Fold!")(fail(false)).pure == "Success!")
                 assert(Aborts.fold("Fold!")(fail(true)).pure == "Fold!")
             }
+            "incremental" in {
+                def fail(b: Boolean): Int < (Aborts[Boolean] & Aborts[String]) =
+                    Aborts.when(b)("Fail!")
+                        .andThen(Aborts.when(!b)(false))
+                        .andThen(-1)
+
+                def fold(b: Boolean): Int =
+                    val s: Int < Aborts[Boolean] = Aborts.fold[String, Int](1)(fail(b))
+                    val i: Int < Any             = Aborts.fold[Boolean, Int](2)(s)
+                    i.pure
+                end fold
+
+                assert(fold(true) == 1)
+                assert(fold(false) == 2)
+            }
         }
         "fail" in {
             val ex: Throwable = new Exception("throwable failure")


### PR DESCRIPTION
A little handler experiment I am working on to understand handlers deeper.

I am concerned that this will cause a too high of allocation rate, but I intentionally used extension to enable users to potentially avoid this...

Consider something like:
```scala

val FoldResponse = Aborts.fold(HttpResponse.default)
...

FoldResponse(v)
```