### PR TITLE
prelude: Batch optimizations

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Batch.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Batch.scala
@@ -106,7 +106,7 @@ object Batch:
       * @return
       *   A sequence of results from executing the batched operations
       */
-    def run[A: Flat, S, S2](v: A < (Batch[S] & S2))(using Frame): Seq[A] < (S & S2) =
+    def run[A: Flat, S, S2](v: A < (Batch[S] & S2))(using Frame): Chunk[A] < (S & S2) =
 
         type SourceAny = Source[Any, Any, S]
         type ContAny   = Any => (ToExpand | Expanded | A) < (Batch[S] & S & S2)
@@ -133,7 +133,7 @@ object Batch:
                 case done: A @unchecked            => Chunk(done)
             }.map(_.flattenChunk)
 
-        def loop(state: Seq[ToExpand | Expanded | A]): Seq[A] < (S & S2) =
+        def loop(state: Seq[ToExpand | Expanded | A]): Chunk[A] < (S & S2) =
             expand(state).map { expanded =>
                 if !expanded.exists((_: @unchecked).isInstanceOf[Expanded]) then
                     expanded.asInstanceOf[Chunk[A]]

--- a/kyo-prelude/shared/src/main/scala/kyo/Batch.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Batch.scala
@@ -37,7 +37,7 @@ object Batch:
       * results for each input.
       */
     inline def source[A, B, S](f: Seq[A] => (A => B < S) < S)(using inline frame: Frame): A => B < Batch[S] =
-        (v: A) => ArrowEffect.suspend[B](erasedTag[S], Op.Call(v, f))
+        (v: A) => ArrowEffect.suspend[B](erasedTag[S], Call(v, f))
 
     /** Creates a batched computation from a source function that returns a Map.
       *
@@ -83,7 +83,7 @@ object Batch:
       *   A batched operation that produces a single value from the sequence
       */
     inline def eval[A](seq: Seq[A])(using inline frame: Frame): A < Batch[Any] =
-        ArrowEffect.suspend[A](erasedTag[Any], Op.Eval(seq))
+        ArrowEffect.suspend[A](erasedTag[Any], seq)
 
     /** Applies a function to each element of a sequence in a batched context.
       *
@@ -97,7 +97,7 @@ object Batch:
       *   A batched computation that produces a single value of type B
       */
     inline def foreach[A, B, S](seq: Seq[A])(inline f: A => B < S): B < (Batch[Any] & S) =
-        ArrowEffect.suspendMap[A](erasedTag[Any], Op.Eval(seq))(f)
+        ArrowEffect.suspendMap[A](erasedTag[Any], seq)(f)
 
     /** Runs a computation with Batch effect, executing all batched operations.
       *
@@ -108,62 +108,63 @@ object Batch:
       */
     def run[A: Flat, S, S2](v: A < (Batch[S] & S2))(using Frame): Seq[A] < (S & S2) =
 
-        case class Cont(op: Op[?, S], cont: Any => (Cont | A) < (Batch[S] & S & S2))
-        def runCont(v: (Cont | A) < (Batch[S] & S & S2)): (Cont | A) < (S & S2) =
+        type SourceAny = Source[Any, Any, S]
+        type ContAny   = Any => (ToExpand | Expanded | A) < (Batch[S] & S & S2)
+
+        case class ToExpand(op: Seq[Any], cont: ContAny)
+        case class Expanded(value: Any, source: SourceAny, cont: ContAny)
+
+        def runCont(v: (ToExpand | Expanded | A) < (Batch[S] & S & S2)): (ToExpand | Expanded | A) < (S & S2) =
             ArrowEffect.handle(erasedTag[S], v) {
-                [C] => (input, cont) => Cont(input, v => cont(v.asInstanceOf[C]))
+                [C] =>
+                    (input, cont) =>
+                        val contAny = cont.asInstanceOf[ContAny]
+                        input match
+                            case Call(v, source) => Expanded(v, source.asInstanceOf[SourceAny], contAny)
+                            case v: Seq[C]       => ToExpand(v, contAny)
             }
         end runCont
 
-        case class Expanded(v: Any, source: Source[Any, Any, S], cont: Any => (Cont | A) < (Batch[S] & S & S2))
-        def expand(state: Seq[Cont | A]): Seq[Expanded | A] < (S & S2) =
+        def expand(state: Seq[ToExpand | Expanded | A]): Chunk[Expanded | A] < (S & S2) =
             Kyo.foreach(state) {
-                case Cont(Op.Eval(seq), cont) =>
+                case ToExpand(seq: Seq[Any], cont) =>
                     Kyo.foreach(seq)(v => runCont(cont(v))).map(expand)
-                case Cont(Op.Call(v, source), cont) =>
-                    Seq(Expanded(v, source.asInstanceOf, cont))
-                case a: A @unchecked =>
-                    Seq(a)
-            }.map(_.flatten)
+                case expanded: Expanded @unchecked => Chunk(expanded)
+                case done: A @unchecked            => Chunk(done)
+            }.map(_.flattenChunk)
 
-        def loop(state: Seq[Cont | A]): Seq[A] < (S & S2) =
+        def loop(state: Seq[ToExpand | Expanded | A]): Seq[A] < (S & S2) =
             expand(state).map { expanded =>
-                val (completed, pending) =
-                    expanded.zipWithIndex.partitionMap {
-                        case (e: Expanded @unchecked, idx) => Right((e, idx))
-                        case (a: A @unchecked, idx)        => Left((a, idx))
-                    }
-
-                if pending.isEmpty then
-                    completed.sortBy(_._2).map(_._1)
+                if !expanded.exists((_: @unchecked).isInstanceOf[Expanded]) then
+                    expanded.asInstanceOf[Chunk[A]]
                 else
-                    val grouped = pending.groupBy(_._1.source)
-
-                    Kyo.foreach(grouped.toSeq) { case (source, items) =>
-                        val (expandedItems, indices) = items.unzip
-                        val values                   = expandedItems.map(_.v)
-                        val uniqueValues             = values.distinct
-
-                        source(uniqueValues).map { map =>
-                            Kyo.foreach(expandedItems.zip(indices)) { case (e, idx) =>
-                                runCont(map(e.v).map(e.cont)).map((_, idx))
-                            }
+                    val pending: Map[SourceAny | Unit, Seq[Expanded | A]] =
+                        expanded.groupBy {
+                            case Expanded(_, source, _) => source
+                            case _                      => ()
                         }
+                    Kyo.foreach(pending.toSeq) {
+                        case (_: Unit, items) => Chunk.from(items)
+                        case (source: SourceAny, items: Seq[Expanded] @unchecked) =>
+                            source(items.map(_.value).distinct).map { map =>
+                                Kyo.foreach(items) { e =>
+                                    runCont(map(e.value).map(e.cont))
+                                }
+                            }
                     }.map { results =>
-                        loop(completed.map(_._1) ++ results.flatten.map(_._1))
+                        loop(results.flattenChunk)
                     }
-                end if
             }
         end loop
-        runCont(v).map(c => loop(Seq(c)))
+
+        runCont(v).map(initial => loop(Seq(initial)))
     end run
 
     object internal:
         type Source[A, B, S] = Seq[A] => (A => B < S) < S
 
-        enum Op[V, -S]:
-            case Eval[A](seq: Seq[A])                         extends Op[A, Any]
-            case Call[A, B, S](v: A, source: Source[A, B, S]) extends Op[B, S]
+        type Op[V, -S] = Seq[V] | Call[?, V, S]
+        case class Call[A, B, -S](v: A, source: Source[A, B, S])
     end internal
 
 end Batch


### PR DESCRIPTION
[Benchmark results](https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fwbrasil/5eae45217e6646aa77c193d081093920/raw/07acdb06bb3cf53faa466581f32cbd971afb47c0/jmh-result.json) with this change on top of https://github.com/getkyo/kyo/pull/718 and the other recent optimizations.

![image](https://github.com/user-attachments/assets/f6a0b2b4-1de6-4867-8893-303027c1a77e)
