### PR TITLE
[build] make scala-java-time a regular dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -533,7 +533,7 @@ lazy val readme =
 lazy val `native-settings` = Seq(
     fork                                        := false,
     bspEnabled                                  := false,
-    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.6.0" % "provided"
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.6.0"
 )
 
 lazy val `js-settings` = Seq(
@@ -541,7 +541,7 @@ lazy val `js-settings` = Seq(
     fork                                        := false,
     bspEnabled                                  := false,
     jsEnv                                       := new NodeJSEnv(NodeJSEnv.Config().withArgs(List("--max_old_space_size=5120"))),
-    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.6.0" % "provided"
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.6.0"
 )
 
 def scalacOptionToken(proposedScalacOption: ScalacOption) =


### PR DESCRIPTION
Moving from https://github.com/getkyo/kyo/pull/878/files#r1864504393 to a separate PR. I'm not sure it was marked as `provided` in the first place but it seems to be necessary so Kyo can be used in Native and JS without having to add the `scala-java-time` dependency explicitly.