### PR TITLE
[scheduler] cats-effect integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,6 +88,7 @@ lazy val kyoJVM = project
     .aggregate(
         `kyo-scheduler`.jvm,
         `kyo-scheduler-zio`.jvm,
+        `kyo-scheduler-cats`.jvm,
         `kyo-data`.jvm,
         `kyo-prelude`.jvm,
         `kyo-core`.jvm,
@@ -186,6 +187,22 @@ lazy val `kyo-scheduler-zio` = sbtcrossproject.CrossProject("kyo-scheduler-zio",
         scalacOptions ++= scalacOptionToken(ScalacOptions.source3).value,
         crossScalaVersions := List(scala3Version, scala212Version, scala213Version)
     )
+lazy val `kyo-scheduler-cats` =
+    crossProject(JVMPlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Full)
+        .dependsOn(`kyo-scheduler`)
+        .in(file("kyo-scheduler-cats"))
+        .settings(
+            `kyo-settings`,
+            libraryDependencies += "org.typelevel" %%% "cats-effect" % catsVersion,
+            libraryDependencies += "org.scalatest" %%% "scalatest"   % scalaTestVersion % Test
+        )
+        .jvmSettings(mimaCheck(false))
+        .settings(
+            scalacOptions ++= scalacOptionToken(ScalacOptions.source3).value,
+            crossScalaVersions := List(scala3Version, scala212Version, scala213Version)
+        )
 
 lazy val `kyo-data` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform)
@@ -460,6 +477,7 @@ lazy val `kyo-bench` =
         .dependsOn(`kyo-sttp`)
         .dependsOn(`kyo-stm`)
         .dependsOn(`kyo-scheduler-zio`)
+        .dependsOn(`kyo-scheduler-cats`)
         .disablePlugins(MimaPlugin)
         .settings(
             `kyo-settings`,

--- a/kyo-scheduler-cats/jvm/src/main/scala/kyo/KyoSchedulerIOApp.scala
+++ b/kyo-scheduler-cats/jvm/src/main/scala/kyo/KyoSchedulerIOApp.scala
@@ -1,0 +1,9 @@
+package kyo
+
+import cats.effect.IOApp
+import cats.effect.unsafe.IORuntime
+import cats.effect.unsafe.IORuntime.global
+
+trait KyoSchedulerIOApp extends IOApp {
+    override def runtime = KyoSchedulerIORuntime.global
+}

--- a/kyo-scheduler-cats/jvm/src/main/scala/kyo/KyoSchedulerIORuntime.scala
+++ b/kyo-scheduler-cats/jvm/src/main/scala/kyo/KyoSchedulerIORuntime.scala
@@ -1,0 +1,11 @@
+package kyo
+
+import cats.effect.unsafe.IORuntime
+import cats.effect.unsafe.IORuntime.global
+
+object KyoSchedulerIORuntime {
+    implicit lazy val global: IORuntime = {
+        val exec = kyo.scheduler.Scheduler.get.asExecutionContext
+        IORuntime(exec, exec, IORuntime.global.scheduler, () => (), IORuntime.global.config)
+    }
+}

--- a/kyo-scheduler-cats/jvm/src/test/scala/kyo/KyoSchedulerIOAppTest.scala
+++ b/kyo-scheduler-cats/jvm/src/test/scala/kyo/KyoSchedulerIOAppTest.scala
@@ -1,0 +1,18 @@
+package kyo
+
+import cats.effect.ExitCode
+import cats.effect.IO
+import cats.effect.IOApp
+
+object KyoSchedulerIOAppTest extends KyoSchedulerIOApp {
+
+    override def run(args: List[String]): IO[ExitCode] =
+        IO {
+            if (!Thread.currentThread().getName().contains("kyo")) {
+                println("Not using Kyo Scheduler")
+                ExitCode.Error
+            } else {
+                ExitCode.Success
+            }
+        }
+}

--- a/kyo-scheduler-cats/jvm/src/test/scala/kyo/KyoSchedulerIORuntimeTest.scala
+++ b/kyo-scheduler-cats/jvm/src/test/scala/kyo/KyoSchedulerIORuntimeTest.scala
@@ -1,0 +1,19 @@
+package kyo
+
+import cats.effect.*
+import org.scalatest.freespec.AsyncFreeSpec
+
+class KyoSchedulerIORuntimeTest extends AsyncFreeSpec {
+
+    import KyoSchedulerIORuntime.global
+
+    "compute" in {
+        val thread = IO.cede.map(_ => Thread.currentThread().getName()).unsafeRunSync()
+        assert(thread.contains("kyo"))
+    }
+
+    "blocking" in {
+        val thread = IO.cede.flatMap(_ => IO.blocking(Thread.currentThread().getName())).unsafeRunSync()
+        assert(thread.contains("kyo"))
+    }
+}

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -209,7 +209,7 @@ final class Scheduler(
       *   An Executor that submits Runnables as scheduler tasks
       */
     def asExecutor: Executor =
-        (r: Runnable) => schedule(Task(r.run()))
+        (r: Runnable) => schedule(Task(r))
 
     /** Provides a Scala ExecutionContext interface to the scheduler.
       *

--- a/kyo-scheduler/shared/src/main/scala/kyo/scheduler/Task.scala
+++ b/kyo-scheduler/shared/src/main/scala/kyo/scheduler/Task.scala
@@ -41,6 +41,14 @@ object Task {
     val Preempted: Result = true
     val Done: Result      = false
 
+    def apply(runnable: Runnable): Task =
+        new Task {
+            def run(startMillis: Long, clock: InternalClock) = {
+                runnable.run()
+                Task.Done
+            }
+        }
+
     def apply(r: => Unit): Task =
         apply(r, 0)
 


### PR DESCRIPTION
Benchmark [results](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/fwbrasil/24a082e8f25d6ca29e02e0720948af3c/raw/c2eb9471cf6a730ee8a636cec9d887733dc6ef0e/jmh-result-baseline.json,https://gist.githubusercontent.com/fwbrasil/24a082e8f25d6ca29e02e0720948af3c/raw/c2eb9471cf6a730ee8a636cec9d887733dc6ef0e/jmh-result-candidate.json) are mixed but use in realistic workloads might yield significant improvements, especially in containerized environments given Kyo's adaptive concurrency control.

![image](https://github.com/user-attachments/assets/d9748650-9325-417b-a077-06fd71e11d62)
