### PR TITLE
Chunk.Indexed extends IndexedSeq

### DIFF
--- a/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
@@ -17,7 +17,7 @@ class ClockTest extends Test:
         "unsafe now" in {
             import AllowUnsafe.embrace.danger
             val now = Clock.live.unsafe.now()
-            assert(now - javaNow() < 1.milli)
+            assert(now - javaNow() < 10.milli)
         }
 
         "now at epoch" in run {

--- a/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
@@ -10,14 +10,14 @@ class ClockTest extends Test:
 
         "now" in run {
             Clock.now.map { now =>
-                assert(now - javaNow() < 10.milli)
+                assert(now - javaNow() < 10.millis)
             }
         }
 
         "unsafe now" in {
             import AllowUnsafe.embrace.danger
             val now = Clock.live.unsafe.now()
-            assert(now - javaNow() < 10.milli)
+            assert(now - javaNow() < 10.millis)
         }
 
         "now at epoch" in run {

--- a/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
@@ -10,7 +10,7 @@ class ClockTest extends Test:
 
         "now" in run {
             Clock.now.map { now =>
-                assert(now - javaNow() < 1.milli)
+                assert(now - javaNow() < 10.milli)
             }
         }
 

--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -5,6 +5,8 @@ import scala.annotation.tailrec
 import scala.annotation.targetName
 import scala.collection.IterableFactoryDefaults
 import scala.collection.StrictOptimizedSeqFactory
+import scala.collection.immutable.IndexedSeq
+import scala.collection.immutable.IndexedSeqOps
 import scala.collection.immutable.StrictOptimizedSeqOps
 import scala.reflect.ClassTag
 
@@ -17,7 +19,8 @@ import scala.reflect.ClassTag
   *   the type of elements in this Chunk
   */
 sealed abstract class Chunk[+A]
-    extends Seq[A]
+    extends IndexedSeq[A]
+    with IndexedSeqOps[A, Chunk, Chunk[A]]
     with StrictOptimizedSeqOps[A, Chunk, Chunk[A]]
     with IterableFactoryDefaults[A, Chunk]
     derives CanEqual:

--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -343,7 +343,7 @@ sealed abstract class Chunk[+A]
                 case c: Compact[A] @unchecked =>
                     val l = c.array.length
                     if l > 0 then
-                        System.arraycopy(c.array, dropLeft, array, start, l - dropRight - dropLeft)
+                        Array.copy(c.array, dropLeft, array, start, l - dropRight - dropLeft)
                 case c: FromSeq[A] @unchecked =>
                     val seq    = c.value
                     val length = Math.min(end, c.value.length - dropLeft - dropRight)

--- a/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
@@ -173,7 +173,7 @@ class DebugTest extends Test:
                 "DebugTest.scala:63:28",
                 "6",
                 "DebugTest.scala:64:14",
-                "Seq(Seq(Seq(7)))"
+                "IndexedSeq(IndexedSeq(IndexedSeq(7)))"
             ) {
                 choiceComputation.eval
             }


### PR DESCRIPTION
UPDATE:
Chunk.Indexed now extends IndexedSeq

---

It probably makes sense for `Chunk` to extend `IndexedSeq`. That in turn requires to extend `IndexedSeqOps`.

The potential con is that more mixins may make it more difficult for the JIT compiler to optimize the code.

Context
 * https://github.com/getkyo/kyo/pull/889/files#r1868549282
 * https://github.com/getkyo/kyo/pull/962

What do you think, is it worth it?