### PR TITLE
[core] fix IOPromise exception handling

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -49,11 +49,7 @@ private[kyo] class IOPromise[+E, +A](init: State[E, A]) extends Safepoint.Interc
                 case l: Linked[E, A] @unchecked =>
                     interruptsLoop(l.p)
                 case _ =>
-                    try discard(other.interrupt(Result.Panic(Interrupt(frame))))
-                    catch
-                        case ex if NonFatal(ex) =>
-                            import AllowUnsafe.embrace.danger
-                            Log.live.unsafe.error("uncaught exception", ex)
+                    discard(other.interrupt(Result.Panic(Interrupt(frame))))
         interruptsLoop(this)
     end interrupts
 
@@ -128,12 +124,7 @@ private[kyo] class IOPromise[+E, +A](init: State[E, A]) extends Safepoint.Interc
                 case l: Linked[E, A] @unchecked =>
                     onCompleteLoop(l.p)
                 case v =>
-                    try f(v.asInstanceOf[Result[E, A]])
-                    catch
-                        case ex if NonFatal(ex) =>
-                            given Frame = Frame.internal
-                            import AllowUnsafe.embrace.danger
-                            Log.live.unsafe.error("uncaught exception", ex)
+                    IOPromise.eval(f, v.asInstanceOf[Result[E, A]])
         onCompleteLoop(this)
     end onComplete
 
@@ -246,16 +237,10 @@ private[kyo] object IOPromise:
             new Pending[E, A]:
                 def waiters: Int = self.waiters + 1
                 def interrupt[E2 >: E](error: Error[E2]) =
-                    f(error.asInstanceOf[Error[E]])
+                    eval(f, error.asInstanceOf[Error[E]])
                     self
                 def run[E2 >: E, A2 >: A](v: Result[E2, A2]) =
-                    try f(v.asInstanceOf[Result[E, A]])
-                    catch
-                        case ex if NonFatal(ex) =>
-                            given Frame = Frame.internal
-                            import AllowUnsafe.embrace.danger
-                            Log.live.unsafe.error("uncaught exception", ex)
-                    end try
+                    eval(f, v.asInstanceOf[Result[E, A]])
                     self
                 end run
 
@@ -272,7 +257,7 @@ private[kyo] object IOPromise:
         inline def onInterrupt(inline f: Error[E] => Unit): Pending[E, A] =
             new Pending[E, A]:
                 def interrupt[E2 >: E](error: Error[E2]) =
-                    f(error.asInstanceOf[Error[E]])
+                    eval(f, error.asInstanceOf[Error[E]])
                     self
                 def waiters: Int = self.waiters + 1
                 def run[E2 >: E, A2 >: A](v: Result[E2, A2]) =
@@ -325,4 +310,14 @@ private[kyo] object IOPromise:
             def run[E2, A2](v: Result[E2, A2])         = this
         end Empty
     end Pending
+
+    private inline def eval[A, B](inline f: A => Unit, value: A): Unit =
+        try f(value)
+        catch
+            case ex if NonFatal(ex) =>
+                given Frame = Frame.internal
+                import AllowUnsafe.embrace.danger
+                Log.live.unsafe.error("uncaught exception", ex)
+        end try
+    end eval
 end IOPromise


### PR DESCRIPTION
I noticed an odd scenario in a project I'm working on. The `IOPromise` flushing was throwing an exception due to a buggy `onInterrupt` function in the project. This PR ensures exception handling is present in all callback function evaluations.