### PR TITLE
IO.ensure: avoid inlining `private[kyo]` class

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/IO.scala
+++ b/kyo-core/shared/src/main/scala/kyo/IO.scala
@@ -56,7 +56,7 @@ object IO:
       * @return
       *   The result of the main computation, with the finalizer guaranteed to run.
       */
-    inline def ensure[A, S](inline f: => Unit < IO)(v: A < S)(using inline frame: Frame): A < (IO & S) =
+    def ensure[A, S](f: => Unit < IO)(v: A < S)(using frame: Frame): A < (IO & S) =
         Unsafe(Safepoint.ensure(IO.Unsafe.run(f).eval)(v))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */


### PR DESCRIPTION
Inlining this to user code will produce the error:
```
class Ensure cannot be accessed as a member of (Safepoint$_this : ($proxy15 : kyo.kernel.Safepoint.type{type State = Long})) from anonymous class Safepoint$_this.Ensure {...}.
  private[kyo] class Ensure can only be accessed from package kyo.
```