### PR TITLE
prelude: fix use of the Trace circular buffer in Trace.Owner.enrich

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo2/Ansi.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo2/Ansi.scala
@@ -59,15 +59,13 @@ object Ansi:
             if line.trim.startsWith("//") then
                 line.green // Make entire line green for single-line comments
             else
-                line.split("\\b")
-                    .map { token =>
-                        if keywords.contains(token) then token.yellow
-                        else if token.matches("\".*\"") then token.green
-                        else if token.matches("/\\*.*\\*/") then token.green // Inline multi-line comments
-                        else if token.matches("[0-9]+") then token.cyan
-                        else token
-                    }
-                    .mkString
+                line.split(" ").map { token =>
+                    if keywords.contains(token) then token.yellow
+                    else if token.matches("\".*\"") then token.green
+                    else if token.matches("/\\*.*\\*/") then token.green // Inline multi-line comments
+                    else if token.matches("[0-9]+") then token.cyan
+                    else token
+                }.mkString(" ")
         end highlightLine
 
         private val keywords = Set(


### PR DESCRIPTION
Traces use a circular buffer internally to store frames, which can make the first frame to land in any index of the array, not necessarily at index `0`. This PR fixes `Trace.Owner.enrich` to consider this scenario correctly.