### PR TITLE
prelude: misc improvements and fixes

### DIFF
--- a/kyo-prelude/js/src/main/scala/java/lang/ThreadLocal.scala
+++ b/kyo-prelude/js/src/main/scala/java/lang/ThreadLocal.scala
@@ -2,11 +2,11 @@ package java.lang
 
 import java.util.function.Supplier
 
-class ThreadLocal[T](private var value: T):
-    def this() = this(null.asInstanceOf[T])
+class ThreadLocal[A](private var value: A):
+    def this() = this(null.asInstanceOf[A])
     def get()     = value
-    def set(v: T) = value = v
+    def set(v: A) = value = v
 end ThreadLocal
 
 object ThreadLocal:
-    def withInitial[T](f: Supplier[T]): ThreadLocal[T] = ThreadLocal(f.get())
+    def withInitial[A](f: Supplier[A]): ThreadLocal[A] = ThreadLocal(f.get())

--- a/kyo-prelude/jvm/src/test/scala/kyo2/MonadLawsTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo2/MonadLawsTest.scala
@@ -11,7 +11,7 @@ import zio.test.laws.*
 
 object MonadLawsTest extends ZIOSpecDefault:
 
-    case class Myo[+T](v: T < (Env[String] & Abort[String] & Sum[Int] & Var[Boolean]))
+    case class Myo[+A](v: A < (Env[String] & Abort[String] & Sum[Int] & Var[Boolean]))
 
     val listGenF: GenF[Any, Myo] =
         new GenF[Any, Myo]:

--- a/kyo-prelude/jvm/src/test/scala/kyo2/kernel/BytecodeTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo2/kernel/BytecodeTest.scala
@@ -40,7 +40,7 @@ class BytecodeTest extends Test:
         assert(map == Map("test" -> 30, "anonfun" -> 15, "handleLoop" -> 266))
     }
 
-    def methodBytecodeSize[T](using ct: ClassTag[T]): Map[String, Int] =
+    def methodBytecodeSize[A](using ct: ClassTag[A]): Map[String, Int] =
         import javassist.*
         val classpath = System.getProperty("java.class.path")
         val classPool = ClassPool.getDefault

--- a/kyo-prelude/shared/src/main/scala/kyo2/Aspect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Aspect.scala
@@ -4,36 +4,36 @@ object Aspect:
 
     private[kyo2] val local = Local.init(Map.empty[Aspect[?, ?, ?], Cut[?, ?, ?]])
 
-    def init[T, U, S](using Frame): Aspect[T, U, S] =
-        init(new Cut[T, U, S]:
-            def apply[S2](v: T < S2)(f: T => U < S) =
+    def init[A, B, S](using Frame): Aspect[A, B, S] =
+        init(new Cut[A, B, S]:
+            def apply[S2](v: A < S2)(f: A => B < S) =
                 v.map(f)
         )
 
-    def init[T, U, S](default: Cut[T, U, S])(using Frame): Aspect[T, U, S] =
-        new Aspect[T, U, S](default)
+    def init[A, B, S](default: Cut[A, B, S])(using Frame): Aspect[A, B, S] =
+        new Aspect[A, B, S](default)
 
-    def chain[T, U, S](head: Cut[T, U, S], tail: Seq[Cut[T, U, S]])(using Frame) =
+    def chain[A, B, S](head: Cut[A, B, S], tail: Seq[Cut[A, B, S]])(using Frame) =
         tail.foldLeft(head)(_.andThen(_))
 end Aspect
 
 import Aspect.*
 
-abstract class Cut[T, U, S]:
-    def apply[S2](v: T < S2)(f: T => U < S): U < (S & S2)
+abstract class Cut[A, B, S]:
+    def apply[S2](v: A < S2)(f: A => B < S): B < (S & S2)
 
-    def andThen(other: Cut[T, U, S])(using Frame): Cut[T, U, S] =
-        new Cut[T, U, S]:
-            def apply[S2](v: T < S2)(f: T => U < S) =
+    def andThen(other: Cut[A, B, S])(using Frame): Cut[A, B, S] =
+        new Cut[A, B, S]:
+            def apply[S2](v: A < S2)(f: A => B < S) =
                 Cut.this(v)(other(_)(f))
 end Cut
 
-final class Aspect[T, U, S] private[kyo2] (default: Cut[T, U, S])(using Frame) extends Cut[T, U, S]:
+final class Aspect[A, B, S] private[kyo2] (default: Cut[A, B, S])(using Frame) extends Cut[A, B, S]:
 
-    def apply[S2](v: T < S2)(f: T => U < S) =
+    def apply[S2](v: A < S2)(f: A => B < S) =
         local.use { map =>
             map.get(this) match
-                case Some(a: Cut[T, U, S] @unchecked) =>
+                case Some(a: Cut[A, B, S] @unchecked) =>
                     local.let(map - this) {
                         a(v)(f)
                     }
@@ -41,10 +41,10 @@ final class Aspect[T, U, S] private[kyo2] (default: Cut[T, U, S])(using Frame) e
                     default(v)(f)
         }
 
-    def sandbox[S](v: T < S)(using Frame): T < S =
+    def sandbox[S](v: A < S)(using Frame): A < S =
         local.use { map =>
             map.get(this) match
-                case Some(a: Cut[T, U, S] @unchecked) =>
+                case Some(a: Cut[A, B, S] @unchecked) =>
                     local.let(map - this) {
                         v
                     }
@@ -52,11 +52,11 @@ final class Aspect[T, U, S] private[kyo2] (default: Cut[T, U, S])(using Frame) e
                     v
         }
 
-    def let[V, S2](a: Cut[T, U, S])(v: V < S2)(using Frame): V < (S & S2) =
+    def let[V, S2](a: Cut[A, B, S])(v: V < S2)(using Frame): V < (S & S2) =
         local.use { map =>
             val cut =
                 map.get(this) match
-                    case Some(b: Cut[T, U, S] @unchecked) =>
+                    case Some(b: Cut[A, B, S] @unchecked) =>
                         b.andThen(a)
                     case _ =>
                         a

--- a/kyo-prelude/shared/src/main/scala/kyo2/Choice.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Choice.scala
@@ -7,13 +7,13 @@ sealed trait Choice extends Effect[Seq, Id]
 
 object Choice:
 
-    inline def get[T](seq: Seq[T])(using inline frame: Frame): T < Choice =
-        Effect.suspend[T](Tag[Choice], seq)
+    inline def get[A](seq: Seq[A])(using inline frame: Frame): A < Choice =
+        Effect.suspend[A](Tag[Choice], seq)
 
-    inline def eval[T, U, S](seq: Seq[T])(inline f: T => U < S)(using inline frame: Frame): U < (Choice & S) =
+    inline def eval[A, B, S](seq: Seq[A])(inline f: A => B < S)(using inline frame: Frame): B < (Choice & S) =
         seq match
             case Seq(head) => f(head)
-            case seq       => Effect.suspendMap[T](Tag[Choice], seq)(f)
+            case seq       => Effect.suspendMap[A](Tag[Choice], seq)(f)
 
     inline def dropIf(condition: Boolean)(using inline frame: Frame): Unit < Choice =
         if condition then drop
@@ -22,8 +22,8 @@ object Choice:
     inline def drop(using inline frame: Frame): Nothing < Choice =
         Effect.suspend[Nothing](Tag[Choice], Seq.empty)
 
-    def run[T, S](v: T < (Choice & S))(using Frame): Seq[T] < S =
-        Effect.handle(Tag[Choice], v.map(Seq[T](_))) {
+    def run[A, S](v: A < (Choice & S))(using Frame): Seq[A] < S =
+        Effect.handle(Tag[Choice], v.map(Seq[A](_))) {
             [C] =>
                 (input, cont) =>
                     Kyo.seq.map(input)(v => Choice.run(cont(v))).map(_.flatten.flatten)

--- a/kyo-prelude/shared/src/main/scala/kyo2/Env.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Env.scala
@@ -15,23 +15,25 @@ object Env:
     inline def get[R](using inline tag: Tag[R])(using inline frame: Frame): R < Env[R] =
         use[R](identity)
 
-    def run[R >: Nothing: Tag, T, S, VR](env: R)(v: T < (Env[R & VR] & S))(
+    def run[R >: Nothing: Tag, A, S, VR](env: R)(v: A < (Env[R & VR] & S))(
         using
         reduce: Reducible[Env[VR]],
         frame: Frame
-    ): T < (S & reduce.SReduced) =
+    ): A < (S & reduce.SReduced) =
         runTypeMap(TypeMap(env))(v)
 
-    def runTypeMap[R >: Nothing, T, S, VR](env: TypeMap[R])(v: T < (Env[R & VR] & S))(
+    def runTypeMap[R >: Nothing, A, S, VR](env: TypeMap[R])(v: A < (Env[R & VR] & S))(
         using
         reduce: Reducible[Env[VR]],
         frame: Frame
-    ): T < (S & reduce.SReduced) =
-        reduce(ContextEffect.handle(erasedTag[R], env, _.union(env))(v): T < (Env[VR] & S))
+    ): A < (S & reduce.SReduced) =
+        reduce(ContextEffect.handle(erasedTag[R], env, _.union(env))(v): A < (Env[VR] & S))
 
     final class UseOps[R >: Nothing](dummy: Unit) extends AnyVal:
         inline def apply[A, S](inline f: R => A < S)(
-            using tag: Tag[R]
+            using
+            inline tag: Tag[R],
+            inline frame: Frame
         ): A < (Env[R] & S) =
             ContextEffect.suspendMap(erasedTag[R]) { map =>
                 f(map.asInstanceOf[TypeMap[R]].get(using tag))

--- a/kyo-prelude/shared/src/main/scala/kyo2/Local.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Local.scala
@@ -3,35 +3,34 @@ package kyo2
 import kyo.Tag
 import kyo2.kernel.*
 
-abstract class Local[T]:
+abstract class Local[A]:
 
     import Local.State
 
-    val default: T
+    val default: A
 
-    def get(using Frame): T < Any =
-        ContextEffect.suspendMap(Tag[Local.State], Map.empty)(_.getOrElse(this, default).asInstanceOf[T])
+    def get(using Frame): A < Any =
+        ContextEffect.suspendMap(Tag[Local.State], Map.empty)(_.getOrElse(this, default).asInstanceOf[A])
 
-    // TODO Compilation error if inlined
-    def use[U, S](f: T => U < S)(using Frame): U < S =
-        ContextEffect.suspendMap(Tag[Local.State], Map.empty)(map => f(map.getOrElse(this, default).asInstanceOf[T]))
+    def use[B, S](f: A => B < S)(using Frame): B < S =
+        ContextEffect.suspendMap(Tag[Local.State], Map.empty)(map => f(map.getOrElse(this, default).asInstanceOf[A]))
 
-    def let[U, S](value: T)(v: U < S)(using Frame): U < S =
+    def let[B, S](value: A)(v: B < S)(using Frame): B < S =
         ContextEffect.handle(Tag[Local.State], Map(this -> value), _.updated(this, value.asInstanceOf[AnyRef]))(v)
 
-    def update[U, S](f: T => T)(v: U < S)(using Frame): U < S =
+    def update[B, S](f: A => A)(v: B < S)(using Frame): B < S =
         ContextEffect.handle(
             Tag[Local.State],
             Map(this -> f(default)),
-            map => map.updated(this, f(map.getOrElse(this, default).asInstanceOf[T]).asInstanceOf[AnyRef])
+            map => map.updated(this, f(map.getOrElse(this, default).asInstanceOf[A]).asInstanceOf[AnyRef])
         )(v)
 end Local
 
 object Local:
 
-    inline def init[T](inline defaultValue: T): Local[T] =
-        new Local[T]:
-            val default: T = defaultValue
+    inline def init[A](inline defaultValue: A): Local[A] =
+        new Local[A]:
+            val default: A = defaultValue
 
     sealed private trait State extends ContextEffect[Map[Local[?], AnyRef]]
 end Local

--- a/kyo-prelude/shared/src/main/scala/kyo2/Result.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Result.scala
@@ -30,6 +30,9 @@ object Result:
     inline def fail[E, A](inline error: E): Result[E, A]              = Fail(error)
     inline def panic[E, A](inline exception: Throwable): Result[E, A] = Panic(exception)
 
+    private val _unit            = Success(())
+    def unit[E]: Result[E, Unit] = _unit
+
     def fromEither[E, A](either: Either[E, A]): Result[E, A] =
         either.fold(fail, success)
 

--- a/kyo-prelude/shared/src/main/scala/kyo2/Sum.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Sum.scala
@@ -12,11 +12,11 @@ object Sum:
         Effect.suspend[Any](tag, v)
 
     final class RunOps[V](dummy: Unit) extends AnyVal:
-        def apply[T, S](v: T < (Sum[V] & S))(
+        def apply[A, S](v: A < (Sum[V] & S))(
             using
             tag: Tag[Sum[V]],
             frame: Frame
-        ): (Chunk[V], T) < S =
+        ): (Chunk[V], A) < S =
             Effect.handle.state(tag, Chunk.empty[V], v)(
                 handle = [C] => (input, state, cont) => (state.append(input), cont(())),
                 done = (state, res) => (state, res)

--- a/kyo-prelude/shared/src/main/scala/kyo2/TypeMap.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/TypeMap.scala
@@ -9,7 +9,7 @@ opaque type TypeMap[+A] = HashMap[Tag[Any], Any]
 object TypeMap:
     extension [A](self: TypeMap[A])
 
-        private inline def fatal[T](using t: Tag[T]): Nothing =
+        private inline def fatal[B](using t: Tag[B]): Nothing =
             throw new RuntimeException(s"fatal: kyo.TypeMap of contents [${self.show}] missing value of type: [${t.showTpe}].")
 
         def get[B >: A](using t: Tag[B]): B =
@@ -48,7 +48,7 @@ object TypeMap:
 
         private[kyo2] inline def tag: Intersection[?] = Intersection(self.keySet.toIndexedSeq)
 
-        private[kyo2] inline def <:<[T](tag: Tag[T]): Boolean =
+        private[kyo2] inline def <:<[B](tag: Tag[B]): Boolean =
             self.keySet.exists(_ <:< tag)
     end extension
 

--- a/kyo-prelude/shared/src/main/scala/kyo2/internal/BaseKyoTest.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/internal/BaseKyoTest.scala
@@ -35,8 +35,8 @@ trait BaseKyoTest[S]:
         else
             Future.successful(success)
 
-    given tryCanEqual[T]: CanEqual[Try[T], Try[T]]                   = CanEqual.derived
-    given eitherCanEqual[T, U]: CanEqual[Either[T, U], Either[T, U]] = CanEqual.derived
+    given tryCanEqual[A]: CanEqual[Try[A], Try[A]]                   = CanEqual.derived
+    given eitherCanEqual[A, B]: CanEqual[Either[A, B], Either[A, B]] = CanEqual.derived
     given throwableCanEqual: CanEqual[Throwable, Throwable]          = CanEqual.derived
 
     def untilTrue[S](f: => Boolean < S): Boolean < S =

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/ContextEffect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/ContextEffect.scala
@@ -10,20 +10,20 @@ abstract class ContextEffect[+A]
 
 object ContextEffect:
 
-    inline def suspend[A, E <: ContextEffect[A]](inline tag: Tag[E]): A < E =
+    inline def suspend[A, E <: ContextEffect[A]](inline tag: Tag[E])(using inline frame: Frame): A < E =
         suspendMap(tag)(identity)
 
     inline def suspendMap[A, E <: ContextEffect[A], B, S](
         inline tag: Tag[E]
     )(
         inline f: Safepoint ?=> A => B < S
-    ): B < (E & S) =
+    )(using inline frame: Frame): B < (E & S) =
         suspendMap(tag, bug("Unexpected pending context effect: " + tag.show))(f)
 
     inline def suspend[A, E <: ContextEffect[A]](
         inline tag: Tag[E],
         inline default: => A
-    ): A < Any =
+    )(using inline frame: Frame): A < Any =
         suspendMap(tag, default)(identity)
 
     inline def suspendMap[A, E <: ContextEffect[A], B, S](

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
@@ -159,16 +159,16 @@ object Effect:
             handle3Loop(v, Context.empty)
         end apply
 
-        inline def state[I[_], O[_], E <: Effect[I, O], State, A, U, S, S2](
+        inline def state[I[_], O[_], E <: Effect[I, O], State, A, B, S, S2](
             inline tag: Tag[E],
             inline state: State,
             v: A < (E & S)
         )(
             inline handle: Safepoint ?=> [C] => (I[C], State, O[C] => A < (E & S & S2)) => (State, A < (E & S & S2)),
-            inline done: (State, A) => U < (S & S2) = (_: State, v: A) => v,
+            inline done: (State, A) => B < (S & S2) = (_: State, v: A) => v,
             inline accept: [C] => I[C] => Boolean = [C] => (v: I[C]) => true
-        )(using inline _frame: Frame, safepoint: Safepoint): U < (S & S2) =
-            def handleLoop(state: State, v: A < (E & S & S2), context: Context)(using Safepoint): U < (S & S2) =
+        )(using inline _frame: Frame, safepoint: Safepoint): B < (S & S2) =
+            def handleLoop(state: State, v: A < (E & S & S2), context: Context)(using Safepoint): B < (S & S2) =
                 v match
                     case <(kyo: KyoSuspend[I, O, E, Any, A, E & S & S2] @unchecked) if tag =:= kyo.tag && accept(kyo.input) =>
                         Safepoint.handle(kyo.input)(
@@ -178,7 +178,7 @@ object Effect:
                                 handleLoop(nst, res, context)
                         )
                     case <(kyo: KyoSuspend[IX, OX, EX, Any, A, E & S & S2] @unchecked) =>
-                        new KyoContinue[IX, OX, EX, Any, U, S & S2](kyo):
+                        new KyoContinue[IX, OX, EX, Any, B, S & S2](kyo):
                             def frame = _frame
                             def apply(v: OX[Any], context: Context)(using Safepoint) =
                                 handleLoop(state, kyo(v, context), context)

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Safepoint.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Safepoint.scala
@@ -102,7 +102,7 @@ object Safepoint:
         lazy val f0 = f
         val ensure  = () => f0
 
-        inline def run[T](inline thunk: => T)(using safepoint: Safepoint): T =
+        inline def run[A](inline thunk: => A)(using safepoint: Safepoint): A =
             val interceptor = safepoint.interceptor
             if !isNull(interceptor) then interceptor.addEnsure(ensure)
             try thunk
@@ -128,9 +128,9 @@ object Safepoint:
         run(loop(v))
     end ensure
 
-    private[kernel] inline def eval[T](
-        inline f: => T
-    )(using inline frame: Frame): T =
+    private[kernel] inline def eval[A](
+        inline f: => A
+    )(using inline frame: Frame): A =
         val parent = Safepoint.local.get()
         val self   = new Safepoint(0, parent.interceptor, State.empty)
         Safepoint.local.set(self)

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/package.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/package.scala
@@ -6,7 +6,7 @@ import scala.collection.immutable
 package object kernel:
 
     type Id[A]    = A
-    type Const[A] = [U] =>> A
+    type Const[A] = [B] =>> A
 
     enum Mode derives CanEqual:
         case Development, Staging, Production
@@ -22,28 +22,28 @@ package object kernel:
 
         sealed trait Defer extends Effect[Const[Unit], Const[Unit]]
 
-        sealed abstract class Kyo[+T, -S]
+        sealed abstract class Kyo[+A, -S]
 
-        abstract class KyoSuspend[I[_], O[_], E <: Effect[I, O], A, U, S]
-            extends Kyo[U, S]:
+        abstract class KyoSuspend[I[_], O[_], E <: Effect[I, O], A, B, S]
+            extends Kyo[B, S]:
             def tag: Tag[E]
             def input: I[A]
             def frame: Frame
 
-            def apply(v: O[A], context: Context)(using Safepoint): U < S
+            def apply(v: O[A], context: Context)(using Safepoint): B < S
 
             final override def toString =
                 val parsed = frame.parse
                 s"Kyo(${tag.show}, Input($input), ${parsed.position}, ${parsed.snippetShort})"
         end KyoSuspend
 
-        abstract class KyoContinue[I[_], O[_], E <: Effect[I, O], A, U, S](kyo: KyoSuspend[I, O, E, A, ?, ?])
-            extends KyoSuspend[I, O, E, A, U, S]:
+        abstract class KyoContinue[I[_], O[_], E <: Effect[I, O], A, B, S](kyo: KyoSuspend[I, O, E, A, ?, ?])
+            extends KyoSuspend[I, O, E, A, B, S]:
             val tag   = kyo.tag
             val input = kyo.input
         end KyoContinue
 
-        abstract class KyoDefer[T, S] extends KyoSuspend[Const[Unit], Const[Unit], Defer, Any, T, S]:
+        abstract class KyoDefer[A, S] extends KyoSuspend[Const[Unit], Const[Unit], Defer, Any, A, S]:
             final def tag   = Tag[Defer]
             final def input = ()
 

--- a/kyo-prelude/shared/src/main/scala/kyo2/package.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/package.scala
@@ -9,10 +9,10 @@ private[kyo2] inline def Frame = kernel.Frame
 export kernel.<
 export kernel.Loop
 
-private[kyo2] inline def isNull[T](v: T): Boolean =
+private[kyo2] inline def isNull[A](v: A): Boolean =
     v.asInstanceOf[AnyRef] eq null
 
-private[kyo2] inline def discard[T](v: T): Unit =
+private[kyo2] inline def discard[A](v: A): Unit =
     val _ = v
     ()
 
@@ -20,9 +20,9 @@ private[kyo2] object bug:
 
     case class KyoBugException(msg: String) extends Exception(msg)
 
-    def failTag[T, U, S](
-        kyo: T < S,
-        expected: Tag.Full[U]
+    def failTag[A, B, S](
+        kyo: A < S,
+        expected: Tag.Full[B]
     ): Nothing =
         bug(s"Unexpected pending effect while handling ${expected.show}: " + kyo)
 

--- a/kyo-prelude/shared/src/test/scala/kyo2/KyoTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/KyoTest.scala
@@ -9,7 +9,7 @@ class KyoTest extends Test:
 
     "toString JVM" taggedAs jvmOnly in run {
         assert(Env.use[Int](_ + 1).toString() ==
-            "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(()), KyoTest.scala:11:16, assert(Env.use[Int](_ + 1)))")
+            "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(()), KyoTest.scala:11:35, assert(Env.use[Int](_ + 1)))")
         assert(
             Env.get[Int].map(_ + 1).toString() ==
                 "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(()), KyoTest.scala:14:36, Env.get[Int].map(_ + 1)))"
@@ -18,7 +18,7 @@ class KyoTest extends Test:
 
     "toString JS" taggedAs jsOnly in run {
         assert(Env.use[Int](_ + 1).toString() ==
-            "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(undefined), KyoTest.scala:20:16, assert(Env.use[Int](_ + 1)))")
+            "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(undefined), KyoTest.scala:20:35, assert(Env.use[Int](_ + 1)))")
         assert(
             Env.get[Int].map(_ + 1).toString() ==
                 "<(Kyo(Tag[kyo2.kernel.package$.internal$.Defer], Input(undefined), KyoTest.scala:23:36, Env.get[Int].map(_ + 1)))"
@@ -51,7 +51,7 @@ class KyoTest extends Test:
     }
 
     "flatten" in {
-        def test[T](v: T)                = Env.use[Int](_ => v)
+        def test[A](v: A)                = Env.use[Int](_ => v)
         val a: Int < Env[Int] < Env[Int] = test(Env.get[Int])
         val b: Int < Env[Int]            = a.flatten
         assert(Env.run(1)(b).eval == 1)
@@ -72,9 +72,9 @@ class KyoTest extends Test:
     }
 
     "nested" - {
-        def lift[T](v: T): T < Env[Unit]                                = Env.use[Unit](_ => v)
+        def lift[A](v: A): A < Env[Unit]                                = Env.use[Unit](_ => v)
         def add(v: Int < Env[Unit])                                     = v.map(_ + 1)
-        def transform[T, U](v: T < Env[Unit], f: T => U): U < Env[Unit] = v.map(f(_))
+        def transform[A, B](v: A < Env[Unit], f: A => B): B < Env[Unit] = v.map(f(_))
         val io: Int < Env[Unit] < Env[Unit]                             = lift(lift(1))
         "map + flatten" in {
             val a: Int < Env[Unit] < Env[Unit] =

--- a/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ResultTest.scala
@@ -27,6 +27,10 @@ class ResultTest extends Test:
         }
     }
 
+    "unit" in {
+        assert(Result.unit == Result.success(()))
+    }
+
     "fromTry" - {
         "should return Success for successful Try" in {
             val tryValue = scala.util.Try(5)

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/TraceTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/TraceTest.scala
@@ -90,7 +90,7 @@ class TraceTest extends Test:
         }
     }
 
-    def assertTrace[T](f: => T, expected: String) =
+    def assertTrace[A](f: => A, expected: String) =
         try
             f
             fail()


### PR DESCRIPTION
- Updates all generics to the new naming strategy
- Adds missing `Frame` implicits
- Introduces convenience `Result.unit` method.