### PR TITLE
[core] add `Signal.Handler` class to install shutdown hook

### DIFF
--- a/kyo-core/js-native/src/main/scala/kyo/internal/SignalPlatformSpecific.scala
+++ b/kyo-core/js-native/src/main/scala/kyo/internal/SignalPlatformSpecific.scala
@@ -1,0 +1,4 @@
+package kyo.internal
+
+private[internal] class SignalPlatformSpecific:
+    val handle: Signal.Handler = Signal.Handler.Noop

--- a/kyo-core/jvm/src/main/scala/kyo/internal/SignalPlatformSpecific.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/internal/SignalPlatformSpecific.scala
@@ -1,0 +1,89 @@
+package kyo.internal
+
+import Signal.Handler
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.util.logging.Logger
+import kyo.Result
+
+/** This class provides a jvm-specific implementation of signal handling. It uses reflection to install signal handlers as they may not be
+  * available on all implementations of the JVM.
+  */
+private[internal] class SignalPlatformSpecific:
+    private val logger = Logger.getLogger("kyo.internal.Signal")
+    val handle: Handler = {
+        for
+            signalClass        <- findClass("sun.misc.Signal")
+            signalHandlerClass <- findClass("sun.misc.SignalHandler")
+            lookup = MethodHandles.lookup()
+            constructorHandle  <- initSignalConstructorMethodHandle(lookup, signalClass)
+            staticMethodHandle <- initHandleStaticMethodHandle(lookup, signalClass, signalHandlerClass)
+        yield SunMisc(signalHandlerClass, constructorHandle, staticMethodHandle)
+    }.fold { error =>
+        logger.warning(
+            s"sun.misc.Signal and sun.misc.SignalHandler are not available on this platform. Defaulting to no-op signal handling implementation. ${error.getFailure}"
+        )
+        Handler.Noop
+    }(identity)
+    end handle
+
+    final class SunMisc(
+        signalHandlerClass: Class[?],
+        constructorMethodHandle: MethodHandle,
+        staticMethodHandle: MethodHandle
+    ) extends Handler:
+        override def apply(signal: String, handle: => Unit): Unit =
+            val invocationHandler =
+                new InvocationHandler:
+                    def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef =
+                        if args.nonEmpty then handle
+                        this
+
+            val proxy = Proxy.newProxyInstance(
+                Signal.getClass.getClassLoader,
+                Array(signalHandlerClass),
+                invocationHandler
+            )
+            try
+                val s = constructorMethodHandle.invoke(signal)
+                staticMethodHandle.invoke(s, proxy)
+            catch
+                case e: Throwable =>
+                    logger.warning(s"Failed to install signal handler for $signal. ${e.getMessage}")
+            end try
+        end apply
+        override def toString = "Signal.Handler.SunMisc"
+    end SunMisc
+
+    private def findClass(name: String): Result[ClassNotFoundException, Class[?]] =
+        Result.catching[ClassNotFoundException](Class.forName(name))
+
+    private def initSignalConstructorMethodHandle(
+        lookup: MethodHandles.Lookup,
+        signalClass: Class[?]
+    ): Result[Exception, MethodHandle] =
+        Result.catching[Exception] {
+            lookup.findConstructor(
+                signalClass,
+                MethodType.methodType(classOf[Unit], classOf[String])
+            )
+        }
+
+    private def initHandleStaticMethodHandle(
+        lookup: MethodHandles.Lookup,
+        signalClass: Class[?],
+        signalHandlerClass: Class[?]
+    ): Result[Exception, MethodHandle] =
+        Result.catching[Exception] {
+            lookup.findStatic(
+                signalClass,
+                "handle",
+                MethodType.methodType(signalHandlerClass, signalClass, signalHandlerClass)
+            )
+        }
+    end initHandleStaticMethodHandle
+end SignalPlatformSpecific

--- a/kyo-core/jvm/src/test/scala/kyo/internal/SignalTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/internal/SignalTest.scala
@@ -1,0 +1,26 @@
+package kyo.internal
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kyo.Test
+import kyo.kernel.Platform
+
+class SignalTest extends Test:
+
+    "handles on signal" in {
+        val wasHandled = new CountDownLatch(1)
+
+        Signal.handle("USR2", wasHandled.countDown())
+
+        val signal = new sun.misc.Signal("USR2")
+        sun.misc.Signal.raise(signal)
+
+        assert(wasHandled.await(100, TimeUnit.MILLISECONDS))
+    }
+
+    "lazy" in {
+        var wasHandled = false
+        Signal.handle("USR2", { wasHandled = true })
+        assert(!wasHandled)
+    }
+end SignalTest

--- a/kyo-core/shared/src/main/scala/kyo/internal/Signal.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/Signal.scala
@@ -1,0 +1,18 @@
+package kyo.internal
+
+/** This class provides a platform-specific implementation of signal handling.
+  */
+private[kyo] object Signal extends SignalPlatformSpecific:
+    /** A handler for signals. */
+    abstract class Handler:
+        def apply(signal: String, handle: => Unit): Unit
+
+    object Handler:
+        /** A no-op handler for signals. Does nothing. */
+        object Noop extends Handler:
+            def apply(signal: String, handle: => Unit): Unit = ()
+
+            override def toString = s"Signal.Handler.Noop"
+        end Noop
+    end Handler
+end Signal


### PR DESCRIPTION
This is step 1 of solving #491. Next, we need a hook to shutdown the scheduler/interrupt tasks.