### PR TITLE
prelude: Loop improvements

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo2/Kyo.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Kyo.scala
@@ -29,7 +29,7 @@ object Kyo:
                                 else f(seq(idx)).map(u => Loop.continue(acc.append(u)))
                             }
                         case seq: List[A] =>
-                            Loop.transform(seq, Chunk.empty[B]) { (seq, acc) =>
+                            Loop(seq, Chunk.empty[B]) { (seq, acc) =>
                                 seq match
                                     case Nil          => Loop.done(acc.toSeq)
                                     case head :: tail => f(head).map(u => Loop.continue(tail, acc.append(u)))
@@ -50,7 +50,7 @@ object Kyo:
                                 else f(seq(idx)).andThen(Loop.continue)
                             }
                         case seq: List[A] =>
-                            Loop.transform(seq) {
+                            Loop(seq) {
                                 case Nil          => Loop.done
                                 case head :: tail => f(head).andThen(Loop.continue(tail))
                             }
@@ -72,7 +72,7 @@ object Kyo:
                                 else f(acc, seq(idx)).map(Loop.continue(_))
                             }
                         case seq: List[A] =>
-                            Loop.transform(seq, acc) { (seq, acc) =>
+                            Loop(seq, acc) { (seq, acc) =>
                                 seq match
                                     case Nil          => Loop.done(acc)
                                     case head :: tail => f(acc, head).map(Loop.continue(tail, _))
@@ -95,7 +95,7 @@ object Kyo:
                                 else seq(idx).map(u => Loop.continue(acc.append(u)))
                             }
                         case seq: List[A < S] =>
-                            Loop.transform(seq, Chunk.empty[A]) { (seq, acc) =>
+                            Loop(seq, Chunk.empty[A]) { (seq, acc) =>
                                 seq match
                                     case Nil          => Loop.done(acc.toSeq)
                                     case head :: tail => head.map(u => Loop.continue(tail, acc.append(u)))
@@ -116,7 +116,7 @@ object Kyo:
                                 else seq(idx).map(u => Loop.continue)
                             }
                         case seq: List[Unit < S] =>
-                            Loop.transform(seq) { seq =>
+                            Loop(seq) { seq =>
                                 seq match
                                     case Nil          => Loop.done
                                     case head :: tail => head.andThen(Loop.continue(tail))

--- a/kyo-prelude/shared/src/main/scala/kyo2/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Stream.scala
@@ -190,7 +190,7 @@ object Stream:
         Stream[S, V](
             chunk.map { chunk =>
                 Emit.andMap(Chunk.empty[V]) { ack =>
-                    Loop.transform(chunk, ack) { (c, ack) =>
+                    Loop(chunk, ack) { (c, ack) =>
                         ack match
                             case Stop =>
                                 Loop.done(Stop)

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Loop.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Loop.scala
@@ -7,77 +7,77 @@ import scala.util.NotGiven
 
 object Loop:
 
-    abstract class Continue[V1]:
-        private[Loop] def _v1: V1
-    abstract class Continue2[V1, V2]:
-        private[Loop] def _v1: V1
-        private[Loop] def _v2: V2
-    abstract class Continue3[V1, V2, V3]:
-        private[Loop] def _v1: V1
-        private[Loop] def _v2: V2
-        private[Loop] def _v3: V3
+    abstract class Continue[A]:
+        private[Loop] def _1: A
+    abstract class Continue2[A, B]:
+        private[Loop] def _1: A
+        private[Loop] def _2: B
+    abstract class Continue3[A, B, C]:
+        private[Loop] def _1: A
+        private[Loop] def _2: B
+        private[Loop] def _3: C
     end Continue3
-    abstract class Continue4[V1, V2, V3, V4]:
-        private[Loop] def _v1: V1
-        private[Loop] def _v2: V2
-        private[Loop] def _v3: V3
-        private[Loop] def _v4: V4
+    abstract class Continue4[A, B, C, D]:
+        private[Loop] def _1: A
+        private[Loop] def _2: B
+        private[Loop] def _3: C
+        private[Loop] def _4: D
     end Continue4
 
-    opaque type Result[I, O]               = O | Continue[I]
-    opaque type Result2[I1, I2, O]         = O | Continue2[I1, I2]
-    opaque type Result3[I1, I2, I3, O]     = O | Continue3[I1, I2, I3]
-    opaque type Result4[I1, I2, I3, I4, O] = O | Continue4[I1, I2, I3, I4]
+    opaque type Result[A, O]           = O | Continue[A]
+    opaque type Result2[A, B, O]       = O | Continue2[A, B]
+    opaque type Result3[A, B, C, O]    = O | Continue3[A, B, C]
+    opaque type Result4[A, B, C, D, O] = O | Continue4[A, B, C, D]
 
     private val _continueUnit: Continue[Unit] =
         new Continue:
-            def _v1 = ()
+            def _1 = ()
 
     inline def continue[A]: Result[Unit, A] = _continueUnit
 
     @targetName("done0")
     def done[A]: Result[A, Unit] = ()
     @targetName("done1")
-    def done[I, O](v: O): Result[I, O] = v
+    def done[A, O](v: O): Result[A, O] = v
     @targetName("done2")
-    def done[I1, I2, O](v: O): Result2[I1, I2, O] = v
+    def done[A, B, O](v: O): Result2[A, B, O] = v
     @targetName("done3")
-    def done[I1, I2, I3, O](v: O): Result3[I1, I2, I3, O] = v
+    def done[A, B, C, O](v: O): Result3[A, B, C, O] = v
     @targetName("done4")
-    def done[I1, I2, I3, I4, O](v: O): Result4[I1, I2, I3, I4, O] = v
+    def done[A, B, C, D, O](v: O): Result4[A, B, C, D, O] = v
 
-    inline def continue[I, O, S](inline v: I): Result[I, O] =
+    inline def continue[A, O, S](inline v: A): Result[A, O] =
         new Continue:
-            def _v1 = v
+            def _1 = v
 
-    inline def continue[I1, I2, o](inline v1: I1, inline v2: I2): Result2[I1, I2, o] =
+    inline def continue[A, B, o](inline v1: A, inline v2: B): Result2[A, B, o] =
         new Continue2:
-            def _v1 = v1
-            def _v2 = v2
+            def _1 = v1
+            def _2 = v2
 
-    inline def continue[I1, I2, I3, O](inline v1: I1, inline v2: I2, inline v3: I3): Result3[I1, I2, I3, O] =
+    inline def continue[A, B, C, O](inline v1: A, inline v2: B, inline v3: C): Result3[A, B, C, O] =
         new Continue3:
-            def _v1 = v1
-            def _v2 = v2
-            def _v3 = v3
+            def _1 = v1
+            def _2 = v2
+            def _3 = v3
 
-    inline def continue[I1, I2, I3, I4, O](inline v1: I1, inline v2: I2, inline v3: I3, inline v4: I4): Result4[I1, I2, I3, I4, O] =
+    inline def continue[A, B, C, D, O](inline v1: A, inline v2: B, inline v3: C, inline v4: D): Result4[A, B, C, D, O] =
         new Continue4:
-            def _v1 = v1
-            def _v2 = v2
-            def _v3 = v3
-            def _v4 = v4
+            def _1 = v1
+            def _2 = v2
+            def _3 = v3
+            def _4 = v4
 
-    inline def apply[I, O, S](inline input: I)(inline run: I => Result[I, O] < S)(using Frame): O < S =
-        def _loop(i1: I): O < S = loop(i1)
-        @tailrec def loop(i1: I): O < S =
+    inline def apply[A, O, S](inline input: A)(inline run: A => Result[A, O] < S)(using Frame): O < S =
+        def _loop(i1: A): O < S = loop(i1)
+        @tailrec def loop(i1: A): O < S =
             run(i1) match
-                case <(next: Continue[I] @unchecked) =>
-                    loop(next._v1)
-                case kyo @ <(_: Kyo[O | Continue[I], S] @unchecked) =>
+                case <(next: Continue[A] @unchecked) =>
+                    loop(next._1)
+                case kyo @ <(_: Kyo[O | Continue[A], S] @unchecked) =>
                     kyo.map {
-                        case next: Continue[I] @unchecked =>
-                            _loop(next._v1)
+                        case next: Continue[A] @unchecked =>
+                            _loop(next._1)
                         case res =>
                             res.asInstanceOf[O]
                     }
@@ -86,16 +86,16 @@ object Loop:
         loop(input)
     end apply
 
-    inline def apply[I1, I2, O, S](input1: I1, input2: I2)(inline run: (I1, I2) => Result2[I1, I2, O] < S)(using Frame): O < S =
-        def _loop(i1: I1, i2: I2): O < S = loop(i1, i2)
-        @tailrec def loop(i1: I1, i2: I2): O < S =
+    inline def apply[A, B, O, S](input1: A, input2: B)(inline run: (A, B) => Result2[A, B, O] < S)(using Frame): O < S =
+        def _loop(i1: A, i2: B): O < S = loop(i1, i2)
+        @tailrec def loop(i1: A, i2: B): O < S =
             run(i1, i2) match
-                case <(next: Continue2[I1, I2] @unchecked) =>
-                    loop(next._v1, next._v2)
-                case kyo @ <(_: Kyo[o | Continue2[I1, I2], S] @unchecked) =>
+                case <(next: Continue2[A, B] @unchecked) =>
+                    loop(next._1, next._2)
+                case kyo @ <(_: Kyo[o | Continue2[A, B], S] @unchecked) =>
                     kyo.map {
-                        case next: Continue2[I1, I2] @unchecked =>
-                            _loop(next._v1, next._v2)
+                        case next: Continue2[A, B] @unchecked =>
+                            _loop(next._1, next._2)
                         case res =>
                             res.asInstanceOf[O]
                     }
@@ -104,18 +104,18 @@ object Loop:
         loop(input1, input2)
     end apply
 
-    inline def apply[I1, I2, I3, O, S](input1: I1, input2: I2, input3: I3)(
-        inline run: (I1, I2, I3) => Result3[I1, I2, I3, O] < S
+    inline def apply[A, B, C, O, S](input1: A, input2: B, input3: C)(
+        inline run: (A, B, C) => Result3[A, B, C, O] < S
     )(using Frame): O < S =
-        def _loop(i1: I1, i2: I2, i3: I3): O < S = loop(i1, i2, i3)
-        @tailrec def loop(i1: I1, i2: I2, i3: I3): O < S =
+        def _loop(i1: A, i2: B, i3: C): O < S = loop(i1, i2, i3)
+        @tailrec def loop(i1: A, i2: B, i3: C): O < S =
             run(i1, i2, i3) match
-                case <(next: Continue3[I1, I2, I3] @unchecked) =>
-                    loop(next._v1, next._v2, next._v3)
-                case kyo @ <(_: Kyo[O | Continue3[I1, I2, I3], S] @unchecked) =>
+                case <(next: Continue3[A, B, C] @unchecked) =>
+                    loop(next._1, next._2, next._3)
+                case kyo @ <(_: Kyo[O | Continue3[A, B, C], S] @unchecked) =>
                     kyo.map {
-                        case next: Continue3[I1, I2, I3] @unchecked =>
-                            _loop(next._v1, next._v2, next._v3)
+                        case next: Continue3[A, B, C] @unchecked =>
+                            _loop(next._1, next._2, next._3)
                         case res =>
                             res.asInstanceOf[O]
                     }
@@ -124,18 +124,18 @@ object Loop:
         loop(input1, input2, input3)
     end apply
 
-    inline def apply[I1, I2, I3, I4, O, S](input1: I1, input2: I2, input3: I3, input4: I4)(
-        inline run: (I1, I2, I3, I4) => Result4[I1, I2, I3, I4, O] < S
+    inline def apply[A, B, C, D, O, S](input1: A, input2: B, input3: C, input4: D)(
+        inline run: (A, B, C, D) => Result4[A, B, C, D, O] < S
     )(using Frame): O < S =
-        def _loop(i1: I1, i2: I2, i3: I3, i4: I4): O < S = loop(i1, i2, i3, i4)
-        @tailrec def loop(i1: I1, i2: I2, i3: I3, i4: I4): O < S =
+        def _loop(i1: A, i2: B, i3: C, i4: D): O < S = loop(i1, i2, i3, i4)
+        @tailrec def loop(i1: A, i2: B, i3: C, i4: D): O < S =
             run(i1, i2, i3, i4) match
-                case <(next: Continue4[I1, I2, I3, I4] @unchecked) =>
-                    loop(next._v1, next._v2, next._v3, next._v4)
-                case kyo @ <(_: Kyo[O | Continue4[I1, I2, I3, I4], S] @unchecked) =>
+                case <(next: Continue4[A, B, C, D] @unchecked) =>
+                    loop(next._1, next._2, next._3, next._4)
+                case kyo @ <(_: Kyo[O | Continue4[A, B, C, D], S] @unchecked) =>
                     kyo.map {
-                        case next: Continue4[I1, I2, I3, I4] @unchecked =>
-                            _loop(next._v1, next._v2, next._v3, next._v4)
+                        case next: Continue4[A, B, C, D] @unchecked =>
+                            _loop(next._1, next._2, next._3, next._4)
                         case res =>
                             res.asInstanceOf[O]
                     }
@@ -162,16 +162,16 @@ object Loop:
         loop(0)
     end indexed
 
-    inline def indexed[I, O, S](input: I)(inline run: (Int, I) => Result[I, O] < S)(using Frame): O < S =
-        def _loop(idx: Int, i1: I): O < S = loop(idx, i1)
-        @tailrec def loop(idx: Int, i1: I): O < S =
+    inline def indexed[A, O, S](input: A)(inline run: (Int, A) => Result[A, O] < S)(using Frame): O < S =
+        def _loop(idx: Int, i1: A): O < S = loop(idx, i1)
+        @tailrec def loop(idx: Int, i1: A): O < S =
             run(idx, i1) match
-                case <(next: Continue[I] @unchecked) =>
-                    loop(idx + 1, next._v1)
-                case kyo @ <(_: Kyo[O | Continue[I], S] @unchecked) =>
+                case <(next: Continue[A] @unchecked) =>
+                    loop(idx + 1, next._1)
+                case kyo @ <(_: Kyo[O | Continue[A], S] @unchecked) =>
                     kyo.map {
-                        case next: Continue[I] @unchecked =>
-                            _loop(idx + 1, next._v1)
+                        case next: Continue[A] @unchecked =>
+                            _loop(idx + 1, next._1)
                         case res =>
                             res.asInstanceOf[O]
                     }
@@ -180,16 +180,16 @@ object Loop:
         loop(0, input)
     end indexed
 
-    inline def indexed[I1, I2, O, S](input1: I1, input2: I2)(inline run: (Int, I1, I2) => Result2[I1, I2, O] < S)(using Frame): O < S =
-        def _loop(idx: Int, i1: I1, i2: I2): O < S = loop(idx, i1, i2)
-        @tailrec def loop(idx: Int, i1: I1, i2: I2): O < S =
+    inline def indexed[A, B, O, S](input1: A, input2: B)(inline run: (Int, A, B) => Result2[A, B, O] < S)(using Frame): O < S =
+        def _loop(idx: Int, i1: A, i2: B): O < S = loop(idx, i1, i2)
+        @tailrec def loop(idx: Int, i1: A, i2: B): O < S =
             run(idx, i1, i2) match
-                case <(next: Continue2[I1, I2] @unchecked) =>
-                    loop(idx + 1, next._v1, next._v2)
-                case kyo @ <(_: Kyo[O | Continue2[I1, I2], S] @unchecked) =>
+                case <(next: Continue2[A, B] @unchecked) =>
+                    loop(idx + 1, next._1, next._2)
+                case kyo @ <(_: Kyo[O | Continue2[A, B], S] @unchecked) =>
                     kyo.map {
-                        case next: Continue2[I1, I2] @unchecked =>
-                            _loop(idx + 1, next._v1, next._v2)
+                        case next: Continue2[A, B] @unchecked =>
+                            _loop(idx + 1, next._1, next._2)
                         case res =>
                             res.asInstanceOf[O]
                     }
@@ -198,18 +198,18 @@ object Loop:
         loop(0, input1, input2)
     end indexed
 
-    inline def indexed[I1, I2, I3, O, S](input1: I1, input2: I2, input3: I3)(
-        inline run: (Int, I1, I2, I3) => Result3[I1, I2, I3, O] < S
+    inline def indexed[A, B, C, O, S](input1: A, input2: B, input3: C)(
+        inline run: (Int, A, B, C) => Result3[A, B, C, O] < S
     )(using Frame): O < S =
-        def _loop(idx: Int, i1: I1, i2: I2, i3: I3): O < S = loop(idx, i1, i2, i3)
-        @tailrec def loop(idx: Int, i1: I1, i2: I2, i3: I3): O < S =
+        def _loop(idx: Int, i1: A, i2: B, i3: C): O < S = loop(idx, i1, i2, i3)
+        @tailrec def loop(idx: Int, i1: A, i2: B, i3: C): O < S =
             run(idx, i1, i2, i3) match
-                case <(next: Continue3[I1, I2, I3] @unchecked) =>
-                    loop(idx + 1, next._v1, next._v2, next._v3)
-                case kyo @ <(_: Kyo[O | Continue3[I1, I2, I3], S] @unchecked) =>
+                case <(next: Continue3[A, B, C] @unchecked) =>
+                    loop(idx + 1, next._1, next._2, next._3)
+                case kyo @ <(_: Kyo[O | Continue3[A, B, C], S] @unchecked) =>
                     kyo.map {
-                        case next: Continue3[I1, I2, I3] @unchecked =>
-                            _loop(idx + 1, next._v1, next._v2, next._v3)
+                        case next: Continue3[A, B, C] @unchecked =>
+                            _loop(idx + 1, next._1, next._2, next._3)
                         case res =>
                             res.asInstanceOf[O]
                     }
@@ -218,18 +218,18 @@ object Loop:
         loop(0, input1, input2, input3)
     end indexed
 
-    inline def indexed[I1, I2, I3, I4, O, S](input1: I1, input2: I2, input3: I3, input4: I4)(
-        inline run: (Int, I1, I2, I3, I4) => Result4[I1, I2, I3, I4, O] < S
+    inline def indexed[A, B, C, D, O, S](input1: A, input2: B, input3: C, input4: D)(
+        inline run: (Int, A, B, C, D) => Result4[A, B, C, D, O] < S
     )(using Frame): O < S =
-        def _loop(idx: Int, i1: I1, i2: I2, i3: I3, i4: I4): O < S = loop(idx, i1, i2, i3, i4)
-        @tailrec def loop(idx: Int, i1: I1, i2: I2, i3: I3, i4: I4): O < S =
+        def _loop(idx: Int, i1: A, i2: B, i3: C, i4: D): O < S = loop(idx, i1, i2, i3, i4)
+        @tailrec def loop(idx: Int, i1: A, i2: B, i3: C, i4: D): O < S =
             run(idx, i1, i2, i3, i4) match
-                case <(next: Continue4[I1, I2, I3, I4] @unchecked) =>
-                    loop(idx + 1, next._v1, next._v2, next._v3, next._v4)
-                case kyo @ <(_: Kyo[O | Continue4[I1, I2, I3, I4], S] @unchecked) =>
+                case <(next: Continue4[A, B, C, D] @unchecked) =>
+                    loop(idx + 1, next._1, next._2, next._3, next._4)
+                case kyo @ <(_: Kyo[O | Continue4[A, B, C, D], S] @unchecked) =>
                     kyo.map {
-                        case next: Continue4[I1, I2, I3, I4] @unchecked =>
-                            _loop(idx + 1, next._v1, next._v2, next._v3, next._v4)
+                        case next: Continue4[A, B, C, D] @unchecked =>
+                            _loop(idx + 1, next._1, next._2, next._3, next._4)
                         case res =>
                             res.asInstanceOf[O]
                     }

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/LoopTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/LoopTest.scala
@@ -4,27 +4,27 @@ import kyo2.*
 
 class LoopTest extends Test:
 
-    "transform" - {
+    "apply" - {
         "with a single iteration" in {
             assert(
-                Loop.transform(1)(i => if i < 5 then Loop.continue(i + 1) else Loop.done(i)).eval == 5
+                Loop(1)(i => if i < 5 then Loop.continue(i + 1) else Loop.done(i)).eval == 5
             )
         }
 
         "with multiple iterations" in {
             assert(
-                Loop.transform(1)(i => if i < 5 then Loop.continue(i + 1) else Loop.done(i)).eval == 5
+                Loop(1)(i => if i < 5 then Loop.continue(i + 1) else Loop.done(i)).eval == 5
             )
         }
 
         "with no iterations" in {
             assert(
-                Loop.transform(5)(i => if i < 5 then Loop.continue(i + 1) else Loop.done(i)).eval == 5
+                Loop(5)(i => if i < 5 then Loop.continue(i + 1) else Loop.done(i)).eval == 5
             )
         }
 
         "accumulate results in a List" in {
-            val result = Loop.transform((0, List.empty[Int])) { case (i, acc) =>
+            val result = Loop((0, List.empty[Int])) { case (i, acc) =>
                 if i < 5 then
                     Loop.continue((i + 1, i :: acc))
                 else
@@ -36,7 +36,7 @@ class LoopTest extends Test:
         "stack safety" in {
             val largeNumber = 100000
             assert(
-                Loop.transform(1)(i => if i < largeNumber then Loop.continue(i + 1) else Loop.done(i)).eval == largeNumber
+                Loop(1)(i => if i < largeNumber then Loop.continue(i + 1) else Loop.done(i)).eval == largeNumber
             )
         }
 
@@ -45,9 +45,9 @@ class LoopTest extends Test:
             val innerLoopIterations = 1000
 
             assert(
-                Loop.transform(0)(i =>
+                Loop(0)(i =>
                     if i < outerLoopIterations then
-                        Loop.continue(Loop.transform(0)(j =>
+                        Loop.continue(Loop(0)(j =>
                             if j < innerLoopIterations then Loop.continue(j + 1) else Loop.done(j)
                         ).eval)
                     else
@@ -62,13 +62,13 @@ class LoopTest extends Test:
             val level3Iterations = 100
 
             assert(
-                Loop.transform(0)(i =>
+                Loop(0)(i =>
                     if i < level1Iterations then
                         Loop.continue(
-                            Loop.transform(0)(j =>
+                            Loop(0)(j =>
                                 if j < level2Iterations then
                                     Loop.continue(
-                                        Loop.transform(0)(k => if k < level3Iterations then Loop.continue(k + 1) else Loop.done(k)).eval
+                                        Loop(0)(k => if k < level3Iterations then Loop.continue(k + 1) else Loop.done(k)).eval
                                     )
                                 else
                                     Loop.done(j)
@@ -81,7 +81,7 @@ class LoopTest extends Test:
         }
 
         "suspend at the beginning" in {
-            val result = Loop.transform(1)(i =>
+            val result = Loop(1)(i =>
                 Effect.defer {
                     if i < 5 then Loop.continue(i + 1) else Loop.done(i)
                 }
@@ -90,7 +90,7 @@ class LoopTest extends Test:
         }
 
         "suspend in the middle" in {
-            val result = Loop.transform(1)(i =>
+            val result = Loop(1)(i =>
                 if i < 3 then
                     Effect.defer(Loop.continue(i + 1))
                 else if i < 5 then
@@ -102,7 +102,7 @@ class LoopTest extends Test:
         }
 
         "suspend at the end" in {
-            val result = Loop.transform(1)(i =>
+            val result = Loop(1)(i =>
                 if i < 5 then
                     Loop.continue(i + 1)
                 else
@@ -112,29 +112,29 @@ class LoopTest extends Test:
         }
     }
 
-    "transform2" - {
+    "apply2" - {
         "with a single iteration" in {
             assert(
-                Loop.transform(1, 1)((i, j) => if i + j < 5 then Loop.continue(i + 1, j + 1) else Loop.done(i + j)).eval == 6
+                Loop(1, 1)((i, j) => if i + j < 5 then Loop.continue(i + 1, j + 1) else Loop.done(i + j)).eval == 6
             )
         }
 
         "with multiple iterations" in {
             assert(
-                Loop.transform(1, 1)((i, j) => if i + j < 10 then Loop.continue(i + 1, j + 1) else Loop.done(i + j)).eval == 10
+                Loop(1, 1)((i, j) => if i + j < 10 then Loop.continue(i + 1, j + 1) else Loop.done(i + j)).eval == 10
             )
         }
 
         "with no iterations" in {
             assert(
-                Loop.transform(5, 5)((i, j) => if i + j < 10 then Loop.continue(i + 1, j + 1) else Loop.done(i + j)).eval == 10
+                Loop(5, 5)((i, j) => if i + j < 10 then Loop.continue(i + 1, j + 1) else Loop.done(i + j)).eval == 10
             )
         }
 
         "stack safety" in {
             val largeNumber = 100000
             assert(
-                Loop.transform(1, 1)((i, j) =>
+                Loop(1, 1)((i, j) =>
                     if i + j < largeNumber then Loop.continue(i + 1, j + 1)
                     else Loop.done(i + j)
                 ).eval == largeNumber
@@ -145,11 +145,11 @@ class LoopTest extends Test:
             val outerLoopIterations = 1000
             val innerLoopIterations = 1000
             assert(
-                Loop.transform(0, 0)((i, j) =>
+                Loop(0, 0)((i, j) =>
                     if i < outerLoopIterations then
                         Loop.continue(
                             i + 1,
-                            Loop.transform(0)(k =>
+                            Loop(0)(k =>
                                 if k < innerLoopIterations then Loop.continue(k + 1)
                                 else Loop.done(k)
                             ).eval
@@ -162,7 +162,7 @@ class LoopTest extends Test:
         "stack safety with interleaved iterations" in {
             val iterations = 100000
             assert(
-                Loop.transform(0, 0)((i, j) =>
+                Loop(0, 0)((i, j) =>
                     if i + j < iterations then
                         if i % 2 == 0 then Loop.continue(i + 1, j)
                         else Loop.continue(i, j + 1)
@@ -172,7 +172,7 @@ class LoopTest extends Test:
         }
 
         "suspend at the beginning" in {
-            val result = Loop.transform(1, 1)((i, j) =>
+            val result = Loop(1, 1)((i, j) =>
                 Effect.defer {
                     if i + j < 5 then Loop.continue(i + 1, j + 1) else Loop.done(i + j)
                 }
@@ -181,7 +181,7 @@ class LoopTest extends Test:
         }
 
         "suspend in the middle" in {
-            val result = Loop.transform(1, 1)((i, j) =>
+            val result = Loop(1, 1)((i, j) =>
                 if i + j < 3 then
                     Effect.defer(Loop.continue(i + 1, j + 1))
                 else if i + j < 5 then
@@ -193,7 +193,7 @@ class LoopTest extends Test:
         }
 
         "suspend at the end" in {
-            val result = Loop.transform(1, 1)((i, j) =>
+            val result = Loop(1, 1)((i, j) =>
                 if i + j < 5 then
                     Loop.continue(i + 1, j + 1)
                 else
@@ -203,10 +203,10 @@ class LoopTest extends Test:
         }
     }
 
-    "transform3" - {
+    "apply3" - {
         "with a single iteration" in {
             assert(
-                Loop.transform(1, 1, 1)((i, j, k) =>
+                Loop(1, 1, 1)((i, j, k) =>
                     if i + j + k < 5 then Loop.continue(i + 1, j + 1, k + 1) else Loop.done(i + j + k)
                 ).eval == 6
             )
@@ -214,7 +214,7 @@ class LoopTest extends Test:
 
         "with multiple iterations" in {
             assert(
-                Loop.transform(1, 1, 1)((i, j, k) =>
+                Loop(1, 1, 1)((i, j, k) =>
                     if i + j + k < 10 then Loop.continue(i + 1, j + 1, k + 1) else Loop.done(i + j + k)
                 ).eval == 12
             )
@@ -222,7 +222,7 @@ class LoopTest extends Test:
 
         "with no iterations" in {
             assert(
-                Loop.transform(5, 5, 5)((i, j, k) =>
+                Loop(5, 5, 5)((i, j, k) =>
                     if i + j + k < 10 then Loop.continue(i + 1, j + 1, k + 1) else Loop.done(i + j + k)
                 ).eval == 15
             )
@@ -231,7 +231,7 @@ class LoopTest extends Test:
         "stack safety" in {
             val largeNumber = 100000
             assert(
-                Loop.transform(1, 1, 1)((i, j, k) =>
+                Loop(1, 1, 1)((i, j, k) =>
                     if i + j + k < largeNumber then Loop.continue(i + 1, j + 1, k + 1)
                     else Loop.done(i + j + k)
                 ).eval == largeNumber + 2
@@ -241,7 +241,7 @@ class LoopTest extends Test:
         "stack safety with interleaved iterations" in {
             val iterations = 100000
             assert(
-                Loop.transform(0, 0, 0)((i, j, k) =>
+                Loop(0, 0, 0)((i, j, k) =>
                     if i + j + k < iterations then
                         if i % 3 == 0 then Loop.continue(i + 1, j, k)
                         else if i % 3 == 1 then Loop.continue(i, j + 1, k)
@@ -252,7 +252,7 @@ class LoopTest extends Test:
         }
 
         "suspend at the beginning" in {
-            val result = Loop.transform(1, 1, 1)((i, j, k) =>
+            val result = Loop(1, 1, 1)((i, j, k) =>
                 Effect.defer {
                     if i + j + k < 5 then Loop.continue(i + 1, j + 1, k + 1) else Loop.done(i + j + k)
                 }
@@ -261,7 +261,7 @@ class LoopTest extends Test:
         }
 
         "suspend in the middle" in {
-            val result = Loop.transform(1, 1, 1)((i, j, k) =>
+            val result = Loop(1, 1, 1)((i, j, k) =>
                 if i + j + k < 3 then
                     Effect.defer(Loop.continue(i + 1, j + 1, k + 1))
                 else if i + j + k < 5 then
@@ -273,13 +273,94 @@ class LoopTest extends Test:
         }
 
         "suspend at the end" in {
-            val result = Loop.transform(1, 1, 1)((i, j, k) =>
+            val result = Loop(1, 1, 1)((i, j, k) =>
                 if i + j + k < 5 then
                     Loop.continue(i + 1, j + 1, k + 1)
                 else
                     Effect.defer(Loop.done(i + j + k))
             )
             assert(result.eval == 6)
+        }
+    }
+
+    "apply4" - {
+        "with a single iteration" in {
+            assert(
+                Loop(1, 1, 1, 1)((i, j, k, l) =>
+                    if i + j + k + l < 5 then Loop.continue(i + 1, j + 1, k + 1, l + 1) else Loop.done(i + j + k + l)
+                ).eval == 8
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loop(1, 1, 1, 1)((i, j, k, l) =>
+                    if i + j + k + l < 10 then Loop.continue(i + 1, j + 1, k + 1, l + 1) else Loop.done(i + j + k + l)
+                ).eval == 12
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loop(5, 5, 5, 5)((i, j, k, l) =>
+                    if i + j + k + l < 10 then Loop.continue(i + 1, j + 1, k + 1, l + 1) else Loop.done(i + j + k + l)
+                ).eval == 20
+            )
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loop(1, 1, 1, 1)((i, j, k, l) =>
+                    if i + j + k + l < largeNumber then Loop.continue(i + 1, j + 1, k + 1, l + 1)
+                    else Loop.done(i + j + k + l)
+                ).eval == largeNumber
+            )
+        }
+
+        "stack safety with interleaved iterations" in {
+            val iterations = 100000
+            assert(
+                Loop(0, 0, 0, 0)((i, j, k, l) =>
+                    if i + j + k + l < iterations then
+                        if i % 4 == 0 then Loop.continue(i + 1, j, k, l)
+                        else if i % 4 == 1 then Loop.continue(i, j + 1, k, l)
+                        else if i % 4 == 2 then Loop.continue(i, j, k + 1, l)
+                        else Loop.continue(i, j, k, l + 1)
+                    else Loop.done(i + j + k + l)
+                ).eval == iterations
+            )
+        }
+
+        "suspend at the beginning" in {
+            val result = Loop(1, 1, 1, 1)((i, j, k, l) =>
+                Effect.defer {
+                    if i + j + k + l < 5 then Loop.continue(i + 1, j + 1, k + 1, l + 1) else Loop.done(i + j + k + l)
+                }
+            )
+            assert(result.eval == 8)
+        }
+
+        "suspend in the middle" in {
+            val result = Loop(1, 1, 1, 1)((i, j, k, l) =>
+                if i + j + k + l < 3 then
+                    Effect.defer(Loop.continue(i + 1, j + 1, k + 1, i + 1))
+                else if i + j + k + l < 5 then
+                    Loop.continue(i + 1, j + 1, k + 1, l + 1)
+                else
+                    Loop.done(i + j + k + l)
+            )
+            assert(result.eval == 8)
+        }
+
+        "suspend at the end" in {
+            val result = Loop(1, 1, 1, 1)((i, j, k, l) =>
+                if i + j + k + l < 5 then
+                    Loop.continue(i + 1, j + 1, k + 1, l + 1)
+                else
+                    Effect.defer(Loop.done(i + j + k + l))
+            )
+            assert(result.eval == 8)
         }
     }
 
@@ -438,6 +519,51 @@ class LoopTest extends Test:
                     Effect.defer(Loop.done(i + j + k))
             )
             assert(result.eval == 18)
+        }
+    }
+
+    "indexed4" - {
+        "with a single iteration" in {
+            assert(
+                Loop.indexed(1, 1, 1, 1)((idx, i, j, k, l) =>
+                    if idx < 5 then Loop.continue(i + 1, j + 1, k + 1, l + 1) else Loop.done(i + j + k + l)
+                ).eval == 24
+            )
+        }
+
+        "with multiple iterations" in {
+            assert(
+                Loop.indexed(1, 1, 1, 1)((idx, i, j, k, l) =>
+                    if idx < 10 then Loop.continue(i + 1, j + 1, k + 1, l + 1) else Loop.done(i + j + k + l)
+                ).eval == 44
+            )
+        }
+
+        "with no iterations" in {
+            assert(
+                Loop.indexed(1, 1, 1, 1)((idx, i, j, k, l) =>
+                    if idx < 0 then Loop.continue(i + 1, j + 1, k + 1, l + 1) else Loop.done(i + j + k + l)
+                ).eval == 4
+            )
+        }
+
+        "stack safety" in {
+            val largeNumber = 100000
+            assert(
+                Loop.indexed(1, 1, 1, 1)((idx, i, j, k, l) =>
+                    if idx < largeNumber then Loop.continue(i + 1, j + 1, k + 1, l + 1) else Loop.done(i + j + k + l)
+                ).eval == 4 * largeNumber + 4
+            )
+        }
+
+        "suspend" in {
+            val result = Loop.indexed(1, 1, 1, 1)((idx, i, j, k, l) =>
+                if idx < 5 then
+                    Effect.defer(Loop.continue(i + 1, j + 1, k + 1, l + 1))
+                else
+                    Effect.defer(Loop.done(i + j + k + l))
+            )
+            assert(result.eval == 24)
         }
     }
 


### PR DESCRIPTION
This PR introduces an optimization to specialize `Continue*` instances. They're currently generic, which requires boxing of primitive types in the `Continue` instance fields. After this change, the fields in the final bytecode are specialized. Example from a decompiled loop:

```java
new Loop.Continue2<String, Object>(i1, i2){
    private final String i1$tailLocal1$1;
    private final int i2$tailLocal1$1;
```

There's still boxing when the value is recovered in the generic scope of the `Loop` body but that's something the JIT can easily optimize.

I'm also using abbreviated generic names. It makes it easier for me to read the code but I'd be ok to moving back to more descriptive names. The `Loop.transform*` methods are renamed to `Loop.apply*` to improve readability since `transform` doesn't seem to communicate much meaning in this context.