### PR TITLE
[stm][bench] Ref log optimization + benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -143,7 +143,7 @@ lazy val kyoNative = project
         `kyo-stats-registry`.native,
         `kyo-scheduler`.native,
         `kyo-core`.native,
-        `kyo-direct`.native
+        `kyo-direct`.native,
         `kyo-combinators`.native,
         `kyo-sttp`.native
     )

--- a/build.sbt
+++ b/build.sbt
@@ -143,7 +143,7 @@ lazy val kyoNative = project
         `kyo-stats-registry`.native,
         `kyo-scheduler`.native,
         `kyo-core`.native,
-        `kyo-direct`.native,
+        `kyo-direct`.native
     )
 
 lazy val `kyo-scheduler` =
@@ -453,6 +453,7 @@ lazy val `kyo-bench` =
         .enablePlugins(JmhPlugin)
         .dependsOn(`kyo-core`)
         .dependsOn(`kyo-sttp`)
+        .dependsOn(`kyo-stm`)
         .dependsOn(`kyo-scheduler-zio`)
         .disablePlugins(MimaPlugin)
         .settings(
@@ -480,27 +481,28 @@ lazy val `kyo-bench` =
                     )
                 }
             },
-            libraryDependencies += "dev.zio"             %% "izumi-reflect"       % "2.3.10",
-            libraryDependencies += "org.typelevel"       %% "cats-effect"         % catsVersion,
-            libraryDependencies += "org.typelevel"       %% "log4cats-core"       % "2.7.0",
-            libraryDependencies += "org.typelevel"       %% "log4cats-slf4j"      % "2.7.0",
-            libraryDependencies += "org.typelevel"       %% "cats-mtl"            % "1.5.0",
-            libraryDependencies += "org.typelevel"       %% "cats-mtl"            % "1.5.0",
-            libraryDependencies += "com.47deg"           %% "fetch"               % "3.1.2",
-            libraryDependencies += "dev.zio"             %% "zio-logging"         % "2.4.0",
-            libraryDependencies += "dev.zio"             %% "zio-logging-slf4j2"  % "2.4.0",
-            libraryDependencies += "dev.zio"             %% "zio"                 % zioVersion,
-            libraryDependencies += "dev.zio"             %% "zio-concurrent"      % zioVersion,
-            libraryDependencies += "dev.zio"             %% "zio-query"           % "0.7.6",
-            libraryDependencies += "dev.zio"             %% "zio-prelude"         % "1.0.0-RC35",
-            libraryDependencies += "com.softwaremill.ox" %% "core"                % "0.0.25",
-            libraryDependencies += "co.fs2"              %% "fs2-core"            % "3.11.0",
-            libraryDependencies += "org.http4s"          %% "http4s-ember-client" % "0.23.29",
-            libraryDependencies += "org.http4s"          %% "http4s-dsl"          % "0.23.29",
-            libraryDependencies += "dev.zio"             %% "zio-http"            % "3.0.1",
-            libraryDependencies += "io.vertx"             % "vertx-core"          % "5.0.0.CR2",
-            libraryDependencies += "io.vertx"             % "vertx-web"           % "5.0.0.CR2",
-            libraryDependencies += "org.scalatest"       %% "scalatest"           % scalaTestVersion % Test
+            libraryDependencies += "dev.zio"              %% "izumi-reflect"       % "2.3.10",
+            libraryDependencies += "org.typelevel"        %% "cats-effect"         % catsVersion,
+            libraryDependencies += "org.typelevel"        %% "log4cats-core"       % "2.7.0",
+            libraryDependencies += "org.typelevel"        %% "log4cats-slf4j"      % "2.7.0",
+            libraryDependencies += "org.typelevel"        %% "cats-mtl"            % "1.5.0",
+            libraryDependencies += "org.typelevel"        %% "cats-mtl"            % "1.5.0",
+            libraryDependencies += "io.github.timwspence" %% "cats-stm"            % "0.13.5",
+            libraryDependencies += "com.47deg"            %% "fetch"               % "3.1.2",
+            libraryDependencies += "dev.zio"              %% "zio-logging"         % "2.4.0",
+            libraryDependencies += "dev.zio"              %% "zio-logging-slf4j2"  % "2.4.0",
+            libraryDependencies += "dev.zio"              %% "zio"                 % zioVersion,
+            libraryDependencies += "dev.zio"              %% "zio-concurrent"      % zioVersion,
+            libraryDependencies += "dev.zio"              %% "zio-query"           % "0.7.6",
+            libraryDependencies += "dev.zio"              %% "zio-prelude"         % "1.0.0-RC35",
+            libraryDependencies += "com.softwaremill.ox"  %% "core"                % "0.0.25",
+            libraryDependencies += "co.fs2"               %% "fs2-core"            % "3.11.0",
+            libraryDependencies += "org.http4s"           %% "http4s-ember-client" % "0.23.29",
+            libraryDependencies += "org.http4s"           %% "http4s-dsl"          % "0.23.29",
+            libraryDependencies += "dev.zio"              %% "zio-http"            % "3.0.1",
+            libraryDependencies += "io.vertx"              % "vertx-core"          % "5.0.0.CR2",
+            libraryDependencies += "io.vertx"              % "vertx-web"           % "5.0.0.CR2",
+            libraryDependencies += "org.scalatest"        %% "scalatest"           % scalaTestVersion % Test
         )
 
 lazy val rewriteReadmeFile = taskKey[Unit]("Rewrite README file")

--- a/kyo-bench/src/main/scala/kyo/bench/TMapMultiKeyBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TMapMultiKeyBench.scala
@@ -54,7 +54,7 @@ class TMapMultiKeyBench(parallelism: Int) extends Bench.ForkOnly(parallelism):
         for
             map <- TMap.empty[Int, Int].commit
             _ <-
-                ZIO.collectAllPar(
+                ZIO.collectAllParDiscard(
                     (0 until parallelism).map { i =>
                         STM.atomically {
                             for

--- a/kyo-bench/src/main/scala/kyo/bench/TMapMultiKeyBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TMapMultiKeyBench.scala
@@ -1,0 +1,72 @@
+package kyo.bench
+
+class TMapMultiKeyBench(parallelism: Int) extends Bench.ForkOnly(parallelism):
+
+    def this() = this(Runtime.getRuntime().availableProcessors() * 2)
+
+    def catsBench() =
+        import cats.effect.*
+        import cats.syntax.all.*
+        import io.github.timwspence.cats.stm.*
+
+        STM.runtime[IO].flatMap { stm =>
+            for
+                ref <- stm.commit(stm.TVar.of(Map.empty[Int, Int]))
+                _ <-
+                    (0 until parallelism).map { i =>
+                        stm.commit {
+                            for
+                                map <- ref.get
+                                _   <- ref.set(map.updated(i, map.getOrElse(i, 0) + 1))
+                            yield ()
+                        }
+                    }.toList.parSequence_
+                results <- stm.commit(ref.get.map(_.values.sum))
+            yield results
+        }
+    end catsBench
+
+    override def kyoBenchFiber() =
+        import kyo.*
+
+        for
+            map <- TMap.initNow[Int, Int]()
+            _ <-
+                Async.parallelUnbounded(
+                    (0 until parallelism).map { i =>
+                        STM.run {
+                            for
+                                current <- map.get(i)
+                                _       <- map.put(i, current.getOrElse(0) + 1)
+                            yield ()
+                        }
+                    }
+                )
+            results <- STM.run(map.snapshot)
+        yield results.values.sum
+        end for
+    end kyoBenchFiber
+
+    def zioBench() =
+        import zio.*
+        import zio.stm.*
+
+        for
+            map <- TMap.empty[Int, Int].commit
+            _ <-
+                ZIO.collectAllPar(
+                    (0 until parallelism).map { i =>
+                        STM.atomically {
+                            for
+                                current <- map.get(i)
+                                _       <- map.put(i, current.getOrElse(0) + 1)
+                            yield ()
+                        }
+                    }
+                )
+            results <- map.toMap.commit
+        yield results.values.sum
+        end for
+    end zioBench
+
+end TMapMultiKeyBench

--- a/kyo-bench/src/main/scala/kyo/bench/TMapSingleKeyBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TMapSingleKeyBench.scala
@@ -1,0 +1,70 @@
+package kyo.bench
+
+class TMapSingleKeyBench(parallelism: Int) extends Bench.ForkOnly(parallelism):
+
+    def this() = this(Runtime.getRuntime().availableProcessors() * 2)
+
+    def catsBench() =
+        import cats.effect.*
+        import cats.syntax.all.*
+        import io.github.timwspence.cats.stm.*
+
+        STM.runtime[IO].flatMap { stm =>
+            for
+                ref <- stm.commit(stm.TVar.of(Map.empty[Int, Int]))
+                _ <- Seq.fill(parallelism)(
+                    stm.commit {
+                        for
+                            map <- ref.get
+                            current = map.getOrElse(0, 0)
+                            _ <- ref.set(map.updated(0, current + 1))
+                        yield ()
+                    }
+                ).parSequence_
+                result <- stm.commit(ref.get.map(_.getOrElse(0, 0)))
+            yield result
+        }
+    end catsBench
+
+    override def kyoBenchFiber() =
+        import kyo.*
+
+        for
+            map <- TMap.initNow[Int, Int]()
+            _ <- Async.parallelUnbounded(
+                Seq.fill(parallelism)(
+                    STM.run {
+                        for
+                            current <- map.get(0)
+                            _       <- map.put(0, current.getOrElse(0) + 1)
+                        yield ()
+                    }
+                )
+            )
+            result <- STM.run(map.get(0))
+        yield result.getOrElse(0)
+        end for
+    end kyoBenchFiber
+
+    def zioBench() =
+        import zio.*
+        import zio.stm.*
+
+        for
+            map <- TMap.empty[Int, Int].commit
+            _ <- ZIO.collectAllPar(
+                Seq.fill(parallelism)(
+                    STM.atomically {
+                        for
+                            current <- map.get(0)
+                            _       <- map.put(0, current.getOrElse(0) + 1)
+                        yield ()
+                    }
+                )
+            )
+            result <- map.get(0).commit
+        yield result.getOrElse(0)
+        end for
+    end zioBench
+
+end TMapSingleKeyBench

--- a/kyo-bench/src/main/scala/kyo/bench/TMapSingleKeyBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TMapSingleKeyBench.scala
@@ -52,7 +52,7 @@ class TMapSingleKeyBench(parallelism: Int) extends Bench.ForkOnly(parallelism):
 
         for
             map <- TMap.empty[Int, Int].commit
-            _ <- ZIO.collectAllPar(
+            _ <- ZIO.collectAllParDiscard(
                 Seq.fill(parallelism)(
                     STM.atomically {
                         for

--- a/kyo-bench/src/main/scala/kyo/bench/TRefMultiBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TRefMultiBench.scala
@@ -1,0 +1,46 @@
+package kyo.bench
+
+import java.util.concurrent.locks.LockSupport
+
+class TRefMultiBench(parallelism: Int) extends Bench.ForkOnly(parallelism):
+
+    def this() = this(Runtime.getRuntime().availableProcessors() * 2)
+
+    def catsBench() =
+        import cats.effect.*
+        import cats.syntax.all.*
+        import io.github.timwspence.cats.stm.*
+
+        STM.runtime[IO].flatMap { stm =>
+            for
+                refs <- stm.commit(Seq.fill(parallelism)(stm.TVar.of(0)).sequence)
+                x: Seq[IO[Unit]] = refs.map(ref => stm.commit(ref.modify(_ + 1)))
+                _      <- x.parSequence_
+                result <- stm.commit(refs.traverse(_.get).map(_.sum))
+            yield result
+        }
+    end catsBench
+
+    override def kyoBenchFiber() =
+        import kyo.*
+
+        for
+            refs   <- Kyo.fill(parallelism)(TRef.initNow(0))
+            _      <- Async.parallelUnbounded(refs.map(ref => STM.run(ref.update(_ + 1))))
+            result <- STM.run(Kyo.foreach(refs)(_.get).map(_.sum))
+        yield result
+        end for
+    end kyoBenchFiber
+
+    def zioBench() =
+        import zio.*
+        import zio.stm.*
+
+        for
+            refs   <- ZIO.collectAll(Seq.fill(parallelism)(TRef.make(0).commit))
+            _      <- ZIO.collectAllPar(refs.map(_.update(_ + 1).commit))
+            result <- STM.collectAll(refs.map(_.get)).map(_.sum).commit
+        yield result
+        end for
+    end zioBench
+end TRefMultiBench

--- a/kyo-bench/src/main/scala/kyo/bench/TRefMultiBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TRefMultiBench.scala
@@ -13,7 +13,7 @@ class TRefMultiBench(parallelism: Int) extends Bench.ForkOnly(parallelism):
 
         STM.runtime[IO].flatMap { stm =>
             for
-                refs <- stm.commit(Seq.fill(parallelism)(stm.TVar.of(0)).sequence)
+                refs   <- stm.commit(Seq.fill(parallelism)(stm.TVar.of(0)).sequence)
                 _      <- refs.map(ref => stm.commit(ref.modify(_ + 1))).parSequence_
                 result <- stm.commit(refs.traverse(_.get).map(_.sum))
             yield result

--- a/kyo-bench/src/main/scala/kyo/bench/TRefSingleBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TRefSingleBench.scala
@@ -1,0 +1,47 @@
+package kyo.bench
+
+import java.util.concurrent.locks.LockSupport
+
+class TRefSingleBench(parallelism: Int) extends Bench.ForkOnly(parallelism):
+
+    def this() = this(Runtime.getRuntime().availableProcessors() * 2)
+
+    def catsBench() =
+        import cats.effect.*
+        import cats.syntax.all.*
+        import io.github.timwspence.cats.stm.*
+
+        STM.runtime[IO].flatMap { stm =>
+            for
+                ref <- stm.commit(stm.TVar.of(0))
+                _ <- Seq.fill(parallelism)(
+                    stm.commit(ref.modify(_ + 1))
+                ).parSequence_
+                result <- stm.commit(ref.get)
+            yield result
+        }
+    end catsBench
+
+    override def kyoBenchFiber() =
+        import kyo.*
+
+        for
+            ref    <- TRef.initNow(0)
+            _      <- Async.parallelUnbounded(Seq.fill(parallelism)(STM.run(ref.update(_ + 1))))
+            result <- STM.run(ref.get)
+        yield result
+        end for
+    end kyoBenchFiber
+
+    def zioBench() =
+        import zio.*
+        import zio.stm.*
+
+        for
+            ref    <- TRef.make(0).commit
+            _      <- ZIO.collectAllPar(Seq.fill(parallelism)(ref.update(_ + 1).commit))
+            result <- ref.get.commit
+        yield result
+        end for
+    end zioBench
+end TRefSingleBench

--- a/kyo-bench/src/main/scala/kyo/bench/TRefSingleBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/TRefSingleBench.scala
@@ -39,7 +39,7 @@ class TRefSingleBench(parallelism: Int) extends Bench.ForkOnly(parallelism):
 
         for
             ref    <- TRef.make(0).commit
-            _      <- ZIO.collectAllPar(Seq.fill(parallelism)(ref.update(_ + 1).commit))
+            _      <- ZIO.collectAllParDiscard(Seq.fill(parallelism)(ref.update(_ + 1).commit))
             result <- ref.get.commit
         yield result
         end for

--- a/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
@@ -249,8 +249,8 @@ class ClockTest extends Test:
                 _         <- fiber2.get
                 end       <- stopwatch.elapsed
             yield
-                assert(mid >= 3.millis && mid < 30.millis)
-                assert(end >= 8.millis && end < 50.millis)
+                assert(mid >= 3.millis)
+                assert(end >= 8.millis)
         }
 
         "sleep with zero duration" in run {

--- a/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
@@ -235,7 +235,7 @@ class ClockTest extends Test:
                 fiber     <- clock.sleep(5.millis)
                 _         <- fiber.get
                 elapsed   <- stopwatch.elapsed
-            yield assert(elapsed >= 3.millis && elapsed < 20.millis)
+            yield assert(elapsed >= 3.millis && elapsed < 100.millis)
         }
 
         "multiple sequential sleeps" in run {

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -882,7 +882,7 @@ class FiberTest extends Test:
                     fiber <- Fiber.gather(2)(Seq(
                         latch1.release.andThen(1),
                         latch2.release.andThen(2),
-                        Async.delay(1.millis)(3)
+                        Async.delay(50.millis)(3)
                     ))
                     _      <- latch1.await
                     _      <- latch2.await

--- a/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
@@ -151,7 +151,7 @@ class STMTest extends Test:
                         for
                             _ <- ref.set(2)
                             _ <- Var.set(1)
-                            innerResult <- Var.isolate.update.run {
+                            innerResult <- TRefLog.isolate {
                                 for
                                     _  <- ref.set(3)
                                     _  <- Var.set(2)

--- a/kyo-stm/shared/src/test/scala/kyo/TRefLogTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TRefLogTest.scala
@@ -1,14 +1,14 @@
 package kyo
 
-import kyo.RefLog.*
+import kyo.TRefLog.*
 
-class RefLogTest extends Test:
+class TTRefLogTest extends Test:
 
     given [A, B]: CanEqual[A, B] = CanEqual.derived
 
-    "RefLog" - {
+    "TTRefLog" - {
         "empty" in run {
-            val log = RefLog.empty
+            val log = TRefLog.empty
             assert(log.toSeq.isEmpty)
         }
 
@@ -16,7 +16,7 @@ class RefLogTest extends Test:
             IO {
                 val ref   = new TRefImpl[Int](Write(0, 0))
                 val entry = Write(1, 42)
-                val log   = RefLog.empty.put(ref, entry)
+                val log   = TRefLog.empty.put(ref, entry)
                 assert(log.toSeq.size == 1)
                 assert(log.toSeq.head._1 == ref)
                 assert(log.toSeq.head._2 == entry)
@@ -27,7 +27,7 @@ class RefLogTest extends Test:
             IO {
                 val ref   = new TRefImpl[Int](Write(0, 0))
                 val entry = Write(1, 42)
-                val log   = RefLog.empty.put(ref, entry)
+                val log   = TRefLog.empty.put(ref, entry)
                 assert(log.get(ref) == Maybe(entry))
                 assert(log.get(new TRefImpl[Int](Write(0, 0))).isEmpty)
             }
@@ -40,7 +40,7 @@ class RefLogTest extends Test:
                 val entry1 = Write(1, 42)
                 val entry2 = Read(1, 24)
 
-                val log = RefLog.empty
+                val log = TRefLog.empty
                     .put(ref1, entry1)
                     .put(ref2, entry2)
 
@@ -51,4 +51,4 @@ class RefLogTest extends Test:
             }
         }
     }
-end RefLogTest
+end TTRefLogTest


### PR DESCRIPTION
Introduces an initial set of benchmarks for the STM module and optimizes ref log usage. I was surprised by how well optimized ZIO's STM is :)

[Benchmark results](https://jmh.morethan.io/?source=https://gist.githubusercontent.com/fwbrasil/308dc726e9a4f5913170d7d49f7a2dcf/raw/19d284bd0fff6556f83a408db993d4f814b56a89/jmh-result.json):

![image](https://github.com/user-attachments/assets/bd9de6ea-ef6a-4cdd-bb75-4868df583a26)
