### PR TITLE
data: use Set to represent unions and intersections in SafeClassTag

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/internal/SafeClassTagMacro.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/SafeClassTagMacro.scala
@@ -41,14 +41,14 @@ private[kyo] object SafeClassTagMacro:
                             case OrType(a, b) => flatten(a) ++ flatten(b)
                             case _            => Seq(tpe)
                     val exprs = flatten(tpe).map(create)
-                    '{ Union(${ Expr.ofList(exprs) }) }
+                    '{ Union(Set(${ Varargs(exprs) }*)) }
                 case AndType(_, _) =>
                     def flatten(tpe: TypeRepr): Seq[TypeRepr] =
                         tpe match
                             case AndType(a, b) => flatten(a) ++ flatten(b)
                             case _             => Seq(tpe)
                     val exprs = flatten(tpe).map(create)
-                    '{ Intersection(${ Expr.ofList(exprs) }) }
+                    '{ Intersection(Set(${ Varargs(exprs) }*)) }
                 case _ => createSingle(tpe)
             end match
         end create


### PR DESCRIPTION
So it's possible to provide a `CanEqual` evidence.