### PR TITLE
refactor Duration to avoid conflict with < in the new core

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Duration.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Duration.scala
@@ -4,17 +4,23 @@ import java.time.Duration as JavaDuration
 import java.time.temporal.ChronoUnit.*
 import kyo.Duration.Units
 import kyo.Duration.Units.*
-import kyo.duration.*
 import scala.concurrent.duration.Duration as ScalaDuration
 
-type Duration = duration.Duration
-given CanEqual[Duration, Duration] = canEqual
+type Duration = Duration.Value
 
 object Duration:
-    val Zero: Duration     = _Zero
-    val Infinity: Duration = _Infinity
 
-    inline def fromNanos(value: Long): Duration = value.nanos
+    opaque type Value = Long
+
+    given CanEqual[Duration, Duration] = CanEqual.derived
+
+    val Zero: Duration     = 0L
+    val Infinity: Duration = Long.MaxValue
+
+    inline def fromNanos(value: Long): Duration = value
+
+    def fromUnits(value: Long, unit: Units): Duration =
+        if value <= 0 then Duration.Zero else Duration.*(value)(unit.factor).min(Infinity)
 
     def fromJava(value: JavaDuration): Duration =
         (value.toNanos: @annotation.switch) match
@@ -23,7 +29,7 @@ object Duration:
             case n                       => n.nanos
 
     def fromScala(value: ScalaDuration): Duration =
-        if value.isFinite then value.toNanos.nanos max Zero else Infinity
+        if value.isFinite then value.toNanos.nanos.max(Zero) else Infinity
 
     enum Units(val factor: Double):
         case Nanos   extends Units(NANOS.getDuration.toNanos.toDouble)
@@ -38,10 +44,64 @@ object Duration:
         case Years   extends Units(YEARS.getDuration.toNanos.toDouble)
     end Units
 
+    extension (self: Duration)
+
+        private inline def toLong: Long = self
+
+        inline infix def >=(that: Duration): Boolean = self.toLong >= that.toLong
+        inline infix def <=(that: Duration): Boolean = self.toLong <= that.toLong
+        inline infix def >(that: Duration): Boolean  = self.toLong > that.toLong
+        inline infix def <(that: Duration): Boolean  = self.toLong < that.toLong
+        inline infix def ==(that: Duration): Boolean = self.toLong == that.toLong
+        inline infix def !=(that: Duration): Boolean = self.toLong != that.toLong
+
+        inline infix def +(that: Duration): Duration =
+            val sum: Long = self.toLong + that.toLong
+            if sum >= 0 then sum else Duration.Infinity
+
+        inline infix def *(factor: Double): Duration =
+            if factor <= 0 || self.toLong <= 0L then Duration.Zero
+            else if factor <= Long.MaxValue / self.toLong.toDouble then Math.round(self.toLong.toDouble * factor)
+            else Duration.Infinity
+
+        inline def max(that: Duration): Duration = Math.max(self.toLong, that.toLong)
+        inline def min(that: Duration): Duration = Math.min(self.toLong, that.toLong)
+
+        inline def to(unit: Units): Long =
+            Math.max(Math.round(self.toLong / unit.factor), Duration.Zero)
+
+        inline def toNanos: Long   = self.toLong
+        inline def toMicros: Long  = self.to(Micros)
+        inline def toMillis: Long  = self.to(Millis)
+        inline def toSeconds: Long = self.to(Seconds)
+        inline def toMinutes: Long = self.to(Minutes)
+        inline def toHours: Long   = self.to(Hours)
+        inline def toDays: Long    = self.to(Days)
+        inline def toWeeks: Long   = self.to(Weeks)
+        inline def toMonths: Long  = self.to(Months)
+        inline def toYears: Long   = self.to(Years)
+
+        def toScala: ScalaDuration =
+            (self: @annotation.switch) match
+                case Duration.Zero     => ScalaDuration.Zero
+                case Duration.Infinity => ScalaDuration.Inf
+                case n                 => ScalaDuration.fromNanos(n.toNanos)
+
+        def toJava: JavaDuration =
+            (self: @annotation.switch) match
+                case Duration.Zero => JavaDuration.ZERO
+                case n             => JavaDuration.of(n.toNanos, NANOS)
+
+        inline def render: String = s"Duration($self ns)"
+
+        // Is this Robust enough?
+        private[kyo] inline def isFinite: Boolean = self < Duration.Infinity
+    end extension
+
 end Duration
 
 extension (value: Long)
-    inline def nanos: Duration   = value.asNanos
+    inline def nanos: Duration   = Duration.fromNanos(value)
     inline def micros: Duration  = value.as(Micros)
     inline def millis: Duration  = value.as(Millis)
     inline def seconds: Duration = value.as(Seconds)
@@ -61,10 +121,13 @@ extension (value: Long)
     inline def week: Duration    = compiletime.error("please use `.weeks`")
     inline def month: Duration   = compiletime.error("please use `.months`")
     inline def year: Duration    = compiletime.error("please use `.years`")
+
+    inline def as(unit: Units): Duration =
+        Duration.fromUnits(value, unit)
 end extension
 
 extension (value: 1)
-    inline def nano: Duration   = value.asNanos
+    inline def nano: Duration   = Duration.fromNanos(value)
     inline def micro: Duration  = value.as(Micros)
     inline def milli: Duration  = value.as(Millis)
     inline def second: Duration = value.as(Seconds)
@@ -75,87 +138,3 @@ extension (value: 1)
     inline def month: Duration  = value.as(Months)
     inline def year: Duration   = value.as(Years)
 end extension
-
-extension (self: Duration)
-
-    infix def >=(that: Duration): Boolean = self.gtEq(that)
-    infix def <=(that: Duration): Boolean = self.ltEq(that)
-    infix def >(that: Duration): Boolean  = self.gt(that)
-    infix def <(that: Duration): Boolean  = self.lt(that)
-    infix def ==(that: Duration): Boolean = self.eqEq(that)
-    infix def !=(that: Duration): Boolean = self.neEq(that)
-
-    inline def +(that: Duration): Duration = self.add(that)
-    inline def *(factor: Double): Duration = self.multiply(factor)
-
-    infix def max(that: Duration): Duration = self._max(that)
-    infix def min(that: Duration): Duration = self._min(that)
-
-    inline def toNanos: Long   = self._toNanos
-    inline def toMicros: Long  = self.to(Micros)
-    inline def toMillis: Long  = self.to(Millis)
-    inline def toSeconds: Long = self.to(Seconds)
-    inline def toMinutes: Long = self.to(Minutes)
-    inline def toHours: Long   = self.to(Hours)
-    inline def toDays: Long    = self.to(Days)
-    inline def toWeeks: Long   = self.to(Weeks)
-    inline def toMonths: Long  = self.to(Months)
-    inline def toYears: Long   = self.to(Years)
-
-    def toScala: ScalaDuration =
-        (self: @annotation.switch) match
-            case Duration.Zero     => ScalaDuration.Zero
-            case Duration.Infinity => ScalaDuration.Inf
-            case n                 => ScalaDuration.fromNanos(n.toNanos)
-
-    def toJava: JavaDuration =
-        (self: @annotation.switch) match
-            case Duration.Zero => JavaDuration.ZERO
-            case n             => JavaDuration.of(n.toNanos, NANOS)
-
-    inline def render: String = s"Duration($self ns)"
-
-    // Is this Robust enough?
-    private[kyo] inline def isFinite: Boolean = self < Duration.Infinity
-end extension
-
-private[kyo] object duration:
-    opaque type Duration = Long
-    val canEqual: CanEqual[Duration, Duration] = CanEqual.derived
-
-    val _Zero: Duration     = 0
-    val _Infinity: Duration = Long.MaxValue
-
-    extension (value: Long)
-        inline def as(unit: Units): Duration =
-            if value <= 0 then Duration.Zero else Math.min(value.multiply(unit.factor), Duration.Infinity)
-
-        inline def asNanos: Duration = value
-    end extension
-    extension (self: Duration)
-
-        inline def to(unit: Units): Long = Math.max(Math.round(self / unit.factor), Duration.Zero)
-        inline def _toNanos: Long        = self
-
-        inline def add(that: Duration): Duration =
-            val sum: Long = self + that
-            if sum >= 0 then sum else Duration.Infinity
-        end add
-
-        inline def multiply(factor: Double): Duration = // fix type inference in `as`
-            if factor <= 0 || self <= 0 then Duration.Zero
-            else if factor <= Long.MaxValue / self.toDouble then Math.round(self.toDouble * factor)
-            else Duration.Infinity
-        end multiply
-
-        inline def gtEq(that: Duration): Boolean = self >= that
-        inline def ltEq(that: Duration): Boolean = self <= that
-        inline def gt(that: Duration): Boolean   = self > that
-        inline def lt(that: Duration): Boolean   = self < that
-        inline def eqEq(that: Duration): Boolean = self == that
-        inline def neEq(that: Duration): Boolean = self != that
-
-        inline def _max(that: Duration): Duration = Math.max(self, that)
-        inline def _min(that: Duration): Duration = Math.min(self, that)
-    end extension
-end duration

--- a/kyo-core/shared/src/test/scala/kyoTest/DurationSpec.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/DurationSpec.scala
@@ -99,7 +99,7 @@ object DurationSpec extends ZIOSpecDefault:
             test("Long.to*") {
                 for
                     result <- typeCheck("Long.MaxValue.toNanos")
-                yield assertTrue(result.is(_.left).contains("Required: kyo.Duration"))
+                yield assertTrue(result.is(_.left).contains("value toNanos is not a member of Long"))
             },
             test("toString") {
                 val d = 10.nanos.toString


### PR DESCRIPTION
I'm working on the changes to introduce the new core design but I'm having trouble with `<` now being a case class and the symbol conflicting with `<` from the `Duration` extension methods. This PR changes the encoding of `Duration` so the extension methods can be under the companion object instead of the package to avoid the conflict.