### PR TITLE
state benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -361,6 +361,7 @@ lazy val `kyo-bench` =
             libraryDependencies += "org.typelevel"       %% "cats-effect"         % "3.5.4",
             libraryDependencies += "org.typelevel"       %% "log4cats-core"       % "2.7.0",
             libraryDependencies += "org.typelevel"       %% "log4cats-slf4j"      % "2.7.0",
+            libraryDependencies += "org.typelevel"       %% "cats-mtl"            % "1.4.0",
             libraryDependencies += "dev.zio"             %% "zio-logging"         % "2.3.0",
             libraryDependencies += "dev.zio"             %% "zio-logging-slf4j2"  % "2.3.0",
             libraryDependencies += "dev.zio"             %% "zio"                 % zioVersion,

--- a/kyo-bench/src/main/scala/kyo/bench/StateBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/StateBench.scala
@@ -1,0 +1,51 @@
+package kyo.bench
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class StateBench extends Bench.SyncAndFork(0):
+
+    val n = 1000
+
+    def catsBench() =
+        import cats.*
+        import cats.effect.*
+        import cats.mtl.*
+        import cats.implicits.*
+        import cats.data.*
+
+        def program[F[_]: Monad](using S: Stateful[F, Int]): F[Int] =
+            S.get.flatMap { n =>
+                if n <= 0
+                then n.pure
+                else S.set(n - 1).flatMap(_ => program)
+            }
+
+        program[StateT[IO, Int, *]].run(n).map(_._2)
+    end catsBench
+
+    def kyoBench() =
+        import kyo.*
+
+        def program: Int < Vars[Int] =
+            Vars.use[Int] { n =>
+                if n <= 0
+                then n
+                else Vars.set(n - 1).flatMap(_ => program)
+            }
+
+        Vars.run(n)(program)
+    end kyoBench
+
+    def zioBench() =
+        import zio.*
+
+        def program: ZIO[ZState[Int], Nothing, Int] =
+            ZIO.getState[Int].flatMap { n =>
+                if n <= 0
+                then ZIO.succeed(n)
+                else ZIO.setState(n - 1).flatMap(_ => program)
+            }
+
+        ZIO.stateful(n)(program)
+    end zioBench
+end StateBench

--- a/kyo-bench/src/main/scala/kyo/bench/StateMapBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/StateMapBench.scala
@@ -1,0 +1,51 @@
+package kyo.bench
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class StateMapBench extends Bench.SyncAndFork(1000):
+
+    val n = 1000
+
+    def catsBench() =
+        import cats.*
+        import cats.effect.*
+        import cats.mtl.*
+        import cats.implicits.*
+        import cats.data.*
+
+        def program[F[_]: Monad](using S: Stateful[F, Int]): F[Int] =
+            S.get.flatMap { n =>
+                if n <= 0
+                then n.pure
+                else S.set(n - 1).flatMap(_ => program).map(_ + 1)
+            }
+
+        program[StateT[IO, Int, *]].run(n).map(_._2)
+    end catsBench
+
+    def kyoBench() =
+        import kyo.*
+
+        def program: Int < Vars[Int] =
+            Vars.use[Int] { n =>
+                if n <= 0
+                then n
+                else Vars.set(n - 1).flatMap(_ => program).map(_ + 1)
+            }
+
+        Vars.run(n)(program)
+    end kyoBench
+
+    def zioBench() =
+        import zio.*
+
+        def program: ZIO[ZState[Int], Nothing, Int] =
+            ZIO.getState[Int].flatMap { n =>
+                if n <= 0
+                then ZIO.succeed(n)
+                else ZIO.setState(n - 1).flatMap(_ => program).map(_ + 1)
+            }
+
+        ZIO.stateful(n)(program)
+    end zioBench
+end StateMapBench


### PR DESCRIPTION
These benchmarks reproduce the issue reported in #531 and are inspired in the implementations in https://github.com/marcinzh/effect-zoo. Kyo's performance is ahead for the regular use of `Var` but the scenario with an additional `map` after the recursion shows a performance issue. This behavior is due to Kyo's encoding of effect suspension, which introduces more overhead due to the large number of suspensions that have to accumulate the `map` transformation. The scenario seems atypical but it can be useful to uncover new optimizations.

[Benchmark results](https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fwbrasil/089284da94a4d5024392548d31e2446f/raw/5d3b7e4076898d3852f703cc7663f5a432773c1d/jmh-result.json):

<img width="656" alt="image" src="https://github.com/getkyo/kyo/assets/831175/da5ad677-f97d-4001-ba72-77cfaab0ca80">
