### PR TITLE
disable release workflow for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: release
 on:
   push:
-    branches: [main]
+    branches: [disabled]
     tags: ["v0.*"]
 jobs:
   publish:


### PR DESCRIPTION
I'm not sure why the build on main is always failing due to the release job. I think something might have changed in Sonatype. I'd like to disable it for now as a workaround. We'll have to address this issue before the next release.