### PR TITLE
[prelude] make Stream lazier

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -451,8 +451,11 @@ object Chunk:
       * @return
       *   a new Chunk.Indexed containing the elements from the Array
       */
-    def from[A <: AnyRef](values: Array[A]): Chunk.Indexed[A] =
-        Compact(Arrays.copyOf(values, values.length))
+    def from[A](values: Array[A]): Chunk.Indexed[A] =
+        if values.isEmpty then cachedEmpty.asInstanceOf[Chunk.Indexed[A]]
+        else
+            Compact(Array.copyAs(values, values.length)(using ClassTag.AnyRef).asInstanceOf[Array[A]])
+    end from
 
     /** Creates a Chunk from a Seq of elements.
       *

--- a/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
@@ -26,7 +26,7 @@ class ChunkTest extends Test:
                 assert(chunk(0) == "a")
             }
 
-            "boxes primitives" taggedAs jvmOnly in {
+            "boxes primitives" in {
                 val boxed: java.lang.Integer = Chunk.from(Array(1)).head
                 assert(classOf[Integer].isAssignableFrom(boxed.getClass))
             }

--- a/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
@@ -25,11 +25,6 @@ class ChunkTest extends Test:
                 array(0) = "x"
                 assert(chunk(0) == "a")
             }
-
-            "boxes primitives" in {
-                val boxed: java.lang.Integer = Chunk.from(Array(1)).head
-                assert(classOf[Integer].isAssignableFrom(boxed.getClass))
-            }
         }
 
         "from Seq" - {

--- a/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
@@ -26,7 +26,7 @@ class ChunkTest extends Test:
                 assert(chunk(0) == "a")
             }
 
-            "boxes primitives" in {
+            "boxes primitives" taggedAs jvmOnly in {
                 val boxed: java.lang.Integer = Chunk.from(Array(1)).head
                 assert(classOf[Integer].isAssignableFrom(boxed.getClass))
             }

--- a/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
@@ -25,6 +25,11 @@ class ChunkTest extends Test:
                 array(0) = "x"
                 assert(chunk(0) == "a")
             }
+
+            "boxes primitives" in {
+                val boxed: java.lang.Integer = Chunk.from(Array(1)).head
+                assert(classOf[Integer].isAssignableFrom(boxed.getClass))
+            }
         }
 
         "from Seq" - {

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -337,7 +337,8 @@ object Stream:
     private val _empty           = Stream(Stop)
     def empty[V]: Stream[V, Any] = _empty.asInstanceOf[Stream[V, Any]]
 
-    private inline def DefaultChunkSize = 4096
+    /** The default chunk size for streams. */
+    inline def DefaultChunkSize: Int = 4096
 
     /** Creates a stream from a sequence of values.
       *
@@ -408,7 +409,7 @@ object Stream:
                                         else
                                             ((current - end - 1) / step.abs).abs + 1
                                     val size  = (n min _chunkSize) min remaining
-                                    val chunk = Chunk.from(Array.range(current, current + size * step, step))
+                                    val chunk = Chunk.from(Range(current, current + size * step, step))
                                     Emit.andMap(chunk)(ack => Loop.continue(current + step * size, ack))
                                 end if
                     }


### PR DESCRIPTION
- stop using class member, enforcing accidental eagerness
- add new method: Stream.range to simplify creation of streams
- init/range: accept `chunkSize` to limit size of Chunks- Chunk.from (Array): remove AnyRef type bound

The first PR to address #679. This change is important to ensure the laziness of streams initialized from non-effectful sources.