### PR TITLE
[prelude] introduce `Stream#rechunk`

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -279,7 +279,7 @@ sealed abstract class Stream[V, -S]:
                         if input.isEmpty && buffer.nonEmpty then
                             Emit.andMap(buffer)(ack => (Chunk.empty, cont(ack)))
                         else
-                            val combined = Chunk.from(buffer.appendedAll(input))
+                            val combined = buffer.concat(input)
                             if combined.size < cs then
                                 (combined, cont(Continue()))
                             else

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -6,7 +6,10 @@ import kyo.kernel.Reducible
 
 class StreamTest extends Test:
 
-    val n = 10000
+    val n = 100000
+
+    def chunkSizes[V: Tag, S](stream: Stream[V, S]): Chunk[Int] < S =
+        stream.mapChunk(chunk => Chunk(chunk.size)).run
 
     "empty" in {
         assert(
@@ -39,12 +42,7 @@ class StreamTest extends Test:
 
         "chunk size" in {
             def size(n: Int, c: Int): Chunk[Int] =
-                Var.runTuple(Chunk.empty[Int])(
-                    Stream
-                        .init(Seq.fill(n)(""), chunkSize = c)
-                        .mapChunk(chunk => Var.update[Chunk[Int]](_.append(chunk.size)))
-                        .runDiscard
-                ).eval._1
+                chunkSizes(Stream.init(Seq.fill(n)(""), chunkSize = c)).eval
 
             assert(size(10240, 4096) == Chunk(4096, 4096, 2048))
             assert(size(301, 100) == Chunk(100, 100, 100, 1))
@@ -96,19 +94,14 @@ class StreamTest extends Test:
 
         "chunk size" in {
             def size(n: Int, c: Int): Chunk[Int] =
-                Var.runTuple(Chunk.empty[Int])(
-                    Stream
-                        .range(0, n, chunkSize = c)
-                        .mapChunk(chunk => Var.update[Chunk[Int]](_.append(chunk.size)))
-                        .runDiscard
-                ).eval._1
+                chunkSizes(Stream.range(0, n, chunkSize = c)).eval
 
             assert(size(10240, 4096) == Chunk(4096, 4096, 2048))
             assert(size(301, 100) == Chunk(100, 100, 100, 1))
         }
 
         "stack safety" in {
-            assert(Stream.range(0, 1000000).take(5).run.eval == (0 until 5))
+            assert(Stream.range(0, n).take(5).run.eval == (0 until 5))
         }
     }
 
@@ -602,8 +595,65 @@ class StreamTest extends Test:
             assert(
                 Stream.init(1 to n)
                     .concat(Stream.init(n + 1 to 2 * n))
-                    .run.eval == (1 to (2 * n)).toSeq
+                    .run.eval == (1 to (2 * n))
             )
+        }
+    }
+
+    "rechunk" - {
+        "negative" in {
+            val sizes = chunkSizes(Stream.init(1 until 5).rechunk(-10)).eval
+            assert(sizes == Chunk(1, 1, 1, 1))
+        }
+
+        "smaller" in {
+            val sizes = chunkSizes(Stream.range(1, 5000, step = 2).rechunk(1024)).eval
+            assert(sizes == Chunk(1024, 1024, 452))
+        }
+
+        "same" in {
+            val sizes = chunkSizes(Stream.range(0, 250, chunkSize = 100).rechunk(100)).eval
+            assert(sizes == Chunk(100, 100, 50))
+        }
+
+        "larger" in {
+            val sizes = chunkSizes(Stream.range(0, 5001).rechunk(5000)).eval
+            assert(sizes == Chunk(5000, 1))
+        }
+
+        "larger than stream" in {
+            val sizes = chunkSizes(Stream.range(0, 100_000).rechunk(500_000)).eval
+            assert(sizes == Chunk(100_000))
+        }
+
+        "with effects" in {
+            val stream = Stream.range(0, 100).map(i => Env.use[Int](_ + i)).rechunk(48)
+            val result = Env.run(10)(stream.run).eval
+            val chunks = Env.run(10)(chunkSizes(stream)).eval
+            assert(result == (10 until 110))
+            assert(chunks == Chunk(48, 48, 4))
+        }
+
+        "order" in {
+            val stream = Stream.range(0, 100).rechunk(8)
+            assert(stream.run.eval == (0 until 100))
+        }
+
+        "empty chunks" in {
+            def emit(n: Int): Ack < (Emit[Chunk[Int]]) =
+                n match
+                    case 0 => Stop
+                    case 5 => Emit.andMap(Chunk.empty)(_ => emit(n - 1))
+                    case _ => Emit.andMap(Chunk.fill(3)(n))(_ => emit(n - 1))
+            end emit
+
+            val stream = Stream(emit(10)).rechunk(10).mapChunk(Chunk(_))
+            assert(stream.run.eval == Chunk(
+                Chunk(10, 10, 10, 9, 9, 9, 8, 8, 8, 7),
+                Chunk(7, 7, 6, 6, 6), // empty chunk causes buffer flush
+                Chunk(4, 4, 4, 3, 3, 3, 2, 2, 2, 1),
+                Chunk(1, 1)
+            ))
         }
     }
 


### PR DESCRIPTION
PR 2 for #679 

Rechunk was a bit tricky to implement as the remaining 'buffer' would get dropped unless the chunks perfectly aligned with the number of emits. Because of this, it's necessary to Emit a final empty chunk to ensure the buffer is flushed. This can sometimes drop the number of elements in a given chunk if a user Emits an empty chunk, but that shouldn't be a problem.