### PR TITLE
combinators: avoid effectful parameters

### DIFF
--- a/kyo-cache/shared/src/main/scala/kyo/Cache.scala
+++ b/kyo-cache/shared/src/main/scala/kyo/Cache.scala
@@ -49,11 +49,11 @@ class Cache(private[kyo] val store: Store):
                             Abort.run[Throwable](f(v)).map {
                                 case Result.Success(v) =>
                                     p.complete(Result.Success(v))
-                                        .unit.andThen(v)
+                                        .as(v)
                                 case r =>
                                     IO(store.invalidate(key))
                                         .andThen(p.complete(r))
-                                        .unit.andThen(r.getOrThrow)
+                                        .as(r.getOrThrow)
                             }
                         }
                     else

--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -637,32 +637,6 @@ extension [A, S](effect: A < (S & Choice))
       */
     def handleChoice(using Flat[A], Frame): Seq[A] < S = Choice.run(effect)
 
-    /** Translates the Choice effect to an Abort[E] effect in case the result is empty.
-      *
-      * @return
-      *   A computation that produces the result of this computation with Abort[E] effect
-      */
-    def choiceToAbort[E](error: => E)(using Flat[A], Frame): A < (S & Abort[E]) =
-        Choice.run(effect).map {
-            case s if s.isEmpty => Kyo.fail(error)
-            case s              => s.head
-        }
-
-    /** Translates the Choice effect to an Abort[Throwable] effect.
-      *
-      * @return
-      *   A computation that produces the result of this computation with Abort[Throwable] effect
-      */
-    def choiceToThrowable(using Flat[A], Frame): A < (S & Abort[Throwable]) =
-        choiceToAbort(new NoSuchElementException("head of empty list"))
-
-    /** Translates the Choice effect to an Abort[Maybe.Empty] effect.
-      *
-      * @return
-      *   A computation that produces the result of this computation with Abort[Maybe.Empty] effect
-      */
-    def choiceToEmpty(using Flat[A], Frame): A < (S & Abort[Maybe.Empty]) =
-        choiceToAbort(Maybe.Empty)
 end extension
 
 extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))

--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -41,16 +41,6 @@ extension [A, S](effect: A < S)
     def <*>[A1, S1](next: => A1 < S1)(using Frame): (A, A1) < (S & S1) =
         effect.map(e => next.map(n => (e, n)))
 
-    /** Performs this computation, discards its result, and returns the given value.
-      *
-      * @param value
-      *   The value to return
-      * @return
-      *   A computation that produces the given value
-      */
-    inline def as[A1, S1](value: => A1 < S1)(using inline frame: Frame): A1 < (S & S1) =
-        effect.map(_ => value)
-
     /** Performs this computation and prints its result to the console.
       *
       * @return
@@ -72,8 +62,8 @@ extension [A, S](effect: A < S)
       * @return
       *   A computation that produces the result of this computation with Async effect
       */
-    def delayed[S1](duration: Duration < S1)(using Frame): A < (S & S1 & Async) =
-        duration.map(d => Async.delay(d)(effect))
+    def delayed(duration: Duration)(using Frame): A < (S & Async) =
+        Async.delay(duration)(effect)
 
     /** Performs this computation repeatedly with a backoff policy.
       *
@@ -95,12 +85,10 @@ extension [A, S](effect: A < S)
       * @return
       *   A computation that produces the result of the last execution
       */
-    def repeat[S1](limit: Int < S1)(using Flat[A], Frame): A < (S & S1) =
-        limit.map { limit =>
-            Loop.indexed { i =>
-                if i >= limit then effect.map(Loop.done)
-                else effect.as(Loop.continue)
-            }
+    def repeat(limit: Int)(using Flat[A], Frame): A < S =
+        Loop.indexed { i =>
+            if i >= limit then effect.map(Loop.done)
+            else effect.as(Loop.continue)
         }
 
     /** Performs this computation repeatedly with a backoff policy and a limit.
@@ -112,17 +100,11 @@ extension [A, S](effect: A < S)
       * @return
       *   A computation that produces the result of this computation with Async effect
       */
-    def repeat[S1](backoff: Int => Duration, limit: => Int < S1)(using
-        Flat[A],
-        Frame
-    ): A < (S & S1 & Async) =
-        limit.map { limit =>
-            Loop.indexed { i =>
-                if i >= limit then effect.map(Loop.done)
-                else effect.delayed(backoff(i)).as(Loop.continue)
-            }
+    def repeat(backoff: Int => Duration, limit: => Int)(using Flat[A], Frame): A < (S & Async) =
+        Loop.indexed { i =>
+            if i >= limit then effect.map(Loop.done)
+            else effect.delayed(backoff(i)).as(Loop.continue)
         }
-    end repeat
 
     /** Performs this computation repeatedly while the given condition holds.
       *
@@ -149,10 +131,7 @@ extension [A, S](effect: A < S)
       * @return
       *   A computation that produces the result of the last successful execution before the condition becomes false
       */
-    def repeatWhile[S1](fn: (A, Int) => (Boolean, Duration) < S1)(using
-        Flat[A],
-        Frame
-    ): A < (S & S1 & Async) =
+    def repeatWhile[S1](fn: (A, Int) => (Boolean, Duration) < S1)(using Flat[A], Frame): A < (S & S1 & Async) =
         def loop(last: A, i: Int): A < (S & S1 & Async) =
             fn(last, i).map { case (cont, duration) =>
                 if cont then effect.delayed(duration).map(v => loop(v, i + 1))
@@ -217,8 +196,8 @@ extension [A, S](effect: A < S)
       * @return
       *   A computation that produces the result of this computation with Async and Abort[Throwable] effects
       */
-    def retry[S1](n: => Int < S1)(using Flat[A], Frame): A < (S & S1 & Async & Abort[Throwable]) =
-        n.map(nPure => Retry[Throwable](Retry.Policy(_ => Duration.Zero, nPure))(effect))
+    def retry(n: Int)(using Flat[A], Frame): A < (S & Async & Abort[Throwable]) =
+        Retry[Throwable](Retry.Policy(_ => Duration.Zero, n))(effect)
 
     /** Performs this computation repeatedly with a backoff policy and a limit in case of failures.
       *
@@ -229,11 +208,8 @@ extension [A, S](effect: A < S)
       * @return
       *   A computation that produces the result of this computation with Async and Abort[Throwable] effects
       */
-    def retry[S1](backoff: Int => Duration, n: => Int < S1)(using
-        Flat[A],
-        Frame
-    ): A < (S & S1 & Async & Abort[Throwable]) =
-        n.map(nPure => Retry[Throwable](Retry.Policy(backoff, nPure))(effect))
+    def retry(backoff: Int => Duration, n: Int)(using Flat[A], Frame): A < (S & Async & Abort[Throwable]) =
+        Retry[Throwable](Retry.Policy(backoff, n))(effect)
 
     /** Performs this computation indefinitely.
       *
@@ -417,7 +393,7 @@ extension [A, S, E](effect: A < (Abort[Maybe.Empty] & S))
       * @return
       *   A computation that produces the result of this computation with the Abort[Maybe.Empty] effect handled
       */
-    def handleEmptyAbort(using f: Flat[A], frame: Frame): Maybe[A] < S =
+    def handleEmptyAbort(using Flat[A], Frame): Maybe[A] < S =
         Abort.run[Maybe.Empty](effect).map {
             case Result.Fail(_)    => Maybe.Empty
             case Result.Panic(e)   => throw e
@@ -429,7 +405,7 @@ extension [A, S, E](effect: A < (Abort[Maybe.Empty] & S))
       * @return
       *   A computation that produces the result of this computation with the Abort[Maybe.Empty] effect translated to Choice
       */
-    def emptyAbortToChoice(using f: Flat[A], frame: Frame): A < (S & Choice) =
+    def emptyAbortToChoice(using Flat[A], Frame): A < (S & Choice) =
         effect.someAbortToChoice[Maybe.Empty]()
 
     /** Handles the Abort[Maybe.Empty] effect translating it to an Abort[E] effect.
@@ -437,12 +413,11 @@ extension [A, S, E](effect: A < (Abort[Maybe.Empty] & S))
       * @return
       *   A computation that produces the result of this computation with the Abort[Maybe.Empty] effect translated to Abort[E]
       */
-    def emptyAbortToFailure[S1](failure: => E < S1)(using f: Flat[A], frame: Frame): A < (S & S1 & Abort[E]) =
+    def emptyAbortToFailure(failure: E)(using Flat[A], Frame): A < (S & Abort[E]) =
         for
-            f   <- failure
             res <- effect.handleSomeAbort[Maybe.Empty]()
         yield res match
-            case Result.Fail(_)    => Abort.get(Result.Fail(f))
+            case Result.Fail(_)    => Abort.get(Result.Fail(failure))
             case Result.Panic(e)   => Abort.get(Result.Panic(e))
             case Result.Success(a) => Abort.get(Result.success(a))
 end extension
@@ -592,15 +567,15 @@ extension [A, S, E](effect: A < (S & Env[E]))
       * @return
       *   A computation that produces the result of this computation with the Env[E] effect handled
       */
-    def provideValue[S1, E1 >: E, ER](dependency: E1 < S1)(
+    def provideValue[E1 >: E, ER](dependency: E1)(
         using
         ev: E => E1 & ER,
         flat: Flat[A],
         reduce: Reducible[Env[ER]],
         tag: Tag[E1],
         frame: Frame
-    ): A < (S & S1 & reduce.SReduced) =
-        dependency.map(d => Env.run[E1, A, S, ER](d)(effect.asInstanceOf[A < (S & Env[E1 | ER])]))
+    ): A < (S & reduce.SReduced) =
+        Env.run[E1, A, S, ER](dependency)(effect.asInstanceOf[A < (S & Env[E1 | ER])])
 
     /** Handles the Env[E] effect with the provided layer.
       *
@@ -609,17 +584,16 @@ extension [A, S, E](effect: A < (S & Env[E]))
       * @return
       *   A computation that produces the result of this computation
       */
-    inline def provideLayer[S1, S2, E1 >: E, ER](layer: Layer[E1, S1] < S2)(
+    inline def provideLayer[S1, E1 >: E, ER](layer: Layer[E1, S1])(
         using
         ev: E => E1 & ER,
         flat: Flat[A],
         reduce: Reducible[Env[ER]],
         tag: Tag[E1],
         frame: Frame
-    ): A < (S & S1 & S2 & Memo & reduce.SReduced) =
+    ): A < (S & S1 & Memo & reduce.SReduced) =
         for
-            l  <- layer
-            tm <- l.run
+            tm <- layer.run
             e1 = tm.get[E1]
         yield effect.provideValue(e1)
 
@@ -657,13 +631,9 @@ extension [A, S](effect: A < (S & Choice))
       * @return
       *   A computation that produces the result of this computation with Abort[E] effect
       */
-    def choiceToAbort[E, S1](error: => E < S1)(
-        using
-        Flat[A],
-        Frame
-    ): A < (S & S1 & Abort[E]) =
+    def choiceToAbort[E](error: E)(using Flat[A], Frame): A < (S & Abort[E]) =
         Choice.run(effect).map {
-            case s if s.isEmpty => Kyo.fail[E, S1](error)
+            case s if s.isEmpty => Kyo.fail(error)
             case s              => s.head
         }
 
@@ -673,7 +643,7 @@ extension [A, S](effect: A < (S & Choice))
       *   A computation that produces the result of this computation with Abort[Throwable] effect
       */
     def choiceToThrowable(using Flat[A], Frame): A < (S & Abort[Throwable]) =
-        choiceToAbort[Throwable, Any](new NoSuchElementException("head of empty list"))
+        choiceToAbort(new NoSuchElementException("head of empty list"))
 
     /** Translates the Choice effect to an Abort[Maybe.Empty] effect.
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -86,7 +86,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that prints the message to the console
       */
-    def debugln[S](message: String)(using Frame): Unit < IO =
+    def debugln(message: String)(using Frame): Unit < IO =
         Console.println(message)
 
     /** Creates an effect that fails with Abort[E].
@@ -96,7 +96,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that fails with the given error
       */
-    def fail[E](error: E)(using Frame): Nothing < Abort[E] =
+    def fail[E](error: => E)(using Frame): Nothing < Abort[E] =
         Abort.fail(error)
 
     /** Applies a function to each element in parallel and returns a new sequence with the results.
@@ -108,7 +108,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   A new sequence with elements collected using the function
       */
-    def foreachPar[E, A, S, A1, Ctx](sequence: Seq[A])(useElement: A => A1 < (Abort[E] & Async))(
+    def foreachPar[E, A, S, A1, Ctx](sequence: Seq[A])(useElement: A => A1 < (Abort[E] & Async & Ctx))(
         using
         flat: Flat[A1],
         boundary: Boundary[Ctx, Async],
@@ -126,7 +126,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   Discards the results of the function application and returns Unit
       */
-    def foreachParDiscard[E, A, S, A1, Ctx](sequence: Seq[A])(useElement: A => A1 < (Abort[E] & Async))(
+    def foreachParDiscard[E, A, S, A1, Ctx](sequence: Seq[A])(useElement: A => A1 < (Abort[E] & Async & Ctx))(
         using
         flat: Flat[A1],
         boundary: Boundary[Ctx, Async],
@@ -192,7 +192,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that attempts to run the given effect and handles the Future to Async.
       */
-    def fromFuture[A: Flat](future: Future[A])(using Frame): A < (Async & Abort[Throwable]) =
+    def fromFuture[A: Flat](future: => Future[A])(using Frame): A < (Async & Abort[Throwable]) =
         Async.fromFuture(future)
 
     /** Creates an effect from a Promise[A] and handles the Promise to Async.
@@ -202,7 +202,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that attempts to run the given effect and handles the Promise to Async.
       */
-    def fromPromiseScala[A: Flat](promise: scala.concurrent.Promise[A])(using Frame): A < (Async & Abort[Throwable]) =
+    def fromPromiseScala[A: Flat](promise: => scala.concurrent.Promise[A])(using Frame): A < (Async & Abort[Throwable]) =
         fromFuture(promise.future)
 
     /** Creates an effect from a sequence and handles the sequence to Choice.

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -465,6 +465,6 @@ extension (kyoObject: Kyo.type)
     def traverseParDiscard[A](
         sequence: => Seq[A < Async]
     )(using Flat[A], Frame): Unit < Async =
-        foreachPar(sequence.map(_.unit))(identity).unit
+        foreachPar(sequence)(identity).unit
 
 end extension

--- a/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorTest.scala
@@ -25,44 +25,6 @@ class ChoiceCombinatorTest extends Test:
             }
         }
 
-        "convert" - {
-
-            "should convert choice to abort, constructing Right from Seq#head" in {
-                val failure: Int < Choice             = Choice.get(Nil)
-                val failureAbort: Int < Abort[String] = failure.choiceToAbort("failure")
-                val handledFailureAbort               = Abort.run[String](failureAbort)
-                assert(handledFailureAbort.eval == Result.fail("failure"))
-                val success: Int < Choice             = Choice.get(Seq(1, 2, 3))
-                val successAbort: Int < Abort[String] = success.choiceToAbort("failure")
-                val handledSuccessAbort               = Abort.run[String](successAbort)
-                assert(handledSuccessAbort.eval == Result.success(1))
-            }
-
-            "should convert choice to throwable abort, constructing Right from Seq#head" in {
-                val failure: Int < Choice                = Choice.get(Nil)
-                val failureAbort: Int < Abort[Throwable] = failure.choiceToThrowable
-                val handledFailureAbort                  = Abort.run[Throwable](failureAbort)
-                assert(handledFailureAbort.eval.failure.get.getMessage.contains(
-                    "head of empty list"
-                ))
-                val success: Int < Choice                = Choice.get(Seq(1, 2, 3))
-                val successAbort: Int < Abort[Throwable] = success.choiceToThrowable
-                val handledSuccessAbort                  = Abort.run[Throwable](successAbort)
-                assert(handledSuccessAbort.eval == Result.success(1))
-            }
-
-            "should convert choice to empty abort, constructing Right from Seq#head" in {
-                val failure: Int < Choice                  = Choice.get(Nil)
-                val failureAbort: Int < Abort[Maybe.Empty] = failure.choiceToEmpty
-                val handledFailureAbort                    = Abort.run[Maybe.Empty](failureAbort)
-                assert(handledFailureAbort.eval == Result.fail(Maybe.Empty))
-                val success: Int < Choice                  = Choice.get(Seq(1, 2, 3))
-                val successAbort: Int < Abort[Maybe.Empty] = success.choiceToEmpty
-                val handledSuccessAbort                    = Abort.run[Maybe.Empty](successAbort)
-                assert(handledSuccessAbort.eval == Result.success(1))
-            }
-        }
-
         "iteration" - {
             "should iterate using foreach" in {
                 var state             = 0

--- a/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
@@ -155,6 +155,31 @@ class ConstructorsTest extends Test:
                 assert(failureResult.isInstanceOf[Result.Fail[?]])
             }
         }
+
+        "foreachPar" - {
+            "should apply a function to each element in parallel" in run {
+                val input  = Seq(1, 2, 3, 4, 5)
+                val result = Kyo.foreachPar(input)(x => Async.sleep(10.millis).andThen(x * 2))
+                result.map { r =>
+                    assert(r == Seq(2, 4, 6, 8, 10))
+                }
+            }
+        }
+
+        "foreachParDiscard" - {
+            "should apply a function to each element in parallel and discard the results" in run {
+                val input = Seq(1, 2, 3, 4, 5)
+                AtomicInt.init(0).map { counter =>
+                    Kyo.foreachParDiscard(input) { x =>
+                        Async.sleep(10.millis).andThen(counter.incrementAndGet)
+                    }.map { _ =>
+                        counter.get.map { count =>
+                            assert(count == 5)
+                        }
+                    }
+                }
+            }
+        }
     }
 
 end ConstructorsTest

--- a/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
@@ -159,9 +159,18 @@ class ConstructorsTest extends Test:
         "foreachPar" - {
             "should apply a function to each element in parallel" in run {
                 val input  = Seq(1, 2, 3, 4, 5)
-                val result = Kyo.foreachPar(input)(x => Async.sleep(10.millis).andThen(x * 2))
+                val result = Kyo.foreachPar(input)(x => Async.sleep(1.millis).andThen(x * 2))
                 result.map { r =>
                     assert(r == Seq(2, 4, 6, 8, 10))
+                }
+            }
+            "should support context effects" in run {
+                val input  = Seq(1, 2, 3, 4, 5)
+                val result = Kyo.foreachPar(input)(x => Env.use[Int](d => Async.sleep(d.millis)).andThen(x * 2))
+                Env.run(1) {
+                    result.map { r =>
+                        assert(r == Seq(2, 4, 6, 8, 10))
+                    }
                 }
             }
         }
@@ -171,10 +180,24 @@ class ConstructorsTest extends Test:
                 val input = Seq(1, 2, 3, 4, 5)
                 AtomicInt.init(0).map { counter =>
                     Kyo.foreachParDiscard(input) { x =>
-                        Async.sleep(10.millis).andThen(counter.incrementAndGet)
+                        Async.sleep(1.millis).andThen(counter.incrementAndGet)
                     }.map { _ =>
                         counter.get.map { count =>
                             assert(count == 5)
+                        }
+                    }
+                }
+            }
+            "should support context effects" in run {
+                val input = Seq(1, 2, 3, 4, 5)
+                Env.run(1) {
+                    AtomicInt.init(0).map { counter =>
+                        Kyo.foreachParDiscard(input) { x =>
+                            Env.use[Int](d => Async.sleep(d.millis)).andThen(counter.incrementAndGet)
+                        }.map { _ =>
+                            counter.get.map { count =>
+                                assert(count == 5)
+                            }
                         }
                     }
                 }

--- a/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
@@ -331,5 +331,11 @@ class EffectCombinatorTest extends Test:
                 assert(handled.eval.isSuccess)
             }
         }
+
+        "ensuring" in run {
+            var finalizerCalled = false
+            Resource.run(IO(()).ensuring(IO { finalizerCalled = true }))
+                .andThen(assert(finalizerCalled))
+        }
     }
 end EffectCombinatorTest

--- a/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
@@ -3,20 +3,6 @@ package kyo
 class EffectCombinatorTest extends Test:
 
     "all effects" - {
-        "as" - {
-            "with string value" in {
-                val effect         = IO(23)
-                val effectAsString = effect.as("hello")
-                val handled        = IO.run(effectAsString)
-                assert(handled.eval == "hello")
-            }
-            "with integer value" in {
-                val effect      = IO("test")
-                val effectAsInt = effect.as(42)
-                val handled     = IO.run(effectAsInt)
-                assert(handled.eval == 42)
-            }
-        }
 
         "debug" - {
             "with string value" in {
@@ -173,12 +159,12 @@ class EffectCombinatorTest extends Test:
 
         "delayed" - {
             "with short delay" in {
-                val effect  = IO(42).delayed(IO(1.millis))
+                val effect  = IO(42).delayed(1.millis)
                 val handled = IO.run(Async.run(effect).map(_.toFuture)).eval
                 handled.map(v => assert(v == 42))
             }
             "with zero delay" in {
-                val effect  = IO("test").delayed(IO(0.millis))
+                val effect  = IO("test").delayed(0.millis)
                 val handled = IO.run(Async.run(effect).map(_.toFuture)).eval
                 handled.map(v => assert(v == "test"))
             }
@@ -219,7 +205,7 @@ class EffectCombinatorTest extends Test:
                 "repeat with exponential backoff" in {
                     var count   = 0
                     val backoff = (i: Int) => Math.pow(2, i).toLong.millis
-                    val effect  = IO { count += 1; count }.repeat(backoff, IO(3))
+                    val effect  = IO { count += 1; count }.repeat(backoff, 3)
                     val handled = IO.run(Async.run(effect).map(_.toFuture)).eval
                     handled.map { v =>
                         assert(v == 4)
@@ -326,7 +312,7 @@ class EffectCombinatorTest extends Test:
                         count += 1
                         if count < 3 then throw new Exception("Retry")
                         else count
-                    }.retry(backoff, IO(3))
+                    }.retry(backoff, 3)
                     val handled = IO.run(Async.run(effect).map(_.toFuture)).eval
                     handled.map(v => assert(v == 3))
                 }

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -189,7 +189,7 @@ class AsyncTest extends Test:
         }
 
         "multiple fibers timeout" in runJVM {
-            Kyo.fill(100)(Async.sleep(1.milli)).unit.andThen(1)
+            Kyo.fill(100)(Async.sleep(1.milli)).as(1)
                 .pipe(Async.runAndBlock(10.millis))
                 .pipe(Abort.run[Timeout](_))
                 .map {

--- a/kyo-prelude/jvm/src/test/scala/kyo/MonadLawsTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo/MonadLawsTest.scala
@@ -27,7 +27,7 @@ object MonadLawsTest extends ZIOSpecDefault:
                         if b then Abort.fail("fail") else (v: A < Any)
                     ),
                     gen.zip(intGen).map((v, i) =>
-                        Emit(i).unit.andThen(v)
+                        Emit(i).as(v)
                     ),
                     gen.zip(boolGen).map((v, b) =>
                         Var.setDiscard(b).andThen(v)

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -45,6 +45,14 @@ object `<`:
         ): B < (S & S2) =
             map(_ => f)
 
+        inline def as[B, S2](other: B < S2)(
+            using
+            inline frame: Frame,
+            inline flatA: Flat.Weak[A],
+            inline flatB: Flat.Weak[B]
+        ): B < (S & S2) =
+            map(_ => other)
+
         inline def flatMap[B, S2](inline f: Safepoint ?=> A => B < S2)(
             using
             inline frame: Frame,

--- a/kyo-prelude/shared/src/test/scala/kyo/VarTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/VarTest.scala
@@ -47,7 +47,7 @@ class VarTest extends Test:
     }
 
     "runTuple" in {
-        val r = Var.runTuple(1)(Var.update[Int](_ + 1).unit.andThen(Var.get[Int]).map(_ + 1)).eval
+        val r = Var.runTuple(1)(Var.update[Int](_ + 1).as(Var.get[Int]).map(_ + 1)).eval
         assert(r == (2, 3))
     }
 
@@ -73,7 +73,7 @@ class VarTest extends Test:
                 Var.get[Int].map { innerValue =>
                     assert(innerValue == 2)
                 }
-            }.unit.andThen(Var.get[Int])
+            }.as(Var.get[Int])
                 .map { outerValue =>
                     assert(outerValue == 1)
                 }


### PR DESCRIPTION
Fixes #650

Some of the methods I still kept receiving effectful parameters and I've also promoted `as` to the pending type since it's a common pattern.