### PR TITLE
use: scala-js-macrotask-executor as ExecutionContext

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,10 @@ lazy val `kyo-scheduler` =
             libraryDependencies += "org.scalatest" %%% "scalatest"       % "3.2.16" % Test,
             libraryDependencies += "ch.qos.logback"  % "logback-classic" % "1.5.5"  % Test
         )
-        .jsSettings(`js-settings`)
+        .jsSettings(
+            `js-settings`,
+            libraryDependencies += "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1",
+        )
 
 lazy val `kyo-scheduler-zio` =
     crossProject(JVMPlatform)

--- a/kyo-core/js/src/test/scala/kyoTest/Platform.scala
+++ b/kyo-core/js/src/test/scala/kyoTest/Platform.scala
@@ -1,7 +1,7 @@
 package kyoTest
 
 object Platform:
-    def executionContext        = scala.scalajs.concurrent.JSExecutionContext.queue
+    def executionContext        = org.scalajs.macrotaskexecutor.MacrotaskExecutor
     def isJVM: Boolean          = false
     def isJS: Boolean           = true
     def isDebugEnabled: Boolean = false

--- a/kyo-scheduler/js/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/js/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -1,6 +1,6 @@
 package kyo.scheduler
 
-import scala.scalajs.concurrent.JSExecutionContext
+import org.scalajs.macrotaskexecutor.MacrotaskExecutor
 
 object Scheduler {
     val get = new Scheduler
@@ -10,12 +10,11 @@ class Scheduler {
 
     private val clock = new InternalClock()
 
-    def schedule(t: Task): Unit = {
-        JSExecutionContext.queue.execute { () =>
+    def schedule(t: Task): Unit =
+        MacrotaskExecutor.execute { () =>
             if (t.run(clock.currentMillis(), clock) == Task.Preempted)
                 schedule(t)
         }
-    }
 
     def flush(): Unit = {}
 


### PR DESCRIPTION
/claims #302
/resolves #302 

re: your comment @fwbrasil 
- https://github.com/getkyo/kyo/issues/302#issuecomment-2107925967

I think the artifacts were not published for non-js targets after `1.1.0`. If we add this only under JS settings, all is well.

Regarding build time, I think that was a bug potentially having to do with adding the dependency for all targets. For a full clean + build of core, the build time is now 28s on my machine.

<img width="304" alt="Screenshot 2024-05-24 at 7 48 22 PM" src="https://github.com/getkyo/kyo/assets/22334119/550d0231-479f-4fe4-a93f-ba6e6cc95a68">

I also went ahead and updated this as the executor under kyoTest. Do you think we need a direct dependency under kyo-core? I think transitive should be okay...

