### PR TITLE
prelude: add `evalNow` and `evalPartial` methods to the pending type

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Pending.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Pending.scala
@@ -2,6 +2,7 @@ package kyo2.kernel
 
 import internal.*
 import kyo.*
+import kyo2.Maybe
 import scala.annotation.tailrec
 import scala.language.implicitConversions
 import scala.util.NotGiven
@@ -50,6 +51,26 @@ object `<`:
                         )
             mapLoop(v)
         end map
+
+        inline def evalNow: Maybe[A] =
+            v match
+                case <(kyo: Kyo[?, ?]) => Maybe.empty
+                case <(v)              => Maybe(v.asInstanceOf[A])
+
+        private[kyo2] inline def evalPartial(interceptor: Safepoint.Interceptor)(using frame: Frame, safepoint: Safepoint): A < S =
+            @tailrec def partialEvalLoop(kyo: A < S)(using Safepoint): A < S =
+                if !interceptor.enter(frame, ()) then kyo
+                else
+                    kyo match
+                        case <(kyo: KyoSuspend[Const[Unit], Const[Unit], Defer, Any, A, S] @unchecked)
+                            if kyo.tag =:= Tag[Defer] =>
+                            partialEvalLoop(kyo((), Context.empty))
+                        case kyo =>
+                            kyo
+            end partialEvalLoop
+            Safepoint.immediate(interceptor)(partialEvalLoop(v))
+        end evalPartial
+
     end extension
 
     extension [A, S, S2](inline kyo: A < S < S2)

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/PendingTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/PendingTest.scala
@@ -1,6 +1,7 @@
 package kyo2.kernel
 
 import kyo.Tag
+import kyo2.Maybe
 import kyo2.Test
 import kyo2.kernel.*
 
@@ -90,4 +91,66 @@ class PendingTest extends Test:
         }
     }
 
+    sealed trait TestEffect extends Effect[Const[Int], Const[Int]]
+
+    def testEffect(i: Int): Int < TestEffect =
+        Effect.suspend[Int](Tag[TestEffect], i)
+
+    "evalNow" - {
+        "returns Defined for pure values" in {
+            val x: Int < Any = 5
+            assert(x.evalNow == Maybe(5))
+        }
+
+        "returns Empty for suspended computations" in {
+            val x: Int < TestEffect = testEffect(5)
+            assert(x.evalNow == Maybe.empty)
+        }
+
+        "returns Defined for nested pure values" in {
+            val x: Int < Any < Any = <(1: Int < Any)
+            assert(x.evalNow.flatMap(_.evalNow) == Maybe(1))
+        }
+    }
+
+    "evalPartial" - {
+        "evaluates pure values" in {
+            val x: Int < Any = 5
+            val result = x.evalPartial(new Safepoint.Interceptor:
+                def enter(frame: Frame, value: Any) = true
+                def exit()                          = ()
+            )
+            assert(result.eval == 5)
+        }
+
+        "suspends at effects" in {
+            val x: Int < TestEffect = testEffect(5).map(_ + 1)
+            val result = x.evalPartial(new Safepoint.Interceptor:
+                def enter(frame: Frame, value: Any) = true
+                def exit()                          = ()
+            )
+            assert(result.evalNow.isEmpty)
+        }
+
+        "respects the interceptor" in {
+            var called       = false
+            val x: Int < Any = Effect.defer(5)
+            val result = x.evalPartial(new Safepoint.Interceptor:
+                def enter(frame: Frame, value: Any) =
+                    called = true; false
+                def exit() = ()
+            )
+            assert(called)
+            assert(result.evalNow.isEmpty)
+        }
+
+        "evaluates nested suspensions" in {
+            val x: Int < Any = Effect.defer(Effect.defer(5))
+            val result = x.evalPartial(new Safepoint.Interceptor:
+                def enter(frame: Frame, value: Any) = true
+                def exit()                          = ()
+            )
+            assert(result.eval == 5)
+        }
+    }
 end PendingTest


### PR DESCRIPTION
I'm using both methods to implement fibers based on `kyo-prelude`. 

The `evalNow` method inspects if the computation has no pending effects to return its value if possible (via `Maybe`). In fibers, this method is used to avoid forking computations that are already complete. I'm wasn't sure about keeping this method public since it's low-level but it seems useful to allow users and library authors to implement logic that avoids overhead in case the computation is already complete.

The `evalPartial` is used from the `IOTask` effect handling to install the interceptor and stop evaluation once the interceptor signals to stop (preemption in fibers).