### PR TITLE
prelude: optimizations for IOTask

### DIFF
--- a/kyo-prelude/jvm/src/test/scala/kyo2/kernel/SafepointTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo2/kernel/SafepointTest.scala
@@ -244,7 +244,7 @@ class SafepointTest extends Test:
                     yield 42
                 }.eval
 
-                assert(count == 6)
+                assert(count == 4)
             }
 
             "restores previous interceptor after completion" in {
@@ -278,7 +278,7 @@ class SafepointTest extends Test:
                 }.eval
 
                 assert(outerCount == 0)
-                assert(innerCount == 6)
+                assert(innerCount == 4)
             }
         }
 
@@ -319,19 +319,11 @@ class SafepointTest extends Test:
             assert(result == 26)
 
             val expectedLogs = Seq(
-                "Entering apply with value: ()",
-                "Exiting method",
                 "Entering computation with value: 6",
-                "Exiting method",
-                "Entering apply with value: ()",
                 "Exiting method",
                 "Entering Unknown with value: 12",
                 "Exiting method",
-                "Entering apply with value: ()",
-                "Exiting method",
                 "Entering computation with value: 13",
-                "Exiting method",
-                "Entering apply with value: ()",
                 "Exiting method",
                 "Entering $anonfun with value: 26",
                 "Exiting method"
@@ -383,7 +375,7 @@ class SafepointTest extends Test:
                 assert(duration < 3000000)
             }
 
-            assert(interceptor.log.size == 8)
+            assert(interceptor.log.size == 4)
             assert(interceptor.log.exists(_._1.parse.methodName == "computation"))
         }
     }

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Boundary.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Boundary.scala
@@ -1,51 +1,29 @@
 package kyo2.kernel
 
 import internal.*
+import kyo.Tag
+import scala.annotation.tailrec
 import scala.quoted.*
 
-final class Boundary[Ctx, S] private (dummy: Unit) extends AnyVal:
-
-    inline def apply[A, B, S2, S3](inline v: => A < (Ctx & S & S2))(
-        inline f: A < (S & S2) => B < S3
-    )(using inline _frame: Frame): B < (Ctx & S3) =
-        new KyoDefer[B, Ctx & S3]:
-            def frame = _frame
-            def apply(dummy: Unit, context: Context)(using safepoint: Safepoint) =
-                val state = safepoint.save(context)
-                f(Effect.defer(boundaryLoop(v, state)))
-
-    inline def apply[A, B, S2, S3](seq: Seq[A < (Ctx & S & S2)])(
-        inline f: Seq[A < (S & S2)] => B < S3
-    )(using inline _frame: Frame): B < (Ctx & S3) =
-        new KyoDefer[B, Ctx & S3]:
-            def frame = _frame
-            def apply(dummy: Unit, context: Context)(using safepoint: Safepoint) =
-                val state = safepoint.save(context)
-                f(seq.map(item => boundaryLoop(item, state)))
-
-    private def boundaryLoop[A, S2](v: A < (Ctx & S & S2), state: Safepoint.State)(using Frame): A < (S & S2) =
-        v match
-            case <(kyo: KyoSuspend[IX, OX, EX, Any, A, S] @unchecked) =>
-                new KyoContinue[IX, OX, EX, Any, A, S & S2](kyo):
-                    def frame = summon[Frame]
-                    def apply(v: OX[Any], context: Context)(using Safepoint) =
-                        val parent = Safepoint.local.get()
-                        Safepoint.local.set(Safepoint(parent.depth, parent.interceptor, state))
-                        val r =
-                            try kyo(v, state.context)
-                            finally Safepoint.local.set(parent)
-                        boundaryLoop(r, state)
-                    end apply
-            case <(kyo) =>
-                kyo.asInstanceOf[A]
+final class Boundary[Ctx, +S] private (dummy: Unit) extends AnyVal:
 
 end Boundary
 
-object Boundary:
+private[kyo2] object Boundary:
+
+    extension [Ctx, S](boundary: Boundary[Ctx, S])
+        private[kyo2] inline def apply[A, S2](inline f: (Trace, Context) => A < S2)(using inline _frame: Frame): A < (S & S2) =
+            new KyoDefer[A, S & S2]:
+                def frame = _frame
+                def apply(v: Unit, context: Context)(using safepoint: Safepoint) =
+                    f(safepoint.saveTrace(), context)
 
     inline given derive[Ctx, S]: Boundary[Ctx, S] = ${ boundaryImpl[Ctx, S] }
 
-    def apply[Ctx, S](using boundary: Boundary[Ctx, S]): Boundary[Ctx, S] = boundary
+    private[kyo2] inline def restoring[Ctx, A, S](trace: Trace, interceptor: Safepoint.Interceptor)(
+        inline v: => A < (Ctx & S)
+    )(using frame: Frame, safepoint: Safepoint): A < (Ctx & S) =
+        Safepoint.immediate(interceptor)(safepoint.withTrace(trace)(v))
 
     private def create[Ctx, S]: Boundary[Ctx, S] = new Boundary(())
 

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Context.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Context.scala
@@ -9,7 +9,7 @@ object Context:
     val empty: Context = Map.empty
 
     extension (context: Context)
-        inline def isEmpty = context eq Map.empty
+        inline def isEmpty = context eq empty
 
         inline def contains[A, E <: ContextEffect[A]](tag: Tag[E]): Boolean =
             context.contains(tag.erased)

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Context.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Context.scala
@@ -1,0 +1,27 @@
+package kyo2.kernel
+
+import kyo.Tag
+import kyo2.bug
+
+opaque type Context = Map[Tag[Any], AnyRef]
+
+object Context:
+    val empty: Context = Map.empty
+
+    extension (context: Context)
+        inline def isEmpty = context eq Map.empty
+
+        inline def contains[A, E <: ContextEffect[A]](tag: Tag[E]): Boolean =
+            context.contains(tag.erased)
+
+        inline def getOrElse[A, E <: ContextEffect[A], B >: A](tag: Tag[E], inline default: => B): B =
+            if !contains(tag) then default
+            else context(tag.erased).asInstanceOf[B]
+
+        private[kernel] inline def get[A, E <: ContextEffect[A]](tag: Tag[E]): A =
+            getOrElse(tag, bug(s"Missing value for context effect '${tag}'. Values: $context"))
+
+        private[kernel] inline def set[A, E <: ContextEffect[A]](tag: Tag[E], value: A): Context =
+            context.updated(tag.erased, value.asInstanceOf[AnyRef])
+    end extension
+end Context

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
@@ -13,10 +13,7 @@ object Effect:
         new KyoDefer[A, S]:
             def frame = summon[Frame]
             def apply(v: Unit, context: Context)(using Safepoint) =
-                Safepoint.handle(v)(
-                    suspend = this,
-                    continue = f
-                )
+                f
 
     final class SuspendOps[A](dummy: Unit) extends AnyVal:
 
@@ -164,6 +161,51 @@ object Effect:
             end handle3Loop
             handle3Loop(v, Context.empty)
         end apply
+
+        private[kyo2] inline def partial[I1[_], O1[_], E1 <: Effect[I1, O1], I2[_], O2[_], E2 <: Effect[I2, O2], I3[_], O3[_], E3 <: Effect[
+            I3,
+            O3
+        ], A, S, S2](
+            inline tag1: Tag[E1],
+            inline tag2: Tag[E2],
+            inline tag3: Tag[E3],
+            v: A < (E1 & E2 & E3 & S),
+            context: Context
+        )(
+            inline stop: => Boolean,
+            inline handle1: Safepoint ?=> [C] => (I1[C], O1[C] => A < (E1 & E2 & E3 & S & S2)) => A < (E1 & E2 & E3 & S & S2),
+            inline handle2: Safepoint ?=> [C] => (I2[C], O2[C] => A < (E1 & E2 & E3 & S & S2)) => A < (E1 & E2 & E3 & S & S2),
+            inline handle3: Safepoint ?=> [C] => (I3[C], O3[C] => A < (E1 & E2 & E3 & S & S2)) => A < (E1 & E2 & E3 & S & S2)
+        )(using inline _frame: Frame, safepoint: Safepoint): A < (E1 & E2 & E3 & S & S2) =
+            def partialLoop(v: A < (E1 & E2 & E3 & S & S2), context: Context)(using safepoint: Safepoint): A < (E1 & E2 & E3 & S & S2) =
+                if stop then v
+                else
+                    v match
+                        case <(kyo: KyoSuspend[?, ?, ?, ?, ?, ?]) =>
+                            if kyo.tag =:= Tag[Defer] then
+                                val k = kyo.asInstanceOf[KyoSuspend[Const[Unit], Const[Unit], Defer, Any, A, Any]]
+                                partialLoop(k((), context), context)
+                            else
+                                safepoint.pushFrame(kyo.frame)
+                                if tag1 =:= kyo.tag then
+                                    val k = kyo.asInstanceOf[KyoSuspend[I1, O1, E1, Any, A, E1 & E2 & E3 & S & S2]]
+                                    partialLoop(handle1[Any](k.input, k(_, context)), context)
+                                else if tag2 =:= kyo.tag then
+                                    val k = kyo.asInstanceOf[KyoSuspend[I2, O2, E2, Any, A, E1 & E2 & E3 & S & S2]]
+                                    partialLoop(handle2[Any](k.input, k(_, context)), context)
+                                else if tag3 =:= kyo.tag then
+                                    val k = kyo.asInstanceOf[KyoSuspend[I3, O3, E3, Any, A, E1 & E2 & E3 & S & S2]]
+                                    partialLoop(handle3[Any](k.input, k(_, context)), context)
+                                else
+                                    v
+                                end if
+                            end if
+                        case _ =>
+                            v
+                    end match
+            end partialLoop
+            partialLoop(v, context)
+        end partial
 
         inline def state[I[_], O[_], E <: Effect[I, O], State, A, B, S, S2, S3](
             inline tag: Tag[E],

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Effect.scala
@@ -182,19 +182,20 @@ object Effect:
                 else
                     v match
                         case <(kyo: KyoSuspend[?, ?, ?, ?, ?, ?]) =>
+                            type Suspend[I[_], O[_], E <: Effect[I, O]] = KyoSuspend[I, O, E, Any, A, E1 & E2 & E3 & S & S2]
                             if kyo.tag =:= Tag[Defer] then
-                                val k = kyo.asInstanceOf[KyoSuspend[Const[Unit], Const[Unit], Defer, Any, A, Any]]
+                                val k = kyo.asInstanceOf[Suspend[Const[Unit], Const[Unit], Defer]]
                                 partialLoop(k((), context), context)
                             else
                                 safepoint.pushFrame(kyo.frame)
                                 if tag1 =:= kyo.tag then
-                                    val k = kyo.asInstanceOf[KyoSuspend[I1, O1, E1, Any, A, E1 & E2 & E3 & S & S2]]
+                                    val k = kyo.asInstanceOf[Suspend[I1, O1, E1]]
                                     partialLoop(handle1[Any](k.input, k(_, context)), context)
                                 else if tag2 =:= kyo.tag then
-                                    val k = kyo.asInstanceOf[KyoSuspend[I2, O2, E2, Any, A, E1 & E2 & E3 & S & S2]]
+                                    val k = kyo.asInstanceOf[Suspend[I2, O2, E2]]
                                     partialLoop(handle2[Any](k.input, k(_, context)), context)
                                 else if tag3 =:= kyo.tag then
-                                    val k = kyo.asInstanceOf[KyoSuspend[I3, O3, E3, Any, A, E1 & E2 & E3 & S & S2]]
+                                    val k = kyo.asInstanceOf[Suspend[I3, O3, E3]]
                                     partialLoop(handle3[Any](k.input, k(_, context)), context)
                                 else
                                     v

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Pending.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Pending.scala
@@ -78,20 +78,6 @@ object `<`:
                 case <(kyo: Kyo[?, ?]) => Maybe.empty
                 case <(v)              => Maybe(v.asInstanceOf[A])
 
-        private[kyo2] inline def evalPartial(interceptor: Safepoint.Interceptor)(using frame: Frame, safepoint: Safepoint): A < S =
-            @tailrec def partialEvalLoop(kyo: A < S)(using Safepoint): A < S =
-                if !interceptor.enter(frame, ()) then kyo
-                else
-                    kyo match
-                        case <(kyo: KyoSuspend[Const[Unit], Const[Unit], Defer, Any, A, S] @unchecked)
-                            if kyo.tag =:= Tag[Defer] =>
-                            partialEvalLoop(kyo((), Context.empty))
-                        case kyo =>
-                            kyo
-            end partialEvalLoop
-            Safepoint.immediate(interceptor)(partialEvalLoop(v))
-        end evalPartial
-
     end extension
 
     extension [A, S, S2](inline kyo: A < S < S2)

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Trace.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Trace.scala
@@ -20,13 +20,13 @@ object Trace:
         final private var frames = new Array[Frame](maxTraceFrames)
         final private var index  = 0
 
-        final protected def pushFrame(frame: Frame): Unit =
+        final private[kernel] def pushFrame(frame: Frame): Unit =
             val idx = this.index
             frames(idx & (maxTraceFrames - 1)) = frame
             this.index = idx + 1
         end pushFrame
 
-        final protected def saveTrace(): Trace =
+        final private[kernel] def saveTrace(): Trace =
             val newTrace   = borrow()
             val newFrames  = newTrace.frames
             val copyLength = math.min(index, maxTraceFrames)

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/package.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/package.scala
@@ -47,25 +47,5 @@ package object kernel:
             final def tag   = Tag[Defer]
             final def input = ()
 
-        opaque type Context = Map[Tag[Any], AnyRef]
-
-        object Context:
-            val empty: Context = Map.empty
-
-            extension (context: Context)
-                inline def contains[A, E <: ContextEffect[A]](tag: Tag[E]): Boolean =
-                    context.contains(tag.erased)
-
-                inline def getOrElse[A, E <: ContextEffect[A], B >: A](tag: Tag[E], inline default: => B): B =
-                    if !contains(tag) then default
-                    else context(tag.erased).asInstanceOf[B]
-
-                inline def get[A, E <: ContextEffect[A]](tag: Tag[E]): A =
-                    getOrElse(tag, bug(s"Missing value for context effect '${tag}'. Values: $context"))
-
-                inline def set[A, E <: ContextEffect[A]](tag: Tag[E], value: A): Context =
-                    context.updated(tag.erased, value.asInstanceOf[AnyRef])
-            end extension
-        end Context
     end internal
 end kernel

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/BoundaryTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/BoundaryTest.scala
@@ -1,314 +1,131 @@
 package kyo2.kernel
 
 import kyo.Tag
-import kyo2.Kyo
+import kyo2.*
 import kyo2.Test
-import scala.concurrent.Future
 
 class BoundaryTest extends Test:
-    sealed trait TestEffect       extends ContextEffect[Int]
-    sealed trait AnotherEffect    extends ContextEffect[String]
+
+    sealed trait TestEffect1      extends ContextEffect[Int]
+    sealed trait TestEffect2      extends ContextEffect[String]
+    sealed trait TestEffect3      extends ContextEffect[Boolean]
     sealed trait NotContextEffect extends Effect[Const[Int], Const[Int]]
 
-    "isolates runtime effect" in {
-        val a = ContextEffect.suspend(Tag[TestEffect])
-        val b: Int < TestEffect =
-            Boundary[TestEffect, Any](a) { cont =>
-                val _: Int < Any = cont
-                cont.map(_ * 2)
-            }
-        val c = ContextEffect.handle(Tag[TestEffect], 2, _ => 3)(b)
-        assert(c.eval == 4)
+    "apply" - {
+        "creates a boundary for context effects" in {
+            val boundary = Boundary.derive[TestEffect1 & TestEffect2, Any]
+            assert(boundary.isInstanceOf[Boundary[TestEffect1 & TestEffect2, Any]])
+        }
+
+        "fails compilation for non-context effects" in {
+            assertDoesNotCompile("Boundary.derive[Int, Any]")
+            assertDoesNotCompile("Boundary.derive[String, Any]")
+        }
+
+        "fails compilation for non-context effect traits" in {
+            assertDoesNotCompile("Boundary.derive[NotContextEffect, Any]")
+        }
     }
 
-    "continuation can be evaluated" in {
-        var called = 0
-        val a =
-            ContextEffect.suspend(Tag[TestEffect]).map { v =>
-                called += 1
-                v
+    "boundary application" - {
+        "no context effect suspension" in {
+            val boundary = Boundary.derive[TestEffect1 & TestEffect2, Any]
+            val effect: Context < Any = boundary { (trace: Trace, context: Context) =>
+                context
             }
-        val b: Int < TestEffect =
-            Boundary[TestEffect, Any](a) { cont =>
-                assert(called == 0)
-                val _: Int < Any = cont
-                assert(called == 0)
-                val r = cont.map(_ * 2).eval
-                assert(called == 1)
-                r
-            }
-        val c = ContextEffect.handle(Tag[TestEffect], 2, _ => 3)(b)
-        assert(c.eval == 4)
-        assert(called == 1)
-    }
+            assert(effect.eval.isEmpty)
+        }
 
-    "preserve outer runtime effects" in {
-        val outerEffect = ContextEffect.suspend(Tag[TestEffect])
-        val innerEffect = ContextEffect.suspend(Tag[TestEffect])
-        val result =
-            for
-                outer <- outerEffect
-                inner <- Boundary[TestEffect, Any](innerEffect) { isolatedEffect =>
-                    isolatedEffect.map(_ * 2)
-                }
-            yield outer + inner
-        val handled = ContextEffect.handle(Tag[TestEffect], 20, _ => 20)(result)
-        assert(handled.eval == 60)
+        "allows access to context" in {
+            val boundary = Boundary.derive[TestEffect1, Any]
+            val effect = boundary { (trace, context) =>
+                context.getOrElse[Int, TestEffect1, Int](Tag[TestEffect1], 42)
+            }
+            val result = ContextEffect.handle(Tag[TestEffect1], 10, _ + 1)(effect)
+            assert(result.eval == 10)
+        }
+
+        "isolates runtime effect" in {
+            val boundary = Boundary.derive[TestEffect1, Any]
+            val effect: Int < TestEffect1 = boundary { (trace, context) =>
+                ContextEffect.suspend(Tag[TestEffect1])
+            }
+            val result = ContextEffect.handle(Tag[TestEffect1], 42, _ + 1)(effect)
+            assert(result.eval == 42)
+        }
     }
 
     "nested boundaries" in {
-        val effect: Int < TestEffect = ContextEffect.suspend(Tag[TestEffect])
-        val result: Int < TestEffect =
-            Boundary[TestEffect, Any](effect) { outer =>
-                Boundary[TestEffect, Any](outer) { inner =>
-                    inner.map(_ * 2)
-                }
+        val outerBoundary = Boundary.derive[TestEffect1, Any]
+        val innerBoundary = Boundary.derive[TestEffect2, Any]
+
+        val effect: Int < (TestEffect1 & TestEffect2) = outerBoundary { (outerTrace, outerContext) =>
+            innerBoundary { (innerTrace, innerContext) =>
+                for
+                    x <- ContextEffect.suspend[Int, TestEffect1](Tag[TestEffect1])
+                    y <- ContextEffect.suspend[String, TestEffect2](Tag[TestEffect2])
+                yield x + y.length
             }
-        val handled: Int < Any = ContextEffect.handle(Tag[TestEffect], 10, _ => 21)(result)
-        assert(handled.eval == 20)
+        }
+
+        val result = ContextEffect.handle(Tag[TestEffect1], 10, _ + 1) {
+            ContextEffect.handle(Tag[TestEffect2], "test", _.toUpperCase)(effect)
+        }
+        assert(result.eval == 14)
     }
 
-    "two effects" in {
-        val effect1 = ContextEffect.suspend[Int, TestEffect](Tag[TestEffect])
-        val effect2 = ContextEffect.suspend[String, AnotherEffect](Tag[AnotherEffect])
+    "restoring" in {
+        var interceptorCalled = false
+        val interceptor = new Safepoint.Interceptor:
+            def addEnsure(f: () => Unit): Unit    = ()
+            def removeEnsure(f: () => Unit): Unit = ()
+            def enter(frame: Frame, value: Any): Boolean =
+                interceptorCalled = true
+                true
+            def exit(): Unit = ()
 
-        val effect: String < (TestEffect & AnotherEffect) =
-            for
-                i <- effect1
-                s <- effect2
-            yield s"$i-$s"
-
-        val result = Boundary[TestEffect & AnotherEffect, Any](effect) { isolated =>
-            val _: String < Any = isolated
-            isolated.map(_.toUpperCase)
+        val boundary = Boundary.derive[TestEffect1, Any]
+        val effect: Int < Any = boundary { (trace, context) =>
+            Boundary.restoring(trace, interceptor) {
+                (10: Int < Any).map(_ + 1)
+            }
         }
 
-        val handled = ContextEffect.handle(Tag[TestEffect], 10, _ => 42) {
-            ContextEffect.handle(Tag[AnotherEffect], "default", _.reverse)(result)
-        }
-
-        assert(handled.eval == "10-DEFAULT")
+        assert(effect.eval == 11)
+        assert(interceptorCalled)
     }
 
     "with non-context effect" in {
-        val effect1 = ContextEffect.suspend[Int, TestEffect](Tag[TestEffect])
-        val effect2 = Effect.suspend[Int](Tag[NotContextEffect], 1)
-
-        val effect: String < (TestEffect & NotContextEffect) =
+        val boundary = Boundary.derive[TestEffect1, Any]
+        val effect: Int < (TestEffect1 & NotContextEffect) = boundary { (trace, context) =>
             for
-                i <- effect1
-                s <- effect2
-            yield s"$i-$s"
-
-        val result = Boundary[TestEffect, Any](effect) { isolated =>
-            val _: String < NotContextEffect = isolated
-            assertDoesNotCompile("val _: String < Any = isolated")
-            isolated.map(_.toUpperCase)
+                x <- ContextEffect.suspend[Int, TestEffect1](Tag[TestEffect1])
+                y <- Effect.suspend[Int](Tag[NotContextEffect], 1)
+            yield x + y
         }
 
-        val handled = ContextEffect.handle(Tag[TestEffect], 10, _ => 42) {
-            Effect.handle(Tag[NotContextEffect], result) {
+        val result = ContextEffect.handle(Tag[TestEffect1], 10, _ + 1) {
+            Effect.handle(Tag[NotContextEffect], effect) {
                 [C] => (input, cont) => cont(input + 1)
             }
         }
 
-        assert(handled.eval == "10-2")
+        assert(result.eval == 12)
     }
 
-    "detects for non-context effects" in {
-        assertDoesNotCompile("Boundary[NotContextEffect, Any]")
+    "preserves outer runtime effects" in {
+        val outerEffect = ContextEffect.suspend[Int, TestEffect1](Tag[TestEffect1])
+        val innerEffect = ContextEffect.suspend[Int, TestEffect1](Tag[TestEffect1])
+        val boundary    = Boundary.derive[TestEffect1, Any]
+
+        val effect: Int < TestEffect1 =
+            for
+                outer <- outerEffect
+                inner <- boundary { (trace, context) => innerEffect }
+            yield outer + inner
+
+        val result = ContextEffect.handle(Tag[TestEffect1], 20, _ + 1)(effect)
+        assert(result.eval == 40)
     }
 
-    "fork boundary" - {
-
-        "leaving only context effects pending" - {
-
-            def fork[E, A, Ctx](v: => A < (NotContextEffect & Ctx))(
-                using b: Boundary[Ctx, Any]
-            ): Future[A] < Ctx =
-                b(v) { v =>
-                    val _: A < NotContextEffect = v
-                    assertDoesNotCompile("val _: A < Any = v")
-                    Future {
-                        Effect.handle(Tag[NotContextEffect], v) {
-                            [C] => (input, cont) => cont(input + 1)
-                        }.eval
-                    }
-                }
-            end fork
-
-            "no suspension" in {
-                fork(1).eval.map(i => assert(i == 1))
-            }
-
-            "context effect suspension" in {
-                val a: Future[Int] < TestEffect = fork(ContextEffect.suspend(Tag[TestEffect]))
-                val b: Future[Int] < Any        = ContextEffect.handle(Tag[TestEffect], 10, _ + 10)(a)
-                b.eval.map(i => assert(i == 10))
-            }
-
-            "non-context effect suspension" in {
-                val a: Future[Int] < Any = fork(Effect.suspend[Any](Tag[NotContextEffect], 1))
-                a.eval.map(i => assert(i == 2))
-            }
-
-            "context and non-context effect suspension" in {
-                val a: Future[Int] < TestEffect =
-                    fork(Effect.suspend[Any](Tag[NotContextEffect], 1).map(i => ContextEffect.suspend(Tag[TestEffect]).map(_ + i)))
-                val b: Future[Int] < Any =
-                    ContextEffect.handle(Tag[TestEffect], 10, _ + 10)(a)
-                b.eval.map(i => assert(i == 12))
-            }
-        }
-
-        "leaving context effects + non-context effect pending" - {
-
-            def fork[E, A, Ctx](v: => A < (NotContextEffect & Ctx))(
-                using b: Boundary[Ctx, NotContextEffect]
-            ): Future[A] < (Ctx & NotContextEffect) =
-                b(v) { v =>
-                    val _: A < NotContextEffect = v
-                    assertDoesNotCompile("val _: A < Any = v")
-                    Effect.suspendMap[Any](Tag[NotContextEffect], 1) { i =>
-                        Future {
-                            Effect.handle(Tag[NotContextEffect], v) {
-                                [C] => (input, cont) => cont(input + i)
-                            }.eval
-                        }
-                    }
-                }
-            end fork
-
-            "no suspension" in {
-                val a: Future[Int] < NotContextEffect = fork(1)
-                val b: Future[Int] < Any =
-                    Effect.handle(Tag[NotContextEffect], a) {
-                        [C] => (input, cont) => cont(input + 1)
-                    }
-                b.eval.map(i => assert(i == 1))
-            }
-
-            "context effect suspension" in {
-                val a: Future[Int] < (TestEffect & NotContextEffect) =
-                    fork(ContextEffect.suspend(Tag[TestEffect]))
-                val b: Future[Int] < NotContextEffect =
-                    ContextEffect.handle(Tag[TestEffect], 10, _ + 10)(a)
-                val c: Future[Int] < Any =
-                    Effect.handle(Tag[NotContextEffect], b) {
-                        [C] => (input, cont) => cont(input + 1)
-                    }
-                c.eval.map(i => assert(i == 10))
-            }
-
-            "non-context effect suspension" in {
-                val a: Future[Int] < NotContextEffect = fork(Effect.suspend[Any](Tag[NotContextEffect], 1))
-                val b: Future[Int] < Any =
-                    Effect.handle(Tag[NotContextEffect], a) {
-                        [C] => (input, cont) => cont(input + 1)
-                    }
-                b.eval.map(i => assert(i == 3))
-            }
-
-            "context and non-context effect suspension" in {
-                val a: Future[Int] < (TestEffect & NotContextEffect) =
-                    fork(Effect.suspend[Any](Tag[NotContextEffect], 1).map(i => ContextEffect.suspend(Tag[TestEffect]).map(_ + i)))
-                val b: Future[Int] < NotContextEffect =
-                    ContextEffect.handle(Tag[TestEffect], 10, _ + 10)(a)
-                val c =
-                    Effect.handle(Tag[NotContextEffect], b) {
-                        [C] => (input, cont) => cont(input + 1)
-                    }
-                c.eval.map(i => assert(i == 13))
-            }
-        }
-    }
-
-    "seq boundary" - {
-        "empty sequence" in {
-            val result = Boundary[TestEffect, Any](Seq.empty[Int < TestEffect]) { seq =>
-                assert(seq.isEmpty)
-                42
-            }
-            val handled = ContextEffect.handle(Tag[TestEffect], 0, _ => 0)(result)
-            assert(handled.eval == 42)
-        }
-
-        "sequence of pure values" in {
-            val seq = Seq(1, 2, 3)
-            val result = Boundary[TestEffect, Any](seq.map(x => x: Int < TestEffect)) { isolatedSeq =>
-                assert(isolatedSeq.size == 3)
-                isolatedSeq.map(_.eval).sum
-            }
-            val handled = ContextEffect.handle(Tag[TestEffect], 0, _ => 0)(result)
-            assert(handled.eval == 6)
-        }
-
-        "sequence with effects" in {
-            val seq = Seq(
-                ContextEffect.suspend(Tag[TestEffect]),
-                ContextEffect.suspend(Tag[TestEffect]),
-                ContextEffect.suspend(Tag[TestEffect])
-            )
-            val result = Boundary[TestEffect, Any](seq) { isolatedSeq =>
-                isolatedSeq.map(_.eval).sum
-            }
-            val handled = ContextEffect.handle(Tag[TestEffect], 10, _ + 1)(result)
-            assert(handled.eval == 30)
-        }
-
-        "sequence with mixed pure and effect values" in {
-            val seq = Seq(
-                1: Int < TestEffect,
-                ContextEffect.suspend(Tag[TestEffect]),
-                3: Int < TestEffect
-            )
-            val result = Boundary[TestEffect, Any](seq) { isolatedSeq =>
-                isolatedSeq.map(_.eval).sum
-            }
-            val handled = ContextEffect.handle(Tag[TestEffect], 10, _ + 1)(result)
-            assert(handled.eval == 14)
-        }
-
-        "nested effects in sequence" in {
-            val seq = Seq(
-                ContextEffect.suspend(Tag[TestEffect]).map(_ * 2),
-                ContextEffect.suspend(Tag[TestEffect]).flatMap(x => ContextEffect.suspend(Tag[TestEffect]).map(_ + x)),
-                ContextEffect.suspend(Tag[TestEffect])
-            )
-            val result = Boundary[TestEffect, Any](seq) { isolatedSeq =>
-                isolatedSeq.map(_.eval).sum
-            }
-            val handled = ContextEffect.handle(Tag[TestEffect], 10, _ + 1)(result)
-            assert(handled.eval == 50)
-        }
-
-        "with multiple effect types" in {
-            val seq = Seq(
-                ContextEffect.suspend[Int, TestEffect](Tag[TestEffect]),
-                ContextEffect.suspend[String, AnotherEffect](Tag[AnotherEffect]).map(_.length)
-            )
-            val result = Boundary[TestEffect & AnotherEffect, Any](seq) { isolatedSeq =>
-                isolatedSeq.map(_.eval).sum
-            }
-            val handled = ContextEffect.handle(Tag[TestEffect], 10, _ + 1) {
-                ContextEffect.handle(Tag[AnotherEffect], "test", _.toUpperCase)(result)
-            }
-            assert(handled.eval == 14)
-        }
-        "preserves ordering of the provided sequence" in {
-            val seq = Seq(
-                ContextEffect.suspend[Int, TestEffect](Tag[TestEffect]).map(_ + 1),
-                ContextEffect.suspend[Int, TestEffect](Tag[TestEffect]).map(_ + 2),
-                ContextEffect.suspend[Int, TestEffect](Tag[TestEffect]).map(_ + 3)
-            )
-
-            val result = Boundary[TestEffect, Any](seq) { isolatedSeq =>
-                Kyo.seq.collect(isolatedSeq)
-            }
-
-            val handled = ContextEffect.handle(Tag[TestEffect], 10, _ => 10)(result)
-
-            assert(handled.eval == Seq(11, 12, 13))
-        }
-    }
 end BoundaryTest

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/ContextTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/ContextTest.scala
@@ -1,0 +1,67 @@
+package kyo2.kernel
+
+import kyo.Tag
+import kyo2.Test
+
+class ContextTest extends Test:
+
+    sealed trait TestEffect1 extends ContextEffect[Int]
+    sealed trait TestEffect2 extends ContextEffect[String]
+
+    "empty" - {
+        "should be empty" in {
+            assert(Context.empty.isEmpty)
+        }
+
+        "should not contain any tags" in {
+            assert(!Context.empty.contains(Tag[TestEffect1]))
+            assert(!Context.empty.contains(Tag[TestEffect2]))
+        }
+    }
+
+    "contains" - {
+        "should return true for contained tags" in {
+            val context = Context.empty.set(Tag[TestEffect1], 42)
+            assert(context.contains(Tag[TestEffect1]))
+        }
+
+        "should return false for non-contained tags" in {
+            val context = Context.empty.set(Tag[TestEffect1], 42)
+            assert(!context.contains(Tag[TestEffect2]))
+        }
+    }
+
+    "getOrElse" - {
+        "should return value for contained tags" in {
+            val context = Context.empty.set(Tag[TestEffect1], 42)
+            assert(context.getOrElse(Tag[TestEffect1], 0) == 42)
+        }
+
+        "should return default for non-contained tags" in {
+            val context = Context.empty.set(Tag[TestEffect1], 42)
+            assert(context.getOrElse(Tag[TestEffect2], "default") == "default")
+        }
+    }
+
+    "set" - {
+        "should add new values" in {
+            val context = Context.empty.set(Tag[TestEffect1], 42)
+            assert(context.getOrElse(Tag[TestEffect1], 0) == 42)
+        }
+
+        "should update existing values" in {
+            val context = Context.empty.set(Tag[TestEffect1], 42).set(Tag[TestEffect1], 24)
+            assert(context.getOrElse(Tag[TestEffect1], 0) == 24)
+        }
+    }
+
+    "multiple effects" in {
+        val context = Context.empty
+            .set(Tag[TestEffect1], 42)
+            .set(Tag[TestEffect2], "test")
+
+        assert(context.getOrElse(Tag[TestEffect1], 0) == 42)
+        assert(context.getOrElse(Tag[TestEffect2], "") == "test")
+    }
+
+end ContextTest

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/PendingTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/PendingTest.scala
@@ -162,48 +162,4 @@ class PendingTest extends Test:
         }
     }
 
-    "evalPartial" - {
-        abstract class TestInterceptor extends Safepoint.Interceptor:
-            def addEnsure(f: () => Unit): Unit    = {}
-            def removeEnsure(f: () => Unit): Unit = {}
-
-        "evaluates pure values" in {
-            val x: Int < Any = 5
-            val result = x.evalPartial(new TestInterceptor:
-                def enter(frame: Frame, value: Any) = true
-                def exit()                          = ()
-            )
-            assert(result.eval == 5)
-        }
-
-        "suspends at effects" in {
-            val x: Int < TestEffect = testEffect(5).map(_ + 1)
-            val result = x.evalPartial(new TestInterceptor:
-                def enter(frame: Frame, value: Any) = true
-                def exit()                          = ()
-            )
-            assert(result.evalNow.isEmpty)
-        }
-
-        "respects the interceptor" in {
-            var called       = false
-            val x: Int < Any = Effect.defer(5)
-            val result = x.evalPartial(new TestInterceptor:
-                def enter(frame: Frame, value: Any) =
-                    called = true; false
-                def exit() = ()
-            )
-            assert(called)
-            assert(result.evalNow.isEmpty)
-        }
-
-        "evaluates nested suspensions" in {
-            val x: Int < Any = Effect.defer(Effect.defer(5))
-            val result = x.evalPartial(new TestInterceptor:
-                def enter(frame: Frame, value: Any) = true
-                def exit()                          = ()
-            )
-            assert(result.eval == 5)
-        }
-    }
 end PendingTest


### PR DESCRIPTION
This seems to be the last optimizations needed to port `kyo-core` to the new design. I had designed a generic `Boundary` mechanism that could be used even by user-defined effects but the abstraction requires a few allocations in the critical path of the the fiber execution (`IOTask`). I'm kind of throwing the towel for now and providing more low-level APIs designed specifically to ensure peak performance for fibers.