### PR TITLE
prelude: Flat macro fix

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Batch.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Batch.scala
@@ -110,8 +110,6 @@ object Batch:
 
         case class Cont(op: Op[?, S], cont: Any => (Cont | A) < (Batch[S] & S & S2))
         def runCont(v: (Cont | A) < (Batch[S] & S & S2)): (Cont | A) < (S & S2) =
-            // TODO workaround, Flat macro isn't inferring correctly with nested classes
-            import Flat.unsafe.bypass
             ArrowEffect.handle(erasedTag[S], v) {
                 [C] => (input, cont) => Cont(input, v => cont(v.asInstanceOf[C]))
             }

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Flat.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Flat.scala
@@ -79,10 +79,10 @@ private object FlatMacro:
                     base =:= TypeRepr.of[Duration]
                 case _ => false
 
-        def hasTag(t: TypeRepr): Boolean =
+        def canDerive(t: TypeRepr): Boolean =
             t.asType match
                 case '[t] =>
-                    Expr.summon[Tag.Full[t]].isDefined
+                    Expr.summon[Tag.Full[t]].isDefined || Expr.summon[Flat[t]].isDefined
 
         def check(t: TypeRepr): Unit =
             t match
@@ -93,7 +93,7 @@ private object FlatMacro:
                     check(a)
                     check(b)
                 case _ =>
-                    if isAny(t) || (!isConcrete(t.dealias) && !hasTag(t) && !isKyoData(t)) then
+                    if isAny(t) || (!isConcrete(t.dealias) && !canDerive(t) && !isKyoData(t)) then
                         fail(
                             s"Cannot prove ${code(print(t))} isn't nested. " +
                                 s"This error can be reported an unsupported pending effect is passed to a method. " +

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Flat.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Flat.scala
@@ -82,7 +82,7 @@ private object FlatMacro:
         def canDerive(t: TypeRepr): Boolean =
             t.asType match
                 case '[t] =>
-                    Expr.summon[Tag.Full[t]].isDefined || Expr.summon[Flat[t]].isDefined
+                    Expr.summon[Flat[t]].isDefined || Expr.summon[Tag.Full[t]].isDefined
 
         def check(t: TypeRepr): Unit =
             t match

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/FlatTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/FlatTest.scala
@@ -18,6 +18,26 @@ class FlatTest extends Test:
                 succeed
             test[Int]
         }
+        "derived from Flat" - {
+            "simple" in {
+                def test[A: Flat] =
+                    implicitly[Flat[A]]
+                    succeed
+                test[Int]
+            }
+            "union item" in {
+                def test[A: Flat] =
+                    implicitly[Flat[Int | A]]
+                    succeed
+                test[Int]
+            }
+            "intersection item" in {
+                def test[A: Flat] =
+                    implicitly[Flat[Thread & A]]
+                    succeed
+                test[Int]
+            }
+        }
     }
 
     "nok" - {
@@ -151,4 +171,5 @@ class FlatTest extends Test:
             succeed
         }
     }
+
 end FlatTest


### PR DESCRIPTION
Addressing a TODO. The `Flat` macro was incorrectly not considering existing evidences in scope.