### PR TITLE
prelude tests cleanup

### DIFF
--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -351,16 +351,16 @@ class AbortsTest extends Test:
                     }
                 "success" in {
                     assert(
-                        kyo.Env.run(2)(
-                            Abort.run[Ex1](Abort.catching[Ex1](test(kyo.Env.get)))
+                        Env.run(2)(
+                            Abort.run[Ex1](Abort.catching[Ex1](test(Env.get)))
                         ).eval ==
                             Result.success(5)
                     )
                 }
                 "failure" in {
                     assert(
-                        kyo.Env.run(0)(
-                            Abort.run[Ex1](Abort.catching[Ex1](test(kyo.Env.get)))
+                        Env.run(0)(
+                            Abort.run[Ex1](Abort.catching[Ex1](test(Env.get)))
                         ).eval ==
                             Result.fail(ex1)
                     )
@@ -388,34 +388,34 @@ class AbortsTest extends Test:
             "interactions with Env" - {
                 "should have access to the environment within Abort" in {
                     val env    = "test"
-                    val result = kyo.Env.run(env)(Abort.run[String](kyo.Env.get[String]))
+                    val result = Env.run(env)(Abort.run[String](Env.get[String]))
                     assert(result.eval == Result.success(env))
                 }
 
                 "should propagate Abort failures within Env" in {
-                    val result = kyo.Env.run("test")(Abort.run[String](Abort.fail("failure")))
+                    val result = Env.run("test")(Abort.run[String](Abort.fail("failure")))
                     assert(result.eval == Result.fail("failure"))
                 }
             }
 
             "interactions with Var" - {
                 "should have access to the state within Abort" in {
-                    val result = kyo.Var.run(42)(
+                    val result = Var.run(42)(
                         Abort.run[String](
-                            kyo.Var.get[Int].map(_.toString)
+                            Var.get[Int].map(_.toString)
                         )
                     )
                     assert(result.eval == Result.success("42"))
                 }
 
                 "should not modify state on Abort failures" in {
-                    val result = kyo.Var.run(42)(
+                    val result = Var.run(42)(
                         Abort.run[String](
-                            kyo.Var.set[Int](24).map(_ => Abort.fail("failure"))
+                            Var.set[Int](24).map(_ => Abort.fail("failure"))
                         )
                     )
                     assert(result.eval == Result.fail("failure"))
-                    assert(kyo.Var.run(42)(kyo.Var.get[Int]).eval == 42)
+                    assert(Var.run(42)(Var.get[Int]).eval == 42)
                 }
             }
 

--- a/kyo-prelude/shared/src/test/scala/kyo/ChunkTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/ChunkTest.scala
@@ -205,12 +205,12 @@ class ChunkTest extends Test:
         }
         "with a function using Env and Abort" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
-            val result = kyo.Env.run(3) {
-                kyo.Abort.run[String] {
+            val result = Env.run(3) {
+                Abort.run[String] {
                     Kyo.foreach(chunk) { n =>
-                        kyo.Env.get[Int].map { factor =>
+                        Env.get[Int].map { factor =>
                             if n % factor == 0 then n * factor
-                            else kyo.Abort.fail(s"$n is not divisible by $factor")
+                            else Abort.fail(s"$n is not divisible by $factor")
                         }
                     }
                 }
@@ -219,12 +219,12 @@ class ChunkTest extends Test:
         }
         "with a function using Var and Abort" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
-            val result = kyo.Var.run(1) {
-                kyo.Abort.run[String] {
+            val result = Var.run(1) {
+                Abort.run[String] {
                     Kyo.foreach(chunk) { n =>
-                        kyo.Var.get[Int].map { multiplier =>
-                            if n % 2 == 0 then kyo.Var.setDiscard(multiplier * n).andThen(n * multiplier)
-                            else kyo.Abort.fail("Odd number encountered")
+                        Var.get[Int].map { multiplier =>
+                            if n % 2 == 0 then Var.setDiscard(multiplier * n).andThen(n * multiplier)
+                            else Abort.fail("Odd number encountered")
                         }
                     }
                 }
@@ -247,11 +247,11 @@ class ChunkTest extends Test:
 
         "with a predicate using Env and Var" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
-            val result = kyo.Var.run(0) {
-                kyo.Env.run(2) {
+            val result = Var.run(0) {
+                Env.run(2) {
                     Kyo.filter(chunk) { n =>
-                        kyo.Var.update[Int](_ + 1).unit.andThen {
-                            kyo.Env.get[Int].map(_ == n)
+                        Var.update[Int](_ + 1).unit.andThen {
+                            Env.get[Int].map(_ == n)
                         }
                     }
                 }
@@ -261,14 +261,14 @@ class ChunkTest extends Test:
 
         "with a predicate using Abort and Var" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
-            val result = kyo.Var.run(true) {
-                kyo.Abort.run[Unit] {
+            val result = Var.run(true) {
+                Abort.run[Unit] {
                     Kyo.filter(chunk) { n =>
-                        kyo.Var.get[Boolean].map { b =>
+                        Var.get[Boolean].map { b =>
                             if b then
-                                if n % 2 == 0 then kyo.Var.setDiscard(false).andThen(true)
+                                if n % 2 == 0 then Var.setDiscard(false).andThen(true)
                                 else false
-                            else kyo.Abort.fail(())
+                            else Abort.fail(())
                         }
                     }
                 }
@@ -292,12 +292,12 @@ class ChunkTest extends Test:
 
         "with a function using Env and Abort" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
-            val result = kyo.Env.run(10) {
-                kyo.Abort.run[String] {
+            val result = Env.run(10) {
+                Abort.run[String] {
                     Kyo.foldLeft(chunk)(0) { (acc, n) =>
-                        kyo.Env.get[Int].map { max =>
+                        Env.get[Int].map { max =>
                             if acc + n <= max then acc + n
-                            else kyo.Abort.fail(s"Sum exceeded max value of $max")
+                            else Abort.fail(s"Sum exceeded max value of $max")
                         }
                     }
                 }
@@ -307,13 +307,13 @@ class ChunkTest extends Test:
 
         "with a function using Var and Env" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
-            val result = kyo.Var.run(1) {
-                kyo.Env.run("*") {
+            val result = Var.run(1) {
+                Env.run("*") {
                     Kyo.foldLeft(chunk)(1) { (acc, n) =>
-                        kyo.Var.get[Int].map { multiplier =>
-                            kyo.Env.get[String].map { op =>
-                                if op == "*" then kyo.Var.setDiscard(multiplier * n).andThen(acc * n)
-                                else if op == "+" then kyo.Var.setDiscard(multiplier + n).andThen(acc + n)
+                        Var.get[Int].map { multiplier =>
+                            Env.get[String].map { op =>
+                                if op == "*" then Var.setDiscard(multiplier * n).andThen(acc * n)
+                                else if op == "+" then Var.setDiscard(multiplier + n).andThen(acc + n)
                                 else acc
                             }
                         }
@@ -758,11 +758,11 @@ class ChunkTest extends Test:
 
         "handles effectful predicates" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
-            val result = kyo.Env.run(4) {
-                kyo.Var.run(0) {
+            val result = Env.run(4) {
+                Var.run(0) {
                     Kyo.takeWhile(chunk) { n =>
-                        kyo.Var.update[Int](_ + 1).unit.andThen(kyo.Var.get[Int]).map { count =>
-                            kyo.Env.get[Int].map(_ > count)
+                        Var.update[Int](_ + 1).unit.andThen(Var.get[Int]).map { count =>
+                            Env.get[Int].map(_ > count)
                         }
                     }
                 }
@@ -792,11 +792,11 @@ class ChunkTest extends Test:
 
         "handles effectful predicates" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
-            val result = kyo.Env.run(3) {
-                kyo.Var.run(0) {
+            val result = Env.run(3) {
+                Var.run(0) {
                     Kyo.dropWhile(chunk) { n =>
-                        kyo.Var.update[Int](_ + 1).unit.andThen(kyo.Var.get[Int]).map { count =>
-                            kyo.Env.get[Int].map(_ > count)
+                        Var.update[Int](_ + 1).unit.andThen(Var.get[Int]).map { count =>
+                            Env.get[Int].map(_ > count)
                         }
                     }
                 }
@@ -863,9 +863,9 @@ class ChunkTest extends Test:
         "with a function using Env" in {
             val chunk = Chunk(1, 2, 3, 4, 5)
             var sum   = 0
-            val result = kyo.Env.run(0) {
+            val result = Env.run(0) {
                 Kyo.foreachDiscard(chunk) { x =>
-                    kyo.Env.use[Int](_ + x).map(sum += _)
+                    Env.use[Int](_ + x).map(sum += _)
                 }
             }
             assert(result.eval == ())
@@ -924,14 +924,14 @@ class ChunkTest extends Test:
 
     "Kyo.collect" - {
         "collects elements from a chunk of effectful computations" in {
-            val chunk  = Chunk[Int < Env[Int]](kyo.Env.use[Int](_ + 1), kyo.Env.use[Int](_ + 2))
-            val result = kyo.Env.run(1)(Kyo.collect(chunk))
+            val chunk  = Chunk[Int < Env[Int]](Env.use[Int](_ + 1), Env.use[Int](_ + 2))
+            val result = Env.run(1)(Kyo.collect(chunk))
             assert(result.eval == Chunk(2, 3))
         }
 
         "collects elements from a chunk of effectful computations with different effect types" in {
-            val chunk  = Chunk[Int < (Env[Int] & Var[Int])](kyo.Env.use[Int](_ + 1), kyo.Var.use[Int](_ + 2))
-            val result = kyo.Var.run(2)(kyo.Env.run(1)(Kyo.collect(chunk)))
+            val chunk  = Chunk[Int < (Env[Int] & Var[Int])](Env.use[Int](_ + 1), Var.use[Int](_ + 2))
+            val result = Var.run(2)(Env.run(1)(Kyo.collect(chunk)))
             assert(result.eval == Chunk(2, 4))
         }
     }

--- a/kyo-prelude/shared/src/test/scala/kyo/EnvTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/EnvTest.scala
@@ -148,11 +148,11 @@ class EnvTest extends Test:
 
         val service1 = new Service1:
             def apply(i: Int) = i match
-                case 0 => kyo.Abort.get(Option.empty[Int])
+                case 0 => Abort.get(Option.empty[Int])
                 case i => i + 1
         val service2 = new Service2:
             def apply(i: Int) = i match
-                case 0 => kyo.Abort.get(Some(1))
+                case 0 => Abort.get(Some(1))
                 case i => i + 1
 
         "one service" - {
@@ -160,7 +160,7 @@ class EnvTest extends Test:
                 val a =
                     Env.get[Service1].map(_(1))
                 assert(
-                    kyo.Abort.run(Env.run(service1)(a)).eval ==
+                    Abort.run(Env.run(service1)(a)).eval ==
                         Result.success(2)
                 )
             }
@@ -168,7 +168,7 @@ class EnvTest extends Test:
                 val a =
                     Env.get[Service1].map(_(0))
                 assert(
-                    kyo.Abort.run(Env.run(service1)(a)).eval ==
+                    Abort.run(Env.run(service1)(a)).eval ==
                         Result.fail(Maybe.empty)
                 )
             }
@@ -184,20 +184,20 @@ class EnvTest extends Test:
                     val b = Env.run(service2)(v)
                     val c = Env.run(service1)(b)
                     assert(
-                        kyo.Abort.run(c).eval == Result.success(3)
+                        Abort.run(c).eval == Result.success(3)
                     )
                 }
                 "reverse handling order" in {
                     val b = Env.run(service1)(v)
                     val c = Env.run(service2)(b)
                     assert(
-                        kyo.Abort.run(c).eval == Result.success(3)
+                        Abort.run(c).eval == Result.success(3)
                     )
                 }
                 "dependent services" in {
                     val v2: Int < (Env[Service2] & Abort[Maybe.Empty]) = Env.run(service1)(v)
                     assert(
-                        kyo.Abort.run(Env.run(service2)(v2)).eval ==
+                        Abort.run(Env.run(service2)(v2)).eval ==
                             Result.success(3)
                     )
                 }
@@ -297,13 +297,13 @@ class EnvTest extends Test:
 
     "interactions with Abort" - {
         "should propagate Abort failures within Env" in {
-            val result = Env.run("test")(kyo.Abort.run[String](kyo.Abort.fail("failure")))
+            val result = Env.run("test")(Abort.run[String](Abort.fail("failure")))
             assert(result.eval == Result.fail("failure"))
         }
 
         "should have access to the environment within Abort" in {
             val env    = "test"
-            val result = Env.run(env)(kyo.Abort.run[String](Env.get[String]))
+            val result = Env.run(env)(Abort.run[String](Env.get[String]))
             assert(result.eval == Result.success(env))
         }
     }

--- a/kyo-prelude/shared/src/test/scala/kyo/KyoTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/KyoTest.scala
@@ -167,14 +167,14 @@ class KyoTest extends Test:
 
         "collectUnit" in {
             var count = 0
-            val io    = kyo.Env.use[Unit](_ => count += 1)
-            kyo.Env.run(())(Kyo.collectDiscard(Seq.empty)).eval
+            val io    = Env.use[Unit](_ => count += 1)
+            Env.run(())(Kyo.collectDiscard(Seq.empty)).eval
             assert(count == 0)
-            kyo.Env.run(())(Kyo.collectDiscard(Seq(io))).eval
+            Env.run(())(Kyo.collectDiscard(Seq(io))).eval
             assert(count == 1)
-            kyo.Env.run(())(Kyo.collectDiscard(List.fill(42)(io))).eval
+            Env.run(())(Kyo.collectDiscard(List.fill(42)(io))).eval
             assert(count == 43)
-            kyo.Env.run(())(Kyo.collectDiscard(Vector.fill(10)(io))).eval
+            Env.run(())(Kyo.collectDiscard(Vector.fill(10)(io))).eval
             assert(count == 53)
         }
 
@@ -233,8 +233,8 @@ class KyoTest extends Test:
 
             "collectUnit" in {
                 var count = 0
-                val io    = kyo.Env.use[Unit](_ => count += 1)
-                kyo.Env.run(())(Kyo.collectDiscard(Seq.fill(n)(io))).eval
+                val io    = Env.use[Unit](_ => count += 1)
+                Env.run(())(Kyo.collectDiscard(Seq.fill(n)(io))).eval
                 assert(count == n)
             }
 


### PR DESCRIPTION
It seems automatic refactoring introduced the `kyo.` prefix for effects in tests.