### PR TITLE
core: avoid Unit suffix in method names

### DIFF
--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -50,7 +50,7 @@ extension (kyoObject: Kyo.type)
             registerFn = (eff: A < Async) =>
                 val effFiber = Async.run(eff)
                 val updatePromise =
-                    effFiber.map(_.onComplete(a => promise.completeUnit(a)))
+                    effFiber.map(_.onComplete(a => promise.completeDiscard(a)))
                 val updatePromiseIO = Async.run(updatePromise).unit
                 import AllowUnsafe.embrace.danger
                 IO.Unsafe.run(updatePromiseIO).eval

--- a/kyo-core/jvm/src/main/scala/kyo/internal/FiberPlatformSpecific.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/internal/FiberPlatformSpecific.scala
@@ -12,8 +12,8 @@ trait FiberPlatformSpecific:
         IO {
             val p = new IOPromise[Nothing, A]()
             cs.whenComplete { (success, error) =>
-                if error == null then p.completeUnit(Result.success(success))
-                else p.completeUnit(Result.panic(error))
+                if error == null then p.completeDiscard(Result.success(success))
+                else p.completeDiscard(Result.panic(error))
             }
             Fiber.initUnsafe(p)
         }

--- a/kyo-core/shared/src/main/scala/kyo/Barrier.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Barrier.scala
@@ -64,7 +64,7 @@ object Barrier:
                             if c > 0 && !count.cas(c, c - 1) then
                                 loop(count.get())
                             else
-                                if c == 1 then promise.completeUnit(Result.unit)
+                                if c == 1 then promise.completeDiscard(Result.unit)
                                 Fiber.Unsafe.fromPromise(promise)
                         loop(count.get())
                     end await

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -33,7 +33,7 @@ abstract class Channel[A]:
       * @param v
       *   The element to offer
       */
-    def offerUnit(v: A)(using Frame): Unit < IO
+    def offerDiscard(v: A)(using Frame): Unit < IO
 
     /** Attempts to poll an element from the channel without blocking.
       *
@@ -149,7 +149,7 @@ object Channel:
                             }
                         }
 
-                    def offerUnit(v: A)(using Frame) =
+                    def offerDiscard(v: A)(using Frame) =
                         IO.Unsafe {
                             if !u.closed() then
                                 try discard(u.offer(v))
@@ -256,13 +256,13 @@ object Channel:
                                         takes.poll() match
                                             case null =>
                                             case p =>
-                                                p.completeUnit(c)
+                                                p.completeDiscard(c)
                                                 dropTakes()
                                     def dropPuts(): Unit =
                                         puts.poll() match
                                             case null => ()
                                             case (_, p) =>
-                                                p.completeUnit(c)
+                                                p.completeDiscard(c)
                                                 dropPuts()
                                     dropTakes()
                                     dropPuts()

--- a/kyo-core/shared/src/main/scala/kyo/Hub.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Hub.scala
@@ -35,7 +35,7 @@ class Hub[A] private[kyo] (
       * @param v
       *   the element to offer
       */
-    def offerUnit(v: A)(using Frame): Unit < IO = ch.offerUnit(v)
+    def offerDiscard(v: A)(using Frame): Unit < IO = ch.offerDiscard(v)
 
     /** Checks if the Hub is empty.
       *
@@ -80,7 +80,7 @@ class Hub[A] private[kyo] (
       *   a Maybe containing any remaining elements in the Hub
       */
     def close(using frame: Frame): Maybe[Seq[A]] < IO =
-        fiber.interruptUnit(Result.Panic(Closed("Hub", initFrame, frame))).andThen {
+        fiber.interruptDiscard(Result.Panic(Closed("Hub", initFrame, frame))).andThen {
             ch.close.map { r =>
                 IO {
                     val array = listeners.toArray()

--- a/kyo-core/shared/src/main/scala/kyo/Latch.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Latch.scala
@@ -75,7 +75,7 @@ object Latch:
                             if c > 0 && !count.cas(c, c - 1) then
                                 loop(count.get())
                             else if c == 1 then
-                                promise.completeUnit(Result.unit)
+                                promise.completeDiscard(Result.unit)
                         loop(count.get())
                     end release
 

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -84,7 +84,7 @@ object Meter:
             offer(concurrency, chan, ()).map { _ =>
                 new Meter:
                     def available(using Frame) = chan.size
-                    def release(using Frame)   = chan.offerUnit(())
+                    def release(using Frame)   = chan.offerDiscard(())
 
                     def run[A, S](v: => A < S)(using Frame) =
                         IO.ensure(release) {

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -91,7 +91,7 @@ object Resource:
                                     .map(_.fold(ex => Log.error("Resource finalizer failed", ex.exception))(_ => ()))
                             )
                                 .pipe(Async.run)
-                                .map(p.becomeUnit)
+                                .map(p.becomeDiscard)
                     }
                 ContextEffect.handle(Tag[Resource], finalizer, _ => finalizer)(v)
                     .pipe(IO.ensure(close))

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -64,7 +64,7 @@ private[kyo] class IOPromise[E, A](init: State[E, A]) extends Safepoint.Intercep
 
     final def mask: IOPromise[E, A] =
         val p = IOPromise[E, A]()
-        onComplete(p.completeUnit)
+        onComplete(p.completeDiscard)
         p
     end mask
 
@@ -103,7 +103,7 @@ private[kyo] class IOPromise[E, A](init: State[E, A]) extends Safepoint.Intercep
         mergeLoop(this)
     end merge
 
-    final def becomeUnit[E2 <: E, A2 <: A](other: IOPromise[E2, A2]): Unit =
+    final def becomeDiscard[E2 <: E, A2 <: A](other: IOPromise[E2, A2]): Unit =
         discard(become(other))
 
     final def become[E2 <: E, A2 <: A](other: IOPromise[E2, A2]): Boolean =
@@ -166,7 +166,7 @@ private[kyo] class IOPromise[E, A](init: State[E, A]) extends Safepoint.Intercep
             true
         }
 
-    final def completeUnit[E2 <: E, A2 <: A](v: Result[E2, A2]): Unit =
+    final def completeDiscard[E2 <: E, A2 <: A](v: Result[E2, A2]): Unit =
         discard(complete(v))
 
     final def complete[E2 <: E, A2 <: A](v: Result[E2, A2]): Boolean =

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -42,7 +42,7 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
                     [C] =>
                         (input, cont) =>
                             locally {
-                                completeUnit(input.asInstanceOf[Result[E, A]])
+                                completeDiscard(input.asInstanceOf[Result[E, A]])
                                 nullResult
                         },
                     [C] =>
@@ -56,17 +56,17 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
                                 this.trace = null.asInstanceOf[Trace]
                                 input.onComplete { r =>
                                     val task = IOTask(IO(cont(r.asInstanceOf[Result[Nothing, C]])), trace, context, ensures, runtime)
-                                    this.becomeUnit(task)
+                                    this.becomeDiscard(task)
                                 }
                                 nullResult
                         }
                 )
             }
             if !isNull(curr) then
-                curr.evalNow.foreach(a => completeUnit(Result.success(a)))
+                curr.evalNow.foreach(a => completeDiscard(Result.success(a)))
         catch
             case ex =>
-                completeUnit(Result.panic(ex))
+                completeDiscard(Result.panic(ex))
         end try
     end eval
 

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -88,20 +88,20 @@ class AsyncTest extends Test:
             }
         }
 
-        "completeUnit" in run {
+        "completeDiscard" in run {
             for
                 p <- Promise.init[Nothing, Int]
-                _ <- p.completeUnit(Result.success(1))
+                _ <- p.completeDiscard(Result.success(1))
                 v <- p.get
             yield assert(v == 1)
         }
 
-        "becomeUnit" in run {
+        "becomeDiscard" in run {
             for
                 p1 <- Promise.init[Nothing, Int]
                 p2 <- Promise.init[Nothing, Int]
                 _  <- p2.complete(Result.success(42))
-                _  <- p1.becomeUnit(p2)
+                _  <- p1.becomeDiscard(p2)
                 v  <- p1.get
             yield assert(v == 42)
         }

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -124,7 +124,7 @@ class ChannelTest extends Test:
                 f <- c.putFiber(3)
                 r <- c.close
                 d <- f.getResult
-                _ <- c.offerUnit(1)
+                _ <- c.offerDiscard(1)
             yield assert(r == Maybe(Seq(1, 2)) && d.isPanic)
         }
         "no buffer w/ pending put" in runJVM {

--- a/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
@@ -47,17 +47,17 @@ class IOPromiseTest extends Test:
         }
     }
 
-    "completeUnit" - {
+    "completeDiscard" - {
         "success" in {
             val p = new IOPromise[Nothing, Int]()
-            p.completeUnit(Result.success(1))
+            p.completeDiscard(Result.success(1))
             assert(p.block(timeout.toMillis) == Result.success(1))
         }
 
-        "completeUnit with failure" in {
+        "completeDiscard with failure" in {
             val p  = new IOPromise[Exception, Int]()
             val ex = new Exception("Test exception")
-            p.completeUnit(Result.fail(ex))
+            p.completeDiscard(Result.fail(ex))
             assert(p.block(timeout.toMillis) == Result.fail(ex))
         }
     }
@@ -112,20 +112,20 @@ class IOPromiseTest extends Test:
         }
     }
 
-    "becomeUnit" - {
+    "becomeDiscard" - {
         "success" in {
             val p1 = new IOPromise[Nothing, Int]()
             val p2 = new IOPromise[Nothing, Int]()
             p2.complete(Result.success(42))
-            p1.becomeUnit(p2)
+            p1.becomeDiscard(p2)
             val v = p1.block(timeout.toMillis)
             assert(v == Result.success(42))
         }
 
-        "becomeUnit with incomplete promise" in {
+        "becomeDiscard with incomplete promise" in {
             val p1 = new IOPromise[Nothing, Int]()
             val p2 = new IOPromise[Nothing, Int]()
-            p1.becomeUnit(p2)
+            p1.becomeDiscard(p2)
             p2.complete(Result.success(42))
             val v = p1.block(timeout.toMillis)
             assert(v == Result.success(42))


### PR DESCRIPTION
Cleanup to replace `Unit` with `Discard` in methods that discard the result of the operation