### PR TITLE
[prelude][core] effect isolates

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -96,6 +96,29 @@ object Async:
     ): A < (Abort[E] & Async & Ctx) =
         _run(v).map(_.mask.map(_.get))
 
+    /** Runs an async computation with interrupt masking and state isolation.
+      *
+      * @param isolate
+      *   Controls state propagation during masked execution
+      * @param v
+      *   The computation to mask
+      * @return
+      *   The computation result
+      */
+    inline def mask[E, A: Flat, S, Ctx](isolate: Isolate[S])(v: => A < (Abort[E] & Async & S & Ctx))(
+        using frame: Frame
+    ): A < (Abort[E] & Async & S & Ctx) =
+        _mask(isolate)(v)
+
+    private def _mask[E, A: Flat, S, Ctx](isolate: Isolate[S])(v: => A < (Abort[E] & Async & S & Ctx))(
+        using
+        boundary: Boundary[Ctx, S & Async & Abort[E]],
+        frame: Frame
+    ): A < (Abort[E] & Async & S & Ctx) =
+        isolate.use { state =>
+            _mask(isolate.resume(state, v)).map(isolate.restore(_, _))
+        }
+
     /** Delays execution of a computation by a specified duration.
       *
       * @param d
@@ -150,6 +173,31 @@ object Async:
                 }
             }
 
+    /** Runs a computation with timeout and state isolation.
+      *
+      * @param after
+      *   The timeout duration
+      * @param isolate
+      *   Controls state propagation during execution
+      * @param v
+      *   The computation to timeout
+      * @return
+      *   The result or Timeout error
+      */
+    inline def timeout[E, A: Flat, S, Ctx](after: Duration, isolate: Isolate[S])(v: => A < (Abort[E] & Async & S & Ctx))(
+        using frame: Frame
+    ): A < (Abort[E | Timeout] & Async & S & Ctx) =
+        _timeout(after, isolate)(v)
+
+    private def _timeout[E, A: Flat, S, Ctx](after: Duration, isolate: Isolate[S])(v: => A < (Abort[E] & Async & S & Ctx))(
+        using
+        boundary: Boundary[Ctx, S & Async & Abort[E | Timeout]],
+        frame: Frame
+    ): A < (Abort[E | Timeout] & Async & S & Ctx) =
+        isolate.use { state =>
+            _timeout(after)(isolate.resume(state, v)).map(isolate.restore(_, _))
+        }
+
     /** Races multiple computations and returns the result of the first to complete. When one computation completes, all other computations
       * are interrupted.
       *
@@ -171,6 +219,29 @@ object Async:
         if seq.isEmpty then seq(0)
         else Fiber._race(seq).map(_.get)
 
+    /** Races computations with state isolation, returning first to complete.
+      *
+      * @param isolate
+      *   Controls state propagation during race
+      * @param seq
+      *   Computations to race
+      * @return
+      *   First successful result
+      */
+    inline def race[E, A: Flat, S, Ctx](isolate: Isolate[S])(seq: Seq[A < (Abort[E] & Async & S & Ctx)])(
+        using frame: Frame
+    ): A < (Abort[E] & Async & S & Ctx) =
+        _race(isolate)(seq)
+
+    private def _race[E, A: Flat, S, Ctx](isolate: Isolate[S])(seq: Seq[A < (Abort[E] & Async & S & Ctx)])(
+        using
+        boundary: Boundary[Ctx, S & Async & Abort[E]],
+        frame: Frame
+    ): A < (Abort[E] & Async & S & Ctx) =
+        isolate.use { state =>
+            _race(seq.map(isolate.resume(state, _))).map(isolate.restore(_, _))
+        }
+
     /** Races two or more computations and returns the result of the first to complete.
       *
       * @param first
@@ -187,6 +258,25 @@ object Async:
         using frame: Frame
     ): A < (Abort[E] & Async & Ctx) =
         race[E, A, Ctx](first +: rest)
+
+    /** Races multiple computations with state isolation.
+      *
+      * @param isolate
+      *   Controls state propagation during race
+      * @param first
+      *   First computation to race
+      * @param rest
+      *   Additional computations to race
+      * @return
+      *   First successful result
+      */
+    inline def race[E, A: Flat, S, Ctx](isolate: Isolate[S])(
+        first: A < (Abort[E] & Async & S & Ctx),
+        rest: A < (Abort[E] & Async & S & Ctx)*
+    )(
+        using frame: Frame
+    ): A < (Abort[E] & Async & S & Ctx) =
+        race[E, A, S, Ctx](isolate)(first +: rest)
 
     /** Runs multiple computations in parallel with unlimited parallelism and returns their results.
       *
@@ -217,6 +307,31 @@ object Async:
             case _ => Fiber._parallelUnbounded(seq).map(_.get)
         end match
     end _parallelUnbounded
+
+    /** Runs computations in parallel with unlimited concurrency and state isolation.
+      *
+      * @param isolate
+      *   Controls state propagation during parallel execution
+      * @param seq
+      *   Computations to run in parallel
+      * @return
+      *   Results in original order
+      */
+    inline def parallelUnbounded[E, A: Flat, S, Ctx](isolate: Isolate[S], seq: Seq[A < (Abort[E] & Async & S & Ctx)])(
+        using frame: Frame
+    ): Seq[A] < (Abort[E] & Async & S & Ctx) =
+        _parallelUnbounded(isolate, seq)
+
+    private def _parallelUnbounded[E, A: Flat, S, Ctx](isolate: Isolate[S], seq: Seq[A < (Abort[E] & Async & S & Ctx)])(
+        using
+        boundary: Boundary[Ctx, S & Async & Abort[E]],
+        frame: Frame
+    ): Seq[A] < (Abort[E] & Async & S & Ctx) =
+        isolate.use { state =>
+            _parallelUnbounded(seq.map(isolate.resume(state, _))).map { results =>
+                Kyo.collect(results.map((state, result) => isolate.restore(state, result)))
+            }
+        }
 
     /** Runs multiple computations in parallel with a specified level of parallelism and returns their results.
       *
@@ -251,6 +366,33 @@ object Async:
             case 1 => seq(0).map(Seq(_))
             case n => Fiber._parallel(parallelism)(seq).map(_.get)
 
+    /** Runs computations in parallel with controlled concurrency and state isolation.
+      *
+      * @param parallelism
+      *   Maximum concurrent computations
+      * @param isolate
+      *   Controls state propagation during parallel execution
+      * @param seq
+      *   Computations to run in parallel
+      * @return
+      *   Results in original order
+      */
+    inline def parallel[E, A: Flat, S, Ctx](parallelism: Int, isolate: Isolate[S])(seq: Seq[A < (Abort[E] & Async & S & Ctx)])(
+        using frame: Frame
+    ): Seq[A] < (Abort[E] & Async & S & Ctx) =
+        _parallel(parallelism, isolate)(seq)
+
+    private def _parallel[E, A: Flat, S, Ctx](parallelism: Int, isolate: Isolate[S])(seq: Seq[A < (Abort[E] & Async & S & Ctx)])(
+        using
+        boundary: Boundary[Ctx, S & Async & Abort[E]],
+        frame: Frame
+    ): Seq[A] < (Abort[E] & Async & S & Ctx) =
+        isolate.use { state =>
+            _parallel(parallelism)(seq.map(isolate.resume(state, _))).map { results =>
+                Kyo.collect(results.map((state, result) => isolate.restore(state, result)))
+            }
+        }
+
     /** Runs two computations in parallel and returns their results as a tuple.
       *
       * @param v1
@@ -270,6 +412,27 @@ object Async:
             (s(0).asInstanceOf[A1], s(1).asInstanceOf[A2])
         }
 
+    /** Runs two computations in parallel with state isolation.
+      *
+      * @param isolate
+      *   Controls state propagation during parallel execution
+      * @param v1
+      *   First computation
+      * @param v2
+      *   Second computation
+      * @return
+      *   Tuple of results
+      */
+    inline def parallel[E, A1: Flat, A2: Flat, S, Ctx](isolate: Isolate[S])(
+        v1: A1 < (Abort[E] & Async & S & Ctx),
+        v2: A2 < (Abort[E] & Async & S & Ctx)
+    )(
+        using frame: Frame
+    ): (A1, A2) < (Abort[E] & Async & S & Ctx) =
+        parallelUnbounded(isolate, Seq(v1, v2))(using Flat.unsafe.bypass).map { s =>
+            (s(0).asInstanceOf[A1], s(1).asInstanceOf[A2])
+        }
+
     /** Runs three computations in parallel and returns their results as a tuple.
       *
       * @param v1
@@ -282,6 +445,30 @@ object Async:
       *   A tuple containing the results of all three computations
       */
     inline def parallel[E, A1: Flat, A2: Flat, A3: Flat, Ctx](
+        v1: A1 < (Abort[E] & Async & Ctx),
+        v2: A2 < (Abort[E] & Async & Ctx),
+        v3: A3 < (Abort[E] & Async & Ctx)
+    )(
+        using frame: Frame
+    ): (A1, A2, A3) < (Abort[E] & Async & Ctx) =
+        parallelUnbounded(Seq(v1, v2, v3))(using Flat.unsafe.bypass).map { s =>
+            (s(0).asInstanceOf[A1], s(1).asInstanceOf[A2], s(2).asInstanceOf[A3])
+        }
+
+    /** Runs three computations in parallel with state isolation.
+      *
+      * @param isolate
+      *   Controls state propagation during parallel execution
+      * @param v1
+      *   First computation
+      * @param v2
+      *   Second computation
+      * @param v3
+      *   Third computation
+      * @return
+      *   Tuple of results
+      */
+    inline def parallel[E, A1: Flat, A2: Flat, A3: Flat, S, Ctx](isolate: Isolate[S])(
         v1: A1 < (Abort[E] & Async & Ctx),
         v2: A2 < (Abort[E] & Async & Ctx),
         v3: A3 < (Abort[E] & Async & Ctx)
@@ -314,6 +501,33 @@ object Async:
         using frame: Frame
     ): (A1, A2, A3, A4) < (Abort[E] & Async & Ctx) =
         parallelUnbounded(Seq(v1, v2, v3, v4))(using Flat.unsafe.bypass).map { s =>
+            (s(0).asInstanceOf[A1], s(1).asInstanceOf[A2], s(2).asInstanceOf[A3], s(3).asInstanceOf[A4])
+        }
+
+    /** Runs four computations in parallel with state isolation.
+      *
+      * @param isolate
+      *   Controls state propagation during parallel execution
+      * @param v1
+      *   First computation
+      * @param v2
+      *   Second computation
+      * @param v3
+      *   Third computation
+      * @param v4
+      *   Fourth computation
+      * @return
+      *   Tuple of results
+      */
+    inline def parallel[E, A1: Flat, A2: Flat, A3: Flat, A4: Flat, S, Ctx](isolate: Isolate[S])(
+        v1: A1 < (Abort[E] & Async & S & Ctx),
+        v2: A2 < (Abort[E] & Async & S & Ctx),
+        v3: A3 < (Abort[E] & Async & S & Ctx),
+        v4: A4 < (Abort[E] & Async & S & Ctx)
+    )(
+        using frame: Frame
+    ): (A1, A2, A3, A4) < (Abort[E] & Async & S & Ctx) =
+        parallelUnbounded(isolate, Seq(v1, v2, v3, v4))(using Flat.unsafe.bypass).map { s =>
             (s(0).asInstanceOf[A1], s(1).asInstanceOf[A2], s(2).asInstanceOf[A3], s(3).asInstanceOf[A4])
         }
 

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -694,7 +694,7 @@ class AsyncTest extends Test:
             val emitIsolate = Emit.isolate.merge[Int]
 
             Emit.run {
-                Async.timeout(10.millis, emitIsolate) {
+                Async.timeout(1.hour, emitIsolate) {
                     for
                         _ <- Emit(1)
                         _ <- Async.sleep(1.millis)

--- a/kyo-prelude/shared/src/main/scala/kyo/Check.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Check.scala
@@ -88,4 +88,51 @@ object Check:
             [C] => (_, cont) => cont(())
         )
 
+    object isolate:
+
+        /** Creates an isolate that combines check failures.
+          *
+          * When the isolation ends, accumulates any check failures that occurred during the isolated computation with failures from the
+          * outer context. This allows building up a complete set of failed checks.
+          *
+          * @return
+          *   An isolate that accumulates check failures
+          */
+        def merge: Isolate[Check] =
+            new Isolate[Check]:
+                type State = Chunk[CheckFailed]
+
+                def use[A, S2](f: State => A < S2)(using Frame) = f(Chunk.empty)
+
+                def resume[A: Flat, S2](state: Chunk[CheckFailed], v: A < (Check & S2))(using Frame) =
+                    Check.runChunk(v)
+
+                def restore[A: Flat, S2](state: Chunk[CheckFailed], v: A < S2)(using Frame) =
+                    Kyo.foreach(state)(check => Check(false, check.message)(using check.frame)).andThen(v)
+            end new
+        end merge
+
+        /** Creates an isolate that contains check failures.
+          *
+          * Allows checks to fail within the isolated computation without propagating those failures to the outer context. The failures are
+          * discarded when isolation ends.
+          *
+          * @return
+          *   An isolate that contains check failures
+          */
+        def discard: Isolate[Check] =
+            new Isolate[Check]:
+                type State = Chunk[CheckFailed]
+
+                def use[A, S2](f: State => A < S2)(using Frame) = f(Chunk.empty)
+
+                def resume[A: Flat, S2](state: Chunk[CheckFailed], v: A < (Check & S2))(using Frame) =
+                    Check.runChunk(v)
+
+                def restore[A: Flat, S2](state: Chunk[CheckFailed], v: A < S2)(using Frame) =
+                    v
+            end new
+        end discard
+    end isolate
+
 end Check

--- a/kyo-prelude/shared/src/main/scala/kyo/Check.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Check.scala
@@ -98,7 +98,7 @@ object Check:
           * @return
           *   An isolate that accumulates check failures
           */
-        def merge: Isolate[Check] =
+        val merge: Isolate[Check] =
             new Isolate[Check]:
                 type State = Chunk[CheckFailed]
 
@@ -120,7 +120,7 @@ object Check:
           * @return
           *   An isolate that contains check failures
           */
-        def discard: Isolate[Check] =
+        val discard: Isolate[Check] =
             new Isolate[Check]:
                 type State = Chunk[CheckFailed]
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Isolate.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Isolate.scala
@@ -1,0 +1,141 @@
+package kyo
+
+import internal.*
+import kyo.Flat
+import kyo.Frame
+import kyo.Kyo
+import kyo.Var.isolate
+import kyo.kernel.ContextEffect
+import kyo.kernel.Safepoint.Interceptor
+import scala.quoted.*
+
+/** Provides fine-grained control over state isolation and propagation within computations.
+  *
+  * The `Isolate` mechanism allows you to control how effect state is handled, contained, and propagated during computation. This is
+  * essential for implementing effects that need careful control over their state visibility and ordering of operations.
+  *
+  * While Isolate provides a low-level API through `use`, `resume`, and `restore` for advanced use cases, most users should rely on the
+  * high-level `run` method which composes these operations safely and handles all the complexity of state management internally.
+  *
+  * Effects typically provide their isolation strategies through their companion objects (e.g. `Var.isolate.update`, `Check.isolate.merge`).
+  * These isolates can be composed using `andThen`, which enforces the ordering of effect handling - ensuring effects are handled in the
+  * specified sequence.
+  *
+  * Key use cases include:
+  *   - Transactional effects where state changes may need to be contained until commit
+  *   - Effects that require explicit control over state propagation order
+  *   - Parallel computations where state needs to be merged in specific ways
+  *   - Scenarios where effect state should be temporarily scoped or discarded
+  *   - Error handling where partial effects must be rolled back atomically
+  *   - Complex workflows requiring nested transaction boundaries
+  *
+  * Implementations typically choose one of three strategies:
+  *   - Merge: Combine states when multiple computations need to reconcile their effects
+  *   - Update: Unconditionally updates the state with the last available value
+  *   - Discard: Prevent state from propagating beyond a defined scope
+  *
+  * A key feature of Isolate is its interaction with error handling through the Abort effect. When an Abort occurs within an isolated scope,
+  * the isolation acts as a transaction boundary - isolated effects within the isolated scope are rolled back or discarded, maintaining
+  * consistency of the outer scope. This transactional behavior applies across all effect types:
+  *   - State changes are rolled back to their pre-isolation values
+  *   - Emitted values are discarded rather than being merged
+  *   - Cached computations remain isolated and don't propagate
+  *   - Nested isolations maintain these guarantees at each level
+  *
+  * This combination of isolation strategies and error handling makes Isolate particularly powerful for implementing robust,
+  * transaction-like behaviors across different effect types while maintaining clean separation of concerns.
+  *
+  * @tparam S
+  *   The type of effect being isolated
+  */
+abstract class Isolate[S]:
+    self =>
+
+    /** The type of state managed by this isolate.
+      *
+      * This abstract type member represents the concrete state type that will be managed during isolation. The exact type depends on the
+      * effect being isolated.
+      */
+    type State
+
+    /** Isolates a computation.
+      *
+      * This is the primary method users should use for isolation. It handles all the complexity of state management internally by composing
+      * the lower-level isolation operations.
+      *
+      * @param v
+      *   The computation to run with isolation
+      * @return
+      *   The computation result with isolated state handling
+      */
+    def run[A: Flat, S2](v: A < S2)(using Frame): A < (S & S2) =
+        use(resume(_, v).map(restore(_, _)))
+
+    /** Starts the isolation flow by providing access to the initial state.
+      *
+      * Advanced usage: This is the first step in the low-level state isolation API. Most users should use `run` instead. It provides access
+      * to the current effect state, which can then be used with resume to begin isolated execution.
+      *
+      * @param f
+      *   Function that receives initial state and starts the isolation flow
+      * @return
+      *   A computation that includes the isolated effect
+      */
+    def use[A, S2](f: State => A < S2)(using Frame): A < (S & S2)
+
+    /** Begins isolated execution of a computation using the provided state.
+      *
+      * Advanced usage: After obtaining initial state via use, resume begins isolated execution of a computation. Most users should use
+      * `run` instead. It returns both the final state and computation result, allowing the state to be later restored via restore.
+      *
+      * @param state
+      *   Initial state obtained from use
+      * @param v
+      *   Computation to execute in isolation
+      * @return
+      *   A pair of final state and computation result
+      */
+    def resume[A: Flat, S2](state: State, v: A < (S & S2))(using Frame): (State, A) < S2
+
+    /** Completes the isolation flow by restoring the final state.
+      *
+      * Advanced usage: This is the final step in the low-level isolation API. Most users should use `run` instead. Takes the state and
+      * result from resume and determines how that state should be applied when returning to the normal execution context. The exact
+      * behavior (merge/update/discard) depends on the isolation strategy.
+      *
+      * @param state
+      *   Final state from resume to restore
+      * @param v
+      *   Computation to continue with restored state
+      * @return
+      *   Computation result with restored state
+      */
+    def restore[A: Flat, S2](state: State, v: A < S2)(using Frame): A < (S & S2)
+
+    /** Combines this isolate with another one in sequence.
+      *
+      * Creates a new isolate that manages both effects' states, defining how their respective states interact and propagate when composed
+      * together.
+      *
+      * @param next
+      *   The isolate to combine with this one
+      * @return
+      *   A new isolate managing both effects
+      */
+    def andThen[S2](next: Isolate[S2])(using Frame): Isolate[S & S2] =
+        new Isolate[S & S2]:
+            type State = (self.State, next.State)
+
+            def use[A, S2](f: State => A < S2)(using Frame) =
+                self.use(s1 => next.use(s2 => f((s1, s2))))
+
+            def resume[A: Flat, S3](state: (self.State, next.State), v: A < (S & S2 & S3))(using Frame) =
+                self.resume(state._1, next.resume(state._2, v)).map {
+                    case (s1, (s2, r)) => ((s1, s2), r)
+                }
+            def restore[A: Flat, S2](state: (self.State, next.State), v: A < S2)(using Frame) =
+                self.restore(state._1, next.restore(state._2, v))
+        end new
+    end andThen
+
+end Isolate

--- a/kyo-prelude/shared/src/main/scala/kyo/Memo.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Memo.scala
@@ -67,7 +67,7 @@ object Memo:
           * @return
           *   An isolate that preserves memoized results
           */
-        def merge: Isolate[Memo] =
+        val merge: Isolate[Memo] =
             Var.isolate.merge[Memo.Cache]((m1, m2) => Cache(m1.map ++ m2.map))
 
         /** Creates an isolate that overwrites the memoization cache.
@@ -78,7 +78,7 @@ object Memo:
           * @return
           *   An isolate that updates the cache with isolated results
           */
-        def update: Isolate[Memo] =
+        val update: Isolate[Memo] =
             Var.isolate.update[Memo.Cache]
 
         /** Creates an isolate that provides a temporary cache.
@@ -89,7 +89,7 @@ object Memo:
           * @return
           *   An isolate that discards the isolated cache
           */
-        def discard: Isolate[Memo] =
+        val discard: Isolate[Memo] =
             Var.isolate.discard[Memo.Cache]
     end isolate
 end Memo

--- a/kyo-prelude/shared/src/main/scala/kyo/Memo.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Memo.scala
@@ -15,7 +15,7 @@ object Memo:
     // has a different key space
     private[kyo] class MemoIdentity
 
-    private[kyo] class Cache(map: Map[(Any, Any), Any]):
+    private[kyo] case class Cache(map: Map[(Any, Any), Any]):
         def get[A](input: A, id: MemoIdentity): Maybe[Any] =
             val key = (input, id)
             if map.contains(key) then
@@ -57,4 +57,39 @@ object Memo:
     def run[A: Flat, S](v: A < (Memo & S))(using Frame): A < S =
         Var.run(empty)(v)
 
+    object isolate:
+
+        /** Creates an isolate that combines memoization caches.
+          *
+          * When the isolation ends, merges any cached results from the isolated computation with the outer cache using the later result on
+          * conflicts. This allows memoized results computed in isolation to be reused later.
+          *
+          * @return
+          *   An isolate that preserves memoized results
+          */
+        def merge: Isolate[Memo] =
+            Var.isolate.merge[Memo.Cache]((m1, m2) => Cache(m1.map ++ m2.map))
+
+        /** Creates an isolate that overwrites the memoization cache.
+          *
+          * When the isolation ends, replaces the outer cache with the cache from the isolated computation. Earlier cached results are
+          * discarded in favor of any new results computed in isolation.
+          *
+          * @return
+          *   An isolate that updates the cache with isolated results
+          */
+        def update: Isolate[Memo] =
+            Var.isolate.update[Memo.Cache]
+
+        /** Creates an isolate that provides a temporary cache.
+          *
+          * Allows the isolated computation to build and use its own memoization cache, but discards that cache when isolation ends. Results
+          * are only cached within the isolation boundary.
+          *
+          * @return
+          *   An isolate that discards the isolated cache
+          */
+        def discard: Isolate[Memo] =
+            Var.isolate.discard[Memo.Cache]
+    end isolate
 end Memo

--- a/kyo-prelude/shared/src/test/scala/kyo/IsolateTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/IsolateTest.scala
@@ -1,0 +1,266 @@
+package kyo
+
+class IsolateTest extends Test:
+
+    "run" - {
+        "with Var isolate" in run {
+            val result = Var.runTuple(1) {
+                Var.isolate.update[Int].run {
+                    for
+                        start <- Var.get[Int]
+                        _     <- Var.set(start + 1)
+                        end   <- Var.get[Int]
+                    yield (start, end)
+                }
+            }
+            assert(result.eval == (2, (1, 2)))
+        }
+
+        "with Memo isolate" in run {
+            var count = 0
+            val f = Memo[Int, Int, Any] { x =>
+                count += 1
+                x * 2
+            }
+
+            val result = Memo.run {
+                Memo.isolate.merge.run {
+                    for
+                        a <- f(1)
+                        b <- f(1)
+                    yield (a, b, count)
+                }
+            }
+            assert(result.eval == (2, 2, 1))
+        }
+
+        "with Emit isolate" in run {
+            val result = Emit.run {
+                Emit.isolate.merge[Int].run {
+                    for
+                        _ <- Emit(1)
+                        _ <- Emit(2)
+                    yield "done"
+                }
+            }
+            assert(result.eval == (Chunk(1, 2), "done"))
+        }
+    }
+
+    "andThen" - {
+        "composing Var and Emit isolates" in run {
+            val varIsolate  = Var.isolate.update[Int]
+            val emitIsolate = Emit.isolate.merge[Int]
+
+            val combined = varIsolate.andThen(emitIsolate)
+
+            val result = Var.runTuple(1) {
+                Emit.run {
+                    combined.run {
+                        for
+                            start <- Var.get[Int]
+                            _     <- Emit(start)
+                            _     <- Var.set(start + 1)
+                            end   <- Var.get[Int]
+                            _     <- Emit(end)
+                        yield (start, end)
+                    }
+                }
+            }
+            assert(result.eval == (2, (Chunk(1, 2), (1, 2))))
+        }
+
+        "composing Memo and Var isolates" in run {
+            var count = 0
+            val f = Memo[Int, Int, Any] { x =>
+                count += 1
+                x * 2
+            }
+
+            val memoIsolate = Memo.isolate.merge
+            val varIsolate  = Var.isolate.update[Int]
+
+            val combined = memoIsolate.andThen(varIsolate)
+
+            val result = Memo.run {
+                Var.runTuple(1) {
+                    combined.run {
+                        for
+                            a <- f(1)
+                            _ <- Var.set(a)
+                            b <- f(1)
+                            v <- Var.get[Int]
+                        yield (a, b, v, count)
+                    }
+                }
+            }
+            assert(result.eval == (2, (2, 2, 2, 1)))
+        }
+
+        "composing three isolates" in run {
+            val varIsolate  = Var.isolate.update[Int]
+            val emitIsolate = Emit.isolate.merge[Int]
+            val memoIsolate = Memo.isolate.merge
+
+            var count = 0
+            val f = Memo[Int, Int, Any] { x =>
+                count += 1
+                x * 2
+            }
+
+            val combined = varIsolate.andThen(emitIsolate).andThen(memoIsolate)
+
+            val result = Var.runTuple(1) {
+                Emit.run {
+                    Memo.run {
+                        combined.run {
+                            for
+                                start <- Var.get[Int]
+                                _     <- Emit(start)
+                                a     <- f(start)
+                                _     <- Var.set(a)
+                                end   <- Var.get[Int]
+                                _     <- Emit(end)
+                                b     <- f(end)
+                            yield (start, end, a, b, count)
+                        }
+                    }
+                }
+            }
+            assert(result.eval == (2, (Chunk(1, 2), (1, 2, 2, 4, 2))))
+        }
+    }
+
+    "enables transactional behavior via Abort interaction" - {
+        "Var isolate rolls back on abort" in run {
+            val result = Var.runTuple(0) {
+                Abort.run {
+                    for
+                        start <- Var.get[Int]
+                        _ <- Var.isolate.update[Int].run {
+                            for
+                                _ <- Var.set(start + 1)
+                                _ <- Abort.fail("Failed")
+                            yield ()
+                        }
+                        end <- Var.get[Int]
+                    yield (start, end)
+                }
+            }
+            assert(result.eval == (0, Result.fail("Failed")))
+        }
+
+        "Emit isolate discards emissions on abort" in run {
+            val result = Emit.run {
+                Abort.run {
+                    for
+                        _ <- Emit(1)
+                        _ <- Emit.isolate.merge[Int].run {
+                            for
+                                _ <- Emit(2)
+                                _ <- Emit(3)
+                                _ <- Abort.fail("Failed")
+                            yield ()
+                        }
+                        _ <- Emit(4)
+                    yield "done"
+                }
+            }
+            assert(result.eval == (Chunk(1), Result.fail("Failed")))
+        }
+
+        "Memo isolate preserves cache isolation on abort" in run {
+            var count = 0
+            val f = Memo[Int, Int, Any] { x =>
+                count += 1
+                x * 2
+            }
+
+            val result = Memo.run {
+                Abort.run {
+                    for
+                        a <- f(1)
+                        _ <- Memo.isolate.merge.run {
+                            for
+                                b <- f(2)
+                                _ <- Abort.fail("Failed")
+                            yield b
+                        }
+                        c <- f(2)
+                    yield (a, c)
+                }
+            }
+            assert(result.eval == Result.fail("Failed"))
+            assert(count == 2)
+        }
+
+        "nested isolates maintain transactional behavior" in run {
+            val result = Var.runTuple(0) {
+                Emit.run {
+                    Abort.run {
+                        for
+                            _ <- Var.set(1)
+                            _ <- Emit("start")
+                            _ <-
+                                Var.isolate.update[Int]
+                                    .andThen(Emit.isolate.merge[String])
+                                    .run {
+                                        for
+                                            _ <- Var.set(2)
+                                            _ <- Emit("inner")
+                                            _ <- (Var.isolate.update[Int].andThen(Emit.isolate.merge[String])).run {
+                                                for
+                                                    _ <- Var.set(3)
+                                                    _ <- Emit("nested")
+                                                    _ <- Abort.fail("Failed")
+                                                yield ()
+                                            }
+                                        yield ()
+                                    }
+                            v <- Var.get[Int]
+                            _ <- Emit("end")
+                        yield v
+                    }
+                }
+            }
+            assert(result.eval == (1, (Chunk("start"), Result.fail("Failed"))))
+        }
+
+        "multiple effects maintain consistency on abort" in run {
+            var memoCount = 0
+            val f = Memo[Int, Int, Any] { x =>
+                memoCount += 1
+                x * 2
+            }
+
+            val result = Var.runTuple(0) {
+                Emit.run {
+                    Memo.run {
+                        Abort.run {
+                            for
+                                _ <- Var.set(1)
+                                _ <- Emit("start")
+                                a <- f(1)
+                                _ <- Var.isolate.update[Int]
+                                    .andThen(Emit.isolate.merge[String])
+                                    .andThen(Memo.isolate.merge)
+                                    .run {
+                                        for
+                                            _ <- Var.set(2)
+                                            _ <- Emit("inner")
+                                            b <- f(2)
+                                            _ <- Abort.fail("Failed")
+                                        yield (a, b)
+                                    }
+                                v <- Var.get[Int]
+                                _ <- Emit("end")
+                            yield v
+                        }
+                    }
+                }
+            }
+            assert(result.eval == (1, (Chunk("start"), Result.fail("Failed"))))
+            assert(memoCount == 2)
+        }
+    }
+end IsolateTest

--- a/kyo-prelude/shared/src/test/scala/kyo/VarTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/VarTest.scala
@@ -108,4 +108,201 @@ class VarTest extends Test:
         val e: String < Any                      = Var.run("t")(d)
         assert(e.eval == "1")
     }
+
+    "isolate" - {
+        "merge" - {
+            "combines values from isolated and outer scopes" in run {
+                val result = Var.runTuple(42) {
+                    Var.isolate.merge[Int](_ + _).run {
+                        for
+                            outer <- Var.get[Int]
+                            _     <- Var.set(10)
+                            inner <- Var.get[Int]
+                        yield (outer, inner)
+                    }
+                }
+                assert(result.eval == (52, (42, 10)))
+            }
+
+            "proper state restoration after nested isolations" in run {
+                val result = Var.runTuple(1) {
+                    for
+                        start <- Var.get[Int]
+                        v1 <- Var.isolate.merge[Int](_ + _).run {
+                            Var.update[Int](_ + 1).andThen(Var.get[Int])
+                        }
+                        middle <- Var.get[Int]
+                        v2 <- Var.isolate.merge[Int](_ + _).run {
+                            Var.update[Int](_ + 2).andThen(Var.get[Int])
+                        }
+                        end <- Var.get[Int]
+                    yield (start, v1, middle, v2, end)
+                }
+                assert(result.eval == (8, (1, 2, 3, 5, 8)))
+            }
+
+        }
+
+        "update" - {
+            "replaces outer value with inner value" in run {
+                val result = Var.runTuple(42) {
+                    for
+                        before <- Var.get[Int]
+                        _ <- Var.isolate.update[Int].run {
+                            Var.set(10)
+                        }
+                        after <- Var.get[Int]
+                    yield (before, after)
+                }
+                assert(result.eval == (10, (42, 10)))
+            }
+
+            "nested updates apply in order" in run {
+                val result = Var.runTuple(1) {
+                    for
+                        start <- Var.get[Int]
+                        _ <- Var.isolate.update[Int].run {
+                            Var.update[Int](_ + 1).andThen {
+                                Var.isolate.update[Int].run {
+                                    Var.update[Int](_ * 2)
+                                }
+                            }
+                        }
+                        end <- Var.get[Int]
+                    yield (start, end)
+                }
+                assert(result.eval == (4, (1, 4)))
+            }
+
+            "value changes preserved after effects" in run {
+                val result = Var.runTuple(5) {
+                    Env.run(2) {
+                        for
+                            start <- Var.get[Int]
+                            _ <- Var.isolate.update[Int].run {
+                                Env.use[Int] { multiplier =>
+                                    Var.update[Int](_ * multiplier)
+                                }
+                            }
+                            end <- Var.get[Int]
+                        yield (start, end)
+                    }
+                }
+                assert(result.eval == (10, (5, 10)))
+            }
+        }
+
+        "discard" - {
+            "inner modifications don't affect outer scope" in run {
+                val result = Var.runTuple(42) {
+                    for
+                        before <- Var.get[Int]
+                        _ <- Var.isolate.discard[Int].run {
+                            Var.set(10)
+                        }
+                        after <- Var.get[Int]
+                    yield (before, after)
+                }
+                assert(result.eval == (42, (42, 42)))
+            }
+
+            "nested discards maintain isolation" in run {
+                val result = Var.runTuple(1) {
+                    for
+                        start <- Var.get[Int]
+                        _ <- Var.isolate.discard[Int].run {
+                            Var.update[Int](_ + 1).andThen {
+                                Var.isolate.discard[Int].run {
+                                    Var.update[Int](_ * 2)
+                                }
+                            }
+                        }
+                        end <- Var.get[Int]
+                    yield (start, end)
+                }
+                assert(result.eval == (1, (1, 1)))
+            }
+
+            "effects execute but state changes discarded" in run {
+                var sideEffect = 0
+                val result = Var.runTuple(5) {
+                    for
+                        start <- Var.get[Int]
+                        _ <- Var.isolate.discard[Int].run {
+                            Var.update[Int] { x =>
+                                sideEffect += 1
+                                x * 2
+                            }
+                        }
+                        end <- Var.get[Int]
+                    yield (start, end, sideEffect)
+                }
+                assert(result.eval == (5, (5, 5, 1)))
+            }
+
+        }
+
+        "composition" - {
+            "can combine multiple isolates" in run {
+                val i1 = Var.isolate.merge[Int](_ + _)
+                val i2 = Var.isolate.update[Int]
+
+                val combined = i1.andThen(i2)
+
+                val result = Var.runTuple(1) {
+                    for
+                        start <- Var.get[Int]
+                        _ <- combined.run {
+                            Var.update[Int](_ + 1)
+                        }
+                        end <- Var.get[Int]
+                    yield (start, end)
+                }
+                assert(result.eval == (2, (1, 2)))
+            }
+
+            "preserves individual isolation behaviors when composed" in run {
+                val i1 = Var.isolate.discard[Int]
+                val i2 = Var.isolate.update[Int]
+
+                val result = Var.runTuple(1) {
+                    for
+                        start <- Var.get[Int]
+                        _ <- i1.run {
+                            Var.set(10)
+                        }
+                        middle <- Var.get[Int]
+                        _ <- i2.run {
+                            Var.set(20)
+                        }
+                        end <- Var.get[Int]
+                    yield (start, middle, end)
+                }
+                assert(result.eval == (20, (1, 1, 20)))
+            }
+
+            "with Emit isolate" in run {
+                val varIsolate  = Var.isolate.discard[Int]
+                val emitIsolate = Emit.isolate.merge[Int]
+
+                val combined = varIsolate.andThen(emitIsolate)
+
+                val result = Var.runTuple(1) {
+                    Emit.run {
+                        combined.run {
+                            for
+                                _  <- Var.update[Int](_ + 1)
+                                v  <- Var.get[Int]
+                                _  <- Emit(v)
+                                _  <- Var.update[Int](_ * 2)
+                                v2 <- Var.get[Int]
+                                _  <- Emit(v2)
+                            yield ()
+                        }
+                    }
+                }
+                assert(result.eval == (1, (Chunk(2, 4), ())))
+            }
+        }
+    }
 end VarTest


### PR DESCRIPTION
Please see the `Isolate` scaladoc for more background. Ideally, we should find a way to merge `Boundary` and `Isolate` but that's challenging with the inference issues we've been having and it's difficult to match the current performance of `Boundary` since it's optimized by using more low-level kernel APIs. This new mechanism is focused only on effects that maintain state but don't transform values.

Main benefits of this change:

 - It allows users to fork computations with `Var`,  `Emit`, `Memo`, and `Check`. 
 - Users can leverage `isolate.run` directly to enforce the effect handling for a computation
 - Isolates provide transaction-like behavior via interaction with `Abort`. This behavior will be necessary for an STM-based effect since it'll need to rollback state to retry computations if necessary.

`Isolate` can't support effects like `Choice` since it transforms `A` into `Seq[A]`.