### PR TITLE
adopt `*With` naming strategy + avoid some `apply` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,14 +1372,14 @@ import kyo.*
 
 // Add a value
 val a: Ack < Emit[Int] =
-    Emit(42)
+    Emit.value(42)
 
 // Add multiple values
 val b: String < Emit[Int] =
     for
-        _ <- Emit(1)
-        _ <- Emit(2)
-        _ <- Emit(3)
+        _ <- Emit.value(1)
+        _ <- Emit.value(2)
+        _ <- Emit.value(3)
     yield "r"
 
 // Handle the effect to obtain the
@@ -1397,9 +1397,9 @@ import kyo.*
 
 val a: String < (Emit[Int] & Emit[String]) =
     for
-        _ <- Emit(1)
-        _ <- Emit("log")
-        _ <- Emit(2)
+        _ <- Emit.value(1)
+        _ <- Emit.value("log")
+        _ <- Emit.value(2)
     yield "result"
 
 // Note how `run` requires an explicit type
@@ -1555,13 +1555,13 @@ import kyo.*
 
 // Create a simple check
 val a: Unit < Check =
-    Check(1 + 1 == 2, "Basic math works")
+    Check.require(1 + 1 == 2, "Basic math works")
 
 // Checks can be composed with other effects
 val b: Int < (Check & IO) =
     for
         value <- IO(42)
-        _     <- Check(value > 0, "Value is positive")
+        _     <- Check.require(value > 0, "Value is positive")
     yield value
 
 // Handle checks by converting the first failed check to Abort

--- a/kyo-bench/src/main/scala/kyo/bench/MtlBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/MtlBench.scala
@@ -17,7 +17,7 @@ class MtlBench extends Bench(()):
             Kyo.foreachDiscard(loops)(_ =>
                 for
                     conf <- Env.use[EnvValue](_.config)
-                    _    <- Emit(Event(s"Env = $conf"))
+                    _    <- Emit.value(Event(s"Env = $conf"))
                     _    <- Var.update((state: State) => state.copy(value = state.value + 1))
                 yield ()
             )

--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -981,7 +981,7 @@ extension [A, B, S](effect: B < (Emit[A] & S))
                 (v, buffer, cont) =>
                     val b2 = buffer.append(v)
                     if b2.size >= chunkSize then
-                        Emit.andMap(b2): ack =>
+                        Emit.valueWith(b2): ack =>
                             (Chunk.empty, cont(ack))
                     else
                         (b2, cont(Ack.Continue()))
@@ -989,7 +989,7 @@ extension [A, B, S](effect: B < (Emit[A] & S))
             ,
             (buffer, v) =>
                 if buffer.isEmpty then v
-                else Emit.andMap(buffer)(_ => v)
+                else Emit.valueWith(buffer)(_ => v)
         )
 
     /** Convert emitting effect to stream, chunking Emitted values in [[chunkSize]], and discarding result.

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -95,7 +95,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that emits a value
       */
     def emit[A](value: A)(using Tag[A], Frame): Ack < Emit[A] =
-        Emit(value)
+        Emit.value(value)
 
     /** Creates an effect that fails with Abort[E].
       *

--- a/kyo-combinators/shared/src/test/scala/kyo/EmitCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EmitCombinatorTest.scala
@@ -9,19 +9,19 @@ class EmitCombinatorTest extends Test:
 
     "emit" - {
         "handleEmit" in run {
-            val emit = Loop(1)(i => if i == 4 then Loop.done(()) else Emit.andMap(i)(_ => Loop.continue(i + 1))).map(_ => "done")
+            val emit = Loop(1)(i => if i == 4 then Loop.done(()) else Emit.valueWith(i)(_ => Loop.continue(i + 1))).map(_ => "done")
             emit.handleEmit.map:
                 case (chunk, res) => assert(chunk == Chunk(1, 2, 3) && res == "done")
         }
 
         "handleEmitDiscarding" in run {
-            val emit = Loop(1)(i => if i == 4 then Loop.done(()) else Emit.andMap(i)(_ => Loop.continue(i + 1))).map(_ => "done")
+            val emit = Loop(1)(i => if i == 4 then Loop.done(()) else Emit.valueWith(i)(_ => Loop.continue(i + 1))).map(_ => "done")
             emit.handleEmitDiscarding.map:
                 case chunk => assert(chunk == Chunk(1, 2, 3))
         }
 
         "foreachEmit" in run {
-            val emit = Loop(1)(i => if i == 4 then Loop.done(()) else Emit.andMap(i)(_ => Loop.continue(i + 1))).map(_ => "done")
+            val emit = Loop(1)(i => if i == 4 then Loop.done(()) else Emit.valueWith(i)(_ => Loop.continue(i + 1))).map(_ => "done")
             val effect = emit.foreachEmit(i => Var.update[Int](v => v + i).unit).map: result =>
                 Var.get[Int].map(v => (result, v))
             Var.run(0)(effect).map:
@@ -29,7 +29,7 @@ class EmitCombinatorTest extends Test:
         }
 
         "emitToChannel" in run {
-            val emit = Loop(1)(i => if i == 4 then Loop.done(()) else Emit.andMap(i)(_ => Loop.continue(i + 1)))
+            val emit = Loop(1)(i => if i == 4 then Loop.done(()) else Emit.valueWith(i)(_ => Loop.continue(i + 1)))
             for
                 channel <- Channel.init[Int](10)
                 _       <- emit.emitToChannel(channel)
@@ -39,35 +39,35 @@ class EmitCombinatorTest extends Test:
         }
 
         "emitChunked with number of emitted values divisible by chunk size" in run {
-            val emit        = Loop(1)(i => if i == 5 then Loop.done(()) else Emit.andMap(i)(_ => Loop.continue(i + 1)))
+            val emit        = Loop(1)(i => if i == 5 then Loop.done(()) else Emit.valueWith(i)(_ => Loop.continue(i + 1)))
             val chunkedEmit = emit.emitChunked(2)
             chunkedEmit.handleEmitDiscarding.map: result =>
                 assert(result == Chunk(Chunk(1, 2), Chunk(3, 4)))
         }
 
         "emitChunked with number of emitted values not divisible by chunk size" in run {
-            val emit        = Loop(1)(i => if i == 6 then Loop.done(()) else Emit.andMap(i)(_ => Loop.continue(i + 1)))
+            val emit        = Loop(1)(i => if i == 6 then Loop.done(()) else Emit.valueWith(i)(_ => Loop.continue(i + 1)))
             val chunkedEmit = emit.emitChunked(2)
             chunkedEmit.handleEmitDiscarding.map: result =>
                 assert(result == Chunk(Chunk(1, 2), Chunk(3, 4), Chunk(5)))
         }
 
         "emitChunkedToStream" in run {
-            val emit   = Loop(0)(i => if i == 9 then Loop.done(()) else Emit.andMap(i)(_ => Loop.continue(i + 1))).map(_ => Ack.Continue())
+            val emit = Loop(0)(i => if i == 9 then Loop.done(()) else Emit.valueWith(i)(_ => Loop.continue(i + 1))).map(_ => Ack.Continue())
             val stream = emit.emitChunkedToStream(2)
             stream.run.map: chunk =>
                 assert(chunk == Chunk.from(0 until 9))
         }
 
         "emitChunkedToStreamDiscarding" in run {
-            val emit   = Loop(0)(i => if i == 9 then Loop.done(()) else Emit.andMap(i)(_ => Loop.continue(i + 1)))
+            val emit   = Loop(0)(i => if i == 9 then Loop.done(()) else Emit.valueWith(i)(_ => Loop.continue(i + 1)))
             val stream = emit.emitChunkedToStreamDiscarding(2)
             stream.run.map: chunk =>
                 assert(chunk == Chunk.from(0 until 9))
         }
 
         "emitChunkedToStreamAndResult" in run {
-            val emit = Loop(0)(i => if i == 9 then Loop.done(()) else Emit.andMap(i)(_ => Loop.continue(i + 1))).map(_ => "done")
+            val emit = Loop(0)(i => if i == 9 then Loop.done(()) else Emit.valueWith(i)(_ => Loop.continue(i + 1))).map(_ => "done")
             for
                 (stream, handled) <- emit.emitChunkedToStreamAndResult(2)
                 streamRes         <- stream.run
@@ -86,14 +86,14 @@ class EmitCombinatorTest extends Test:
         }
 
         "emitToStreamDiscarding" in run {
-            val emit   = Kyo.foreach(0 until 3)(i => Emit[Chunk[Int]](Chunk.from((i * 3) until (i * 3) + 3)).map(_ => i))
+            val emit   = Kyo.foreach(0 until 3)(i => Emit.value[Chunk[Int]](Chunk.from((i * 3) until (i * 3) + 3)).map(_ => i))
             val stream = emit.emitToStreamDiscarding
             stream.run.map: chunk =>
                 assert(chunk == Chunk.from(0 until 9))
         }
 
         "emitToStreamAndResult" in run {
-            val emit = Kyo.foreach(0 until 3)(i => Emit[Chunk[Int]](Chunk.from((i * 3) until (i * 3) + 3)).map(_ => i))
+            val emit = Kyo.foreach(0 until 3)(i => Emit.value[Chunk[Int]](Chunk.from((i * 3) until (i * 3) + 3)).map(_ => i))
             for
                 (stream, handled) <- emit.emitToStreamAndResult
                 streamRes         <- stream.run

--- a/kyo-core/jvm/src/main/scala/kyo/Path.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Path.scala
@@ -164,7 +164,7 @@ class Path private (val path: List[String]) derives CanEqual:
                     Loop(state) {
                         case Absent => Loop.done(Ack.Stop)
                         case Present(content) =>
-                            Emit.andMap(writeOnce(content)) {
+                            Emit.valueWith(writeOnce(content)) {
                                 case Ack.Stop => Loop.done(Ack.Stop)
                                 case _        => readOnce(res).map(Loop.continue(_))
                             }

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -773,6 +773,6 @@ object Async:
         ArrowEffect.suspend[A](Tag[Join], v).asInstanceOf[Result[E, A] < Async]
 
     private[kyo] def useResult[E, A, B, S](v: IOPromise[E, A])(f: Result[E, A] => B < S)(using Frame): B < (S & Async) =
-        ArrowEffect.suspendAndMap[A](Tag[Join], v)(f)
+        ArrowEffect.suspendWith[A](Tag[Join], v)(f)
 
 end Async

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -184,7 +184,7 @@ object Channel:
             else if maxChunkSize == 1 then
                 Loop(()): _ =>
                     Channel.take(self).map: v =>
-                        Emit.andMap(Chunk(v)):
+                        Emit.valueWith(Chunk(v)):
                             case Ack.Stop => Loop.done(Ack.Stop)
                             case _        => Loop.continue(())
             else
@@ -194,7 +194,7 @@ object Channel:
                 Loop[Unit, Ack, Abort[Closed] & Async & Emit[Chunk[A]]](()): _ =>
                     Channel.take(self).map: a =>
                         drainEffect.map: chunk =>
-                            Emit.andMap(Chunk(a).concat(chunk)):
+                            Emit.valueWith(Chunk(a).concat(chunk)):
                                 case Ack.Stop => Loop.done(Ack.Stop)
                                 case _        => Loop.continue(())
 

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -27,7 +27,7 @@ object Resource:
       *   A unit value wrapped in Resource and IO effects.
       */
     def ensure(v: => Unit < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & IO) =
-        ContextEffect.suspendAndMap(Tag[Resource]) { finalizer =>
+        ContextEffect.suspendWith(Tag[Resource]) { finalizer =>
             Abort.run(finalizer.queue.offer(IO(v))).map {
                 case Result.Success(_) => ()
                 case _ =>

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -696,9 +696,9 @@ class AsyncTest extends Test:
             Emit.run {
                 Async.timeout(1.hour, emitIsolate) {
                     for
-                        _ <- Emit(1)
+                        _ <- Emit.value(1)
                         _ <- Async.sleep(1.millis)
-                        _ <- Emit(2)
+                        _ <- Emit.value(2)
                     yield "done"
                 }
             }.map { result =>
@@ -762,14 +762,14 @@ class AsyncTest extends Test:
                     emitIsolate,
                     Seq(
                         for
-                            _ <- Emit("a1")
+                            _ <- Emit.value("a1")
                             _ <- Async.sleep(2.millis)
-                            _ <- Emit("a2")
+                            _ <- Emit.value("a2")
                         yield 1,
                         for
-                            _ <- Emit("b1")
+                            _ <- Emit.value("b1")
                             _ <- Async.sleep(1.millis)
-                            _ <- Emit("b2")
+                            _ <- Emit.value("b2")
                         yield 2
                     )
                 )
@@ -821,14 +821,14 @@ class AsyncTest extends Test:
                     Async.gather(emitIsolate)(
                         Seq(
                             for
-                                _ <- Emit("a1")
+                                _ <- Emit.value("a1")
                                 _ <- Async.sleep(2.millis)
-                                _ <- Emit("a2")
+                                _ <- Emit.value("a2")
                             yield 1,
                             for
-                                _ <- Emit("b1")
+                                _ <- Emit.value("b1")
                                 _ <- Async.sleep(1.millis)
-                                _ <- Emit("b2")
+                                _ <- Emit.value("b2")
                             yield 2
                         )
                     )
@@ -845,14 +845,14 @@ class AsyncTest extends Test:
                     Async.gather(1, emitIsolate)(
                         Seq(
                             for
-                                _ <- Emit("a1")
+                                _ <- Emit.value("a1")
                                 _ <- Async.sleep(5.millis)
-                                _ <- Emit("a2")
+                                _ <- Emit.value("a2")
                             yield 1,
                             for
-                                _ <- Emit("b1")
+                                _ <- Emit.value("b1")
                                 _ <- Async.sleep(1.millis)
-                                _ <- Emit("b2")
+                                _ <- Emit.value("b2")
                             yield 2
                         )
                     )
@@ -869,14 +869,14 @@ class AsyncTest extends Test:
                 Emit.run {
                     Async.gather(emitIsolate)(
                         for
-                            _ <- Emit("a1")
+                            _ <- Emit.value("a1")
                             _ <- Async.sleep(2.millis)
-                            _ <- Emit("a2")
+                            _ <- Emit.value("a2")
                         yield 1,
                         for
-                            _ <- Emit("b1")
+                            _ <- Emit.value("b1")
                             _ <- Async.sleep(1.millis)
-                            _ <- Emit("b2")
+                            _ <- Emit.value("b2")
                         yield 2
                     )
                 }.map { result =>
@@ -891,14 +891,14 @@ class AsyncTest extends Test:
                 Emit.run {
                     Async.gather(1, emitIsolate)(
                         for
-                            _ <- Emit("a1")
+                            _ <- Emit.value("a1")
                             _ <- Async.sleep(10.millis)
-                            _ <- Emit("a2")
+                            _ <- Emit.value("a2")
                         yield 1,
                         for
-                            _ <- Emit("b1")
+                            _ <- Emit.value("b1")
                             _ <- Async.sleep(1.millis)
-                            _ <- Emit("b2")
+                            _ <- Emit.value("b2")
                         yield 2
                     )
                 }.map { result =>
@@ -916,14 +916,14 @@ class AsyncTest extends Test:
                     Abort.run {
                         Async.gather(emitIsolate)(
                             for
-                                _ <- Emit("a1")
+                                _ <- Emit.value("a1")
                                 _ <- Abort.fail(error)
-                                _ <- Emit("a2")
+                                _ <- Emit.value("a2")
                             yield 1,
                             for
-                                _ <- Emit("b1")
+                                _ <- Emit.value("b1")
                                 _ <- Async.sleep(1.millis)
-                                _ <- Emit("b2")
+                                _ <- Emit.value("b2")
                             yield 2
                         )
                     }
@@ -942,17 +942,17 @@ class AsyncTest extends Test:
                     Abort.run {
                         Async.gather(emitIsolate)(
                             for
-                                _ <- Emit("a1")
+                                _ <- Emit.value("a1")
                                 _ <- Abort.fail(error1)
                             yield 1,
                             for
-                                _ <- Emit("b1")
+                                _ <- Emit.value("b1")
                                 _ <- Abort.fail(error2)
                             yield 2,
                             for
-                                _ <- Emit("c1")
+                                _ <- Emit.value("c1")
                                 _ <- Async.sleep(1.millis)
-                                _ <- Emit("c2")
+                                _ <- Emit.value("c2")
                             yield 3
                         )
                     }
@@ -969,18 +969,18 @@ class AsyncTest extends Test:
                 Emit.run {
                     Async.gather(2, emitIsolate)(
                         for
-                            _ <- Emit("a1")
+                            _ <- Emit.value("a1")
                             _ <- Abort.fail(error)
                         yield 1,
                         for
-                            _ <- Emit("b1")
+                            _ <- Emit.value("b1")
                             _ <- Async.sleep(2.millis)
-                            _ <- Emit("b2")
+                            _ <- Emit.value("b2")
                         yield 2,
                         for
-                            _ <- Emit("c1")
+                            _ <- Emit.value("c1")
                             _ <- Async.sleep(1.millis)
-                            _ <- Emit("c2")
+                            _ <- Emit.value("c2")
                         yield 3
                     )
                 }.map { case (emitted, results) =>

--- a/kyo-kernel/jvm/src/test/scala/kyo/kernel/BytecodeTest.scala
+++ b/kyo-kernel/jvm/src/test/scala/kyo/kernel/BytecodeTest.scala
@@ -12,7 +12,7 @@ class BytecodeTest extends Test:
         def test() = ArrowEffect.suspend[Int](Tag[TestEffect.type], 42)
 
     class TestSuspendMap:
-        def test() = ArrowEffect.suspendAndMap[Int](Tag[TestEffect.type], 42)(_ + 1)
+        def test() = ArrowEffect.suspendWith[Int](Tag[TestEffect.type], 42)(_ + 1)
 
     class TestMap:
         def test(v: Int < TestEffect.type) = v.map(_ + 1)
@@ -25,7 +25,7 @@ class BytecodeTest extends Test:
         assert(map == Map("test" -> 16))
     }
 
-    "suspendAndMap" in {
+    "suspendWith" in {
         val map = methodBytecodeSize[TestSuspendMap]
         assert(map == Map("test" -> 16))
     }

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/ArrowEffect.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/ArrowEffect.scala
@@ -100,7 +100,7 @@ object ArrowEffect:
     end SuspendAndMapOps
 
     /** See [[SuspendAndMapOps.apply]] */
-    inline def suspendAndMap[A]: SuspendAndMapOps[A] = SuspendAndMapOps(())
+    inline def suspendWith[A]: SuspendAndMapOps[A] = SuspendAndMapOps(())
 
     object handle:
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/ContextEffect.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/ContextEffect.scala
@@ -44,7 +44,7 @@ object ContextEffect:
       *   A computation that will receive the requested value when executed
       */
     inline def suspend[A, E <: ContextEffect[A]](inline effectTag: Tag[E])(using inline frame: Frame): A < E =
-        suspendAndMap(effectTag)(identity)
+        suspendWith(effectTag)(identity)
 
     /** Creates a suspended computation that requests a context value and transforms it immediately upon receipt. This combines the
       * operations of requesting and transforming a context value into a single step.
@@ -56,12 +56,12 @@ object ContextEffect:
       * @return
       *   A computation containing the transformed value
       */
-    inline def suspendAndMap[A, E <: ContextEffect[A], B, S](
+    inline def suspendWith[A, E <: ContextEffect[A], B, S](
         inline effectTag: Tag[E]
     )(
         inline f: Safepoint ?=> A => B < S
     )(using inline frame: Frame): B < (E & S) =
-        suspendAndMap(effectTag, bug("Unexpected pending context effect: " + effectTag.show))(f)
+        suspendWith(effectTag, bug("Unexpected pending context effect: " + effectTag.show))(f)
 
     /** Requests a value from a context effect with a specified default value. Unlike standard suspend, this version does not create a
       * mandatory effect requirement. If no handler provides a value, the computation proceeds with the default value instead. This makes
@@ -78,7 +78,7 @@ object ContextEffect:
         inline effectTag: Tag[E],
         inline default: => A
     )(using inline frame: Frame): A < Any =
-        suspendAndMap(effectTag, default)(identity)
+        suspendWith(effectTag, default)(identity)
 
     /** Requests an optional context value and transforms it, using a default if no value is available. This combines requesting an optional
       * context value with immediate transformation. The transformation function receives either the context value if available or the
@@ -94,7 +94,7 @@ object ContextEffect:
       *   A computation containing the transformed value
       */
     @nowarn("msg=anonymous")
-    inline def suspendAndMap[A, E <: ContextEffect[A], B, S](
+    inline def suspendWith[A, E <: ContextEffect[A], B, S](
         inline effectTag: Tag[E],
         inline default: => A
     )(

--- a/kyo-prelude/jvm/src/test/scala/kyo/MonadLawsTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo/MonadLawsTest.scala
@@ -27,7 +27,7 @@ object MonadLawsTest extends ZIOSpecDefault:
                         if b then Abort.fail("fail") else (v: A < Any)
                     ),
                     gen.zip(intGen).map((v, i) =>
-                        Emit(i).andThen(v)
+                        Emit.value(i).andThen(v)
                     ),
                     gen.zip(boolGen).map((v, b) =>
                         Var.setDiscard(b).andThen(v)
@@ -39,13 +39,13 @@ object MonadLawsTest extends ZIOSpecDefault:
                         Var.get[Boolean].map(x => if x then v else Abort.fail("var fail"))
                     ),
                     gen.zip(intGen).map((v, i) =>
-                        Emit(i).map(_ => if i % 2 == 0 then v else Abort.fail("sum fail"))
+                        Emit.value(i).map(_ => if i % 2 == 0 then v else Abort.fail("sum fail"))
                     ),
                     gen.map(v =>
                         for
                             s <- Env.get[String]
                             _ <- Var.update[Boolean](!_)
-                            i <- Emit(s.length)
+                            i <- Emit.value(s.length)
                             _ <- Abort.when(s.length() > 10)("length exceeded")
                         yield v
                     )

--- a/kyo-prelude/jvm/src/test/scala/kyo/ParseTest.scala
+++ b/kyo-prelude/jvm/src/test/scala/kyo/ParseTest.scala
@@ -1286,10 +1286,10 @@ class ParseTest extends Test:
                 def parseAndEmit: Unit < (Parse & Emit[Int]) =
                     for
                         n1 <- Parse.int
-                        _  <- Emit(n1)
+                        _  <- Emit.value(n1)
                         _  <- Parse.whitespaces
                         n2 <- Parse.int
-                        _  <- Emit(n2)
+                        _  <- Emit.value(n2)
                     yield ()
 
                 val result = Abort.run(Emit.run(Parse.run("42 123")(parseAndEmit))).eval

--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -47,7 +47,7 @@ object Abort:
       *   A computation that immediately fails with the given error value
       */
     inline def error[E](inline e: Error[E])(using inline frame: Frame): Nothing < Abort[E] =
-        ArrowEffect.suspendAndMap[Any](erasedTag[E], e)(_ => ???)
+        ArrowEffect.suspendWith[Any](erasedTag[E], e)(_ => ???)
 
     /** Fails the computation if the condition is true.
       *

--- a/kyo-prelude/shared/src/main/scala/kyo/Batch.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Batch.scala
@@ -32,7 +32,7 @@ object Batch:
       * results for each input.
       */
     inline def source[A, B, S](f: Seq[A] => (A => B < S) < S)(using inline frame: Frame): A => B < (Batch & S) =
-        (v: A) => ArrowEffect.suspendAndMap(Tag[Batch], Call(v, f))(identity)
+        (v: A) => ArrowEffect.suspendWith(Tag[Batch], Call(v, f))(identity)
 
     /** Creates a batched computation from a source function that returns a Map.
       *
@@ -92,7 +92,7 @@ object Batch:
       *   A batched computation that produces a single value of type B
       */
     inline def foreach[A, B, S](seq: Seq[A])(inline f: A => B < S): B < (Batch & S) =
-        ArrowEffect.suspendAndMap[A](Tag[Batch], Eval(seq))(f)
+        ArrowEffect.suspendWith[A](Tag[Batch], Eval(seq))(f)
 
     /** Runs a computation with Batch effect, executing all batched operations.
       *

--- a/kyo-prelude/shared/src/main/scala/kyo/Check.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Check.scala
@@ -33,8 +33,8 @@ object Check:
       * @return
       *   A unit computation that fails if the condition is false
       */
-    inline def apply(inline condition: Boolean)(using inline frame: Frame): Unit < Check =
-        Check(condition, "")
+    inline def require(inline condition: Boolean)(using inline frame: Frame): Unit < Check =
+        Check.require(condition, "")
 
     /** Checks the boolean condition with a custom failure message.
       *
@@ -45,7 +45,7 @@ object Check:
       * @return
       *   A unit computation that fails with the given message if the condition is false
       */
-    inline def apply(inline condition: Boolean, inline message: => String)(using inline frame: Frame): Unit < Check =
+    inline def require(inline condition: Boolean, inline message: => String)(using inline frame: Frame): Unit < Check =
         if condition then ()
         else ArrowEffect.suspend[Unit](Tag[Check], new CheckFailed(message, frame))
 
@@ -108,7 +108,7 @@ object Check:
                     Check.runChunk(v)
 
                 def restore[A: Flat, S2](state: Chunk[CheckFailed], v: A < S2)(using Frame) =
-                    Kyo.foreach(state)(check => Check(false, check.message)(using check.frame)).andThen(v)
+                    Kyo.foreach(state)(check => Check.require(false, check.message)(using check.frame)).andThen(v)
             end new
         end merge
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
@@ -34,7 +34,7 @@ object Choice:
     inline def eval[A, B, S](seq: Seq[A])(inline f: A => B < S)(using inline frame: Frame): B < (Choice & S) =
         seq match
             case Seq(head) => f(head)
-            case seq       => ArrowEffect.suspendAndMap[A](Tag[Choice], seq)(f)
+            case seq       => ArrowEffect.suspendWith[A](Tag[Choice], seq)(f)
 
     /** Conditionally introduces a failure branch in the computation.
       *

--- a/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
@@ -22,7 +22,7 @@ object Emit:
       * @return
       *   An effect that emits the given value
       */
-    inline def apply[V](inline value: V)(using inline tag: Tag[Emit[V]], inline frame: Frame): Ack < Emit[V] =
+    inline def value[V](inline value: V)(using inline tag: Tag[Emit[V]], inline frame: Frame): Ack < Emit[V] =
         ArrowEffect.suspend[Any](tag, value)
 
     /** Emits a single value and maps the resulting Ack.
@@ -34,12 +34,12 @@ object Emit:
       * @return
       *   The result of applying f to the Ack
       */
-    inline def andMap[V, A, S](inline value: V)(inline f: Ack => A < S)(
+    inline def valueWith[V, A, S](inline value: V)(inline f: Ack => A < S)(
         using
         inline tag: Tag[Emit[V]],
         inline frame: Frame
     ): A < (S & Emit[V]) =
-        ArrowEffect.suspendAndMap[Any](tag, value)(f(_))
+        ArrowEffect.suspendWith[Any](tag, value)(f(_))
 
     final class RunOps[V](dummy: Unit) extends AnyVal:
         /** Runs an Emit effect, collecting all emitted values into a Chunk.
@@ -169,7 +169,7 @@ object Emit:
                     Loop(state: Seq[V]) {
                         case Seq() => Loop.done
                         case head +: tail =>
-                            Emit.andMap(head) {
+                            Emit.valueWith(head) {
                                 case Ack.Stop => Loop.done
                                 case _        => Loop.continue(tail)
                             }

--- a/kyo-prelude/shared/src/main/scala/kyo/Env.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Env.scala
@@ -94,7 +94,7 @@ object Env:
             inline tag: Tag[R],
             inline frame: Frame
         ): A < (Env[R] & S) =
-            ContextEffect.suspendAndMap(erasedTag[R]) { map =>
+            ContextEffect.suspendWith(erasedTag[R]) { map =>
                 f(map.asInstanceOf[TypeMap[R]].get(using tag))
             }
     end UseOps

--- a/kyo-prelude/shared/src/main/scala/kyo/Local.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Local.scala
@@ -102,10 +102,10 @@ object Local:
             def tag: Tag[E]
 
             def get(using Frame) =
-                ContextEffect.suspendAndMap(tag, Map.empty)(_.getOrElse(this, default).asInstanceOf[A])
+                ContextEffect.suspendWith(tag, Map.empty)(_.getOrElse(this, default).asInstanceOf[A])
 
             def use[B, S](f: A => B < S)(using Frame) =
-                ContextEffect.suspendAndMap(tag, Map.empty)(map => f(map.getOrElse(this, default).asInstanceOf[A]))
+                ContextEffect.suspendWith(tag, Map.empty)(map => f(map.getOrElse(this, default).asInstanceOf[A]))
 
             def let[B, S](value: A)(v: B < S)(using Frame) =
                 ContextEffect.handle(tag, Map.empty[Local[?], AnyRef].updated(this, value), _.updated(this, value.asInstanceOf[AnyRef]))(v)

--- a/kyo-prelude/shared/src/main/scala/kyo/Parse.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Parse.scala
@@ -712,7 +712,7 @@ object Parse:
                                     else
                                         // Successfully parsed a value with remaining text.
                                         // Emit the parsed value and continue with unconsumed text
-                                        Emit.andMap(Chunk(value)) { ack =>
+                                        Emit.valueWith(Chunk(value)) { ack =>
                                             (state.remaining, ack)
                                         }
                                 case seq =>
@@ -726,7 +726,7 @@ object Parse:
                     case Ack.Stop => Ack.Stop
                     case _        =>
                         // Try to parse any complete results from remaining text
-                        run(text)(repeat(v)).map(Emit(_))
+                        run(text)(repeat(v)).map(Emit.value(_))
             }
         }
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
@@ -56,7 +56,7 @@ object Poll:
     ): Maybe[V] < Poll[V] =
         one(Ack.Continue())
 
-    final class ApplyOps[V](dummy: Unit) extends AnyVal:
+    final class ValuesOps[V](dummy: Unit) extends AnyVal:
 
         /** Processes polled values with a function. Values are processed until n is reached or the stream completes.
           *
@@ -91,14 +91,9 @@ object Poll:
                     case Absent     => Loop.done
                 }
             }
-    end ApplyOps
+    end ValuesOps
 
-    /** Creates an instance of ApplyOps for processing polled values.
-      *
-      * @return
-      *   An instance of ApplyOps
-      */
-    inline def apply[V]: ApplyOps[V] = ApplyOps(())
+    inline def values[V]: ValuesOps[V] = ValuesOps(())
 
     final case class AndMapOps[V](dummy: Unit) extends AnyVal:
 
@@ -130,7 +125,7 @@ object Poll:
             inline tag: Tag[Poll[V]],
             inline frame: Frame
         ): A < (Poll[V] & S) =
-            ArrowEffect.suspendAndMap[Unit](tag, ack)(f)
+            ArrowEffect.suspendWith[Unit](tag, ack)(f)
     end AndMapOps
 
     def andMap[V]: AndMapOps[V] = AndMapOps(())

--- a/kyo-prelude/shared/src/main/scala/kyo/Var.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Var.scala
@@ -36,7 +36,7 @@ object Var:
             inline tag: Tag[Var[V]],
             inline frame: Frame
         ): A < (Var[V] & S) =
-            ArrowEffect.suspendAndMap[V](tag, Get: Op[V])(f)
+            ArrowEffect.suspendWith[V](tag, Get: Op[V])(f)
     end UseOps
 
     /** Creates a new UseOps instance for the given type V.
@@ -73,7 +73,7 @@ object Var:
         inline tag: Tag[Var[V]],
         inline frame: Frame
     ): A < (Var[V] & S) =
-        ArrowEffect.suspendAndMap[Unit](tag, value: Op[V])(_ => f)
+        ArrowEffect.suspendWith[Unit](tag, value: Op[V])(_ => f)
 
     /** Sets a new value and returns `Unit`.
       *
@@ -85,7 +85,7 @@ object Var:
       *   Unit
       */
     inline def setDiscard[V](inline value: V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
-        ArrowEffect.suspendAndMap[Unit](tag, value: Op[V])(_ => ())
+        ArrowEffect.suspendWith[Unit](tag, value: Op[V])(_ => ())
 
     /** Applies the update function and returns the new value.
       *
@@ -111,7 +111,7 @@ object Var:
       */
     @nowarn("msg=anonymous")
     inline def updateDiscard[V](inline f: V => V)(using inline tag: Tag[Var[V]], inline frame: Frame): Unit < Var[V] =
-        ArrowEffect.suspendAndMap[Unit](tag, (v => f(v)): Update[V])(_ => ())
+        ArrowEffect.suspendWith[Unit](tag, (v => f(v)): Update[V])(_ => ())
 
     private[kyo] inline def runWith[V, A: Flat, S, B, S2](state: V)(v: A < (Var[V] & S))(
         inline f: (V, A) => B < S2

--- a/kyo-prelude/shared/src/test/scala/kyo/EmitTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/EmitTest.scala
@@ -7,9 +7,9 @@ class EmitTest extends Test:
     "int" in {
         val v: String < Emit[Int] =
             for
-                _ <- Emit(1)
-                _ <- Emit(1)
-                _ <- Emit(1)
+                _ <- Emit.value(1)
+                _ <- Emit.value(1)
+                _ <- Emit.value(1)
             yield "a"
 
         assert(Emit.run(v).eval == (Chunk(1, 1, 1), "a"))
@@ -17,9 +17,9 @@ class EmitTest extends Test:
     "string" in {
         val v: String < Emit[String] =
             for
-                _ <- Emit("1")
-                _ <- Emit("2")
-                _ <- Emit("3")
+                _ <- Emit.value("1")
+                _ <- Emit.value("2")
+                _ <- Emit.value("3")
             yield "a"
         val res = Emit.run(v)
         assert(res.eval == (Chunk("1", "2", "3"), "a"))
@@ -27,12 +27,12 @@ class EmitTest extends Test:
     "int and string" in {
         val v: String < (Emit[Int] & Emit[String]) =
             for
-                _ <- Emit(3)
-                _ <- Emit("1")
-                _ <- Emit(2)
-                _ <- Emit("2")
-                _ <- Emit(1)
-                _ <- Emit("3")
+                _ <- Emit.value(3)
+                _ <- Emit.value("1")
+                _ <- Emit.value(2)
+                _ <- Emit.value("2")
+                _ <- Emit.value(1)
+                _ <- Emit.value("3")
             yield "a"
         val res: (Chunk[String], (Chunk[Int], String)) =
             Emit.run(Emit.run[Int](v)).eval
@@ -50,9 +50,9 @@ class EmitTest extends Test:
     "List" in {
         val v =
             for
-                _ <- Emit(List(1))
-                _ <- Emit(List(2))
-                _ <- Emit(List(3))
+                _ <- Emit.value(List(1))
+                _ <- Emit.value(List(2))
+                _ <- Emit.value(List(3))
             yield "a"
         val res = Emit.run(v)
         assert(res.eval == (Chunk(List(1), List(2), List(3)), "a"))
@@ -61,9 +61,9 @@ class EmitTest extends Test:
     "Set" in {
         val v =
             for
-                _ <- Emit(Set(1))
-                _ <- Emit(Set(2))
-                _ <- Emit(Set(3))
+                _ <- Emit.value(Set(1))
+                _ <- Emit.value(Set(2))
+                _ <- Emit.value(Set(3))
             yield "a"
         val res = Emit.run(v)
         assert(res.eval == (Chunk(Set(1), Set(2), Set(3)), "a"))
@@ -165,7 +165,7 @@ class EmitTest extends Test:
                 def emits(i: Int): Unit < Emit[Int] =
                     if i == 5 then ()
                     else
-                        Emit.andMap(i) {
+                        Emit.valueWith(i) {
                             case Stop        => ()
                             case Continue(_) => emits(i + 1)
                         }
@@ -183,7 +183,7 @@ class EmitTest extends Test:
                 def emits(i: Int): Unit < Emit[Int] =
                     if i == 5 then ()
                     else
-                        Emit.andMap(i) {
+                        Emit.valueWith(i) {
                             case Stop        => ()
                             case Continue(_) => emits(i + 1)
                         }
@@ -210,7 +210,7 @@ class EmitTest extends Test:
                 def emits(i: Int): Unit < Emit[Int] =
                     if i == 5 then ()
                     else
-                        Emit.andMap(i) {
+                        Emit.valueWith(i) {
                             case Stop        => ()
                             case Continue(_) => emits(i + 1)
                         }
@@ -232,9 +232,9 @@ class EmitTest extends Test:
         "basic folding" in {
             val v =
                 for
-                    _ <- Emit(1)
-                    _ <- Emit(2)
-                    _ <- Emit(3)
+                    _ <- Emit.value(1)
+                    _ <- Emit.value(2)
+                    _ <- Emit.value(3)
                 yield "a"
 
             val result = Emit.runFold(0)((acc, v: Int) => (acc + v, Ack.Continue()))(v).eval
@@ -244,10 +244,10 @@ class EmitTest extends Test:
         "early termination" in {
             val v =
                 for
-                    _ <- Emit(1)
-                    _ <- Emit(2)
-                    _ <- Emit(3)
-                    _ <- Emit(4)
+                    _ <- Emit.value(1)
+                    _ <- Emit.value(2)
+                    _ <- Emit.value(3)
+                    _ <- Emit.value(4)
                 yield "a"
 
             val result = Emit.runFold(0)((acc, v: Int) =>
@@ -260,9 +260,9 @@ class EmitTest extends Test:
         "with effects" in {
             val v =
                 for
-                    _ <- Emit(1)
-                    _ <- Emit(2)
-                    _ <- Emit(3)
+                    _ <- Emit.value(1)
+                    _ <- Emit.value(2)
+                    _ <- Emit.value(3)
                 yield "a"
 
             val result = Env.run(10) {
@@ -281,9 +281,9 @@ class EmitTest extends Test:
         "discards all values" in {
             val v =
                 for
-                    _ <- Emit(1)
-                    _ <- Emit(2)
-                    _ <- Emit(3)
+                    _ <- Emit.value(1)
+                    _ <- Emit.value(2)
+                    _ <- Emit.value(3)
                 yield "a"
 
             val result = Emit.runDiscard(v).eval
@@ -294,9 +294,9 @@ class EmitTest extends Test:
             var count = 0
             val v =
                 for
-                    _ <- Emit(1)
-                    _ <- Emit(2)
-                    _ <- Emit(3)
+                    _ <- Emit.value(1)
+                    _ <- Emit.value(2)
+                    _ <- Emit.value(3)
                 yield count
 
             val result = Emit.runDiscard(v).eval
@@ -309,9 +309,9 @@ class EmitTest extends Test:
         "basic operation" in run {
             val v =
                 for
-                    _ <- Emit(1)
-                    _ <- Emit(2)
-                    _ <- Emit(3)
+                    _ <- Emit.value(1)
+                    _ <- Emit.value(2)
+                    _ <- Emit.value(3)
                 yield "done"
 
             for
@@ -344,9 +344,9 @@ class EmitTest extends Test:
         "with effects" in run {
             val v =
                 for
-                    _ <- Emit(1)
+                    _ <- Emit.value(1)
                     _ <- Var.update[Int](_ + 1)
-                    _ <- Emit(2)
+                    _ <- Emit.value(2)
                     _ <- Var.update[Int](_ + 1)
                 yield "done"
 
@@ -374,7 +374,7 @@ class EmitTest extends Test:
     "generic type parameters" - {
         "single generic emit" in {
             def emitGeneric[T: Tag](value: T): Unit < Emit[T] =
-                Emit(value).unit
+                Emit.value(value).unit
 
             val result = Emit.run(emitGeneric(42)).eval
             assert(result == (Chunk(42), ()))
@@ -383,8 +383,8 @@ class EmitTest extends Test:
         "multiple generic emits" in {
             def emitMultipleGeneric[T: Tag, U: Tag](t: T, u: U): Unit < (Emit[T] & Emit[U]) =
                 for
-                    _ <- Emit(t)
-                    _ <- Emit(u)
+                    _ <- Emit.value(t)
+                    _ <- Emit.value(u)
                 yield ()
 
             val result = Emit.run[Int](Emit.run[String](emitMultipleGeneric(42, "hello"))).eval
@@ -394,9 +394,9 @@ class EmitTest extends Test:
         "nested generic emits" in {
             def nestedEmit[T: Tag, U: Tag](t: T, u: U): Unit < (Emit[T] & Emit[U] & Emit[(T, U)]) =
                 for
-                    _ <- Emit(t)
-                    _ <- Emit(u)
-                    _ <- Emit((t, u))
+                    _ <- Emit.value(t)
+                    _ <- Emit.value(u)
+                    _ <- Emit.value((t, u))
                 yield ()
 
             val result = Emit.run[Int](Emit.run[String](Emit.run[(Int, String)](nestedEmit(42, "world")))).eval
@@ -406,9 +406,9 @@ class EmitTest extends Test:
         "multiple generic emits with different types" in {
             def multiEmit[T: Tag, U: Tag, V: Tag](t: T, u: U, v: V): Unit < (Emit[T] & Emit[U] & Emit[V]) =
                 for
-                    _ <- Emit(t)
-                    _ <- Emit(u)
-                    _ <- Emit(v)
+                    _ <- Emit.value(t)
+                    _ <- Emit.value(u)
+                    _ <- Emit.value(v)
                 yield ()
 
             val result = Emit.run[Int](Emit.run[String](Emit.run[Boolean](multiEmit(42, "test", true)))).eval
@@ -424,8 +424,8 @@ class EmitTest extends Test:
         "two emitters with same object" in {
             def emitC: Unit < (Emit[A] & Emit[B]) =
                 for
-                    _ <- Emit[A](C)
-                    _ <- Emit[B](C)
+                    _ <- Emit.value[A](C)
+                    _ <- Emit.value[B](C)
                 yield ()
 
             val result = Emit.run[A] {
@@ -447,8 +447,8 @@ class EmitTest extends Test:
             def emitMultiple(values: List[D]): Unit < (Emit[X] & Emit[Y]) =
                 Kyo.foreachDiscard(values) { d =>
                     for
-                        _ <- Emit[X](d)
-                        _ <- Emit[Y](d)
+                        _ <- Emit.value[X](d)
+                        _ <- Emit.value[Y](d)
                     yield ()
                 }
 
@@ -474,9 +474,9 @@ class EmitTest extends Test:
             def complexEmit(values: List[E]): Unit < (Emit[P] & Emit[Q] & Emit[R]) =
                 Kyo.foreachDiscard(values) { e =>
                     for
-                        _ <- Emit[P](e)
-                        _ <- Emit[Q](e)
-                        _ <- Emit[R](e)
+                        _ <- Emit.value[P](e)
+                        _ <- Emit.value[Q](e)
+                        _ <- Emit.value[R](e)
                     yield ()
                 }
 
@@ -502,14 +502,14 @@ class EmitTest extends Test:
             "combines emitted values from isolated and outer scopes" in run {
                 val result = Emit.run {
                     for
-                        _ <- Emit(1)
+                        _ <- Emit.value(1)
                         isolated <- Emit.isolate.merge[Int].run {
                             for
-                                _ <- Emit(2)
-                                _ <- Emit(3)
+                                _ <- Emit.value(2)
+                                _ <- Emit.value(3)
                             yield "inner"
                         }
-                        _ <- Emit(4)
+                        _ <- Emit.value(4)
                     yield (isolated)
                 }
                 assert(result.eval == (Chunk(1, 2, 3, 4), "inner"))
@@ -518,16 +518,16 @@ class EmitTest extends Test:
             "proper state restoration after nested isolations" in run {
                 val result = Emit.run {
                     for
-                        _ <- Emit("start")
+                        _ <- Emit.value("start")
                         v1 <- Emit.isolate.merge[String].run {
                             for
-                                _ <- Emit("inner1")
+                                _ <- Emit.value("inner1")
                                 v2 <- Emit.isolate.merge[String].run {
-                                    Emit("nested").map(_ => "nested-result")
+                                    Emit.value("nested").map(_ => "nested-result")
                                 }
                             yield v2
                         }
-                        _ <- Emit("end")
+                        _ <- Emit.value("end")
                     yield v1
                 }
                 assert(result.eval == (Chunk("start", "inner1", "nested", "end"), "nested-result"))
@@ -538,14 +538,14 @@ class EmitTest extends Test:
             "inner emissions don't affect outer scope" in run {
                 val result = Emit.run {
                     for
-                        _ <- Emit(1)
+                        _ <- Emit.value(1)
                         isolated <- Emit.isolate.discard[Int].run {
                             for
-                                _ <- Emit(2)
-                                _ <- Emit(3)
+                                _ <- Emit.value(2)
+                                _ <- Emit.value(3)
                             yield "inner"
                         }
-                        _ <- Emit(4)
+                        _ <- Emit.value(4)
                     yield isolated
                 }
                 assert(result.eval == (Chunk(1, 4), "inner"))
@@ -554,16 +554,16 @@ class EmitTest extends Test:
             "nested discards maintain isolation" in run {
                 val result = Emit.run {
                     for
-                        _ <- Emit("outer")
+                        _ <- Emit.value("outer")
                         v1 <- Emit.isolate.discard[String].run {
                             for
-                                _ <- Emit("discarded1")
+                                _ <- Emit.value("discarded1")
                                 v2 <- Emit.isolate.discard[String].run {
-                                    Emit("discarded2").map(_ => "nested-result")
+                                    Emit.value("discarded2").map(_ => "nested-result")
                                 }
                             yield v2
                         }
-                        _ <- Emit("final")
+                        _ <- Emit.value("final")
                     yield v1
                 }
                 assert(result.eval == (Chunk("outer", "final"), "nested-result"))
@@ -581,10 +581,10 @@ class EmitTest extends Test:
                     Var.runTuple(0) {
                         combined.run {
                             for
-                                _ <- Emit(1)
+                                _ <- Emit.value(1)
                                 _ <- Var.update[Int](_ + 1)
                                 v <- Var.get[Int]
-                                _ <- Emit(v)
+                                _ <- Emit.value(v)
                             yield "done"
                         }
                     }
@@ -609,9 +609,9 @@ class EmitTest extends Test:
                         combined.run {
                             for
                                 a <- f(1)
-                                _ <- Emit(a)
+                                _ <- Emit.value(a)
                                 b <- f(1)
-                                _ <- Emit(b)
+                                _ <- Emit.value(b)
                             yield (a, b)
                         }
                     }
@@ -626,15 +626,15 @@ class EmitTest extends Test:
 
                 val result = Emit.run {
                     for
-                        _ <- Emit(1)
+                        _ <- Emit.value(1)
                         _ <- emitDiscard.run {
-                            Emit(2)
+                            Emit.value(2)
                         }
-                        _ <- Emit(3)
+                        _ <- Emit.value(3)
                         _ <- emitMerge.run {
-                            Emit(4)
+                            Emit.value(4)
                         }
-                        _ <- Emit(5)
+                        _ <- Emit.value(5)
                     yield "done"
                 }
                 assert(result.eval == (Chunk(1, 3, 4, 5), "done"))

--- a/kyo-prelude/shared/src/test/scala/kyo/IsolateTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/IsolateTest.scala
@@ -38,8 +38,8 @@ class IsolateTest extends Test:
             val result = Emit.run {
                 Emit.isolate.merge[Int].run {
                     for
-                        _ <- Emit(1)
-                        _ <- Emit(2)
+                        _ <- Emit.value(1)
+                        _ <- Emit.value(2)
                     yield "done"
                 }
             }
@@ -59,10 +59,10 @@ class IsolateTest extends Test:
                     combined.run {
                         for
                             start <- Var.get[Int]
-                            _     <- Emit(start)
+                            _     <- Emit.value(start)
                             _     <- Var.set(start + 1)
                             end   <- Var.get[Int]
-                            _     <- Emit(end)
+                            _     <- Emit.value(end)
                         yield (start, end)
                     }
                 }
@@ -116,11 +116,11 @@ class IsolateTest extends Test:
                         combined.run {
                             for
                                 start <- Var.get[Int]
-                                _     <- Emit(start)
+                                _     <- Emit.value(start)
                                 a     <- f(start)
                                 _     <- Var.set(a)
                                 end   <- Var.get[Int]
-                                _     <- Emit(end)
+                                _     <- Emit.value(end)
                                 b     <- f(end)
                             yield (start, end, a, b, count)
                         }
@@ -154,15 +154,15 @@ class IsolateTest extends Test:
             val result = Emit.run {
                 Abort.run {
                     for
-                        _ <- Emit(1)
+                        _ <- Emit.value(1)
                         _ <- Emit.isolate.merge[Int].run {
                             for
-                                _ <- Emit(2)
-                                _ <- Emit(3)
+                                _ <- Emit.value(2)
+                                _ <- Emit.value(3)
                                 _ <- Abort.fail("Failed")
                             yield ()
                         }
-                        _ <- Emit(4)
+                        _ <- Emit.value(4)
                     yield "done"
                 }
             }
@@ -200,25 +200,25 @@ class IsolateTest extends Test:
                     Abort.run {
                         for
                             _ <- Var.set(1)
-                            _ <- Emit("start")
+                            _ <- Emit.value("start")
                             _ <-
                                 Var.isolate.update[Int]
                                     .andThen(Emit.isolate.merge[String])
                                     .run {
                                         for
                                             _ <- Var.set(2)
-                                            _ <- Emit("inner")
+                                            _ <- Emit.value("inner")
                                             _ <- (Var.isolate.update[Int].andThen(Emit.isolate.merge[String])).run {
                                                 for
                                                     _ <- Var.set(3)
-                                                    _ <- Emit("nested")
+                                                    _ <- Emit.value("nested")
                                                     _ <- Abort.fail("Failed")
                                                 yield ()
                                             }
                                         yield ()
                                     }
                             v <- Var.get[Int]
-                            _ <- Emit("end")
+                            _ <- Emit.value("end")
                         yield v
                     }
                 }
@@ -239,7 +239,7 @@ class IsolateTest extends Test:
                         Abort.run {
                             for
                                 _ <- Var.set(1)
-                                _ <- Emit("start")
+                                _ <- Emit.value("start")
                                 a <- f(1)
                                 _ <- Var.isolate.update[Int]
                                     .andThen(Emit.isolate.merge[String])
@@ -247,13 +247,13 @@ class IsolateTest extends Test:
                                     .run {
                                         for
                                             _ <- Var.set(2)
-                                            _ <- Emit("inner")
+                                            _ <- Emit.value("inner")
                                             b <- f(2)
                                             _ <- Abort.fail("Failed")
                                         yield (a, b)
                                     }
                                 v <- Var.get[Int]
-                                _ <- Emit("end")
+                                _ <- Emit.value("end")
                             yield v
                         }
                     }

--- a/kyo-prelude/shared/src/test/scala/kyo/MemoTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/MemoTest.scala
@@ -437,9 +437,9 @@ class MemoTest extends Test:
                         combined.run {
                             for
                                 a <- f(1)
-                                _ <- Emit(a)
+                                _ <- Emit.value(a)
                                 b <- f(2)
-                                _ <- Emit(b)
+                                _ <- Emit.value(b)
                             yield (a, b)
                         }
                     }
@@ -465,14 +465,14 @@ class MemoTest extends Test:
                             _ <- i1.run {
                                 for
                                     b <- f(2)
-                                    _ <- Emit(b)
+                                    _ <- Emit.value(b)
                                 yield b
                             }
                             c <- f(2)
                             _ <- i2.run {
                                 for
                                     d <- f(3)
-                                    _ <- Emit(d)
+                                    _ <- Emit.value(d)
                                 yield d
                             }
                             e <- f(3)

--- a/kyo-prelude/shared/src/test/scala/kyo/PollTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/PollTest.scala
@@ -224,12 +224,12 @@ class PollTest extends Test:
 
     "run Emit" - {
         "one" in {
-            val result = Poll.run(Emit(1))(Poll.one[Int])
+            val result = Poll.run(Emit.value(1))(Poll.one[Int])
             assert(result.eval == (Ack.Continue(), Maybe(1)))
         }
 
         "two" in {
-            val result = Poll.run(Emit(1).andThen(Emit(2))) {
+            val result = Poll.run(Emit.value(1).andThen(Emit.value(2))) {
                 Poll.andMap[Int] {
                     case Absent     => Maybe.empty
                     case Present(v) => Maybe(v * 3)
@@ -241,9 +241,9 @@ class PollTest extends Test:
         "basic emit-poll cycle" in run {
             val emitter =
                 for
-                    _ <- Emit(1)
-                    _ <- Emit(2)
-                    _ <- Emit(3)
+                    _ <- Emit.value(1)
+                    _ <- Emit.value(2)
+                    _ <- Emit.value(3)
                 yield "emitted"
 
             val poller =
@@ -259,9 +259,9 @@ class PollTest extends Test:
         "early poller termination" in run {
             val emitter =
                 for
-                    ack1 <- Emit(1)
-                    ack2 <- Emit(2)
-                    ack3 <- Emit(3)
+                    ack1 <- Emit.value(1)
+                    ack2 <- Emit.value(2)
+                    ack3 <- Emit.value(3)
                 yield (ack1, ack2, ack3, "emitted")
 
             val poller = Poll.one[Int](Ack.Stop)
@@ -273,9 +273,9 @@ class PollTest extends Test:
         "fold with emit" in run {
             val emitter =
                 for
-                    _ <- Emit(1)
-                    _ <- Emit(2)
-                    _ <- Emit(3)
+                    _ <- Emit.value(1)
+                    _ <- Emit.value(2)
+                    _ <- Emit.value(3)
                 yield "done"
 
             val poller = Poll.fold[Int](0)(_ + _)
@@ -289,9 +289,9 @@ class PollTest extends Test:
 
             val emitter =
                 for
-                    _ <- Emit(1)
+                    _ <- Emit.value(1)
                     _ <- Var.update[Int](_ + 1)
-                    _ <- Emit(2)
+                    _ <- Emit.value(2)
                     _ <- Var.update[Int](_ + 1)
                 yield "emitted"
 

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -142,11 +142,11 @@ class StreamTest extends Test:
                     case Continue(maxItems) =>
                         for
                             n    <- Var.update[Int](_ + 1)
-                            next <- Emit.andMap(Chunk(n))(emit)
+                            next <- Emit.valueWith(Chunk(n))(emit)
                         yield next
             end emit
 
-            val stream         = Stream(Emit.andMap(Chunk.empty[Int])(emit(_))).take(5).run
+            val stream         = Stream(Emit.valueWith(Chunk.empty[Int])(emit(_))).take(5).run
             val (count, chunk) = Var.runTuple(0)(stream).eval
 
             assert(
@@ -162,12 +162,12 @@ class StreamTest extends Test:
                         for
                             end <- Var.update[Int](_ + maxItems)
                             start = end - maxItems + 1
-                            next <- Emit.andMap(Chunk.from(start to end): Chunk[Int])(emit)
+                            next <- Emit.valueWith(Chunk.from(start to end): Chunk[Int])(emit)
                         yield next
                         end for
             end emit
 
-            val stream         = Stream(Emit.andMap(Chunk.empty[Int])(emit(_))).take(5).run
+            val stream         = Stream(Emit.valueWith(Chunk.empty[Int])(emit(_))).take(5).run
             val (count, chunk) = Var.runTuple(0)(stream).eval
 
             assert(
@@ -641,8 +641,8 @@ class StreamTest extends Test:
             def emit(n: Int): Ack < (Emit[Chunk[Int]]) =
                 n match
                     case 0 => Stop
-                    case 5 => Emit.andMap(Chunk.empty)(_ => emit(n - 1))
-                    case _ => Emit.andMap(Chunk.fill(3)(n))(_ => emit(n - 1))
+                    case 5 => Emit.valueWith(Chunk.empty)(_ => emit(n - 1))
+                    case _ => Emit.valueWith(Chunk.fill(3)(n))(_ => emit(n - 1))
             end emit
 
             val stream = Stream(emit(10)).rechunk(10).mapChunk(Chunk(_))

--- a/kyo-prelude/shared/src/test/scala/kyo/VarTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/VarTest.scala
@@ -300,10 +300,10 @@ class VarTest extends Test:
                             for
                                 _  <- Var.update[Int](_ + 1)
                                 v  <- Var.get[Int]
-                                _  <- Emit(v)
+                                _  <- Emit.value(v)
                                 _  <- Var.update[Int](_ * 2)
                                 v2 <- Var.get[Int]
-                                _  <- Emit(v2)
+                                _  <- Emit.value(v2)
                             yield ()
                         }
                     }

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscriber.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscriber.scala
@@ -244,7 +244,7 @@ final private[kyo] class StreamSubscriber[V](
     end interupt
 
     private[interop] def emit(using Frame, Tag[Emit[Chunk[V]]]): Ack < (Emit[Chunk[V]] & Async) =
-        Emit.andMap(Chunk.empty) { ack =>
+        Emit.valueWith(Chunk.empty) { ack =>
             Loop(ack) {
                 case Ack.Stop => interupt.andThen(Loop.done(Ack.Stop))
                 case Ack.Continue(_) =>
@@ -252,7 +252,7 @@ final private[kyo] class StreamSubscriber[V](
                         .map {
                             case true => request.andThen(Ack.Continue())
                             case false => poll.map {
-                                    case Result.Success(nextChunk)  => Emit(nextChunk)
+                                    case Result.Success(nextChunk)  => Emit.value(nextChunk)
                                     case Result.Error(e: Throwable) => Abort.panic(e)
                                     case _                          => Ack.Stop
                                 }

--- a/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
@@ -113,9 +113,9 @@ class STMTest extends Test:
                     STM.run(Emit.isolate.merge[Int]) {
                         for
                             _ <- ref.set(1)
-                            _ <- Emit(42)
+                            _ <- Emit.value(42)
                             v <- ref.get
-                            _ <- Emit(v)
+                            _ <- Emit.value(v)
                         yield v
                     }
                 }
@@ -133,9 +133,9 @@ class STMTest extends Test:
                             STM.run(Emit.isolate.merge[Int]) {
                                 for
                                     _ <- ref.set(42)
-                                    _ <- Emit(1)
+                                    _ <- Emit.value(1)
                                     _ <- Abort.fail(ex)
-                                    _ <- Emit(2)
+                                    _ <- Emit.value(2)
                                 yield "unreachable"
                             }
                         }
@@ -205,11 +205,11 @@ class STMTest extends Test:
                             STM.run(Emit.isolate.merge[Int].andThen(Var.isolate.update)) {
                                 for
                                     _ <- ref.set(1)
-                                    _ <- Emit(1)
+                                    _ <- Emit.value(1)
                                     _ <- Var.set(1)
                                     _ <- Abort.fail(ex)
                                     _ <- ref.set(2)
-                                    _ <- Emit(2)
+                                    _ <- Emit.value(2)
                                     _ <- Var.set(2)
                                 yield "unreachable"
                             }

--- a/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
@@ -52,7 +52,7 @@ object Routes:
     def add[A: Tag, I, E: SafeClassTag, O: Flat](e: Endpoint[A, I, E, O, Any])(
         f: I => O < (Async & Env[A] & Abort[E])
     )(using Frame): Unit < Routes =
-        Emit(
+        Emit.value(
             Route(
                 e.serverSecurityLogic[A, KyoSttpMonad.M](a => Right(a)).serverLogic((a: A) =>
                     (i: I) =>


### PR DESCRIPTION
Following up on https://github.com/getkyo/kyo/pull/970#discussion_r1903664424. I've also removed some `apply` methods where I think having an explicit method name can help with readability. For example, `Emit.value(1)` seems to read more naturally than `Emit(1)`