### PR TITLE
[prelude] reduce allocation in Context.inherit

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Context.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Context.scala
@@ -1,32 +1,48 @@
 package kyo.kernel
 
+import Context.internal.*
 import kyo.Tag
 import kyo.bug
 
-opaque type Context = Map[Tag[Any], AnyRef]
+opaque type Context = Map[Tag[Any] | IsolationFlag, AnyRef]
 
 object Context:
     inline given Flat[Context] = Flat.unsafe.bypass
 
     val empty: Context = Map.empty
 
-    extension (context: Context)
-        inline def isEmpty = context eq empty
+    extension (self: Context)
+        inline def isEmpty = self eq empty
 
         inline def contains[A, E <: ContextEffect[A]](tag: Tag[E]): Boolean =
-            context.contains(tag.erased)
+            self.contains(tag.erased)
 
         inline def inherit: Context =
-            context.filterNot(_._1 <:< Tag[ContextEffect.Isolated])
+            if !self.contains(IsolationFlag) then self
+            else
+                self.filter { (k, _) =>
+                    !IsolationFlag.equals(k) &&
+                    !(k.asInstanceOf[Tag[Any]] <:< Tag[ContextEffect.Isolated])
+                }
 
         inline def getOrElse[A, E <: ContextEffect[A], B >: A](tag: Tag[E], inline default: => B): B =
             if !contains(tag) then default
-            else context(tag.erased).asInstanceOf[B]
+            else self(tag.erased).asInstanceOf[B]
 
         private[kyo] inline def get[A, E <: ContextEffect[A]](tag: Tag[E]): A =
-            getOrElse(tag, bug(s"Missing value for context effect '${tag}'. Values: $context"))
+            getOrElse(tag, bug(s"Missing value for context effect '${tag}'. Values: $self"))
 
         private[kernel] inline def set[A, E <: ContextEffect[A]](tag: Tag[E], value: A): Context =
-            context.updated(tag.erased, value.asInstanceOf[AnyRef])
+            val newContext = self.updated(tag.erased, value.asInstanceOf[AnyRef])
+            if tag <:< Tag[ContextEffect.Isolated] then
+                newContext.updated(IsolationFlag, IsolationFlag)
+            else
+                newContext
+            end if
+        end set
     end extension
+
+    private[kyo] object internal:
+        class IsolationFlag
+        object IsolationFlag extends IsolationFlag
 end Context


### PR DESCRIPTION
I've noticed that https://github.com/getkyo/kyo/pull/775 introduced new allocations in the hot path of fiber forking while profiling benchmarks. The `Map.filter` call requires multiple allocations.

This PR creates a fast path that enables `Context.inherit` to execute without allocations in case there are no isolated context effects, which should be the most common scenario. In case isolated effects are present, there's a penalty with additional allocations in both `Context.set` and `Context.inherit`.

I think we'll need to eventually introduce our own collection types. It should be possible to traverse a `Map` to check if there are isolated context keys without allocating, which would avoid the workaround with `IsolationFlag`.