### PR TITLE
Reword note about the only macro in Kyo

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ The `defer` method in Kyo mirrors Scala's `for`-comprehensions in providing a co
 
 The `kyo-direct` module is constructed as a wrapper around [dotty-cps-async](https://github.com/rssh/dotty-cps-async).
 
-> Note: `defer` is currently the only macro in Kyo. All other features use regular language constructs.
+> Note: `defer` is currently the only user-facing macro in Kyo. All other features use regular language constructs.
 
 ### Defining an App
 


### PR DESCRIPTION
fixes #439

I'm not sure if this is the best thing to say. It seems vague enough that it is kinda true. I considered mentioning where others were used but it became too long and lost the point.