### PR TITLE
core: Clock stopwatch, deadline, and unsafe APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1392,6 +1392,8 @@ val f: Unit < IO =
 
 ### Clock: Time Management
 
+The `Clock` effect provides utilities for time-related operations, including getting the current time, creating stopwatches, and managing deadlines.
+
 ```scala
 import java.time.Instant
 import kyo.*
@@ -1400,10 +1402,51 @@ import kyo.*
 val a: Instant < IO =
     Clock.now
 
-// Run with an explicit 'Clock'
-val c: Instant < IO =
-    Clock.let(Clock.live)(a)
+// Create a stopwatch
+val b: Clock.Stopwatch < IO =
+    Clock.stopwatch
+
+// Measure elapsed time with a stopwatch
+val c: Duration < IO =
+    for
+        sw      <- Clock.stopwatch
+        elapsed <- sw.elapsed
+    yield elapsed
+
+// Create a deadline
+val d: Clock.Deadline < IO =
+    Clock.deadline(5.seconds)
+
+// Check time left until deadline
+val e: Duration < IO =
+    for
+        deadline <- Clock.deadline(5.seconds)
+        timeLeft <- deadline.timeLeft
+    yield timeLeft
+
+// Check if a deadline is overdue
+val f: Boolean < IO =
+    for
+        deadline <- Clock.deadline(5.seconds)
+        isOverdue <- deadline.isOverdue
+    yield isOverdue
+
+// Run with an explicit `Clock` implementation
+val g: Instant < IO =
+    Clock.let(Clock.live)(Clock.now)
+
+// Access unsafe (non-effectful) clock operations
+val h: Instant =
+    Clock.live.unsafe.now
+
+val i: Clock.Unsafe.Stopwatch =
+    Clock.live.unsafe.stopwatch
+
+val j: Clock.Unsafe.Deadline =
+    Clock.live.unsafe.deadline(5.seconds)
 ```
+
+`Clock` both safe (effectful) and unsafe (non-effectful) versions of its operations. The safe versions are suspended in `IO` and should be used in most cases. The unsafe versions are available through the `unsafe` property and should be used with caution, typically only in performance-critical sections or when integrating with non-effectful code.
 
 ### System: Environment Variables and System Properties
 

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -4,12 +4,60 @@ import java.time.Instant
 
 abstract class Clock:
     def now(using Frame): Instant < IO
+    def stopwatch(using Frame): Clock.Stopwatch < IO
+    def deadline(duration: Duration)(using Frame): Clock.Deadline < IO
+    def unsafe: Clock.Unsafe
+end Clock
 
 object Clock:
 
-    val live: Clock =
-        new Clock:
-            def now(using Frame) = IO(Instant.now())
+    abstract class Unsafe:
+        def now: Instant
+        def stopwatch: Unsafe.Stopwatch
+        def deadline(duration: Duration): Unsafe.Deadline
+    end Unsafe
+
+    object Unsafe:
+        class Stopwatch(start: Instant, clock: Clock.Unsafe):
+            def elapsed: Duration =
+                Duration.fromJava(java.time.Duration.between(start, clock.now))
+
+        class Deadline(end: Instant, clock: Clock.Unsafe):
+            def timeLeft: Duration =
+                val remaining = java.time.Duration.between(clock.now, end)
+                if remaining.isNegative then Duration.Zero else Duration.fromJava(remaining)
+            def isOverdue: Boolean = clock.now.isAfter(end)
+        end Deadline
+    end Unsafe
+
+    abstract class Stopwatch:
+        def elapsed(using Frame): Duration < IO
+        def unsafe: Unsafe.Stopwatch
+
+    abstract class Deadline:
+        def timeLeft(using Frame): Duration < IO
+        def isOverdue(using Frame): Boolean < IO
+        def unsafe: Unsafe.Deadline
+    end Deadline
+
+    val live: Clock = new Clock:
+        val unsafe: Unsafe = new Unsafe:
+            def now: Instant                                  = Instant.now()
+            def stopwatch: Unsafe.Stopwatch                   = new Unsafe.Stopwatch(now, this)
+            def deadline(duration: Duration): Unsafe.Deadline = new Unsafe.Deadline(now.plus(duration.toJava), this)
+
+        def now(using Frame): Instant < IO = IO(unsafe.now)
+        def stopwatch(using Frame): Stopwatch < IO = IO {
+            new Stopwatch:
+                val unsafe                              = Clock.live.unsafe.stopwatch
+                def elapsed(using Frame): Duration < IO = IO(unsafe.elapsed)
+        }
+        def deadline(duration: Duration)(using Frame): Deadline < IO = IO {
+            new Deadline:
+                val unsafe                               = Clock.live.unsafe.deadline(duration)
+                def timeLeft(using Frame): Duration < IO = IO(unsafe.timeLeft)
+                def isOverdue(using Frame): Boolean < IO = IO(unsafe.isOverdue)
+        }
 
     private val local = Local.init(live)
 
@@ -19,4 +67,9 @@ object Clock:
     def now(using Frame): Instant < IO =
         local.use(_.now)
 
+    def stopwatch(using Frame): Stopwatch < IO =
+        local.use(_.stopwatch)
+
+    def deadline(duration: Duration)(using Frame): Deadline < IO =
+        local.use(_.deadline(duration))
 end Clock

--- a/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
@@ -1,25 +1,189 @@
 package kyo
 
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
-class clocksTest extends Test:
+class ClockTest extends Test:
 
-    object testClock extends Clock:
+    given CanEqual[Instant, Instant] = CanEqual.derived
 
-        var nows = List.empty[Instant]
+    class TestClock extends Clock:
+        var currentTime = Instant.now()
 
-        def now(using Frame): Instant < IO =
-            IO {
-                val v = nows.head
-                nows = nows.tail
-                v
-            }
-    end testClock
+        val unsafe: Clock.Unsafe = new Clock.Unsafe:
+            def now: Instant                                        = currentTime
+            def stopwatch: Clock.Unsafe.Stopwatch                   = new Clock.Unsafe.Stopwatch(currentTime, this)
+            def deadline(duration: Duration): Clock.Unsafe.Deadline = new Clock.Unsafe.Deadline(currentTime.plus(duration.toJava), this)
 
-    "now" in {
-        val instant = Instant.now()
-        testClock.nows = List(instant)
-        val io = Clock.let(testClock)(Clock.now)
-        assert(IO.run(io).eval eq instant)
+        def now(using Frame): Instant < IO = IO(currentTime)
+        def stopwatch(using Frame): Clock.Stopwatch < IO = IO(new Clock.Stopwatch:
+            val unsafe                              = TestClock.this.unsafe.stopwatch
+            def elapsed(using Frame): Duration < IO = IO(unsafe.elapsed)
+        )
+        def deadline(duration: Duration)(using Frame): Clock.Deadline < IO = IO(new Clock.Deadline:
+            val unsafe                               = TestClock.this.unsafe.deadline(duration)
+            def timeLeft(using Frame): Duration < IO = IO(unsafe.timeLeft)
+            def isOverdue(using Frame): Boolean < IO = IO(unsafe.isOverdue)
+        )
+
+        def advance(duration: Duration): Unit =
+            currentTime = currentTime.plus(duration.toJava)
+
+        def set(instant: Instant): Unit =
+            currentTime = instant
+    end TestClock
+
+    "Clock" - {
+        "now" in run {
+            val testClock = new TestClock
+            val instant   = testClock.currentTime
+            for
+                result <- Clock.let(testClock)(Clock.now)
+            yield assert(result == instant)
+        }
+
+        "unsafe now" in {
+            val testClock = new TestClock
+            val instant   = testClock.currentTime
+            assert(testClock.unsafe.now == instant)
+        }
+
+        "now at epoch" in run {
+            val testClock = new TestClock
+            testClock.set(Instant.EPOCH)
+            for
+                result <- Clock.let(testClock)(Clock.now)
+            yield assert(result == Instant.EPOCH)
+        }
+
+        "now at max instant" in run {
+            val testClock = new TestClock
+            testClock.set(Instant.MAX)
+            for
+                result <- Clock.let(testClock)(Clock.now)
+            yield assert(result == Instant.MAX)
+        }
     }
-end clocksTest
+
+    "Stopwatch" - {
+        "elapsed time" in run {
+            val testClock = new TestClock
+            for
+                stopwatch <- Clock.let(testClock)(Clock.stopwatch)
+                _ = testClock.advance(5.seconds)
+                elapsed <- stopwatch.elapsed
+            yield assert(elapsed == 5.seconds)
+            end for
+        }
+
+        "unsafe elapsed time" in {
+            val testClock = new TestClock
+            val stopwatch = testClock.unsafe.stopwatch
+            testClock.advance(5.seconds)
+            assert(stopwatch.elapsed == 5.seconds)
+        }
+
+        "zero elapsed time" in run {
+            val testClock = new TestClock
+            for
+                stopwatch <- Clock.let(testClock)(Clock.stopwatch)
+                elapsed   <- stopwatch.elapsed
+            yield assert(elapsed == Duration.Zero)
+            end for
+        }
+    }
+
+    "Deadline" - {
+        "timeLeft" in run {
+            val testClock = new TestClock
+            for
+                deadline <- Clock.let(testClock)(Clock.deadline(10.seconds))
+                _ = testClock.advance(3.seconds)
+                timeLeft <- deadline.timeLeft
+            yield assert(timeLeft == 7.seconds)
+            end for
+        }
+
+        "isOverdue" in run {
+            val testClock = new TestClock
+            for
+                deadline   <- Clock.let(testClock)(Clock.deadline(5.seconds))
+                notOverdue <- deadline.isOverdue
+                _ = testClock.advance(6.seconds)
+                overdue <- deadline.isOverdue
+            yield assert(!notOverdue && overdue)
+            end for
+        }
+
+        "unsafe timeLeft" in {
+            val testClock = new TestClock
+            val deadline  = testClock.unsafe.deadline(10.seconds)
+            testClock.advance(3.seconds)
+            assert(deadline.timeLeft == 7.seconds)
+        }
+
+        "unsafe isOverdue" in {
+            val testClock = new TestClock
+            val deadline  = testClock.unsafe.deadline(5.seconds)
+            assert(!deadline.isOverdue)
+            testClock.advance(6.seconds)
+            assert(deadline.isOverdue)
+        }
+
+        "zero duration deadline" in run {
+            val testClock = new TestClock
+            for
+                deadline  <- Clock.let(testClock)(Clock.deadline(Duration.Zero))
+                isOverdue <- deadline.isOverdue
+                timeLeft  <- deadline.timeLeft
+            yield assert(!isOverdue && timeLeft == Duration.Zero)
+            end for
+        }
+
+        "deadline exactly at expiration" in run {
+            val testClock = new TestClock
+            for
+                deadline <- Clock.let(testClock)(Clock.deadline(5.seconds))
+                _ = testClock.advance(5.seconds)
+                isOverdue <- deadline.isOverdue
+                timeLeft  <- deadline.timeLeft
+            yield assert(!isOverdue && timeLeft == Duration.Zero)
+            end for
+        }
+    }
+
+    "Integration" - {
+        "using stopwatch with deadline" in run {
+            val testClock = new TestClock
+            for
+                stopwatch <- Clock.let(testClock)(Clock.stopwatch)
+                deadline  <- Clock.let(testClock)(Clock.deadline(10.seconds))
+                _ = testClock.advance(7.seconds)
+                elapsed  <- stopwatch.elapsed
+                timeLeft <- deadline.timeLeft
+            yield assert(elapsed == 7.seconds && timeLeft == 3.seconds)
+            end for
+        }
+
+        "multiple stopwatches and deadlines" in run {
+            val testClock = new TestClock
+            for
+                stopwatch1 <- Clock.let(testClock)(Clock.stopwatch)
+                deadline1  <- Clock.let(testClock)(Clock.deadline(10.seconds))
+                _ = testClock.advance(3.seconds)
+                stopwatch2 <- Clock.let(testClock)(Clock.stopwatch)
+                deadline2  <- Clock.let(testClock)(Clock.deadline(5.seconds))
+                _ = testClock.advance(4.seconds)
+                elapsed1  <- stopwatch1.elapsed
+                elapsed2  <- stopwatch2.elapsed
+                timeLeft1 <- deadline1.timeLeft
+                timeLeft2 <- deadline2.timeLeft
+            yield
+                assert(elapsed1 == 7.seconds)
+                assert(elapsed2 == 4.seconds)
+                assert(timeLeft1 == 3.seconds)
+                assert(timeLeft2 == 1.second)
+            end for
+        }
+    }
+end ClockTest

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
@@ -2,6 +2,9 @@ package kyo
 
 import Tagged.*
 import java.time.Instant
+import kyo.Clock.Deadline
+import kyo.Clock.Stopwatch
+import kyo.Clock.Unsafe
 
 class KyoAppTest extends Test:
 
@@ -73,7 +76,10 @@ class KyoAppTest extends Test:
             instantRef <- AtomicRef.init(Instant.MAX)
             randomRef  <- AtomicRef.init("")
             testClock = new Clock:
-                override def now(using Frame): Instant < IO = Instant.EPOCH
+                override def unsafe: Unsafe                            = ???
+                override def now(using Frame)                          = Instant.EPOCH
+                override def deadline(duration: Duration)(using Frame) = ???
+                override def stopwatch(using Frame)                    = ???
             testRandom = new Random:
                 override def nextInt(using Frame): Int < IO = ???
 


### PR DESCRIPTION
I'm planning to use the deadline API to fix `Async.block` that should use `Clock` instead of Java's `System` directly. 