### PR TITLE
fix release of JS artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: olafurpg/setup-scala@v13
         with:
           java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz
-      - run: sbt "ci-release"
+      - run: sbt "kyoJVM/ci-release kyoJS/ci-release"
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
The split of the project into `kyoJVM` and `kyoJS` by https://github.com/getkyo/kyo/pull/450 made the release workflow not publish JS artifacts since only `kyoJVM` is selected by default.