### PR TITLE
bench: introduce JIT profile warmup mechanism

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/Bench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/Bench.scala
@@ -1,6 +1,10 @@
 package kyo.bench
 
+import WarmupJITProfile.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import org.openjdk.jmh.annotations.*
+import scala.concurrent.duration.*
 
 @State(Scope.Benchmark)
 @Fork(
@@ -52,19 +56,19 @@ object Bench:
     abstract class Fork[A: kyo.Flat](expectedResult: A) extends Base[A](expectedResult):
 
         @Benchmark
-        def forkKyo(): A =
+        def forkKyo(warmup: KyoWarmup): A =
             import kyo.*
             IO.run(Async.run(kyoBenchFiber()).flatMap(_.block(Duration.Infinity))).eval.getOrThrow
         end forkKyo
 
         @Benchmark
-        def forkCats(): A =
+        def forkCats(warmup: CatsWarmup): A =
             import cats.effect.unsafe.implicits.global
             cats.effect.IO.cede.flatMap(_ => catsBench()).unsafeRunSync()
         end forkCats
 
         @Benchmark
-        def forkZIO(): A = zio.Unsafe.unsafe(implicit u =>
+        def forkZIO(warmup: ZIOWarmup): A = zio.Unsafe.unsafe(implicit u =>
             zioRuntime.run(zio.ZIO.yieldNow.flatMap(_ => zioBench())).getOrThrow()
         )
     end Fork
@@ -75,16 +79,16 @@ object Bench:
     abstract class SyncAndFork[A: kyo.Flat](expectedResult: A) extends Fork[A](expectedResult):
 
         @Benchmark
-        def syncKyo(): A = kyo.IO.run(kyoBench()).eval
+        def syncKyo(warmup: KyoWarmup): A = kyo.IO.run(kyoBench()).eval
 
         @Benchmark
-        def syncCats(): A =
+        def syncCats(warmup: CatsWarmup): A =
             import cats.effect.unsafe.implicits.global
             catsBench().unsafeRunSync()
         end syncCats
 
         @Benchmark
-        def syncZIO(): A = zio.Unsafe.unsafe(implicit u =>
+        def syncZIO(warmup: ZIOWarmup): A = zio.Unsafe.unsafe(implicit u =>
             zioRuntime.run(zioBench()).getOrThrow()
         )
     end SyncAndFork

--- a/kyo-bench/src/main/scala/kyo/bench/Bench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/Bench.scala
@@ -56,19 +56,19 @@ object Bench:
     abstract class Fork[A: kyo.Flat](expectedResult: A) extends Base[A](expectedResult):
 
         @Benchmark
-        def forkKyo(warmup: KyoWarmup): A =
+        def forkKyo(warmup: KyoForkWarmup): A =
             import kyo.*
             IO.run(Async.run(kyoBenchFiber()).flatMap(_.block(Duration.Infinity))).eval.getOrThrow
         end forkKyo
 
         @Benchmark
-        def forkCats(warmup: CatsWarmup): A =
+        def forkCats(warmup: CatsForkWarmup): A =
             import cats.effect.unsafe.implicits.global
             cats.effect.IO.cede.flatMap(_ => catsBench()).unsafeRunSync()
         end forkCats
 
         @Benchmark
-        def forkZIO(warmup: ZIOWarmup): A = zio.Unsafe.unsafe(implicit u =>
+        def forkZIO(warmup: ZIOForkWarmup): A = zio.Unsafe.unsafe(implicit u =>
             zioRuntime.run(zio.ZIO.yieldNow.flatMap(_ => zioBench())).getOrThrow()
         )
     end Fork
@@ -79,16 +79,16 @@ object Bench:
     abstract class SyncAndFork[A: kyo.Flat](expectedResult: A) extends Fork[A](expectedResult):
 
         @Benchmark
-        def syncKyo(warmup: KyoWarmup): A = kyo.IO.run(kyoBench()).eval
+        def syncKyo(warmup: KyoSyncWarmup): A = kyo.IO.run(kyoBench()).eval
 
         @Benchmark
-        def syncCats(warmup: CatsWarmup): A =
+        def syncCats(warmup: CatsSyncWarmup): A =
             import cats.effect.unsafe.implicits.global
             catsBench().unsafeRunSync()
         end syncCats
 
         @Benchmark
-        def syncZIO(warmup: ZIOWarmup): A = zio.Unsafe.unsafe(implicit u =>
+        def syncZIO(warmup: ZIOSyncWarmup): A = zio.Unsafe.unsafe(implicit u =>
             zioRuntime.run(zioBench()).getOrThrow()
         )
     end SyncAndFork

--- a/kyo-bench/src/main/scala/kyo/bench/WarmupJITProfile.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/WarmupJITProfile.scala
@@ -75,7 +75,7 @@ object WarmupJITProfile:
     class ZIOForkWarmup extends ForkWarmup:
         def runFork[A](bench: Fork[A]) = bench.forkZIO(this)
 
-    def warmupSeconds = System.getProperty("warmupJITProfileSeconds", "5").toInt
+    def warmupSeconds = System.getProperty("warmupJITProfileSeconds", "0").toInt
 
     val warmupThreads = Runtime.getRuntime().availableProcessors()
 

--- a/kyo-bench/src/main/scala/kyo/bench/WarmupJITProfile.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/WarmupJITProfile.scala
@@ -1,0 +1,85 @@
+package kyo.bench
+
+import WarmupJITProfile.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import kyo.bench.Bench.*
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import scala.concurrent.duration.*
+
+@State(Scope.Benchmark)
+abstract class WarmupJITProfile:
+    run()
+    def run() =
+        if warmupSeconds <= 0 then
+            println("JIT profile warmup disabled")
+        else
+            println("Warming up JIT profile for " + warmupSeconds.seconds)
+            val deadline = System.currentTimeMillis() + warmupSeconds.seconds.toMillis
+            val exec     = Executors.newFixedThreadPool(warmupThreads)
+            try
+                val cdl = new CountDownLatch(warmupThreads)
+                (0 until warmupThreads).foreach { _ =>
+                    exec.execute(() =>
+                        while System.currentTimeMillis() < deadline do
+                            warmupBenchs.foreach {
+                                case bench: SyncAndFork[?] => sync(bench)
+                                case bench: Fork[?]        => fork(bench)
+                            }
+                        end while
+                        cdl.countDown()
+                    )
+                }
+                cdl.await()
+                println("Wamup done!")
+            finally
+                exec.shutdown()
+            end try
+    end run
+
+    def sync[A](bench: SyncAndFork[A]): A
+
+    def fork[A](bench: Fork[A]): A
+
+end WarmupJITProfile
+
+object WarmupJITProfile:
+
+    class CatsWarmup extends WarmupJITProfile:
+        def sync[A](bench: SyncAndFork[A]) = bench.syncCats(this)
+        def fork[A](bench: Fork[A])        = bench.forkCats(this)
+
+    class KyoWarmup extends WarmupJITProfile:
+        def sync[A](bench: SyncAndFork[A]) = bench.syncKyo(this)
+        def fork[A](bench: Fork[A])        = bench.forkKyo(this)
+
+    class ZIOWarmup extends WarmupJITProfile:
+        def sync[A](bench: SyncAndFork[A]) = bench.syncZIO(this)
+        def fork[A](bench: Fork[A])        = bench.forkZIO(this)
+
+    def warmupSeconds = System.getProperty("warmupJITProfileSeconds", "0").toInt
+
+    val warmupThreads = Runtime.getRuntime().availableProcessors()
+
+    def warmupBenchs =
+        Seq[Bench[?]](
+            new BlockingBench,
+            new BroadFlatMapBench,
+            new CollectBench,
+            new CountdownLatchBench,
+            new DeepBindMapBench,
+            new EnqueueDequeueBench,
+            new FailureBench,
+            new ForkChainedBench,
+            new ForkJoinBench,
+            new LoggingBench,
+            new NarrowBindMapBench,
+            new PingPongBench,
+            new ProducerConsumerBench,
+            new RandomBench,
+            new SemaphoreBench,
+            new StateMapBench,
+            new StreamBench
+        )
+end WarmupJITProfile

--- a/kyo-bench/src/test/scala/kyo/benchTest/CatsBenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/benchTest/CatsBenchTest.scala
@@ -5,7 +5,7 @@ import kyo.bench.*
 class CatsBenchTest extends BenchTest:
 
     def target                                 = Target.Cats
-    def runFork[A](b: Bench.Fork[A]): A        = b.forkCats()
-    def runSync[A](b: Bench.SyncAndFork[A]): A = b.syncCats()
+    def runFork[A](b: Bench.Fork[A]): A        = b.forkCats(null)
+    def runSync[A](b: Bench.SyncAndFork[A]): A = b.syncCats(null)
 
 end CatsBenchTest

--- a/kyo-bench/src/test/scala/kyo/benchTest/KyoBenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/benchTest/KyoBenchTest.scala
@@ -5,7 +5,7 @@ import kyo.bench.*
 class KyoBenchTest extends BenchTest:
 
     def target                                 = Target.Kyo
-    def runFork[A](b: Bench.Fork[A]): A        = b.forkKyo()
-    def runSync[A](b: Bench.SyncAndFork[A]): A = b.syncKyo()
+    def runFork[A](b: Bench.Fork[A]): A        = b.forkKyo(null)
+    def runSync[A](b: Bench.SyncAndFork[A]): A = b.syncKyo(null)
 
 end KyoBenchTest

--- a/kyo-bench/src/test/scala/kyo/benchTest/ZIOBenchTest.scala
+++ b/kyo-bench/src/test/scala/kyo/benchTest/ZIOBenchTest.scala
@@ -5,7 +5,7 @@ import kyo.bench.*
 class ZIOBenchTest extends BenchTest:
 
     def target                                 = Target.ZIO
-    def runFork[A](b: Bench.Fork[A]): A        = b.forkZIO()
-    def runSync[A](b: Bench.SyncAndFork[A]): A = b.syncZIO()
+    def runFork[A](b: Bench.Fork[A]): A        = b.forkZIO(null)
+    def runSync[A](b: Bench.SyncAndFork[A]): A = b.syncZIO(null)
 
 end ZIOBenchTest


### PR DESCRIPTION
A major downside of microbenchmarks in a JIT-compiled runtime like the JVM is how the execution can be extremely different from how the code would behave in a real application. This happens because benchmarks typically use a very narrow subset of the code and the profiling information collected by the JVM to generate optimized native code doesn't represent well how the code is actually used.

This PR introduces a warmup mechanism that executes several of the existing benchmarks to populate the JIT profile with more realistic information. I did just an initial analysis of Kyo's results and created https://github.com/getkyo/kyo/pull/620 but I'm planning to continue working on it. The mechanism is disabled by default for now.