### PR TITLE
KyoException initialize Exception

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -9,7 +9,7 @@ class KyoException private[kyo] (
     cause: Text | Throwable = null
 )(using val frame: Frame) extends Exception(
         message match
-            case message: Text => message.toString; case _ => null,
+            case null => null; case _ => message.toString,
         cause match
             case cause: Throwable => cause; case _ => null
     ) with NoStackTrace:

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -9,7 +9,7 @@ class KyoException private[kyo] (
     cause: Text | Throwable | Null = null
 )(using val frame: Frame) extends Exception(
         message match
-            case null => null; case _ => message.toString,
+            case null: Null => null; case _ => message.toString,
         cause match
             case cause: Throwable => cause; case _ => null
     ) with NoStackTrace:

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -10,8 +10,7 @@ class KyoException private[kyo] (
 )(using val frame: Frame) extends Exception(
         message.toString,
         cause match
-            case cause: Throwable => cause
-            case _                => null
+            case cause: Throwable => cause; case _ => null
     ) with NoStackTrace:
 
     override def getCause(): Throwable =

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -8,7 +8,8 @@ class KyoException private[kyo] (
     message: Text | Null = null,
     cause: Text | Throwable | Null = null
 )(using val frame: Frame) extends Exception(
-        if message.eq(null) then null else message.toString,
+        Option(message) match
+            case Some(message) => message.toString; case _ => null,
         cause match
             case cause: Throwable => cause; case _ => null
     ) with NoStackTrace:

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -7,7 +7,7 @@ import scala.util.control.NoStackTrace
 class KyoException private[kyo] (
     message: Text = null,
     cause: Text | Throwable = null
-)(using val frame: Frame) extends Exception with NoStackTrace:
+)(using val frame: Frame) extends Exception(message.toString, cause match { case cause: Throwable => cause; case _ => null }) with NoStackTrace:
 
     override def getCause(): Throwable =
         cause match

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -7,7 +7,12 @@ import scala.util.control.NoStackTrace
 class KyoException private[kyo] (
     message: Text = null,
     cause: Text | Throwable = null
-)(using val frame: Frame) extends Exception(message.toString, cause match { case cause: Throwable => cause; case _ => null }) with NoStackTrace:
+)(using val frame: Frame) extends Exception(
+        message.toString,
+        cause match
+            case cause: Throwable => cause
+            case _                => null
+    ) with NoStackTrace:
 
     override def getCause(): Throwable =
         cause match

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -8,7 +8,8 @@ class KyoException private[kyo] (
     message: Text = null,
     cause: Text | Throwable = null
 )(using val frame: Frame) extends Exception(
-        message.toString,
+        message match
+            case message: Text => message.toString; case _ => null,
         cause match
             case cause: Throwable => cause; case _ => null
     ) with NoStackTrace:

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -5,8 +5,8 @@ import kyo.Ansi.*
 import scala.util.control.NoStackTrace
 
 class KyoException private[kyo] (
-    message: Text = null,
-    cause: Text | Throwable = null
+    message: Text | Null = null,
+    cause: Text | Throwable | Null = null
 )(using val frame: Frame) extends Exception(
         message match
             case null => null; case _ => message.toString,

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -8,8 +8,7 @@ class KyoException private[kyo] (
     message: Text | Null = null,
     cause: Text | Throwable | Null = null
 )(using val frame: Frame) extends Exception(
-        message match
-            case null: Null => null; case _ => message.toString,
+        if message.eq(null) then null else message.toString,
         cause match
             case cause: Throwable => cause; case _ => null
     ) with NoStackTrace:


### PR DESCRIPTION
Maybe I'm being superstitious or overly cautious, but I feel like it's much safer if the Exception is initialized with these fields. For interoperability purposes and the like. With the Exception initialized like I'm suggesting, nothing can go wrong ever.

A very small, trivial thing, but I felt a strong urge to do it :sweat_smile: 
