### PR TITLE
[build] fix kyo-scheduler-finagle release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,6 @@ jobs:
       run: |
         sbt '+kyoJVM/test'
 
-    - name: Build kyo-scheduler-finagle
-      run: |
-        sbt '+kyo-scheduler-finagle/test'
-
     - name: Build JS
       run: |
         sbt '+kyoJS/test'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
       run: |
         sbt '+kyoJVM/test'
 
+    - name: Build kyo-scheduler-finagle
+      run: |
+        sbt '+kyo-scheduler-finagle/test'
+
     - name: Build JS
       run: |
         sbt '+kyoJS/test'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      # - run: sbt -Dplatform=JVM "kyo-scheduler-finagle/ci-release"
+      #   env:
+      #     PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+      #     PGP_SECRET: ${{ secrets.PGP_SECRET }}
+      #     SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      #     SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       - run: sbt -Dplatform=JS "ci-release"
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,6 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-      # - run: sbt -Dplatform=JVM "kyo-scheduler-finagle/ci-release"
-      #   env:
-      #     PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-      #     PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      #     SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-      #     SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       - run: sbt -Dplatform=JS "ci-release"
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
I tried for a couple of hours to avoid `kyoJVM` aggregating `kyo-scheduler-finagle` in Scala 3 but didn't have success. As a work around, I've kept the cross to Scala 3 but disabled all source code + dependency + release in the module's config.