### PR TITLE
core: don't print Unit result in KyoApp

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -8,7 +8,10 @@ abstract class KyoApp extends KyoApp.Base[KyoApp.Effects]:
     def clock: Clock    = Clock.live
 
     override protected def handle[A: Flat](v: A < KyoApp.Effects)(using Frame): Unit =
-        v.map(Console.println)
+        v.map { v =>
+            if (()).equals(v) then ()
+            else Console.println(v)
+        }
             .pipe(Clock.let(clock))
             .pipe(Random.let(random))
             .pipe(Log.let(log))


### PR DESCRIPTION
fixes #492

Makes `KyoApp` print the result of `run` only if it's not `Unit`.