### PR TITLE
kernel: optimize Effect.handle.state

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Effect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Effect.scala
@@ -228,10 +228,7 @@ object Effect:
             def handleLoop(state: State, v: A < (E & S & S2 & S3), context: Context)(using Safepoint): B < (S & S2 & S3) =
                 v match
                     case kyo: KyoSuspend[I, O, E, Any, A, E & S & S2] @unchecked if tag =:= kyo.tag && accept(kyo.input) =>
-                        Safepoint.handle(kyo.input)(
-                            suspend = handleLoop(state, kyo, context),
-                            continue = handle(kyo.input, state, kyo(_, context)).map(handleLoop(_, _, context))
-                        )
+                        handle(kyo.input, state, kyo(_, context)).map(handleLoop(_, _, context))
                     case kyo: KyoSuspend[IX, OX, EX, Any, A, E & S & S2] @unchecked =>
                         new KyoContinue[IX, OX, EX, Any, B, S & S2 & S3](kyo):
                             def frame = _frame


### PR DESCRIPTION
The method invokes `Safepoint.enter` twice: once by `Safepoint.handle` and another time by the `.map` call. We lose a bit of information because the frame with show up only after the `handle` call but it seems a reasonable tradeoff.

Results for related benchmarks:

![image](https://github.com/user-attachments/assets/be9f18f1-4b60-4e15-a239-83b4a728fffa)
https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/fwbrasil/22b12ca7fe9c4175ce9aeb00086d3a5d/raw/3f5c5f410f14434b72fc18e4a3d9866b377413ad/jmh-result-baseline.json,https://gist.githubusercontent.com/fwbrasil/22b12ca7fe9c4175ce9aeb00086d3a5d/raw/3f5c5f410f14434b72fc18e4a3d9866b377413ad/jmh-result-candidate.json