### PR TITLE
prelude: support handling Abort[Nothing]

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -20,8 +20,9 @@ sealed trait Abort[-E] extends ArrowEffect[Const[Error[E]], Const[Unit]]
 
 object Abort:
 
+    import internal.*
+
     given eliminateAbort: Reducible.Eliminable[Abort[Nothing]] with {}
-    private inline def erasedTag[E]: Tag[Abort[E]] = Tag[Abort[Any]].asInstanceOf[Tag[Abort[E]]]
 
     /** Fails the computation with the given value.
       *
@@ -161,11 +162,11 @@ object Abort:
           */
         def apply[A: Flat, S, ER](v: => A < (Abort[E | ER] & S))(
             using
-            ct: ClassTag[E],
-            tag: Tag[E],
             frame: Frame,
+            abortable: Abortable[E],
             reduce: Reducible[Abort[ER]]
         ): Result[E, A] < (S & reduce.SReduced) =
+            given ct: ClassTag[E] = abortable.classTag
             reduce {
                 ArrowEffect.handle.catching[
                     Const[Error[E]],
@@ -194,11 +195,12 @@ object Abort:
                         case fail => Result.panic(fail)
                 )
             }
+        end apply
     end RunOps
 
     /** Runs an Abort effect. This operation handles the Abort effect, converting it into a Result type.
       */
-    inline def run[E >: Nothing]: RunOps[E] = RunOps(())
+    inline def run[E]: RunOps[E] = RunOps(())
 
     final class CatchingOps[E <: Throwable](dummy: Unit) extends AnyVal:
         /** Catches exceptions of type E and converts them to Abort failures.
@@ -226,5 +228,17 @@ object Abort:
     /** Catches exceptions and converts them to Abort failures. This is useful for integrating exception-based code with the Abort effect.
       */
     inline def catching[E <: Throwable]: CatchingOps[E] = CatchingOps(())
+
+    object internal:
+        final case class Abortable[E] private (classTag: ClassTag[E]) extends AnyVal
+
+        object Abortable:
+            inline given Abortable[Nothing] = Abortable[Nothing](ClassTag.Nothing)
+            inline given [E](using inline ct: ClassTag[E], inline tag: Tag[E]): Abortable[E] =
+                Abortable[E](ct)
+        end Abortable
+
+        private[Abort] inline def erasedTag[E]: Tag[Abort[E]] = Tag[Abort[Any]].asInstanceOf[Tag[Abort[E]]]
+    end internal
 
 end Abort

--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -234,6 +234,12 @@ object Abort:
 
         object Abortable:
             inline given Abortable[Nothing] = Abortable[Nothing](ClassTag.Nothing)
+
+            // The `tag` parameter is used to disallow handling multiple aborts at once
+            // like `Abort.run[Int | String]`, which would make the compiler infer a
+            // `ClassTag[Any]` and incorrectly handle all aborts. The `tag` parameter
+            // is used as a workaround since the macro currently doesn't materialize
+            // tags for union types.
             inline given [E](using inline ct: ClassTag[E], inline tag: Tag[E]): Abortable[E] =
                 Abortable[E](ct)
         end Abortable

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -628,4 +628,39 @@ class AbortsTest extends Test:
         succeed
     }
 
+    "Abortable" - {
+        "handle Abort[Nothing]" in {
+            val computation: Int < Abort[Nothing] = Abort.panic(new RuntimeException("Panic!"))
+            val result                            = Abort.run(computation).eval
+            val _: Result[Nothing, Int]           = result
+            assert(result.isPanic)
+        }
+
+        "handle Abort[Nothing] with custom error type" in {
+            val computation: Int < Abort[Nothing] = Abort.panic(new RuntimeException("Panic!"))
+            val result                            = Abort.run[String](computation).eval
+            val _: Result[String, Int]            = result
+            assert(result.isPanic)
+        }
+
+        "allow handling of pure values" in {
+            val computation: Int < Abort[Nothing] = 42
+            val result                            = Abort.run(computation).eval
+            val _: Result[Nothing, Int]           = result
+            assert(result == Result.success(42))
+        }
+
+        "work with other effect" in {
+            val computation: Int < (Abort[Nothing] & Env[Int]) =
+                Env.use[Int](_ => Abort.panic(new RuntimeException("IO Panic!")))
+
+            val result =
+                Env.run(42)(Abort.run(computation)).eval
+
+            val _: Result[Nothing, Int] = result
+
+            assert(result.isPanic)
+        }
+    }
+
 end AbortsTest

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -629,18 +629,20 @@ class AbortsTest extends Test:
     }
 
     "Abortable" - {
+        val ex = new RuntimeException("Panic!")
+
         "handle Abort[Nothing]" in {
-            val computation: Int < Abort[Nothing] = Abort.panic(new RuntimeException("Panic!"))
+            val computation: Int < Abort[Nothing] = Abort.panic(ex)
             val result                            = Abort.run(computation).eval
             val _: Result[Nothing, Int]           = result
-            assert(result.isPanic)
+            assert(result == Result.panic(ex))
         }
 
         "handle Abort[Nothing] with custom error type" in {
-            val computation: Int < Abort[Nothing] = Abort.panic(new RuntimeException("Panic!"))
+            val computation: Int < Abort[Nothing] = Abort.panic(ex)
             val result                            = Abort.run[String](computation).eval
             val _: Result[String, Int]            = result
-            assert(result.isPanic)
+            assert(result == Result.panic(ex))
         }
 
         "allow handling of pure values" in {
@@ -652,14 +654,14 @@ class AbortsTest extends Test:
 
         "work with other effect" in {
             val computation: Int < (Abort[Nothing] & Env[Int]) =
-                Env.use[Int](_ => Abort.panic(new RuntimeException("IO Panic!")))
+                Env.use[Int](_ => Abort.panic(ex))
 
             val result =
                 Env.run(42)(Abort.run(computation)).eval
 
             val _: Result[Nothing, Int] = result
 
-            assert(result.isPanic)
+            assert(result == Result.panic(ex))
         }
     }
 


### PR DESCRIPTION
A solution for https://github.com/getkyo/kyo/issues/689 inspired by @steinybot's approach using a type class in https://github.com/getkyo/kyo/pull/692. I noticed that it's possible to simplify it by encoding only the necessary runtime information in the type class instead of the actual method implementation.