### PR TITLE
Use Typelevel scalac-options

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -26,4 +26,7 @@ fileOverride {
   "glob:**/kyo-stats-otel/**" {
     runner.dialect = scala212source3
   }
-} 
+  "glob:**/scala-3/**" {
+    runner.dialect = scala3
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,6 @@ lazy val `kyo-settings` = Seq(
     scalaVersion       := scala3Version,
     crossScalaVersions := List(scala3Version),
     scalacOptions     ++= scalacOptionTokens(compilerOptions).value,
-    Test / scalacOptions --= scalacOptionToken(ScalacOptions.languageStrictEquality).value,
     scalafmtOnCompile := false,
     organization      := "io.getkyo",
     homepage          := Some(url("https://getkyo.io")),

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+import org.scalajs.jsenv.nodejs.*
+import org.typelevel.scalacoptions.{ScalaVersion, ScalacOption, ScalacOptions}
+
 val scala3Version   = "3.4.2"
 val scala212Version = "2.12.19"
 val scala213Version = "2.13.14"
@@ -5,14 +8,14 @@ val scala213Version = "2.13.14"
 val zioVersion       = "2.1.2"
 val scalaTestVersion = "3.2.18"
 
-val compilerOptions = Seq(
-    "-encoding",
-    "utf8",
-    "-feature",
-    "-unchecked",
-    "-deprecation",
-    "-Wvalue-discard",
-    "-language:strictEquality"
+val compilerOptions = Set(
+    ScalacOptions.encoding("utf8"),
+    ScalacOptions.feature,
+    ScalacOptions.unchecked,
+    ScalacOptions.deprecation,
+    ScalacOptions.warnValueDiscard,
+    ScalacOptions.languageStrictEquality,
+    ScalacOptions.release("11")
 )
 
 ThisBuild / scalaVersion           := scala3Version
@@ -25,7 +28,8 @@ lazy val `kyo-settings` = Seq(
     fork               := true,
     scalaVersion       := scala3Version,
     crossScalaVersions := List(scala3Version),
-    scalacOptions ++= compilerOptions,
+    scalacOptions     ++= scalacOptionTokens(compilerOptions).value,
+    Test / scalacOptions --= scalacOptionToken(ScalacOptions.languageStrictEquality).value,
     scalafmtOnCompile := false,
     organization      := "io.getkyo",
     homepage          := Some(url("https://getkyo.io")),
@@ -43,7 +47,6 @@ lazy val `kyo-settings` = Seq(
     sonatypeProfileName                := "io.getkyo",
     Test / testOptions += Tests.Argument("-oDG"),
     ThisBuild / versionScheme := Some("early-semver"),
-    scalacOptions ++= Seq("-release:11"),
     libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % Test,
     Test / javaOptions += "--add-opens=java.base/java.lang=ALL-UNNAMED"
 )
@@ -97,12 +100,7 @@ lazy val `kyo-scheduler` =
         .in(file("kyo-scheduler"))
         .settings(
             `kyo-settings`,
-            scalacOptions --= Seq(
-                "-Wvalue-discard",
-                "-Wunused:all",
-                "-language:strictEquality"
-            ),
-            scalacOptions += "-Xsource:3",
+            scalacOptions ++= scalacOptionToken(ScalacOptions.source3).value,
             crossScalaVersions                      := List(scala3Version, scala212Version, scala213Version),
             libraryDependencies += "org.scalatest" %%% "scalatest"       % scalaTestVersion % Test,
             libraryDependencies += "ch.qos.logback"  % "logback-classic" % "1.5.6"          % Test
@@ -118,16 +116,11 @@ lazy val `kyo-scheduler-zio` = sbtcrossproject.CrossProject("kyo-scheduler-zio",
     .dependsOn(`kyo-scheduler`)
     .settings(
         `kyo-settings`,
-        scalacOptions --= Seq(
-            "-Wvalue-discard",
-            "-Wunused:all",
-            "-language:strictEquality"
-        ),
         libraryDependencies += "dev.zio"       %%% "zio"       % zioVersion,
         libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
     )
     .settings(
-        scalacOptions ++= (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 2)) Seq("-Xsource:3") else Nil),
+        scalacOptions ++= scalacOptionToken(ScalacOptions.source3).value,
         crossScalaVersions := List(scala3Version, scala212Version, scala213Version)
     )
 
@@ -181,12 +174,7 @@ lazy val `kyo-stats-registry` =
         .in(file("kyo-stats-registry"))
         .settings(
             `kyo-settings`,
-            scalacOptions --= Seq(
-                "-Wvalue-discard",
-                "-Wunused:all",
-                "-language:strictEquality"
-            ),
-            scalacOptions += "-Xsource:3",
+            scalacOptions ++= scalacOptionToken(ScalacOptions.source3).value,
             libraryDependencies += "org.hdrhistogram" % "HdrHistogram" % "2.2.2",
             libraryDependencies += "org.scalatest"  %%% "scalatest"    % scalaTestVersion % Test,
             crossScalaVersions                       := List(scala3Version, scala212Version, scala213Version)
@@ -402,11 +390,17 @@ lazy val readme =
             libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-zio" % "1.10.7"
         )
 
-import org.scalajs.jsenv.nodejs.*
-
 lazy val `js-settings` = Seq(
     Compile / doc / sources                     := Seq.empty,
     fork                                        := false,
     jsEnv                                       := new NodeJSEnv(NodeJSEnv.Config().withArgs(List("--max_old_space_size=5120"))),
     libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.5.0" % "provided"
 )
+
+def scalacOptionToken(proposedScalacOption: ScalacOption) =
+    scalacOptionTokens(Set(proposedScalacOption))
+
+def scalacOptionTokens(proposedScalacOptions: Set[ScalacOption]) = Def.setting {
+    val version = ScalaVersion.fromString(scalaVersion.value).right.get
+    ScalacOptions.tokensForVersion(version, proposedScalacOptions)
+}

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -194,7 +194,7 @@ final class Scheduler(
                 if (worker ne null) {
                     if (position >= currentWorkers)
                         worker.drain()
-                    worker.checkAvailability(nowMs)
+                    val _ = worker.checkAvailability(nowMs)
                 }
                 position += 1
             }

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Regulator.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Regulator.scala
@@ -76,7 +76,7 @@ abstract class Regulator(
 
     def stop(): Unit = {
         collectTask.cancel()
-        regulateTask.cancel()
+        val _ = regulateTask.cancel()
     }
 
     protected val statsScope = kyo.scheduler.statsScope.scope("regulator", getClass.getSimpleName().toLowerCase())

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/top/Reporter.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/top/Reporter.scala
@@ -25,18 +25,19 @@ class Reporter(
 
     private var lastConsoleStatus: Status = null
 
-    if (enableTopConsoleMs > 0)
-        timer.schedule(enableTopConsoleMs.millis) {
+    if (enableTopConsoleMs > 0) {
+        val _ = timer.schedule(enableTopConsoleMs.millis) {
             val currentStatus = status()
             if (lastConsoleStatus ne null) {
                 println(Printer(currentStatus - lastConsoleStatus))
             }
             lastConsoleStatus = currentStatus
         }
+    }
 
     if (enableTopJMX) {
         close()
-        mBeanServer.registerMBean(new StandardMBean(this, classOf[TopMBean]), objectName)
+        val _ = mBeanServer.registerMBean(new StandardMBean(this, classOf[TopMBean]), objectName)
     }
 
     def getStatus() = status()

--- a/kyo-scheduler/shared/src/test/scala-3/kyoTest/scheduler/TaskImplicits.scala
+++ b/kyo-scheduler/shared/src/test/scala-3/kyoTest/scheduler/TaskImplicits.scala
@@ -1,0 +1,5 @@
+package kyoTest.scheduler
+
+import kyo.scheduler.Task
+
+given CanEqual[Task, Task] = CanEqual.derived

--- a/kyo-stats-registry/jvm/src/main/scala/kyo/stats/internal/StatsRefresh.scala
+++ b/kyo-stats-registry/jvm/src/main/scala/kyo/stats/internal/StatsRefresh.scala
@@ -22,5 +22,7 @@ trait StatsRefresh {
     Executors.newSingleThreadScheduledExecutor(threadFactory)
         .scheduleAtFixedRate(() => refresh(), refreshInterval, refreshInterval, TimeUnit.MILLISECONDS)
 
-    ServiceLoader.load(classOf[StatsExporter]).iterator().forEachRemaining(exporters.add(_))
+    ServiceLoader.load(classOf[StatsExporter]).iterator().forEachRemaining { exporter =>
+        val _ = exporters.add(exporter)
+    }
 }

--- a/kyo-stats-registry/shared/src/main/scala/kyo/stats/internal/StatsRegistry.scala
+++ b/kyo-stats-registry/shared/src/main/scala/kyo/stats/internal/StatsRegistry.scala
@@ -57,7 +57,7 @@ object StatsRegistry {
         val counterGauges  = new Store[UnsafeCounterGauge]
         lazy val exporters = Collections.newSetFromMap(new ConcurrentHashMap[StatsExporter, java.lang.Boolean])
 
-        class Store[T] {
+        class Store[T <: AnyRef] {
             val map = new ConcurrentHashMap[List[String], (WeakReference[T], String)]
 
             @tailrec final def get(reversePath: List[String], description: String, init: => T): T = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.12")
 // addSbtPlugin("com.gradle" % "sbt-develocity" % "1.0.1")
 
 // addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.4.0")
+
+libraryDependencies ++= Seq(
+    "org.typelevel" %% "scalac-options" % "0.1.5"
+)


### PR DESCRIPTION
Take 2.

Since starting this, the `-Wunused:all` option had been removed which makes things a bit easier.

FTR If we do need to ignore unused locals in a way that is compatible with Scala 2.12, 2.13 and 3 I think we can do this:
```
    /**
     * A way to ignore the unused warning that works in Scala 2.12, 2.13 and 3.
     */
    @elidable(ASSERTION)
    private[scheduler] def unused(a: => Any): Unit = {
        val _ = a
        ()
    }
```