### PR TITLE
scheduler: dispatch java interrupts

### DIFF
--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -171,7 +171,7 @@ final class Scheduler(
     private def ensureWorkers() =
         for (idx <- allocatedWorkers until currentWorkers) {
             workers(idx) =
-                new Worker(idx, pool, schedule, steal, clock, timeSliceMs) {
+                new Worker(idx, pool, schedule, steal, clock, timeSliceMs, javaInterruptAfterMs) {
                     def shouldStop(): Boolean = idx >= currentWorkers
                 }
             allocatedWorkers += 1
@@ -257,22 +257,24 @@ object Scheduler {
         virtualizeWorkers: Boolean,
         timeSliceMs: Int,
         cycleNs: Int,
+        javaInterruptAfterMs: Int,
         enableTopJMX: Boolean,
         enableTopConsoleMs: Int
     )
     object Config {
         val default: Config = {
-            val cores             = Runtime.getRuntime().availableProcessors()
-            val coreWorkers       = Math.max(1, Flag("coreWorkers", cores * 10))
-            val minWorkers        = Math.max(1, Flag("minWorkers", coreWorkers.toDouble / 2).intValue())
-            val maxWorkers        = Math.max(minWorkers, Flag("maxWorkers", coreWorkers * 100))
-            val scheduleStride    = Math.max(1, Flag("scheduleStride", cores))
-            val stealStride       = Math.max(1, Flag("stealStride", cores * 4))
-            val virtualizeWorkers = Flag("virtualizeWorkers", false)
-            val timeSliceMs       = Flag("timeSliceMs", 10)
-            val cycleNs           = Flag("cycleNs", 100000)
-            val enableTopJMX      = Flag("enableTopJMX", true)
-            val enableTopConsole  = Flag("enableTopConsoleMs", 0)
+            val cores                = Runtime.getRuntime().availableProcessors()
+            val coreWorkers          = Math.max(1, Flag("coreWorkers", cores * 10))
+            val minWorkers           = Math.max(1, Flag("minWorkers", coreWorkers.toDouble / 2).intValue())
+            val maxWorkers           = Math.max(minWorkers, Flag("maxWorkers", coreWorkers * 100))
+            val scheduleStride       = Math.max(1, Flag("scheduleStride", cores))
+            val stealStride          = Math.max(1, Flag("stealStride", cores * 4))
+            val virtualizeWorkers    = Flag("virtualizeWorkers", false)
+            val timeSliceMs          = Flag("timeSliceMs", 10)
+            val cycleNs              = Flag("cycleNs", 100000)
+            val javaInterruptAfterMs = Flag("javaInterruptAfterMs", timeSliceMs * 4)
+            val enableTopJMX         = Flag("enableTopJMX", true)
+            val enableTopConsole     = Flag("enableTopConsoleMs", 0)
             Config(
                 cores,
                 coreWorkers,
@@ -283,6 +285,7 @@ object Scheduler {
                 virtualizeWorkers,
                 timeSliceMs,
                 cycleNs,
+                javaInterruptAfterMs,
                 enableTopJMX,
                 enableTopConsole
             )

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Worker.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Worker.scala
@@ -14,7 +14,8 @@ abstract private class Worker(
     scheduleTask: (Task, Worker) => Unit,
     stealTask: Worker => Task,
     clock: InternalClock,
-    timeSliceMs: Int
+    timeSliceMs: Int,
+    javaInterruptAfterMs: Int
 ) extends Runnable {
 
     import Worker.internal.*
@@ -84,6 +85,11 @@ abstract private class Worker(
         val stalled = (task ne null) && start > 0 && start < nowMs - timeSliceMs
         if (stalled) {
             task.doPreempt()
+            if (javaInterruptAfterMs > 0) {
+                val thread = mount
+                if (thread != null && (currentTask eq task) && start < nowMs - javaInterruptAfterMs && !thread.isInterrupted())
+                    thread.interrupt()
+            }
         }
         stalled
     }

--- a/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/SchedulerTest.scala
+++ b/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/SchedulerTest.scala
@@ -123,6 +123,19 @@ class SchedulerTest extends AnyFreeSpec with NonImplicitAssertions {
         }
     }
 
+    "dispatches java interrupt" in withScheduler { scheduler =>
+        val cdl = new CountDownLatch(1)
+        scheduler.schedule(TestTask(_run = () => {
+            try Thread.sleep(Int.MaxValue)
+            catch {
+                case ex: InterruptedException =>
+                    cdl.countDown()
+            }
+            Task.Done
+        }))
+        cdl.await()
+    }
+
     "asExecutor" - {
         "returns an executor that schedules tasks" in withScheduler { scheduler =>
             val executor = scheduler.asExecutor

--- a/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/WorkerTest.scala
+++ b/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/WorkerTest.scala
@@ -25,7 +25,7 @@ class WorkerTest extends AnyFreeSpec with NonImplicitAssertions {
         currentCycle: () => Long = () => 0
     ): Worker = {
         val clock = InternalClock(executor)
-        new Worker(0, executor, scheduleTask, stealTask, clock, 5) {
+        new Worker(0, executor, scheduleTask, stealTask, clock, 5, 20) {
             def getCurrentCycle() = currentCycle()
             def shouldStop()      = stop()
         }


### PR DESCRIPTION
When a worker gets blocked, Kyo's scheduler attempts to preempt the fiber but never dispatches a Java interrupt to the thread. This can be an issue in systems that rely on interruptions in blocking code since it can lead to significant accumulation of state, which can produce degradation.

I hadn't included this initially because Java interrupts are normally a headache but this seems to be a common practice in effect systems. In case of issues, it's also possible to disable the behavior by setting the config to `-1`.