### PR TITLE
[core] Resource improvements + Async.parallelGrouped

### DIFF
--- a/README.md
+++ b/README.md
@@ -1931,18 +1931,23 @@ val a: Int < IO =
 val b: (Int, String) < Async =
     Async.parallel(a, "example")
 
-// Alternatively, it's possible to provide
-// a 'Seq' of computations and produce a 'Seq'
-// with the results
+// Run with unlimited concurrency - starts all
+// computations immediately
 val c: Seq[Int] < Async =
-    Async.parallel(Seq(a, a.map(_ + 1)))
+    Async.parallelUnbounded(Seq(a, a.map(_ + 1)))
+
+// Run with controlled concurrency (max 2 tasks)
+val d: Seq[Int] < Async =
+    Async.parallel(2)(Seq(a, a.map(_ + 1)))
 
 // The 'Fiber.parallel' method is similar but
 // it doesn't automatically join the fibers and
 // produces a 'Fiber[Seq[T]]'
-val d: Fiber[Nothing, Seq[Int]] < IO =
-    Fiber.parallel(Seq(a, a.map(_ + 1)))
+val e: Fiber[Nothing, Seq[Int]] < IO =
+    Fiber.parallel(2)(Seq(a, a.map(_ + 1)))
 ```
+
+For better resource management, prefer `Async.parallel(n)(seq)` to control the maximum number of concurrent computations. If any computation fails or is interrupted, all other computations are automatically interrupted.
 
 The `race` methods are similar to `parallel` but they return the first computation to complete with either a successful result or a failure. Once the first result is produced, the other computations are automatically interrupted.
 

--- a/kyo-bench/src/main/scala/kyo/bench/BlockingContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/BlockingContentionBench.scala
@@ -12,7 +12,7 @@ class BlockingContentionBench extends Bench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        Async.parallel(Seq.fill(concurrency)(IO(block()))).unit
+        Async.parallelUnbounded(Seq.fill(concurrency)(IO(block()))).unit
     end kyoBenchFiber
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/CollectParBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/CollectParBench.scala
@@ -10,7 +10,7 @@ class CollectParBench extends Bench.ForkOnly(Seq.fill(1000)(1)):
     override def kyoBenchFiber() =
         import kyo.*
 
-        Async.parallel(kyoTasks)
+        Async.parallelUnbounded(kyoTasks)
     end kyoBenchFiber
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/ForkJoinContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForkJoinContentionBench.scala
@@ -27,7 +27,7 @@ class ForkJoinContentionBench extends Bench.ForkOnly(()):
         val forkAllFibers     = Kyo.foreach(range)(_ => forkFiber)
         val forkJoinAllFibers = forkAllFibers.flatMap(fibers => Kyo.foreach(fibers)(_.get).unit)
 
-        Async.parallel(Seq.fill(parallism)(forkJoinAllFibers)).unit
+        Async.parallelUnbounded(Seq.fill(parallism)(forkJoinAllFibers)).unit
     end kyoBenchFiber
 
     def zioBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/HttpClientContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/HttpClientContentionBench.scala
@@ -37,7 +37,7 @@ class HttpClientContentionBench
     override def kyoBenchFiber() =
         import kyo.*
 
-        Async.parallel(Seq.fill(concurrency)(Requests(_.get(kyoUrl))))
+        Async.parallelUnbounded(Seq.fill(concurrency)(Requests(_.get(kyoUrl))))
     end kyoBenchFiber
 
     val zioUrl =

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -116,7 +116,7 @@ extension (kyoObject: Kyo.type)
         boundary: Boundary[Ctx, Async & Abort[E]],
         frame: Frame
     ): Seq[A1] < (Abort[E] & Async & Ctx) =
-        Async.parallel[E, A1, Ctx](sequence.map(useElement))
+        Async.parallelUnbounded[E, A1, Ctx](sequence.map(useElement))
 
     /** Applies a function to each element in parallel and discards the results.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -290,15 +290,46 @@ object Fiber extends FiberPlatformSpecific:
             }
         }
 
-    /** Runs multiple Fibers in parallel and returns a Fiber that completes with their results. If any Fiber fails or is interrupted, all
-      * other Fibers are interrupted.
+    /** Runs multiple computations in parallel with a specified level of parallelism and returns a Fiber that completes with their results.
+      *
+      * This method allows you to execute a sequence of computations with controlled parallelism by grouping them into batches. If any
+      * computation fails or is interrupted, all other computations are interrupted.
+      *
+      * @param parallelism
+      *   The maximum number of computations to run concurrently. The input sequence will be divided into groups of size ceil(n/parallelism)
+      *   where n is the total number of computations.
+      * @param seq
+      *   The sequence of computations to run in parallel
+      * @return
+      *   A Fiber that completes with a sequence containing the results of all computations in their original order
+      */
+    def parallel[E, A: Flat, Ctx](parallelism: Int)(seq: Seq[A < (Abort[E] & Async & Ctx)])(
+        using
+        boundary: Boundary[Ctx, IO & Abort[E]],
+        frame: Frame,
+        safepoint: Safepoint
+    ): Fiber[E, Seq[A]] < (IO & Ctx) =
+        seq.size match
+            case 0 => Fiber.success(Seq.empty)
+            case n =>
+                val groupSize = Math.ceil(n.toDouble / Math.max(1, parallelism)).toInt
+                parallelUnbounded(seq.grouped(groupSize).map(Kyo.collect).toSeq).map(_.map(_.flatten))
+    end parallel
+
+    /** Runs multiple computations in parallel with unlimited parallelism and returns a Fiber that completes with their results.
+      *
+      * Unlike [[parallel]], this method starts all computations immediately without any concurrency control. This can lead to resource
+      * exhaustion if the input sequence is large. Consider using [[parallel]] instead, which allows you to control the level of
+      * concurrency.
+      *
+      * If any computation fails or is interrupted, all other computations are interrupted.
       *
       * @param seq
-      *   The sequence of Fibers to run in parallel
+      *   The sequence of computations to run in parallel
       * @return
-      *   A Fiber that completes with the results of all Fibers
+      *   A Fiber that completes with a sequence containing the results of all computations in their original order
       */
-    def parallel[E, A: Flat, Ctx](seq: Seq[A < (Abort[E] & Async & Ctx)])(
+    def parallelUnbounded[E, A: Flat, Ctx](seq: Seq[A < (Abort[E] & Async & Ctx)])(
         using
         boundary: Boundary[Ctx, IO & Abort[E]],
         frame: Frame,

--- a/kyo-core/shared/src/main/scala/kyo/Hub.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Hub.scala
@@ -163,7 +163,7 @@ object Hub:
                                     listeners.toArray
                                         .toList.asInstanceOf[List[Channel[A]]]
                                         .map(child => Abort.run[Throwable](child.put(v)))
-                                Async.parallel(puts).map(_ => Loop.continue)
+                                Async.parallelUnbounded(puts).map(_ => Loop.continue)
                             }
                         }
                     }

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -15,7 +15,7 @@ sealed trait Resource extends ContextEffect[Resource.Finalizer]
 object Resource:
 
     /** Represents a finalizer for a resource. */
-    case class Finalizer(createdAt: Frame, queue: Queue.Unbounded[Unit < Async])
+    case class Finalizer(createdAt: Frame, queue: Queue.Unbounded[Unit < (Async & Abort[Throwable])])
 
     /** Ensures that the given effect is executed when the resource is released.
       *
@@ -26,7 +26,7 @@ object Resource:
       * @return
       *   A unit value wrapped in Resource and IO effects.
       */
-    def ensure(v: => Unit < Async)(using frame: Frame): Unit < (Resource & IO) =
+    def ensure(v: => Unit < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & IO) =
         ContextEffect.suspendAndMap(Tag[Resource]) { finalizer =>
             Abort.run(finalizer.queue.offer(IO(v))).map {
                 case Result.Success(_) => ()
@@ -51,7 +51,7 @@ object Resource:
       * @return
       *   The acquired resource wrapped in Resource, IO, and S effects.
       */
-    def acquireRelease[A, S](acquire: A < S)(release: A => Unit < Async)(using Frame): A < (Resource & IO & S) =
+    def acquireRelease[A, S](acquire: A < S)(release: A => Unit < (Async & Abort[Throwable]))(using Frame): A < (Resource & IO & S) =
         acquire.map { resource =>
             ensure(release(resource)).andThen(resource)
         }
@@ -68,7 +68,10 @@ object Resource:
     def acquire[A <: Closeable, S](resource: A < S)(using Frame): A < (Resource & IO & S) =
         acquireRelease(resource)(r => IO(r.close()))
 
-    /** Runs a resource-managed effect.
+    /** Runs a resource-managed effect with default parallelism of 1.
+      *
+      * This method collects all resources used within the computation and ensures they are properly closed when the computation completes
+      * (either successfully or with an error). Resources are closed sequentially (parallelism = 1).
       *
       * @param v
       *   The effect to run with resource management.
@@ -78,18 +81,39 @@ object Resource:
       *   The result of the effect wrapped in Async and S effects.
       */
     def run[A, S](v: A < (Resource & S))(using frame: Frame): A < (Async & S) =
-        Queue.Unbounded.init[Unit < Async](Access.MultiProducerSingleConsumer).map { q =>
+        run(1)(v)
+
+    /** Runs a resource-managed effect with specified parallelism for cleanup.
+      *
+      * This method tracks all resources acquired during the computation and ensures they are properly closed when the computation completes
+      * (either successfully or with an error). The cleanup phase runs resource finalizers in parallel, grouped according to the specified
+      * parallelism level. For example, with closeParallelism=3, up to 3 resources can be cleaned up simultaneously.
+      *
+      * @param closeParallelism
+      *   The number of parallel tasks to use when running finalizers. This controls how many resources can be cleaned up simultaneously.
+      * @param v
+      *   The effect to run with resource management.
+      * @param frame
+      *   The implicit Frame for context.
+      * @return
+      *   The result of the effect wrapped in Async and S effects.
+      */
+    def run[A, S](closeParallelism: Int)(v: A < (Resource & S))(using frame: Frame): A < (Async & S) =
+        Queue.Unbounded.init[Unit < (Async & Abort[Throwable])](Access.MultiProducerSingleConsumer).map { q =>
             Promise.init[Nothing, Unit].map { p =>
                 val finalizer = Finalizer(frame, q)
                 def close: Unit < IO =
                     q.close.map {
                         case Absent =>
                             bug("Resource finalizer queue already closed.")
-                        case Present(l) =>
-                            Kyo.foreachDiscard(l)(task =>
-                                Abort.run[Throwable](task)
-                                    .map(_.fold(ex => Log.error("Resource finalizer failed", ex.exception))(_ => ()))
-                            )
+                        case Present(tasks) =>
+                            Async.parallelGrouped(closeParallelism) {
+                                tasks.map { task =>
+                                    Abort.run[Throwable](task)
+                                        .map(_.fold(ex => Log.error("Resource finalizer failed", ex.exception))(_ => ()))
+                                }
+                            }
+                                .unit
                                 .pipe(Async.run)
                                 .map(p.becomeDiscard)
                     }

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -107,7 +107,7 @@ object Resource:
                         case Absent =>
                             bug("Resource finalizer queue already closed.")
                         case Present(tasks) =>
-                            Async.parallelGrouped(closeParallelism) {
+                            Async.parallel(closeParallelism) {
                                 tasks.map { task =>
                                     Abort.run[Throwable](task)
                                         .map(_.fold(ex => Log.error("Resource finalizer failed", ex.exception))(_ => ()))

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -188,14 +188,14 @@ class AsyncTest extends Test:
         }
     }
 
-    "parallel" - {
+    "parallelUnbounded" - {
         "zero" in run {
-            Async.parallel(Seq()).map { r =>
+            Async.parallelUnbounded(Seq()).map { r =>
                 assert(r == Seq())
             }
         }
         "one" in run {
-            Async.parallel(Seq(1)).map { r =>
+            Async.parallelUnbounded(Seq(1)).map { r =>
                 assert(r == Seq(1))
             }
         }
@@ -211,7 +211,7 @@ class AsyncTest extends Test:
                     else
                         s
                 }
-            Async.parallel(List(loop(1, "a"), loop(5, "b"))).map { r =>
+            Async.parallelUnbounded(List(loop(1, "a"), loop(5, "b"))).map { r =>
                 assert(r == List("a", "b"))
                 assert(ac.get() == 1)
                 assert(bc.get() == 5)
@@ -233,7 +233,7 @@ class AsyncTest extends Test:
         for
             v1       <- Async.run(1).map(_.get)
             (v2, v3) <- Async.parallel(2, 3)
-            l        <- Async.parallel(List[Int < Any](4, 5))
+            l        <- Async.parallelUnbounded(List[Int < Any](4, 5))
         yield assert(v1 + v2 + v3 + l.sum == 15)
     }
 
@@ -334,10 +334,10 @@ class AsyncTest extends Test:
         }
         "collect" - {
             "default" in run {
-                Async.parallel(List(l.get, l.get)).map(v => assert(v == List(10, 10)))
+                Async.parallelUnbounded(List(l.get, l.get)).map(v => assert(v == List(10, 10)))
             }
             "let" in run {
-                l.let(20)(Async.parallel(List(l.get, l.get)).map(v => assert(v == List(20, 20))))
+                l.let(20)(Async.parallelUnbounded(List(l.get, l.get)).map(v => assert(v == List(20, 20))))
             }
         }
     }
@@ -407,7 +407,7 @@ class AsyncTest extends Test:
             val _: Int < (Abort[Int | Timeout] & Async)        = Async.timeout(1.second)(v)
             val _: Int < (Abort[Int] & Async)                  = Async.race(Seq(v))
             val _: Int < (Abort[Int] & Async)                  = Async.race(v, v)
-            val _: Seq[Int] < (Abort[Int] & Async)             = Async.parallel(Seq(v))
+            val _: Seq[Int] < (Abort[Int] & Async)             = Async.parallelUnbounded(Seq(v))
             val _: (Int, Int) < (Abort[Int] & Async)           = Async.parallel(v, v)
             val _: (Int, Int, Int) < (Abort[Int] & Async)      = Async.parallel(v, v, v)
             val _: (Int, Int, Int, Int) < (Abort[Int] & Async) = Async.parallel(v, v, v, v)
@@ -421,7 +421,7 @@ class AsyncTest extends Test:
             val _: Int < (Abort[Int | Timeout | String] & Async)        = Async.timeout(1.second)(v)
             val _: Int < (Abort[Int | String] & Async)                  = Async.race(Seq(v))
             val _: Int < (Abort[Int | String] & Async)                  = Async.race(v, v)
-            val _: Seq[Int] < (Abort[Int | String] & Async)             = Async.parallel(Seq(v))
+            val _: Seq[Int] < (Abort[Int | String] & Async)             = Async.parallelUnbounded(Seq(v))
             val _: (Int, Int) < (Abort[Int | String] & Async)           = Async.parallel(v, v)
             val _: (Int, Int, Int) < (Abort[Int | String] & Async)      = Async.parallel(v, v, v)
             val _: (Int, Int, Int, Int) < (Abort[Int | String] & Async) = Async.parallel(v, v, v, v)
@@ -603,15 +603,15 @@ class AsyncTest extends Test:
         succeed
     }
 
-    "parallelGrouped" - {
+    "parallel" - {
         "empty sequence" in run {
-            Async.parallelGrouped(2)(Seq()).map { r =>
+            Async.parallel(2)(Seq()).map { r =>
                 assert(r == Seq())
             }
         }
 
         "sequence smaller than parallelism" in run {
-            Async.parallelGrouped(5)(Seq(1, 2, 3)).map { r =>
+            Async.parallel(5)(Seq(1, 2, 3)).map { r =>
                 assert(r == Seq(1, 2, 3))
             }
         }
@@ -627,7 +627,7 @@ class AsyncTest extends Test:
                         assert(current < 2)
                         i
 
-                Async.parallelGrouped(2)((1 to 20).map(task)).map { r =>
+                Async.parallel(2)((1 to 20).map(task)).map { r =>
                     counter.get.map { counter =>
                         assert(r == (1 to 20))
                         assert(counter == 0)
@@ -647,7 +647,7 @@ class AsyncTest extends Test:
                         assert(current == 0)
                         i
 
-                Async.parallelGrouped(1)((1 to 5).map(task)).map { r =>
+                Async.parallel(1)((1 to 5).map(task)).map { r =>
                     counter.get.map { counter =>
                         assert(r == (1 to 5))
                         assert(counter == 0)

--- a/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
@@ -43,7 +43,7 @@ class BarrierTest extends Test:
     "contention" in runJVM {
         for
             barrier <- Barrier.init(1000)
-            _       <- Async.parallel(List.fill(1000)(barrier.await))
+            _       <- Async.parallelUnbounded(List.fill(1000)(barrier.await))
         yield succeed
     }
 

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -159,8 +159,8 @@ class ChannelTest extends Test:
         "with buffer" in runJVM {
             for
                 c  <- Channel.init[Int](10)
-                f1 <- Fiber.parallel(List.fill(1000)(c.put(1)))
-                f2 <- Fiber.parallel(List.fill(1000)(c.take))
+                f1 <- Fiber.parallelUnbounded(List.fill(1000)(c.put(1)))
+                f2 <- Fiber.parallelUnbounded(List.fill(1000)(c.take))
                 _  <- f1.get
                 _  <- f2.get
                 b  <- c.empty
@@ -170,8 +170,8 @@ class ChannelTest extends Test:
         "no buffer" in runJVM {
             for
                 c  <- Channel.init[Int](10)
-                f1 <- Fiber.parallel(List.fill(1000)(c.put(1)))
-                f2 <- Fiber.parallel(List.fill(1000)(c.take))
+                f1 <- Fiber.parallelUnbounded(List.fill(1000)(c.put(1)))
+                f2 <- Fiber.parallelUnbounded(List.fill(1000)(c.take))
                 _  <- f1.get
                 _  <- f2.get
                 b  <- c.empty
@@ -216,7 +216,7 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(i => Abort.run(channel.offer(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(i => Abort.run(channel.offer(i)))))
                 )
                 closeFiber    <- Async.run(latch.await.andThen(channel.close))
                 _             <- latch.release
@@ -242,10 +242,10 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(i => Abort.run(channel.offer(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(i => Abort.run(channel.offer(i)))))
                 )
                 pollFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(_ => Abort.run(channel.poll))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(_ => Abort.run(channel.poll))))
                 )
                 _           <- latch.release
                 offered     <- offerFiber.get
@@ -262,10 +262,10 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 putFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(i => Abort.run(channel.put(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(i => Abort.run(channel.put(i)))))
                 )
                 takeFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(_ => Abort.run(channel.take))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(_ => Abort.run(channel.take))))
                 )
                 _     <- latch.release
                 puts  <- putFiber.get
@@ -282,7 +282,7 @@ class ChannelTest extends Test:
                 _       <- Kyo.foreach(1 to size)(i => channel.offer(i))
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(i => Abort.run(channel.offer(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(i => Abort.run(channel.offer(i)))))
                 )
                 closeFiber <- Async.run(latch.await.andThen(channel.close))
                 _          <- latch.release
@@ -304,10 +304,10 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(i => Abort.run(channel.offer(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(i => Abort.run(channel.offer(i)))))
                 )
                 closeFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(_ => channel.close)))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(_ => channel.close)))
                 )
                 _        <- latch.release
                 offered  <- offerFiber.get
@@ -328,16 +328,16 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 50).map(i => Abort.run(channel.offer(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 50).map(i => Abort.run(channel.offer(i)))))
                 )
                 pollFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 50).map(_ => Abort.run(channel.poll))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 50).map(_ => Abort.run(channel.poll))))
                 )
                 putFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((51 to 100).map(i => Abort.run(channel.put(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((51 to 100).map(i => Abort.run(channel.put(i)))))
                 )
                 takeFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 50).map(_ => Abort.run(channel.take))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 50).map(_ => Abort.run(channel.take))))
                 )
                 closeFiber <- Async.run(latch.await.andThen(channel.close))
                 _          <- latch.release

--- a/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
@@ -48,7 +48,7 @@ class LatchTest extends Test:
     "contention" in runJVM {
         for
             latch <- Latch.init(1000)
-            _     <- Async.parallel(List.fill(1000)(latch.release))
+            _     <- Async.parallelUnbounded(List.fill(1000)(latch.release))
             _     <- latch.await
         yield succeed
     }

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -123,7 +123,7 @@ class MeterTest extends Test:
                     meter   <- Meter.initSemaphore(size)
                     counter <- AtomicInt.init(0)
                     results <-
-                        Async.parallel((1 to 100).map(_ =>
+                        Async.parallelUnbounded((1 to 100).map(_ =>
                             Abort.run(meter.run(counter.incrementAndGet))
                         ))
                     count   <- counter.get
@@ -144,7 +144,7 @@ class MeterTest extends Test:
                     latch   <- Latch.init(1)
                     counter <- AtomicInt.init(0)
                     runFiber <- Async.run(
-                        latch.await.andThen(Async.parallel((1 to 100).map(_ =>
+                        latch.await.andThen(Async.parallelUnbounded((1 to 100).map(_ =>
                             Abort.run(meter.run(counter.incrementAndGet))
                         )))
                     )
@@ -173,7 +173,7 @@ class MeterTest extends Test:
                     runFibers <- Kyo.foreach(1 to 100)(_ =>
                         Async.run(latch.await.andThen(meter.run(counter.incrementAndGet)))
                     )
-                    interruptFiber <- Async.run(latch.await.andThen(Async.parallel(
+                    interruptFiber <- Async.run(latch.await.andThen(Async.parallelUnbounded(
                         runFibers.take(50).map(_.interrupt(panic))
                     )))
                     _           <- latch.release

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -213,7 +213,7 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(i => Abort.run(queue.offer(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(i => Abort.run(queue.offer(i)))))
                 )
                 closeFiber  <- Async.run(latch.await.andThen(queue.close))
                 _           <- latch.release
@@ -239,10 +239,10 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(i => Abort.run(queue.offer(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(i => Abort.run(queue.offer(i)))))
                 )
                 pollFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(_ => Abort.run(queue.poll))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(_ => Abort.run(queue.poll))))
                 )
                 _       <- latch.release
                 offered <- offerFiber.get
@@ -260,7 +260,7 @@ class QueueTest extends Test:
                 _     <- Kyo.foreach(1 to size)(i => queue.offer(i))
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(i => Abort.run(queue.offer(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(i => Abort.run(queue.offer(i)))))
                 )
                 closeFiber <- Async.run(latch.await.andThen(queue.close))
                 _          <- latch.release
@@ -282,10 +282,10 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(i => Abort.run(queue.offer(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(i => Abort.run(queue.offer(i)))))
                 )
                 closeFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(_ => queue.close)))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(_ => queue.close)))
                 )
                 _        <- latch.release
                 offered  <- offerFiber.get
@@ -306,10 +306,10 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(i => Abort.run(queue.offer(i)))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(i => Abort.run(queue.offer(i)))))
                 )
                 pollFiber <- Async.run(
-                    latch.await.andThen(Async.parallel((1 to 100).map(_ => Abort.run(queue.poll))))
+                    latch.await.andThen(Async.parallelUnbounded((1 to 100).map(_ => Abort.run(queue.poll))))
                 )
                 closeFiber <- Async.run(latch.await.andThen(queue.close))
                 _          <- latch.release


### PR DESCRIPTION
- Parallel resource closing
- Allows `Abort[Throwable]` in resource close functions
- `Async.parallelGrouped`: similar to `Async.parallel` but with a max parallelism