### PR TITLE
[scheduler] don't preempt task if worker queue is empty

### DIFF
--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Worker.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Worker.scala
@@ -174,7 +174,7 @@ abstract private class Worker(
         val task    = currentTask
         val start   = taskStartMs
         val stalled = (task ne null) && start > 0 && start < nowMs - timeSliceMs
-        if (stalled) {
+        if (stalled && !queue.isEmpty()) {
             task.doPreempt()
         }
         stalled


### PR DESCRIPTION
There's no need to preempt the current task if the worker queue is empty and there isn't another task waiting for execution.