### PR TITLE
chunk fixes

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/chunks.scala
+++ b/kyo-core/shared/src/main/scala/kyo/chunks.scala
@@ -162,7 +162,7 @@ sealed abstract class Chunk[T] derives CanEqual:
                     end if
                 else
                     acc
-            loop(0, null, Chunks.init)
+            loop(0, first, Chunks.init)
     end changes
 
     final def collect[U, S](pf: PartialFunction[T, U < S])(using Trace): Chunk[U] < S =
@@ -278,7 +278,7 @@ sealed abstract class Chunk[T] derives CanEqual:
                     if dropRight > 0 then
                         loop(c.chunk, end, dropLeft, dropRight - 1)
                     else if end > 0 then
-                        array(end - 1) = c.value
+                        array(start + end - 1) = c.value
                         loop(c.chunk, end - 1, dropLeft, dropRight)
                 case c: Drop[T] =>
                     loop(c.chunk, end, dropLeft + c.dropLeft, dropRight + c.dropRight)

--- a/kyo-core/shared/src/test/scala/kyoTest/chunksTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/chunksTest.scala
@@ -425,6 +425,12 @@ class chunksTest extends KyoTest:
             val chunk = Chunks.init(Chunks.init(1), Chunks.init(2, 3), Chunks.init(4, 5, 6, 7))
             assert(chunk.flatten == Chunks.init(1, 2, 3, 4, 5, 6, 7))
         }
+
+        "appends" in {
+            val chunk: Chunk[Chunk[Int]] =
+                Chunks.init(Chunks.init[Int].append(1).append(2), Chunks.init(3, 4).append(5), Chunks.init(6, 7).append(8).append(9))
+            assert(chunk.flatten == Chunks.init(1, 2, 3, 4, 5, 6, 7, 8, 9))
+        }
     }
 
     "toArray" - {
@@ -712,6 +718,12 @@ class chunksTest extends KyoTest:
         "handles a chunk with all duplicate elements" in {
             val chunk = Chunks.init(1, 1, 1, 1, 1)
             assert(chunk.changes == Chunks.init(1))
+        }
+
+        "with initial values" in {
+            val chunk = Chunks.init(1, 1, 1, 1, 1)
+            assert(chunk.changes(0) == Chunks.init(1))
+            assert(chunk.changes(1) == Chunks.init[Int])
         }
     }
 


### PR DESCRIPTION
I noticed two `Chunk` bugs while working on https://github.com/getkyo/kyo/issues/368. `Chunk.changes` was ignoring the `first` param and `Chunk.copyTo` wasn't considering the offset correctly for appends.