### PR TITLE
blocking benchmarks

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/BlockingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/BlockingBench.scala
@@ -1,0 +1,27 @@
+package kyo.bench
+
+import java.util.concurrent.locks.LockSupport
+
+class BlockingBench extends Bench.ForkOnly(()):
+
+    def block(): Unit =
+        LockSupport.parkNanos(100000) // 0.1 ms
+
+    override def kyoBenchFiber() =
+        import kyo.*
+
+        IOs(block())
+    end kyoBenchFiber
+
+    def catsBench() =
+        import cats.effect.*
+
+        IO.blocking(block())
+    end catsBench
+
+    def zioBench() =
+        import zio.*
+
+        ZIO.attemptBlocking(block()).orDie
+    end zioBench
+end BlockingBench

--- a/kyo-bench/src/main/scala/kyo/bench/BlockingContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/BlockingContentionBench.scala
@@ -1,0 +1,31 @@
+package kyo.bench
+
+import java.util.concurrent.locks.LockSupport
+
+class BlockingContentionBench extends Bench.ForkOnly(()):
+
+    val concurrency = Runtime.getRuntime().availableProcessors() * 10
+
+    def block(): Unit =
+        LockSupport.parkNanos(100000) // 0.1 ms
+
+    override def kyoBenchFiber() =
+        import kyo.*
+
+        Fibers.parallel(Seq.fill(concurrency)(IOs(block()))).unit
+    end kyoBenchFiber
+
+    def catsBench() =
+        import cats.effect.*
+        import cats.implicits.*
+
+        Seq.fill(concurrency)(IO.blocking(block())).parSequence.void
+    end catsBench
+
+    def zioBench() =
+        import zio.*
+
+        ZIO.collectAll(Seq.fill(concurrency)(ZIO.blocking(ZIO.succeed(block())).forkDaemon)).flatMap(ZIO.foreach(_)(_.join)).unit
+    end zioBench
+
+end BlockingContentionBench


### PR DESCRIPTION
I'm testing the scheduler's scalability and noticed an issue with how it handles blocking. The main issue is the `schedule` method draining blocked workers over and over.

I'm adding these benchmarks to guide the optimization. Current results:

![image](https://github.com/getkyo/kyo/assets/831175/c8ddda06-b498-4457-9583-9ae794212b6a)
https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fwbrasil/5d0d73efeb75e2ed6f5edb0b5a47bdac/raw/c8773ddbecc1c66f378af2852e326968d604e2dd/jmh-result.json