### PR TITLE
prelude: lift pure functions

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo2/Layer.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Layer.scala
@@ -49,19 +49,6 @@ object Layer:
             Kyo.zip(Env.get[A], Env.get[B], Env.get[C], Env.get[D]).map { case (a, b, c, d) => f(a, b, c, d) }
         }
 
-    @targetName("fromPure1")
-    inline def from[A: Tag, B: Tag](inline f: A => B): Layer[B, Env[A]] =
-        from[A, B, Any](f(_))
-    @targetName("fromPure2")
-    inline def from[A: Tag, B: Tag, C: Tag](inline f: (A, B) => C): Layer[C, Env[A & B]] =
-        from[A, B, C, Any](f(_, _))
-    @targetName("fromPure3")
-    inline def from[A: Tag, B: Tag, C: Tag, D: Tag](inline f: (A, B, C) => D): Layer[D, Env[A & B & C]] =
-        from[A, B, C, D, Any](f(_, _, _))
-    @targetName("fromPure4")
-    inline def from[A: Tag, B: Tag, C: Tag, D: Tag, E: Tag](inline f: (A, B, C, D) => E): Layer[E, Env[A & B & C & D]] =
-        from[A, B, C, D, E, Any](f(_, _, _, _))
-
     transparent inline def init[Target](inline layers: Layer[?, ?]*): Layer[Target, ?] =
         kyo2.internal.LayerMacros.make[Target](layers*)
 

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Pending.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Pending.scala
@@ -14,7 +14,28 @@ object `<`:
 
     implicit private[kyo2] inline def apply[A, S](p: Kyo[A, S]): A < S = new <(p)
 
-    implicit inline def lift[A, S](v: A)(using inline ng: NotGiven[A <:< (Any < Nothing)]): A < S = <(v)
+    implicit inline def lift[A, S](v: A)(using inline ng: NotGiven[A <:< (Any < Nothing)]): A < S =
+        <(v)
+
+    implicit inline def liftPureFunction1[A1, B](inline f: A1 => B)(
+        using inline ng: NotGiven[B <:< (Any < Nothing)]
+    ): A1 => B < Any =
+        a1 => f(a1)
+
+    implicit inline def liftPureFunction2[A1, A2, B](inline f: (A1, A2) => B)(
+        using inline ng: NotGiven[B <:< (Any < Nothing)]
+    ): (A1, A2) => B < Any =
+        (a1, a2) => f(a1, a2)
+
+    implicit inline def liftPureFunction3[A1, A2, A3, B](inline f: (A1, A2, A3) => B)(
+        using inline ng: NotGiven[B <:< (Any < Nothing)]
+    ): (A1, A2, A3) => B < Any =
+        (a1, a2, a3) => f(a1, a2, a3)
+
+    implicit inline def liftPureFunction4[A1, A2, A3, A4, B](inline f: (A1, A2, A3, A4) => B)(
+        using inline ng: NotGiven[B <:< (Any < Nothing)]
+    ): (A1, A2, A3, A4) => B < Any =
+        (a1, a2, a3, a4) => f(a1, a2, a3, a4)
 
     extension [A, S](inline v: A < S)
 

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/PendingTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/PendingTest.scala
@@ -89,6 +89,55 @@ class PendingTest extends Test:
                 assertDoesNotCompile("val _: Int < Any < Any = (1: Int < Any)")
             }
         }
+
+        "functions" - {
+            "one param" in {
+                val f: Int => String =
+                    _.toString
+                val lifted: Int => String < Any = f
+                assert(lifted(42).eval == "42")
+            }
+
+            "two params" in {
+                val f: (Int, Int) => String =
+                    (a, b) => (a + b).toString
+                val lifted: (Int, Int) => String < Any = f
+                assert(lifted(20, 22).eval == "42")
+            }
+
+            "three params" in {
+                val f: (Int, Int, Int) => String =
+                    (a, b, c) => (a + b + c).toString
+                val lifted: (Int, Int, Int) => String < Any = f
+                assert(lifted(10, 20, 12).eval == "42")
+            }
+
+            "four params" in {
+                val f: (Int, Int, Int, Int) => String =
+                    (a, b, c, d) => (a + b + c + d).toString
+                val lifted: (Int, Int, Int, Int) => String < Any = f
+                assert(lifted(10, 20, 10, 2).eval == "42")
+            }
+
+            "doesn't lift nested computations" in {
+                val f1: Int => String < Any                  = (_) => "test"
+                val f2: (Int, Int) => String < Any           = (_, _) => "test"
+                val f3: (Int, Int, Int) => String < Any      = (_, _, _) => "test"
+                val f4: (Int, Int, Int, Int) => String < Any = (_, _, _, _) => "test"
+                assertDoesNotCompile("""
+                    val _: Int => String < Any < Any = f1
+                """)
+                assertDoesNotCompile("""
+                    val _: (Int, Int) => String < Any < Any = f2
+                """)
+                assertDoesNotCompile("""
+                    val _: (Int, Int, Int) => String < Any < Any = f3
+                """)
+                assertDoesNotCompile("""
+                    val _: (Int, Int, Int, Int) => String < Any < Any = f4
+                """)
+            }
+        }
     }
 
     sealed trait TestEffect extends Effect[Const[Int], Const[Int]]


### PR DESCRIPTION
I'm noticing more scenarios where pure functions fail compile when passed to methods that take effectful functions while porting `kyo-core`. This PR introduces implicit conversions for pure functions with up to four parameters.