### PR TITLE
[core] Clock.nowMonotonic + fix flaky tests in JS

### DIFF
--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -519,7 +519,7 @@ class AsyncTest extends Test:
             yield assert(result == 42)
         }
 
-        "interrupts computation" in run {
+        "interrupts computation" in runJVM {
             for
                 flag  <- AtomicBoolean.init(false)
                 fiber <- Promise.init[Nothing, Int]

--- a/kyo-data/shared/src/main/scala/kyo/Instant.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Instant.scala
@@ -212,6 +212,16 @@ object Instant:
           */
         def toJava: JInstant = instant
 
+        /** Converts this Instant to a Duration representing the time elapsed since the epoch (1970-01-01T00:00:00Z).
+          *
+          * @return
+          *   The Duration since the epoch.
+          */
+        def toDuration: Duration =
+            if instant == Max then Duration.Infinity
+            else if instant == Min then Duration.Zero
+            else instant - Epoch
+
     end extension
 
 end Instant

--- a/kyo-data/shared/src/test/scala/kyo/InstantTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/InstantTest.scala
@@ -441,4 +441,34 @@ class InstantTest extends Test:
         }
     }
 
+    "toDuration" - {
+        "from Epoch" in {
+            val instant = Instant.Epoch
+            assert(instant.toDuration == Duration.Zero)
+        }
+
+        "positive duration" in {
+            val instant = Instant.Epoch + 1000.seconds
+            assert(instant.toDuration == 1000.seconds)
+        }
+
+        "negative duration" in {
+            val instant = Instant.Epoch - 1000.seconds
+            assert(instant.toDuration == Duration.Zero)
+        }
+
+        "with nanoseconds" in {
+            val instant = Instant.Epoch + 1000.seconds + 500.nanos
+            assert(instant.toDuration == 1000.seconds + 500.nanos)
+        }
+
+        "Max instant" in {
+            assert(Instant.Max.toDuration == Duration.Infinity)
+        }
+
+        "Min instant" in {
+            assert(Instant.Min.toDuration == Duration.Zero)
+        }
+    }
+
 end InstantTest


### PR DESCRIPTION
Time-based tests are flaky in JS. It seems the default timer implementation has precision issues. This PR introduces `Clock.nowMonotonic` to provide more a more accurate `Stopwatch` and updates test thresholds to account for the timer imprecision.