### PR TITLE
readme: IDE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ libraryDependencies += "io.getkyo" %%  "kyo-data"        % "<version>"
 
 Replace `<version>` with the latest version: ![Version](https://img.shields.io/maven-central/v/io.getkyo/kyo-core_3).
 
+### IDE Support
+
+Kyo utilizes features from the latest Scala 3 versions that are not yet properly supported by IntelliJ IDEA. For the best development experience and to ensure all Kyo features are correctly recognized, we recommend using a [Metals-based](https://scalameta.org/metals/) IDE for your Kyo projects.
 
 ### The "Pending" type: `<`
 


### PR DESCRIPTION
It seems important to highlight this since users might try the library with IntelliJ, which currently doesn't provide the experience Kyo is designed for. 