### PR TITLE
error handling naming refactoring

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/FailureBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/FailureBench.scala
@@ -49,17 +49,17 @@ class FailureBench extends Bench.SyncAndFork[Either[Ex1 | Ex2, Int]](Left(Ex2)):
             if i > depth then i
             else
                 (i % 5) match
-                    case 0 => loop(i + 1).map(_ => Abort.fail(Ex1))
-                    case 1 => loop(i + 1).map(_ => Abort.fail(Ex2))
+                    case 0 => loop(i + 1).map(_ => Abort.error(Ex1))
+                    case 1 => loop(i + 1).map(_ => Abort.error(Ex2))
                     case 2 =>
                         Abort.run[Ex1](loop(i + 1)).map {
-                            case Result.Fail(_)    => Abort.fail(Ex2)
+                            case Result.Error(_)   => Abort.error(Ex2)
                             case Result.Success(v) => v
                             case Result.Panic(ex)  => Abort.panic(ex)
                         }
                     case 3 =>
                         Abort.run[Ex2](loop(i + 1)).map {
-                            case Result.Fail(_)    => Abort.fail(Ex1)
+                            case Result.Error(_)   => Abort.error(Ex1)
                             case Result.Success(v) => v
                             case Result.Panic(ex)  => Abort.panic(ex)
                         }
@@ -67,9 +67,9 @@ class FailureBench extends Bench.SyncAndFork[Either[Ex1 | Ex2, Int]](Left(Ex2)):
                 end match
         end loop
         Abort.run[Exception](loop(0)).map {
-            case Result.Fail(ex: (Ex1 | Ex2)) => Left(ex)
-            case Result.Success(v)            => Right(v)
-            case _                            => ???
+            case Result.Error(ex: (Ex1 | Ex2)) => Left(ex)
+            case Result.Success(v)             => Right(v)
+            case _                             => ???
         }
     end kyoBench
 

--- a/kyo-bench/src/main/scala/kyo/bench/RendezvousBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/RendezvousBench.scala
@@ -71,7 +71,7 @@ class RendezvousBench extends Bench.ForkOnly(10000 * (10000 + 1) / 2):
                     waiting.cas(null, (p, n)).flatMap {
                         case false =>
                             waiting.getAndSet(null).flatMap {
-                                _.asInstanceOf[Promise[Nothing, Int]].complete(Result.success(n))
+                                _.asInstanceOf[Promise[Nothing, Int]].complete(Result.succeed(n))
                             }
                         case true =>
                             p.get

--- a/kyo-cache/shared/src/test/scala/kyo/CacheTest.scala
+++ b/kyo-cache/shared/src/test/scala/kyo/CacheTest.scala
@@ -51,7 +51,7 @@ class CacheTest extends Test:
             }
             v1 <- Abort.run[Throwable](m(1))
             v2 <- Abort.run[Throwable](m(1))
-        yield assert(calls == 2 && v1 == Result.fail(ex) && v2 == Result.success(2))
+        yield assert(calls == 2 && v1 == Result.error(ex) && v2 == Result.succeed(2))
         end for
     }
 end CacheTest

--- a/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
+++ b/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
@@ -25,10 +25,10 @@ class CatsTest extends Test:
         "kyo then cats" in runKyo {
             object catsFailure extends RuntimeException
             object kyoFailure  extends RuntimeException
-            val a = Abort.fail(kyoFailure)
+            val a = Abort.error(kyoFailure)
             val b = Cats.get(CatsIO.raiseError(catsFailure))
             Abort.run[Throwable](a.map(_ => b)).map {
-                case Result.Fail(ex) =>
+                case Result.Error(ex) =>
                     assert(ex == kyoFailure)
                 case _ =>
                     fail()
@@ -38,9 +38,9 @@ class CatsTest extends Test:
             object catsFailure extends RuntimeException
             object kyoFailure  extends RuntimeException
             val a = Cats.get(CatsIO.raiseError(catsFailure))
-            val b = Abort.fail(kyoFailure)
+            val b = Abort.error(kyoFailure)
             Abort.run[Throwable](a.map(_ => b)).map {
-                case Result.Fail(ex) =>
+                case Result.Error(ex) =>
                     assert(ex == catsFailure)
                 case ex =>
                     fail()
@@ -130,11 +130,11 @@ class CatsTest extends Test:
 
     "Error handling" - {
         "Kyo Abort to Cats IO error" in runKyo {
-            val kyoAbort  = Abort.fail(new Exception("Kyo error"))
+            val kyoAbort  = Abort.error(new Exception("Kyo error"))
             val converted = Cats.get(CatsIO.fromEither(Abort.run(kyoAbort).eval.toEither))
             Abort.run[Throwable](converted).map {
-                case Result.Fail(ex) => assert(ex.getMessage() == "Kyo error")
-                case _               => fail("Expected a String error")
+                case Result.Error(ex) => assert(ex.getMessage() == "Kyo error")
+                case _                => fail("Expected a String error")
             }
         }
 
@@ -142,8 +142,8 @@ class CatsTest extends Test:
             val catsError = CatsIO.raiseError[Int](new Exception("Cats error"))
             val converted = Cats.get(catsError)
             Abort.run[Throwable](converted).map {
-                case Result.Fail(error: Exception) => assert(error.getMessage == "Cats error")
-                case _                             => fail("Expected an Exception")
+                case Result.Error(error: Exception) => assert(error.getMessage == "Cats error")
+                case _                              => fail("Expected an Exception")
             }
         }
     }

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -99,8 +99,8 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that fails with the given error
       */
-    def fail[E, S](error: => E < S)(using Frame): Nothing < (S & Abort[E]) =
-        error.map(e => Abort.fail(e))
+    def error[E, S](error: => E < S)(using Frame): Nothing < (S & Abort[E]) =
+        error.map(e => Abort.error(e))
 
     /** Applies a function to each element in parallel and returns a new sequence with the results.
       *

--- a/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorTest.scala
@@ -31,11 +31,11 @@ class ChoiceCombinatorTest extends Test:
                 val failure: Int < Choice             = Choice.get(Nil)
                 val failureAbort: Int < Abort[String] = failure.choiceToAbort("failure")
                 val handledFailureAbort               = Abort.run[String](failureAbort)
-                assert(handledFailureAbort.eval == Result.fail("failure"))
+                assert(handledFailureAbort.eval == Result.error("failure"))
                 val success: Int < Choice             = Choice.get(Seq(1, 2, 3))
                 val successAbort: Int < Abort[String] = success.choiceToAbort("failure")
                 val handledSuccessAbort               = Abort.run[String](successAbort)
-                assert(handledSuccessAbort.eval == Result.success(1))
+                assert(handledSuccessAbort.eval == Result.succeed(1))
             }
 
             "should convert choice to throwable abort, constructing Right from Seq#head" in {
@@ -48,18 +48,18 @@ class ChoiceCombinatorTest extends Test:
                 val success: Int < Choice                = Choice.get(Seq(1, 2, 3))
                 val successAbort: Int < Abort[Throwable] = success.choiceToThrowable
                 val handledSuccessAbort                  = Abort.run[Throwable](successAbort)
-                assert(handledSuccessAbort.eval == Result.success(1))
+                assert(handledSuccessAbort.eval == Result.succeed(1))
             }
 
             "should convert choice to empty abort, constructing Right from Seq#head" in {
                 val failure: Int < Choice                  = Choice.get(Nil)
                 val failureAbort: Int < Abort[Maybe.Empty] = failure.choiceToEmpty
                 val handledFailureAbort                    = Abort.run[Maybe.Empty](failureAbort)
-                assert(handledFailureAbort.eval == Result.fail(Maybe.Empty))
+                assert(handledFailureAbort.eval == Result.error(Maybe.Empty))
                 val success: Int < Choice                  = Choice.get(Seq(1, 2, 3))
                 val successAbort: Int < Abort[Maybe.Empty] = success.choiceToEmpty
                 val handledSuccessAbort                    = Abort.run[Maybe.Empty](successAbort)
-                assert(handledSuccessAbort.eval == Result.success(1))
+                assert(handledSuccessAbort.eval == Result.succeed(1))
             }
         }
 

--- a/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
@@ -18,9 +18,9 @@ class ConstructorsTest extends Test:
 
         "fail" - {
             "should create an effect that fails with Abort[E]" in {
-                val effect = Kyo.fail("Error message")
+                val effect = Kyo.error("Error message")
                 val result = Abort.run[String](effect).eval
-                assert(result == Result.fail("Error message"))
+                assert(result == Result.error("Error message"))
             }
         }
 
@@ -32,8 +32,8 @@ class ConstructorsTest extends Test:
                 val successResult = Abort.run[String](successEffect).eval
                 val failureResult = Abort.run[String](failureEffect).eval
 
-                assert(successResult == Result.success(42))
-                assert(failureResult == Result.fail("Error"))
+                assert(successResult == Result.succeed(42))
+                assert(failureResult == Result.error("Error"))
             }
         }
 
@@ -45,8 +45,8 @@ class ConstructorsTest extends Test:
                 val someResult = Abort.run[Maybe.Empty](someEffect).eval
                 val noneResult = Abort.run[Maybe.Empty](noneEffect).eval
 
-                assert(someResult == Result.success(42))
-                assert(noneResult == Result.fail(Maybe.Empty))
+                assert(someResult == Result.succeed(42))
+                assert(noneResult == Result.error(Maybe.Empty))
             }
         }
 
@@ -58,21 +58,21 @@ class ConstructorsTest extends Test:
                 val definedResult = Abort.run[Maybe.Empty](definedEffect).eval
                 val emptyResult   = Abort.run[Maybe.Empty](emptyEffect).eval
 
-                assert(definedResult == Result.success(42))
-                assert(emptyResult == Result.fail(Maybe.Empty))
+                assert(definedResult == Result.succeed(42))
+                assert(emptyResult == Result.error(Maybe.Empty))
             }
         }
 
         "fromResult" - {
             "should create an effect from Result[E, A]" in {
-                val successEffect = Kyo.fromResult(Result.success(42))
-                val failureEffect = Kyo.fromResult(Result.fail("Error"))
+                val successEffect = Kyo.fromResult(Result.succeed(42))
+                val failureEffect = Kyo.fromResult(Result.error("Error"))
 
                 val successResult = Abort.run[String](successEffect).eval
                 val failureResult = Abort.run[String](failureEffect).eval
 
-                assert(successResult == Result.success(42))
-                assert(failureResult == Result.fail("Error"))
+                assert(successResult == Result.succeed(42))
+                assert(failureResult == Result.error("Error"))
             }
         }
 
@@ -84,8 +84,8 @@ class ConstructorsTest extends Test:
                 val successResult = Abort.run[Throwable](successEffect).eval
                 val failureResult = Abort.run[Throwable](failureEffect).eval
 
-                assert(successResult == Result.success(42))
-                assert(failureResult.isInstanceOf[Result.Fail[?]])
+                assert(successResult == Result.succeed(42))
+                assert(failureResult.isInstanceOf[Result.Error[?]])
             }
         }
 
@@ -151,8 +151,8 @@ class ConstructorsTest extends Test:
                 val successResult = IO.run(Abort.run[Throwable](successEffect)).eval
                 val failureResult = IO.run(Abort.run[Throwable](failureEffect)).eval
 
-                assert(successResult == Result.success(42))
-                assert(failureResult.isInstanceOf[Result.Fail[?]])
+                assert(successResult == Result.succeed(42))
+                assert(failureResult.isInstanceOf[Result.Error[?]])
             }
         }
     }

--- a/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
@@ -119,7 +119,7 @@ class EffectCombinatorTest extends Test:
                 val getState          = IO(state)
                 val effectWhen        = (toggleState *> getState).when(getState)
                 val handledEffectWhen = IO.run(Abort.run(effectWhen))
-                assert(handledEffectWhen.eval == Result.fail(Maybe.Empty))
+                assert(handledEffectWhen.eval == Result.error(Maybe.Empty))
             }
             "condition is true" in {
                 var state: Boolean = true
@@ -129,7 +129,7 @@ class EffectCombinatorTest extends Test:
                 val getState          = IO(state)
                 val effectWhen        = (toggleState *> getState).when(getState)
                 val handledEffectWhen = IO.run(Abort.run(effectWhen))
-                assert(handledEffectWhen.eval == Result.success(false))
+                assert(handledEffectWhen.eval == Result.succeed(false))
             }
         }
 
@@ -143,7 +143,7 @@ class EffectCombinatorTest extends Test:
                         }
                     }
                 }.eval
-                assert(result == Result.fail(Maybe.Empty))
+                assert(result == Result.error(Maybe.Empty))
             }
             "condition is false" in {
                 val effect = IO("value").unless(Env.get[Boolean])
@@ -154,7 +154,7 @@ class EffectCombinatorTest extends Test:
                         }
                     }
                 }.eval
-                assert(result == Result.success("value"))
+                assert(result == Result.succeed("value"))
             }
         }
 

--- a/kyo-combinators/shared/src/test/scala/kyo/FiberCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/FiberCombinatorTest.scala
@@ -56,8 +56,8 @@ class FiberCombinatorTest extends Test:
                         Abort.catching[Throwable](r)
                     })
                     assert(handledEffect.eval match
-                        case Result.Fail(_: Timeout) => true
-                        case _                       => false
+                        case Result.Error(_: Timeout) => true
+                        case _                        => false
                     )
                 }
             }

--- a/kyo-core/jvm/src/main/scala/kyo/internal/FiberPlatformSpecific.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/internal/FiberPlatformSpecific.scala
@@ -12,7 +12,7 @@ trait FiberPlatformSpecific:
         IO {
             val p = new IOPromise[Nothing, A]()
             cs.whenComplete { (success, error) =>
-                if error == null then p.completeUnit(Result.success(success))
+                if error == null then p.completeUnit(Result.succeed(success))
                 else p.completeUnit(Result.panic(error))
             }
             Fiber.initUnsafe(p)

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -228,7 +228,7 @@ object Channel:
                                         takes.add(p)
                                         Fiber.initUnsafe(p)
                                     else
-                                        Fiber.success(v)
+                                        Fiber.succeed(v)
                                     end if
                             finally
                                 flush()
@@ -288,7 +288,7 @@ object Channel:
                                     // If the queue has been emptied before the
                                     // transfer, requeue the consumer's promise.
                                     discard(takes.add(p))
-                                else if !p.complete(Result.success(v)) && !u.offer(v) then
+                                else if !p.complete(Result.succeed(v)) && !u.offer(v) then
                                     // If completing the take fails and the queue
                                     // cannot accept the value back, enqueue a
                                     // placeholder put operation to preserve the value.
@@ -307,7 +307,7 @@ object Channel:
                                     // Complete the put's promise if the value is
                                     // successfully enqueued. If the fiber became
                                     // interrupted, the completion will be ignored.
-                                    discard(p.complete(Result.success(())))
+                                    discard(p.complete(Result.succeed(())))
                                 else
                                     // If the queue becomes full before the transfer,
                                     // requeue the producer's operation.
@@ -322,12 +322,12 @@ object Channel:
                             if t != null then
                                 val (v, p) = t
                                 val p2     = takes.poll()
-                                if p2 != null && p2.complete(Result.success(v)) then
+                                if p2 != null && p2.complete(Result.succeed(v)) then
                                     // If the transfer is successful, complete
                                     // the put's promise. If the consumer's fiber
                                     // became interrupted, the completion will be
                                     // ignored.
-                                    discard(p.complete(Result.success(())))
+                                    discard(p.complete(Result.succeed(())))
                                 else
                                     // If the transfer to the consumer fails, requeue
                                     // the producer's operation.

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -183,7 +183,7 @@ object System:
 
     /** Companion object for Parser, containing default implementations. */
     object Parser:
-        given Parser[Nothing, String]                    = v => Result.success(v)
+        given Parser[Nothing, String]                    = v => Result.succeed(v)
         given Parser[NumberFormatException, Int]         = v => Result.catching(v.toInt)
         given Parser[NumberFormatException, Long]        = v => Result.catching(v.toLong)
         given Parser[NumberFormatException, Float]       = v => Result.catching(v.toFloat)
@@ -216,8 +216,8 @@ object System:
 
         given Parser[IllegalArgumentException, Char] =
             v =>
-                if v.length() == 1 then Result.success(v(0))
-                else Result.fail(new IllegalArgumentException("String must have exactly one character"))
+                if v.length() == 1 then Result.succeed(v(0))
+                else Result.error(new IllegalArgumentException("String must have exactly one character"))
 
     end Parser
 

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -168,7 +168,7 @@ private[kyo] class IOPromise[E, A](init: State[E, A]) extends Safepoint.Intercep
                             if isNull(result) then
                                 val remainingNanos = deadline - java.lang.System.currentTimeMillis()
                                 if remainingNanos <= 0 then
-                                    return Result.fail(Timeout(frame))
+                                    return Result.error(Timeout(frame))
                                 else if remainingNanos == Long.MaxValue then
                                     LockSupport.park(this)
                                 else

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -63,7 +63,7 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
                 )
             }
             if !isNull(curr) then
-                curr.evalNow.foreach(a => completeUnit(Result.success(a)))
+                curr.evalNow.foreach(a => completeUnit(Result.succeed(a)))
         catch
             case ex =>
                 completeUnit(Result.panic(ex))

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -10,7 +10,7 @@ class AsyncTest extends Test:
         "complete" in run {
             for
                 p <- Promise.init[Nothing, Int]
-                a <- p.complete(Result.success(1))
+                a <- p.complete(Result.succeed(1))
                 b <- p.done
                 c <- p.get
             yield assert(a && b && c == 1)
@@ -18,8 +18,8 @@ class AsyncTest extends Test:
         "complete twice" in run {
             for
                 p <- Promise.init[Nothing, Int]
-                a <- p.complete(Result.success(1))
-                b <- p.complete(Result.success(2))
+                a <- p.complete(Result.succeed(1))
+                b <- p.complete(Result.succeed(2))
                 c <- p.done
                 d <- p.get
             yield assert(a && !b && c && d == 1)
@@ -35,10 +35,10 @@ class AsyncTest extends Test:
             val ex = new Exception
             for
                 p <- Promise.init[Exception, Int]
-                a <- p.complete(Result.fail(ex))
+                a <- p.complete(Result.error(ex))
                 b <- p.done
                 c <- p.getResult
-            yield assert(a && b && c == Result.fail(ex))
+            yield assert(a && b && c == Result.error(ex))
             end for
         }
 
@@ -47,7 +47,7 @@ class AsyncTest extends Test:
                 for
                     p1 <- Promise.init[Nothing, Int]
                     p2 <- Promise.init[Nothing, Int]
-                    a  <- p2.complete(Result.success(42))
+                    a  <- p2.complete(Result.succeed(42))
                     b  <- p1.become(p2)
                     c  <- p1.done
                     d  <- p1.get
@@ -59,11 +59,11 @@ class AsyncTest extends Test:
                 for
                     p1 <- Promise.init[Exception, Int]
                     p2 <- Promise.init[Exception, Int]
-                    a  <- p2.complete(Result.fail(ex))
+                    a  <- p2.complete(Result.error(ex))
                     b  <- p1.become(p2)
                     c  <- p1.done
                     d  <- p1.getResult
-                yield assert(a && b && c && d == Result.fail(ex))
+                yield assert(a && b && c && d == Result.error(ex))
                 end for
             }
 
@@ -71,8 +71,8 @@ class AsyncTest extends Test:
                 for
                     p1 <- Promise.init[Nothing, Int]
                     p2 <- Promise.init[Nothing, Int]
-                    a  <- p1.complete(Result.success(42))
-                    b  <- p2.complete(Result.success(99))
+                    a  <- p1.complete(Result.succeed(42))
+                    b  <- p2.complete(Result.succeed(99))
                     c  <- p1.become(p2)
                     d  <- p1.get
                 yield assert(a && b && !c && d == 42)
@@ -81,7 +81,7 @@ class AsyncTest extends Test:
             "done fiber" in run {
                 for
                     p <- Promise.init[Nothing, Int]
-                    a <- p.become(Fiber.success(42))
+                    a <- p.become(Fiber.succeed(42))
                     b <- p.done
                     c <- p.get
                 yield assert(a && b && c == 42)
@@ -155,8 +155,8 @@ class AsyncTest extends Test:
                 .pipe(Async.runAndBlock(Duration.Infinity))
                 .pipe(Abort.run[Timeout](_))
                 .map {
-                    case Result.Fail(Timeout(_)) => succeed
-                    case v                       => fail(v.toString())
+                    case Result.Error(Timeout(_)) => succeed
+                    case v                        => fail(v.toString())
                 }
         }
 
@@ -165,8 +165,8 @@ class AsyncTest extends Test:
                 .pipe(Async.runAndBlock(10.millis))
                 .pipe(Abort.run[Timeout](_))
                 .map {
-                    case Result.Fail(Timeout(_)) => succeed
-                    case v                       => fail(v.toString())
+                    case Result.Error(Timeout(_)) => succeed
+                    case v                        => fail(v.toString())
                 }
         }
 
@@ -175,8 +175,8 @@ class AsyncTest extends Test:
                 .pipe(Async.runAndBlock(10.millis))
                 .pipe(Abort.run[Timeout](_))
                 .map {
-                    case Result.Fail(Timeout(_)) => succeed
-                    case v                       => fail(v.toString())
+                    case Result.Error(Timeout(_)) => succeed
+                    case v                        => fail(v.toString())
                 }
         }
     }

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
@@ -49,12 +49,12 @@ class KyoAppTest extends Test:
             for
                 _ <- Clock.now
                 _ <- Random.nextInt
-                _ <- Abort.fail(new RuntimeException("Aborts!"))
+                _ <- Abort.error(new RuntimeException("Aborts!"))
             yield ()
 
         KyoApp.attempt(Duration.Infinity)(run) match
-            case Result.Fail(exception) => assert(exception.getMessage == "Aborts!")
-            case _                      => fail("Unexpected Success...")
+            case Result.Error(exception) => assert(exception.getMessage == "Aborts!")
+            case _                       => fail("Unexpected Success...")
     }
 
     "effect mismatch" taggedAs jvmOnly in {

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -24,11 +24,11 @@ class MeterTest extends Test:
                 a2 <- t.isAvailable
                 d1 <- f1.done
                 d2 <- f2.done
-                _  <- p.complete(Result.success(1))
+                _  <- p.complete(Result.succeed(1))
                 v1 <- f1.get
                 v2 <- f2.get
                 a3 <- t.isAvailable
-            yield assert(!a1 && !d1 && !d2 && !a2 && v1 == Result.success(1) && v2 == 2 && a3)
+            yield assert(!a1 && !d1 && !d2 && !a2 && v1 == Result.succeed(1) && v2 == 2 && a3)
         }
 
         "tryRun" in runJVM {
@@ -41,9 +41,9 @@ class MeterTest extends Test:
                 a1  <- sem.isAvailable
                 b1  <- sem.tryRun(2)
                 b2  <- f1.done
-                _   <- p.complete(Result.success(1))
+                _   <- p.complete(Result.succeed(1))
                 v1  <- f1.get
-            yield assert(!a1 && b1.isEmpty && !b2 && v1.contains(Result.success(1)))
+            yield assert(!a1 && b1.isEmpty && !b2 && v1.contains(Result.succeed(1)))
         }
     }
 
@@ -73,11 +73,11 @@ class MeterTest extends Test:
                 a2 <- t.isAvailable
                 d1 <- f1.done
                 d2 <- f2.done
-                _  <- p.complete(Result.success(1))
+                _  <- p.complete(Result.succeed(1))
                 v1 <- f1.get
                 v2 <- f2.get
                 a3 <- t.isAvailable
-            yield assert(!a1 && !d1 && !d2 && !a2 && v1 == Result.success(1) && v2 == 2 && a3)
+            yield assert(!a1 && !d1 && !d2 && !a2 && v1 == Result.succeed(1) && v2 == 2 && a3)
         }
 
         "tryRun" in runJVM {
@@ -94,10 +94,10 @@ class MeterTest extends Test:
                 b3  <- sem.tryRun(2)
                 b4  <- f1.done
                 b5  <- f2.done
-                _   <- p.complete(Result.success(1))
+                _   <- p.complete(Result.succeed(1))
                 v1  <- f1.get
                 v2  <- f2.get
-            yield assert(!a1 && b3.isEmpty && !b4 && !b5 && v1.contains(Result.success(1)) && v2.contains(Result.success(1)))
+            yield assert(!a1 && b3.isEmpty && !b4 && !b5 && v1.contains(Result.succeed(1)) && v2.contains(Result.succeed(1)))
         }
     }
 

--- a/kyo-core/shared/src/test/scala/kyo/TimerTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/TimerTest.scala
@@ -8,7 +8,7 @@ class TimerTest extends Test:
     "schedule" in run {
         for
             p     <- Promise.init[Nothing, String]
-            _     <- Timer.schedule(1.milli)(p.complete(Result.success("hello")).map(require(_)))
+            _     <- Timer.schedule(1.milli)(p.complete(Result.succeed("hello")).map(require(_)))
             hello <- p.get
         yield assert(hello == "hello")
     }
@@ -18,7 +18,7 @@ class TimerTest extends Test:
         Timer.let(Timer(exec)) {
             for
                 p     <- Promise.init[Nothing, String]
-                _     <- Timer.schedule(1.milli)(p.complete(Result.success("hello")).map(require(_)))
+                _     <- Timer.schedule(1.milli)(p.complete(Result.succeed("hello")).map(require(_)))
                 hello <- p.get
             yield assert(hello == "hello")
         }
@@ -27,7 +27,7 @@ class TimerTest extends Test:
     "cancel" in runJVM {
         for
             p         <- Promise.init[Nothing, String]
-            task      <- Timer.schedule(5.seconds)(p.complete(Result.success("hello")).map(require(_)))
+            task      <- Timer.schedule(5.seconds)(p.complete(Result.succeed("hello")).map(require(_)))
             _         <- task.cancel
             cancelled <- untilTrue(task.cancelled)
             done1     <- p.done

--- a/kyo-data/shared/src/main/scala/kyo/Duration.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Duration.scala
@@ -29,18 +29,18 @@ object Duration:
     def parse(s: String): Result[InvalidDuration, Duration] =
         val pattern = """(\d+)\s*([a-zA-Z]+)""".r
         s.trim.toLowerCase match
-            case "infinity" | "inf" => Result.success(Infinity)
+            case "infinity" | "inf" => Result.succeed(Infinity)
             case pattern(value, unit) =>
                 for
                     longValue <-
                         Result.catching[NumberFormatException](value.toLong)
-                            .mapFail(_ => InvalidDuration(s"Invalid number: $value"))
+                            .mapError(_ => InvalidDuration(s"Invalid number: $value"))
                     unitEnum <-
                         Units.values.find(_.names.exists(_.startsWith(unit)))
-                            .map(Result.success)
-                            .getOrElse(Result.fail(InvalidDuration(s"Invalid unit: $unit")))
+                            .map(Result.succeed)
+                            .getOrElse(Result.error(InvalidDuration(s"Invalid unit: $unit")))
                 yield fromUnits(longValue, unitEnum)
-            case _ => Result.fail(InvalidDuration(s"Invalid duration format: $s"))
+            case _ => Result.error(InvalidDuration(s"Invalid duration format: $s"))
         end match
     end parse
 

--- a/kyo-data/shared/src/test/scala/kyo/DurationSpec.scala
+++ b/kyo-data/shared/src/test/scala/kyo/DurationSpec.scala
@@ -124,7 +124,7 @@ object DurationSpec extends ZIOSpecDefault:
 
                 TestResult.allSuccesses(
                     testCases.map { case (input, expected) =>
-                        assertTrue(Duration.parse(input) == Result.success(expected))
+                        assertTrue(Duration.parse(input) == Result.succeed(expected))
                     }
                 )
             },
@@ -145,15 +145,15 @@ object DurationSpec extends ZIOSpecDefault:
             },
             test("case insensitivity") {
                 TestResult.allSuccesses(
-                    assertTrue(Duration.parse("1MS") == Result.success(1.millis)),
-                    assertTrue(Duration.parse("2H") == Result.success(2.hours)),
-                    assertTrue(Duration.parse("3D") == Result.success(3.days))
+                    assertTrue(Duration.parse("1MS") == Result.succeed(1.millis)),
+                    assertTrue(Duration.parse("2H") == Result.succeed(2.hours)),
+                    assertTrue(Duration.parse("3D") == Result.succeed(3.days))
                 )
             },
             test("whitespace handling") {
                 TestResult.allSuccesses(
-                    assertTrue(Duration.parse("  1  second  ") == Result.success(1.seconds)),
-                    assertTrue(Duration.parse("5\tminutes") == Result.success(5.minutes))
+                    assertTrue(Duration.parse("  1  second  ") == Result.succeed(1.seconds)),
+                    assertTrue(Duration.parse("5\tminutes") == Result.succeed(5.minutes))
                 )
             }
         )

--- a/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
@@ -8,12 +8,12 @@ class ResultTest extends Test:
 
     val ex = new Exception
 
-    val try2: Result[String, Result[String, Int]] = Success(Fail("error"))
+    val try2: Result[String, Result[String, Int]] = Success(Error("error"))
 
-    "should match Success containing Fail" in {
+    "should match Success containing Error" in {
         val result = try2 match
-            case Success(Fail(e)) => e
-            case _                => ""
+            case Success(Error(e)) => e
+            case _                 => ""
         assert(result == "error")
     }
 
@@ -22,7 +22,7 @@ class ResultTest extends Test:
             assert(Result.catching[Exception](1) == Success(1))
         }
         "fail" in {
-            assert(Result.catching[Exception](throw ex) == Fail(ex))
+            assert(Result.catching[Exception](throw ex) == Error(ex))
         }
         "panic" in {
             assert(Result.catching[IllegalArgumentException](throw ex) == Panic(ex))
@@ -30,21 +30,21 @@ class ResultTest extends Test:
     }
 
     "unit" in {
-        assert(Result.unit == Result.success(()))
+        assert(Result.unit == Result.succeed(()))
     }
 
     "fromTry" - {
         "should return Success for successful Try" in {
             val tryValue = scala.util.Try(5)
             val result   = Result.fromTry(tryValue)
-            assert(result == Result.success(5))
+            assert(result == Result.succeed(5))
         }
 
-        "should return Fail for failed Try" in {
+        "should return Error for failed Try" in {
             val exception = new RuntimeException("Test exception")
             val tryValue  = scala.util.Try(throw exception)
             val result    = Result.fromTry(tryValue)
-            assert(result == Result.fail(exception))
+            assert(result == Result.error(exception))
         }
     }
 
@@ -52,31 +52,31 @@ class ResultTest extends Test:
         "should return Success for Right" in {
             val eitherValue = Right(5)
             val result      = Result.fromEither(eitherValue)
-            assert(result == Result.success(5))
+            assert(result == Result.succeed(5))
         }
 
-        "should return Fail for Left" in {
-            val eitherValue = Left("Fail message")
+        "should return Error for Left" in {
+            val eitherValue = Left("Error message")
             val result      = Result.fromEither(eitherValue)
-            assert(result == Result.fail("Fail message"))
+            assert(result == Result.error("Error message"))
         }
 
         "should maintain type parameters" in {
             val result: Result[String, Int] = Result.fromEither(Right(5))
-            assert(result == Result.success(5))
+            assert(result == Result.succeed(5))
 
-            val result2: Result[String, Int] = Result.fromEither(Left("Fail"))
-            assert(result2 == Result.fail("Fail"))
+            val result2: Result[String, Int] = Result.fromEither(Left("Error"))
+            assert(result2 == Result.error("Error"))
         }
     }
 
     "value" - {
         "returns Defined with the value for Success" in {
-            assert(Result.success(42).value == Maybe(42))
+            assert(Result.succeed(42).value == Maybe(42))
         }
 
-        "returns Empty for Fail" in {
-            assert(Result.fail("error").value == Maybe.empty)
+        "returns Empty for Error" in {
+            assert(Result.error("error").value == Maybe.empty)
         }
 
         "returns Empty for Panic" in {
@@ -85,12 +85,12 @@ class ResultTest extends Test:
     }
 
     "failure" - {
-        "returns Defined with the error for Fail" in {
-            assert(Result.fail("error").failure == Maybe("error"))
+        "returns Defined with the error for Error" in {
+            assert(Result.error("error").failure == Maybe("error"))
         }
 
         "returns Empty for Success" in {
-            assert(Result.success(42).failure == Maybe.empty)
+            assert(Result.succeed(42).failure == Maybe.empty)
         }
 
         "returns Empty for Panic" in {
@@ -105,20 +105,20 @@ class ResultTest extends Test:
         }
 
         "returns Empty for Success" in {
-            assert(Result.success(42).panic == Maybe.empty)
+            assert(Result.succeed(42).panic == Maybe.empty)
         }
 
-        "returns Empty for Fail" in {
-            assert(Result.fail("error").panic == Maybe.empty)
+        "returns Empty for Error" in {
+            assert(Result.error("error").panic == Maybe.empty)
         }
     }
 
     "isSuccess" - {
         "returns true for Success" in {
-            assert(Result.success(1).isSuccess)
+            assert(Result.succeed(1).isSuccess)
         }
-        "returns false for Fail" in {
-            assert(!Result.fail(ex).isSuccess)
+        "returns false for Error" in {
+            assert(!Result.error(ex).isSuccess)
         }
         "returns false for Panic" in {
             assert(!Result.panic(ex).isSuccess)
@@ -127,10 +127,10 @@ class ResultTest extends Test:
 
     "isFail" - {
         "returns false for Success" in {
-            assert(!Result.success(1).isFail)
+            assert(!Result.succeed(1).isFail)
         }
-        "returns true for Fail" in {
-            assert(Result.fail(ex).isFail)
+        "returns true for Error" in {
+            assert(Result.error(ex).isFail)
         }
         "returns false for Panic" in {
             assert(!Result.panic(ex).isFail)
@@ -139,10 +139,10 @@ class ResultTest extends Test:
 
     "isPanic" - {
         "returns false for Success" in {
-            assert(!Result.success(1).isPanic)
+            assert(!Result.succeed(1).isPanic)
         }
-        "returns false for Fail" in {
-            assert(!Result.fail(ex).isPanic)
+        "returns false for Error" in {
+            assert(!Result.error(ex).isPanic)
         }
         "returns true for Panic" in {
             assert(Result.panic(ex).isPanic)
@@ -151,9 +151,9 @@ class ResultTest extends Test:
 
     "get" - {
         "returns the value for Success" in {
-            assert(Result.success(1).get == 1)
+            assert(Result.succeed(1).get == 1)
         }
-        "can't be called for Fail" in {
+        "can't be called for Error" in {
             assertDoesNotCompile("Result.error(ex).get")
         }
         "throws an exception for Panic" in {
@@ -163,10 +163,10 @@ class ResultTest extends Test:
 
     "getOrElse" - {
         "returns the value for Success" in {
-            assert(Result.success(1).getOrElse(0) == 1)
+            assert(Result.succeed(1).getOrElse(0) == 1)
         }
-        "returns the default value for Fail" in {
-            assert(Result.fail(ex).getOrElse(0) == 0)
+        "returns the default value for Error" in {
+            assert(Result.error(ex).getOrElse(0) == 0)
         }
         "returns the default value for Panic" in {
             assert(Result.panic(ex).getOrElse(0) == 0)
@@ -179,25 +179,25 @@ class ResultTest extends Test:
 
     "getOrThrow" - {
         "returns the value for Success" in {
-            assert(Result.success(1).getOrThrow == 1)
+            assert(Result.succeed(1).getOrThrow == 1)
         }
-        "doesn't compile for non-Throwable Fail" in {
-            assertDoesNotCompile("Result.fail(1).getOrThrow")
+        "doesn't compile for non-Throwable Error" in {
+            assertDoesNotCompile("Result.error(1).getOrThrow")
         }
-        "throws for Throwable Fail" in {
-            assert(Result.catching[Exception](Result.fail(ex).getOrThrow) == Result.fail(ex))
+        "throws for Throwable Error" in {
+            assert(Result.catching[Exception](Result.error(ex).getOrThrow) == Result.error(ex))
         }
         "throws for Panic" in {
-            assert(Result.catching[Exception](Result.panic(ex).getOrThrow) == Result.fail(ex))
+            assert(Result.catching[Exception](Result.panic(ex).getOrThrow) == Result.error(ex))
         }
     }
 
     "orElse" - {
         "returns itself for Success" in {
-            assert(Result.success(1).orElse(Result.success(2)) == Success(1))
+            assert(Result.succeed(1).orElse(Result.succeed(2)) == Success(1))
         }
-        "returns the alternative for Fail" in {
-            assert(Result.fail(ex).orElse(Success(1)) == Success(1))
+        "returns the alternative for Error" in {
+            assert(Result.error(ex).orElse(Success(1)) == Success(1))
         }
         "returns the alternative for Panic" in {
             assert(Result.panic(ex).orElse(Success(1)) == Success(1))
@@ -206,10 +206,10 @@ class ResultTest extends Test:
 
     "flatMap" - {
         "applies the function for Success" in {
-            assert(Result.success(1).flatMap(x => Result.success(x + 1)) == Success(2))
+            assert(Result.succeed(1).flatMap(x => Result.succeed(x + 1)) == Success(2))
         }
-        "does not apply the function for Fail" in {
-            assert(Result.fail[String, Int]("error").flatMap(x => Success(x + 1)) == Fail("error"))
+        "does not apply the function for Error" in {
+            assert(Result.error[String, Int]("error").flatMap(x => Success(x + 1)) == Error("error"))
         }
         "does not apply the function for Panic" in {
             assert(Result.panic[String, Int](ex).flatMap(x => Success(x + 1)) == Panic(ex))
@@ -218,10 +218,10 @@ class ResultTest extends Test:
 
     "map" - {
         "applies the function for Success" in {
-            assert(Result.success(1).map(_ + 1) == Success(2))
+            assert(Result.succeed(1).map(_ + 1) == Success(2))
         }
-        "does not apply the function for Fail" in {
-            assert(Result.fail[String, Int]("error").map(_ + 1) == Fail("error"))
+        "does not apply the function for Error" in {
+            assert(Result.error[String, Int]("error").map(_ + 1) == Error("error"))
         }
         "does not apply the function for Panic" in {
             assert(Result.panic[String, Int](ex).map(_ + 1) == Panic(ex))
@@ -230,62 +230,62 @@ class ResultTest extends Test:
 
     "fold" - {
         "applies the success function for Success" in {
-            assert(Result.success(1).fold(_ => 0)(x => x + 1) == 2)
+            assert(Result.succeed(1).fold(_ => 0)(x => x + 1) == 2)
         }
         "applies the failure function for Failure" in {
-            assert(Result.fail[String, Int]("error").fold(_ => 0)(x => x) == 0)
+            assert(Result.error[String, Int]("error").fold(_ => 0)(x => x) == 0)
         }
     }
 
     "filter" - {
         "adds NoSuchElementException" in {
-            val x = Result.success(2).filter(_ % 2 == 0)
+            val x = Result.succeed(2).filter(_ % 2 == 0)
             discard(x)
             assertCompiles("val _: Result[NoSuchElementException, Int] = x")
         }
         "returns itself if the predicate holds for Success" in {
-            assert(Result.success(2).filter(_ % 2 == 0) == Success(2))
+            assert(Result.succeed(2).filter(_ % 2 == 0) == Success(2))
         }
-        "returns Fail if the predicate doesn't hold for Success" in {
-            assert(Result.success(1).filter(_ % 2 == 0).isFail)
+        "returns Error if the predicate doesn't hold for Success" in {
+            assert(Result.succeed(1).filter(_ % 2 == 0).isFail)
         }
-        "returns itself for Fail" in {
-            assert(Result.fail[String, Int]("error").filter(_ => true) == Fail("error"))
+        "returns itself for Error" in {
+            assert(Result.error[String, Int]("error").filter(_ => true) == Error("error"))
         }
     }
 
     "recover" - {
         "returns itself for Success" in {
-            assert(Result.success(1).recover { case _ => 0 } == Success(1))
+            assert(Result.succeed(1).recover { case _ => 0 } == Success(1))
         }
-        "returns Success with the mapped value if the partial function is defined for Fail" in {
-            assert(Result.fail("error").recover { case _ => 0 } == Success(0))
+        "returns Success with the mapped value if the partial function is defined for Error" in {
+            assert(Result.error("error").recover { case _ => 0 } == Success(0))
         }
-        "returns itself if the partial function is not defined for Fail" in {
-            assert(Result.fail("error").recover { case _ if false => 0 } == Fail("error"))
+        "returns itself if the partial function is not defined for Error" in {
+            assert(Result.error("error").recover { case _ if false => 0 } == Error("error"))
         }
     }
 
     "recoverWith" - {
         "returns itself for Success" in {
-            assert(Result.success(1).recoverWith { case _ => Success(0) } == Success(1))
+            assert(Result.succeed(1).recoverWith { case _ => Success(0) } == Success(1))
         }
-        "returns the mapped Result if the partial function is defined for Fail" in {
-            assert(Fail("error").recoverWith { case _ => Success(0) } == Success(0))
+        "returns the mapped Result if the partial function is defined for Error" in {
+            assert(Error("error").recoverWith { case _ => Success(0) } == Success(0))
         }
-        "returns itself if the partial function is not defined for Fail" in {
-            val error = Fail("error")
-            assert(Fail(error).recoverWith { case _ if false => Success(0) } == Fail(error))
+        "returns itself if the partial function is not defined for Error" in {
+            val error = Error("error")
+            assert(Error(error).recoverWith { case _ if false => Success(0) } == Error(error))
         }
     }
 
     "toEither" - {
         "returns Right with the value for Success" in {
-            assert(Result.success(1).toEither == Right(1))
+            assert(Result.succeed(1).toEither == Right(1))
         }
-        "returns Left with the error for Fail" in {
+        "returns Left with the error for Error" in {
             val error = "error"
-            assert(Fail(error).toEither == Left(error))
+            assert(Error(error).toEither == Left(error))
         }
     }
 
@@ -315,11 +315,11 @@ class ResultTest extends Test:
 
     "exception" - {
         "only available if E is Throwable" in {
-            assertDoesNotCompile("Result.Fail(1).exception")
+            assertDoesNotCompile("Result.Error(1).exception")
         }
-        "from Fail" in {
+        "from Error" in {
             val ex = new Exception
-            assert(Result.Fail(ex).exception == ex)
+            assert(Result.Error(ex).exception == ex)
         }
         "from Panic" in {
             val ex = new Exception
@@ -335,20 +335,20 @@ class ResultTest extends Test:
             assert(tryResult.get == 42)
         }
 
-        "Fail to Try" - {
+        "Error to Try" - {
             "Throwable error" in {
-                val failure: Result[Exception, Int] = Fail(ex)
+                val failure: Result[Exception, Int] = Error(ex)
                 val tryResult                       = failure.toTry
                 assert(tryResult.isFailure)
                 assert(tryResult.failed.get == ex)
             }
             "Nothing error" in {
-                val failure: Result[Nothing, Int] = Result.success(1)
+                val failure: Result[Nothing, Int] = Result.succeed(1)
                 val tryResult                     = failure.toTry
                 assert(tryResult == Try(1))
             }
             "fails to compile for non-Throwable error" in {
-                val failure: Result[String, Int] = Fail("Something went wrong")
+                val failure: Result[String, Int] = Error("Something went wrong")
                 val _                            = failure
                 assertDoesNotCompile("failure.toTry")
             }
@@ -376,21 +376,21 @@ class ResultTest extends Test:
             assert(flatMapped == Success("mapped: null"))
         }
 
-        "Fail with null error" in {
-            val result: Result[String, Int] = Fail(null)
-            assert(result == Fail(null))
+        "Error with null error" in {
+            val result: Result[String, Int] = Error(null)
+            assert(result == Error(null))
         }
 
-        "Fail with null exception flatMap" in {
-            val result: Result[String, Int] = Fail(null)
+        "Error with null exception flatMap" in {
+            val result: Result[String, Int] = Error(null)
             val flatMapped                  = result.flatMap(num => Success(num + 1))
-            assert(flatMapped == Fail(null))
+            assert(flatMapped == Error(null))
         }
 
-        "Fail with null exception map" in {
-            val result: Result[String, Int] = Fail(null)
+        "Error with null exception map" in {
+            val result: Result[String, Int] = Error(null)
             val mapped                      = result.map(num => num + 1)
-            assert(mapped == Fail(null))
+            assert(mapped == Error(null))
         }
     }
 
@@ -417,37 +417,37 @@ class ResultTest extends Test:
                 val result = tryy match
                     case Success(x) if x > 1 => "greater than 1"
                     case Success(_)          => "less than or equal to 1"
-                    case Fail(_)             => "failure"
+                    case Error(_)            => "failure"
                 assert(result == "greater than 1")
             }
 
-            "should match Fail with a guard" in {
-                val tryy: Result[String, Int] = Fail("error")
+            "should match Error with a guard" in {
+                val tryy: Result[String, Int] = Error("error")
                 val result = tryy match
-                    case Fail(e) if e.length > 5 => "long error"
-                    case Fail(_)                 => "short error"
-                    case Success(_)              => "success"
+                    case Error(e) if e.length > 5 => "long error"
+                    case Error(_)                 => "short error"
+                    case Success(_)               => "success"
                 assert(result == "short error")
             }
         }
         "Error.unapply" - {
-            "should match Fail" in {
-                val result = Result.fail("FAIL!")
+            "should match Error" in {
+                val result = Result.error("FAIL!")
                 result match
-                    case Error(_) => succeed
-                    case _        => fail()
+                    case Failure(_) => succeed
+                    case _          => fail()
             }
             "should match Panic" in {
                 val result = Result.panic(new AssertionError)
                 result match
-                    case Error(_) => succeed
-                    case _        => fail()
+                    case Failure(_) => succeed
+                    case _          => fail()
             }
             "should not match Success" in {
-                val result = Result.success(1)
+                val result = Result.succeed(1)
                 result match
-                    case Error(_) => fail()
-                    case _        => succeed
+                    case Failure(_) => fail()
+                    case _          => succeed
             }
         }
 
@@ -455,27 +455,27 @@ class ResultTest extends Test:
 
     "inference" - {
         "flatMap" in {
-            val result: Result[String, Int]    = Result.success(5)
-            val mapped: Result[String, String] = result.flatMap(x => Result.success(x.toString))
+            val result: Result[String, Int]    = Result.succeed(5)
+            val mapped: Result[String, String] = result.flatMap(x => Result.succeed(x.toString))
             assert(mapped == Success("5"))
         }
 
         "flatMap with different error types" in {
-            val r1: Result[String, Int]              = Result.success(5)
-            val r2: Result[Int, String]              = Result.success("hello")
+            val r1: Result[String, Int]              = Result.succeed(5)
+            val r2: Result[Int, String]              = Result.succeed("hello")
             val nested: Result[String | Int, String] = r1.flatMap(x => r2.map(y => s"$x $y"))
             assert(nested == Success("5 hello"))
         }
 
         "for-comprehension with multiple flatMaps" in {
             def divideIfEven(x: Int): Result[String, Int] =
-                if x % 2 == 0 then Result.success(10 / x) else Result.fail("Odd number")
+                if x % 2 == 0 then Result.succeed(10 / x) else Result.error("Odd number")
 
             val complex: Result[String, String] =
                 for
-                    a <- Result.success(4)
+                    a <- Result.succeed(4)
                     b <- divideIfEven(a)
-                    c <- Result.success(b * 2)
+                    c <- Result.succeed(b * 2)
                 yield c.toString
 
             assert(complex == Success("4"))
@@ -544,29 +544,29 @@ class ResultTest extends Test:
             assert(result == "no exception")
         }
 
-        "nested Success containing Fail" in {
-            val nested: Result[String, Result[Int, String]] = Result.success(Result.fail(42))
+        "nested Success containing Error" in {
+            val nested: Result[String, Result[Int, String]] = Result.succeed(Result.error(42))
             val flattened                                   = nested.flatten
 
-            assert(flattened == Fail(42))
+            assert(flattened == Error(42))
         }
 
         "recover with a partial function" in {
-            val result: Result[String, Int] = Result.fail("error")
+            val result: Result[String, Int] = Result.error("error")
             val recovered = result.recover {
-                case Fail("error") => 0
-                case _             => -1
+                case Error("error") => 0
+                case _              => -1
             }
 
             assert(recovered == Success(0))
         }
 
         "empty Success" in {
-            val empty: Result[Nothing, Unit] = Result.success(())
+            val empty: Result[Nothing, Unit] = Result.succeed(())
             assert(empty == Success(()))
         }
 
-        "Panic distinct from Fail" in {
+        "Panic distinct from Error" in {
             val exception = new RuntimeException("Unexpected error")
             val panic     = Result.panic(exception)
             assert(!panic.isFail)
@@ -576,56 +576,56 @@ class ResultTest extends Test:
             )
         }
 
-        "deeply nested Success/Fail" in {
-            val deeplyNested = Success(Success(Success(Fail("deep error"))))
-            assert(deeplyNested.flatten == Success(Success(Fail("deep error"))))
-            assert(deeplyNested.flatten.flatten == Success(Fail("deep error")))
-            assert(deeplyNested.flatten.flatten.flatten == Fail("deep error"))
+        "deeply nested Success/Error" in {
+            val deeplyNested = Success(Success(Success(Error("deep error"))))
+            assert(deeplyNested.flatten == Success(Success(Error("deep error"))))
+            assert(deeplyNested.flatten.flatten == Success(Error("deep error")))
+            assert(deeplyNested.flatten.flatten.flatten == Error("deep error"))
         }
 
         "Panic propagation through flatMap" in {
             val panic  = Result.panic(new RuntimeException("Unexpected"))
-            val result = panic.flatMap(_ => Success(1)).flatMap(_ => Fail("won't happen"))
+            val result = panic.flatMap(_ => Success(1)).flatMap(_ => Error("won't happen"))
             assert(result == panic)
         }
 
-        "Fail type widening" in {
-            val r1: Result[String, Int] = Fail("error1")
-            val r2: Result[Int, String] = Fail(42)
+        "Error type widening" in {
+            val r1: Result[String, Int] = Error("error1")
+            val r2: Result[Int, String] = Error(42)
             val combined                = r1.orElse(r2)
             assert(combined.isFail)
             assert(combined match
-                case Fail(_: String | _: Int) => true
-                case _                        => false
+                case Error(_: String | _: Int) => true
+                case _                         => false
             )
         }
 
         "nested flatMap with type changes" in {
             def f(i: Int): Result[String, Int] =
-                if i > 0 then Success(i) else Fail("non-positive")
+                if i > 0 then Success(i) else Error("non-positive")
             def g(d: Int): Result[Int, String] =
-                if d < 10 then Success(d.toString) else Fail(d.toInt)
+                if d < 10 then Success(d.toString) else Error(d.toInt)
 
             val result = Success(5).flatMap(f).flatMap(g)
             assert(result == Success("5"))
 
             val result2 = Success(-1).flatMap(f).flatMap(g)
-            assert(result2 == Fail("non-positive"))
+            assert(result2 == Error("non-positive"))
 
             val result3 = Success(20).flatMap(f).flatMap(g)
-            assert(result3 == Fail(20))
+            assert(result3 == Error(20))
         }
     }
 
     "swap" - {
-        "Success to Fail" in {
-            val result = Result.success[String, Int](42)
-            assert(result.swap == Result.fail(42))
+        "Success to Error" in {
+            val result = Result.succeed[String, Int](42)
+            assert(result.swap == Result.error(42))
         }
 
-        "Fail to Success" in {
-            val result = Result.fail[String, Int]("error")
-            assert(result.swap == Result.success("error"))
+        "Error to Success" in {
+            val result = Result.error[String, Int]("error")
+            assert(result.swap == Result.succeed("error"))
         }
 
         "Panic remains Panic" in {
@@ -635,21 +635,21 @@ class ResultTest extends Test:
         }
 
         "nested Results" in {
-            val nested = Result.success[Int, Result[String, Boolean]](Result.fail("inner"))
-            assert(nested.swap == Result.fail(Result.fail("inner")))
+            val nested = Result.succeed[Int, Result[String, Boolean]](Result.error("inner"))
+            assert(nested.swap == Result.error(Result.error("inner")))
         }
 
         "type inference" in {
-            val result: Result[Int, String]  = Result.success("hello")
+            val result: Result[Int, String]  = Result.succeed("hello")
             val swapped: Result[String, Int] = result.swap
-            assert(swapped == Result.fail("hello"))
+            assert(swapped == Result.error("hello"))
         }
 
         "idempotence" in {
-            val success = Result.success[String, Int](42)
+            val success = Result.succeed[String, Int](42)
             assert(success.swap.swap == success)
 
-            val failure = Result.fail[String, Int]("error")
+            val failure = Result.error[String, Int]("error")
             assert(failure.swap.swap == failure)
 
             val panic = Result.panic[Int, String](new Exception("test"))
@@ -661,20 +661,20 @@ class ResultTest extends Test:
         "yield a Success result" in {
             val result =
                 for
-                    x <- Result.success(1)
-                    y <- Result.success(2)
-                    z <- Result.success(3)
+                    x <- Result.succeed(1)
+                    y <- Result.succeed(2)
+                    z <- Result.succeed(3)
                 yield x + y + z
 
-            assert(result == Result.success(6))
+            assert(result == Result.succeed(6))
         }
 
         "short-circuit on Failure" in {
             val result =
                 for
-                    x <- Result.success(1)
-                    y <- Result.fail[Exception, Int](new Exception("error"))
-                    z <- Result.success(3)
+                    x <- Result.succeed(1)
+                    y <- Result.error[Exception, Int](new Exception("error"))
+                    z <- Result.succeed(3)
                 yield x + y + z
 
             assert(result.isFail)
@@ -683,8 +683,8 @@ class ResultTest extends Test:
         "handle exceptions in the yield" in {
             val result =
                 for
-                    _ <- Result.success(1)
-                    _ <- Result.success(2)
+                    _ <- Result.succeed(1)
+                    _ <- Result.succeed(2)
                 yield throw new Exception("error")
 
             assert(result.isPanic)
@@ -693,20 +693,20 @@ class ResultTest extends Test:
         "sequence operations with flatMap" in {
             val result =
                 for
-                    x <- Result.success(1)
-                    y <- Result.success(2)
+                    x <- Result.succeed(1)
+                    y <- Result.succeed(2)
                     if y > 0
-                    z <- Result.success(3)
+                    z <- Result.succeed(3)
                 yield x + y + z
 
-            assert(result == Result.success(6))
+            assert(result == Result.succeed(6))
         }
 
         "fail the comprehension with a guard" in {
             val result =
                 for
-                    x <- Result.success(1)
-                    y <- Result.success(-1)
+                    x <- Result.succeed(1)
+                    y <- Result.succeed(-1)
                     if y > 0
                 yield x + y
 
@@ -714,77 +714,77 @@ class ResultTest extends Test:
         }
     }
 
-    "mapFail" - {
+    "mapError" - {
         "should not change Success" in {
-            val result = Result.success[String, Int](5)
-            val mapped = result.mapFail(_ => 42)
+            val result = Result.succeed[String, Int](5)
+            val mapped = result.mapError(_ => 42)
             assert(mapped == Success(5))
         }
 
-        "should apply the function to Fail" in {
-            val result = Result.fail[String, Int]("error")
-            val mapped = result.mapFail(_.length)
-            assert(mapped == Fail(5))
+        "should apply the function to Error" in {
+            val result = Result.error[String, Int]("error")
+            val mapped = result.mapError(_.length)
+            assert(mapped == Error(5))
         }
 
         "should not change Panic" in {
             val ex     = new Exception("test")
             val result = Result.panic[String, Int](ex)
-            val mapped = result.mapFail(_ => 42)
+            val mapped = result.mapError(_ => 42)
             assert(mapped == Panic(ex))
         }
 
         "should allow changing the error type" in {
-            val result: Result[String, Int] = Result.fail("error")
-            val mapped: Result[Int, Int]    = result.mapFail(_.length)
-            assert(mapped == Fail(5))
+            val result: Result[String, Int] = Result.error("error")
+            val mapped: Result[Int, Int]    = result.mapError(_.length)
+            assert(mapped == Error(5))
         }
 
         "should handle exceptions in the mapping function" in {
-            val result = Result.fail[String, Int]("error")
-            val mapped = result.mapFail(_ => throw new RuntimeException("Mapping error"))
+            val result = Result.error[String, Int]("error")
+            val mapped = result.mapError(_ => throw new RuntimeException("Mapping error"))
             assert(mapped.isPanic)
         }
 
         "should work with for-comprehensions" in {
             val result =
                 for
-                    x <- Result.success[String, Int](5)
-                    y <- Result.fail[String, Int]("error")
+                    x <- Result.succeed[String, Int](5)
+                    y <- Result.error[String, Int]("error")
                 yield x + y
 
-            val mapped = result.mapFail(_.toUpperCase)
-            assert(mapped == Fail("ERROR"))
+            val mapped = result.mapError(_.toUpperCase)
+            assert(mapped == Error("ERROR"))
         }
     }
 
     "collect" - {
         "all Success results" in {
             val results = Seq(
-                Result.success(1),
-                Result.success(2),
-                Result.success(3)
+                Result.succeed(1),
+                Result.succeed(2),
+                Result.succeed(3)
             )
             val collected = Result.collect(results)
             assert(collected == Success(Seq(1, 2, 3)))
         }
 
-        "first Fail encountered" in {
+        "first Error encountered" in {
             val results = Seq(
-                Result.success(1),
-                Result.fail("error"),
-                Result.success(3)
+                Result.succeed(1),
+                Result.error("error"),
+                Result.succeed(3)
             )
             val collected = Result.collect(results)
-            assert(collected == Fail("error"))
+            assert(collected == Error("error"))
         }
 
         "Panic encountered" in {
             val ex = new Exception("panic")
             val results = Seq(
-                Result.success(1),
+                Result.succeed(1),
                 Result.panic(ex),
-                Result.fail("error")
+                Result.error("error")
             )
             val collected = Result.collect(results)
             assert(collected == Panic(ex))
@@ -798,10 +798,10 @@ class ResultTest extends Test:
 
         "mixed error types" in {
             val results = Seq(
-                Result.success(1),
-                Result.fail("string error"),
-                Result.fail(42),
-                Result.success(3)
+                Result.succeed(1),
+                Result.error("string error"),
+                Result.error(42),
+                Result.succeed(3)
             )
             val collected: Result[String | Int, Seq[Int]] =
                 Result.collect(results)
@@ -809,13 +809,13 @@ class ResultTest extends Test:
             assert(collected.failure.get.equals("string error"))
         }
 
-        "mixed Success and Fail with different error types" in {
+        "mixed Success and Error with different error types" in {
             val results: Seq[Result[Any, Int]] = Seq(
-                Result.success(1),
-                Result.fail("string error"),
-                Result.success(2),
-                Result.fail(42),
-                Result.success(3)
+                Result.succeed(1),
+                Result.error("string error"),
+                Result.succeed(2),
+                Result.error(42),
+                Result.succeed(3)
             )
             val collected = Result.collect(results)
             assert(collected.isFail)
@@ -826,11 +826,11 @@ class ResultTest extends Test:
 
     "show" - {
         "Success" in {
-            assert(Result.success(42).show == "Success(42)")
+            assert(Result.succeed(42).show == "Success(42)")
         }
 
-        "Fail" in {
-            assert(Result.fail("error").show == "Fail(error)")
+        "Error" in {
+            assert(Result.error("error").show == "Error(error)")
         }
 
         "Panic" in {
@@ -839,20 +839,20 @@ class ResultTest extends Test:
         }
 
         "nested Success" in {
-            val nested = Result.success(Result.success(Result.fail("error")))
-            assert(nested.show == "Success(Success(Success(Fail(error))))")
+            val nested = Result.succeed(Result.succeed(Result.error("error")))
+            assert(nested.show == "Success(Success(Success(Error(error))))")
         }
     }
 
     "SuccessError.toString" - {
         "single level" in {
-            val successError = Result.Success(Result.Fail("error"))
-            assert(successError.toString == "Success(Fail(error))")
+            val successError = Result.Success(Result.Error("error"))
+            assert(successError.toString == "Success(Error(error))")
         }
 
         "multiple levels" in {
-            val nested = Result.Success(Result.Success(Result.Success(Result.Fail("error"))))
-            assert(nested.toString == "Success(Success(Success(Fail(error))))")
+            val nested = Result.Success(Result.Success(Result.Success(Result.Error("error"))))
+            assert(nested.toString == "Success(Success(Success(Error(error))))")
         }
     }
 

--- a/kyo-direct/shared/src/test/scala/kyo/DirectTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/DirectTest.scala
@@ -40,7 +40,7 @@ class DirectTest extends Test:
                 val b = await(IO("world"))
                 a + " " + b
             }
-        assert(IO.run(Abort.run(io)).eval == Result.success("hello world"))
+        assert(IO.run(Abort.run(io)).eval == Result.succeed("hello world"))
     }
 
     "if" in {

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/api/Handler.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/api/Handler.scala
@@ -26,8 +26,8 @@ object Handler:
 
     final class Live(db: DB) extends Handler:
 
-        private val notFound            = Abort.fail[StatusCode](StatusCode.NotFound)
-        private val unprocessableEntity = Abort.fail[StatusCode](StatusCode.UnprocessableEntity)
+        private val notFound            = Abort.error[StatusCode](StatusCode.NotFound)
+        private val unprocessableEntity = Abort.error[StatusCode](StatusCode.UnprocessableEntity)
 
         def transaction(account: Int, request: Transaction) = defer {
             import request.*

--- a/kyo-prelude/jvm/src/test/scala/kyo/MonadLawsTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo/MonadLawsTest.scala
@@ -24,7 +24,7 @@ object MonadLawsTest extends ZIOSpecDefault:
                 Gen.oneOf(
                     gen.map(v => (v: A < Any)),
                     gen.zip(boolGen).map((v, b) =>
-                        if b then Abort.fail("fail") else (v: A < Any)
+                        if b then Abort.error("fail") else (v: A < Any)
                     ),
                     gen.zip(intGen).map((v, i) =>
                         Emit(i).unit.andThen(v)
@@ -36,10 +36,10 @@ object MonadLawsTest extends ZIOSpecDefault:
                         Env.use[String](_ => ()).andThen(v)
                     ),
                     gen.zip(boolGen).map((v, b) =>
-                        Var.get[Boolean].map(x => if x then v else Abort.fail("var fail"))
+                        Var.get[Boolean].map(x => if x then v else Abort.error("var fail"))
                     ),
                     gen.zip(intGen).map((v, i) =>
-                        Emit(i).map(_ => if i % 2 == 0 then v else Abort.fail("sum fail"))
+                        Emit(i).map(_ => if i % 2 == 0 then v else Abort.error("sum fail"))
                     ),
                     gen.map(v =>
                         for
@@ -73,7 +73,7 @@ object MonadLawsTest extends ZIOSpecDefault:
                             ).eval._2
                         (run(l), run(r)) match
                             case (Result.Success(l), Result.Success(r)) => summon[Equal[A]].equal(l, r)
-                            case (Result.Fail(l), Result.Fail(r))       => l == r
+                            case (Result.Error(l), Result.Error(r))     => l == r
                             case _                                      => false
                         end match
                     end checkEqual

--- a/kyo-prelude/shared/src/main/scala/kyo/Check.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Check.scala
@@ -66,7 +66,7 @@ object Check:
       */
     def runAbort[A: Flat, S](v: A < (Check & S))(using Frame): A < (Abort[CheckFailed] & S) =
         ArrowEffect.handle(Tag[Check], v)(
-            [C] => (input, cont) => Abort.fail(input)
+            [C] => (input, cont) => Abort.error(input)
         )
 
     /** Runs a computation with Check effect, collecting all failures.

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -12,13 +12,13 @@ class AbortsTest extends Test:
         "handle" in {
             assert(
                 Abort.run[Ex1](Abort.get[Ex1](Right(1))).eval ==
-                    Result.success(1)
+                    Result.succeed(1)
             )
         }
         "handle + transform" in {
             assert(
                 Abort.run[Ex1](Abort.get[Ex1](Right(1)).map(_ + 1)).eval ==
-                    Result.success(2)
+                    Result.succeed(2)
             )
         }
         "handle + effectful transform" in {
@@ -26,7 +26,7 @@ class AbortsTest extends Test:
                 Abort.run[Ex1](Abort.get[Ex1](Right(1)).map(i =>
                     Abort.get[Ex1](Right(i + 1))
                 )).eval ==
-                    Result.success(2)
+                    Result.succeed(2)
             )
         }
         "handle + transform + effectful transform" in {
@@ -34,7 +34,7 @@ class AbortsTest extends Test:
                 Abort.run[Ex1](Abort.get[Ex1](Right(1)).map(_ + 1).map(i =>
                     Abort.get[Ex1](Right(i + 1))
                 )).eval ==
-                    Result.success(3)
+                    Result.succeed(3)
             )
         }
         "handle + transform + failed effectful transform" in {
@@ -43,31 +43,31 @@ class AbortsTest extends Test:
                 Abort.run[Ex1](Abort.get[Ex1](Right(1)).map(_ + 1).map(_ =>
                     Abort.get(fail)
                 )).eval ==
-                    Result.fail(ex1)
+                    Result.error(ex1)
             )
         }
         "union tags" - {
             "in suspend 1" in {
                 val effect1: Int < Abort[String | Boolean] =
-                    Abort.fail("failure")
+                    Abort.error("failure")
                 val handled1: Result[String, Int] < Abort[Boolean] =
                     Abort.run[String](effect1)
                 val handled2: Result[Boolean, Result[String, Int]] =
                     Abort.run[Boolean](handled1).eval
-                assert(handled2 == Result.success(Result.fail("failure")))
+                assert(handled2 == Result.succeed(Result.error("failure")))
             }
             "in suspend 2" in {
                 val effect1: Int < Abort[String | Boolean] =
-                    Abort.fail("failure")
+                    Abort.error("failure")
                 val handled1: Result[Boolean, Int] < Abort[String] =
                     Abort.run[Boolean](effect1)
                 val handled2: Result[String, Result[Boolean, Int]] =
                     Abort.run[String](handled1).eval
-                assert(handled2 == Result.fail("failure"))
+                assert(handled2 == Result.error("failure"))
             }
             "in handle" in {
                 val effect: Int < Abort[String | Boolean] =
-                    Abort.fail("failure")
+                    Abort.error("failure")
                 val _ = effect
                 assertDoesNotCompile("Abort.run[String | Boolean](effect)")
             }
@@ -75,27 +75,27 @@ class AbortsTest extends Test:
         "try" in {
             import scala.util.Try
 
-            assert(Abort.run(Abort.get(Try(throw ex1))).eval == Result.fail(ex1))
-            assert(Abort.run(Abort.get(Try("success!"))).eval == Result.success("success!"))
+            assert(Abort.run(Abort.get(Try(throw ex1))).eval == Result.error(ex1))
+            assert(Abort.run(Abort.get(Try("success!"))).eval == Result.succeed("success!"))
         }
     }
 
     "get" - {
         "either" in {
-            assert(Abort.run(Abort.get(Left(1))).eval == Result.fail(1))
-            assert(Abort.run(Abort.get[Ex1](Right(1))).eval == Result.success(1))
+            assert(Abort.run(Abort.get(Left(1))).eval == Result.error(1))
+            assert(Abort.run(Abort.get[Ex1](Right(1))).eval == Result.succeed(1))
         }
         "result" in {
-            assert(Abort.run(Abort.get(Result.success[Ex1, Int](1))).eval == Result.success(1))
-            assert(Abort.run(Abort.get(Result.fail(ex1))).eval == Result.fail(ex1))
+            assert(Abort.run(Abort.get(Result.succeed[Ex1, Int](1))).eval == Result.succeed(1))
+            assert(Abort.run(Abort.get(Result.error(ex1))).eval == Result.error(ex1))
         }
         "option" in {
-            assert(Abort.run(Abort.get(Option.empty)).eval == Result.fail(Maybe.Empty))
-            assert(Abort.run(Abort.get(Some(1))).eval == Result.success(1))
+            assert(Abort.run(Abort.get(Option.empty)).eval == Result.error(Maybe.Empty))
+            assert(Abort.run(Abort.get(Some(1))).eval == Result.succeed(1))
         }
         "maybe" in {
-            assert(Abort.run(Abort.get(Maybe.empty)).eval == Result.fail(Maybe.Empty))
-            assert(Abort.run(Abort.get(Maybe(1))).eval == Result.success(1))
+            assert(Abort.run(Abort.get(Maybe.empty)).eval == Result.error(Maybe.Empty))
+            assert(Abort.run(Abort.get(Maybe(1))).eval == Result.succeed(1))
         }
     }
 
@@ -105,32 +105,32 @@ class AbortsTest extends Test:
             "handle" in {
                 assert(
                     Abort.run[Ex1](v).eval ==
-                        Result.success(1)
+                        Result.succeed(1)
                 )
             }
             "handle + transform" in {
                 assert(
                     Abort.run[Ex1](v.map(_ + 1)).eval ==
-                        Result.success(2)
+                        Result.succeed(2)
                 )
             }
             "handle + effectful transform" in {
                 assert(
                     Abort.run[Ex1](v.map(i => Abort.get[Ex1](Right(i + 1)))).eval ==
-                        Result.success(2)
+                        Result.succeed(2)
                 )
             }
             "handle + transform + effectful transform" in {
                 assert(
                     Abort.run[Ex1](v.map(_ + 1).map(i => Abort.get[Ex1](Right(i + 1)))).eval ==
-                        Result.success(3)
+                        Result.succeed(3)
                 )
             }
             "handle + transform + failed effectful transform" in {
                 val fail = Left[Ex1, Int](ex1)
                 assert(
                     Abort.run[Ex1](v.map(_ + 1).map(_ => Abort.get(fail))).eval ==
-                        Result.fail(ex1)
+                        Result.error(ex1)
                 )
             }
         }
@@ -139,32 +139,32 @@ class AbortsTest extends Test:
             "handle" in {
                 assert(
                     Abort.run[Ex1](v).eval ==
-                        Result.fail(ex1)
+                        Result.error(ex1)
                 )
             }
             "handle + transform" in {
                 assert(
                     Abort.run[Ex1](v.map(_ + 1)).eval ==
-                        Result.fail(ex1)
+                        Result.error(ex1)
                 )
             }
             "handle + effectful transform" in {
                 assert(
                     Abort.run[Ex1](v.map(i => Abort.get[Ex1](Right(i + 1)))).eval ==
-                        Result.fail(ex1)
+                        Result.error(ex1)
                 )
             }
             "handle + transform + effectful transform" in {
                 assert(
                     Abort.run[Ex1](v.map(_ + 1).map(i => Abort.get[Ex1](Right(i + 1)))).eval ==
-                        Result.fail(ex1)
+                        Result.error(ex1)
                 )
             }
             "handle + transform + failed effectful transform" in {
                 val fail = Left[Ex1, Int](ex1)
                 assert(
                     Abort.run[Ex1](v.map(_ + 1).map(_ => Abort.get(fail))).eval ==
-                        Result.fail(ex1)
+                        Result.error(ex1)
                 )
             }
         }
@@ -174,19 +174,19 @@ class AbortsTest extends Test:
         def test(v: Int): Int < Abort[Ex1] =
             v match
                 case 0 =>
-                    Abort.fail(ex1)
+                    Abort.error(ex1)
                 case i => 10 / i
         "run" - {
             "success" in {
                 assert(
                     Abort.run[Ex1](test(2)).eval ==
-                        Result.success(5)
+                        Result.succeed(5)
                 )
             }
             "failure" in {
                 assert(
                     Abort.run[Ex1](test(0)).eval ==
-                        Result.fail(ex1)
+                        Result.error(ex1)
                 )
             }
             "panic" in {
@@ -220,14 +220,14 @@ class AbortsTest extends Test:
             }
             "super" in {
                 val ex                        = new Exception
-                val a: Int < Abort[Exception] = Abort.fail(ex)
+                val a: Int < Abort[Exception] = Abort.error(ex)
                 val b: Result[Throwable, Int] = Abort.run[Throwable](a).eval
-                assert(b == Result.fail(ex))
+                assert(b == Result.error(ex))
             }
             "super success" in {
                 val a: Int < Abort[Exception] = 24
                 val b: Result[Throwable, Int] = Abort.run[Throwable](a).eval
-                assert(b == Result.success(24))
+                assert(b == Result.succeed(24))
             }
             "reduce large union incrementally" in {
                 val t1: Int < Abort[Int | String | Boolean | Float | Char | Double] =
@@ -238,7 +238,7 @@ class AbortsTest extends Test:
                 val t5 = Abort.run[Float](t4)
                 val t6 = Abort.run[Char](t5)
                 val t7 = Abort.run[Double](t6)
-                assert(t7.eval == Result.success(Result.success(Result.success(Result.success(Result.success(Result.success(18)))))))
+                assert(t7.eval == Result.succeed(Result.succeed(Result.succeed(Result.succeed(Result.succeed(Result.succeed(18)))))))
             }
             "reduce large union in a single expression" in {
                 val t: Int < Abort[Int | String | Boolean | Float | Char | Double] = 18
@@ -256,33 +256,33 @@ class AbortsTest extends Test:
                         )
                     ).eval
                 val expected: Result[Double, Result[Char, Result[Float, Result[Boolean, Result[String, Result[Int, Int]]]]]] =
-                    Result.success(Result.success(Result.success(Result.success(Result.success(Result.success(18))))))
+                    Result.succeed(Result.succeed(Result.succeed(Result.succeed(Result.succeed(Result.succeed(18))))))
                 assert(res == expected)
             }
-            "doesn't produce Fail if E isn't Throwable" in run {
+            "doesn't produce Error if E isn't Throwable" in run {
                 val ex = new Exception
                 Abort.run[Any](throw ex).map(result => assert(result == Result.panic(ex)))
             }
         }
         "fail" in {
             val ex: Throwable = new Exception("throwable failure")
-            val a             = Abort.fail(ex)
-            assert(Abort.run[Throwable](a).eval == Result.fail(ex))
+            val a             = Abort.error(ex)
+            assert(Abort.run[Throwable](a).eval == Result.error(ex))
         }
         "fail inferred" in {
             val e = "test"
-            val f = Abort.fail(e)
-            assert(Abort.run(f).eval == Result.fail(e))
+            val f = Abort.error(e)
+            assert(Abort.run(f).eval == Result.error(e))
         }
         "error" - {
             "fail" in {
                 val ex: Throwable = new Exception("throwable failure")
-                val a             = Abort.error(Result.Fail(ex))
-                assert(Abort.run[Throwable](a).eval == Result.fail(ex))
+                val a             = Abort.fail(Result.Error(ex))
+                assert(Abort.run[Throwable](a).eval == Result.error(ex))
             }
             "panic" in {
                 val ex: Throwable = new Exception("throwable failure")
-                val a             = Abort.error(Result.Panic(ex))
+                val a             = Abort.fail(Result.Panic(ex))
                 assert(Abort.run[Throwable](a).eval == Result.panic(ex))
             }
         }
@@ -290,8 +290,8 @@ class AbortsTest extends Test:
             "basic usage" in {
                 def test(b: Boolean) = Abort.run[String](Abort.when(b)("FAIL!")).eval
 
-                assert(test(true) == Result.fail("FAIL!"))
-                assert(test(false) == Result.success(()))
+                assert(test(true) == Result.error("FAIL!"))
+                assert(test(false) == Result.succeed(()))
             }
 
             "with Env" in {
@@ -305,9 +305,9 @@ class AbortsTest extends Test:
                     )
                 }.eval
 
-                assert(test(3) == Result.success(3))
-                assert(test(7) == Result.fail("Too big"))
-                assert(test(-1) == Result.fail("Negative"))
+                assert(test(3) == Result.succeed(3))
+                assert(test(7) == Result.error("Too big"))
+                assert(test(-1) == Result.error("Negative"))
             }
 
             "with Var" in {
@@ -323,9 +323,9 @@ class AbortsTest extends Test:
                     }
                 }.eval
 
-                assert(test(1) == Result.success(2))
-                assert(test(2) == Result.fail("Even"))
-                assert(test(5) == Result.fail("Too big"))
+                assert(test(1) == Result.succeed(2))
+                assert(test(2) == Result.error("Even"))
+                assert(test(5) == Result.error("Too big"))
             }
 
             "short-circuiting" in {
@@ -337,9 +337,9 @@ class AbortsTest extends Test:
                     yield ()
                 }
 
-                assert(Env.run(())(test(true)).eval == Result.fail("FAIL!"))
+                assert(Env.run(())(test(true)).eval == Result.error("FAIL!"))
                 assert(sideEffect == 0)
-                assert(Env.run(())(test(false)).eval == Result.success(()))
+                assert(Env.run(())(test(false)).eval == Result.succeed(()))
                 assert(sideEffect == 1)
             }
         }
@@ -348,9 +348,9 @@ class AbortsTest extends Test:
             "basic usage" in {
                 def test(x: Int) = Abort.run[String](Abort.ensuring(x > 0, x)("Non-positive")).eval
 
-                assert(test(5) == Result.success(5))
-                assert(test(0) == Result.fail("Non-positive"))
-                assert(test(-3) == Result.fail("Non-positive"))
+                assert(test(5) == Result.succeed(5))
+                assert(test(0) == Result.error("Non-positive"))
+                assert(test(-3) == Result.error("Non-positive"))
             }
 
             "with Env" in {
@@ -363,11 +363,11 @@ class AbortsTest extends Test:
                     }
                 }.eval
 
-                assert(test(5) == Result.success(10))
-                assert(test(0) == Result.success(0))
-                assert(test(10) == Result.success(20))
-                assert(test(-1) == Result.fail("Out of range"))
-                assert(test(11) == Result.fail("Out of range"))
+                assert(test(5) == Result.succeed(10))
+                assert(test(0) == Result.succeed(0))
+                assert(test(10) == Result.succeed(20))
+                assert(test(-1) == Result.error("Out of range"))
+                assert(test(11) == Result.error("Out of range"))
             }
 
             "with Var" in {
@@ -382,10 +382,10 @@ class AbortsTest extends Test:
                     }
                 }.eval
 
-                assert(test(2) == Result.success(4))
-                assert(test(4) == Result.success(8))
-                assert(test(1) == Result.fail("Odd"))
-                assert(test(3) == Result.fail("Odd"))
+                assert(test(2) == Result.succeed(4))
+                assert(test(4) == Result.succeed(8))
+                assert(test(1) == Result.error("Odd"))
+                assert(test(3) == Result.error("Odd"))
             }
 
         }
@@ -398,19 +398,19 @@ class AbortsTest extends Test:
                 "success" in {
                     assert(
                         Abort.run[Ex1](Abort.catching[Ex1](test(2))).eval ==
-                            Result.success(5)
+                            Result.succeed(5)
                     )
                 }
                 "failure" in {
                     assert(
                         Abort.run[Ex1](Abort.catching[Ex1](test(0))).eval ==
-                            Result.fail(ex1)
+                            Result.error(ex1)
                     )
                 }
                 "subclass" in {
                     assert(
                         Abort.run[RuntimeException](Abort.catching[RuntimeException](test(0))).eval ==
-                            Result.fail(ex1)
+                            Result.error(ex1)
                     )
                 }
                 "distinct" in {
@@ -427,10 +427,10 @@ class AbortsTest extends Test:
 
                     val a = Abort.run[Distinct1](distinct)
                     val b = Abort.run[Distinct2](a).eval
-                    assert(b == Result.success(Result.fail(d1)))
+                    assert(b == Result.succeed(Result.error(d1)))
                     assertDoesNotCompile("Abort.run[Distinct1 | Distinct2](distinct)")
                     val c = Abort.run[Throwable](distinct).eval
-                    assert(c == Result.fail(d1))
+                    assert(c == Result.error(d1))
                 }
                 "ClassTag inference" in pendingUntilFixed {
                     assertCompiles("""
@@ -452,7 +452,7 @@ class AbortsTest extends Test:
                         Env.run(2)(
                             Abort.run[Ex1](Abort.catching[Ex1](test(Env.get)))
                         ).eval ==
-                            Result.success(5)
+                            Result.succeed(5)
                     )
                 }
                 "failure" in {
@@ -460,7 +460,7 @@ class AbortsTest extends Test:
                         Env.run(0)(
                             Abort.run[Ex1](Abort.catching[Ex1](test(Env.get)))
                         ).eval ==
-                            Result.fail(ex1)
+                            Result.error(ex1)
                     )
                 }
             }
@@ -469,17 +469,17 @@ class AbortsTest extends Test:
                 "should propagate the innermost failure" in {
                     val nested = Abort.run[String](
                         Abort.run[Int](
-                            Abort.fail[String]("inner").map(_ => Abort.fail[Int](42))
+                            Abort.error[String]("inner").map(_ => Abort.error[Int](42))
                         )
                     )
-                    assert(nested.eval == Result.fail("inner"))
+                    assert(nested.eval == Result.error("inner"))
                 }
 
                 "should propagate the outermost failure if there are no inner failures" in {
                     val nested = Abort.run(Abort.run[String](
                         Abort.run[Int](Abort.get[Int](Right(42)))
-                    ).map(_ => Abort.fail("outer")))
-                    assert(nested.eval == Result.fail("outer"))
+                    ).map(_ => Abort.error("outer")))
+                    assert(nested.eval == Result.error("outer"))
                 }
             }
 
@@ -487,12 +487,12 @@ class AbortsTest extends Test:
                 "should have access to the environment within Abort" in {
                     val env    = "test"
                     val result = Env.run(env)(Abort.run[String](Env.get[String]))
-                    assert(result.eval == Result.success(env))
+                    assert(result.eval == Result.succeed(env))
                 }
 
                 "should propagate Abort failures within Env" in {
-                    val result = Env.run("test")(Abort.run[String](Abort.fail("failure")))
-                    assert(result.eval == Result.fail("failure"))
+                    val result = Env.run("test")(Abort.run[String](Abort.error("failure")))
+                    assert(result.eval == Result.error("failure"))
                 }
             }
 
@@ -503,16 +503,16 @@ class AbortsTest extends Test:
                             Var.get[Int].map(_.toString)
                         )
                     )
-                    assert(result.eval == Result.success("42"))
+                    assert(result.eval == Result.succeed("42"))
                 }
 
                 "should not modify state on Abort failures" in {
                     val result = Var.run(42)(
                         Abort.run[String](
-                            Var.set[Int](24).map(_ => Abort.fail("failure"))
+                            Var.set[Int](24).map(_ => Abort.error("failure"))
                         )
                     )
-                    assert(result.eval == Result.fail("failure"))
+                    assert(result.eval == Result.error("failure"))
                     assert(Var.run(42)(Var.get[Int]).eval == 42)
                 }
             }
@@ -521,9 +521,9 @@ class AbortsTest extends Test:
                 "should not execute subsequent operations on failure" in {
                     var executed = false
                     val result = Abort.run[String](
-                        Abort.fail("failure").map(_ => executed = true)
+                        Abort.error("failure").map(_ => executed = true)
                     )
-                    assert(result.eval == Result.fail("failure"))
+                    assert(result.eval == Result.error("failure"))
                     assert(!executed)
                 }
 
@@ -532,7 +532,7 @@ class AbortsTest extends Test:
                     val result = Abort.run(Abort.run[String](
                         Abort.get[Int](Right(42)).map(_ => executed = true)
                     ))
-                    assert(result.eval == Result.success(Result.success(())))
+                    assert(result.eval == Result.succeed(Result.succeed(())))
                     assert(executed)
                 }
             }
@@ -545,12 +545,12 @@ class AbortsTest extends Test:
                 Abort.run[String] {
                     for
                         x <- Env.get[Int]
-                        _ <- if x > 10 then Abort.fail("Too big") else Env.get[Int]
+                        _ <- if x > 10 then Abort.error("Too big") else Env.get[Int]
                         y <- Env.use[Int](_ * 2)
                     yield y
                 }
             }
-            assert(result.eval == Result.success(10))
+            assert(result.eval == Result.succeed(10))
         }
 
         "Abort failure through Env and Var" in {
@@ -560,12 +560,12 @@ class AbortsTest extends Test:
                         for
                             x <- Env.get[Int]
                             _ <- Var.update[Int](_ + x)
-                            _ <- if x > 10 then Abort.fail("Too big") else Var.get[Int]
+                            _ <- if x > 10 then Abort.error("Too big") else Var.get[Int]
                         yield ()
                     }
                 }
             }
-            assert(result.eval == Result.fail("Too big"))
+            assert(result.eval == Result.error("Too big"))
         }
     }
 
@@ -573,36 +573,36 @@ class AbortsTest extends Test:
         "Abort within map" in {
             val result = Abort.run[String] {
                 Env.get[Int].map { x =>
-                    if x > 5 then Abort.fail("Too big")
+                    if x > 5 then Abort.error("Too big")
                     else Env.get[Int]
                 }
             }
-            assert(Env.run(10)(result).eval == Result.fail("Too big"))
+            assert(Env.run(10)(result).eval == Result.error("Too big"))
         }
 
         "multiple Aborts in for-comprehension" in {
             val result = Abort.run[String] {
                 for
                     x <- Env.get[Int]
-                    _ <- if x > 5 then Abort.fail("Too big") else Env.get[Int]
+                    _ <- if x > 5 then Abort.error("Too big") else Env.get[Int]
                     y <- Var.get[Int]
-                    _ <- if y < 0 then Abort.fail("Negative") else Var.get[Int]
+                    _ <- if y < 0 then Abort.error("Negative") else Var.get[Int]
                 yield (x, y)
             }
             val finalResult = Env.run(3) {
                 Var.run(-1)(result)
             }
-            assert(finalResult.eval == Result.fail("Negative"))
+            assert(finalResult.eval == Result.error("Negative"))
         }
 
         "Abort within Abort" in {
             val innerAbort = Abort.run[Int] {
-                Abort.fail[String]("Inner error").map(_ => 42)
+                Abort.error[String]("Inner error").map(_ => 42)
             }
             val outerAbort = Abort.run[String] {
-                innerAbort.map(x => if x.value.exists(_ > 50) then Abort.fail("Outer error") else x)
+                innerAbort.map(x => if x.value.exists(_ > 50) then Abort.error("Outer error") else x)
             }
-            assert(outerAbort.eval == Result.fail("Inner error"))
+            assert(outerAbort.eval == Result.error("Inner error"))
         }
 
         "deeply nested Aborts" in {
@@ -611,7 +611,7 @@ class AbortsTest extends Test:
                 else Abort.get(Right(depth)).map(_ => nestedAborts(depth - 1))
 
             val result = Abort.run(nestedAborts(10000))
-            assert(result.eval == Result.success(0))
+            assert(result.eval == Result.succeed(0))
         }
     }
 
@@ -620,7 +620,7 @@ class AbortsTest extends Test:
             for
                 x <- Env.get[Int]
                 y <- Var.get[Int]
-                _ <- if x + y > 10 then Abort.fail("Sum too large") else Env.get[Int]
+                _ <- if x + y > 10 then Abort.error("Sum too large") else Env.get[Int]
             yield x + y
         }
         val finalResult: Result[String, Int] < (Env[Int] & Var[Int]) = result

--- a/kyo-prelude/shared/src/test/scala/kyo/CheckTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/CheckTest.scala
@@ -35,7 +35,7 @@ class CheckTest extends Test:
                     _ <- Check(1 + 1 == 2, "Basic math works")
                 yield "All checks passed"
             }
-            Abort.run(result).map(r => assert(r == Result.success("All checks passed")))
+            Abort.run(result).map(r => assert(r == Result.succeed("All checks passed")))
         }
 
         "returns failure for failing checks" in run {

--- a/kyo-prelude/shared/src/test/scala/kyo/EmitTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/EmitTest.scala
@@ -130,11 +130,11 @@ class EmitTest extends Test:
                     Emit.runAck(emits(0)) { v =>
                         seen :+= v
                         if v < 3 then Emit.Ack.Continue()
-                        else Abort.fail("Reached 3")
+                        else Abort.error("Reached 3")
                     }
                 }.eval
                 assert(seen == List(0, 1, 2, 3))
-                assert(result == Result.fail("Reached 3"))
+                assert(result == Result.error("Reached 3"))
             }
         }
     }

--- a/kyo-prelude/shared/src/test/scala/kyo/EnvTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/EnvTest.scala
@@ -161,7 +161,7 @@ class EnvTest extends Test:
                     Env.get[Service1].map(_(1))
                 assert(
                     Abort.run(Env.run(service1)(a)).eval ==
-                        Result.success(2)
+                        Result.succeed(2)
                 )
             }
             "short circuit" in {
@@ -169,7 +169,7 @@ class EnvTest extends Test:
                     Env.get[Service1].map(_(0))
                 assert(
                     Abort.run(Env.run(service1)(a)).eval ==
-                        Result.fail(Maybe.empty)
+                        Result.error(Maybe.empty)
                 )
             }
         }
@@ -184,21 +184,21 @@ class EnvTest extends Test:
                     val b = Env.run(service2)(v)
                     val c = Env.run(service1)(b)
                     assert(
-                        Abort.run(c).eval == Result.success(3)
+                        Abort.run(c).eval == Result.succeed(3)
                     )
                 }
                 "reverse handling order" in {
                     val b = Env.run(service1)(v)
                     val c = Env.run(service2)(b)
                     assert(
-                        Abort.run(c).eval == Result.success(3)
+                        Abort.run(c).eval == Result.succeed(3)
                     )
                 }
                 "dependent services" in {
                     val v2: Int < (Env[Service2] & Abort[Maybe.Empty]) = Env.run(service1)(v)
                     assert(
                         Abort.run(Env.run(service2)(v2)).eval ==
-                            Result.success(3)
+                            Result.succeed(3)
                     )
                 }
             }
@@ -297,14 +297,14 @@ class EnvTest extends Test:
 
     "interactions with Abort" - {
         "should propagate Abort failures within Env" in {
-            val result = Env.run("test")(Abort.run[String](Abort.fail("failure")))
-            assert(result.eval == Result.fail("failure"))
+            val result = Env.run("test")(Abort.run[String](Abort.error("failure")))
+            assert(result.eval == Result.error("failure"))
         }
 
         "should have access to the environment within Abort" in {
             val env    = "test"
             val result = Env.run(env)(Abort.run[String](Env.get[String]))
-            assert(result.eval == Result.success(env))
+            assert(result.eval == Result.succeed(env))
         }
     }
 

--- a/kyo-prelude/shared/src/test/scala/kyo/MemoTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/MemoTest.scala
@@ -196,7 +196,7 @@ class MemoTest extends Test:
             var count = 0
             val f = Memo[Int, Int, Abort[String]] { x =>
                 count += 1
-                if x < 0 then Abort.fail("Negative input")
+                if x < 0 then Abort.error("Negative input")
                 else x * 2
             }
 
@@ -210,7 +210,7 @@ class MemoTest extends Test:
                 }
             }
 
-            assert(result.eval == Result.fail("Negative input"))
+            assert(result.eval == Result.error("Negative input"))
             assert(count == 2)
         }
 
@@ -250,7 +250,7 @@ class MemoTest extends Test:
                 for
                     env <- Env.get[Int]
                     _   <- Var.update[String](s => s"$s-$x")
-                    _   <- if x > 10 then Abort.fail("Too large") else Abort.get(Right(()))
+                    _   <- if x > 10 then Abort.error("Too large") else Abort.get(Right(()))
                 yield x * env
                 end for
             }
@@ -271,7 +271,7 @@ class MemoTest extends Test:
                 }
             }
 
-            assert(result.eval == Result.fail("Too large"))
+            assert(result.eval == Result.error("Too large"))
             assert(count == 3)
         }
     }

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/PendingTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/PendingTest.scala
@@ -185,11 +185,11 @@ class PendingTest extends Test:
 
         "preserves the effect type" in {
             val effect: Int < (Env[Int] & Abort[String]) =
-                Env.get[Int].flatMap(x => if x > 5 then Abort.fail("Too big") else x)
+                Env.get[Int].flatMap(x => if x > 5 then Abort.error("Too big") else x)
             val result = effect.pipe { v =>
                 Abort.run(Env.run(10)(v))
             }
-            assert(result.eval == Result.fail("Too big"))
+            assert(result.eval == Result.error("Too big"))
         }
 
         "works with identity function" in {

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -54,7 +54,7 @@ class KyoSttpMonad extends MonadAsyncError[M]:
             val canceller =
                 register {
                     case Left(t)  => discard(p.complete(Result.panic(t)))
-                    case Right(t) => discard(p.complete(Result.success(t)))
+                    case Right(t) => discard(p.complete(Result.succeed(t)))
                 }
             p.onComplete { r =>
                 if r.isPanic then

--- a/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
@@ -33,7 +33,7 @@ class KyoSttpMonadTest extends Test:
 
     "error" in run {
         val ex = new Exception
-        Abort.run[Throwable](KyoSttpMonad.error(ex)).map(r => assert(r == Result.fail(ex)))
+        Abort.run[Throwable](KyoSttpMonad.error(ex)).map(r => assert(r == Result.error(ex)))
     }
 
     "unit" in {
@@ -47,7 +47,7 @@ class KyoSttpMonadTest extends Test:
         }
         "nok" in run {
             val ex = new Exception
-            Abort.run[Throwable](KyoSttpMonad.eval(throw ex)).map(r => assert(r == Result.fail(ex)))
+            Abort.run[Throwable](KyoSttpMonad.eval(throw ex)).map(r => assert(r == Result.error(ex)))
         }
     }
 
@@ -57,7 +57,7 @@ class KyoSttpMonadTest extends Test:
         }
         "nok" in run {
             val ex = new Exception
-            Abort.run[Throwable](KyoSttpMonad.suspend(throw ex)).map(r => assert(r == Result.fail(ex)))
+            Abort.run[Throwable](KyoSttpMonad.suspend(throw ex)).map(r => assert(r == Result.error(ex)))
         }
     }
 

--- a/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
@@ -59,7 +59,7 @@ object Routes:
                     (i: I) =>
                         Abort.run[E](Env.run(a)(f(i))).map {
                             case Result.Success(v) => Right(v)
-                            case Result.Fail(e)    => Left(e)
+                            case Result.Error(e)   => Left(e)
                             case Result.Panic(ex)  => throw ex
                         }
                 )

--- a/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
@@ -11,7 +11,7 @@ object KyoUtil:
                 nettyFuture.addListener((future: ChannelFuture) =>
                     discard {
                         IO.run {
-                            if future.isSuccess then p.unsafe.complete(Result.success(future.channel()))
+                            if future.isSuccess then p.unsafe.complete(Result.succeed(future.channel()))
                             else p.unsafe.complete(Result.panic(future.cause()))
                         }.eval
                     }
@@ -26,7 +26,7 @@ object KyoUtil:
                 f.addListener((future: io.netty.util.concurrent.Future[A]) =>
                     discard {
                         IO.run {
-                            if future.isSuccess then p.unsafe.complete(Result.success(future.getNow))
+                            if future.isSuccess then p.unsafe.complete(Result.succeed(future.getNow))
                             else p.unsafe.complete(Result.panic(future.cause()))
                         }.eval
                     }

--- a/kyo-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
+++ b/kyo-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
@@ -16,10 +16,10 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
             ),
             suite("failing!")(
                 test("IO fail") {
-                    IO(throw new Exception("Fail!")).map(_ => assertCompletes)
+                    IO(throw new Exception("Error!")).map(_ => assertCompletes)
                 },
                 test("IO Succeed") {
-                    Abort.fail[Throwable](new RuntimeException("Abort!")).map(_ => assertCompletes)
+                    Abort.error[Throwable](new RuntimeException("Abort!")).map(_ => assertCompletes)
                 },
                 test("Async.delay") {
                     Async.delay(Duration.Infinity)(assertCompletes)

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -29,7 +29,7 @@ object ZIOs:
       *   A Kyo effect that will produce A or abort with E
       */
     def get[E >: Nothing: Tag, A](v: ZIO[Any, E, A])(using Frame): A < (Abort[E] & ZIOs) =
-        val task = v.fold(Result.fail, Result.success)
+        val task = v.fold(Result.error, Result.succeed)
         ArrowEffect.suspendMap(Tag[GetZIO], task)(Abort.get(_))
 
     /** Executes a ZIO effect that cannot fail and returns its result within the Kyo effect system.
@@ -79,7 +79,7 @@ object ZIOs:
                 ).pipe(Async.run).map { fiber =>
                     ZIO.asyncInterrupt[Any, E, A] { cb =>
                         fiber.unsafe.onComplete {
-                            case Result.Fail(ex)   => cb(Exit.fail(ex))
+                            case Result.Error(ex)  => cb(Exit.fail(ex))
                             case Result.Panic(ex)  => cb(Exit.die(ex))
                             case Result.Success(v) => cb(v)
                         }

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -37,10 +37,10 @@ class ZIOsTest extends Test:
         "kyo then zio" in runKyo {
             object zioFailure extends RuntimeException
             object kyoFailure extends RuntimeException
-            val a = Abort.fail(kyoFailure)
+            val a = Abort.error(kyoFailure)
             val b = ZIOs.get(ZIO.fail(zioFailure))
             Abort.run(a.map(_ => b)).map {
-                case Result.Fail(ex) =>
+                case Result.Error(ex) =>
                     assert(ex == kyoFailure)
                 case _ =>
                     fail()
@@ -50,9 +50,9 @@ class ZIOsTest extends Test:
             object zioFailure extends RuntimeException
             object kyoFailure extends RuntimeException
             val a = ZIOs.get(ZIO.fail(zioFailure))
-            val b = Abort.fail(kyoFailure)
+            val b = Abort.error(kyoFailure)
             Abort.run(a.map(_ => b)).map {
-                case Result.Fail(ex) =>
+                case Result.Error(ex) =>
                     assert(ex == zioFailure)
                 case _ =>
                     fail()


### PR DESCRIPTION
Initial change for https://github.com/getkyo/kyo/issues/651

- Refactor `Result` hierarchy:  `Error` => `Failure`, `Fail` => `Error`
- Refactor related method names: `success` => `succeed`, `fail` => `error`, `error` => `fail`, `mapFail` => `mapError` 