### PR TITLE
[prelude] tests for Choice with collection operations

### DIFF
--- a/kyo-prelude/shared/src/test/scala/kyo/ChoiceTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/ChoiceTest.scala
@@ -97,4 +97,51 @@ class ChoiceTest extends Test:
         end try
         ()
     }
+
+    "interaction with collection operations" - {
+        "foreach" in {
+            val result = Choice.run(
+                Kyo.foreach(List("x", "y")) { str =>
+                    Choice.get(List(true, false)).map(b =>
+                        if b then str.toUpperCase else str
+                    )
+                }
+            ).eval
+
+            assert(result.contains(Chunk("X", "Y")))
+            assert(result.contains(Chunk("X", "y")))
+            assert(result.contains(Chunk("x", "Y")))
+            assert(result.contains(Chunk("x", "y")))
+            assert(result.size == 4)
+        }
+
+        "collect" in {
+            val effects =
+                List("x", "y").map { str =>
+                    Choice.get(List(true, false)).map(b =>
+                        if b then str.toUpperCase else str
+                    )
+                }
+            val result = Choice.run(Kyo.collect(effects)).eval
+
+            assert(result.contains(Chunk("X", "Y")))
+            assert(result.contains(Chunk("X", "y")))
+            assert(result.contains(Chunk("x", "Y")))
+            assert(result.contains(Chunk("x", "y")))
+            assert(result.size == 4)
+        }
+
+        "foldLeft" in {
+            val result = Choice.run(
+                Kyo.foldLeft(List(1, 1))(0) { (acc, _) =>
+                    Choice.get(List(0, 1)).map(n => acc + n)
+                }
+            ).eval
+
+            assert(result.contains(0))
+            assert(result.contains(1))
+            assert(result.contains(2))
+            assert(result.size == 4)
+        }
+    }
 end ChoiceTest


### PR DESCRIPTION
Kyo provides more strict purity in its implementations due to its support for effects that may invoke the continuation multiple times. Other effect systems typically optimize collection operations by using under-the-hood mutation via builders and iterators but we can't do the same because of the purity restriction. This PR introduces tests to ensure that remains the case or, if we find another solution, multi-shot continuations continue working properly.