### PR TITLE
make Chunk a Seq

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,13 +740,13 @@ val a: Chunk[Int] = Chunk(1, 2, 3)
 val b: Chunk[Int] = Chunk.from(Seq(4, 5, 6))
 
 // Perform O(1) operations
-val c: Chunk[Int] = a.append(4)
-val d: Chunk[Int] = b.take(2)
-val e: Chunk[Int] = c.dropLeft(1)
+val c = a.append(4)
+val d = b.take(2)
+val e = c.dropLeft(1)
 
 // Perform O(n) operations
-val f: Chunk[String] = d.map(_.toString).eval
-val g: Chunk[Int]    = e.filter(_ % 2 == 0).eval
+val f = d.map(_.toString)
+val g = e.filter(_ % 2 == 0)
 ```
 
 `Chunk` provides two main subtypes: `Chunk` for regular chunks and `Chunk.Indexed` for indexed chunks. The table below summarizes the time complexity of various operations for each type:
@@ -817,17 +817,6 @@ val h: Int        = a.last
 
 // Concatenation
 val i: Chunk[Int] = a.concat(b)
-
-// Effectful map and filter
-val j: Chunk[String] < Any = a.map(_.toString)
-val k: Chunk[Int] < Any    = a.filter(_ % 2 == 0)
-
-// Effectful side effects
-val l: Unit < IO =
-    a.foreach(v => Console.println(v))
-
-// Effectful fold
-val m: Int < Any = a.foldLeft(0)(_ + _)
 
 // Copying to arrays
 val n: Array[Int] = a.toArray

--- a/kyo-bench/src/main/scala/kyo/bench/CollectBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/CollectBench.scala
@@ -11,7 +11,7 @@ class CollectBench extends Bench.SyncAndFork(Seq.fill(1000)(1)):
     def kyoBench() =
         import kyo.*
 
-        Kyo.seq.collect(kyoTasks)
+        Kyo.collect(kyoTasks)
     end kyoBench
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/ForkJoinBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForkJoinBench.scala
@@ -21,9 +21,9 @@ class ForkJoinBench extends Bench.ForkOnly(()):
         import kyo.*
 
         val forkFiber     = Async.run(())
-        val forkAllFibers = Kyo.seq.map(range)(_ => forkFiber)
+        val forkAllFibers = Kyo.foreach(range)(_ => forkFiber)
 
-        forkAllFibers.flatMap(fibers => Kyo.seq.foreach(fibers)(_.get))
+        forkAllFibers.flatMap(fibers => Kyo.foreachDiscard(fibers)(_.get))
     end kyoBenchFiber
 
     def zioBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/ForkJoinContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForkJoinContentionBench.scala
@@ -24,8 +24,8 @@ class ForkJoinContentionBench extends Bench.ForkOnly(()):
         import kyo.*
 
         val forkFiber         = Async.run(())
-        val forkAllFibers     = Kyo.seq.map(range)(_ => forkFiber)
-        val forkJoinAllFibers = forkAllFibers.flatMap(fibers => Kyo.seq.map(fibers)(_.get).unit)
+        val forkAllFibers     = Kyo.foreach(range)(_ => forkFiber)
+        val forkJoinAllFibers = forkAllFibers.flatMap(fibers => Kyo.foreach(fibers)(_.get).unit)
 
         Async.parallel(Seq.fill(parallism)(forkJoinAllFibers)).unit
     end kyoBenchFiber

--- a/kyo-bench/src/main/scala/kyo/bench/MtlBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/MtlBench.scala
@@ -14,7 +14,7 @@ class MtlBench extends Bench(()):
     def syncKyo() =
         import kyo.*
         def testKyo: Unit < (Abort[Throwable] & Env[EnvValue] & Var[State] & Emit[Event]) =
-            Kyo.seq.foreach(loops)(_ =>
+            Kyo.foreachDiscard(loops)(_ =>
                 for
                     conf <- Env.use[EnvValue](_.config)
                     _    <- Emit(Event(s"Env = $conf"))

--- a/kyo-bench/src/main/scala/kyo/bench/SchedulingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/SchedulingBench.scala
@@ -41,10 +41,10 @@ class SchedulingBench extends Bench.ForkOnly(1001000):
                 }
             }
 
-        Kyo.seq.map(range) { i =>
+        Kyo.foreach(range) { i =>
             Async.run(fiber(i))
         }.map { fibers =>
-            Kyo.seq.map(fibers)(_.get)
+            Kyo.foreach(fibers)(_.get)
         }.map(_.sum)
     end kyoBenchFiber
 

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -40,27 +40,13 @@ extension (kyoObject: Kyo.type)
     )(
         useElement: PartialFunction[A, A1 < S1]
     ): Seq[A1] < (S & S1) =
-        sequence.flatMap((seq: Seq[A]) => Kyo.seq.collect(seq.collect(useElement)))
+        sequence.flatMap((seq: Seq[A]) => Kyo.collect(seq.collect(useElement)))
 
     def debugln[S](message: => String < S): Unit < (S & IO) =
         message.map(m => Console.println(m))
 
     def fail[E, S](error: => E < S): Nothing < (S & Abort[E]) =
         error.map(e => Abort.fail(e))
-
-    def foreach[A, S, A1, S1](
-        sequence: => Seq[A] < S
-    )(
-        useElement: A => A1 < S1
-    ): Seq[A1] < (S & S1) =
-        collect(sequence)(a => useElement(a))
-
-    def foreachDiscard[A, S, S1](
-        sequence: => Seq[A] < S
-    )(
-        useElement: A => Any < S1
-    ): Unit < (S & S1) =
-        foreach(sequence)(useElement).unit
 
     def foreachPar[A, S, A1](
         sequence: => Seq[A] < S
@@ -181,13 +167,13 @@ extension (kyoObject: Kyo.type)
     def traverse[A, S, S1](
         sequence: => Seq[A < S] < S1
     ): Seq[A] < (S & S1) =
-        sequence.flatMap((seq: Seq[A < S]) => Kyo.seq.collect(seq))
+        sequence.flatMap((seq: Seq[A < S]) => Kyo.collect(seq))
 
     def traverseDiscard[A, S, S1](
         sequence: => Seq[A < S] < S1
     ): Unit < (S & S1) =
         sequence.flatMap { (seq: Seq[A < S]) =>
-            Kyo.seq.collect(seq.map(_.map(_ => ()))).unit
+            Kyo.collect(seq.map(_.map(_ => ()))).unit
         }
     end traverseDiscard
 

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -172,10 +172,7 @@ extension (kyoObject: Kyo.type)
     def traverseDiscard[A, S, S1](
         sequence: => Seq[A < S] < S1
     ): Unit < (S & S1) =
-        sequence.flatMap { (seq: Seq[A < S]) =>
-            Kyo.collect(seq.map(_.map(_ => ()))).unit
-        }
-    end traverseDiscard
+        sequence.flatMap(Kyo.collectDiscard)
 
     def traversePar[A, S](
         sequence: => Seq[A < Async] < S

--- a/kyo-core/jvm/src/main/scala/kyo/Path.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Path.scala
@@ -30,7 +30,7 @@ class Path(val path: List[String]):
 
     def readAll(extension: String)(using Frame): Seq[(String, String)] < IO =
         list(extension).map { paths =>
-            Kyo.seq.map(paths) { p =>
+            Kyo.foreach(paths) { p =>
                 p.read.map(content => p.toJava.getName(0).toString() -> content)
             }
         }

--- a/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
@@ -50,8 +50,8 @@ class PathTest extends Test:
             for
                 v <- useFile(name, text).map { _ =>
                     Path(name).readStream()
-                }.map(_.runSeq)
-            yield assert(v == IndexedSeq("some text"))
+                }.map(_.run)
+            yield assert(v == Chunk("some text"))
             end for
         }
         "read file as bytes stream" in run {
@@ -60,8 +60,8 @@ class PathTest extends Test:
             for
                 v <- useFile(name, text).map { _ =>
                     Path(name).readBytesStream
-                }.map(_.runSeq)
-            yield assert(v == IndexedSeq[Byte](115, 111, 109, 101, 32, 116, 101, 120, 116))
+                }.map(_.run)
+            yield assert(v == Chunk[Byte](115, 111, 109, 101, 32, 116, 101, 120, 116))
         }
         "read file as lines stream" in run {
             val name = "read-file-string.txt"
@@ -69,8 +69,8 @@ class PathTest extends Test:
             for
                 v <- useFile(name, text).map { _ =>
                     Path(name).readLinesStream()
-                }.map(_.runSeq)
-            yield assert(v == IndexedSeq("some text", "more text"))
+                }.map(_.run)
+            yield assert(v == Chunk("some text", "more text"))
         }
         "readLinesStream defers side effects" in {
             Path("inexistent").readLinesStream()
@@ -255,7 +255,7 @@ class PathTest extends Test:
                 _ <- folder.mkDir
                 _ <- path1.mkFile
                 _ <- path2.mkFile
-                v <- folder.walk.runSeq
+                v <- folder.walk.run
                 _ <- folder.removeAll
             yield assert(v.toSet.map(_.toString) == Set(
                 """Path("folder")""",

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -94,7 +94,7 @@ object Meter:
         pipeline[S1 & S2 & S3 & S4](List(m1, m2, m3, m4))
 
     def pipeline[S](meters: Seq[Meter < (IO & S)])(using Frame): Meter < (IO & S) =
-        Kyo.seq.collect(meters).map { seq =>
+        Kyo.collect(meters).map { seq =>
             val meters = seq.toIndexedSeq
             new Meter:
 
@@ -123,7 +123,7 @@ object Meter:
                 end tryRun
 
                 def close(using Frame): Boolean < IO =
-                    Kyo.seq.map(meters)(_.close).map(_.exists(identity))
+                    Kyo.foreach(meters)(_.close).map(_.exists(identity))
             end new
         }
 

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -41,7 +41,7 @@ object Resource:
                         case Maybe.Empty =>
                             bug("Resource finalizer queue already closed.")
                         case Maybe.Defined(l) =>
-                            Kyo.seq.foreach(l)(task =>
+                            Kyo.foreachDiscard(l)(task =>
                                 Abort.run[Throwable](task)
                                     .map(_.fold(ex => Log.error("Resource finalizer failed", ex.exception))(_ => ()))
                             )

--- a/kyo-core/shared/src/main/scala/kyo/stats/internal/TraceReceiver.scala
+++ b/kyo-core/shared/src/main/scala/kyo/stats/internal/TraceReceiver.scala
@@ -45,6 +45,6 @@ object TraceReceiver:
                 parent: Maybe[Span] = Maybe.empty,
                 a: Attributes = Attributes.empty
             ) =
-                Kyo.seq.map(receivers)(_.startSpan(scope, name, Maybe.empty, a))
+                Kyo.foreach(receivers)(_.startSpan(scope, name, Maybe.empty, a))
                     .map(Span.all)
 end TraceReceiver

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -173,7 +173,7 @@ class AsyncTest extends Test:
         }
 
         "multiple fibers timeout" in runJVM {
-            Kyo.seq.fill(100)(Async.sleep(1.milli)).unit.andThen(1)
+            Kyo.fill(100)(Async.sleep(1.milli)).unit.andThen(1)
                 .pipe(Async.runAndBlock(10.millis))
                 .pipe(Abort.run[Timeout](_))
                 .map {

--- a/kyo-core/shared/src/test/scala/kyo/HubTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/HubTest.scala
@@ -136,8 +136,8 @@ class HubTest extends Test:
             for
                 h  <- Hub.init[Int](2)
                 l  <- h.listen
-                _  <- Kyo.seq.fill(100)(Async.run(h.put(1)))
-                t  <- Kyo.seq.fill(100)(l.take)
+                _  <- Kyo.fill(100)(Async.run(h.put(1)))
+                t  <- Kyo.fill(100)(l.take)
                 e1 <- h.isEmpty
                 e2 <- l.isEmpty
             yield assert(t == List.fill(100)(1) && e1 && e2)
@@ -146,8 +146,8 @@ class HubTest extends Test:
             for
                 h  <- Hub.init[Int](2)
                 l  <- h.listen
-                _  <- Kyo.seq.fill(100)(Async.run(h.put(1)))
-                t  <- Kyo.seq.fill(100)(Async.run(l.take).map(_.get))
+                _  <- Kyo.fill(100)(Async.run(h.put(1)))
+                t  <- Kyo.fill(100)(Async.run(l.take).map(_.get))
                 e1 <- h.isEmpty
                 e2 <- l.isEmpty
             yield assert(t == List.fill(100)(1) && e1 && e2)
@@ -155,12 +155,12 @@ class HubTest extends Test:
         "listeners" in runJVM {
             for
                 h  <- Hub.init[Int](2)
-                l  <- Kyo.seq.fill(100)(Async.run(h.listen).map(_.get))
+                l  <- Kyo.fill(100)(Async.run(h.listen).map(_.get))
                 _  <- Async.run(h.put(1))
-                t  <- Kyo.seq.map(l)(l => Async.run(l.take).map(_.get))
+                t  <- Kyo.foreach(l)(l => Async.run(l.take).map(_.get))
                 e1 <- h.isEmpty
-                e2 <- Kyo.seq.map(l)(_.isEmpty)
-            yield assert(t == List.fill(100)(1) && e1 && e2 == Seq.fill(100)(true))
+                e2 <- Kyo.foreach(l)(_.isEmpty)
+            yield assert(t == Chunk.fill(100)(1) && e1 && e2 == Chunk.fill(100)(true))
         }
     }
 end HubTest

--- a/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
@@ -22,11 +22,11 @@ object Choice:
     inline def drop(using inline frame: Frame): Nothing < Choice =
         Effect.suspend[Nothing](Tag[Choice], Seq.empty)
 
-    def run[A, S](v: A < (Choice & S))(using Frame): Seq[A] < S =
-        Effect.handle(Tag[Choice], v.map(Seq[A](_))) {
+    def run[A, S](v: A < (Choice & S))(using Frame): Chunk[A] < S =
+        Effect.handle(Tag[Choice], v.map(Chunk[A](_))) {
             [C] =>
                 (input, cont) =>
-                    Kyo.seq.map(input)(v => Choice.run(cont(v))).map(_.flatten.flatten)
+                    Kyo.foreach(input)(v => Choice.run(cont(v))).map(_.flatten.flatten)
         }
 
 end Choice

--- a/kyo-prelude/shared/src/main/scala/kyo/Kyo.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Kyo.scala
@@ -15,121 +15,202 @@ object Kyo:
     def zip[A1, A2, A3, A4, S](v1: A1 < S, v2: A2 < S, v3: A3 < S, v4: A4 < S)(using Frame): (A1, A2, A3, A4) < S =
         v1.map(t1 => v2.map(t2 => v3.map(t3 => v4.map(t4 => (t1, t2, t3, t4)))))
 
-    object seq:
-        def map[A, B, S, S2](seq: Seq[A])(f: A => B < S2)(using Frame): Seq[B] < (S & S2) =
-            seq.size match
-                case 0 => Seq.empty
-                case 1 => f(seq(0)).map(Seq(_))
-                case size =>
-                    seq match
-                        case seq: IndexedSeq[A] =>
-                            Loop.indexed(Chunk.empty[B]) { (idx, acc) =>
-                                if idx == size then Loop.done(acc.toSeq)
-                                else f(seq(idx)).map(u => Loop.continue(acc.append(u)))
-                            }
-                        case seq: List[A] =>
-                            Loop(seq, Chunk.empty[B]) { (seq, acc) =>
-                                seq match
-                                    case Nil          => Loop.done(acc.toSeq)
-                                    case head :: tail => f(head).map(u => Loop.continue(tail, acc.append(u)))
-                            }
-                        case seq =>
-                            Chunk.from(seq).map(f).map(_.toSeq)
-                    end match
+    def foreach[A, B, S, S2](seq: Seq[A])(f: A => B < S2)(using Frame): Chunk[B] < (S & S2) =
+        seq.size match
+            case 0 => Chunk.empty
+            case 1 => f(seq(0)).map(Chunk(_))
+            case size =>
+                seq match
+                    case seq: List[A] =>
+                        Loop(seq, Chunk.empty[B]) { (seq, acc) =>
+                            seq match
+                                case Nil          => Loop.done(acc)
+                                case head :: tail => f(head).map(u => Loop.continue(tail, acc.append(u)))
+                        }
+                    case seq =>
+                        val indexed = toIndexed(seq)
+                        Loop.indexed(Chunk.empty[B]) { (idx, acc) =>
+                            if idx == size then Loop.done(acc)
+                            else f(indexed(idx)).map(u => Loop.continue(acc.append(u)))
+                        }
+                end match
 
-        def foreach[A, B, S](seq: Seq[A])(f: A => Unit < S)(using Frame): Unit < S =
-            seq.size match
-                case 0 =>
-                case 1 => f(seq(0))
-                case size =>
-                    seq match
-                        case seq: IndexedSeq[A] =>
-                            Loop.indexed { idx =>
-                                if idx == size then Loop.done
-                                else f(seq(idx)).andThen(Loop.continue)
-                            }
-                        case seq: List[A] =>
-                            Loop(seq) {
+    def foreachDiscard[A, B, S](seq: Seq[A])(f: A => Unit < S)(using Frame): Unit < S =
+        seq.size match
+            case 0 =>
+            case 1 => f(seq(0))
+            case size =>
+                seq match
+                    case seq: List[A] =>
+                        Loop(seq) {
+                            case Nil          => Loop.done
+                            case head :: tail => f(head).andThen(Loop.continue(tail))
+                        }
+                    case seq =>
+                        val indexed = toIndexed(seq)
+                        Loop.indexed { idx =>
+                            if idx == size then Loop.done
+                            else f(indexed(idx)).andThen(Loop.continue)
+                        }
+                end match
+        end match
+    end foreachDiscard
+
+    def filter[A, S, S2](seq: Seq[A])(f: A => Boolean < S2)(using Frame): Chunk[A] < (S & S2) =
+        seq.size match
+            case 0 => Chunk.empty
+            case size =>
+                seq match
+                    case seq: List[A] =>
+                        Loop(seq, Chunk.empty[A]) { (seq, acc) =>
+                            seq match
+                                case Nil => Loop.done(acc)
+                                case head :: tail =>
+                                    f(head).map {
+                                        case true  => Loop.continue(tail, acc.append(head))
+                                        case false => Loop.continue(tail, acc)
+                                    }
+                        }
+                    case seq =>
+                        val indexed = toIndexed(seq)
+                        Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
+                            if idx == size then Loop.done(acc)
+                            else
+                                val curr = indexed(idx)
+                                f(curr).map {
+                                    case true  => Loop.continue(acc.append(curr))
+                                    case false => Loop.continue(acc)
+                                }
+                        }
+                end match
+
+    def foldLeft[A, B, S](seq: Seq[A])(acc: B)(f: (B, A) => B < S)(using Frame): B < S =
+        seq.size match
+            case 0 => acc
+            case 1 => f(acc, seq(0))
+            case size =>
+                seq match
+                    case seq: List[A] =>
+                        Loop(seq, acc) { (seq, acc) =>
+                            seq match
+                                case Nil          => Loop.done(acc)
+                                case head :: tail => f(acc, head).map(Loop.continue(tail, _))
+                        }
+                    case seq =>
+                        val indexed = toIndexed(seq)
+                        Loop.indexed(acc) { (idx, acc) =>
+                            if idx == size then Loop.done(acc)
+                            else f(acc, indexed(idx)).map(Loop.continue(_))
+                        }
+                end match
+        end match
+    end foldLeft
+
+    def collect[A, S](seq: Seq[A < S])(using Frame): Chunk[A] < S =
+        seq.size match
+            case 0 => Chunk.empty
+            case 1 => seq(0).map(Chunk(_))
+            case size =>
+                seq match
+                    case seq: List[A < S] =>
+                        Loop(seq, Chunk.empty[A]) { (seq, acc) =>
+                            seq match
+                                case Nil          => Loop.done(acc)
+                                case head :: tail => head.map(u => Loop.continue(tail, acc.append(u)))
+                        }
+                    case seq =>
+                        val indexed = toIndexed(seq)
+                        Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
+                            if idx == size then Loop.done(acc)
+                            else indexed(idx).map(u => Loop.continue(acc.append(u)))
+                        }
+                end match
+
+    def collectDiscard[A, S](seq: Seq[A < S])(using Frame): Unit < S =
+        seq.size match
+            case 0 =>
+            case 1 => seq(0).unit
+            case size =>
+                seq match
+                    case seq: List[A < S] =>
+                        Loop(seq) { seq =>
+                            seq match
                                 case Nil          => Loop.done
-                                case head :: tail => f(head).andThen(Loop.continue(tail))
-                            }
-                        case seq =>
-                            Chunk.from(seq).foreach(f)
-                    end match
-            end match
-        end foreach
+                                case head :: tail => head.map(_ => Loop.continue(tail))
+                        }
+                    case seq =>
+                        val indexed = toIndexed(seq)
+                        Loop.indexed { idx =>
+                            if idx == size then Loop.done
+                            else indexed(idx).map(u => Loop.continue)
+                        }
+                end match
 
-        def foldLeft[A, B, S](seq: Seq[A])(acc: B)(f: (B, A) => B < S)(using Frame): B < S =
-            seq.size match
-                case 0 => acc
-                case 1 => f(acc, seq(0))
-                case size =>
-                    seq match
-                        case seq: IndexedSeq[A] =>
-                            Loop.indexed(acc) { (idx, acc) =>
-                                if idx == size then Loop.done(acc)
-                                else f(acc, seq(idx)).map(Loop.continue(_))
-                            }
-                        case seq: List[A] =>
-                            Loop(seq, acc) { (seq, acc) =>
-                                seq match
-                                    case Nil          => Loop.done(acc)
-                                    case head :: tail => f(acc, head).map(Loop.continue(tail, _))
-                            }
-                        case seq =>
-                            Chunk.from(seq).foldLeft(acc)(f)
-                    end match
-            end match
-        end foldLeft
+    def takeWhile[A, S](seq: Seq[A])(f: A => Boolean < S)(using Frame): Chunk[A] < S =
+        seq.size match
+            case 0 => Chunk.empty
+            case size =>
+                seq match
+                    case seq: List[A] =>
+                        Loop(seq, Chunk.empty[A]) { (seq, acc) =>
+                            seq match
+                                case Nil => Loop.done(acc)
+                                case head :: tail =>
+                                    f(head).map {
+                                        case true  => Loop.continue(tail, acc.append(head))
+                                        case false => Loop.done(acc)
+                                    }
+                        }
+                    case seq =>
+                        val indexed = toIndexed(seq)
+                        Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
+                            if idx == size then Loop.done(acc)
+                            else
+                                val curr = indexed(idx)
+                                f(curr).map {
+                                    case true  => Loop.continue(acc.append(curr))
+                                    case false => Loop.done(acc)
+                                }
+                        }
+                end match
 
-        def collect[A, S](seq: Seq[A < S])(using Frame): Seq[A] < S =
-            seq.size match
-                case 0 => Seq.empty
-                case 1 => seq(0).map(Seq(_))
-                case size =>
-                    seq match
-                        case seq: IndexedSeq[A < S] =>
-                            Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
-                                if idx == size then Loop.done(acc.toSeq)
-                                else seq(idx).map(u => Loop.continue(acc.append(u)))
-                            }
-                        case seq: List[A < S] =>
-                            Loop(seq, Chunk.empty[A]) { (seq, acc) =>
-                                seq match
-                                    case Nil          => Loop.done(acc.toSeq)
-                                    case head :: tail => head.map(u => Loop.continue(tail, acc.append(u)))
-                            }
-                        case seq =>
-                            Chunk.from(seq).map(identity).map(_.toSeq)
-                    end match
+    def dropWhile[A, S](seq: Seq[A])(f: A => Boolean < S)(using Frame): Chunk[A] < S =
+        seq.size match
+            case 0 => Chunk.empty
+            case size =>
+                seq match
+                    case seq: List[A] =>
+                        Loop(seq) { seq =>
+                            seq match
+                                case Nil => Loop.done(Chunk.empty)
+                                case head :: tail =>
+                                    f(head).map {
+                                        case true  => Loop.continue(tail)
+                                        case false => Loop.done(Chunk.from(tail))
+                                    }
+                        }
+                    case seq =>
+                        val indexed = toIndexed(seq)
+                        Loop.indexed { idx =>
+                            if idx == size then Loop.done(Chunk.empty)
+                            else
+                                val curr = indexed(idx)
+                                f(curr).map {
+                                    case true  => Loop.continue
+                                    case false => Loop.done(Chunk.from(indexed.drop(idx)))
+                                }
+                        }
+                end match
 
-        def collectUnit[A, S](seq: Seq[Unit < S])(using Frame): Unit < S =
-            seq.size match
-                case 0 =>
-                case 1 => seq(0)
-                case size =>
-                    seq match
-                        case seq: IndexedSeq[Unit < S] =>
-                            Loop.indexed { idx =>
-                                if idx == size then Loop.done
-                                else seq(idx).map(u => Loop.continue)
-                            }
-                        case seq: List[Unit < S] =>
-                            Loop(seq) { seq =>
-                                seq match
-                                    case Nil          => Loop.done
-                                    case head :: tail => head.andThen(Loop.continue(tail))
-                            }
-                        case seq =>
-                            Chunk.from(seq).foreach(identity)
-                    end match
-        end collectUnit
+    def fill[A, S](n: Int)(v: => A < S)(using Frame): Chunk[A] < S =
+        Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
+            if idx == n then Loop.done(acc)
+            else v.map(t => Loop.continue(acc.append(t)))
+        }
 
-        def fill[A, S](n: Int)(v: => A < S)(using Frame): Seq[A] < S =
-            Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
-                if idx == n then Loop.done(acc.toSeq)
-                else v.map(t => Loop.continue(acc.append(t)))
-            }
-    end seq
+    private def toIndexed[A](seq: Seq[A]): Seq[A] =
+        seq match
+            case seq: IndexedSeq[A] => seq
+            case seq                => Chunk.from(seq)
 
 end Kyo

--- a/kyo-prelude/shared/src/main/scala/kyo/Kyo.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Kyo.scala
@@ -16,10 +16,10 @@ object Kyo:
         v1.map(t1 => v2.map(t2 => v3.map(t3 => v4.map(t4 => (t1, t2, t3, t4)))))
 
     def foreach[A, B, S, S2](seq: Seq[A])(f: A => B < S2)(using Frame): Chunk[B] < (S & S2) =
-        seq.size match
+        seq.knownSize match
             case 0 => Chunk.empty
             case 1 => f(seq(0)).map(Chunk(_))
-            case size =>
+            case _ =>
                 seq match
                     case seq: List[A] =>
                         Loop(seq, Chunk.empty[B]) { (seq, acc) =>
@@ -29,6 +29,7 @@ object Kyo:
                         }
                     case seq =>
                         val indexed = toIndexed(seq)
+                        val size    = indexed.size
                         Loop.indexed(Chunk.empty[B]) { (idx, acc) =>
                             if idx == size then Loop.done(acc)
                             else f(indexed(idx)).map(u => Loop.continue(acc.append(u)))
@@ -36,10 +37,10 @@ object Kyo:
                 end match
 
     def foreachDiscard[A, B, S](seq: Seq[A])(f: A => Unit < S)(using Frame): Unit < S =
-        seq.size match
+        seq.knownSize match
             case 0 =>
             case 1 => f(seq(0))
-            case size =>
+            case _ =>
                 seq match
                     case seq: List[A] =>
                         Loop(seq) {
@@ -48,6 +49,7 @@ object Kyo:
                         }
                     case seq =>
                         val indexed = toIndexed(seq)
+                        val size    = indexed.size
                         Loop.indexed { idx =>
                             if idx == size then Loop.done
                             else f(indexed(idx)).andThen(Loop.continue)
@@ -57,9 +59,9 @@ object Kyo:
     end foreachDiscard
 
     def filter[A, S, S2](seq: Seq[A])(f: A => Boolean < S2)(using Frame): Chunk[A] < (S & S2) =
-        seq.size match
+        seq.knownSize match
             case 0 => Chunk.empty
-            case size =>
+            case _ =>
                 seq match
                     case seq: List[A] =>
                         Loop(seq, Chunk.empty[A]) { (seq, acc) =>
@@ -73,6 +75,7 @@ object Kyo:
                         }
                     case seq =>
                         val indexed = toIndexed(seq)
+                        val size    = indexed.size
                         Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
                             if idx == size then Loop.done(acc)
                             else
@@ -85,10 +88,10 @@ object Kyo:
                 end match
 
     def foldLeft[A, B, S](seq: Seq[A])(acc: B)(f: (B, A) => B < S)(using Frame): B < S =
-        seq.size match
+        seq.knownSize match
             case 0 => acc
             case 1 => f(acc, seq(0))
-            case size =>
+            case _ =>
                 seq match
                     case seq: List[A] =>
                         Loop(seq, acc) { (seq, acc) =>
@@ -98,6 +101,7 @@ object Kyo:
                         }
                     case seq =>
                         val indexed = toIndexed(seq)
+                        val size    = indexed.size
                         Loop.indexed(acc) { (idx, acc) =>
                             if idx == size then Loop.done(acc)
                             else f(acc, indexed(idx)).map(Loop.continue(_))
@@ -107,10 +111,10 @@ object Kyo:
     end foldLeft
 
     def collect[A, S](seq: Seq[A < S])(using Frame): Chunk[A] < S =
-        seq.size match
+        seq.knownSize match
             case 0 => Chunk.empty
             case 1 => seq(0).map(Chunk(_))
-            case size =>
+            case _ =>
                 seq match
                     case seq: List[A < S] =>
                         Loop(seq, Chunk.empty[A]) { (seq, acc) =>
@@ -120,6 +124,7 @@ object Kyo:
                         }
                     case seq =>
                         val indexed = toIndexed(seq)
+                        val size    = indexed.size
                         Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
                             if idx == size then Loop.done(acc)
                             else indexed(idx).map(u => Loop.continue(acc.append(u)))
@@ -127,10 +132,10 @@ object Kyo:
                 end match
 
     def collectDiscard[A, S](seq: Seq[A < S])(using Frame): Unit < S =
-        seq.size match
+        seq.knownSize match
             case 0 =>
             case 1 => seq(0).unit
-            case size =>
+            case _ =>
                 seq match
                     case seq: List[A < S] =>
                         Loop(seq) { seq =>
@@ -140,16 +145,17 @@ object Kyo:
                         }
                     case seq =>
                         val indexed = toIndexed(seq)
+                        val size    = indexed.size
                         Loop.indexed { idx =>
                             if idx == size then Loop.done
-                            else indexed(idx).map(u => Loop.continue)
+                            else indexed(idx).map(_ => Loop.continue)
                         }
                 end match
 
     def takeWhile[A, S](seq: Seq[A])(f: A => Boolean < S)(using Frame): Chunk[A] < S =
-        seq.size match
+        seq.knownSize match
             case 0 => Chunk.empty
-            case size =>
+            case _ =>
                 seq match
                     case seq: List[A] =>
                         Loop(seq, Chunk.empty[A]) { (seq, acc) =>
@@ -163,6 +169,7 @@ object Kyo:
                         }
                     case seq =>
                         val indexed = toIndexed(seq)
+                        val size    = indexed.size
                         Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
                             if idx == size then Loop.done(acc)
                             else
@@ -175,9 +182,9 @@ object Kyo:
                 end match
 
     def dropWhile[A, S](seq: Seq[A])(f: A => Boolean < S)(using Frame): Chunk[A] < S =
-        seq.size match
+        seq.knownSize match
             case 0 => Chunk.empty
-            case size =>
+            case _ =>
                 seq match
                     case seq: List[A] =>
                         Loop(seq) { seq =>
@@ -191,6 +198,7 @@ object Kyo:
                         }
                     case seq =>
                         val indexed = toIndexed(seq)
+                        val size    = indexed.size
                         Loop.indexed { idx =>
                             if idx == size then Loop.done(Chunk.empty)
                             else

--- a/kyo-prelude/shared/src/test/scala/kyo/KyoTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/KyoTest.scala
@@ -157,105 +157,105 @@ class KyoTest extends Test:
     "seq" - {
 
         "collect" in {
-            assert(kyo.Kyo.seq.collect(Seq.empty).eval == Seq.empty)
-            assert(kyo.Kyo.seq.collect(Seq(1)).eval == Seq(1))
-            assert(kyo.Kyo.seq.collect(Seq(1, 2)).eval == Seq(1, 2))
-            assert(kyo.Kyo.seq.collect(Seq.fill(100)(1)).eval == Seq.fill(100)(1))
-            assert(kyo.Kyo.seq.collect(List(1, 2, 3)).eval == List(1, 2, 3))
-            assert(kyo.Kyo.seq.collect(Vector(1, 2, 3)).eval == Vector(1, 2, 3))
+            assert(Kyo.collect(Seq.empty).eval == Chunk.empty)
+            assert(Kyo.collect(Seq(1)).eval == Chunk(1))
+            assert(Kyo.collect(Seq(1, 2)).eval == Chunk(1, 2))
+            assert(Kyo.collect(Seq.fill(100)(1)).eval == Chunk.fill(100)(1))
+            assert(Kyo.collect(List(1, 2, 3)).eval == Chunk(1, 2, 3))
+            assert(Kyo.collect(Vector(1, 2, 3)).eval == Chunk(1, 2, 3))
         }
 
         "collectUnit" in {
             var count = 0
             val io    = kyo.Env.use[Unit](_ => count += 1)
-            kyo.Env.run(())(kyo.Kyo.seq.collectUnit(Seq.empty)).eval
+            kyo.Env.run(())(Kyo.collectDiscard(Seq.empty)).eval
             assert(count == 0)
-            kyo.Env.run(())(kyo.Kyo.seq.collectUnit(Seq(io))).eval
+            kyo.Env.run(())(Kyo.collectDiscard(Seq(io))).eval
             assert(count == 1)
-            kyo.Env.run(())(kyo.Kyo.seq.collectUnit(List.fill(42)(io))).eval
+            kyo.Env.run(())(Kyo.collectDiscard(List.fill(42)(io))).eval
             assert(count == 43)
-            kyo.Env.run(())(kyo.Kyo.seq.collectUnit(Vector.fill(10)(io))).eval
+            kyo.Env.run(())(Kyo.collectDiscard(Vector.fill(10)(io))).eval
             assert(count == 53)
         }
 
         "map" in {
-            assert(kyo.Kyo.seq.map(Seq.empty[Int])(_ + 1).eval == Seq.empty)
-            assert(kyo.Kyo.seq.map(Seq(1))(_ + 1).eval == Seq(2))
-            assert(kyo.Kyo.seq.map(Seq(1, 2))(_ + 1).eval == Seq(2, 3))
-            assert(kyo.Kyo.seq.map(Seq.fill(100)(1))(_ + 1).eval == Seq.fill(100)(2))
-            assert(kyo.Kyo.seq.map(List(1, 2, 3))(_ + 1).eval == List(2, 3, 4))
-            assert(kyo.Kyo.seq.map(Vector(1, 2, 3))(_ + 1).eval == Vector(2, 3, 4))
+            assert(Kyo.foreach(Seq.empty[Int])(_ + 1).eval == Chunk.empty)
+            assert(Kyo.foreach(Seq(1))(_ + 1).eval == Chunk(2))
+            assert(Kyo.foreach(Seq(1, 2))(_ + 1).eval == Chunk(2, 3))
+            assert(Kyo.foreach(Seq.fill(100)(1))(_ + 1).eval == Chunk.fill(100)(2))
+            assert(Kyo.foreach(List(1, 2, 3))(_ + 1).eval == Chunk(2, 3, 4))
+            assert(Kyo.foreach(Vector(1, 2, 3))(_ + 1).eval == Chunk(2, 3, 4))
         }
 
         "foreach" in {
             var acc = Seq.empty[Int]
-            kyo.Kyo.seq.foreach(Seq.empty[Int])(v => acc :+= v).eval
-            assert(acc == Seq.empty)
+            Kyo.foreachDiscard(Seq.empty[Int])(v => acc :+= v).eval
+            assert(acc == Chunk.empty)
             acc = Seq.empty[Int]
-            kyo.Kyo.seq.foreach(Seq(1))(v => acc :+= v).eval
-            assert(acc == Seq(1))
+            Kyo.foreachDiscard(Seq(1))(v => acc :+= v).eval
+            assert(acc == Chunk(1))
             acc = Seq.empty[Int]
-            kyo.Kyo.seq.foreach(Seq(1, 2))(v => acc :+= v).eval
-            assert(acc == Seq(1, 2))
+            Kyo.foreachDiscard(Seq(1, 2))(v => acc :+= v).eval
+            assert(acc == Chunk(1, 2))
             acc = Seq.empty[Int]
-            kyo.Kyo.seq.foreach(Seq.fill(100)(1))(v => acc :+= v).eval
-            assert(acc == Seq.fill(100)(1))
+            Kyo.foreachDiscard(Seq.fill(100)(1))(v => acc :+= v).eval
+            assert(acc == Chunk.fill(100)(1))
             acc = Seq.empty[Int]
-            kyo.Kyo.seq.foreach(List(1, 2, 3))(v => acc :+= v).eval
-            assert(acc == List(1, 2, 3))
+            Kyo.foreachDiscard(List(1, 2, 3))(v => acc :+= v).eval
+            assert(acc == Chunk(1, 2, 3))
             acc = Seq.empty[Int]
-            kyo.Kyo.seq.foreach(Vector(1, 2, 3))(v => acc :+= v).eval
-            assert(acc == Vector(1, 2, 3))
+            Kyo.foreachDiscard(Vector(1, 2, 3))(v => acc :+= v).eval
+            assert(acc == Chunk(1, 2, 3))
         }
 
         "foldLeft" in {
-            assert(kyo.Kyo.seq.foldLeft(Seq.empty[Int])(0)(_ + _).eval == 0)
-            assert(kyo.Kyo.seq.foldLeft(Seq(1))(0)(_ + _).eval == 1)
-            assert(kyo.Kyo.seq.foldLeft(Seq(1, 2, 3))(0)(_ + _).eval == 6)
-            assert(kyo.Kyo.seq.foldLeft(Seq.fill(100)(1))(0)(_ + _).eval == 100)
-            assert(kyo.Kyo.seq.foldLeft(List(1, 2, 3))(0)(_ + _).eval == 6)
-            assert(kyo.Kyo.seq.foldLeft(Vector(1, 2, 3))(0)(_ + _).eval == 6)
+            assert(Kyo.foldLeft(Seq.empty[Int])(0)(_ + _).eval == 0)
+            assert(Kyo.foldLeft(Seq(1))(0)(_ + _).eval == 1)
+            assert(Kyo.foldLeft(Seq(1, 2, 3))(0)(_ + _).eval == 6)
+            assert(Kyo.foldLeft(Seq.fill(100)(1))(0)(_ + _).eval == 100)
+            assert(Kyo.foldLeft(List(1, 2, 3))(0)(_ + _).eval == 6)
+            assert(Kyo.foldLeft(Vector(1, 2, 3))(0)(_ + _).eval == 6)
         }
 
         "fill" in {
-            assert(kyo.Kyo.seq.fill(0)(1).eval == Seq.empty)
-            assert(kyo.Kyo.seq.fill(1)(1).eval == Seq(1))
-            assert(kyo.Kyo.seq.fill(3)(1).eval == Seq(1, 1, 1))
-            assert(kyo.Kyo.seq.fill(100)(1).eval == Seq.fill(100)(1))
+            assert(Kyo.fill(0)(1).eval == Chunk.empty)
+            assert(Kyo.fill(1)(1).eval == Chunk(1))
+            assert(Kyo.fill(3)(1).eval == Chunk(1, 1, 1))
+            assert(Kyo.fill(100)(1).eval == Chunk.fill(100)(1))
         }
 
         "stack safety" - {
             val n = 1000
 
             "collect" in {
-                assert(kyo.Kyo.seq.collect(Seq.fill(n)(1)).eval == Seq.fill(n)(1))
+                assert(Kyo.collect(Seq.fill(n)(1)).eval == Chunk.fill(n)(1))
             }
 
             "collectUnit" in {
                 var count = 0
                 val io    = kyo.Env.use[Unit](_ => count += 1)
-                kyo.Env.run(())(kyo.Kyo.seq.collectUnit(Seq.fill(n)(io))).eval
+                kyo.Env.run(())(Kyo.collectDiscard(Seq.fill(n)(io))).eval
                 assert(count == n)
             }
 
             "map" in {
                 val largeSeq = Seq.fill(n)(1)
-                assert(kyo.Kyo.seq.map(largeSeq)(_ + 1).eval == Seq.fill(n)(2))
+                assert(Kyo.foreach(largeSeq)(_ + 1).eval == Chunk.fill(n)(2))
             }
 
             "foreach" in {
                 var acc = Seq.empty[Int]
-                kyo.Kyo.seq.foreach(Seq.fill(n)(1))(v => acc :+= v).eval
-                assert(acc == Seq.fill(n)(1))
+                Kyo.foreachDiscard(Seq.fill(n)(1))(v => acc :+= v).eval
+                assert(acc == Chunk.fill(n)(1))
             }
 
             "foldLeft" in {
                 val largeSeq = Seq.fill(n)(1)
-                assert(kyo.Kyo.seq.foldLeft(largeSeq)(0)(_ + _).eval == n)
+                assert(Kyo.foldLeft(largeSeq)(0)(_ + _).eval == n)
             }
 
             "fill" in {
-                assert(kyo.Kyo.seq.fill(n)(1).eval == Seq.fill(n)(1))
+                assert(Kyo.fill(n)(1).eval == Chunk.fill(n)(1))
             }
         }
     }

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -7,13 +7,13 @@ class StreamTest extends Test:
     "init" - {
         "empty" in {
             assert(
-                Stream.init(Seq[Int]()).runSeq.eval == Seq.empty
+                Stream.init(Seq[Int]()).run.eval == Seq.empty
             )
         }
 
         "non-empty" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).runSeq.eval == Seq(1, 2, 3)
+                Stream.init(Seq(1, 2, 3)).run.eval == Seq(1, 2, 3)
             )
         }
     }
@@ -21,13 +21,13 @@ class StreamTest extends Test:
     "initChunk" - {
         "empty" in {
             assert(
-                Stream.init(Chunk.empty[Int]).runSeq.eval == Seq.empty
+                Stream.init(Chunk.empty[Int]).run.eval == Seq.empty
             )
         }
 
         "non-empty" in {
             assert(
-                Stream.init(Chunk(1, 2, 3)).runSeq.eval == Seq(1, 2, 3)
+                Stream.init(Chunk(1, 2, 3)).run.eval == Seq(1, 2, 3)
             )
         }
     }
@@ -35,31 +35,31 @@ class StreamTest extends Test:
     "take" - {
         "zero" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).take(0).runSeq.eval == Seq.empty
+                Stream.init(Seq(1, 2, 3)).take(0).run.eval == Seq.empty
             )
         }
 
         "negative" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).take(-1).runSeq.eval == Seq.empty
+                Stream.init(Seq(1, 2, 3)).take(-1).run.eval == Seq.empty
             )
         }
 
         "two" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).take(2).runSeq.eval == Seq(1, 2)
+                Stream.init(Seq(1, 2, 3)).take(2).run.eval == Seq(1, 2)
             )
         }
 
         "more than available" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).take(5).runSeq.eval == Seq(1, 2, 3)
+                Stream.init(Seq(1, 2, 3)).take(5).run.eval == Seq(1, 2, 3)
             )
         }
 
         "stack safety" in {
             assert(
-                Stream.init(Seq.fill(100000)(1)).take(5).runSeq.eval ==
+                Stream.init(Seq.fill(100000)(1)).take(5).run.eval ==
                     Seq.fill(5)(1)
             )
         }
@@ -68,31 +68,31 @@ class StreamTest extends Test:
     "drop" - {
         "zero" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).drop(0).runSeq.eval == Seq(1, 2, 3)
+                Stream.init(Seq(1, 2, 3)).drop(0).run.eval == Seq(1, 2, 3)
             )
         }
 
         "negative" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).drop(-1).runSeq.eval == Seq(1, 2, 3)
+                Stream.init(Seq(1, 2, 3)).drop(-1).run.eval == Seq(1, 2, 3)
             )
         }
 
         "two" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).drop(2).runSeq.eval == Seq(3)
+                Stream.init(Seq(1, 2, 3)).drop(2).run.eval == Seq(3)
             )
         }
 
         "more than available" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).drop(5).runSeq.eval == Seq.empty
+                Stream.init(Seq(1, 2, 3)).drop(5).run.eval == Seq.empty
             )
         }
 
         "stack safety" in {
             assert(
-                Stream.init(Seq.fill(n)(1)).drop(5).runSeq.eval.size == n - 5
+                Stream.init(Seq.fill(n)(1)).drop(5).run.eval.size == n - 5
             )
         }
     }
@@ -100,27 +100,27 @@ class StreamTest extends Test:
     "takeWhile" - {
         "take none" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).takeWhile(_ < 0).runSeq.eval == Seq.empty
+                Stream.init(Seq(1, 2, 3)).takeWhile(_ < 0).run.eval == Seq.empty
             )
         }
 
         "take some" in {
             assert(
-                Stream.init(Seq(1, 2, 3, 4, 5)).takeWhile(_ < 4).runSeq.eval ==
+                Stream.init(Seq(1, 2, 3, 4, 5)).takeWhile(_ < 4).run.eval ==
                     Seq(1, 2, 3)
             )
         }
 
         "take all" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).takeWhile(_ < 10).runSeq.eval ==
+                Stream.init(Seq(1, 2, 3)).takeWhile(_ < 10).run.eval ==
                     Seq(1, 2, 3)
             )
         }
 
         "empty stream" in {
             assert(
-                Stream.init(Seq.empty[Int]).takeWhile(_ => true).runSeq.eval ==
+                Stream.init(Seq.empty[Int]).takeWhile(_ => true).run.eval ==
                     Seq.empty
             )
         }
@@ -129,13 +129,13 @@ class StreamTest extends Test:
             val stream = Stream.init(Seq(1, 2, 3, 4, 5))
             val taken = stream.takeWhile { v =>
                 Var.update[Int](_ + 1).map(_ < 4)
-            }.runSeq
+            }.run
             assert(Var.runTuple(0)(taken).eval == (4, Seq(1, 2, 3)))
         }
 
         "stack safety" in {
             assert(
-                Stream.init(Seq.fill(n)(1)).takeWhile(_ == 1).runSeq.eval ==
+                Stream.init(Seq.fill(n)(1)).takeWhile(_ == 1).run.eval ==
                     Seq.fill(n)(1)
             )
         }
@@ -144,28 +144,28 @@ class StreamTest extends Test:
     "dropWhile" - {
         "drop none" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).dropWhile(_ < 0).runSeq.eval ==
+                Stream.init(Seq(1, 2, 3)).dropWhile(_ < 0).run.eval ==
                     Seq(1, 2, 3)
             )
         }
 
         "drop some" in {
             assert(
-                Stream.init(Seq(1, 2, 3, 4, 5)).dropWhile(_ < 4).runSeq.eval ==
+                Stream.init(Seq(1, 2, 3, 4, 5)).dropWhile(_ < 4).run.eval ==
                     Seq(4, 5)
             )
         }
 
         "drop all" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).dropWhile(_ < 10).runSeq.eval ==
+                Stream.init(Seq(1, 2, 3)).dropWhile(_ < 10).run.eval ==
                     Seq.empty
             )
         }
 
         "empty stream" in {
             assert(
-                Stream.init(Seq.empty[Int]).dropWhile(_ => false).runSeq.eval ==
+                Stream.init(Seq.empty[Int]).dropWhile(_ => false).run.eval ==
                     Seq.empty
             )
         }
@@ -175,13 +175,13 @@ class StreamTest extends Test:
             val stream = Stream.init(Seq(1, 2, 3, 4, 5))
             val dropped = stream.dropWhile { v =>
                 Var.update[Int](_ + 1).map(_ < 3)
-            }.runSeq
+            }.run
             assert(Var.runTuple(0)(dropped).eval == (3, Seq(3, 4, 5)))
         }
 
         "stack safety" in {
             assert(
-                Stream.init(Seq.fill(n)(1) ++ Seq(2)).dropWhile(_ == 1).runSeq.eval ==
+                Stream.init(Seq.fill(n)(1) ++ Seq(2)).dropWhile(_ == 1).run.eval ==
                     Seq(2)
             )
         }
@@ -190,28 +190,28 @@ class StreamTest extends Test:
     "filter" - {
         "non-empty" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).filter(_ % 2 == 0).runSeq.eval ==
+                Stream.init(Seq(1, 2, 3)).filter(_ % 2 == 0).run.eval ==
                     Seq(2)
             )
         }
 
         "all in" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).filter(_ => true).runSeq.eval ==
+                Stream.init(Seq(1, 2, 3)).filter(_ => true).run.eval ==
                     Seq(1, 2, 3)
             )
         }
 
         "all out" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).filter(_ => false).runSeq.eval ==
+                Stream.init(Seq(1, 2, 3)).filter(_ => false).run.eval ==
                     Seq.empty
             )
         }
 
         "stack safety" in {
             assert(
-                Stream.init(1 to n).filter(_ % 2 == 0).runSeq.eval.size ==
+                Stream.init(1 to n).filter(_ % 2 == 0).run.eval.size ==
                     n / 2
             )
         }
@@ -220,35 +220,35 @@ class StreamTest extends Test:
     "changes" - {
         "no duplicates" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).changes.runSeq.eval ==
+                Stream.init(Seq(1, 2, 3)).changes.run.eval ==
                     Seq(1, 2, 3)
             )
         }
 
         "with duplicates" in {
             assert(
-                Stream.init(Seq(1, 2, 2, 3, 2, 3, 3)).changes.runSeq.eval ==
+                Stream.init(Seq(1, 2, 2, 3, 2, 3, 3)).changes.run.eval ==
                     Seq(1, 2, 3, 2, 3)
             )
         }
 
         "with initial value" in {
             assert(
-                Stream.init(Seq(1, 2, 2, 3, 2, 3, 3)).changes(1).runSeq.eval ==
+                Stream.init(Seq(1, 2, 2, 3, 2, 3, 3)).changes(1).run.eval ==
                     Seq(2, 3, 2, 3)
             )
         }
 
         "empty stream" in {
             assert(
-                Stream.init(Seq.empty[Int]).changes.runSeq.eval ==
+                Stream.init(Seq.empty[Int]).changes.run.eval ==
                     Seq.empty
             )
         }
 
         "stack safety" in {
             assert(
-                Stream.init(Seq.fill(n)(1)).changes.runSeq.eval ==
+                Stream.init(Seq.fill(n)(1)).changes.run.eval ==
                     Seq(1)
             )
         }
@@ -257,32 +257,32 @@ class StreamTest extends Test:
     "map" - {
         "double" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).map(_ * 2).runSeq.eval == Seq(2, 4, 6)
+                Stream.init(Seq(1, 2, 3)).map(_ * 2).run.eval == Seq(2, 4, 6)
             )
         }
 
         "to string" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).map(_.toString).runSeq.eval ==
+                Stream.init(Seq(1, 2, 3)).map(_.toString).run.eval ==
                     Seq("1", "2", "3")
             )
         }
 
         "with effects" in {
             val stream      = Stream.init(Seq(1, 2, 3))
-            val transformed = stream.map(v => Env.use[Int](v * _)).runSeq
+            val transformed = stream.map(v => Env.use[Int](v * _)).run
             assert(Env.run(2)(transformed).eval == Seq(2, 4, 6))
         }
 
         "with failures" in {
             val stream      = Stream.init(Seq("1", "2", "abc", "3"))
-            val transformed = stream.map(v => Abort.catching[NumberFormatException](v.toInt)).runSeq
+            val transformed = stream.map(v => Abort.catching[NumberFormatException](v.toInt)).run
             assert(Abort.run(transformed).eval.isFail)
         }
 
         "stack safety" in {
             assert(
-                Stream.init(Seq.fill(n)(1)).map(_ + 1).runSeq.eval ==
+                Stream.init(Seq.fill(n)(1)).map(_ + 1).run.eval ==
                     Seq.fill(n)(2)
             )
         }
@@ -293,7 +293,7 @@ class StreamTest extends Test:
                     .init(0 until 100)
                     .map(_ => counter += 1)
                     .take(0)
-                    .runSeq
+                    .run
                     .eval
             assert(counter == 0)
             assert(result.isEmpty)
@@ -303,32 +303,32 @@ class StreamTest extends Test:
     "mapChunk" - {
         "double" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).mapChunk(_.take(2).map(_ * 2)).runSeq.eval == Seq(2, 4)
+                Stream.init(Seq(1, 2, 3)).mapChunk(_.take(2).map(_ * 2)).run.eval == Seq(2, 4)
             )
         }
 
         "to string" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).mapChunk(_.append(4).map(_.toString)).runSeq.eval ==
+                Stream.init(Seq(1, 2, 3)).mapChunk(_.append(4).map(_.toString)).run.eval ==
                     Seq("1", "2", "3", "4")
             )
         }
 
         "with effects" in {
             val stream      = Stream.init(Seq(1, 2, 3))
-            val transformed = stream.mapChunk(v => Env.use[Int](i => v.map(_ * i))).runSeq
+            val transformed = stream.mapChunk(v => Env.use[Int](i => v.map(_ * i))).run
             assert(Env.run(2)(transformed).eval == Seq(2, 4, 6))
         }
 
         "with failures" in {
             val stream      = Stream.init(Seq("1", "2", "abc", "3"))
-            val transformed = stream.mapChunk(c => Abort.catching[NumberFormatException](c.map(_.toInt))).runSeq
+            val transformed = stream.mapChunk(c => Abort.catching[NumberFormatException](c.map(_.toInt))).run
             assert(Abort.run(transformed).eval.isFail)
         }
 
         "stack safety" in {
             assert(
-                Stream.init(Seq.fill(n)(1)).mapChunk(_.map(_ + 1)).runSeq.eval ==
+                Stream.init(Seq.fill(n)(1)).mapChunk(_.map(_ + 1)).run.eval ==
                     Seq.fill(n)(2)
             )
         }
@@ -339,7 +339,7 @@ class StreamTest extends Test:
                     .init(0 until 100)
                     .mapChunk(_.map(_ => counter += 1))
                     .take(0)
-                    .runSeq
+                    .run
                     .eval
             assert(counter == 0)
             assert(result.isEmpty)
@@ -349,13 +349,13 @@ class StreamTest extends Test:
     "flatMap" - {
         "empty stream" in {
             assert(
-                Stream.init(Seq.empty[Int]).flatMap(i => Stream.init(Seq(i, i + 1))).runSeq.eval == Seq.empty
+                Stream.init(Seq.empty[Int]).flatMap(i => Stream.init(Seq(i, i + 1))).run.eval == Seq.empty
             )
         }
 
         "one-to-many transformation" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).flatMap(i => Stream.init(Seq(i, i + 1))).runSeq.eval == Seq(1, 2, 2, 3, 3, 4)
+                Stream.init(Seq(1, 2, 3)).flatMap(i => Stream.init(Seq(i, i + 1))).run.eval == Seq(1, 2, 2, 3, 3, 4)
             )
         }
 
@@ -363,7 +363,7 @@ class StreamTest extends Test:
             val result = Env.run(10) {
                 Stream.init(Seq(1, 2, 3))
                     .flatMap(i => Stream.init(Seq(i, i + 1)).map(j => Env.use[Int](_ + j)))
-                    .runSeq
+                    .run
             }
             assert(result.eval == Seq(11, 12, 12, 13, 13, 14))
         }
@@ -375,14 +375,14 @@ class StreamTest extends Test:
                         if i > 2 then Abort.fail("Too large")
                         else Stream.init(Seq(i, i + 1))
                     )
-                    .runSeq
+                    .run
             }
             assert(result.eval == Result.fail("Too large"))
         }
 
         "chunked input" in {
             val input  = Stream.init(Chunk(1, 2, 3))
-            val result = input.flatMap(i => Stream.init(Seq(i, i * 10))).runSeq
+            val result = input.flatMap(i => Stream.init(Seq(i, i * 10))).run
             assert(result.eval == Seq(1, 10, 2, 20, 3, 30))
         }
     }
@@ -390,22 +390,22 @@ class StreamTest extends Test:
     "flatMapChunk" - {
         "empty stream" in {
             assert(
-                Stream.init(Seq.empty[Int]).flatMapChunk(c => Stream.init(c.map(_ + 1).eval)).runSeq.eval == Seq.empty
+                Stream.init(Seq.empty[Int]).flatMapChunk(c => Stream.init(c.map(_ + 1))).run.eval == Seq.empty
             )
         }
 
         "chunk transformation" in {
             val result = Stream.init(Seq(1, 2, 3))
-                .flatMapChunk(c => Stream.init(c.map(_ * 2).eval.append(0)))
-                .runSeq
+                .flatMapChunk(c => Stream.init(c.map(_ * 2) :+ 0))
+                .run
             assert(result.eval == Seq(2, 4, 6, 0))
         }
 
         "nested effects" in {
             val result = Env.run(10) {
                 Stream.init(Seq(1, 2, 3))
-                    .flatMapChunk(c => Env.use[Int](i => Stream.init(c.map(_ + i).eval)))
-                    .runSeq
+                    .flatMapChunk(c => Env.use[Int](i => Stream.init(c.map(_ + i))))
+                    .run
             }
             assert(result.eval == Seq(11, 12, 13))
         }
@@ -414,10 +414,10 @@ class StreamTest extends Test:
             val result = Abort.run[String] {
                 Stream.init(Seq(1, 2, 3))
                     .flatMapChunk(c =>
-                        if !c.filter(_ > 2).eval.isEmpty then Abort.fail("Too large")
-                        else Stream.init(c.map(_ * 2).eval)
+                        if !c.filter(_ > 2).isEmpty then Abort.fail("Too large")
+                        else Stream.init(c.map(_ * 2))
                     )
-                    .runSeq
+                    .run
             }
             assert(result.eval == Result.fail("Too large"))
         }
@@ -428,7 +428,7 @@ class StreamTest extends Test:
                 Stream.init(Chunk(4, 5, 6)).flatMapChunk(c2 =>
                     Stream.init(c1.concat(c2))
                 )
-            ).runSeq
+            ).run
             assert(result.eval == Seq(1, 2, 3, 4, 5, 6))
         }
     }
@@ -438,7 +438,7 @@ class StreamTest extends Test:
             assert(
                 Stream.init(Seq(1, 2, 3))
                     .concat(Stream.init(Seq(4, 5, 6)))
-                    .runSeq.eval == Seq(1, 2, 3, 4, 5, 6)
+                    .run.eval == Seq(1, 2, 3, 4, 5, 6)
             )
         }
 
@@ -446,7 +446,7 @@ class StreamTest extends Test:
             assert(
                 Stream.init(Seq.empty[Int])
                     .concat(Stream.init(Seq(1, 2, 3)))
-                    .runSeq.eval == Seq(1, 2, 3)
+                    .run.eval == Seq(1, 2, 3)
             )
         }
 
@@ -454,7 +454,7 @@ class StreamTest extends Test:
             assert(
                 Stream.init(Seq(1, 2, 3))
                     .concat(Stream.init(Seq.empty[Int]))
-                    .runSeq.eval == Seq(1, 2, 3)
+                    .run.eval == Seq(1, 2, 3)
             )
         }
 
@@ -462,7 +462,7 @@ class StreamTest extends Test:
             assert(
                 Stream.init(Seq.empty[Int])
                     .concat(Stream.init(Seq.empty[Int]))
-                    .runSeq.eval == Seq.empty
+                    .run.eval == Seq.empty
             )
         }
 
@@ -470,7 +470,7 @@ class StreamTest extends Test:
             assert(
                 Stream.init(1 to n)
                     .concat(Stream.init(n + 1 to 2 * n))
-                    .runSeq.eval == (1 to (2 * n)).toSeq
+                    .run.eval == (1 to (2 * n)).toSeq
             )
         }
     }
@@ -535,7 +535,7 @@ class StreamTest extends Test:
         "executes the function for each chunk" in run {
             var sum = 0
             Stream.init(Chunk(1, 2, 3, 4, 5)).runForeachChunk(chunk =>
-                sum += chunk.foldLeft(0)(_ + _).eval
+                sum += chunk.foldLeft(0)(_ + _)
             ).map { _ =>
                 assert(sum == 15)
             }
@@ -552,7 +552,7 @@ class StreamTest extends Test:
             var sum = 0
             Stream.init(Chunk(1, 2, 3, 4, 5)).runForeachChunk { chunk =>
                 Env.use[Int] { multiplier =>
-                    sum += chunk.foldLeft(0)(_ + _).eval * multiplier
+                    sum += chunk.foldLeft(0)(_ + _) * multiplier
                 }
             }.pipe(Env.run(2)).map { _ =>
                 assert(sum == 30)
@@ -591,7 +591,7 @@ class StreamTest extends Test:
     "nesting with other effect" in {
         val stream: Stream[Int, Any] < Env[Seq[Int]] =
             Env.use[Seq[Int]](seq => Stream.init(seq))
-        Env.run(Seq(1, 2, 3))(stream.map(_.runSeq)).eval
+        Env.run(Seq(1, 2, 3))(stream.map(_.run)).eval
         succeed
     }
 
@@ -606,7 +606,7 @@ class StreamTest extends Test:
                             else Stream.init(Seq(j, j * 10))
                         )
                     )
-                    .runSeq
+                    .run
             }
             assert(result.eval == Result.fail("Value too large: 4"))
         }
@@ -618,12 +618,12 @@ class StreamTest extends Test:
                     .flatMapChunk(c =>
                         if abortCounter % 2 == 0 then
                             abortCounter += 1
-                            Stream.init(c.map(i => if i > 3 then Abort.fail(s"Odd abort: $i") else i))
+                            Stream.init(Kyo.foreach(c)(i => if i > 3 then Abort.fail(s"Odd abort: $i") else i))
                         else
                             abortCounter += 1
                             Stream.init(c)
                     )
-                    .runSeq
+                    .run
             }
             assert(result.eval == Result.fail("Odd abort: 4"))
         }
@@ -640,7 +640,7 @@ class StreamTest extends Test:
                                 )
                             )
                         )
-                        .runSeq
+                        .run
                 }
             }
             assert(result.eval == Result.fail("Exceeded threshold 3: 4"))
@@ -656,7 +656,7 @@ class StreamTest extends Test:
                             Env.use[Int](env => if sum > env then Abort.fail("Sum too large") else j)
                         }
                     )
-                    .runSeq
+                    .run
             }
             assert(Abort.run(result).eval == Result.fail("Sum too large"))
         }
@@ -675,7 +675,7 @@ class StreamTest extends Test:
                             else Env.use[Int](_ + m)
                         }
                     end if
-                }.runSeq
+                }.run
             }
             assert(Env.run(0)(result).eval == Result.fail("Even counter: 2"))
             assert(counter == 2)
@@ -691,7 +691,7 @@ class StreamTest extends Test:
                             if newState > 3 then Abort.fail(s"State too high: $newState")
                             else chunk.map(_ * newState)
                         }
-                    }.runSeq
+                    }.run
                 }
             }
             assert(result.eval == Result.fail("State too high: 5"))
@@ -704,7 +704,7 @@ class StreamTest extends Test:
                     Env.use[Int] { chunkSize =>
                         Stream.init(Chunk.fill(chunkSize)(n))
                     }
-                }.runSeq
+                }.run
             }
             assert(result.eval == Seq(1, 1, 2, 2, 3, 3, 4, 4, 5, 5))
         }
@@ -718,7 +718,7 @@ class StreamTest extends Test:
                             if n > limit then Abort.fail(s"Value $n exceeds limit $limit")
                             else Stream.init(Seq(n, n * 10))
                         }
-                    }.runSeq
+                    }.run
                 }
             }
             assert(result.eval == Result.fail("Value 4 exceeds limit 3"))

--- a/kyo-tapir/shared/src/main/scala/kyo/routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/routes.scala
@@ -47,6 +47,6 @@ object Routes:
         add(e(endpoint))(f)
 
     def collect(init: (Unit < Routes)*)(using Frame): Unit < Routes =
-        Kyo.seq.collect(init).unit
+        Kyo.collect(init).unit
 
 end Routes


### PR DESCRIPTION
This PR makes `Chunk` extend from `Seq` so we can avoid additional allocations to transform between the types and improve usability. It's not ideal since Scala's `Seq` methods aren't well-optimized but it seems a good tradeoff.

The methods that used to take effectful functions like `map` and `filter` were moved to `Kyo.*` and the methods from `Kyo.seq.*` are now available directly in `Kyo.*`.