### PR TITLE
Env.runLayer can handle effects introduced by layers

### DIFF
--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -348,7 +348,7 @@ class SwapSomeAbortOps[A, S, E, E1 <: E](effect: A < (Abort[E] & S)) extends Any
 end SwapSomeAbortOps
 
 extension [A, S, E](effect: A < (S & Env[E]))
-    def provide[S1, E1 >: E, ER](dependency: E1 < S1)(
+    def provideValue[S1, E1 >: E, ER](dependency: E1 < S1)(
         using
         ev: E => E1 & ER,
         flat: Flat[A],
@@ -358,7 +358,7 @@ extension [A, S, E](effect: A < (S & Env[E]))
     ): A < (S & S1 & reduce.SReduced) =
         dependency.map(d => Env.run[E1, A, S, ER](d)(effect.asInstanceOf[A < (S & Env[E1 | ER])]))
 
-    def provideLayer[S1, S2, E1 >: E, ER](layer: Layer[E1, S1] < S2)(
+    inline def provideLayer[S1, S2, E1 >: E, ER](layer: Layer[E1, S1] < S2)(
         using
         ev: E => E1 & ER,
         flat: Flat[A],
@@ -370,7 +370,10 @@ extension [A, S, E](effect: A < (S & Env[E]))
             l  <- layer
             tm <- l.run
             e1 = tm.get[E1]
-        yield effect.provide(e1)
+        yield effect.provideValue(e1)
+
+    transparent inline def provide(inline layers: Layer[?, ?]*): A < (Memo & S & Nothing) =
+        Env.runLayer(layers*)(effect)
 
 end extension
 

--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -372,7 +372,7 @@ extension [A, S, E](effect: A < (S & Env[E]))
             e1 = tm.get[E1]
         yield effect.provideValue(e1)
 
-    transparent inline def provide(inline layers: Layer[?, ?]*): A < (Memo & S & Nothing) =
+    transparent inline def provide(inline layers: Layer[?, ?]*): A < Nothing =
         Env.runLayer(layers*)(effect)
 
 end extension

--- a/kyo-combinators/shared/src/test/scala/kyo/EnvCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EnvCombinatorTest.scala
@@ -58,14 +58,14 @@ class EnvCombinatorTest extends Test:
                 assert(Memo.run(handled).eval == 23)
             }
 
-            "should provide all layers" in {
+            "should provide all layers and infer types correctly" in {
                 val effect: Int < Env[String & Int & Boolean & Char] =
                     Env.get[String] *> Env.get[Int] *> Env.get[Boolean] *> Env.get[Char].as(23)
                 val layerChar   = Layer(Kyo.suspend('c'))
                 val layerString = Layer("value")
                 val layerInt    = Layer(1)
                 val layerBool   = Layer(false)
-                val handled: Int < (IO & Memo) =
+                val handled =
                     effect
                         .provide(
                             layerChar,
@@ -73,6 +73,7 @@ class EnvCombinatorTest extends Test:
                             layerInt,
                             layerBool
                         )
+                val handledTyped: Int < (IO & Memo) = handled
                 assert(IO.run(Memo.run(handled)).eval == 23)
             }
         }

--- a/kyo-combinators/shared/src/test/scala/kyo/FiberCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/FiberCombinatorTest.scala
@@ -86,25 +86,6 @@ class FiberCombinatorTest extends Test:
             }
         }
 
-        "handle" - {
-            "should provide" in {
-                val effect: Int < Env[String] = Env.get[String].map(_.length)
-                assert(effect.provide("value").eval == 5)
-            }
-
-            "should provide incrementally" in {
-                val effect: Int < Env[String & Int & Boolean & Char] =
-                    Env.get[String] *> Env.get[Int] *> Env.get[Boolean] *> Env.get[Char].as(23)
-                val handled =
-                    effect
-                        .provide('c')
-                        .provide("value")
-                        .provide(1)
-                        .provide(false)
-                assert(handled.eval == 23)
-            }
-        }
-
         "zip par" - {
             "should zip right par" in {
                 val e1      = IO(1)

--- a/kyo-prelude/shared/src/main/scala/kyo/Env.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Env.scala
@@ -29,7 +29,7 @@ object Env:
     ): A < (S & reduce.SReduced) =
         reduce(ContextEffect.handle(erasedTag[R], env, _.union(env))(v): A < (Env[VR] & S))
 
-    transparent inline def runLayer[A, S, V](inline layers: Layer[?, ?]*)(value: A < (Env[V] & S)): A < (S & Memo & Nothing) =
+    transparent inline def runLayer[A, S, V](inline layers: Layer[?, ?]*)(value: A < (Env[V] & S)): A < Nothing =
         inline Layer.init[V](layers*) match
             case layer: Layer[V, s] =>
                 layer.run.map { env =>

--- a/kyo-prelude/shared/src/main/scala/kyo/Env.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Env.scala
@@ -29,10 +29,12 @@ object Env:
     ): A < (S & reduce.SReduced) =
         reduce(ContextEffect.handle(erasedTag[R], env, _.union(env))(v): A < (Env[VR] & S))
 
-    transparent inline def runLayer[A, S, V](inline layers: Layer[?, ?]*)(value: A < (Env[V] & S)): A < (S & Memo) =
-        Layer.init[V](layers*).run.map { env =>
-            runTypeMap(env)(value)
-        }.asInstanceOf[A < (S & Memo)]
+    transparent inline def runLayer[A, S, V](inline layers: Layer[?, ?]*)(value: A < (Env[V] & S)): A < (S & Memo & Nothing) =
+        inline Layer.init[V](layers*) match
+            case layer: Layer[V, s] =>
+                layer.run.map { env =>
+                    runTypeMap(env)(value)
+                }
 
     final class UseOps[R >: Nothing](dummy: Unit) extends AnyVal:
         inline def apply[A, S](inline f: R => A < S)(

--- a/kyo-prelude/shared/src/test/scala/kyo/LayerTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/LayerTest.scala
@@ -249,12 +249,15 @@ class LayerTest extends Test:
 
             Memo.run(Env.runLayer(a, b, c)(Env.get[Boolean].map(assert(_))))
         }
-        "multiple layers with effects" in run {
+        "multiple layers with effects and infer types correctly" in run {
             val a = Layer(Var.get[Int])
-            val b = Layer.from((i: Int) => i.toString: String < Abort[Int])
+            val b = Layer.from((i: Int) => i.toString: String < Abort[String])
             val c = Layer.from((s: String) => (s.length % 2 == 0))
 
-            val result = Abort.run(Var.run(42)(Memo.run(Env.runLayer(a, b, c)(Env.get[Boolean])))).eval
+            val handled                                                   = Env.runLayer(a, b, c)(Env.get[Boolean])
+            val handledTyped: Boolean < (Memo & Var[Int] & Abort[String]) = handled
+
+            val result = Abort.run(Var.run(42)(Memo.run(handled))).eval
             assert(result == Result.Success(true))
         }
         "missing layer" in {

--- a/kyo-prelude/shared/src/test/scala/kyo/LayerTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/LayerTest.scala
@@ -249,6 +249,14 @@ class LayerTest extends Test:
 
             Memo.run(Env.runLayer(a, b, c)(Env.get[Boolean].map(assert(_))))
         }
+        "multiple layers with effects" in run {
+            val a = Layer(Var.get[Int])
+            val b = Layer.from((i: Int) => i.toString: String < Abort[Int])
+            val c = Layer.from((s: String) => (s.length % 2 == 0))
+
+            val result = Abort.run(Var.run(42)(Memo.run(Env.runLayer(a, b, c)(Env.get[Boolean])))).eval
+            assert(result == Result.Success(true))
+        }
         "missing layer" in {
             val c = Layer('c')
             val d = Layer.from((c: Char) => c.isDigit)


### PR DESCRIPTION
Also separated `provideValue` and` provideLayer` from provide in kyo-combinators. `provide` now provides all layers, just like in ZIO