### PR TITLE
Fix field nullability in Caliban schema instances

### DIFF
--- a/kyo-caliban/src/main/scala/kyo/schemas.scala
+++ b/kyo-caliban/src/main/scala/kyo/schemas.scala
@@ -10,7 +10,8 @@ import zio.query.ZQuery
 
 given zioSchema[R, T: Flat, S](using ev: Schema[R, T], ev2: (T < S) <:< (T < (Aborts[Throwable] & ZIOs))): Schema[R, T < S] =
     new Schema[R, T < S]:
-        override def canFail: Boolean = true
+        override def nullable: Boolean = ev.nullable
+        override def canFail: Boolean  = ev.canFail
 
         override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
             ev.toType_(isInput, isSubscription)
@@ -25,7 +26,8 @@ trait Runner[S]:
 
 given runnerSchema[R, T: Flat, S](using ev: Schema[R, T], tag: zio.Tag[Runner[S]]): Schema[R & Runner[S], T < S] =
     new Schema[R & Runner[S], T < S]:
-        override def canFail: Boolean = true
+        override def nullable: Boolean = ev.nullable
+        override def canFail: Boolean  = ev.canFail
 
         override def toType(isInput: Boolean, isSubscription: Boolean): __Type =
             ev.toType_(isInput, isSubscription)

--- a/kyo-caliban/src/test/scala/kyo/resolversTest.scala
+++ b/kyo-caliban/src/test/scala/kyo/resolversTest.scala
@@ -35,11 +35,11 @@ class resolversTest extends KyoTest:
 
     "schema derivation" in {
         val expected = """type Query {
-                         |  k1: Int
-                         |  k2: Int
-                         |  k3: Int
-                         |  k4: Int
-                         |  k5: Int
+                         |  k1: Int!
+                         |  k2: Int!
+                         |  k3: Int!
+                         |  k4: Int!
+                         |  k5: Int!
                          |}""".stripMargin
         assert(render[Query].trim == expected)
     }


### PR DESCRIPTION
I copied the Cats Effect integration but it turns out [there was a bug in it](https://github.com/ghostdogpr/caliban/pull/2296) 😄 