### PR TITLE
Maybe: allocationless Option (with nesting support!)

### DIFF
--- a/kyo-core/jvm/src/test/scala/kyoTest/MaybeMonadLawsTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/MaybeMonadLawsTest.scala
@@ -1,0 +1,42 @@
+package kyoTest
+
+import kyo.Maybe
+import zio.Trace
+import zio.prelude.Equal
+import zio.prelude.coherent.CovariantDeriveEqual
+import zio.prelude.coherent.CovariantDeriveEqualIdentityFlatten
+import zio.prelude.laws.*
+import zio.test.*
+import zio.test.laws.*
+
+object MaybeMonadLawsTest extends ZIOSpecDefault:
+
+    val listGenF: GenF[Any, Maybe] =
+        new GenF[Any, Maybe]:
+            def apply[R, A](gen: Gen[R, A])(using trace: Trace) =
+                Gen.oneOf(
+                    gen.map(Maybe.Defined(_)),
+                    Gen.const(Maybe.empty[A])
+                )
+
+    given CovariantDeriveEqualIdentityFlatten[Maybe] =
+        new CovariantDeriveEqualIdentityFlatten[Maybe]:
+            override def flatten[A](ffa: Maybe[Maybe[A]]): Maybe[A] =
+                ffa.flatten
+            override def any: Maybe[Any] =
+                Maybe(())
+            override def map[A, B](f: A => B): Maybe[A] => Maybe[B] =
+                m => m.map(f)
+            override def derive[A: Equal]: Equal[Maybe[A]] =
+                new Equal[Maybe[A]]:
+                    protected def checkEqual(l: Maybe[A], r: Maybe[A]): Boolean =
+                        given CanEqual[A, A] = CanEqual.derived
+                        l == r
+
+    def spec = suite("MaybeMonadLawsTest")(
+        test("covariant")(checkAllLaws(CovariantLaws)(listGenF, Gen.int)),
+        test("identityFlatten")(
+            checkAllLaws(IdentityFlattenLaws)(listGenF, Gen.int)
+        )
+    )
+end MaybeMonadLawsTest

--- a/kyo-core/jvm/src/test/scala/kyoTest/MaybeMonadLawsTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/MaybeMonadLawsTest.scala
@@ -27,11 +27,10 @@ object MaybeMonadLawsTest extends ZIOSpecDefault:
                 Maybe(())
             override def map[A, B](f: A => B): Maybe[A] => Maybe[B] =
                 m => m.map(f)
-            override def derive[A: Equal]: Equal[Maybe[A]] =
+            override def derive[A](using e: Equal[A]): Equal[Maybe[A]] =
                 new Equal[Maybe[A]]:
                     protected def checkEqual(l: Maybe[A], r: Maybe[A]): Boolean =
-                        given CanEqual[A, A] = CanEqual.derived
-                        l == r
+                        l.zip(r).forall(e.equal)
 
     def spec = suite("MaybeMonadLawsTest")(
         test("covariant")(checkAllLaws(CovariantLaws)(listGenF, Gen.int)),

--- a/kyo-core/shared/src/main/scala/kyo/Maybe.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Maybe.scala
@@ -74,7 +74,7 @@ object Maybe:
         inline def getOrElse[B >: T](inline default: => B): B =
             if isEmpty then default else get
 
-        inline def fold[U](inline ifEmpty: => U, inline ifDefined: T => U): U =
+        inline def fold[U](inline ifEmpty: => U)(inline ifDefined: T => U): U =
             if isEmpty then ifEmpty else ifDefined(get)
 
         inline def map[U](inline f: T => U): Maybe[U] =

--- a/kyo-core/shared/src/main/scala/kyo/Maybe.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Maybe.scala
@@ -1,0 +1,159 @@
+package kyo
+
+import Maybe.*
+import Maybe.internal.*
+
+opaque type Maybe[+T] >: (Empty | Defined[T]) = Empty | Defined[T]
+
+object Maybe:
+    given [T, U](using CanEqual[T, U]): CanEqual[Maybe[T], Maybe[U]] = CanEqual.derived
+    given [T]: Conversion[Maybe[T], IterableOnce[T]]                 = _.iterator
+    given [T: Flat]: Flat[Maybe[T]]                                  = Flat.unsafe.bypass
+
+    def apply[T](v: T): Maybe[T] =
+        if isNull(v) then
+            Empty
+        else
+            v match
+                case v: DefinedEmpty => v.nest
+                case v               => v
+
+    def fromScala[T](opt: Option[T]): Maybe[T] =
+        opt match
+            case Some(v) => Defined(v)
+            case None    => Empty
+
+    def empty[T]: Maybe[T] = Empty
+
+    def when[T](cond: Boolean)(v: => T): Maybe[T] =
+        if cond then v else Empty
+
+    opaque type Defined[+T] = T | DefinedEmpty
+
+    object Defined:
+
+        def apply[T](v: T): Defined[T] =
+            v match
+                case v: DefinedEmpty => v.nest
+                case v: Empty        => DefinedEmpty()
+                case v               => v
+
+        // TODO avoid allocation
+        def unapply[T](opt: Maybe[T]): Option[T] =
+            opt.toScala
+    end Defined
+
+    sealed abstract class Empty
+    case object Empty extends Empty
+
+    extension [T](self: Maybe[T])
+
+        inline def toScala: Option[T] =
+            if isEmpty then None
+            else Some(get)
+
+        inline def isEmpty: Boolean =
+            self match
+                case _: Empty => true
+                case _        => false
+
+        inline def isDefined: Boolean = !isEmpty
+
+        inline def nonEmpty: Boolean = !isEmpty
+
+        // TODO compilation failure if inlined
+        def get: T =
+            (self: @unchecked) match
+                case _: Empty =>
+                    throw new NoSuchElementException("Maybe.get")
+                case self: DefinedEmpty =>
+                    self.unnest.asInstanceOf[T]
+                case v: T @unchecked =>
+                    v
+
+        inline def getOrElse[B >: T](inline default: => B): B =
+            if isEmpty then default else get
+
+        inline def fold[U](inline ifEmpty: => U, inline ifDefined: T => U): U =
+            if isEmpty then ifEmpty else ifDefined(get)
+
+        inline def map[U](inline f: T => U): Maybe[U] =
+            if isEmpty then Empty else f(get)
+
+        inline def flatMap[U](inline f: T => Maybe[U]): Maybe[U] =
+            if isEmpty then Maybe.empty else f(get)
+
+        inline def flatten[U](using inline ev: T <:< Maybe[U]): Maybe[U] =
+            if isEmpty then Empty else ev(get)
+
+        inline def filter(inline f: T => Boolean): Maybe[T] =
+            if isEmpty || f(get) then self else Empty
+
+        inline def filterNot(inline f: T => Boolean): Maybe[T] =
+            if isEmpty || !f(get) then self else Empty
+
+        // TODO compilation failure if inlined
+        def contains[U](elem: U)(using CanEqual[T, U]): Boolean =
+            !isEmpty && self.get == elem
+
+        inline def exists(inline f: T => Boolean): Boolean =
+            !isEmpty && f(get)
+
+        inline def forall(inline f: T => Boolean): Boolean =
+            isEmpty || f(get)
+
+        inline def foreach(inline f: T => Unit): Unit =
+            if !isEmpty then f(get)
+
+        inline def collect[U](inline pf: PartialFunction[T, U]): Maybe[U] =
+            if !isEmpty then
+                val value = get
+                if pf.isDefinedAt(value) then
+                    pf(value)
+                else
+                    Empty
+                end if
+            else Empty
+
+        inline def orElse[B >: T](inline alternative: => Maybe[B]): Maybe[B] =
+            if isEmpty then alternative else self
+
+        def zip[B](that: Maybe[B]): Maybe[(T, B)] =
+            if isEmpty || that.isEmpty then Empty else (get, that.get)
+
+        inline def iterator: Iterator[T] =
+            if isEmpty then collection.Iterator.empty else collection.Iterator.single(get)
+
+        inline def toList: List[T] =
+            if isEmpty then List.empty else get :: Nil
+
+        inline def toRight[X](inline left: => X): Either[X, T] =
+            if isEmpty then Left(left) else Right(get)
+
+        inline def toLeft[X](inline right: => X): Either[T, X] =
+            if isEmpty then Right(right) else Left(get)
+
+    end extension
+
+    private[kyo] object internal:
+
+        case class DefinedEmpty(val depth: Int):
+            def unnest =
+                if depth > 1 then
+                    DefinedEmpty(depth - 1)
+                else
+                    Empty
+            def nest =
+                DefinedEmpty(depth + 1)
+        end DefinedEmpty
+
+        object DefinedEmpty:
+            val cache = (0 until 100).map(new DefinedEmpty(_)).toArray
+            def apply(depth: Int = 1): DefinedEmpty =
+                if depth < cache.length then
+                    cache(depth)
+                else
+                    new DefinedEmpty(depth)
+        end DefinedEmpty
+    end internal
+end Maybe

--- a/kyo-core/shared/src/main/scala/kyo/Maybe.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Maybe.scala
@@ -18,7 +18,7 @@ object Maybe:
                 case v: DefinedEmpty => v.nest
                 case v               => v
 
-    def fromScala[T](opt: Option[T]): Maybe[T] =
+    def fromOption[T](opt: Option[T]): Maybe[T] =
         opt match
             case Some(v) => Defined(v)
             case None    => Empty
@@ -35,12 +35,12 @@ object Maybe:
         def apply[T](v: T): Defined[T] =
             v match
                 case v: DefinedEmpty => v.nest
-                case v: Empty        => DefinedEmpty()
+                case v: Empty        => DefinedEmpty.one
                 case v               => v
 
         // TODO avoid allocation
         def unapply[T](opt: Maybe[T]): Option[T] =
-            opt.toScala
+            opt.toOption
     end Defined
 
     sealed abstract class Empty
@@ -48,7 +48,7 @@ object Maybe:
 
     extension [T](self: Maybe[T])
 
-        inline def toScala: Option[T] =
+        inline def toOption: Option[T] =
             if isEmpty then None
             else Some(get)
 
@@ -94,7 +94,7 @@ object Maybe:
 
         // TODO compilation failure if inlined
         def contains[U](elem: U)(using CanEqual[T, U]): Boolean =
-            !isEmpty && self.get == elem
+            !isEmpty && get == elem
 
         inline def exists(inline f: T => Boolean): Boolean =
             !isEmpty && f(get)
@@ -149,7 +149,8 @@ object Maybe:
 
         object DefinedEmpty:
             val cache = (0 until 100).map(new DefinedEmpty(_)).toArray
-            def apply(depth: Int = 1): DefinedEmpty =
+            val one   = DefinedEmpty(1)
+            def apply(depth: Int): DefinedEmpty =
                 if depth < cache.length then
                     cache(depth)
                 else

--- a/kyo-core/shared/src/test/scala/kyoTest/MaybeTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/MaybeTest.scala
@@ -58,10 +58,10 @@ class MaybeTest extends KyoTest:
 
     "fold" - {
         "applies the empty function for Empty" in {
-            assert(Empty.fold(0, _ => 1) == 0)
+            assert(Empty.fold(0)(_ => 1) == 0)
         }
         "applies the non-empty function for Defined" in {
-            assert(Defined(1).fold(0, x => x + 1) == 2)
+            assert(Defined(1).fold(0)(x => x + 1) == 2)
         }
     }
 

--- a/kyo-core/shared/src/test/scala/kyoTest/MaybeTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/MaybeTest.scala
@@ -1,0 +1,396 @@
+package kyoTest
+
+import kyo.*
+import kyo.Maybe.*
+
+class MaybeTest extends KyoTest:
+
+    "apply" - {
+        "creates Defined for non-null values" in {
+            assert(Maybe(1) == Defined(1))
+            assert(Maybe("hello") == Defined("hello"))
+        }
+        "creates Empty for null values" in {
+            assert(Maybe(null) == Empty)
+        }
+    }
+
+    "isEmpty" - {
+        "returns true for Empty" in {
+            assert(Empty.isEmpty)
+        }
+        "returns false for Defined" in {
+            assert(!Defined(1).isEmpty)
+        }
+    }
+
+    "isDefined" - {
+        "returns false for Empty" in {
+            assert(!Empty.isDefined)
+        }
+        "returns true for Defined" in {
+            assert(Defined(1).isDefined)
+        }
+    }
+
+    "get" - {
+        "returns the value for Defined" in {
+            assert(Defined(1).get == 1)
+            assert(Defined("hello").get == "hello")
+        }
+        "throws NoSuchElementException for Empty" in {
+            assertThrows[NoSuchElementException] {
+                Empty.get
+            }
+        }
+    }
+
+    "getOrElse" - {
+        "returns the value for Defined" in {
+            assert(Defined(1).getOrElse(0) == 1)
+            assert(Defined("hello").getOrElse("") == "hello")
+        }
+        "returns the default value for Empty" in {
+            assert(Empty.getOrElse(0) == 0)
+            assert(Empty.getOrElse("") == "")
+        }
+    }
+
+    "fold" - {
+        "applies the empty function for Empty" in {
+            assert(Empty.fold(0, _ => 1) == 0)
+        }
+        "applies the non-empty function for Defined" in {
+            assert(Defined(1).fold(0, x => x + 1) == 2)
+        }
+    }
+
+    "flatMap" - {
+        "returns Empty for Empty" in {
+            assert(Maybe.empty[Int].flatMap(x => Defined(x + 1)) == Empty)
+        }
+        "applies the function for Defined" in {
+            assert(Defined(1).flatMap(x => Defined(x + 1)) == Defined(2))
+        }
+    }
+
+    "flatten" - {
+        "returns Empty for Empty" in {
+            assert(Empty.flatten == Empty)
+        }
+        "returns the nested value for Defined" in {
+            assert(Defined(Defined(1)).flatten == Defined(1))
+        }
+    }
+
+    "filter" - {
+        "returns Empty for Empty" in {
+            assert(Empty.filter(_ => true) == Empty)
+        }
+        "returns Empty if the predicate is false" in {
+            assert(Defined(1).filter(_ > 1) == Empty)
+        }
+        "returns Defined if the predicate is true" in {
+            assert(Defined(1).filter(_ == 1) == Defined(1))
+        }
+    }
+
+    "filterNot" - {
+        "returns Empty for Empty" in {
+            assert(Empty.filterNot(_ => false) == Empty)
+        }
+        "returns Defined if the predicate is false" in {
+            assert(Defined(1).filterNot(_ > 1) == Defined(1))
+        }
+        "returns Empty if the predicate is true" in {
+            assert(Defined(1).filterNot(_ == 1) == Empty)
+        }
+    }
+
+    "contains" - {
+        "returns false for Empty" in {
+            assert(!Empty.contains(1))
+        }
+        "returns true if the element is equal" in {
+            assert(Defined(1).contains(1))
+        }
+        "returns false if the element is not equal" in {
+            assert(!Defined(1).contains(2))
+        }
+    }
+
+    "exists" - {
+        "returns false for Empty" in {
+            assert(!Empty.exists(_ => true))
+        }
+        "returns true if the predicate is satisfied" in {
+            assert(Defined(1).exists(_ == 1))
+        }
+        "returns false if the predicate is not satisfied" in {
+            assert(!Defined(1).exists(_ != 1))
+        }
+    }
+
+    "forall" - {
+        "returns true for Empty" in {
+            assert(Empty.forall(_ => false))
+        }
+        "returns true if the predicate is satisfied" in {
+            assert(Defined(1).forall(_ == 1))
+        }
+        "returns false if the predicate is not satisfied" in {
+            assert(!Defined(1).forall(_ != 1))
+        }
+    }
+
+    "foreach" - {
+        "does not apply the function for Empty" in {
+            var applied = false
+            Empty.foreach(_ => applied = true)
+            assert(!applied)
+        }
+        "applies the function for Defined" in {
+            var result = 0
+            Defined(1).foreach(result += _)
+            assert(result == 1)
+        }
+    }
+
+    "collect" - {
+        "returns Empty for Empty" in {
+            assert(Empty.collect { case _ => 1 } == Empty)
+        }
+        "returns Empty if the partial function is not defined" in {
+            assert(Defined(1).collect { case 2 => 3 } == Empty)
+        }
+        "returns Defined if the partial function is defined" in {
+            assert(Defined(1).collect { case 1 => 2 } == Defined(2))
+        }
+    }
+
+    "orElse" - {
+        "returns the fallback option for Empty" in {
+            assert(Empty.orElse(Defined(1)) == Defined(1))
+        }
+        "returns itself for Defined" in {
+            assert(Defined(1).orElse(Defined(2)) == Defined(1))
+        }
+    }
+
+    "zip" - {
+        "returns Empty if either option is Empty" in {
+            assert(Empty.zip(Empty) == Empty)
+            assert(Empty.zip(Defined(1)) == Empty)
+            assert(Defined(1).zip(Empty) == Empty)
+        }
+        "returns Defined with a tuple if both options are Defined" in {
+            assert(Defined(1).zip(Defined(2)) == Defined((1, 2)))
+        }
+    }
+
+    "iterator" - {
+        "returns an empty iterator for Empty" in {
+            assert(Empty.iterator.isEmpty)
+        }
+        "returns a single element iterator for Defined" in {
+            assert(Defined(1).iterator.toList == List(1))
+        }
+    }
+
+    "toList" - {
+        "returns an empty list for Empty" in {
+            assert(Empty.toList == Nil)
+        }
+        "returns a single element list for Defined" in {
+            assert(Defined(1).toList == List(1))
+        }
+    }
+
+    "toRight" - {
+        "returns Left with the argument for Empty" in {
+            assert(Empty.toRight(0) == Left(0))
+        }
+        "returns Right with the value for Defined" in {
+            assert(Defined(1).toRight(0) == Right(1))
+        }
+    }
+
+    "toLeft" - {
+        "returns Right with the argument for Empty" in {
+            assert(Empty.toLeft(0) == Right(0))
+        }
+        "returns Left with the value for Defined" in {
+            assert(Defined(1).toLeft(0) == Left(1))
+        }
+    }
+
+    "nested Defined(Empty)" - {
+        "flatten should return the nested Maybe" in {
+            assert(Defined(Defined(1)).flatten == Defined(1))
+            assert(Defined(Empty).flatten == Empty)
+            assert(Empty.flatten == Empty)
+        }
+
+        "get should return the value of the nested Maybe" in {
+            assert(Defined(Defined(1)).get == Defined(1))
+            assert(Defined(Empty).get == Empty)
+        }
+
+        "getOrElse should return the value of the nested Maybe" in {
+            assert(Defined(Defined(1)).getOrElse(Defined(2)) == Defined(1))
+            assert(Defined(Empty).getOrElse(Defined(2)) == Empty)
+        }
+
+        "orElse should return the value of the nested Maybe" in {
+            assert(Defined(Defined(1)).orElse(Defined(Defined(2))) == Defined(Defined(1)))
+            assert(Defined(Empty).orElse(Defined(Defined(2))) == Defined(Empty))
+        }
+
+        "fold should apply the non-empty function to the nested Maybe" in {
+            assert(Defined(Defined(1)).fold(Defined(0), x => x.map(_ + 1)) == Defined(2))
+            assert(Defined(Maybe.empty[Int]).fold(Defined(0), x => x.map(_ + 1)) == Empty)
+        }
+
+        "flatMap should apply the function to the nested Maybe" in {
+            assert(Defined(Defined(1)).flatMap(x => x.map(_ + 1)) == Defined(2))
+            assert(Defined(Maybe.empty[Int]).flatMap(x => x.map(_ + 1)) == Empty)
+        }
+
+        "map should apply the function to the nested Maybe" in {
+            assert(Defined(Defined(1)).map(_ => Defined(2)) == Defined(Defined(2)))
+            assert(Defined(Empty).map(_ => Defined(2)) == Defined(Defined(2)))
+        }
+
+        "filter should apply the predicate to the nested Maybe" in {
+            assert(Defined(Defined(1)).filter(_.contains(1)) == Defined(Defined(1)))
+            assert(Defined(Defined(1)).filter(_.contains(2)) == Empty)
+            assert(Defined(Empty).filter(_.contains(1)) == Empty)
+        }
+
+        "filterNot should apply the predicate to the nested Maybe" in {
+            assert(Defined(Defined(1)).filterNot(_.contains(2)) == Defined(Defined(1)))
+            assert(Defined(Defined(1)).filterNot(_.contains(1)) == Empty)
+            assert(Defined(Empty).filterNot(_.contains(1)) == Defined(Empty))
+        }
+
+        "exists should apply the predicate to the nested Maybe" in {
+            assert(Defined(Defined(1)).exists(_.contains(1)))
+            assert(!Defined(Defined(1)).exists(_.contains(2)))
+            assert(!Defined(Empty).exists(_.contains(1)))
+        }
+
+        "forall should apply the predicate to the nested Maybe" in {
+            assert(Defined(Defined(1)).forall(_.contains(1)))
+            assert(!Defined(Defined(1)).forall(_.contains(2)))
+            assert(!Defined(Empty).forall(_.contains(1)))
+        }
+    }
+
+    "deeplyNestedDefined" - {
+        val deeplyNestedDefined = Defined(Defined(Defined(Defined(Defined(1)))))
+
+        "get should return deeply nested value" in {
+            assert(deeplyNestedDefined.get == Defined(Defined(Defined(Defined(1)))))
+        }
+
+        "flatten should flatten deeply nested Defined" in {
+            assert(deeplyNestedDefined.flatten.flatten == Defined(Defined(Defined(1))))
+            assert(deeplyNestedDefined.flatten.flatten.flatten == Defined(Defined(1)))
+            assert(deeplyNestedDefined.flatten.flatten.flatten.flatten == Defined(1))
+        }
+
+        "flatMap should apply function and flatten result" in {
+            assert(deeplyNestedDefined.flatMap(x => x.flatMap(y => y.flatMap(z => z))) == Defined(Defined(1)))
+        }
+
+        "exists should apply to deeply nested predicate" in {
+            assert(deeplyNestedDefined.exists(_.exists(_.exists(_.exists(_.exists(_ == 1))))))
+            assert(!deeplyNestedDefined.exists(_.exists(_.exists(_.exists(_.exists(_ == 2))))))
+        }
+
+        "forall should apply to deeply nested predicate" in {
+            assert(deeplyNestedDefined.forall(_.forall(_.forall(_.forall(_.forall(_ == 1))))))
+            assert(!deeplyNestedDefined.forall(_.forall(_.forall(_.forall(_.forall(_ == 2))))))
+        }
+    }
+
+    "equals" - {
+        "should equate two deeply nested Maybes" in {
+            assert(Defined(Defined(Defined(1))) == Defined(Defined(Defined(1))))
+            assert(Defined(Defined(Empty)) == Defined(Defined(Empty)))
+        }
+
+        "should not equate different nested Maybes" in {
+            assert(Defined(Defined(Defined(1))) != Defined(Defined(Defined(2))))
+            assert(Defined(Defined(Defined(1))) != Defined(Defined(Empty)))
+            assert(Defined(Defined(Empty)) != Defined(Empty))
+        }
+    }
+
+    "pattern matching" - {
+        "simple match" - {
+            "should match Defined and extract value" in {
+                val result = Defined(1) match
+                    case Defined(x) => x
+                    case Empty      => 0
+                assert(result == 1)
+            }
+
+            "should match Empty" in {
+                val result = Empty match
+                    case Defined(x) => x
+                    case Empty      => 0
+                assert(result == 0)
+            }
+        }
+
+        "nested match" - {
+            "should match nested Defined and extract inner value" in {
+                val result = Defined(Defined(1)) match
+                    case Defined(Defined(x)) => x
+                    case _                   => 0
+                assert(result == 1)
+            }
+
+            "should match outer Empty" in {
+                val result = Empty match
+                    case Defined(Defined(x)) => x
+                    case _                   => 0
+                assert(result == 0)
+            }
+
+            "should match inner Empty" in {
+                val result = Defined(Empty) match
+                    case Defined(Defined(x)) => x
+                    case _                   => 0
+                assert(result == 0)
+            }
+        }
+
+        "deep matching" - {
+            val nestedMaybe = Defined(Defined(Defined(Defined(1))))
+
+            "should match deeply nested Defined and extract inner value" in {
+                val result = nestedMaybe match
+                    case Defined(Defined(Defined(Defined(x)))) => x
+                    case _                                     => 0
+                assert(result == 1)
+            }
+
+            "should return default for deep mismatch" in {
+                val result = nestedMaybe match
+                    case Defined(Defined(Defined(Empty))) => 1
+                    case _                                => 0
+                assert(result == 0)
+            }
+
+            "should match partially and extract nested Defined" in {
+                val result = nestedMaybe match
+                    case Defined(Defined(x)) => x
+                    case _                   => Empty
+                assert(result == Defined(Defined(1)))
+            }
+        }
+    }
+
+end MaybeTest

--- a/kyo-core/shared/src/test/scala/kyoTest/MaybeTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/MaybeTest.scala
@@ -247,8 +247,8 @@ class MaybeTest extends KyoTest:
         }
 
         "fold should apply the non-empty function to the nested Maybe" in {
-            assert(Defined(Defined(1)).fold(Defined(0), x => x.map(_ + 1)) == Defined(2))
-            assert(Defined(Maybe.empty[Int]).fold(Defined(0), x => x.map(_ + 1)) == Empty)
+            assert(Defined(Defined(1)).fold(Defined(0))(x => x.map(_ + 1)) == Defined(2))
+            assert(Defined(Maybe.empty[Int]).fold(Defined(0))(x => x.map(_ + 1)) == Empty)
         }
 
         "flatMap should apply the function to the nested Maybe" in {


### PR DESCRIPTION
The implementation matches the behavior of Scala's `Option`, even when there's nesting! The key insight is that nesting is only a problem when there are nested `Some(None)`, which the implementation tracks via cached internal `SomeNone` instances. The only scenarios where this implementation allocates objects is when the nesting of `Some(None)` exceeds `100` (quite unlikely) and when `Some.unapply` is used. I had to use Scala's `Option` for pattern matching because the compiler isn't able to locate `isDefined`/`get` as extension methods to consider `Some.unapply` an extractor.

I'm a bit uneasy about naming this new impl `Option` since it can be confusing to users but we have a precedence with `Duration`. 