### PR TITLE
kyo-tapir: fix netty future integration to consider Void completions

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/fibers.scala
+++ b/kyo-core/shared/src/main/scala/kyo/fibers.scala
@@ -104,7 +104,10 @@ case class Promise[T] private (private val p: IOPromise[T]) extends Fiber[T]:
         }
 
     def complete(v: T < IOs): Boolean < IOs =
+        if isNull(v) then
+            throw new NullPointerException("Can't complete a fiber with `null`.")
         IOs(p.complete(v))
+    end complete
 
     def become(other: Fiber[T]): Boolean < IOs =
         other match

--- a/kyo-core/shared/src/main/scala/kyo/fibers.scala
+++ b/kyo-core/shared/src/main/scala/kyo/fibers.scala
@@ -104,10 +104,7 @@ case class Promise[T] private (private val p: IOPromise[T]) extends Fiber[T]:
         }
 
     def complete(v: T < IOs): Boolean < IOs =
-        if isNull(v) then
-            throw new NullPointerException("Can't complete a fiber with `null`.")
         IOs(p.complete(v))
-    end complete
 
     def become(other: Fiber[T]): Boolean < IOs =
         other match

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -114,11 +114,16 @@ private[kyo] class IOPromise[T](state: State[T])
             true
         }
 
+    private val nullCompletion = IOs(null)
+
     final def complete(v: T < IOs): Boolean =
+        val r =
+            if !isNull(v) then v
+            else nullCompletion.asInstanceOf[T < IOs]
         @tailrec def loop(): Boolean =
             get() match
                 case p: Pending[T] @unchecked =>
-                    complete(p, v) || loop()
+                    complete(p, r) || loop()
                 case _ =>
                     false
         loop()

--- a/kyo-core/shared/src/test/scala/kyoTest/fibersTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/fibersTest.scala
@@ -27,6 +27,14 @@ class fibersTest extends KyoTest:
                 d <- p.get
             yield assert(a && !b && c && d == 1)
         }
+        "complete null" in run {
+            IOs.attempt(Fibers.initPromise[AnyRef].map(_.complete(null))).map {
+                case Failure(ex) =>
+                    assert(ex.isInstanceOf[NullPointerException])
+                case _ =>
+                    fail()
+            }
+        }
         "failure" in run {
             val ex = new Exception
             for

--- a/kyo-core/shared/src/test/scala/kyoTest/fibersTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/fibersTest.scala
@@ -28,12 +28,11 @@ class fibersTest extends KyoTest:
             yield assert(a && !b && c && d == 1)
         }
         "complete null" in run {
-            IOs.attempt(Fibers.initPromise[AnyRef].map(_.complete(null))).map {
-                case Failure(ex) =>
-                    assert(ex.isInstanceOf[NullPointerException])
-                case _ =>
-                    fail()
-            }
+            for
+                p <- Fibers.initPromise[AnyRef]
+                b <- p.complete(null)
+                r <- p.get
+            yield assert(b && r == null)
         }
         "failure" in run {
             val ex = new Exception

--- a/kyo-tapir/shared/src/test/scala/kyoTest/server/NettyKyoServerTest.scala
+++ b/kyo-tapir/shared/src/test/scala/kyoTest/server/NettyKyoServerTest.scala
@@ -1,0 +1,15 @@
+package kyoTest.server
+
+import kyo.*
+import kyoTest.KyoTest
+import sttp.tapir.server.netty.NettyKyoServer
+
+class NettyKyoServerTest extends KyoTest:
+
+    "start stop" in run {
+        for
+            bindings <- NettyKyoServer().start()
+            _        <- bindings.stop()
+        yield succeed
+    }
+end NettyKyoServerTest


### PR DESCRIPTION
Netty's future represents computations with result type `Void`, which is encoded at runtime as a `null` value. The code that integrates Kyo's fibers with Netty's wasn't considering this scenario and lifting the result directly to `T < IOs`. This PR fixes that by completing with a pending `IOs(null)` if Netty's Future completes with `null`, indicating the result of a `Void` computation.

I've also added a NPE guard in `fiber.complete` to make it easier to detect this issue since this is a low-level API meant for integration with other libraries.