### PR TITLE
[core] make IO.ensure private[kyo]

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/IO.scala
+++ b/kyo-core/shared/src/main/scala/kyo/IO.scala
@@ -68,7 +68,7 @@ object IO:
       * @return
       *   The result of the main computation, with the finalizer guaranteed to run.
       */
-    def ensure[A, S](f: => Unit < IO)(v: A < S)(using frame: Frame): A < (IO & S) =
+    private[kyo] def ensure[A, S](f: => Unit < IO)(v: A < S)(using frame: Frame): A < (IO & S) =
         Unsafe(Safepoint.ensure(IO.Unsafe.evalOrThrow(f))(v))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */


### PR DESCRIPTION
I think `IO.ensure` method exposes too much of the current underlying implementation, which might block potential kernel improvements and optimizations in the future. Since `Resource` provides the same functionality in a more high-level API, `IO.ensure` can be kept internal to the library. 