### PR TITLE
data types readme + for-comprehension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2095,6 +2095,144 @@ val h: Unit < IOs =
   doubleAdder.map(_.reset)
 ```
 
+## Data Types
+
+## Maybe: Allocation-free Optional Values
+
+`Maybe` provides an allocation-free alternative to Scala's standard `Option` type. It is designed to be a drop-in replacement for `Option`, offering similar functionality while minimizing memory allocation.
+
+```scala
+import kyo._
+
+// Create a 'Maybe' value
+val a: Maybe[Int] = Maybe(42)
+
+// 'Maybe.empty' represents the absence of a value
+val b: Maybe[Int] = Maybe.empty[Int]
+
+// 'Maybe.when' conditionally creates a 'Maybe' value
+val c: Maybe[Int] = Maybe.when(true)(42)
+
+// 'Maybe.fromOption' converts an 'Option' to a 'Maybe'
+val d: Maybe[Int] = Maybe.fromOption(Some(42))
+
+// 'isEmpty' checks if the 'Maybe' is empty
+val e: Boolean = a.isEmpty
+
+// 'isDefined' checks if the 'Maybe' has a value
+val f: Boolean = a.isDefined
+
+// 'get' retrieves the value, throwing if empty
+val g: Int = a.get
+
+// 'getOrElse' provides a default value if empty
+val h: Int = b.getOrElse(0)
+
+// 'fold' applies a function based on emptiness
+val i: String = a.fold("Empty")(_.toString)
+
+// 'map' transforms the value if present
+val j: Maybe[String] = a.map(_.toString)
+
+// 'flatMap' allows chaining 'Maybe' operations
+val k: Maybe[Int] = a.flatMap(v => Maybe(v + 1))
+
+// 'filter' conditionally keeps or discards the value
+val l: Maybe[Int] = a.filter(_ > 0)
+
+// 'contains' checks if the 'Maybe' contains a value
+val m: Boolean = a.contains(42)
+
+// 'exists' checks if a predicate holds for the value
+val n: Boolean = a.exists(_ > 0)
+
+// 'foreach' applies a side-effecting function if non-empty
+a.foreach(println)
+
+// 'collect' applies a partial function if defined
+val o: Maybe[String] = a.collect { case 42 => "forty-two" }
+
+// 'orElse' returns an alternative if empty
+val p: Maybe[Int] = b.orElse(Maybe(0))
+
+// 'zip' combines two 'Maybe' values into a tuple
+val q: Maybe[(Int, String)] = a.zip(Maybe("hello"))
+
+// 'toOption' converts a 'Maybe' to an 'Option'
+val r: Option[Int] = a.toOption
+
+// Using 'Maybe' in a for-comprehension
+val s: Maybe[Int] = for {
+  x <- Maybe(1)
+  y <- Maybe(2)
+  if x < y
+} yield x + y
+
+// Nesting 'Maybe' values
+val nested: Maybe[Maybe[Int]] = Maybe(Maybe(42))
+val flattened: Maybe[Int] = nested.flatten
+```
+
+## Result: Low-allocation Try Alternative
+
+`Result` is a low-allocation alternative to Scala's `Try` type, designed to represent the result of a computation that may either succeed with a value or fail with an exception. It minimizes memory allocation overhead, especially in the case of successful results.
+
+```scala
+import kyo._
+import scala.util.Try
+
+// Create a 'Result' from a value
+val a: Result[Int] = Result.success(42)
+
+// Create a 'Result' from an exception
+val b: Result[Int] = Result.failure(new Exception("Oops"))
+
+// Use 'apply' to create a 'Result' from a block of code
+val c: Result[Int] = Result(42 / 0)
+
+// 'isSuccess' checks if the 'Result' is a success
+val d: Boolean = a.isSuccess
+
+// 'isFailure' checks if the 'Result' is a failure
+val e: Boolean = b.isFailure
+
+// 'get' retrieves the value if successful, otherwise throws
+val f: Int = a.get
+
+// 'getOrElse' provides a default value for failures
+val g: Int = b.getOrElse(0)
+
+// 'fold' applies a function based on success or failure
+val h: String = a.fold(_.getMessage)(_.toString)
+
+// 'map' transforms the value if successful
+val i: Result[String] = a.map(_.toString)
+
+// 'flatMap' allows chaining 'Result' operations
+val j: Result[Int] = a.flatMap(v => Result.success(v + 1))
+
+// 'flatten' removes one level of nesting from a 'Result[Result[T]]'
+val k: Result[Result[Int]] = Result.success(a)
+val l: Result[Int] = k.flatten
+
+// 'filter' conditionally keeps or discards the value
+val m: Result[Int] = a.filter(_ > 0)
+
+// 'recover' allows handling failures with a partial function
+val n: Result[Int] = b.recover { case _: ArithmeticException => 0 }
+
+// 'recoverWith' allows handling failures with a partial function returning a 'Result'
+val o: Result[Int] = b.recoverWith { case _: ArithmeticException => Result.success(0) }
+
+// 'toEither' converts a 'Result' to an 'Either'
+val p: Either[Throwable, Int] = a.toEither
+
+// 'toTry' converts a 'Result' to a 'Try'
+val q: Try[Int] = a.toTry
+```
+
+Under the hood, `Result` is defined as an opaque type that is a supertype of `Success[T]` and `Failure[T]`. Success[T] represents a successful result and is encoded as either the value itself (`T`) or a special SuccessFailure[`T`] case class. The `SuccessFailure[T]` case class is used to handle the rare case where a `Failure[T]` needs to be wrapped in a `Success[T]`. On the other hand, a failed `Result` is always represented by a `Failure[T]` case class, which contains the exception that caused the failure. This means that creating a `Failure[T]` does incur an allocation cost. Additionally, some methods on `Result`, such as `fold`, `map`, and `flatMap`, may allocate in certain cases due to the need to catch and handle exceptions.
+
 ## Integrations
 
 ### Caches: Memoized Functions via Caffeine

--- a/kyo-core/shared/src/main/scala/kyo/Maybe.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Maybe.scala
@@ -86,6 +86,9 @@ object Maybe:
         inline def flatten[U](using inline ev: T <:< Maybe[U]): Maybe[U] =
             if isEmpty then Empty else ev(get)
 
+        inline def withFilter(inline f: T => Boolean): Maybe[T] =
+            filter(f)
+
         inline def filter(inline f: T => Boolean): Maybe[T] =
             if isEmpty || f(get) then self else Empty
 

--- a/kyo-core/shared/src/main/scala/kyo/Result.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Result.scala
@@ -99,6 +99,9 @@ object Result:
         inline def map[U](inline f: T => U): Result[U] =
             flatMap(v => Result.success(f(v)))
 
+        inline def withFilter(inline p: T => Boolean): Result[T] =
+            filter(p)
+
         inline def filter(inline p: T => Boolean): Result[T] =
             flatMap { v =>
                 if !p(v) then

--- a/kyo-core/shared/src/test/scala/kyoTest/MaybeTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/MaybeTest.scala
@@ -393,4 +393,114 @@ class MaybeTest extends KyoTest:
         }
     }
 
+    "for comprehensions" - {
+        "with single Defined" - {
+            "should return Defined with value" in {
+                val result =
+                    for
+                        x <- Defined(1)
+                    yield x
+                assert(result == Defined(1))
+            }
+        }
+
+        "with single Empty" - {
+            "should return Empty" in {
+                val result =
+                    for
+                        x <- Empty
+                    yield x
+                assert(result == Empty)
+            }
+        }
+
+        "with multiple Defined" - {
+            "should return Defined with result of yield" in {
+                val result =
+                    for
+                        x <- Defined(1)
+                        y <- Defined(2)
+                    yield x + y
+                assert(result == Defined(3))
+            }
+        }
+
+        "with multiple Defined and Empty" - {
+            "should return Empty if any are Empty" in {
+                val result1 =
+                    for
+                        x <- Defined(1)
+                        y <- Empty
+                        z <- Defined(3)
+                    yield ()
+                assert(result1 == Empty)
+
+                val result2 =
+                    for
+                        x <- Empty
+                        y <- Defined(2)
+                        z <- Defined(3)
+                    yield ()
+                assert(result2 == Empty)
+
+                val result3 =
+                    for
+                        x <- Defined(1)
+                        y <- Defined(2)
+                        z <- Empty
+                    yield ()
+                assert(result3 == Empty)
+            }
+        }
+
+        "with if guards" - {
+            "should return Defined if guard passes" in {
+                val result =
+                    for
+                        x <- Defined(2)
+                        if x % 2 == 0
+                    yield x
+                assert(result == Defined(2))
+            }
+
+            "should return Empty if guard fails" in {
+                val result =
+                    for
+                        x <- Defined(3)
+                        if x % 2 == 0
+                    yield x
+                assert(result == Empty)
+            }
+        }
+
+        "with nested for comprehensions" - {
+            "should return flat Defined if all succeed" in {
+                val result =
+                    for
+                        x <- Defined(1)
+                        y <-
+                            for
+                                a <- Defined(2)
+                                b <- Defined(3)
+                            yield a + b
+                    yield x + y
+                assert(result == Defined(6))
+            }
+
+            "should return Empty if any inner comprehension is Empty" in {
+                val result =
+                    for
+                        x <- Defined(1)
+                        y <-
+                            for
+                                a <- Empty
+                                b <- Defined(3)
+                            yield ()
+                    yield ()
+                assert(result == Empty)
+            }
+        }
+
+    }
+
 end MaybeTest

--- a/kyo-core/shared/src/test/scala/kyoTest/ResultTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/ResultTest.scala
@@ -373,4 +373,61 @@ class ResultTest extends KyoTest:
         }
     }
 
+    "for comprehensions" - {
+        "yield a Success result" in {
+            val result =
+                for
+                    x <- Success(1)
+                    y <- Success(2)
+                    z <- Success(3)
+                yield x + y + z
+
+            assert(result == Success(6))
+        }
+
+        "short-circuit on Failure" in {
+            val result =
+                for
+                    x <- Success(1)
+                    y <- Failure[Int](new Exception("error"))
+                    z <- Success(3)
+                yield x + y + z
+
+            assert(result.isFailure)
+        }
+
+        "handle exceptions in the yield" in {
+            val result =
+                for
+                    x <- Success(1)
+                    y <- Success(2)
+                yield throw new Exception("error")
+
+            assert(result.isFailure)
+        }
+
+        "sequence operations with flatMap" in {
+            val result =
+                for
+                    x <- Success(1)
+                    y <- Success(2)
+                    if y > 0
+                    z <- Success(3)
+                yield x + y + z
+
+            assert(result == Success(6))
+        }
+
+        "fail the comprehension with a guard" in {
+            val result =
+                for
+                    x <- Success(1)
+                    y <- Success(-1)
+                    if y > 0
+                yield x + y
+
+            assert(result.isFailure)
+        }
+    }
+
 end ResultTest


### PR DESCRIPTION
I've aded a new "Data Types" section to the readme with `Maybe` and `Result`. I also noticed that the impls were missing tests for for-comprehensions and `withFilter`.