### PR TITLE
prelude: safepoint interceptors

### DIFF
--- a/kyo-prelude/jvm/src/test/scala/kyo2/kernel/BytecodeTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo2/kernel/BytecodeTest.scala
@@ -32,12 +32,12 @@ class BytecodeTest extends Test:
 
     "map" in {
         val map = methodBytecodeSize[TestMap]
-        assert(map == Map("test" -> 24, "anonfun" -> 14, "mapLoop" -> 156))
+        assert(map == Map("test" -> 24, "anonfun" -> 14, "mapLoop" -> 161))
     }
 
     "handle" in {
         val map = methodBytecodeSize[TestHandle]
-        assert(map == Map("test" -> 50, "anonfun" -> 17, "handleLoop" -> 264))
+        assert(map == Map("test" -> 50, "anonfun" -> 17, "handleLoop" -> 273))
     }
 
     def methodBytecodeSize[T](using ct: ClassTag[T]): Map[String, Int] =

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Boundary.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Boundary.scala
@@ -21,7 +21,7 @@ final class Boundary[Ctx, S](dummy: Unit) extends AnyVal:
                                 def frame = _frame
                                 def apply(v: OX[Any], context: Context)(using Safepoint) =
                                     val parent = Safepoint.local.get()
-                                    Safepoint.local.set(Safepoint(parent.depth, state))
+                                    Safepoint.local.set(Safepoint(parent.depth, parent.interceptor, state))
                                     val r =
                                         try kyo(v, state.context)
                                         finally Safepoint.local.set(parent)

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/ContextEffect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/ContextEffect.scala
@@ -35,7 +35,7 @@ object ContextEffect:
         new KyoDefer[B, S]:
             def frame = _frame
             def apply(v: Unit, context: Context)(using Safepoint) =
-                Safepoint.handle(
+                Safepoint.handle(v)(
                     suspend = this,
                     continue = f(context.getOrElse(_tag, default).asInstanceOf[A])
                 )

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
@@ -11,8 +11,11 @@ object Effect:
     def defer[A, S](f: Safepoint ?=> A < S): A < S =
         new KyoDefer[A, S]:
             def frame = summon[Frame]
-            def apply(dummy: Unit, context: Context)(using Safepoint) =
-                f
+            def apply(v: Unit, context: Context)(using Safepoint) =
+                Safepoint.handle(v)(
+                    suspend = this,
+                    continue = f
+                )
 
     final class SuspendOps[A](dummy: Unit) extends AnyVal:
 

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
@@ -42,7 +42,7 @@ object Effect:
                 def tag   = _tag
                 def input = _input
                 def apply(v: O[A], context: Context)(using Safepoint) =
-                    Safepoint.handle(
+                    Safepoint.handle(v)(
                         suspend = _cont(v),
                         continue = _cont(v)
                     )
@@ -62,7 +62,7 @@ object Effect:
             def handleLoop(v: A < (E & S & S2 & S3), context: Context)(using Safepoint): B < (S & S2 & S3) =
                 v match
                     case <(kyo: KyoSuspend[I, O, E, Any, A, E & S & S2] @unchecked) if accept(kyo.input, kyo.tag.erased) =>
-                        Safepoint.handle(
+                        Safepoint.handle(kyo.input)(
                             suspend = handleLoop(kyo, context),
                             continue = handleLoop(handle[Any](kyo.input, kyo(_, context)), context)
                         )
@@ -92,12 +92,12 @@ object Effect:
             def handle2Loop(kyo: A < (E1 & E2 & S & S2), context: Context)(using Safepoint): A < (S & S2) =
                 kyo match
                     case <(kyo: KyoSuspend[I1, O1, E1, Any, A, E1 & E2 & S & S2] @unchecked) if tag1 =:= kyo.tag =>
-                        Safepoint.handle(
+                        Safepoint.handle(kyo.input)(
                             suspend = handle2Loop(kyo, context),
                             continue = handle2Loop(handle1[Any](kyo.input, kyo(_, context)), context)
                         )
                     case <(kyo: KyoSuspend[I2, O2, E2, Any, A, E1 & E2 & S & S2] @unchecked) if tag2 =:= kyo.tag =>
-                        Safepoint.handle(
+                        Safepoint.handle(kyo.input)(
                             suspend = handle2Loop(kyo, context),
                             continue = handle2Loop(handle2[Any](kyo.input, kyo(_, context)), context)
                         )
@@ -132,17 +132,17 @@ object Effect:
             def handle3Loop(v: A < (E1 & E2 & E3 & S & S2), context: Context)(using Safepoint): A < (S & S2) =
                 v match
                     case <(kyo: KyoSuspend[I1, O1, E1, Any, A, E1 & E2 & E3 & S & S2] @unchecked) if tag1 =:= kyo.tag =>
-                        Safepoint.handle(
+                        Safepoint.handle(kyo.input)(
                             suspend = handle3Loop(kyo, context),
                             continue = handle3Loop(handle1[Any](kyo.input, kyo(_, context)), context)
                         )
                     case <(kyo: KyoSuspend[I2, O2, E2, Any, A, E1 & E2 & E3 & S & S2] @unchecked) if tag2 =:= kyo.tag =>
-                        Safepoint.handle(
+                        Safepoint.handle(kyo.input)(
                             suspend = handle3Loop(kyo, context),
                             continue = handle3Loop(handle2[Any](kyo.input, kyo(_, context)), context)
                         )
                     case <(kyo: KyoSuspend[I3, O3, E3, Any, A, E1 & E2 & E3 & S & S2] @unchecked) if tag3 =:= kyo.tag =>
-                        Safepoint.handle(
+                        Safepoint.handle(kyo.input)(
                             suspend = handle3Loop(kyo, context),
                             continue = handle3Loop(handle3[Any](kyo.input, kyo(_, context)), context)
                         )
@@ -173,7 +173,7 @@ object Effect:
             def handleLoop(state: State, v: A < (E & S & S2), context: Context)(using Safepoint): U < (S & S2) =
                 v match
                     case <(kyo: KyoSuspend[I, O, E, Any, A, E & S & S2] @unchecked) if accept(kyo.input, kyo.tag.erased) =>
-                        Safepoint.handle(
+                        Safepoint.handle(kyo.input)(
                             suspend = handleLoop(state, kyo, context),
                             continue =
                                 val (nst, res) = handle(kyo.input, state, kyo(_, context))

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Pending.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Pending.scala
@@ -43,7 +43,7 @@ object `<`:
                                 mapLoop(kyo(v, context))
                     case <(v) =>
                         val value = v.asInstanceOf[A]
-                        Safepoint.handle(
+                        Safepoint.handle(value)(
                             suspend = mapLoop(value),
                             continue = f(value)
                         )

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Safepoint.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Safepoint.scala
@@ -3,19 +3,23 @@ package kyo2.kernel
 import internal.*
 import java.util.Arrays
 import kyo2.isNull
+import kyo2.kernel.Safepoint.*
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
-final class Safepoint(initDepth: Int, initState: Safepoint.State):
+final class Safepoint(initDepth: Int, initInterceptor: Interceptor, initState: State):
     import Safepoint.State
 
-    private val owner         = Thread.currentThread()
-    private[kernel] var depth = initDepth
-    private var traceIdx      = initState.traceIdx
-    private val trace         = Safepoint.copyTrace(initState.trace, traceIdx)
+    private val owner               = Thread.currentThread()
+    private[kernel] var depth       = initDepth
+    private[kernel] var interceptor = initInterceptor
+    private var traceIdx            = initState.traceIdx
+    private val trace               = copyTrace(initState.trace, traceIdx)
 
     private def enter(frame: Frame, value: Any): Int =
-        if (Thread.currentThread eq owner) && depth < maxStackDepth then
+        if (Thread.currentThread eq owner) && depth < maxStackDepth &&
+            (isNull(interceptor) || interceptor.enter(frame, value))
+        then
             pushFrame(frame)
             val depth = this.depth
             this.depth = depth + 1
@@ -36,6 +40,9 @@ final class Safepoint(initDepth: Int, initState: Safepoint.State):
 
     private def exit(depth: Int): Unit =
         this.depth = depth - 1
+        if !isNull(interceptor) then
+            interceptor.exit()
+    end exit
 
     private[kernel] def save(context: Context) =
         State(Safepoint.copyTrace(trace, traceIdx), traceIdx, context)
@@ -45,11 +52,51 @@ object Safepoint:
 
     implicit def get: Safepoint = local.get()
 
+    abstract private[kyo2] class Interceptor:
+        def enter(frame: Frame, value: Any): Boolean
+        def exit(): Unit
+    end Interceptor
+
+    private[kyo2] inline def immediate[A, S](p: Interceptor)(inline v: => A < S)(
+        using safepoint: Safepoint
+    ): A < S =
+        val prev = safepoint.interceptor
+        val np =
+            if isNull(prev) || (prev eq p) then p
+            else
+                new Interceptor:
+                    def enter(frame: Frame, value: Any) =
+                        p.enter(frame, value) && prev.enter(frame, value)
+                    def exit() =
+                        p.exit()
+                        prev.exit()
+        safepoint.interceptor = np
+        try v
+        finally safepoint.interceptor = prev
+    end immediate
+
+    private[kyo2] inline def propagating[A, S](p: Interceptor)(inline v: => A < S)(
+        using
+        inline safepoint: Safepoint,
+        inline _frame: Frame
+    ): A < S =
+        def loop(v: A < S): A < S =
+            v match
+                case <(kyo: KyoSuspend[IX, OX, EX, Any, A, S] @unchecked) =>
+                    new KyoContinue[IX, OX, EX, Any, A, S](kyo):
+                        def frame = _frame
+                        def apply(v: OX[Any], context: Context)(using Safepoint): A < S =
+                            loop(immediate(p)(kyo(v, context)))
+                case _ =>
+                    v
+        immediate(p)(loop(v))
+    end propagating
+
     private[kernel] inline def eval[T](
         inline f: => T
     )(using inline frame: Frame): T =
         val parent = Safepoint.local.get()
-        val self   = new Safepoint(0, State.empty)
+        val self   = new Safepoint(0, parent.interceptor, State.empty)
         Safepoint.local.set(self)
         self.pushFrame(frame)
         try f
@@ -117,6 +164,6 @@ object Safepoint:
     object State:
         val empty = State(new Array(maxStackDepth), 0, Context.empty)
 
-    private[kernel] val local = ThreadLocal.withInitial(() => Safepoint(0, State.empty))
+    private[kernel] val local = ThreadLocal.withInitial(() => Safepoint(0, null, State.empty))
 
 end Safepoint


### PR DESCRIPTION
I'm working on providing a way to customize `Safepoint` with additional `enter` and `exit` implementations. The mechanism will be used for preemption in fibers but it can be easily extended to provide other features like profiling and debugging. This PR propagates the current value of the computation alongside its frame to `Safepoint.enter` as preparation. This will allow a custom `enter` to also inspect the current value. The main use case would be a `Debug` effect that also presents values that appear during execution.

**Edit**: I've pushed a commit with the new interceptor mechanism. `Safepoint.immediate` will be used by fibers to preempt execution in evaluation loop (suspension is managed by the fiber itself) and `Safepoint.propagating` provides similar functionality but ensuring propagation across suspensions.