### PR TITLE
[stm] fix TTable index initialization

### DIFF
--- a/kyo-stm/shared/src/main/scala/kyo/TTable.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TTable.scala
@@ -204,6 +204,8 @@ object TTable:
         def isEmpty(using Frame)  = store.isEmpty
         def snapshot(using Frame) = store.snapshot
 
+        def indexFields: Set[Field[?, ?]] = indexes.keySet
+
         private inline val indexMismatch = """
             Cannot query on fields that are not indexed.
             The filter contains fields that are not part of the table's index configuration.
@@ -287,11 +289,11 @@ object TTable:
           * @return
           *   A new Indexed table instance within the IO effect
           */
-        def init[Fields: AsFields as fields, Indexes >: Fields: AsFields as indexes](using Frame): Indexed[Fields, Indexes] < IO =
+        def init[Fields: AsFields as fields, Indexes >: Fields: AsFields as indexFields](using Frame): Indexed[Fields, Indexes] < IO =
             for
                 table <- TTable.init[Fields]
                 indexes <-
-                    Kyo.foreach(fields.toSeq) { field =>
+                    Kyo.foreach(indexFields.toSeq) { field =>
                         TMap.init[Any, Set[Int]].map(field -> _)
                     }
             yield new Indexed(table, indexes.toMap)(using fields)

--- a/kyo-stm/shared/src/test/scala/kyo/TTableTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TTableTest.scala
@@ -240,6 +240,30 @@ class TTableTest extends Test:
                     assert(age32Results.isEmpty)
             }
         }
+
+        "indexing verification" - {
+            "should only create specified indexes" in run {
+                for
+                    table <- TTable.Indexed.init["name" ~ String & "age" ~ Int & "email" ~ String, "name" ~ String & "age" ~ Int]
+                    indexFields = table.indexFields
+                yield
+                    assert(indexFields.size == 2)
+                    assert(indexFields.exists(_.name == "name"))
+                    assert(indexFields.exists(_.name == "age"))
+                    assert(!indexFields.exists(_.name == "email"))
+            }
+
+            "should handle single index field" in run {
+                for
+                    table <- TTable.Indexed.init["name" ~ String & "age" ~ Int & "email" ~ String, "age" ~ Int]
+                    indexFields = table.indexFields
+                yield
+                    assert(indexFields.size == 1)
+                    assert(indexFields.exists(_.name == "age"))
+                    assert(!indexFields.exists(_.name == "name"))
+                    assert(!indexFields.exists(_.name == "email"))
+            }
+        }
     }
 
     "Complex field manipulation" - {


### PR DESCRIPTION
The wrong implicit was being used to initialize the indexes, which caused all fields to be indexed.