### PR TITLE
[core] introduce `initWith` convenience methods to initialize and use values

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Adder.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Adder.scala
@@ -59,7 +59,16 @@ object LongAdder:
       * @return
       *   A new LongAdder
       */
-    def init(using frame: Frame): LongAdder < IO = IO.Unsafe(LongAdder(Unsafe.init()))
+    def init(using frame: Frame): LongAdder < IO = use(identity)
+
+    /** Uses a new LongAdder.
+      * @param f
+      *   The function to apply to the new LongAdder
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A, S](inline f: LongAdder => A < S)(using inline frame: Frame): A < (IO & S) =
+        IO.Unsafe(f(LongAdder(Unsafe.init())))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.LongAdder
@@ -124,7 +133,16 @@ object DoubleAdder:
       * @return
       *   A new DoubleAdder
       */
-    def init(using Frame): DoubleAdder < IO = IO(DoubleAdder(new j.DoubleAdder))
+    def init(using Frame): DoubleAdder < IO = use(identity)
+
+    /** Uses a new DoubleAdder.
+      * @param f
+      *   The function to apply to the new DoubleAdder
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A, S](inline f: DoubleAdder => A < S)(using inline frame: Frame): A < (IO & S) =
+        IO.Unsafe(f(DoubleAdder(Unsafe.init())))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.DoubleAdder

--- a/kyo-core/shared/src/main/scala/kyo/Adder.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Adder.scala
@@ -59,7 +59,7 @@ object LongAdder:
       * @return
       *   A new LongAdder
       */
-    def init(using frame: Frame): LongAdder < IO = use(identity)
+    def init(using frame: Frame): LongAdder < IO = initWith(identity)
 
     /** Uses a new LongAdder.
       * @param f
@@ -67,7 +67,7 @@ object LongAdder:
       * @return
       *   The result of applying the function
       */
-    inline def use[A, S](inline f: LongAdder => A < S)(using inline frame: Frame): A < (IO & S) =
+    inline def initWith[A, S](inline f: LongAdder => A < S)(using inline frame: Frame): A < (IO & S) =
         IO.Unsafe(f(LongAdder(Unsafe.init())))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
@@ -133,7 +133,7 @@ object DoubleAdder:
       * @return
       *   A new DoubleAdder
       */
-    def init(using Frame): DoubleAdder < IO = use(identity)
+    def init(using Frame): DoubleAdder < IO = initWith(identity)
 
     /** Uses a new DoubleAdder.
       * @param f
@@ -141,7 +141,7 @@ object DoubleAdder:
       * @return
       *   The result of applying the function
       */
-    inline def use[A, S](inline f: DoubleAdder => A < S)(using inline frame: Frame): A < (IO & S) =
+    inline def initWith[A, S](inline f: DoubleAdder => A < S)(using inline frame: Frame): A < (IO & S) =
         IO.Unsafe(f(DoubleAdder(Unsafe.init())))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */

--- a/kyo-core/shared/src/main/scala/kyo/Atomic.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Atomic.scala
@@ -105,7 +105,7 @@ object AtomicInt:
       * @return
       *   A new AtomicInt instance initialized to 0
       */
-    def init(using Frame): AtomicInt < IO = use(0)(identity)
+    def init(using Frame): AtomicInt < IO = initWith(0)(identity)
 
     /** Creates a new AtomicInt with the given initial value.
       * @param v
@@ -113,7 +113,7 @@ object AtomicInt:
       * @return
       *   A new AtomicInt instance
       */
-    def init(initialValue: Int)(using Frame): AtomicInt < IO = use(initialValue)(identity)
+    def init(initialValue: Int)(using Frame): AtomicInt < IO = initWith(initialValue)(identity)
 
     /** Uses a new AtomicInt with initial value 0 in the given function.
       * @param f
@@ -121,8 +121,8 @@ object AtomicInt:
       * @return
       *   The result of applying the function
       */
-    inline def use[A, S](inline f: AtomicInt => A < S)(using inline frame: Frame): A < (S & IO) =
-        use(0)(f)
+    inline def initWith[A, S](inline f: AtomicInt => A < S)(using inline frame: Frame): A < (S & IO) =
+        initWith(0)(f)
 
     /** Uses a new AtomicInt with the given initial value in the function.
       * @param initialValue
@@ -132,7 +132,7 @@ object AtomicInt:
       * @return
       *   The result of applying the function
       */
-    inline def use[A, S](initialValue: Int)(inline f: AtomicInt => A < S)(using inline frame: Frame): A < (S & IO) =
+    inline def initWith[A, S](initialValue: Int)(inline f: AtomicInt => A < S)(using inline frame: Frame): A < (S & IO) =
         IO.Unsafe(f(AtomicInt(Unsafe.init(initialValue))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
@@ -275,7 +275,7 @@ object AtomicLong:
       *   A new AtomicLong instance
       */
     def init(initialValue: Long)(using Frame): AtomicLong < IO =
-        use(initialValue)(identity)
+        initWith(initialValue)(identity)
 
     /** Uses a new AtomicLong with initial value 0 in the given function.
       * @param f
@@ -283,8 +283,8 @@ object AtomicLong:
       * @return
       *   The result of applying the function
       */
-    inline def use[A, S](inline f: AtomicLong => A < S)(using inline frame: Frame): A < (S & IO) =
-        use(0)(f)
+    inline def initWith[A, S](inline f: AtomicLong => A < S)(using inline frame: Frame): A < (S & IO) =
+        initWith(0)(f)
 
     /** Uses a new AtomicLong with the given initial value in the function.
       * @param initialValue
@@ -294,7 +294,7 @@ object AtomicLong:
       * @return
       *   The result of applying the function
       */
-    inline def use[A, S](initialValue: Long)(inline f: AtomicLong => A < S)(using inline frame: Frame): A < (S & IO) =
+    inline def initWith[A, S](initialValue: Long)(inline f: AtomicLong => A < S)(using inline frame: Frame): A < (S & IO) =
         IO.Unsafe(f(AtomicLong(Unsafe.init(initialValue))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
@@ -397,7 +397,7 @@ object AtomicBoolean:
       *   A new AtomicBoolean instance
       */
     def init(initialValue: Boolean)(using Frame): AtomicBoolean < IO =
-        use(initialValue)(identity)
+        initWith(initialValue)(identity)
 
     /** Uses a new AtomicBoolean with initial value false in the given function.
       * @param f
@@ -405,8 +405,8 @@ object AtomicBoolean:
       * @return
       *   The result of applying the function
       */
-    inline def use[A, S](inline f: AtomicBoolean => A < S)(using inline frame: Frame): A < (S & IO) =
-        use(false)(f)
+    inline def initWith[A, S](inline f: AtomicBoolean => A < S)(using inline frame: Frame): A < (S & IO) =
+        initWith(false)(f)
 
     /** Uses a new AtomicBoolean with the given initial value in the function.
       * @param initialValue
@@ -416,7 +416,7 @@ object AtomicBoolean:
       * @return
       *   The result of applying the function
       */
-    inline def use[A, S](initialValue: Boolean)(inline f: AtomicBoolean => A < S)(using inline frame: Frame): A < (S & IO) =
+    inline def initWith[A, S](initialValue: Boolean)(inline f: AtomicBoolean => A < S)(using inline frame: Frame): A < (S & IO) =
         IO.Unsafe(f(AtomicBoolean(Unsafe.init(initialValue))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
@@ -527,7 +527,7 @@ object AtomicRef:
       *   The type of the referenced value
       */
     def init[A](initialValue: A)(using Frame): AtomicRef[A] < IO =
-        use(initialValue)(identity)
+        initWith(initialValue)(identity)
 
     /** Uses a new AtomicRef with the given initial value in the function.
       * @param initialValue
@@ -539,7 +539,7 @@ object AtomicRef:
       * @tparam A
       *   The type of the referenced value
       */
-    inline def use[A, B, S](initialValue: A)(inline f: AtomicRef[A] => B < S)(using inline frame: Frame): B < (S & IO) =
+    inline def initWith[A, B, S](initialValue: A)(inline f: AtomicRef[A] => B < S)(using inline frame: Frame): B < (S & IO) =
         IO.Unsafe(f(AtomicRef(Unsafe.init(initialValue))))
 
     opaque type Unsafe[A] = j.AtomicReference[A]

--- a/kyo-core/shared/src/main/scala/kyo/Atomic.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Atomic.scala
@@ -10,7 +10,16 @@ final case class AtomicInt private (unsafe: AtomicInt.Unsafe):
       * @return
       *   The current integer value
       */
-    inline def get(using inline frame: Frame): Int < IO = IO.Unsafe(unsafe.get())
+    inline def get(using inline frame: Frame): Int < IO = use(identity)
+
+    /** Uses the current value with a transformation function.
+      * @param f
+      *   The function to apply to the current value
+      * @return
+      *   The result of applying the function to the current value
+      */
+    inline def use[A, S](inline f: Int => A < S)(using inline frame: Frame): A < (S & IO) =
+        IO.Unsafe(f(unsafe.get()))
 
     /** Sets to the given value.
       * @param v
@@ -96,7 +105,7 @@ object AtomicInt:
       * @return
       *   A new AtomicInt instance initialized to 0
       */
-    def init(using Frame): AtomicInt < IO = init(0)
+    def init(using Frame): AtomicInt < IO = use(0)(identity)
 
     /** Creates a new AtomicInt with the given initial value.
       * @param v
@@ -104,7 +113,27 @@ object AtomicInt:
       * @return
       *   A new AtomicInt instance
       */
-    def init(v: Int)(using Frame): AtomicInt < IO = IO.Unsafe(AtomicInt(Unsafe.init(v)))
+    def init(initialValue: Int)(using Frame): AtomicInt < IO = use(initialValue)(identity)
+
+    /** Uses a new AtomicInt with initial value 0 in the given function.
+      * @param f
+      *   The function to apply to the new AtomicInt
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A, S](inline f: AtomicInt => A < S)(using inline frame: Frame): A < (S & IO) =
+        use(0)(f)
+
+    /** Uses a new AtomicInt with the given initial value in the function.
+      * @param initialValue
+      *   The initial value
+      * @param f
+      *   The function to apply to the new AtomicInt
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A, S](initialValue: Int)(inline f: AtomicInt => A < S)(using inline frame: Frame): A < (S & IO) =
+        IO.Unsafe(f(AtomicInt(Unsafe.init(initialValue))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.AtomicInteger
@@ -141,7 +170,16 @@ final case class AtomicLong private (unsafe: AtomicLong.Unsafe):
       * @return
       *   The current long value
       */
-    inline def get(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.get())
+    inline def get(using inline frame: Frame): Long < IO = use(identity)
+
+    /** Uses the current value with a transformation function.
+      * @param f
+      *   The function to apply to the current value
+      * @return
+      *   The result of applying the function to the current value
+      */
+    inline def use[A, S](inline f: Long => A < S)(using inline frame: Frame): A < (S & IO) =
+        IO.Unsafe(f(unsafe.get()))
 
     /** Sets to the given value.
       * @param v
@@ -231,12 +269,33 @@ object AtomicLong:
     def init(using Frame): AtomicLong < IO = init(0)
 
     /** Creates a new AtomicLong with the given initial value.
-      * @param v
+      * @param initialValue
       *   The initial value
       * @return
       *   A new AtomicLong instance
       */
-    def init(v: Long)(using Frame): AtomicLong < IO = IO.Unsafe(AtomicLong(Unsafe.init(v)))
+    def init(initialValue: Long)(using Frame): AtomicLong < IO =
+        use(initialValue)(identity)
+
+    /** Uses a new AtomicLong with initial value 0 in the given function.
+      * @param f
+      *   The function to apply to the new AtomicLong
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A, S](inline f: AtomicLong => A < S)(using inline frame: Frame): A < (S & IO) =
+        use(0)(f)
+
+    /** Uses a new AtomicLong with the given initial value in the function.
+      * @param initialValue
+      *   The initial value
+      * @param f
+      *   The function to apply to the new AtomicLong
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A, S](initialValue: Long)(inline f: AtomicLong => A < S)(using inline frame: Frame): A < (S & IO) =
+        IO.Unsafe(f(AtomicLong(Unsafe.init(initialValue))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.AtomicLong
@@ -273,7 +332,16 @@ final case class AtomicBoolean private (unsafe: AtomicBoolean.Unsafe):
       * @return
       *   The current boolean value
       */
-    inline def get(using inline frame: Frame): Boolean < IO = IO.Unsafe(unsafe.get())
+    inline def get(using inline frame: Frame): Boolean < IO = use(identity)
+
+    /** Uses the current value with a transformation function.
+      * @param f
+      *   The function to apply to the current value
+      * @return
+      *   The result of applying the function to the current value
+      */
+    inline def use[A, S](inline f: Boolean => A < S)(using inline frame: Frame): A < (S & IO) =
+        IO.Unsafe(f(unsafe.get()))
 
     /** Sets to the given value.
       * @param v
@@ -323,12 +391,33 @@ object AtomicBoolean:
     def init(using Frame): AtomicBoolean < IO = init(false)
 
     /** Creates a new AtomicBoolean with the given initial value.
-      * @param v
+      * @param initialValue
       *   The initial value
       * @return
       *   A new AtomicBoolean instance
       */
-    def init(v: Boolean)(using Frame): AtomicBoolean < IO = IO.Unsafe(AtomicBoolean(Unsafe.init(v)))
+    def init(initialValue: Boolean)(using Frame): AtomicBoolean < IO =
+        use(initialValue)(identity)
+
+    /** Uses a new AtomicBoolean with initial value false in the given function.
+      * @param f
+      *   The function to apply to the new AtomicBoolean
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A, S](inline f: AtomicBoolean => A < S)(using inline frame: Frame): A < (S & IO) =
+        use(false)(f)
+
+    /** Uses a new AtomicBoolean with the given initial value in the function.
+      * @param initialValue
+      *   The initial value
+      * @param f
+      *   The function to apply to the new AtomicBoolean
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A, S](initialValue: Boolean)(inline f: AtomicBoolean => A < S)(using inline frame: Frame): A < (S & IO) =
+        IO.Unsafe(f(AtomicBoolean(Unsafe.init(initialValue))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.AtomicBoolean
@@ -364,7 +453,16 @@ final case class AtomicRef[A] private (unsafe: AtomicRef.Unsafe[A]):
       * @return
       *   The current value
       */
-    inline def get(using inline frame: Frame): A < IO = IO.Unsafe(unsafe.get())
+    inline def get(using inline frame: Frame): A < IO = use(identity)
+
+    /** Uses the current value with a transformation function.
+      * @param f
+      *   The function to apply to the current value
+      * @return
+      *   The result of applying the function to the current value
+      */
+    inline def use[B, S](inline f: A => B < S)(using inline frame: Frame): B < (S & IO) =
+        IO.Unsafe(f(unsafe.get()))
 
     /** Sets to the given value.
       * @param v
@@ -421,14 +519,28 @@ end AtomicRef
 object AtomicRef:
 
     /** Creates a new AtomicRef with the given initial value.
-      * @param v
+      * @param initialValue
       *   The initial value
       * @return
       *   A new AtomicRef instance
       * @tparam A
       *   The type of the referenced value
       */
-    def init[A](v: A)(using Frame): AtomicRef[A] < IO = IO.Unsafe(AtomicRef(Unsafe.init(v)))
+    def init[A](initialValue: A)(using Frame): AtomicRef[A] < IO =
+        use(initialValue)(identity)
+
+    /** Uses a new AtomicRef with the given initial value in the function.
+      * @param initialValue
+      *   The initial value
+      * @param f
+      *   The function to apply to the new AtomicRef
+      * @return
+      *   The result of applying the function
+      * @tparam A
+      *   The type of the referenced value
+      */
+    inline def use[A, B, S](initialValue: A)(inline f: AtomicRef[A] => B < S)(using inline frame: Frame): B < (S & IO) =
+        IO.Unsafe(f(AtomicRef(Unsafe.init(initialValue))))
 
     opaque type Unsafe[A] = j.AtomicReference[A]
 

--- a/kyo-core/shared/src/main/scala/kyo/Barrier.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Barrier.scala
@@ -30,12 +30,23 @@ object Barrier:
 
     /** Creates a new Barrier instance.
       *
-      * @param n
+      * @param parties
       *   The number of parties that must call await before the barrier is released
       * @return
       *   A new Barrier instance
       */
-    def init(n: Int)(using Frame): Barrier < IO = IO.Unsafe(Barrier(Unsafe.init(n)))
+    def init(parties: Int)(using Frame): Barrier < IO = use(parties)(identity)
+
+    /** Uses a new Barrier with the provided number of parties.
+      * @param parties
+      *   The number of parties that must call await before the barrier is released
+      * @param f
+      *   The function to apply to the new Barrier
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A, S](parties: Int)(inline f: Barrier => A < S)(using inline frame: Frame): A < (S & IO) =
+        IO.Unsafe(f(Barrier(Unsafe.init(parties))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     sealed abstract class Unsafe:

--- a/kyo-core/shared/src/main/scala/kyo/Barrier.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Barrier.scala
@@ -35,7 +35,7 @@ object Barrier:
       * @return
       *   A new Barrier instance
       */
-    def init(parties: Int)(using Frame): Barrier < IO = use(parties)(identity)
+    def init(parties: Int)(using Frame): Barrier < IO = initWith(parties)(identity)
 
     /** Uses a new Barrier with the provided number of parties.
       * @param parties
@@ -45,7 +45,7 @@ object Barrier:
       * @return
       *   The result of applying the function
       */
-    inline def use[A, S](parties: Int)(inline f: Barrier => A < S)(using inline frame: Frame): A < (S & IO) =
+    inline def initWith[A, S](parties: Int)(inline f: Barrier => A < S)(using inline frame: Frame): A < (S & IO) =
         IO.Unsafe(f(Barrier(Unsafe.init(parties))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -247,7 +247,7 @@ object Channel:
       *   The actual capacity may be larger than the specified capacity due to rounding.
       */
     def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Channel[A] < IO =
-        use[A](capacity, access)(identity)
+        initWith[A](capacity, access)(identity)
 
     /** Uses a new Channel with the provided configuration.
       * @param f
@@ -255,7 +255,7 @@ object Channel:
       * @return
       *   The result of applying the function
       */
-    inline def use[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](
+    inline def initWith[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](
         inline f: Channel[A] => B < S
     )(using inline frame: Frame): B < (S & IO) =
         IO.Unsafe(f(Unsafe.init(capacity, access)))

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -247,7 +247,18 @@ object Channel:
       *   The actual capacity may be larger than the specified capacity due to rounding.
       */
     def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Channel[A] < IO =
-        IO.Unsafe(Unsafe.init(capacity, access))
+        use[A](capacity, access)(identity)
+
+    /** Uses a new Channel with the provided configuration.
+      * @param f
+      *   The function to apply to the new Channel
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](
+        inline f: Channel[A] => B < S
+    )(using inline frame: Frame): B < (S & IO) =
+        IO.Unsafe(f(Unsafe.init(capacity, access)))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe[A]:

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -645,7 +645,16 @@ object Fiber extends FiberPlatformSpecific:
           * @return
           *   A new Promise
           */
-        def init[E, A](using Frame): Promise[E, A] < IO = IO(IOPromise())
+        def init[E, A](using Frame): Promise[E, A] < IO = use[E, A](identity)
+
+        /** Uses a new Promise with the provided type parameters.
+          * @param f
+          *   The function to apply to the new Promise
+          * @return
+          *   The result of applying the function
+          */
+        inline def use[E, A](using inline frame: Frame)[B, S](inline f: Promise[E, A] => B < S): B < (S & IO) =
+            IO(f(IOPromise()))
 
         extension [E, A](self: Promise[E, A])
             /** Completes the Promise with a result.

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -645,7 +645,7 @@ object Fiber extends FiberPlatformSpecific:
           * @return
           *   A new Promise
           */
-        def init[E, A](using Frame): Promise[E, A] < IO = use[E, A](identity)
+        def init[E, A](using Frame): Promise[E, A] < IO = initWith[E, A](identity)
 
         /** Uses a new Promise with the provided type parameters.
           * @param f
@@ -653,7 +653,7 @@ object Fiber extends FiberPlatformSpecific:
           * @return
           *   The result of applying the function
           */
-        inline def use[E, A](using inline frame: Frame)[B, S](inline f: Promise[E, A] => B < S): B < (S & IO) =
+        inline def initWith[E, A](using inline frame: Frame)[B, S](inline f: Promise[E, A] => B < S): B < (S & IO) =
             IO(f(IOPromise()))
 
         extension [E, A](self: Promise[E, A])

--- a/kyo-core/shared/src/main/scala/kyo/Hub.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Hub.scala
@@ -152,6 +152,19 @@ object Hub:
       *   a new Hub instance
       */
     def init[A](capacity: Int)(using Frame): Hub[A] < IO =
+        use[A](capacity)(identity)
+
+    /** Uses a new Hub with the given type and capacity.
+      * @param capacity
+      *   the maximum number of elements the Hub can hold
+      * @param f
+      *   The function to apply to the new Hub
+      * @tparam A
+      *   the type of elements in the Hub
+      * @return
+      *   The result of applying the function
+      */
+    def use[A](capacity: Int)[B, S](f: Hub[A] => B < S)(using Frame): B < (S & IO) =
         Channel.init[A](capacity).map { ch =>
             IO {
                 val listeners = new CopyOnWriteArraySet[Channel[A]]
@@ -168,7 +181,7 @@ object Hub:
                         }
                     }
                 }.map { fiber =>
-                    new Hub(ch, fiber, listeners)
+                    f(new Hub(ch, fiber, listeners))
                 }
             }
         }

--- a/kyo-core/shared/src/main/scala/kyo/Hub.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Hub.scala
@@ -152,7 +152,7 @@ object Hub:
       *   a new Hub instance
       */
     def init[A](capacity: Int)(using Frame): Hub[A] < IO =
-        use[A](capacity)(identity)
+        initWith[A](capacity)(identity)
 
     /** Uses a new Hub with the given type and capacity.
       * @param capacity
@@ -164,7 +164,7 @@ object Hub:
       * @return
       *   The result of applying the function
       */
-    def use[A](capacity: Int)[B, S](f: Hub[A] => B < S)(using Frame): B < (S & IO) =
+    def initWith[A](capacity: Int)[B, S](f: Hub[A] => B < S)(using Frame): B < (S & IO) =
         Channel.init[A](capacity).map { ch =>
             IO {
                 val listeners = new CopyOnWriteArraySet[Channel[A]]

--- a/kyo-core/shared/src/main/scala/kyo/Latch.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Latch.scala
@@ -37,12 +37,24 @@ object Latch:
 
     /** Creates a new Latch initialized with the given count.
       *
-      * @param n
+      * @param count
       *   The initial count for the latch
       * @return
       *   A new Latch instance wrapped in an IO effect
       */
-    def init(n: Int)(using Frame): Latch < IO = IO.Unsafe(Latch(Unsafe.init(n)))
+    def init(count: Int)(using Frame): Latch < IO =
+        use(count)(identity)
+
+    /** Uses a new Latch with the provided count.
+      * @param count
+      *   The initial count for the latch
+      * @param f
+      *   The function to apply to the new Latch
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A, S](count: Int)(inline f: Latch => A < S)(using inline frame: Frame): A < (S & IO) =
+        IO.Unsafe(f(Latch(Unsafe.init(count))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     sealed abstract class Unsafe:

--- a/kyo-core/shared/src/main/scala/kyo/Latch.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Latch.scala
@@ -43,7 +43,7 @@ object Latch:
       *   A new Latch instance wrapped in an IO effect
       */
     def init(count: Int)(using Frame): Latch < IO =
-        use(count)(identity)
+        initWith(count)(identity)
 
     /** Uses a new Latch with the provided count.
       * @param count
@@ -53,7 +53,7 @@ object Latch:
       * @return
       *   The result of applying the function
       */
-    inline def use[A, S](count: Int)(inline f: Latch => A < S)(using inline frame: Frame): A < (S & IO) =
+    inline def initWith[A, S](count: Int)(inline f: Latch => A < S)(using inline frame: Frame): A < (S & IO) =
         IO.Unsafe(f(Latch(Unsafe.init(count))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -127,7 +127,22 @@ object Queue:
       *   The actual capacity may be larger than the specified capacity due to rounding.
       */
     def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Queue[A] < IO =
-        IO.Unsafe(Unsafe.init(capacity, access))
+        use[A](capacity, access)(identity)
+
+    /** Uses a new Queue with the provided count.
+      * @param capacity
+      *   the desired capacity of the queue. Note that this will be rounded up to the next power of two.
+      * @param access
+      *   the access pattern (default is MPMC)
+      * @param f
+      *   The function to apply to the new Queue
+      * @return
+      *   The result of applying the function
+      */
+    inline def use[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](inline f: Queue[A] => B < S)(
+        using inline frame: Frame
+    ): B < (IO & S) =
+        IO.Unsafe(f(Unsafe.init(capacity, access)))
 
     /** An unbounded queue that can grow indefinitely.
       *
@@ -158,7 +173,20 @@ object Queue:
           *   a new Unbounded Queue instance
           */
         def init[A](access: Access = Access.MultiProducerMultiConsumer, chunkSize: Int = 8)(using Frame): Unbounded[A] < IO =
-            IO.Unsafe(Unsafe.init(access, chunkSize))
+            use[A](access, chunkSize)(identity)
+
+        /** Uses a new unbounded Queue with the provided count.
+          * @param count
+          *   The initial count for the latch
+          * @param f
+          *   The function to apply to the new Queue
+          * @return
+          *   The result of applying the function
+          */
+        inline def use[A](access: Access = Access.MultiProducerMultiConsumer, chunkSize: Int = 8)[B, S](inline f: Unbounded[A] => B < S)(
+            using inline frame: Frame
+        ): B < (IO & S) =
+            IO.Unsafe(f(Unsafe.init(access, chunkSize)))
 
         /** Initializes a new dropping queue with the specified capacity and access pattern.
           *

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -127,7 +127,7 @@ object Queue:
       *   The actual capacity may be larger than the specified capacity due to rounding.
       */
     def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Queue[A] < IO =
-        use[A](capacity, access)(identity)
+        initWith[A](capacity, access)(identity)
 
     /** Uses a new Queue with the provided count.
       * @param capacity
@@ -139,7 +139,7 @@ object Queue:
       * @return
       *   The result of applying the function
       */
-    inline def use[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](inline f: Queue[A] => B < S)(
+    inline def initWith[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](inline f: Queue[A] => B < S)(
         using inline frame: Frame
     ): B < (IO & S) =
         IO.Unsafe(f(Unsafe.init(capacity, access)))
@@ -173,7 +173,7 @@ object Queue:
           *   a new Unbounded Queue instance
           */
         def init[A](access: Access = Access.MultiProducerMultiConsumer, chunkSize: Int = 8)(using Frame): Unbounded[A] < IO =
-            use[A](access, chunkSize)(identity)
+            initWith[A](access, chunkSize)(identity)
 
         /** Uses a new unbounded Queue with the provided count.
           * @param count
@@ -183,7 +183,10 @@ object Queue:
           * @return
           *   The result of applying the function
           */
-        inline def use[A](access: Access = Access.MultiProducerMultiConsumer, chunkSize: Int = 8)[B, S](inline f: Unbounded[A] => B < S)(
+        inline def initWith[A](
+            access: Access = Access.MultiProducerMultiConsumer,
+            chunkSize: Int = 8
+        )[B, S](inline f: Unbounded[A] => B < S)(
             using inline frame: Frame
         ): B < (IO & S) =
             IO.Unsafe(f(Unsafe.init(access, chunkSize)))

--- a/kyo-core/shared/src/test/scala/kyo/AdderTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AdderTest.scala
@@ -48,6 +48,9 @@ class AdderTest extends Test:
                 v2  <- ref.get
             yield assert(v1 == 5 && v2 == 0)
         }
+        "LongAdder.use" in run {
+            LongAdder.use(_.get).map(r => assert(r == 0))
+        }
     }
 
     "double" - {
@@ -79,6 +82,9 @@ class AdderTest extends Test:
                 v1  <- ref.sumThenReset
                 v2  <- ref.get
             yield assert(v1 == 5 && v2 == 0)
+        }
+        "DoubleAdder.use" in run {
+            DoubleAdder.use(_.get).map(r => assert(r == 0))
         }
     }
 

--- a/kyo-core/shared/src/test/scala/kyo/AdderTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AdderTest.scala
@@ -48,8 +48,8 @@ class AdderTest extends Test:
                 v2  <- ref.get
             yield assert(v1 == 5 && v2 == 0)
         }
-        "LongAdder.use" in run {
-            LongAdder.use(_.get).map(r => assert(r == 0))
+        "LongAdder.initWith" in run {
+            LongAdder.initWith(_.get).map(r => assert(r == 0))
         }
     }
 
@@ -83,8 +83,8 @@ class AdderTest extends Test:
                 v2  <- ref.get
             yield assert(v1 == 5 && v2 == 0)
         }
-        "DoubleAdder.use" in run {
-            DoubleAdder.use(_.get).map(r => assert(r == 0))
+        "DoubleAdder.initWith" in run {
+            DoubleAdder.initWith(_.get).map(r => assert(r == 0))
         }
     }
 

--- a/kyo-core/shared/src/test/scala/kyo/AtomicTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AtomicTest.scala
@@ -89,12 +89,12 @@ class AtomicTest extends Test:
         }
         "should use new atomic with function" in run {
             for
-                v <- AtomicInt.use(ref => ref.incrementAndGet)
+                v <- AtomicInt.initWith(ref => ref.incrementAndGet)
             yield assert(v == 1)
         }
         "should use new atomic with initial value" in run {
             for
-                v <- AtomicInt.use(5)(ref => ref.incrementAndGet)
+                v <- AtomicInt.initWith(5)(ref => ref.incrementAndGet)
             yield assert(v == 6)
         }
     }
@@ -186,12 +186,12 @@ class AtomicTest extends Test:
         }
         "should use new atomic with function" in run {
             for
-                v <- AtomicLong.use(ref => ref.incrementAndGet)
+                v <- AtomicLong.initWith(ref => ref.incrementAndGet)
             yield assert(v == 1L)
         }
         "should use new atomic with initial value" in run {
             for
-                v <- AtomicLong.use(5L)(ref => ref.incrementAndGet)
+                v <- AtomicLong.initWith(5L)(ref => ref.incrementAndGet)
             yield assert(v == 6L)
         }
     }
@@ -247,12 +247,12 @@ class AtomicTest extends Test:
         }
         "should use new atomic with function" in run {
             for
-                v <- AtomicBoolean.use(ref => ref.get)
+                v <- AtomicBoolean.initWith(ref => ref.get)
             yield assert(!v) // default value is false
         }
         "should use new atomic with initial value" in run {
             for
-                v <- AtomicBoolean.use(true)(ref => ref.get)
+                v <- AtomicBoolean.initWith(true)(ref => ref.get)
             yield assert(v)
         }
     }
@@ -313,7 +313,7 @@ class AtomicTest extends Test:
         }
         "should use new atomic with initial value" in run {
             for
-                v <- AtomicRef.use("hello")(ref => ref.get)
+                v <- AtomicRef.initWith("hello")(ref => ref.get)
             yield assert(v == "hello")
         }
     }

--- a/kyo-core/shared/src/test/scala/kyo/AtomicTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AtomicTest.scala
@@ -81,6 +81,22 @@ class AtomicTest extends Test:
                 v2  <- ref.get
             yield assert(v1 == 5 && v2 == 6)
         }
+        "should use current value with transformation" in run {
+            for
+                ref <- AtomicInt.init(5)
+                v   <- ref.use(x => x * 2)
+            yield assert(v == 10)
+        }
+        "should use new atomic with function" in run {
+            for
+                v <- AtomicInt.use(ref => ref.incrementAndGet)
+            yield assert(v == 1)
+        }
+        "should use new atomic with initial value" in run {
+            for
+                v <- AtomicInt.use(5)(ref => ref.incrementAndGet)
+            yield assert(v == 6)
+        }
     }
 
     "long" - {
@@ -162,6 +178,22 @@ class AtomicTest extends Test:
                 v2  <- ref.get
             yield assert(v1 == 5 && v2 == 6)
         }
+        "should use current value with transformation" in run {
+            for
+                ref <- AtomicLong.init(5L)
+                v   <- ref.use(x => x * 2)
+            yield assert(v == 10L)
+        }
+        "should use new atomic with function" in run {
+            for
+                v <- AtomicLong.use(ref => ref.incrementAndGet)
+            yield assert(v == 1L)
+        }
+        "should use new atomic with initial value" in run {
+            for
+                v <- AtomicLong.use(5L)(ref => ref.incrementAndGet)
+            yield assert(v == 6L)
+        }
     }
 
     "boolean" - {
@@ -175,7 +207,7 @@ class AtomicTest extends Test:
             for
                 ref <- AtomicBoolean.init(true)
                 v   <- ref.get
-            yield assert(v == true)
+            yield assert(v)
         }
         "should set the value" in run {
             for
@@ -206,6 +238,22 @@ class AtomicTest extends Test:
                 v1  <- ref.getAndSet(false)
                 v2  <- ref.get
             yield assert(v1 && !v2)
+        }
+        "should use current value with transformation" in run {
+            for
+                ref <- AtomicBoolean.init(true)
+                v   <- ref.use(x => !x)
+            yield assert(!v)
+        }
+        "should use new atomic with function" in run {
+            for
+                v <- AtomicBoolean.use(ref => ref.get)
+            yield assert(!v) // default value is false
+        }
+        "should use new atomic with initial value" in run {
+            for
+                v <- AtomicBoolean.use(true)(ref => ref.get)
+            yield assert(v)
         }
     }
 
@@ -256,6 +304,17 @@ class AtomicTest extends Test:
                 _   <- ref.lazySet("new")
                 v   <- ref.get
             yield assert(v == "new")
+        }
+        "should use current value with transformation" in run {
+            for
+                ref <- AtomicRef.init("hello")
+                v   <- ref.use(x => x.toUpperCase)
+            yield assert(v == "HELLO")
+        }
+        "should use new atomic with initial value" in run {
+            for
+                v <- AtomicRef.use("hello")(ref => ref.get)
+            yield assert(v == "hello")
         }
     }
 

--- a/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
@@ -4,6 +4,10 @@ import kyo.*
 
 class BarrierTest extends Test:
 
+    "use" in run {
+        Barrier.use(0)(_.await.andThen(succeed))
+    }
+
     "zero" in run {
         for
             barrier <- Barrier.init(0)

--- a/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
@@ -4,8 +4,8 @@ import kyo.*
 
 class BarrierTest extends Test:
 
-    "use" in run {
-        Barrier.use(0)(_.await.andThen(succeed))
+    "initWith" in run {
+        Barrier.initWith(0)(_.await.andThen(succeed))
     }
 
     "zero" in run {

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -2,8 +2,8 @@ package kyo
 
 class ChannelTest extends Test:
 
-    "use" in run {
-        Channel.use[Int](10) { c =>
+    "initWith" in run {
+        Channel.initWith[Int](10) { c =>
             for
                 b <- c.offer(1)
                 v <- c.poll

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -2,6 +2,15 @@ package kyo
 
 class ChannelTest extends Test:
 
+    "use" in run {
+        Channel.use[Int](10) { c =>
+            for
+                b <- c.offer(1)
+                v <- c.poll
+            yield assert(b && v == Maybe(1))
+        }
+    }
+
     "offer and poll" in run {
         for
             c <- Channel.init[Int](2)

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -6,6 +6,13 @@ import org.scalatest.compatible.Assertion
 class FiberTest extends Test:
 
     "promise" - {
+        "use" in run {
+            for
+                result <- Promise.use[Nothing, Int] { p =>
+                    p.complete(Result.success(42)).andThen(p.get)
+                }
+            yield assert(result == 42)
+        }
         "complete" in run {
             for
                 p <- Promise.init[Nothing, Int]

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -6,9 +6,9 @@ import org.scalatest.compatible.Assertion
 class FiberTest extends Test:
 
     "promise" - {
-        "use" in run {
+        "initWith" in run {
             for
-                result <- Promise.use[Nothing, Int] { p =>
+                result <- Promise.initWith[Nothing, Int] { p =>
                     p.complete(Result.success(42)).andThen(p.get)
                 }
             yield assert(result == 42)

--- a/kyo-core/shared/src/test/scala/kyo/HubTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/HubTest.scala
@@ -2,6 +2,16 @@ package kyo
 
 class HubTest extends Test:
 
+    "use" in runNotJS {
+        Hub.use[Int](2) { h =>
+            for
+                l <- h.listen
+                b <- h.offer(1)
+                v <- l.take
+            yield assert(b && v == 1)
+        }
+    }
+
     "listen/offer/take" in runNotJS {
         for
             h <- Hub.init[Int](2)

--- a/kyo-core/shared/src/test/scala/kyo/HubTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/HubTest.scala
@@ -3,7 +3,7 @@ package kyo
 class HubTest extends Test:
 
     "use" in runNotJS {
-        Hub.use[Int](2) { h =>
+        Hub.initWith[Int](2) { h =>
             for
                 l <- h.listen
                 b <- h.offer(1)

--- a/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
@@ -5,7 +5,7 @@ import kyo.*
 class LatchTest extends Test:
 
     "use" in run {
-        Latch.use(1) { latch =>
+        Latch.initWith(1) { latch =>
             for
                 _ <- latch.release
                 _ <- latch.await

--- a/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
@@ -4,6 +4,15 @@ import kyo.*
 
 class LatchTest extends Test:
 
+    "use" in run {
+        Latch.use(1) { latch =>
+            for
+                _ <- latch.release
+                _ <- latch.await
+            yield succeed
+        }
+    }
+
     "zero" in run {
         for
             latch <- Latch.init(0)

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -9,6 +9,14 @@ class QueueTest extends Test:
     "bounded" - {
         access.foreach { access =>
             access.toString() - {
+                "use" in run {
+                    Queue.use[Int](2, access) { q =>
+                        for
+                            b <- q.offer(1)
+                            v <- q.poll
+                        yield assert(b && v == Maybe(1))
+                    }
+                }
                 "isEmpty" in run {
                     for
                         q <- Queue.init[Int](2, access)

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -9,8 +9,8 @@ class QueueTest extends Test:
     "bounded" - {
         access.foreach { access =>
             access.toString() - {
-                "use" in run {
-                    Queue.use[Int](2, access) { q =>
+                "initWith" in run {
+                    Queue.initWith[Int](2, access) { q =>
                         for
                             b <- q.offer(1)
                             v <- q.poll


### PR DESCRIPTION
In the majority of the cases, `init` is immediately followed by a `map` to use the new value. This PR introduces a new pattern with `use` methods in the companion objects. It seems a good usability improvement and it'll also help with performance since it avoids a second allocation.