### PR TITLE
[test] add support for `Gen`/`check`

### DIFF
--- a/kyo-test/shared/src/main/scala/kyo/test/KyoSpecAbstract.scala
+++ b/kyo-test/shared/src/main/scala/kyo/test/KyoSpecAbstract.scala
@@ -21,25 +21,39 @@ abstract class KyoSpecAbstract[S] extends ZIOSpecAbstract:
 
     def spec: Spec[Environment, Any]
 
-    def run[In: Flat](v: => In < S)(using Frame): ZIO[Environment, Throwable, In]
+    protected def run[In: Flat](v: => In < S)(using Frame): ZIO[Environment, Throwable, In]
 
-    def test[In <: TestResult: Flat](label: String)(assertion: => In < S)(using
+    final def test[In](label: String)(assertion: => In)(using
+        tc: TestConstructor[Nothing, In],
         sl: SourceLocation,
-        tr: Trace,
-        fr: Frame
-    ): Spec[Any, Throwable] =
-        Spec.labeled(
-            label,
-            Spec
-                .test(ZTest(label, run(assertion)), TestAnnotationMap.empty)
-                .annotate(trace, sl :: Nil)
-        )
+        tr: Trace
+    ): tc.Out =
+        tc(label)(assertion)
 
-    def suite[In](label: String)(specs: In*)(using
+    final def suite[In](label: String)(specs: In*)(using
         sc: SuiteConstructor[In],
         sl: SourceLocation,
         tr: Trace
     ): Spec[sc.OutEnvironment, sc.OutError] =
         zio.test.suite(label)(specs*)
+
+    given KyoTestConstructor[S1 >: S, A <: TestResult: Flat](using Frame): TestConstructor.WithOut[Any, A < S1, Spec[Any, Throwable]] =
+        new TestConstructor[Any, A < S1]:
+            type Out = Spec[Any, Throwable]
+            def apply(
+                label: String
+            )(assertion: => A < S1)(using sl: SourceLocation, tr: Trace): Out =
+                Spec.labeled(
+                    label,
+                    Spec
+                        .test(ZTest(label, run[A](assertion)), TestAnnotationMap.empty)
+                        .annotate(trace, sl :: Nil)
+                )
+
+    given KyoCheckConstructor[S1 >: S, A <: TestResult: Flat](using Frame): CheckConstructor.WithOut[Any, A < S1, Any, Throwable] =
+        new CheckConstructor[Any, A < S1]:
+            type OutEnvironment = Any
+            type OutError       = Throwable
+            def apply(input: => A < S1)(using Trace): ZIO[OutEnvironment, OutError, TestResult] = run(input)
 
 end KyoSpecAbstract

--- a/kyo-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
+++ b/kyo-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
@@ -24,7 +24,29 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
                 test("Async.delay") {
                     Async.delay(Duration.Infinity)(assertCompletes)
                 } @@ TestAspect.timeout(Duration.Zero.toJava)
-            ) @@ TestAspect.failing
+            ) @@ TestAspect.failing,
+            suite("Gen")(
+                test("check1")(
+                    check(Gen.boolean) { b =>
+                        assertTrue(b == b)
+                    }
+                ),
+                test("check2")(
+                    check(Gen.boolean, Gen.int) { (b, i) =>
+                        assertTrue(b == b && i == i)
+                    }
+                ),
+                test("check3")(
+                    check(Gen.boolean, Gen.int, Gen.string) { (b, i, s) =>
+                        assertTrue(b == b && i == i && s == s)
+                    }
+                ),
+                test("checkKyo")(
+                    check(Gen.boolean) { b =>
+                        IO(assertTrue(b == b))
+                    }
+                )
+            )
         ) @@ TestAspect.timed
 
 end KyoSpecDefaultSpec


### PR DESCRIPTION
- refactor methods to use `TestConstructor`/`CheckConstructor`
- mark `test`/`suite` as final
- mark `run` as protected

/fixes #877 