### PR TITLE
[data] anchored and jittered schedules

### DIFF
--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -77,10 +77,12 @@ extension [A, S](effect: A < S)
       */
     def repeat(schedule: Schedule)(using Flat[A], Frame): A < (S & Async) =
         Loop(schedule) { schedule =>
-            schedule.next.map { (delay, nextSchedule) =>
-                effect.delayed(delay).andThen(Loop.continue(nextSchedule))
-            }.getOrElse {
-                effect.map(Loop.done)
+            Clock.now.map { now =>
+                schedule.next(now).map { (delay, nextSchedule) =>
+                    effect.delayed(delay).andThen(Loop.continue(nextSchedule))
+                }.getOrElse {
+                    effect.map(Loop.done)
+                }
             }
         }
 

--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -76,12 +76,14 @@ extension [A, S](effect: A < S)
       *   A computation that produces the result of the last execution
       */
     def repeat(schedule: Schedule)(using Flat[A], Frame): A < (S & Async) =
-        Loop(schedule) { schedule =>
-            Clock.now.map { now =>
-                schedule.next(now).map { (delay, nextSchedule) =>
-                    effect.delayed(delay).andThen(Loop.continue(nextSchedule))
-                }.getOrElse {
-                    effect.map(Loop.done)
+        Clock.use { clock =>
+            Loop(schedule) { schedule =>
+                clock.now.map { now =>
+                    schedule.next(now).map { (delay, nextSchedule) =>
+                        effect.delayed(delay).andThen(Loop.continue(nextSchedule))
+                    }.getOrElse {
+                        effect.map(Loop.done)
+                    }
                 }
             }
         }

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -401,7 +401,7 @@ object Clock:
         Async.run {
             Clock.use { clock =>
                 Loop(state, delaySchedule) { (state, schedule) =>
-                    Clock.now.map { now =>
+                    clock.now.map { now =>
                         schedule.next(now) match
                             case Absent => Loop.done(state)
                             case Present((duration, nextSchedule)) =>
@@ -504,7 +504,7 @@ object Clock:
             Clock.use { clock =>
                 clock.now.map { now =>
                     Loop(now, state, intervalSchedule) { (lastExecution, state, period) =>
-                        Clock.now.map { now =>
+                        clock.now.map { now =>
                             period.next(now) match
                                 case Absent => Loop.done(state)
                                 case Present((duration, nextSchedule)) =>

--- a/kyo-core/shared/src/main/scala/kyo/Retry.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Retry.scala
@@ -29,10 +29,12 @@ object Retry:
         ): A < (Async & Abort[E] & S) =
             Loop(schedule) { schedule =>
                 Abort.run[E](v).map(_.fold { r =>
-                    schedule.next.map { (delay, nextSchedule) =>
-                        Async.delay(delay)(Loop.continue(nextSchedule))
-                    }.getOrElse {
-                        Abort.get(r)
+                    Clock.now.map { now =>
+                        schedule.next(now).map { (delay, nextSchedule) =>
+                            Async.delay(delay)(Loop.continue(nextSchedule))
+                        }.getOrElse {
+                            Abort.get(r)
+                        }
                     }
                 }(Loop.done(_)))
             }

--- a/kyo-core/shared/src/main/scala/kyo/Retry.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Retry.scala
@@ -7,10 +7,25 @@ import scala.util.*
 object Retry:
 
     /** The default retry schedule. */
-    val defaultSchedule = Schedule.exponentialBackoff(initial = 100.millis, factor = 2, maxBackoff = 5.seconds).take(3)
+    val defaultSchedule =
+        Schedule.exponentialBackoff(initial = 100.millis, factor = 2, maxBackoff = 5.seconds)
+            .jitter(0.2).take(3)
 
     /** Provides retry operations for a specific error type. */
     final class RetryOps[E >: Nothing](dummy: Unit) extends AnyVal:
+
+        /** Retries an operation using the default retry schedule.
+          *
+          * Uses [[defaultSchedule]] which implements exponential backoff with jitter. See [[defaultSchedule]] for the specific
+          * configuration.
+          *
+          * @param v
+          *   The operation to retry
+          * @return
+          *   The result of the operation, or an abort if all retries fail
+          */
+        def apply[A: Flat, S](v: => A < (Abort[E] & S))(using SafeClassTag[E], Frame): A < (Async & Abort[E] & S) =
+            apply(defaultSchedule)(v)
 
         /** Retries an operation using a custom policy builder.
           *
@@ -24,7 +39,6 @@ object Retry:
         def apply[A: Flat, S](schedule: Schedule)(v: => A < (Abort[E] & S))(
             using
             SafeClassTag[E],
-            Tag[E],
             Frame
         ): A < (Async & Abort[E] & S) =
             Loop(schedule) { schedule =>

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -719,7 +719,7 @@ class AsyncTest extends Test:
                         yield v,
                         for
                             _ <- Var.set(2)
-                            _ <- Async.sleep(2.millis)
+                            _ <- Async.sleep(50.millis)
                             v <- Var.get[Int]
                         yield v
                     )

--- a/kyo-core/shared/src/test/scala/kyo/RetryTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/RetryTest.scala
@@ -62,4 +62,28 @@ class RetryTest extends Test:
             assert(v.isFail && calls == 5 && (java.lang.System.currentTimeMillis() - start) >= 15)
         }
     }
+
+    "default schedule" - {
+        "succeeds immediately without retries" in run {
+            var calls = 0
+            Retry[Any] {
+                calls += 1
+                42
+            }.map { v =>
+                assert(v == 42 && calls == 1)
+            }
+        }
+
+        "retries up to max attempts" in run {
+            var calls = 0
+            Abort.run[Exception] {
+                Retry[Exception] {
+                    calls += 1
+                    throw ex
+                }
+            }.map { v =>
+                assert(v.isFail && calls == 4)
+            }
+        }
+    }
 end RetryTest

--- a/kyo-data/shared/src/test/scala/kyo/ScheduleTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ScheduleTest.scala
@@ -2,17 +2,19 @@ package kyo
 
 class ScheduleTest extends Test:
 
+    val now = Instant.fromJava(java.time.Instant.EPOCH)
+
     "fixed" - {
         "returns correct next duration and same schedule" in {
             val interval             = 5.seconds
             val schedule             = Schedule.fixed(interval)
-            val (next, nextSchedule) = schedule.next.get
+            val (next, nextSchedule) = schedule.next(now).get
             assert(next == interval)
             assert(nextSchedule == schedule)
         }
 
         "works with zero interval" in {
-            val (next, _) = Schedule.fixed(Duration.Zero).next.get
+            val (next, _) = Schedule.fixed(Duration.Zero).next(now).get
             assert(next == Duration.Zero)
         }
     }
@@ -20,32 +22,32 @@ class ScheduleTest extends Test:
     "exponential" - {
         "increases interval exponentially" in {
             val schedule           = Schedule.exponential(1.second, 2.0)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, _)         = schedule2.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, _)         = schedule2.next(now).get
             assert(next1 == 1.second)
             assert(next2 == 2.seconds)
         }
 
         "works with factor less than 1" in {
             val schedule           = Schedule.exponential(1.second, 0.5)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, _)         = schedule2.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, _)         = schedule2.next(now).get
             assert(next1 == 1.second)
             assert(next2 == 500.millis)
         }
 
         "handles very large intervals" in {
             val schedule           = Schedule.exponential(365.days, 2.0)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, _)         = schedule2.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, _)         = schedule2.next(now).get
             assert(next1 == 365.days)
             assert(next2 == 730.days)
         }
 
         "works with factor of 1" in {
             val schedule           = Schedule.exponential(1.second, 1.0)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, _)         = schedule2.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, _)         = schedule2.next(now).get
             assert(next1 == 1.second)
             assert(next2 == 1.second)
         }
@@ -54,9 +56,9 @@ class ScheduleTest extends Test:
     "fibonacci" - {
         "follows fibonacci sequence" in {
             val schedule           = Schedule.fibonacci(1.second, 1.second)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, schedule3) = schedule2.next.get
-            val (next3, _)         = schedule3.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, schedule3) = schedule2.next(now).get
+            val (next3, _)         = schedule3.next(now).get
             assert(next1 == 1.second)
             assert(next2 == 1.second)
             assert(next3 == 2.seconds)
@@ -64,9 +66,9 @@ class ScheduleTest extends Test:
 
         "works with different initial values" in {
             val schedule           = Schedule.fibonacci(1.second, 2.seconds)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, schedule3) = schedule2.next.get
-            val (next3, _)         = schedule3.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, schedule3) = schedule2.next(now).get
+            val (next3, _)         = schedule3.next(now).get
             assert(next1 == 1.second)
             assert(next2 == 2.seconds)
             assert(next3 == 3.seconds)
@@ -74,9 +76,9 @@ class ScheduleTest extends Test:
 
         "works with zero initial values" in {
             val schedule           = Schedule.fibonacci(Duration.Zero, Duration.Zero)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, schedule3) = schedule2.next.get
-            val (next3, _)         = schedule3.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, schedule3) = schedule2.next(now).get
+            val (next3, _)         = schedule3.next(now).get
             assert(next1 == Duration.Zero)
             assert(next2 == Duration.Zero)
             assert(next3 == Duration.Zero)
@@ -85,19 +87,19 @@ class ScheduleTest extends Test:
 
     "immediate" - {
         "returns zero duration" in {
-            val (next, nextSchedule) = Schedule.immediate.next.get
+            val (next, nextSchedule) = Schedule.immediate.next(now).get
             assert(next == Duration.Zero)
             assert(nextSchedule == Schedule.done)
         }
 
         "always returns never as next schedule" in {
-            assert(Schedule.immediate.next.flatMap(_._2.next).isEmpty)
+            assert(Schedule.immediate.next(now).flatMap(_._2.next(now)).isEmpty)
         }
     }
 
     "never" - {
         "always returns infinite duration" in {
-            assert(Schedule.never.next.isEmpty)
+            assert(Schedule.never.next(now).isEmpty)
         }
     }
 
@@ -107,9 +109,9 @@ class ScheduleTest extends Test:
             val factor             = 2.0
             val maxDelay           = 4.seconds
             val schedule           = Schedule.exponentialBackoff(initial, factor, maxDelay)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, schedule3) = schedule2.next.get
-            val (next3, _)         = schedule3.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, schedule3) = schedule2.next(now).get
+            val (next3, _)         = schedule3.next(now).get
             assert(next1 == 1.second)
             assert(next2 == 2.seconds)
             assert(next3 == 4.seconds)
@@ -122,7 +124,7 @@ class ScheduleTest extends Test:
             val schedule = Schedule.exponentialBackoff(initial, factor, maxDelay)
             var current  = schedule
             for _ <- 1 to 5 do
-                val (nextDuration, nextSchedule) = current.next.get
+                val (nextDuration, nextSchedule) = current.next(now).get
                 assert(nextDuration <= maxDelay)
                 current = nextSchedule
             end for
@@ -134,8 +136,8 @@ class ScheduleTest extends Test:
             val factor             = 0.5
             val maxDelay           = 4.seconds
             val schedule           = Schedule.exponentialBackoff(initial, factor, maxDelay)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, _)         = schedule2.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, _)         = schedule2.next(now).get
             assert(next1 == 4.seconds)
             assert(next2 == 2.seconds)
         }
@@ -144,10 +146,10 @@ class ScheduleTest extends Test:
     "repeat" - {
         "repeats specified number of times" in {
             val schedule           = Schedule.repeat(3)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, schedule3) = schedule2.next.get
-            val (next3, schedule4) = schedule3.next.get
-            val next4              = schedule4.next
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, schedule3) = schedule2.next(now).get
+            val (next3, schedule4) = schedule3.next(now).get
+            val next4              = schedule4.next(now)
             assert(next1 == Duration.Zero)
             assert(next2 == Duration.Zero)
             assert(next3 == Duration.Zero)
@@ -156,25 +158,25 @@ class ScheduleTest extends Test:
 
         "works with zero repetitions" in {
             val schedule = Schedule.repeat(0)
-            assert(schedule.next.isEmpty)
+            assert(schedule.next(now).isEmpty)
         }
 
         "works with finite inner schedule" in {
             val innerSchedule = Schedule.fixed(1.second).take(2)
             val s             = innerSchedule.repeat(3)
             val results = List.unfold(s) { schedule =>
-                schedule.next.map((next, newSchedule) => Some((next, newSchedule))).getOrElse(None)
+                schedule.next(now).map((next, newSchedule) => Some((next, newSchedule))).getOrElse(None)
             }
             assert(results == List(1.second, 1.second, 1.second, 1.second, 1.second, 1.second))
         }
 
         "repeats correct number of times with complex inner schedule" in {
             val s           = Schedule.immediate.andThen(Schedule.fixed(1.second).take(1)).repeat(2)
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val (next3, s4) = s3.next.get
-            val (next4, s5) = s4.next.get
-            val next5       = s5.next
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val (next3, s4) = s3.next(now).get
+            val (next4, s5) = s4.next(now).get
+            val next5       = s5.next(now)
             assert(next1 == Duration.Zero)
             assert(next2 == 1.second)
             assert(next3 == Duration.Zero)
@@ -185,10 +187,10 @@ class ScheduleTest extends Test:
         "Schedule.repeat" - {
             "repeats immediate schedule specified number of times" in {
                 val s           = Schedule.repeat(3)
-                val (next1, s2) = s.next.get
-                val (next2, s3) = s2.next.get
-                val (next3, s4) = s3.next.get
-                val next4       = s4.next
+                val (next1, s2) = s.next(now).get
+                val (next2, s3) = s2.next(now).get
+                val (next3, s4) = s3.next(now).get
+                val next4       = s4.next(now)
 
                 assert(next1 == Duration.Zero)
                 assert(next2 == Duration.Zero)
@@ -197,15 +199,15 @@ class ScheduleTest extends Test:
             }
 
             "works with zero repetitions" in {
-                assert(Schedule.repeat(0).next.isEmpty)
+                assert(Schedule.repeat(0).next(now).isEmpty)
             }
 
             "can be chained with other schedules" in {
                 val s           = Schedule.repeat(2).andThen(Schedule.fixed(1.second))
-                val (next1, s2) = s.next.get
-                val (next2, s3) = s2.next.get
-                val (next3, s4) = s3.next.get
-                val (next4, _)  = s4.next.get
+                val (next1, s2) = s.next(now).get
+                val (next2, s3) = s2.next(now).get
+                val (next3, s4) = s3.next(now).get
+                val (next4, _)  = s4.next(now).get
 
                 assert(next1 == Duration.Zero)
                 assert(next2 == Duration.Zero)
@@ -220,9 +222,9 @@ class ScheduleTest extends Test:
         "increases interval linearly" in {
             val base               = 1.second
             val schedule           = Schedule.linear(base)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, schedule3) = schedule2.next.get
-            val (next3, _)         = schedule3.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, schedule3) = schedule2.next(now).get
+            val (next3, _)         = schedule3.next(now).get
             assert(next1 == 1.second)
             assert(next2 == 2.seconds)
             assert(next3 == 4.seconds)
@@ -230,8 +232,8 @@ class ScheduleTest extends Test:
 
         "works with zero base" in {
             val schedule           = Schedule.linear(Duration.Zero)
-            val (next1, schedule2) = schedule.next.get
-            val (next2, _)         = schedule2.next.get
+            val (next1, schedule2) = schedule.next(now).get
+            val (next2, _)         = schedule2.next(now).get
             assert(next1 == Duration.Zero)
             assert(next2 == Duration.Zero)
         }
@@ -242,19 +244,19 @@ class ScheduleTest extends Test:
             val s1        = Schedule.fixed(1.second)
             val s2        = Schedule.fixed(2.seconds)
             val combined  = s1.max(s2)
-            val (next, _) = combined.next.get
+            val (next, _) = combined.next(now).get
             assert(next == 2.seconds)
         }
 
         "handles one schedule being never" in {
             val s1 = Schedule.fixed(1.second)
             val s2 = Schedule.never
-            assert(s1.max(s2).next.isEmpty)
+            assert(s1.max(s2).next(now).isEmpty)
         }
 
         "handles both schedules being never" in {
             val combined = Schedule.never.max(Schedule.never)
-            assert(combined.next.isEmpty)
+            assert(combined.next(now).isEmpty)
         }
     }
 
@@ -263,7 +265,7 @@ class ScheduleTest extends Test:
             val s1        = Schedule.fixed(1.second)
             val s2        = Schedule.fixed(2.seconds)
             val combined  = s1.min(s2)
-            val (next, _) = combined.next.get
+            val (next, _) = combined.next(now).get
             assert(next == 1.second)
         }
 
@@ -271,13 +273,13 @@ class ScheduleTest extends Test:
             val s1        = Schedule.fixed(1.second)
             val s2        = Schedule.immediate
             val combined  = s1.min(s2)
-            val (next, _) = combined.next.get
+            val (next, _) = combined.next(now).get
             assert(next == Duration.Zero)
         }
 
         "handles both schedules being immediate" in {
             val combined  = Schedule.immediate.min(Schedule.immediate)
-            val (next, _) = combined.next.get
+            val (next, _) = combined.next(now).get
             assert(next == Duration.Zero)
         }
     }
@@ -285,9 +287,9 @@ class ScheduleTest extends Test:
     "take" - {
         "limits number of executions" in {
             val s           = Schedule.fixed(1.second).take(2)
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val next3       = s3.next
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val next3       = s3.next(now)
             assert(next1 == 1.second)
             assert(next2 == 1.second)
             assert(next3.isEmpty)
@@ -304,9 +306,9 @@ class ScheduleTest extends Test:
             val s1          = Schedule.repeat(2)
             val s2          = Schedule.fixed(1.second)
             val combined    = s1.andThen(s2)
-            val (next1, c2) = combined.next.get
-            val (next2, c3) = c2.next.get
-            val (next3, _)  = c3.next.get
+            val (next1, c2) = combined.next(now).get
+            val (next2, c3) = c2.next(now).get
+            val (next3, _)  = c3.next(now).get
             assert(next1 == Duration.Zero)
             assert(next2 == Duration.Zero)
             assert(next3 == 1.second)
@@ -316,25 +318,25 @@ class ScheduleTest extends Test:
             val s1       = Schedule.never
             val s2       = Schedule.fixed(1.second)
             val combined = s1.andThen(s2)
-            assert(combined.next.isEmpty)
+            assert(combined.next(now).isEmpty)
         }
 
         "works with never as second schedule" in {
             val s1          = Schedule.immediate
             val s2          = Schedule.never
             val combined    = s1.andThen(s2)
-            val (next1, c2) = combined.next.get
-            val next2       = c2.next
+            val (next1, c2) = combined.next(now).get
+            val next2       = c2.next(now)
             assert(next1 == Duration.Zero)
             assert(next2.isEmpty)
         }
 
         "chains multiple schedules" in {
             val s           = Schedule.immediate.andThen(Schedule.fixed(1.second).take(1)).andThen(Schedule.fixed(2.seconds).take(1))
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val (next3, s4) = s3.next.get
-            val next4       = s4.next
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val (next3, s4) = s3.next(now).get
+            val next4       = s4.next(now)
             assert(next1 == Duration.Zero)
             assert(next2 == 1.second)
             assert(next3 == 2.seconds)
@@ -345,9 +347,9 @@ class ScheduleTest extends Test:
     "maxDuration" - {
         "stops after specified duration" in {
             val s           = Schedule.fixed(1.second).maxDuration(2.seconds + 500.millis)
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val next3       = s3.next
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val next3       = s3.next(now)
             assert(next1 == 1.second)
             assert(next2 == 1.second)
             assert(next3.isEmpty)
@@ -355,23 +357,23 @@ class ScheduleTest extends Test:
 
         "works with zero duration" in {
             val s = Schedule.fixed(1.second).maxDuration(Duration.Zero)
-            assert(s.next.isEmpty)
+            assert(s.next(now).isEmpty)
         }
 
         "works with complex schedule" in {
             val s = Schedule.exponential(1.second, 2.0).repeat(5).maxDuration(7.seconds)
             val results = List.unfold(s) { schedule =>
-                schedule.next.map((next, newSchedule) => Some((next, newSchedule))).getOrElse(None)
+                schedule.next(now).map((next, newSchedule) => Some((next, newSchedule))).getOrElse(None)
             }
             assert(results == List(1.second, 2.seconds, 4.seconds))
         }
 
         "limits duration correctly with delayed start" in {
             val s           = Schedule.fixed(2.seconds).take(1).andThen(Schedule.linear(1.second)).maxDuration(5.seconds)
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val (next3, s4) = s3.next.get
-            val next4       = s4.next
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val (next3, s4) = s3.next(now).get
+            val next4       = s4.next(now)
             assert(next1 == 2.seconds)
             assert(next2 == 1.second)
             assert(next3 == 2.seconds)
@@ -382,31 +384,31 @@ class ScheduleTest extends Test:
     "forever" - {
         "repeats indefinitely" in {
             val s           = Schedule.repeat(1).forever
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val (next3, _)  = s3.next.get
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val (next3, _)  = s3.next(now).get
             assert(next1 == Duration.Zero)
             assert(next2 == Duration.Zero)
             assert(next3 == Duration.Zero)
         }
 
         "works with never schedule" in {
-            assert(Schedule.never.forever.next.isEmpty)
+            assert(Schedule.never.forever.next(now).isEmpty)
         }
 
         "works with immediate schedule" in {
             val s           = Schedule.immediate.forever
-            val (next1, s2) = s.next.get
-            val (next2, _)  = s2.next.get
+            val (next1, s2) = s.next(now).get
+            val (next2, _)  = s2.next(now).get
             assert(next1 == Duration.Zero)
             assert(next2 == Duration.Zero)
         }
 
         "works with fixed schedule" in {
             val s           = Schedule.fixed(1.second).forever
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val (next3, _)  = s3.next.get
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val (next3, _)  = s3.next(now).get
             assert(next1 == 1.second)
             assert(next2 == 1.second)
             assert(next3 == 1.second)
@@ -414,9 +416,9 @@ class ScheduleTest extends Test:
 
         "works with exponential schedule" in {
             val s           = Schedule.exponential(1.second, 2.0).forever
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val (next3, _)  = s3.next.get
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val (next3, _)  = s3.next(now).get
             assert(next1 == 1.second)
             assert(next2 == 2.seconds)
             assert(next3 == 4.seconds)
@@ -424,10 +426,10 @@ class ScheduleTest extends Test:
 
         "works with complex schedule" in {
             val s           = (Schedule.immediate.andThen(Schedule.fixed(1.second).take(1))).forever
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val (next3, s4) = s3.next.get
-            val (next4, _)  = s4.next.get
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val (next3, s4) = s3.next(now).get
+            val (next4, _)  = s4.next(now).get
             assert(next1 == Duration.Zero)
             assert(next2 == 1.second)
             assert(next3 == Duration.Zero)
@@ -440,8 +442,8 @@ class ScheduleTest extends Test:
             val original = Schedule.fixed(1.second)
             val delayed  = original.delay(500.millis)
 
-            val (next1, s2) = delayed.next.get
-            val (next2, _)  = s2.next.get
+            val (next1, s2) = delayed.next(now).get
+            val (next2, _)  = s2.next(now).get
 
             assert(next1 == 1500.millis)
             assert(next2 == 1500.millis)
@@ -451,7 +453,7 @@ class ScheduleTest extends Test:
             val original = Schedule.fixed(1.second)
             val delayed  = original.delay(Duration.Zero)
 
-            val (next, _) = delayed.next.get
+            val (next, _) = delayed.next(now).get
 
             assert(next == 1.second)
         }
@@ -459,8 +461,8 @@ class ScheduleTest extends Test:
         "works with immediate schedule" in {
             val delayed = Schedule.immediate.delay(1.second)
 
-            val (next1, s1) = delayed.next.get
-            val next2       = s1.next
+            val (next1, s1) = delayed.next(now).get
+            val next2       = s1.next(now)
 
             assert(next1 == 1.second)
             assert(next2.isEmpty)
@@ -468,17 +470,17 @@ class ScheduleTest extends Test:
 
         "works with never schedule" in {
             val delayed = Schedule.never.delay(1.second)
-            assert(delayed.next.isEmpty)
+            assert(delayed.next(now).isEmpty)
         }
 
         "works with complex schedule" in {
             val original = Schedule.exponential(1.second, 2.0).take(3)
             val delayed  = original.delay(500.millis)
 
-            val (next1, s2) = delayed.next.get
-            val (next2, s3) = s2.next.get
-            val (next3, s4) = s3.next.get
-            val next4       = s4.next
+            val (next1, s2) = delayed.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val (next3, s4) = s3.next(now).get
+            val next4       = s4.next(now)
 
             assert(next1 == 1500.millis)
             assert(next2 == 2500.millis)
@@ -489,8 +491,8 @@ class ScheduleTest extends Test:
         "Schedule.delay" - {
             "creates a delayed immediate schedule" in {
                 val s           = Schedule.delay(1.second)
-                val (next1, s2) = s.next.get
-                val next2       = s2.next
+                val (next1, s2) = s.next(now).get
+                val next2       = s2.next(now)
 
                 assert(next1 == 1.second)
                 assert(next2.isEmpty)
@@ -498,15 +500,15 @@ class ScheduleTest extends Test:
 
             "works with zero delay" in {
                 val s         = Schedule.delay(Duration.Zero)
-                val (next, _) = s.next.get
+                val (next, _) = s.next(now).get
 
                 assert(next == Duration.Zero)
             }
 
             "can be chained with other schedules" in {
                 val s           = Schedule.delay(500.millis).andThen(Schedule.fixed(1.second))
-                val (next1, s2) = s.next.get
-                val (next2, _)  = s2.next.get
+                val (next1, s2) = s.next(now).get
+                val (next2, _)  = s2.next(now).get
 
                 assert(next1 == 500.millis)
                 assert(next2 == 1.second)
@@ -517,11 +519,11 @@ class ScheduleTest extends Test:
                 val s2       = Schedule.exponential(2.seconds, 2.0).take(2)
                 val combined = s1.andThen(Schedule.delay(3.seconds)).andThen(s2)
 
-                val (next1, c2) = combined.next.get
-                val (next2, c3) = c2.next.get
-                val (next3, c4) = c3.next.get
-                val (next4, c5) = c4.next.get
-                val (next5, _)  = c5.next.get
+                val (next1, c2) = combined.next(now).get
+                val (next2, c3) = c2.next(now).get
+                val (next3, c4) = c3.next(now).get
+                val (next4, c5) = c4.next(now).get
+                val (next5, _)  = c5.next(now).get
 
                 assert(next1 == 1.second)
                 assert(next2 == 1.second)
@@ -539,8 +541,8 @@ class ScheduleTest extends Test:
             val s3       = Schedule.fixed(3.seconds)
             val combined = s1.max(s2).min(s3)
 
-            val (next1, c2) = combined.next.get
-            val (next2, _)  = c2.next.get
+            val (next1, c2) = combined.next(now).get
+            val (next2, _)  = c2.next(now).get
 
             assert(next1 == 2.seconds)
             assert(next2 == 2.seconds)
@@ -549,9 +551,9 @@ class ScheduleTest extends Test:
         "limits a forever schedule" in {
             val s = Schedule.exponential(1.second, 2.0).forever.maxDuration(5.seconds)
 
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val next3       = s3.next
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val next3       = s3.next(now)
 
             assert(next1 == 1.second)
             assert(next2 == 2.seconds)
@@ -561,11 +563,11 @@ class ScheduleTest extends Test:
         "combines repeat with exponential backoff" in {
             val s = Schedule.repeat(3).andThen(Schedule.exponentialBackoff(1.second, 2.0, 8.seconds))
 
-            val (next1, s2) = s.next.get
-            val (next2, s3) = s2.next.get
-            val (next3, s4) = s3.next.get
-            val (next4, s5) = s4.next.get
-            val (next5, _)  = s5.next.get
+            val (next1, s2) = s.next(now).get
+            val (next2, s3) = s2.next(now).get
+            val (next3, s4) = s3.next(now).get
+            val (next4, s5) = s4.next(now).get
+            val (next5, _)  = s5.next(now).get
 
             assert(next1 == Duration.Zero)
             assert(next2 == Duration.Zero)
@@ -829,6 +831,366 @@ class ScheduleTest extends Test:
         "correctly represents schedules with delay" in {
             val s1 = Schedule.fixed(1.second).delay(500.millis)
             assert(s1.show == s"(Schedule.fixed(${1.second.show})).delay(${500.millis.show})")
+        }
+    }
+
+    "anchored" - {
+        "anchored" - {
+            "basic behavior" - {
+                "creates schedule with specified period" in {
+                    val s         = Schedule.anchored(1.hour)
+                    val (next, _) = s.next(now).get
+                    assert(next == 1.hour)
+                }
+
+                "handles zero period" in {
+                    val s = Schedule.anchored(Duration.Zero)
+                    assert(s == Schedule.immediate)
+                }
+            }
+
+            "offset handling" - {
+                "applies offset for first execution" in {
+                    val s         = Schedule.anchored(1.day, 2.hours)                // "daily at 2am"
+                    val start     = Instant.parse("2024-01-01T00:00:00Z").getOrThrow // midnight
+                    val (next, _) = s.next(start).get
+                    assert(next == 2.hours) // should wait 2 hours for first execution
+                }
+
+                "skips to next period if offset already passed" in {
+                    val s         = Schedule.anchored(1.day, 2.hours)                // "daily at 2am"
+                    val start     = Instant.parse("2024-01-01T03:00:00Z").getOrThrow // 3am
+                    val (next, _) = s.next(start).get
+                    assert(next == 23.hours) // should wait until 2am tomorrow
+                }
+
+                "handles zero offset" in {
+                    val s         = Schedule.anchored(1.hour, Duration.Zero)
+                    val (next, _) = s.next(now).get
+                    assert(next == 1.hour)
+                }
+            }
+
+            "time alignment" - {
+                "maintains wall clock alignment across multiple periods" in {
+                    val s     = Schedule.anchored(1.day, 2.hours) // "daily at 2am"
+                    val start = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+
+                    val (next1, s2) = s.next(start).get                  // first execution at 2am
+                    val (next2, s3) = s2.next(start + next1).get         // second at 2am tomorrow
+                    val (next3, _)  = s3.next(start + next1 + next2).get // third at 2am day after
+
+                    assert(next1 == 2.hours)
+                    assert(next2 == 24.hours)
+                    assert(next3 == 24.hours)
+                }
+
+                "aligns to consistent boundaries with short periods" in {
+                    val s     = Schedule.anchored(15.minutes, 5.minutes) // "every 15 min, offset by 5"
+                    val start = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+
+                    val (next1, s2) = s.next(start).get                  // XX:05
+                    val (next2, s3) = s2.next(start + next1).get         // XX:20
+                    val (next3, _)  = s3.next(start + next1 + next2).get // XX:35
+
+                    assert(next1 == 5.minutes)
+                    assert(next2 == 15.minutes)
+                    assert(next3 == 15.minutes)
+                }
+            }
+
+            "handling delays and missed periods" - {
+                "catches up immediately after missing one period" in {
+                    val s       = Schedule.anchored(1.hour) // hourly on the hour
+                    val start   = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+                    val delayed = start + 70.minutes        // 1:10, missed the 1:00 execution
+
+                    val (next, _) = s.next(delayed).get
+                    assert(next == 50.minutes) // should wait until 2:00
+                }
+
+                "skips multiple missed periods" in {
+                    val s       = Schedule.anchored(1.hour)
+                    val start   = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+                    val delayed = start + 4.hours + 20.minutes // 4:20, missed several executions
+
+                    val (next, _) = s.next(delayed).get
+                    assert(next == 40.minutes) // should wait until 5:00
+                }
+
+                "handles very long delays" in {
+                    val s       = Schedule.anchored(1.day, 2.hours) // daily at 2am
+                    val start   = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+                    val delayed = start + 30.days + 12.hours        // noon on Jan 31
+
+                    val (next, _) = s.next(delayed).get
+                    assert(next == 14.hours) // should wait until 2am Feb 1
+                }
+            }
+
+            "boundary conditions" - {
+                "handles epoch boundary" in {
+                    val s         = Schedule.anchored(1.hour, 30.minutes)
+                    val epochTime = Instant.Epoch
+                    val (next, _) = s.next(epochTime).get
+                    assert(next == 30.minutes)
+                }
+
+                "handles pre-epoch time" in {
+                    val s         = Schedule.anchored(1.hour)
+                    val start     = Instant.Epoch - 2.hours
+                    val (next, _) = s.next(start).get
+                    assert(next == 1.hour)
+                }
+            }
+
+            "high frequency scenarios" - {
+                "handles microsecond-level periods" in {
+                    val s         = Schedule.anchored(1.micro)
+                    val start     = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+                    val (next, _) = s.next(start).get
+                    assert(next <= 1.micro)
+                }
+
+                "maintains precision with high-frequency offsets" in {
+                    val s           = Schedule.anchored(1.milli, 100.micros)
+                    val start       = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+                    val (next1, s2) = s.next(start).get
+                    val (next2, _)  = s2.next(start + next1).get
+
+                    assert(next1 <= 1.milli)
+                    assert(next2 == 1.milli)
+                }
+            }
+
+            "composition with other combinators" - {
+                "works with take" in {
+                    val s     = Schedule.anchored(1.hour).take(2)
+                    val start = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+
+                    val (next1, s2) = s.next(start).get
+                    val (next2, s3) = s2.next(start + next1).get
+                    val next3       = s3.next(start + next1 + next2)
+
+                    assert(next1 == 1.hour)
+                    assert(next2 == 1.hour)
+                    assert(next3.isEmpty)
+                }
+
+                "works with forever" in {
+                    val s     = Schedule.anchored(1.hour).forever
+                    val start = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+
+                    val (next1, s2) = s.next(start).get
+                    val (next2, _)  = s2.next(start + next1).get
+
+                    assert(next1 == 1.hour)
+                    assert(next2 == 1.hour)
+                }
+
+                "can be chained with andThen" in {
+                    val s = Schedule.anchored(1.hour, 15.minutes).take(2)
+                        .andThen(Schedule.anchored(1.hour, 45.minutes))
+                    val start = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+
+                    val (next1, s2) = s.next(start).get                  // XX:15
+                    val (next2, s3) = s2.next(start + next1).get         // XX:15
+                    val (next3, _)  = s3.next(start + next1 + next2).get // XX:45
+
+                    assert(next1 == 15.minutes)
+                    assert(next2 == 1.hour)
+                    assert(next3 == 30.minutes) // adjusts to new offset
+                }
+            }
+
+            "edge cases" - {
+                "handles very small periods" in {
+                    val s         = Schedule.anchored(1.milli)
+                    val (next, _) = s.next(now).get
+                    assert(next == 1.milli)
+                }
+
+                "handles very large periods" in {
+                    val s         = Schedule.anchored(365.days)
+                    val (next, _) = s.next(now).get
+                    assert(next == 365.days)
+                }
+
+                "handles offset larger than period" in {
+                    val s         = Schedule.anchored(1.hour, 2.hours)
+                    val (next, _) = s.next(now).get
+                    assert(next == 2.hours)
+                }
+
+                "maintains precision with subsecond periods" in {
+                    val s     = Schedule.anchored(100.millis, 30.millis)
+                    val start = Instant.parse("2024-01-01T00:00:00Z").getOrThrow
+
+                    val (next1, s2) = s.next(start).get
+                    val (next2, _)  = s2.next(start + next1).get
+
+                    assert(next1 == 30.millis)
+                    assert(next2 == 100.millis)
+                }
+            }
+
+            "show format" in {
+                val s1 = Schedule.anchored(1.day)
+                assert(s1.show == "Schedule.anchored(1.days)")
+
+                val s2 = Schedule.anchored(1.day, 2.hours)
+                assert(s2.show == "Schedule.anchored(1.days, 2.hours)")
+            }
+        }
+    }
+
+    "jitter" - {
+        "basic behavior" - {
+            "maintains deterministic output for same instant" in {
+                val base     = Schedule.fixed(1.second)
+                val jittered = base.jitter(0.5)
+                val now      = Instant.Epoch
+
+                val (next1, _) = jittered.next(now).get
+                val (next2, _) = jittered.next(now).get
+
+                assert(next1 == next2)
+                assert(next1 >= 500.millis)
+                assert(next1 <= 1500.millis)
+            }
+
+            "maintains consistency across schedule iterations" in {
+                val base     = Schedule.fixed(1.second)
+                val jittered = base.jitter(0.5)
+                val now      = Instant.Epoch
+
+                val (next1, s2) = jittered.next(now).get
+                val (next2, _)  = s2.next(now + next1).get
+
+                assert(next1 >= 500.millis && next1 <= 1500.millis)
+                assert(next2 >= 500.millis && next2 <= 1500.millis)
+            }
+        }
+
+        "edge cases" - {
+            "zero jitter factor returns original schedule" in {
+                val base      = Schedule.fixed(1.second)
+                val jittered  = base.jitter(0.0)
+                val (next, _) = jittered.next(Instant.Epoch).get
+
+                assert(next == 1.second)
+            }
+
+            "handles very small base durations" in {
+                val base      = Schedule.fixed(1.micro)
+                val jittered  = base.jitter(0.5)
+                val (next, _) = jittered.next(Instant.Epoch).get
+
+                assert(next >= 500.nanos)
+                assert(next <= 1500.nanos)
+            }
+
+            "handles extreme jitter factors" - {
+                "very small factor" in {
+                    val base      = Schedule.fixed(1.second)
+                    val jittered  = base.jitter(0.001)
+                    val (next, _) = jittered.next(Instant.Epoch).get
+
+                    assert(next >= 999.millis)
+                    assert(next <= 1001.millis)
+                }
+
+                "factor of 1.0" in {
+                    val base      = Schedule.fixed(1.second)
+                    val jittered  = base.jitter(1.0)
+                    val (next, _) = jittered.next(Instant.Epoch).get
+
+                    assert(next >= Duration.Zero)
+                    assert(next <= 2.seconds)
+                }
+
+                "large factor" in {
+                    val base      = Schedule.fixed(1.second)
+                    val jittered  = base.jitter(2.0)
+                    val (next, _) = jittered.next(Instant.Epoch).get
+
+                    assert(next >= Duration.Zero)
+                    assert(next <= 3.seconds)
+                }
+            }
+        }
+
+        "composition" - {
+            "works with take" in {
+                val s = Schedule.fixed(1.second)
+                    .jitter(0.5)
+                    .take(2)
+
+                val now         = Instant.Epoch
+                val (next1, s2) = s.next(now).get
+                val (next2, s3) = s2.next(now + next1).get
+                val next3       = s3.next(now + next1 + next2)
+
+                assert(next1 >= 500.millis && next1 <= 1500.millis)
+                assert(next2 >= 500.millis && next2 <= 1500.millis)
+                assert(next3.isEmpty)
+            }
+
+            "works with exponential backoff" in {
+                val s = Schedule.exponential(1.second, 2.0)
+                    .jitter(0.5)
+
+                val now         = Instant.Epoch
+                val (next1, s2) = s.next(now).get
+                val (next2, _)  = s2.next(now + next1).get
+
+                assert(next1 >= 500.millis && next1 <= 1500.millis)
+                assert(next2 >= 1000.millis && next2 <= 3000.millis)
+            }
+
+            "works with fibonacci" in {
+                val s = Schedule.fibonacci(1.second, 1.second)
+                    .jitter(0.5)
+
+                val now         = Instant.Epoch
+                val (next1, s2) = s.next(now).get
+                val (next2, s3) = s2.next(now + next1).get
+                val (next3, _)  = s3.next(now + next1 + next2).get
+
+                assert(next1 >= 500.millis && next1 <= 1500.millis)
+                assert(next2 >= 500.millis && next2 <= 1500.millis)
+                assert(next3 >= 1000.millis && next3 <= 3000.millis)
+            }
+        }
+
+        "distribution" in {
+            val jittered = Schedule.fixed(1.second).jitter(0.5)
+
+            val samples = (1 to 1000).map { i =>
+                val now = Instant.Epoch + i.seconds
+                jittered.next(now).get._1.toMillis
+            }
+
+            val mean = samples.sum.toDouble / samples.size
+            assert(math.abs(mean - 1000.0) < 100.0)
+
+            assert(samples.min >= 500)
+            assert(samples.max <= 1500)
+        }
+
+        "handles negative jitter factors" in {
+            val base      = Schedule.fixed(1.second)
+            val jittered  = base.jitter(-0.5)
+            val (next, _) = jittered.next(Instant.Epoch).get
+
+            // Should behave same as positive factor
+            assert(next >= 500.millis)
+            assert(next <= 1500.millis)
+        }
+
+        "show format" in {
+            val s = Schedule.fixed(1.second).jitter(0.5)
+            assert(s.show == "(Schedule.fixed(1.seconds)).jitter(0.5)")
         }
     }
 

--- a/kyo-stm/shared/src/main/scala/kyo/STM.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/STM.scala
@@ -42,7 +42,7 @@ opaque type STM <: (Var[TRefLog] & Abort[FailedTransaction] & Async) =
 object STM:
 
     /** The default retry schedule for failed transactions */
-    val defaultRetrySchedule = Schedule.fixed(1.millis * 0.5).take(20)
+    val defaultRetrySchedule = Schedule.fixed(1.millis).jitter(0.5).take(20)
 
     /** Forces a transaction retry by aborting the current transaction and rolling back all changes. This is useful when a transaction
       * detects that it cannot proceed due to invalid state.


### PR DESCRIPTION
I'm working on STM optimizations and want to use a jittered schedule to reduce the impact of retry storms. Since we avoid side effects in `kyo-data`, I'm passing the current `Instant` to `schedule.next` and calculating the jitter deterministically via hashing. It isn't random but, given that `Instant` has nanosecond precision, it seems reasonable.

We could pass a random number from `kyo-core` instead but we'd need to eventually pass the instant anyway to implement more advanced schedules like the new `Schedule.anchored` I've also added in this PR.