### PR TITLE
prelude: Coroutine effect

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo2/Coroutine.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Coroutine.scala
@@ -1,0 +1,48 @@
+package kyo2
+
+import kernel.*
+import kyo.Tag
+import scala.collection.immutable.Queue
+
+sealed trait Coroutine[+S] extends Effect[Const[Coroutine.Op[S]], Const[Unit]]
+
+object Coroutine:
+
+    sealed trait Op[-S] derives CanEqual
+    object Op:
+        case object Pause extends Op[Any]
+        abstract class Spawn[-S] extends Op[S]:
+            def apply(): Unit < (Coroutine[S] & S)
+    end Op
+
+    private def erasedTag[S] = Tag[Coroutine[Any]].asInstanceOf[Tag[Coroutine[S]]]
+
+    inline def pause: Unit < Coroutine[Any] =
+        Effect.suspend[Any](erasedTag[Any], Op.Pause)
+
+    inline def spawn[A, S](inline v: => Unit < (Coroutine[S] & S)): Unit < Coroutine[S] =
+        Effect.suspend[Any](erasedTag[S], (() => v): Op.Spawn[S])
+
+    def run[A, S](v: A < (Coroutine[S] & S)): A < S =
+        Loop.transform(Queue(v.map(Maybe(_))), Maybe.empty[A]) { (state, result) =>
+            if state.isEmpty then Loop.done(result.get)
+            else
+                val (task, rest) = state.dequeue
+                Effect.handle.state(erasedTag[S], rest, task)(
+                    handle = [C] =>
+                        (input, state, cont) =>
+                            input match
+                                case Op.Pause =>
+                                    (state.enqueue(cont(())), Maybe.empty)
+                                case input: Op.Spawn[S] =>
+                                    (state.enqueue(input().andThen(Maybe.empty[A])), cont(()))
+                            end match
+                    ,
+                    done = (state, result2) =>
+                        Loop.continue(state, result.orElse(result2))
+                )
+            end if
+        }
+    end run
+
+end Coroutine

--- a/kyo-prelude/shared/src/test/scala/kyo2/CoroutineTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/CoroutineTest.scala
@@ -1,0 +1,255 @@
+package kyo2
+
+class CoroutineTest extends Test:
+
+    "single pause" in {
+        val effect = Coroutine.pause
+        val result = Coroutine.run(effect)
+        assert(result.eval == ())
+    }
+
+    "multiple pauses" in {
+        val effect =
+            for
+                _ <- Coroutine.pause
+                _ <- Coroutine.pause
+                _ <- Coroutine.pause
+            yield ()
+        val result = Coroutine.run(effect)
+        assert(result.eval == ())
+    }
+
+    "single spawn" in {
+        var executed = false
+        val effect   = Coroutine.spawn { executed = true }
+        val result   = Coroutine.run(effect)
+        assert(result.eval == ())
+        assert(executed)
+    }
+
+    "spawn with value" in {
+        val effect = Coroutine.spawn { () }
+        val result = Coroutine.run(effect)
+        assert(result.eval == ())
+    }
+
+    "spawn after pause" in {
+        var executed = false
+        val effect =
+            for
+                _ <- Coroutine.pause
+                _ <- Coroutine.spawn { executed = true }
+            yield ()
+        val result = Coroutine.run(effect)
+        assert(result.eval == ())
+        assert(executed)
+    }
+
+    "nested spawns" in {
+        var order = List.empty[Int]
+        val effect =
+            for
+                _ <- Coroutine.spawn {
+                    order = 1 :: order
+                    Coroutine.spawn {
+                        order = 2 :: order
+                    }
+                }
+                _ <- Coroutine.spawn {
+                    order = 3 :: order
+                }
+            yield ()
+
+        val result = Coroutine.run(effect)
+        assert(result.eval == ())
+        assert(order == List(2, 3, 1))
+    }
+
+    "interleaved pauses and spawns" in {
+        var order = List.empty[Int]
+        val effect =
+            for
+                _ <- Coroutine.pause
+                _ <- Coroutine.spawn {
+                    order = 1 :: order
+                }
+                _ <- Coroutine.pause
+                _ <- Coroutine.spawn {
+                    order = 2 :: order
+                }
+            yield ()
+
+        val result = Coroutine.run(effect)
+        assert(result.eval == ())
+        assert(order == List(2, 1))
+    }
+
+    "recursive coroutine" in {
+        def recursive(n: Int): Unit < Coroutine[Any] =
+            if n == 0 then Coroutine.pause
+            else Coroutine.spawn { recursive(n - 1) }
+
+        val effect = recursive(100000)
+        val result = Coroutine.run(effect)
+        assert(result.eval == ())
+    }
+
+    "nested coroutines" in run {
+        var order = List.empty[Int]
+        val effect =
+            for
+                _ <- Coroutine.spawn {
+                    order = 1 :: order
+                    Coroutine.spawn {
+                        order = 2 :: order
+                        Coroutine.spawn {
+                            order = 3 :: order
+                        }
+                    }
+                }
+                _ <- Coroutine.pause
+                _ <- Coroutine.spawn {
+                    order = 4 :: order
+                }
+            yield ()
+
+        val result = Coroutine.run(effect)
+        assert(result.eval == ())
+        assert(order == List(3, 4, 2, 1))
+    }
+
+    "spawn with side effects" in run {
+        var a, b, c = 0
+        val effect =
+            for
+                _ <- Coroutine.spawn { a = 1 }
+                _ <- Coroutine.spawn { b = 2 }
+                _ <- Coroutine.spawn { c = 3 }
+            yield a + b + c
+
+        val result = Coroutine.run(effect)
+        assert(result.eval == 6)
+    }
+
+    "complex control flow" in run {
+        var executed = List.empty[Int]
+        def subRoutine(n: Int): Unit < Coroutine[Any] =
+            for
+                _ <- Coroutine.pause
+                _ <- Coroutine.spawn { executed = n :: executed }
+                _ <- if n > 0 then subRoutine(n - 1) else Coroutine.pause
+            yield ()
+
+        val effect =
+            for
+                _ <- Coroutine.spawn { executed = 1 :: executed }
+                _ <- subRoutine(3)
+                _ <- Coroutine.spawn { executed = 5 :: executed }
+            yield ()
+
+        val result = Coroutine.run(effect)
+        assert(result.eval == ())
+        assert(executed == List(5, 0, 1, 2, 3, 1))
+    }
+
+    "error propagation" in run {
+        val effect =
+            for
+                _ <- Coroutine.spawn { throw new RuntimeException("Spawn error") }
+                _ <- Coroutine.pause
+                _ <- Coroutine.spawn { () } // This should not execute
+            yield ()
+
+        assertThrows[RuntimeException] {
+            Coroutine.run(effect).eval
+        }
+    }
+
+    "large number of coroutines" in run {
+        val n   = 10000
+        var sum = 0
+        val effect =
+            for
+                _ <- Kyo.seq.collectUnit((1 to n).map(i =>
+                    Coroutine.spawn {
+                        sum += i
+                    }
+                ))
+            yield sum
+
+        val result = Coroutine.run(effect)
+        assert(result.eval == (1 to n).sum)
+    }
+
+    "Coroutine with Env and Var" in run {
+        val effect =
+            for
+                _ <- Coroutine.spawn {
+                    for
+                        env   <- Env.get[String]
+                        _     <- Var.update[Int](_ + 1)
+                        value <- Var.get[Int]
+                        _     <- Coroutine.pause
+                        _     <- Var.update[List[String]](s"$env-$value" :: _)
+                    yield ()
+                }
+                _ <- Coroutine.spawn {
+                    for
+                        env   <- Env.get[String]
+                        _     <- Var.update[Int](_ + 5)
+                        value <- Var.get[Int]
+                        _     <- Coroutine.pause
+                        _     <- Var.update[List[String]](s"$env-$value" :: _)
+                    yield ()
+                }
+            yield ()
+
+        val result =
+            Coroutine.run(effect)
+                .andThen(Var.get[List[String]])
+                .pipe(Var.run(List.empty[String]))
+                .pipe(Var.run(0))
+                .pipe(Env.run("env"))
+
+        assert(result.eval.reverse == List("env-1", "env-6"))
+    }
+
+    "Coroutine with Abort and Choice" in run {
+        val effect =
+            for
+                _ <- Coroutine.spawn {
+                    for
+                        _ <- Coroutine.pause
+                        _ <- Choice.eval(List(1, 2, 3)) { n =>
+                            if n == 2 then Choice.drop
+                            else
+                                Coroutine.spawn {
+                                    Var.update[List[String]](s"Choice $n" :: _)
+                                }
+                        }
+                    yield ()
+                }
+                _ <- Coroutine.spawn {
+                    for
+                        _ <- Coroutine.pause
+                        _ <- Abort.when(false)("This should not abort")
+                        _ <- Var.update[List[String]]("After Abort check" :: _)
+                    yield ()
+                }
+            yield ()
+
+        val result =
+            Coroutine
+                .run(effect)
+                .andThen(Var.get[List[String]])
+                .pipe(Abort.run(_))
+                .pipe(Var.run(List.empty[String]))
+                .pipe(Choice.run)
+
+        assert(result.eval == Seq(
+            Result.success(List("Choice 1", "After Abort check")),
+            Result.success(List("Choice 3", "After Abort check"))
+        ))
+    }
+
+end CoroutineTest


### PR DESCRIPTION
I've been trying to find an effect that can leverage the fact that the new kernel makes effect handling aware of the return type of the computation. My first try was a `Shift` effect that encodes delimited continuations (`shift`/`reset`) since it requires the type of the computation being handled to be the same as the shift being handled. Although the effect is [remarkably safer and cleaner](https://gist.github.com/fwbrasil/8f9e7e6204ed88ca1d90014a0ce0f884) with the new core design, I think it's too low-level to introduce in the codebase.

This PR introduces a purely functional `Coroutine` implementation. It provides cooperative multitasking within a single thread, allowing for deterministic and more controlled concurrency. The effect uses suspensions to provide two operations:

1. `Coroutine.pause`: Yields the execution, moving the current computation to the end of the queue.
2. `Coroutine.spawn`: Submits a sub-task to the queue and immediately resumes execution.

The return type of the effect handling is used to maintain the final result of the computation via a `Maybe`, even when other sub-tasks are still being processed. An important limitation of this initial version is that spawn returns `Unit`, so it's not possible to directly use the result of a spawned computation. But, as the tests demonstrate, it's possible to use other effects to propagate values in and out of spawned computations. The use of `Queue` is also not optimized yet.

This new effect **is not meant** as a replacement for `Fiber` but it can be useful to provide computation scheduling behavior without `IO`. Something I worry about is users getting confused with Kyo providing both `Coroutine` and `Fiber`, maybe we could use a more opaque name for this new effect like `Coop` to avoid that?