### PR TITLE
Lazily initialize `default` in `Local`

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo2/Local.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Local.scala
@@ -7,18 +7,18 @@ abstract class Local[A]:
 
     import Local.State
 
-    val default: A
+    lazy val default: A
 
-    def get(using Frame): A < Any =
+    final def get(using Frame): A < Any =
         ContextEffect.suspendMap(Tag[Local.State], Map.empty)(_.getOrElse(this, default).asInstanceOf[A])
 
-    def use[B, S](f: A => B < S)(using Frame): B < S =
+    final def use[B, S](f: A => B < S)(using Frame): B < S =
         ContextEffect.suspendMap(Tag[Local.State], Map.empty)(map => f(map.getOrElse(this, default).asInstanceOf[A]))
 
-    def let[B, S](value: A)(v: B < S)(using Frame): B < S =
+    final def let[B, S](value: A)(v: B < S)(using Frame): B < S =
         ContextEffect.handle(Tag[Local.State], Map(this -> value), _.updated(this, value.asInstanceOf[AnyRef]))(v)
 
-    def update[B, S](f: A => A)(v: B < S)(using Frame): B < S =
+    final def update[B, S](f: A => A)(v: B < S)(using Frame): B < S =
         ContextEffect.handle(
             Tag[Local.State],
             Map(this -> f(default)),
@@ -30,7 +30,7 @@ object Local:
 
     inline def init[A](inline defaultValue: A): Local[A] =
         new Local[A]:
-            val default: A = defaultValue
+            lazy val default: A = defaultValue
 
     sealed private trait State extends ContextEffect[Map[Local[?], AnyRef]]
 end Local

--- a/kyo-prelude/shared/src/test/scala/kyo2/LocalTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/LocalTest.scala
@@ -35,6 +35,17 @@ class LocalTest extends Test:
                 Kyo.zip(l1.get, l2.get).eval == (10, 20)
             )
         }
+        "lazy" in {
+            var invoked = 0
+            def default =
+                invoked += 1
+                10
+            val l = Local.init(default)
+            assert(invoked == 0)
+            assert(l.default == 10)
+            assert(l.default == 10)
+            assert(invoked == 1)
+        }
     }
 
     "let" - {


### PR DESCRIPTION
When working with KyoApp locally, I noticed that SLF4J was being initialized even when I was providing a Local value to override it from the very start. This should prevent that behavior at some cost to the first access.

@fwbrasil if you prefer, I can create an `initLazy`.