### PR TITLE
core: cleanup direct use of IOPromise

### DIFF
--- a/kyo-core/jvm/src/main/scala/kyo/internal/FiberPlatformSpecific.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/internal/FiberPlatformSpecific.scala
@@ -2,19 +2,18 @@ package kyo.internal
 
 import java.util.concurrent.CompletionStage
 import kyo.*
-import kyo.scheduler.IOPromise
 
 trait FiberPlatformSpecific:
     def fromCompletionStage[A](cs: CompletionStage[A])(using Frame): A < Async =
         fromCompletionStageFiber(cs).map(_.get)
 
     def fromCompletionStageFiber[A](cs: CompletionStage[A])(using Frame): Fiber[Nothing, A] < IO =
-        IO {
-            val p = new IOPromise[Nothing, A]()
+        IO.Unsafe {
+            val p = Promise.Unsafe.init[Nothing, A]()
             cs.whenComplete { (success, error) =>
                 if error == null then p.completeDiscard(Result.success(success))
                 else p.completeDiscard(Result.panic(error))
             }
-            Fiber.initUnsafe(p)
+            p.safe
         }
 end FiberPlatformSpecific

--- a/kyo-core/shared/src/main/scala/kyo/Barrier.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Barrier.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import kyo.scheduler.IOPromise
 import scala.annotation.tailrec
 
 /** A synchronization primitive that allows a fixed number of parties to wait for each other to reach a common point of execution.
@@ -65,7 +64,7 @@ object Barrier:
                                 loop(count.get())
                             else
                                 if c == 1 then promise.completeDiscard(Result.unit)
-                                Fiber.Unsafe.fromPromise(promise)
+                                promise
                         loop(count.get())
                     end await
 

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -100,8 +100,6 @@ object Fiber extends FiberPlatformSpecific:
 
     private def result[E, A](result: Result[E, A]): Fiber[E, A] = IOPromise(result)
 
-    private[kyo] inline def initUnsafe[E, A](p: IOPromise[E, A]): Fiber[E, A] = p
-
     extension [E, A](self: Fiber[E, A])
 
         /** Gets the result of the Fiber.
@@ -389,6 +387,7 @@ object Fiber extends FiberPlatformSpecific:
         extension [E, A](self: Unsafe[E, A])
             def done()(using AllowUnsafe): Boolean                                                       = self.done()
             def onComplete(f: Result[E, A] => Unit)(using AllowUnsafe): Unit                             = self.onComplete(f)
+            def onInterrupt(f: Panic => Unit)(using Frame): Unit                                         = self.onInterrupt(f)
             def block(deadline: Clock.Deadline.Unsafe)(using AllowUnsafe, Frame): Result[E | Timeout, A] = self.block(deadline)
             def interrupt(error: Panic)(using AllowUnsafe): Boolean                                      = self.interrupt(error)
             def interruptDiscard(error: Panic)(using AllowUnsafe): Unit                                  = discard(self.interrupt(error))
@@ -400,6 +399,8 @@ object Fiber extends FiberPlatformSpecific:
 
     object Promise:
         inline given [E, A]: Flat[Promise[E, A]] = Flat.unsafe.bypass
+
+        private[kyo] inline def fromTask[E, A](inline ioTask: IOTask[?, E, A]): Promise[E, A] = ioTask
 
         /** Initializes a new Promise.
           *
@@ -444,7 +445,7 @@ object Fiber extends FiberPlatformSpecific:
             def unsafe: Unsafe[E, A] = self
         end extension
 
-        opaque type Unsafe[E, A] = IOPromise[E, A]
+        opaque type Unsafe[E, A] <: Fiber.Unsafe[E, A] = IOPromise[E, A]
 
         /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
         object Unsafe:

--- a/kyo-core/shared/src/main/scala/kyo/Latch.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Latch.scala
@@ -1,7 +1,6 @@
 package kyo
 
 import java.util.concurrent.atomic.AtomicInteger
-import kyo.scheduler.IOPromise
 import scala.annotation.tailrec
 
 /** A synchronization primitive that allows one or more tasks to wait until a set of operations being performed in other tasks completes.
@@ -68,7 +67,7 @@ object Latch:
                     val promise = Promise.Unsafe.init[Nothing, Unit]()
                     val count   = AtomicInt.Unsafe.init(n)
 
-                    def await()(using AllowUnsafe) = Fiber.Unsafe.fromPromise(promise)
+                    def await()(using AllowUnsafe) = promise
 
                     def release()(using AllowUnsafe) =
                         @tailrec def loop(c: Int): Unit =


### PR DESCRIPTION
Now that we have unsafe APIs for `Fiber` and `Promise`, there shouldn't be direct use of `IOPromise` in other places of the codebase.