### PR TITLE
tags: fix perf regression with int encoding

### DIFF
--- a/kyo-tag/shared/src/main/scala/kyo/internal/IntEncoder.scala
+++ b/kyo-tag/shared/src/main/scala/kyo/internal/IntEncoder.scala
@@ -1,0 +1,37 @@
+package kyo.internal
+
+object IntEncoder:
+    private val charsStart    = ' '
+    private val charsEnd      = '~'
+    private val charsReserved = Set('[', ']', '(', ')', ';', ',')
+
+    private val table =
+        val array = new Array[Int](charsEnd - charsStart + 1)
+        var char  = charsStart
+        var value = 0
+        while char <= charsEnd do
+            if !charsReserved.contains(char) then
+                array(char - charsStart) = value
+                value += 1
+            else
+                array(char - charsStart) = -1
+            end if
+            char = (char + 1).toChar
+        end while
+        array
+    end table
+
+    def encode(i: Int): Char =
+        val idx = table.indexOf(i)
+        if idx < 0 || i < 0 then
+            throw new Exception(s"Encoded tag 'Int($i)' exceeds supported range: ${table(0)} to ${table(table.length - 1)}")
+        (idx + charsStart).toChar
+    end encode
+
+    def decode(c: Char): Int =
+        table(c - charsStart)
+
+    def encodeHash(hash: Int): Char =
+        encode(Math.abs(hash) % table(table.length - 1))
+
+end IntEncoder

--- a/kyo-tag/shared/src/test/scala/kyoTest/internal/IntEncoderTest.scala
+++ b/kyo-tag/shared/src/test/scala/kyoTest/internal/IntEncoderTest.scala
@@ -1,0 +1,26 @@
+package kyoTest.internal
+
+import kyo.internal.IntEncoder
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class IntEncoderTest extends AnyFreeSpec with Matchers:
+
+    "supports 0 to 88" in {
+        for i <- 0 to 88 do
+            assert(IntEncoder.decode(IntEncoder.encode(i)) == i)
+    }
+
+    "fails out of range" in {
+        intercept[Exception](IntEncoder.encode(-1))
+        intercept[Exception](IntEncoder.encode(89))
+        intercept[Exception](IntEncoder.encode(Int.MaxValue))
+        intercept[Exception](IntEncoder.encode(Int.MinValue))
+    }
+
+    "encodes hashes" in {
+        for _ <- 0 until 100 do
+            IntEncoder.encodeHash((new Object).hashCode())
+    }
+
+end IntEncoderTest


### PR DESCRIPTION
I noticed a performance regression introduced by https://github.com/getkyo/kyo/pull/432. The mechanism to decode `Int`s has to scan an array of chars, which introduces overhead and even allocations in some cases because `indexOf` is an unoptimized Scala implementation.

This PR fixes the regression by moving the search to compile time and producing a table that can be used with a simple offset lookup.

Benchmark results:

![image](https://github.com/getkyo/kyo/assets/831175/72b5d5cf-c756-4941-b048-c8c6ed18df51)
https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/fwbrasil/872121366422a6cd4d1d19b9df1e95b9/raw/c4ccc79d42f61514c7fcdbdfc9ca12f4178caf67/jmh-result-baseline.json,https://gist.githubusercontent.com/fwbrasil/872121366422a6cd4d1d19b9df1e95b9/raw/c4ccc79d42f61514c7fcdbdfc9ca12f4178caf67/jmh-result-candidate.json