### PR TITLE
[data] records more than 22 AsFields (#1006)

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Record.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Record.scala
@@ -1,6 +1,7 @@
 package kyo
 
 import Record.*
+import internal.FieldsLikeMacro
 import scala.annotation.implicitNotFound
 import scala.compiletime.constValue
 import scala.compiletime.summonInline
@@ -81,9 +82,9 @@ class Record[+Fields](val toMap: Map[Field[?, ?], Any]) extends AnyVal with Dyna
       *   The field name to look up
       */
     def selectDynamic[Name <: String & Singleton, Value](name: Name)(using
-        @implicitNotFound(""" 
+        @implicitNotFound("""
         Invalid field access: ${Name}
-        
+
         Record[${Fields}]
 
         Possible causes:
@@ -250,394 +251,34 @@ object Record:
       */
     opaque type AsFields[+A] <: Set[Field[?, ?]] = Set[Field[?, ?]]
 
-    trait AsFields22:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12],
-            a13: AsField[A13],
-            a14: AsField[A14],
-            a15: AsField[A15],
-            a16: AsField[A16],
-            a17: AsField[A17],
-            a18: AsField[A18],
-            a19: AsField[A19],
-            a20: AsField[A20],
-            a21: AsField[A21],
-            a22: AsField[A22]
-        ): AsFields[
-            A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12 & A13 & A14 & A15 & A16 & A17 & A18 & A19 & A20 & A21 & A22
-        ] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22)
-    end AsFields22
+    object AsFields:
+        /** Evidence that every tuple member has AsField instance
+          *
+          * @param fields
+          *   Set of all fields of tuple
+          */
+        class All[T <: Tuple](val fields: Set[Field[?, ?]]) extends AnyVal
+        object All:
+            given All[EmptyTuple] = All(Set())
+            given [H, T <: Tuple](using a: AsField[H], f: All[T]): All[H *: T] =
+                All(f.fields + a)
+        end All
 
-    trait AsFields21 extends AsFields22:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12],
-            a13: AsField[A13],
-            a14: AsField[A14],
-            a15: AsField[A15],
-            a16: AsField[A16],
-            a17: AsField[A17],
-            a18: AsField[A18],
-            a19: AsField[A19],
-            a20: AsField[A20],
-            a21: AsField[A21]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12 & A13 & A14 & A15 & A16 & A17 & A18 & A19 & A20 & A21] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21)
-    end AsFields21
-
-    trait AsFields20 extends AsFields21:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12],
-            a13: AsField[A13],
-            a14: AsField[A14],
-            a15: AsField[A15],
-            a16: AsField[A16],
-            a17: AsField[A17],
-            a18: AsField[A18],
-            a19: AsField[A19],
-            a20: AsField[A20]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12 & A13 & A14 & A15 & A16 & A17 & A18 & A19 & A20] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
-    end AsFields20
-
-    trait AsFields19 extends AsFields20:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12],
-            a13: AsField[A13],
-            a14: AsField[A14],
-            a15: AsField[A15],
-            a16: AsField[A16],
-            a17: AsField[A17],
-            a18: AsField[A18],
-            a19: AsField[A19]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12 & A13 & A14 & A15 & A16 & A17 & A18 & A19] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19)
-    end AsFields19
-
-    trait AsFields18 extends AsFields19:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12],
-            a13: AsField[A13],
-            a14: AsField[A14],
-            a15: AsField[A15],
-            a16: AsField[A16],
-            a17: AsField[A17],
-            a18: AsField[A18]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12 & A13 & A14 & A15 & A16 & A17 & A18] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18)
-    end AsFields18
-
-    trait AsFields17 extends AsFields18:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12],
-            a13: AsField[A13],
-            a14: AsField[A14],
-            a15: AsField[A15],
-            a16: AsField[A16],
-            a17: AsField[A17]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12 & A13 & A14 & A15 & A16 & A17] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17)
-    end AsFields17
-
-    trait AsFields16 extends AsFields17:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12],
-            a13: AsField[A13],
-            a14: AsField[A14],
-            a15: AsField[A15],
-            a16: AsField[A16]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12 & A13 & A14 & A15 & A16] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)
-    end AsFields16
-
-    trait AsFields15 extends AsFields16:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12],
-            a13: AsField[A13],
-            a14: AsField[A14],
-            a15: AsField[A15]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12 & A13 & A14 & A15] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
-    end AsFields15
-
-    trait AsFields14 extends AsFields15:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12],
-            a13: AsField[A13],
-            a14: AsField[A14]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12 & A13 & A14] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)
-    end AsFields14
-
-    trait AsFields13 extends AsFields14:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12],
-            a13: AsField[A13]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12 & A13] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)
-    end AsFields13
-
-    trait AsFields12 extends AsFields13:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11],
-            a12: AsField[A12]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11 & A12] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
-    end AsFields12
-
-    trait AsFields11 extends AsFields12:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10],
-            a11: AsField[A11]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10 & A11] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)
-    end AsFields11
-
-    trait AsFields10 extends AsFields11:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9],
-            a10: AsField[A10]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9 & A10] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
-    end AsFields10
-
-    trait AsFields9 extends AsFields10:
-        given [A1, A2, A3, A4, A5, A6, A7, A8, A9](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8],
-            a9: AsField[A9]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8 & A9] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8, a9)
-    end AsFields9
-
-    trait AsFields8 extends AsFields9:
-        given [A1, A2, A3, A4, A5, A6, A7, A8](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7],
-            a8: AsField[A8]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7 & A8] =
-            Set(a1, a2, a3, a4, a5, a6, a7, a8)
-    end AsFields8
-
-    trait AsFields7 extends AsFields8:
-        given [A1, A2, A3, A4, A5, A6, A7](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6],
-            a7: AsField[A7]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6 & A7] =
-            Set(a1, a2, a3, a4, a5, a6, a7)
-    end AsFields7
-
-    trait AsFields6 extends AsFields7:
-        given [A1, A2, A3, A4, A5, A6](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5],
-            a6: AsField[A6]
-        ): AsFields[A1 & A2 & A3 & A4 & A5 & A6] =
-            Set(a1, a2, a3, a4, a5, a6)
-    end AsFields6
-
-    trait AsFields5 extends AsFields6:
-        given [A1, A2, A3, A4, A5](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4],
-            a5: AsField[A5]
-        ): AsFields[A1 & A2 & A3 & A4 & A5] =
-            Set(a1, a2, a3, a4, a5)
-    end AsFields5
-
-    trait AsFields4 extends AsFields5:
-        given [A1, A2, A3, A4](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3],
-            a4: AsField[A4]
-        ): AsFields[A1 & A2 & A3 & A4] =
-            Set(a1, a2, a3, a4)
-    end AsFields4
-
-    trait AsFields3 extends AsFields4:
-        given [A1, A2, A3](using
-            a1: AsField[A1],
-            a2: AsField[A2],
-            a3: AsField[A3]
-        ): AsFields[A1 & A2 & A3] =
-            Set(a1, a2, a3)
-    end AsFields3
-
-    trait AsFields2 extends AsFields3:
-        given [A1, A2](using
-            a1: AsField[A1],
-            a2: AsField[A2]
-        ): AsFields[A1 & A2] =
-            Set(a1, a2)
-    end AsFields2
-
-    object AsFields extends AsFields2:
-
-        given [A1](using
-            a1: AsField[A1]
-        ): AsFields[A1] =
-            Set(a1)
+        given [A](using ev: FieldsLike[A], a: All[ev.T]): AsFields[A] = a.fields
 
         def apply[A](using af: AsFields[A]): Set[Field[?, ?]] = af
     end AsFields
 
+    /** Evidence that type `Fields` is intersection on `~` types. `T` is a tuple of these types.
+      */
+    trait FieldsLike[A]:
+        type T <: Tuple
+
+    object FieldsLike:
+        type Aux[A, _T] = FieldsLike[A]:
+            type T = _T
+
+        transparent inline given derive[A]: FieldsLike[A] =
+            ${ FieldsLikeMacro.fieldsLikeImpl[A] }
+    end FieldsLike
 end Record

--- a/kyo-data/shared/src/main/scala/kyo/Record.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Record.scala
@@ -269,12 +269,18 @@ object Record:
         def apply[A](using af: AsFields[A]): Set[Field[?, ?]] = af
     end AsFields
 
-    /** Evidence that type `Fields` is intersection on `~` types. `T` is a tuple of these types.
+    /** Evidence that type `A` is intersection of `~` types. `T` is a tuple of these types.
       */
+    @implicitNotFound(
+        "Unable to prove that type `${A}` is an intersection of `~` types"
+    )
     trait FieldsLike[A]:
         type T <: Tuple
+    end FieldsLike
 
     object FieldsLike:
+        def apply[A](using f: FieldsLike[A]): FieldsLike[A] = f
+
         type Aux[A, _T] = FieldsLike[A]:
             type T = _T
 

--- a/kyo-data/shared/src/main/scala/kyo/internal/FieldsLikeMacro.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/FieldsLikeMacro.scala
@@ -1,0 +1,39 @@
+package kyo.internal
+
+import kyo.Record.~
+import kyo.Record.FieldsLike
+import scala.quoted.*
+
+object FieldsLikeMacro:
+    def fieldsLikeImpl[A: Type](using
+        Quotes
+    ): Expr[FieldsLike[A]] =
+        import quotes.reflect.*
+
+        def decompose(base: TypeRepr): Vector[TypeRepr] =
+            base match
+                case AndType(l, r) =>
+                    decompose(l) ++ decompose(r)
+                case AppliedType(constr, _) if (constr =:= TypeRepr.of[~]) =>
+                    Vector(base)
+                case _ =>
+                    if base =:= TypeRepr.of[Any] then Vector()
+                    else
+                        report.errorAndAbort(s"Unable to decompose param for ${base.show}")
+
+        def tupled(typs: Vector[TypeRepr]): TypeRepr =
+            typs match
+                case h +: t => TypeRepr.of[*:].appliedTo(List(h, tupled(t)))
+                case _      => TypeRepr.of[EmptyTuple]
+
+        tupled(decompose(TypeRepr.of[A].dealias)).asType match
+            case '[
+                type x <: Tuple; x] =>
+                '{
+                    (new FieldsLike[A]:
+                        type T = x
+                    ): FieldsLike.Aux[A, x]
+                }
+        end match
+    end fieldsLikeImpl
+end FieldsLikeMacro

--- a/kyo-data/shared/src/test/scala/kyo/RecordTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/RecordTest.scala
@@ -265,11 +265,6 @@ class RecordTest extends Test:
         "preserves defined fields" in {
             val record: Record["name" ~ String & "age" ~ Int] =
                 "name" ~ "Frank" & "age" ~ 40
-            import Record.AsFields
-            import Record.AsFields.given
-
-            AsFields["name" ~ String & "age" ~ Int]
-
             val compacted = record.compact
 
             assert(compacted.size == 2)

--- a/kyo-data/shared/src/test/scala/kyo/RecordTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/RecordTest.scala
@@ -265,6 +265,11 @@ class RecordTest extends Test:
         "preserves defined fields" in {
             val record: Record["name" ~ String & "age" ~ Int] =
                 "name" ~ "Frank" & "age" ~ 40
+            import Record.AsFields
+            import Record.AsFields.given
+
+            AsFields["name" ~ String & "age" ~ Int]
+
             val compacted = record.compact
 
             assert(compacted.size == 2)
@@ -312,7 +317,7 @@ class RecordTest extends Test:
             assertCompiles("Record.AsFields[Fields22]")
         }
 
-        "intersections with more than 22 fields" in pendingUntilFixed {
+        "intersections with more than 22 fields" in {
             type Fields23 =
                 "1" ~ Int & "2" ~ Int & "3" ~ Int & "4" ~ Int & "5" ~ Int & "6" ~ Int & "7" ~ Int & "8" ~ Int & "9" ~ Int & "10" ~ Int &
                     "11" ~ Int & "12" ~ Int & "13" ~ Int & "14" ~ Int & "15" ~ Int & "16" ~ Int & "17" ~ Int & "18" ~ Int & "19" ~ Int &
@@ -555,7 +560,7 @@ class RecordTest extends Test:
                 val record = ("name" ~ "test" & "age" ~ 42)
                     .asInstanceOf[Record[Int & "name" ~ String & "age" ~ Int]]
                 assertDoesNotCompile("""
-                    record.compact 
+                    record.compact
                 """)
             }
         }


### PR DESCRIPTION
I haven't found a way to avoid macro (intersection types don't play well with implicits). So I have created typeclass `FieldsLike` (evidence) that splits `Fields` type into tuple of `~` types, and then derives instance for every tuple member.

This typeclass `FieldsLike` could potentially be used for other features like removing fields by keys.