### PR TITLE
prelude: eliminate Abort[Nothing] for panic (#689)

### DIFF
--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -252,7 +252,7 @@ class AsyncTest extends Test:
             val ex = new Exception
             Async.race(
                 Async.sleep(1.milli).andThen(42),
-                Abort.panic[Exception](ex)
+                Abort.panic(ex)
             ).map { r =>
                 assert(r == 42)
             }
@@ -262,10 +262,10 @@ class AsyncTest extends Test:
             val ex2 = new Exception
             val race =
                 Async.race(
-                    Async.sleep(1.milli).andThen(Abort.panic[Int](ex1)),
-                    Abort.panic[Int](ex2)
+                    Async.sleep(1.milli).andThen(Abort.panic(ex1)),
+                    Abort.panic(ex2)
                 )
-            Abort.run(race).map {
+            Async.run(race).map(_.getResult).map {
                 r => assert(r == Result.panic(ex1))
             }
         }

--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -30,7 +30,8 @@ object Abort:
       * @return
       *   A computation that immediately fails with the given value
       */
-    inline def fail[E](inline value: E)(using inline frame: Frame): Nothing < Abort[E] = error(Fail(value))
+    inline def fail[E](inline value: E)(using inline frame: Frame): Nothing < Abort[E] =
+        error(Fail(value))
 
     /** Fails the computation with a panic value (unchecked exception).
       *
@@ -39,7 +40,8 @@ object Abort:
       * @return
       *   A computation that immediately fails with the given exception
       */
-    inline def panic[E](inline ex: Throwable)(using inline frame: Frame): Nothing < Abort[E] = error(Panic(ex))
+    inline def panic(inline ex: Throwable)(using inline frame: Frame): Nothing < Any =
+        Reducible.eliminate[Abort[Nothing]](error(Panic(ex)))
 
     inline def error[E](inline e: Error[E])(using inline frame: Frame): Nothing < Abort[E] =
         ArrowEffect.suspendMap[Any](erasedTag[E], e)(_ => ???)


### PR DESCRIPTION
Fixes #689.