### PR TITLE
[core][combinators] workaround issue with nested boundaries

### DIFF
--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -637,14 +637,12 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
       * @return
       *   A computation that produces the result of this computation with Async effect
       */
-    def fork(
+    inline def fork(
         using
         flat: Flat[A],
-        boundary: Boundary[Ctx, IO & Abort[E]],
-        reduce: Reducible[Abort[E]],
         frame: Frame
     ): Fiber[E, A] < (IO & Ctx) =
-        Async.run(effect)(using flat, boundary)
+        Async.run(effect)
 
     /** Forks this computation using the Async effect and returns its result as a `Fiber[E, A]`, managed by the Resource effect. Unlike
       * `fork`, which creates an unmanaged fiber, `forkScoped` ensures that the fiber is properly cleaned up when the enclosing scope is
@@ -653,11 +651,9 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
       * @return
       *   A computation that produces the result of this computation with Async and Resource effects
       */
-    def forkScoped(
+    inline def forkScoped(
         using
         flat: Flat[A],
-        boundary: Boundary[Ctx, IO & Abort[E]],
-        reduce: Reducible[Abort[E]],
         frame: Frame
     ): Fiber[E, A] < (IO & Ctx & Resource) =
         Kyo.acquireRelease(Async.run(effect))(_.interrupt.unit)
@@ -693,7 +689,17 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
       *   A computation that produces the result of `next`
       */
     @targetName("zipRightPar")
-    def &>[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
+    inline def &>[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
+        using
+        f: Flat[A],
+        f1: Flat[A1],
+        r: Reducible[Abort[E]],
+        r1: Reducible[Abort[E1]],
+        fr: Frame
+    ): A1 < (r.SReduced & r1.SReduced & Async & Ctx & Ctx1) =
+        _zipRightPar(next)
+
+    private def _zipRightPar[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
         using
         f: Flat[A],
         f1: Flat[A1],
@@ -704,8 +710,8 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
         fr: Frame
     ): A1 < (r.SReduced & r1.SReduced & Async & Ctx & Ctx1) =
         for
-            fiberA  <- effect.fork
-            fiberA1 <- next.fork
+            fiberA  <- Async._run(effect)
+            fiberA1 <- Async._run(next)
             _       <- fiberA.awaitCompletion
             a1      <- fiberA1.join
         yield a1
@@ -718,7 +724,17 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
       *   A computation that produces the result of this computation
       */
     @targetName("zipLeftPar")
-    def <&[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
+    inline def <&[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
+        using
+        f: Flat[A],
+        f1: Flat[A1],
+        r: Reducible[Abort[E]],
+        r1: Reducible[Abort[E1]],
+        fr: Frame
+    ): A < (r.SReduced & r1.SReduced & Async & Ctx & Ctx1) =
+        _zipLeftPar(next)
+
+    private def _zipLeftPar[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
         using
         f: Flat[A],
         f1: Flat[A1],
@@ -729,8 +745,8 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
         fr: Frame
     ): A < (r.SReduced & r1.SReduced & Async & Ctx & Ctx1) =
         for
-            fiberA  <- effect.fork
-            fiberA1 <- next.fork
+            fiberA  <- Async._run(effect)
+            fiberA1 <- Async._run(next)
             a       <- fiberA.join
             _       <- fiberA1.awaitCompletion
         yield a
@@ -743,7 +759,17 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
       *   A computation that produces a tuple of both results
       */
     @targetName("zipPar")
-    def <&>[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
+    inline def <&>[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
+        using
+        f: Flat[A],
+        f1: Flat[A1],
+        r: Reducible[Abort[E]],
+        r1: Reducible[Abort[E1]],
+        fr: Frame
+    ): (A, A1) < (r.SReduced & r1.SReduced & Async & Ctx & Ctx1) =
+        _zipPar(next)
+
+    private def _zipPar[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
         using
         f: Flat[A],
         f1: Flat[A1],
@@ -754,8 +780,8 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
         fr: Frame
     ): (A, A1) < (r.SReduced & r1.SReduced & Async & Ctx & Ctx1) =
         for
-            fiberA  <- effect.fork
-            fiberA1 <- next.fork
+            fiberA  <- Async._run(effect)
+            fiberA1 <- Async._run(next)
             a       <- fiberA.join
             a1      <- fiberA1.join
         yield (a, a1)

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -1,7 +1,6 @@
 package kyo
 
 import java.io.IOException
-import kyo.kernel.Boundary
 import kyo.kernel.Reducible
 import scala.annotation.tailrec
 import scala.concurrent.Future
@@ -109,10 +108,9 @@ extension (kyoObject: Kyo.type)
       * @return
       *   A new sequence with elements collected using the function
       */
-    def foreachPar[E, A, S, A1, Ctx](sequence: Seq[A])(useElement: A => A1 < (Abort[E] & Async & Ctx))(
+    inline def foreachPar[E, A, S, A1, Ctx](sequence: Seq[A])(useElement: A => A1 < (Abort[E] & Async & Ctx))(
         using
         flat: Flat[A1],
-        boundary: Boundary[Ctx, Async & Abort[E]],
         frame: Frame
     ): Seq[A1] < (Abort[E] & Async & Ctx) =
         Async.parallelUnbounded[E, A1, Ctx](sequence.map(useElement))
@@ -126,10 +124,9 @@ extension (kyoObject: Kyo.type)
       * @return
       *   Discards the results of the function application and returns Unit
       */
-    def foreachParDiscard[E, A, S, A1, Ctx](sequence: Seq[A])(useElement: A => A1 < (Abort[E] & Async & Ctx))(
+    inline def foreachParDiscard[E, A, S, A1, Ctx](sequence: Seq[A])(useElement: A => A1 < (Abort[E] & Async & Ctx))(
         using
         flat: Flat[A1],
-        boundary: Boundary[Ctx, Async & Abort[E]],
         frame: Frame
     ): Unit < (Abort[E] & Async & Ctx) =
         foreachPar(sequence)(useElement).unit

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -427,73 +427,81 @@ class AsyncTest extends Test:
             succeed
         }
         "nested" - {
-            "run" in pendingUntilFixed {
+            "run" in {
                 val v: Int < Abort[Int] = 1
-                assertCompiles("Async.run(Async.run(v))")
-                assertCompiles("Async.run(Async.runAndBlock(1.second)(v))")
-                assertCompiles("Async.run(Async.mask(v))")
-                assertCompiles("Async.run(Async.timeout(1.second)(v))")
-                assertCompiles("Async.run(Async.race(Seq(v)))")
-                assertCompiles("Async.run(Async.race(v, v))")
-                assertCompiles("Async.run(Async.parallel(Seq(v)))")
-                assertCompiles("Async.run(Async.parallel(v, v))")
-                assertCompiles("Async.run(Async.parallel(v, v, v))")
-                assertCompiles("Async.run(Async.parallel(v, v, v, v))")
+
+                val _: Fiber[Nothing, Fiber[Int, Int]] < IO  = Async.run(Async.run(v))
+                val _: Fiber[Int | Timeout, Int] < IO        = Async.run(Async.runAndBlock(1.second)(v))
+                val _: Fiber[Int, Int] < IO                  = Async.run(Async.mask(v))
+                val _: Fiber[Int | Timeout, Int] < IO        = Async.run(Async.timeout(1.second)(v))
+                val _: Fiber[Int, Int] < IO                  = Async.run(Async.race(Seq(v)))
+                val _: Fiber[Int, Int] < IO                  = Async.run(Async.race(v, v))
+                val x: Fiber[Int, Seq[Int]] < IO             = Async.run(Async.parallel(10)(Seq(v)))
+                val _: Fiber[Int, (Int, Int)] < IO           = Async.run(Async.parallel(v, v))
+                val _: Fiber[Int, (Int, Int, Int)] < IO      = Async.run(Async.parallel(v, v, v))
+                val _: Fiber[Int, (Int, Int, Int, Int)] < IO = Async.run(Async.parallel(v, v, v, v))
+                succeed
             }
 
-            "parallel" in pendingUntilFixed {
+            "parallel" in run {
                 val v: Int < Abort[Int] = 1
-                discard(v)
-                assertCompiles("Async.parallel(Async.run(v), Async.run(v))")
-                assertCompiles("Async.parallel(Async.runAndBlock(1.second)(v), Async.runAndBlock(1.second)(v))")
-                assertCompiles("Async.parallel(Async.mask(v), Async.mask(v))")
-                assertCompiles("Async.parallel(Async.timeout(1.second)(v), Async.timeout(1.second)(v))")
-                assertCompiles("Async.parallel(Async.race(v, v), Async.race(v, v))")
-                assertCompiles("Async.parallel(Async.parallel(v, v), Async.parallel(v, v))")
+
+                val _: (Fiber[Int, Int], Fiber[Int, Int]) < Async = Async.parallel(Async.run(v), Async.run(v))
+                val _: (Int, Int) < (Abort[Int | Timeout] & Async) =
+                    Async.parallel(Async.runAndBlock(1.second)(v), Async.runAndBlock(1.second)(v))
+                val _: (Int, Int) < (Abort[Int] & Async)           = Async.parallel(Async.mask(v), Async.mask(v))
+                val _: (Int, Int) < (Abort[Int | Timeout] & Async) = Async.parallel(Async.timeout(1.second)(v), Async.timeout(1.second)(v))
+                val _: (Int, Int) < (Abort[Int] & Async)           = Async.parallel(Async.race(v, v), Async.race(v, v))
+                val _: ((Int, Int), (Int, Int)) < (Abort[Int] & Async) = Async.parallel(Async.parallel(v, v), Async.parallel(v, v))
+                succeed
             }
 
-            "race" in pendingUntilFixed {
+            "race" in {
                 val v: Int < Abort[Int] = 1
-                discard(v)
-                assertCompiles("Async.race(Async.run(v), Async.run(v))")
-                assertCompiles("Async.race(Async.runAndBlock(1.second)(v), Async.runAndBlock(1.second)(v))")
-                assertCompiles("Async.race(Async.mask(v), Async.mask(v))")
-                assertCompiles("Async.race(Async.timeout(1.second)(v), Async.timeout(1.second)(v))")
-                assertCompiles("Async.race(Async.race(v, v), Async.race(v, v))")
-                assertCompiles("Async.race(Async.parallel(v, v), Async.parallel(v, v))")
+
+                val _: Fiber[Int, Int] < Async              = Async.race(Async.run(v), Async.run(v))
+                val _: Int < (Abort[Int | Timeout] & Async) = Async.race(Async.runAndBlock(1.second)(v), Async.runAndBlock(1.second)(v))
+                val _: Int < (Abort[Int] & Async)           = Async.race(Async.mask(v), Async.mask(v))
+                val _: Int < (Abort[Int | Timeout] & Async) = Async.race(Async.timeout(1.second)(v), Async.timeout(1.second)(v))
+                val _: Int < (Abort[Int] & Async)           = Async.race(Async.race(v, v), Async.race(v, v))
+                val _: (Int, Int) < (Abort[Int] & Async)    = Async.race(Async.parallel(v, v), Async.parallel(v, v))
+                succeed
             }
 
-            "mask" in pendingUntilFixed {
+            "mask" in {
                 val v: Int < Abort[Int] = 1
-                discard(v)
-                assertCompiles("Async.mask(Async.run(v))")
-                assertCompiles("Async.mask(Async.runAndBlock(1.second)(v))")
-                assertCompiles("Async.mask(Async.mask(v))")
-                assertCompiles("Async.mask(Async.timeout(1.second)(v))")
-                assertCompiles("Async.mask(Async.race(v, v))")
-                assertCompiles("Async.mask(Async.parallel(v, v))")
+
+                val _: Fiber[Int, Int] < Async              = Async.mask(Async.run(v))
+                val _: Int < (Abort[Int | Timeout] & Async) = Async.mask(Async.runAndBlock(1.second)(v))
+                val _: Int < (Abort[Int] & Async)           = Async.mask(Async.mask(v))
+                val _: Int < (Abort[Int | Timeout] & Async) = Async.mask(Async.timeout(1.second)(v))
+                val _: Int < (Abort[Int] & Async)           = Async.mask(Async.race(v, v))
+                val _: (Int, Int) < (Abort[Int] & Async)    = Async.mask(Async.parallel(v, v))
+                succeed
             }
 
-            "timeout" in pendingUntilFixed {
+            "timeout" in {
                 val v: Int < Abort[Int] = 1
-                discard(v)
-                assertCompiles("Async.timeout(1.second)(Async.run(v))")
-                assertCompiles("Async.timeout(1.second)(Async.runAndBlock(1.second)(v))")
-                assertCompiles("Async.timeout(1.second)(Async.mask(v))")
-                assertCompiles("Async.timeout(1.second)(Async.timeout(1.second)(v))")
-                assertCompiles("Async.timeout(1.second)(Async.race(v, v))")
-                assertCompiles("Async.timeout(1.second)(Async.parallel(v, v))")
+
+                val _: Fiber[Int, Int] < (Abort[Timeout] & Async)  = Async.timeout(1.second)(Async.run(v))
+                val _: Int < (Abort[Int | Timeout] & Async)        = Async.timeout(1.second)(Async.runAndBlock(1.second)(v))
+                val _: Int < (Abort[Int | Timeout] & Async)        = Async.timeout(1.second)(Async.mask(v))
+                val _: Int < (Abort[Int | Timeout] & Async)        = Async.timeout(1.second)(Async.timeout(1.second)(v))
+                val _: Int < (Abort[Int | Timeout] & Async)        = Async.timeout(1.second)(Async.race(v, v))
+                val _: (Int, Int) < (Abort[Int | Timeout] & Async) = Async.timeout(1.second)(Async.parallel(v, v))
+                succeed
             }
 
-            "runAndBlock" in pendingUntilFixed {
+            "runAndBlock" in {
                 val v: Int < Abort[Int] = 1
-                discard(v)
-                assertCompiles("Async.runAndBlock(1.second)(Async.run(v))")
-                assertCompiles("Async.runAndBlock(1.second)(Async.runAndBlock(1.second)(v))")
-                assertCompiles("Async.runAndBlock(1.second)(Async.mask(v))")
-                assertCompiles("Async.runAndBlock(1.second)(Async.timeout(1.second)(v))")
-                assertCompiles("Async.runAndBlock(1.second)(Async.race(v, v))")
-                assertCompiles("Async.runAndBlock(1.second)(Async.parallel(v, v))")
+
+                val _: Fiber[Int, Int] < (Abort[Timeout] & IO)  = Async.runAndBlock(1.second)(Async.run(v))
+                val _: Int < (Abort[Int | Timeout] & IO)        = Async.runAndBlock(1.second)(Async.runAndBlock(1.second)(v))
+                val _: Int < (Abort[Int | Timeout] & IO)        = Async.runAndBlock(1.second)(Async.mask(v))
+                val _: Int < (Abort[Int | Timeout] & IO)        = Async.runAndBlock(1.second)(Async.timeout(1.second)(v))
+                val _: Int < (Abort[Int | Timeout] & IO)        = Async.runAndBlock(1.second)(Async.race(v, v))
+                val _: (Int, Int) < (Abort[Int | Timeout] & IO) = Async.runAndBlock(1.second)(Async.parallel(v, v))
+                succeed
             }
         }
     }


### PR DESCRIPTION
This PR applies the workaround identified by @hearnadam with an `inline` indirection. I think we should still keep #804 open to explore a more proper solution. Users might need to define methods with boundaries and the workaround can be confusing.