### PR TITLE
prelude: Maybe and Result improvements

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo2/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Abort.scala
@@ -45,7 +45,7 @@ object Abort:
                 case Failure(v) => fail(v)
 
         inline def apply[E, A](r: Result[E, A]): A < Abort[E | Throwable] =
-            r.fold(fail)(fail)(identity)
+            r.fold(e => fail(e.getFailure))(identity)
 
         @targetName("maybe")
         inline def apply[A](m: Maybe[A]): A < Abort[Maybe.Empty] =

--- a/kyo-prelude/shared/src/main/scala/kyo2/Maybe.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Maybe.scala
@@ -127,10 +127,10 @@ object Maybe:
         def toList: List[A] =
             if isEmpty then List.empty else get :: Nil
 
-        def toRight[X](left: => X): Either[X, A] =
+        inline def toRight[X](inline left: => X): Either[X, A] =
             if isEmpty then Left(left) else Right(get)
 
-        def toLeft[X](right: => X): Either[A, X] =
+        inline def toLeft[X](inline right: => X): Either[A, X] =
             if isEmpty then Right(right) else Left(get)
 
     end extension

--- a/kyo-prelude/shared/src/main/scala/kyo2/Maybe.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Maybe.scala
@@ -115,7 +115,7 @@ object Maybe:
                 end if
             else Empty
 
-        def orElse[B >: A](alternative: => Maybe[B]): Maybe[B] =
+        inline def orElse[B >: A](inline alternative: => Maybe[B]): Maybe[B] =
             if isEmpty then alternative else self
 
         def zip[B](that: Maybe[B]): Maybe[(A, B)] =

--- a/kyo-prelude/shared/src/main/scala/kyo2/Maybe.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Maybe.scala
@@ -41,7 +41,7 @@ object Maybe:
 
     end Defined
 
-    implicit class Ops[A](maybe: Maybe[A]) extends AnyVal:
+    implicit final class Ops[A](maybe: Maybe[A]) extends AnyVal:
         def isEmpty: Boolean = maybe.isEmpty
         def get: A           = maybe.get
 
@@ -55,9 +55,7 @@ object Maybe:
             else Some(get)
 
         def isEmpty: Boolean =
-            self match
-                case _: Empty => true
-                case _        => false
+            self.isInstanceOf[Empty]
 
         inline def isDefined: Boolean = !isEmpty
 

--- a/kyo-prelude/shared/src/main/scala/kyo2/Maybe.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Maybe.scala
@@ -105,7 +105,7 @@ object Maybe:
         inline def foreach(inline f: A => Unit): Unit =
             if !isEmpty then f(get)
 
-        inline def collect[B](inline pf: PartialFunction[A, B]): Maybe[B] =
+        inline def collect[B](pf: PartialFunction[A, B]): Maybe[B] =
             if !isEmpty then
                 val value = get
                 if pf.isDefinedAt(value) then

--- a/kyo-prelude/shared/src/main/scala/kyo2/Result.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Result.scala
@@ -140,7 +140,7 @@ object Result:
                     v
             }
 
-        inline def recover[B >: A](inline pf: PartialFunction[Failure[E], B]): Result[E, B] =
+        inline def recover[B >: A](pf: PartialFunction[Failure[E], B]): Result[E, B] =
             try
                 self match
                     case self: Failure[E] @unchecked if pf.isDefinedAt(self) =>
@@ -149,7 +149,7 @@ object Result:
             catch
                 case ex => Panic(ex)
 
-        inline def recoverWith[E2, B >: A](inline pf: PartialFunction[Failure[E], Result[E2, B]]): Result[E | E2, B] =
+        inline def recoverWith[E2, B >: A](pf: PartialFunction[Failure[E], Result[E2, B]]): Result[E | E2, B] =
             try
                 self match
                     case self: Failure[E] @unchecked if pf.isDefinedAt(self) =>

--- a/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
@@ -166,13 +166,10 @@ class ResultTest extends Test:
 
     "fold" - {
         "applies the success function for Success" in {
-            assert(Result.success(1).fold(_ => 0)(_ => 0)(x => x + 1) == 2)
+            assert(Result.success(1).fold(_ => 0)(x => x + 1) == 2)
         }
-        "applies the failure function for Error" in {
-            assert(Result.error[String, Int]("error").fold(_ => 0)(_ => 1)(x => x) == 0)
-        }
-        "applies the panic function for Panic" in {
-            assert(Result.panic[String, Int](ex).fold(_ => 0)(_ => 1)(x => x) == 1)
+        "applies the failure function for Failure" in {
+            assert(Result.error[String, Int]("error").fold(_ => 0)(x => x) == 0)
         }
     }
 
@@ -391,7 +388,7 @@ class ResultTest extends Test:
             val exception = new RuntimeException("exception")
             val result =
                 try
-                    tryy.fold(_ => throw exception)(_ => throw exception)(_ => throw exception)
+                    tryy.fold(_ => throw exception)(_ => throw exception)
                     "no exception"
                 catch
                     case e: RuntimeException => "caught exception"
@@ -403,7 +400,7 @@ class ResultTest extends Test:
             val exception = new RuntimeException("exception")
             val result =
                 try
-                    tryy.fold(_ => throw exception)(_ => throw exception)(_ => throw exception)
+                    tryy.fold(_ => throw exception)(_ => throw exception)
                     "no exception"
                 catch
                     case e: RuntimeException => "caught exception"
@@ -415,7 +412,7 @@ class ResultTest extends Test:
             val exception = new RuntimeException("exception")
             val result =
                 try
-                    tryy.fold(_ => 0)(_ => 0)(_ => throw exception)
+                    tryy.fold(_ => 0)(_ => throw exception)
                     "no exception"
                 catch
                     case e: RuntimeException => "caught exception"

--- a/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
@@ -27,6 +27,43 @@ class ResultTest extends Test:
         }
     }
 
+    "fromTry" - {
+        "should return Success for successful Try" in {
+            val tryValue = scala.util.Try(5)
+            val result   = Result.fromTry(tryValue)
+            assert(result == Result.success(5))
+        }
+
+        "should return Error for failed Try" in {
+            val exception = new RuntimeException("Test exception")
+            val tryValue  = scala.util.Try(throw exception)
+            val result    = Result.fromTry(tryValue)
+            assert(result == Result.error(exception))
+        }
+    }
+
+    "fromEither" - {
+        "should return Success for Right" in {
+            val eitherValue = Right(5)
+            val result      = Result.fromEither(eitherValue)
+            assert(result == Result.success(5))
+        }
+
+        "should return Error for Left" in {
+            val eitherValue = Left("Error message")
+            val result      = Result.fromEither(eitherValue)
+            assert(result == Result.error("Error message"))
+        }
+
+        "should maintain type parameters" in {
+            val result: Result[String, Int] = Result.fromEither(Right(5))
+            assert(result == Result.success(5))
+
+            val result2: Result[String, Int] = Result.fromEither(Left("Error"))
+            assert(result2 == Result.error("Error"))
+        }
+    }
+
     "isSuccess" - {
         "returns true for Success" in {
             assert(Result.success(1).isSuccess)


### PR DESCRIPTION
This PR introduces a few improvements. The main one is allocation-free pattern matching for both `Maybe` and `Result`. The new implicit class `Maybe.Ops` wraps a `Maybe` into an `AnyVal`, which satisfies the compiler to consider the method an extractor.