### PR TITLE
[core] fix interrupts in Fiber.parallelUnbounded

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -69,6 +69,9 @@ private[kyo] class IOPromise[+E, +A](init: State[E, A]) extends Safepoint.Interc
         p
     end mask
 
+    def interruptDiscard[E2 >: E](error: Error[E2]): Unit =
+        discard(interrupt(error))
+
     def interrupt[E2 >: E](error: Error[E2]): Boolean =
         @tailrec def interruptLoop(promise: IOPromise[E, A]): Boolean =
             promise.state match

--- a/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
@@ -158,6 +158,12 @@ class IOPromiseTest extends Test:
             assert(p1.interrupt(Result.Panic(new Exception("Interrupted"))))
             assert(p3.block(deadline()).isPanic)
         }
+
+        "interruptDiscard" in {
+            val p = new IOPromise[Nothing, Int]()
+            p.interruptDiscard(Result.Panic(new Exception("Interrupted")))
+            assert(p.block(deadline()).isPanic)
+        }
     }
 
     "onComplete" - {


### PR DESCRIPTION
Hopefully the last bug related to the split of completions and interruptions!

I'm not sure it's possible to provide the exact same behavior in `Fiber.parallel` with bounded parallelism. Since each group runs its computations in sequence via `Kyo.collect`, it can park at any computation even if a following one would fail. 