### PR TITLE
[prelude][core] Remove `as` from the pending type + make `andThen` always discard

### DIFF
--- a/kyo-cache/shared/src/main/scala/kyo/Cache.scala
+++ b/kyo-cache/shared/src/main/scala/kyo/Cache.scala
@@ -49,11 +49,11 @@ class Cache(private[kyo] val store: Store):
                             Abort.run[Throwable](f(v)).map {
                                 case Result.Success(v) =>
                                     p.complete(Result.Success(v))
-                                        .as(v)
+                                        .andThen(v)
                                 case r =>
                                     IO(store.invalidate(key))
                                         .andThen(p.complete(r))
-                                        .as(r.getOrThrow)
+                                        .andThen(r.getOrThrow)
                             }
                         }
                     else

--- a/kyo-combinators/shared/src/test/scala/kyo/EnvCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EnvCombinatorTest.scala
@@ -26,7 +26,7 @@ class EnvCombinatorTest extends Test:
 
             "should provide incrementally" in {
                 val effect: Int < Env[String & Int & Boolean & Char] =
-                    Env.get[String] *> Env.get[Int] *> Env.get[Boolean] *> Env.get[Char].as(23)
+                    Env.get[String] *> Env.get[Int] *> Env.get[Boolean] *> Env.get[Char].andThen(23)
                 val handled =
                     effect
                         .provideValue('c')
@@ -44,7 +44,7 @@ class EnvCombinatorTest extends Test:
 
             "should provide layer incrementally" in {
                 val effect: Int < Env[String & Int & Boolean & Char] =
-                    Env.get[String] *> Env.get[Int] *> Env.get[Boolean] *> Env.get[Char].as(23)
+                    Env.get[String] *> Env.get[Int] *> Env.get[Boolean] *> Env.get[Char].andThen(23)
                 val layerChar   = Layer('c')
                 val layerString = Layer("value")
                 val layerInt    = Layer(1)
@@ -60,7 +60,7 @@ class EnvCombinatorTest extends Test:
 
             "should provide all layers and infer types correctly" in run {
                 val effect: Int < Env[String & Int & Boolean & Char] =
-                    Env.get[String] *> Env.get[Int] *> Env.get[Boolean] *> Env.get[Char].as(23)
+                    Env.get[String] *> Env.get[Int] *> Env.get[Boolean] *> Env.get[Char].andThen(23)
                 val layerChar   = Layer(Kyo.suspend('c'))
                 val layerString = Layer("value")
                 val layerInt    = Layer(1)

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -88,7 +88,7 @@ class AsyncTest extends Test:
         }
 
         "multiple fibers timeout" in runJVM {
-            Kyo.fill(100)(Async.sleep(1.milli)).as(1)
+            Kyo.fill(100)(Async.sleep(1.milli)).andThen(1)
                 .pipe(Async.runAndBlock(10.millis))
                 .pipe(Abort.run[Timeout](_))
                 .map {
@@ -504,7 +504,7 @@ class AsyncTest extends Test:
         "times out" in run {
             val result =
                 for
-                    value <- Async.timeout(5.millis)(Async.sleep(1.second).as(42))
+                    value <- Async.timeout(5.millis)(Async.sleep(1.second).andThen(42))
                 yield value
 
             Abort.run[Timeout](result).map {

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -233,7 +233,7 @@ class ChannelTest extends Test:
                 assert(isClosed)
             )
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
 
         "offer and poll" in run {
@@ -253,7 +253,7 @@ class ChannelTest extends Test:
                 channelSize <- channel.size
             yield assert(offered.count(_.contains(true)) == polled.count(_.toMaybe.flatten.isDefined) + channelSize))
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
 
         "put and take" in run {
@@ -272,7 +272,7 @@ class ChannelTest extends Test:
                 takes <- takeFiber.get
             yield assert(puts.count(_.isSuccess) == takes.count(_.isSuccess) && takes.flatMap(_.toMaybe.toList).toSet == (1 to 100).toSet))
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
 
         "offer to full channel during close" in run {
@@ -295,7 +295,7 @@ class ChannelTest extends Test:
                 assert(isClosed)
             )
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
 
         "concurrent close attempts" in run {
@@ -319,7 +319,7 @@ class ChannelTest extends Test:
                 assert(isClosed)
             )
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
 
         "offer, poll, put, take, and close" in run {
@@ -355,7 +355,7 @@ class ChannelTest extends Test:
                 assert(isClosed)
             )
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
     }
 

--- a/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
@@ -439,7 +439,7 @@ class ClockTest extends Test:
             for
                 channel <- Channel.init[Int](10)
                 task <- Clock.repeatWithDelay(Schedule.fixed(1.millis), 0) { state =>
-                    channel.put(state).as(state + 1)
+                    channel.put(state).andThen(state + 1)
                 }
                 numbers <- Kyo.fill(10)(channel.take)
                 _       <- task.interrupt

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -134,7 +134,7 @@ class MeterTest extends Test:
                     assert(permits == size)
                 )
                     .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                    .as(succeed)
+                    .andThen(succeed)
             }
 
             "close" in run {
@@ -161,7 +161,7 @@ class MeterTest extends Test:
                     assert(available.isFail)
                 )
                     .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                    .as(succeed)
+                    .andThen(succeed)
             }
 
             "with interruptions" in run {
@@ -182,7 +182,7 @@ class MeterTest extends Test:
                     count       <- counter.get
                 yield assert(interrupted.count(identity) + completed.count(_.isSuccess) == 100))
                     .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                    .as(succeed)
+                    .andThen(succeed)
             }
         }
     }

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -230,7 +230,7 @@ class QueueTest extends Test:
                 assert(isClosed)
             )
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
 
         "offer and poll" in run {
@@ -250,7 +250,7 @@ class QueueTest extends Test:
                 left    <- queue.size
             yield assert(offered.count(_.contains(true)) == polled.count(_.toMaybe.flatten.isDefined) + left))
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
 
         "offer to full queue during close" in run {
@@ -273,7 +273,7 @@ class QueueTest extends Test:
                 assert(isClosed)
             )
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
 
         "concurrent close attempts" in run {
@@ -297,7 +297,7 @@ class QueueTest extends Test:
                 assert(isClosed)
             )
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
 
         "offer, poll and close" in run {
@@ -323,7 +323,7 @@ class QueueTest extends Test:
                 assert(isClosed)
             )
                 .pipe(Choice.run, _.unit, Loop.repeat(repeats))
-                .as(succeed)
+                .andThen(succeed)
         }
     }
 

--- a/kyo-prelude/jvm/src/test/scala/kyo/MonadLawsTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo/MonadLawsTest.scala
@@ -27,7 +27,7 @@ object MonadLawsTest extends ZIOSpecDefault:
                         if b then Abort.fail("fail") else (v: A < Any)
                     ),
                     gen.zip(intGen).map((v, i) =>
-                        Emit(i).as(v)
+                        Emit(i).andThen(v)
                     ),
                     gen.zip(boolGen).map((v, b) =>
                         Var.setDiscard(b).andThen(v)

--- a/kyo-prelude/shared/src/main/scala/kyo/Parse.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Parse.scala
@@ -33,7 +33,7 @@ object Parse:
             f(state.remaining).map {
                 case Present((remaining, result)) =>
                     val consumed = state.remaining.length - remaining.length
-                    Var.set(state.advance(consumed)).as(result)
+                    Var.set(state.advance(consumed)).andThen(result)
                 case Absent =>
                     Choice.drop
             }
@@ -192,7 +192,7 @@ object Parse:
                     current match
                         case Absent => Choice.drop
                         case Present((state, a)) =>
-                            Var.set(state).as(Loop.done(a))
+                            Var.set(state).andThen(Loop.done(a))
                 case head +: tail =>
                     peek(head.map(a => Var.use[State]((_, a)))).map {
                         case Absent =>
@@ -219,7 +219,7 @@ object Parse:
             case Absent =>
                 Var.use[State] { state =>
                     if state.done then Parse.drop
-                    else Var.set(state.advance(1)).as(skipUntil(v))
+                    else Var.set(state.advance(1)).andThen(skipUntil(v))
                 }
             case Present(v) => v
         }
@@ -238,7 +238,7 @@ object Parse:
             Choice.run(v).map { r =>
                 result(r).map {
                     case Absent =>
-                        Var.set(start).as(Maybe.empty)
+                        Var.set(start).andThen(Maybe.empty)
                     case result =>
                         result
                 }
@@ -274,7 +274,7 @@ object Parse:
     def peek[A: Flat, S](v: A < (Parse & S))(using Frame): Maybe[A] < (Parse & S) =
         Var.use[State] { start =>
             Choice.run(v).map { r =>
-                Var.set(start).as(result(r))
+                Var.set(start).andThen(result(r))
             }
         }
 

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -38,20 +38,11 @@ object `<`:
 
         inline def andThen[B, S2](inline f: Safepoint ?=> B < S2)(
             using
-            inline ev: A => Unit,
             inline frame: Frame,
             inline flatA: WeakFlat[A],
             inline flatB: WeakFlat[B]
         ): B < (S & S2) =
             map(_ => f)
-
-        inline def as[B, S2](other: B < S2)(
-            using
-            inline frame: Frame,
-            inline flatA: WeakFlat[A],
-            inline flatB: WeakFlat[B]
-        ): B < (S & S2) =
-            map(_ => other)
 
         inline def flatMap[B, S2](inline f: Safepoint ?=> A => B < S2)(
             using

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -943,7 +943,7 @@ class AbortsTest extends Test:
                 val computation: Int < Abort[CustomError] = Abort.panic(ex)
                 val recovered = Abort.recover[CustomError](
                     onFail = _ => Env.get[Int],
-                    onPanic = _ => Var.update[Int](_ + 1).as(Var.get[Int])
+                    onPanic = _ => Var.update[Int](_ + 1).andThen(Var.get[Int])
                 )(computation)
 
                 val result = Env.run(42)(Var.run(10)(recovered))

--- a/kyo-prelude/shared/src/test/scala/kyo/ParseTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/ParseTest.scala
@@ -29,8 +29,8 @@ class ParseTest extends Test:
         "firstOf" - {
             "takes first match" in run {
                 val parser = Parse.firstOf(
-                    Parse.literal("test").as(1),
-                    Parse.literal("test").as(2)
+                    Parse.literal("test").andThen(1),
+                    Parse.literal("test").andThen(2)
                 )
                 Parse.run("test")(parser).map { result =>
                     assert(result == 1)
@@ -39,9 +39,9 @@ class ParseTest extends Test:
 
             "tries alternatives" in run {
                 val parser = Parse.firstOf(
-                    Parse.literal("hello").as(1),
-                    Parse.literal("world").as(2),
-                    Parse.literal("test").as(3)
+                    Parse.literal("hello").andThen(1),
+                    Parse.literal("world").andThen(2),
+                    Parse.literal("test").andThen(3)
                 )
                 Parse.run("test")(parser).map { result =>
                     assert(result == 3)
@@ -51,7 +51,7 @@ class ParseTest extends Test:
 
         "skipUntil" - {
             "skips until pattern" in run {
-                val parser = Parse.skipUntil(Parse.literal("end").as("found"))
+                val parser = Parse.skipUntil(Parse.literal("end").andThen("found"))
                 Parse.run("abc123end")(parser).map { result =>
                     assert(result == "found")
                 }
@@ -65,7 +65,7 @@ class ParseTest extends Test:
 
             "large skip" in run {
                 val input = "a" * 10000 + "end"
-                Parse.run(input)(Parse.skipUntil(Parse.literal("end").as("found"))).map { result =>
+                Parse.run(input)(Parse.skipUntil(Parse.literal("end").andThen("found"))).map { result =>
                     assert(result == "found")
                 }
             }
@@ -121,7 +121,7 @@ class ParseTest extends Test:
 
         "repeat" - {
             "repeats until failure" in run {
-                val parser = Parse.repeat(Parse.literal("a")).as(Parse.literal("b"))
+                val parser = Parse.repeat(Parse.literal("a")).andThen(Parse.literal("b"))
                 Parse.run("aaab")(parser).map { result =>
                     assert(result == ())
                 }
@@ -148,7 +148,7 @@ class ParseTest extends Test:
             }
 
             "exceeds fixed count" in run {
-                Parse.run("aaaa")(Parse.repeat(3)(Parse.literal("a")).map(r => Parse.literal("a").as(r))).map { result =>
+                Parse.run("aaaa")(Parse.repeat(3)(Parse.literal("a")).map(r => Parse.literal("a").andThen(r))).map { result =>
                     assert(result.length == 3)
                 }
             }
@@ -219,14 +219,14 @@ class ParseTest extends Test:
             }
 
             "missing separator fails" in run {
-                val parser = Parse.separatedBy(Parse.int.as(Parse.char(' ')), Parse.char(','))
+                val parser = Parse.separatedBy(Parse.int.andThen(Parse.char(' ')), Parse.char(','))
                 Abort.run(Parse.run("1 2 ,3 ")(parser)).map { result =>
                     assert(result.isFail)
                 }
             }
 
             "multiple missing separators fails" in run {
-                val parser = Parse.separatedBy(Parse.int.as(Parse.char(' ')), Parse.char(','))
+                val parser = Parse.separatedBy(Parse.int.andThen(Parse.char(' ')), Parse.char(','))
                 Abort.run(Parse.run("1 2 3")(parser)).map { result =>
                     assert(result.isFail)
                 }
@@ -304,9 +304,9 @@ class ParseTest extends Test:
 
             "with whitespace" in run {
                 val parser = Parse.between(
-                    Parse.char('[').as(Parse.whitespaces),
+                    Parse.char('[').andThen(Parse.whitespaces),
                     Parse.int,
-                    Parse.whitespaces.as(Parse.char(']'))
+                    Parse.whitespaces.andThen(Parse.char(']'))
                 )
                 Parse.run("[ 42 ]")(parser).map { result =>
                     assert(result == 42)
@@ -354,8 +354,8 @@ class ParseTest extends Test:
         "inOrder" - {
             "two parsers" in run {
                 val parser = Parse.inOrder(
-                    Parse.literal("hello").as(1),
-                    Parse.literal("world").as(2)
+                    Parse.literal("hello").andThen(1),
+                    Parse.literal("world").andThen(2)
                 )
                 Parse.run("helloworld")(parser).map { case (r1, r2) =>
                     assert(r1 == 1)
@@ -365,9 +365,9 @@ class ParseTest extends Test:
 
             "three parsers" in run {
                 val parser = Parse.inOrder(
-                    Parse.literal("hello").as(1),
-                    Parse.literal("world").as(2),
-                    Parse.literal("!").as(3)
+                    Parse.literal("hello").andThen(1),
+                    Parse.literal("world").andThen(2),
+                    Parse.literal("!").andThen(3)
                 )
                 Parse.run("helloworld!")(parser).map { case (r1, r2, r3) =>
                     assert(r1 == 1)
@@ -378,10 +378,10 @@ class ParseTest extends Test:
 
             "four parsers" in run {
                 val parser = Parse.inOrder(
-                    Parse.literal("hello").as(1),
-                    Parse.literal("world").as(2),
-                    Parse.literal("!").as(3),
-                    Parse.literal("?").as(4)
+                    Parse.literal("hello").andThen(1),
+                    Parse.literal("world").andThen(2),
+                    Parse.literal("!").andThen(3),
+                    Parse.literal("?").andThen(4)
                 )
                 Parse.run("helloworld!?")(parser).map { case (r1, r2, r3, r4) =>
                     assert(r1 == 1)
@@ -393,9 +393,9 @@ class ParseTest extends Test:
 
             "sequence of parsers" in run {
                 val parser = Parse.inOrder(Seq(
-                    Parse.literal("hello").as(1),
-                    Parse.literal(" ").as(2),
-                    Parse.literal("world").as(3)
+                    Parse.literal("hello").andThen(1),
+                    Parse.literal(" ").andThen(2),
+                    Parse.literal("world").andThen(3)
                 ))
                 Parse.run("hello world")(parser).map { result =>
                     assert(result == Chunk(1, 2, 3))
@@ -410,7 +410,7 @@ class ParseTest extends Test:
             }
 
             "single parser" in run {
-                val parser = Parse.inOrder(Seq(Parse.literal("test").as(1)))
+                val parser = Parse.inOrder(Seq(Parse.literal("test").andThen(1)))
                 Parse.run("test")(parser).map { result =>
                     assert(result == Chunk(1))
                 }
@@ -418,9 +418,9 @@ class ParseTest extends Test:
 
             "fails if any parser fails" in run {
                 val parser = Parse.inOrder(Seq(
-                    Parse.literal("hello").as(1),
-                    Parse.literal("world").as(2),
-                    Parse.literal("!").as(3)
+                    Parse.literal("hello").andThen(1),
+                    Parse.literal("world").andThen(2),
+                    Parse.literal("!").andThen(3)
                 ))
                 Abort.run(Parse.run("hello test")(parser)).map { result =>
                     assert(result.isFail)
@@ -429,9 +429,9 @@ class ParseTest extends Test:
 
             "consumes input sequentially" in run {
                 val parser = Parse.inOrder(Seq(
-                    Parse.literal("a").as(1),
-                    Parse.literal("b").as(2),
-                    Parse.literal("c").as(3)
+                    Parse.literal("a").andThen(1),
+                    Parse.literal("b").andThen(2),
+                    Parse.literal("c").andThen(3)
                 ))
                 Parse.run("abc")(parser).map { result =>
                     assert(result == Chunk(1, 2, 3))
@@ -445,10 +445,10 @@ class ParseTest extends Test:
         "shortest/longest" - {
             "shortest selects minimum length match" in run {
                 val parser = Parse.shortest(
-                    Parse.literal("test").as(1),
-                    Parse.literal("testing").as(2)
+                    Parse.literal("test").andThen(1),
+                    Parse.literal("testing").andThen(2)
                 ).map { r =>
-                    Parse.literal("ing").as(r)
+                    Parse.literal("ing").andThen(r)
                 }
                 Parse.run("testing")(parser).map { result =>
                     assert(result == 1)
@@ -457,8 +457,8 @@ class ParseTest extends Test:
 
             "longest selects maximum length match" in run {
                 val parser = Parse.longest(
-                    Parse.literal("test").as(1),
-                    Parse.literal("testing").as(2)
+                    Parse.literal("test").andThen(1),
+                    Parse.literal("testing").andThen(2)
                 )
                 Parse.run("testing")(parser).map { result =>
                     assert(result == 2)
@@ -867,8 +867,8 @@ class ParseTest extends Test:
 
         "ambiguous parse" in run {
             val parser = Parse.anyOf(
-                Parse.literal("ab").as(1),
-                Parse.literal("abc").as(2)
+                Parse.literal("ab").andThen(1),
+                Parse.literal("abc").andThen(2)
             )
             val input = Stream.init(Seq("abc").map(Text(_)))
 
@@ -959,8 +959,8 @@ class ParseTest extends Test:
 
         "backtracking across chunks" in run {
             val parser = Parse.firstOf(
-                Parse.literal("foo bar").as(1),
-                Parse.literal("foo baz").as(2)
+                Parse.literal("foo bar").andThen(1),
+                Parse.literal("foo baz").andThen(2)
             )
             val input = Stream.init(Seq[Text]("foo ", "ba", "z"))
             Parse.run(input)(parser).run.map { result =>

--- a/kyo-prelude/shared/src/test/scala/kyo/VarTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/VarTest.scala
@@ -47,7 +47,7 @@ class VarTest extends Test:
     }
 
     "runTuple" in {
-        val r = Var.runTuple(1)(Var.update[Int](_ + 1).as(Var.get[Int]).map(_ + 1)).eval
+        val r = Var.runTuple(1)(Var.update[Int](_ + 1).andThen(Var.get[Int]).map(_ + 1)).eval
         assert(r == (2, 3))
     }
 
@@ -73,7 +73,7 @@ class VarTest extends Test:
                 Var.get[Int].map { innerValue =>
                     assert(innerValue == 2)
                 }
-            }.as(Var.get[Int])
+            }.andThen(Var.get[Int])
                 .map { outerValue =>
                     assert(outerValue == 1)
                 }

--- a/kyo-prelude/shared/src/test/scala/kyo/kernel/PendingTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/kernel/PendingTest.scala
@@ -269,35 +269,4 @@ class PendingTest extends Test:
         assert(test(nest((): Unit < Any)).eval == ())
     }
 
-    "as" - {
-        "with pure values" in {
-            val x: Int < Any    = 5
-            val y: String < Any = x.as("hello")
-            assert(y.eval == "hello")
-        }
-
-        "with effectful values" in {
-            val effect: Int < Env[Int]    = Env.get[Int]
-            val result: String < Env[Int] = effect.as("test")
-            assert(Env.run(10)(result).eval == "test")
-        }
-
-        "chaining with other operations" in {
-            val x: Int < Any = 5
-            val y: String < Any = x
-                .map(_ * 2)
-                .as("result")
-                .map(_.toUpperCase)
-            assert(y.eval == "RESULT")
-        }
-
-        "preserving effect types" in {
-            val effect: Int < (Env[Int] & Abort[String]) =
-                Env.get[Int].flatMap(x => if x > 5 then Abort.fail("Too big") else x)
-            val result: String < (Env[Int] & Abort[String]) = effect.as("success")
-            val handled                                     = Abort.run(Env.run(10)(result))
-            assert(handled.eval == Result.fail("Too big"))
-        }
-    }
-
 end PendingTest


### PR DESCRIPTION
As elaborated in https://github.com/getkyo/kyo/pull/823#discussion_r1833693316, I don't think we need both methods. The `as` name also doesn't feel very intuitive since it doesn't indicate chaining of computations.