### PR TITLE
[build] use coursier/cache-action

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
+      - uses: coursier/cache-action@v6
       - uses: olafurpg/setup-scala@v13
         with:
           java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
     - uses: actions/checkout@v3.0.2
       with:
         fetch-depth: 0
+    - uses: coursier/cache-action@v6
     - name: Install Dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
+      - uses: coursier/cache-action@v6
       - uses: olafurpg/setup-scala@v13
         with:
           java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
+      - uses: coursier/cache-action@v6
       - uses: olafurpg/setup-scala@v13
         with:
           java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz

--- a/.github/workflows/scalafmt.yml
+++ b/.github/workflows/scalafmt.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
+      - uses: coursier/cache-action@v6
       - uses: olafurpg/setup-scala@v13
         with:
           java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz


### PR DESCRIPTION
The action caches dependencies across runs: https://github.com/coursier/cache-action