### PR TITLE
scheduler: avoid primitive boxing in regulators

### DIFF
--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -43,10 +43,10 @@ final class Scheduler(
     private val timer = InternalTimer(timerExecutor)
 
     private val admissionRegulator =
-        new Admission(loadAvg, schedule, System.currentTimeMillis, timer)
+        new Admission(() => loadAvg(), schedule, () => System.currentTimeMillis, timer)
 
     private val concurrencyRegulator =
-        new Concurrency(loadAvg, updateWorkers, Thread.sleep(_), System.nanoTime, timer)
+        new Concurrency(() => loadAvg(), updateWorkers, Thread.sleep(_), () => System.nanoTime, timer)
 
     private val top = new Reporter(status, enableTopJMX, enableTopConsoleMs, timer)
 

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Admission.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Admission.scala
@@ -2,6 +2,8 @@ package kyo.scheduler.regulator
 
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.atomic.LongAdder
+import java.util.function.DoubleSupplier
+import java.util.function.LongSupplier
 import kyo.scheduler.*
 import kyo.scheduler.InternalTimer
 import kyo.scheduler.top.AdmissionStatus
@@ -11,9 +13,9 @@ import scala.concurrent.duration.*
 import scala.util.hashing.MurmurHash3
 
 final class Admission(
-    loadAvg: () => Double,
+    loadAvg: DoubleSupplier,
     schedule: Task => Unit,
-    nowMillis: () => Long,
+    nowMillis: LongSupplier,
     timer: InternalTimer,
     config: Config = Admission.defaultConfig
 ) extends Regulator(loadAvg, timer, config) {
@@ -40,9 +42,9 @@ final class Admission(
     }
 
     final private class ProbeTask extends Task {
-        val start = nowMillis()
+        val start = nowMillis.getAsLong()
         def run(startMillis: Long, clock: InternalClock) = {
-            measure(nowMillis() - start)
+            measure(nowMillis.getAsLong() - start)
             Task.Done
         }
     }

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Concurrency.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Concurrency.scala
@@ -1,23 +1,25 @@
 package kyo.scheduler.regulator
 
+import java.util.function.DoubleSupplier
+import java.util.function.LongSupplier
 import kyo.scheduler.*
 import kyo.scheduler.top.ConcurrencyStatus
 import kyo.scheduler.util.Flag
 import scala.concurrent.duration.*
 
 final class Concurrency(
-    loadAvg: () => Double,
+    loadAvg: DoubleSupplier,
     updateConcurrency: Int => Unit,
     sleep: Int => Unit,
-    nowNanos: () => Long,
+    nowNanos: LongSupplier,
     timer: InternalTimer,
     config: Config = Concurrency.defaultConfig
 ) extends Regulator(loadAvg, timer, config) {
 
     protected def probe() = {
-        val start = nowNanos()
+        val start = nowNanos.getAsLong()
         sleep(1)
-        measure(nowNanos() - start - 1000000)
+        measure(nowNanos.getAsLong() - start - 1000000)
     }
 
     protected def update(diff: Int): Unit =

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Regulator.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Regulator.scala
@@ -1,13 +1,14 @@
 package kyo.scheduler.regulator
 
 import java.util.concurrent.atomic.LongAdder
+import java.util.function.DoubleSupplier
 import kyo.scheduler.InternalTimer
 import kyo.scheduler.top.RegulatorStatus
 import kyo.scheduler.util.*
 import scala.util.control.NonFatal
 
 abstract class Regulator(
-    loadAvg: () => Double,
+    loadAvg: DoubleSupplier,
     timer: InternalTimer,
     config: Config
 ) {
@@ -49,7 +50,7 @@ abstract class Regulator(
         try {
             adjustments.increment()
             val jitter = synchronized(measurements.dev())
-            val load   = loadAvg()
+            val load   = loadAvg.getAsDouble()
             if (jitter > jitterUpperThreshold) {
                 if (step < 0) step -= 1
                 else step = -1


### PR DESCRIPTION
I noticed some boxing allocations in regulators. Since Scala 3 doesn't have specialization yet, I'm using Java's supplier interfaces. This is a minor cleanup since the allocation rate is low.

![image](https://github.com/user-attachments/assets/c8c7b65a-168d-4598-bf17-1716d93e6c44)
