### PR TITLE
fix: `.pure` when used with intersections types

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/package.scala
+++ b/kyo-core/shared/src/main/scala/kyo/package.scala
@@ -1,3 +1,4 @@
+import scala.annotation.implicitNotFound
 import scala.util.NotGiven
 
 package object kyo:
@@ -35,13 +36,13 @@ package object kyo:
 
     end extension
 
-    extension [T: Flat](v: T < Any)
-        def pure: T =
-            v match
-                case kyo: kyo.core.internal.Suspend[?, ?, ?, ?] =>
-                    bug.failTag(kyo.tag)
-                case v =>
-                    v.asInstanceOf[T]
+    extension [T, S](v: T < S)
+        def pure(using
+            @implicitNotFound(msg = """
+              | .pure must be called on Kyos with no remaining pending effects.
+              | Expected: `$T < Any`, but found: `$T < $S`.
+              """.stripMargin) ev: S =:= Any
+        ): T = v.asInstanceOf[T]
     end extension
 
     def zip[T1, T2, S](v1: T1 < S, v2: T2 < S): (T1, T2) < S =

--- a/kyo-core/shared/src/test/scala/kyoTest/methodsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/methodsTest.scala
@@ -7,6 +7,10 @@ class methodsTest extends KyoTest:
     "pure" in {
         assert(IOs.run(IOs(1)).pure == 1)
         assertDoesNotCompile("IOs(1).pure")
+        def widen[A](v: A < Any) = v
+        assert(widen(TypeMap(1, true)).pure.get[Boolean])
+        val _: Int < IOs = widen(IOs(42)).pure
+        assertDoesNotCompile("widen(IOs(42)).pure == 42")
     }
 
     "map" in {


### PR DESCRIPTION
This is necessary due to `Flat` now being derived from `Tag`s (#366). Not sure if there is a way we can bypass that only in some cases.

Rarely will effects ever need to be run with values that are intersection types, but for Layers (#203), this is definitely necessary.

