### PR TITLE
streams: fix nesting with other effects

### DIFF
--- a/kyo-core/shared/src/test/scala/kyoTest/streamsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/streamsTest.scala
@@ -517,4 +517,11 @@ class streamsTest extends KyoTest:
         }
     }
 
+    "nesting with other effect" in {
+        val stream: Stream[Unit, Int, Any] < IOs =
+            IOs(Seq(1, 2, 3)).map(seq => Streams.initSeq(seq))
+        IOs.run(stream.map(_.runSeq)).pure
+        succeed
+    }
+
 end streamsTest


### PR DESCRIPTION
As identified by @pablf in https://github.com/getkyo/kyo/pull/428#issuecomment-2138228061, `Streams` can end up producing nesting of effects due to the encoding using `opaque type`, which is unsound. This PR fixes it by using a wrapper class to hold the nested computation. It also can't be an `AnyVal` since we need the wrapper class at runtime to enable safe nesting.

An important lesson from this: it's not safe to alias Kyo computations directly via `opaque type`.