### PR TITLE
new encoding for zio and cats-effect integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3105,8 +3105,8 @@ import kyo.*
 import cats.effect.IO as CatsIO
 import cats.effect.kernel.Outcome.Succeeded
 
-// Note how Cats includes the IO, Async, and Abort[Throwable] effects:
-val a: Int < (Abort[Throwable] & Async) =
+// Note how Cats includes the IO, Async, and Abort[Nothing] effects:
+val a: Int < (Abort[Nothing] & Async) =
     for
         v1 <- Cats.get(CatsIO.pure(21))
         v2 <- IO(21)
@@ -3115,7 +3115,7 @@ val a: Int < (Abort[Throwable] & Async) =
     yield v1 + v2 + v3
 
 // Using fibers from both libraries:
-val b: Int < (Abort[Throwable] & Async) =
+val b: Int < (Abort[Nothing] & Async) =
     for
         f1 <- Cats.get(CatsIO.pure(21).start)
         f2 <- Async.run(IO(21))
@@ -3124,7 +3124,7 @@ val b: Int < (Abort[Throwable] & Async) =
     yield v1 + v2
 
 // Transforming Cats Effect IO within Kyo computations:
-val c: Int < (Abort[Throwable] & Async) =
+val c: Int < (Abort[Nothing] & Async) =
     Cats.get(CatsIO.pure(21)).map(_ * 2)
 
 // Transforming Kyo effects within Cats Effect IO:

--- a/README.md
+++ b/README.md
@@ -3034,11 +3034,11 @@ import kyo.*
 import zio.*
 
 // Use the 'get' method to extract a 'ZIO' effect
-val a: Int < ZIOs =
+val a: Int < (Abort[Nothing] & Async) =
     ZIOs.get(ZIO.succeed(42))
 
 // 'get' also supports error handling with 'Abort'
-val b: Int < (Abort[String] & ZIOs) =
+val b: Int < (Abort[String] & Async) =
     ZIOs.get(ZIO.fail("error"))
 
 // Handle the 'ZIO' effect to obtain a 'ZIO' effect
@@ -3054,7 +3054,7 @@ import zio.*
 
 // Note how ZIO includes the
 // IO and Async effects
-val a: Int < ZIOs =
+val a: Int < (Abort[Nothing] & Async) =
     for
         v1 <- ZIOs.get(ZIO.succeed(21))
         v2 <- IO(21)
@@ -3062,7 +3062,7 @@ val a: Int < ZIOs =
     yield v1 + v2 + v3
 
 // Using fibers from both libraries
-val b: Int < ZIOs =
+val b: Int < (Abort[Nothing] & Async) =
     for
         f1 <- ZIOs.get(ZIO.succeed(21).fork)
         f2 <- Async.run(IO(21))
@@ -3071,7 +3071,7 @@ val b: Int < ZIOs =
     yield v1 + v2
 
 // Transforming ZIO effects within Kyo computations
-val c: Int < ZIOs =
+val c: Int < (Abort[Nothing] & Async) =
     ZIOs.get(ZIO.succeed(21)).map(_ * 2)
 
 // Transforming Kyo effects within ZIO effects
@@ -3090,7 +3090,7 @@ import kyo.*
 import cats.effect.IO as CatsIO
 
 // Use the 'get' method to extract a 'IO' effect from Cats Effect:
-val a: Int < Cats =
+val a: Int < (Abort[Throwable] & Async) =
     Cats.get(CatsIO.pure(42))
 
 // Handle the 'Cats' effect to obtain a 'CatsIO' effect:
@@ -3106,7 +3106,7 @@ import cats.effect.IO as CatsIO
 import cats.effect.kernel.Outcome.Succeeded
 
 // Note how Cats includes the IO, Async, and Abort[Throwable] effects:
-val a: Int < Cats =
+val a: Int < (Abort[Throwable] & Async) =
     for
         v1 <- Cats.get(CatsIO.pure(21))
         v2 <- IO(21)
@@ -3115,7 +3115,7 @@ val a: Int < Cats =
     yield v1 + v2 + v3
 
 // Using fibers from both libraries:
-val b: Int < Cats =
+val b: Int < (Abort[Throwable] & Async) =
     for
         f1 <- Cats.get(CatsIO.pure(21).start)
         f2 <- Async.run(IO(21))
@@ -3124,7 +3124,7 @@ val b: Int < Cats =
     yield v1 + v2
 
 // Transforming Cats Effect IO within Kyo computations:
-val c: Int < Cats =
+val c: Int < (Abort[Throwable] & Async) =
     Cats.get(CatsIO.pure(21)).map(_ * 2)
 
 // Transforming Kyo effects within Cats Effect IO:
@@ -3170,11 +3170,11 @@ import zio.Task
 case class Query(k: Int < Abort[Throwable]) derives Schema.SemiAuto
 val api = graphQL(RootResolver(Query(42)))
 
-val a: NettyKyoServerBinding < (ZIOs & Abort[CalibanError]) =
+val a: NettyKyoServerBinding < (Async & Abort[CalibanError]) =
     Resolvers.run { Resolvers.get(api) }
 
 // similarly to the tapir integration, you can also pass a `NettyKyoServer` explicitly
-val b: NettyKyoServerBinding < (ZIOs & Abort[CalibanError]) =
+val b: NettyKyoServerBinding < (Async & Abort[CalibanError]) =
     Resolvers.run(NettyKyoServer().port(9999)) { Resolvers.get(api) }
 
 // you can turn this into a ZIO as seen in the ZIO integration

--- a/README.md
+++ b/README.md
@@ -3110,7 +3110,6 @@ val a: Int < (Abort[Nothing] & Async) =
     for
         v1 <- Cats.get(CatsIO.pure(21))
         v2 <- IO(21)
-        _  <- Abort.when(v1 > 10)(new Exception)
         v3 <- Async.run(-42).map(_.get)
     yield v1 + v2 + v3
 

--- a/kyo-caliban/src/main/scala/kyo/Resolvers.scala
+++ b/kyo-caliban/src/main/scala/kyo/Resolvers.scala
@@ -20,7 +20,7 @@ import zio.ZIO
 import zio.stream.ZStream
 
 /** Effect for interacting with Caliban GraphQL resolvers. */
-opaque type Resolvers <: (Abort[CalibanError] & ZIOs) = Abort[CalibanError] & ZIOs
+opaque type Resolvers <: (Abort[CalibanError] & Async) = Abort[CalibanError] & Async
 
 object Resolvers:
 
@@ -38,7 +38,7 @@ object Resolvers:
       */
     def run[A, S](v: HttpInterpreter[Any, CalibanError] < (Resolvers & S))(
         using Frame
-    ): NettyKyoServerBinding < (ZIOs & Abort[CalibanError] & S) =
+    ): NettyKyoServerBinding < (Async & Abort[CalibanError] & S) =
         run[A, S](NettyKyoServer())(v)
 
     /** Runs a GraphQL server with a custom NettyKyoServer configuration.
@@ -54,7 +54,7 @@ object Resolvers:
       */
     def run[A, S](server: NettyKyoServer)(v: HttpInterpreter[Any, CalibanError] < (Resolvers & S))(
         using Frame
-    ): NettyKyoServerBinding < (ZIOs & Abort[CalibanError] & S) =
+    ): NettyKyoServerBinding < (Async & Abort[CalibanError] & S) =
         ZIOs.get(ZIO.runtime[Any]).map(runtime => run(server, runtime)(v))
 
     /** Runs a GraphQL server with a custom Runner.
@@ -74,7 +74,7 @@ object Resolvers:
         using
         tag: Tag[Runner[R]],
         frame: Frame
-    ): NettyKyoServerBinding < (ZIOs & Abort[CalibanError] & S) =
+    ): NettyKyoServerBinding < (Async & Abort[CalibanError] & S) =
         run[R, A, S](NettyKyoServer(), runner)(v)
 
     /** Runs a GraphQL server with a custom NettyKyoServer configuration and Runner.
@@ -96,7 +96,7 @@ object Resolvers:
         using
         tag: Tag[Runner[R]],
         frame: Frame
-    ): NettyKyoServerBinding < (ZIOs & Abort[CalibanError] & S) =
+    ): NettyKyoServerBinding < (Async & Abort[CalibanError] & S) =
         ZIOs.get(ZIO.runtime[Any]).map(runtime => run(server, runtime.withEnvironment(ZEnvironment(runner)))(v))
 
     /** Runs a GraphQL server with a custom NettyKyoServer configuration and Runtime.
@@ -115,7 +115,7 @@ object Resolvers:
     def run[R, A, S](
         server: NettyKyoServer,
         runtime: Runtime[R]
-    )(v: HttpInterpreter[R, CalibanError] < (Resolvers & S))(using Frame): NettyKyoServerBinding < (ZIOs & Abort[CalibanError] & S) =
+    )(v: HttpInterpreter[R, CalibanError] < (Resolvers & S))(using Frame): NettyKyoServerBinding < (Async & Abort[CalibanError] & S) =
         for
             interpreter <- v
             endpoints = interpreter.serverEndpoints[R, NoStreams](NoStreams).map(convertEndpoint(_, runtime))

--- a/kyo-caliban/src/main/scala/kyo/Schema.scala
+++ b/kyo-caliban/src/main/scala/kyo/Schema.scala
@@ -8,7 +8,7 @@ import zio.Task
 import zio.ZIO
 import zio.query.ZQuery
 
-given zioSchema[R, A: Flat, S](using ev: Schema[R, A], ev2: (A < S) <:< (A < (Abort[Throwable] & ZIOs))): Schema[R, A < S] =
+given zioSchema[R, A: Flat, S](using ev: Schema[R, A], ev2: (A < S) <:< (A < (Abort[Throwable] & Async))): Schema[R, A < S] =
     new Schema[R, A < S]:
         override def nullable: Boolean = ev.nullable
         override def canFail: Boolean  = ev.canFail

--- a/kyo-caliban/src/test/scala/kyo/ResolversTest.scala
+++ b/kyo-caliban/src/test/scala/kyo/ResolversTest.scala
@@ -26,8 +26,8 @@ class ResolverTest extends Test:
 
     case class Query(
         k1: Int < Abort[Throwable],
-        k2: Int < ZIOs,
-        k3: Int < (Abort[Throwable] & ZIOs),
+        k2: Int < Async,
+        k3: Int < (Abort[Throwable] & Async),
         k4: Int < IO,
         k5: Int < Async
     ) derives Schema.SemiAuto

--- a/kyo-cats/shared/src/main/scala/kyo/Cats.scala
+++ b/kyo-cats/shared/src/main/scala/kyo/Cats.scala
@@ -1,11 +1,10 @@
 package kyo
 
-import Cats.GetCatsIO
 import cats.effect.IO as CatsIO
 import kyo.kernel.*
+import kyo.scheduler.IOPromise
+import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
-
-opaque type Cats <: (Async & Abort[Throwable]) = GetCatsIO & Async & Abort[Throwable]
 
 object Cats:
 
@@ -16,31 +15,35 @@ object Cats:
       * @return
       *   A Kyo effect that, when run, will execute the cats.effect.IO
       */
-    def get[A](io: CatsIO[A])(using Frame): A < Cats =
-        ArrowEffect.suspendMap(Tag[GetCatsIO], io)(Abort.get(_))
+    def get[A](io: CatsIO[A])(using Frame): A < (Abort[Throwable] & Async) =
+        IO {
+            import cats.effect.unsafe.implicits.global
+            val p                = new IOPromise[Throwable, A]
+            val (result, cancel) = io.unsafeToFutureCancelable()
+            result.onComplete(t => p.complete(Result.fromTry(t)))(ExecutionContext.parasitic)
+            p.onInterrupt(_ => discard(cancel()))
+            Async.get(p)
+        }
+    end get
 
-    /** Runs a Kyo effect that uses Cats and converts it to a cats.effect.IO.
+    /** Interprets a Kyo computation to cats.effect.IO. Note that this method only accepts Abort[Throwable] and Async pending effects. Plase
+      * handle any other effects before calling this method.
       *
       * @param v
       *   The Kyo effect to run
       * @return
       *   A cats.effect.IO that, when run, will execute the Kyo effect
       */
-    def run[A](v: => A < Cats)(using frame: Frame): CatsIO[A] =
+    def run[A: Flat](v: => A < (Abort[Throwable] & Async))(using frame: Frame): CatsIO[A] =
         CatsIO.defer {
-            ArrowEffect.handle(Tag[GetCatsIO], v.map(CatsIO.pure))(
-                [C] => (input, cont) => input.attempt.flatMap(r => run(cont(r)).flatten)
-            ).pipe(Async.run)
-                .map { fiber =>
-                    CatsIO.async[CatsIO[A]] { cb =>
-                        CatsIO {
-                            fiber.unsafe.onComplete(r => cb(r.toEither))
-                            Some(CatsIO(fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))).void)
-                        }
+            Async.run(v).map { fiber =>
+                CatsIO.async[A] { cb =>
+                    CatsIO {
+                        fiber.unsafe.onComplete(r => cb(r.toEither))
+                        Some(CatsIO(fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))).void)
                     }
-                }.pipe(IO.run).eval.flatten
+                }
+            }.pipe(IO.run).eval
         }
     end run
-
-    sealed private[kyo] trait GetCatsIO extends ArrowEffect[CatsIO, Either[Throwable, *]]
 end Cats

--- a/kyo-cats/shared/src/main/scala/kyo/Cats.scala
+++ b/kyo-cats/shared/src/main/scala/kyo/Cats.scala
@@ -17,12 +17,12 @@ object Cats:
       * @return
       *   A Kyo effect that, when run, will execute the cats.effect.IO
       */
-    def get[A](io: CatsIO[A])(using Frame): A < (Abort[Nothing] & Async) =
+    def get[A](io: => CatsIO[A])(using Frame): A < (Abort[Nothing] & Async) =
         IO {
             import cats.effect.unsafe.implicits.global
             val p                = new IOPromise[Nothing, A]
-            val (result, cancel) = io.unsafeToFutureCancelable()
-            result.onComplete {
+            val (future, cancel) = io.unsafeToFutureCancelable()
+            future.onComplete {
                 case Success(v)  => p.complete(Result.success(v))
                 case Failure(ex) => p.complete(Result.panic(ex))
             }(ExecutionContext.parasitic)

--- a/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
+++ b/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
@@ -7,6 +7,7 @@ import cats.effect.unsafe.implicits.global
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kyo.*
+import kyo.debug.Debug
 import kyo.kernel.Platform
 import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.Eventually.*
@@ -18,7 +19,7 @@ class CatsTest extends Test:
     def runCatsIO[T](v: CatsIO[T]): Future[T] =
         v.unsafeToFuture()
 
-    def runKyo(v: => Assertion < (Abort[Throwable] & Cats)): Future[Assertion] =
+    def runKyo(v: => Assertion < (Abort[Throwable] & Async)): Future[Assertion] =
         Cats.run(v).unsafeToFuture()
 
     "Abort ordering" - {
@@ -59,71 +60,213 @@ class CatsTest extends Test:
         a.map(s => assert(s == "Nested"))
     }
 
-    "fibers" in runKyo {
-        for
-            v1 <- Cats.get(CatsIO.pure(1))
-            v2 <- Async.run(2).map(_.get)
-            v3 <- Cats.get(CatsIO.pure(3))
-        yield assert(v1 == 1 && v2 == 2 && v3 == 3)
+    "fibers" - {
+        "basic interop" in runKyo {
+            for
+                v1 <- Cats.get(CatsIO.pure(1))
+                v2 <- Async.run(2).map(_.get)
+                v3 <- Cats.get(CatsIO.pure(3))
+            yield assert(v1 == 1 && v2 == 2 && v3 == 3)
+        }
+
+        "nested Kyo in Cats" in runKyo {
+            Cats.get(CatsIO.defer {
+                val kyoComputation = Async.run(42).map(_.get)
+                Cats.run(kyoComputation)
+            }).map(v => assert(v == 42))
+        }
+
+        "nested Cats in Kyo" in runKyo {
+            val nestedCats = Cats.get(CatsIO.pure("nested"))
+            Async.run(nestedCats).map(_.get).map(s => assert(s == "nested"))
+        }
+
+        "complex nested pattern with parallel and race" in runKyo {
+            def kyoTask(i: Int): Int < (Abort[Nothing] & Async)    = Async.run(i * 2).map(_.get)
+            def catsTask(i: Int): Int < (Abort[Throwable] & Async) = Cats.get(CatsIO.pure(i + 1))
+
+            for
+                (v1, v2) <- Async.parallel(kyoTask(1), catsTask(2))
+                (v3, v4) <- Async.race(
+                    Async.parallel[Throwable, Int, Int, Any](kyoTask(v1), catsTask(v2)),
+                    Cats.get(CatsIO.pure((v1, v2)))
+                )
+                (v5, v6) <- Async.parallel(
+                    kyoTask(v3 + v4),
+                    Async.race[Throwable, Int, Any](catsTask(v1), kyoTask(v2))
+                )
+                result <- Cats.get(CatsIO.pure(v1 + v2 + v4 + v5))
+            yield assert(result >= 15 && result <= 30)
+            end for
+        }
     }
 
     "interrupts" - {
 
-        def kyoLoop(cdl: CountDownLatch): Unit < IO =
-            def loop(): Unit < IO =
-                IO(()).flatMap(_ => loop())
-            IO.ensure(IO(cdl.countDown()))(loop())
+        def kyoLoop(started: CountDownLatch, done: CountDownLatch): Unit < IO =
+            def loop(i: Int): Unit < IO =
+                IO {
+                    if i == 0 then
+                        IO(started.countDown()).andThen(loop(i + 1))
+                    else
+                        loop(i + 2)
+                }
+            IO.ensure(IO(done.countDown()))(loop(0))
         end kyoLoop
 
-        def catsLoop(cdl: CountDownLatch): CatsIO[Unit] =
-            def loop(): CatsIO[Unit] =
-                CatsIO.unit.flatMap(_ => loop())
-            loop().guarantee(CatsIO(cdl.countDown()))
+        def catsLoop(started: CountDownLatch, done: CountDownLatch): CatsIO[Unit] =
+            def loop(i: Int): CatsIO[Unit] =
+                CatsIO.defer {
+                    if i == 0 then
+                        CatsIO(started.countDown())
+                            .flatMap(_ => loop(i + 1))
+                    else
+                        loop(i + 1)
+                }
+            loop(0).guarantee(CatsIO(done.countDown()))
         end catsLoop
 
         if Platform.isJVM then
 
-            "cats to kyo" in runCatsIO {
-                pending
-                val cdl = new CountDownLatch(1)
-                for
-                    f <- Cats.run(kyoLoop(cdl)).start
-                    _ <- f.cancel
-                    r <- f.join
-                yield
-                    assert(cdl.await(100, TimeUnit.MILLISECONDS))
-                    assert(r.isCanceled)
-                end for
-            }
-            "kyo to cats" in runKyo {
-                pending
-                val cdl   = new CountDownLatch(1)
-                val panic = Result.Panic(new Exception)
-                for
-                    f <- Async.run(Cats.run(catsLoop(cdl)))
-                    _ <- f.interrupt(panic)
-                    r <- f.getResult
-                yield
-                    assert(cdl.await(100, TimeUnit.MILLISECONDS))
-                    assert(r == panic)
-                end for
-            }
-            "both" in runCatsIO {
-                pending
-                val cdl = new CountDownLatch(1)
-                val v =
+            "runCatsIO" - {
+                "cats to kyo" in runCatsIO {
+                    val started = new CountDownLatch(1)
+                    val done    = new CountDownLatch(1)
                     for
-                        _ <- Cats.get(catsLoop(cdl))
-                        _ <- Async.run(kyoLoop(cdl))
-                    yield ()
-                for
-                    f <- Cats.run(v).start
-                    _ <- f.cancel
-                    r <- f.join
-                yield
-                    assert(cdl.await(100, TimeUnit.MILLISECONDS))
-                    assert(r.isCanceled)
-                end for
+                        f <- Cats.run(kyoLoop(started, done)).start
+                        _ <- CatsIO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- f.cancel
+                        r <- f.join
+                        _ <- CatsIO(done.await(100, TimeUnit.MILLISECONDS))
+                    yield assert(r.isCanceled)
+                    end for
+                }
+
+                "both" in runCatsIO {
+                    val started = new CountDownLatch(2)
+                    val done    = new CountDownLatch(2)
+                    val v =
+                        for
+                            _ <- Cats.get(catsLoop(started, done))
+                            _ <- Async.run(kyoLoop(started, done))
+                        yield ()
+                    for
+                        f <- Cats.run(v).start
+                        _ <- CatsIO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- f.cancel
+                        r <- f.join
+                        _ <- CatsIO(done.await(100, TimeUnit.MILLISECONDS))
+                    yield assert(r.isCanceled)
+                    end for
+                }
+
+                "parallel loops" in runCatsIO {
+                    val started = new CountDownLatch(2)
+                    val done    = new CountDownLatch(2)
+                    def parallelEffect =
+                        Cats.run {
+                            val loop1 = Cats.get(catsLoop(started, done))
+                            val loop2 = kyoLoop(started, done)
+                            Async.parallel[Throwable, Unit, Unit, Any](loop1, loop2)
+                        }
+                    for
+                        f <- parallelEffect.start
+                        _ <- CatsIO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- f.cancel
+                        r <- f.join
+                        _ <- CatsIO(done.await(100, TimeUnit.MILLISECONDS))
+                    yield assert(r.isCanceled)
+                    end for
+                }
+
+                "race loops" in runCatsIO {
+                    val started = new CountDownLatch(2)
+                    val done    = new CountDownLatch(2)
+                    def raceEffect =
+                        Cats.run {
+                            val loop1 = Cats.get(catsLoop(started, done))
+                            val loop2 = kyoLoop(started, done)
+                            Async.race[Throwable, Unit, Any](loop1, loop2)
+                        }
+                    for
+                        f <- raceEffect.start
+                        _ <- CatsIO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- f.cancel
+                        r <- f.join
+                        _ <- CatsIO(done.await(100, TimeUnit.MILLISECONDS))
+                    yield assert(r.isCanceled)
+                    end for
+                }
+            }
+
+            "runKyo" - {
+                "kyo to cats" in runKyo {
+                    val started = new CountDownLatch(1)
+                    val done    = new CountDownLatch(1)
+                    val panic   = Result.Panic(new Exception)
+                    for
+                        f <- Async.run(Cats.get(catsLoop(started, done)))
+                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- f.interrupt(panic)
+                        r <- f.getResult
+                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                    yield assert(r == panic)
+                    end for
+                }
+
+                "both" in runKyo {
+                    val started = new CountDownLatch(2)
+                    val done    = new CountDownLatch(2)
+                    val v =
+                        for
+                            _ <- Cats.get(catsLoop(started, done))
+                            _ <- kyoLoop(started, done)
+                        yield ()
+                    for
+                        f <- Async.run(v)
+                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- f.interrupt
+                        r <- f.getResult
+                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                    yield assert(r.isPanic)
+                    end for
+                }
+
+                "parallel loops" in runKyo {
+                    val started = new CountDownLatch(2)
+                    val done    = new CountDownLatch(2)
+                    def parallelEffect =
+                        val loop1 = Cats.get(catsLoop(started, done))
+                        val loop2 = kyoLoop(started, done)
+                        Async.parallel[Throwable, Unit, Unit, Any](loop1, loop2)
+                    end parallelEffect
+                    for
+                        f <- Async.run(parallelEffect)
+                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- f.interrupt
+                        r <- f.getResult
+                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                    yield assert(r.isPanic)
+                    end for
+                }
+
+                "race loops" in runKyo {
+                    val started = new CountDownLatch(2)
+                    val done    = new CountDownLatch(2)
+                    def raceEffect =
+                        val loop1 = Cats.get(catsLoop(started, done))
+                        val loop2 = kyoLoop(started, done)
+                        Async.race(loop1, loop2)
+                    end raceEffect
+                    for
+                        f <- Async.run(raceEffect)
+                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- f.interrupt
+                        r <- f.getResult
+                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                    yield assert(r.isPanic)
+                    end for
+                }
             }
         end if
     }

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -18,7 +18,7 @@ object ZIOs:
       * @return
       *   A Kyo effect that, when run, will execute the zio.ZIO
       */
-    def get[E, A](v: ZIO[Any, E, A])(using Frame): A < (Abort[E] & Async) =
+    def get[E, A](v: => ZIO[Any, E, A])(using Frame): A < (Abort[E] & Async) =
         IO {
             val p = new IOPromise[E, A]
             val result =

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -55,7 +55,7 @@ object ZIOs:
             Async.run(v).map { fiber =>
                 ZIO.asyncInterrupt[Any, E, A] { cb =>
                     fiber.unsafe.onComplete {
-                        case Result.Success(a) => cb(ZIO.succeed(a))
+                        case Result.Success(a) => cb(Exit.succeed(a))
                         case Result.Fail(e)    => cb(ZIO.fail(e))
                         case Result.Panic(e)   => cb(ZIO.die(e))
                     }

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -20,11 +20,8 @@ object ZIOs:
       */
     def get[E, A](v: => ZIO[Any, E, A])(using Frame): A < (Abort[E] & Async) =
         IO {
-            val p = new IOPromise[E, A]
-            val result =
-                Unsafe.unsafe { implicit unsafe =>
-                    Runtime.default.unsafe.runToFuture(v.either)
-                }
+            val p      = new IOPromise[E, A]
+            val result = Unsafe.unsafely(Runtime.default.unsafe.runToFuture(v.either))
             result.onComplete { r =>
                 p.complete(r.fold(ex => Result.panic(ex), e => Result.fromEither(e)))
             }(ExecutionContext.parasitic)

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -18,7 +18,7 @@ object ZIOs:
       * @return
       *   A Kyo effect that, when run, will execute the zio.ZIO
       */
-    def get[E, A](v: => ZIO[Any, E, A])(using Frame): A < (Abort[E] & Async) =
+    def get[E, A](v: => ZIO[Any, E, A])(using Frame, zio.Trace): A < (Abort[E] & Async) =
         IO {
             val p      = new IOPromise[E, A]
             val result = Unsafe.unsafely(Runtime.default.unsafe.runToFuture(v.either))
@@ -39,7 +39,7 @@ object ZIOs:
       * @tparam A
       *   The result type
       */
-    inline def get[R: zio.Tag, E, A](v: ZIO[R, E, A])(using Tag[Env[R]], Frame): A < (Env[R] & Abort[E] & Async) =
+    inline def get[R: zio.Tag, E, A](v: ZIO[R, E, A])(using Tag[Env[R]], Frame, zio.Trace): A < (Env[R] & Abort[E] & Async) =
         compiletime.error("ZIO environments are not supported yet. Please handle them before calling this method.")
 
     /** Interprets a Kyo computation to ZIO. Note that this method only accepts Abort[E] and Async pending effects. Plase handle any other
@@ -50,7 +50,7 @@ object ZIOs:
       * @return
       *   A zio.ZIO that, when run, will execute the Kyo effect
       */
-    def run[A: Flat, E](v: => A < (Abort[E] & Async))(using frame: Frame): ZIO[Any, E, A] =
+    def run[A: Flat, E](v: => A < (Abort[E] & Async))(using frame: Frame, trace: zio.Trace): ZIO[Any, E, A] =
         ZIO.suspendSucceed {
             Async.run(v).map { fiber =>
                 ZIO.asyncInterrupt[Any, E, A] { cb =>

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -1,50 +1,37 @@
 package kyo
 
-import ZIOs.GetZIO
 import kyo.kernel.*
+import kyo.scheduler.IOPromise
+import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 import zio.Exit
+import zio.Runtime
+import zio.Unsafe
 import zio.ZIO
-
-/** Effect to integrate ZIO with Kyo */
-opaque type ZIOs <: Async = GetZIO & Async
 
 object ZIOs:
 
-    /** Executes a ZIO effect and returns its result within the Kyo effect system.
+    /** Lifts a zio.ZIO into a Kyo effect.
       *
-      * @param v
-      *   The ZIO effect to execute
-      * @param ev
-      *   Evidence that E is a subtype of Nothing
-      * @param tag
-      *   Tag for E
-      * @param frame
-      *   Implicit Frame
-      * @tparam E
-      *   The error type (must be a subtype of Nothing)
-      * @tparam A
-      *   The result type
+      * @param zio
+      *   The zio.ZIO to lift
       * @return
-      *   A Kyo effect that will produce A or abort with E
+      *   A Kyo effect that, when run, will execute the zio.ZIO
       */
-    def get[E >: Nothing: Tag, A](v: ZIO[Any, E, A])(using Frame): A < (Abort[E] & ZIOs) =
-        val task = v.fold(Result.fail, Result.success)
-        ArrowEffect.suspendMap(Tag[GetZIO], task)(Abort.get(_))
-
-    /** Executes a ZIO effect that cannot fail and returns its result within the Kyo effect system.
-      *
-      * @param v
-      *   The ZIO effect to execute
-      * @param frame
-      *   Implicit Frame
-      * @tparam A
-      *   The result type
-      * @return
-      *   A Kyo effect that will produce A
-      */
-    def get[A](v: ZIO[Any, Nothing, A])(using Frame): A < ZIOs =
-        ArrowEffect.suspend(Tag[GetZIO], v)
+    def get[E, A](v: ZIO[Any, E, A])(using Frame): A < (Abort[E] & Async) =
+        IO {
+            val p = new IOPromise[E, A]
+            val result =
+                Unsafe.unsafe { implicit unsafe =>
+                    Runtime.default.unsafe.runToFuture(v.either)
+                }
+            result.onComplete { r =>
+                p.complete(r.fold(ex => Result.panic(ex), e => Result.fromEither(e)))
+            }(ExecutionContext.parasitic)
+            p.onInterrupt(_ => discard(result.cancel()))
+            Async.get(p)
+        }
+    end get
 
     /** Placeholder for ZIO effects with environments (currently not supported).
       *
@@ -55,47 +42,32 @@ object ZIOs:
       * @tparam A
       *   The result type
       */
-    inline def get[R: zio.Tag, E, A](v: ZIO[R, E, A])(using Tag[Env[R]], Frame): A < (Env[R] & ZIOs) =
+    inline def get[R: zio.Tag, E, A](v: ZIO[R, E, A])(using Tag[Env[R]], Frame): A < (Env[R] & Abort[E] & Async) =
         compiletime.error("ZIO environments are not supported yet. Please handle them before calling this method.")
 
-    /** Runs a Kyo effect within the ZIO runtime.
+    /** Interprets a Kyo computation to ZIO. Note that this method only accepts Abort[E] and Async pending effects. Plase handle any other
+      * effects before calling this method.
       *
       * @param v
       *   The Kyo effect to run
-      * @param frame
-      *   Implicit Frame
-      * @tparam E
-      *   The error type
-      * @tparam A
-      *   The result type
       * @return
-      *   A ZIO effect that will produce A or fail with E
+      *   A zio.ZIO that, when run, will execute the Kyo effect
       */
-    def run[E, A](v: => A < (Abort[E] & ZIOs))(using frame: Frame): ZIO[Any, E, A] =
+    def run[A: Flat, E](v: => A < (Abort[E] & Async))(using frame: Frame): ZIO[Any, E, A] =
         ZIO.suspendSucceed {
-            try
-                ArrowEffect.handle(Tag[GetZIO], v.map(r => ZIO.succeed(r): ZIO[Any, E, A]))(
-                    [C] => (input, cont) => input.flatMap(r => run(cont(r)).flatten)
-                ).pipe(Async.run).map { fiber =>
-                    ZIO.asyncInterrupt[Any, E, A] { cb =>
-                        fiber.unsafe.onComplete {
-                            case Result.Fail(ex)   => cb(Exit.fail(ex))
-                            case Result.Panic(ex)  => cb(Exit.die(ex))
-                            case Result.Success(v) => cb(v)
-                        }
-                        Left(ZIO.succeed {
-                            fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))
-                        })
+            Async.run(v).map { fiber =>
+                ZIO.asyncInterrupt[Any, E, A] { cb =>
+                    fiber.unsafe.onComplete {
+                        case Result.Success(a) => cb(ZIO.succeed(a))
+                        case Result.Fail(e)    => cb(ZIO.fail(e))
+                        case Result.Panic(e)   => cb(ZIO.die(e))
                     }
-                }.pipe(IO.run).eval
-            catch
-                case ex =>
-                    ZIO.isFatalWith { isFatal =>
-                        if !isFatal(ex) then Exit.die(ex)
-                        else throw ex
-                    }
+                    Left(ZIO.succeed {
+                        fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))
+                    })
+                }
+            }.pipe(IO.run).eval
         }
     end run
 
-    sealed private[kyo] trait GetZIO extends ArrowEffect[ZIO[Any, Nothing, *], Id]
 end ZIOs

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -56,8 +56,8 @@ object ZIOs:
                 ZIO.asyncInterrupt[Any, E, A] { cb =>
                     fiber.unsafe.onComplete {
                         case Result.Success(a) => cb(Exit.succeed(a))
-                        case Result.Fail(e)    => cb(ZIO.fail(e))
-                        case Result.Panic(e)   => cb(ZIO.die(e))
+                        case Result.Fail(e)    => cb(Exit.fail(e))
+                        case Result.Panic(e)   => cb(Exit.die(e))
                     }
                     Left(ZIO.succeed {
                         fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -134,7 +134,7 @@ class ZIOsTest extends Test:
                     if i == 0 then
                         IO(started.countDown()).andThen(loop(i + 1))
                     else
-                        loop(i + 2)
+                        loop(i + 1)
                 }
             IO.ensure(IO(done.countDown()))(loop(0))
         end kyoLoop

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -102,8 +102,8 @@ class ZIOsTest extends Test:
         }
 
         "nested ZIO in Kyo" in runKyo {
-            val nestedZIO = ZIOs.get(ZIO.succeed("nested"))
-            Async.run(nestedZIO).map(_.get).map(s => assert(s == "nested"))
+            Async.run(ZIOs.get(ZIOs.run(42))).map(_.get)
+                .map(v => assert(v == 42))
         }
 
         "complex nested pattern with parallel and race" in runKyo {


### PR DESCRIPTION
Fixes #682

The current encoding of the integrations with ZIO and cats-effect uses custom effects and Kyo's Async has limitations to fork computations with arbitrary pending effects. This PR changes `get` to be based directly on `Async` but keeps the `run` method to interpret Kyo computations to the other effect systems.

This approach was explored in collaboration with @hearnadam