### PR TITLE
[tapir] propagate shutdown timeout to netty

### DIFF
--- a/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServer.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServer.scala
@@ -153,7 +153,7 @@ case class NettyKyoServer(
         gracefulShutdownTimeout: Option[FiniteDuration]
     ): KyoSttpMonad.M[Unit] =
         isShuttingDown.set(true)
-        val timeout = gracefulShutdownTimeout.map(_.toNanos).getOrElse(Long.MaxValue)
+        val timeout = gracefulShutdownTimeout.fold(Long.MaxValue)(_.toNanos)
         waitForClosedChannels(
             channelGroup,
             startNanos = JSystem.nanoTime(),


### PR DESCRIPTION
Tests that start a tapir server are taking ~2s to finalize because Netty waits for some time before shutting down. This PR makes the shut down process respect the timeout defined by the user.