### PR TITLE
Run abort nothing workaround

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -9,7 +9,6 @@ import kyo.kernel.Effect
 import kyo.kernel.Reducible
 import scala.annotation.targetName
 import scala.reflect.ClassTag
-import scala.util.NotGiven
 
 /** The Abort effect allows for short-circuiting computations with failure values. This effect is used for handling errors and early
   * termination scenarios in a functional manner and handle thrown exceptions.

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -189,10 +189,17 @@ class AbortsTest extends Test:
                         Result.fail(ex1)
                 )
             }
-            "panic" in {
+            "throw" in {
                 val p = new Exception
                 assert(
                     Abort.run[Ex1](throw p).eval ==
+                        Result.panic(p)
+                )
+            }
+            "panic" in {
+                val p = new Exception
+                assert(
+                    Abort.run(Abort.panic[Nothing](p)).eval ==
                         Result.panic(p)
                 )
             }


### PR DESCRIPTION
A bit of a crazy workaround to the ambiguous overload in the other version here: https://github.com/getkyo/kyo/pull/691/files#r1775045877

I suspect that this isn't worth the overhead but interested to hear what others think.