### PR TITLE
[scheduler] tuning + cats improvement + scaladocs

### DIFF
--- a/kyo-scheduler-cats/jvm/src/main/scala/kyo/KyoSchedulerIORuntime.scala
+++ b/kyo-scheduler-cats/jvm/src/main/scala/kyo/KyoSchedulerIORuntime.scala
@@ -1,10 +1,25 @@
 package kyo
 
 import cats.effect.unsafe.IORuntime
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
 
 object KyoSchedulerIORuntime {
     implicit lazy val global: IORuntime = {
-        val exec = kyo.scheduler.Scheduler.get.asExecutionContext
-        IORuntime(exec, exec, IORuntime.global.scheduler, () => (), IORuntime.global.config)
+        val scheduler = new cats.effect.unsafe.Scheduler {
+            val scheduledExecutor = Executors.newScheduledThreadPool(2)
+            def sleep(delay: FiniteDuration, task: Runnable): Runnable = {
+                val t = scheduledExecutor.schedule(task, delay.toNanos, TimeUnit.NANOSECONDS)
+                () => {
+                    t.cancel(false)
+                    ()
+                }
+            }
+            def monotonicNanos(): Long = System.nanoTime()
+            def nowMillis(): Long      = System.currentTimeMillis()
+        }
+        val kyoExecutor = kyo.scheduler.Scheduler.get.asExecutionContext
+        IORuntime(kyoExecutor, kyoExecutor, scheduler, () => (), IORuntime.global.config)
     }
 }

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -529,15 +529,15 @@ object Scheduler {
     object Config {
         val default: Config = {
             val cores             = Runtime.getRuntime().availableProcessors()
-            val coreWorkers       = Math.max(1, Flag("coreWorkers", cores * 10))
+            val coreWorkers       = Math.max(1, Flag("coreWorkers", cores))
             val minWorkers        = Math.max(1, Flag("minWorkers", coreWorkers.toDouble / 2).intValue())
             val maxWorkers        = Math.max(minWorkers, Flag("maxWorkers", coreWorkers * 100))
             val scheduleStride    = Math.max(1, Flag("scheduleStride", cores))
-            val stealStride       = Math.max(1, Flag("stealStride", cores * 4))
+            val stealStride       = Math.max(1, Flag("stealStride", cores * 8))
             val virtualizeWorkers = Flag("virtualizeWorkers", false)
             val timeSliceMs       = Flag("timeSliceMs", 10)
             val cycleIntervalNs   = Flag("cycleIntervalNs", 100000)
-            val enableTopJMX      = Flag("enableTopJMX", true)
+            val enableTopJMX      = Flag("enableTopJMX", false)
             val enableTopConsole  = Flag("enableTopConsoleMs", 0)
             Config(
                 cores,

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/util/Flag.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/util/Flag.scala
@@ -1,5 +1,10 @@
 package kyo.scheduler.util
 
+/** Type-safe scheduler configuration using system properties.
+  *
+  * Reads configuration from "kyo.scheduler.[name]" system properties with fallback to defaults. Supports primitive types, strings, and
+  * their lists through implicit readers.
+  */
 private[kyo] object Flag {
     abstract class Reader[A] {
         def apply(s: String): A

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/util/MovingStdDev.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/util/MovingStdDev.scala
@@ -1,5 +1,20 @@
 package kyo.scheduler.util
 
+/** Moving standard deviation calculator optimized for high-throughput measurements.
+  *
+  * IMPORTANT: This implementation is not thread-safe and is only be accessed by its owning worker thread.
+  *
+  * This implementation maintains a fixed-size window of values and efficiently calculates rolling statistics without allocation or array
+  * copying. It uses a circular buffer approach to update values in place, making it suitable for high-frequency measurement scenarios like
+  * scheduler instrumentation.
+  *
+  * To use the MovingStdDev, create an instance with a specified window size, then call observe() to record measurements. The current
+  * standard deviation and mean can be retrieved at any time using dev() and avg() respectively. The implementation automatically maintains
+  * the sliding window as new values arrive.
+  *
+  * @param window
+  *   Size of the measurement window
+  */
 final private[kyo] class MovingStdDev(window: Int) {
     private val values = new Array[Long](window)
     private var idx    = 0L

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/util/SelfCheck.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/util/SelfCheck.scala
@@ -7,6 +7,33 @@ import java.util.concurrent.atomic.AtomicLong
 import kyo.scheduler.*
 import scala.annotation.tailrec
 
+/** Self-test utility for verifying scheduler behavior under load.
+  *
+  * This utility creates controlled load conditions to verify scheduler performance, admission control, and concurrency regulation. It
+  * incrementally increases concurrency until reaching rejection thresholds, helping validate proper scheduler operation and capacity
+  * limits.
+  *
+  * The testing process can be customized through several parameters. Task duration controls the length of individual test operations. The
+  * rejection threshold determines the maximum acceptable task rejection rate. Monitoring and step intervals control the pace of
+  * measurements and client count increases respectively.
+  *
+  * The companion object provides a main method to run the self-check with default settings. For more precise testing, create an instance
+  * with custom parameters to control the exact test conditions. The test runs until either reaching steady state or determining the
+  * system's capacity limits.
+  *
+  * @param scheduler
+  *   Scheduler instance to test
+  * @param executor
+  *   Executor for running test clients
+  * @param rejectionThreshold
+  *   Maximum acceptable rejection rate
+  * @param taskDurationMs
+  *   Duration of each test task
+  * @param monitorIntervalMs
+  *   Interval between measurements
+  * @param stepMs
+  *   Duration to maintain each client count
+  */
 final class SelfCheck(
     scheduler: Scheduler = Scheduler.get,
     executor: Executor = Executors.newCachedThreadPool(Threads("kyo-selfcheck")),

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/util/Threads.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/util/Threads.scala
@@ -3,6 +3,16 @@ package kyo.scheduler.util
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
 
+/** Thread factory for creating consistently named daemon threads.
+  *
+  * Creates daemon threads with auto-incrementing IDs prefixed by the given name. Optionally accepts a custom thread creation function while
+  * maintaining naming.
+  *
+  * @param name
+  *   Base name for created threads
+  * @param create
+  *   Optional custom thread creation function
+  */
 object Threads {
 
     def apply(name: String): ThreadFactory =

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/util/XSRandom.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/util/XSRandom.scala
@@ -2,6 +2,15 @@ package kyo.scheduler.util
 
 import java.util.Random
 
+/** Fast pseudo-random number generator for scheduler operations.
+  *
+  * Uses a thread-hashed seed array and xorshift algorithm for quick random generation. Designed for scheduler operations like work stealing
+  * and load balancing where speed is prioritized over perfect randomness or thread isolation.
+  *
+  * The design deliberately trades thread isolation for simplicity and performance. A shared seed array with 32 slots provides sufficient
+  * randomness for scheduler decisions while minimizing memory overhead. Thread conflicts in the same array slot may impact randomness but
+  * do not affect correctness of the scheduling algorithms.
+  */
 private[kyo] object XSRandom extends Random {
     private val seeds = List.fill(32)(31L).toArray
     override def next(nbits: Int): Int = {


### PR DESCRIPTION
I did some more testing using Kyo's scheduler with cats-effect and identified tunings to offset the regression in some benchmarks. [Results](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/fwbrasil/396006030e3dae7e157982d04c1f7235/raw/921394ba87a1ffb8f9c09c5a17488c02e23597cf/jmh-result-baseline.json,https://gist.githubusercontent.com/fwbrasil/396006030e3dae7e157982d04c1f7235/raw/921394ba87a1ffb8f9c09c5a17488c02e23597cf/jmh-result-candidate.json) with/without the tuning using Kyo's scheduler for both ZIO and cats-effect:

![image](https://github.com/user-attachments/assets/8070c362-1e56-4a3f-a9a8-56815b96d2fa)
