### PR TITLE
[kernel] TracePool flaky test

### DIFF
--- a/kyo-kernel/jvm/src/test/scala/kyo/kernel/internal/TracePoolConcurrencyTest.scala
+++ b/kyo-kernel/jvm/src/test/scala/kyo/kernel/internal/TracePoolConcurrencyTest.scala
@@ -1,0 +1,72 @@
+package kyo.kernel.internal
+
+import java.util.concurrent.Executors
+import kyo.Frame
+import kyo.Tagged.*
+import kyo.Test
+import kyo.discard
+import scala.concurrent.Future
+
+class TracePoolConcurrencyTest extends Test:
+
+    class TestLocal extends TracePool.Local
+
+    "borrow should never return null under concurrency" in {
+        val threadCount         = 8
+        val iterationsPerThread = 1000
+        val locals              = List.fill(threadCount)(new TestLocal)
+        val executor            = Executors.newFixedThreadPool(threadCount)
+
+        @volatile var foundNull    = false
+        @volatile var nullLocation = ""
+
+        try
+            val futures = locals.map { local =>
+                executor.submit {
+                    new Runnable:
+                        def run(): Unit =
+                            val batchSizes = List(
+                                1,
+                                2,
+                                TracePool.localCapacity - 1,
+                                TracePool.localCapacity,
+                                TracePool.localCapacity + 1,
+                                TracePool.localCapacity * 2
+                            )
+
+                            for
+                                i         <- 1 to iterationsPerThread if !foundNull
+                                batchSize <- batchSizes if !foundNull
+                            do
+                                val traces = List.fill(batchSize)(local.borrow())
+                                traces.zipWithIndex.foreach { (trace, idx) =>
+                                    if trace == null then
+                                        foundNull = true
+                                        nullLocation = s"First batch (size $batchSize) at index $idx"
+                                }
+
+                                val (toRelease, toKeep) = traces.splitAt(batchSize / 2)
+                                toRelease.foreach(local.release)
+
+                                val nextBatchSize = batchSize + 1
+                                val moreBorrowed  = List.fill(nextBatchSize)(local.borrow())
+                                moreBorrowed.zipWithIndex.foreach { (trace, idx) =>
+                                    if trace == null then
+                                        foundNull = true
+                                        nullLocation = s"Second batch (size $nextBatchSize) at index $idx after releasing ${toRelease.size}"
+                                }
+
+                                toKeep.foreach(local.release)
+                                moreBorrowed.foreach(local.release)
+                            end for
+                        end run
+                }
+            }
+
+            futures.foreach(_.get())
+            assert(!foundNull, s"Found null trace! Location: $nullLocation")
+        finally
+            executor.shutdown()
+        end try
+    }
+end TracePoolConcurrencyTest

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/TracePoolTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/TracePoolTest.scala
@@ -2,8 +2,10 @@ package kyo.kernel.internal
 
 import java.util.concurrent.Executors
 import kyo.Frame
+import kyo.Tagged.*
 import kyo.Test
 import kyo.discard
+import scala.concurrent.Future
 
 class TracePoolTest extends Test:
 
@@ -126,62 +128,4 @@ class TracePoolTest extends Test:
         assert(finalTrace != null, "Pool was corrupted after sequential operations")
     }
 
-    "borrow should never return null under concurrency" in {
-        val threadCount         = 8
-        val iterationsPerThread = 1000
-        val locals              = List.fill(threadCount)(new TestLocal)
-        val executor            = Executors.newFixedThreadPool(threadCount)
-
-        @volatile var foundNull    = false
-        @volatile var nullLocation = ""
-
-        try
-            val futures = locals.map { local =>
-                executor.submit {
-                    new Runnable:
-                        def run(): Unit =
-                            val batchSizes = List(
-                                1,
-                                2,
-                                TracePool.localCapacity - 1,
-                                TracePool.localCapacity,
-                                TracePool.localCapacity + 1,
-                                TracePool.localCapacity * 2
-                            )
-
-                            for
-                                i         <- 1 to iterationsPerThread if !foundNull
-                                batchSize <- batchSizes if !foundNull
-                            do
-                                val traces = List.fill(batchSize)(local.borrow())
-                                traces.zipWithIndex.foreach { (trace, idx) =>
-                                    if trace == null then
-                                        foundNull = true
-                                        nullLocation = s"First batch (size $batchSize) at index $idx"
-                                }
-
-                                val (toRelease, toKeep) = traces.splitAt(batchSize / 2)
-                                toRelease.foreach(local.release)
-
-                                val nextBatchSize = batchSize + 1
-                                val moreBorrowed  = List.fill(nextBatchSize)(local.borrow())
-                                moreBorrowed.zipWithIndex.foreach { (trace, idx) =>
-                                    if trace == null then
-                                        foundNull = true
-                                        nullLocation = s"Second batch (size $nextBatchSize) at index $idx after releasing ${toRelease.size}"
-                                }
-
-                                toKeep.foreach(local.release)
-                                moreBorrowed.foreach(local.release)
-                            end for
-                        end run
-                }
-            }
-
-            futures.foreach(_.get())
-            assert(!foundNull, s"Found null trace! Location: $nullLocation")
-        finally
-            executor.shutdown()
-        end try
-    }
 end TracePoolTest

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/TracePoolTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/TracePoolTest.scala
@@ -1,7 +1,9 @@
 package kyo.kernel.internal
 
+import java.util.concurrent.Executors
 import kyo.Frame
 import kyo.Test
+import kyo.discard
 
 class TracePoolTest extends Test:
 
@@ -50,4 +52,136 @@ class TracePoolTest extends Test:
         succeed
     }
 
+    "borrow should never return null" in {
+        val local = new TestLocal
+
+        val traces = List.newBuilder[Trace]
+        for i <- 1 to TracePool.localCapacity * 2 do
+            val trace = local.borrow()
+            assert(trace != null, s"borrow returned null on iteration $i")
+            traces += trace
+        end for
+
+        traces.result().foreach { trace =>
+            local.release(trace)
+            val borrowed = local.borrow()
+            assert(borrowed != null, "borrow returned null after release")
+        }
+        succeed
+    }
+
+    "size management should be correct" in {
+        val local = new TestLocal
+
+        val traces = for (_ <- 1 to TracePool.localCapacity) yield local.borrow()
+
+        local.release(traces.head)
+
+        val borrowed = local.borrow()
+        assert(borrowed != null, "Failed to borrow after single release")
+
+        traces.tail.foreach(local.release)
+        local.release(borrowed)
+
+        val newTraces =
+            for (_ <- 1 to TracePool.localCapacity) yield
+                val trace = local.borrow()
+                assert(trace != null, "Failed to borrow after releasing all traces")
+                trace
+
+        assert(newTraces.size == TracePool.localCapacity, s"Expected ${TracePool.localCapacity} traces, got ${newTraces.size}")
+    }
+
+    "release should properly clear traces" in {
+        val local = new TestLocal
+        val trace = local.borrow()
+
+        trace.frames(0) = Frame.derive
+        trace.frames(1) = Frame.derive
+        trace.index = 2
+
+        local.release(trace)
+
+        val recycled = local.borrow()
+        assert(recycled.frames.take(2).forall(_ == null), "Frames were not cleared on release")
+        assert(recycled.index == 0, "Index was not reset on release")
+    }
+
+    "sequential borrow/release should maintain pool integrity" in {
+        val local               = new TestLocal
+        var lastBorrowed: Trace = null
+
+        for i <- 1 to TracePool.localCapacity * 3 do
+            val trace = local.borrow()
+            assert(trace != null, s"Got null trace on iteration $i")
+
+            if lastBorrowed != null then
+                local.release(lastBorrowed)
+            lastBorrowed = trace
+        end for
+        if lastBorrowed != null then
+            local.release(lastBorrowed)
+
+        val finalTrace = local.borrow()
+        assert(finalTrace != null, "Pool was corrupted after sequential operations")
+    }
+
+    "borrow should never return null under concurrency" in {
+        val threadCount         = 8
+        val iterationsPerThread = 1000
+        val locals              = List.fill(threadCount)(new TestLocal)
+        val executor            = Executors.newFixedThreadPool(threadCount)
+
+        @volatile var foundNull    = false
+        @volatile var nullLocation = ""
+
+        try
+            val futures = locals.map { local =>
+                executor.submit {
+                    new Runnable:
+                        def run(): Unit =
+                            val batchSizes = List(
+                                1,
+                                2,
+                                TracePool.localCapacity - 1,
+                                TracePool.localCapacity,
+                                TracePool.localCapacity + 1,
+                                TracePool.localCapacity * 2
+                            )
+
+                            for
+                                i         <- 1 to iterationsPerThread if !foundNull
+                                batchSize <- batchSizes if !foundNull
+                            do
+                                val traces = List.fill(batchSize)(local.borrow())
+                                traces.zipWithIndex.foreach { (trace, idx) =>
+                                    if trace == null then
+                                        foundNull = true
+                                        nullLocation = s"First batch (size $batchSize) at index $idx"
+                                }
+
+                                val (toRelease, toKeep) = traces.splitAt(batchSize / 2)
+                                toRelease.foreach(local.release)
+
+                                val nextBatchSize = batchSize + 1
+                                val moreBorrowed  = List.fill(nextBatchSize)(local.borrow())
+                                moreBorrowed.zipWithIndex.foreach { (trace, idx) =>
+                                    if trace == null then
+                                        foundNull = true
+                                        nullLocation = s"Second batch (size $nextBatchSize) at index $idx after releasing ${toRelease.size}"
+                                }
+
+                                toKeep.foreach(local.release)
+                                moreBorrowed.foreach(local.release)
+                            end for
+                        end run
+                }
+            }
+
+            futures.foreach(_.get())
+            assert(!foundNull, s"Found null trace! Location: $nullLocation")
+        finally
+            executor.shutdown()
+        end try
+    }
 end TracePoolTest


### PR DESCRIPTION
I noticed a [flaky test in CI](https://github.com/getkyo/kyo/actions/runs/12665683690/job/35295758155?pr=984#step:6:5797) and decided to investigate. `TracePool.Local.borrow` returned a `null`, which shouldn't be possible. I wasn't able to reproduce it locally but I've introduced new tests and implemented a preventive measure.

I think there's a possibility that `MpmcArrayQueue.drain` may pass a `null` to the consumer in rare race conditions. I've added a check to ignore values if that's the case. I believe we don't use this method in other places.