### PR TITLE
prelude: Var improvements

### DIFF
--- a/kyo-prelude/jvm/src/test/scala/kyo2/MonadLawsTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo2/MonadLawsTest.scala
@@ -29,7 +29,7 @@ object MonadLawsTest extends ZIOSpecDefault:
                         Emit(i).unit.andThen(v)
                     ),
                     gen.zip(boolGen).map((v, b) =>
-                        Var.setUnit(b).andThen(v)
+                        Var.setDiscard(b).andThen(v)
                     ),
                     gen.zip(stringGen).map((v, s) =>
                         Env.use[String](_ => ()).andThen(v)

--- a/kyo-prelude/jvm/src/test/scala/kyo2/MonadLawsTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo2/MonadLawsTest.scala
@@ -29,7 +29,7 @@ object MonadLawsTest extends ZIOSpecDefault:
                         Emit(i).unit.andThen(v)
                     ),
                     gen.zip(boolGen).map((v, b) =>
-                        Var.set(b).andThen(v)
+                        Var.setUnit(b).andThen(v)
                     ),
                     gen.zip(stringGen).map((v, s) =>
                         Env.use[String](_ => ()).andThen(v)

--- a/kyo-prelude/shared/src/main/scala/kyo2/Var.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Var.scala
@@ -4,29 +4,41 @@ import Var.internal.*
 import kyo.Tag
 import kyo2.kernel.*
 
-sealed trait Var[V] extends Effect[Input[V, *], Id]
+sealed trait Var[V] extends Effect[Const[Op[V]], Const[V]]
 
 object Var:
 
+    /** Obtains the current value of the 'Var'. */
     inline def get[V](using inline tag: Tag[Var[V]], inline frame: Frame): V < Var[V] =
         use[V](identity)
 
     final class UseOps[V](dummy: Unit) extends AnyVal:
+        /** Invokes the provided function with the current value of the `Var`. */
         inline def apply[A, S](inline f: V => A < S)(
             using
             inline tag: Tag[Var[V]],
             inline frame: Frame
         ): A < (Var[V] & S) =
-            Effect.suspendMap[V](tag, internal.get[V])(f)
+            Effect.suspendMap[V](tag, Get: Op[V])(f)
     end UseOps
 
     inline def use[V]: UseOps[V] = UseOps(())
 
-    inline def set[V](inline value: V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
-        Effect.suspend[Unit](tag, (() => value): Set[V])
+    /** Sets a new value and returns the previous one. */
+    inline def set[V](inline value: V)(using inline tag: Tag[Var[V]], inline frame: Frame): V < Var[V] =
+        Effect.suspend[Unit](tag, value: Op[V])
 
+    /** Sets a new value and returns `Unit`. */
+    inline def setUnit[V](inline value: V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
+        Effect.suspendMap[Unit](tag, value: Op[V])(_ => ())
+
+    /** Applies the update function and returns the new value. */
     inline def update[V](inline f: V => V)(using inline tag: Tag[Var[V]], inline frame: Frame): V < Var[V] =
         Effect.suspend[V](tag, (v => f(v)): Update[V])
+
+    /** Applies the update function and returns `Unit`. */
+    inline def updateUnit[V](inline f: V => V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
+        Effect.suspendMap[Unit](tag, (v => f(v)): Update[V])(_ => ())
 
     private inline def runWith[V, A, S, B, S2](state: V)(v: A < (Var[V] & S))(
         inline f: (V, A) => B < S2
@@ -35,31 +47,30 @@ object Var:
             [C] =>
                 (input, state, cont) =>
                     input match
-                        case input: Get[?] =>
+                        case input: Get =>
                             (state, cont(state))
-                        case input: Set[?] =>
-                            (input(), cont(()))
-                        case input: Update[?] =>
+                        case input: Update[V] @unchecked =>
                             val nst = input(state)
-                            (nst, cont(nst)),
+                            (nst, cont(nst))
+                        case input: V @unchecked =>
+                            (input, cont(state)),
             done = f
         )
 
+    /** Handles the effect and discards the 'Var' state. */
     def run[V, A, S](state: V)(v: A < (Var[V] & S))(using Tag[Var[V]], Frame): A < S =
         runWith(state)(v)((_, result) => result)
 
+    /** Handles the effect and returns a tuple with the final `Var` state and the computation's result. */
     def runTuple[V, A, S](state: V)(v: A < (Var[V] & S))(using Tag[Var[V]], Frame): (V, A) < S =
         runWith(state)(v)((state, result) => (state, result))
 
     object internal:
-        sealed trait Input[V, X]
-        case class Get[V]() extends Input[V, V]
-        abstract class Set[V] extends Input[V, Unit]:
-            def apply(): V
-        abstract class Update[V] extends Input[V, V]:
+        type Op[V] = Get | V | Update[V]
+        class Get
+        object Get extends Get
+        abstract class Update[V]:
             def apply(v: V): V
-        private val _get = Get[Any]()
-        def get[V]       = _get.asInstanceOf[Get[V]]
     end internal
 
 end Var

--- a/kyo-prelude/shared/src/main/scala/kyo2/Var.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Var.scala
@@ -47,7 +47,7 @@ object Var:
             [C] =>
                 (input, state, cont) =>
                     input match
-                        case input: Get =>
+                        case input: Get.type =>
                             (state, cont(state))
                         case input: Update[V] @unchecked =>
                             val nst = input(state)
@@ -66,9 +66,8 @@ object Var:
         runWith(state)(v)((state, result) => (state, result))
 
     object internal:
-        type Op[V] = Get | V | Update[V]
-        class Get
-        object Get extends Get
+        type Op[V] = Get.type | V | Update[V]
+        object Get
         abstract class Update[V]:
             def apply(v: V): V
     end internal

--- a/kyo-prelude/shared/src/main/scala/kyo2/Var.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Var.scala
@@ -29,7 +29,7 @@ object Var:
         Effect.suspend[Unit](tag, value: Op[V])
 
     /** Sets a new value and returns `Unit`. */
-    inline def setUnit[V](inline value: V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
+    inline def setDiscard[V](inline value: V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
         Effect.suspendMap[Unit](tag, value: Op[V])(_ => ())
 
     /** Applies the update function and returns the new value. */
@@ -37,7 +37,7 @@ object Var:
         Effect.suspend[V](tag, (v => f(v)): Update[V])
 
     /** Applies the update function and returns `Unit`. */
-    inline def updateUnit[V](inline f: V => V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
+    inline def updateDiscard[V](inline f: V => V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
         Effect.suspendMap[Unit](tag, (v => f(v)): Update[V])(_ => ())
 
     private inline def runWith[V, A, S, B, S2](state: V)(v: A < (Var[V] & S))(

--- a/kyo-prelude/shared/src/test/scala/kyo2/ChunkTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ChunkTest.scala
@@ -172,7 +172,7 @@ class ChunkTest extends Test:
                 kyo2.Abort.run[String] {
                     chunk.map { n =>
                         kyo2.Var.get[Int].map { multiplier =>
-                            if n % 2 == 0 then kyo2.Var.setUnit(multiplier * n).andThen(n * multiplier)
+                            if n % 2 == 0 then kyo2.Var.setDiscard(multiplier * n).andThen(n * multiplier)
                             else kyo2.Abort.fail("Odd number encountered")
                         }
                     }
@@ -215,7 +215,7 @@ class ChunkTest extends Test:
                     chunk.filter { n =>
                         kyo2.Var.get[Boolean].map { b =>
                             if b then
-                                if n % 2 == 0 then kyo2.Var.setUnit(false).andThen(true)
+                                if n % 2 == 0 then kyo2.Var.setDiscard(false).andThen(true)
                                 else false
                             else kyo2.Abort.fail(())
                         }
@@ -261,8 +261,8 @@ class ChunkTest extends Test:
                     chunk.foldLeft(1) { (acc, n) =>
                         kyo2.Var.get[Int].map { multiplier =>
                             kyo2.Env.get[String].map { op =>
-                                if op == "*" then kyo2.Var.setUnit(multiplier * n).andThen(acc * n)
-                                else if op == "+" then kyo2.Var.setUnit(multiplier + n).andThen(acc + n)
+                                if op == "*" then kyo2.Var.setDiscard(multiplier * n).andThen(acc * n)
+                                else if op == "+" then kyo2.Var.setDiscard(multiplier + n).andThen(acc + n)
                                 else acc
                             }
                         }
@@ -815,7 +815,7 @@ class ChunkTest extends Test:
                                 kyo2.Var.get[Int].map { multiplier =>
                                     kyo2.Env.get[Int].map { max =>
                                         if sum + n * multiplier <= max then
-                                            kyo2.Var.setUnit(multiplier * n).andThen(sum += n * multiplier)
+                                            kyo2.Var.setDiscard(multiplier * n).andThen(sum += n * multiplier)
                                         else kyo2.Abort.fail(s"Sum exceeded max value of $max")
                                     }
                                 }

--- a/kyo-prelude/shared/src/test/scala/kyo2/ChunkTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/ChunkTest.scala
@@ -172,7 +172,7 @@ class ChunkTest extends Test:
                 kyo2.Abort.run[String] {
                     chunk.map { n =>
                         kyo2.Var.get[Int].map { multiplier =>
-                            if n % 2 == 0 then kyo2.Var.set(multiplier * n).andThen(n * multiplier)
+                            if n % 2 == 0 then kyo2.Var.setUnit(multiplier * n).andThen(n * multiplier)
                             else kyo2.Abort.fail("Odd number encountered")
                         }
                     }
@@ -215,7 +215,7 @@ class ChunkTest extends Test:
                     chunk.filter { n =>
                         kyo2.Var.get[Boolean].map { b =>
                             if b then
-                                if n % 2 == 0 then kyo2.Var.set(false).andThen(true)
+                                if n % 2 == 0 then kyo2.Var.setUnit(false).andThen(true)
                                 else false
                             else kyo2.Abort.fail(())
                         }
@@ -261,8 +261,8 @@ class ChunkTest extends Test:
                     chunk.foldLeft(1) { (acc, n) =>
                         kyo2.Var.get[Int].map { multiplier =>
                             kyo2.Env.get[String].map { op =>
-                                if op == "*" then kyo2.Var.set(multiplier * n).andThen(acc * n)
-                                else if op == "+" then kyo2.Var.set(multiplier + n).andThen(acc + n)
+                                if op == "*" then kyo2.Var.setUnit(multiplier * n).andThen(acc * n)
+                                else if op == "+" then kyo2.Var.setUnit(multiplier + n).andThen(acc + n)
                                 else acc
                             }
                         }
@@ -815,7 +815,7 @@ class ChunkTest extends Test:
                                 kyo2.Var.get[Int].map { multiplier =>
                                     kyo2.Env.get[Int].map { max =>
                                         if sum + n * multiplier <= max then
-                                            kyo2.Var.set(multiplier * n).andThen(sum += n * multiplier)
+                                            kyo2.Var.setUnit(multiplier * n).andThen(sum += n * multiplier)
                                         else kyo2.Abort.fail(s"Sum exceeded max value of $max")
                                     }
                                 }

--- a/kyo-prelude/shared/src/test/scala/kyo2/VarTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/VarTest.scala
@@ -3,77 +3,77 @@ package kyo2
 class VarTest extends Test:
 
     "get" in {
-        val r = kyo2.Var.run(1)(kyo2.Var.get[Int].map(_ + 1)).eval
+        val r = Var.run(1)(Var.get[Int].map(_ + 1)).eval
         assert(r == 2)
     }
 
     "use" in {
-        val r = kyo2.Var.run(1)(kyo2.Var.use[Int](_ + 1)).eval
+        val r = Var.run(1)(Var.use[Int](_ + 1)).eval
         assert(r == 2)
     }
 
     "setUnit, get" in {
-        val r = kyo2.Var.run(1)(kyo2.Var.setDiscard(2).andThen(kyo2.Var.get[Int])).eval
+        val r = Var.run(1)(Var.setDiscard(2).andThen(Var.get[Int])).eval
         assert(r == 2)
     }
 
     "set, get" in {
-        val r = kyo2.Var.run(1)(kyo2.Var.set(2)).eval
+        val r = Var.run(1)(Var.set(2)).eval
         assert(r == 1)
     }
 
     "get, setUnit, get" in {
-        val r = kyo2.Var.run(1)(
-            kyo2.Var.get[Int].map(i => kyo2.Var.setDiscard[Int](i + 1)).andThen(kyo2.Var.get[Int])
+        val r = Var.run(1)(
+            Var.get[Int].map(i => Var.setDiscard[Int](i + 1)).andThen(Var.get[Int])
         ).eval
         assert(r == 2)
     }
 
     "get, set" in {
-        val r = kyo2.Var.run(1)(
-            kyo2.Var.get[Int].map(i => kyo2.Var.set[Int](i + 1))
+        val r = Var.run(1)(
+            Var.get[Int].map(i => Var.set[Int](i + 1))
         ).eval
         assert(r == 1)
     }
 
     "update" in {
-        val r = kyo2.Var.run(1)(kyo2.Var.update[Int](_ + 1)).eval
+        val r = Var.run(1)(Var.update[Int](_ + 1)).eval
         assert(r == 2)
     }
 
     "updateUnit" in {
-        val r = kyo2.Var.run(1)(kyo2.Var.updateDiscard[Int](_ + 1).andThen(Var.get[Int])).eval
+        val r = Var.run(1)(Var.updateDiscard[Int](_ + 1).andThen(Var.get[Int])).eval
         assert(r == 2)
     }
 
     "runTuple" in {
-        val r = kyo2.Var.runTuple(1)(kyo2.Var.update[Int](_ + 1).unit.andThen(kyo2.Var.get[Int]).map(_ + 1)).eval
+        val r = Var.runTuple(1)(Var.update[Int](_ + 1).unit.andThen(Var.get[Int]).map(_ + 1)).eval
         assert(r == (2, 3))
     }
 
     "scope" - {
         "should not affect the outer state" in {
-            val result = kyo2.Var.run(42)(
-                kyo2.Var.run(24)(kyo2.Var.get[Int]).map(_ => kyo2.Var.get[Int])
+            val result = Var.run(42)(
+                Var.run(24)(Var.get[Int]).map(_ => Var.get[Int])
             )
             assert(result.eval == 42)
         }
 
         "should allow updating the local state" in {
-            val result = kyo2.Var.run(42)(
-                kyo2.Var.run(24)(kyo2.Var.update[Int](_ + 1).map(_ => kyo2.Var.get[Int]))
+            val result = Var.run(42)(
+                Var.run(24)(Var.update[Int](_ + 1).map(_ => Var.get[Int]))
             )
             assert(result.eval == 25)
         }
     }
 
     "nested let" in {
-        kyo2.Var.run(1) {
-            kyo2.Var.run(2) {
-                kyo2.Var.get[Int].map { innerValue =>
+        Var.run(1) {
+            Var.run(2) {
+                Var.get[Int].map { innerValue =>
                     assert(innerValue == 2)
                 }
-            }.unit.andThen(kyo2.Var.get[Int])
+            }.unit.andThen(Var.get[Int])
                 .map { outerValue =>
                     assert(outerValue == 1)
                 }
@@ -81,31 +81,31 @@ class VarTest extends Test:
     }
 
     "string value" in {
-        val result = kyo2.Var.run("a")(kyo2.Var.setDiscard("b").andThen(kyo2.Var.get[String])).eval
+        val result = Var.run("a")(Var.setDiscard("b").andThen(Var.get[String])).eval
         assert(result == "b")
     }
 
     "side effect" in {
         var calls = 0
         val result =
-            kyo2.Var.run(1) {
+            Var.run(1) {
                 for
-                    u <- kyo2.Var.update[Int] { value =>
+                    u <- Var.update[Int] { value =>
                         calls += 1
                         value + 1
                     }
-                    result <- kyo2.Var.get[Int]
+                    result <- Var.get[Int]
                 yield (u, result)
             }.eval
         assert(result == (2, 2) && calls == 1)
     }
 
     "inference" in {
-        val a: Int < Var[Int]                    = kyo2.Var.get[Int]
-        val b: Unit < (Var[Int] & Var[String])   = a.map(i => kyo2.Var.setDiscard(i.toString()))
-        val c: String < (Var[Int] & Var[String]) = b.andThen(kyo2.Var.set("c"))
-        val d: String < Var[String]              = kyo2.Var.run(1)(c)
-        val e: String < Any                      = kyo2.Var.run("t")(d)
+        val a: Int < Var[Int]                    = Var.get[Int]
+        val b: Unit < (Var[Int] & Var[String])   = a.map(i => Var.setDiscard(i.toString()))
+        val c: String < (Var[Int] & Var[String]) = b.andThen(Var.set("c"))
+        val d: String < Var[String]              = Var.run(1)(c)
+        val e: String < Any                      = Var.run("t")(d)
         assert(e.eval == "1")
     }
 end VarTest

--- a/kyo-prelude/shared/src/test/scala/kyo2/VarTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/VarTest.scala
@@ -13,7 +13,7 @@ class VarTest extends Test:
     }
 
     "setUnit, get" in {
-        val r = kyo2.Var.run(1)(kyo2.Var.setUnit(2).andThen(kyo2.Var.get[Int])).eval
+        val r = kyo2.Var.run(1)(kyo2.Var.setDiscard(2).andThen(kyo2.Var.get[Int])).eval
         assert(r == 2)
     }
 
@@ -24,7 +24,7 @@ class VarTest extends Test:
 
     "get, setUnit, get" in {
         val r = kyo2.Var.run(1)(
-            kyo2.Var.get[Int].map(i => kyo2.Var.setUnit[Int](i + 1)).andThen(kyo2.Var.get[Int])
+            kyo2.Var.get[Int].map(i => kyo2.Var.setDiscard[Int](i + 1)).andThen(kyo2.Var.get[Int])
         ).eval
         assert(r == 2)
     }
@@ -42,7 +42,7 @@ class VarTest extends Test:
     }
 
     "updateUnit" in {
-        val r = kyo2.Var.run(1)(kyo2.Var.updateUnit[Int](_ + 1).andThen(Var.get[Int])).eval
+        val r = kyo2.Var.run(1)(kyo2.Var.updateDiscard[Int](_ + 1).andThen(Var.get[Int])).eval
         assert(r == 2)
     }
 
@@ -81,7 +81,7 @@ class VarTest extends Test:
     }
 
     "string value" in {
-        val result = kyo2.Var.run("a")(kyo2.Var.setUnit("b").andThen(kyo2.Var.get[String])).eval
+        val result = kyo2.Var.run("a")(kyo2.Var.setDiscard("b").andThen(kyo2.Var.get[String])).eval
         assert(result == "b")
     }
 
@@ -102,7 +102,7 @@ class VarTest extends Test:
 
     "inference" in {
         val a: Int < Var[Int]                    = kyo2.Var.get[Int]
-        val b: Unit < (Var[Int] & Var[String])   = a.map(i => kyo2.Var.setUnit(i.toString()))
+        val b: Unit < (Var[Int] & Var[String])   = a.map(i => kyo2.Var.setDiscard(i.toString()))
         val c: String < (Var[Int] & Var[String]) = b.andThen(kyo2.Var.set("c"))
         val d: String < Var[String]              = kyo2.Var.run(1)(c)
         val e: String < Any                      = kyo2.Var.run("t")(d)


### PR DESCRIPTION
I'm taking a look at the profiling session for https://github.com/getkyo/kyo/issues/531 and noticed that we can avoid the allocation of `Input.Set`. This PR updates the effect to use a union type for its input, introduces new APIs, and includes scaladocs (you read that right 😅)