### PR TITLE
build: enable nonunit-statement compiler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ Replace `<version>` with the latest version: ![Version](https://img.shields.io/m
 
 Kyo utilizes features from the latest Scala 3 versions that are not yet properly supported by IntelliJ IDEA. For the best development experience and to ensure all Kyo features are correctly recognized, we recommend using a [Metals-based](https://scalameta.org/metals/) IDE for your Kyo projects.
 
+### Recommended Compiler Flags
+
+We strongly recommend enabling two Scala compiler flags when working with Kyo:
+
+1. `-Wvalue-discard`: Warns when non-Unit expression results are unused.
+2. `-Wnonunit-statement`: Warns when non-Unit expressions are used in statement position.
+
+Add these to your `build.sbt`:
+
+```scala 
+scalacOptions ++= Seq("-Wvalue-discard", "-Wnonunit-statement")
+```
+
+These flags help catch unintended effect discards, enforce proper effect sequencing, and prevent subtle bugs in Kyo applications.
+
+Note: In test code, you might want to selectively disable these warnings, as tests often assert side effects without using returned values.
+
 ### The "Pending" type: `<`
 
 In Kyo, computations are expressed via the infix type `<`, known as "Pending". It takes two type parameters:

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ val compilerOptions = Set(
     ScalacOptions.unchecked,
     ScalacOptions.deprecation,
     ScalacOptions.warnValueDiscard,
+    ScalacOptions.warnNonUnitStatement,
     ScalacOptions.languageStrictEquality,
     ScalacOptions.release("11"),
     ScalacOptions.advancedKindProjector
@@ -49,6 +50,7 @@ lazy val `kyo-settings` = Seq(
     scalaVersion       := scala3Version,
     crossScalaVersions := List(scala3Version),
     scalacOptions ++= scalacOptionTokens(compilerOptions).value,
+    Test / scalacOptions --= scalacOptionTokens(Set(ScalacOptions.warnNonUnitStatement)).value,
     scalafmtOnCompile := true,
     Test / testOptions += Tests.Argument("-oDG"),
     ThisBuild / versionScheme               := Some("early-semver"),
@@ -460,6 +462,7 @@ lazy val readme =
             `kyo-settings`,
             mdocIn  := new File("./../../README-in.md"),
             mdocOut := new File("./../../README-out.md"),
+            scalacOptions --= scalacOptionTokens(Set(ScalacOptions.warnNonUnitStatement)).value,
             rewriteReadmeFile := {
                 val readmeFile       = new File("README.md")
                 val targetReadmeFile = new File("target/README-in.md")

--- a/kyo-bench/src/main/scala/kyo/bench/ForkChainedBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForkChainedBench.scala
@@ -65,7 +65,7 @@ class ForkChainedBench extends Bench.ForkOnly(0):
 
         scoped {
             val p = new CompletableFuture[Unit]()
-            fork(iterate(p, depth))
+            discard(fork(iterate(p, depth)))
             p.get()
         }
     end forkOx

--- a/kyo-bench/src/main/scala/kyo/bench/TagsBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TagsBench.scala
@@ -17,36 +17,36 @@ class TagsBench extends Bench(()):
     @Benchmark
     def syncKyo() =
         import kyo.*
-        Tag[String] =:= Tag[String]
-        Tag[Int] <:< Tag[Any]
-        Tag[Sub1] <:< Tag[Super]
-        Tag[Super] <:< Tag[Sub2]
-        Tag[Test1[Sub1]] <:< Tag[Test1[Super]]
-        Tag[Test2[Super]] <:< Tag[Test2[Sub1]]
-        Tag[Test3[String, Int]] =:= Tag[Test3[String, Int]]
-        Tag[Test4[Super, Super]] <:< Tag[Test4[Sub1, Sub2]]
-        Tag[Test5[Sub1, String]] <:< Tag[Test5[Super, String]]
-        Tag[Test6[Int, String, Boolean, Double, Char]] =:= Tag[Test6[Int, String, Boolean, Double, Char]]
-        Tag[Test3[Test1[Sub1], Test2[Super]]] <:< Tag[Test3[Test1[Super], Test2[Sub1]]]
-        Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]] =:=
+        val _ = Tag[String] =:= Tag[String]
+        val _ = Tag[Int] <:< Tag[Any]
+        val _ = Tag[Sub1] <:< Tag[Super]
+        val _ = Tag[Super] <:< Tag[Sub2]
+        val _ = Tag[Test1[Sub1]] <:< Tag[Test1[Super]]
+        val _ = Tag[Test2[Super]] <:< Tag[Test2[Sub1]]
+        val _ = Tag[Test3[String, Int]] =:= Tag[Test3[String, Int]]
+        val _ = Tag[Test4[Super, Super]] <:< Tag[Test4[Sub1, Sub2]]
+        val _ = Tag[Test5[Sub1, String]] <:< Tag[Test5[Super, String]]
+        val _ = Tag[Test6[Int, String, Boolean, Double, Char]] =:= Tag[Test6[Int, String, Boolean, Double, Char]]
+        val _ = Tag[Test3[Test1[Sub1], Test2[Super]]] <:< Tag[Test3[Test1[Super], Test2[Sub1]]]
+        val _ = Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]] =:=
             Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]]
     end syncKyo
 
     @Benchmark
     def syncIzumi() =
         import izumi.reflect.*
-        Tag[String] =:= Tag[String]
-        Tag[Int] <:< Tag[Any]
-        Tag[Sub1] <:< Tag[Super]
-        Tag[Super] <:< Tag[Sub2]
-        Tag[Test1[Sub1]] <:< Tag[Test1[Super]]
-        Tag[Test2[Super]] <:< Tag[Test2[Sub1]]
-        Tag[Test3[String, Int]] =:= Tag[Test3[String, Int]]
-        Tag[Test4[Super, Super]] <:< Tag[Test4[Sub1, Sub2]]
-        Tag[Test5[Sub1, String]] <:< Tag[Test5[Super, String]]
-        Tag[Test6[Int, String, Boolean, Double, Char]] =:= Tag[Test6[Int, String, Boolean, Double, Char]]
-        Tag[Test3[Test1[Sub1], Test2[Super]]] <:< Tag[Test3[Test1[Super], Test2[Sub1]]]
-        Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]] =:=
+        val _ = Tag[String] =:= Tag[String]
+        val _ = Tag[Int] <:< Tag[Any]
+        val _ = Tag[Sub1] <:< Tag[Super]
+        val _ = Tag[Super] <:< Tag[Sub2]
+        val _ = Tag[Test1[Sub1]] <:< Tag[Test1[Super]]
+        val _ = Tag[Test2[Super]] <:< Tag[Test2[Sub1]]
+        val _ = Tag[Test3[String, Int]] =:= Tag[Test3[String, Int]]
+        val _ = Tag[Test4[Super, Super]] <:< Tag[Test4[Sub1, Sub2]]
+        val _ = Tag[Test5[Sub1, String]] <:< Tag[Test5[Super, String]]
+        val _ = Tag[Test6[Int, String, Boolean, Double, Char]] =:= Tag[Test6[Int, String, Boolean, Double, Char]]
+        val _ = Tag[Test3[Test1[Sub1], Test2[Super]]] <:< Tag[Test3[Test1[Super], Test2[Sub1]]]
+        val _ = Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]] =:=
             Tag[Test6[Test4[Super, Super], Test5[Sub1, String], Int, String, Boolean]]
     end syncIzumi
 

--- a/kyo-core/jvm/src/main/scala/kyo/Process.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Process.scala
@@ -167,7 +167,7 @@ object Process:
                         val builder = new ProcessBuilder(command*)
 
                         builder.redirectErrorStream(redirectErrorStream)
-                        cwd.map(p => builder.directory(p.toFile()))
+                        cwd.foreach(p => builder.directory(p.toFile()))
 
                         if env.nonEmpty then
                             builder.environment().putAll(env.asJava)

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -258,13 +258,13 @@ object Channel:
                                         takes.poll() match
                                             case null =>
                                             case p =>
-                                                p.complete(c)
+                                                p.completeUnit(c)
                                                 dropTakes()
                                     def dropPuts(): Unit =
                                         puts.poll() match
                                             case null => ()
                                             case (_, p) =>
-                                                p.complete(c)
+                                                p.completeUnit(c)
                                                 dropPuts()
                                     dropTakes()
                                     dropPuts()

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -248,7 +248,7 @@ object Queue:
                     def empty()  = u.empty()
                     def full()   = false
                     def offer(v: A) =
-                        u.offer(v)
+                        discard(u.offer(v))
                         true
                     def poll() = u.poll()
                     def peek() = u.peek()
@@ -280,7 +280,7 @@ object Queue:
                             val u = q.unsafe
                             if u.offer(v) then ()
                             else
-                                u.poll()
+                                discard(u.poll())
                                 loop(v)
                             end if
                         end loop

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
@@ -23,7 +23,7 @@ object Log:
         val cfg = await(Env.get[DB.Config])
         val q   = await(Queue.initUnbounded[Entry](Access.MultiProducerSingleConsumer))
         val log = await(IO(Live(cfg.workingDir + "/log.dat", q)))
-        await(Async.run(log.flushLoop(cfg.flushInterval)))
+        val _   = await(Async.run(log.flushLoop(cfg.flushInterval)))
         log
     }
 

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Reducible.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Reducible.scala
@@ -2,7 +2,7 @@ package kyo.kernel
 
 sealed trait Reducible[S]:
     type SReduced
-    def apply[A, S1](value: A < (S1 & S)): A < (S1 & SReduced)
+    private[kyo] def apply[A, S1](value: A < (S1 & S)): A < (S1 & SReduced)
 
 sealed trait LowPriorityReducibles:
     inline given irreducible[S]: Reducible.Aux[S, S] =

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Queue.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Queue.scala
@@ -73,26 +73,27 @@ final private class Queue[A](implicit ord: Ordering[A]) extends AtomicBoolean {
 
     def stealingBy(to: Queue[A]): A = {
         var t: A = null.asInstanceOf[A]
-        !isEmpty() && tryLock() && {
-            try {
-                !isEmpty() && to.isEmpty() && to.tryLock() && {
-                    try {
-                        t = queue.dequeue()
-                        val s = size() - 1
-                        var i = s - Math.ceil(s.toDouble / 2).intValue()
-                        items -= i + 1
-                        to.items += i
-                        while (i > 0) {
-                            to.queue += queue.dequeue()
-                            i -= 1
-                        }
-                        true
-                    } finally
-                        to.unlock()
-                }
-            } finally
-                unlock()
-        }
+        val _ =
+            !isEmpty() && tryLock() && {
+                try {
+                    !isEmpty() && to.isEmpty() && to.tryLock() && {
+                        try {
+                            t = queue.dequeue()
+                            val s = size() - 1
+                            var i = s - Math.ceil(s.toDouble / 2).intValue()
+                            items -= i + 1
+                            to.items += i
+                            while (i > 0) {
+                                to.queue += queue.dequeue()
+                                i -= 1
+                            }
+                            true
+                        } finally
+                            to.unlock()
+                    }
+                } finally
+                    unlock()
+            }
         t
     }
 

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Regulator.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Regulator.scala
@@ -76,8 +76,8 @@ abstract class Regulator(
     }
 
     def stop(): Unit = {
-        collectTask.cancel()
-        val _ = regulateTask.cancel()
+        val ign = collectTask.cancel()
+        val _   = regulateTask.cancel()
     }
 
     protected val statsScope = kyo.scheduler.statsScope.scope("regulator", getClass.getSimpleName().toLowerCase())

--- a/kyo-stats-otel/shared/src/main/scala/kyo/stats/otel/OTelTraceReceiver.scala
+++ b/kyo-stats-otel/shared/src/main/scala/kyo/stats/otel/OTelTraceReceiver.scala
@@ -24,9 +24,11 @@ class OTelTraceReceiver extends TraceReceiver {
                 otel.getTracer(scope.mkString("_"))
                     .spanBuilder(name)
                     .setAllAttributes(OTelAttributes(attributes))
-            parent.collect {
-                case Span(SpanImpl(c)) =>
-                    b.setParent(c)
+            discard {
+                parent.collect {
+                    case Span(SpanImpl(c)) =>
+                        b.setParent(c)
+                }
             }
             Span(SpanImpl(b.startSpan().storeInContext(Context.current())))
         }

--- a/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServer.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServer.scala
@@ -86,7 +86,7 @@ case class NettyKyoServer(
                 IO.run(Async.run(block())).eval
         val future = IO.run(fiber.toFuture).eval
         val cancel = () =>
-            IO.run(fiber.interrupt).eval
+            val _ = IO.run(fiber.interrupt).eval
             Future.unit
         (future, cancel)
     end unsafeRunAsync


### PR DESCRIPTION
The compiler needs this other flag to detect the issue discussed in https://github.com/getkyo/kyo/pull/685. I've fixed the warnings and didn't notice bugs besides the expected ones in `Async.scala`