### PR TITLE
[core] avoid AnyVal

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Adder.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Adder.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic as j
 
 /** A wrapper for Java's LongAdder.
   */
-final case class LongAdder private (unsafe: LongAdder.Unsafe) extends AnyVal:
+final case class LongAdder private (unsafe: LongAdder.Unsafe):
 
     /** Adds the given value to the sum.
       *
@@ -83,7 +83,7 @@ end LongAdder
 
 /** A wrapper for Java's DoubleAdde
   */
-final case class DoubleAdder private (unsafe: DoubleAdder.Unsafe) extends AnyVal:
+final case class DoubleAdder private (unsafe: DoubleAdder.Unsafe):
 
     /** Adds the given value to the sum.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Atomic.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Atomic.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic as j
 
 /** A wrapper for Java's AtomicInteger.
   */
-final case class AtomicInt private (unsafe: AtomicInt.Unsafe) extends AnyVal:
+final case class AtomicInt private (unsafe: AtomicInt.Unsafe):
 
     /** Gets the current value.
       * @return
@@ -127,7 +127,7 @@ end AtomicInt
 
 /** A wrapper for Java's AtomicLong.
   */
-final case class AtomicLong private (unsafe: AtomicLong.Unsafe) extends AnyVal:
+final case class AtomicLong private (unsafe: AtomicLong.Unsafe):
     /** Gets the current value.
       * @return
       *   The current long value
@@ -250,7 +250,7 @@ end AtomicLong
 
 /** A wrapper for Java's AtomicBoolean.
   */
-final case class AtomicBoolean private (unsafe: AtomicBoolean.Unsafe) extends AnyVal:
+final case class AtomicBoolean private (unsafe: AtomicBoolean.Unsafe):
     /** Gets the current value.
       * @return
       *   The current boolean value
@@ -330,7 +330,7 @@ end AtomicBoolean
   * @tparam A
   *   The type of the referenced value
   */
-final case class AtomicRef[A] private (unsafe: AtomicRef.Unsafe[A]) extends AnyVal:
+final case class AtomicRef[A] private (unsafe: AtomicRef.Unsafe[A]):
 
     /** Gets the current value.
       * @return

--- a/kyo-core/shared/src/main/scala/kyo/Barrier.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Barrier.scala
@@ -8,7 +8,7 @@ import scala.annotation.tailrec
   *   - The barrier releases all waiting parties when the last party arrives.
   *   - The barrier can only be used once. After all parties have been released, the barrier cannot be reset.
   */
-final case class Barrier private (unsafe: Barrier.Unsafe) extends AnyVal:
+final case class Barrier private (unsafe: Barrier.Unsafe):
 
     /** Waits for the barrier to be released.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -52,7 +52,7 @@ end Clock
 object Clock:
 
     /** A stopwatch for measuring elapsed time. */
-    final case class Stopwatch private[Clock] (unsafe: Stopwatch.Unsafe) extends AnyVal:
+    final case class Stopwatch private[Clock] (unsafe: Stopwatch.Unsafe):
         /** Gets the elapsed time since the stopwatch was created.
           *
           * @return
@@ -70,7 +70,7 @@ object Clock:
     end Stopwatch
 
     /** A deadline for checking remaining time or if it's overdue. */
-    final case class Deadline private[Clock] (unsafe: Deadline.Unsafe) extends AnyVal:
+    final case class Deadline private[Clock] (unsafe: Deadline.Unsafe):
         /** Gets the time left until the deadline.
           *
           * @return

--- a/kyo-core/shared/src/main/scala/kyo/Console.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Console.scala
@@ -5,7 +5,7 @@ import java.io.IOException
 
 /** Represents a console for input and output operations.
   */
-final case class Console(unsafe: Console.Unsafe) extends AnyVal:
+final case class Console(unsafe: Console.Unsafe):
 
     /** Reads a line from the console.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Latch.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Latch.scala
@@ -7,7 +7,7 @@ import scala.annotation.tailrec
   *
   * A `Latch` is initialized with a count and can be awaited. It is released by calling `release` the specified number of times.
   */
-final case class Latch private (unsafe: Latch.Unsafe) extends AnyVal:
+final case class Latch private (unsafe: Latch.Unsafe):
 
     /** Waits until the latch has counted down to zero.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Stat.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Stat.scala
@@ -86,7 +86,7 @@ abstract class CounterGauge:
     def collect(using Frame): Long < IO
 end CounterGauge
 
-final class Stat(private val registryScope: StatsRegistry.Scope) extends AnyVal:
+final class Stat(private val registryScope: StatsRegistry.Scope):
 
     /** Create a new Stat instance with an additional scope.
       * @param path

--- a/kyo-core/shared/src/main/scala/kyo/stats/attributes.scala
+++ b/kyo-core/shared/src/main/scala/kyo/stats/attributes.scala
@@ -3,7 +3,7 @@ package kyo.stats
 import kyo.stats.Attributes.AsAttribute
 import scala.annotation.implicitNotFound
 
-case class Attributes(get: List[Attributes.Attribute]) extends AnyVal:
+case class Attributes(get: List[Attributes.Attribute]):
     def add(a: Attributes): Attributes =
         Attributes(get ++ a.get)
     def add[A](name: String, value: A)(implicit a: AsAttribute[A]): Attributes =


### PR DESCRIPTION
Following up on https://github.com/getkyo/kyo/pull/800#discussion_r1824897284. Since Scala 3 doesn't have specialization `AnyVal` values can keep boxing on every transformation.