### PR TITLE
chunks: avoid ClassTag cache lookup

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/chunks.scala
+++ b/kyo-core/shared/src/main/scala/kyo/chunks.scala
@@ -9,6 +9,8 @@ sealed abstract class Chunk[T] derives CanEqual:
 
     import Chunks.internal.*
 
+    private inline given ClassTag[T] = ClassTag.Any.asInstanceOf[ClassTag[T]]
+
     //////////////////
     // O(1) methods //
     //////////////////
@@ -75,7 +77,7 @@ sealed abstract class Chunk[T] derives CanEqual:
         else if other.isEmpty then this
         else
             val s     = size
-            val array = new Array[T](s + other.size)(using ClassTag(classOf[Any]))
+            val array = new Array[T](s + other.size)
             this.copyTo(array, 0)
             other.copyTo(array, s)
             Compact(array)
@@ -256,7 +258,7 @@ sealed abstract class Chunk[T] derives CanEqual:
                 else
                     acc
 
-            val unnested = new Array[U](totalSize())(using ClassTag(classOf[Any]))
+            val unnested = new Array[U](totalSize())(using ClassTag.Any.asInstanceOf[ClassTag[U]])
 
             @tailrec def copy(idx: Int = 0, offset: Int = 0): Unit =
                 if idx < nested.length then
@@ -313,7 +315,7 @@ sealed abstract class Chunk[T] derives CanEqual:
             case c: Compact[T] =>
                 c.array
             case c =>
-                c.toArray(using ClassTag(classOf[Any]))
+                c.toArray
 
     override def equals(other: Any) =
         (this eq other.asInstanceOf[Object]) || {
@@ -392,7 +394,7 @@ object Chunks:
         else
             values match
                 case seq: IndexedSeq[T] => FromSeq(seq)
-                case _                  => Compact(values.toArray(using ClassTag(classOf[Any])))
+                case _                  => Compact(values.toArray(using ClassTag.Any.asInstanceOf[ClassTag[T]]))
 
     def fill[T](n: Int)(v: T): Chunk[T] =
         if n <= 0 then Chunks.init

--- a/kyo-prelude/shared/src/main/scala/kyo2/Chunk.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Chunk.scala
@@ -10,6 +10,8 @@ sealed abstract class Chunk[A] derives CanEqual:
 
     import Chunk.internal.*
 
+    private inline given ClassTag[A] = ClassTag.Any.asInstanceOf[ClassTag[A]]
+
     //////////////////
     // O(1) methods //
     //////////////////
@@ -76,7 +78,7 @@ sealed abstract class Chunk[A] derives CanEqual:
         else if other.isEmpty then this
         else
             val s     = size
-            val array = new Array[A](s + other.size)(using ClassTag(classOf[Any]))
+            val array = new Array[A](s + other.size)
             this.copyTo(array, 0)
             other.copyTo(array, s)
             Compact(array)
@@ -257,7 +259,7 @@ sealed abstract class Chunk[A] derives CanEqual:
                 else
                     acc
 
-            val unnested = new Array[B](totalSize())(using ClassTag(classOf[Any]))
+            val unnested = new Array[B](totalSize())(using ClassTag.Any.asInstanceOf[ClassTag[B]])
 
             @tailrec def copy(idx: Int = 0, offset: Int = 0): Unit =
                 if idx < nested.length then
@@ -314,7 +316,7 @@ sealed abstract class Chunk[A] derives CanEqual:
             case c: Compact[A] =>
                 c.array
             case c =>
-                c.toArray(using ClassTag(classOf[Any]))
+                c.toArray
 
     override def equals(other: Any) =
         (this eq other.asInstanceOf[Object]) || {
@@ -390,7 +392,7 @@ object Chunk:
         else
             values match
                 case seq: IndexedSeq[T] => FromSeq(seq)
-                case _                  => Compact(values.toArray(using ClassTag(classOf[Any])))
+                case _                  => Compact(values.toArray(using ClassTag.Any.asInstanceOf[ClassTag[T]]))
 
     def fill[T](n: Int)(v: T): Chunk[T] =
         if n <= 0 then empty


### PR DESCRIPTION
I've been doing some performance testing as part of the work on the new core design and noticed thread contention when using chunks due to `ClassTag` lookups, which are synchronized by Scala's `ClassTag` cache. We don't really need the `ClassTag` lookup since the goal in chunks is to always use `Any` for internal arrays. I've tried to introduce a benchmark for it but I couldn't reproduce the issue in isolation.

I'm updating both versions in `kyo-core` and `kyo-prelude`.