### PR TITLE
[kyo-reactive-streams]: Remove un-necessary sleep time in test cases

### DIFF
--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
@@ -11,35 +11,25 @@ abstract private class PublisherToSubscriberTest extends Test:
     protected def streamSubscriber: StreamSubscriber[Int] < IO
 
     "should have the same output as input" in runJVM {
-        val stream = Stream
-            .range(0, MaxStreamLength, 1, BufferSize)
-            .map { int =>
-                Random
-                    .use(_.nextInt(10))
-                    .map(millis => Async.sleep(Duration.fromUnits(millis, Duration.Units.Millis)))
-                    .andThen(int)
-            }
+        val stream = Stream.range(0, MaxStreamLength, 1, BufferSize)
         for
             publisher  <- stream.toPublisher
             subscriber <- streamSubscriber
             _ = publisher.subscribe(subscriber)
             (isSame, _) <- subscriber.stream
                 .runFold(true -> 0) { case ((acc, expected), cur) =>
-                    Random
-                        .use(_.nextInt(10))
-                        .map(millis => Async.sleep(Duration.fromUnits(millis, Duration.Units.Millis)))
-                        .andThen((acc && (expected == cur)) -> (expected + 1))
+                    (acc && (expected == cur)) -> (expected + 1)
                 }
         yield assert(isSame)
         end for
     }
 
     "should propagate errors downstream" in runJVM {
-        val inputStream = Stream
+        val inputStream: Stream[Int, IO] = Stream
             .range(0, 10, 1, 1)
             .map { int =>
                 if int < 5 then
-                    Async.sleep(Duration.fromUnits(10, Duration.Units.Millis)).andThen(int)
+                    IO(int)
                 else
                     Abort.panic(TestError)
             }
@@ -76,19 +66,16 @@ abstract private class PublisherToSubscriberTest extends Test:
 
     "single publisher & multiple subscribers" - {
         "contention" in runJVM {
-            def emit(ack: Ack, counter: AtomicInt): Ack < (Emit[Chunk[Int]] & Async) =
+            def emit(ack: Ack, counter: AtomicInt): Ack < (Emit[Chunk[Int]] & IO) =
                 ack match
                     case Ack.Stop => IO(Ack.Stop)
                     case Ack.Continue(_) =>
-                        for
-                            millis <- Random.use(_.nextInt(10))
-                            _      <- Async.sleep(Duration.fromUnits(millis, Duration.Units.Millis))
-                            value  <- counter.getAndIncrement
-                            nextAck <- if value >= MaxStreamLength then
+                        counter.getAndIncrement.map: value =>
+                            if value >= MaxStreamLength then
                                 IO(Ack.Stop)
                             else
                                 Emit.andMap(Chunk(value))(emit(_, counter))
-                        yield nextAck
+                            end if
             end emit
 
             def checkStrictIncrease(chunk: Chunk[Int]): Boolean =
@@ -128,20 +115,16 @@ abstract private class PublisherToSubscriberTest extends Test:
         }
 
         "one subscriber's failure does not affect others." in runJVM {
-            def emit(ack: Ack, counter: AtomicInt): Ack < (Emit[Chunk[Int]] & Async) =
+            def emit(ack: Ack, counter: AtomicInt): Ack < (Emit[Chunk[Int]] & IO) =
                 ack match
                     case Ack.Stop => IO(Ack.Stop)
                     case Ack.Continue(_) =>
-                        for
-                            millis <- Random.use(_.nextInt(10))
-                            _      <- Async.sleep(Duration.fromUnits(millis, Duration.Units.Millis))
-                            value  <- counter.getAndIncrement
-                            nextAck <- if value >= MaxStreamLength then
+                        counter.getAndIncrement.map: value =>
+                            if value >= MaxStreamLength then
                                 IO(Ack.Stop)
                             else
                                 Emit.andMap(Chunk(value))(emit(_, counter))
-                        yield nextAck
-                end match
+                            end if
             end emit
 
             def checkStrictIncrease(chunk: Chunk[Int]): Boolean =
@@ -188,17 +171,16 @@ abstract private class PublisherToSubscriberTest extends Test:
         }
 
         "publisher's interuption should end all subscribed parties" in runJVM {
-            def emit(ack: Ack, counter: AtomicInt): Ack < (Emit[Chunk[Int]] & Async) =
+            def emit(ack: Ack, counter: AtomicInt): Ack < (Emit[Chunk[Int]] & IO) =
                 ack match
                     case Ack.Stop => IO(Ack.Stop)
                     case Ack.Continue(_) =>
-                        for
-                            millis  <- Random.use(_.nextInt(10))
-                            _       <- Async.sleep(Duration.fromUnits(millis, Duration.Units.Millis))
-                            value   <- counter.getAndIncrement
-                            nextAck <- Emit.andMap(Chunk(value))(emit(_, counter))
-                        yield nextAck
-                end match
+                        counter.getAndIncrement.map: value =>
+                            if value >= MaxStreamLength then
+                                IO(Ack.Stop)
+                            else
+                                Emit.andMap(Chunk(value))(emit(_, counter))
+                            end if
             end emit
 
             for
@@ -208,7 +190,7 @@ abstract private class PublisherToSubscriberTest extends Test:
                 subscriber2 <- streamSubscriber
                 subscriber3 <- streamSubscriber
                 subscriber4 <- streamSubscriber
-                _ <- Fiber.parallelUnbounded[Nothing, Unit, Any](List(
+                gatherFiber <- Fiber.gather[Nothing, Unit, Any](List(
                     subscriber1.stream.run.unit,
                     subscriber2.stream.run.unit,
                     subscriber3.stream.run.unit,
@@ -223,17 +205,13 @@ abstract private class PublisherToSubscriberTest extends Test:
                             publisher.subscribe(subscriber3)
                             publisher.subscribe(subscriber4)
                         }
-                        .andThen(Async.sleep(2.seconds))
+                        .andThen(Async.sleep(1.seconds))
                 ))
-                _ <- Clock.sleep(1.seconds).map { fiber =>
+                _ <- Clock.sleep(10.millis).map { fiber =>
                     fiber.onComplete(_ => publisherFiber.interrupt.unit).andThen(fiber)
                 }.map(_.get)
-                count1 <- counter.get
-                _      <- Async.sleep(1.seconds)
-                count2 <- counter.get
-                _      <- Async.sleep(1.seconds)
-                count3 <- counter.get
-            yield assert((count2 - count1 <= 4) && (count3 - count2 <= 4))
+                _ <- gatherFiber.get
+            yield assert(true)
             end for
         }
     }

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamPublisherTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamPublisherTest.scala
@@ -8,7 +8,7 @@ import org.reactivestreams.tck.PublisherVerification
 import org.reactivestreams.tck.TestEnvironment
 import org.scalatestplus.testng.*
 
-final class StreamPublisherTest extends PublisherVerification[Int](new TestEnvironment(1000L)), TestNGSuiteLike:
+final class StreamPublisherTest extends PublisherVerification[Int](new TestEnvironment(10L)), TestNGSuiteLike:
     import AllowUnsafe.embrace.danger
     given Frame = Frame.internal
 

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamPublisherTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamPublisherTest.scala
@@ -17,12 +17,7 @@ final class StreamPublisherTest extends PublisherVerification[Int](new TestEnvir
             Stream.empty[Int]
         else
             val chunkSize = Math.sqrt(n).floor.intValue
-            Stream.range(0, n, 1, chunkSize).map { int =>
-                Random
-                    .use(_.nextInt(50))
-                    .map(millis => Async.sleep(Duration.fromUnits(millis, Duration.Units.Millis)))
-                    .andThen(int)
-            }
+            Stream.range(0, n, 1, chunkSize)
 
     override def createPublisher(n: Long): Publisher[Int] =
         if n > Int.MaxValue then

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamSubscriberTest.scala
@@ -12,7 +12,7 @@ import org.reactivestreams.tck.SubscriberWhiteboxVerification.WhiteboxSubscriber
 import org.reactivestreams.tck.TestEnvironment
 import org.scalatestplus.testng.*
 
-class StreamSubscriberTest extends SubscriberWhiteboxVerification[Int](new TestEnvironment(1000L)), TestNGSuiteLike:
+class StreamSubscriberTest extends SubscriberWhiteboxVerification[Int](new TestEnvironment(10L)), TestNGSuiteLike:
     import AllowUnsafe.embrace.danger
     private val counter = new AtomicInteger()
 


### PR DESCRIPTION
Originally, `Async.sleep` was used to mimic the real-life delay of a publisher/subscriber, but in the `reactive-streams-tck` test cases, it provides little to no benefit while significantly slowing down the overall test. Additionally, a quick look at `fs2` and `zio` shows that they also do not use sleep in their test cases.

This PR takes it a step further by removing `Async.sleep` from all `kyo-reactive-stream` test cases. Since this feature is primarily about correctly combining effects, I believe that if individual components have been thoroughly tested, we can proceed with just the minimal testing.

Furthermore, because `StreamSubscriber` has two strategies, I initially duplicated the tests for both. However, I think it suffices to randomly choose one strategy for each test in the suite.

Overall, on my MacBook M3, the old tests took `1 minute and 37 seconds` to run, while the new tests complete in just `34 seconds`.

Aim to resolve #938