### PR TITLE
docs: Correct heading levels for Data Types sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2097,7 +2097,7 @@ val h: Unit < IOs =
 
 ## Data Types
 
-## Maybe: Allocation-free Optional Values
+### Maybe: Allocation-free Optional Values
 
 `Maybe` provides an allocation-free alternative to Scala's standard `Option` type. It is designed to be a drop-in replacement for `Option`, offering similar functionality while minimizing memory allocation.
 
@@ -2173,7 +2173,7 @@ val nested: Maybe[Maybe[Int]] = Maybe(Maybe(42))
 val flattened: Maybe[Int] = nested.flatten
 ```
 
-## Result: Low-allocation Try Alternative
+### Result: Low-allocation Try Alternative
 
 `Result` is a low-allocation alternative to Scala's `Try` type, designed to represent the result of a computation that may either succeed with a value or fail with an exception. It minimizes memory allocation overhead, especially in the case of successful results.
 


### PR DESCRIPTION
Hello,

This is my first contribution to this project. I noticed some inconsistencies in the documentation's heading levels under the Data Types section and decided to fix them.

Specifically, the headings for 'Maybe: Allocation-free Optional Values' and 'Result: Low-allocation Try Alternative' were updated from '##' to '###'. This change ensures a uniform structure and improves the readability of the documentation. No functional changes were made to the codebase.

Thank you for considering this pull request.