### PR TITLE
cats/zios: reproduce interruption issues

### DIFF
--- a/kyo-cats/js/src/test/scala/java/util/concurrent/CountDownLatch.scala
+++ b/kyo-cats/js/src/test/scala/java/util/concurrent/CountDownLatch.scala
@@ -1,0 +1,5 @@
+package java.util.concurrent
+
+class CountDownLatch(count: Int):
+    def await(time: Long, unit: TimeUnit): Boolean = ???
+    def countDown()                                = ???

--- a/kyo-zio/js/src/test/scala/java/util/concurrent/CountDownLatch.scala
+++ b/kyo-zio/js/src/test/scala/java/util/concurrent/CountDownLatch.scala
@@ -1,0 +1,5 @@
+package java.util.concurrent
+
+class CountDownLatch(count: Int):
+    def await(time: Long, unit: TimeUnit): Boolean = ???
+    def countDown()                                = ???

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -1,5 +1,7 @@
 package kyo
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kyo.*
 import kyo.kernel.Platform
 import org.scalatest.compatible.Assertion
@@ -93,43 +95,58 @@ class ZIOsTest extends Test:
 
     "interrupts" - {
 
-        import java.util.concurrent.atomic.LongAdder
+        def kyoLoop(cdl: CountDownLatch): Unit < IO =
+            def loop(): Unit < IO =
+                IO(()).flatMap(_ => loop())
+            IO.ensure(IO(cdl.countDown()))(loop())
+        end kyoLoop
 
-        def kyoLoop(a: LongAdder = new LongAdder): Unit < IO =
-            IO(a.increment()).map(_ => kyoLoop(a))
-
-        def zioLoop(a: LongAdder = new LongAdder): Task[Unit] =
-            ZIO.attempt(a.increment()).flatMap(_ => zioLoop(a))
+        def zioLoop(cdl: CountDownLatch): Task[Unit] =
+            def loop(): Task[Unit] =
+                ZIO.unit.flatMap(_ => loop())
+            loop().ensuring(ZIO.attempt(cdl.countDown()).ignore)
+        end zioLoop
 
         if Platform.isJVM then
 
             "zio to kyo" in runZIO {
+                val cdl = new CountDownLatch(1)
                 for
-                    f <- ZIOs.run(kyoLoop()).fork
+                    f <- ZIOs.run(kyoLoop(cdl)).fork
                     _ <- f.interrupt
                     r <- f.await
-                yield assert(r.isFailure)
+                yield
+                    assert(cdl.await(10, TimeUnit.MILLISECONDS))
+                    assert(r.isFailure)
                 end for
             }
             "kyo to zio" in runKyo {
+                pending
+                val cdl = new CountDownLatch(1)
                 for
-                    f <- Async.run(ZIOs.run(zioLoop()))
+                    f <- Async.run(ZIOs.run(zioLoop(cdl)))
                     _ <- f.interrupt(Result.Panic(new Exception))
                     r <- f.getResult
-                yield assert(r.isPanic)
+                yield
+                    assert(cdl.await(10, TimeUnit.MILLISECONDS))
+                    assert(r.isPanic)
                 end for
             }
             "both" in runZIO {
+                pending
+                val cdl = new CountDownLatch(1)
                 val v =
                     for
-                        _ <- ZIOs.get(zioLoop())
-                        _ <- Async.run(kyoLoop())
+                        _ <- ZIOs.get(zioLoop(cdl))
+                        _ <- Async.run(kyoLoop(cdl))
                     yield ()
                 for
                     f <- ZIOs.run(v).fork
                     _ <- f.interrupt
                     r <- f.await
-                yield assert(r.isFailure)
+                yield
+                    assert(cdl.await(10, TimeUnit.MILLISECONDS))
+                    assert(r.isFailure)
                 end for
             }
         end if


### PR DESCRIPTION
The recent CI instability with the `cats-effect` tests is a symptom of a bug. I was expecting the interruption thunk provided to `IO.async` to be evaluated independently of the fiber yielding the execution to the scheduler but that's not the case. Additionally, interruptions from Kyo aren't being propagated to cats-effect.

This issue wasn't detected earlier because the tests copied from `kyo-zio` were incorrect. For ZIO, the interruption from ZIO to Kyo via the provided thunk to `ZIO.asyncInterrupt` is working properly but propagating interruptions from Kyo to ZIO is also not working.

This PR fixes the tests to show the issue.