### PR TITLE
Make kyo build with Intellij (#138)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import sys.process.*
-
 val scala3Version   = "3.4.2"
 val scala212Version = "2.12.19"
 val scala213Version = "2.13.14"
@@ -17,7 +15,7 @@ val compilerOptions = Seq(
     "-language:strictEquality"
 )
 
-scalaVersion                       := scala3Version
+ThisBuild / scalaVersion           := scala3Version
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 sonatypeRepository                 := "https://s01.oss.sonatype.org/service/local"
 sonatypeProfileName                := "io.getkyo"
@@ -97,11 +95,10 @@ lazy val `kyo-scheduler` =
         )
         .jsSettings(`js-settings`)
 
-lazy val `kyo-scheduler-zio` =
-    crossProject(JVMPlatform)
+def `kyo-scheduler-zio-base` =
+    sbtcrossproject.CrossProject("kyo-scheduler-zio", file("kyo-scheduler-zio"))(JVMPlatform)
         .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
-        .in(file("kyo-scheduler-zio"))
         .dependsOn(`kyo-scheduler`)
         .settings(
             `kyo-settings`,
@@ -110,11 +107,18 @@ lazy val `kyo-scheduler-zio` =
                 "-Wunused:all",
                 "-language:strictEquality"
             ),
-            scalacOptions += "-Xsource:3",
             libraryDependencies += "dev.zio"       %%% "zio"       % zioVersion,
-            libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.16" % Test,
-            crossScalaVersions                      := List(scala3Version, scala212Version, scala213Version)
+            libraryDependencies += "org.scalatest" %%% "scalatest" % "3.2.16" % Test
         )
+
+lazy val `kyo-scheduler-zio-3` = `kyo-scheduler-zio-base`.settings(
+    crossScalaVersions := List(scala3Version)
+)
+
+lazy val `kyo-scheduler-zio` = `kyo-scheduler-zio-base`.settings(
+    scalacOptions += "-Xsource:3",
+    crossScalaVersions := List(scala3Version, scala212Version, scala213Version)
+)
 
 lazy val `kyo-tag` =
     crossProject(JSPlatform, JVMPlatform)
@@ -273,7 +277,7 @@ lazy val `kyo-bench` =
         .enablePlugins(JmhPlugin)
         .dependsOn(`kyo-core`)
         .dependsOn(`kyo-sttp`)
-        .dependsOn(`kyo-scheduler-zio`)
+        .dependsOn(`kyo-scheduler-zio-3`)
         .settings(
             `kyo-settings`,
             // Forks each test suite individually
@@ -281,7 +285,6 @@ lazy val `kyo-bench` =
                 val javaOptionsValue = javaOptions.value.toVector
                 val envsVarsValue    = envVars.value
                 (Test / definedTests).value map { test =>
-                    import sbt.dsl.LinterLevel.Ignore
                     Tests.Group(
                         name = test.name,
                         tests = Seq(test),
@@ -356,5 +359,5 @@ lazy val `js-settings` = Seq(
     Compile / doc / sources                     := Seq.empty,
     fork                                        := false,
     jsEnv                                       := new NodeJSEnv(NodeJSEnv.Config().withArgs(List("--max_old_space_size=5120"))),
-    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.5.0"
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.5.0" % "provided"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ lazy val `kyo-scheduler-zio-3` = `kyo-scheduler-zio-base`.settings(
 )
 
 lazy val `kyo-scheduler-zio` = `kyo-scheduler-zio-base`.settings(
-    scalacOptions += "-Xsource:3",
+    scalacOptions ++= (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 3)) Seq("-Xsource:3") else Nil),
     crossScalaVersions := List(scala3Version, scala212Version, scala213Version)
 )
 

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/InternalClock.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/InternalClock.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.locks.LockSupport
 import kyo.stats.internal.MetricReceiver
 
-final private case class InternalClock(executor: Executor) {
+final case class InternalClock(executor: Executor) {
 
     @volatile private var _stop = false
 

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/InternalClock.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/InternalClock.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.locks.LockSupport
 import kyo.stats.internal.MetricReceiver
 
-final case class InternalClock(executor: Executor) {
+final private[kyo] case class InternalClock(executor: Executor) {
 
     @volatile private var _stop = false
 


### PR DESCRIPTION
The removal of private is not 100% necessary, but intellij load cross projects by default as Scala 2. And when compiling Scala 2 it fails with an error that the class is exposed via a public method but it self is private. Which is actually a smell I guess.
Maybe both should be package private?

fixes #138 
/claim #138