### PR TITLE
prelude: typed failures in Result

### DIFF
--- a/kyo-core/shared/src/test/scala/kyoTest/ResultTest.scala
+++ b/kyo-core/shared/src/test/scala/kyoTest/ResultTest.scala
@@ -105,10 +105,10 @@ class ResultTest extends KyoTest:
 
     "filter" - {
         "returns itself if the predicate holds for Success" in {
-            assert(Success(2).filter(_ % 2 == 0) == Success(2))
+            assert(Result.success(2).filter(_ % 2 == 0) == Success(2))
         }
         "returns Failure if the predicate doesn't hold for Success" in {
-            assert(Success(1).filter(_ % 2 == 0).isFailure)
+            assert(Result.success(1).filter(_ % 2 == 0).isFailure)
         }
         "returns itself for Failure" in {
             val ex = new Exception("error")

--- a/kyo-prelude/jvm/src/test/scala/kyo2/MonadLawsTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo2/MonadLawsTest.scala
@@ -1,5 +1,6 @@
 package kyo2
 
+import kyo2.Result
 import zio.Trace
 import zio.prelude.Equal
 import zio.prelude.coherent.CovariantDeriveEqual
@@ -61,7 +62,7 @@ object MonadLawsTest extends ZIOSpecDefault:
             override def derive[A: Equal]: Equal[Myo[A]] =
                 new Equal[Myo[A]]:
                     protected def checkEqual(l: Myo[A], r: Myo[A]): Boolean =
-                        def run(m: Myo[A]): Either[String, A] =
+                        def run(m: Myo[A]): Result[String, A] =
                             Var.run(true)(
                                 Sum.run(
                                     Abort.run(

--- a/kyo-prelude/shared/src/main/scala/kyo2/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Abort.scala
@@ -44,8 +44,8 @@ object Abort:
                 case Success(t) => t
                 case Failure(v) => fail(v)
 
-        inline def apply[A](r: Result[A]): A < Abort[Throwable] =
-            r.fold(fail)(identity)
+        inline def apply[E, A](r: Result[E, A]): A < Abort[E | Throwable] =
+            r.fold(fail)(fail)(identity)
 
         @targetName("maybe")
         inline def apply[A](m: Maybe[A]): A < Abort[Maybe.Empty] =

--- a/kyo-prelude/shared/src/main/scala/kyo2/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Abort.scala
@@ -72,11 +72,11 @@ object Abort:
                                 (input.asInstanceOf[Any]) match
                                     case input: E => true
                                     case _        => false,
-                        handle = [C] => (input, _) => Result.failure(input)
+                        handle = [C] => (input, _) => Result.error(input)
                     )
                 }
             } {
-                case fail: E => Result.failure(fail)
+                case fail: E => Result.error(fail)
                 case fail    => Result.panic(fail)
             }
     end RunOps

--- a/kyo-prelude/shared/src/main/scala/kyo2/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Abort.scala
@@ -55,28 +55,29 @@ object Abort:
     inline def get[E >: Nothing]: GetOps[E] = GetOps(())
 
     final class RunOps[E >: Nothing](dummy: Unit) extends AnyVal:
-        def apply[A, S, ES, ER](v: A < (Abort[E | ER] & S))(
+        def apply[A, S, ES, ER](v: => A < (Abort[E | ER] & S))(
             using
             ct: ClassTag[E],
             frame: Frame,
             reduce: Reducible[Abort[ER]]
-        ): Either[E, A] < (S & reduce.SReduced) =
+        ): Result[E, A] < (S & reduce.SReduced) =
             Effect.catching {
                 reduce {
-                    Effect.handle[Const[E], Const[Unit], Abort[E], Either[E, A], Either[E, A], Abort[ER] & S, Abort[ER] & S, Any](
+                    Effect.handle[Const[E], Const[Unit], Abort[E], Result[E, A], Result[E, A], Abort[ER] & S, Abort[ER] & S, Any](
                         erasedTag[E],
-                        v.map(Right(_): Either[E, A])
+                        v.map(Result.success[E, A](_))
                     )(
                         accept = [C] =>
                             (input, _) =>
                                 (input.asInstanceOf[Any]) match
                                     case input: E => true
                                     case _        => false,
-                        handle = [C] => (input, _) => Left(input)
+                        handle = [C] => (input, _) => Result.failure(input)
                     )
                 }
             } {
-                case fail: E => Left(fail)
+                case fail: E => Result.failure(fail)
+                case fail    => Result.panic(fail)
             }
     end RunOps
 

--- a/kyo-prelude/shared/src/main/scala/kyo2/Result.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Result.scala
@@ -1,6 +1,7 @@
 package kyo2
 
 import Result.*
+import scala.annotation.implicitNotFound
 import scala.util.Try
 import scala.util.control.NonFatal
 
@@ -24,28 +25,27 @@ object Result:
         catch
             case ex: Throwable if NonFatal(ex) => Error(ex)
 
-    def success[E, A](value: A): Result[E, A] = Success(value)
-
-    def error[E, A](error: E): Result[E, A] = Error(error)
-
+    def success[E, A](value: A): Result[E, A]           = Success(value)
+    def error[E, A](error: E): Result[E, A]             = Error(error)
     def panic[E, A](exception: Throwable): Result[E, A] = Panic(exception)
 
-    def fromEither[E, A](either: Either[E, A]): Result[E, A] = either match
-        case Right(value) => Success(value)
-        case Left(error)  => Error(error)
+    def fromEither[E, A](either: Either[E, A]): Result[E, A] =
+        either match
+            case Right(value) => Success(value)
+            case Left(error)  => Error(error)
 
-    opaque type Success[+T] = T | SuccessError[T]
+    opaque type Success[+A] = A | SuccessError[A]
 
     object Success:
 
-        def apply[T](value: T): Success[T] =
+        def apply[A](value: A): Success[A] =
             value match
-                case v: SuccessError[?]     => v.nest.asInstanceOf[Success[T]]
-                case v: Error[T] @unchecked => SuccessError(v)
+                case v: SuccessError[?]     => v.nest.asInstanceOf[Success[A]]
+                case v: Error[A] @unchecked => SuccessError(v)
                 case v                      => v
 
         // TODO avoid Option allocation
-        def unapply[E, T](self: Result[E, T]): Option[T] =
+        def unapply[E, A](self: Result[E, A]): Option[A] =
             self.fold(_ => None)(_ => None)(Some(_))
 
     end Success
@@ -63,7 +63,7 @@ object Result:
 
     case class Panic(exception: Throwable) extends Failure[Nothing]
 
-    extension [E, T](self: Result[E, T])
+    extension [E, A](self: Result[E, A])
 
         def isSuccess: Boolean =
             self match
@@ -76,7 +76,7 @@ object Result:
         def isPanic: Boolean =
             self.isInstanceOf[Panic]
 
-        inline def fold[U](inline ifError: E => U)(inline ifPanic: Throwable => U)(inline ifSuccess: T => U): U =
+        inline def fold[B](inline ifError: E => B)(inline ifPanic: Throwable => B)(inline ifSuccess: A => B): B =
             (self: @unchecked) match
                 case self: Error[E] =>
                     ifError(self.error)
@@ -85,41 +85,41 @@ object Result:
                 case _ =>
                     try
                         self match
-                            case self: SuccessError[T] @unchecked =>
-                                ifSuccess(self.unnest.asInstanceOf[T])
+                            case self: SuccessError[A] @unchecked =>
+                                ifSuccess(self.unnest.asInstanceOf[A])
                             case self =>
-                                ifSuccess(self.asInstanceOf[T])
+                                ifSuccess(self.asInstanceOf[A])
                     catch
                         case ex if NonFatal(ex) => ifPanic(ex)
 
-        def get(using E =:= Nothing): T =
+        def get(using E =:= Nothing): A =
             fold(ex => throw new NoSuchElementException(s"Failure: $ex"))(throw _)(identity)
 
-        inline def getOrElse[U >: T](inline default: => U): U =
+        inline def getOrElse[B >: A](inline default: => B): B =
             fold(_ => default)(_ => default)(identity)
 
-        def orElse[E2, U >: T](alternative: => Result[E2, U]): Result[E | E2, U] =
+        def orElse[E2, B >: A](alternative: => Result[E2, B]): Result[E | E2, B] =
             fold(_ => alternative)(_ => alternative)(Result.success)
 
-        inline def flatMap[E2, U](inline f: T => Result[E2, U]): Result[E | E2, U] =
+        inline def flatMap[E2, B](inline f: A => Result[E2, B]): Result[E | E2, B] =
             (self: @unchecked) match
                 case self: Failure[E] => self
                 case self =>
-                    try f(self.asInstanceOf[Success[T]].get)
+                    try f(self.asInstanceOf[Success[A]].get)
                     catch
                         case ex if NonFatal(ex) =>
                             Panic(ex)
 
-        def flatten[E2, U](using ev: T <:< Result[E2, U]): Result[E | E2, U] =
+        def flatten[E2, B](using ev: A <:< Result[E2, B]): Result[E | E2, B] =
             flatMap(ev)
 
-        inline def map[U](inline f: T => U): Result[E, U] =
+        inline def map[B](inline f: A => B): Result[E, B] =
             flatMap(v => Result.success(f(v)))
 
-        inline def withFilter(inline p: T => Boolean): Result[E | NoSuchElementException, T] =
+        inline def withFilter(inline p: A => Boolean): Result[E | NoSuchElementException, A] =
             filter(p)
 
-        inline def filter(inline p: T => Boolean): Result[E | NoSuchElementException, T] =
+        inline def filter(inline p: A => Boolean): Result[E | NoSuchElementException, A] =
             flatMap { v =>
                 if !p(v) then
                     Error(new NoSuchElementException("Predicate does not hold for " + v))
@@ -127,7 +127,7 @@ object Result:
                     v
             }
 
-        inline def recover[U >: T](inline pf: PartialFunction[Failure[E], U]): Result[E, U] =
+        inline def recover[B >: A](inline pf: PartialFunction[Failure[E], B]): Result[E, B] =
             try
                 (self: @unchecked) match
                     case self: Failure[E] if pf.isDefinedAt(self) =>
@@ -137,7 +137,7 @@ object Result:
                 case ex: Throwable if NonFatal(ex) =>
                     Panic(ex)
 
-        inline def recoverWith[E2, U >: T](inline pf: PartialFunction[Failure[E], Result[E2, U]]): Result[E | E2, U] =
+        inline def recoverWith[E2, B >: A](inline pf: PartialFunction[Failure[E], Result[E2, B]]): Result[E | E2, B] =
             try
                 (self: @unchecked) match
                     case self: Failure[E] if pf.isDefinedAt(self) =>
@@ -147,21 +147,25 @@ object Result:
                 case ex: Throwable if NonFatal(ex) =>
                     Panic(ex)
 
-        def toEither: Either[E | Throwable, T] =
+        def toEither: Either[E | Throwable, A] =
             fold(Left(_))(Left(_))(Right(_))
 
-        def toTry: Try[T] =
-            fold(e => scala.util.Failure(new NoSuchElementException(s"Failure: $e")))(scala.util.Failure(_))(scala.util.Success(_))
+        def toTry(using
+            @implicitNotFound("Error type must be a 'Throwable' to invoke 'toTry'. Found: '${E}'")
+            ev: E <:< Throwable
+        ): Try[A] =
+            fold(e => scala.util.Failure(ev(e)))(scala.util.Failure(_))(scala.util.Success(_))
+
     end extension
 
     private object internal:
-        case class SuccessError[+T](failure: Failure[T], depth: Int = 1):
-            def unnest: Result[Any, T] =
+        case class SuccessError[+A](failure: Failure[A], depth: Int = 1):
+            def unnest: Result[Any, A] =
                 if depth > 1 then
                     SuccessError(failure, depth - 1)
                 else
                     failure
-            def nest: Success[T] =
+            def nest: Success[A] =
                 SuccessError(failure, depth + 1)
         end SuccessError
     end internal

--- a/kyo-prelude/shared/src/main/scala/kyo2/Result.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Result.scala
@@ -18,6 +18,12 @@ object Result:
         catch
             case ex: Throwable if NonFatal(ex) => Panic(ex)
 
+    def attempt[A](expr: => A): Result[Throwable, A] =
+        try
+            Success(expr)
+        catch
+            case ex: Throwable if NonFatal(ex) => Error(ex)
+
     def success[E, A](value: A): Result[E, A] = Success(value)
 
     def error[E, A](error: E): Result[E, A] = Error(error)

--- a/kyo-prelude/shared/src/main/scala/kyo2/Result.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Result.scala
@@ -4,7 +4,7 @@ import Result.*
 import scala.util.Try
 import scala.util.control.NonFatal
 
-opaque type Result[+E, +A] >: (Success[A] | Failure[E]) = Success[A] | Cause[E]
+opaque type Result[+E, +A] >: (Success[A] | Failure[E]) = Success[A] | Failure[E]
 
 object Result:
     import internal.*
@@ -20,23 +20,23 @@ object Result:
 
     def success[E, A](value: A): Result[E, A] = Success(value)
 
-    def failure[E, A](error: E): Result[E, A] = Failure(error)
+    def error[E, A](error: E): Result[E, A] = Error(error)
 
     def panic[E, A](exception: Throwable): Result[E, A] = Panic(exception)
 
-    def fromEither[E, T](either: Either[E, T]): Result[E, T] = either match
-        case Right(value)    => Success(value)
-        case Left(exception) => Failure(exception)
+    def fromEither[E, A](either: Either[E, A]): Result[E, A] = either match
+        case Right(value) => Success(value)
+        case Left(error)  => Error(error)
 
-    opaque type Success[+T] = T | SuccessFailure[T]
+    opaque type Success[+T] = T | SuccessError[T]
 
     object Success:
 
         def apply[T](value: T): Success[T] =
             value match
-                case v: SuccessFailure[?]     => v.nest.asInstanceOf[Success[T]]
-                case v: Failure[T] @unchecked => SuccessFailure(v)
-                case v                        => v
+                case v: SuccessError[?]     => v.nest.asInstanceOf[Success[T]]
+                case v: Error[T] @unchecked => SuccessError(v)
+                case v                      => v
 
         // TODO avoid Option allocation
         def unapply[E, T](self: Result[E, T]): Option[T] =
@@ -44,42 +44,42 @@ object Result:
 
     end Success
 
-    sealed abstract class Cause[+E]
+    sealed abstract class Failure[+E]
 
-    case class Failure[+E](error: E) extends Cause[E]
+    case class Error[+E](error: E) extends Failure[E]
 
-    object Failure:
+    object Error:
         def unapply[E, A](result: Result[E, A]): Option[E] =
             (result: @unchecked) match
-                case result: Failure[E] => Some(result.error)
-                case _                  => None
-    end Failure
+                case result: Error[E] => Some(result.error)
+                case _                => None
+    end Error
 
-    case class Panic(exception: Throwable) extends Cause[Nothing]
+    case class Panic(exception: Throwable) extends Failure[Nothing]
 
     extension [E, T](self: Result[E, T])
 
         def isSuccess: Boolean =
             self match
-                case _: Cause[?] => false
-                case _           => true
+                case _: Failure[?] => false
+                case _             => true
 
-        def isFailure: Boolean =
-            self.isInstanceOf[Failure[?]]
+        def isError: Boolean =
+            self.isInstanceOf[Error[?]]
 
         def isPanic: Boolean =
             self.isInstanceOf[Panic]
 
-        inline def fold[U](inline ifFailure: E => U)(inline ifPanic: Throwable => U)(inline ifSuccess: T => U): U =
+        inline def fold[U](inline ifError: E => U)(inline ifPanic: Throwable => U)(inline ifSuccess: T => U): U =
             (self: @unchecked) match
-                case self: Failure[E] =>
-                    ifFailure(self.error)
+                case self: Error[E] =>
+                    ifError(self.error)
                 case self: Panic =>
                     ifPanic(self.exception)
                 case _ =>
                     try
                         self match
-                            case self: SuccessFailure[T] @unchecked =>
+                            case self: SuccessError[T] @unchecked =>
                                 ifSuccess(self.unnest.asInstanceOf[T])
                             case self =>
                                 ifSuccess(self.asInstanceOf[T])
@@ -87,17 +87,17 @@ object Result:
                         case ex if NonFatal(ex) => ifPanic(ex)
 
         def get(using E =:= Nothing): T =
-            fold(ex => throw new NoSuchElementException(s"Cause: $ex"))(throw _)(identity)
+            fold(ex => throw new NoSuchElementException(s"Failure: $ex"))(throw _)(identity)
 
         inline def getOrElse[U >: T](inline default: => U): U =
             fold(_ => default)(_ => default)(identity)
 
         def orElse[E2, U >: T](alternative: => Result[E2, U]): Result[E | E2, U] =
-            fold(_ => alternative)(_ => alternative)(v => Result.success(v))
+            fold(_ => alternative)(_ => alternative)(Result.success)
 
         inline def flatMap[E2, U](inline f: T => Result[E2, U]): Result[E | E2, U] =
             (self: @unchecked) match
-                case self: Cause[E] => self
+                case self: Failure[E] => self
                 case self =>
                     try f(self.asInstanceOf[Success[T]].get)
                     catch
@@ -116,25 +116,25 @@ object Result:
         inline def filter(inline p: T => Boolean): Result[E | NoSuchElementException, T] =
             flatMap { v =>
                 if !p(v) then
-                    Panic(new NoSuchElementException("Predicate does not hold for " + v))
+                    Error(new NoSuchElementException("Predicate does not hold for " + v))
                 else
                     v
             }
 
-        inline def recover[U >: T](inline pf: PartialFunction[Cause[E], U]): Result[E, U] =
+        inline def recover[U >: T](inline pf: PartialFunction[Failure[E], U]): Result[E, U] =
             try
                 (self: @unchecked) match
-                    case self: Cause[E] if pf.isDefinedAt(self) =>
+                    case self: Failure[E] if pf.isDefinedAt(self) =>
                         Result.success(pf(self))
                     case _ => self
             catch
                 case ex: Throwable if NonFatal(ex) =>
                     Panic(ex)
 
-        inline def recoverWith[E2, U >: T](inline pf: PartialFunction[Cause[E], Result[E2, U]]): Result[E | E2, U] =
+        inline def recoverWith[E2, U >: T](inline pf: PartialFunction[Failure[E], Result[E2, U]]): Result[E | E2, U] =
             try
                 (self: @unchecked) match
-                    case self: Cause[E] if pf.isDefinedAt(self) =>
+                    case self: Failure[E] if pf.isDefinedAt(self) =>
                         pf(self)
                     case _ => self
             catch
@@ -145,18 +145,18 @@ object Result:
             fold(Left(_))(Left(_))(Right(_))
 
         def toTry: Try[T] =
-            fold(e => scala.util.Failure(new NoSuchElementException(s"Cause: $e")))(scala.util.Failure(_))(scala.util.Success(_))
+            fold(e => scala.util.Failure(new NoSuchElementException(s"Failure: $e")))(scala.util.Failure(_))(scala.util.Success(_))
     end extension
 
     private object internal:
-        case class SuccessFailure[+T](cause: Cause[T], depth: Int = 1):
+        case class SuccessError[+T](failure: Failure[T], depth: Int = 1):
             def unnest: Result[Any, T] =
                 if depth > 1 then
-                    SuccessFailure(cause, depth - 1)
+                    SuccessError(failure, depth - 1)
                 else
-                    cause
+                    failure
             def nest: Success[T] =
-                SuccessFailure(cause, depth + 1)
-        end SuccessFailure
+                SuccessError(failure, depth + 1)
+        end SuccessError
     end internal
 end Result

--- a/kyo-prelude/shared/src/test/scala/kyo2/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/AbortTest.scala
@@ -12,13 +12,13 @@ class AbortsTest extends Test:
         "handle" in {
             assert(
                 kyo2.Abort.run[Ex1](kyo2.Abort.get[Ex1](Right(1))).eval ==
-                    Right(1)
+                    Result.success(1)
             )
         }
         "handle + transform" in {
             assert(
                 kyo2.Abort.run[Ex1](kyo2.Abort.get[Ex1](Right(1)).map(_ + 1)).eval ==
-                    Right(2)
+                    Result.success(2)
             )
         }
         "handle + effectful transform" in {
@@ -26,7 +26,7 @@ class AbortsTest extends Test:
                 kyo2.Abort.run[Ex1](kyo2.Abort.get[Ex1](Right(1)).map(i =>
                     kyo2.Abort.get[Ex1](Right(i + 1))
                 )).eval ==
-                    Right(2)
+                    Result.success(2)
             )
         }
         "handle + transform + effectful transform" in {
@@ -34,7 +34,7 @@ class AbortsTest extends Test:
                 kyo2.Abort.run[Ex1](kyo2.Abort.get[Ex1](Right(1)).map(_ + 1).map(i =>
                     kyo2.Abort.get[Ex1](Right(i + 1))
                 )).eval ==
-                    Right(3)
+                    Result.success(3)
             )
         }
         "handle + transform + failed effectful transform" in {
@@ -43,60 +43,60 @@ class AbortsTest extends Test:
                 kyo2.Abort.run[Ex1](kyo2.Abort.get[Ex1](Right(1)).map(_ + 1).map(_ =>
                     kyo2.Abort.get(fail)
                 )).eval ==
-                    fail
+                    Result.failure(ex1)
             )
         }
         "union tags" - {
             "in suspend 1" in {
                 val effect1: Int < Abort[String | Boolean] =
                     kyo2.Abort.fail("failure")
-                val handled1: Either[String, Int] < Abort[Boolean] =
+                val handled1: Result[String, Int] < Abort[Boolean] =
                     kyo2.Abort.run[String](effect1)
-                val handled2: Either[Boolean, Either[String, Int]] =
+                val handled2: Result[Boolean, Result[String, Int]] =
                     kyo2.Abort.run[Boolean](handled1).eval
-                assert(handled2 == Right(Left("failure")))
+                assert(handled2 == Result.success(Result.failure("failure")))
             }
             "in suspend 2" in {
                 val effect1: Int < Abort[String | Boolean] =
                     kyo2.Abort.fail("failure")
-                val handled1: Either[Boolean, Int] < Abort[String] =
+                val handled1: Result[Boolean, Int] < Abort[String] =
                     kyo2.Abort.run[Boolean](effect1)
-                val handled2: Either[String, Either[Boolean, Int]] =
+                val handled2: Result[String, Result[Boolean, Int]] =
                     kyo2.Abort.run[String](handled1).eval
-                assert(handled2 == Left("failure"))
+                assert(handled2 == Result.failure("failure"))
             }
             "in handle" in {
                 val effect: Int < Abort[String | Boolean] =
                     kyo2.Abort.fail("failure")
-                val handled: Either[String | Boolean, Int] =
+                val handled: Result[String | Boolean, Int] =
                     kyo2.Abort.run[String | Boolean](effect).eval
-                assert(handled == Left("failure"))
+                assert(handled == Result.failure("failure"))
             }
         }
         "try" in {
             import scala.util.Try
 
-            assert(kyo2.Abort.run(kyo2.Abort.get(Try(throw ex1))).eval == Left(ex1))
-            assert(kyo2.Abort.run(kyo2.Abort.get(Try("success!"))).eval == Right("success!"))
+            assert(kyo2.Abort.run(kyo2.Abort.get(Try(throw ex1))).eval == Result.failure(ex1))
+            assert(kyo2.Abort.run(kyo2.Abort.get(Try("success!"))).eval == Result.success("success!"))
         }
     }
 
     "get" - {
         "either" in {
-            assert(Abort.run(Abort.get(Left(1))).eval == Left(1))
-            assert(Abort.run(Abort.get[Ex1](Right(1))).eval == Right(1))
+            assert(Abort.run(Abort.get(Left(1))).eval == Result.failure(1))
+            assert(Abort.run(Abort.get[Ex1](Right(1))).eval == Result.success(1))
         }
         "result" in {
-            assert(Abort.run(Abort.get(Result.success(1))).eval == Right(1))
-            assert(Abort.run(Abort.get(Result.failure(ex1))).eval == Left(ex1))
+            assert(Abort.run(Abort.get(Result.success(1))).eval == Result.success(1))
+            assert(Abort.run(Abort.get(Result.failure(ex1))).eval == Result.failure(ex1))
         }
         "option" in {
-            assert(Abort.run(Abort.get(Option.empty)).eval == Left(None))
-            assert(Abort.run(Abort.get(Some(1))).eval == Right(1))
+            assert(Abort.run(Abort.get(Option.empty)).eval == Result.failure(None))
+            assert(Abort.run(Abort.get(Some(1))).eval == Result.success(1))
         }
         "maybe" in {
-            assert(Abort.run(Abort.get(Maybe.empty)).eval == Left(Maybe.Empty))
-            assert(Abort.run(Abort.get(Maybe(1))).eval == Right(1))
+            assert(Abort.run(Abort.get(Maybe.empty)).eval == Result.failure(Maybe.Empty))
+            assert(Abort.run(Abort.get(Maybe(1))).eval == Result.success(1))
         }
     }
 
@@ -106,32 +106,32 @@ class AbortsTest extends Test:
             "handle" in {
                 assert(
                     kyo2.Abort.run[Ex1](v).eval ==
-                        Right(1)
+                        Result.success(1)
                 )
             }
             "handle + transform" in {
                 assert(
                     kyo2.Abort.run[Ex1](v.map(_ + 1)).eval ==
-                        Right(2)
+                        Result.success(2)
                 )
             }
             "handle + effectful transform" in {
                 assert(
                     kyo2.Abort.run[Ex1](v.map(i => kyo2.Abort.get[Ex1](Right(i + 1)))).eval ==
-                        Right(2)
+                        Result.success(2)
                 )
             }
             "handle + transform + effectful transform" in {
                 assert(
                     kyo2.Abort.run[Ex1](v.map(_ + 1).map(i => kyo2.Abort.get[Ex1](Right(i + 1)))).eval ==
-                        Right(3)
+                        Result.success(3)
                 )
             }
             "handle + transform + failed effectful transform" in {
                 val fail = Left[Ex1, Int](ex1)
                 assert(
                     kyo2.Abort.run[Ex1](v.map(_ + 1).map(_ => kyo2.Abort.get(fail))).eval ==
-                        fail
+                        Result.failure(ex1)
                 )
             }
         }
@@ -140,32 +140,32 @@ class AbortsTest extends Test:
             "handle" in {
                 assert(
                     kyo2.Abort.run[Ex1](v).eval ==
-                        Left(ex1)
+                        Result.failure(ex1)
                 )
             }
             "handle + transform" in {
                 assert(
                     kyo2.Abort.run[Ex1](v.map(_ + 1)).eval ==
-                        Left(ex1)
+                        Result.failure(ex1)
                 )
             }
             "handle + effectful transform" in {
                 assert(
                     kyo2.Abort.run[Ex1](v.map(i => kyo2.Abort.get[Ex1](Right(i + 1)))).eval ==
-                        Left(ex1)
+                        Result.failure(ex1)
                 )
             }
             "handle + transform + effectful transform" in {
                 assert(
                     kyo2.Abort.run[Ex1](v.map(_ + 1).map(i => kyo2.Abort.get[Ex1](Right(i + 1)))).eval ==
-                        Left(ex1)
+                        Result.failure(ex1)
                 )
             }
             "handle + transform + failed effectful transform" in {
                 val fail = Left[Ex1, Int](ex1)
                 assert(
                     kyo2.Abort.run[Ex1](v.map(_ + 1).map(_ => kyo2.Abort.get(fail))).eval ==
-                        Left(ex1)
+                        Result.failure(ex1)
                 )
             }
         }
@@ -181,40 +181,54 @@ class AbortsTest extends Test:
             "success" in {
                 assert(
                     kyo2.Abort.run[Ex1](test(2)).eval ==
-                        Right(5)
+                        Result.success(5)
                 )
             }
             "failure" in {
                 assert(
                     kyo2.Abort.run[Ex1](test(0)).eval ==
-                        Left(ex1)
+                        Result.failure(ex1)
+                )
+            }
+            "panic" in {
+                val p = new Exception
+                assert(
+                    kyo2.Abort.run[Ex1](throw p).eval ==
+                        Result.panic(p)
+                )
+            }
+            "suspension + panic" in {
+                val p = new Exception
+                assert(
+                    kyo2.Abort.run[Ex1](Abort.get(Right(1)).map(_ => throw p)).eval ==
+                        Result.panic(p)
                 )
             }
             "inference" in {
                 def t1(v: Int < Abort[Int | String]) =
                     kyo2.Abort.run[Int](v)
-                val _: Either[Int, Int] < Abort[String] =
+                val _: Result[Int, Int] < Abort[String] =
                     t1(42)
                 def t2(v: Int < (Abort[Int] & Abort[String])) =
                     kyo2.Abort.run[String](v)
-                val _: Either[String, Int] < Abort[Int] =
+                val _: Result[String, Int] < Abort[Int] =
                     t2(42)
                 def t3(v: Int < Abort[Int]) =
                     kyo2.Abort.run[Int](v).eval
-                val _: Either[Int, Int] =
+                val _: Result[Int, Int] =
                     t3(42)
                 succeed
             }
             "super" in {
                 val ex                        = new Exception
                 val a: Int < Abort[Exception] = kyo2.Abort.fail(ex)
-                val b: Either[Throwable, Int] = kyo2.Abort.run[Throwable](a).eval
-                assert(b == Left(ex))
+                val b: Result[Throwable, Int] = kyo2.Abort.run[Throwable](a).eval
+                assert(b == Result.failure(ex))
             }
             "super success" in {
                 val a: Int < Abort[Exception] = 24
-                val b: Either[Throwable, Int] = kyo2.Abort.run[Throwable](a).eval
-                assert(b == Right(24))
+                val b: Result[Throwable, Int] = kyo2.Abort.run[Throwable](a).eval
+                assert(b == Result.success(24))
             }
             "reduce large union incrementally" in {
                 val t1: Int < Abort[Int | String | Boolean | Float | Char | Double] =
@@ -225,7 +239,7 @@ class AbortsTest extends Test:
                 val t5 = kyo2.Abort.run[Float](t4)
                 val t6 = kyo2.Abort.run[Char](t5)
                 val t7 = kyo2.Abort.run[Double](t6)
-                assert(t7.eval == Right(Right(Right(Right(Right(Right(18)))))))
+                assert(t7.eval == Result.success(Result.success(Result.success(Result.success(Result.success(Result.success(18)))))))
             }
             "reduce large union in a single expression" in {
                 val t: Int < Abort[Int | String | Boolean | Float | Char | Double] = 18
@@ -242,26 +256,26 @@ class AbortsTest extends Test:
                             )
                         )
                     ).eval
-                val expected: Either[Double, Either[Char, Either[Float, Either[Boolean, Either[String, Either[Int, Int]]]]]] =
-                    Right(Right(Right(Right(Right(Right(18))))))
+                val expected: Result[Double, Result[Char, Result[Float, Result[Boolean, Result[String, Result[Int, Int]]]]]] =
+                    Result.success(Result.success(Result.success(Result.success(Result.success(Result.success(18))))))
                 assert(res == expected)
             }
         }
         "fail" in {
             val ex: Throwable = new Exception("throwable failure")
             val a             = kyo2.Abort.fail(ex)
-            assert(kyo2.Abort.run[Throwable](a).eval == Left(ex))
+            assert(kyo2.Abort.run[Throwable](a).eval == Result.failure(ex))
         }
         "fail inferred" in {
             val e = "test"
             val f = kyo2.Abort.fail(e)
-            assert(kyo2.Abort.run(f).eval == Left(e))
+            assert(kyo2.Abort.run(f).eval == Result.failure(e))
         }
         "when" in {
             def test(b: Boolean) = kyo2.Abort.run[String](kyo2.Abort.when(b)("FAIL!")).eval
 
-            assert(test(true) == Left("FAIL!"))
-            assert(test(false) == Right(()))
+            assert(test(true) == Result.failure("FAIL!"))
+            assert(test(false) == Result.success(()))
         }
         "catching" - {
             "only effect" - {
@@ -272,19 +286,19 @@ class AbortsTest extends Test:
                 "success" in {
                     assert(
                         kyo2.Abort.run[Ex1](kyo2.Abort.catching[Ex1](test(2))).eval ==
-                            Right(5)
+                            Result.success(5)
                     )
                 }
                 "failure" in {
                     assert(
                         kyo2.Abort.run[Ex1](kyo2.Abort.catching[Ex1](test(0))).eval ==
-                            Left(ex1)
+                            Result.failure(ex1)
                     )
                 }
                 "subclass" in {
                     assert(
                         kyo2.Abort.run[RuntimeException](kyo2.Abort.catching[RuntimeException](test(0))).eval ==
-                            Left(ex1)
+                            Result.failure(ex1)
                     )
                 }
                 "distinct" in {
@@ -301,10 +315,10 @@ class AbortsTest extends Test:
 
                     val a = kyo2.Abort.run[Distinct1](distinct)
                     val b = kyo2.Abort.run[Distinct2](a).eval
-                    assert(b == Right(Left(d1)))
+                    assert(b == Result.success(Result.failure(d1)))
 
                     val c = kyo2.Abort.run(distinct).eval
-                    assert(c == Left(d1))
+                    assert(c == Result.failure(d1))
                 }
                 "ClassTag inference" in pendingUntilFixed {
                     assertCompiles("""
@@ -326,7 +340,7 @@ class AbortsTest extends Test:
                         kyo2.Env.run(2)(
                             kyo2.Abort.run[Ex1](kyo2.Abort.catching[Ex1](test(kyo2.Env.get)))
                         ).eval ==
-                            Right(5)
+                            Result.success(5)
                     )
                 }
                 "failure" in {
@@ -334,7 +348,7 @@ class AbortsTest extends Test:
                         kyo2.Env.run(0)(
                             kyo2.Abort.run[Ex1](kyo2.Abort.catching[Ex1](test(kyo2.Env.get)))
                         ).eval ==
-                            Left(ex1)
+                            Result.failure(ex1)
                     )
                 }
             }
@@ -346,14 +360,14 @@ class AbortsTest extends Test:
                             kyo2.Abort.fail[String]("inner").map(_ => kyo2.Abort.fail[Int](42))
                         )
                     )
-                    assert(nested.eval == Left("inner"))
+                    assert(nested.eval == Result.failure("inner"))
                 }
 
                 "should propagate the outermost failure if there are no inner failures" in {
                     val nested = kyo2.Abort.run(kyo2.Abort.run[String](
                         kyo2.Abort.run[Int](kyo2.Abort.get[Int](Right(42)))
                     ).map(_ => kyo2.Abort.fail("outer")))
-                    assert(nested.eval == Left("outer"))
+                    assert(nested.eval == Result.failure("outer"))
                 }
             }
 
@@ -361,12 +375,12 @@ class AbortsTest extends Test:
                 "should have access to the environment within Abort" in {
                     val env    = "test"
                     val result = kyo2.Env.run(env)(kyo2.Abort.run[String](kyo2.Env.get[String]))
-                    assert(result.eval == Right(env))
+                    assert(result.eval == Result.success(env))
                 }
 
                 "should propagate Abort failures within Env" in {
                     val result = kyo2.Env.run("test")(kyo2.Abort.run[String](kyo2.Abort.fail("failure")))
-                    assert(result.eval == Left("failure"))
+                    assert(result.eval == Result.failure("failure"))
                 }
             }
 
@@ -377,7 +391,7 @@ class AbortsTest extends Test:
                             kyo2.Var.get[Int].map(_.toString)
                         )
                     )
-                    assert(result.eval == Right("42"))
+                    assert(result.eval == Result.success("42"))
                 }
 
                 "should not modify state on Abort failures" in {
@@ -386,7 +400,7 @@ class AbortsTest extends Test:
                             kyo2.Var.set[Int](24).map(_ => kyo2.Abort.fail("failure"))
                         )
                     )
-                    assert(result.eval == Left("failure"))
+                    assert(result.eval == Result.failure("failure"))
                     assert(kyo2.Var.run(42)(kyo2.Var.get[Int]).eval == 42)
                 }
             }
@@ -397,7 +411,7 @@ class AbortsTest extends Test:
                     val result = kyo2.Abort.run[String](
                         kyo2.Abort.fail("failure").map(_ => executed = true)
                     )
-                    assert(result.eval == Left("failure"))
+                    assert(result.eval == Result.failure("failure"))
                     assert(!executed)
                 }
 
@@ -406,7 +420,7 @@ class AbortsTest extends Test:
                     val result = kyo2.Abort.run(kyo2.Abort.run[String](
                         kyo2.Abort.get[Int](Right(42)).map(_ => executed = true)
                     ))
-                    assert(result.eval == Right(Right(())))
+                    assert(result.eval == Result.success(Result.success(())))
                     assert(executed)
                 }
             }

--- a/kyo-prelude/shared/src/test/scala/kyo2/ChunkTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ChunkTest.scala
@@ -164,7 +164,7 @@ class ChunkTest extends Test:
                     }
                 }
             }
-            assert(result.eval == Result.failure("1 is not divisible by 3"))
+            assert(result.eval == Result.error("1 is not divisible by 3"))
         }
         "with a function using Var and Abort" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
@@ -178,7 +178,7 @@ class ChunkTest extends Test:
                     }
                 }
             }
-            assert(result.eval == Result.failure("Odd number encountered"))
+            assert(result.eval == Result.error("Odd number encountered"))
         }
         "with an empty chunk" in {
             val chunk  = kyo2.Chunk.empty[Int]
@@ -222,7 +222,7 @@ class ChunkTest extends Test:
                     }
                 }
             }
-            assert(result.eval == Result.failure(()))
+            assert(result.eval == Result.error(()))
         }
 
         "with a predicate that filters out all elements" in {
@@ -251,7 +251,7 @@ class ChunkTest extends Test:
                     }
                 }
             }
-            assert(result.eval == Result.failure("Sum exceeded max value of 10"))
+            assert(result.eval == Result.error("Sum exceeded max value of 10"))
         }
 
         "with a function using Var and Env" in {
@@ -821,7 +821,7 @@ class ChunkTest extends Test:
                     }
                 }
             }
-            assert(result.eval == Result.failure("Sum exceeded max value of 10"))
+            assert(result.eval == Result.error("Sum exceeded max value of 10"))
             assert(sum == 4)
         }
     }

--- a/kyo-prelude/shared/src/test/scala/kyo2/ChunkTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ChunkTest.scala
@@ -164,7 +164,7 @@ class ChunkTest extends Test:
                     }
                 }
             }
-            assert(result.eval == Left("1 is not divisible by 3"))
+            assert(result.eval == Result.failure("1 is not divisible by 3"))
         }
         "with a function using Var and Abort" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
@@ -178,7 +178,7 @@ class ChunkTest extends Test:
                     }
                 }
             }
-            assert(result.eval == Left("Odd number encountered"))
+            assert(result.eval == Result.failure("Odd number encountered"))
         }
         "with an empty chunk" in {
             val chunk  = kyo2.Chunk.empty[Int]
@@ -222,7 +222,7 @@ class ChunkTest extends Test:
                     }
                 }
             }
-            assert(result.eval == Left(()))
+            assert(result.eval == Result.failure(()))
         }
 
         "with a predicate that filters out all elements" in {
@@ -251,7 +251,7 @@ class ChunkTest extends Test:
                     }
                 }
             }
-            assert(result.eval == Left("Sum exceeded max value of 10"))
+            assert(result.eval == Result.failure("Sum exceeded max value of 10"))
         }
 
         "with a function using Var and Env" in {
@@ -821,7 +821,7 @@ class ChunkTest extends Test:
                     }
                 }
             }
-            assert(result.eval == Left("Sum exceeded max value of 10"))
+            assert(result.eval == Result.failure("Sum exceeded max value of 10"))
             assert(sum == 4)
         }
     }

--- a/kyo-prelude/shared/src/test/scala/kyo2/EnvTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/EnvTest.scala
@@ -169,7 +169,7 @@ class EnvTest extends Test:
                     kyo2.Env.get[Service1].map(_(0))
                 assert(
                     kyo2.Abort.run(kyo2.Env.run(service1)(a)).eval ==
-                        Result.failure(None)
+                        Result.error(None)
                 )
             }
         }
@@ -298,7 +298,7 @@ class EnvTest extends Test:
     "interactions with Abort" - {
         "should propagate Abort failures within Env" in {
             val result = kyo2.Env.run("test")(kyo2.Abort.run[String](kyo2.Abort.fail("failure")))
-            assert(result.eval == Result.failure("failure"))
+            assert(result.eval == Result.error("failure"))
         }
 
         "should have access to the environment within Abort" in {

--- a/kyo-prelude/shared/src/test/scala/kyo2/EnvTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/EnvTest.scala
@@ -161,7 +161,7 @@ class EnvTest extends Test:
                     kyo2.Env.get[Service1].map(_(1))
                 assert(
                     kyo2.Abort.run(kyo2.Env.run(service1)(a)).eval ==
-                        Right(2)
+                        Result.success(2)
                 )
             }
             "short circuit" in {
@@ -169,7 +169,7 @@ class EnvTest extends Test:
                     kyo2.Env.get[Service1].map(_(0))
                 assert(
                     kyo2.Abort.run(kyo2.Env.run(service1)(a)).eval ==
-                        Left(None)
+                        Result.failure(None)
                 )
             }
         }
@@ -184,21 +184,21 @@ class EnvTest extends Test:
                     val b = kyo2.Env.run(service2)(v)
                     val c = kyo2.Env.run(service1)(b)
                     assert(
-                        kyo2.Abort.run(c).eval == Right(3)
+                        kyo2.Abort.run(c).eval == Result.success(3)
                     )
                 }
                 "reverse handling order" in {
                     val b = kyo2.Env.run(service1)(v)
                     val c = kyo2.Env.run(service2)(b)
                     assert(
-                        kyo2.Abort.run(c).eval == Right(3)
+                        kyo2.Abort.run(c).eval == Result.success(3)
                     )
                 }
                 "dependent services" in {
                     val v2: Int < (Env[Service2] & Abort[None.type]) = kyo2.Env.run(service1)(v)
                     assert(
                         kyo2.Abort.run(kyo2.Env.run(service2)(v2)).eval ==
-                            Right(3)
+                            Result.success(3)
                     )
                 }
             }
@@ -298,13 +298,13 @@ class EnvTest extends Test:
     "interactions with Abort" - {
         "should propagate Abort failures within Env" in {
             val result = kyo2.Env.run("test")(kyo2.Abort.run[String](kyo2.Abort.fail("failure")))
-            assert(result.eval == Left("failure"))
+            assert(result.eval == Result.failure("failure"))
         }
 
         "should have access to the environment within Abort" in {
             val env    = "test"
             val result = kyo2.Env.run(env)(kyo2.Abort.run[String](kyo2.Env.get[String]))
-            assert(result.eval == Right(env))
+            assert(result.eval == Result.success(env))
         }
     }
 

--- a/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
@@ -1,217 +1,147 @@
 package kyo2
 
-import Tagged.jvmOnly
 import kyo2.Result
-import kyo2.Result.Failure
-import kyo2.Result.Success
+import kyo2.Result.*
 
 class ResultTest extends Test:
 
-    val try2: Result[Result[Int]] = Success(Failure(new Exception("error")))
+    val try2: Result[String, Result[String, Int]] = Success(Failure("error"))
 
     "should match Success containing Failure" in {
         val result = try2 match
-            case Success(Failure(e)) => e.getMessage
+            case Success(Failure(e)) => e
             case _                   => ""
         assert(result == "error")
     }
 
     "isSuccess" - {
         "returns true for Success" in {
-            assert(Success(1).isSuccess)
+            assert(Result.success(1).isSuccess)
         }
         "returns false for Failure" in {
-            assert(!Failure[Int](new Exception("error")).isSuccess)
+            assert(!Failure("error").isSuccess)
         }
     }
 
     "isFailure" - {
         "returns false for Success" in {
-            assert(!Success(1).isFailure)
+            assert(!Result.success(1).isFailure)
         }
         "returns true for Failure" in {
-            assert(Failure[Int](new Exception("error")).isFailure)
+            assert(Failure("error").isFailure)
         }
     }
 
     "get" - {
         "returns the value for Success" in {
-            assert(Success(1).get == 1)
+            assert(Result.success(1).get == 1)
         }
-        "throws the exception for Failure" in {
-            val ex = new Exception("error")
-            assertThrows[Exception](Failure[Int](ex).get)
+        "throws an exception for Failure" in {
+            assertThrows[Exception](Result.panic(new Exception).get)
         }
     }
 
     "getOrElse" - {
         "returns the value for Success" in {
-            assert(Success(1).getOrElse(0) == 1)
+            assert(Result.success(1).getOrElse(0) == 1)
         }
         "returns the default value for Failure" in {
-            assert(Failure[Int](new Exception("error")).getOrElse(0) == 0)
-        }
-        "inference" in {
-            val r: List[String] = Result(List.empty[String]).getOrElse(List.empty)
-            assert(r == List.empty)
+            assert(Failure("error").getOrElse(0) == 0)
         }
     }
 
     "orElse" - {
         "returns itself for Success" in {
-            assert(Success(1).orElse(Success(2)) == Success(1))
+            assert(Result.success(1).orElse(Result.success(2)) == Success(1))
         }
         "returns the alternative for Failure" in {
-            assert(Failure[Int](new Exception("error")).orElse(Success(1)) == Success(1))
-        }
-        "inference" in {
-            val r: Result[List[String]] = Result(List.empty[String]).orElse(Result(List.empty))
-            assert(r.get == List.empty)
+            assert(Failure("error").orElse(Success(1)) == Success(1))
         }
     }
 
     "flatMap" - {
         "applies the function for Success" in {
-            assert(Success(1).flatMap(x => Success(x + 1)) == Success(2))
+            assert(Result.success(1).flatMap(x => Result.success(x + 1)) == Success(2))
         }
         "does not apply the function for Failure" in {
-            val ex = new Exception("error")
-            assert(Failure[Int](ex).flatMap(x => Success(x + 1)) == Failure[Int](ex))
+            assert(Result.failure[String, Int]("error").flatMap(x => Success(x + 1)) == Failure("error"))
         }
     }
 
     "map" - {
         "applies the function for Success" in {
-            assert(Success(1).map(_ + 1) == Success(2))
+            assert(Result.success(1).map(_ + 1) == Success(2))
         }
         "does not apply the function for Failure" in {
-            val ex = new Exception("error")
-            assert(Failure[Int](ex).map(_ + 1) == Failure[Int](ex))
+            assert(Result.failure[String, Int]("error").map(_ + 1) == Failure("error"))
         }
     }
 
     "fold" - {
         "applies the success function for Success" in {
-            assert(Success(1).fold(_ => 0)(x => x + 1) == 2)
+            assert(Result.success(1).fold(_ => 0)(_ => 0)(x => x + 1) == 2)
         }
         "applies the failure function for Failure" in {
-            assert(Failure[Int](new Exception("error")).fold(_ => 0)(x => x) == 0)
-        }
-        "catches failures in ifSuccess" in {
-            val ex = new Exception
-            assert(Success(1).fold(_ => 0)(_ => throw ex) == 0)
-        }
-    }
-
-    "filter" - {
-        "returns itself if the predicate holds for Success" in {
-            assert(Success(2).filter(_ % 2 == 0) == Success(2))
-        }
-        "returns Failure if the predicate doesn't hold for Success" in {
-            assert(Success(1).filter(_ % 2 == 0).isFailure)
-        }
-        "returns itself for Failure" in {
-            val ex = new Exception("error")
-            assert(Failure[Int](ex).filter(_ => true) == Failure[Int](ex))
+            assert(Result.failure[String, Int]("error").fold(_ => 0)(_ => 0)(x => x) == 0)
         }
     }
 
     "recover" - {
         "returns itself for Success" in {
-            assert(Success(1).recover { case _: Exception => 0 } == Success(1))
+            assert(Result.success(1).recover { case _ => 0 } == Success(1))
         }
         "returns Success with the mapped value if the partial function is defined for Failure" in {
-            assert(Failure[Int](new Exception("error")).recover { case _: Exception => 0 } == Success(0))
+            assert(Failure("error").recover { case _ => 0 } == Success(0))
         }
         "returns itself if the partial function is not defined for Failure" in {
-            val ex = new Exception("error")
-            assert(Failure[Int](ex).recover { case _: RuntimeException => 0 } == Failure[Int](ex))
+            val error = Failure("error")
+            assert(Failure(error).recover { case _ if false => 0 } == Failure(error))
         }
     }
 
     "recoverWith" - {
         "returns itself for Success" in {
-            assert(Success(1).recoverWith { case _: Exception => Success(0) } == Success(1))
+            assert(Result.success(1).recoverWith { case _ => Success(0) } == Success(1))
         }
         "returns the mapped Result if the partial function is defined for Failure" in {
-            assert(Failure[Int](new Exception("error")).recoverWith { case _: Exception => Success(0) } == Success(0))
+            assert(Failure("error").recoverWith { case _ => Success(0) } == Success(0))
         }
         "returns itself if the partial function is not defined for Failure" in {
-            val ex = new Exception("error")
-            assert(Failure[Int](ex).recoverWith { case _: RuntimeException => Success(0) } == Failure[Int](ex))
+            val error = Failure("error")
+            assert(Failure(error).recoverWith { case _ if false => Success(0) } == Failure(error))
         }
     }
 
     "toEither" - {
         "returns Right with the value for Success" in {
-            assert(Success(1).toEither == Right(1))
+            assert(Result.success(1).toEither == Right(1))
         }
-        "returns Left with the exception for Failure" in {
-            val ex = new Exception("error")
-            assert(Failure[Int](ex).toEither == Left(ex))
-        }
-    }
-
-    "deeply nested Result" - {
-        val nestedResult = Success(Success(Success(Success(1))))
-
-        "get should return the deeply nested value" in {
-            assert(nestedResult.get.get.get.get == 1)
-        }
-
-        "map should apply the function to the deeply nested Result" in {
-            assert(nestedResult.map(_.map(_.map(_.map(_ + 1)))) == Success(Success(Success(Success(2)))))
-        }
-
-        "flatMap should apply the function and flatten the result" in {
-            assert(nestedResult.flatMap(x => x.flatMap(y => y.flatMap(z => z.map(_ + 1)))) == Success(2))
-        }
-
-        "isSuccess should return true for deeply nested Success" in {
-            assert(nestedResult.isSuccess)
-        }
-
-        "isFailure should return false for deeply nested Success" in {
-            assert(!nestedResult.isFailure)
+        "returns Left with the error for Failure" in {
+            val error = "error"
+            assert(Failure(error).toEither == Left(error))
         }
     }
 
-    "Success with nested Failure" - {
-        val successWithNestedFailure: Success[Failure[Int]] = Success(Failure[Int](new Exception("error")))
-
-        "get should return the nested Failure" in {
-            assert(successWithNestedFailure.get.isFailure)
+    "toTry" - {
+        "Success to Try" in {
+            val success: Result[Nothing, Int] = Success(42)
+            val tryResult                     = success.toTry
+            assert(tryResult.isSuccess)
+            assert(tryResult.get == 42)
         }
 
-        "isSuccess should return true" in {
-            assert(successWithNestedFailure.isSuccess)
-        }
-
-        "isFailure should return false" in {
-            assert(!successWithNestedFailure.isFailure)
+        "Failure to Try" in {
+            val failure: Result[String, Int] = Failure("Something went wrong")
+            val tryResult                    = failure.toTry
+            assert(tryResult.isFailure)
+            assert(tryResult.failed.get.isInstanceOf[NoSuchElementException])
         }
     }
 
     "pattern matching" - {
-        "deep matching" - {
-            val nestedResult = Success(Success(Success(Success(1))))
-
-            "should match deeply nested Success and extract inner value" in {
-                val result = nestedResult match
-                    case Success(Success(Success(Success(x)))) => x
-                assert(result == 1)
-            }
-
-            "should match partially and extract nested Result" in {
-                val result = nestedResult match
-                    case Success(Success(x)) => x
-                assert(result == Success(Success(1)))
-            }
-        }
-
         "matching with guards" - {
             "should match Success with a guard" in {
-                val tryy: Result[Int] = Success(2)
+                val tryy: Result[Nothing, Int] = Success(2)
                 val result = tryy match
                     case Success(x) if x > 1 => "greater than 1"
                     case Success(_)          => "less than or equal to 1"
@@ -220,156 +150,116 @@ class ResultTest extends Test:
             }
 
             "should match Failure with a guard" in {
-                val tryy: Result[Int] = Failure(new Exception("error"))
+                val tryy: Result[String, Int] = Failure("error")
                 val result = tryy match
-                    case Failure(e) if e.getMessage.length > 5 => "long error"
-                    case Failure(_)                            => "short error"
-                    case Success(_)                            => "success"
+                    case Failure(e) if e.length > 5 => "long error"
+                    case Failure(_)                 => "short error"
+                    case Success(_)                 => "success"
                 assert(result == "short error")
             }
         }
+    }
 
-        "matching nested Results" - {
-            val try1: Result[Result[Int]] = Success(Success(1))
-            val try2: Result[Result[Int]] = Success(Failure(new Exception("error")))
-            val try3: Result[Result[Int]] = Failure(new Exception("error"))
+    "inference" - {
+        "flatMap" in {
+            val result: Result[String, Int]    = Result.success(5)
+            val mapped: Result[String, String] = result.flatMap(x => Result.success(x.toString))
+            assert(mapped == Success("5"))
+        }
 
-            "should match deeply nested Success" in {
-                val result = try1 match
-                    case Success(Success(x)) => x
-                    case _                   => 0
-                assert(result == 1)
-            }
+        "flatMap with different error types" in {
+            val r1: Result[String, Int]              = Result.success(5)
+            val r2: Result[Int, String]              = Result.success("hello")
+            val nested: Result[String | Int, String] = r1.flatMap(x => r2.map(y => s"$x $y"))
+            assert(nested == Success("5 hello"))
+        }
 
-            "should match Success containing Failure" in {
-                val result = try2 match
-                    case Success(Failure(e)) => e.getMessage
-                    case _                   => ""
-                assert(result == "error")
-            }
+        "for-comprehension with multiple flatMaps" in {
+            def divideIfEven(x: Int): Result[String, Double] =
+                if x % 2 == 0 then Result.success(10.0 / x) else Result.failure("Odd number")
 
-            "should match top-level Failure" in {
-                val result = try3 match
-                    case Failure(e) => e.getMessage
-                    case _          => ""
-                assert(result == "error")
-            }
+            val complex: Result[String, String] =
+                for
+                    a <- Result.success(4)
+                    b <- divideIfEven(a)
+                    c <- Result.success(b * 2)
+                yield c.toString
+
+            assert(complex == Success("5.0"))
         }
     }
 
     "edge cases" - {
-        "should not handle exceptions in ifFailure" in {
-            val tryy      = Success(1)
-            val exception = new RuntimeException("exception")
-            val result =
-                try
-                    tryy.fold(_ => throw exception)(_ => throw exception)
-                    "no exception"
-                catch
-                    case e: RuntimeException => "caught exception"
-            assert(result == "caught exception")
+        "nested Success containing Failure" in {
+            val nested: Result[String, Result[Int, String]] = Result.success(Result.failure(42))
+            val flattened                                   = nested.flatten
+
+            assert(flattened == Failure(42))
         }
 
-        "should handle exceptions in ifSuccess" in {
-            val tryy      = Success(1)
-            val exception = new RuntimeException("exception")
-            val result =
-                try
-                    tryy.fold(_ => 0)(_ => throw exception)
-                    "no exception"
-                catch
-                    case e: RuntimeException => "caught exception"
-            assert(result == "no exception")
+        "recover with a partial function" in {
+            val result: Result[String, Int] = Result.failure("error")
+            val recovered = result.recover {
+                case Failure("error") => 0
+                case _                => -1
+            }
+
+            assert(recovered == Success(0))
         }
 
-        "should handle exceptions during map" in {
-            val tryy      = Success(1)
-            val exception = new RuntimeException("exception")
-            val result =
-                try
-                    tryy.map(_ => throw exception)
-                    "no exception"
-                catch
-                    case e: RuntimeException => "caught exception"
-            assert(result == "no exception")
+        "empty Success" in {
+            val empty: Result[Nothing, Unit] = Result.success(())
+            assert(empty == Success(()))
         }
 
-        "should handle exceptions during flatMap" in {
-            val tryy      = Success(1)
-            val exception = new RuntimeException("exception")
-            val result =
-                try
-                    tryy.flatMap(_ => throw exception)
-                    "no exception"
-                catch
-                    case e: RuntimeException => "caught exception"
-            assert(result == "no exception")
-        }
-    }
-
-    "toTry" - {
-        "Success to Try" in {
-            val success: Result[Int] = Success(42)
-            val tryResult            = success.toTry
-            assert(tryResult.isSuccess)
-            assert(tryResult.get == 42)
+        "Panic distinct from Failure" in {
+            val exception = new RuntimeException("Unexpected error")
+            val panic     = Result.panic(exception)
+            assert(!panic.isFailure)
+            assert(panic match
+                case Panic(_) => true
+                case _        => false
+            )
         }
 
-        "Failure to Try" in {
-            val exception            = new RuntimeException("Something went wrong")
-            val failure: Result[Int] = Failure(exception)
-            val tryResult            = failure.toTry
-            assert(tryResult.isFailure)
-            assert(tryResult.failed.get == exception)
+        "deeply nested Success/Failure" in {
+            val deeplyNested = Success(Success(Success(Failure("deep error"))))
+            assert(deeplyNested.flatten == Success(Success(Failure("deep error"))))
+            assert(deeplyNested.flatten.flatten == Success(Failure("deep error")))
+            assert(deeplyNested.flatten.flatten.flatten == Failure("deep error"))
         }
 
-        "deeply nested Success to Try" in {
-            val nested: Result[Result[Result[Int]]] = Success(Success(Success(42)))
-            val tryResult                           = nested.toTry
-            assert(tryResult.isSuccess)
-            assert(tryResult.get == Success(Success(42)))
+        "Panic propagation through flatMap" in {
+            val panic  = Result.panic(new RuntimeException("Unexpected"))
+            val result = panic.flatMap(_ => Success(1)).flatMap(_ => Failure("won't happen"))
+            assert(result == panic)
         }
 
-        "deeply nested Failure to Try" in {
-            val exception                           = new RuntimeException("Something went wrong")
-            val nested: Result[Result[Result[Int]]] = Success(Success(Failure(exception)))
-            val tryResult                           = nested.toTry
-            assert(tryResult.isSuccess)
-            assert(tryResult.get == Success(Failure(exception)))
-        }
-    }
-
-    "null values" - {
-        "Success with null value" in {
-            val result: Result[String] = Success(null)
-            assert(result.isSuccess)
-            assert(result.get == null)
+        "Error type widening" in {
+            val r1: Result[String, Int] = Failure("error1")
+            val r2: Result[Int, String] = Failure(42)
+            val combined                = r1.orElse(r2)
+            assert(combined.isFailure)
+            assert(combined match
+                case Failure(_: String | _: Int) => true
+                case _                           => false
+            )
         }
 
-        "Success with null value flatMap" in {
-            val result: Result[String] = Success(null)
-            val flatMapped             = result.flatMap(str => Success(s"mapped: $str"))
-            assert(flatMapped == Success("mapped: null"))
-        }
+        "nested flatMap with type changes" in {
+            def f(i: Int): Result[String, Double] =
+                if i > 0 then Success(i.toDouble) else Failure("non-positive")
+            def g(d: Double): Result[Int, String] =
+                if d < 10 then Success(d.toString) else Failure(d.toInt)
 
-        "Failure with null exception" taggedAs jvmOnly in {
-            val result: Result[Int] = Failure(null)
-            assert(result.isFailure)
-            assertThrows[NullPointerException](result.get)
-        }
+            val result = Success(5).flatMap(f).flatMap(g)
+            assert(result == Success("5.0"))
 
-        "Failure with null exception flatMap" taggedAs jvmOnly in {
-            val result: Result[Int] = Failure(null)
-            val flatMapped          = result.flatMap(num => Success(num + 1))
-            assert(flatMapped.isFailure)
-            assertThrows[NullPointerException](flatMapped.get)
-        }
+            val result2 = Success(-1).flatMap(f).flatMap(g)
+            assert(result2 == Failure("non-positive"))
 
-        "Failure with null exception map" taggedAs jvmOnly in {
-            val result: Result[Int] = Failure(null)
-            val mapped              = result.map(num => num + 1)
-            assert(mapped.isFailure)
-            assertThrows[NullPointerException](mapped.get)
+            val result3 = Success(20).flatMap(f).flatMap(g)
+            assert(result3 == Failure(20))
         }
     }
 

--- a/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
@@ -8,12 +8,12 @@ class ResultTest extends Test:
 
     val ex = new Exception
 
-    val try2: Result[String, Result[String, Int]] = Success(Failure("error"))
+    val try2: Result[String, Result[String, Int]] = Success(Error("error"))
 
-    "should match Success containing Failure" in {
+    "should match Success containing Error" in {
         val result = try2 match
-            case Success(Failure(e)) => e
-            case _                   => ""
+            case Success(Error(e)) => e
+            case _                 => ""
         assert(result == "error")
     }
 
@@ -21,23 +21,23 @@ class ResultTest extends Test:
         "returns true for Success" in {
             assert(Result.success(1).isSuccess)
         }
-        "returns false for Failure" in {
-            assert(!Result.failure(ex).isSuccess)
+        "returns false for Error" in {
+            assert(!Result.error(ex).isSuccess)
         }
         "returns false for Panic" in {
             assert(!Result.panic(ex).isSuccess)
         }
     }
 
-    "isFailure" - {
+    "isError" - {
         "returns false for Success" in {
-            assert(!Result.success(1).isFailure)
+            assert(!Result.success(1).isError)
         }
-        "returns true for Failure" in {
-            assert(Result.failure(ex).isFailure)
+        "returns true for Error" in {
+            assert(Result.error(ex).isError)
         }
         "returns false for Panic" in {
-            assert(!Result.panic(ex).isFailure)
+            assert(!Result.panic(ex).isError)
         }
     }
 
@@ -45,8 +45,8 @@ class ResultTest extends Test:
         "returns false for Success" in {
             assert(!Result.success(1).isPanic)
         }
-        "returns false for Failure" in {
-            assert(!Result.failure(ex).isPanic)
+        "returns false for Error" in {
+            assert(!Result.error(ex).isPanic)
         }
         "returns true for Panic" in {
             assert(Result.panic(ex).isPanic)
@@ -57,7 +57,7 @@ class ResultTest extends Test:
         "returns the value for Success" in {
             assert(Result.success(1).get == 1)
         }
-        "can't be called for Failure" in {
+        "can't be called for Error" in {
             assertDoesNotCompile("Result.failure(ex).get")
         }
         "throws an exception for Panic" in {
@@ -69,8 +69,8 @@ class ResultTest extends Test:
         "returns the value for Success" in {
             assert(Result.success(1).getOrElse(0) == 1)
         }
-        "returns the default value for Failure" in {
-            assert(Result.failure(ex).getOrElse(0) == 0)
+        "returns the default value for Error" in {
+            assert(Result.error(ex).getOrElse(0) == 0)
         }
         "returns the default value for Panic" in {
             assert(Result.panic(ex).getOrElse(0) == 0)
@@ -85,8 +85,8 @@ class ResultTest extends Test:
         "returns itself for Success" in {
             assert(Result.success(1).orElse(Result.success(2)) == Success(1))
         }
-        "returns the alternative for Failure" in {
-            assert(Result.failure(ex).orElse(Success(1)) == Success(1))
+        "returns the alternative for Error" in {
+            assert(Result.error(ex).orElse(Success(1)) == Success(1))
         }
         "returns the alternative for Panic" in {
             assert(Result.panic(ex).orElse(Success(1)) == Success(1))
@@ -97,8 +97,8 @@ class ResultTest extends Test:
         "applies the function for Success" in {
             assert(Result.success(1).flatMap(x => Result.success(x + 1)) == Success(2))
         }
-        "does not apply the function for Failure" in {
-            assert(Result.failure[String, Int]("error").flatMap(x => Success(x + 1)) == Failure("error"))
+        "does not apply the function for Error" in {
+            assert(Result.error[String, Int]("error").flatMap(x => Success(x + 1)) == Error("error"))
         }
         "does not apply the function for Panic" in {
             assert(Result.panic[String, Int](ex).flatMap(x => Success(x + 1)) == Panic(ex))
@@ -109,8 +109,8 @@ class ResultTest extends Test:
         "applies the function for Success" in {
             assert(Result.success(1).map(_ + 1) == Success(2))
         }
-        "does not apply the function for Failure" in {
-            assert(Result.failure[String, Int]("error").map(_ + 1) == Failure("error"))
+        "does not apply the function for Error" in {
+            assert(Result.error[String, Int]("error").map(_ + 1) == Error("error"))
         }
         "does not apply the function for Panic" in {
             assert(Result.panic[String, Int](ex).map(_ + 1) == Panic(ex))
@@ -121,8 +121,8 @@ class ResultTest extends Test:
         "applies the success function for Success" in {
             assert(Result.success(1).fold(_ => 0)(_ => 0)(x => x + 1) == 2)
         }
-        "applies the failure function for Failure" in {
-            assert(Result.failure[String, Int]("error").fold(_ => 0)(_ => 1)(x => x) == 0)
+        "applies the failure function for Error" in {
+            assert(Result.error[String, Int]("error").fold(_ => 0)(_ => 1)(x => x) == 0)
         }
         "applies the panic function for Panic" in {
             assert(Result.panic[String, Int](ex).fold(_ => 0)(_ => 1)(x => x) == 1)
@@ -137,11 +137,11 @@ class ResultTest extends Test:
         "returns itself if the predicate holds for Success" in {
             assert(Result.success(2).filter(_ % 2 == 0) == Success(2))
         }
-        "returns Panic if the predicate doesn't hold for Success" in {
-            assert(Result.success(1).filter(_ % 2 == 0).isPanic)
+        "returns Error if the predicate doesn't hold for Success" in {
+            assert(Result.success(1).filter(_ % 2 == 0).isError)
         }
-        "returns itself for Failure" in {
-            assert(Result.failure[String, Int]("error").filter(_ => true) == Failure("error"))
+        "returns itself for Error" in {
+            assert(Result.error[String, Int]("error").filter(_ => true) == Error("error"))
         }
     }
 
@@ -149,11 +149,11 @@ class ResultTest extends Test:
         "returns itself for Success" in {
             assert(Result.success(1).recover { case _ => 0 } == Success(1))
         }
-        "returns Success with the mapped value if the partial function is defined for Failure" in {
-            assert(Result.failure("error").recover { case _ => 0 } == Success(0))
+        "returns Success with the mapped value if the partial function is defined for Error" in {
+            assert(Result.error("error").recover { case _ => 0 } == Success(0))
         }
-        "returns itself if the partial function is not defined for Failure" in {
-            assert(Result.failure("error").recover { case _ if false => 0 } == Failure("error"))
+        "returns itself if the partial function is not defined for Error" in {
+            assert(Result.error("error").recover { case _ if false => 0 } == Error("error"))
         }
     }
 
@@ -161,12 +161,12 @@ class ResultTest extends Test:
         "returns itself for Success" in {
             assert(Result.success(1).recoverWith { case _ => Success(0) } == Success(1))
         }
-        "returns the mapped Result if the partial function is defined for Failure" in {
-            assert(Failure("error").recoverWith { case _ => Success(0) } == Success(0))
+        "returns the mapped Result if the partial function is defined for Error" in {
+            assert(Error("error").recoverWith { case _ => Success(0) } == Success(0))
         }
-        "returns itself if the partial function is not defined for Failure" in {
-            val error = Failure("error")
-            assert(Failure(error).recoverWith { case _ if false => Success(0) } == Failure(error))
+        "returns itself if the partial function is not defined for Error" in {
+            val error = Error("error")
+            assert(Error(error).recoverWith { case _ if false => Success(0) } == Error(error))
         }
     }
 
@@ -174,9 +174,9 @@ class ResultTest extends Test:
         "returns Right with the value for Success" in {
             assert(Result.success(1).toEither == Right(1))
         }
-        "returns Left with the error for Failure" in {
+        "returns Left with the error for Error" in {
             val error = "error"
-            assert(Failure(error).toEither == Left(error))
+            assert(Error(error).toEither == Left(error))
         }
     }
 
@@ -199,8 +199,8 @@ class ResultTest extends Test:
             assert(nestedResult.isSuccess)
         }
 
-        "isFailure should return false for deeply nested Success" in {
-            assert(!nestedResult.isFailure)
+        "isError should return false for deeply nested Success" in {
+            assert(!nestedResult.isError)
         }
     }
 
@@ -212,8 +212,8 @@ class ResultTest extends Test:
             assert(tryResult.get == 42)
         }
 
-        "Failure to Try" in {
-            val failure: Result[String, Int] = Failure("Something went wrong")
+        "Error to Try" in {
+            val failure: Result[String, Int] = Error("Something went wrong")
             val tryResult                    = failure.toTry
             assert(tryResult.isFailure)
             assert(tryResult.failed.get.isInstanceOf[NoSuchElementException])
@@ -241,21 +241,21 @@ class ResultTest extends Test:
             assert(flatMapped == Success("mapped: null"))
         }
 
-        "Failure with null error" taggedAs jvmOnly in {
-            val result: Result[String, Int] = Failure(null)
-            assert(result == Failure(null))
+        "Error with null error" taggedAs jvmOnly in {
+            val result: Result[String, Int] = Error(null)
+            assert(result == Error(null))
         }
 
-        "Failure with null exception flatMap" taggedAs jvmOnly in {
-            val result: Result[String, Int] = Failure(null)
+        "Error with null exception flatMap" taggedAs jvmOnly in {
+            val result: Result[String, Int] = Error(null)
             val flatMapped                  = result.flatMap(num => Success(num + 1))
-            assert(flatMapped == Failure(null))
+            assert(flatMapped == Error(null))
         }
 
-        "Failure with null exception map" taggedAs jvmOnly in {
-            val result: Result[String, Int] = Failure(null)
+        "Error with null exception map" taggedAs jvmOnly in {
+            val result: Result[String, Int] = Error(null)
             val mapped                      = result.map(num => num + 1)
-            assert(mapped == Failure(null))
+            assert(mapped == Error(null))
         }
     }
 
@@ -282,16 +282,16 @@ class ResultTest extends Test:
                 val result = tryy match
                     case Success(x) if x > 1 => "greater than 1"
                     case Success(_)          => "less than or equal to 1"
-                    case Failure(_)          => "failure"
+                    case Error(_)            => "failure"
                 assert(result == "greater than 1")
             }
 
-            "should match Failure with a guard" in {
-                val tryy: Result[String, Int] = Failure("error")
+            "should match Error with a guard" in {
+                val tryy: Result[String, Int] = Error("error")
                 val result = tryy match
-                    case Failure(e) if e.length > 5 => "long error"
-                    case Failure(_)                 => "short error"
-                    case Success(_)                 => "success"
+                    case Error(e) if e.length > 5 => "long error"
+                    case Error(_)                 => "short error"
+                    case Success(_)               => "success"
                 assert(result == "short error")
             }
         }
@@ -313,7 +313,7 @@ class ResultTest extends Test:
 
         "for-comprehension with multiple flatMaps" in {
             def divideIfEven(x: Int): Result[String, Int] =
-                if x % 2 == 0 then Result.success(10 / x) else Result.failure("Odd number")
+                if x % 2 == 0 then Result.success(10 / x) else Result.error("Odd number")
 
             val complex: Result[String, String] =
                 for
@@ -328,7 +328,7 @@ class ResultTest extends Test:
 
     "edge cases" - {
 
-        "should not handle exceptions in ifFailure" in {
+        "should not handle exceptions in ifError" in {
             val tryy      = Success(1)
             val exception = new RuntimeException("exception")
             val result =
@@ -388,18 +388,18 @@ class ResultTest extends Test:
             assert(result == "no exception")
         }
 
-        "nested Success containing Failure" in {
-            val nested: Result[String, Result[Int, String]] = Result.success(Result.failure(42))
+        "nested Success containing Error" in {
+            val nested: Result[String, Result[Int, String]] = Result.success(Result.error(42))
             val flattened                                   = nested.flatten
 
-            assert(flattened == Failure(42))
+            assert(flattened == Error(42))
         }
 
         "recover with a partial function" in {
-            val result: Result[String, Int] = Result.failure("error")
+            val result: Result[String, Int] = Result.error("error")
             val recovered = result.recover {
-                case Failure("error") => 0
-                case _                => -1
+                case Error("error") => 0
+                case _              => -1
             }
 
             assert(recovered == Success(0))
@@ -410,54 +410,54 @@ class ResultTest extends Test:
             assert(empty == Success(()))
         }
 
-        "Panic distinct from Failure" in {
+        "Panic distinct from Error" in {
             val exception = new RuntimeException("Unexpected error")
             val panic     = Result.panic(exception)
-            assert(!panic.isFailure)
+            assert(!panic.isError)
             assert(panic match
                 case Panic(_) => true
                 case _        => false
             )
         }
 
-        "deeply nested Success/Failure" in {
-            val deeplyNested = Success(Success(Success(Failure("deep error"))))
-            assert(deeplyNested.flatten == Success(Success(Failure("deep error"))))
-            assert(deeplyNested.flatten.flatten == Success(Failure("deep error")))
-            assert(deeplyNested.flatten.flatten.flatten == Failure("deep error"))
+        "deeply nested Success/Error" in {
+            val deeplyNested = Success(Success(Success(Error("deep error"))))
+            assert(deeplyNested.flatten == Success(Success(Error("deep error"))))
+            assert(deeplyNested.flatten.flatten == Success(Error("deep error")))
+            assert(deeplyNested.flatten.flatten.flatten == Error("deep error"))
         }
 
         "Panic propagation through flatMap" in {
             val panic  = Result.panic(new RuntimeException("Unexpected"))
-            val result = panic.flatMap(_ => Success(1)).flatMap(_ => Failure("won't happen"))
+            val result = panic.flatMap(_ => Success(1)).flatMap(_ => Error("won't happen"))
             assert(result == panic)
         }
 
         "Error type widening" in {
-            val r1: Result[String, Int] = Failure("error1")
-            val r2: Result[Int, String] = Failure(42)
+            val r1: Result[String, Int] = Error("error1")
+            val r2: Result[Int, String] = Error(42)
             val combined                = r1.orElse(r2)
-            assert(combined.isFailure)
+            assert(combined.isError)
             assert(combined match
-                case Failure(_: String | _: Int) => true
-                case _                           => false
+                case Error(_: String | _: Int) => true
+                case _                         => false
             )
         }
 
         "nested flatMap with type changes" in {
             def f(i: Int): Result[String, Int] =
-                if i > 0 then Success(i) else Failure("non-positive")
+                if i > 0 then Success(i) else Error("non-positive")
             def g(d: Int): Result[Int, String] =
-                if d < 10 then Success(d.toString) else Failure(d.toInt)
+                if d < 10 then Success(d.toString) else Error(d.toInt)
 
             val result = Success(5).flatMap(f).flatMap(g)
             assert(result == Success("5"))
 
             val result2 = Success(-1).flatMap(f).flatMap(g)
-            assert(result2 == Failure("non-positive"))
+            assert(result2 == Error("non-positive"))
 
             val result3 = Success(20).flatMap(f).flatMap(g)
-            assert(result3 == Failure(20))
+            assert(result3 == Error(20))
         }
     }
 

--- a/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
@@ -17,6 +17,15 @@ class ResultTest extends Test:
         assert(result == "error")
     }
 
+    "attempt" - {
+        "success" in {
+            assert(Result.attempt(1) == Success(1))
+        }
+        "failure" in {
+            assert(Result.attempt(throw ex) == Error(ex))
+        }
+    }
+
     "isSuccess" - {
         "returns true for Success" in {
             assert(Result.success(1).isSuccess)

--- a/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
@@ -2,8 +2,11 @@ package kyo2
 
 import kyo2.Result
 import kyo2.Result.*
+import kyo2.Tagged.*
 
 class ResultTest extends Test:
+
+    val ex = new Exception
 
     val try2: Result[String, Result[String, Int]] = Success(Failure("error"))
 
@@ -19,7 +22,10 @@ class ResultTest extends Test:
             assert(Result.success(1).isSuccess)
         }
         "returns false for Failure" in {
-            assert(!Failure("error").isSuccess)
+            assert(!Result.failure(ex).isSuccess)
+        }
+        "returns false for Panic" in {
+            assert(!Result.panic(ex).isSuccess)
         }
     }
 
@@ -28,7 +34,22 @@ class ResultTest extends Test:
             assert(!Result.success(1).isFailure)
         }
         "returns true for Failure" in {
-            assert(Failure("error").isFailure)
+            assert(Result.failure(ex).isFailure)
+        }
+        "returns false for Panic" in {
+            assert(!Result.panic(ex).isFailure)
+        }
+    }
+
+    "isPanic" - {
+        "returns false for Success" in {
+            assert(!Result.success(1).isPanic)
+        }
+        "returns false for Failure" in {
+            assert(!Result.failure(ex).isPanic)
+        }
+        "returns true for Panic" in {
+            assert(Result.panic(ex).isPanic)
         }
     }
 
@@ -36,8 +57,11 @@ class ResultTest extends Test:
         "returns the value for Success" in {
             assert(Result.success(1).get == 1)
         }
-        "throws an exception for Failure" in {
-            assertThrows[Exception](Result.panic(new Exception).get)
+        "can't be called for Failure" in {
+            assertDoesNotCompile("Result.failure(ex).get")
+        }
+        "throws an exception for Panic" in {
+            assertThrows[Exception](Result.panic(ex).get)
         }
     }
 
@@ -46,7 +70,14 @@ class ResultTest extends Test:
             assert(Result.success(1).getOrElse(0) == 1)
         }
         "returns the default value for Failure" in {
-            assert(Failure("error").getOrElse(0) == 0)
+            assert(Result.failure(ex).getOrElse(0) == 0)
+        }
+        "returns the default value for Panic" in {
+            assert(Result.panic(ex).getOrElse(0) == 0)
+        }
+        "inference" in {
+            val r: List[String] = Result(List.empty[String]).getOrElse(List.empty)
+            assert(r == List.empty)
         }
     }
 
@@ -55,7 +86,10 @@ class ResultTest extends Test:
             assert(Result.success(1).orElse(Result.success(2)) == Success(1))
         }
         "returns the alternative for Failure" in {
-            assert(Failure("error").orElse(Success(1)) == Success(1))
+            assert(Result.failure(ex).orElse(Success(1)) == Success(1))
+        }
+        "returns the alternative for Panic" in {
+            assert(Result.panic(ex).orElse(Success(1)) == Success(1))
         }
     }
 
@@ -66,6 +100,9 @@ class ResultTest extends Test:
         "does not apply the function for Failure" in {
             assert(Result.failure[String, Int]("error").flatMap(x => Success(x + 1)) == Failure("error"))
         }
+        "does not apply the function for Panic" in {
+            assert(Result.panic[String, Int](ex).flatMap(x => Success(x + 1)) == Panic(ex))
+        }
     }
 
     "map" - {
@@ -75,6 +112,9 @@ class ResultTest extends Test:
         "does not apply the function for Failure" in {
             assert(Result.failure[String, Int]("error").map(_ + 1) == Failure("error"))
         }
+        "does not apply the function for Panic" in {
+            assert(Result.panic[String, Int](ex).map(_ + 1) == Panic(ex))
+        }
     }
 
     "fold" - {
@@ -82,7 +122,26 @@ class ResultTest extends Test:
             assert(Result.success(1).fold(_ => 0)(_ => 0)(x => x + 1) == 2)
         }
         "applies the failure function for Failure" in {
-            assert(Result.failure[String, Int]("error").fold(_ => 0)(_ => 0)(x => x) == 0)
+            assert(Result.failure[String, Int]("error").fold(_ => 0)(_ => 1)(x => x) == 0)
+        }
+        "applies the panic function for Panic" in {
+            assert(Result.panic[String, Int](ex).fold(_ => 0)(_ => 1)(x => x) == 1)
+        }
+    }
+
+    "filter" - {
+        "adds NoSuchElementException" in {
+            val x = Result.success(2).filter(_ % 2 == 0)
+            assertCompiles("val _: Result[NoSuchElementException, Int] = x")
+        }
+        "returns itself if the predicate holds for Success" in {
+            assert(Result.success(2).filter(_ % 2 == 0) == Success(2))
+        }
+        "returns Panic if the predicate doesn't hold for Success" in {
+            assert(Result.success(1).filter(_ % 2 == 0).isPanic)
+        }
+        "returns itself for Failure" in {
+            assert(Result.failure[String, Int]("error").filter(_ => true) == Failure("error"))
         }
     }
 
@@ -91,11 +150,10 @@ class ResultTest extends Test:
             assert(Result.success(1).recover { case _ => 0 } == Success(1))
         }
         "returns Success with the mapped value if the partial function is defined for Failure" in {
-            assert(Failure("error").recover { case _ => 0 } == Success(0))
+            assert(Result.failure("error").recover { case _ => 0 } == Success(0))
         }
         "returns itself if the partial function is not defined for Failure" in {
-            val error = Failure("error")
-            assert(Failure(error).recover { case _ if false => 0 } == Failure(error))
+            assert(Result.failure("error").recover { case _ if false => 0 } == Failure("error"))
         }
     }
 
@@ -122,6 +180,30 @@ class ResultTest extends Test:
         }
     }
 
+    "deeply nested Result" - {
+        val nestedResult = Success(Success(Success(Success(1))))
+
+        "get should return the deeply nested value" in {
+            assert(nestedResult.get.get.get.get == 1)
+        }
+
+        "map should apply the function to the deeply nested Result" in {
+            assert(nestedResult.map(_.map(_.map(_.map(_ + 1)))) == Success(Success(Success(Success(2)))))
+        }
+
+        "flatMap should apply the function and flatten the result" in {
+            assert(nestedResult.flatMap(x => x.flatMap(y => y.flatMap(z => z.map(_ + 1)))) == Success(2))
+        }
+
+        "isSuccess should return true for deeply nested Success" in {
+            assert(nestedResult.isSuccess)
+        }
+
+        "isFailure should return false for deeply nested Success" in {
+            assert(!nestedResult.isFailure)
+        }
+    }
+
     "toTry" - {
         "Success to Try" in {
             val success: Result[Nothing, Int] = Success(42)
@@ -136,9 +218,64 @@ class ResultTest extends Test:
             assert(tryResult.isFailure)
             assert(tryResult.failed.get.isInstanceOf[NoSuchElementException])
         }
+
+        "Panic to Try" in {
+            val panic: Result[String, Int] = Result.panic(new Exception("Panic"))
+            val tryResult                  = panic.toTry
+            assert(tryResult.isFailure)
+            assert(tryResult.failed.get.isInstanceOf[Exception])
+            assert(tryResult.failed.get.getMessage == "Panic")
+        }
+    }
+
+    "null values" - {
+        "Success with null value" in {
+            val result: Result[Nothing, String] = Success(null)
+            assert(result.isSuccess)
+            assert(result.get == null)
+        }
+
+        "Success with null value flatMap" in {
+            val result: Result[Nothing, String] = Success(null)
+            val flatMapped                      = result.flatMap(str => Success(s"mapped: $str"))
+            assert(flatMapped == Success("mapped: null"))
+        }
+
+        "Failure with null error" taggedAs jvmOnly in {
+            val result: Result[String, Int] = Failure(null)
+            assert(result == Failure(null))
+        }
+
+        "Failure with null exception flatMap" taggedAs jvmOnly in {
+            val result: Result[String, Int] = Failure(null)
+            val flatMapped                  = result.flatMap(num => Success(num + 1))
+            assert(flatMapped == Failure(null))
+        }
+
+        "Failure with null exception map" taggedAs jvmOnly in {
+            val result: Result[String, Int] = Failure(null)
+            val mapped                      = result.map(num => num + 1)
+            assert(mapped == Failure(null))
+        }
     }
 
     "pattern matching" - {
+        "deep matching" - {
+            val nestedResult = Success(Success(Success(Success(1))))
+
+            "should match deeply nested Success and extract inner value" in {
+                val result = nestedResult match
+                    case Success(Success(Success(Success(x)))) => x
+                assert(result == 1)
+            }
+
+            "should match partially and extract nested Result" in {
+                val result = nestedResult match
+                    case Success(Success(x)) => x
+                assert(result == Success(Success(1)))
+            }
+        }
+
         "matching with guards" - {
             "should match Success with a guard" in {
                 val tryy: Result[Nothing, Int] = Success(2)
@@ -175,8 +312,8 @@ class ResultTest extends Test:
         }
 
         "for-comprehension with multiple flatMaps" in {
-            def divideIfEven(x: Int): Result[String, Double] =
-                if x % 2 == 0 then Result.success(10.0 / x) else Result.failure("Odd number")
+            def divideIfEven(x: Int): Result[String, Int] =
+                if x % 2 == 0 then Result.success(10 / x) else Result.failure("Odd number")
 
             val complex: Result[String, String] =
                 for
@@ -185,11 +322,72 @@ class ResultTest extends Test:
                     c <- Result.success(b * 2)
                 yield c.toString
 
-            assert(complex == Success("5.0"))
+            assert(complex == Success("4"))
         }
     }
 
     "edge cases" - {
+
+        "should not handle exceptions in ifFailure" in {
+            val tryy      = Success(1)
+            val exception = new RuntimeException("exception")
+            val result =
+                try
+                    tryy.fold(_ => throw exception)(_ => throw exception)(_ => throw exception)
+                    "no exception"
+                catch
+                    case e: RuntimeException => "caught exception"
+            assert(result == "caught exception")
+        }
+
+        "should not handle exceptions in ifPanic" in {
+            val tryy      = Result.panic(ex)
+            val exception = new RuntimeException("exception")
+            val result =
+                try
+                    tryy.fold(_ => throw exception)(_ => throw exception)(_ => throw exception)
+                    "no exception"
+                catch
+                    case e: RuntimeException => "caught exception"
+            assert(result == "caught exception")
+        }
+
+        "should handle exceptions in ifSuccess" in {
+            val tryy      = Success(1)
+            val exception = new RuntimeException("exception")
+            val result =
+                try
+                    tryy.fold(_ => 0)(_ => 0)(_ => throw exception)
+                    "no exception"
+                catch
+                    case e: RuntimeException => "caught exception"
+            assert(result == "no exception")
+        }
+
+        "should handle exceptions during map" in {
+            val tryy      = Success(1)
+            val exception = new RuntimeException("exception")
+            val result =
+                try
+                    tryy.map(_ => throw exception)
+                    "no exception"
+                catch
+                    case e: RuntimeException => "caught exception"
+            assert(result == "no exception")
+        }
+
+        "should handle exceptions during flatMap" in {
+            val tryy      = Success(1)
+            val exception = new RuntimeException("exception")
+            val result =
+                try
+                    tryy.flatMap(_ => throw exception)
+                    "no exception"
+                catch
+                    case e: RuntimeException => "caught exception"
+            assert(result == "no exception")
+        }
+
         "nested Success containing Failure" in {
             val nested: Result[String, Result[Int, String]] = Result.success(Result.failure(42))
             val flattened                                   = nested.flatten
@@ -247,13 +445,13 @@ class ResultTest extends Test:
         }
 
         "nested flatMap with type changes" in {
-            def f(i: Int): Result[String, Double] =
-                if i > 0 then Success(i.toDouble) else Failure("non-positive")
-            def g(d: Double): Result[Int, String] =
+            def f(i: Int): Result[String, Int] =
+                if i > 0 then Success(i) else Failure("non-positive")
+            def g(d: Int): Result[Int, String] =
                 if d < 10 then Success(d.toString) else Failure(d.toInt)
 
             val result = Success(5).flatMap(f).flatMap(g)
-            assert(result == Success("5.0"))
+            assert(result == Success("5"))
 
             val result2 = Success(-1).flatMap(f).flatMap(g)
             assert(result2 == Failure("non-positive"))


### PR DESCRIPTION
I'm working on porting `kyo-core` to `kyo-prelude` and part of the change introduces typed error handling for fibers. This PR makes `Result` a low-allocation mix of `Either` and `Try` to use it in fiber completions. 