### PR TITLE
improve toString for Kyo computations + bug error messages

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/core.scala
+++ b/kyo-core/shared/src/main/scala/kyo/core.scala
@@ -224,7 +224,7 @@ object core:
             def deepHandleLoop(v: T < (E & S)): Command[T] < S =
                 v match
                     case kyo: Suspend[Command, Any, T, E] @unchecked =>
-                        bug.checkTag(kyo.tag, tag)
+                        bug.checkTag(kyo, tag)
                         handler.resume(
                             kyo.command,
                             (v: Any) => deepHandleLoop(kyo(v))
@@ -245,6 +245,7 @@ object core:
             def tag: Tag[Any]
             inline def apply(v: T) = apply(v, Safepoint.noop, Locals.State.empty)
             def apply(v: T, s: Safepoint[S], l: Locals.State): U < S
+            override def toString() = s"Kyo(${tag.show},Command($command),${trace.show})"
         end Suspend
 
         abstract class Continue[Command[_], T, U, S](

--- a/kyo-core/shared/src/main/scala/kyo/internal/Trace.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/Trace.scala
@@ -10,10 +10,10 @@ object Trace:
     private val maxSnippetLines = 3
 
     extension (t: Trace)
-        def show: String       = t
-        def position: Position = Position(t.takeWhile(_ != '\n').drop(1))
-        def method: String     = t.drop(position.show.length + 2).takeWhile(isIdentifierPart)
-        def snippet: String    = t.drop(position.show.length + 2)
+        def show: String       = s"Trace(${position},method=${method},snippet=${snippet})"
+        def position: Position = Position(t.takeWhile(_ != '\n'))
+        def method: String     = t.drop(position.show.length + 1).takeWhile(isIdentifierPart)
+        def snippet: String    = t.drop(position.show.length + 1)
     end extension
 
     implicit inline def derive: Trace =

--- a/kyo-core/shared/src/main/scala/kyo/ios.scala
+++ b/kyo-core/shared/src/main/scala/kyo/ios.scala
@@ -51,7 +51,7 @@ sealed trait IOs extends Effect[IOs]:
         @tailrec def runLoop(v: T < IOs): T =
             v match
                 case kyo: Suspend[IO, Unit, T, IOs] @unchecked =>
-                    bug.checkTag(kyo.tag, tag)
+                    bug.checkTag(kyo, tag)
                     runLoop(kyo(()))
                 case _ =>
                     v.asInstanceOf[T]

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -69,7 +69,7 @@ private[kyo] class IOTask[T](
                                 )
                         end match
                     else
-                        IOs(bug.failTag(kyo.tag, Tag.Intersection[FiberGets & IOs]))
+                        IOs(bug.failTag(kyo, Tag.Intersection[FiberGets & IOs]))
                 case _ =>
                     complete(curr.asInstanceOf[T < IOs])
                     finalize()

--- a/kyo-core/shared/src/test/scala/kyoTest/internal/TraceTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/internal/TraceTest.scala
@@ -8,8 +8,7 @@ class TraceTest extends KyoTest:
     "show" in {
         def test(i: Int)(using t: Trace) = t.show
         assert(test(42) ==
-            """TraceTest.scala:10
-            |test(42)""".stripMargin)
+            "Trace(TraceTest.scala:10,method=test,snippet=test(42))")
     }
 
     "no param" in {

--- a/kyo-core/shared/src/test/scala/kyoTest/methodsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/methodsTest.scala
@@ -6,6 +6,20 @@ class methodsTest extends KyoTest:
 
     def widen[A](v: A < Any) = v
 
+    "toString JVM" in runJVM {
+        assert(IOs(1).toString() == "Kyo(Tag[kyo.IOs],Command(()),Trace(methodsTest.scala:10,method=IOs,snippet=IOs(1)))")
+        assert(
+            IOs(1).map(_ + 1).toString() == "Kyo(Tag[kyo.IOs],Command(()),Trace(methodsTest.scala:12,method=map,snippet=map(_ + 1)))"
+        )
+    }
+
+    "toString JS" in runJS {
+        assert(IOs(1).toString() == "Kyo(Tag[kyo.IOs],Command(undefined),Trace(methodsTest.scala:17,method=IOs,snippet=IOs(1)))")
+        assert(
+            IOs(1).map(_ + 1).toString() == "Kyo(Tag[kyo.IOs],Command(undefined),Trace(methodsTest.scala:19,method=map,snippet=map(_ + 1)))"
+        )
+    }
+
     "pure" in {
         assert(IOs.run(IOs(1)).pure == 1)
         assertDoesNotCompile("IOs(1).pure")

--- a/kyo-core/shared/src/test/scala/kyoTest/typeMapTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/typeMapTest.scala
@@ -72,11 +72,11 @@ class typeMapTest extends KyoTest:
 
         "empty" in {
             val e: TypeMap[Boolean] = TypeMap.empty.asInstanceOf[TypeMap[Boolean]]
-            test(e, "HashMap()", "scala.Boolean")
+            test(e, "HashMap()", "Tag[scala.Boolean]")
         }
         "non-empty" in {
             val e: TypeMap[String & Boolean] = TypeMap[Boolean](true).asInstanceOf[TypeMap[String & Boolean]]
-            test[String](e, """HashMap(!_9;!W3;!U1;!V2; -> true)""", "java.lang.String")
+            test[String](e, """HashMap(!_9;!W3;!U1;!V2; -> true)""", "Tag[java.lang.String]")
         }
     }
 

--- a/kyo-tag/shared/src/main/scala/kyo/tags.scala
+++ b/kyo-tag/shared/src/main/scala/kyo/tags.scala
@@ -26,7 +26,8 @@ object Tag:
             t1 match
                 case t1: String =>
                     val decoded = t1.drop(2).takeWhile(_ != ';')
-                    fromCompact.getOrElse(decoded, decoded)
+                    val s       = fromCompact.getOrElse(decoded, decoded)
+                    s"Tag[$s]"
                 case t1: Set[T] =>
                     t1.show
 
@@ -67,7 +68,8 @@ object Tag:
 
     case class Union[T](tags: Seq[Tag[Any]]) extends AnyVal with Set[T]:
         def show: String =
-            tags.map(_.show).mkString(" | ")
+            val s = tags.map(_.show).mkString(" | ")
+            s"Tag.Union[$s]"
 
         infix def <:<[U](t2: Full[U]): Boolean =
             t2 match
@@ -98,7 +100,8 @@ object Tag:
 
     case class Intersection[T](tags: Seq[Tag[Any]]) extends AnyVal with Set[T]:
         def show: String =
-            tags.map(_.show).mkString(" & ")
+            val s = tags.map(_.show).mkString(" & ")
+            s"Tag.Intersection[$s]"
 
         infix def <:<[U](t2: Full[U]): Boolean =
             t2 match

--- a/kyo-tag/shared/src/test/scala/kyoTest/tagsTest.scala
+++ b/kyo-tag/shared/src/test/scala/kyoTest/tagsTest.scala
@@ -225,20 +225,20 @@ class tagsTest extends AsyncFreeSpec with NonImplicitAssertions:
     "show" - {
 
         "compact" in {
-            assert(Tag[Object].show == "java.lang.Object")
-            assert(Tag[Matchable].show == "scala.Matchable")
-            assert(Tag[Any].show == "scala.Any")
-            assert(Tag[String].show == "java.lang.String")
+            assert(Tag[Object].show == "Tag[java.lang.Object]")
+            assert(Tag[Matchable].show == "Tag[scala.Matchable]")
+            assert(Tag[Any].show == "Tag[scala.Any]")
+            assert(Tag[String].show == "Tag[java.lang.String]")
         }
 
         "no type params" in {
-            assert(Tag[Int].show == "scala.Int")
-            assert(Tag[Thread].show == "java.lang.Thread")
+            assert(Tag[Int].show == "Tag[scala.Int]")
+            assert(Tag[Thread].show == "Tag[java.lang.Thread]")
         }
 
         "type params" in pendingUntilFixed {
             class Test[T]
-            assert(Tag[Test[Int]].show == s"${classOf[Test[?]].getName}[scala.Int]")
+            assert(Tag[Test[Int]].show == s"Tag[${classOf[Test[?]].getName}[scala.Int]]")
             ()
         }
     }

--- a/kyo-zio/shared/src/main/scala/kyo/zios.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/zios.scala
@@ -46,7 +46,7 @@ object ZIOs:
                             val k = kyo.asInstanceOf[Suspend[Task, Any, U, ZIOs]]
                             k.command.flatMap(v => loop(k(v)))
                         else
-                            bug.failTag(kyo.tag, Tag.Intersection[FiberGets & Tasks & IOs])
+                            bug.failTag(kyo, Tag.Intersection[FiberGets & Tasks & IOs])
                     catch
                         case ex if NonFatal(ex) =>
                             ZIO.fail(ex)


### PR DESCRIPTION
The `toString` of Kyo computations currently print `<function1>`. This PR introduces a custom `toString` showing the details of the computation, including the new `Trace` information, to help aid in debugging and error reporting. I've also improved the bug error messages to use the new `toString`.