### PR TITLE
Disable cooperative yielding in zio scheduler

### DIFF
--- a/kyo-scheduler-zio/jvm/src/main/scala/kyo/KyoSchedulerZIORuntime.scala
+++ b/kyo-scheduler-zio/jvm/src/main/scala/kyo/KyoSchedulerZIORuntime.scala
@@ -19,7 +19,7 @@ object KyoSchedulerZIORuntime {
                     true
                 }
             }
-        Runtime.setExecutor(exec) ++ Runtime.setBlockingExecutor(exec)
+        Runtime.setExecutor(exec) ++ Runtime.setBlockingExecutor(exec) ++ Runtime.disableFlags(RuntimeFlag.CooperativeYielding)
     }
 
     lazy val default: Runtime[Any] = {


### PR DESCRIPTION
The flag landed in 2.1.2 so we can now disable the automatic yielding that ZIO does every 128 forks and 10240 operations.

Is there a good way to check the impact of this? I see there's a `bench` job but you trigger it manually?