### PR TITLE
[stm] use current transaction in initNow if available

### DIFF
--- a/kyo-stm/shared/src/test/scala/kyo/TRefTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TRefTest.scala
@@ -33,4 +33,43 @@ class TRefTest extends Test:
             }
         yield assert(result == (20, 10))
     }
+
+    "initNow behavior" - {
+        "creates ref with new transaction ID outside transaction" in run {
+            for
+                ref   <- TRef.initNow(1)
+                value <- STM.run(ref.get)
+            yield assert(value == 1)
+        }
+
+        "uses current transaction ID within transaction" in run {
+            STM.run {
+                for
+                    ref1 <- TRef.initNow(1)
+                    ref2 <- TRef.initNow(2)
+                    _    <- ref1.set(3)
+                    _    <- ref2.set(4)
+                    val1 <- ref1.get
+                    val2 <- ref2.get
+                yield assert(val1 == 3 && val2 == 4)
+            }
+        }
+
+        "nests properly in nested transactions" in run {
+            STM.run {
+                for
+                    ref1 <- TRef.initNow(1)
+                    result <- STM.run {
+                        for
+                            ref2 <- TRef.initNow(2)
+                            _    <- ref1.set(3)
+                            _    <- ref2.set(4)
+                            v1   <- ref1.get
+                            v2   <- ref2.get
+                        yield (v1, v2)
+                    }
+                yield assert(result == (3, 4))
+            }
+        }
+    }
 end TRefTest


### PR DESCRIPTION
`TRef.initNow` is essentially a footgun. If called within a transaction, it'll make the transaction entry a retry loop for as long as the retry `Schedule` allows. I spent some time debugging an issue caused by this scenario because I added a transaction in an outer scope that had a `Tref.initNow` in it.