### PR TITLE
[scheduler] disable singleton mechanism

### DIFF
--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -483,13 +483,13 @@ final class Scheduler(
     }
 }
 
-object Scheduler extends Singleton[Scheduler] {
-
-    override protected def init() = new Scheduler()
+object Scheduler {
 
     private lazy val defaultWorkerExecutor = Executors.newCachedThreadPool(Threads("kyo-scheduler-worker", new Worker.WorkerThread(_)))
     private lazy val defaultClockExecutor  = Executors.newSingleThreadExecutor(Threads("kyo-scheduler-clock"))
     private lazy val defaultTimerExecutor  = Executors.newScheduledThreadPool(2, Threads("kyo-scheduler-timer"))
+
+    val get = new Scheduler()
 
     /** Configuration parameters controlling worker behavior and performance characteristics.
       *


### PR DESCRIPTION
We're noticing issues with Scala's standard library assuming all properties contain `String` values:

```
[error] Caused by: java.lang.ClassCastException: class kyo.scheduler.Scheduler cannot be cast to class java.lang.String (kyo.scheduler.Scheduler is in unnamed module of loader sbt.internal.LayeredClassLoader @db22014; java.lang.String is in module java.base of loader 'bootstrap')
[error]         at scala.collection.convert.JavaCollectionWrappers$JPropertiesWrapper$$anon$6.next(JavaCollectionWrappers.scala:614)
[error]         at scala.collection.convert.JavaCollectionWrappers$JPropertiesWrapper$$anon$6.next(JavaCollectionWrappers.scala:609)
[error]         at scala.collection.IterableOnceOps.find(IterableOnce.scala:677)
[error]         at scala.collection.IterableOnceOps.find$(IterableOnce.scala:674)
[error]         at scala.collection.AbstractIterator.find(Iterator.scala:1303)
```