### PR TITLE
ContextEffect.handle for constant values

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/ContextEffect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/ContextEffect.scala
@@ -39,7 +39,17 @@ object ContextEffect:
                     continue = f(context.getOrElse(_tag, default).asInstanceOf[A])
                 )
 
-    inline def handle[A: Flat, E <: ContextEffect[A], B, S](
+    inline def handle[A, E <: ContextEffect[A], B, S](
+        inline _tag: Tag[E],
+        inline value: A
+    )(v: B < (E & S))(
+        using
+        inline _frame: Frame,
+        inline flat: Flat[A]
+    ): B < S =
+        handle(_tag, value, _ => value)(v)
+
+    inline def handle[A, E <: ContextEffect[A], B, S](
         inline _tag: Tag[E],
         inline ifUndefined: A,
         inline ifDefined: A => A

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/ContextEffectTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/ContextEffectTest.scala
@@ -25,6 +25,13 @@ class RuntimeEffectTest extends Test:
     }
 
     "handle" - {
+
+        "const value" in {
+            val effect = testRuntimeEffect1
+            val result = ContextEffect.handle(Tag[TestRuntimeEffect1], 42)(effect)
+            assert(result.eval == 42)
+        }
+
         "single effect" in {
             val effect = testRuntimeEffect1
             val result = ContextEffect.handle(Tag[TestRuntimeEffect1], 42, _ + 1)(effect)


### PR DESCRIPTION
A minor API improvement providing an overloaded method `ContextEffect.handle` that takes a constant value instead of `ifDefined`/`ifUndefined`. 