### PR TITLE
prelude: tracing fixes and improvements

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo2/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Abort.scala
@@ -17,41 +17,41 @@ object Abort:
     given eliminateAbort: Reducible.Eliminable[Abort[Nothing]] with {}
     private inline def erasedTag[E]: Tag[Abort[E]] = Tag[Abort[Any]].asInstanceOf[Tag[Abort[E]]]
 
-    inline def fail[E](inline value: E): Nothing < Abort[E] = error(Fail(value))
+    inline def fail[E](inline value: E)(using inline frame: Frame): Nothing < Abort[E] = error(Fail(value))
 
-    inline def panic[E](inline ex: Throwable): Nothing < Abort[E] = error(Panic(ex))
+    inline def panic[E](inline ex: Throwable)(using inline frame: Frame): Nothing < Abort[E] = error(Panic(ex))
 
-    private[kyo2] inline def error[E](inline e: Error[E]): Nothing < Abort[E] =
+    private[kyo2] inline def error[E](inline e: Error[E])(using inline frame: Frame): Nothing < Abort[E] =
         Effect.suspendMap[Any](erasedTag[E], e)(_ => ???)
 
-    inline def when[E](b: Boolean)(inline value: => E): Unit < Abort[E] =
+    inline def when[E](b: Boolean)(inline value: => E)(using inline frame: Frame): Unit < Abort[E] =
         if b then fail(value)
         else ()
 
     final class GetOps[E >: Nothing](dummy: Unit) extends AnyVal:
-        inline def apply[A](either: Either[E, A]): A < Abort[E] =
+        inline def apply[A](either: Either[E, A])(using inline frame: Frame): A < Abort[E] =
             either match
                 case Right(value) => value
                 case Left(value)  => fail(value)
 
-        inline def apply[A](opt: Option[A]): A < Abort[Maybe.Empty] =
+        inline def apply[A](opt: Option[A])(using inline frame: Frame): A < Abort[Maybe.Empty] =
             opt match
                 case None    => fail(Maybe.Empty)
                 case Some(v) => v
 
-        inline def apply[A](e: scala.util.Try[A]): A < Abort[Throwable] =
+        inline def apply[A](e: scala.util.Try[A])(using inline frame: Frame): A < Abort[Throwable] =
             e match
                 case scala.util.Success(t) => t
                 case scala.util.Failure(v) => fail(v)
 
-        inline def apply[E, A](r: Result[E, A]): A < Abort[E] =
+        inline def apply[E, A](r: Result[E, A])(using inline frame: Frame): A < Abort[E] =
             r.fold {
                 case e: Fail[E] => fail(e.error)
                 case Panic(ex)  => Abort.panic(ex)
             }(identity)
 
         @targetName("maybe")
-        inline def apply[A](m: Maybe[A]): A < Abort[Maybe.Empty] =
+        inline def apply[A](m: Maybe[A])(using inline frame: Frame): A < Abort[Maybe.Empty] =
             m.fold(fail(Maybe.Empty))(identity)
     end GetOps
 

--- a/kyo-prelude/shared/src/main/scala/kyo2/Choice.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Choice.scala
@@ -7,19 +7,19 @@ sealed trait Choice extends Effect[Seq, Id]
 
 object Choice:
 
-    inline def get[T](seq: Seq[T]): T < Choice =
+    inline def get[T](seq: Seq[T])(using inline frame: Frame): T < Choice =
         Effect.suspend[T](Tag[Choice], seq)
 
-    inline def eval[T, U, S](seq: Seq[T])(inline f: T => U < S): U < (Choice & S) =
+    inline def eval[T, U, S](seq: Seq[T])(inline f: T => U < S)(using inline frame: Frame): U < (Choice & S) =
         seq match
             case Seq(head) => f(head)
             case seq       => Effect.suspendMap[T](Tag[Choice], seq)(f)
 
-    inline def dropIf(condition: Boolean): Unit < Choice =
+    inline def dropIf(condition: Boolean)(using inline frame: Frame): Unit < Choice =
         if condition then drop
         else ()
 
-    inline def drop: Nothing < Choice =
+    inline def drop(using inline frame: Frame): Nothing < Choice =
         Effect.suspend[Nothing](Tag[Choice], Seq.empty)
 
     def run[T, S](v: T < (Choice & S))(using Frame): Seq[T] < S =

--- a/kyo-prelude/shared/src/main/scala/kyo2/Env.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Env.scala
@@ -12,7 +12,7 @@ object Env:
     given eliminateEnv: Reducible.Eliminable[Env[Any]] with {}
     private inline def erasedTag[R] = Tag[Env[Any]].asInstanceOf[Tag[Env[R]]]
 
-    inline def get[R](using inline tag: Tag[R]): R < Env[R] =
+    inline def get[R](using inline tag: Tag[R])(using inline frame: Frame): R < Env[R] =
         use[R](identity)
 
     def run[R >: Nothing: Tag, T, S, VR](env: R)(v: T < (Env[R & VR] & S))(
@@ -33,7 +33,7 @@ object Env:
         inline def apply[A, S](inline f: R => A < S)(
             using tag: Tag[R]
         ): A < (Env[R] & S) =
-            ContextEffect.suspend(erasedTag[R]) { map =>
+            ContextEffect.suspendMap(erasedTag[R]) { map =>
                 f(map.asInstanceOf[TypeMap[R]].get(using tag))
             }
     end UseOps

--- a/kyo-prelude/shared/src/main/scala/kyo2/Local.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Local.scala
@@ -9,14 +9,12 @@ abstract class Local[T]:
 
     val default: T
 
-    private val _get: T < Any =
-        ContextEffect.suspend(Tag[Local.State], Map.empty)(_.getOrElse(this, default).asInstanceOf[T])
-
-    def get: T < Any = _get
+    def get(using Frame): T < Any =
+        ContextEffect.suspendMap(Tag[Local.State], Map.empty)(_.getOrElse(this, default).asInstanceOf[T])
 
     // TODO Compilation error if inlined
     def use[U, S](f: T => U < S)(using Frame): U < S =
-        ContextEffect.suspend(Tag[Local.State], Map.empty)(map => f(map.getOrElse(this, default).asInstanceOf[T]))
+        ContextEffect.suspendMap(Tag[Local.State], Map.empty)(map => f(map.getOrElse(this, default).asInstanceOf[T]))
 
     def let[U, S](value: T)(v: U < S)(using Frame): U < S =
         ContextEffect.handle(Tag[Local.State], Map(this -> value), _.updated(this, value.asInstanceOf[AnyRef]))(v)

--- a/kyo-prelude/shared/src/main/scala/kyo2/Sum.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Sum.scala
@@ -8,7 +8,7 @@ sealed trait Sum[V] extends Effect[Const[V], Const[Unit]]
 
 object Sum:
 
-    inline def add[V](inline v: V)(using inline tag: Tag[Sum[V]]): Unit < Sum[V] =
+    inline def add[V](inline v: V)(using inline tag: Tag[Sum[V]], inline frame: Frame): Unit < Sum[V] =
         Effect.suspend[Any](tag, v)
 
     final class RunOps[V](dummy: Unit) extends AnyVal:

--- a/kyo-prelude/shared/src/main/scala/kyo2/Var.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Var.scala
@@ -8,22 +8,24 @@ sealed trait Var[V] extends Effect[Input[V, *], Id]
 
 object Var:
 
-    inline def get[V](using inline tag: Tag[Var[V]]): V < Var[V] =
+    inline def get[V](using inline tag: Tag[Var[V]], inline frame: Frame): V < Var[V] =
         use[V](identity)
 
     final class UseOps[V](dummy: Unit) extends AnyVal:
         inline def apply[A, S](inline f: V => A < S)(
-            using inline tag: Tag[Var[V]]
+            using
+            inline tag: Tag[Var[V]],
+            inline frame: Frame
         ): A < (Var[V] & S) =
             Effect.suspendMap[V](tag, internal.get[V])(f)
     end UseOps
 
     inline def use[V]: UseOps[V] = UseOps(())
 
-    inline def set[V](inline value: V)(using inline tag: Tag[Var[V]]): Unit < Var[V] =
+    inline def set[V](inline value: V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
         Effect.suspend[Unit](tag, (() => value): Set[V])
 
-    inline def update[V](inline f: V => V)(using inline tag: Tag[Var[V]]): Unit < Var[V] =
+    inline def update[V](inline f: V => V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
         Effect.suspend[Unit](tag, (v => f(v)): Update[V])
 
     private inline def runWith[V, A, S, B, S2](state: V)(v: A < (Var[V] & S))(

--- a/kyo-prelude/shared/src/main/scala/kyo2/internal/BaseKyoTest.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/internal/BaseKyoTest.scala
@@ -39,6 +39,15 @@ trait BaseKyoTest[S]:
     given eitherCanEqual[T, U]: CanEqual[Either[T, U], Either[T, U]] = CanEqual.derived
     given throwableCanEqual: CanEqual[Throwable, Throwable]          = CanEqual.derived
 
+    def retry[S](f: => Boolean < S): Boolean < S =
+        def loop(): Boolean < S =
+            f.map {
+                case true  => true
+                case false => loop()
+            }
+        loop()
+    end retry
+
     def timeout =
         if Platform.isDebugEnabled then
             Duration.Infinity

--- a/kyo-prelude/shared/src/main/scala/kyo2/internal/BaseKyoTest.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/internal/BaseKyoTest.scala
@@ -39,14 +39,14 @@ trait BaseKyoTest[S]:
     given eitherCanEqual[T, U]: CanEqual[Either[T, U], Either[T, U]] = CanEqual.derived
     given throwableCanEqual: CanEqual[Throwable, Throwable]          = CanEqual.derived
 
-    def retry[S](f: => Boolean < S): Boolean < S =
+    def untilTrue[S](f: => Boolean < S): Boolean < S =
         def loop(): Boolean < S =
             f.map {
                 case true  => true
                 case false => loop()
             }
         loop()
-    end retry
+    end untilTrue
 
     def timeout =
         if Platform.isDebugEnabled then

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/ContextEffect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/ContextEffect.scala
@@ -11,22 +11,22 @@ abstract class ContextEffect[+A]
 object ContextEffect:
 
     inline def suspend[A, E <: ContextEffect[A]](inline tag: Tag[E]): A < E =
-        suspend(tag)(identity)
+        suspendMap(tag)(identity)
 
-    inline def suspend[A, E <: ContextEffect[A], B, S](
+    inline def suspendMap[A, E <: ContextEffect[A], B, S](
         inline tag: Tag[E]
     )(
         inline f: Safepoint ?=> A => B < S
     ): B < (E & S) =
-        suspend(tag, bug("Unexpected pending context effect: " + tag.show))(f)
+        suspendMap(tag, bug("Unexpected pending context effect: " + tag.show))(f)
 
     inline def suspend[A, E <: ContextEffect[A]](
         inline tag: Tag[E],
         inline default: => A
     ): A < Any =
-        suspend(tag, default)(identity)
+        suspendMap(tag, default)(identity)
 
-    inline def suspend[A, E <: ContextEffect[A], B, S](
+    inline def suspendMap[A, E <: ContextEffect[A], B, S](
         inline _tag: Tag[E],
         inline default: => A
     )(

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
@@ -209,10 +209,11 @@ object Effect:
                         val tag   = kyo.tag
                         val input = kyo.input
                         def frame = _frame
-                        def apply(v: OX[Any], context: Context)(using Safepoint) =
+                        def apply(v: OX[Any], context: Context)(using safepoint: Safepoint) =
                             try catchingLoop(kyo(v, context))
                             catch
                                 case ex: Throwable if (NonFatal(ex) && pf.isDefinedAt(ex)) =>
+                                    Safepoint.insertTrace(ex)
                                     pf(ex)
                             end try
                         end apply
@@ -221,6 +222,7 @@ object Effect:
         try catchingLoop(v)
         catch
             case ex: Throwable if (NonFatal(ex) && pf.isDefinedAt(ex)) =>
+                Safepoint.insertTrace(ex)
                 pf(ex)
         end try
     end catching

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Safepoint.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Safepoint.scala
@@ -121,7 +121,8 @@ object Safepoint:
                 finally self.exit(depth)
     end handle
 
-    private[kyo2] def insertTrace(cause: Throwable)(using self: Safepoint): Unit =
+    // TODO compiler crash if private[kyo2]
+    def insertTrace(cause: Throwable)(using self: Safepoint): Unit =
         val size = Math.min(self.traceIdx, maxTraceFrames)
         if size > 0 then
             val trace = copyTrace(self.trace, self.traceIdx).filter(_ != null).map(_.parse)

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Safepoint.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Safepoint.scala
@@ -102,7 +102,8 @@ object Safepoint:
         try f
         catch
             case ex: Throwable if NonFatal(ex) =>
-                handle(self, ex)
+                insertTrace(ex)(using self)
+                throw ex
         finally
             Safepoint.local.set(parent)
         end try
@@ -120,25 +121,32 @@ object Safepoint:
                 finally self.exit(depth)
     end handle
 
-    private def handle(self: Safepoint, cause: Throwable): Nothing =
-        val size  = Math.min(self.traceIdx, maxTraceFrames)
-        val trace = copyTrace(self.trace, self.traceIdx).filter(_ != null).map(_.parse)
-        val toPad = trace.map(_.snippetShort.size).max + 1
-        val elements = trace.map { frame =>
-            StackTraceElement(
-                frame.snippetShort.reverse.padTo(toPad, ' ').reverse + " @ " + frame.declaringClass,
-                frame.methodName,
-                frame.position.fileName,
-                frame.position.lineNumber
+    private[kyo2] def insertTrace(cause: Throwable)(using self: Safepoint): Unit =
+        val size = Math.min(self.traceIdx, maxTraceFrames)
+        if size > 0 then
+            val trace = copyTrace(self.trace, self.traceIdx).filter(_ != null).map(_.parse)
+            val toPad = trace.map(_.snippetShort.size).maxOption.getOrElse(0) + 1
+            val elements =
+                trace.foldLeft(List.empty[Frame.Parsed]) {
+                    case (acc, curr) =>
+                        acc match
+                            case `curr` :: tail => acc
+                            case _              => curr :: acc
+                }.reverse.map { frame =>
+                    StackTraceElement(
+                        frame.snippetShort.reverse.padTo(toPad, ' ').reverse + " @ " + frame.declaringClass,
+                        frame.methodName,
+                        frame.position.fileName,
+                        frame.position.lineNumber
+                    )
+                }.reverse
+            val prefix = cause.getStackTrace.takeWhile(e =>
+                e.getFileName() != elements(0).getFileName() || e.getLineNumber != elements(0).getLineNumber()
             )
-        }.reverse
-        val prefix = cause.getStackTrace.takeWhile(e =>
-            e.getFileName() != elements(0).getFileName() || e.getLineNumber != elements(0).getLineNumber()
-        )
-        val suffix = (new Exception).getStackTrace().drop(2)
-        cause.setStackTrace(prefix ++ elements ++ suffix)
-        throw cause
-    end handle
+            val suffix = (new Exception).getStackTrace().drop(2)
+            cause.setStackTrace(prefix ++ elements ++ suffix)
+        end if
+    end insertTrace
 
     private def copyTrace(trace: Array[Frame], idx: Int): Array[Frame] =
         val result = new Array[Frame](maxTraceFrames)

--- a/kyo-prelude/shared/src/test/scala/kyo2/KyoTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/KyoTest.scala
@@ -9,7 +9,7 @@ class KyoTest extends Test:
 
     "toString JVM" taggedAs jvmOnly in run {
         assert(Env.use[Int](_ + 1).toString() ==
-            "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(()), KyoTest.scala:11:16, ssert(Env.use[Int](_ + 1)))")
+            "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(()), KyoTest.scala:11:16, assert(Env.use[Int](_ + 1)))")
         assert(
             Env.get[Int].map(_ + 1).toString() ==
                 "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(()), KyoTest.scala:14:36, Env.get[Int].map(_ + 1)))"
@@ -18,7 +18,7 @@ class KyoTest extends Test:
 
     "toString JS" taggedAs jsOnly in run {
         assert(Env.use[Int](_ + 1).toString() ==
-            "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(undefined), KyoTest.scala:20:16, ssert(Env.use[Int](_ + 1)))")
+            "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(undefined), KyoTest.scala:20:16, assert(Env.use[Int](_ + 1)))")
         assert(
             Env.get[Int].map(_ + 1).toString() ==
                 "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(undefined), KyoTest.scala:23:36, Env.get[Int].map(_ + 1)))"

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/FrameTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/FrameTest.scala
@@ -14,7 +14,7 @@ class FrameTest extends Test:
     }
 
     "show" in {
-        assert(test1.show == "Frame(kyo2.kernel.FrameTest, test1, FrameTest.scala:9:28, test(1 + 2))")
+        assert(test1.show == "Frame(kyo2.kernel.FrameTest, test1, FrameTest.scala:9:28, def test1 = test(1 + 2))")
         assert(test2.show == "Frame(kyo2.kernel.FrameTest, test2, FrameTest.scala:14:6, })")
     }
 
@@ -25,7 +25,7 @@ class FrameTest extends Test:
         assert(parsed.position.fileName == "FrameTest.scala")
         assert(parsed.position.lineNumber == 9)
         assert(parsed.position.columnNumber == 28)
-        assert(parsed.snippetShort == "test(1 + 2)")
+        assert(parsed.snippetShort == "def test1 = test(1 + 2)")
         assert(parsed.snippetLong == "def test1 = test(1 + 2)📍")
     }
 

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/TraceTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/TraceTest.scala
@@ -3,7 +3,7 @@ package kyo2.kernel
 import java.io.PrintWriter
 import java.io.StringWriter
 import kyo2.*
-import kyo2.Tagged.jvmOnly
+import kyo2.Tagged.*
 
 class TraceTest extends Test:
 
@@ -29,7 +29,6 @@ class TraceTest extends Test:
                 |	at kyo2.kernel.TraceTest.ex(TraceTest.scala:10)
                 |	at  oom[S](x: Int < S): Int < S = x.map(_ => throw ex) @ kyo2.kernel.TraceTest.boom(TraceTest.scala:12)
                 |	at                        def evalOnly = boom(10).eval @ kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)
-                |	at kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)
                 """
             )
         }
@@ -48,7 +47,6 @@ class TraceTest extends Test:
                 |	at                               val z = Kyo.zip(x, y) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
                 |	at                         val x = Env.use[Int](_ + 1) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:17)
                 |	at                                  Env.run(1)(z).eval @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)
-                |	at kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)
                 """
             )
         }
@@ -59,7 +57,7 @@ class TraceTest extends Test:
     // and positions. It doesn't fail, only generates a stack trace with Kyo's
     // frames at the wrong poition.
     "js" - {
-        "only eval" taggedAs jvmOnly in pendingUntilFixed {
+        "only eval" taggedAs jsOnly in pendingUntilFixed {
             assertTrace(
                 evalOnly,
                 """
@@ -67,13 +65,12 @@ class TraceTest extends Test:
                 |	at kyo2.kernel.TraceTest.ex(TraceTest.scala:10)
                 |	at  oom[S](x: Int < S): Int < S = x.map(_ => throw ex) @ kyo2.kernel.TraceTest.boom(TraceTest.scala:12)
                 |	at                        def evalOnly = boom(10).eval @ kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)
-                |	at kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)
                 """
             )
             ()
         }
 
-        "with effects" taggedAs jvmOnly in pendingUntilFixed {
+        "with effects" taggedAs jsOnly in pendingUntilFixed {
             assertTrace(
                 withEffects,
                 """
@@ -87,7 +84,6 @@ class TraceTest extends Test:
                 |	at                               val z = Kyo.zip(x, y) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
                 |	at                         val x = Env.use[Int](_ + 1) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:17)
                 |	at                                  Env.run(1)(z).eval @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)
-                |	at kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)
                 """
             )
             ()
@@ -104,7 +100,7 @@ class TraceTest extends Test:
                 val printWriter  = new PrintWriter(stringWriter)
                 ex.printStackTrace(printWriter)
                 printWriter.flush()
-                val trace = stringWriter.toString.linesIterator.takeWhile(!_.contains("$init$$$anonfun")).mkString("\n")
+                val trace = stringWriter.toString.linesIterator.takeWhile(!_.contains("anonfun")).mkString("\n")
                 assert(trace == expected.stripMargin.trim)
 
 end TraceTest

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/TraceTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/TraceTest.scala
@@ -27,9 +27,9 @@ class TraceTest extends Test:
                 """
                 |java.lang.Exception: test exception
                 |	at kyo2.kernel.TraceTest.ex(TraceTest.scala:10)
-                |	at  x.map(_ => throw ex) @ kyo2.kernel.TraceTest.boom(TraceTest.scala:12)
-                |	at         boom(10).eval @ kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)
-                |	at kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)                
+                |	at  oom[S](x: Int < S): Int < S = x.map(_ => throw ex) @ kyo2.kernel.TraceTest.boom(TraceTest.scala:12)
+                |	at                        def evalOnly = boom(10).eval @ kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)
+                |	at kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)
                 """
             )
         }
@@ -40,15 +40,15 @@ class TraceTest extends Test:
                 """
                 |java.lang.Exception: test exception
                 |	at kyo2.kernel.TraceTest.ex(TraceTest.scala:10)
-                |	at       x.map(_ => throw ex) @ kyo2.kernel.TraceTest.boom(TraceTest.scala:12)
-                |	at  , y).map(_ + _).map(boom) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
-                |	at   Kyo.zip(x, y).map(_ + _) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
-                |	at              Kyo.zip(x, y) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
-                |	at        Env.use[Int](_ * 2) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:18)
-                |	at              Kyo.zip(x, y) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
-                |	at        Env.use[Int](_ + 1) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:17)
-                |	at         Env.run(1)(z).eval @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)
-                |	at kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)                
+                |	at  oom[S](x: Int < S): Int < S = x.map(_ => throw ex) @ kyo2.kernel.TraceTest.boom(TraceTest.scala:12)
+                |	at          val z = Kyo.zip(x, y).map(_ + _).map(boom) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
+                |	at                    val z = Kyo.zip(x, y).map(_ + _) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
+                |	at                               val z = Kyo.zip(x, y) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
+                |	at                         val y = Env.use[Int](_ * 2) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:18)
+                |	at                               val z = Kyo.zip(x, y) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
+                |	at                         val x = Env.use[Int](_ + 1) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:17)
+                |	at                                  Env.run(1)(z).eval @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)
+                |	at kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)
                 """
             )
         }
@@ -65,9 +65,9 @@ class TraceTest extends Test:
                 """
                 |java.lang.Exception: test exception
                 |	at kyo2.kernel.TraceTest.ex(TraceTest.scala:10)
-                |	at  x.map(_ => throw ex) @ kyo2.kernel.TraceTest.boom(TraceTest.scala:12)
-                |	at         boom(10).eval @ kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)
-                |	at kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)      
+                |	at  oom[S](x: Int < S): Int < S = x.map(_ => throw ex) @ kyo2.kernel.TraceTest.boom(TraceTest.scala:12)
+                |	at                        def evalOnly = boom(10).eval @ kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)
+                |	at kyo2.kernel.TraceTest.evalOnly(TraceTest.scala:14)
                 """
             )
             ()
@@ -79,15 +79,15 @@ class TraceTest extends Test:
                 """
                 |java.lang.Exception: test exception
                 |	at kyo2.kernel.TraceTest.ex(TraceTest.scala:10)
-                |	at       x.map(_ => throw ex) @ kyo2.kernel.TraceTest.boom(TraceTest.scala:12)
-                |	at  , y).map(_ + _).map(boom) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
-                |	at   Kyo.zip(x, y).map(_ + _) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
-                |	at              Kyo.zip(x, y) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
-                |	at        Env.use[Int](_ * 2) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:18)
-                |	at              Kyo.zip(x, y) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
-                |	at        Env.use[Int](_ + 1) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:17)
-                |	at         Env.run(1)(z).eval @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)
-                |	at kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)  
+                |	at  oom[S](x: Int < S): Int < S = x.map(_ => throw ex) @ kyo2.kernel.TraceTest.boom(TraceTest.scala:12)
+                |	at          val z = Kyo.zip(x, y).map(_ + _).map(boom) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
+                |	at                    val z = Kyo.zip(x, y).map(_ + _) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
+                |	at                               val z = Kyo.zip(x, y) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
+                |	at                         val y = Env.use[Int](_ * 2) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:18)
+                |	at                               val z = Kyo.zip(x, y) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:19)
+                |	at                         val x = Env.use[Int](_ + 1) @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:17)
+                |	at                                  Env.run(1)(z).eval @ kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)
+                |	at kyo2.kernel.TraceTest.withEffects(TraceTest.scala:20)
                 """
             )
             ()


### PR DESCRIPTION
I had thought that we wouldn't need to pass `Frame` explicit in methods marked as `inline` but that's not the the case. Instead of using the frame from the outer call, the compiler summons a new one. This PR introduces the `Frame` implicit to inline methods, reduces the size of the frame payload by inferring the short snippet from the expanded one, and introduces a few other improvements (some unrelated to tracing)