### PR TITLE
cleanup unused code

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/BatchBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/BatchBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench
 
-import java.util.concurrent.locks.LockSupport
-
 class BatchBench extends Bench.SyncAndFork(5050):
 
     val count = 100

--- a/kyo-bench/src/main/scala/kyo/bench/Bench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/Bench.scala
@@ -1,10 +1,7 @@
 package kyo.bench
 
 import WarmupJITProfile.*
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
 import org.openjdk.jmh.annotations.*
-import scala.concurrent.duration.*
 
 @State(Scope.Benchmark)
 @Fork(

--- a/kyo-caliban/src/main/scala/kyo/Resolvers.scala
+++ b/kyo-caliban/src/main/scala/kyo/Resolvers.scala
@@ -6,7 +6,6 @@ import caliban.interop.tapir.TapirAdapter.*
 import kyo.internal.KyoSttpMonad
 import scala.concurrent.ExecutionContext
 import sttp.monad.Canceler
-import sttp.tapir.Codec.JsonCodec
 import sttp.tapir.Endpoint
 import sttp.tapir.capabilities.NoStreams
 import sttp.tapir.server.ServerEndpoint

--- a/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
+++ b/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
@@ -1,18 +1,14 @@
 package kyo
 
 import cats.effect.IO as CatsIO
-import cats.effect.kernel.Fiber as CatsFiber
-import cats.effect.kernel.Outcome
 import cats.effect.unsafe.implicits.global
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kyo.*
-import kyo.debug.Debug
 import kyo.kernel.Platform
 import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.Eventually.*
 import scala.concurrent.Future
-import scala.concurrent.duration.*
 
 class CatsTest extends Test:
 

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -5,7 +5,6 @@ import kyo.kernel.Boundary
 import kyo.kernel.Reducible
 import scala.annotation.tailrec
 import scala.concurrent.Future
-import scala.reflect.ClassTag
 import scala.util.Failure
 import scala.util.NotGiven
 import scala.util.Success

--- a/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
 

--- a/kyo-combinators/shared/src/test/scala/kyo/EnvCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EnvCombinatorTest.scala
@@ -73,7 +73,7 @@ class EnvCombinatorTest extends Test:
                             layerInt,
                             layerBool
                         )
-                val handledTyped: Int < (IO & Memo) = handled
+                val _: Int < (IO & Memo) = handled
                 Memo.run(handled).map { result =>
                     assert(result == 23)
                 }

--- a/kyo-core/shared/src/main/scala/kyo/AllowUnsafe.scala
+++ b/kyo-core/shared/src/main/scala/kyo/AllowUnsafe.scala
@@ -1,7 +1,5 @@
 package kyo
 
-import kyo.Ansi.*
-import kyo.kernel.Safepoint
 import scala.annotation.implicitNotFound
 
 @implicitNotFound("""

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -1,19 +1,13 @@
 package kyo
 
-import java.util.concurrent.atomic.AtomicInteger
 import kyo.Result.Panic
 import kyo.Tag
-import kyo.internal.FiberPlatformSpecific
 import kyo.kernel.*
 import kyo.scheduler.*
-import scala.annotation.implicitNotFound
 import scala.annotation.tailrec
-import scala.collection.immutable.ArraySeq
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.NotGiven
 import scala.util.control.NonFatal
-import scala.util.control.NoStackTrace
 
 /** Represents an asynchronous computation effect.
   *

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -1,15 +1,11 @@
 package kyo
 
 import java.util.concurrent.Callable
-import java.util.concurrent.Delayed
-import java.util.concurrent.DelayQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.LockSupport
 import kyo.Clock.Deadline
 import kyo.Clock.Stopwatch
-import kyo.Result.Panic
 import kyo.scheduler.IOPromise
 import kyo.scheduler.util.Threads
 import scala.annotation.tailrec
@@ -518,7 +514,6 @@ object Clock:
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe:
-        import AllowUnsafe.embrace.danger
 
         def now()(using AllowUnsafe): Instant
 

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -7,7 +7,6 @@ import kyo.Tag
 import kyo.internal.FiberPlatformSpecific
 import kyo.kernel.*
 import kyo.scheduler.*
-import scala.annotation.implicitNotFound
 import scala.annotation.tailrec
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.ExecutionContext
@@ -179,7 +178,6 @@ object Fiber extends FiberPlatformSpecific:
           *   A new Fiber with the mapped result
           */
         def map[B: Flat](f: A => B < IO)(using Frame): Fiber[E, B] < IO =
-            import AllowUnsafe.embrace.danger
             IO.Unsafe(Unsafe.map(self)((r => IO.Unsafe.run(f(r)).eval)))
 
         /** Flat maps the result of the Fiber.
@@ -190,7 +188,6 @@ object Fiber extends FiberPlatformSpecific:
           *   A new Fiber with the flat mapped result
           */
         def flatMap[E2, B](f: A => Fiber[E2, B] < IO)(using Frame): Fiber[E | E2, B] < IO =
-            import AllowUnsafe.embrace.danger
             IO.Unsafe(Unsafe.flatMap(self)(r => IO.Unsafe.run(f(r)).eval))
 
         /** Maps the Result of the Fiber using the provided function.

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -71,8 +71,6 @@ end Meter
 
 object Meter:
 
-    import internal.*
-
     /** A no-op Meter that always allows operations and can't be closed. */
     case object Noop extends Meter:
         def availablePermits(using Frame)          = Int.MaxValue

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -344,7 +344,6 @@ class AsyncTest extends Test:
 
     "fromFuture" - {
         import scala.concurrent.Future
-        import scala.concurrent.ExecutionContext.Implicits.global
 
         "success" in run {
             val future = Future.successful(42)
@@ -444,6 +443,7 @@ class AsyncTest extends Test:
 
             "parallel" in pendingUntilFixed {
                 val v: Int < Abort[Int] = 1
+                discard(v)
                 assertCompiles("Async.parallel(Async.run(v), Async.run(v))")
                 assertCompiles("Async.parallel(Async.runAndBlock(1.second)(v), Async.runAndBlock(1.second)(v))")
                 assertCompiles("Async.parallel(Async.mask(v), Async.mask(v))")
@@ -454,6 +454,7 @@ class AsyncTest extends Test:
 
             "race" in pendingUntilFixed {
                 val v: Int < Abort[Int] = 1
+                discard(v)
                 assertCompiles("Async.race(Async.run(v), Async.run(v))")
                 assertCompiles("Async.race(Async.runAndBlock(1.second)(v), Async.runAndBlock(1.second)(v))")
                 assertCompiles("Async.race(Async.mask(v), Async.mask(v))")
@@ -464,6 +465,7 @@ class AsyncTest extends Test:
 
             "mask" in pendingUntilFixed {
                 val v: Int < Abort[Int] = 1
+                discard(v)
                 assertCompiles("Async.mask(Async.run(v))")
                 assertCompiles("Async.mask(Async.runAndBlock(1.second)(v))")
                 assertCompiles("Async.mask(Async.mask(v))")
@@ -474,6 +476,7 @@ class AsyncTest extends Test:
 
             "timeout" in pendingUntilFixed {
                 val v: Int < Abort[Int] = 1
+                discard(v)
                 assertCompiles("Async.timeout(1.second)(Async.run(v))")
                 assertCompiles("Async.timeout(1.second)(Async.runAndBlock(1.second)(v))")
                 assertCompiles("Async.timeout(1.second)(Async.mask(v))")
@@ -484,6 +487,7 @@ class AsyncTest extends Test:
 
             "runAndBlock" in pendingUntilFixed {
                 val v: Int < Abort[Int] = 1
+                discard(v)
                 assertCompiles("Async.runAndBlock(1.second)(Async.run(v))")
                 assertCompiles("Async.runAndBlock(1.second)(Async.runAndBlock(1.second)(v))")
                 assertCompiles("Async.runAndBlock(1.second)(Async.mask(v))")

--- a/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
@@ -1,9 +1,7 @@
 package kyo
 
-import java.time.temporal.ChronoUnit
 import kyo.Clock.Deadline
 import kyo.Clock.Stopwatch
-import kyo.Clock.stopwatch
 
 class ClockTest extends Test:
 

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import java.io.Closeable
 import java.util.concurrent.atomic.AtomicInteger as JAtomicInteger
 import org.scalatest.compatible.Assertion
 
@@ -308,7 +307,6 @@ class FiberTest extends Test:
 
     "fromFuture" - {
         import scala.concurrent.Future
-        import scala.concurrent.ExecutionContext.Implicits.global
 
         "success" in run {
             val future = Future.successful(42)
@@ -635,7 +633,6 @@ class FiberTest extends Test:
 
             "fromFuture" in run {
                 import scala.concurrent.Future
-                import scala.concurrent.ExecutionContext.Implicits.global
 
                 val future = Future.successful(42)
                 val fiber  = Fiber.Unsafe.fromFuture(future)

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
@@ -1,9 +1,6 @@
 package kyo
 
 import Tagged.*
-import kyo.Clock.Deadline
-import kyo.Clock.Stopwatch
-import kyo.Clock.Unsafe
 
 class KyoAppTest extends Test:
 

--- a/kyo-core/shared/src/test/scala/kyo/TagCompactTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/TagCompactTest.scala
@@ -1,7 +1,6 @@
 package kyo
 
 import kyo.kernel.*
-import org.scalatest.NonImplicitAssertions
 import org.scalatest.compatible.Assertion
 
 class TagCompactTest extends Test:

--- a/kyo-data/shared/src/main/scala/kyo/Flat.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Flat.scala
@@ -1,8 +1,6 @@
 package kyo
 
-import scala.annotation.implicitNotFound
 import scala.quoted.*
-import scala.util.NotGiven
 
 opaque type Flat[A] = Null
 

--- a/kyo-data/shared/src/main/scala/kyo/Frame.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Frame.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import kyo.Ansi
 import kyo.Maybe
 import scala.annotation.tailrec
 import scala.quoted.*

--- a/kyo-data/shared/src/main/scala/kyo/Instant.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Instant.scala
@@ -3,7 +3,6 @@ package kyo
 import java.time.DateTimeException
 import java.time.Instant as JInstant
 import java.time.format.DateTimeParseException
-import java.time.temporal.ChronoUnit
 
 /** Represents a point in time with nanosecond precision by wrapping 'java.time.Instant'.
   *

--- a/kyo-data/shared/src/main/scala/kyo/Result.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Result.scala
@@ -3,7 +3,6 @@ package kyo
 import Result.*
 import scala.annotation.implicitNotFound
 import scala.annotation.targetName
-import scala.reflect.ClassTag
 import scala.util.Try
 import scala.util.control.NonFatal
 

--- a/kyo-data/shared/src/main/scala/kyo/SafeClassTag.scala
+++ b/kyo-data/shared/src/main/scala/kyo/SafeClassTag.scala
@@ -2,7 +2,6 @@ package kyo
 
 import kyo.Maybe
 import kyo.internal.SafeClassTagMacro
-import scala.annotation.tailrec
 import scala.quoted.*
 
 /** An alternative to ClassTag that supports union and intersection types.

--- a/kyo-data/shared/src/main/scala/kyo/Schedule.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Schedule.scala
@@ -2,7 +2,6 @@ package kyo
 
 import Schedule.internal.*
 import kyo.Duration
-import kyo.Instant
 
 /** An immutable, composable scheduling policy.
   *

--- a/kyo-direct/shared/src/test/scala/kyo/DirectTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/DirectTest.scala
@@ -1,7 +1,5 @@
 package kyo
 
-import kyo.Console.Unsafe
-
 class DirectTest extends Test:
 
     // "match" in {

--- a/kyo-prelude/jvm/src/test/scala/kyo/kernel/SafepointTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo/kernel/SafepointTest.scala
@@ -764,8 +764,4 @@ class SafepointTest extends Test:
         }
     }
 
-    private def createStateWithThreadId(threadId: Long): Safepoint.State =
-        val raw = (threadId << 32) | (Safepoint.State.init().depth & 0xffffffffL)
-        raw.asInstanceOf[Safepoint.State]
-
 end SafepointTest

--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -6,7 +6,6 @@ import kyo.Tag
 import kyo.kernel.Effect
 import kyo.kernel.Reducible
 import scala.annotation.targetName
-import scala.reflect.ClassTag
 
 /** The Abort effect allows for short-circuiting computations with failure values. This effect is used for handling errors and early
   * termination scenarios in a functional manner and handle thrown exceptions.

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/ArrowEffect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/ArrowEffect.scala
@@ -6,7 +6,6 @@ import kyo.Flat
 import kyo.Frame
 import kyo.Tag
 import scala.annotation.nowarn
-import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 /** Represents abstract functions whose implementations are provided later by a handler.
@@ -415,7 +414,7 @@ object ArrowEffect:
     )(
         inline handle: [C] => (I[C], Safepoint ?=> O[C] => A < (E & S & S2)) => A < (E & S & S2),
         inline done: A => B < S3 = (v: A) => v,
-        inline accept: [C] => I[C] => Boolean = [C] => (v: I[C]) => true,
+        inline accept: [C] => I[C] => Boolean = [C] => (_: I[C]) => true,
         inline recover: Throwable => B < (S & S2 & S3)
     )(
         using

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Effect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Effect.scala
@@ -2,7 +2,6 @@ package kyo.kernel
 
 import internal.*
 import kyo.Frame
-import kyo.Tag
 import scala.annotation.nowarn
 import scala.util.control.NonFatal
 

--- a/kyo-prelude/shared/src/main/scala/kyo/kernel/Safepoint.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/kernel/Safepoint.scala
@@ -1,6 +1,5 @@
 package kyo.kernel
 
-import Safepoint.State
 import internal.*
 import java.util.concurrent.atomic.AtomicBoolean
 import kyo.Frame

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -6,7 +6,6 @@ import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.LongAdder
 import java.util.concurrent.locks.LockSupport
 import kyo.scheduler.regulator.Admission

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Regulator.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/regulator/Regulator.scala
@@ -76,8 +76,9 @@ abstract class Regulator(
     }
 
     def stop(): Unit = {
-        val ign = collectTask.cancel()
-        val _   = regulateTask.cancel()
+        def discard(v: Any) = {}
+        discard(collectTask.cancel())
+        discard(regulateTask.cancel())
     }
 
     protected val statsScope = kyo.scheduler.statsScope.scope("regulator", getClass.getSimpleName().toLowerCase())

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -1,17 +1,14 @@
 package kyo
 
 import kyo.kernel.*
-import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 import zio.Exit
 import zio.FiberId
 import zio.Runtime
 import zio.Unsafe
 import zio.ZIO
-import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 object ZIOs:
-    import internal.*
 
     /** Lifts a zio.ZIO into a Kyo effect.
       *


### PR DESCRIPTION
I've temporarily enabled the warnings to clean up the codebase. We still can't enable it by default since it significantly increases compilation time.