### PR TITLE
core: fix unsafe APIs scaladocs

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Adder.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Adder.scala
@@ -61,9 +61,10 @@ object LongAdder:
       */
     def init(using frame: Frame): LongAdder < IO = IO.Unsafe(LongAdder(Unsafe.init()))
 
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.LongAdder
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         given Flat[Unsafe]                    = Flat.unsafe.bypass
         def init()(using AllowUnsafe): Unsafe = new j.LongAdder
@@ -125,9 +126,10 @@ object DoubleAdder:
       */
     def init(using Frame): DoubleAdder < IO = IO(DoubleAdder(new j.DoubleAdder))
 
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.DoubleAdder
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         given Flat[Unsafe] = Flat.unsafe.bypass
 

--- a/kyo-core/shared/src/main/scala/kyo/Atomic.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Atomic.scala
@@ -99,9 +99,10 @@ object AtomicInt:
       */
     def init(v: Int)(using Frame): AtomicInt < IO = IO.Unsafe(AtomicInt(Unsafe.init(v)))
 
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.AtomicInteger
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         given Flat[Unsafe] = Flat.unsafe.bypass
 
@@ -221,9 +222,10 @@ object AtomicLong:
       */
     def init(v: Long)(using Frame): AtomicLong < IO = IO.Unsafe(AtomicLong(Unsafe.init(v)))
 
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.AtomicLong
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         given Flat[Unsafe] = Flat.unsafe.bypass
 
@@ -303,9 +305,10 @@ object AtomicBoolean:
       */
     def init(v: Boolean)(using Frame): AtomicBoolean < IO = IO.Unsafe(AtomicBoolean(Unsafe.init(v)))
 
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.AtomicBoolean
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         given Flat[Unsafe] = Flat.unsafe.bypass
 
@@ -401,7 +404,7 @@ object AtomicRef:
 
     opaque type Unsafe[A] = j.AtomicReference[A]
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         given [A]: Flat[Unsafe[A]] = Flat.unsafe.bypass
 

--- a/kyo-core/shared/src/main/scala/kyo/Barrier.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Barrier.scala
@@ -37,14 +37,14 @@ object Barrier:
       */
     def init(n: Int)(using Frame): Barrier < IO = IO.Unsafe(Barrier(Unsafe.init(n)))
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     sealed abstract class Unsafe:
         def await()(using AllowUnsafe): Fiber.Unsafe[Nothing, Unit]
         def pending()(using AllowUnsafe): Int
         def safe: Barrier = Barrier(this)
     end Unsafe
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
 
         val noop = new Unsafe:

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -46,7 +46,7 @@ object Clock:
     end Stopwatch
 
     object Stopwatch:
-        /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+        /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
         class Unsafe(start: Instant, clock: Clock.Unsafe):
             def elapsed()(using AllowUnsafe): Duration = clock.now() - start
             def safe: Stopwatch                        = Stopwatch(this)
@@ -71,7 +71,7 @@ object Clock:
     end Deadline
 
     object Deadline:
-        /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+        /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
         class Unsafe(endInstant: Maybe[Instant], clock: Clock.Unsafe):
 
             def timeLeft()(using AllowUnsafe): Duration =
@@ -143,7 +143,7 @@ object Clock:
                 IO.Unsafe(u.now())
             def unsafe: Unsafe = u
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe:
         def now()(using AllowUnsafe): Instant
 

--- a/kyo-core/shared/src/main/scala/kyo/Console.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Console.scala
@@ -143,7 +143,7 @@ object Console:
             def printlnErr(s: String)(using Frame): Unit < IO = IO.Unsafe(u.printlnErr(s))
             def unsafe: Unsafe                                = u
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe:
         def readln()(using AllowUnsafe): String
         def print(s: String)(using AllowUnsafe): Unit

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -377,7 +377,7 @@ object Fiber extends FiberPlatformSpecific:
 
     opaque type Unsafe[E, A] = IOPromise[E, A]
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         inline given [E, A]: Flat[Unsafe[E, A]] = Flat.unsafe.bypass
 
@@ -448,7 +448,7 @@ object Fiber extends FiberPlatformSpecific:
 
         opaque type Unsafe[E, A] <: Fiber.Unsafe[E, A] = IOPromise[E, A]
 
-        /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+        /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
         object Unsafe:
             inline given [E, A]: Flat[Unsafe[E, A]] = Flat.unsafe.bypass
 

--- a/kyo-core/shared/src/main/scala/kyo/IO.scala
+++ b/kyo-core/shared/src/main/scala/kyo/IO.scala
@@ -59,7 +59,7 @@ object IO:
     inline def ensure[A, S](inline f: => Unit < IO)(v: A < S)(using inline frame: Frame): A < (IO & S) =
         Unsafe(Safepoint.ensure(IO.Unsafe.run(f).eval)(v))
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
 
         inline def apply[A, S](inline f: AllowUnsafe ?=> A < S)(using inline frame: Frame): A < (IO & S) =

--- a/kyo-core/shared/src/main/scala/kyo/Latch.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Latch.scala
@@ -44,7 +44,7 @@ object Latch:
       */
     def init(n: Int)(using Frame): Latch < IO = IO.Unsafe(Latch(Unsafe.init(n)))
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     sealed abstract class Unsafe:
         def await()(using AllowUnsafe): Fiber.Unsafe[Nothing, Unit]
         def release()(using AllowUnsafe): Unit
@@ -52,7 +52,7 @@ object Latch:
         def safe: Latch = Latch(this)
     end Unsafe
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
 
         val noop = new Unsafe:

--- a/kyo-core/shared/src/main/scala/kyo/Log.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Log.scala
@@ -19,7 +19,7 @@ object Log extends LogPlatformSpecific:
     def let[A, S](u: Unsafe)(f: => A < (IO & S))(using Frame): A < (IO & S) =
         local.let(u)(f)
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe:
         def traceEnabled: Boolean
         def debugEnabled: Boolean
@@ -39,7 +39,7 @@ object Log extends LogPlatformSpecific:
         def error(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
     end Unsafe
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         class ConsoleLogger(name: String) extends Log.Unsafe:
             inline def traceEnabled: Boolean = true

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -103,7 +103,7 @@ end Queue
   */
 object Queue:
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe[A]
         extends AtomicBoolean(false):
         def capacity: Int

--- a/kyo-core/shared/src/main/scala/kyo/Random.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Random.scala
@@ -22,7 +22,7 @@ end Random
 
 object Random:
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe:
         def nextInt()(using AllowUnsafe): Int
         def nextInt(exclusiveBound: Int)(using AllowUnsafe): Int
@@ -40,7 +40,7 @@ object Random:
         def safe: Random = Random(this)
     end Unsafe
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         def apply(random: java.util.Random): Unsafe =
             new Unsafe:

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -27,7 +27,7 @@ object System:
     enum OS derives CanEqual:
         case Linux, MacOS, Windows, BSD, Solaris, IBMI, AIX, Unknown
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe:
         def env(name: String)(using AllowUnsafe): Maybe[String]
         def property(name: String)(using AllowUnsafe): Maybe[String]

--- a/kyo-core/shared/src/main/scala/kyo/Timer.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Timer.scala
@@ -177,7 +177,7 @@ object Timer:
             )(f: => Unit < Async)(using Frame): TimerTask < IO =
                 IO.Unsafe(unsafe.scheduleWithFixedDelay(initialDelay, period)(eval(f)).safe)
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe:
         def schedule(delay: Duration)(f: => Unit)(using AllowUnsafe): TimerTask.Unsafe
         def scheduleAtFixedRate(
@@ -191,7 +191,7 @@ object Timer:
         def safe: Timer = Timer(this)
     end Unsafe
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         def apply(exec: ScheduledExecutorService)(using AllowUnsafe): Unsafe = new Unsafe:
             final private class FutureTimerTask(task: ScheduledFuture[?]) extends TimerTask.Unsafe:
@@ -270,7 +270,7 @@ object TimerTask:
     /** A no-op TimerTask that is always considered done and cannot be cancelled. */
     val noop = TimerTask(Unsafe.noop)
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe:
         def cancel()(using AllowUnsafe): Boolean
         def cancelled()(using AllowUnsafe): Boolean
@@ -278,7 +278,7 @@ object TimerTask:
         def safe: TimerTask = TimerTask(this)
     end Unsafe
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         val noop = new Unsafe:
             def cancel()(using AllowUnsafe)    = false

--- a/kyo-core/shared/src/main/scala/kyo/stats/internal/Span.scala
+++ b/kyo-core/shared/src/main/scala/kyo/stats/internal/Span.scala
@@ -16,7 +16,7 @@ end Span
 
 object Span:
 
-    /* WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
+    /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe:
         def end(): Unit
         def event(name: String, a: Attributes): Unit


### PR DESCRIPTION
The unsafe warnings are not showing up in scaladocs because they're formatted as a regular comment. I've also added the warning to a few APIs that were missing it.