### PR TITLE
avoid implicit conversions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,6 @@ val compilerOptions = Seq(
     "-feature",
     "-unchecked",
     "-deprecation",
-    "-language:implicitConversions",
     "-Wvalue-discard",
     "-Wunused:all",
     "-language:strictEquality"

--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -241,7 +241,7 @@ object core:
             val tag     = s.tag
         end Continue
 
-        implicit inline def fromKyo[T, S](v: Kyo[T, S]): T < S =
-            v.asInstanceOf[T < S]
+        inline def fromKyo[T, S](inline v: Kyo[T, S]): T < S =
+            v
     end internal
 end core

--- a/kyo-core/shared/src/main/scala/kyo/defers.scala
+++ b/kyo-core/shared/src/main/scala/kyo/defers.scala
@@ -13,8 +13,10 @@ class Defers extends Effect[Defers]:
 object Defers extends Defers:
 
     inline def apply[T, S](inline v: => T < S): T < (S & Defers) =
-        new Defer[T, S]:
-            def apply(ign: Unit, s: Safepoint[S & Defers], l: Locals.State): T < S = v
+        fromKyo {
+            new Defer[T, S]:
+                def apply(ign: Unit, s: Safepoint[S & Defers], l: Locals.State): T < S = v
+        }
 
     def run[T: Flat, S](v: T < (Defers & S)): T < S =
         this.handle(handler)((), v)

--- a/kyo-core/shared/src/main/scala/kyo/internal/Param.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/Param.scala
@@ -1,6 +1,7 @@
 package kyo.internal
 
 import scala.collection.mutable.LinkedHashMap
+import scala.language.implicitConversions
 import scala.quoted.*
 
 case class Param[T](code: String, value: T) derives CanEqual

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -17,9 +17,11 @@ sealed trait IOs extends Effect[IOs]:
     inline def apply[T, S](
         inline f: => T < (IOs & S)
     ): T < (IOs & S) =
-        new KyoIO[T, S]:
-            def apply(v: Unit, s: Safepoint[IOs & S], l: Locals.State) =
-                f
+        fromKyo {
+            new KyoIO[T, S]:
+                def apply(v: Unit, s: Safepoint[IOs & S], l: Locals.State) =
+                    f
+        }
 
     def fail[T](ex: Throwable): T < IOs =
         IOs(throw ex)
@@ -63,9 +65,11 @@ sealed trait IOs extends Effect[IOs]:
                         runLazyLoop(k(()))
                     else
                         val k = kyo.asInstanceOf[Suspend[MX, Any, T, S & IOs]]
-                        new Continue[MX, Any, T, S](k):
-                            def apply(v: Any, s: Safepoint[S], l: Locals.State) =
-                                runLazyLoop(k(v, s, l))
+                        fromKyo {
+                            new Continue[MX, Any, T, S](k):
+                                def apply(v: Any, s: Safepoint[S], l: Locals.State) =
+                                    runLazyLoop(k(v, s, l))
+                        }
                 case _ =>
                     v.asInstanceOf[T]
             end match

--- a/kyo-core/shared/src/test/scala/kyoTest/KyoTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/KyoTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.concurrent.ScalaFutures.*
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.language.implicitConversions
 import scala.util.Try
 
 class KyoTest extends AsyncFreeSpec with NonImplicitAssertions:

--- a/kyo-core/shared/src/test/scala/kyoTest/internal/PositionTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/internal/PositionTest.scala
@@ -24,7 +24,7 @@ class PositionTest extends KyoTest:
         assert(e == "PositionTest.scala:21 - ")
     }
     "WithOwner" - {
-        import Position.WithOwner.given Position
+        inline given Position = Position.WithOwner.derive
 
         "implicitly" in {
             val f = implicitly[Position]


### PR DESCRIPTION
Implicit conversions might end up getting removed from the language. Kyo has very little use for them but the compiler option enabling the feature is set globally, which can end up leading to more implicit conversions getting introduced into the codebase, which could make a migration to new Scala versions more challenging.

This PR disables the feature globally by default.