### PR TITLE
[scheduler] ensure the scheduler is a singleton across classloaders

### DIFF
--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -1,6 +1,6 @@
 package kyo.scheduler
 
-import Scheduler.*
+import Scheduler.Config
 import java.util.concurrent.Callable
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
@@ -14,6 +14,7 @@ import kyo.scheduler.top.Reporter
 import kyo.scheduler.top.Status
 import kyo.scheduler.util.Flag
 import kyo.scheduler.util.LoomSupport
+import kyo.scheduler.util.Singleton
 import kyo.scheduler.util.Threads
 import kyo.scheduler.util.XSRandom
 import scala.annotation.nowarn
@@ -454,13 +455,11 @@ final class Scheduler(
     }
 }
 
-object Scheduler {
+object Scheduler extends Singleton(() => new Scheduler()) {
 
     private lazy val defaultWorkerExecutor = Executors.newCachedThreadPool(Threads("kyo-scheduler-worker", new Worker.WorkerThread(_)))
     private lazy val defaultClockExecutor  = Executors.newSingleThreadExecutor(Threads("kyo-scheduler-clock"))
     private lazy val defaultTimerExecutor  = Executors.newScheduledThreadPool(2, Threads("kyo-scheduler-timer"))
-
-    val get = new Scheduler()
 
     /** Configuration parameters controlling worker behavior and performance characteristics.
       *

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -455,7 +455,9 @@ final class Scheduler(
     }
 }
 
-object Scheduler extends Singleton(() => new Scheduler()) {
+object Scheduler extends Singleton[Scheduler] {
+
+    override protected def init() = new Scheduler()
 
     private lazy val defaultWorkerExecutor = Executors.newCachedThreadPool(Threads("kyo-scheduler-worker", new Worker.WorkerThread(_)))
     private lazy val defaultClockExecutor  = Executors.newSingleThreadExecutor(Threads("kyo-scheduler-clock"))

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Singleton.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Singleton.scala
@@ -23,9 +23,11 @@ package kyo.scheduler.util
   *   A function that creates the singleton instance when needed. This will be called at most once per JVM, regardless of the number of
   *   classloaders.
   */
-abstract class Singleton[A <: AnyRef](init: () => A) {
+abstract class Singleton[A <: AnyRef] {
 
     @volatile private var instance: A = null.asInstanceOf[A]
+
+    protected def init(): A
 
     def get: A = {
 

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Singleton.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Singleton.scala
@@ -1,0 +1,64 @@
+package kyo.scheduler.util
+
+/** JVM-wide singleton that works across multiple classloaders.
+  *
+  * Regular singleton objects in Scala/Java are only unique within a single classloader. When multiple classloaders are involved (e.g. in
+  * application servers or plugin systems), each classloader creates its own instance, breaking singleton semantics.
+  *
+  * This is particularly important for systems that make adaptive decisions based on global state. For example, Kyo's scheduler dynamically
+  * adjusts its behavior based on system-wide metrics like thread scheduling delays. Having multiple scheduler instances would lead to:
+  *   - Conflicting thread pool adjustments
+  *   - Inaccurate system load measurements
+  *   - Competing admission control decisions
+  *   - Overall degraded performance
+  *
+  * This class ensures proper singleton semantics by:
+  *   - Using System.properties as JVM-wide storage
+  *   - Synchronizing on SystemClassLoader to ensure global atomic initialization
+  *   - Caching the instance locally for fast access
+  *
+  * @tparam A
+  *   The type of the singleton instance.
+  * @param init
+  *   A function that creates the singleton instance when needed. This will be called at most once per JVM, regardless of the number of
+  *   classloaders.
+  */
+abstract class Singleton[A <: AnyRef](init: () => A) {
+
+    @volatile private var instance: A = null.asInstanceOf[A]
+
+    def get: A = {
+
+        // Fast path - check local cache first
+        val cached = instance
+        if (cached ne null) return cached
+
+        // Slow path - instance not cached, need to coordinate across classloaders
+        ClassLoader.getSystemClassLoader.synchronized {
+
+            // Must check again after acquiring lock (double-check pattern)
+            val doubleCheck = instance
+            if (doubleCheck ne null) return doubleCheck
+
+            // Try to get instance from global storage
+            val sysProps = System.getProperties
+            val key      = getClass.getName // Singleton object's class name as key
+
+            val existing = sysProps.get(key).asInstanceOf[A]
+            val result =
+                if (existing ne null) {
+                    // Another classloader created the instance, use it
+                    existing
+                } else {
+                    // We're first - create and store globally
+                    val created = init()
+                    sysProps.put(key, created)
+                    created
+                }
+
+            // Cache for future fast access from this classloader
+            instance = result
+            result
+        }
+    }
+}

--- a/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Singleton.scala
+++ b/kyo-scheduler/jvm/src/main/scala/kyo/scheduler/util/Singleton.scala
@@ -5,6 +5,13 @@ package kyo.scheduler.util
   * Regular singleton objects in Scala/Java are only unique within a single classloader. When multiple classloaders are involved (e.g. in
   * application servers or plugin systems), each classloader creates its own instance, breaking singleton semantics.
   *
+  * This class is designed to be extended by companion objects to provide true JVM-wide singleton semantics. For example:
+  * {{{
+  * object MyService extends Singleton[MyService] {
+  *   override protected def init() = new MyService()
+  * }
+  * }}}
+  *
   * This is particularly important for systems that make adaptive decisions based on global state. For example, Kyo's scheduler dynamically
   * adjusts its behavior based on system-wide metrics like thread scheduling delays. Having multiple scheduler instances would lead to:
   *   - Conflicting thread pool adjustments

--- a/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/SchedulerSingletonTest.scala
+++ b/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/SchedulerSingletonTest.scala
@@ -1,0 +1,69 @@
+package kyo.scheduler
+
+import java.net.URL
+import java.net.URLClassLoader
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.freespec.AnyFreeSpec
+import scala.jdk.CollectionConverters.*
+
+class SchedulerSingletonTest extends AnyFreeSpec with NonImplicitAssertions {
+
+    "should return same instance across multiple calls" in {
+        val scheduler1 = Scheduler.get
+        val scheduler2 = Scheduler.get
+
+        assert(scheduler1 eq scheduler2)
+    }
+
+    "should maintain single instance across different classloaders" in {
+        val cl1 = new URLClassLoader(Array.empty[URL], getClass.getClassLoader)
+        val cl2 = new URLClassLoader(Array.empty[URL], getClass.getClassLoader)
+
+        val schedulerClass1 = cl1.loadClass("kyo.scheduler.Scheduler$")
+        val schedulerClass2 = cl2.loadClass("kyo.scheduler.Scheduler$")
+
+        val scheduler1 = schedulerClass1.getField("MODULE$").get(null)
+        val scheduler2 = schedulerClass2.getField("MODULE$").get(null)
+
+        val instance1 = schedulerClass1.getMethod("get").invoke(scheduler1)
+        val instance2 = schedulerClass2.getMethod("get").invoke(scheduler2)
+
+        assert(instance1 eq instance2)
+    }
+
+    "should handle concurrent initialization safely" in {
+        val threadCount = 32
+        val cdl         = new CountDownLatch(threadCount)
+        val executor    = Executors.newFixedThreadPool(threadCount)
+        val schedulers  = new ConcurrentLinkedQueue[Scheduler]()
+
+        try {
+            val futures = (1 to threadCount).map { _ =>
+                executor.submit(new Runnable {
+                    def run(): Unit = {
+                        val scheduler = Scheduler.get
+                        schedulers.add(scheduler)
+                        val taskCdl = new CountDownLatch(1)
+                        scheduler.schedule(TestTask(_run = () => {
+                            taskCdl.countDown()
+                            Task.Done
+                        }))
+                        taskCdl.await()
+                        cdl.countDown()
+                    }
+                })
+            }
+
+            futures.foreach(_.get(5, TimeUnit.SECONDS))
+
+            assert(futures.size == threadCount)
+            assert(schedulers.asScala.toSet.size == 1)
+        } finally {
+            executor.shutdown()
+        }
+    }
+}

--- a/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/SchedulerSingletonTest.scala
+++ b/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/SchedulerSingletonTest.scala
@@ -2,13 +2,13 @@ package kyo.scheduler
 
 import java.net.URL
 import java.net.URLClassLoader
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AnyFreeSpec
-import scala.jdk.CollectionConverters.*
 
 class SchedulerSingletonTest extends AnyFreeSpec with NonImplicitAssertions {
 
@@ -39,7 +39,7 @@ class SchedulerSingletonTest extends AnyFreeSpec with NonImplicitAssertions {
         val threadCount = 32
         val cdl         = new CountDownLatch(threadCount)
         val executor    = Executors.newFixedThreadPool(threadCount)
-        val schedulers  = new ConcurrentLinkedQueue[Scheduler]()
+        val schedulers  = ConcurrentHashMap.newKeySet[Scheduler]()
 
         try {
             val futures = (1 to threadCount).map { _ =>
@@ -61,7 +61,7 @@ class SchedulerSingletonTest extends AnyFreeSpec with NonImplicitAssertions {
             futures.foreach(_.get(5, TimeUnit.SECONDS))
 
             assert(futures.size == threadCount)
-            assert(schedulers.asScala.toSet.size == 1)
+            assert(schedulers.size == 1)
         } finally {
             executor.shutdown()
         }

--- a/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/util/SingletonTest.scala
+++ b/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/util/SingletonTest.scala
@@ -1,0 +1,153 @@
+package kyo.scheduler.util
+
+import java.net.URL
+import java.net.URLClassLoader
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.freespec.AnyFreeSpec
+import scala.jdk.CollectionConverters.*
+import scala.util.Random
+
+class TestInstance(val value: Int)
+class TestSingleton extends Singleton[TestInstance](() => new TestInstance(42))
+
+class SingletonTest extends AnyFreeSpec with NonImplicitAssertions {
+
+    "basic functionality" - {
+        "should return same instance across multiple calls" in {
+            val singleton = new TestSingleton
+            val instance1 = singleton.get
+            val instance2 = singleton.get
+
+            assert(instance1 eq instance2)
+            assert(instance1.value == 42)
+        }
+
+        "should initialize only once" in {
+            var initCount = 0
+            val singleton = new Singleton[String](() => {
+                initCount += 1
+                s"instance-$initCount"
+            }) {}
+
+            singleton.get
+            singleton.get
+
+            assert(initCount == 1)
+        }
+    }
+
+    "should maintain single instance across different classloaders" in {
+        val cl1 = new URLClassLoader(Array.empty[URL], getClass.getClassLoader)
+        val cl2 = new URLClassLoader(Array.empty[URL], getClass.getClassLoader)
+
+        val singleton1 =
+            cl1.loadClass("kyo.scheduler.util.TestSingleton").getDeclaredConstructor()
+                .newInstance().asInstanceOf[Singleton[TestInstance]]
+        val singleton2 =
+            cl2.loadClass("kyo.scheduler.util.TestSingleton").getDeclaredConstructor()
+                .newInstance().asInstanceOf[Singleton[TestInstance]]
+
+        val instance1 = singleton1.get
+        val instance2 = singleton2.get
+
+        assert(instance1 eq instance2)
+        assert(instance1.value == 42)
+    }
+
+    "concurrency" - {
+        "should handle concurrent initialization safely" in {
+            class TestInstance(val id: String)
+            class TestSingleton extends Singleton[TestInstance](() => new TestInstance("test"))
+
+            val threadCount = 32
+            val latch       = new CountDownLatch(1)
+            val singleton   = new TestSingleton
+            val executor    = Executors.newFixedThreadPool(threadCount)
+            val instances   = new java.util.concurrent.ConcurrentLinkedQueue[TestInstance]()
+
+            try {
+                val futures = (1 to threadCount).map { _ =>
+                    executor.submit(new Runnable {
+                        def run(): Unit = {
+                            latch.await()
+                            val instance = singleton.get
+                            instances.add(instance)
+                            ()
+                        }
+                    })
+                }
+
+                latch.countDown()
+
+                futures.foreach(_.get(5, TimeUnit.SECONDS))
+
+                val finalInstance = singleton.get
+                assert(finalInstance.id == "test")
+                assert(instances.asScala.toSet.size == 1)
+                assert(instances.asScala.forall(_ eq finalInstance))
+            } finally {
+                executor.shutdown()
+            }
+        }
+
+        "should handle concurrent initialization across multiple classloaders" in {
+            val classLoaderCount = 5
+            val threadsPerLoader = 3
+            val totalThreads     = classLoaderCount * threadsPerLoader
+            val instances        = new java.util.concurrent.ConcurrentLinkedQueue[TestInstance]()
+
+            val classLoaders = (1 to classLoaderCount).map { _ =>
+                new URLClassLoader(Array.empty[URL], getClass.getClassLoader)
+            }
+
+            val startLatch = new CountDownLatch(1)
+            val executor   = Executors.newFixedThreadPool(totalThreads)
+
+            try {
+                val futures = for {
+                    classLoader <- classLoaders
+                    _           <- 1 to threadsPerLoader
+                } yield {
+                    executor.submit(new Runnable {
+                        def run(): Unit = {
+                            startLatch.await()
+
+                            val singletonClass = classLoader
+                                .loadClass("kyo.scheduler.util.TestSingleton")
+                                .getDeclaredConstructor()
+                                .newInstance()
+                                .asInstanceOf[Singleton[TestInstance]]
+
+                            val instance = singletonClass.get
+                            instances.add(instance)
+                            ()
+                        }
+                    })
+                }
+
+                startLatch.countDown()
+
+                futures.foreach(_.get(5, TimeUnit.SECONDS))
+
+                val finalLoader = new URLClassLoader(Array.empty[URL], getClass.getClassLoader)
+                val finalSingleton = finalLoader
+                    .loadClass("kyo.scheduler.util.TestSingleton")
+                    .getDeclaredConstructor()
+                    .newInstance()
+                    .asInstanceOf[Singleton[TestInstance]]
+
+                val finalInstance = finalSingleton.get
+                assert(finalInstance.value == 42)
+                assert(instances.asScala.toSet.size == 1)
+                assert(instances.asScala.forall(_ eq finalInstance))
+
+            } finally {
+                executor.shutdown()
+            }
+        }
+    }
+}

--- a/kyo-scheduler/native/src/main/scala/kyo/scheduler/util/Singleton.scala
+++ b/kyo-scheduler/native/src/main/scala/kyo/scheduler/util/Singleton.scala
@@ -1,0 +1,6 @@
+package kyo.scheduler.util
+
+abstract class Singleton[A <: AnyRef](init: () => A) {
+
+    lazy val get = init()
+}

--- a/kyo-scheduler/native/src/main/scala/kyo/scheduler/util/Singleton.scala
+++ b/kyo-scheduler/native/src/main/scala/kyo/scheduler/util/Singleton.scala
@@ -1,6 +1,8 @@
 package kyo.scheduler.util
 
-abstract class Singleton[A <: AnyRef](init: () => A) {
+abstract class Singleton[A <: AnyRef] {
+
+    protected def init(): A
 
     lazy val get = init()
 }


### PR DESCRIPTION
I had issues working on similar adaptive schedulers in the past because the scheduler was loaded multiple times due to class loader isolation. The interference between the multiple schedulers can defeat the adaptive behavior. This PR introduces a work around to ensure the scheduler is a singleton even if multiple class loaders are used.