### PR TITLE
Result: add unified Error.unapply

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Result.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Result.scala
@@ -200,6 +200,12 @@ object Result:
           */
         def getFailure: E | Throwable
     end Error
+    object Error:
+        def unapply[E, A](self: Result[E, A]): Maybe.Ops[E | Throwable] =
+            self match
+                case error: Error[E] @unchecked => Maybe(error.getFailure)
+                case _                          => Maybe.empty
+    end Error
 
     /** Represents a failure in a Result. */
     case class Fail[+E](error: E) extends Error[E]:

--- a/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
@@ -430,6 +430,27 @@ class ResultTest extends Test:
                 assert(result == "short error")
             }
         }
+        "Error.unapply" - {
+            "should match Fail" in {
+                val result = Result.fail("FAIL!")
+                result match
+                    case Error(_) => succeed
+                    case _        => fail()
+            }
+            "should match Panic" in {
+                val result = Result.panic(new AssertionError)
+                result match
+                    case Error(_) => succeed
+                    case _        => fail()
+            }
+            "should not match Success" in {
+                val result = Result.success(1)
+                result match
+                    case Error(_) => fail()
+                    case _        => succeed
+            }
+        }
+
     }
 
     "inference" - {


### PR DESCRIPTION
I found myself needing to manually match on `error: Error[E] @unchecked`...