### PR TITLE
use Result for Fiber completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,10 +1566,10 @@ val c: Int < Fibers =
 val d: Unit < IOs =
   a.onComplete(println(_))
 
-// A variant of `get` that returns a `Try`
+// A variant of `get` that returns a `Result`
 // with the failed or successful result
-val e: Try[Int] < Fibers =
-  a.getTry
+val e: Result[Int] < Fibers =
+  a.getResult
 
 // Try to interrupt/cancel a fiber
 val f: Boolean < IOs =
@@ -1623,7 +1623,7 @@ val a: Promise[Int] < IOs =
 
 // Try to fulfill a promise
 val b: Boolean < IOs =
-  a.map(_.complete(42))
+  a.map(_.completeSuccess(42))
 
 // Fullfil the promise with 
 // another fiber

--- a/kyo-bench/src/main/scala/kyo/bench/ForkChainedBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForkChainedBench.scala
@@ -25,7 +25,7 @@ class ForkChainedBench extends Bench.ForkOnly(0):
         import kyo.*
 
         def iterate(p: Promise[Unit], n: Int): Unit < IOs =
-            if n <= 0 then p.complete(()).unit
+            if n <= 0 then p.completeSuccess(()).unit
             else IOs.unit.flatMap(_ => Fibers.init(iterate(p, n - 1)).unit)
 
         for

--- a/kyo-bench/src/main/scala/kyo/bench/ForkManyBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForkManyBench.scala
@@ -37,7 +37,7 @@ class ForkManyBench extends Bench.ForkOnly(0):
             ref     <- Atomics.initInt(depth)
             effect = ref.decrementAndGet.flatMap {
                 case 1 =>
-                    promise.complete(())
+                    promise.completeSuccess(())
                 case _ =>
                     false
             }

--- a/kyo-bench/src/main/scala/kyo/bench/PingPongBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/PingPongBench.scala
@@ -50,7 +50,7 @@ class PingPongBench extends Bench.ForkOnly(()):
                         _ <- Fibers.init(chan.put(()))
                         _ <- chan.take
                         n <- ref.decrementAndGet
-                        _ <- if n == 0 then promise.complete(()).unit else IOs.unit
+                        _ <- if n == 0 then promise.completeSuccess(()).unit else IOs.unit
                     yield ()
                 _ <- repeat(depth)(Fibers.init(effect))
             yield ()

--- a/kyo-bench/src/main/scala/kyo/bench/RendezvousBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/RendezvousBench.scala
@@ -71,7 +71,7 @@ class RendezvousBench extends Bench.ForkOnly(10000 * (10000 + 1) / 2):
                     waiting.cas(null, (p, n)).flatMap {
                         case false =>
                             waiting.getAndSet(null).flatMap {
-                                _.asInstanceOf[Promise[Int]].complete(n)
+                                _.asInstanceOf[Promise[Int]].completeSuccess(n)
                             }
                         case true =>
                             p.get
@@ -89,7 +89,7 @@ class RendezvousBench extends Bench.ForkOnly(10000 * (10000 + 1) / 2):
                         case false =>
                             waiting.getAndSet(null).flatMap {
                                 case (p2: Promise[Unit] @unchecked, i: Int) =>
-                                    p2.complete(()).map(_ => i)
+                                    p2.completeSuccess(()).map(_ => i)
                             }
                         case true =>
                             p.get

--- a/kyo-cache/shared/src/main/scala/kyo/caches.scala
+++ b/kyo-cache/shared/src/main/scala/kyo/caches.scala
@@ -30,11 +30,11 @@ class Cache(private[kyo] val store: Store):
                             } {
                                 IOs.toTry[U, S](f(v)).map {
                                     case Success(v) =>
-                                        p.complete(v)
+                                        p.completeSuccess(v)
                                             .unit.andThen(v)
                                     case Failure(ex) =>
                                         IOs(store.invalidate(key))
-                                            .andThen(p.complete(IOs.fail(ex)))
+                                            .andThen(p.completeFailure(ex))
                                             .unit.andThen(IOs.fail(ex))
                                 }
                             }

--- a/kyo-combinators/shared/src/main/scala/kyo/constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/constructors.scala
@@ -26,7 +26,7 @@ extension (kyoObject: Kyo.type)
             registerFn = (eff: A < Fibers) =>
                 val effFiber = Fibers.init(eff)
                 val updatePromise =
-                    effFiber.map(_.onComplete(a => promise.complete(a).unit))
+                    effFiber.map(_.onComplete(a => promise.completeResult(a).unit))
                 val updatePromiseIO = Fibers.init(updatePromise).unit
                 IOs.run(updatePromiseIO)
             _ <- register(registerFn)

--- a/kyo-core/jvm/src/main/scala/kyo/fibersPlatformSpecific.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/fibersPlatformSpecific.scala
@@ -14,8 +14,8 @@ trait fibersPlatformSpecific:
                 val p = new IOPromise[T]()
                 cs.whenComplete { (success, error) =>
                     val io = IOs {
-                        if error == null then p.complete(success)
-                        else p.complete(IOs.fail(error))
+                        if error == null then p.complete(Result.success(success))
+                        else p.complete(Result.failure(error))
                     }
                     IOTask(io, st)
                     ()

--- a/kyo-core/jvm/src/test/scala/kyoTest/completionStageTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyoTest/completionStageTest.scala
@@ -19,9 +19,9 @@ class completionStageTest extends KyoTest:
             cf.completeExceptionally(err)
             val res   = Fibers.fromCompletionStage(cf)
             val fiber = Fibers.run(res)
-            fiber.map(_.getTry.map {
-                case Failure(e) => assert(e == err)
-                case Success(_) => assert(false)
+            fiber.map(_.getResult.map {
+                case Result.Failure(e) => assert(e == err)
+                case Result.Success(_) => assert(false)
             })
         }
 

--- a/kyo-core/shared/src/main/scala/kyo/channels.scala
+++ b/kyo-core/shared/src/main/scala/kyo/channels.scala
@@ -152,7 +152,7 @@ object Channels:
                                     // If the queue has been emptied before the
                                     // transfer, requeue the consumer's promise.
                                     discard(takes.add(p))
-                                else if !p.unsafeComplete(v) && !u.offer(v) then
+                                else if !p.unsafeComplete(Result.success(v)) && !u.offer(v) then
                                     // If completing the take fails and the queue
                                     // cannot accept the value back, enqueue a
                                     // placeholder put operation to preserve the value.
@@ -171,7 +171,7 @@ object Channels:
                                     // Complete the put's promise if the value is
                                     // successfully enqueued. If the fiber became
                                     // interrupted, the completion will be ignored.
-                                    discard(p.unsafeComplete(()))
+                                    discard(p.unsafeComplete(Result.success(())))
                                 else
                                     // If the queue becomes full before the transfer,
                                     // requeue the producer's operation.
@@ -186,12 +186,12 @@ object Channels:
                             if t != null then
                                 val (v, p) = t
                                 val p2     = takes.poll()
-                                if p2 != null && p2.unsafeComplete(v) then
+                                if p2 != null && p2.unsafeComplete(Result.success(v)) then
                                     // If the transfer is successful, complete
                                     // the put's promise. If the consumer's fiber
                                     // became interrupted, the completion will be
                                     // ignored.
-                                    discard(p.unsafeComplete(()))
+                                    discard(p.unsafeComplete(Result.success(())))
                                 else
                                     // If the transfer to the consumer fails, requeue
                                     // the producer's operation.

--- a/kyo-core/shared/src/main/scala/kyo/fibers.scala
+++ b/kyo-core/shared/src/main/scala/kyo/fibers.scala
@@ -19,8 +19,8 @@ import scala.util.control.NoStackTrace
 sealed abstract class Fiber[+T]:
     def isDone(using Trace): Boolean < IOs
     def get(using Trace): T < Fibers
-    def getTry(using Trace): Try[T] < Fibers
-    def onComplete(f: T < IOs => Unit < IOs)(using Trace): Unit < IOs
+    def getResult(using Trace): Result[T] < Fibers
+    def onComplete(f: Result[T] => Unit < IOs)(using Trace): Unit < IOs
     def block(timeout: Duration)(using Trace): T < IOs
     def interrupt(using Trace): Boolean < IOs
     def toFuture(using Trace): Future[T] < IOs
@@ -32,10 +32,10 @@ object Fiber:
     val unit: Fiber[Unit] = value(())
 
     def value[T: Flat](v: T): Fiber[T] =
-        Done(v)
+        Done(Result.success(v))
 
     def fail[T: Flat](ex: Throwable): Fiber[T] =
-        Done(IOs.fail(ex))
+        Done(Result.failure(ex))
 
 end Fiber
 
@@ -51,17 +51,17 @@ case class Promise[T] private (private val p: IOPromise[T]) extends Fiber[T]:
 
     def get(using Trace) = FiberGets(this)
 
-    def getTry(using Trace) =
+    def getResult(using Trace) =
         IOs {
-            val r = new IOPromise[Try[T]]
+            val r = new IOPromise[Result[T]]
             r.interrupts(p)
             p.onComplete { t =>
-                discard(r.complete(IOs.toTry(t)))
+                discard(r.complete(Result.success(t)))
             }
             new Promise(r).get
         }
 
-    def onComplete(f: T < IOs => Unit < IOs)(using Trace) =
+    def onComplete(f: Result[T] => Unit < IOs)(using Trace) =
         IOs(p.onComplete(r => IOs.run(f(r))))
 
     def block(timeout: Duration)(using Trace) =
@@ -71,7 +71,7 @@ case class Promise[T] private (private val p: IOPromise[T]) extends Fiber[T]:
                     System.currentTimeMillis() + timeout.toMillis
                 else
                     Long.MaxValue
-            p.block(deadline)
+            p.block(deadline).get
         }
 
     def interrupt(using Trace) =
@@ -81,7 +81,7 @@ case class Promise[T] private (private val p: IOPromise[T]) extends Fiber[T]:
         IOs {
             val r = scala.concurrent.Promise[T]()
             p.onComplete { v =>
-                r.complete(Try(IOs.run(v)))
+                r.complete(v.toTry)
             }
             r.future
         }
@@ -92,29 +92,35 @@ case class Promise[T] private (private val p: IOPromise[T]) extends Fiber[T]:
             r.interrupts(p)
             p.onComplete { v =>
                 try
-                    IOs.run(t(IOs.run(v))) match
+                    IOs.run(t(v.get)) match
                         case Promise(v: IOPromise[U]) =>
                             discard(r.become(v))
                         case Done(v) =>
                             discard(r.complete(v))
                 catch
                     case ex if (NonFatal(ex)) =>
-                        discard(r.complete(IOs.fail(ex)))
+                        discard(r.complete(Result.failure(ex)))
             }
             new Promise(r)
         }
 
-    def complete(v: T < IOs)(using Trace): Boolean < IOs =
+    def completeSuccess(v: T)(using Trace): Boolean < IOs =
+        IOs(p.complete(Result.success(v)))
+
+    def completeFailure(ex: Throwable)(using Trace): Boolean < IOs =
+        IOs(p.complete(Result.failure(ex)))
+
+    def completeResult(v: Result[T])(using Trace): Boolean < IOs =
         IOs(p.complete(v))
 
     def become(other: Fiber[T])(using Trace): Boolean < IOs =
         other match
             case Done(v) =>
-                complete(v)
+                completeResult(v)
             case Promise(p2: IOPromise[T]) =>
                 IOs(p.become(p2))
 
-    private[kyo] def unsafeComplete(v: T < IOs): Boolean =
+    private[kyo] def unsafeComplete(v: Result[T]): Boolean =
         p.complete(v)
 end Promise
 
@@ -130,7 +136,8 @@ object Fibers extends Joins[Fibers] with fibersPlatformSpecific:
         override def getCause() = null
     end Interrupted
 
-    private[kyo] val interrupted = IOs.fail(Interrupted)
+    private[kyo] val interruptedResult = Result.failure(Interrupted)
+    private[kyo] val interruptedIOs    = IOs.fail(Interrupted)
 
     def run[T: Flat](v: T < Fibers)(using Trace): Fiber[T] < IOs =
         FiberGets.run(v)
@@ -187,15 +194,12 @@ object Fibers extends Joins[Fibers] with fibersPlatformSpecific:
                             state.interrupts(fiber)
                             fiber.onComplete { r =>
                                 try
-                                    results(i) =
-                                        IOs.run(r)(
-                                            using Flat.unsafe.bypass // bypass to avoid capturing
-                                        )
+                                    results(i) = r.get
                                     if pending.decrementAndGet() == 0 then
-                                        discard(state.complete(ArraySeq.unsafeWrapArray(results)))
+                                        discard(state.complete(Result.success(ArraySeq.unsafeWrapArray(results))))
                                 catch
                                     case ex if (NonFatal(ex)) =>
-                                        discard(state.complete(IOs.fail(ex)))
+                                        discard(state.complete(Result.failure(ex)))
                             }
                         }
                         Promise(state)
@@ -212,14 +216,14 @@ object Fibers extends Joins[Fibers] with fibersPlatformSpecific:
             case size =>
                 Locals.save { st =>
                     IOs {
-                        class State extends IOPromise[T] with Function1[T < IOs, Unit]:
+                        class State extends IOPromise[T] with Function1[Result[T], Unit]:
                             val pending = new AtomicInteger(size)
-                            def apply(v: T < IOs): Unit =
+                            def apply(v: Result[T]): Unit =
                                 val last = pending.decrementAndGet() == 0
-                                try discard(complete(IOs.run(v)))
+                                try discard(complete(Result.success(v.get)))
                                 catch
                                     case ex if (NonFatal(ex)) =>
-                                        if last then discard(complete(IOs.fail(ex)))
+                                        if last then discard(complete(Result.failure(ex)))
                                 end try
                             end apply
                         end State
@@ -244,7 +248,7 @@ object Fibers extends Joins[Fibers] with fibersPlatformSpecific:
         initPromise[Unit].map { p =>
             if d.isFinite then
                 val run: Unit < IOs =
-                    IOs(discard(IOTask(IOs(p.complete(())), Locals.State.empty)))
+                    IOs(discard(IOTask(IOs(p.completeSuccess(())), Locals.State.empty)))
                 Timers.schedule(d)(run).map { t =>
                     IOs.ensure(t.cancel.unit)(p.get)
                 }
@@ -273,9 +277,9 @@ object Fibers extends Joins[Fibers] with fibersPlatformSpecific:
                         IOs {
                             r match
                                 case Success(v) =>
-                                    p.complete(v)
+                                    p.complete(Result.success(v))
                                 case Failure(ex) =>
-                                    p.complete(IOs.fail(ex))
+                                    p.complete(Result.failure(ex))
                         }
                     IOTask(io, st)
                 }(ExecutionContext.parasitic)
@@ -303,18 +307,20 @@ end Fibers
 
 object fibersInternal:
 
-    case class Done[T: Flat](result: T < IOs) extends Fiber[T]:
-        def isDone(using Trace)                               = true
-        def get(using Trace)                                  = result
-        def getTry(using Trace)                               = IOs.toTry(result)
-        def onComplete(f: T < IOs => Unit < IOs)(using Trace) = f(result)
-        def block(timeout: Duration)(using Trace)             = result
-        def interrupt(using Trace)                            = false
+    case class Done[T: Flat](result: Result[T]) extends Fiber[T]:
+        def isDone(using Trace)                                 = true
+        def get(using Trace)                                    = result.get
+        def getResult(using Trace)                              = result
+        def onComplete(f: Result[T] => Unit < IOs)(using Trace) = f(result)
+        def block(timeout: Duration)(using Trace)               = result.get
+        def interrupt(using Trace)                              = false
 
-        def toFuture(using Trace) = Future.fromTry(Try(IOs.run(result)))
+        def toFuture(using Trace) = Future.fromTry(result.toTry)
 
-        def transform[U: Flat](t: T => Fiber[U] < IOs)(using Trace) =
-            result.map(t)
+        def transform[U: Flat](f: T => Fiber[U] < IOs)(using Trace) =
+            result match
+                case Result.Success(v) => f(v)
+                case _                 => this.asInstanceOf[Fiber[U]]
     end Done
 
     class FiberGets extends Effect[FiberGets]:
@@ -347,11 +353,12 @@ object fibersInternal:
                 val handler =
                     new Handler[Fiber, FiberGets, IOs]:
                         def resume[T, U: Flat, S](m: Fiber[T], f: T => U < (FiberGets & S))(using Tag[FiberGets]) =
-                            m match
-                                case Promise(p) =>
-                                    Resume((), p.block(deadline).map(f))
-                                case Done(v) =>
-                                    Resume((), v.map(f))
+                            val result =
+                                m match
+                                    case Promise(p) => p.block(deadline)
+                                    case Done(v)    => v
+                            Resume((), IOs(f(result.get)))
+                        end resume
                 FiberGets.handle(handler)((), v)
             }
 

--- a/kyo-core/shared/src/main/scala/kyo/latches.scala
+++ b/kyo-core/shared/src/main/scala/kyo/latches.scala
@@ -37,7 +37,7 @@ object Latches:
                                 if c > 0 && !count.compareAndSet(c, c - 1) then
                                     loop(count.get)
                                 else if c == 1 then
-                                    discard(promise.unsafeComplete(()))
+                                    discard(promise.unsafeComplete(Result.success(())))
                             loop(count.get())
                         }
 

--- a/kyo-core/shared/src/test/scala/kyoTest/channelsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/channelsTest.scala
@@ -114,7 +114,7 @@ class channelsTest extends KyoTest:
                 c <- Channels.init[Int](2)
                 f <- c.takeFiber
                 r <- c.close
-                d <- f.getTry
+                d <- f.getResult
                 t <- IOs.toTry(c.isFull)
             yield assert(r == Some(Seq()) && d.isFailure && t.isFailure)
         }
@@ -125,7 +125,7 @@ class channelsTest extends KyoTest:
                 _ <- c.put(2)
                 f <- c.putFiber(3)
                 r <- c.close
-                d <- f.getTry
+                d <- f.getResult
                 t <- IOs.toTry(c.offerUnit(1))
             yield assert(r == Some(Seq(1, 2)) && d.isFailure && t.isFailure)
         }
@@ -134,7 +134,7 @@ class channelsTest extends KyoTest:
                 c <- Channels.init[Int](0)
                 f <- c.putFiber(1)
                 r <- c.close
-                d <- f.getTry
+                d <- f.getResult
                 t <- IOs.toTry(c.poll)
             yield assert(r == Some(Seq()) && d.isFailure && t.isFailure)
         }
@@ -143,7 +143,7 @@ class channelsTest extends KyoTest:
                 c <- Channels.init[Int](0)
                 f <- c.takeFiber
                 r <- c.close
-                d <- f.getTry
+                d <- f.getResult
                 t <- IOs.toTry(c.put(1))
             yield assert(r == Some(Seq()) && d.isFailure && t.isFailure)
         }

--- a/kyo-core/shared/src/test/scala/kyoTest/fibersTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/fibersTest.scala
@@ -13,7 +13,7 @@ class fibersTest extends KyoTest:
         "complete" in run {
             for
                 p <- Fibers.initPromise[Int]
-                a <- p.complete(1)
+                a <- p.completeSuccess(1)
                 b <- p.isDone
                 c <- p.get
             yield assert(a && b && c == 1)
@@ -21,8 +21,8 @@ class fibersTest extends KyoTest:
         "complete twice" in run {
             for
                 p <- Fibers.initPromise[Int]
-                a <- p.complete(1)
-                b <- p.complete(2)
+                a <- p.completeSuccess(1)
+                b <- p.completeSuccess(2)
                 c <- p.isDone
                 d <- p.get
             yield assert(a && !b && c && d == 1)
@@ -30,7 +30,7 @@ class fibersTest extends KyoTest:
         "complete null" in run {
             for
                 p <- Fibers.initPromise[AnyRef]
-                b <- p.complete(null)
+                b <- p.completeSuccess(null)
                 r <- p.get
             yield assert(b && r == null)
         }
@@ -38,10 +38,10 @@ class fibersTest extends KyoTest:
             val ex = new Exception
             for
                 p <- Fibers.initPromise[Int]
-                a <- p.complete(IOs.fail(ex))
+                a <- p.completeFailure(ex)
                 b <- p.isDone
-                c <- p.getTry
-            yield assert(a && b && c == Failure[Int](ex))
+                c <- p.getResult
+            yield assert(a && b && c == Result.Failure[Int](ex))
             end for
         }
 
@@ -50,7 +50,7 @@ class fibersTest extends KyoTest:
                 for
                     p1 <- Fibers.initPromise[Int]
                     p2 <- Fibers.initPromise[Int]
-                    a  <- p2.complete(42)
+                    a  <- p2.completeSuccess(42)
                     b  <- p1.become(p2)
                     c  <- p1.isDone
                     d  <- p1.get
@@ -62,11 +62,11 @@ class fibersTest extends KyoTest:
                 for
                     p1 <- Fibers.initPromise[Int]
                     p2 <- Fibers.initPromise[Int]
-                    a  <- p2.complete(IOs.fail(ex))
+                    a  <- p2.completeFailure(ex)
                     b  <- p1.become(p2)
                     c  <- p1.isDone
-                    d  <- p1.getTry
-                yield assert(a && b && c && d == Failure(ex))
+                    d  <- p1.getResult
+                yield assert(a && b && c && d == Result.Failure(ex))
                 end for
             }
 
@@ -74,8 +74,8 @@ class fibersTest extends KyoTest:
                 for
                     p1 <- Fibers.initPromise[Int]
                     p2 <- Fibers.initPromise[Int]
-                    a  <- p1.complete(42)
-                    b  <- p2.complete(99)
+                    a  <- p1.completeSuccess(42)
+                    b  <- p2.completeSuccess(99)
                     c  <- p1.become(p2)
                     d  <- p1.get
                 yield assert(a && b && !c && d == 42)

--- a/kyo-core/shared/src/test/scala/kyoTest/loopsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/loopsTest.scala
@@ -559,7 +559,7 @@ class loopsTest extends KyoTest:
     "forever" in runJVM {
         for
             p <- Fibers.initPromise[Unit]
-            f <- Fibers.init(Loops.forever(p.complete(()).unit))
+            f <- Fibers.init(Loops.forever(p.completeSuccess(()).unit))
             _ <- p.get
             _ <- f.interrupt
         yield succeed

--- a/kyo-core/shared/src/test/scala/kyoTest/metersTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/metersTest.scala
@@ -17,16 +17,16 @@ class metersTest extends KyoTest:
                 t  <- Meters.initMutex
                 p  <- Fibers.initPromise[Int]
                 b1 <- Fibers.initPromise[Unit]
-                f1 <- Fibers.init(t.run(b1.complete(()).map(_ => p.block(Duration.Infinity))))
+                f1 <- Fibers.init(t.run(b1.completeSuccess(()).map(_ => p.block(Duration.Infinity))))
                 _  <- b1.get
                 a1 <- t.isAvailable
                 b2 <- Fibers.initPromise[Unit]
-                f2 <- Fibers.init(b2.complete(()).map(_ => t.run(2)))
+                f2 <- Fibers.init(b2.completeSuccess(()).map(_ => t.run(2)))
                 _  <- b2.get
                 a2 <- t.isAvailable
                 d1 <- f1.isDone
                 d2 <- f2.isDone
-                _  <- p.complete(1)
+                _  <- p.completeSuccess(1)
                 v1 <- f1.get
                 v2 <- f2.get
                 a3 <- t.isAvailable
@@ -38,12 +38,12 @@ class metersTest extends KyoTest:
                 sem <- Meters.initSemaphore(1)
                 p   <- Fibers.initPromise[Int]
                 b1  <- Fibers.initPromise[Unit]
-                f1  <- Fibers.init(sem.tryRun(b1.complete(()).map(_ => p.block(Duration.Infinity))))
+                f1  <- Fibers.init(sem.tryRun(b1.completeSuccess(()).map(_ => p.block(Duration.Infinity))))
                 _   <- b1.get
                 a1  <- sem.isAvailable
                 b1  <- sem.tryRun(2)
                 b2  <- f1.isDone
-                _   <- p.complete(1)
+                _   <- p.completeSuccess(1)
                 v1  <- f1.get
             yield assert(!a1 && b1 == None && !b2 && v1 == Some(1))
         }
@@ -63,19 +63,19 @@ class metersTest extends KyoTest:
                 t  <- Meters.initSemaphore(2)
                 p  <- Fibers.initPromise[Int]
                 b1 <- Fibers.initPromise[Unit]
-                f1 <- Fibers.init(t.run(b1.complete(()).map(_ => p.block(Duration.Infinity))))
+                f1 <- Fibers.init(t.run(b1.completeSuccess(()).map(_ => p.block(Duration.Infinity))))
                 _  <- b1.get
                 b2 <- Fibers.initPromise[Unit]
-                f2 <- Fibers.init(t.run(b2.complete(()).map(_ => p.block(Duration.Infinity))))
+                f2 <- Fibers.init(t.run(b2.completeSuccess(()).map(_ => p.block(Duration.Infinity))))
                 _  <- b2.get
                 a1 <- t.isAvailable
                 b3 <- Fibers.initPromise[Unit]
-                f2 <- Fibers.init(b3.complete(()).map(_ => t.run(2)))
+                f2 <- Fibers.init(b3.completeSuccess(()).map(_ => t.run(2)))
                 _  <- b3.get
                 a2 <- t.isAvailable
                 d1 <- f1.isDone
                 d2 <- f2.isDone
-                _  <- p.complete(1)
+                _  <- p.completeSuccess(1)
                 v1 <- f1.get
                 v2 <- f2.get
                 a3 <- t.isAvailable
@@ -87,16 +87,16 @@ class metersTest extends KyoTest:
                 sem <- Meters.initSemaphore(2)
                 p   <- Fibers.initPromise[Int]
                 b1  <- Fibers.initPromise[Unit]
-                f1  <- Fibers.init(sem.tryRun(b1.complete(()).map(_ => p.block(Duration.Infinity))))
+                f1  <- Fibers.init(sem.tryRun(b1.completeSuccess(()).map(_ => p.block(Duration.Infinity))))
                 _   <- b1.get
                 b2  <- Fibers.initPromise[Unit]
-                f2  <- Fibers.init(sem.tryRun(b2.complete(()).map(_ => p.block(Duration.Infinity))))
+                f2  <- Fibers.init(sem.tryRun(b2.completeSuccess(()).map(_ => p.block(Duration.Infinity))))
                 _   <- b2.get
                 a1  <- sem.isAvailable
                 b3  <- sem.tryRun(2)
                 b4  <- f1.isDone
                 b5  <- f2.isDone
-                _   <- p.complete(1)
+                _   <- p.completeSuccess(1)
                 v1  <- f1.get
                 v2  <- f2.get
             yield assert(!a1 && b3 == None && !b4 && !b5 && v1 == Some(1) && v2 == Some(1))

--- a/kyo-core/shared/src/test/scala/kyoTest/timersTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/timersTest.scala
@@ -9,7 +9,7 @@ class timersTest extends KyoTest:
     "schedule" in run {
         for
             p     <- Fibers.initPromise[String]
-            _     <- Timers.schedule(1.milli)(p.complete("hello").map(require(_)))
+            _     <- Timers.schedule(1.milli)(p.completeSuccess("hello").map(require(_)))
             hello <- p.get
         yield assert(hello == "hello")
     }
@@ -19,7 +19,7 @@ class timersTest extends KyoTest:
         Timers.let(Timer(exec)) {
             for
                 p     <- Fibers.initPromise[String]
-                _     <- Timers.schedule(1.milli)(p.complete("hello").map(require(_)))
+                _     <- Timers.schedule(1.milli)(p.completeSuccess("hello").map(require(_)))
                 hello <- p.get
             yield assert(hello == "hello")
         }
@@ -28,7 +28,7 @@ class timersTest extends KyoTest:
     "cancel" in runJVM {
         for
             p         <- Fibers.initPromise[String]
-            task      <- Timers.schedule(5.seconds)(p.complete("hello").map(require(_)))
+            task      <- Timers.schedule(5.seconds)(p.completeSuccess("hello").map(require(_)))
             _         <- task.cancel
             cancelled <- retry(task.isCancelled)
             done1     <- p.isDone

--- a/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
@@ -11,10 +11,10 @@ object KyoUtil:
                 nettyFuture.addListener((future: ChannelFuture) =>
                     discard {
                         IOs.run {
-                            if future.isSuccess then p.complete(future.channel())
+                            if future.isSuccess then p.completeSuccess(future.channel())
                             else if future.isCancelled then
-                                p.complete(Fibers.interrupted)
-                            else p.complete(IOs.fail(future.cause()))
+                                p.completeResult(Fibers.interruptedResult)
+                            else p.completeFailure(future.cause())
                         }
                     }
                 )
@@ -28,10 +28,10 @@ object KyoUtil:
                 f.addListener((future: io.netty.util.concurrent.Future[T]) =>
                     discard {
                         IOs.run {
-                            if future.isSuccess then p.complete(future.getNow)
+                            if future.isSuccess then p.completeSuccess(future.getNow)
                             else if future.isCancelled then
-                                p.complete(Fibers.interrupted)
-                            else p.complete(IOs.fail(future.cause()))
+                                p.completeResult(Fibers.interruptedResult)
+                            else p.completeFailure(future.cause())
                         }
                     }
                 )

--- a/kyo-tapir/shared/src/main/scala/kyo/server/internal/NettyKyoRequestBody.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/internal/NettyKyoRequestBody.scala
@@ -26,7 +26,7 @@ private[netty] class NettyKyoRequestBody(val createFile: ServerRequest => KyoStt
     ): KyoSttpMonad.M[Array[Byte]] =
         Fibers.initPromise[Array[Byte]].map { p =>
             val fut = SimpleSubscriber.processAll(publisher, contentLength, maxBytes)
-            fut.onComplete(r => IOs.run(p.complete(IOs(r.get))))(ExecutionContext.parasitic)
+            fut.onComplete(r => IOs.run(p.completeResult(Result(r.get))))(ExecutionContext.parasitic)
             p.get
         }
 

--- a/kyo-zio/shared/src/main/scala/kyo/zios.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/zios.scala
@@ -38,7 +38,7 @@ object ZIOs:
                                     ZIO.suspend(loop(k(v)))
                                 case Promise(p) =>
                                     ZIO.asyncInterrupt[Any, Throwable, U] { cb =>
-                                        p.onComplete(v => cb(ZIO.suspend(loop(v.map(k)))))
+                                        p.onComplete(v => cb(ZIO.suspend(loop(IOs(k(v.get))))))
                                         Left(ZIO.succeed(p.interrupt()))
                                     }
                             end match

--- a/kyo-zio/shared/src/test/scala/kyo/ziosTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ziosTest.scala
@@ -113,7 +113,7 @@ class ziosTest extends KyoTest:
                 for
                     f <- Fibers.init(ZIOs.get(zioLoop()))
                     _ <- f.interrupt
-                    r <- f.getTry
+                    r <- f.getResult
                 yield assert(r.isFailure)
                 end for
             }


### PR DESCRIPTION
Fiber completions use `T < IOs` to avoid allocations but we have `Result` now that provides a proper solution for this use case and allows us to avoid `IOs.run` in a few places.