### PR TITLE
fix compilation warning due to duplicate package methods

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/prelude.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/prelude.scala
@@ -12,13 +12,6 @@ type <[+A, -S] = kernel.<[A, S]
 
 val Loop = kernel.Loop
 
-private[kyo] inline def isNull[A](v: A): Boolean =
-    v.asInstanceOf[AnyRef] eq null
-
-private[kyo] inline def discard[A](inline v: => A*): Unit =
-    val _ = v
-    ()
-
 private[kyo] object bug:
 
     case class KyoBugException(msg: String) extends Exception(msg)


### PR DESCRIPTION
I noticed this new warning after https://github.com/getkyo/kyo/pull/614. It seems the compiler wa ignoring the methods in `kyo-data` and the change exposed the issue.

```
[info] compiling 32 Scala sources to /Users/fwbrasil/workspace/kyo/kyo-core/jvm/target/scala-3.5.0/classes ...
[warn] Toplevel definition isNull is defined in
[warn]   /Users/fwbrasil/workspace/kyo/kyo-prelude/jvm/target/scala-3.5.0/classes/kyo/prelude$package.tasty
[warn] and also in
[warn]   /Users/fwbrasil/workspace/kyo/kyo-data/jvm/target/scala-3.5.0/classes/kyo/data$package.tasty
[warn] Keeping only the definition in /Users/fwbrasil/workspace/kyo/kyo-prelude/jvm/target/scala-3.5.0/classes/kyo/prelude$package.tasty
Warning: mocking up superclass for module class kernel
[warn] one warning found
```