### PR TITLE
ansi frame rendering

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo2/Ansi.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Ansi.scala
@@ -1,0 +1,111 @@
+package kyo2
+
+object Ansi:
+
+    extension (str: String)
+        def black: String   = s"\u001b[30m$str\u001b[0m"
+        def red: String     = s"\u001b[31m$str\u001b[0m"
+        def green: String   = s"\u001b[32m$str\u001b[0m"
+        def yellow: String  = s"\u001b[33m$str\u001b[0m"
+        def blue: String    = s"\u001b[34m$str\u001b[0m"
+        def magenta: String = s"\u001b[35m$str\u001b[0m"
+        def cyan: String    = s"\u001b[36m$str\u001b[0m"
+        def white: String   = s"\u001b[37m$str\u001b[0m"
+        def grey: String    = s"\u001b[90m$str\u001b[0m"
+
+        def bold: String      = s"\u001b[1m$str\u001b[0m"
+        def dim: String       = s"\u001b[2m$str\u001b[0m"
+        def italic: String    = s"\u001b[3m$str\u001b[0m"
+        def underline: String = s"\u001b[4m$str\u001b[0m"
+
+        def stripAnsi: String = str.replaceAll("\u001b\\[[0-9;]*[a-zA-Z]", "")
+    end extension
+
+    object highlight:
+        def apply(header: String, code: String, trailer: String, startLine: Int = 1): String =
+            val headerLines  = if header.nonEmpty then header.split("\n") else Array.empty[String]
+            val codeLines    = code.split("\n").dropWhile(_.trim.isEmpty).reverse.dropWhile(_.trim.isEmpty).reverse
+            val trailerLines = if trailer.nonEmpty then trailer.split("\n") else Array.empty[String]
+
+            val allLines        = headerLines ++ codeLines ++ trailerLines
+            val toDrop          = codeLines.filter(_.trim.nonEmpty).map(_.takeWhile(_ == ' ').length).minOption.getOrElse(0)
+            val lineNumberWidth = (startLine + codeLines.length - 1).toString.length
+            val separator       = "│".dim
+
+            val processedLines = allLines.zipWithIndex.map { case (line, index) =>
+                val isHeader  = index < headerLines.length
+                val isTrailer = index >= (headerLines.length + codeLines.length)
+                val lineNumber =
+                    if isHeader || isTrailer then
+                        " ".repeat(lineNumberWidth)
+                    else
+                        (startLine + index - headerLines.length).toString.padTo(lineNumberWidth, ' ')
+
+                val highlightedLine =
+                    if isHeader || isTrailer then
+                        line.green
+                    else
+                        highlightLine(line.drop(toDrop))
+
+                s"${lineNumber.dim} $separator $highlightedLine"
+            }
+
+            processedLines.mkString("\n")
+        end apply
+
+        def apply(code: String): String = apply("", code, "", 1)
+
+        private def highlightLine(line: String): String =
+            if line.trim.startsWith("//") then
+                line.green // Make entire line green for single-line comments
+            else
+                line.split("((?<=\\W)|(?=\\W))").map { token =>
+                    if keywords.contains(token) then token.yellow
+                    else if token.matches("\".*\"") then token.green
+                    else if token.matches("/\\*.*\\*/") then token.green // Inline multi-line comments
+                    else if token.matches("[0-9]+") then token.cyan
+                    else token
+                }.mkString
+        end highlightLine
+
+        private val keywords = Set(
+            "abstract",
+            "case",
+            "catch",
+            "class",
+            "def",
+            "do",
+            "else",
+            "enum",
+            "export",
+            "extends",
+            "final",
+            "finally",
+            "for",
+            "given",
+            "if",
+            "implicit",
+            "import",
+            "lazy",
+            "match",
+            "new",
+            "object",
+            "override",
+            "package",
+            "private",
+            "protected",
+            "return",
+            "sealed",
+            "super",
+            "throw",
+            "trait",
+            "try",
+            "type",
+            "val",
+            "var",
+            "while",
+            "with",
+            "yield"
+        )
+    end highlight
+end Ansi

--- a/kyo-prelude/shared/src/main/scala/kyo2/Ansi.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Ansi.scala
@@ -59,13 +59,15 @@ object Ansi:
             if line.trim.startsWith("//") then
                 line.green // Make entire line green for single-line comments
             else
-                line.split("((?<=\\W)|(?=\\W))").map { token =>
-                    if keywords.contains(token) then token.yellow
-                    else if token.matches("\".*\"") then token.green
-                    else if token.matches("/\\*.*\\*/") then token.green // Inline multi-line comments
-                    else if token.matches("[0-9]+") then token.cyan
-                    else token
-                }.mkString
+                line.split("\\b")
+                    .map { token =>
+                        if keywords.contains(token) then token.yellow
+                        else if token.matches("\".*\"") then token.green
+                        else if token.matches("/\\*.*\\*/") then token.green // Inline multi-line comments
+                        else if token.matches("[0-9]+") then token.cyan
+                        else token
+                    }
+                    .mkString
         end highlightLine
 
         private val keywords = Set(

--- a/kyo-prelude/shared/src/main/scala/kyo2/kernel/Frame.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/kernel/Frame.scala
@@ -1,5 +1,6 @@
 package kyo2.kernel
 
+import kyo2.Ansi
 import scala.annotation.tailrec
 import scala.quoted.*
 
@@ -18,6 +19,10 @@ object Frame:
         snippetShort: String,
         snippetLong: String
     ) derives CanEqual:
+
+        def show: String =
+            Ansi.highlight(s"// $declaringClass $methodName", snippetLong, s"// $position", position.lineNumber)
+
         override def toString = s"Frame($declaringClass, $methodName, $position, $snippetShort)"
     end Parsed
 
@@ -41,7 +46,7 @@ object Frame:
             )
         end parse
 
-        def show: String = parse.toString
+        def show: String = parse.show
     end extension
 
     implicit inline def derive: Frame = ${ frameImpl }

--- a/kyo-prelude/shared/src/test/scala/kyo2/AnsiTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/AnsiTest.scala
@@ -1,0 +1,64 @@
+package kyo2
+
+class AnsiTest extends Test:
+
+    import Ansi.*
+
+    "black" in {
+        assert("test".black == "\u001b[30mtest\u001b[0m")
+    }
+
+    "red" in {
+        assert("test".red == "\u001b[31mtest\u001b[0m")
+    }
+
+    "green" in {
+        assert("test".green == "\u001b[32mtest\u001b[0m")
+    }
+
+    "yellow" in {
+        assert("test".yellow == "\u001b[33mtest\u001b[0m")
+    }
+
+    "blue" in {
+        assert("test".blue == "\u001b[34mtest\u001b[0m")
+    }
+
+    "magenta" in {
+        assert("test".magenta == "\u001b[35mtest\u001b[0m")
+    }
+
+    "cyan" in {
+        assert("test".cyan == "\u001b[36mtest\u001b[0m")
+    }
+
+    "white" in {
+        assert("test".white == "\u001b[37mtest\u001b[0m")
+    }
+
+    "grey" in {
+        assert("test".grey == "\u001b[90mtest\u001b[0m")
+    }
+
+    "bold" in {
+        assert("test".bold == "\u001b[1mtest\u001b[0m")
+    }
+
+    "dim" in {
+        assert("test".dim == "\u001b[2mtest\u001b[0m")
+    }
+
+    "italic" in {
+        assert("test".italic == "\u001b[3mtest\u001b[0m")
+    }
+
+    "underline" in {
+        assert("test".underline == "\u001b[4mtest\u001b[0m")
+    }
+
+    "stripAnsi" in {
+        val coloredString = "test".red.bold.underline
+        assert(coloredString.stripAnsi == "test")
+    }
+
+end AnsiTest

--- a/kyo-prelude/shared/src/test/scala/kyo2/kernel/FrameTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo2/kernel/FrameTest.scala
@@ -13,9 +13,23 @@ class FrameTest extends Test:
         x / x
     }
 
+    "parse.toString" in {
+        assert(test1.parse.toString == "Frame(kyo2.kernel.FrameTest, test1, FrameTest.scala:9:28, def test1 = test(1 + 2))")
+        assert(test2.parse.toString == "Frame(kyo2.kernel.FrameTest, test2, FrameTest.scala:14:6, })")
+    }
+
     "show" in {
-        assert(test1.show == "Frame(kyo2.kernel.FrameTest, test1, FrameTest.scala:9:28, def test1 = test(1 + 2))")
-        assert(test2.show == "Frame(kyo2.kernel.FrameTest, test2, FrameTest.scala:14:6, })")
+        import kyo2.Ansi.*
+        assert(test1.show.stripAnsi ==
+            """|  │ // kyo2.kernel.FrameTest test1
+               |9 │ def test1 = test(1 + 2)📍
+               |  │ // FrameTest.scala:9:28""".stripMargin)
+
+        assert(test2.show.stripAnsi ==
+            """|   │ // kyo2.kernel.FrameTest test2
+               |14 │     x / x
+               |15 │ }📍
+               |   │ // FrameTest.scala:14:6""".stripMargin)
     }
 
     "parse" in {


### PR DESCRIPTION
This PR introduces a basic syntax highlight mechanism to improve the rendering of frames. Example output of `frame.show`:

```scala
object main extends App:
    def myMethod(i: Int)(using f: Frame) = f
    val f =
        myMethod(Math.pow(1, 0).toInt)
    println(f.show)
end main
```

<img width="340" alt="image" src="https://github.com/user-attachments/assets/c41175fd-5a27-42f5-b93b-bf347cb113d4">
