### PR TITLE
reintroduce bug error message in `kyo.pure`

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/package.scala
+++ b/kyo-core/shared/src/main/scala/kyo/package.scala
@@ -43,7 +43,12 @@ package object kyo:
               | .pure must be called on Kyos with no remaining pending effects.
               | Expected: `$T < Any`, but found: `$T < $S`.
               """.stripMargin) ev: S =:= Any
-        ): T = v.asInstanceOf[T]
+        ): T =
+            v match
+                case kyo: kyo.core.internal.Suspend[?, ?, ?, ?] =>
+                    bug.failTag(kyo.tag)
+                case v =>
+                    v.asInstanceOf[T]
     end extension
 
     def zip[T1, T2, S](v1: T1 < S, v2: T2 < S)(using Trace): (T1, T2) < S =

--- a/kyo-core/shared/src/test/scala/kyoTest/methodsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/methodsTest.scala
@@ -1,16 +1,29 @@
 package kyoTest
 
 import kyo.*
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 class methodsTest extends KyoTest:
+
+    def widen[A](v: A < Any): A < Any = v
 
     "pure" in {
         assert(IOs.run(IOs(1)).pure == 1)
         assertDoesNotCompile("IOs(1).pure")
-        def widen[A](v: A < Any) = v
         assert(widen(TypeMap(1, true)).pure.get[Boolean])
-        val _: Int < IOs = widen(IOs(42)).pure
         assertDoesNotCompile("widen(IOs(42)).pure == 42")
+    }
+
+    "pure widened" in pendingUntilFixed {
+        assertDoesNotCompile("val _: Int < IOs = widen(IOs(42)).pure")
+    }
+
+    "pure bug failure" in {
+        Try((IOs(42)).asInstanceOf[Int < Any].pure) match
+            case Failure(ex) => assert(ex.getClass.getName().contains("KyoBugException"))
+            case Success(_)  => fail()
     }
 
     "map" in {


### PR DESCRIPTION
I noticed that the bug error message in `kyo.pure` got removed after merging https://github.com/getkyo/kyo/pull/431. I've reintroduced it and also noticed a scenario that shouldn't be compiling. I'll work on a fix for it.