### PR TITLE
prelude/core: rename Ensures to Finalizers

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/scheduler/Finalizers.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/Finalizers.scala
@@ -6,20 +6,20 @@ import kyo.discard
 import org.jctools.queues.MpmcArrayQueue
 import scala.annotation.tailrec
 
-private[kyo] opaque type Ensures = Ensures.Empty.type | (() => Unit) | ArrayDeque[() => Unit]
+private[kyo] opaque type Finalizers = Finalizers.Empty.type | (() => Unit) | ArrayDeque[() => Unit]
 
-private[kyo] object Ensures:
+private[kyo] object Finalizers:
     case object Empty derives CanEqual
 
-    val empty: Ensures = Empty
+    val empty: Finalizers = Empty
 
     private val bufferCache = new MpmcArrayQueue[ArrayDeque[() => Unit]](1000)
 
     private def buffer(): ArrayDeque[() => Unit] =
         Maybe(bufferCache.poll()).getOrElse(new ArrayDeque())
 
-    extension (e: Ensures)
-        def add(f: () => Unit): Ensures =
+    extension (e: Finalizers)
+        def add(f: () => Unit): Finalizers =
             (e: @unchecked) match
                 case e if e.equals(Empty) || e.equals(f) => f
                 case f0: (() => Unit) @unchecked =>
@@ -31,7 +31,7 @@ private[kyo] object Ensures:
                     arr.add(f)
                     arr
 
-        def remove(f: () => Unit): Ensures =
+        def remove(f: () => Unit): Finalizers =
             (e: @unchecked) match
                 case e if e.equals(Empty) => e
                 case e if e.equals(f)     => Empty
@@ -66,4 +66,4 @@ private[kyo] object Ensures:
                 case arr: ArrayDeque[() => Unit] @unchecked =>
                     arr.size()
     end extension
-end Ensures
+end Finalizers

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/Finalizers.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/Finalizers.scala
@@ -13,12 +13,14 @@ private[kyo] object Finalizers:
 
     val empty: Finalizers = Empty
 
-    private val bufferCache = new MpmcArrayQueue[ArrayDeque[() => Unit]](1000)
+    private val bufferCache = new MpmcArrayQueue[ArrayDeque[() => Unit]](1024)
 
     private def buffer(): ArrayDeque[() => Unit] =
         Maybe(bufferCache.poll()).getOrElse(new ArrayDeque())
 
     extension (e: Finalizers)
+
+        /** Adds a finalizer function. */
         def add(f: () => Unit): Finalizers =
             (e: @unchecked) match
                 case e if e.equals(Empty) || e.equals(f) => f
@@ -31,6 +33,7 @@ private[kyo] object Finalizers:
                     arr.add(f)
                     arr
 
+        /** Removes a finalizer function by its object identity. */
         def remove(f: () => Unit): Finalizers =
             (e: @unchecked) match
                 case e if e.equals(Empty) => e

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -17,8 +17,8 @@ private[kyo] class IOPromise[E, A](init: State[E, A]) extends Safepoint.Intercep
     def this() = this(Pending())
     def this(interrupts: IOPromise[?, ?]) = this(Pending().interrupts(interrupts))
 
-    def addEnsure(f: () => Unit): Unit           = {}
-    def removeEnsure(f: () => Unit): Unit        = {}
+    def addFinalizer(f: () => Unit): Unit        = {}
+    def removeFinalizer(f: () => Unit): Unit     = {}
     def enter(frame: Frame, value: Any): Boolean = true
 
     private def cas[E2 <: E, A2 <: A](curr: State[E2, A2], next: State[E2, A2]): Boolean =

--- a/kyo-prelude/jvm/src/test/scala/kyo/kernel/SafepointTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo/kernel/SafepointTest.scala
@@ -180,8 +180,8 @@ class SafepointTest extends Test:
 
     "interceptors" - {
         abstract class TestInterceptor extends Safepoint.Interceptor:
-            def addEnsure(f: () => Unit): Unit    = {}
-            def removeEnsure(f: () => Unit): Unit = {}
+            def addFinalizer(f: () => Unit): Unit    = {}
+            def removeFinalizer(f: () => Unit): Unit = {}
 
         "immediate" - {
 
@@ -537,12 +537,12 @@ class SafepointTest extends Test:
         "with interceptor" - {
 
             class TestInterceptor extends Safepoint.Interceptor:
-                var ensuresAdded: List[() => Unit]             = Nil
-                var ensuresRemoved: List[() => Unit]           = Nil
-                override def addEnsure(f: () => Unit): Unit    = ensuresAdded = f :: ensuresAdded
-                override def removeEnsure(f: () => Unit): Unit = ensuresRemoved = f :: ensuresRemoved
-                def enter(frame: Frame, value: Any): Boolean   = true
-                def exit(): Unit                               = {}
+                var ensuresAdded: List[() => Unit]                = Nil
+                var ensuresRemoved: List[() => Unit]              = Nil
+                override def addFinalizer(f: () => Unit): Unit    = ensuresAdded = f :: ensuresAdded
+                override def removeFinalizer(f: () => Unit): Unit = ensuresRemoved = f :: ensuresRemoved
+                def enter(frame: Frame, value: Any): Boolean      = true
+                def exit(): Unit                                  = {}
             end TestInterceptor
 
             "passes ensure function to Interceptor" in {
@@ -564,7 +564,7 @@ class SafepointTest extends Test:
                 assert(interceptor.ensuresAdded.equals(interceptor.ensuresRemoved))
             }
 
-            "calls removeEnsure on completion" in {
+            "calls removeFinalizer on completion" in {
                 val interceptor = new TestInterceptor
 
                 def testEnsure[A, S](v: => A < S)(using Frame): A < S =
@@ -604,15 +604,15 @@ class SafepointTest extends Test:
                 var interceptorCalls = 0
 
                 val interceptor = new Safepoint.Interceptor:
-                    override def addEnsure(f: () => Unit): Unit =
+                    override def addFinalizer(f: () => Unit): Unit =
                         interceptorCalls += 1
                         f()
                         f()
-                    end addEnsure
+                    end addFinalizer
 
-                    override def removeEnsure(f: () => Unit): Unit = {}
-                    def enter(frame: Frame, value: Any): Boolean   = true
-                    def exit(): Unit                               = {}
+                    override def removeFinalizer(f: () => Unit): Unit = {}
+                    def enter(frame: Frame, value: Any): Boolean      = true
+                    def exit(): Unit                                  = {}
 
                 val effect = Safepoint.propagating(interceptor) {
                     Safepoint.ensure {
@@ -631,10 +631,10 @@ class SafepointTest extends Test:
                 var interceptorActive = false
 
                 val interceptor = new Safepoint.Interceptor:
-                    override def addEnsure(f: () => Unit): Unit    = {}
-                    override def removeEnsure(f: () => Unit): Unit = {}
-                    def enter(frame: Frame, value: Any): Boolean   = true
-                    def exit(): Unit                               = {}
+                    override def addFinalizer(f: () => Unit): Unit    = {}
+                    override def removeFinalizer(f: () => Unit): Unit = {}
+                    def enter(frame: Frame, value: Any): Boolean      = true
+                    def exit(): Unit                                  = {}
 
                 val effect = Safepoint.propagating(interceptor) {
                     Safepoint.ensure {
@@ -655,10 +655,10 @@ class SafepointTest extends Test:
                 var interceptorActive = false
 
                 val interceptor = new Safepoint.Interceptor:
-                    override def addEnsure(f: () => Unit): Unit    = {}
-                    override def removeEnsure(f: () => Unit): Unit = {}
-                    def enter(frame: Frame, value: Any): Boolean   = true
-                    def exit(): Unit                               = {}
+                    override def addFinalizer(f: () => Unit): Unit    = {}
+                    override def removeFinalizer(f: () => Unit): Unit = {}
+                    def enter(frame: Frame, value: Any): Boolean      = true
+                    def exit(): Unit                                  = {}
 
                 assertThrows[RuntimeException] {
                     Safepoint.propagating(interceptor) {

--- a/kyo-prelude/shared/src/main/scala/kyo/debug/Debug.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/debug/Debug.scala
@@ -51,8 +51,8 @@ object Debug:
                 println(frame.parse.show)
                 true
             end enter
-            def addEnsure(f: () => Unit): Unit    = ()
-            def removeEnsure(f: () => Unit): Unit = ()
+            def addFinalizer(f: () => Unit): Unit    = ()
+            def removeFinalizer(f: () => Unit): Unit = ()
 
         Safepoint.propagating(interceptor) {
             Effect.catching {

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/ArrowEffectTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/ArrowEffectTest.scala
@@ -197,8 +197,8 @@ class ArrowEffectTest extends Test:
 
     "Effect.partial" - {
         abstract class TestInterceptor extends Safepoint.Interceptor:
-            def addEnsure(f: () => Unit): Unit    = {}
-            def removeEnsure(f: () => Unit): Unit = {}
+            def addFinalizer(f: () => Unit): Unit    = {}
+            def removeFinalizer(f: () => Unit): Unit = {}
 
         "evaluates pure values" in {
             val x: Int < Any = 5

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/BoundaryTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/BoundaryTest.scala
@@ -77,8 +77,8 @@ class BoundaryTest extends Test:
     "restoring" in {
         var interceptorCalled = false
         val interceptor = new Safepoint.Interceptor:
-            def addEnsure(f: () => Unit): Unit    = ()
-            def removeEnsure(f: () => Unit): Unit = ()
+            def addFinalizer(f: () => Unit): Unit    = ()
+            def removeFinalizer(f: () => Unit): Unit = ()
             def enter(frame: Frame, value: Any): Boolean =
                 interceptorCalled = true
                 true


### PR DESCRIPTION
The term "ensure" came from the `IO.ensure` method and seems too opaque regarding its purpose.