### PR TITLE
Upgrade Caliban to 2.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -313,9 +313,8 @@ lazy val `kyo-caliban` =
         .dependsOn(`kyo-sttp`)
         .settings(
             `kyo-settings`,
-            libraryDependencies += "com.github.ghostdogpr"       %% "caliban"        % "2.8.1",
-            libraryDependencies += "com.github.ghostdogpr"       %% "caliban-tapir"  % "2.8.1",
-            libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-zio" % "1.11.5" % Test
+            libraryDependencies += "com.github.ghostdogpr"       %% "caliban"        % "2.9.0",
+            libraryDependencies += "com.github.ghostdogpr"       %% "caliban-tapir"  % "2.9.0"
         )
 
 lazy val `kyo-test` =

--- a/kyo-caliban/src/main/scala/kyo/Resolvers.scala
+++ b/kyo-caliban/src/main/scala/kyo/Resolvers.scala
@@ -135,10 +135,7 @@ object Resolvers:
       * @return
       *   An HttpInterpreter wrapped in Resolvers effect
       */
-    def get[R](api: GraphQL[R])(using
-        requestCodec: JsonCodec[GraphQLRequest],
-        responseValueCodec: JsonCodec[ResponseValue]
-    )(using Frame): HttpInterpreter[R, CalibanError] < Resolvers =
+    def get[R](api: GraphQL[R])(using Frame): HttpInterpreter[R, CalibanError] < Resolvers =
         ZIOs.get(api.interpreter.map(HttpInterpreter(_)))
 
     private val rightUnit: Right[Nothing, Unit] = Right(())

--- a/kyo-caliban/src/test/scala/kyo/ResolversTest.scala
+++ b/kyo-caliban/src/test/scala/kyo/ResolversTest.scala
@@ -7,7 +7,6 @@ import caliban.schema.SchemaDerivation
 import scala.concurrent.Future
 import sttp.model.Uri
 import sttp.tapir.*
-import sttp.tapir.json.zio.*
 import sttp.tapir.server.netty.NettyConfig
 import sttp.tapir.server.netty.NettyKyoServer
 import zio.Task


### PR DESCRIPTION
`JsonCodec` from Tapir are no longer needed since it's now handled internally by Caliban.