### PR TITLE
kernel: safepoint optimizations

### DIFF
--- a/kyo-prelude/jvm/src/test/scala/kyo/kernel/BytecodeTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo/kernel/BytecodeTest.scala
@@ -32,12 +32,12 @@ class BytecodeTest extends Test:
 
     "map" in {
         val map = methodBytecodeSize[TestMap]
-        assert(map == Map("test" -> 18, "anonfun" -> 10, "mapLoop" -> 154))
+        assert(map == Map("test" -> 18, "anonfun" -> 10, "mapLoop" -> 132))
     }
 
     "handle" in {
         val map = methodBytecodeSize[TestHandle]
-        assert(map == Map("test" -> 20, "anonfun" -> 8, "handleLoop" -> 269))
+        assert(map == Map("test" -> 20, "anonfun" -> 8, "handleLoop" -> 247))
     }
 
     def methodBytecodeSize[A](using ct: ClassTag[A]): Map[String, Int] =


### PR DESCRIPTION
`Safepoint.enter` is the hottest code in Kyo after the migration to the new design. This PR reduces its overhead by packing multiple fields into a single `Long`. Benchmark results:

![image](https://github.com/user-attachments/assets/1d5db26d-660a-4532-b95a-cea53f57e477)
https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/fwbrasil/dbce289b4c7e98c3146637ed5f386e1a/raw/1c557d8bc06727d0aea9f8e4170d007846e0eafa/jmh-result-baseline.json,https://gist.githubusercontent.com/fwbrasil/dbce289b4c7e98c3146637ed5f386e1a/raw/1c557d8bc06727d0aea9f8e4170d007846e0eafa/jmh-result-candidate.json