### PR TITLE
debug effect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,7 @@ lazy val `kyo-prelude` =
         .in(file("kyo-prelude"))
         .settings(
             `kyo-settings`,
+            libraryDependencies += "com.lihaoyi" %%% "pprint"        % "0.9.0",
             libraryDependencies += "org.jctools"   % "jctools-core"  % "4.0.5",
             libraryDependencies += "dev.zio"     %%% "zio-laws-laws" % "1.0.0-RC27" % Test,
             libraryDependencies += "dev.zio"     %%% "zio-test-sbt"  % "2.1.2"      % Test,
@@ -182,7 +183,6 @@ lazy val `kyo-core` =
         .in(file("kyo-core"))
         .settings(
             `kyo-settings`,
-            libraryDependencies += "com.lihaoyi"  %%% "pprint"          % "0.9.0",
             libraryDependencies += "org.jctools"    % "jctools-core"    % "4.0.5",
             libraryDependencies += "org.slf4j"      % "slf4j-api"       % "2.0.16",
             libraryDependencies += "dev.zio"      %%% "zio-laws-laws"   % "1.0.0-RC27" % Test,

--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -1,5 +1,6 @@
 package kyo
 
+import kyo.debug.Debug
 import kyo.kernel.Boundary
 import kyo.kernel.Reducible
 import scala.annotation.implicitNotFound
@@ -26,11 +27,9 @@ extension [A, S](effect: A < S)
     inline def as[A1, S1](value: => A1 < S1)(using inline frame: Frame): A1 < (S & S1) =
         effect.map(_ => value)
 
-    def debug(using Frame): A < (S & IO) =
-        effect.tap(value => Console.println(value.toString))
+    def debugValue(using Frame): A < S = Debug(effect)
 
-    def debug(prefix: => String)(using Frame): A < (S & IO) =
-        effect.tap(value => Console.println(s"$prefix: $value"))
+    def debugTrace(using Frame): A < S = Debug.trace(effect)
 
     def delayed[S1](duration: Duration < S1)(using Frame): A < (S & S1 & Async) =
         Kyo.sleep(duration) *> effect

--- a/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
@@ -11,13 +11,13 @@ class EffectCombinatorTest extends Test:
         }
 
         "debug" in {
-            val effect  = IO("Hello World").debug
+            val effect  = IO("Hello World").debugValue
             val handled = IO.run(effect)
             assert(handled.eval == "Hello World")
         }
 
         "debug(prefix)" in {
-            val effect  = IO(true).debug("boolean")
+            val effect  = IO(true).debugTrace
             val handled = IO.run(effect)
             assert(handled.eval == true)
         }

--- a/kyo-data/shared/src/main/scala/kyo/Result.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Result.scala
@@ -214,6 +214,12 @@ object Result:
                 case Success(v) => Result.fail(v)
                 case _          => self.asInstanceOf[Result[A, E]]
 
+        def show: String =
+            self match
+                case Panic(ex) => s"Panic($ex)"
+                case Fail(ex)  => s"Fail($ex)"
+                case v         => s"Success($v)"
+
     end extension
 
     private object internal:

--- a/kyo-prelude/shared/src/main/scala/kyo/debug/Debug.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/debug/Debug.scala
@@ -1,10 +1,13 @@
-package kyo
+package kyo.debug
 
-import Ansi.*
+import kyo.*
+import kyo.Ansi.*
 import kyo.kernel.Effect
 import kyo.kernel.Safepoint
 
 object Debug:
+
+    private inline def maxValueLength = 500
 
     def apply[A, S](v: => A < S)(using frame: Frame): A < S =
         Effect.catching {
@@ -20,7 +23,7 @@ object Debug:
         }
     end apply
 
-    def trace[A, S](v: => A < S): A < S =
+    def trace[A, S](v: => A < S)(using Frame): A < S =
         val interceptor = new Safepoint.Interceptor:
             def enter(frame: Frame, value: Any): Boolean =
                 printValue(value)
@@ -45,7 +48,13 @@ object Debug:
 
     private def printValue(value: Any) =
         println("──────────────────────────────".dim)
-        println(pprint(value).render)
+        val rendered = pprint(value).render
+        val truncated =
+            if rendered.length > maxValueLength then
+                rendered.take(maxValueLength) + " ... (truncated)"
+            else
+                rendered
+        println(truncated)
         println("──────────────────────────────".dim)
     end printValue
 end Debug

--- a/kyo-prelude/shared/src/main/scala/kyo/debug/Debug.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/debug/Debug.scala
@@ -1,0 +1,51 @@
+package kyo
+
+import Ansi.*
+import kyo.kernel.Effect
+import kyo.kernel.Safepoint
+
+object Debug:
+
+    def apply[A, S](v: => A < S)(using frame: Frame): A < S =
+        Effect.catching {
+            v.map { value =>
+                println(frame.show)
+                printValue(value)
+                value
+            }
+        } { ex =>
+            println(frame.show)
+            printValue(ex)
+            throw ex
+        }
+    end apply
+
+    def trace[A, S](v: => A < S): A < S =
+        val interceptor = new Safepoint.Interceptor:
+            def enter(frame: Frame, value: Any): Boolean =
+                printValue(value)
+                println(frame.parse.show)
+                true
+            end enter
+            def addEnsure(f: () => Unit): Unit    = ()
+            def removeEnsure(f: () => Unit): Unit = ()
+
+        Safepoint.propagating(interceptor) {
+            Effect.catching {
+                v.map { value =>
+                    printValue(value)
+                    value
+                }
+            } { ex =>
+                printValue(ex)
+                throw ex
+            }
+        }
+    end trace
+
+    private def printValue(value: Any) =
+        println("──────────────────────────────".dim)
+        println(pprint(value).render)
+        println("──────────────────────────────".dim)
+    end printValue
+end Debug

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Frame.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Frame.scala
@@ -22,7 +22,7 @@ object Frame:
     ) derives CanEqual:
 
         def show: String =
-            Ansi.highlight(s"// $declaringClass $methodName", snippetLong, s"// $position", position.lineNumber)
+            Ansi.highlight(s"// $position $declaringClass $methodName", snippetLong, s"", position.lineNumber)
 
         override def toString = s"Frame($declaringClass, $methodName, $position, $snippetShort)"
     end Parsed

--- a/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
@@ -67,6 +67,12 @@ class DebugTest extends Test:
 
     def largeValueComputation = Debug(List.fill(100)("a"))
 
+    def valuesComputation = Debug.values(1, "test")
+
+    def complexValuesComputation = Debug.values(List(1, 2, 3), Env.get[Int])
+
+    def parameterValuesComputation(param1: Int, param2: String) = Debug.values(param1, param2)
+
     def testOutput(fragments: String*)(code: => Any): Assertion =
         import kyo.Ansi.*
         val outContent = new ByteArrayOutputStream()
@@ -171,6 +177,33 @@ class DebugTest extends Test:
                 "Seq(Seq(Seq(7)))"
             ) {
                 choiceComputation.eval
+            }
+    }
+
+    "values" - {
+        "pure values" in
+            testOutput(
+                "DebugTest.scala:70:52",
+                """Params("1" -> 1, "\"test\"" -> "test")"""
+            ) {
+                valuesComputation
+            }
+
+        "complex values" in
+            testOutput(
+                "DebugTest.scala:72:77",
+                """"List(1, 2, 3)" -> List(1, 2, 3)""",
+                """"Env.get[Int]" -> Kyo(Tag"""
+            ) {
+                complexValuesComputation
+            }
+
+        "parameter values" in
+            testOutput(
+                "DebugTest.scala:74:95",
+                """Params("param1" -> 1, "param2" -> "test")"""
+            ) {
+                parameterValuesComputation(1, "test")
             }
     }
 

--- a/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
@@ -52,7 +52,7 @@ class DebugTest extends Test:
             Stream.init(1 to 5)
                 .map(_ * 2)
                 .filter(_ % 3 == 0)
-                .runSeq
+                .run
         }
 
     def choiceComputation =
@@ -64,6 +64,8 @@ class DebugTest extends Test:
                 yield x + y
             }
         }
+
+    def largeValueComputation = Debug(List.fill(100)("a"))
 
     def testOutput(fragments: String*)(code: => Any): Assertion =
         import kyo.Ansi.*
@@ -111,6 +113,14 @@ class DebugTest extends Test:
             ) {
                 nestedDebugComputation.eval
             }
+
+        "value truncation" in
+            testOutput(
+                "DebugTest.scala:68:59",
+                "... (truncated)"
+            ) {
+                largeValueComputation.eval
+            }
     }
 
     "trace" - {
@@ -146,7 +156,7 @@ class DebugTest extends Test:
                 "DebugTest.scala:53:28",
                 "2",
                 "DebugTest.scala:53:28",
-                "Compact(array = Array(6))"
+                "Seq(6)"
             ) {
                 streamComputation.eval
             }
@@ -158,7 +168,7 @@ class DebugTest extends Test:
                 "DebugTest.scala:64:28",
                 "6",
                 "DebugTest.scala:65:14",
-                "List(List(List(7)))"
+                "Seq(Seq(Seq(7)))"
             ) {
                 choiceComputation.eval
             }

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/FrameTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/FrameTest.scala
@@ -21,15 +21,12 @@ class FrameTest extends Test:
     "show" in {
         import kyo.Ansi.*
         assert(test1.show.stripAnsi ==
-            """|  │ // kyo.kernel.FrameTest test1
-               |9 │ def test1 = test(1 + 2)📍
-               |  │ // FrameTest.scala:9:28""".stripMargin)
-
+            """|  │ // FrameTest.scala:9:28 kyo.kernel.FrameTest test1
+               |9 │ def test1 = test(1 + 2)📍""".stripMargin)
         assert(test2.show.stripAnsi ==
-            """|   │ // kyo.kernel.FrameTest test2
+            """|   │ // FrameTest.scala:14:6 kyo.kernel.FrameTest test2
                |14 │     x / x
-               |15 │ }📍
-               |   │ // FrameTest.scala:14:6""".stripMargin)
+               |15 │ }📍""".stripMargin)
     }
 
     "parse" in {


### PR DESCRIPTION
This new effect uses the `Safepoint.Interceptor` mechanism introduced by https://github.com/getkyo/kyo/pull/489 and the code snippets captured by `Frame` to output debugging information. The `Debug.apply` method only logs the result of the computation with its frame while `Debug.trace` outputs all transformations of a computation with their values. 

There's an important limitation: the `Safepoint.Interceptor` currently isn't propagated to forked fibers so the debugging won't output the trace of computations in forked fibers. I'll follow up on this limitation but it's a bit tricky because we need to avoid increasing the memory footprint of `IOTask`.

Example output of `Debug.trace`:

![image](https://github.com/user-attachments/assets/86f54716-891c-4613-a6a2-404b0ead27c4)
