### PR TITLE
[core][sttp] fix timeout interruption

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -130,7 +130,7 @@ object Async:
                     IO.Unsafe {
                         val sleepFiber = clock.unsafe.sleep(after)
                         val task       = IOTask[Ctx, E | Timeout, A](v, trace, context)
-                        sleepFiber.onComplete(_ => discard(task.complete(Result.fail(Timeout(frame)))))
+                        sleepFiber.onComplete(_ => discard(task.interrupt(Result.Fail(Timeout(frame)))))
                         task.onComplete(_ => discard(sleepFiber.interrupt()))
                         Async.get(task)
                     }

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -514,7 +514,7 @@ object Clock:
                     Promise.Unsafe.fromIOPromise {
                         new IOPromise[Nothing, Unit] with Callable[Unit]:
                             val task = executor.schedule(this, duration.toNanos, TimeUnit.NANOSECONDS)
-                            override def interrupt(error: Panic): Boolean =
+                            override def interrupt[E2 >: Nothing](error: Result.Error[E2]): Boolean =
                                 discard(task.cancel(true))
                                 super.interrupt(error)
                             def call(): Unit = completeDiscard(Result.unit)

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -149,7 +149,7 @@ object Fiber extends FiberPlatformSpecific:
           * @return
           *   A unit value wrapped in IO, representing the registration of the callback
           */
-        def onInterrupt(f: Panic => Unit < IO)(using Frame): Unit < IO =
+        def onInterrupt(f: Result.Error[E] => Unit < IO)(using Frame): Unit < IO =
             import AllowUnsafe.embrace.danger
             IO(self.onInterrupt(r => IO.Unsafe.run(f(r)).eval))
 
@@ -363,7 +363,7 @@ object Fiber extends FiberPlatformSpecific:
         extension [E, A](self: Unsafe[E, A])
             def done()(using AllowUnsafe): Boolean                                                       = self.done()
             def onComplete(f: Result[E, A] => Unit)(using AllowUnsafe): Unit                             = self.onComplete(f)
-            def onInterrupt(f: Panic => Unit)(using Frame): Unit                                         = self.onInterrupt(f)
+            def onInterrupt(f: Result.Error[E] => Unit)(using Frame): Unit                               = self.onInterrupt(f)
             def block(deadline: Clock.Deadline.Unsafe)(using AllowUnsafe, Frame): Result[E | Timeout, A] = self.block(deadline)
             def interrupt()(using frame: Frame, allow: AllowUnsafe): Boolean = self.interrupt(Panic(Interrupted(frame)))
             def interrupt(error: Panic)(using AllowUnsafe): Boolean          = self.interrupt(error)

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -55,9 +55,8 @@ class KyoSttpMonad extends MonadAsyncError[M]:
                     case Left(t)  => discard(p.complete(Result.panic(t)))
                     case Right(t) => discard(p.complete(Result.success(t)))
                 }
-            p.onComplete { r =>
-                if r.isPanic then
-                    canceller.cancel()
+            p.onInterrupt { _ =>
+                canceller.cancel()
             }
             p.safe.get
         }


### PR DESCRIPTION
Easyracer is having trouble with Kyo not interrupting requests on timeout. It's a bug similar to https://github.com/getkyo/kyo/pull/771. `Async.timeout` is only propagating a completion, which isn't enough to interrupt execution now that we split regular completions from interruptions.

This PR changes `IOPromise.interrupt` and related methods to allow an `Error[E]` so it's possible to interrupt the execution with a `Result.Fail(timeoutError)` in `Async.timeout` instead of a `Panic`. 