### PR TITLE
core: async fixes

### DIFF
--- a/kyo-cats/shared/src/main/scala/kyo/Cats.scala
+++ b/kyo-cats/shared/src/main/scala/kyo/Cats.scala
@@ -34,7 +34,7 @@ object Cats:
                 .map { fiber =>
                     CatsIO.async[CatsIO[A]] { cb =>
                         CatsIO {
-                            fiber.unsafe.onComplete(r => cb(r.toEither))
+                            fiber.unsafe.onResult(r => cb(r.toEither))
                             Some(CatsIO(fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))).void)
                         }
                     }

--- a/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
+++ b/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
@@ -91,7 +91,7 @@ class CatsTest extends Test:
                     _ <- f.cancel
                     r <- f.join
                 yield
-                    assert(cdl.await(10, TimeUnit.MILLISECONDS))
+                    assert(cdl.await(100, TimeUnit.MILLISECONDS))
                     assert(r.isCanceled)
                 end for
             }
@@ -104,7 +104,7 @@ class CatsTest extends Test:
                     _ <- f.interrupt(panic)
                     r <- f.getResult
                 yield
-                    assert(cdl.await(10, TimeUnit.MILLISECONDS))
+                    assert(cdl.await(100, TimeUnit.MILLISECONDS))
                     assert(r == panic)
                 end for
             }
@@ -121,7 +121,7 @@ class CatsTest extends Test:
                     _ <- f.cancel
                     r <- f.join
                 yield
-                    assert(cdl.await(10, TimeUnit.MILLISECONDS))
+                    assert(cdl.await(100, TimeUnit.MILLISECONDS))
                     assert(r.isCanceled)
                 end for
             }

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -321,7 +321,7 @@ object Async:
             def mapResult[E2, B](f: Result[E, A] => Result[E2, B])(using Frame): Fiber[E2, B] < IO =
                 IO {
                     val p = new IOPromise[E2, B](interrupts = self) with (Result[E, A] => Unit):
-                        def apply(r: Result[E, A]) = completeUnit(f(r))
+                        def apply(r: Result[E, A]) = completeUnit(Result(f(r)).flatten)
                     self.onResult(p)
                     p
                 }

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -65,7 +65,7 @@ private[kyo] class IOPromise[E, A](init: State[E, A]) extends Safepoint.Intercep
         @tailrec def interruptLoop(promise: IOPromise[E, A]): Boolean =
             promise.state match
                 case p: Pending[E, A] @unchecked =>
-                    promise.complete(p, error) || interruptLoop(promise)
+                    promise.interrupt(p, error) || interruptLoop(promise)
                 case l: Linked[E, A] @unchecked =>
                     interruptLoop(l.p)
                 case _ =>
@@ -113,7 +113,7 @@ private[kyo] class IOPromise[E, A](init: State[E, A]) extends Safepoint.Intercep
         becomeLoop(other.compress())
     end become
 
-    inline def onComplete(inline f: Result[E, A] => Unit): Unit =
+    inline def onResult(inline f: Result[E, A] => Unit): Unit =
         @tailrec def onCompleteLoop(promise: IOPromise[E, A]): Unit =
             promise.state match
                 case p: Pending[E, A] @unchecked =>
@@ -128,9 +128,16 @@ private[kyo] class IOPromise[E, A](init: State[E, A]) extends Safepoint.Intercep
                             given Frame = Frame.internal
                             Log.unsafe.error("uncaught exception", ex)
         onCompleteLoop(this)
-    end onComplete
+    end onResult
 
     protected def onComplete(): Unit = {}
+
+    final private def interrupt(p: Pending[E, A], v: Panic): Boolean =
+        cas(p, v) && {
+            onComplete()
+            p.flushInterrupt(v)
+            true
+        }
 
     final private def complete(p: Pending[E, A], v: Result[E, A]): Boolean =
         cas(p, v) && {
@@ -179,7 +186,7 @@ private[kyo] class IOPromise[E, A](init: State[E, A]) extends Safepoint.Intercep
                                 result
                         end apply
                     end state
-                    onComplete(state)
+                    onResult(state)
                     state()
                 case l: Linked[E, A] @unchecked =>
                     blockLoop(l.p)
@@ -210,12 +217,16 @@ private[kyo] object IOPromise extends IOPromisePlatformSpecific:
         self =>
 
         def waiters: Int
+        def interrupt(v: Panic): Pending[E, A]
         def run(v: Result[E, A]): Pending[E, A]
 
         @nowarn("msg=anonymous")
         inline def add(inline f: Result[E, A] => Unit): Pending[E, A] =
             new Pending[E, A]:
                 def waiters: Int = self.waiters + 1
+                def interrupt(v: Panic) =
+                    f(v)
+                    self
                 def run(v: Result[E, A]) =
                     try f(v)
                     catch
@@ -228,11 +239,15 @@ private[kyo] object IOPromise extends IOPromisePlatformSpecific:
 
         final def interrupts(p: IOPromise[?, ?]): Pending[E, A] =
             new Pending[E, A]:
+                def interrupt(panic: Panic): Pending[E, A] =
+                    p.interrupt(panic)
+                    self
                 def waiters: Int = self.waiters + 1
                 def run(v: Result[E, A]) =
                     self
 
         final def merge(tail: Pending[E, A]): Pending[E, A] =
+
             @tailrec def runLoop(p: Pending[E, A], v: Result[E, A]): Pending[E, A] =
                 p match
                     case _ if (p eq Pending.Empty) =>
@@ -240,10 +255,28 @@ private[kyo] object IOPromise extends IOPromisePlatformSpecific:
                     case p: Pending[E, A] =>
                         runLoop(p.run(v), v)
 
+            @tailrec def interruptLoop(p: Pending[E, A], panic: Panic): Pending[E, A] =
+                p match
+                    case _ if (p eq Pending.Empty) =>
+                        self
+                    case p: Pending[E, A] =>
+                        interruptLoop(p.interrupt(panic), panic)
+
             new Pending[E, A]:
-                def waiters: Int         = self.waiters + 1
-                def run(v: Result[E, A]) = runLoop(self, v)
+                def waiters: Int            = self.waiters + 1
+                def interrupt(panic: Panic) = interruptLoop(self, panic)
+                def run(v: Result[E, A])    = runLoop(self, v)
+            end new
         end merge
+
+        final def flushInterrupt(v: Panic): Unit =
+            @tailrec def flushInterruptLoop(p: Pending[E, A]): Unit =
+                p match
+                    case _ if (p eq Pending.Empty) => ()
+                    case p: Pending[E, A] =>
+                        flushInterruptLoop(p.interrupt(v))
+            flushInterruptLoop(this)
+        end flushInterrupt
 
         final def flush(v: Result[E, A]): Unit =
             @tailrec def flushLoop(p: Pending[E, A]): Unit =
@@ -260,6 +293,8 @@ private[kyo] object IOPromise extends IOPromisePlatformSpecific:
         def apply[E, A](): Pending[E, A] = Empty.asInstanceOf[Pending[E, A]]
         case object Empty extends Pending[Nothing, Nothing]:
             def waiters: Int                     = 0
+            def interrupt(v: Panic)              = this
             def run(v: Result[Nothing, Nothing]) = this
+        end Empty
     end Pending
 end IOPromise

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -54,7 +54,7 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
                                 this.ensures = Ensures.empty
                                 val trace = this.trace
                                 this.trace = null.asInstanceOf[Trace]
-                                input.onComplete { r =>
+                                input.onResult { r =>
                                     val task = IOTask(IO(cont(r.asInstanceOf[Result[Nothing, C]])), trace, context, ensures, runtime)
                                     this.becomeUnit(task)
                                 }

--- a/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
@@ -1,0 +1,294 @@
+package kyo.scheduler
+
+import kyo.*
+import org.scalatest.compatible.Assertion
+import scala.annotation.tailrec
+import scala.concurrent.duration.*
+
+class IOPromiseTest extends Test:
+
+    "complete" - {
+        "success" in {
+            val p = new IOPromise[Nothing, Int]()
+            assert(p.complete(Result.success(1)))
+            assert(p.done())
+            assert(p.block(timeout.toMillis) == Result.success(1))
+        }
+
+        "failure" in {
+            val ex = new Exception("Test exception")
+            val p  = new IOPromise[Exception, Int]()
+            assert(p.complete(Result.fail(ex)))
+            assert(p.done())
+            assert(p.block(timeout.toMillis) == Result.fail(ex))
+        }
+
+        "complete twice" in {
+            val p = new IOPromise[Nothing, Int]()
+            assert(p.complete(Result.success(1)))
+            assert(!p.complete(Result.success(2)))
+            assert(p.done())
+            assert(p.block(timeout.toMillis) == Result.success(1))
+        }
+
+        "complete with null value" in {
+            val p = new IOPromise[Nothing, String]()
+            assert(p.complete(Result.success(null)))
+            assert(p.done())
+            assert(p.block(timeout.toMillis) == Result.success(null))
+        }
+
+        "complete with exception" in {
+            val p  = new IOPromise[Throwable, Int]()
+            val ex = new RuntimeException("Test")
+            assert(p.complete(Result.fail(ex)))
+            assert(p.done())
+            assert(p.block(timeout.toMillis) == Result.fail(ex))
+        }
+    }
+
+    "completeUnit" - {
+        "success" in {
+            val p = new IOPromise[Nothing, Int]()
+            p.completeUnit(Result.success(1))
+            assert(p.block(timeout.toMillis) == Result.success(1))
+        }
+
+        "completeUnit with failure" in {
+            val p  = new IOPromise[Exception, Int]()
+            val ex = new Exception("Test exception")
+            p.completeUnit(Result.fail(ex))
+            assert(p.block(timeout.toMillis) == Result.fail(ex))
+        }
+    }
+
+    "become" - {
+        "success" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+            assert(p2.complete(Result.success(42)))
+            assert(p1.become(p2))
+            assert(p1.done())
+            assert(p1.block(timeout.toMillis) == Result.success(42))
+        }
+
+        "failure" in {
+            val ex = new Exception("Test exception")
+            val p1 = new IOPromise[Exception, Int]()
+            val p2 = new IOPromise[Exception, Int]()
+            assert(p2.complete(Result.fail(ex)))
+            assert(p1.become(p2))
+            assert(p1.done())
+            assert(p1.block(timeout.toMillis) == Result.fail(ex))
+        }
+
+        "already completed" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+            assert(p1.complete(Result.success(42)))
+            assert(p2.complete(Result.success(99)))
+            assert(!p1.become(p2))
+            assert(p1.block(timeout.toMillis) == Result.success(42))
+        }
+
+        "become with incomplete promise" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+            assert(p1.become(p2))
+            p2.complete(Result.success(42))
+            assert(p1.done())
+            assert(p1.block(timeout.toMillis) == Result.success(42))
+        }
+
+        "become with chain of promises" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+            val p3 = new IOPromise[Nothing, Int]()
+            p1.become(p2)
+            p2.become(p3)
+            p3.complete(Result.success(42))
+            val v = p1.block(timeout.toMillis)
+            assert(v == Result.success(42))
+        }
+    }
+
+    "becomeUnit" - {
+        "success" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+            p2.complete(Result.success(42))
+            p1.becomeUnit(p2)
+            val v = p1.block(timeout.toMillis)
+            assert(v == Result.success(42))
+        }
+
+        "becomeUnit with incomplete promise" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+            p1.becomeUnit(p2)
+            p2.complete(Result.success(42))
+            val v = p1.block(timeout.toMillis)
+            assert(v == Result.success(42))
+        }
+    }
+
+    "interrupt" - {
+        "interrupt" in {
+            val p = new IOPromise[Nothing, Int]()
+            assert(p.interrupt(Result.Panic(new Exception("Interrupted"))))
+            assert(p.block(timeout.toMillis).isPanic)
+        }
+
+        "interrupt completed promise" in {
+            val p = new IOPromise[Nothing, Int]()
+            p.complete(Result.success(42))
+            assert(!p.interrupt(Result.Panic(new Exception("Interrupted"))))
+            assert(p.block(timeout.toMillis) == Result.success(42))
+        }
+
+        "interrupt chain of promises" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+            val p3 = new IOPromise[Nothing, Int]()
+            p1.become(p2)
+            p2.become(p3)
+            assert(p1.interrupt(Result.Panic(new Exception("Interrupted"))))
+            assert(p3.block(timeout.toMillis).isPanic)
+        }
+    }
+
+    "onResult" - {
+        "onResult" in {
+            val p      = new IOPromise[Nothing, Int]()
+            var called = false
+            p.onResult(_ => called = true)
+            p.complete(Result.success(42))
+            assert(called)
+        }
+
+        "onResult with multiple callbacks" in {
+            val p       = new IOPromise[Nothing, Int]()
+            var called1 = false
+            var called2 = false
+            p.onResult(_ => called1 = true)
+            p.onResult(_ => called2 = true)
+            p.complete(Result.success(42))
+            assert(called1 && called2)
+        }
+
+        "onResult with exception in callback" in {
+            val p      = new IOPromise[Nothing, Int]()
+            var called = false
+            p.onResult(_ => throw new RuntimeException("Test"))
+            p.onResult(_ => called = true)
+            p.complete(Result.success(42))
+            assert(called)
+        }
+    }
+
+    "block" - {
+        "immediate completion" in {
+            val p = new IOPromise[Nothing, Int]()
+            p.complete(Result.success(42))
+            val result = p.block(timeout.toMillis)
+            assert(result == Result.success(42))
+        }
+
+        "timeout" in runJVM {
+            val p      = new IOPromise[Nothing, Int]()
+            val result = p.block(java.lang.System.currentTimeMillis() + 10)
+            assert(result.isFail)
+        }
+
+        "block with very short timeout" in runJVM {
+            val p      = new IOPromise[Nothing, Int]()
+            val result = p.block(java.lang.System.currentTimeMillis() + 1)
+            assert(result.isFail)
+        }
+    }
+
+    "stack safety" - {
+        "deeply nested become calls" in {
+            def createNestedPromises(depth: Int): IOPromise[Nothing, Int] =
+                @tailrec def loop(currentDepth: Int, promise: IOPromise[Nothing, Int]): IOPromise[Nothing, Int] =
+                    if currentDepth == 0 then
+                        promise.complete(Result.success(42))
+                        promise
+                    else
+                        val newPromise = new IOPromise[Nothing, Int]()
+                        promise.become(newPromise)
+                        loop(currentDepth - 1, newPromise)
+                loop(depth, new IOPromise[Nothing, Int]())
+            end createNestedPromises
+
+            val deeplyNested = createNestedPromises(10000)
+            assert(deeplyNested.block(timeout.toMillis) == Result.success(42))
+        }
+
+        "long chain of onResult callbacks" in {
+            val p     = new IOPromise[Nothing, Int]()
+            var count = 0
+            def addCallback(remaining: Int): Unit =
+                if remaining > 0 then
+                    p.onResult(_ => count += 1)
+                    addCallback(remaining - 1)
+            addCallback(10000)
+            p.complete(Result.success(42))
+            assert(count == 10000)
+        }
+    }
+
+    "interrupts" - {
+        "interrupt linked promise via interrupts" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+
+            p1.interrupts(p2)
+
+            assert(p1.interrupt(Result.Panic(new Exception("Interrupted p1"))))
+
+            assert(p1.block(timeout.toMillis).isPanic)
+            assert(p2.block(timeout.toMillis).isPanic)
+        }
+
+        "interrupt linked chain promises via interrupts" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+            val p3 = new IOPromise[Nothing, Int]()
+
+            p1.interrupts(p2)
+            p2.interrupts(p3)
+
+            assert(p1.interrupt(Result.Panic(new Exception("Interrupted p1"))))
+
+            assert(p1.block(timeout.toMillis).isPanic)
+            assert(p2.block(timeout.toMillis).isPanic)
+            assert(p3.block(timeout.toMillis).isPanic)
+        }
+
+        "interrupt multiple promises via single interrupts" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+            val p3 = new IOPromise[Nothing, Int]()
+
+            p1.interrupts(p2)
+            p1.interrupts(p3)
+
+            assert(p1.interrupt(Result.Panic(new Exception("Interrupted p1"))))
+
+            assert(p1.block(timeout.toMillis).isPanic)
+            assert(p2.block(timeout.toMillis).isPanic)
+            assert(p3.block(timeout.toMillis).isPanic)
+        }
+
+        "ensure interruptions do not propagate without linking" in {
+            val p1 = new IOPromise[Nothing, Int]()
+            val p2 = new IOPromise[Nothing, Int]()
+
+            assert(p1.interrupt(Result.Panic(new Exception("Interrupted p1"))))
+            assert(p1.block(timeout.toMillis).isPanic)
+            assert(!p2.done())
+        }
+    }
+
+end IOPromiseTest

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -56,7 +56,7 @@ class KyoSttpMonad extends MonadAsyncError[M]:
                     case Left(t)  => discard(p.complete(Result.panic(t)))
                     case Right(t) => discard(p.complete(Result.success(t)))
                 }
-            p.onComplete { r =>
+            p.onResult { r =>
                 if r.isPanic then
                     canceller.cancel()
             }

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -78,7 +78,7 @@ object ZIOs:
                     [C] => (input, cont) => input.flatMap(r => run(cont(r)).flatten)
                 ).pipe(Async.run).map { fiber =>
                     ZIO.asyncInterrupt[Any, E, A] { cb =>
-                        fiber.unsafe.onComplete {
+                        fiber.unsafe.onResult {
                             case Result.Fail(ex)   => cb(Exit.fail(ex))
                             case Result.Panic(ex)  => cb(Exit.die(ex))
                             case Result.Success(v) => cb(v)

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -116,7 +116,7 @@ class ZIOsTest extends Test:
                     _ <- f.interrupt
                     r <- f.await
                 yield
-                    assert(cdl.await(10, TimeUnit.MILLISECONDS))
+                    assert(cdl.await(100, TimeUnit.MILLISECONDS))
                     assert(r.isFailure)
                 end for
             }
@@ -128,7 +128,7 @@ class ZIOsTest extends Test:
                     _ <- f.interrupt(Result.Panic(new Exception))
                     r <- f.getResult
                 yield
-                    assert(cdl.await(10, TimeUnit.MILLISECONDS))
+                    assert(cdl.await(100, TimeUnit.MILLISECONDS))
                     assert(r.isPanic)
                 end for
             }
@@ -145,7 +145,7 @@ class ZIOsTest extends Test:
                     _ <- f.interrupt
                     r <- f.await
                 yield
-                    assert(cdl.await(10, TimeUnit.MILLISECONDS))
+                    assert(cdl.await(100, TimeUnit.MILLISECONDS))
                     assert(r.isFailure)
                 end for
             }


### PR DESCRIPTION
I noticed that https://github.com/getkyo/kyo/pull/666 missed tests for `fiber.mapResult` and, when I added them, it reproduced a bug. I've also introduced added a new `IOPromiseTest` that was missing, which also uncovered a bug with `interrupts`.