### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3004,7 +3004,7 @@ val a: Unit < Routes =
     }
 ```
 
-For further examples, Kyo's [example ledger service](https://github.com/getkyo/kyo/tree/main/kyo-examples/jvm/src/main/scala/kyo/examples/ledger) provides practical applications of these concepts.
+For further examples, Kyo's [example ledger service](https://github.com/getkyo/kyo/tree/main/kyo-examples/jvm/src/main/scala/examples/ledger) provides practical applications of these concepts.
 
 ### ZIOs: Integration with ZIO
 


### PR DESCRIPTION
This fixes the example link in the documentation for section `Integrations / Routes: HTTP Server via Tapir`

This package to which this link was pointing was moved in https://github.com/getkyo/kyo/commit/c8b801b61b2ad4f14ab61556c15eb14e6cc86290 (https://github.com/getkyo/kyo/pull/589)