### PR TITLE
[prelude] fix `Stream#drop` with small Chunks

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -160,7 +160,7 @@ final case class Stream[V, -S](v: Ack < (Emit[Chunk[V]] & S)):
                             Emit.andMap(input)(ack => (0, cont(ack)))
                         else
                             val c = input.dropLeft(state)
-                            if c.isEmpty then (state - c.size, cont(Continue()))
+                            if c.isEmpty then (state - input.size, cont(Continue()))
                             else Emit.andMap(c)(ack => (0, cont(ack)))
             ))
 

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -145,6 +145,19 @@ class StreamTest extends Test:
                 Stream.init(Seq.fill(n)(1)).drop(5).run.eval.size == n - 5
             )
         }
+
+        "chunk smaller than n" in {
+            val small = Stream.init(0 until 5)
+
+            val result =
+                small
+                    .concat(small)
+                    .drop(6)
+                    .run
+                    .eval
+
+            assert(result == Seq(1, 2, 3, 4))
+        }
     }
 
     "takeWhile" - {


### PR DESCRIPTION
`Stream#drop` essentially ignored all small chunks if `n` was larger than the Chunk. This resulted in non-termination for Streams with all `Chunks#size <= n`