### PR TITLE
add: TypeMap[A].prune[B]

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/typeMap.scala
+++ b/kyo-core/shared/src/main/scala/kyo/typeMap.scala
@@ -5,48 +5,51 @@ import scala.collection.immutable.HashMap
 
 opaque type TypeMap[+A] = HashMap[Tag[Any], Any]
 
-extension [A](self: TypeMap[A])
-
-    private inline def fatal[T](using t: Tag[T]): Nothing =
-        throw new RuntimeException(s"fatal: kyo.TypeMap of contents [${self.show}] missing value of type: [${t.showTpe}].")
-
-    def get[B >: A](using t: Tag[B]): B =
-        val b = self.getOrElse(t.erased, null)
-        if !isNull(b) then b.asInstanceOf[B]
-        else
-            var sub: B = null.asInstanceOf[B]
-            val it     = self.iterator
-            try // iterator should never throw given type constraint on B
-                while isNull(sub) do
-                    val (tag, item) = it.next()
-                    if tag <:< t then
-                        sub = item.asInstanceOf[B]
-                end while
-            catch
-                case _: NoSuchElementException => fatal
-            end try
-            sub
-        end if
-    end get
-
-    inline def add[B](b: B)(using inline t: Tag[B]): TypeMap[A & B] =
-        self.updated(t.erased, b)
-
-    inline def union[B](that: TypeMap[B]): TypeMap[A & B] =
-        self ++ that
-
-    inline def size: Int        = self.size
-    inline def isEmpty: Boolean = self.isEmpty
-
-    def show: String = self.map { case (tag, value) => s"${tag.showTpe} -> $value" }.toList.sorted.mkString("TypeMap(", ", ", ")")
-
-    private[kyo] inline def tag: Intersection[?] = Intersection(self.keySet.toIndexedSeq)
-
-    private[kyo] inline def <:<[T](tag: Tag[T]): Boolean =
-        self.keySet.exists(_ <:< tag)
-end extension
-
 object TypeMap:
+    extension [A](self: TypeMap[A])
+
+        private inline def fatal[T](using t: Tag[T]): Nothing =
+            throw new RuntimeException(s"fatal: kyo.TypeMap of contents [${self.show}] missing value of type: [${t.showTpe}].")
+
+        def get[B >: A](using t: Tag[B]): B =
+            val b = self.getOrElse(t.erased, null)
+            if !isNull(b) then b.asInstanceOf[B]
+            else
+                var sub: B = null.asInstanceOf[B]
+                val it     = self.iterator
+                try // iterator should never throw given type constraint on B
+                    while isNull(sub) do
+                        val (tag, item) = it.next()
+                        if tag <:< t then
+                            sub = item.asInstanceOf[B]
+                    end while
+                catch
+                    case _: NoSuchElementException => fatal
+                end try
+                sub
+            end if
+        end get
+
+        inline def add[B](b: B)(using inline t: Tag[B]): TypeMap[A & B] =
+            self.updated(t.erased, b)
+
+        inline def union[B](that: TypeMap[B]): TypeMap[A & B] =
+            self ++ that
+
+        def prune[B >: A](using t: Tag[B]): TypeMap[B] =
+            if t =:= Tag[Any] then empty
+            else self.filter { case (tag, _) => tag <:< t }
+
+        inline def size: Int        = self.size
+        inline def isEmpty: Boolean = self.isEmpty
+
+        def show: String = self.map { case (tag, value) => s"${tag.showTpe} -> $value" }.toList.sorted.mkString("TypeMap(", ", ", ")")
+
+        private[kyo] inline def tag: Intersection[?] = Intersection(self.keySet.toIndexedSeq)
+
+        private[kyo] inline def <:<[T](tag: Tag[T]): Boolean =
+            self.keySet.exists(_ <:< tag)
+    end extension
 
     given flat[A]: Flat[TypeMap[A]] = Flat.unsafe.bypass
 

--- a/kyo-core/shared/src/main/scala/kyo/typeMap.scala
+++ b/kyo-core/shared/src/main/scala/kyo/typeMap.scala
@@ -37,7 +37,7 @@ object TypeMap:
             self ++ that
 
         def prune[B >: A](using t: Tag[B]): TypeMap[B] =
-            if t =:= Tag[Any] then empty
+            if t =:= Tag[Any] then self
             else self.filter { case (tag, _) => tag <:< t }
 
         inline def size: Int        = self.size

--- a/kyo-core/shared/src/test/scala/kyoTest/typeMapTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/typeMapTest.scala
@@ -160,7 +160,7 @@ class typeMapTest extends KyoTest:
     ".prune" - {
         "Env[Int] -> Env[Any]" in {
             val p = TypeMap(42).prune[Any]
-            assert(p.isEmpty)
+            assert(p.size == 1)
         }
         "Env[Int & String] -> Env[Int]" in {
             val e = TypeMap(42, "")

--- a/kyo-core/shared/src/test/scala/kyoTest/typeMapTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/typeMapTest.scala
@@ -158,9 +158,11 @@ class typeMapTest extends KyoTest:
     }
 
     ".prune" - {
-        "Env[Int] -> Env[Any]" in {
-            val p = TypeMap(42).prune[Any]
-            assert(p.size == 1)
+        "[Any] noop" in {
+            val e: TypeMap[Int & String & Boolean & Char] = TypeMap(42, "", true, 'c')
+            val p: TypeMap[Any] = e.prune[Any]
+            assert(p.size == 4)
+            assert(p.asInstanceOf[AnyRef] eq e.asInstanceOf[AnyRef])
         }
         "Env[Int & String] -> Env[Int]" in {
             val e = TypeMap(42, "")

--- a/kyo-core/shared/src/test/scala/kyoTest/typeMapTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/typeMapTest.scala
@@ -160,18 +160,18 @@ class typeMapTest extends KyoTest:
     ".prune" - {
         "[Any] noop" in {
             val e: TypeMap[Int & String & Boolean & Char] = TypeMap(42, "", true, 'c')
-            val p: TypeMap[Any] = e.prune[Any]
+            val p: TypeMap[Any]                           = e.prune[Any]
             assert(p.size == 4)
             assert(p.asInstanceOf[AnyRef] eq e.asInstanceOf[AnyRef])
         }
         "Env[Int & String] -> Env[Int]" in {
-            val e = TypeMap(42, "")
-            val p = e.prune[Int]
+            val e: TypeMap[Int & String] = TypeMap(42, "")
+            val p: TypeMap[Int]          = e.prune[Int]
             assert(p.size == 1)
         }
         "Env[Sub] -> Env[Super]" in {
-            val e = TypeMap(new RuntimeException)
-            val p = e.prune[Exception].prune[Throwable]
+            val e: TypeMap[RuntimeException] = TypeMap(new RuntimeException)
+            val p: TypeMap[Throwable]        = e.prune[Exception].prune[Throwable]
             assert(p.size == 1)
         }
         "Env[Super] -> Env[Sub]" in {


### PR DESCRIPTION
I colocated the extension methods so only `import kyo.TypeMap` is necessary for consumers.

I plan to add benchmarks comparing `ZEnvironment` next