### PR TITLE
[core] introduce IO.withLocal

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -160,23 +160,21 @@ object Clock:
     def withTimeShift[A, S](factor: Double)(v: => A < S)(using Frame): A < (IO & S) =
         if factor == 1 then v
         else
-            use { clock =>
-                IO.Unsafe {
-                    val shifted =
-                        new Unsafe:
-                            val underlying  = clock.unsafe
-                            val start       = underlying.now()
-                            val sleepFactor = (1.toDouble / factor)
-                            def nowMonotonic()(using AllowUnsafe) =
-                                now().toDuration
-                            def now()(using AllowUnsafe) =
-                                val diff = underlying.now() - start
-                                start + (diff * factor)
-                            end now
-                            override def sleep(duration: Duration) =
-                                underlying.sleep(duration * sleepFactor)
-                    let(Clock(shifted))(v)
-                }
+            IO.Unsafe.withLocal(local) { clock =>
+                val shifted =
+                    new Unsafe:
+                        val underlying  = clock.unsafe
+                        val start       = underlying.now()
+                        val sleepFactor = (1.toDouble / factor)
+                        def nowMonotonic()(using AllowUnsafe) =
+                            now().toDuration
+                        def now()(using AllowUnsafe) =
+                            val diff = underlying.now() - start
+                            start + (diff * factor)
+                        end now
+                        override def sleep(duration: Duration) =
+                            underlying.sleep(duration * sleepFactor)
+                let(Clock(shifted))(v)
             }
     end withTimeShift
 
@@ -274,7 +272,7 @@ object Clock:
       *   The current time
       */
     def now(using Frame): Instant < IO =
-        use(_.now)
+        IO.Unsafe.withLocal(local)(_.unsafe.now())
 
     /** Gets the current monotonic time using the local Clock instance. Unlike `now`, this is guaranteed to be strictly monotonic and
       * suitable for measuring elapsed time.
@@ -286,10 +284,10 @@ object Clock:
       *   The current monotonic time as a Duration since system start
       */
     def nowMonotonic(using Frame): Duration < IO =
-        use(_.nowMonotonic)
+        IO.Unsafe.withLocal(local)(_.unsafe.nowMonotonic())
 
     private[kyo] def sleep(duration: Duration)(using Frame): Fiber[Nothing, Unit] < IO =
-        use(_.sleep(duration))
+        IO.Unsafe.withLocal(local)(_.unsafe.sleep(duration).safe)
 
     /** Creates a new stopwatch using the local Clock instance.
       *
@@ -297,7 +295,7 @@ object Clock:
       *   A new Stopwatch instance
       */
     def stopwatch(using Frame): Stopwatch < IO =
-        use(_.stopwatch)
+        IO.Unsafe.withLocal(local)(_.unsafe.stopwatch().safe)
 
     /** Creates a new deadline with the specified duration using the local Clock instance.
       *
@@ -307,7 +305,7 @@ object Clock:
       *   A new Deadline instance
       */
     def deadline(duration: Duration)(using Frame): Deadline < IO =
-        use(_.deadline(duration))
+        IO.Unsafe.withLocal(local)(_.unsafe.deadline(duration).safe)
 
     /** Repeatedly executes a task with a fixed delay between completions.
       *

--- a/kyo-core/shared/src/main/scala/kyo/IO.scala
+++ b/kyo-core/shared/src/main/scala/kyo/IO.scala
@@ -96,13 +96,11 @@ object IO:
 
         inline def apply[A, S](inline f: AllowUnsafe ?=> A < S)(using inline frame: Frame): A < (IO & S) =
             Effect.deferInline {
-                import AllowUnsafe.embrace.danger
-                f
+                f(using AllowUnsafe.embrace.danger)
             }
 
         def withLocal[A, B, S](local: Local[A])(f: AllowUnsafe ?=> A => B < S)(using Frame): B < (S & IO) =
-            import AllowUnsafe.embrace.danger
-            local.use(f)
+            local.use(f(using AllowUnsafe.embrace.danger))
 
         /** Evaluates an IO effect that may throw exceptions, converting any thrown exceptions into the final result.
           *

--- a/kyo-core/shared/src/main/scala/kyo/Log.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Log.scala
@@ -173,9 +173,9 @@ object Log extends LogPlatformSpecific:
     private inline def logWhen(inline level: Level)(inline doLog: Log => Unit < IO)(using
         inline frame: Frame
     ): Unit < IO =
-        use { log =>
+        IO.Unsafe.withLocal(local) { log =>
             if level.enabled(log.level) then
-                IO.Unsafe(doLog(log))
+                doLog(log)
             else
                 (
             )

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -262,12 +262,12 @@ object Meter:
 
         private inline def withReentry[A, S](inline reenter: => A < S)(acquire: AllowUnsafe ?=> A < S): A < (IO & S) =
             if reentrant then
-                acquiredMeters.use { meters =>
+                IO.withLocal(acquiredMeters) { meters =>
                     if meters.contains(this) then reenter
-                    else IO.Unsafe(acquire)
+                    else acquire
                 }
             else
-                IO.Unsafe(acquire)
+                acquire
 
         private inline def withAcquiredMeter[A, S](inline v: => A < S) =
             if reentrant then

--- a/kyo-core/shared/src/main/scala/kyo/Random.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Random.scala
@@ -180,7 +180,8 @@ object Random:
       * @return
       *   A random Int value.
       */
-    def nextInt(using Frame): Int < IO = local.use(_.nextInt)
+    def nextInt(using Frame): Int < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextInt())
 
     /** Generates a random integer between 0 (inclusive) and the specified bound (exclusive).
       *
@@ -189,42 +190,48 @@ object Random:
       * @return
       *   A random Int value within the specified range.
       */
-    def nextInt(exclusiveBound: Int)(using Frame): Int < IO = local.use(_.nextInt(exclusiveBound))
+    def nextInt(exclusiveBound: Int)(using Frame): Int < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextInt(exclusiveBound))
 
     /** Generates a random long integer.
       *
       * @return
       *   A random Long value.
       */
-    def nextLong(using Frame): Long < IO = local.use(_.nextLong)
+    def nextLong(using Frame): Long < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextLong())
 
     /** Generates a random double between 0.0 (inclusive) and 1.0 (exclusive).
       *
       * @return
       *   A random Double value between 0.0 and 1.0.
       */
-    def nextDouble(using Frame): Double < IO = local.use(_.nextDouble)
+    def nextDouble(using Frame): Double < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextDouble())
 
     /** Generates a random boolean value.
       *
       * @return
       *   A random Boolean value.
       */
-    def nextBoolean(using Frame): Boolean < IO = local.use(_.nextBoolean)
+    def nextBoolean(using Frame): Boolean < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextBoolean())
 
     /** Generates a random float between 0.0 (inclusive) and 1.0 (exclusive).
       *
       * @return
       *   A random Float value between 0.0 and 1.0.
       */
-    def nextFloat(using Frame): Float < IO = local.use(_.nextFloat)
+    def nextFloat(using Frame): Float < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextFloat())
 
     /** Generates a random double from a Gaussian distribution with mean 0.0 and standard deviation 1.0.
       *
       * @return
       *   A random Double value from a Gaussian distribution.
       */
-    def nextGaussian(using Frame): Double < IO = local.use(_.nextGaussian)
+    def nextGaussian(using Frame): Double < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextGaussian())
 
     /** Selects a random element from the given sequence.
       *
@@ -235,7 +242,8 @@ object Random:
       * @return
       *   A randomly selected element from the sequence.
       */
-    def nextValue[A](seq: Seq[A])(using Frame): A < IO = local.use(_.nextValue(seq))
+    def nextValue[A](seq: Seq[A])(using Frame): A < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextValue(seq): A)
 
     /** Generates a sequence of random elements from the given sequence.
       *
@@ -248,7 +256,8 @@ object Random:
       * @return
       *   A new sequence of randomly selected elements.
       */
-    def nextValues[A](length: Int, seq: Seq[A])(using Frame): Seq[A] < IO = local.use(_.nextValues(length, seq))
+    def nextValues[A](length: Int, seq: Seq[A])(using Frame): Seq[A] < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextValues(length, seq))
 
     /** Generates a random alphanumeric string of the specified length.
       *
@@ -257,7 +266,8 @@ object Random:
       * @return
       *   A random alphanumeric String of the specified length.
       */
-    def nextStringAlphanumeric(length: Int)(using Frame): String < IO = local.use(_.nextStringAlphanumeric(length))
+    def nextStringAlphanumeric(length: Int)(using Frame): String < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextStringAlphanumeric(length))
 
     /** Generates a random string of the specified length using the given character sequence and the current Random instance.
       *
@@ -268,7 +278,8 @@ object Random:
       * @return
       *   A random String of the specified length.
       */
-    def nextString(length: Int, chars: Seq[Char])(using Frame): String < IO = local.use(_.nextString(length, chars))
+    def nextString(length: Int, chars: Seq[Char])(using Frame): String < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextString(length, chars))
 
     /** Generates a sequence of random bytes.
       *
@@ -277,7 +288,8 @@ object Random:
       * @return
       *   A Seq[Byte] of random bytes.
       */
-    def nextBytes(length: Int)(using Frame): Seq[Byte] < IO = local.use(_.nextBytes(length))
+    def nextBytes(length: Int)(using Frame): Seq[Byte] < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.nextBytes(length))
 
     /** Shuffles the elements of the given sequence randomly.
       *
@@ -288,6 +300,7 @@ object Random:
       * @return
       *   A new sequence with the elements shuffled randomly.
       */
-    def shuffle[A](seq: Seq[A])(using Frame): Seq[A] < IO = local.use(_.shuffle(seq))
+    def shuffle[A](seq: Seq[A])(using Frame): Seq[A] < IO =
+        IO.Unsafe.withLocal(local)(_.unsafe.shuffle(seq))
 
 end Random

--- a/kyo-core/shared/src/test/scala/kyo/IOTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/IOTest.scala
@@ -190,4 +190,108 @@ class IOTest extends Test:
         }
     }
 
+    "withLocal" - {
+        "basic usage" in run {
+            val local      = Local.init("test")
+            var sideEffect = ""
+
+            IO.withLocal(local) { value =>
+                sideEffect = value
+                value.length
+            }.map { result =>
+                assert(sideEffect == "test")
+                assert(result == 4)
+            }
+        }
+
+        "respects local modifications" in run {
+            val local    = Local.init("initial")
+            var captured = ""
+
+            local.let("modified") {
+                IO.withLocal(local) { value =>
+                    captured = value
+                    value.toUpperCase
+                }
+            }.map { result =>
+                assert(captured == "modified")
+                assert(result == "MODIFIED")
+            }
+        }
+
+        "lazy evaluation" in run {
+            val local    = Local.init("test")
+            var executed = false
+
+            val computation =
+                IO.withLocal(local) { value =>
+                    executed = true
+                    value
+                }
+
+            assert(!executed)
+            computation.map { result =>
+                assert(executed)
+                assert(result == "test")
+            }
+        }
+    }
+
+    "Unsafe.withLocal" - {
+        import AllowUnsafe.embrace.danger
+
+        def unsafeOperation(value: Int)(using unsafe: AllowUnsafe): Int =
+            value * 2
+
+        "allows unsafe operations" in run {
+            val local      = Local.init(42)
+            var sideEffect = 0
+
+            IO.Unsafe.withLocal(local) { value =>
+                sideEffect = unsafeOperation(value)
+                sideEffect
+            }.map { result =>
+                assert(result == 84)
+                assert(sideEffect == 84)
+            }
+        }
+
+        "respects local context" in run {
+            val local    = Local.init(10)
+            var captured = 0
+
+            local.let(20) {
+                IO.Unsafe.withLocal(local) { value =>
+                    captured = unsafeOperation(value)
+                    value + 1
+                }
+            }.map { result =>
+                assert(captured == 40)
+                assert(result == 21)
+            }
+        }
+
+        "composes with other unsafe operations" in run {
+            val local            = Local.init(5)
+            var steps: List[Int] = Nil
+
+            val computation =
+                for
+                    v1 <- IO.Unsafe.withLocal(local) { value =>
+                        steps = unsafeOperation(value) :: steps
+                        value * 2
+                    }
+                    v2 <- IO.Unsafe {
+                        steps = v1 :: steps
+                        v1 + 1
+                    }
+                yield v2
+
+            computation.map { result =>
+                assert(steps == List(10, 10))
+                assert(result == 11)
+            }
+        }
+    }
+
 end IOTest

--- a/kyo-core/shared/src/test/scala/kyo/RandomTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/RandomTest.scala
@@ -3,21 +3,22 @@ package kyo
 class RandomTest extends Test:
 
     "mocked" - {
-        val testRandom: Random = new Random:
-            def nextInt(using Frame)                                   = 10
-            def nextInt(n: Int)(using Frame)                           = Math.min(55, n - 1)
-            def nextLong(using Frame)                                  = 20L
-            def nextBoolean(using Frame)                               = true
-            def nextDouble(using Frame)                                = 30d
-            def nextFloat(using Frame)                                 = 40f
-            def nextGaussian(using Frame)                              = 50d
-            def nextValue[A](seq: Seq[A])(using Frame)                 = seq.last
-            def nextValues[A](length: Int, seq: Seq[A])(using Frame)   = Seq.fill(length)(seq.last)
-            def nextStringAlphanumeric(length: Int)(using Frame)       = "a" * length
-            def nextString(length: Int, chars: Seq[Char])(using Frame) = chars.last.toString * length
-            def nextBytes(length: Int)(using Frame)                    = Seq.fill(length)(1.toByte)
-            def shuffle[A](seq: Seq[A])(using Frame)                   = seq.reverse
-            def unsafe                                                 = ???
+        val testRandom = Random(
+            new Random.Unsafe:
+                def nextInt()(using AllowUnsafe)                                 = 10
+                def nextInt(n: Int)(using AllowUnsafe)                           = Math.min(55, n - 1)
+                def nextLong()(using AllowUnsafe)                                = 20L
+                def nextBoolean()(using AllowUnsafe)                             = true
+                def nextDouble()(using AllowUnsafe)                              = 30d
+                def nextFloat()(using AllowUnsafe)                               = 40f
+                def nextGaussian()(using AllowUnsafe)                            = 50d
+                def nextValue[A](seq: Seq[A])(using AllowUnsafe)                 = seq.last
+                def nextValues[A](length: Int, seq: Seq[A])(using AllowUnsafe)   = Seq.fill(length)(seq.last)
+                def nextStringAlphanumeric(length: Int)(using AllowUnsafe)       = "a" * length
+                def nextString(length: Int, chars: Seq[Char])(using AllowUnsafe) = chars.last.toString * length
+                def nextBytes(length: Int)(using AllowUnsafe)                    = Seq.fill(length)(1.toByte)
+                def shuffle[A](seq: Seq[A])(using AllowUnsafe)                   = seq.reverse
+        )
 
         "nextInt" in run {
             Random.let(testRandom)(Random.nextInt).map { v =>

--- a/kyo-stm/shared/src/main/scala/kyo/STM.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/STM.scala
@@ -102,7 +102,7 @@ object STM:
       *   The result of the computation if successful
       */
     def run[E, A: Flat](retrySchedule: Schedule)(v: A < (STM & Abort[E] & Async))(using Frame): A < (Async & Abort[E | FailedTransaction]) =
-        TID.use {
+        TID.useIO {
             case -1L =>
                 // New transaction without a parent, use regular commit flow
                 Retry[FailedTransaction](retrySchedule) {

--- a/kyo-stm/shared/src/main/scala/kyo/TID.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TID.scala
@@ -15,11 +15,14 @@ private[kyo] object TID:
             tidLocal.let(tid)(f(tid))
         }
 
-    inline def use[A, S](inline f: Long => A < S)(using inline frame: Frame): A < S =
+    inline def useIO[A, S](inline f: Long => A < S)(using inline frame: Frame): A < S =
         tidLocal.use(f(_))
 
-    inline def useRequired[A, S](inline f: Long => A < S)(using inline frame: Frame): A < S =
-        tidLocal.use {
+    inline def useIOUnsafe[A, S](inline f: AllowUnsafe ?=> Long => A < S)(using inline frame: Frame): A < (S & IO) =
+        IO.Unsafe.withLocal(tidLocal)(f(_))
+
+    inline def useIORequired[A, S](inline f: Long => A < S)(using inline frame: Frame): A < (S & IO) =
+        IO.withLocal(tidLocal) {
             case -1L => bug("STM operation attempted outside of STM.run - this should be impossible due to effect typing")
             case tid => f(tid)
         }

--- a/kyo-stm/shared/src/main/scala/kyo/TMap.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TMap.scala
@@ -64,15 +64,13 @@ object TMap:
     inline def initWith[K, V](inline entries: (K, V)*)[A, S](inline f: TMap[K, V] => A < S)(
         using inline frame: Frame
     ): TMap[K, V] < (IO & S) =
-        TID.use { tid =>
-            IO.Unsafe {
-                val trefs =
-                    entries.foldLeft(Map.empty[K, TRef[V]]) {
-                        case (acc, (k, v)) =>
-                            acc.updated(k, TRef.Unsafe.init(tid, v))
-                    }
-                TRef.Unsafe.init(tid, trefs)
-            }
+        TID.useIOUnsafe { tid =>
+            val trefs =
+                entries.foldLeft(Map.empty[K, TRef[V]]) {
+                    case (acc, (k, v)) =>
+                        acc.updated(k, TRef.Unsafe.init(tid, v))
+                }
+            TRef.Unsafe.init(tid, trefs)
         }
 
     extension [K, V](self: TMap[K, V])

--- a/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
@@ -705,9 +705,9 @@ class STMTest extends Test:
                 ref <- TRef.init(0)
                 (parentTid, childTid) <-
                     STM.run {
-                        TID.use { parentTid =>
+                        TID.useIO { parentTid =>
                             Async.run {
-                                STM.run(TID.use(identity))
+                                STM.run(TID.useIO(identity))
                             }.map(_.get).map { childTid =>
                                 (parentTid, childTid)
                             }


### PR DESCRIPTION
Getting the value of a `Local` and then immediately performing a side effect is a common pattern in the codebase. See [TRef](https://github.com/getkyo/kyo/blob/9cdf197909d2ecdcd9436f5e9c687f5bbd9b5b2a/kyo-stm/shared/src/main/scala/kyo/TRef.scala#L185) as an example. Other methods like [Clock.deadline](https://github.com/getkyo/kyo/blob/9cdf197909d2ecdcd9436f5e9c687f5bbd9b5b2a/kyo-core/shared/src/main/scala/kyo/Clock.scala#L309) have a similar pattern. 

It currently requires two separate suspensions but that's unnecessary. The local get already suspends execution the same way as `IO` does: via the kernel's internal [Defer](https://github.com/getkyo/kyo/blob/9cdf197909d2ecdcd9436f5e9c687f5bbd9b5b2a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Kyo.scala#L80) effect, which is the underlying suspension of `ContextEffect` and is guaranteed to be the last effect to be handled. This PR introduces `IO.withLocal` and `IO.Unsafe.withLocal` as APIs that provide both operations in a single step/allocation.