### PR TITLE
tags: improve interop with Union and Intersection

### DIFF
--- a/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/coreBytecodeSizeTest.scala
@@ -38,7 +38,7 @@ class coreBytecodeSizeTest extends KyoTest:
         assert(map == Map(
             "test"        -> 27,
             "resultLoop"  -> 91,
-            "handleLoop"  -> 265,
+            "handleLoop"  -> 292,
             "_handleLoop" -> 10
         ))
     }

--- a/kyo-core/shared/src/main/scala/kyo/internal/FlatImplicits.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/FlatImplicits.scala
@@ -44,7 +44,7 @@ object FlatImplicits:
         def hasTag(t: TypeRepr): Boolean =
             t.asType match
                 case '[t] =>
-                    Expr.summon[Tag[t]].isDefined
+                    Expr.summon[Tag.Full[t]].isDefined
 
         def check(t: TypeRepr): Unit =
             t match

--- a/kyo-core/shared/src/main/scala/kyo/package.scala
+++ b/kyo-core/shared/src/main/scala/kyo/package.scala
@@ -1,5 +1,4 @@
 import kyo.internal.Trace
-import scala.annotation.implicitNotFound
 import scala.util.NotGiven
 
 package object kyo:
@@ -37,13 +36,13 @@ package object kyo:
 
     end extension
 
-    extension [T, S](v: T < S)
-        def pure(using
-            @implicitNotFound(msg = """
-              | .pure must be called on Kyos with no remaining pending effects.
-              | Expected: `$T < Any`, but found: `$T < $S`.
-              """.stripMargin) ev: S =:= Any
-        ): T = v.asInstanceOf[T]
+    extension [T: Flat](v: T < Any)
+        def pure: T =
+            v match
+                case kyo: kyo.core.internal.Suspend[?, ?, ?, ?] =>
+                    bug.failTag(kyo.tag)
+                case v =>
+                    v.asInstanceOf[T]
     end extension
 
     def zip[T1, T2, S](v1: T1 < S, v2: T2 < S)(using Trace): (T1, T2) < S =

--- a/kyo-core/shared/src/main/scala/kyo/package.scala
+++ b/kyo-core/shared/src/main/scala/kyo/package.scala
@@ -76,15 +76,15 @@ package object kyo:
         ): Nothing =
             bug(s"Unexpected effect '${actual.show}' found in 'pure'.")
 
-        inline def failTag(
-            inline actual: Tag[?],
-            inline expected: Tag[?]*
+        inline def failTag[T, U](
+            inline actual: Tag.Full[T],
+            inline expected: Tag.Full[U]
         ): Nothing =
-            bug(s"Unexpected effect '${actual.show}' found while handling '${expected.map(_.show).mkString(" & ")}'.")
+            bug(s"Unexpected effect '${actual.show}' found while handling '${expected.show}'.")
 
         inline def checkTag[T, U](
-            inline actual: Tag[U],
-            inline expected: Tag[T]
+            inline actual: Tag.Full[U],
+            inline expected: Tag.Full[T]
         ): Unit =
             if actual =!= expected then
                 failTag(actual, expected)

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -69,7 +69,7 @@ private[kyo] class IOTask[T](
                                 )
                         end match
                     else
-                        IOs(bug.failTag(kyo.tag, Tag[FiberGets], Tag[IOs]))
+                        IOs(bug.failTag(kyo.tag, Tag.Intersection[FiberGets & IOs]))
                 case _ =>
                     complete(curr.asInstanceOf[T < IOs])
                     finalize()

--- a/kyo-core/shared/src/main/scala/kyo/typeMap.scala
+++ b/kyo-core/shared/src/main/scala/kyo/typeMap.scala
@@ -45,6 +45,9 @@ extension [A](self: TypeMap[A])
 end extension
 
 object TypeMap:
+
+    given flat[A]: Flat[TypeMap[A]] = Flat.unsafe.bypass
+
     val empty: TypeMap[Any] = HashMap.empty
 
     def apply[A](a: A)(using ta: Tag[A]): TypeMap[A] =

--- a/kyo-core/shared/src/test/scala/kyoTest/methodsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/methodsTest.scala
@@ -4,13 +4,17 @@ import kyo.*
 
 class methodsTest extends KyoTest:
 
+    def widen[A](v: A < Any) = v
+
     "pure" in {
         assert(IOs.run(IOs(1)).pure == 1)
         assertDoesNotCompile("IOs(1).pure")
-        def widen[A](v: A < Any) = v
         assert(widen(TypeMap(1, true)).pure.get[Boolean])
-        val _: Int < IOs = widen(IOs(42)).pure
         assertDoesNotCompile("widen(IOs(42)).pure == 42")
+    }
+
+    "pure widened" in {
+        assertDoesNotCompile("val _: Int < IOs = widen(IOs(42)).pure")
     }
 
     "map" in {

--- a/kyo-core/shared/src/test/scala/kyoTest/typeMapTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/typeMapTest.scala
@@ -76,7 +76,7 @@ class typeMapTest extends KyoTest:
         }
         "non-empty" in {
             val e: TypeMap[String & Boolean] = TypeMap[Boolean](true).asInstanceOf[TypeMap[String & Boolean]]
-            test[String](e, """HashMap(Tag(-4scala.Boolean;,%scala.AnyVal;"b!M;"V!A;) -> true)""", "java.lang.String")
+            test[String](e, """HashMap(!_9;!W3;!U1;!V2; -> true)""", "java.lang.String")
         }
     }
 

--- a/kyo-tag/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-tag/shared/src/main/scala/kyo/tags.scala
@@ -280,10 +280,7 @@ object Tag:
             import quotes.reflect.*
             if i >= charsPrintable.length || i < 0 then
                 report.errorAndAbort(s"Encoded tag 'Int($i)' exceeds supported limit: " + charsPrintable.length)
-            val encoded = charsPrintable(i)
-            if decodeInt(encoded) != i then
-                report.errorAndAbort(s"Bug: invalid Int encoding. Expected $i but got ${decodeInt(encoded)}")
-            encoded
+            charsPrintable(i)
         end encodeInt
 
         def decodeInt(c: Char): Int =

--- a/kyo-tag/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-tag/shared/src/main/scala/kyo/tags.scala
@@ -17,6 +17,9 @@ object Tag:
 
     inline given apply[T]: Tag[T] = ${ tagImpl[T] }
 
+    extension [T](t1: Tag[T])
+        def erased: Tag[Any] = t1.asInstanceOf[Tag[Any]]
+
     extension [T](t1: Full[T])
 
         def show: String =
@@ -45,7 +48,7 @@ object Tag:
         infix def >:>[U](t2: Full[U]): Boolean =
             t2 <:< t1
 
-        def erased: Tag[Any] = t1.asInstanceOf[Tag[Any]]
+        def erased: Full[Any] = t1.asInstanceOf[Full[Any]]
 
     end extension
 

--- a/kyo-tag/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-tag/shared/src/main/scala/kyo/tags.scala
@@ -40,7 +40,7 @@ object Tag:
                     t1 <:< t2
 
         infix def =:=[U](t2: Full[U]): Boolean =
-            (t1 eq t2) || t1 == t2
+            (t1.asInstanceOf[AnyRef] eq t2.asInstanceOf[AnyRef]) || t1 == t2
 
         infix def =!=[U](t2: Full[U]): Boolean =
             !(t1 =:= t2)
@@ -52,7 +52,7 @@ object Tag:
 
     end extension
 
-    sealed trait Set[T]:
+    sealed trait Set[T] extends Any:
         def show: String
         infix def <:<[U](t2: Full[U]): Boolean
         infix def =:=[U](t2: Full[U]): Boolean
@@ -65,7 +65,7 @@ object Tag:
     object Set:
         inline given apply[T]: Set[T] = ${ setImpl[T] }
 
-    case class Union[T](tags: Seq[Tag[Any]]) extends Set[T]:
+    case class Union[T](tags: Seq[Tag[Any]]) extends AnyVal with Set[T]:
         def show: String =
             tags.map(_.show).mkString(" | ")
 
@@ -96,7 +96,7 @@ object Tag:
         private[Tag] def raw[T](tags: Seq[String]) = new Union[T](tags.asInstanceOf[Seq[Tag[Any]]])
         inline given apply[T]: Union[T]            = ${ unionImpl[T] }
 
-    case class Intersection[T](tags: Seq[Tag[Any]]) extends Set[T]:
+    case class Intersection[T](tags: Seq[Tag[Any]]) extends AnyVal with Set[T]:
         def show: String =
             tags.map(_.show).mkString(" & ")
 

--- a/kyo-tag/shared/src/test/scala/kyoTest/tagsTest.scala
+++ b/kyo-tag/shared/src/test/scala/kyoTest/tagsTest.scala
@@ -10,7 +10,7 @@ import scala.annotation.nowarn
 
 class tagsTest extends AsyncFreeSpec with NonImplicitAssertions:
 
-    def test[T1, T2](using k1: Tag[T1], i1: ITag[T1], k2: Tag[T2], i2: ITag[T2]): Unit =
+    inline def test[T1, T2](using k1: Tag[T1], i1: ITag[T1], k2: Tag[T2], i2: ITag[T2]): Unit =
         "T1 <:< T2" in {
             val kresult = k1 <:< k2
             val iresult = i1 <:< i2
@@ -25,6 +25,22 @@ class tagsTest extends AsyncFreeSpec with NonImplicitAssertions:
             assert(
                 kresult == iresult,
                 s"Tag[T2] <:< Tag[T1] is $kresult but ITag[T2] <:< ITag[T1] is $iresult"
+            )
+        }
+        "T2 =:= T1" in {
+            val kresult = k2 =:= k1
+            val iresult = i2 =:= i1
+            assert(
+                kresult == iresult,
+                s"Tag[T2] =:= Tag[T1] is $kresult but ITag[T2] =:= ITag[T1] is $iresult"
+            )
+        }
+        "T2 =!= T1" in {
+            val kresult = k2 =!= k1
+            val iresult = !(i2 =:= i1)
+            assert(
+                kresult == iresult,
+                s"Tag[T2] =!= Tag[T1] is $kresult but ITag[T2] =!= ITag[T1] is $iresult"
             )
         }
         ()
@@ -238,7 +254,7 @@ class tagsTest extends AsyncFreeSpec with NonImplicitAssertions:
 
     "type unions" - {
 
-        def test[T1, T2](using k1: Union[T1], i1: ITag[T1], k2: Union[T2], i2: ITag[T2]): Unit =
+        inline def test[T1, T2](using k1: Union[T1], i1: ITag[T1], k2: Union[T2], i2: ITag[T2]): Unit =
             "T1 <:< T2" in {
                 val kresult = k1 <:< k2
                 val iresult = i1 <:< i2
@@ -253,6 +269,22 @@ class tagsTest extends AsyncFreeSpec with NonImplicitAssertions:
                 assert(
                     kresult == iresult,
                     s"Tag[T2] <:< Tag[T1] is $kresult but ITag[T2] <:< ITag[T1] is $iresult"
+                )
+            }
+            "T2 =:= T1" in {
+                val kresult = k2 =:= k1
+                val iresult = i2 =:= i1
+                assert(
+                    kresult == iresult,
+                    s"Tag[T2] =:= Tag[T1] is $kresult but ITag[T2] =:= ITag[T1] is $iresult"
+                )
+            }
+            "T2 =!= T1" in {
+                val kresult = k2 =!= k1
+                val iresult = !(i2 =:= i1)
+                assert(
+                    kresult == iresult,
+                    s"Tag[T2] =!= Tag[T1] is $kresult but ITag[T2] =!= ITag[T1] is $iresult"
                 )
             }
             ()
@@ -372,7 +404,7 @@ class tagsTest extends AsyncFreeSpec with NonImplicitAssertions:
 
     "type intersections" - {
 
-        def test[T1, T2](using k1: Intersection[T1], i1: ITag[T1], k2: Intersection[T2], i2: ITag[T2]): Unit =
+        inline def test[T1, T2](using k1: Intersection[T1], i1: ITag[T1], k2: Intersection[T2], i2: ITag[T2]): Unit =
             "T1 <:< T2" in {
                 val kresult = k1 <:< k2
                 val iresult = i1 <:< i2
@@ -387,6 +419,22 @@ class tagsTest extends AsyncFreeSpec with NonImplicitAssertions:
                 assert(
                     kresult == iresult,
                     s"Tag[T2] <:< Tag[T1] is $kresult but ITag[T2] <:< ITag[T1] is $iresult"
+                )
+            }
+            "T2 =:= T1" in {
+                val kresult = k2 =:= k1
+                val iresult = i2 =:= i1
+                assert(
+                    kresult == iresult,
+                    s"Tag[T2] =:= Tag[T1] is $kresult but ITag[T2] =:= ITag[T1] is $iresult"
+                )
+            }
+            "T2 =!= T1" in {
+                val kresult = k2 =!= k1
+                val iresult = !(i2 =:= i1)
+                assert(
+                    kresult == iresult,
+                    s"Tag[T2] =!= Tag[T1] is $kresult but ITag[T2] =!= ITag[T1] is $iresult"
                 )
             }
             ()
@@ -508,6 +556,100 @@ class tagsTest extends AsyncFreeSpec with NonImplicitAssertions:
             assertDoesNotCompile("Intersection[A | B & A]")
         }
 
+    }
+
+    "mixing tag types" - {
+
+        inline def test[T1, T2](using k1: Tag.Set[T1], i1: ITag[T1], k2: Tag.Set[T2], i2: ITag[T2]): Unit =
+            "T1 <:< T2" in {
+                val kresult = k1 <:< k2
+                val iresult = i1 <:< i2
+                assert(
+                    kresult == iresult,
+                    s"Tag[T1] <:< Tag[T2] is $kresult but ITag[T1] <:< ITag[T2] is $iresult"
+                )
+            }
+            "T2 <:< T1" in {
+                val kresult = k2 <:< k1
+                val iresult = i2 <:< i1
+                assert(
+                    kresult == iresult,
+                    s"Tag[T2] <:< Tag[T1] is $kresult but ITag[T2] <:< ITag[T1] is $iresult"
+                )
+            }
+            "T2 =:= T1" in {
+                val kresult = k2 =:= k1
+                val iresult = i2 =:= i1
+                assert(
+                    kresult == iresult,
+                    s"Tag[T2] =:= Tag[T1] is $kresult but ITag[T2] =:= ITag[T1] is $iresult"
+                )
+            }
+            "T2 =!= T1" in {
+                val kresult = k2 =!= k1
+                val iresult = !(i2 =:= i1)
+                assert(
+                    kresult == iresult,
+                    s"Tag[T2] =!= Tag[T1] is $kresult but ITag[T2] =!= ITag[T1] is $iresult"
+                )
+            }
+            ()
+        end test
+
+        class A
+        class B extends A
+        class C extends B
+        class D
+        class E extends D
+        class F extends D
+
+        "union, tag" - test[B | C, A]
+        "tag, intersection" - test[C, A & B]
+        "intersection, union" - test[E & F, D | A]
+        "union, union" - test[B | C, C | B]
+        "intersection, intersection" - test[E & F, F & E]
+        "union, intersection" - test[B | C, B & C]
+        "tag, union" - test[B, C | D]
+        "tag, intersection 2" - test[B, C & D]
+        "union, tag 2" - test[A | D, B]
+        "intersection, tag" - test[A & D, B]
+
+        "complex scenario" - {
+            trait A
+            trait B extends A
+            trait C extends B
+            class D
+            class E extends D
+            class F extends E
+            class G extends F
+            test[C & G, A & D | B & E]
+        }
+
+        "edge case 1" - {
+            trait A
+            class B extends A
+            test[B & A, B | A]
+        }
+
+        "edge case 2" - {
+            trait A
+            class B extends A
+            test[A | B, B & A]
+        }
+
+        "edge case 3" - {
+            trait A
+            class B extends A
+            class C extends B
+            test[A & B & C, C]
+        }
+
+        "edge case 4" - {
+            trait A
+            class B extends A
+            class C extends B
+            test[C, A | B | C]
+        }
     }
 
 end tagsTest

--- a/kyo-zio/shared/src/main/scala/kyo/zios.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/zios.scala
@@ -46,7 +46,7 @@ object ZIOs:
                             val k = kyo.asInstanceOf[Suspend[Task, Any, U, ZIOs]]
                             k.command.flatMap(v => loop(k(v)))
                         else
-                            bug.failTag(kyo.tag, Tag[FiberGets], Tag[Tasks])
+                            bug.failTag(kyo.tag, Tag.Intersection[FiberGets & Tasks & IOs])
                     catch
                         case ex if NonFatal(ex) =>
                             ZIO.fail(ex)


### PR DESCRIPTION
The current `Tag` impl has unrelated representations for `Tag` (class types only) and set types (`Union` and `Intersection` of class types). This split has important limitations:

1. The `Envs` effect was [changed](https://github.com/getkyo/kyo/pull/424) by @hearnadam and @kitlangton recently to provide support for intersection types but it [required a hack](https://github.com/getkyo/kyo/blob/921c2f5738098c5a6245ac717d0dd3b9a47b0ab0/kyo-core/shared/src/main/scala/kyo/envs.scala#L12). To avoid the hack we'd need to support set tags in `core.handle` but it's not possible to implement that properly without a common type for the different kinds of tags.
2. The `Flat` check functions similarly to `Tag` since both reject types that don't represent concrete values. We could reimplement it in terms of `Tag` but that's also not possible to do that properly. I think making this change could be a fix for https://github.com/getkyo/kyo/issues/430.

This PR introduces the following types:

1. `Tag`: Still can only represent concrete class types and fails at compile time for unions and intersections
2. `Tag.Union`: Represents union types with concrete types only (`Seq[Tag[Any]]`)
3. `Tag.Intersection`: Same as `Union` but for intersection types
4. `Tag.Set`: Can be both `Union` or `Intersection`
5. `Tag.Full`: A union of all the previous types

With this representation, we can change `core.handle` to take a `Tag.Full` and each effect can chose to to pass a regular `Tag` or any of the others.