### PR TITLE
Scala 3.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import org.typelevel.scalacoptions.ScalacOption
 import org.typelevel.scalacoptions.ScalacOptions
 import org.typelevel.scalacoptions.ScalaVersion
 
-val scala3Version   = "3.4.3"
+val scala3Version   = "3.5.0"
 val scala212Version = "2.12.19"
 val scala213Version = "2.13.14"
 
@@ -19,7 +19,7 @@ val compilerOptions = Set(
     ScalacOptions.warnValueDiscard,
     ScalacOptions.languageStrictEquality,
     ScalacOptions.release("11"),
-    ScalacOptions.privateKindProjector
+    ScalacOptions.advancedKindProjector
 )
 
 ThisBuild / scalaVersion := scala3Version

--- a/kyo-prelude/shared/src/main/scala/kyo/Local.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Local.scala
@@ -2,6 +2,7 @@ package kyo
 
 import kyo.Tag
 import kyo.kernel.*
+import scala.annotation.nowarn
 
 abstract class Local[A]:
 
@@ -28,6 +29,7 @@ end Local
 
 object Local:
 
+    @nowarn("msg=anonymous")
     inline def init[A](inline defaultValue: A): Local[A] =
         new Local[A]:
             lazy val default: A = defaultValue

--- a/kyo-prelude/shared/src/main/scala/kyo/Var.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Var.scala
@@ -3,6 +3,7 @@ package kyo
 import Var.internal.*
 import kyo.Tag
 import kyo.kernel.*
+import scala.annotation.nowarn
 
 sealed trait Var[V] extends Effect[Const[Op[V]], Const[V]]
 
@@ -33,10 +34,12 @@ object Var:
         Effect.suspendMap[Unit](tag, value: Op[V])(_ => ())
 
     /** Applies the update function and returns the new value. */
+    @nowarn("msg=anonymous")
     inline def update[V](inline f: V => V)(using inline tag: Tag[Var[V]], inline frame: Frame): V < Var[V] =
         Effect.suspend[V](tag, (v => f(v)): Update[V])
 
     /** Applies the update function and returns `Unit`. */
+    @nowarn("msg=anonymous")
     inline def updateDiscard[V](inline f: V => V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
         Effect.suspendMap[Unit](tag, (v => f(v)): Update[V])(_ => ())
 

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Boundary.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Boundary.scala
@@ -2,6 +2,7 @@ package kyo.kernel
 
 import internal.*
 import kyo.Tag
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.quoted.*
 
@@ -12,6 +13,7 @@ end Boundary
 private[kyo] object Boundary:
 
     extension [Ctx, S](boundary: Boundary[Ctx, S])
+        @nowarn("msg=anonymous")
         private[kyo] inline def apply[A, S2](inline f: (Trace, Context) => A < S2)(using inline _frame: Frame): A < (S & S2) =
             new KyoDefer[A, S & S2]:
                 def frame = _frame

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/ContextEffect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/ContextEffect.scala
@@ -3,6 +3,7 @@ package kyo.kernel
 import internal.*
 import kyo.Tag
 import kyo.bug
+import scala.annotation.nowarn
 import scala.util.NotGiven
 
 abstract class ContextEffect[+A]
@@ -25,6 +26,7 @@ object ContextEffect:
     )(using inline frame: Frame): A < Any =
         suspendMap(tag, default)(identity)
 
+    @nowarn("msg=anonymous")
     inline def suspendMap[A, E <: ContextEffect[A], B, S](
         inline _tag: Tag[E],
         inline default: => A
@@ -58,6 +60,7 @@ object ContextEffect:
         inline _frame: Frame,
         inline flat: Flat[A]
     ): B < S =
+        @nowarn("msg=anonymous")
         def handleLoop(v: B < (E & S))(using Safepoint): B < S =
             v match
                 case kyo: KyoSuspend[IX, OX, EX, Any, B, S] @unchecked =>

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Effect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Effect.scala
@@ -2,6 +2,7 @@ package kyo.kernel
 
 import internal.*
 import kyo.Tag
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
@@ -19,6 +20,7 @@ object Effect:
 
     final class SuspendOps[A](dummy: Unit) extends AnyVal:
 
+        @nowarn("msg=anonymous")
         inline def apply[I[_], O[_], E <: Effect[I, O]](
             inline _tag: Tag[E],
             inline _input: I[A]
@@ -34,6 +36,7 @@ object Effect:
     inline def suspend[A]: SuspendOps[A] = SuspendOps(())
 
     final class SuspendMapOps[A](dummy: Unit) extends AnyVal:
+        @nowarn("msg=anonymous")
         inline def apply[I[_], O[_], E <: Effect[I, O], B, S](
             inline _tag: Tag[E],
             inline _input: I[A]
@@ -62,6 +65,7 @@ object Effect:
             inline done: A => B < S3 = (v: A) => v,
             inline accept: [C] => I[C] => Boolean = [C] => (v: I[C]) => true
         )(using inline _frame: Frame, inline flat: Flat[A], safepoint: Safepoint): B < (S & S2 & S3) =
+            @nowarn("msg=anonymous")
             def handleLoop(v: A < (E & S & S2 & S3), context: Context)(using Safepoint): B < (S & S2 & S3) =
                 v match
                     case kyo: KyoSuspend[I, O, E, Any, A, E & S & S2] @unchecked if tag =:= kyo.tag && accept(kyo.input) =>
@@ -91,6 +95,7 @@ object Effect:
             inline handle1: [C] => (I1[C], Safepoint ?=> O1[C] => A < (E1 & E2 & S & S2)) => A < (E1 & E2 & S & S2),
             inline handle2: [C] => (I2[C], Safepoint ?=> O2[C] => A < (E1 & E2 & S & S2)) => A < (E1 & E2 & S & S2)
         )(using inline _frame: Frame, inline flat: Flat[A], safepoint: Safepoint): A < (S & S2) =
+            @nowarn("msg=anonymous")
             def handle2Loop(kyo: A < (E1 & E2 & S & S2), context: Context)(using Safepoint): A < (S & S2) =
                 kyo match
                     case kyo: KyoSuspend[I1, O1, E1, Any, A, E1 & E2 & S & S2] @unchecked if tag1 =:= kyo.tag =>
@@ -131,6 +136,7 @@ object Effect:
             inline handle2: [C] => (I2[C], Safepoint ?=> O2[C] => A < (E1 & E2 & E3 & S & S2)) => A < (E1 & E2 & E3 & S & S2),
             inline handle3: [C] => (I3[C], Safepoint ?=> O3[C] => A < (E1 & E2 & E3 & S & S2)) => A < (E1 & E2 & E3 & S & S2)
         )(using inline _frame: Frame, inline flat: Flat[A], safepoint: Safepoint): A < (S & S2) =
+            @nowarn("msg=anonymous")
             def handle3Loop(v: A < (E1 & E2 & E3 & S & S2), context: Context)(using Safepoint): A < (S & S2) =
                 v match
                     case kyo: KyoSuspend[I1, O1, E1, Any, A, E1 & E2 & E3 & S & S2] @unchecked if tag1 =:= kyo.tag =>
@@ -219,6 +225,7 @@ object Effect:
             inline done: (State, A) => B < (S & S2 & S3) = (_: State, v: A) => v,
             inline accept: [C] => I[C] => Boolean = [C] => (v: I[C]) => true
         )(using inline _frame: Frame, inline flat: Flat[A], safepoint: Safepoint): B < (S & S2 & S3) =
+            @nowarn("msg=anonymous")
             def handleLoop(state: State, v: A < (E & S & S2 & S3), context: Context)(using Safepoint): B < (S & S2 & S3) =
                 v match
                     case kyo: KyoSuspend[I, O, E, Any, A, E & S & S2] @unchecked if tag =:= kyo.tag && accept(kyo.input) =>
@@ -248,6 +255,7 @@ object Effect:
             inline accept: [C] => I[C] => Boolean = [C] => (v: I[C]) => true,
             inline recover: Throwable => B < (S & S2 & S3)
         )(using inline _frame: Frame, inline flat: Flat[A], safepoint: Safepoint): B < (S & S2 & S3) =
+            @nowarn("msg=anonymous")
             def handleLoop(v: A < (E & S & S2 & S3), context: Context)(using Safepoint): B < (S & S2 & S3) =
                 v match
                     case kyo: KyoSuspend[I, O, E, Any, A, E & S & S2] @unchecked if tag =:= kyo.tag && accept(kyo.input) =>
@@ -285,6 +293,7 @@ object Effect:
     inline def catching[A, S, B >: A, S2](inline v: => A < S)(
         inline f: Throwable => B < S2
     )(using inline _frame: Frame, safepoint: Safepoint): B < (S & S2) =
+        @nowarn("msg=anonymous")
         def catchingLoop(v: B < (S & S2))(using Safepoint): B < (S & S2) =
             (v: @unchecked) match
                 case kyo: KyoSuspend[IX, OX, EX, Any, B, S & S2] @unchecked =>

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Loop.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Loop.scala
@@ -1,6 +1,7 @@
 package kyo.kernel
 
 import internal.*
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.annotation.targetName
 import scala.util.NotGiven
@@ -46,21 +47,25 @@ object Loop:
     @targetName("done4")
     def done[A, B, C, D, O](v: O): Outcome4[A, B, C, D, O] = v
 
+    @nowarn("msg=anonymous")
     inline def continue[A, O, S](inline v: A): Outcome[A, O] =
         new Continue:
             def _1 = v
 
+    @nowarn("msg=anonymous")
     inline def continue[A, B, o](inline v1: A, inline v2: B): Outcome2[A, B, o] =
         new Continue2:
             def _1 = v1
             def _2 = v2
 
+    @nowarn("msg=anonymous")
     inline def continue[A, B, C, O](inline v1: A, inline v2: B, inline v3: C): Outcome3[A, B, C, O] =
         new Continue3:
             def _1 = v1
             def _2 = v2
             def _3 = v3
 
+    @nowarn("msg=anonymous")
     inline def continue[A, B, C, D, O](inline v1: A, inline v2: B, inline v3: C, inline v4: D): Outcome4[A, B, C, D, O] =
         new Continue4:
             def _1 = v1
@@ -69,6 +74,7 @@ object Loop:
             def _4 = v4
 
     inline def apply[A, O, S](inline input: A)(inline run: A => Outcome[A, O] < S)(using inline _frame: Frame): O < S =
+        @nowarn("msg=anonymous")
         @tailrec def loop(i1: A)(v: Outcome[A, O] < S = run(i1)): O < S =
             v match
                 case next: Continue[A] @unchecked =>
@@ -84,6 +90,7 @@ object Loop:
     end apply
 
     inline def apply[A, B, O, S](input1: A, input2: B)(inline run: (A, B) => Outcome2[A, B, O] < S)(using inline _frame: Frame): O < S =
+        @nowarn("msg=anonymous")
         @tailrec def loop(i1: A, i2: B)(v: Outcome2[A, B, O] < S = run(i1, i2)): O < S =
             v match
                 case next: Continue2[A, B] @unchecked =>
@@ -101,6 +108,7 @@ object Loop:
     inline def apply[A, B, C, O, S](input1: A, input2: B, input3: C)(
         inline run: (A, B, C) => Outcome3[A, B, C, O] < S
     )(using inline _frame: Frame): O < S =
+        @nowarn("msg=anonymous")
         @tailrec def loop(i1: A, i2: B, i3: C)(v: Outcome3[A, B, C, O] < S = run(i1, i2, i3)): O < S =
             v match
                 case next: Continue3[A, B, C] @unchecked =>
@@ -118,6 +126,7 @@ object Loop:
     inline def apply[A, B, C, D, O, S](input1: A, input2: B, input3: C, input4: D)(
         inline run: (A, B, C, D) => Outcome4[A, B, C, D, O] < S
     )(using inline _frame: Frame): O < S =
+        @nowarn("msg=anonymous")
         @tailrec def loop(i1: A, i2: B, i3: C, i4: D)(v: Outcome4[A, B, C, D, O] < S = run(i1, i2, i3, i4)): O < S =
             v match
                 case next: Continue4[A, B, C, D] @unchecked =>
@@ -133,6 +142,7 @@ object Loop:
     end apply
 
     inline def indexed[O, S](inline run: Int => Outcome[Unit, O] < S)(using inline _frame: Frame): O < S =
+        @nowarn("msg=anonymous")
         @tailrec def loop(idx: Int)(v: Outcome[Unit, O] < S = run(idx)): O < S =
             v match
                 case next: Continue[Unit] @unchecked =>
@@ -148,6 +158,7 @@ object Loop:
     end indexed
 
     inline def indexed[A, O, S](input: A)(inline run: (Int, A) => Outcome[A, O] < S)(using inline _frame: Frame): O < S =
+        @nowarn("msg=anonymous")
         @tailrec def loop(idx: Int, i1: A)(v: Outcome[A, O] < S = run(idx, i1)): O < S =
             v match
                 case next: Continue[A] @unchecked =>
@@ -165,6 +176,7 @@ object Loop:
     inline def indexed[A, B, O, S](input1: A, input2: B)(
         inline run: (Int, A, B) => Outcome2[A, B, O] < S
     )(using inline _frame: Frame): O < S =
+        @nowarn("msg=anonymous")
         @tailrec def loop(idx: Int, i1: A, i2: B)(v: Outcome2[A, B, O] < S = run(idx, i1, i2)): O < S =
             v match
                 case next: Continue2[A, B] @unchecked =>
@@ -182,6 +194,7 @@ object Loop:
     inline def indexed[A, B, C, O, S](input1: A, input2: B, input3: C)(
         inline run: (Int, A, B, C) => Outcome3[A, B, C, O] < S
     )(using inline _frame: Frame): O < S =
+        @nowarn("msg=anonymous")
         @tailrec def loop(idx: Int, i1: A, i2: B, i3: C)(v: Outcome3[A, B, C, O] < S = run(idx, i1, i2, i3)): O < S =
             v match
                 case next: Continue3[A, B, C] @unchecked =>
@@ -199,7 +212,9 @@ object Loop:
     inline def indexed[A, B, C, D, O, S](input1: A, input2: B, input3: C, input4: D)(
         inline run: (Int, A, B, C, D) => Outcome4[A, B, C, D, O] < S
     )(using inline _frame: Frame): O < S =
-        @tailrec def loop(idx: Int, i1: A, i2: B, i3: C, i4: D)(v: Outcome4[A, B, C, D, O] < S = run(idx, i1, i2, i3, i4)): O < S =
+        @nowarn("msg=anonymous")
+        @tailrec def loop(idx: Int, i1: A, i2: B, i3: C, i4: D)(v: Outcome4[A, B, C, D, O] < S =
+            run(idx, i1, i2, i3, i4)): O < S =
             v match
                 case next: Continue4[A, B, C, D] @unchecked =>
                     loop(idx + 1, next._1, next._2, next._3, next._4)()
@@ -214,6 +229,7 @@ object Loop:
     end indexed
 
     inline def foreach[S](inline run: => Outcome[Unit, Unit] < S)(using inline _frame: Frame): Unit < S =
+        @nowarn("msg=anonymous")
         @tailrec def loop(v: Outcome[Unit, Unit] < S = run): Unit < S =
             v match
                 case next: Continue[Unit] @unchecked =>
@@ -229,6 +245,7 @@ object Loop:
     end foreach
 
     inline def repeat[S](n: Int)(inline run: => Unit < S)(using inline _frame: Frame): Unit < S =
+        @nowarn("msg=anonymous")
         @tailrec def loop(i: Int)(v: Outcome[Unit, Unit] < S = run): Unit < S =
             if i == n then ()
             else

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -3,6 +3,7 @@ package kyo.kernel
 import internal.*
 import kyo.*
 import kyo.Maybe
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.language.implicitConversions
 import scala.util.NotGiven
@@ -65,7 +66,7 @@ object `<`:
             inline flatB: Flat.Weak[B],
             inline safepoint: Safepoint
         ): B < (S & S2) =
-            def mapLoop(v: A < S)(using Safepoint): B < (S & S2) =
+            @nowarn("msg=anonymous") def mapLoop(v: A < S)(using Safepoint): B < (S & S2) =
                 v match
                     case kyo: KyoSuspend[IX, OX, EX, Any, A, S] @unchecked =>
                         new KyoContinue[IX, OX, EX, Any, B, S & S2](kyo):

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Safepoint.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Safepoint.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kyo.bug
 import kyo.isNull
 import kyo.kernel.Safepoint.*
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import scala.util.control.NoStackTrace
@@ -45,6 +46,7 @@ object Safepoint:
         def enter(frame: Frame, value: Any): Boolean
     end Interceptor
 
+    @nowarn("msg=anonymous")
     private[kyo] inline def immediate[A, S](p: Interceptor)(inline v: => A < S)(
         using safepoint: Safepoint
     ): A < S =
@@ -67,7 +69,7 @@ object Safepoint:
         inline safepoint: Safepoint,
         inline _frame: Frame
     ): A < S =
-        def loop(v: A < S): A < S =
+        @nowarn("msg=anonymous") def loop(v: A < S): A < S =
             v match
                 case kyo: KyoSuspend[IX, OX, EX, Any, A, S] @unchecked =>
                     new KyoContinue[IX, OX, EX, Any, A, S](kyo):
@@ -101,6 +103,7 @@ object Safepoint:
         end try
     end ensuring
 
+    @nowarn("msg=anonymous")
     private[kyo] inline def ensure[A, S](inline f: => Unit)(inline v: => A < S)(using safepoint: Safepoint, inline _frame: Frame): A < S =
         // ensures the function is called once even if an
         // interceptor executes it multiple times


### PR DESCRIPTION
The compiler introduced a new compilation message when an inlined method has an anonymous class warning that it'll generate a new class on the caller. That's the intended behavior in Kyo so I've added `@nowarn` to suppress it.