### PR TITLE
[core] async gather

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -387,7 +387,7 @@ object Fiber extends FiberPlatformSpecific:
                                             completeDiscard(result)
                                 end match
                                 // Complete if we have max successes or all results are in
-                                if ok == max || ok + nok == total then
+                                if ok > 0 && (ok == max || ok + nok == total) then
                                     val size = okInt.min(max)
 
                                     // Handle race condition

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -1,6 +1,7 @@
 package kyo
 
 export Fiber.Promise
+import java.lang.invoke.VarHandle
 import java.util.Arrays
 import kyo.Result.Panic
 import kyo.Tag
@@ -350,6 +351,9 @@ object Fiber extends FiberPlatformSpecific:
         else
             IO.Unsafe {
                 class State extends IOPromise[E, Chunk[A]] with Function2[Int, Result[E, A], Unit]:
+
+                    // Array to store results as they arrive. Ordering is preserved
+                    // indirectly via the indices array
                     val results = new Array[AnyRef](max)
 
                     // Helper array to store original indices to maintain ordering
@@ -373,6 +377,8 @@ object Fiber extends FiberPlatformSpecific:
                                 // CAS failed, retry the update
                                 loop()
                             else
+                                // Note that counters are already updated considering the current
+                                // successful of failed result
                                 val okInt = ok.toInt
                                 result match
                                     case Result.Success(v) =>
@@ -380,11 +386,16 @@ object Fiber extends FiberPlatformSpecific:
                                             // Store successful result and its original index for ordering
                                             indices(okInt - 1) = idx
                                             results(okInt - 1) = v.asInstanceOf[AnyRef]
+
+                                            // Ensure new results are promptly made available
+                                            VarHandle.storeStoreFence()
+
                                     case result: Result.Error[?] =>
                                         if ok == 0 && ok + nok == total then
                                             // If we have no successful results and all computations have completed,
                                             // propagate the last encountered error since there's nothing else to return
                                             completeDiscard(result)
+
                                 end match
                                 // Complete if we have max successes or all results are in
                                 if ok > 0 && (ok == max || ok + nok == total) then
@@ -432,10 +443,17 @@ object Fiber extends FiberPlatformSpecific:
     private def waitForResults(results: Array[AnyRef], size: Int): Unit =
         @tailrec def loop(i: Int): Unit =
             if i < size then
+                // Restart check from beginning if any result is missing
                 if results(i) == null then
+                    // Indicate that the thread is busy waiting and introduce
+                    // a load barrier to ensure new results are promptly visible
+                    Thread.onSpinWait()
                     loop(0)
                 else
                     loop(i + 1)
+                end if
+            end if
+        end loop
         loop(0)
     end waitForResults
 

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -1,7 +1,7 @@
 package kyo
 
 export Fiber.Promise
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.Arrays
 import kyo.Result.Panic
 import kyo.Tag
 import kyo.internal.FiberPlatformSpecific
@@ -253,6 +253,8 @@ object Fiber extends FiberPlatformSpecific:
     /** Races multiple Fibers and returns a Fiber that completes with the result of the first to complete. When one Fiber completes, all
       * other Fibers are interrupted.
       *
+      * WARNING: Executes all computations in parallel without bounds. Use with caution on large sequences to avoid resource exhaustion.
+      *
       * @param seq
       *   The sequence of Fibers to race
       * @return
@@ -271,9 +273,9 @@ object Fiber extends FiberPlatformSpecific:
         frame: Frame,
         safepoint: Safepoint
     ): Fiber[E, A] < (IO & Ctx) =
-        IO {
+        IO.Unsafe {
             class State extends IOPromise[E, A] with Function1[Result[E, A], Unit]:
-                val pending = new AtomicInteger(seq.size)
+                val pending = AtomicInt.Unsafe.init(seq.size)
                 def apply(result: Result[E, A]): Unit =
                     val last = pending.decrementAndGet() == 0
                     result.fold(e => if last then completeDiscard(e))(v => completeDiscard(Result.success(v)))
@@ -283,7 +285,7 @@ object Fiber extends FiberPlatformSpecific:
             import state.*
             boundary { (trace, context) =>
                 IO {
-                    val interruptPanic = Result.Panic(Fiber.Interrupted(frame))
+                    inline def interruptPanic = Result.Panic(Fiber.Interrupted(frame))
                     foreach(seq) { (_, v) =>
                         val fiber = IOTask(v, safepoint.copyTrace(trace), context)
                         state.onComplete(_ => discard(fiber.interrupt(interruptPanic)))
@@ -293,6 +295,166 @@ object Fiber extends FiberPlatformSpecific:
                 }
             }
         }
+
+    /** Concurrently executes effects and collects their successful results.
+      *
+      * WARNING: Executes all computations in parallel without bounds. Use with caution on large sequences to avoid resource exhaustion.
+      *
+      * Executes all effects concurrently and returns successful results in completion order. If all computations fail, the last encountered
+      * error is propagated. The operation completes when all effects have either succeeded or failed.
+      *
+      * @tparam Ctx
+      *   Context requirements
+      * @param seq
+      *   Sequence of effects to execute
+      * @return
+      *   Fiber containing successful results as a Chunk
+      */
+    inline def gather[E, A: Flat, Ctx](seq: Seq[A < (Abort[E] & Async & Ctx)])(
+        using
+        frame: Frame,
+        safepoint: Safepoint
+    ): Fiber[E, Chunk[A]] < (IO & Ctx) =
+        val total = seq.size
+        _gather(total)(total, seq)
+    end gather
+
+    /** Concurrently executes effects and collects up to `max` successful results.
+      *
+      * WARNING: Executes all computations in parallel without bounds. Use with caution on large sequences to avoid resource exhaustion.
+      *
+      * Similar to `gather`, but completes early once the specified number of `max` successful results is reached. If not enough successes
+      * occur and all remaining computations fail, the last encountered error is propagated.
+      *
+      * @param max
+      *   Maximum number of successful results to collect
+      * @param seq
+      *   Sequence of effects to execute
+      * @return
+      *   Fiber containing successful results as a Chunk (size <= max)
+      */
+    inline def gather[E, A: Flat, Ctx](max: Int)(seq: Seq[A < (Abort[E] & Async & Ctx)])(
+        using
+        frame: Frame,
+        safepoint: Safepoint
+    ): Fiber[E, Chunk[A]] < (IO & Ctx) =
+        _gather(max)(seq.size, seq)
+
+    private[kyo] def _gather[E, A: Flat, Ctx](max: Int)(total: Int, seq: Seq[A < (Abort[E] & Async & Ctx)])(
+        using
+        boundary: Boundary[Ctx, IO & Abort[E]],
+        frame: Frame,
+        safepoint: Safepoint
+    ): Fiber[E, Chunk[A]] < (IO & Ctx) =
+        if total == 0 || max <= 0 then Fiber.success(Chunk.empty)
+        else
+            IO.Unsafe {
+                class State extends IOPromise[E, Chunk[A]] with Function2[Int, Result[E, A], Unit]:
+                    val results = new Array[AnyRef](max)
+
+                    // Helper array to store original indices to maintain ordering
+                    // Initialized to Int.MaxValue to handle partial results
+                    val indices = new Array[Int](max)
+                    Arrays.fill(indices, Int.MaxValue)
+
+                    // Packed representation to avoid allocations and ensure atomicity
+                    // - lower 32 bits  => successful results count (ok)
+                    // - higher 32 bits => failed results count (nok)
+                    val packed = AtomicLong.Unsafe.init(0)
+
+                    def apply(idx: Int, result: Result[E, A]): Unit =
+                        @tailrec def loop(): Unit =
+                            // Atomically update both ok/nok counters using CAS
+                            val p   = packed.get()
+                            val ok  = (p & 0xffffffffL) + (if result.isSuccess then 1 else 0)
+                            val nok = (p >>> 32) + (if result.isFail then 1 else 0)
+                            val np  = (nok << 32) | ok
+                            if !packed.cas(p, np) then
+                                // CAS failed, retry the update
+                                loop()
+                            else
+                                val okInt = ok.toInt
+                                result match
+                                    case Result.Success(v) =>
+                                        if ok <= max then
+                                            // Store successful result and its original index for ordering
+                                            results(okInt - 1) = v.asInstanceOf[AnyRef]
+                                            indices(okInt - 1) = idx
+                                    case result: Result.Error[?] =>
+                                        if ok == 0 && ok + nok == total then
+                                            // If we have no successful results and all computations have completed,
+                                            // propagate the last encountered error since there's nothing else to return
+                                            completeDiscard(result)
+                                end match
+                                // Complete if we have max successes or all results are in
+                                if ok == max || ok + nok == total then
+                                    val size = okInt.min(max)
+                                    // Restore original ordering but limit size since later
+                                    // results might still arrive and we want to avoid races
+                                    quickSort(indices, results, size)
+
+                                    // Limit final result to max successful results
+                                    completeDiscard(Result.success(Chunk.from(results).take(size)))
+                                end if
+                            end if
+                        end loop
+                        loop()
+                    end apply
+                end State
+                val state = new State
+                import state.*
+                boundary { (trace, context) =>
+                    IO {
+                        inline def interruptPanic = Result.Panic(Fiber.Interrupted(frame))
+                        foreach(seq) { (idx, v) =>
+                            val fiber = IOTask(v, safepoint.copyTrace(trace), context)
+                            state.onComplete(_ => discard(fiber.interrupt(interruptPanic)))
+                            fiber.onComplete(state(idx, _))
+                        }
+                        state
+                    }
+                }
+            }
+
+    /** Custom quicksort that sorts both indices and results arrays together.
+      *
+      * Since `_gather` collects results as they complete but needs to preserve input sequence order, we sort before returning. This
+      * specialized implementation avoids allocating tuples or wrapper objects by sorting both arrays in-place.
+      */
+    private[kyo] def quickSort(indices: Array[Int], results: Array[AnyRef], items: Int): Unit =
+
+        def swap(i: Int, j: Int): Unit =
+            val tempIdx = indices(i)
+            indices(i) = indices(j)
+            indices(j) = tempIdx
+
+            val tempRes = results(i)
+            results(i) = results(j)
+            results(j) = tempRes
+        end swap
+
+        @tailrec def partitionLoop(low: Int, hi: Int, pivot: Int, i: Int, j: Int): Int =
+            if j >= hi then
+                swap(i, pivot)
+                i
+            else if indices(j) < indices(pivot) then
+                swap(i, j)
+                partitionLoop(low, hi, pivot, i + 1, j + 1)
+            else
+                partitionLoop(low, hi, pivot, i, j + 1)
+
+        def partition(low: Int, hi: Int): Int =
+            partitionLoop(low, hi, hi, low, low)
+
+        def loop(low: Int, hi: Int): Unit =
+            if low < hi then
+                val p = partition(low, hi)
+                loop(low, p - 1)
+                loop(p + 1, hi)
+
+        if items > 0 then
+            loop(0, items - 1)
+    end quickSort
 
     /** Runs multiple computations in parallel with a specified level of parallelism and returns a Fiber that completes with their results.
       *
@@ -356,15 +518,15 @@ object Fiber extends FiberPlatformSpecific:
         seq.size match
             case 0 => Fiber.success(Seq.empty)
             case _ =>
-                IO {
+                IO.Unsafe {
                     class State extends IOPromise[E, Seq[A]] with ((Int, Result[E, A]) => Unit):
                         val results = (new Array[Any](seq.size)).asInstanceOf[Array[A]]
-                        val pending = new AtomicInteger(seq.size)
+                        val pending = AtomicInt.Unsafe.init(seq.size)
                         def apply(idx: Int, result: Result[E, A]): Unit =
                             result.fold(this.interruptDiscard) { value =>
                                 results(idx) = value
                                 if pending.decrementAndGet() == 0 then
-                                    this.completeDiscard(Result.success(ArraySeq.unsafeWrapArray(results)))
+                                    this.completeDiscard(Result.success(Chunk.from(results)))
                             }
                     end State
                     val state = new State

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -398,7 +398,7 @@ object Fiber extends FiberPlatformSpecific:
                                     quickSort(indices, results, size)
 
                                     // Limit final result to max successful results
-                                    completeDiscard(Result.success(Chunk.from(results).take(size)))
+                                    completeDiscard(Result.success(Chunk.fromNoCopy(results).take(size)))
                                 end if
                             end if
                         end loop
@@ -549,7 +549,7 @@ object Fiber extends FiberPlatformSpecific:
                             result.fold(this.interruptDiscard) { value =>
                                 results(idx) = value
                                 if pending.decrementAndGet() == 0 then
-                                    this.completeDiscard(Result.success(Chunk.from(results)))
+                                    this.completeDiscard(Result.success(Chunk.fromNoCopy(results)))
                             }
                     end State
                     val state = new State

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -669,4 +669,38 @@ class AsyncTest extends Test:
         }
     }
 
+    "gather" - {
+        "sequence" - {
+            "delegates to Fiber.gather" in run {
+                for
+                    result <- Async.gather(Seq(IO(1), IO(2), IO(3)))
+                yield assert(result == Chunk(1, 2, 3))
+            }
+
+            "with max limit delegates to Fiber.gather" in run {
+                for
+                    result <- Async.gather(2)(Seq(IO(1), IO(2), IO(3)))
+                yield
+                    assert(result.size == 2)
+                    assert(result.forall(Seq(1, 2, 3).contains))
+            }
+        }
+
+        "varargs" - {
+            "delegates to sequence-based gather" in run {
+                for
+                    result <- Async.gather(IO(1), IO(2), IO(3))
+                yield assert(result == Chunk(1, 2, 3))
+            }
+
+            "with max limit delegates to sequence-based gather" in run {
+                for
+                    result <- Async.gather(2)(IO(1), IO(2), IO(3))
+                yield
+                    assert(result.size == 2)
+                    assert(result.forall(Seq(1, 2, 3).contains))
+            }
+        }
+    }
+
 end AsyncTest

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -730,4 +730,378 @@ class FiberTest extends Test:
         }
     }
 
+    "gather" - {
+
+        val repeats = 100
+
+        "empty sequence" in run {
+            for
+                fiber  <- Fiber.gather(Seq.empty[Int < Async])
+                result <- fiber.get
+            yield assert(result.isEmpty)
+        }
+
+        "collects all successful results" in run {
+            for
+                fiber  <- Fiber.gather(Seq(IO(1), IO(2), IO(3)))
+                result <- fiber.get
+            yield assert(result == Chunk(1, 2, 3))
+        }
+
+        "with max limit" in run {
+            val seq = Seq(1, 2, 3)
+            for
+                fiber  <- Fiber.gather(2)(seq.map(IO(_)))
+                result <- fiber.get
+            yield
+                assert(result.distinct.size == 2)
+                assert(result.forall(seq.contains))
+            end for
+        }
+
+        "handles max=0" in run {
+            for
+                fiber  <- Fiber.gather(0)(Seq(IO(1), IO(2), IO(3)))
+                result <- fiber.get
+            yield assert(result.isEmpty)
+        }
+
+        "handles max=1 with all failures except last" in run {
+            val error = new Exception("test error")
+            for
+                fiber <- Fiber.gather(1)(Seq(
+                    Abort.fail[Exception](error),
+                    Abort.fail[Exception](error),
+                    IO(3)
+                ))
+                result <- fiber.get
+            yield assert(result == Chunk(3))
+            end for
+        }
+
+        "handles negative max" in run {
+            for
+                fiber  <- Fiber.gather(-1)(Seq(IO(1), IO(2), IO(3)))
+                result <- fiber.get
+            yield assert(result.isEmpty)
+        }
+
+        "handles max > size" in run {
+            val seq = Seq(1, 2, 3)
+            for
+                fiber  <- Fiber.gather(10)(seq.map(IO(_)))
+                result <- fiber.get
+            yield assert(result == Chunk(1, 2, 3))
+            end for
+        }
+
+        "handles max > size with failures" in run {
+            val error = new Exception("test error")
+            for
+                fiber <- Fiber.gather(10)(Seq(
+                    IO(1),
+                    Abort.fail[Exception](error),
+                    IO(3)
+                ))
+                result <- fiber.get
+            yield assert(result == Chunk(1, 3))
+            end for
+        }
+
+        "preserves original order" in runJVM {
+            for
+                fiber <- Fiber.gather(Seq(
+                    Async.delay(3.millis)(1),
+                    Async.delay(1.millis)(2),
+                    Async.delay(2.millis)(3)
+                ))
+                result <- fiber.get
+            yield assert(result == Chunk(1, 2, 3))
+        }
+
+        "preserves original order with max limit" in runJVM {
+            for
+                fiber <- Fiber.gather(2)(Seq(
+                    Async.delay(3.millis)(1),
+                    Async.delay(1.millis)(2),
+                    Async.delay(2.millis)(3)
+                ))
+                result <- fiber.get
+            yield assert(result == Chunk(2, 3))
+        }
+
+        "handles concurrent completions" in runJVM {
+            for
+                latch  <- Latch.init(1)
+                fiber  <- Fiber.gather(Seq.fill(20)(latch.await.andThen(42)))
+                _      <- latch.release
+                result <- fiber.get
+            yield assert(result.size == 20 && result.forall(_ == 42))
+        }
+
+        val error = new Exception("test error")
+
+        "filters out failures" in run {
+            for
+                fiber <- Fiber.gather(Seq(
+                    IO(1),
+                    Abort.fail[Exception](error),
+                    IO(3)
+                ))
+                result <- fiber.get
+            yield assert(result == Chunk(1, 3))
+            end for
+        }
+
+        "handles mixed success/failure with exact max" in runJVM {
+            val error = new Exception("test error")
+            for
+                fiber <- Fiber.gather(2)(Seq(
+                    Async.delay(2.millis)(1),
+                    Async.delay(1.millis)(Abort.fail[Exception](error)),
+                    Async.delay(1.millis)(2),
+                    Async.delay(2.millis)(Abort.fail[Exception](error)),
+                    Async.delay(3.millis)(3)
+                ))
+                result <- fiber.get
+            yield
+                assert(result.size == 2)
+                assert(result == Chunk(1, 2))
+            end for
+        }
+
+        "handles race conditions in counter updates" in runJVM {
+            Loop.repeat(repeats) {
+                for
+                    latch1 <- Latch.init(1)
+                    latch2 <- Latch.init(1)
+                    fiber <- Fiber.gather(2)(Seq(
+                        latch1.release.andThen(1),
+                        latch2.release.andThen(2),
+                        Async.delay(1.millis)(3)
+                    ))
+                    _      <- latch1.await
+                    _      <- latch2.await
+                    result <- fiber.get
+                yield
+                    assert(result == Chunk(1, 2))
+                    ()
+            }.andThen(succeed)
+        }
+
+        "race conditions in error propagation" in runJVM {
+            Loop.repeat(50) {
+                for
+                    latch <- Latch.init(1)
+                    error1 = new Exception("error1")
+                    error2 = new Exception("error2")
+                    fiber <- Fiber.gather(Seq(
+                        latch.await.andThen(Abort.fail[Exception](error1)),
+                        latch.await.andThen(Abort.fail[Exception](error2))
+                    ))
+                    _      <- latch.release
+                    result <- Abort.run(fiber.get)
+                yield
+                    assert(result.isFail)
+                    assert(result.failure.exists(e => e == error1 || e == error2))
+                    ()
+            }.andThen(succeed)
+        }
+
+        "propagates error when all fail" in run {
+            for
+                fiber  <- Fiber.gather(Seq[Int < Abort[Throwable]](Abort.fail(error), Abort.fail(error)))
+                result <- Abort.run(fiber.get)
+            yield assert(result.failure.contains(error))
+            end for
+        }
+
+        "max limit with failures" in run {
+            for
+                fiber <- Fiber.gather(2)(Seq(
+                    IO(1),
+                    Abort.fail[Exception](error),
+                    IO(3),
+                    IO(4)
+                ))
+                result <- fiber.get
+            yield
+                assert(result.size == 2)
+                assert(result.forall(Seq(1, 3, 4).contains))
+            end for
+        }
+
+        "completes early when max successful results reached" in run {
+            val seq = Seq(1, 2, 3)
+            for
+                fiber  <- Fiber.gather(2)(seq.map(i => Async.delay(i.millis)(i)))
+                result <- fiber.get
+            yield
+                assert(result.size == 2)
+                assert(result.forall(seq.contains))
+            end for
+        }
+
+        "interrupts all child fibers" in runJVM {
+            Loop.repeat(repeats) {
+                for
+                    interruptCount <- AtomicInt.init
+                    startLatch     <- Latch.init(3)
+                    promise1       <- Promise.init[Nothing, Int]
+                    promise2       <- Promise.init[Nothing, Int]
+                    promise3       <- Promise.init[Nothing, Int]
+                    _              <- promise1.onInterrupt(_ => interruptCount.incrementAndGet.unit)
+                    _              <- promise2.onInterrupt(_ => interruptCount.incrementAndGet.unit)
+                    _              <- promise3.onInterrupt(_ => interruptCount.incrementAndGet.unit)
+                    fiber <- Fiber.gather(Seq(
+                        startLatch.release.andThen(promise1.get),
+                        startLatch.release.andThen(promise2.get),
+                        startLatch.release.andThen(promise3.get)
+                    ))
+                    _     <- startLatch.await
+                    _     <- fiber.interrupt
+                    count <- interruptCount.get
+                yield
+                    assert(count == 3)
+                    ()
+            }.andThen(succeed)
+        }
+
+        "interrupts remaining fibers when max results reached" in runJVM {
+            Loop.repeat(repeats) {
+                for
+                    interruptCount <- AtomicInt.init
+                    startLatch     <- Latch.init(3)
+                    promise1       <- Promise.init[Nothing, Int]
+                    promise2       <- Promise.init[Nothing, Int]
+                    promise3       <- Promise.init[Nothing, Int]
+                    _              <- promise1.onInterrupt(_ => interruptCount.incrementAndGet.unit)
+                    _              <- promise2.onInterrupt(_ => interruptCount.incrementAndGet.unit)
+                    _              <- promise3.onInterrupt(_ => interruptCount.incrementAndGet.unit)
+                    fiber <- Fiber.gather(2)(Seq(
+                        startLatch.release.andThen(promise1.get),
+                        startLatch.release.andThen(promise2.get),
+                        startLatch.release.andThen(promise3.get)
+                    ))
+                    _      <- startLatch.await
+                    done1  <- fiber.done
+                    _      <- promise1.complete(Result.success(1))
+                    done2  <- fiber.done
+                    _      <- promise2.complete(Result.success(1))
+                    result <- fiber.get
+                    count  <- interruptCount.get
+                yield
+                    assert(!done1 && !done2)
+                    assert(result == Seq(1, 1))
+                    assert(count == 1)
+                    ()
+            }.andThen(succeed)
+        }
+
+        "quickSort" - {
+            "empty array" in {
+                val indices = Array[Int]()
+                val results = Array[AnyRef]()
+                Fiber.quickSort(indices, results, 0)
+                assert(indices.isEmpty && results.isEmpty)
+            }
+
+            "single element" in {
+                val indices = Array[Int](0)
+                val results = Array[AnyRef]("a")
+                Fiber.quickSort(indices, results, 1)
+                assert(indices.sameElements(Array(0)) && results.sameElements(Array("a")))
+            }
+
+            "partial sort with items" - {
+                "items = 0" in {
+                    val indices  = Array[Int](3, 1, 4, 2)
+                    val results  = Array[AnyRef]("c", "a", "d", "b")
+                    val original = indices.clone()
+                    Fiber.quickSort(indices, results, 0)
+                    assert(indices.sameElements(original))
+                }
+
+                "items = 1" in {
+                    val indices = Array[Int](3, 1, 4, 2)
+                    val results = Array[AnyRef]("c", "a", "d", "b")
+                    Fiber.quickSort(indices, results, 1)
+                    assert(indices(0) == 3)
+                }
+
+                "items = n-1" in {
+                    val indices = Array[Int](3, 1, 4, 2)
+                    val results = Array[AnyRef]("c", "a", "d", "b")
+                    Fiber.quickSort(indices, results, 3)
+                    assert(indices.take(3).sorted.sameElements(indices.take(3)))
+                    assert(indices(3) == 2)
+                }
+            }
+
+            "full sort" - {
+                "already sorted" in {
+                    val indices = Array[Int](0, 1, 2, 3)
+                    val results = Array[AnyRef]("a", "b", "c", "d")
+                    Fiber.quickSort(indices, results, 4)
+                    assert(indices.sameElements(Array(0, 1, 2, 3)))
+                    assert(results.sameElements(Array("a", "b", "c", "d")))
+                }
+
+                "reverse sorted" in {
+                    val indices = Array[Int](3, 2, 1, 0)
+                    val results = Array[AnyRef]("d", "c", "b", "a")
+                    Fiber.quickSort(indices, results, 4)
+                    assert(indices.sameElements(Array(0, 1, 2, 3)))
+                    assert(results.sameElements(Array("a", "b", "c", "d")))
+                }
+
+                "random order" in {
+                    val indices = Array[Int](3, 1, 4, 2)
+                    val results = Array[AnyRef]("c", "a", "d", "b")
+                    Fiber.quickSort(indices, results, 4)
+                    assert(indices.sameElements(Array(1, 2, 3, 4)))
+                    assert(results.sameElements(Array("a", "b", "c", "d")))
+                }
+            }
+
+            "can handle larger arrays" - {
+                val size = 1000
+
+                "sorted array" in {
+                    val indices = Array.range(0, size)
+                    val results = Array.fill[AnyRef](size)("x")
+                    Fiber.quickSort(indices, results, size)
+                    assert(indices.take(5).sameElements(Array(0, 1, 2, 3, 4)))
+                    assert(indices.takeRight(5).sameElements(Array(size - 5, size - 4, size - 3, size - 2, size - 1)))
+                }
+
+                "reverse sorted array" in {
+                    val indices = Array.range(0, size).reverse
+                    val results = Array.fill[AnyRef](size)("x")
+                    Fiber.quickSort(indices, results, size)
+                    assert(indices.take(5).sameElements(Array(0, 1, 2, 3, 4)))
+                    assert(indices.takeRight(5).sameElements(Array(size - 5, size - 4, size - 3, size - 2, size - 1)))
+                }
+
+                "random sorted array" in run {
+                    val indices = Array.range(0, size).reverse
+                    Random.shuffle(0 until size).map { seq =>
+                        val indices = seq.toArray
+                        val results = Array.fill[AnyRef](size)("x")
+                        Fiber.quickSort(indices, results, size)
+                        assert(indices.take(5).sameElements(Array(0, 1, 2, 3, 4)))
+                        assert(indices.takeRight(5).sameElements(Array(size - 5, size - 4, size - 3, size - 2, size - 1)))
+                    }
+                }
+
+                "array with repeated elements" in {
+                    val indices = Array.fill(size)(42)
+                    val results = Array.fill[AnyRef](size)("x")
+                    Fiber.quickSort(indices, results, size)
+                    assert(indices.forall(_ == 42))
+                }
+            }
+        }
+    }
+
 end FiberTest

--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -42,7 +42,8 @@ sealed abstract class Chunk[A] extends Seq[A] derives CanEqual:
       *   a new Chunk containing the first n elements
       */
     override def take(n: Int): Chunk[A] =
-        dropLeftAndRight(0, length - Math.min(Math.max(0, n), length))
+        if n == length then this
+        else dropLeftAndRight(0, length - Math.min(Math.max(0, n), length))
 
     /** Drops the first n elements of the Chunk.
       *

--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -458,6 +458,11 @@ object Chunk:
             Compact(Array.copyAs(values, values.length)(using ClassTag.AnyRef).asInstanceOf[Array[A]])
     end from
 
+    private[kyo] def fromNoCopy[A](values: Array[A]): Chunk.Indexed[A] =
+        if values.isEmpty then cachedEmpty.asInstanceOf[Chunk.Indexed[A]]
+        else
+            Compact(values)
+
     /** Creates a Chunk from a Seq of elements.
       *
       * @tparam A


### PR DESCRIPTION
New `gather` methods in `Fiber` and `Async` to collect successful computations out of a sequence. It also allows specifying a max number of expected results. See scaladocs for more information.