### PR TITLE
data: Rename Maybe.Defined/Empty to Present/Absent and export them to the kyo package

### DIFF
--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -226,11 +226,10 @@ extension [A, S](effect: A < S)
       * @param condition
       *   The condition to check
       * @return
-      *   A computation that produces the result of this computation wrapped in Maybe.Defined if the condition is satisfied, or Maybe.Empty
-      *   if not
+      *   A computation that produces the result of this computation wrapped in Defined if the condition is satisfied, or Empty if not
       */
     def when[S1](condition: => Boolean < S1)(using Frame): Maybe[A] < (S & S1) =
-        condition.map(c => if c then effect.map(Maybe.Defined.apply) else Maybe.Empty)
+        condition.map(c => if c then effect.map(Defined.apply) else Empty)
 
     /** Performs this computation catching any Throwable in an Abort[Throwable] effect.
       *
@@ -248,15 +247,15 @@ extension [A, S](effect: A < S)
     def tap[S1](f: A => Any < S1)(using Frame): A < (S & S1) =
         effect.map(a => f(a).as(a))
 
-    /** Performs this computation unless the given condition holds, in which case it returns an Abort[Maybe.Empty] effect.
+    /** Performs this computation unless the given condition holds, in which case it returns an Abort[Empty] effect.
       *
       * @param condition
       *   The condition to check
       * @return
-      *   A computation that produces the result of this computation with Abort[Maybe.Empty] effect
+      *   A computation that produces the result of this computation with Abort[Empty] effect
       */
-    def unless[S1](condition: Boolean < S1)(using Frame): A < (S & S1 & Abort[Maybe.Empty]) =
-        condition.map(c => if c then Abort.fail(Maybe.Empty) else effect)
+    def unless[S1](condition: Boolean < S1)(using Frame): A < (S & S1 & Abort[Empty]) =
+        condition.map(c => if c then Abort.fail(Empty) else effect)
 
     /** Ensures that the specified finalizer is executed after this effect, whether it succeeds or fails. The finalizer will execute when
       * the Resource effect is handled.
@@ -303,19 +302,19 @@ extension [A, S, E](effect: A < (Abort[E] & S))
 
     def someAbortToChoice[E1 <: E](using Frame): SomeAbortToChoiceOps[A, S, E, E1] = SomeAbortToChoiceOps(effect)
 
-    /** Translates the Abort[E] effect to an Abort[Maybe.Empty] effect in case of failure.
+    /** Translates the Abort[E] effect to an Abort[Empty] effect in case of failure.
       *
       * @return
-      *   A computation that produces the result of this computation with the Abort[E] effect translated to Abort[Maybe.Empty]
+      *   A computation that produces the result of this computation with the Abort[E] effect translated to Abort[Empty]
       */
     def abortToEmpty(
         using
         ct: SafeClassTag[E],
         tag: Tag[E],
         flat: Flat[A]
-    )(using Frame): A < (S & Abort[Maybe.Empty]) =
+    )(using Frame): A < (S & Abort[Empty]) =
         effect.handleAbort.map {
-            case Result.Fail(_)    => Abort.fail(Maybe.Empty)
+            case Result.Fail(_)    => Abort.fail(Empty)
             case Result.Panic(e)   => throw e
             case Result.Success(a) => a
         }
@@ -398,36 +397,36 @@ extension [A, S, E](effect: A < (Abort[E] & S))
             .map(_.fold(e => throw e.getFailure)(identity))
 end extension
 
-extension [A, S, E](effect: A < (Abort[Maybe.Empty] & S))
+extension [A, S, E](effect: A < (Abort[Empty] & S))
 
-    /** Handles the Abort[Maybe.Empty] effect and returns its result as a `Maybe[A]`.
+    /** Handles the Abort[Empty] effect and returns its result as a `Maybe[A]`.
       *
       * @return
-      *   A computation that produces the result of this computation with the Abort[Maybe.Empty] effect handled
+      *   A computation that produces the result of this computation with the Abort[Empty] effect handled
       */
     def handleEmptyAbort(using Flat[A], Frame): Maybe[A] < S =
-        Abort.run[Maybe.Empty](effect).map {
-            case Result.Fail(_)    => Maybe.Empty
+        Abort.run[Empty](effect).map {
+            case Result.Fail(_)    => Empty
             case Result.Panic(e)   => throw e
-            case Result.Success(a) => Maybe.Defined(a)
+            case Result.Success(a) => Defined(a)
         }
 
-    /** Translates the Abort[Maybe.Empty] effect to a Choice effect.
+    /** Translates the Abort[Empty] effect to a Choice effect.
       *
       * @return
-      *   A computation that produces the result of this computation with the Abort[Maybe.Empty] effect translated to Choice
+      *   A computation that produces the result of this computation with the Abort[Empty] effect translated to Choice
       */
     def emptyAbortToChoice(using Flat[A], Frame): A < (S & Choice) =
-        effect.someAbortToChoice[Maybe.Empty]()
+        effect.someAbortToChoice[Empty]()
 
-    /** Handles the Abort[Maybe.Empty] effect translating it to an Abort[E] effect.
+    /** Handles the Abort[Empty] effect translating it to an Abort[E] effect.
       *
       * @return
-      *   A computation that produces the result of this computation with the Abort[Maybe.Empty] effect translated to Abort[E]
+      *   A computation that produces the result of this computation with the Abort[Empty] effect translated to Abort[E]
       */
     def emptyAbortToFailure(failure: => E)(using Flat[A], Frame): A < (S & Abort[E]) =
         for
-            res <- effect.handleSomeAbort[Maybe.Empty]()
+            res <- effect.handleSomeAbort[Empty]()
         yield res match
             case Result.Fail(_)    => Abort.get(Result.Fail(failure))
             case Result.Success(a) => Abort.get(Result.success(a))
@@ -456,10 +455,10 @@ end SomeAbortToChoiceOps
 
 class SomeAbortToEmptyOps[A, S, E, E1 <: E](effect: A < (Abort[E] & S)) extends AnyVal:
 
-    /** Handles the Abort[E] effect translating it to an Abort[Maybe.Empty] effect.
+    /** Handles the Abort[E] effect translating it to an Abort[Empty] effect.
       *
       * @return
-      *   A computation that produces the result of this computation with Abort[Maybe.Empty] effect
+      *   A computation that produces the result of this computation with Abort[Empty] effect
       */
     def apply[ER]()(
         using
@@ -469,9 +468,9 @@ class SomeAbortToEmptyOps[A, S, E, E1 <: E](effect: A < (Abort[E] & S)) extends 
         reduce: Reducible[Abort[ER]],
         flat: Flat[A],
         frame: Frame
-    ): A < (S & reduce.SReduced & Abort[Maybe.Empty]) =
+    ): A < (S & reduce.SReduced & Abort[Empty]) =
         Abort.run[E1](effect.asInstanceOf[A < (Abort[E1 | ER] & S)]).map {
-            case Result.Fail(_)        => Abort.get(Result.Fail(Maybe.Empty))
+            case Result.Fail(_)        => Abort.get(Result.Fail(Empty))
             case p @ Result.Panic(e)   => Abort.get(p.asInstanceOf[Result[Nothing, Nothing]])
             case s @ Result.Success(a) => Abort.get(s.asInstanceOf[Result[Nothing, A]])
         }

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -156,24 +156,24 @@ extension (kyoObject: Kyo.type)
     def fromEither[E, A](either: Either[E, A])(using Frame): A < Abort[E] =
         Abort.get(either)
 
-    /** Creates an effect from an Option[A] and handles None to Abort[Empty].
+    /** Creates an effect from an Option[A] and handles None to Abort[Absent].
       *
       * @param option
       *   The Option[A] to create an effect from
       * @return
-      *   An effect that attempts to run the given effect and handles None to Abort[Empty].
+      *   An effect that attempts to run the given effect and handles None to Abort[Absent].
       */
-    def fromOption[A](option: Option[A])(using Frame): A < Abort[Empty] =
+    def fromOption[A](option: Option[A])(using Frame): A < Abort[Absent] =
         Abort.get(option)
 
-    /** Creates an effect from a Maybe[A] and handles Empty to Abort[Empty].
+    /** Creates an effect from a Maybe[A] and handles Absent to Abort[Absent].
       *
       * @param maybe
       *   The Maybe[A] to create an effect from
       * @return
-      *   An effect that attempts to run the given effect and handles Empty to Abort[Empty].
+      *   An effect that attempts to run the given effect and handles Absent to Abort[Absent].
       */
-    def fromMaybe[A](maybe: Maybe[A])(using Frame): A < Abort[Empty] =
+    def fromMaybe[A](maybe: Maybe[A])(using Frame): A < Abort[Absent] =
         Abort.get(maybe)
 
     /** Creates an effect from a Result[E, A] and handles Result.Failure[E] to Abort[E].

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -156,24 +156,24 @@ extension (kyoObject: Kyo.type)
     def fromEither[E, A](either: Either[E, A])(using Frame): A < Abort[E] =
         Abort.get(either)
 
-    /** Creates an effect from an Option[A] and handles None to Abort[Maybe.Empty].
+    /** Creates an effect from an Option[A] and handles None to Abort[Empty].
       *
       * @param option
       *   The Option[A] to create an effect from
       * @return
-      *   An effect that attempts to run the given effect and handles None to Abort[Maybe.Empty].
+      *   An effect that attempts to run the given effect and handles None to Abort[Empty].
       */
-    def fromOption[A](option: Option[A])(using Frame): A < Abort[Maybe.Empty] =
+    def fromOption[A](option: Option[A])(using Frame): A < Abort[Empty] =
         Abort.get(option)
 
-    /** Creates an effect from a Maybe[A] and handles Maybe.Empty to Abort[Maybe.Empty].
+    /** Creates an effect from a Maybe[A] and handles Empty to Abort[Empty].
       *
       * @param maybe
       *   The Maybe[A] to create an effect from
       * @return
-      *   An effect that attempts to run the given effect and handles Maybe.Empty to Abort[Maybe.Empty].
+      *   An effect that attempts to run the given effect and handles Empty to Abort[Empty].
       */
-    def fromMaybe[A](maybe: Maybe[A])(using Frame): A < Abort[Maybe.Empty] =
+    def fromMaybe[A](maybe: Maybe[A])(using Frame): A < Abort[Empty] =
         Abort.get(maybe)
 
     /** Creates an effect from a Result[E, A] and handles Result.Failure[E] to Abort[E].

--- a/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorTest.scala
@@ -31,16 +31,16 @@ class AbortCombinatorTest extends Test:
 
             "should construct from option" in {
                 val effect = Kyo.fromOption(None)
-                assert(Abort.run[Empty](effect).eval.failure.get == Empty)
+                assert(Abort.run[Absent](effect).eval.failure.get == Absent)
                 val effect1 = Kyo.fromOption(Some(1))
-                assert(Abort.run[Empty](effect1).eval.getOrElse(-1) == 1)
+                assert(Abort.run[Absent](effect1).eval.getOrElse(-1) == 1)
             }
 
             "should construct from maybe" in {
-                val effect = Kyo.fromMaybe(Empty)
-                assert(Abort.run[Empty](effect).eval.failure.get == Empty)
-                val effect1 = Kyo.fromMaybe(Defined(1))
-                assert(Abort.run[Empty](effect1).eval.getOrElse(-1) == 1)
+                val effect = Kyo.fromMaybe(Absent)
+                assert(Abort.run[Absent](effect).eval.failure.get == Absent)
+                val effect1 = Kyo.fromMaybe(Present(1))
+                assert(Abort.run[Absent](effect1).eval.getOrElse(-1) == 1)
             }
 
             "should construct from a throwing block" in {
@@ -97,25 +97,25 @@ class AbortCombinatorTest extends Test:
             "should convert all abort to empty" in {
                 val failure: Int < Abort[String] =
                     Abort.fail("failure")
-                val failureEmpty: Int < Abort[Empty] = failure.abortToEmpty
-                val handledFailureEmpty              = Abort.run[Empty](failureEmpty)
-                assert(handledFailureEmpty.eval == Result.Fail(Empty))
-                val success: Int < Abort[String]     = 23
-                val successEmpty: Int < Abort[Empty] = success.abortToEmpty
-                val handledSuccessEmpty              = Abort.run[Any](successEmpty)
+                val failureEmpty: Int < Abort[Absent] = failure.abortToEmpty
+                val handledFailureEmpty               = Abort.run[Absent](failureEmpty)
+                assert(handledFailureEmpty.eval == Result.Fail(Absent))
+                val success: Int < Abort[String]      = 23
+                val successEmpty: Int < Abort[Absent] = success.abortToEmpty
+                val handledSuccessEmpty               = Abort.run[Any](successEmpty)
                 assert(handledSuccessEmpty.eval == Result.Success(23))
             }
 
             "should convert some abort to empty" in {
                 val failure: Int < Abort[String | Boolean | Double | Int] =
                     Abort.fail("failure")
-                val failureEmpty: Int < Abort[Empty | Boolean | Double | Int] =
+                val failureEmpty: Int < Abort[Absent | Boolean | Double | Int] =
                     failure.someAbortToEmpty[String]()
                 val handledFailureEmpty = Choice.run(failureEmpty)
                 val handledFailureAbort = Abort.run[Any](handledFailureEmpty)
-                assert(handledFailureAbort.eval == Result.fail(Empty))
+                assert(handledFailureAbort.eval == Result.fail(Absent))
                 val success: Int < Abort[String | Boolean | Double | Int] = 23
-                val successEmpty: Int < (Abort[Empty | Boolean | Double | Int]) =
+                val successEmpty: Int < (Abort[Absent | Boolean | Double | Int]) =
                     success.someAbortToEmpty[String]()
                 val handledSuccessEmpty = Abort.run[Any](successEmpty)
                 assert(handledSuccessEmpty.eval == Result.success(23))
@@ -282,7 +282,7 @@ class AbortCombinatorTest extends Test:
             "should convert some abort to empty" in {
                 val effect: Int < Abort[String | Boolean] = Abort.fail("error")
                 val emptyEffect                           = effect.someAbortToEmpty[String]()
-                assert(Abort.run[Any](emptyEffect).eval == Result.fail(Empty))
+                assert(Abort.run[Any](emptyEffect).eval == Result.fail(Absent))
 
                 val effect2: Int < Abort[String | Boolean] = 42
                 val emptyEffect2                           = effect2.someAbortToEmpty[String]()

--- a/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorTest.scala
@@ -31,16 +31,16 @@ class AbortCombinatorTest extends Test:
 
             "should construct from option" in {
                 val effect = Kyo.fromOption(None)
-                assert(Abort.run[Maybe.Empty](effect).eval.failure.get == Maybe.Empty)
+                assert(Abort.run[Empty](effect).eval.failure.get == Empty)
                 val effect1 = Kyo.fromOption(Some(1))
-                assert(Abort.run[Maybe.Empty](effect1).eval.getOrElse(-1) == 1)
+                assert(Abort.run[Empty](effect1).eval.getOrElse(-1) == 1)
             }
 
             "should construct from maybe" in {
-                val effect = Kyo.fromMaybe(Maybe.Empty)
-                assert(Abort.run[Maybe.Empty](effect).eval.failure.get == Maybe.Empty)
-                val effect1 = Kyo.fromMaybe(Maybe.Defined(1))
-                assert(Abort.run[Maybe.Empty](effect1).eval.getOrElse(-1) == 1)
+                val effect = Kyo.fromMaybe(Empty)
+                assert(Abort.run[Empty](effect).eval.failure.get == Empty)
+                val effect1 = Kyo.fromMaybe(Defined(1))
+                assert(Abort.run[Empty](effect1).eval.getOrElse(-1) == 1)
             }
 
             "should construct from a throwing block" in {
@@ -97,25 +97,25 @@ class AbortCombinatorTest extends Test:
             "should convert all abort to empty" in {
                 val failure: Int < Abort[String] =
                     Abort.fail("failure")
-                val failureEmpty: Int < Abort[Maybe.Empty] = failure.abortToEmpty
-                val handledFailureEmpty                    = Abort.run[Maybe.Empty](failureEmpty)
-                assert(handledFailureEmpty.eval == Result.Fail(Maybe.Empty))
-                val success: Int < Abort[String]           = 23
-                val successEmpty: Int < Abort[Maybe.Empty] = success.abortToEmpty
-                val handledSuccessEmpty                    = Abort.run[Any](successEmpty)
+                val failureEmpty: Int < Abort[Empty] = failure.abortToEmpty
+                val handledFailureEmpty              = Abort.run[Empty](failureEmpty)
+                assert(handledFailureEmpty.eval == Result.Fail(Empty))
+                val success: Int < Abort[String]     = 23
+                val successEmpty: Int < Abort[Empty] = success.abortToEmpty
+                val handledSuccessEmpty              = Abort.run[Any](successEmpty)
                 assert(handledSuccessEmpty.eval == Result.Success(23))
             }
 
             "should convert some abort to empty" in {
                 val failure: Int < Abort[String | Boolean | Double | Int] =
                     Abort.fail("failure")
-                val failureEmpty: Int < Abort[Maybe.Empty | Boolean | Double | Int] =
+                val failureEmpty: Int < Abort[Empty | Boolean | Double | Int] =
                     failure.someAbortToEmpty[String]()
                 val handledFailureEmpty = Choice.run(failureEmpty)
                 val handledFailureAbort = Abort.run[Any](handledFailureEmpty)
-                assert(handledFailureAbort.eval == Result.fail(Maybe.Empty))
+                assert(handledFailureAbort.eval == Result.fail(Empty))
                 val success: Int < Abort[String | Boolean | Double | Int] = 23
-                val successEmpty: Int < (Abort[Maybe.Empty | Boolean | Double | Int]) =
+                val successEmpty: Int < (Abort[Empty | Boolean | Double | Int]) =
                     success.someAbortToEmpty[String]()
                 val handledSuccessEmpty = Abort.run[Any](successEmpty)
                 assert(handledSuccessEmpty.eval == Result.success(23))
@@ -282,7 +282,7 @@ class AbortCombinatorTest extends Test:
             "should convert some abort to empty" in {
                 val effect: Int < Abort[String | Boolean] = Abort.fail("error")
                 val emptyEffect                           = effect.someAbortToEmpty[String]()
-                assert(Abort.run[Any](emptyEffect).eval == Result.fail(Maybe.Empty))
+                assert(Abort.run[Any](emptyEffect).eval == Result.fail(Empty))
 
                 val effect2: Int < Abort[String | Boolean] = 42
                 val emptyEffect2                           = effect2.someAbortToEmpty[String]()

--- a/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
@@ -43,24 +43,24 @@ class ConstructorsTest extends Test:
                 val someEffect = Kyo.fromOption(Some(42))
                 val noneEffect = Kyo.fromOption(None)
 
-                val someResult = Abort.run[Empty](someEffect).eval
-                val noneResult = Abort.run[Empty](noneEffect).eval
+                val someResult = Abort.run[Absent](someEffect).eval
+                val noneResult = Abort.run[Absent](noneEffect).eval
 
                 assert(someResult == Result.success(42))
-                assert(noneResult == Result.fail(Empty))
+                assert(noneResult == Result.fail(Absent))
             }
         }
 
         "fromMaybe" - {
             "should create an effect from Maybe[A]" in {
-                val definedEffect = Kyo.fromMaybe(Defined(42))
-                val emptyEffect   = Kyo.fromMaybe(Empty)
+                val definedEffect = Kyo.fromMaybe(Present(42))
+                val emptyEffect   = Kyo.fromMaybe(Absent)
 
-                val definedResult = Abort.run[Empty](definedEffect).eval
-                val emptyResult   = Abort.run[Empty](emptyEffect).eval
+                val definedResult = Abort.run[Absent](definedEffect).eval
+                val emptyResult   = Abort.run[Absent](emptyEffect).eval
 
                 assert(definedResult == Result.success(42))
-                assert(emptyResult == Result.fail(Empty))
+                assert(emptyResult == Result.fail(Absent))
             }
         }
 

--- a/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
@@ -43,24 +43,24 @@ class ConstructorsTest extends Test:
                 val someEffect = Kyo.fromOption(Some(42))
                 val noneEffect = Kyo.fromOption(None)
 
-                val someResult = Abort.run[Maybe.Empty](someEffect).eval
-                val noneResult = Abort.run[Maybe.Empty](noneEffect).eval
+                val someResult = Abort.run[Empty](someEffect).eval
+                val noneResult = Abort.run[Empty](noneEffect).eval
 
                 assert(someResult == Result.success(42))
-                assert(noneResult == Result.fail(Maybe.Empty))
+                assert(noneResult == Result.fail(Empty))
             }
         }
 
         "fromMaybe" - {
             "should create an effect from Maybe[A]" in {
-                val definedEffect = Kyo.fromMaybe(Maybe.Defined(42))
-                val emptyEffect   = Kyo.fromMaybe(Maybe.Empty)
+                val definedEffect = Kyo.fromMaybe(Defined(42))
+                val emptyEffect   = Kyo.fromMaybe(Empty)
 
-                val definedResult = Abort.run[Maybe.Empty](definedEffect).eval
-                val emptyResult   = Abort.run[Maybe.Empty](emptyEffect).eval
+                val definedResult = Abort.run[Empty](definedEffect).eval
+                val emptyResult   = Abort.run[Empty](emptyEffect).eval
 
                 assert(definedResult == Result.success(42))
-                assert(emptyResult == Result.fail(Maybe.Empty))
+                assert(emptyResult == Result.fail(Empty))
             }
         }
 

--- a/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
@@ -117,7 +117,7 @@ class EffectCombinatorTest extends Test:
                 val getState   = IO(state)
                 val effectWhen = (toggleState *> getState).when(getState)
                 effectWhen.map { handledEffectWhen =>
-                    assert(handledEffectWhen == Empty)
+                    assert(handledEffectWhen == Absent)
                 }
             }
             "condition is true" in run {
@@ -128,7 +128,7 @@ class EffectCombinatorTest extends Test:
                 val getState   = IO(state)
                 val effectWhen = (toggleState *> getState).when(getState)
                 effectWhen.map { handledEffectWhen =>
-                    assert(handledEffectWhen == Defined(false))
+                    assert(handledEffectWhen == Present(false))
                 }
             }
         }
@@ -141,7 +141,7 @@ class EffectCombinatorTest extends Test:
                         effect
                     }
                 }.map { result =>
-                    assert(result == Result.fail(Empty))
+                    assert(result == Result.fail(Absent))
                 }
             }
             "condition is false" in run {

--- a/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EffectCombinatorTest.scala
@@ -117,7 +117,7 @@ class EffectCombinatorTest extends Test:
                 val getState   = IO(state)
                 val effectWhen = (toggleState *> getState).when(getState)
                 effectWhen.map { handledEffectWhen =>
-                    assert(handledEffectWhen == Maybe.Empty)
+                    assert(handledEffectWhen == Empty)
                 }
             }
             "condition is true" in run {
@@ -128,7 +128,7 @@ class EffectCombinatorTest extends Test:
                 val getState   = IO(state)
                 val effectWhen = (toggleState *> getState).when(getState)
                 effectWhen.map { handledEffectWhen =>
-                    assert(handledEffectWhen == Maybe.Defined(false))
+                    assert(handledEffectWhen == Defined(false))
                 }
             }
         }
@@ -141,7 +141,7 @@ class EffectCombinatorTest extends Test:
                         effect
                     }
                 }.map { result =>
-                    assert(result == Result.fail(Maybe.Empty))
+                    assert(result == Result.fail(Empty))
                 }
             }
             "condition is false" in run {

--- a/kyo-core/jvm/src/main/scala/kyo/Path.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Path.scala
@@ -162,8 +162,8 @@ class Path private (val path: List[String]) derives CanEqual:
             Resource.acquireRelease(acquire)(release).map { res =>
                 readOnce(res).map { state =>
                     Loop(state) {
-                        case Empty => Loop.done(Emit.Ack.Stop)
-                        case Defined(content) =>
+                        case Absent => Loop.done(Emit.Ack.Stop)
+                        case Present(content) =>
                             Emit.andMap(writeOnce(content)) {
                                 case Emit.Ack.Stop => Loop.done(Emit.Ack.Stop)
                                 case _             => readOnce(res).map(Loop.continue(_))

--- a/kyo-core/jvm/src/main/scala/kyo/Path.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Path.scala
@@ -162,8 +162,8 @@ class Path private (val path: List[String]) derives CanEqual:
             Resource.acquireRelease(acquire)(release).map { res =>
                 readOnce(res).map { state =>
                     Loop(state) {
-                        case Maybe.Empty => Loop.done(Emit.Ack.Stop)
-                        case Maybe.Defined(content) =>
+                        case Empty => Loop.done(Emit.Ack.Stop)
+                        case Defined(content) =>
                             Emit.andMap(writeOnce(content)) {
                                 case Emit.Ack.Stop => Loop.done(Emit.Ack.Stop)
                                 case _             => readOnce(res).map(Loop.continue(_))

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import java.util.concurrent.atomic.AtomicInteger
-import kyo.Maybe.Empty
+import kyo.Empty
 import kyo.Result.Panic
 import kyo.Tag
 import kyo.internal.FiberPlatformSpecific

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -1,7 +1,6 @@
 package kyo
 
 import java.util.concurrent.atomic.AtomicInteger
-import kyo.Empty
 import kyo.Result.Panic
 import kyo.Tag
 import kyo.internal.FiberPlatformSpecific

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -204,11 +204,11 @@ object Channel:
                                     throw closedException
                                 else
                                     u.poll() match
-                                        case Maybe.Empty =>
+                                        case Empty =>
                                             val p = Promise.Unsafe.init[Nothing, A]()
                                             takes.add(p)
                                             p.safe.get
-                                        case Maybe.Defined(v) =>
+                                        case Defined(v) =>
                                             v
                             finally
                                 flush()
@@ -221,11 +221,11 @@ object Channel:
                                     throw closedException
                                 else
                                     u.poll() match
-                                        case Maybe.Empty =>
+                                        case Empty =>
                                             val p = Promise.Unsafe.init[Nothing, A]()
                                             takes.add(p)
                                             p.safe
-                                        case Maybe.Defined(v) =>
+                                        case Defined(v) =>
                                             Fiber.success(v)
                             finally
                                 flush()
@@ -248,7 +248,7 @@ object Channel:
                     def close(using frame: Frame) =
                         IO.Unsafe {
                             u.close() match
-                                case Maybe.Empty => Maybe.empty
+                                case Empty => Maybe.empty
                                 case r =>
                                     val c = Result.panic(closedException)
                                     def dropTakes(): Unit =
@@ -283,11 +283,11 @@ object Channel:
                             val p = takes.poll()
                             if !isNull(p) then
                                 u.poll() match
-                                    case Maybe.Empty =>
+                                    case Empty =>
                                         // If the queue has been emptied before the
                                         // transfer, requeue the consumer's promise.
                                         discard(takes.add(p))
-                                    case Maybe.Defined(v) =>
+                                    case Defined(v) =>
                                         if !p.complete(Result.success(v)) && !u.offer(v) then
                                             // If completing the take fails and the queue
                                             // cannot accept the value back, enqueue a

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -204,11 +204,11 @@ object Channel:
                                     throw closedException
                                 else
                                     u.poll() match
-                                        case Empty =>
+                                        case Absent =>
                                             val p = Promise.Unsafe.init[Nothing, A]()
                                             takes.add(p)
                                             p.safe.get
-                                        case Defined(v) =>
+                                        case Present(v) =>
                                             v
                             finally
                                 flush()
@@ -221,11 +221,11 @@ object Channel:
                                     throw closedException
                                 else
                                     u.poll() match
-                                        case Empty =>
+                                        case Absent =>
                                             val p = Promise.Unsafe.init[Nothing, A]()
                                             takes.add(p)
                                             p.safe
-                                        case Defined(v) =>
+                                        case Present(v) =>
                                             Fiber.success(v)
                             finally
                                 flush()
@@ -248,7 +248,7 @@ object Channel:
                     def close(using frame: Frame) =
                         IO.Unsafe {
                             u.close() match
-                                case Empty => Maybe.empty
+                                case Absent => Maybe.empty
                                 case r =>
                                     val c = Result.panic(closedException)
                                     def dropTakes(): Unit =
@@ -283,11 +283,11 @@ object Channel:
                             val p = takes.poll()
                             if !isNull(p) then
                                 u.poll() match
-                                    case Empty =>
+                                    case Absent =>
                                         // If the queue has been emptied before the
                                         // transfer, requeue the consumer's promise.
                                         discard(takes.add(p))
-                                    case Defined(v) =>
+                                    case Present(v) =>
                                         if !p.complete(Result.success(v)) && !u.offer(v) then
                                             // If completing the take fails and the queue
                                             // cannot accept the value back, enqueue a

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -2,7 +2,6 @@ package kyo
 
 export Fiber.Promise
 import java.util.concurrent.atomic.AtomicInteger
-import kyo.Empty
 import kyo.Result.Panic
 import kyo.Tag
 import kyo.internal.FiberPlatformSpecific

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -2,7 +2,7 @@ package kyo
 
 export Fiber.Promise
 import java.util.concurrent.atomic.AtomicInteger
-import kyo.Maybe.Empty
+import kyo.Empty
 import kyo.Result.Panic
 import kyo.Tag
 import kyo.internal.FiberPlatformSpecific

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -42,7 +42,7 @@ abstract class Meter:
       * @tparam S
       *   The effect type.
       * @return
-      *   A Maybe containing the result of running the effect, or Empty if no permit was available.
+      *   A Maybe containing the result of running the effect, or Absent if no permit was available.
       */
     def tryRun[A, S](v: => A < S)(using Frame): Maybe[A] < (IO & S)
 
@@ -94,7 +94,7 @@ object Meter:
                     def tryRun[A, S](v: => A < S)(using Frame) =
                         IO.Unsafe {
                             chan.unsafePoll match
-                                case Empty => Maybe.empty
+                                case Absent => Maybe.empty
                                 case _ =>
                                     IO.ensure(release) {
                                         v.map(Maybe(_))
@@ -125,7 +125,7 @@ object Meter:
 
                     def tryRun[A, S](v: => A < S)(using Frame) =
                         chan.poll.map {
-                            case Empty =>
+                            case Absent =>
                                 Maybe.empty
                             case _ =>
                                 v.map(Maybe(_))
@@ -217,8 +217,8 @@ object Meter:
                         if idx == meters.length then v.map(Maybe(_))
                         else
                             meters(idx).tryRun(loop(idx + 1)).map {
-                                case Empty => Maybe.empty
-                                case r     => r.flatten
+                                case Absent => Maybe.empty
+                                case r      => r.flatten
                             }
                     loop()
                 end tryRun

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -94,7 +94,7 @@ object Meter:
                     def tryRun[A, S](v: => A < S)(using Frame) =
                         IO.Unsafe {
                             chan.unsafePoll match
-                                case Maybe.Empty => Maybe.empty
+                                case Empty => Maybe.empty
                                 case _ =>
                                     IO.ensure(release) {
                                         v.map(Maybe(_))
@@ -125,7 +125,7 @@ object Meter:
 
                     def tryRun[A, S](v: => A < S)(using Frame) =
                         chan.poll.map {
-                            case Maybe.Empty =>
+                            case Empty =>
                                 Maybe.empty
                             case _ =>
                                 v.map(Maybe(_))
@@ -217,8 +217,8 @@ object Meter:
                         if idx == meters.length then v.map(Maybe(_))
                         else
                             meters(idx).tryRun(loop(idx + 1)).map {
-                                case Maybe.Empty => Maybe.empty
-                                case r           => r.flatten
+                                case Empty => Maybe.empty
+                                case r     => r.flatten
                             }
                     loop()
                 end tryRun

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -118,8 +118,8 @@ object Queue:
             @tailrec def loop(): Unit =
                 val v = poll()
                 v match
-                    case Empty =>
-                    case Defined(v) =>
+                    case Absent =>
+                    case Present(v) =>
                         b += v
                         loop()
                 end match

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -118,8 +118,8 @@ object Queue:
             @tailrec def loop(): Unit =
                 val v = poll()
                 v match
-                    case Maybe.Empty =>
-                    case Maybe.Defined(v) =>
+                    case Empty =>
+                    case Defined(v) =>
                         b += v
                         loop()
                 end match

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -83,9 +83,9 @@ object Resource:
                 val finalizer = Finalizer(frame, q)
                 def close: Unit < IO =
                     q.close.map {
-                        case Empty =>
+                        case Absent =>
                             bug("Resource finalizer queue already closed.")
-                        case Defined(l) =>
+                        case Present(l) =>
                             Kyo.foreachDiscard(l)(task =>
                                 Abort.run[Throwable](task)
                                     .map(_.fold(ex => Log.error("Resource finalizer failed", ex.exception))(_ => ()))

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -83,9 +83,9 @@ object Resource:
                 val finalizer = Finalizer(frame, q)
                 def close: Unit < IO =
                     q.close.map {
-                        case Maybe.Empty =>
+                        case Empty =>
                             bug("Resource finalizer queue already closed.")
-                        case Maybe.Defined(l) =>
+                        case Defined(l) =>
                             Kyo.foreachDiscard(l)(task =>
                                 Abort.run[Throwable](task)
                                     .map(_.fold(ex => Log.error("Resource finalizer failed", ex.exception))(_ => ()))

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -42,14 +42,14 @@ object System:
             def env[E, A](name: String)(using p: Parser[E, A], frame: Frame): Maybe[A] < (Abort[E] & IO) =
                 IO.Unsafe {
                     u.env(name) match
-                        case Empty      => Empty
-                        case Defined(v) => Abort.get(p(v).map(Maybe(_)))
+                        case Absent     => Absent
+                        case Present(v) => Abort.get(p(v).map(Maybe(_)))
                 }
             def property[E, A](name: String)(using p: Parser[E, A], frame: Frame): Maybe[A] < (Abort[E] & IO) =
                 IO.Unsafe {
                     u.property(name) match
-                        case Empty      => Empty
-                        case Defined(v) => Abort.get(p(v).map(Maybe(_)))
+                        case Absent     => Absent
+                        case Present(v) => Abort.get(p(v).map(Maybe(_)))
                 }
             def lineSeparator(using Frame): String < IO = IO.Unsafe(u.lineSeparator())
             def userName(using Frame): String < IO      = IO.Unsafe(u.userName())

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -42,14 +42,14 @@ object System:
             def env[E, A](name: String)(using p: Parser[E, A], frame: Frame): Maybe[A] < (Abort[E] & IO) =
                 IO.Unsafe {
                     u.env(name) match
-                        case Maybe.Empty      => Maybe.Empty
-                        case Maybe.Defined(v) => Abort.get(p(v).map(Maybe(_)))
+                        case Empty      => Empty
+                        case Defined(v) => Abort.get(p(v).map(Maybe(_)))
                 }
             def property[E, A](name: String)(using p: Parser[E, A], frame: Frame): Maybe[A] < (Abort[E] & IO) =
                 IO.Unsafe {
                     u.property(name) match
-                        case Maybe.Empty      => Maybe.Empty
-                        case Maybe.Defined(v) => Abort.get(p(v).map(Maybe(_)))
+                        case Empty      => Empty
+                        case Defined(v) => Abort.get(p(v).map(Maybe(_)))
                 }
             def lineSeparator(using Frame): String < IO = IO.Unsafe(u.lineSeparator())
             def userName(using Frame): String < IO      = IO.Unsafe(u.userName())

--- a/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
@@ -181,7 +181,7 @@ class ResourceTest extends Test:
                 .pipe(Resource.run)
                 .pipe(Async.runAndBlock(timeout))
                 .pipe(Abort.run[Timeout](_))
-                .pipe(Abort.run[Empty](_))
+                .pipe(Abort.run[Absent](_))
                 .map { _ =>
                     assert(closes == 1)
                 }

--- a/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
@@ -181,7 +181,7 @@ class ResourceTest extends Test:
                 .pipe(Resource.run)
                 .pipe(Async.runAndBlock(timeout))
                 .pipe(Abort.run[Timeout](_))
-                .pipe(Abort.run[Maybe.Empty](_))
+                .pipe(Abort.run[Empty](_))
                 .map { _ =>
                     assert(closes == 1)
                 }

--- a/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
@@ -309,9 +309,9 @@ class SystemTest extends Test:
             assert(testUnsafe.env(TEST_ENV) == Maybe("test_env_value"))
         }
 
-        "should return Empty for non-existent environment variable" in {
+        "should return Absent for non-existent environment variable" in {
             val testUnsafe = new TestUnsafeSystem()
-            assert(testUnsafe.env("NON_EXISTENT_ENV") == Empty)
+            assert(testUnsafe.env("NON_EXISTENT_ENV") == Absent)
         }
 
         "should get system property correctly" in {
@@ -319,9 +319,9 @@ class SystemTest extends Test:
             assert(testUnsafe.property(TEST_PROP) == Maybe("test_prop_value"))
         }
 
-        "should return Empty for non-existent system property" in {
+        "should return Absent for non-existent system property" in {
             val testUnsafe = new TestUnsafeSystem()
-            assert(testUnsafe.property("NON_EXISTENT_PROP") == Empty)
+            assert(testUnsafe.property("NON_EXISTENT_PROP") == Absent)
         }
 
         "should get line separator correctly" in {

--- a/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
@@ -309,9 +309,9 @@ class SystemTest extends Test:
             assert(testUnsafe.env(TEST_ENV) == Maybe("test_env_value"))
         }
 
-        "should return Maybe.Empty for non-existent environment variable" in {
+        "should return Empty for non-existent environment variable" in {
             val testUnsafe = new TestUnsafeSystem()
-            assert(testUnsafe.env("NON_EXISTENT_ENV") == Maybe.Empty)
+            assert(testUnsafe.env("NON_EXISTENT_ENV") == Empty)
         }
 
         "should get system property correctly" in {
@@ -319,9 +319,9 @@ class SystemTest extends Test:
             assert(testUnsafe.property(TEST_PROP) == Maybe("test_prop_value"))
         }
 
-        "should return Maybe.Empty for non-existent system property" in {
+        "should return Empty for non-existent system property" in {
             val testUnsafe = new TestUnsafeSystem()
-            assert(testUnsafe.property("NON_EXISTENT_PROP") == Maybe.Empty)
+            assert(testUnsafe.property("NON_EXISTENT_PROP") == Empty)
         }
 
         "should get line separator correctly" in {

--- a/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
@@ -300,7 +300,7 @@ class IOPromiseTest extends Test:
             val masked   = original.mask()
 
             var originalCompleted                         = false
-            var maskedResult: Maybe[Result[Nothing, Int]] = Maybe.Empty
+            var maskedResult: Maybe[Result[Nothing, Int]] = Empty
 
             original.onComplete(_ => originalCompleted = true)
             masked.onComplete(r => maskedResult = Maybe(r))
@@ -314,7 +314,7 @@ class IOPromiseTest extends Test:
             val original = new IOPromise[Nothing, Int]()
             val masked   = original.mask()
 
-            var maskedResult: Maybe[Result[Nothing, Int]] = Maybe.Empty
+            var maskedResult: Maybe[Result[Nothing, Int]] = Empty
             masked.onComplete(r => maskedResult = Maybe(r))
 
             original.complete(Result.success(42))
@@ -325,7 +325,7 @@ class IOPromiseTest extends Test:
             val original = new IOPromise[Exception, Int]()
             val masked   = original.mask()
 
-            var maskedResult: Maybe[Result[Exception, Int]] = Maybe.Empty
+            var maskedResult: Maybe[Result[Exception, Int]] = Empty
             masked.onComplete(r => maskedResult = Maybe(r))
 
             val ex = new Exception("Test exception")
@@ -337,8 +337,8 @@ class IOPromiseTest extends Test:
             val original = new IOPromise[Nothing, Int]()
             val masked   = original.mask()
 
-            var originalResult: Maybe[Result[Nothing, Int]] = Maybe.Empty
-            var maskedResult: Maybe[Result[Nothing, Int]]   = Maybe.Empty
+            var originalResult: Maybe[Result[Nothing, Int]] = Empty
+            var maskedResult: Maybe[Result[Nothing, Int]]   = Empty
 
             original.onComplete(r => originalResult = Maybe(r))
             masked.onComplete(r => maskedResult = Maybe(r))
@@ -355,7 +355,7 @@ class IOPromiseTest extends Test:
 
             var originalCompleted                          = false
             var masked1Completed                           = false
-            var masked2Result: Maybe[Result[Nothing, Int]] = Maybe.Empty
+            var masked2Result: Maybe[Result[Nothing, Int]] = Empty
 
             original.onComplete(_ => originalCompleted = true)
             masked1.onComplete(_ => masked1Completed = true)
@@ -375,7 +375,7 @@ class IOPromiseTest extends Test:
             original.complete(Result.success(42))
 
             val masked                                    = original.mask()
-            var maskedResult: Maybe[Result[Nothing, Int]] = Maybe.Empty
+            var maskedResult: Maybe[Result[Nothing, Int]] = Empty
             masked.onComplete(r => maskedResult = Maybe(r))
 
             assert(maskedResult.contains(Result.success(42)))
@@ -385,8 +385,8 @@ class IOPromiseTest extends Test:
             val original = new IOPromise[Nothing, Int]()
             val masked   = original.mask()
 
-            var originalResult: Maybe[Result[Nothing, Int]] = Maybe.Empty
-            var maskedResult: Maybe[Result[Nothing, Int]]   = Maybe.Empty
+            var originalResult: Maybe[Result[Nothing, Int]] = Empty
+            var maskedResult: Maybe[Result[Nothing, Int]]   = Empty
 
             original.onComplete(r => originalResult = Maybe(r))
             masked.onComplete(r => maskedResult = Maybe(r))
@@ -402,9 +402,9 @@ class IOPromiseTest extends Test:
             val masked1  = original.mask()
             val masked2  = masked1.mask()
 
-            var originalResult: Maybe[Result[Nothing, Int]] = Maybe.Empty
-            var masked1Result: Maybe[Result[Nothing, Int]]  = Maybe.Empty
-            var masked2Result: Maybe[Result[Nothing, Int]]  = Maybe.Empty
+            var originalResult: Maybe[Result[Nothing, Int]] = Empty
+            var masked1Result: Maybe[Result[Nothing, Int]]  = Empty
+            var masked2Result: Maybe[Result[Nothing, Int]]  = Empty
 
             original.onComplete(r => originalResult = Maybe(r))
             masked1.onComplete(r => masked1Result = Maybe(r))
@@ -428,9 +428,9 @@ class IOPromiseTest extends Test:
             val masked   = original.mask()
             val other    = new IOPromise[Nothing, Int]()
 
-            var originalResult: Maybe[Result[Nothing, Int]] = Maybe.Empty
-            var maskedResult: Maybe[Result[Nothing, Int]]   = Maybe.Empty
-            var otherResult: Maybe[Result[Nothing, Int]]    = Maybe.Empty
+            var originalResult: Maybe[Result[Nothing, Int]] = Empty
+            var maskedResult: Maybe[Result[Nothing, Int]]   = Empty
+            var otherResult: Maybe[Result[Nothing, Int]]    = Empty
 
             original.onComplete(r => originalResult = Maybe(r))
             masked.onComplete(r => maskedResult = Maybe(r))

--- a/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
@@ -300,7 +300,7 @@ class IOPromiseTest extends Test:
             val masked   = original.mask()
 
             var originalCompleted                         = false
-            var maskedResult: Maybe[Result[Nothing, Int]] = Empty
+            var maskedResult: Maybe[Result[Nothing, Int]] = Absent
 
             original.onComplete(_ => originalCompleted = true)
             masked.onComplete(r => maskedResult = Maybe(r))
@@ -314,7 +314,7 @@ class IOPromiseTest extends Test:
             val original = new IOPromise[Nothing, Int]()
             val masked   = original.mask()
 
-            var maskedResult: Maybe[Result[Nothing, Int]] = Empty
+            var maskedResult: Maybe[Result[Nothing, Int]] = Absent
             masked.onComplete(r => maskedResult = Maybe(r))
 
             original.complete(Result.success(42))
@@ -325,7 +325,7 @@ class IOPromiseTest extends Test:
             val original = new IOPromise[Exception, Int]()
             val masked   = original.mask()
 
-            var maskedResult: Maybe[Result[Exception, Int]] = Empty
+            var maskedResult: Maybe[Result[Exception, Int]] = Absent
             masked.onComplete(r => maskedResult = Maybe(r))
 
             val ex = new Exception("Test exception")
@@ -337,8 +337,8 @@ class IOPromiseTest extends Test:
             val original = new IOPromise[Nothing, Int]()
             val masked   = original.mask()
 
-            var originalResult: Maybe[Result[Nothing, Int]] = Empty
-            var maskedResult: Maybe[Result[Nothing, Int]]   = Empty
+            var originalResult: Maybe[Result[Nothing, Int]] = Absent
+            var maskedResult: Maybe[Result[Nothing, Int]]   = Absent
 
             original.onComplete(r => originalResult = Maybe(r))
             masked.onComplete(r => maskedResult = Maybe(r))
@@ -355,7 +355,7 @@ class IOPromiseTest extends Test:
 
             var originalCompleted                          = false
             var masked1Completed                           = false
-            var masked2Result: Maybe[Result[Nothing, Int]] = Empty
+            var masked2Result: Maybe[Result[Nothing, Int]] = Absent
 
             original.onComplete(_ => originalCompleted = true)
             masked1.onComplete(_ => masked1Completed = true)
@@ -375,7 +375,7 @@ class IOPromiseTest extends Test:
             original.complete(Result.success(42))
 
             val masked                                    = original.mask()
-            var maskedResult: Maybe[Result[Nothing, Int]] = Empty
+            var maskedResult: Maybe[Result[Nothing, Int]] = Absent
             masked.onComplete(r => maskedResult = Maybe(r))
 
             assert(maskedResult.contains(Result.success(42)))
@@ -385,8 +385,8 @@ class IOPromiseTest extends Test:
             val original = new IOPromise[Nothing, Int]()
             val masked   = original.mask()
 
-            var originalResult: Maybe[Result[Nothing, Int]] = Empty
-            var maskedResult: Maybe[Result[Nothing, Int]]   = Empty
+            var originalResult: Maybe[Result[Nothing, Int]] = Absent
+            var maskedResult: Maybe[Result[Nothing, Int]]   = Absent
 
             original.onComplete(r => originalResult = Maybe(r))
             masked.onComplete(r => maskedResult = Maybe(r))
@@ -402,9 +402,9 @@ class IOPromiseTest extends Test:
             val masked1  = original.mask()
             val masked2  = masked1.mask()
 
-            var originalResult: Maybe[Result[Nothing, Int]] = Empty
-            var masked1Result: Maybe[Result[Nothing, Int]]  = Empty
-            var masked2Result: Maybe[Result[Nothing, Int]]  = Empty
+            var originalResult: Maybe[Result[Nothing, Int]] = Absent
+            var masked1Result: Maybe[Result[Nothing, Int]]  = Absent
+            var masked2Result: Maybe[Result[Nothing, Int]]  = Absent
 
             original.onComplete(r => originalResult = Maybe(r))
             masked1.onComplete(r => masked1Result = Maybe(r))
@@ -428,9 +428,9 @@ class IOPromiseTest extends Test:
             val masked   = original.mask()
             val other    = new IOPromise[Nothing, Int]()
 
-            var originalResult: Maybe[Result[Nothing, Int]] = Empty
-            var maskedResult: Maybe[Result[Nothing, Int]]   = Empty
-            var otherResult: Maybe[Result[Nothing, Int]]    = Empty
+            var originalResult: Maybe[Result[Nothing, Int]] = Absent
+            var maskedResult: Maybe[Result[Nothing, Int]]   = Absent
+            var otherResult: Maybe[Result[Nothing, Int]]    = Absent
 
             original.onComplete(r => originalResult = Maybe(r))
             masked.onComplete(r => maskedResult = Maybe(r))

--- a/kyo-data/shared/src/main/scala/kyo/Maybe.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Maybe.scala
@@ -10,6 +10,9 @@ import Maybe.internal.*
   */
 opaque type Maybe[+A] >: (Empty | Defined[A]) = Empty | Defined[A]
 
+export Maybe.Defined
+export Maybe.Empty
+
 /** Companion object for Maybe type */
 object Maybe:
     inline given [A, B](using inline ce: CanEqual[A, B]): CanEqual[Maybe[A], Maybe[B]] = CanEqual.derived

--- a/kyo-data/shared/src/main/scala/kyo/Maybe.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Maybe.scala
@@ -69,7 +69,7 @@ object Maybe:
         if cond then v else Absent
 
     /** Represents a defined value in a Maybe. */
-    opaque type Present[+A] = A | PresentEmpty
+    opaque type Present[+A] = A | PresentAbsent
 
     object Present:
 
@@ -84,9 +84,9 @@ object Maybe:
           */
         def apply[A](v: A): Present[A] =
             v match
-                case v: PresentEmpty => v.nest
-                case v: Absent       => PresentEmpty.one
-                case v               => v
+                case v: PresentAbsent => v.nest
+                case v: Absent        => PresentAbsent.one
+                case v                => v
 
         /** Extracts the value from a Maybe instance.
           *
@@ -168,7 +168,7 @@ object Maybe:
             (self: @unchecked) match
                 case _: Absent =>
                     throw new NoSuchElementException("Maybe.get")
-                case self: PresentEmpty =>
+                case self: PresentAbsent =>
                     self.unnest.asInstanceOf[A]
                 case v: A =>
                     v
@@ -398,27 +398,27 @@ object Maybe:
 
     private[kyo] object internal:
 
-        case class PresentEmpty(val depth: Int):
+        case class PresentAbsent(val depth: Int):
             def unnest =
                 if depth > 1 then
-                    PresentEmpty(depth - 1)
+                    PresentAbsent(depth - 1)
                 else
                     Absent
             def nest =
-                PresentEmpty(depth + 1)
+                PresentAbsent(depth + 1)
 
             override def toString: String =
                 "Present(" * depth + "Absent" + ")" * depth
-        end PresentEmpty
+        end PresentAbsent
 
-        object PresentEmpty:
-            val cache = (0 until 100).map(new PresentEmpty(_)).toArray
-            val one   = PresentEmpty(1)
-            def apply(depth: Int): PresentEmpty =
+        object PresentAbsent:
+            val cache = (0 until 100).map(new PresentAbsent(_)).toArray
+            val one   = PresentAbsent(1)
+            def apply(depth: Int): PresentAbsent =
                 if depth < cache.length then
                     cache(depth)
                 else
-                    new PresentEmpty(depth)
-        end PresentEmpty
+                    new PresentAbsent(depth)
+        end PresentAbsent
     end internal
 end Maybe

--- a/kyo-data/shared/src/test/scala/kyo/MaybeTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/MaybeTest.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.Maybe.*
-import kyo.Maybe.internal.DefinedEmpty
+import kyo.Maybe.internal.PresentAbsent
 
 class MaybeTest extends Test:
 
@@ -13,8 +13,8 @@ class MaybeTest extends Test:
         "creates Absent for null values" in {
             assert(Maybe(null) == Absent)
         }
-        "creates DefinedEmpty for Absent" in {
-            assert(Maybe(Maybe.empty).equals(DefinedEmpty.one))
+        "creates PresentAbsent for Absent" in {
+            assert(Maybe(Maybe.empty).equals(PresentAbsent.one))
         }
     }
 
@@ -521,17 +521,17 @@ class MaybeTest extends Test:
         }
     }
 
-    "DefinedEmpty.toString" - {
+    "PresentAbsent.toString" - {
         "should return correct string representation" in {
-            assert(DefinedEmpty(1).toString == "Present(Absent)")
-            assert(DefinedEmpty(2).toString == "Present(Present(Absent))")
-            assert(DefinedEmpty(3).toString == "Present(Present(Present(Absent)))")
+            assert(PresentAbsent(1).toString == "Present(Absent)")
+            assert(PresentAbsent(2).toString == "Present(Present(Absent))")
+            assert(PresentAbsent(3).toString == "Present(Present(Present(Absent)))")
         }
 
         "should handle large depths" in {
             val largeDepth = 10
             val expected   = "Present(" * largeDepth + "Absent" + ")" * largeDepth
-            assert(DefinedEmpty(largeDepth).toString == expected)
+            assert(PresentAbsent(largeDepth).toString == expected)
         }
     }
 

--- a/kyo-data/shared/src/test/scala/kyo/MaybeTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/MaybeTest.scala
@@ -6,304 +6,304 @@ import kyo.Maybe.internal.DefinedEmpty
 class MaybeTest extends Test:
 
     "apply" - {
-        "creates Defined for non-null values" in {
-            assert(Maybe(1) == Defined(1))
-            assert(Maybe("hello") == Defined("hello"))
+        "creates Present for non-null values" in {
+            assert(Maybe(1) == Present(1))
+            assert(Maybe("hello") == Present("hello"))
         }
-        "creates Empty for null values" in {
-            assert(Maybe(null) == Empty)
+        "creates Absent for null values" in {
+            assert(Maybe(null) == Absent)
         }
-        "creates DefinedEmpty for Empty" in {
+        "creates DefinedEmpty for Absent" in {
             assert(Maybe(Maybe.empty).equals(DefinedEmpty.one))
         }
     }
 
     "isEmpty" - {
-        "returns true for Empty" in {
-            assert(Empty.isEmpty)
+        "returns true for Absent" in {
+            assert(Absent.isEmpty)
         }
-        "returns false for Defined" in {
-            assert(!Defined(1).isEmpty)
+        "returns false for Present" in {
+            assert(!Present(1).isEmpty)
         }
     }
 
     "isDefined" - {
-        "returns false for Empty" in {
-            assert(!Empty.isDefined)
+        "returns false for Absent" in {
+            assert(!Absent.isDefined)
         }
-        "returns true for Defined" in {
-            assert(Defined(1).isDefined)
+        "returns true for Present" in {
+            assert(Present(1).isDefined)
         }
     }
 
     "get" - {
-        "returns the value for Defined" in {
-            assert(Defined(1).get == 1)
-            assert(Defined("hello").get == "hello")
+        "returns the value for Present" in {
+            assert(Present(1).get == 1)
+            assert(Present("hello").get == "hello")
         }
-        "throws NoSuchElementException for Empty" in {
+        "throws NoSuchElementException for Absent" in {
             assertThrows[NoSuchElementException] {
-                Empty.get
+                Absent.get
             }
         }
     }
 
     "getOrElse" - {
-        "returns the value for Defined" in {
-            assert(Defined(1).getOrElse(0) == 1)
-            assert(Defined("hello").getOrElse("") == "hello")
+        "returns the value for Present" in {
+            assert(Present(1).getOrElse(0) == 1)
+            assert(Present("hello").getOrElse("") == "hello")
         }
-        "returns the default value for Empty" in {
-            assert(Empty.getOrElse(0) == 0)
-            assert(Empty.getOrElse("") == "")
+        "returns the default value for Absent" in {
+            assert(Absent.getOrElse(0) == 0)
+            assert(Absent.getOrElse("") == "")
         }
     }
 
     "fold" - {
-        "applies the empty function for Empty" in {
-            assert(Empty.fold(0)(_ => 1) == 0)
+        "applies the empty function for Absent" in {
+            assert(Absent.fold(0)(_ => 1) == 0)
         }
-        "applies the non-empty function for Defined" in {
-            assert(Defined(1).fold(0)(x => x + 1) == 2)
+        "applies the non-empty function for Present" in {
+            assert(Present(1).fold(0)(x => x + 1) == 2)
         }
     }
 
     "flatMap" - {
-        "returns Empty for Empty" in {
-            assert(Maybe.empty[Int].flatMap(x => Defined(x + 1)) == Empty)
+        "returns Absent for Absent" in {
+            assert(Maybe.empty[Int].flatMap(x => Present(x + 1)) == Absent)
         }
-        "applies the function for Defined" in {
-            assert(Defined(1).flatMap(x => Defined(x + 1)) == Defined(2))
+        "applies the function for Present" in {
+            assert(Present(1).flatMap(x => Present(x + 1)) == Present(2))
         }
     }
 
     "flatten" - {
-        "returns Empty for Empty" in {
-            assert(Empty.flatten == Empty)
+        "returns Absent for Absent" in {
+            assert(Absent.flatten == Absent)
         }
-        "returns the nested value for Defined" in {
-            assert(Defined(Defined(1)).flatten == Defined(1))
+        "returns the nested value for Present" in {
+            assert(Present(Present(1)).flatten == Present(1))
         }
     }
 
     "filter" - {
-        "returns Empty for Empty" in {
-            assert(Empty.filter(_ => true) == Empty)
+        "returns Absent for Absent" in {
+            assert(Absent.filter(_ => true) == Absent)
         }
-        "returns Empty if the predicate is false" in {
-            assert(Defined(1).filter(_ > 1) == Empty)
+        "returns Absent if the predicate is false" in {
+            assert(Present(1).filter(_ > 1) == Absent)
         }
-        "returns Defined if the predicate is true" in {
-            assert(Defined(1).filter(_ == 1) == Defined(1))
+        "returns Present if the predicate is true" in {
+            assert(Present(1).filter(_ == 1) == Present(1))
         }
     }
 
     "filterNot" - {
-        "returns Empty for Empty" in {
-            assert(Empty.filterNot(_ => false) == Empty)
+        "returns Absent for Absent" in {
+            assert(Absent.filterNot(_ => false) == Absent)
         }
-        "returns Defined if the predicate is false" in {
-            assert(Defined(1).filterNot(_ > 1) == Defined(1))
+        "returns Present if the predicate is false" in {
+            assert(Present(1).filterNot(_ > 1) == Present(1))
         }
-        "returns Empty if the predicate is true" in {
-            assert(Defined(1).filterNot(_ == 1) == Empty)
+        "returns Absent if the predicate is true" in {
+            assert(Present(1).filterNot(_ == 1) == Absent)
         }
     }
 
     "contains" - {
-        "returns false for Empty" in {
-            assert(!Empty.contains(1))
+        "returns false for Absent" in {
+            assert(!Absent.contains(1))
         }
         "returns true if the element is equal" in {
-            assert(Defined(1).contains(1))
+            assert(Present(1).contains(1))
         }
         "returns false if the element is not equal" in {
-            assert(!Defined(1).contains(2))
+            assert(!Present(1).contains(2))
         }
     }
 
     "exists" - {
-        "returns false for Empty" in {
-            assert(!Empty.exists(_ => true))
+        "returns false for Absent" in {
+            assert(!Absent.exists(_ => true))
         }
         "returns true if the predicate is satisfied" in {
-            assert(Defined(1).exists(_ == 1))
+            assert(Present(1).exists(_ == 1))
         }
         "returns false if the predicate is not satisfied" in {
-            assert(!Defined(1).exists(_ != 1))
+            assert(!Present(1).exists(_ != 1))
         }
     }
 
     "forall" - {
-        "returns true for Empty" in {
-            assert(Empty.forall(_ => false))
+        "returns true for Absent" in {
+            assert(Absent.forall(_ => false))
         }
         "returns true if the predicate is satisfied" in {
-            assert(Defined(1).forall(_ == 1))
+            assert(Present(1).forall(_ == 1))
         }
         "returns false if the predicate is not satisfied" in {
-            assert(!Defined(1).forall(_ != 1))
+            assert(!Present(1).forall(_ != 1))
         }
     }
 
     "foreach" - {
-        "does not apply the function for Empty" in {
+        "does not apply the function for Absent" in {
             var applied = false
-            Empty.foreach(_ => applied = true)
+            Absent.foreach(_ => applied = true)
             assert(!applied)
         }
-        "applies the function for Defined" in {
+        "applies the function for Present" in {
             var result = 0
-            Defined(1).foreach(result += _)
+            Present(1).foreach(result += _)
             assert(result == 1)
         }
     }
 
     "collect" - {
-        "returns Empty for Empty" in {
-            assert(Empty.collect { case _ => 1 } == Empty)
+        "returns Absent for Absent" in {
+            assert(Absent.collect { case _ => 1 } == Absent)
         }
-        "returns Empty if the partial function is not defined" in {
-            assert(Defined(1).collect { case 2 => 3 } == Empty)
+        "returns Absent if the partial function is not defined" in {
+            assert(Present(1).collect { case 2 => 3 } == Absent)
         }
-        "returns Defined if the partial function is defined" in {
-            assert(Defined(1).collect { case 1 => 2 } == Defined(2))
+        "returns Present if the partial function is defined" in {
+            assert(Present(1).collect { case 1 => 2 } == Present(2))
         }
     }
 
     "orElse" - {
-        "returns the fallback option for Empty" in {
-            assert(Empty.orElse(Defined(1)) == Defined(1))
+        "returns the fallback option for Absent" in {
+            assert(Absent.orElse(Present(1)) == Present(1))
         }
-        "returns itself for Defined" in {
-            assert(Defined(1).orElse(Defined(2)) == Defined(1))
+        "returns itself for Present" in {
+            assert(Present(1).orElse(Present(2)) == Present(1))
         }
     }
 
     "zip" - {
-        "returns Empty if either option is Empty" in {
-            assert(Empty.zip(Empty) == Empty)
-            assert(Empty.zip(Defined(1)) == Empty)
-            assert(Defined(1).zip(Empty) == Empty)
+        "returns Absent if either option is Absent" in {
+            assert(Absent.zip(Absent) == Absent)
+            assert(Absent.zip(Present(1)) == Absent)
+            assert(Present(1).zip(Absent) == Absent)
         }
-        "returns Defined with a tuple if both options are Defined" in {
-            assert(Defined(1).zip(Defined(2)) == Defined((1, 2)))
+        "returns Present with a tuple if both options are Present" in {
+            assert(Present(1).zip(Present(2)) == Present((1, 2)))
         }
     }
 
     "iterator" - {
-        "returns an empty iterator for Empty" in {
-            assert(Empty.iterator.isEmpty)
+        "returns an empty iterator for Absent" in {
+            assert(Absent.iterator.isEmpty)
         }
-        "returns a single element iterator for Defined" in {
-            assert(Defined(1).iterator.toList == List(1))
+        "returns a single element iterator for Present" in {
+            assert(Present(1).iterator.toList == List(1))
         }
     }
 
     "toList" - {
-        "returns an empty list for Empty" in {
-            assert(Empty.toList == Nil)
+        "returns an empty list for Absent" in {
+            assert(Absent.toList == Nil)
         }
-        "returns a single element list for Defined" in {
-            assert(Defined(1).toList == List(1))
+        "returns a single element list for Present" in {
+            assert(Present(1).toList == List(1))
         }
     }
 
     "toRight" - {
-        "returns Left with the argument for Empty" in {
-            assert(Empty.toRight(0) == Left(0))
+        "returns Left with the argument for Absent" in {
+            assert(Absent.toRight(0) == Left(0))
         }
-        "returns Right with the value for Defined" in {
-            assert(Defined(1).toRight(0) == Right(1))
+        "returns Right with the value for Present" in {
+            assert(Present(1).toRight(0) == Right(1))
         }
     }
 
     "toLeft" - {
-        "returns Right with the argument for Empty" in {
-            assert(Empty.toLeft(0) == Right(0))
+        "returns Right with the argument for Absent" in {
+            assert(Absent.toLeft(0) == Right(0))
         }
-        "returns Left with the value for Defined" in {
-            assert(Defined(1).toLeft(0) == Left(1))
+        "returns Left with the value for Present" in {
+            assert(Present(1).toLeft(0) == Left(1))
         }
     }
 
-    "nested Defined(Empty)" - {
+    "nested Present(Absent)" - {
         "flatten should return the nested Maybe" in {
-            assert(Defined(Defined(1)).flatten == Defined(1))
-            assert(Defined(Empty).flatten == Empty)
-            assert(Empty.flatten == Empty)
+            assert(Present(Present(1)).flatten == Present(1))
+            assert(Present(Absent).flatten == Absent)
+            assert(Absent.flatten == Absent)
         }
 
         "get should return the value of the nested Maybe" in {
-            assert(Defined(Defined(1)).get == Defined(1))
-            assert(Defined(Empty).get == Empty)
+            assert(Present(Present(1)).get == Present(1))
+            assert(Present(Absent).get == Absent)
         }
 
         "getOrElse should return the value of the nested Maybe" in {
-            assert(Defined(Defined(1)).getOrElse(Defined(2)) == Defined(1))
-            assert(Defined(Empty).getOrElse(Defined(2)) == Empty)
+            assert(Present(Present(1)).getOrElse(Present(2)) == Present(1))
+            assert(Present(Absent).getOrElse(Present(2)) == Absent)
         }
 
         "orElse should return the value of the nested Maybe" in {
-            assert(Defined(Defined(1)).orElse(Defined(Defined(2))) == Defined(Defined(1)))
-            assert(Defined(Empty).orElse(Defined(Defined(2))) == Defined(Empty))
+            assert(Present(Present(1)).orElse(Present(Present(2))) == Present(Present(1)))
+            assert(Present(Absent).orElse(Present(Present(2))) == Present(Absent))
         }
 
         "fold should apply the non-empty function to the nested Maybe" in {
-            assert(Defined(Defined(1)).fold(Defined(0))(x => x.map(_ + 1)) == Defined(2))
-            assert(Defined(Maybe.empty[Int]).fold(Defined(0))(x => x.map(_ + 1)) == Empty)
+            assert(Present(Present(1)).fold(Present(0))(x => x.map(_ + 1)) == Present(2))
+            assert(Present(Maybe.empty[Int]).fold(Present(0))(x => x.map(_ + 1)) == Absent)
         }
 
         "flatMap should apply the function to the nested Maybe" in {
-            assert(Defined(Defined(1)).flatMap(x => x.map(_ + 1)) == Defined(2))
-            assert(Defined(Maybe.empty[Int]).flatMap(x => x.map(_ + 1)) == Empty)
+            assert(Present(Present(1)).flatMap(x => x.map(_ + 1)) == Present(2))
+            assert(Present(Maybe.empty[Int]).flatMap(x => x.map(_ + 1)) == Absent)
         }
 
         "map should apply the function to the nested Maybe" in {
-            assert(Defined(Defined(1)).map(_ => Defined(2)) == Defined(Defined(2)))
-            assert(Defined(Empty).map(_ => Defined(2)) == Defined(Defined(2)))
+            assert(Present(Present(1)).map(_ => Present(2)) == Present(Present(2)))
+            assert(Present(Absent).map(_ => Present(2)) == Present(Present(2)))
         }
 
         "filter should apply the predicate to the nested Maybe" in {
-            assert(Defined(Defined(1)).filter(_.contains(1)) == Defined(Defined(1)))
-            assert(Defined(Defined(1)).filter(_.contains(2)) == Empty)
-            assert(Defined(Empty).filter(_.contains(1)) == Empty)
+            assert(Present(Present(1)).filter(_.contains(1)) == Present(Present(1)))
+            assert(Present(Present(1)).filter(_.contains(2)) == Absent)
+            assert(Present(Absent).filter(_.contains(1)) == Absent)
         }
 
         "filterNot should apply the predicate to the nested Maybe" in {
-            assert(Defined(Defined(1)).filterNot(_.contains(2)) == Defined(Defined(1)))
-            assert(Defined(Defined(1)).filterNot(_.contains(1)) == Empty)
-            assert(Defined(Empty).filterNot(_.contains(1)) == Defined(Empty))
+            assert(Present(Present(1)).filterNot(_.contains(2)) == Present(Present(1)))
+            assert(Present(Present(1)).filterNot(_.contains(1)) == Absent)
+            assert(Present(Absent).filterNot(_.contains(1)) == Present(Absent))
         }
 
         "exists should apply the predicate to the nested Maybe" in {
-            assert(Defined(Defined(1)).exists(_.contains(1)))
-            assert(!Defined(Defined(1)).exists(_.contains(2)))
-            assert(!Defined(Empty).exists(_.contains(1)))
+            assert(Present(Present(1)).exists(_.contains(1)))
+            assert(!Present(Present(1)).exists(_.contains(2)))
+            assert(!Present(Absent).exists(_.contains(1)))
         }
 
         "forall should apply the predicate to the nested Maybe" in {
-            assert(Defined(Defined(1)).forall(_.contains(1)))
-            assert(!Defined(Defined(1)).forall(_.contains(2)))
-            assert(!Defined(Empty).forall(_.contains(1)))
+            assert(Present(Present(1)).forall(_.contains(1)))
+            assert(!Present(Present(1)).forall(_.contains(2)))
+            assert(!Present(Absent).forall(_.contains(1)))
         }
     }
 
     "deeplyNestedDefined" - {
-        val deeplyNestedDefined = Defined(Defined(Defined(Defined(Defined(1)))))
+        val deeplyNestedDefined = Present(Present(Present(Present(Present(1)))))
 
         "get should return deeply nested value" in {
-            assert(deeplyNestedDefined.get == Defined(Defined(Defined(Defined(1)))))
+            assert(deeplyNestedDefined.get == Present(Present(Present(Present(1)))))
         }
 
-        "flatten should flatten deeply nested Defined" in {
-            assert(deeplyNestedDefined.flatten.flatten == Defined(Defined(Defined(1))))
-            assert(deeplyNestedDefined.flatten.flatten.flatten == Defined(Defined(1)))
-            assert(deeplyNestedDefined.flatten.flatten.flatten.flatten == Defined(1))
+        "flatten should flatten deeply nested Present" in {
+            assert(deeplyNestedDefined.flatten.flatten == Present(Present(Present(1))))
+            assert(deeplyNestedDefined.flatten.flatten.flatten == Present(Present(1)))
+            assert(deeplyNestedDefined.flatten.flatten.flatten.flatten == Present(1))
         }
 
         "flatMap should apply function and flatten result" in {
-            assert(deeplyNestedDefined.flatMap(x => x.flatMap(y => y.flatMap(z => z))) == Defined(Defined(1)))
+            assert(deeplyNestedDefined.flatMap(x => x.flatMap(y => y.flatMap(z => z))) == Present(Present(1)))
         }
 
         "exists should apply to deeply nested predicate" in {
@@ -319,218 +319,218 @@ class MaybeTest extends Test:
 
     "equals" - {
         "should equate two deeply nested Maybes" in {
-            assert(Defined(Defined(Defined(1))) == Defined(Defined(Defined(1))))
-            assert(Defined(Defined(Empty)) == Defined(Defined(Empty)))
+            assert(Present(Present(Present(1))) == Present(Present(Present(1))))
+            assert(Present(Present(Absent)) == Present(Present(Absent)))
         }
 
         "should not equate different nested Maybes" in {
-            assert(Defined(Defined(Defined(1))) != Defined(Defined(Defined(2))))
-            assert(Defined(Defined(Defined(1))) != Defined(Defined(Empty)))
-            assert(Defined(Defined(Empty)) != Defined(Empty))
+            assert(Present(Present(Present(1))) != Present(Present(Present(2))))
+            assert(Present(Present(Present(1))) != Present(Present(Absent)))
+            assert(Present(Present(Absent)) != Present(Absent))
         }
     }
 
     "pattern matching" - {
         "simple match" - {
-            "should match Defined and extract value" in {
-                val result = Defined(1) match
-                    case Defined(x) => x
-                    case Empty      => 0
+            "should match Present and extract value" in {
+                val result = Present(1) match
+                    case Present(x) => x
+                    case Absent     => 0
                 assert(result == 1)
             }
 
-            "should match Empty" in {
-                val result = Empty match
-                    case Defined(x) => x
-                    case Empty      => 0
+            "should match Absent" in {
+                val result = Absent match
+                    case Present(x) => x
+                    case Absent     => 0
                 assert(result == 0)
             }
         }
 
         "nested match" - {
-            "should match nested Defined and extract inner value" in {
-                val result = Defined(Defined(1)) match
-                    case Defined(Defined(x)) => x
+            "should match nested Present and extract inner value" in {
+                val result = Present(Present(1)) match
+                    case Present(Present(x)) => x
                     case _                   => 0
                 assert(result == 1)
             }
 
-            "should match outer Empty" in {
-                val result = Empty match
-                    case Defined(Defined(x)) => x
+            "should match outer Absent" in {
+                val result = Absent match
+                    case Present(Present(x)) => x
                     case _                   => 0
                 assert(result == 0)
             }
 
-            "should match inner Empty" in {
-                val result = Defined(Empty) match
-                    case Defined(Defined(x)) => x
+            "should match inner Absent" in {
+                val result = Present(Absent) match
+                    case Present(Present(x)) => x
                     case _                   => 0
                 assert(result == 0)
             }
         }
 
         "deep matching" - {
-            val nestedMaybe = Defined(Defined(Defined(Defined(1))))
+            val nestedMaybe = Present(Present(Present(Present(1))))
 
-            "should match deeply nested Defined and extract inner value" in {
+            "should match deeply nested Present and extract inner value" in {
                 val result = nestedMaybe match
-                    case Defined(Defined(Defined(Defined(x)))) => x
+                    case Present(Present(Present(Present(x)))) => x
                     case _                                     => 0
                 assert(result == 1)
             }
 
             "should return default for deep mismatch" in {
                 val result = nestedMaybe match
-                    case Defined(Defined(Defined(Empty))) => 1
-                    case _                                => 0
+                    case Present(Present(Present(Absent))) => 1
+                    case _                                 => 0
                 assert(result == 0)
             }
 
-            "should match partially and extract nested Defined" in {
+            "should match partially and extract nested Present" in {
                 val result = nestedMaybe match
-                    case Defined(Defined(x)) => x
-                    case _                   => Empty
-                assert(result == Defined(Defined(1)))
+                    case Present(Present(x)) => x
+                    case _                   => Absent
+                assert(result == Present(Present(1)))
             }
         }
     }
 
     "for comprehensions" - {
-        "with single Defined" - {
-            "should return Defined with value" in {
+        "with single Present" - {
+            "should return Present with value" in {
                 val result =
                     for
-                        x <- Defined(1)
+                        x <- Present(1)
                     yield x
-                assert(result == Defined(1))
+                assert(result == Present(1))
             }
         }
 
-        "with single Empty" - {
-            "should return Empty" in {
+        "with single Absent" - {
+            "should return Absent" in {
                 val result =
                     for
-                        x <- Empty
+                        x <- Absent
                     yield x
-                assert(result == Empty)
+                assert(result == Absent)
             }
         }
 
-        "with multiple Defined" - {
-            "should return Defined with result of yield" in {
+        "with multiple Present" - {
+            "should return Present with result of yield" in {
                 val result =
                     for
-                        x <- Defined(1)
-                        y <- Defined(2)
+                        x <- Present(1)
+                        y <- Present(2)
                     yield x + y
-                assert(result == Defined(3))
+                assert(result == Present(3))
             }
         }
 
-        "with multiple Defined and Empty" - {
-            "should return Empty if any are Empty" in {
+        "with multiple Present and Absent" - {
+            "should return Absent if any are Absent" in {
                 val result1 =
                     for
-                        _ <- Defined(1)
-                        _ <- Empty
-                        _ <- Defined(3)
+                        _ <- Present(1)
+                        _ <- Absent
+                        _ <- Present(3)
                     yield ()
-                assert(result1 == Empty)
+                assert(result1 == Absent)
 
                 val result2 =
                     for
-                        _ <- Empty
-                        _ <- Defined(2)
-                        _ <- Defined(3)
+                        _ <- Absent
+                        _ <- Present(2)
+                        _ <- Present(3)
                     yield ()
-                assert(result2 == Empty)
+                assert(result2 == Absent)
 
                 val result3 =
                     for
-                        _ <- Defined(1)
-                        _ <- Defined(2)
-                        _ <- Empty
+                        _ <- Present(1)
+                        _ <- Present(2)
+                        _ <- Absent
                     yield ()
-                assert(result3 == Empty)
+                assert(result3 == Absent)
             }
         }
 
         "with if guards" - {
-            "should return Defined if guard passes" in {
+            "should return Present if guard passes" in {
                 val result =
                     for
-                        x <- Defined(2)
+                        x <- Present(2)
                         if x % 2 == 0
                     yield x
-                assert(result == Defined(2))
+                assert(result == Present(2))
             }
 
-            "should return Empty if guard fails" in {
+            "should return Absent if guard fails" in {
                 val result =
                     for
-                        x <- Defined(3)
+                        x <- Present(3)
                         if x % 2 == 0
                     yield x
-                assert(result == Empty)
+                assert(result == Absent)
             }
         }
 
         "with nested for comprehensions" - {
-            "should return flat Defined if all succeed" in {
+            "should return flat Present if all succeed" in {
                 val result =
                     for
-                        x <- Defined(1)
+                        x <- Present(1)
                         y <-
                             for
-                                a <- Defined(2)
-                                b <- Defined(3)
+                                a <- Present(2)
+                                b <- Present(3)
                             yield a + b
                     yield x + y
-                assert(result == Defined(6))
+                assert(result == Present(6))
             }
 
-            "should return Empty if any inner comprehension is Empty" in {
+            "should return Absent if any inner comprehension is Absent" in {
                 val result =
                     for
-                        _ <- Defined(1)
+                        _ <- Present(1)
                         _ <-
                             for
-                                _ <- Empty
-                                _ <- Defined(3)
+                                _ <- Absent
+                                _ <- Present(3)
                             yield ()
                     yield ()
-                assert(result == Empty)
+                assert(result == Absent)
             }
         }
 
     }
 
     "show" - {
-        "should return 'Empty' for Empty" in {
-            assert(Empty.show == "Empty")
+        "should return 'Absent' for Absent" in {
+            assert(Absent.show == "Absent")
         }
 
-        "should return 'Defined(value)' for Defined" in {
-            assert(Defined(1).show == "Defined(1)")
-            assert(Defined("hello").show == "Defined(hello)")
+        "should return 'Present(value)' for Present" in {
+            assert(Present(1).show == "Present(1)")
+            assert(Present("hello").show == "Present(hello)")
         }
 
-        "should handle nested Defined values" in {
-            assert(Defined(Empty).show == "Defined(Empty)")
+        "should handle nested Present values" in {
+            assert(Present(Absent).show == "Present(Absent)")
         }
     }
 
     "DefinedEmpty.toString" - {
         "should return correct string representation" in {
-            assert(DefinedEmpty(1).toString == "Defined(Empty)")
-            assert(DefinedEmpty(2).toString == "Defined(Defined(Empty))")
-            assert(DefinedEmpty(3).toString == "Defined(Defined(Defined(Empty)))")
+            assert(DefinedEmpty(1).toString == "Present(Absent)")
+            assert(DefinedEmpty(2).toString == "Present(Present(Absent))")
+            assert(DefinedEmpty(3).toString == "Present(Present(Present(Absent)))")
         }
 
         "should handle large depths" in {
             val largeDepth = 10
-            val expected   = "Defined(" * largeDepth + "Empty" + ")" * largeDepth
+            val expected   = "Present(" * largeDepth + "Absent" + ")" * largeDepth
             assert(DefinedEmpty(largeDepth).toString == expected)
         }
     }

--- a/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
@@ -100,44 +100,44 @@ class ResultTest extends Test:
     }
 
     "value" - {
-        "returns Defined with the value for Success" in {
+        "returns Present with the value for Success" in {
             assert(Result.success(42).value == Maybe(42))
         }
 
-        "returns Empty for Fail" in {
+        "returns Absent for Fail" in {
             assert(Result.fail("error").value == Maybe.empty)
         }
 
-        "returns Empty for Panic" in {
+        "returns Absent for Panic" in {
             assert(Result.panic(new Exception).value == Maybe.empty)
         }
     }
 
     "failure" - {
-        "returns Defined with the error for Fail" in {
+        "returns Present with the error for Fail" in {
             assert(Result.fail("error").failure == Maybe("error"))
         }
 
-        "returns Empty for Success" in {
+        "returns Absent for Success" in {
             assert(Result.success(42).failure == Maybe.empty)
         }
 
-        "returns Empty for Panic" in {
+        "returns Absent for Panic" in {
             assert(Result.panic(new Exception).failure == Maybe.empty)
         }
     }
 
     "panic" - {
-        "returns Defined with the exception for Panic" in {
+        "returns Present with the exception for Panic" in {
             val ex = new Exception("test")
             assert(Result.panic(ex).panic == Maybe(ex))
         }
 
-        "returns Empty for Success" in {
+        "returns Absent for Success" in {
             assert(Result.success(42).panic == Maybe.empty)
         }
 
-        "returns Empty for Fail" in {
+        "returns Absent for Fail" in {
             assert(Result.fail("error").panic == Maybe.empty)
         }
     }

--- a/kyo-direct/shared/src/test/scala/kyo/DirectTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/DirectTest.scala
@@ -40,7 +40,7 @@ class DirectTest extends Test:
     }
 
     "two effects" in run {
-        val io: String < (IO & Abort[Empty]) =
+        val io: String < (IO & Abort[Absent]) =
             defer {
                 val a = await(Abort.get(Some("hello")))
                 val b = await(IO("world"))

--- a/kyo-direct/shared/src/test/scala/kyo/DirectTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/DirectTest.scala
@@ -40,7 +40,7 @@ class DirectTest extends Test:
     }
 
     "two effects" in run {
-        val io: String < (IO & Abort[Maybe.Empty]) =
+        val io: String < (IO & Abort[Empty]) =
             defer {
                 val a = await(Abort.get(Some("hello")))
                 val b = await(IO("world"))

--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -91,16 +91,16 @@ object Abort:
                 case Right(value) => value
                 case Left(value)  => fail(value)
 
-        /** Lifts an Option into the Abort effect with Empty as the failure value.
+        /** Lifts an Option into the Abort effect with Absent as the failure value.
           *
           * @param opt
           *   The Option to lift
           * @return
-          *   A computation that succeeds with the Some value or fails with Empty
+          *   A computation that succeeds with the Some value or fails with Absent
           */
-        inline def apply[A](opt: Option[A])(using inline frame: Frame): A < Abort[Empty] =
+        inline def apply[A](opt: Option[A])(using inline frame: Frame): A < Abort[Absent] =
             opt match
-                case None    => fail(Empty)
+                case None    => fail(Absent)
                 case Some(v) => v
 
         /** Lifts a scala.util.Try into the Abort effect.
@@ -133,11 +133,11 @@ object Abort:
           * @param m
           *   The Maybe to lift
           * @return
-          *   A computation that succeeds with the Defined value or fails with Empty
+          *   A computation that succeeds with the Present value or fails with Absent
           */
         @targetName("maybe")
-        inline def apply[A](m: Maybe[A])(using inline frame: Frame): A < Abort[Empty] =
-            m.fold(fail(Empty))(identity)
+        inline def apply[A](m: Maybe[A])(using inline frame: Frame): A < Abort[Absent] =
+            m.fold(fail(Absent))(identity)
     end GetOps
 
     /** Operations for lifting various types into the Abort effect.

--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -91,16 +91,16 @@ object Abort:
                 case Right(value) => value
                 case Left(value)  => fail(value)
 
-        /** Lifts an Option into the Abort effect with Maybe.Empty as the failure value.
+        /** Lifts an Option into the Abort effect with Empty as the failure value.
           *
           * @param opt
           *   The Option to lift
           * @return
-          *   A computation that succeeds with the Some value or fails with Maybe.Empty
+          *   A computation that succeeds with the Some value or fails with Empty
           */
-        inline def apply[A](opt: Option[A])(using inline frame: Frame): A < Abort[Maybe.Empty] =
+        inline def apply[A](opt: Option[A])(using inline frame: Frame): A < Abort[Empty] =
             opt match
-                case None    => fail(Maybe.Empty)
+                case None    => fail(Empty)
                 case Some(v) => v
 
         /** Lifts a scala.util.Try into the Abort effect.
@@ -133,11 +133,11 @@ object Abort:
           * @param m
           *   The Maybe to lift
           * @return
-          *   A computation that succeeds with the Defined value or fails with Maybe.Empty
+          *   A computation that succeeds with the Defined value or fails with Empty
           */
         @targetName("maybe")
-        inline def apply[A](m: Maybe[A])(using inline frame: Frame): A < Abort[Maybe.Empty] =
-            m.fold(fail(Maybe.Empty))(identity)
+        inline def apply[A](m: Maybe[A])(using inline frame: Frame): A < Abort[Empty] =
+            m.fold(fail(Empty))(identity)
     end GetOps
 
     /** Operations for lifting various types into the Abort effect.

--- a/kyo-prelude/shared/src/main/scala/kyo/Memo.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Memo.scala
@@ -47,9 +47,9 @@ object Memo:
         input =>
             Var.use[Cache] { cache =>
                 cache.get(input, id) match
-                    case Maybe.Defined(cached) =>
+                    case Defined(cached) =>
                         cached.asInstanceOf[B]
-                    case Maybe.Empty =>
+                    case Empty =>
                         f(input).map { result =>
                             Var.update[Cache](_.updated(input, id, result))
                                 .map(_ => result)

--- a/kyo-prelude/shared/src/main/scala/kyo/Memo.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Memo.scala
@@ -47,9 +47,9 @@ object Memo:
         input =>
             Var.use[Cache] { cache =>
                 cache.get(input, id) match
-                    case Defined(cached) =>
+                    case Present(cached) =>
                         cached.asInstanceOf[B]
-                    case Empty =>
+                    case Absent =>
                         f(input).map { result =>
                             Var.update[Cache](_.updated(input, id, result))
                                 .map(_ => result)

--- a/kyo-prelude/shared/src/main/scala/kyo/internal/LayerMacros.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/internal/LayerMacros.scala
@@ -114,7 +114,7 @@ private[kyo] object LayerMacros:
         case And(left: LayerLike[A], right: LayerLike[A])
         case To(left: LayerLike[A], right: LayerLike[A])
         case Value(value: A)
-        case Absent
+        case Empty
 
         infix def and[A1 >: A](that: LayerLike[A1]): LayerLike[A1] = And(this, that)
         infix def to[A1 >: A](that: LayerLike[A1]): LayerLike[A1]  = To(this, that)
@@ -126,7 +126,7 @@ private[kyo] object LayerMacros:
                 case To(left, right) =>
                     toCase(left.fold(andCase, toCase, valueCase, emptyCase), right.fold(andCase, toCase, valueCase, emptyCase))
                 case Value(value) => valueCase(value)
-                case Absent       => emptyCase
+                case Empty        => emptyCase
     end LayerLike
 
     object LayerLike:
@@ -199,7 +199,7 @@ private[kyo] object LayerMacros:
                         buildTargets(node.inputs, Some(node), seen = seen + node)
                             .map { input => input to LayerLike.Value(node) }
                 }
-            yield values.reduceOption(_ and _).getOrElse(LayerLike.Absent)
+            yield values.reduceOption(_ and _).getOrElse(LayerLike.Empty)
         end buildTargets
 
         def findNodesWithOutputs(

--- a/kyo-prelude/shared/src/main/scala/kyo/internal/LayerMacros.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/internal/LayerMacros.scala
@@ -59,11 +59,11 @@ private[kyo] object LayerMacros:
                     _.value, {
                         // TODO: MAke nIcEr PlZEaz
                         val debugFold =
-                            targetLayer.fold[String]("(" + _ + " and " + _ + ")", "(" + _ + " to " + _ + ")", _.value.show, "Empty")
+                            targetLayer.fold[String]("(" + _ + " and " + _ + ")", "(" + _ + " to " + _ + ")", _.value.show, "Absent")
 
                         report.errorAndAbort(
                             s"""|
-                                | Empty layer found as input to Layer with non-zero requirements. Did you fully resolve dependencies?
+                                | Absent layer found as input to Layer with non-zero requirements. Did you fully resolve dependencies?
                                 | Debug: $debugFold
                                 |""".stripMargin
                         )
@@ -114,7 +114,7 @@ private[kyo] object LayerMacros:
         case And(left: LayerLike[A], right: LayerLike[A])
         case To(left: LayerLike[A], right: LayerLike[A])
         case Value(value: A)
-        case Empty
+        case Absent
 
         infix def and[A1 >: A](that: LayerLike[A1]): LayerLike[A1] = And(this, that)
         infix def to[A1 >: A](that: LayerLike[A1]): LayerLike[A1]  = To(this, that)
@@ -126,7 +126,7 @@ private[kyo] object LayerMacros:
                 case To(left, right) =>
                     toCase(left.fold(andCase, toCase, valueCase, emptyCase), right.fold(andCase, toCase, valueCase, emptyCase))
                 case Value(value) => valueCase(value)
-                case Empty        => emptyCase
+                case Absent       => emptyCase
     end LayerLike
 
     object LayerLike:
@@ -199,7 +199,7 @@ private[kyo] object LayerMacros:
                         buildTargets(node.inputs, Some(node), seen = seen + node)
                             .map { input => input to LayerLike.Value(node) }
                 }
-            yield values.reduceOption(_ and _).getOrElse(LayerLike.Empty)
+            yield values.reduceOption(_ and _).getOrElse(LayerLike.Absent)
         end buildTargets
 
         def findNodesWithOutputs(

--- a/kyo-prelude/shared/src/main/scala/kyo/internal/LayerMacros.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/internal/LayerMacros.scala
@@ -59,11 +59,11 @@ private[kyo] object LayerMacros:
                     _.value, {
                         // TODO: MAke nIcEr PlZEaz
                         val debugFold =
-                            targetLayer.fold[String]("(" + _ + " and " + _ + ")", "(" + _ + " to " + _ + ")", _.value.show, "Absent")
+                            targetLayer.fold[String]("(" + _ + " and " + _ + ")", "(" + _ + " to " + _ + ")", _.value.show, "Empty")
 
                         report.errorAndAbort(
                             s"""|
-                                | Absent layer found as input to Layer with non-zero requirements. Did you fully resolve dependencies?
+                                | Empty layer found as input to Layer with non-zero requirements. Did you fully resolve dependencies?
                                 | Debug: $debugFold
                                 |""".stripMargin
                         )

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -90,11 +90,11 @@ class AbortsTest extends Test:
             assert(Abort.run(Abort.get(Result.fail(ex1))).eval == Result.fail(ex1))
         }
         "option" in {
-            assert(Abort.run(Abort.get(Option.empty)).eval == Result.fail(Empty))
+            assert(Abort.run(Abort.get(Option.empty)).eval == Result.fail(Absent))
             assert(Abort.run(Abort.get(Some(1))).eval == Result.success(1))
         }
         "maybe" in {
-            assert(Abort.run(Abort.get(Maybe.empty)).eval == Result.fail(Empty))
+            assert(Abort.run(Abort.get(Maybe.empty)).eval == Result.fail(Absent))
             assert(Abort.run(Abort.get(Maybe(1))).eval == Result.success(1))
         }
     }

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -90,11 +90,11 @@ class AbortsTest extends Test:
             assert(Abort.run(Abort.get(Result.fail(ex1))).eval == Result.fail(ex1))
         }
         "option" in {
-            assert(Abort.run(Abort.get(Option.empty)).eval == Result.fail(Maybe.Empty))
+            assert(Abort.run(Abort.get(Option.empty)).eval == Result.fail(Empty))
             assert(Abort.run(Abort.get(Some(1))).eval == Result.success(1))
         }
         "maybe" in {
-            assert(Abort.run(Abort.get(Maybe.empty)).eval == Result.fail(Maybe.Empty))
+            assert(Abort.run(Abort.get(Maybe.empty)).eval == Result.fail(Empty))
             assert(Abort.run(Abort.get(Maybe(1))).eval == Result.success(1))
         }
     }

--- a/kyo-prelude/shared/src/test/scala/kyo/EnvTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/EnvTest.scala
@@ -142,9 +142,9 @@ class EnvTest extends Test:
     "effectful services" - {
 
         trait Service1:
-            def apply(i: Int): Int < Abort[Empty]
+            def apply(i: Int): Int < Abort[Absent]
         trait Service2:
-            def apply(i: Int): Int < Abort[Empty]
+            def apply(i: Int): Int < Abort[Absent]
 
         val service1 = new Service1:
             def apply(i: Int) = i match
@@ -179,7 +179,7 @@ class EnvTest extends Test:
                     Env.get[Service1].map(_(1)).map { i =>
                         Env.get[Service2].map(_(i))
                     }
-                val v: Int < (Env[Service1] & Env[Service2] & Abort[Empty]) = a
+                val v: Int < (Env[Service1] & Env[Service2] & Abort[Absent]) = a
                 "same handling order" in {
                     val b = Env.run(service2)(v)
                     val c = Env.run(service1)(b)
@@ -195,7 +195,7 @@ class EnvTest extends Test:
                     )
                 }
                 "dependent services" in {
-                    val v2: Int < (Env[Service2] & Abort[Empty]) = Env.run(service1)(v)
+                    val v2: Int < (Env[Service2] & Abort[Absent]) = Env.run(service1)(v)
                     assert(
                         Abort.run(Env.run(service2)(v2)).eval ==
                             Result.success(3)

--- a/kyo-prelude/shared/src/test/scala/kyo/EnvTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/EnvTest.scala
@@ -142,9 +142,9 @@ class EnvTest extends Test:
     "effectful services" - {
 
         trait Service1:
-            def apply(i: Int): Int < Abort[Maybe.Empty]
+            def apply(i: Int): Int < Abort[Empty]
         trait Service2:
-            def apply(i: Int): Int < Abort[Maybe.Empty]
+            def apply(i: Int): Int < Abort[Empty]
 
         val service1 = new Service1:
             def apply(i: Int) = i match
@@ -179,7 +179,7 @@ class EnvTest extends Test:
                     Env.get[Service1].map(_(1)).map { i =>
                         Env.get[Service2].map(_(i))
                     }
-                val v: Int < (Env[Service1] & Env[Service2] & Abort[Maybe.Empty]) = a
+                val v: Int < (Env[Service1] & Env[Service2] & Abort[Empty]) = a
                 "same handling order" in {
                     val b = Env.run(service2)(v)
                     val c = Env.run(service1)(b)
@@ -195,7 +195,7 @@ class EnvTest extends Test:
                     )
                 }
                 "dependent services" in {
-                    val v2: Int < (Env[Service2] & Abort[Maybe.Empty]) = Env.run(service1)(v)
+                    val v2: Int < (Env[Service2] & Abort[Empty]) = Env.run(service1)(v)
                     assert(
                         Abort.run(Env.run(service2)(v2)).eval ==
                             Result.success(3)

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/PendingTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/PendingTest.scala
@@ -138,12 +138,12 @@ class PendingTest extends Test:
         ArrowEffect.suspend[Int](Tag[TestEffect], i)
 
     "evalNow" - {
-        "returns Defined for pure values" in {
+        "returns Present for pure values" in {
             val x: Int < Any = 5
             assert(x.evalNow == Maybe(5))
         }
 
-        "returns Empty for suspended computations" in {
+        "returns Absent for suspended computations" in {
             val x: Int < TestEffect = testEffect(5)
             assert(x.evalNow == Maybe.empty)
         }


### PR DESCRIPTION
I sometimes avoid pattern matching on `Maybe` because it feels too verbose. This PR exports `Maybe.Empty` and `Maybe.Defined` as members in the `kyo` package. It also reduces the syntax overhead for tracking `Abort[Empty]`. It seems reasonable since the type names shouldn't conflict with common types.