### PR TITLE
[prelude] Parse effect

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Tag.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Tag.scala
@@ -19,6 +19,8 @@ object Tag:
 
     inline given apply[A]: Tag[A] = ${ TagMacro.tagImpl[A] }
 
+    private[kyo] def fromRaw[A](tag: String): Tag[A] = tag
+
     extension [A](t1: Tag[A])
 
         inline def erased: Tag[Any] = t1.asInstanceOf[Tag[Any]]

--- a/kyo-data/shared/src/main/scala/kyo/Text.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Text.scala
@@ -7,6 +7,8 @@ opaque type Text >: String = String | Op
 
 object Text:
 
+    given Tag[Text] = Tag.fromRaw("kyo.Text")
+
     def apply(s: String): Text = s
 
     def empty: Text = ""
@@ -229,6 +231,17 @@ object Text:
         def show: String = self.toString()
 
         def compact: Text = self.toString()
+
+        def is(other: Text): Boolean =
+            if self.length != other.length then false
+            else
+                @tailrec
+                def loop(i: Int): Boolean =
+                    if i >= self.length then true
+                    else if self.charAt(i) != other.charAt(i) then false
+                    else loop(i + 1)
+                loop(0)
+        end is
 
     end extension
 

--- a/kyo-data/shared/src/test/scala/kyo/TextTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/TextTest.scala
@@ -569,4 +569,49 @@ class TextTest extends Test:
         }
     }
 
+    "is (equality)" - {
+        "simple texts" in {
+            assert(Text("hello").is(Text("hello")))
+            assert(!Text("hello").is(Text("world")))
+        }
+
+        "empty texts" in {
+            assert(Text("").is(Text("")))
+            assert(!Text("").is(Text("a")))
+        }
+
+        "case sensitivity" in {
+            assert(!Text("Hello").is(Text("hello")))
+        }
+
+        "concatenated texts" in {
+            assert((Text("hello") + " world").is(Text("hello world")))
+            assert(!(Text("hello") + "world").is(Text("helloworld ")))
+        }
+
+        "cut texts" in {
+            assert(Text("hello world").substring(0, 5).is(Text("hello")))
+            assert(!Text("hello world").substring(0, 5).is(Text("world")))
+        }
+
+        "mixed operations" in {
+            val text1 = Text("hello") + " " + "world"
+            val text2 = Text("hello world").substring(0, 11)
+            assert(text1.is(text2))
+        }
+
+        "unicode support" in {
+            assert(Text("Hello 🌍").is(Text("Hello 🌍")))
+            assert(!Text("Hello 🌍").is(Text("Hello 🌎")))
+        }
+
+        "large texts" in {
+            val large1 = Text("a" * 1000000)
+            val large2 = Text("a" * 1000000)
+            val large3 = Text("a" * 999999 + "b")
+            assert(large1.is(large2))
+            assert(!large1.is(large3))
+        }
+    }
+
 end TextTest

--- a/kyo-prelude/shared/src/main/scala/kyo/Parse.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Parse.scala
@@ -1,0 +1,473 @@
+package kyo
+
+import kyo.Ansi.*
+import kyo.kernel.*
+
+/** The Parse effect combines three fundamental capabilities needed for parsing:
+  *   - State management (Var[Parse.State]) to track input position
+  *   - Choice for handling alternatives and backtracking
+  *   - Error handling (Abort[ParseFailed]) for parse failures
+  *
+  * This combination enables building complex parsers that can handle ambiguous grammars, implement look-ahead, and provide detailed error
+  * messages.
+  */
+opaque type Parse <: (Var[Parse.State] & Choice & Abort[ParseFailed]) = Var[Parse.State] & Choice & Abort[ParseFailed]
+
+object Parse:
+
+    // avoids splicing the derived tag on each use
+    private given Tag[Var[State]] = Tag[Var[State]]
+
+    /** Attempts to parse input using the provided parsing function
+      *
+      * @param f
+      *   Function that takes remaining text and returns:
+      *   - Present((remaining, value)) when parsing succeeds, containing the unconsumed text and parsed value
+      *   - Absent when the parser doesn't match at the current position, allowing for backtracking
+      * @return
+      *   Parsed value if successful, drops the current parse branch if unsuccessful
+      */
+    def read[A, S](f: Text => Maybe[(Text, A)] < S)(using Frame): A < (Parse & S) =
+        Var.use[State] { state =>
+            f(state.remaining).map {
+                case Present((remaining, result)) =>
+                    val consumed = state.remaining.length - remaining.length
+                    Var.set(state.advance(consumed)).as(result)
+                case Absent =>
+                    Choice.drop
+            }
+        }
+
+    /** Drops the current parse branch
+      *
+      * @return
+      *   Nothing, as this always fails the current branch
+      */
+    def drop(using Frame): Nothing < Parse =
+        Choice.drop
+
+    /** Drops the current parse branch if condition is true
+      *
+      * @param condition
+      *   When true, drops the current parse branch
+      */
+    def dropIf(condition: Boolean)(using Frame): Unit < Parse =
+        Choice.dropIf(condition)
+
+    /** Terminally fail parsing with a message
+      *
+      * @param message
+      *   Error message for the failure
+      */
+    def fail(message: String)(using frame: Frame): Nothing < Parse =
+        Var.use[State](s => fail(Seq(s), message))
+
+    private def fail(states: Seq[State], message: String)(using frame: Frame): Nothing < Abort[ParseFailed] =
+        Abort.fail(ParseFailed(frame, states, message))
+
+    /** Tries all parsers in sequence and returns results from all successful parses. Unlike firstOf, this will evaluate all parsers even
+      * after finding a successful one, which is useful when you need to handle ambiguous grammars.
+      *
+      * @param seq
+      *   Sequence of parsers to try
+      * @return
+      *   Result from all successful parsers
+      */
+    def anyOf[A, S](seq: (A < (Parse & S))*)(using Frame): A < (Parse & S) =
+        Choice.eval(seq)(identity)
+
+    /** Like anyOf but commits to first successful parse
+      *
+      * @param seq
+      *   Sequence of parsers to try
+      * @return
+      *   Result from first successful parser, fails if none succeed
+      */
+    def firstOf[A: Flat, S](seq: (A < (Parse & S))*)(using Frame): A < (Parse & S) =
+        Loop(seq) {
+            case Seq() => Choice.drop
+            case head +: tail =>
+                attempt(head).map {
+                    case Present(value) => Loop.done(value)
+                    case Absent         => Loop.continue(tail)
+                }
+        }
+
+    /** Selects between multiple successful parses using a selection function. This is useful for implementing custom disambiguation
+      * strategies between multiple valid parses.
+      *
+      * @param seq
+      *   Sequence of parsers to try - all parsers will be evaluated
+      * @param f
+      *   Selection function that receives pairs of successful parses (with their states) and decides which one to keep. Returns Maybe.empty
+      *   to skip both.
+      * @return
+      *   The parse result selected by the selection function
+      */
+    def select[A: Flat, S, S2](seq: (A < (Parse & S))*)(f: ((State, A), (State, A)) => Maybe[(State, A)] < S2)(
+        using Frame
+    ): A < (Parse & S & S2) =
+        Loop(seq, Maybe.empty[(State, A)]) { (seq, current) =>
+            seq match
+                case Seq() =>
+                    current match
+                        case Absent => Choice.drop
+                        case Present((state, a)) =>
+                            Var.set(state).as(Loop.done(a))
+                case head +: tail =>
+                    peek(head.map(a => Var.use[State]((_, a)))).map {
+                        case Absent =>
+                            Loop.continue(tail, current)
+                        case next @ Present(nextState) =>
+                            current match
+                                case Absent =>
+                                    Loop.continue(tail, next)
+                                case Present(currentState) =>
+                                    f(currentState, nextState).map(Loop.continue(tail, _))
+                    }
+        }
+    end select
+
+    /** Skips input until parser succeeds
+      *
+      * @param v
+      *   Parser to try at each position
+      * @return
+      *   Result when parser succeeds
+      */
+    def skipUntil[A: Flat, S](v: A < (Parse & S))(using Frame): A < (Parse & S) =
+        attempt(v).map {
+            case Absent =>
+                Var.use[State] { state =>
+                    if state.done then Parse.drop
+                    else Var.set(state.advance(1)).as(skipUntil(v))
+                }
+            case Present(v) => v
+        }
+
+    /** Tries a parser but backtracks on failure. If the parser succeeds, the input is consumed normally. If it fails, the input position is
+      * restored to where it was before the attempt. This is essential for implementing look-ahead and alternative parsing strategies where
+      * failed attempts shouldn't consume input.
+      *
+      * @param v
+      *   Parser to attempt
+      * @return
+      *   Maybe containing the result if successful, Absent if parser failed
+      */
+    def attempt[A: Flat, S](v: A < (Parse & S))(using Frame): Maybe[A] < (Parse & S) =
+        Var.use[State] { start =>
+            Choice.run(v).map { r =>
+                result(r).map {
+                    case Absent =>
+                        Var.set(start).as(Maybe.empty)
+                    case result =>
+                        result
+                }
+            }
+        }
+
+    /** Like attempt but commits to the parse result and fails instead of returning Maybe.empty. This is useful when you want to commit to a
+      * parsing branch and prevent backtracking, effectively saying "if we got this far, this must be the correct parse".
+      *
+      * @param v
+      *   Parser to attempt
+      * @return
+      *   Parser result, fails if parser fails with no possibility of backtracking
+      */
+    def cut[A: Flat, S](v: A < (Parse & S))(using Frame): A < (Parse & S) =
+        attempt(v).map {
+            case Present(a) => a
+            case Absent     => Parse.fail("Failed to parse required element")
+        }
+
+    /** Tries a parser without consuming input
+      *
+      * @param v
+      *   Parser to peek with
+      * @return
+      *   Maybe containing the result if successful
+      */
+    def peek[A: Flat, S](v: A < (Parse & S))(using Frame): Maybe[A] < (Parse & S) =
+        Var.use[State] { start =>
+            Choice.run(v).map { r =>
+                Var.set(start).as(result(r))
+            }
+        }
+
+    /** Repeats a parser until it fails
+      *
+      * @param p
+      *   Parser to repeat
+      * @return
+      *   Chunk of all successful results
+      */
+    def repeat[A: Flat, S](p: A < (Parse & S))(using Frame): Chunk[A] < (Parse & S) =
+        Loop(Chunk.empty[A]) { acc =>
+            attempt(p).map {
+                case Present(a) => Loop.continue(acc.append(a))
+                case Absent     => Loop.done(acc)
+            }
+        }
+
+    /** Repeats a parser exactly n times
+      *
+      * @param n
+      *   Number of repetitions required
+      * @param p
+      *   Parser to repeat
+      * @return
+      *   Chunk of n results, fails if can't get n results
+      */
+    def repeat[A: Flat, S](n: Int)(p: A < (Parse & S))(using Frame): Chunk[A] < (Parse & S) =
+        Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
+            if idx == n then Loop.done(acc)
+            else
+                attempt(p).map {
+                    case Present(a) => Loop.continue(acc.append(a))
+                    case Absent     => Parse.drop
+                }
+        }
+
+    /** Runs a parser on input text
+      *
+      * @param input
+      *   Text to parse
+      * @param v
+      *   Parser to run
+      * @return
+      *   Parsed result if successful
+      */
+    def run[A: Flat, S](input: Text)(v: A < (Parse & S))(using Frame): A < (S & Abort[ParseFailed]) =
+        Choice.run(Var.runTuple(State(input, 0))(v)).map {
+            case Seq() =>
+                Parse.fail(Seq(State(input, 0)), "No valid parse results found")
+            case Seq((state, value)) =>
+                if state.done then value
+                else Parse.fail(Seq(state), "Incomplete parse - remaining input not consumed")
+            case seq =>
+                Parse.fail(seq.map(_._1), "Ambiguous parse - multiple results found")
+        }
+
+    private def result[A](seq: Seq[A])(using Frame): Maybe[A] < Parse =
+        seq match
+            case Seq()      => Maybe.empty
+            case Seq(value) => Maybe(value)
+            case _          => Parse.fail("Ambiguous parse result - multiple values found")
+
+    /** Represents the current state of parsing
+      *
+      * @param input
+      *   The complete input text being parsed
+      * @param position
+      *   Current position in the input text
+      */
+    case class State(input: Text, position: Int):
+
+        /** Returns the remaining unparsed input text */
+        def remaining: Text =
+            input.drop(position)
+
+        /** Advances the position by n characters, not exceeding input length
+          *
+          * @param n
+          *   Number of characters to advance
+          * @return
+          *   New state with updated position
+          */
+        def advance(n: Int): State =
+            copy(position = Math.min(input.length, position + n))
+
+        /** Checks if all input has been consumed
+          *
+          * @return
+          *   true if position has reached the end of input
+          */
+        def done: Boolean =
+            position == input.length
+    end State
+
+    // **********************
+    // ** Standard parsers **
+    // **********************
+
+    /** Selects shortest matching parse from alternatives
+      *
+      * @param seq
+      *   Sequence of parsers to try
+      * @return
+      *   Result that consumed least input
+      */
+    def shortest[A: Flat, S](seq: (A < (Parse & S))*)(using Frame): A < (Parse & S) =
+        select(seq*) {
+            case (curr @ (state1, _), next @ (state2, _)) =>
+                if state2.position < state1.position then Maybe(next)
+                else Maybe(curr)
+        }
+
+    /** Selects longest matching parse from alternatives
+      *
+      * @param seq
+      *   Sequence of parsers to try
+      * @return
+      *   Result that consumed most input
+      */
+    def longest[A: Flat, S](seq: (A < (Parse & S))*)(using Frame): A < (Parse & S) =
+        select(seq*) {
+            case (curr @ (state1, _), next @ (state2, _)) =>
+                if state2.position > state1.position then Maybe(next)
+                else Maybe(curr)
+        }
+
+    /** Consumes whitespace characters
+      *
+      * @return
+      *   Unit after consuming whitespace
+      */
+    def whitespaces(using Frame): Unit < Parse =
+        Parse.read(s => Maybe((s.dropWhile(_.isWhitespace), ())))
+
+    /** Parses an integer
+      *
+      * @return
+      *   Parsed integer value
+      */
+    def int(using Frame): Int < Parse =
+        Parse.read { s =>
+            val (num, rest) = s.span(c => c.isDigit || c == '-')
+            Maybe.fromOption(num.show.toIntOption).map((rest, _))
+        }
+
+    /** Parses a decimal number
+      *
+      * @return
+      *   Parsed double value
+      */
+    def decimal(using Frame): Double < Parse =
+        Parse.read { s =>
+            val (num, rest) = s.span(c => c.isDigit || c == '.' || c == '-')
+            Maybe.fromOption(num.show.toDoubleOption).map((rest, _))
+        }
+
+    /** Parses a boolean ("true" or "false")
+      *
+      * @return
+      *   Parsed boolean value
+      */
+    def boolean(using Frame): Boolean < Parse =
+        Parse.read { s =>
+            if s.startsWith("true") then Maybe((s.drop(4), true))
+            else if s.startsWith("false") then Maybe((s.drop(5), false))
+            else Maybe.empty
+        }
+
+    /** Matches a specific character
+      *
+      * @param c
+      *   Character to match
+      * @return
+      *   Unit if character matches
+      */
+    def char(c: Char)(using Frame): Unit < Parse =
+        Parse.read { s =>
+            s.head.filter(_ == c).map(_ => (s.drop(1), ()))
+        }
+
+    /** Matches exact text
+      *
+      * @param str
+      *   Text to match
+      * @return
+      *   Unit if text matches
+      */
+    def literal(str: Text)(using Frame): Unit < Parse =
+        Parse.read(s => if s.startsWith(str) then Maybe((s.drop(str.length), ())) else Maybe.empty)
+
+    /** Consumes any single character
+      *
+      * @return
+      *   The character consumed
+      */
+    def anyChar(using Frame): Char < Parse =
+        Parse.read(s => s.head.map(c => (s.drop(1), c)))
+
+    /** Consumes a character matching predicate
+      *
+      * @param p
+      *   Predicate function for character
+      * @return
+      *   Matching character
+      */
+    def satisfy(p: Char => Boolean)(using Frame): Char < Parse =
+        Parse.read(s => s.head.filter(p).map(c => (s.drop(1), c)))
+
+    /** Matches text using regex pattern
+      *
+      * @param pattern
+      *   Regex pattern string
+      * @return
+      *   Matched text
+      */
+    def regex(pattern: String)(using Frame): Text < Parse =
+        Parse.read { s =>
+            val regex = pattern.r
+            Maybe.fromOption(regex.findPrefixOf(s.show).map(m => (s.drop(m.length), Text(m))))
+        }
+
+    /** Parses an identifier (letter/underscore followed by letters/digits/underscores)
+      *
+      * @return
+      *   Parsed identifier text
+      */
+    def identifier(using Frame): Text < Parse =
+        Parse.read { s =>
+            s.head.filter(c => c.isLetter || c == '_').map { _ =>
+                val (id, rest) = s.span(c => c.isLetterOrDigit || c == '_')
+                (rest, id)
+            }
+        }
+
+    /** Matches any character in string
+      *
+      * @param chars
+      *   String of valid characters
+      * @return
+      *   Matched character
+      */
+    def oneOf(chars: String)(using Frame): Char < Parse =
+        satisfy(c => chars.contains(c))
+
+    /** Matches any character not in string
+      *
+      * @param chars
+      *   String of invalid characters
+      * @return
+      *   Matched character
+      */
+    def noneOf(chars: String)(using Frame): Char < Parse =
+        satisfy(c => !chars.contains(c))
+
+    /** Succeeds only at end of input
+      *
+      * @return
+      *   Unit if at end of input
+      */
+    def end(using Frame): Unit < Parse =
+        Parse.read(s => if s.isEmpty then Maybe((s, ())) else Maybe.empty)
+
+end Parse
+
+case class ParseFailed(frame: Frame, states: Seq[Parse.State], message: String) extends Exception with Serializable:
+
+    override def getMessage() =
+        Seq(
+            "\n".dim,
+            "──────────────────────────────".dim,
+            "Parse failed! ".red.bold + message,
+            "──────────────────────────────".dim,
+            frame.parse.show,
+            "──────────────────────────────".dim,
+            pprint(states).plainText,
+            "──────────────────────────────".dim
+        ).mkString("\n")
+    end getMessage
+end ParseFailed

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Flat.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Flat.scala
@@ -4,6 +4,7 @@ import kyo.Duration
 import kyo.Maybe
 import kyo.Result
 import kyo.Tag
+import kyo.Text
 import kyo.TypeMap
 import scala.annotation.implicitNotFound
 import scala.quoted.*
@@ -75,9 +76,10 @@ private object FlatMacro:
                 case AppliedType(base, _) =>
                     base =:= TypeRepr.of[Maybe] ||
                     base =:= TypeRepr.of[Result] ||
-                    base =:= TypeRepr.of[TypeMap] ||
-                    base =:= TypeRepr.of[Duration]
-                case _ => false
+                    base =:= TypeRepr.of[TypeMap]
+                case _ =>
+                    t =:= TypeRepr.of[Duration] ||
+                    t =:= TypeRepr.of[Text]
 
         def canDerive(t: TypeRepr): Boolean =
             t.asType match

--- a/kyo-prelude/shared/src/test/scala/kyo/ParseTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/ParseTest.scala
@@ -1,0 +1,562 @@
+package kyo
+
+import kyo.debug.Debug
+
+class ParseTest extends Test:
+
+    "combinators" - {
+        "anyOf" - {
+            "matches any parser" in run {
+                val parser = Parse.anyOf(
+                    Parse.literal("hello"),
+                    Parse.literal("world"),
+                    Parse.literal("test")
+                )
+                Parse.run("test")(parser).map(_ => succeed)
+            }
+
+            "fails when no parser matches" in run {
+                val parser = Parse.anyOf(
+                    Parse.literal("hello"),
+                    Parse.literal("world")
+                )
+                Abort.run(Parse.run("test")(parser)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+        }
+
+        "firstOf" - {
+            "takes first match" in run {
+                val parser = Parse.firstOf(
+                    Parse.literal("test").as(1),
+                    Parse.literal("test").as(2)
+                )
+                Parse.run("test")(parser).map { result =>
+                    assert(result == 1)
+                }
+            }
+
+            "tries alternatives" in run {
+                val parser = Parse.firstOf(
+                    Parse.literal("hello").as(1),
+                    Parse.literal("world").as(2),
+                    Parse.literal("test").as(3)
+                )
+                Parse.run("test")(parser).map { result =>
+                    assert(result == 3)
+                }
+            }
+        }
+
+        "skipUntil" - {
+            "skips until pattern" in run {
+                val parser = Parse.skipUntil(Parse.literal("end").as("found"))
+                Parse.run("abc123end")(parser).map { result =>
+                    assert(result == "found")
+                }
+            }
+
+            "empty input" in run {
+                Abort.run(Parse.run("")(Parse.skipUntil(Parse.literal("end")))).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "large skip" in run {
+                val input = "a" * 10000 + "end"
+                Parse.run(input)(Parse.skipUntil(Parse.literal("end").as("found"))).map { result =>
+                    assert(result == "found")
+                }
+            }
+
+            "pattern never matches" in run {
+                Abort.run(Parse.run("abcdef")(Parse.skipUntil(Parse.literal("xyz")))).map { result =>
+                    assert(result.isFail)
+                }
+            }
+        }
+
+        "attempt" - {
+            "backtracks on failure" in run {
+                val parser =
+                    Parse.attempt(Parse.literal("hello")).map { r =>
+                        assert(r.isEmpty)
+                        Parse.literal("world")
+                    }
+                Parse.run("world")(parser).map { result =>
+                    assert(result == ())
+                }
+            }
+
+            "preserves success" in run {
+                val parser = Parse.attempt(Parse.literal("hello"))
+                Parse.run("hello")(parser).map { r =>
+                    assert(r.isDefined)
+                }
+            }
+        }
+
+        "peek" - {
+            "doesn't consume input on success" in run {
+                val parser =
+                    for
+                        _      <- Parse.peek(Parse.literal("hello"))
+                        result <- Parse.literal("hello")
+                    yield result
+                Parse.run("hello")(parser).map(_ => succeed)
+            }
+
+            "doesn't consume input on failure" in run {
+                val parser =
+                    for
+                        r      <- Parse.peek(Parse.literal("hello"))
+                        result <- Parse.literal("world")
+                    yield (r, result)
+                Parse.run("world")(parser).map { case (r, _) =>
+                    assert(r.isEmpty)
+                }
+            }
+        }
+
+        "repeat" - {
+            "repeats until failure" in run {
+                val parser = Parse.repeat(Parse.literal("a")).as(Parse.literal("b"))
+                Parse.run("aaab")(parser).map { result =>
+                    assert(result == ())
+                }
+            }
+
+            "fixed repetitions" in run {
+                val parser = Parse.repeat(3)(Parse.literal("a"))
+                Parse.run("aaa")(parser).map { result =>
+                    assert(result.length == 3)
+                }
+            }
+
+            "fails if not enough repetitions" in run {
+                val parser = Parse.repeat(3)(Parse.literal("a"))
+                Abort.run(Parse.run("aa")(parser)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "empty input" in run {
+                Parse.run("")(Parse.repeat(Parse.literal("a"))).map { result =>
+                    assert(result.isEmpty)
+                }
+            }
+
+            "exceeds fixed count" in run {
+                Parse.run("aaaa")(Parse.repeat(3)(Parse.literal("a")).map(r => Parse.literal("a").as(r))).map { result =>
+                    assert(result.length == 3)
+                }
+            }
+
+            "large repetition" in run {
+                val parser = Parse.repeat(1000)(Parse.literal("a"))
+                Parse.run("a" * 1000)(parser).map { result =>
+                    assert(result.length == 1000)
+                }
+            }
+        }
+
+        "cut" - {
+            "succeeds with match" in run {
+                val parser = Parse.cut(Parse.literal("test"))
+                Parse.run("test")(parser).map(_ => succeed)
+            }
+
+            "fails without backtracking" in run {
+                val parser =
+                    Parse.firstOf(
+                        Parse.cut(Parse.literal("test")),
+                        Parse.literal("world")
+                    )
+                Abort.run(Parse.run("world")(parser)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+        }
+    }
+
+    "standard parsers" - {
+
+        "shortest/longest" - {
+            "shortest selects minimum length match" in run {
+                val parser = Parse.shortest(
+                    Parse.literal("test").as(1),
+                    Parse.literal("testing").as(2)
+                ).map { r =>
+                    Parse.literal("ing").as(r)
+                }
+                Parse.run("testing")(parser).map { result =>
+                    assert(result == 1)
+                }
+            }
+
+            "longest selects maximum length match" in run {
+                val parser = Parse.longest(
+                    Parse.literal("test").as(1),
+                    Parse.literal("testing").as(2)
+                )
+                Parse.run("testing")(parser).map { result =>
+                    assert(result == 2)
+                }
+            }
+        }
+
+        "whitespaces" - {
+            "empty string" in run {
+                Parse.run("")(Parse.whitespaces).map { result =>
+                    assert(result == ())
+                }
+            }
+
+            "mixed whitespace types" in run {
+                Parse.run(" \t\n\r ")(Parse.whitespaces).map { result =>
+                    assert(result == ())
+                }
+            }
+
+            "large whitespace input" in run {
+                Parse.run(" " * 10000)(Parse.whitespaces).map { result =>
+                    assert(result == ())
+                }
+            }
+        }
+
+        "int" - {
+            "positive" in run {
+                Parse.run("123")(Parse.int).map { result =>
+                    assert(result == 123)
+                }
+            }
+
+            "negative" in run {
+                Parse.run("-123")(Parse.int).map { result =>
+                    assert(result == -123)
+                }
+            }
+
+            "invalid" in run {
+                Abort.run(Parse.run("abc")(Parse.int)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "max int" in run {
+                Parse.run(s"${Int.MaxValue}")(Parse.int).map { result =>
+                    assert(result == Int.MaxValue)
+                }
+            }
+
+            "min int" in run {
+                Parse.run(s"${Int.MinValue}")(Parse.int).map { result =>
+                    assert(result == Int.MinValue)
+                }
+            }
+        }
+
+        "boolean" - {
+            "true" in run {
+                Parse.run("true")(Parse.boolean).map { result =>
+                    assert(result == true)
+                }
+            }
+
+            "false" in run {
+                Parse.run("false")(Parse.boolean).map { result =>
+                    assert(result == false)
+                }
+            }
+
+            "invalid" in run {
+                Abort.run(Parse.run("xyz")(Parse.boolean)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+        }
+
+        "char" in run {
+            Parse.run("a")(Parse.char('a')).map(_ => succeed)
+        }
+
+        "literal" - {
+            "empty literal" in run {
+                Parse.run("")(Parse.literal("")).map(_ => succeed)
+            }
+
+            "partial match" in run {
+                Abort.run(Parse.run("hell")(Parse.literal("hello"))).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "case sensitive" in run {
+                Abort.run(Parse.run("HELLO")(Parse.literal("hello"))).map { result =>
+                    assert(result.isFail)
+                }
+            }
+        }
+
+        "decimal" - {
+            "positive" in run {
+                Parse.run("123.45")(Parse.decimal).map { result =>
+                    assert(result == 123.45)
+                }
+            }
+
+            "negative" in run {
+                Parse.run("-123.45")(Parse.decimal).map { result =>
+                    assert(result == -123.45)
+                }
+            }
+
+            "integer" in run {
+                Parse.run("123")(Parse.decimal).map { result =>
+                    assert(result == 123.0)
+                }
+            }
+
+            "invalid" in run {
+                Abort.run(Parse.run("abc")(Parse.decimal)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "leading dot" in run {
+                Parse.run(".123")(Parse.decimal).map { result =>
+                    assert(result == 0.123)
+                }
+            }
+
+            "trailing dot" in run {
+                Parse.run("123.")(Parse.decimal).map { result =>
+                    assert(result == 123.0)
+                }
+            }
+
+            "multiple dots" in run {
+                Abort.run(Parse.run("1.2.3")(Parse.decimal)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "multiple leading dots" in run {
+                Abort.run(Parse.run("..123")(Parse.decimal)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "malformed negative" in run {
+                Abort.run(Parse.run(".-123")(Parse.decimal)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "very large precision" in run {
+                Parse.run("123.45678901234567890")(Parse.decimal).map { result =>
+                    assert(result == 123.45678901234567890)
+                }
+            }
+        }
+
+        "identifier" - {
+            "valid identifiers" in run {
+                Parse.run("_hello123")(Parse.identifier).map { result =>
+                    assert(result.is("_hello123"))
+                }
+            }
+
+            "starting with number" in run {
+                Abort.run(Parse.run("123abc")(Parse.identifier)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "special characters" in run {
+                Abort.run(Parse.run("hello@world")(Parse.identifier)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "very long identifier" in run {
+                val longId = "a" * 1000
+                Parse.run(longId)(Parse.identifier).map { result =>
+                    assert(result.is(longId))
+                }
+            }
+
+            "unicode letters" in run {
+                Parse.run("αβγ123")(Parse.identifier).map { result =>
+                    assert(result.is("αβγ123"))
+                }
+            }
+
+            "empty string" in run {
+                Abort.run(Parse.run("")(Parse.identifier)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+        }
+
+        "regex" - {
+            "simple pattern" in run {
+                Parse.run("abc123")(Parse.regex("[a-z]+[0-9]+")).map { result =>
+                    assert(result.is("abc123"))
+                }
+            }
+
+            "no match" in run {
+                Abort.run(Parse.run("123abc")(Parse.regex("[a-z]+[0-9]+"))).map { result =>
+                    assert(result.isFail)
+                }
+            }
+
+            "empty match pattern" in run {
+                Parse.run("")(Parse.regex(".*")).map { result =>
+                    assert(result.is(""))
+                }
+            }
+        }
+
+        "oneOf" - {
+            "single match" in run {
+                Parse.run("a")(Parse.oneOf("abc")).map { result =>
+                    assert(result == 'a')
+                }
+            }
+
+            "no match" in run {
+                Abort.run(Parse.run("d")(Parse.oneOf("abc"))).map { result =>
+                    assert(result.isFail)
+                }
+            }
+        }
+
+        "noneOf" - {
+            "valid char" in run {
+                Parse.run("d")(Parse.noneOf("abc")).map { result =>
+                    assert(result == 'd')
+                }
+            }
+
+            "invalid char" in run {
+                Abort.run(Parse.run("a")(Parse.noneOf("abc"))).map { result =>
+                    assert(result.isFail)
+                }
+            }
+        }
+
+        "end" - {
+            "empty string" in run {
+                Parse.run("")(Parse.end).map(_ => succeed)
+            }
+
+            "non-empty string" in run {
+                Abort.run(Parse.run("abc")(Parse.end)).map { result =>
+                    assert(result.isFail)
+                }
+            }
+        }
+    }
+
+    "complex parsers" - {
+        "arithmetic expression" in run {
+
+            def eval(left: Int, op: Char, right: Int): Int = op match
+                case '+' => left + right
+                case '-' => left - right
+                case '*' => left * right
+                case '/' => left / right
+
+            def term =
+                for
+                    _ <- Parse.whitespaces
+                    n <- Parse.firstOf(
+                        for
+                            _ <- Parse.char('(')
+                            _ <- Parse.whitespaces
+                            r <- expr
+                            _ <- Parse.whitespaces
+                            _ <- Parse.char(')')
+                        yield r,
+                        Parse.int
+                    )
+                    _ <- Parse.whitespaces
+                yield n
+
+            def expr: Int < Parse =
+                for
+                    left <- term
+                    rest <- Parse.firstOf(
+                        for
+                            _     <- Parse.whitespaces
+                            op    <- Parse.oneOf("+-*/")
+                            right <- expr
+                        yield eval(left, op, right),
+                        left
+                    )
+                yield rest
+
+            for
+                r1 <- Parse.run("(1 + (2 * 3))")(expr)
+                r2 <- Parse.run("((1 + 2) * 3)")(expr)
+                r3 <- Parse.run("((10 - 5) + 2)")(expr)
+                r4 <- Parse.run("(2 * (3 + 4))")(expr)
+            yield
+                assert(r1 == 7)
+                assert(r2 == 9)
+                assert(r3 == 7)
+                assert(r4 == 14)
+            end for
+        }
+    }
+
+    "integration with other effects" - {
+        "Parse with Emit" - {
+            "emit parsed values" in run {
+                def parseAndEmit: Unit < (Parse & Emit[Int]) =
+                    for
+                        n1 <- Parse.int
+                        _  <- Emit(n1)
+                        _  <- Parse.whitespaces
+                        n2 <- Parse.int
+                        _  <- Emit(n2)
+                    yield ()
+
+                val result = Abort.run(Emit.run(Parse.run("42 123")(parseAndEmit))).eval
+                assert(result.contains((Chunk(42, 123), ())))
+            }
+        }
+
+        "Parse with Env" - {
+            trait NumberParser:
+                def parseNumber: Int < Parse
+
+            "configurable number parsing" in run {
+                val hexParser = new NumberParser:
+                    def parseNumber =
+                        Parse.read { s =>
+                            val (num, rest) = s.span(c => c.isDigit || ('a' to 'f').contains(c.toLower))
+                            Result(Integer.parseInt(num.show, 16)).toMaybe.map((rest, _))
+                        }
+
+                val decimalParser = new NumberParser:
+                    def parseNumber = Parse.int
+
+                def parseWithConfig: Int < (Parse & Env[NumberParser]) =
+                    Env.use[NumberParser](_.parseNumber)
+
+                for
+                    hex <- Env.run(hexParser)(Parse.run("ff")(parseWithConfig))
+                    dec <- Env.run(decimalParser)(Parse.run("42")(parseWithConfig))
+                yield
+                    assert(hex == 255)
+                    assert(dec == 42)
+                end for
+            }
+        }
+    }
+end ParseTest

--- a/kyo-prelude/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/Test.scala
@@ -7,9 +7,9 @@ import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-abstract class Test extends AsyncFreeSpec with BaseKyoTest[Any] with NonImplicitAssertions:
+abstract class Test extends AsyncFreeSpec with BaseKyoTest[Abort[Throwable]] with NonImplicitAssertions:
 
-    def run(v: Future[Assertion] < Any): Future[Assertion] = v.eval
+    def run(v: Future[Assertion] < Abort[Throwable]): Future[Assertion] = Abort.run(v).eval.getOrThrow
 
     type Assertion = org.scalatest.compatible.Assertion
     def success = succeed

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/FlatTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/FlatTest.scala
@@ -38,6 +38,14 @@ class FlatTest extends Test:
                 test[Int]
             }
         }
+        "kyo data" in {
+            implicitly[Flat[Maybe[Int]]]
+            implicitly[Flat[Result[String, Int]]]
+            implicitly[Flat[TypeMap[String & Int]]]
+            implicitly[Flat[Duration]]
+            implicitly[Flat[Text]]
+            succeed
+        }
     }
 
     "nok" - {


### PR DESCRIPTION
Provides parsing capabilities with backtracking and lookahead support. The effect assumes there's an input string in scope (`Var`) being parsed and operations consume from it, evaluating multiple possible branches with `Choice` and failing with `Abort` if necessary. It's also possible to mix other effects with `Parse`.