### PR TITLE
core: make masked IOPromise not interruptible

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -23,7 +23,8 @@ object Fiber extends FiberPlatformSpecific:
 
     inline given [E, A]: Flat[Fiber[E, A]] = Flat.unsafe.bypass
 
-    private val _unit = success(())
+    private val _unit  = success(()).mask
+    private val _never = IOPromise[Nothing, Unit]().mask
 
     private[kyo] inline def fromTask[E, A](inline ioTask: IOTask[?, E, A]): Fiber[E, A] = ioTask
 
@@ -39,7 +40,7 @@ object Fiber extends FiberPlatformSpecific:
       * @return
       *   A Fiber that never completes
       */
-    def never: Fiber[Nothing, Unit] = IOPromise[Nothing, Unit]()
+    def never[E]: Fiber[E, Unit] = _never.asInstanceOf[Fiber[E, Unit]]
 
     /** Creates a successful Fiber.
       *

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -63,12 +63,13 @@ private[kyo] class IOPromise[E, A](init: State[E, A]) extends Safepoint.Intercep
     end interrupts
 
     final def mask: IOPromise[E, A] =
-        val p = IOPromise[E, A]()
+        val p = new IOPromise[E, A]:
+            override def interrupt(error: Panic): Boolean = false
         onComplete(p.completeDiscard)
         p
     end mask
 
-    final def interrupt(error: Panic): Boolean =
+    def interrupt(error: Panic): Boolean =
         @tailrec def interruptLoop(promise: IOPromise[E, A]): Boolean =
             promise.state match
                 case p: Pending[E, A] @unchecked =>

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -777,8 +777,8 @@ class AsyncTest extends Test:
                         for
                             _ <- start.release
                             _ <- run.await
-                            _ <- stop.release
                             _ <- result.set(42)
+                            _ <- stop.release
                         yield ()
                     }
                 fiber <- Async.run(masked)

--- a/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
@@ -305,8 +305,8 @@ class IOPromiseTest extends Test:
             original.onComplete(_ => originalCompleted = true)
             masked.onComplete(r => maskedResult = Maybe(r))
 
-            assert(masked.interrupt(Result.Panic(new Exception("Interrupted"))))
-            assert(maskedResult.exists(_.isPanic))
+            assert(!masked.interrupt(Result.Panic(new Exception("Interrupted"))))
+            assert(maskedResult.isEmpty)
             assert(!originalCompleted)
         }
 
@@ -361,8 +361,8 @@ class IOPromiseTest extends Test:
             masked1.onComplete(_ => masked1Completed = true)
             masked2.onComplete(r => masked2Result = Maybe(r))
 
-            assert(masked2.interrupt(Result.Panic(new Exception("Interrupted"))))
-            assert(masked2Result.exists(_.isPanic))
+            assert(!masked2.interrupt(Result.Panic(new Exception("Interrupted"))))
+            assert(masked2Result.isEmpty)
             assert(!masked1Completed)
             assert(!originalCompleted)
 
@@ -410,9 +410,9 @@ class IOPromiseTest extends Test:
             masked1.onComplete(r => masked1Result = Maybe(r))
             masked2.onComplete(r => masked2Result = Maybe(r))
 
-            assert(masked2.interrupt(Result.Panic(new Exception("Interrupted"))))
+            assert(!masked2.interrupt(Result.Panic(new Exception("Interrupted"))))
 
-            assert(masked2Result.exists(_.isPanic))
+            assert(masked2Result.isEmpty)
             assert(masked1Result.isEmpty)
             assert(originalResult.isEmpty)
 
@@ -420,7 +420,7 @@ class IOPromiseTest extends Test:
 
             assert(originalResult.contains(Result.success(42)))
             assert(masked1Result.contains(Result.success(42)))
-            assert(masked2Result.exists(_.isPanic))
+            assert(masked2Result.contains(Result.success(42)))
         }
 
         "mask interaction with become" in {
@@ -458,10 +458,10 @@ class IOPromiseTest extends Test:
 
             masked.interrupts(other)
 
-            assert(masked.interrupt(Result.Panic(new Exception("Interrupted"))))
+            assert(!masked.interrupt(Result.Panic(new Exception("Interrupted"))))
 
-            assert(masked.block(deadline()).isPanic)
-            assert(other.block(deadline()).isPanic)
+            assert(!masked.done())
+            assert(!other.done())
             assert(!original.done())
         }
     }
@@ -503,8 +503,8 @@ class IOPromiseTest extends Test:
             original.onInterrupt(_ => originalInterrupted = true)
             masked.onInterrupt(_ => maskedInterrupted = true)
 
-            assert(masked.interrupt(Result.Panic(new Exception("Interrupted"))))
-            assert(maskedInterrupted)
+            assert(!masked.interrupt(Result.Panic(new Exception("Interrupted"))))
+            assert(!maskedInterrupted)
             assert(!originalInterrupted)
         }
 
@@ -521,8 +521,8 @@ class IOPromiseTest extends Test:
             masked1.onInterrupt(_ => masked1Interrupted = true)
             masked2.onInterrupt(_ => masked2Interrupted = true)
 
-            assert(masked2.interrupt(Result.Panic(new Exception("Interrupted"))))
-            assert(masked2Interrupted)
+            assert(!masked2.interrupt(Result.Panic(new Exception("Interrupted"))))
+            assert(!masked2Interrupted)
             assert(!masked1Interrupted)
             assert(!originalInterrupted)
         }
@@ -598,11 +598,11 @@ class IOPromiseTest extends Test:
 
             masked.interrupts(other)
 
-            assert(masked.interrupt(Result.Panic(new Exception("Interrupted"))))
+            assert(!masked.interrupt(Result.Panic(new Exception("Interrupted"))))
 
             assert(!originalInterrupted)
-            assert(maskedInterrupted)
-            assert(otherInterrupted)
+            assert(!maskedInterrupted)
+            assert(!otherInterrupted)
         }
     }
 


### PR DESCRIPTION
As pointed out by @hearnadam in https://github.com/getkyo/kyo/pull/707, the fiber returned by `mask` doesn't propagate interrupts to its previous steps but the instance itself can still be interrupted. It's a behavior that is different from other effect systems and makes the masking feature less useful. This PR fixes that by using a custom `IOPromise` class with a method override.