### PR TITLE
use KyoContinue to reduce bytecode size

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Boundary.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Boundary.scala
@@ -26,9 +26,7 @@ final class Boundary[Ctx, S] private (dummy: Unit) extends AnyVal:
     private def boundaryLoop[A, S2](v: A < (Ctx & S & S2), state: Safepoint.State)(using Frame): A < (S & S2) =
         v match
             case <(kyo: KyoSuspend[IX, OX, EX, Any, A, S] @unchecked) =>
-                new KyoSuspend[IX, OX, EX, Any, A, S & S2]:
-                    val tag   = kyo.tag
-                    val input = kyo.input
+                new KyoContinue[IX, OX, EX, Any, A, S & S2](kyo):
                     def frame = summon[Frame]
                     def apply(v: OX[Any], context: Context)(using Safepoint) =
                         val parent = Safepoint.local.get()

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/ContextEffect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/ContextEffect.scala
@@ -50,9 +50,7 @@ object ContextEffect:
         def handleLoop(v: B < (E & S))(using Safepoint): B < S =
             v match
                 case <(kyo: KyoSuspend[IX, OX, EX, Any, B, S] @unchecked) =>
-                    new KyoSuspend[IX, OX, EX, Any, B, S]:
-                        val tag   = kyo.tag
-                        val input = kyo.input
+                    new KyoContinue[IX, OX, EX, Any, B, S](kyo):
                         def frame = _frame
                         def apply(v: OX[Any], context: Context)(using Safepoint) =
                             val tag = _tag // avoid inlining the tag multiple times

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
@@ -2,6 +2,7 @@ package kyo2.kernel
 
 import internal.*
 import kyo.Tag
+import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 abstract class Effect[-I[_], +O[_]]
@@ -70,9 +71,7 @@ object Effect:
                             continue = handleLoop(handle[Any](kyo.input, kyo(_, context)), context)
                         )
                     case <(kyo: KyoSuspend[IX, OX, EX, Any, A, E & S & S2 & S3] @unchecked) =>
-                        new KyoSuspend[IX, OX, EX, Any, B, S & S2 & S3]:
-                            val tag   = kyo.tag
-                            val input = kyo.input
+                        new KyoContinue[IX, OX, EX, Any, B, S & S2 & S3](kyo):
                             def frame = _frame
                             def apply(v: OX[Any], context: Context)(using Safepoint) =
                                 handleLoop(kyo(v, context), context)
@@ -105,9 +104,7 @@ object Effect:
                             continue = handle2Loop(handle2[Any](kyo.input, kyo(_, context)), context)
                         )
                     case <(kyo: KyoSuspend[IX, OX, EX, Any, A, E1 & E2 & S & S2] @unchecked) =>
-                        new KyoSuspend[IX, OX, EX, Any, A, S & S2]:
-                            val tag   = kyo.tag
-                            val input = kyo.input
+                        new KyoContinue[IX, OX, EX, Any, A, S & S2](kyo):
                             def frame = _frame
                             def apply(v: OX[Any], context: Context)(using Safepoint) =
                                 handle2Loop(kyo(v, context), context)
@@ -150,9 +147,7 @@ object Effect:
                             continue = handle3Loop(handle3[Any](kyo.input, kyo(_, context)), context)
                         )
                     case <(kyo: KyoSuspend[IX, OX, EX, Any, A, E1 & E2 & E3 & S & S2] @unchecked) =>
-                        new KyoSuspend[IX, OX, EX, Any, A, S & S2]:
-                            val tag   = kyo.tag
-                            val input = kyo.input
+                        new KyoContinue[IX, OX, EX, Any, A, S & S2](kyo):
                             def frame = _frame
                             def apply(v: OX[Any], context: Context)(using Safepoint) =
                                 handle3Loop(kyo(v, context), context)
@@ -183,9 +178,7 @@ object Effect:
                                 handleLoop(nst, res, context)
                         )
                     case <(kyo: KyoSuspend[IX, OX, EX, Any, A, E & S & S2] @unchecked) =>
-                        new KyoSuspend[IX, OX, EX, Any, U, S & S2]:
-                            val tag   = kyo.tag
-                            val input = kyo.input
+                        new KyoContinue[IX, OX, EX, Any, U, S & S2](kyo):
                             def frame = _frame
                             def apply(v: OX[Any], context: Context)(using Safepoint) =
                                 handleLoop(state, kyo(v, context), context)
@@ -205,9 +198,7 @@ object Effect:
         def catchingLoop(v: B < (S & S2))(using Safepoint): B < (S & S2) =
             (v: @unchecked) match
                 case <(kyo: KyoSuspend[IX, OX, EX, Any, B, S & S2] @unchecked) =>
-                    new KyoSuspend[IX, OX, EX, Any, B, S & S2]:
-                        val tag   = kyo.tag
-                        val input = kyo.input
+                    new KyoContinue[IX, OX, EX, Any, B, S & S2](kyo):
                         def frame = _frame
                         def apply(v: OX[Any], context: Context)(using safepoint: Safepoint) =
                             try catchingLoop(kyo(v, context))


### PR DESCRIPTION
I introduced `KyoContinue` late in the development of `kyo-prelude` and didn't update all classes to use it. It reduces the bytecode size by moving the `tag` and `input` fields to a shared super class. 