### PR TITLE
kernel: EffectTS-inspired 'pipe' methods

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -13,7 +13,7 @@ object Clock:
 
     private val local = Local.init(live)
 
-    def let[A, S](c: Clock)(f: => A < (IO & S))(using Frame): A < (IO & S) =
+    def let[A, S](c: Clock)(f: => A < S)(using Frame): A < S =
         local.let(c)(f)
 
     def now(using Frame): Instant < IO =

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -11,11 +11,12 @@ abstract class KyoApp extends KyoApp.Base[KyoApp.Effects]:
         v.map { v =>
             if (()).equals(v) then ()
             else Console.println(v)
-        }
-            .pipe(Clock.let(clock))
-            .pipe(Random.let(random))
-            .pipe(Log.let(log))
-            .pipe(KyoApp.run)
+        }.pipe(
+            Clock.let(clock),
+            Random.let(random),
+            Log.let(log),
+            KyoApp.run
+        )
 end KyoApp
 
 object KyoApp:
@@ -53,5 +54,5 @@ object KyoApp:
         runFiber(Duration.Infinity)(v)
 
     def runFiber[A: Flat](timeout: Duration)(v: A < Effects)(using Frame): Fiber[Throwable, A] =
-        v.pipe(Resource.run).pipe(Async.run).pipe(IO.run).eval
+        v.pipe(Resource.run, Async.run, IO.run).eval
 end KyoApp

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -53,11 +53,6 @@ object `<`:
         ): B < (S & S2) =
             map(v => f(v))
 
-        inline def pipe[B](f: (=> A < S) => B)(
-            using inline flat: Flat.Weak[A]
-        ): B =
-            f(v)
-
         inline def map[B, S2](inline f: Safepoint ?=> A => B < S2)(
             using
             inline _frame: Frame,
@@ -103,6 +98,63 @@ object `<`:
                         ()
             unitLoop(v)
         end unit
+
+        inline def pipe[B](inline f: (=> A < S) => B)(
+            using inline flat: Flat.Weak[A]
+        ): B =
+            def pipe1 = v
+            f(pipe1)
+        end pipe
+
+        inline def pipe[B, C](
+            inline f1: A < S => B,
+            inline f2: (=> B) => C
+        )(using inline flat: Flat.Weak[A]): C =
+            def pipe2 = v.pipe(f1)
+            f2(pipe2)
+        end pipe
+
+        inline def pipe[B, C, D](
+            inline f1: A < S => B,
+            inline f2: (=> B) => C,
+            inline f3: (=> C) => D
+        )(using inline flat: Flat.Weak[A]): D =
+            def pipe3 = v.pipe(f1, f2)
+            f3(pipe3)
+        end pipe
+
+        inline def pipe[B, C, D, E](
+            inline f1: A < S => B,
+            inline f2: (=> B) => C,
+            inline f3: (=> C) => D,
+            inline f4: (=> D) => E
+        )(using inline flat: Flat.Weak[A]): E =
+            def pipe4 = v.pipe(f1, f2, f3)
+            f4(pipe4)
+        end pipe
+
+        inline def pipe[B, C, D, E, F](
+            inline f1: A < S => B,
+            inline f2: (=> B) => C,
+            inline f3: (=> C) => D,
+            inline f4: (=> D) => E,
+            inline f5: (=> E) => F
+        )(using inline flat: Flat.Weak[A]): F =
+            def pipe5 = v.pipe(f1, f2, f3, f4)
+            f5(pipe5)
+        end pipe
+
+        inline def pipe[B, C, D, E, F, G](
+            inline f1: A < S => B,
+            inline f2: (=> B) => C,
+            inline f3: (=> C) => D,
+            inline f4: (=> D) => E,
+            inline f5: (=> E) => F,
+            inline f6: (=> F) => G
+        )(using inline flat: Flat.Weak[A]): G =
+            def pipe6 = v.pipe(f1, f2, f3, f4, f5)
+            f6(pipe6)
+        end pipe
 
     end extension
 

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -99,6 +99,7 @@ object `<`:
             unitLoop(v)
         end unit
 
+        // TODO Nested 'pipe*' methods required to work around compiler crash
         inline def pipe[B](inline f: (=> A < S) => B)(
             using inline flat: Flat.Weak[A]
         ): B =

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/PendingTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/PendingTest.scala
@@ -203,6 +203,56 @@ class PendingTest extends Test:
             assert(result == 5)
         }
 
+        "works with two functions" in {
+            val result = (5: Int < Any).pipe(
+                _.map(_ + 1),
+                _.map(_ * 2)
+            )
+            assert(result.eval == 12)
+        }
+
+        "works with three functions" in {
+            val result = (5: Int < Any).pipe(
+                _.map(_ + 1),
+                _.map(_ * 2),
+                _.map(_.toString)
+            )
+            assert(result.eval == "12")
+        }
+
+        "works with four functions" in {
+            val result = (5: Int < Any).pipe(
+                _.map(_ + 1),
+                _.map(_ * 2),
+                _.map(_.toString),
+                _.map(_.length)
+            )
+            assert(result.eval == 2)
+        }
+
+        "works with five functions" in {
+            val result = (5: Int < Any).pipe(
+                _.map(_ + 1),
+                _.map(_ * 2),
+                _.map(_.toString),
+                _.map(_.length),
+                _.map(_ > 1)
+            )
+            assert(result.eval == true)
+        }
+
+        "works with six functions" in {
+            val result = (5: Int < Any).pipe(
+                _.map(_ + 1),
+                _.map(_ * 2),
+                _.map(_.toString),
+                _.map(_.length),
+                _.map(_ > 1),
+                _.map(if _ then "Yes" else "No")
+            )
+            assert(result.eval == "Yes")
+        }
+
         "piped computation is by-name" in {
             val ex     = new Exception
             val result = (1: Int < Any).map(_ => (throw ex): Int).pipe(Abort.run[Exception](_)).eval


### PR DESCRIPTION
This PR introduces overloaded `pipe` methods for up to six functions similarly to EffectTS but it's a method on the pending type, not in a companion object https://effect.website/docs/guides/essentials/pipeline