### PR TITLE
[prelude][core] isolated locals and reentrant meters

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -135,7 +135,7 @@ object Meter:
             new Base(rate, reentrant):
                 val timerTask =
                     // Schedule periodic task to replenish permits
-                    IO.Unsafe.run(Clock.repeatAtInterval(period)(replenish())).eval
+                    IO.Unsafe.run(Clock.repeatAtInterval(period, period)(replenish())).eval
 
                 def dispatch[A, S](v: => A < S) =
                     // Don't release a permit since it's managed by the timer task

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -262,7 +262,7 @@ object Meter:
         protected def dispatch[A, S](v: => A < S): A < (S & IO)
         protected def onClose(): Unit
 
-        private inline def withReentry[A, S](inline reenter: => A < S)(inline acquire: => A < S): A < S =
+        private inline def withReentry[A, S](inline reenter: => A < S)(acquire: => A < S): A < S =
             if reentrant then
                 acquiredMeters.use { meters =>
                     if meters.contains(this) then reenter

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -227,7 +227,7 @@ class MeterTest extends Test:
         }
         "replenish doesn't overflow" in runJVM {
             for
-                meter     <- Meter.initRateLimiter(5, 10.millis)
+                meter     <- Meter.initRateLimiter(5, 5.millis)
                 _         <- Async.sleep(32.millis)
                 available <- meter.availablePermits
             yield assert(available == 5)
@@ -251,7 +251,7 @@ class MeterTest extends Test:
 
         "tryRun" in runJVM {
             for
-                meter   <- Meter.pipeline(Meter.initRateLimiter(2, 10.millis), Meter.initMutex)
+                meter   <- Meter.pipeline(Meter.initRateLimiter(2, 5.millis), Meter.initMutex)
                 counter <- AtomicInt.init(0)
                 f1      <- Async.run(loop(meter, counter))
                 _       <- Async.sleep(5.millis)
@@ -260,6 +260,187 @@ class MeterTest extends Test:
                 r       <- meter.tryRun(())
                 _       <- f1.interrupt(panic)
             yield assert(r.isEmpty)
+        }
+    }
+
+    "reentrancy" - {
+        "mutex" - {
+            "reentrant by default" in runJVM {
+                for
+                    mutex <- Meter.initMutex
+                    result <- mutex.run {
+                        mutex.run {
+                            mutex.run(42)
+                        }
+                    }
+                yield assert(result == 42)
+            }
+
+            "non-reentrant" in runJVM {
+                for
+                    meter  <- Meter.initMutex(reentrant = false)
+                    p      <- Promise.init[Nothing, Int]
+                    f      <- Async.run(meter.run(meter.run(42)))
+                    _      <- Async.sleep(5.millis)
+                    done   <- f.done
+                    _      <- f.interrupt
+                    result <- f.getResult
+                yield assert(!done && result.isPanic)
+            }
+
+            "nested forked fiber can't reenter" in runJVM {
+                for
+                    meter <- Meter.initMutex
+                    (done, result) <- meter.run {
+                        meter.run {
+                            for
+                                f      <- Async.run(meter.run(42))
+                                _      <- Async.sleep(5.millis)
+                                done   <- f.done
+                                _      <- f.interrupt
+                                result <- f.getResult
+                            yield (done, result)
+                        }
+                    }
+                yield assert(!done && result.isPanic)
+            }
+        }
+
+        "semaphore" - {
+            "reentrant by default" in runJVM {
+                for
+                    sem <- Meter.initSemaphore(1)
+                    result <- sem.run {
+                        sem.run {
+                            sem.run(42)
+                        }
+                    }
+                yield assert(result == 42)
+            }
+
+            "non-reentrant" in runJVM {
+                for
+                    meter  <- Meter.initSemaphore(1, reentrant = false)
+                    p      <- Promise.init[Nothing, Int]
+                    f      <- Async.run(meter.run(meter.run(42)))
+                    _      <- Async.sleep(5.millis)
+                    done   <- f.done
+                    _      <- f.interrupt
+                    result <- f.getResult
+                yield assert(!done && result.isPanic)
+            }
+
+            "nested forked fiber can't reenter" in runJVM {
+                for
+                    meter <- Meter.initSemaphore(1)
+                    (done, result) <- meter.run {
+                        meter.run {
+                            for
+                                f      <- Async.run(meter.run(42))
+                                _      <- Async.sleep(5.millis)
+                                done   <- f.done
+                                _      <- f.interrupt
+                                result <- f.getResult
+                            yield (done, result)
+                        }
+                    }
+                yield assert(!done && result.isPanic)
+            }
+        }
+
+        "rate limiter" - {
+            "reentrant by default" in runJVM {
+                for
+                    rateLimiter <- Meter.initRateLimiter(1, 1.second)
+                    result <- rateLimiter.run {
+                        rateLimiter.run {
+                            rateLimiter.run(42)
+                        }
+                    }
+                yield assert(result == 42)
+            }
+
+            "non-reentrant" in runJVM {
+                for
+                    meter  <- Meter.initRateLimiter(1, 1.second, reentrant = false)
+                    p      <- Promise.init[Nothing, Int]
+                    f      <- Async.run(meter.run(meter.run(42)))
+                    _      <- Async.sleep(5.millis)
+                    done   <- f.done
+                    _      <- f.interrupt
+                    result <- f.getResult
+                yield assert(!done && result.isPanic)
+            }
+
+            "nested forked fiber can't reenter" in runJVM {
+                for
+                    meter <- Meter.initRateLimiter(1, 1.second)
+                    (done, result) <- meter.run {
+                        meter.run {
+                            for
+                                f      <- Async.run(meter.run(42))
+                                _      <- Async.sleep(5.millis)
+                                done   <- f.done
+                                _      <- f.interrupt
+                                result <- f.getResult
+                            yield (done, result)
+                        }
+                    }
+                yield assert(!done && result.isPanic)
+            }
+        }
+
+        "pipeline" - {
+            "reentrant when all components are reentrant" in runJVM {
+                for
+                    mutex       <- Meter.initMutex
+                    sem         <- Meter.initSemaphore(1)
+                    rateLimiter <- Meter.initRateLimiter(1, 1.second)
+                    pipeline    <- Meter.pipeline(mutex, sem, rateLimiter)
+                    result <- pipeline.run {
+                        pipeline.run {
+                            pipeline.run(42)
+                        }
+                    }
+                yield assert(result == 42)
+            }
+
+            "non-reentrant when any component is non-reentrant" in runJVM {
+                for
+                    mutex       <- Meter.initMutex
+                    sem         <- Meter.initSemaphore(1, reentrant = false)
+                    rateLimiter <- Meter.initRateLimiter(1, 1.second)
+                    pipeline    <- Meter.pipeline(mutex, sem, rateLimiter)
+                    p           <- Promise.init[Nothing, Int]
+                    f <- Async.run(pipeline.run {
+                        pipeline.run(42)
+                    })
+                    _      <- Async.sleep(5.millis)
+                    done   <- f.done
+                    _      <- f.interrupt
+                    result <- f.getResult
+                yield assert(!done && result.isPanic)
+            }
+
+            "nested forked fiber can't reenter" in runJVM {
+                for
+                    mutex       <- Meter.initMutex
+                    sem         <- Meter.initSemaphore(1)
+                    rateLimiter <- Meter.initRateLimiter(1, 1.second)
+                    meter       <- Meter.pipeline(mutex, sem, rateLimiter)
+                    (done, result) <- meter.run {
+                        meter.run {
+                            for
+                                f      <- Async.run(meter.run(42))
+                                _      <- Async.sleep(5.millis)
+                                done   <- f.done
+                                _      <- f.interrupt
+                                result <- f.getResult
+                            yield (done, result)
+                        }
+                    }
+                yield assert(!done && result.isPanic)
+            }
         }
     }
 

--- a/kyo-data/shared/src/main/scala/kyo/Ansi.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Ansi.scala
@@ -68,7 +68,7 @@ object Ansi:
         def apply(header: String, code: String, trailer: String, startLine: Int = 1): String =
             try
                 val headerLines  = if header.nonEmpty then header.split("\n") else Array.empty[String]
-                val codeLines    = code.split("\n").dropWhile(_.trim.isEmpty).reverse.dropWhile(_.trim.isEmpty).reverse
+                val codeLines    = code.split("\n").dropWhile(_.isBlank).reverse.dropWhile(_.isBlank).reverse
                 val trailerLines = if trailer.nonEmpty then trailer.split("\n") else Array.empty[String]
 
                 val allLines        = headerLines ++ codeLines ++ trailerLines

--- a/kyo-prelude/shared/src/main/scala/kyo/Local.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Local.scala
@@ -7,7 +7,10 @@ import scala.annotation.nowarn
 
 /** Represents a local value that can be accessed and modified within a specific scope.
   *
-  * Local provides a way to manage thread-local state in a functional manner.
+  * Local provides a way to manage thread-local-like state in a functional manner. There are two types of locals: regular and isolated.
+  *
+  * Regular locals behave similarly to inheritable thread locals, where child fibers inherit the value from their parent fiber. Isolated
+  * locals, on the other hand, are similar to non-inheritable thread locals, where child fibers always start with the default value.
   *
   * @tparam A
   *   The type of the local value
@@ -58,12 +61,14 @@ end Local
 /** Companion object for Local, providing utility methods for creating Local instances. */
 object Local:
 
-    /** Creates a new Local instance with the given default value.
+    /** Creates a new regular Local instance with the given default value.
+      *
+      * Regular locals are similar to inheritable thread locals, where child fibers inherit the value from their parent fiber.
       *
       * @param defaultValue
       *   The default value for the Local
       * @return
-      *   A new Local instance
+      *   A new regular Local instance
       */
     @nowarn("msg=anonymous")
     inline def init[A](inline defaultValue: A): Local[A] =
@@ -71,6 +76,16 @@ object Local:
             def tag             = Tag[State]
             lazy val default: A = defaultValue
 
+    /** Creates a new isolated Local instance with the given default value.
+      *
+      * Isolated locals are similar to non-inheritable thread locals, where child fibers always start with the default value and do not
+      * inherit from their parent fiber.
+      *
+      * @param defaultValue
+      *   The default value for the Local
+      * @return
+      *   A new isolated Local instance
+      */
     @nowarn("msg=anonymous")
     inline def initIsolated[A](inline defaultValue: A): Local[A] =
         new Base[A, IsolatedState]:

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Boundary.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Boundary.scala
@@ -16,7 +16,7 @@ private[kyo] object Boundary:
             new KyoDefer[A, S & S2]:
                 def frame = _frame
                 def apply(v: Unit, context: Context)(using safepoint: Safepoint) =
-                    f(safepoint.saveTrace(), context)
+                    f(safepoint.saveTrace(), context.inherit)
 
     inline given derive[Ctx, S]: Boundary[Ctx, S] = ${ boundaryImpl[Ctx, S] }
 

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Context.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Context.scala
@@ -16,11 +16,14 @@ object Context:
         inline def contains[A, E <: ContextEffect[A]](tag: Tag[E]): Boolean =
             context.contains(tag.erased)
 
+        inline def inherit: Context =
+            context.filterNot(_._1 <:< Tag[ContextEffect.Isolated])
+
         inline def getOrElse[A, E <: ContextEffect[A], B >: A](tag: Tag[E], inline default: => B): B =
             if !contains(tag) then default
             else context(tag.erased).asInstanceOf[B]
 
-        private[kernel] inline def get[A, E <: ContextEffect[A]](tag: Tag[E]): A =
+        private[kyo] inline def get[A, E <: ContextEffect[A]](tag: Tag[E]): A =
             getOrElse(tag, bug(s"Missing value for context effect '${tag}'. Values: $context"))
 
         private[kernel] inline def set[A, E <: ContextEffect[A]](tag: Tag[E], value: A): Context =

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/ContextEffect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/ContextEffect.scala
@@ -10,6 +10,9 @@ abstract class ContextEffect[+A] extends Effect
 
 object ContextEffect:
 
+    trait Isolated:
+        self: ContextEffect[?] =>
+
     inline def suspend[A, E <: ContextEffect[A]](inline tag: Tag[E])(using inline frame: Frame): A < E =
         suspendMap(tag)(identity)
 

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/BoundaryTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/BoundaryTest.scala
@@ -189,4 +189,23 @@ class BoundaryTest extends Test:
         }
     }
 
+    "context inheritance" - {
+        sealed trait IsolatedEffect    extends ContextEffect[Int] with ContextEffect.Isolated
+        sealed trait NonIsolatedEffect extends ContextEffect[String]
+
+        "should propagate only non-isolated effects" in {
+            val boundary = Boundary.derive[NonIsolatedEffect, Any]
+
+            val context =
+                ContextEffect.handle(Tag[IsolatedEffect], 24, _ + 1) {
+                    ContextEffect.handle(Tag[NonIsolatedEffect], "test", _.toUpperCase) {
+                        boundary { (trace, context) => context }
+                    }
+                }.eval
+
+            assert(!context.contains(Tag[IsolatedEffect]))
+            assert(context.contains(Tag[NonIsolatedEffect]))
+        }
+    }
+
 end BoundaryTest

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/ContextTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/ContextTest.scala
@@ -64,4 +64,33 @@ class ContextTest extends Test:
         assert(context.getOrElse(Tag[TestEffect2], "") == "test")
     }
 
+    "inherit" - {
+        sealed trait NonIsolatedEffect extends ContextEffect[String]
+        sealed trait IsolatedEffect    extends ContextEffect[String] with ContextEffect.Isolated
+
+        "should keep non-isolated effects" in {
+            val context = Context.empty
+                .set(Tag[NonIsolatedEffect], "test")
+                .set(Tag[TestEffect1], 42)
+
+            val inherited = context.inherit
+
+            assert(inherited.contains(Tag[NonIsolatedEffect]))
+            assert(inherited.contains(Tag[TestEffect1]))
+            assert(inherited.getOrElse(Tag[NonIsolatedEffect], "") == "test")
+            assert(inherited.getOrElse(Tag[TestEffect1], 0) == 42)
+        }
+
+        "should remove isolated effects" in {
+            val context = Context.empty
+                .set(Tag[IsolatedEffect], 100)
+                .set(Tag[TestEffect1], 42)
+
+            val inherited = context.inherit
+
+            assert(!inherited.contains(Tag[IsolatedEffect]))
+            assert(inherited.contains(Tag[TestEffect1]))
+        }
+    }
+
 end ContextTest


### PR DESCRIPTION
Kyo's `Meter`s are currently non-reentrant. That's not an ideal default because it can easily lead to deadlocks. If a fiber tries to obtain the same mutex multiple times for example, it won't ever resume. This PR is the initial step to enable reentrancy by providing a new mechanism that isolates locals so they aren't inherited by forked fibers.

The solution uses a new `ContextEffect.Isolated` marker trait to filter entries from `Context` when a computation is being forked via a `Boundary`. The `Local` implementation uses two effect types to differentiate locals that are isolated or not.

With this new mechanism, I'm planning to change `Meter` to propagate an isolated local indicating that the fiber is currently holding a permit for a specific meter. Since locals are scoped, they will be cleared up as soon as the computation is finished, right before the permit is released. Forked fibers also won't see the local since it'll be isolated. The goal is to allow users to customize if a meter should be reentrant or not.