### PR TITLE
remove IO.unit

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/CountdownLatchBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/CountdownLatchBench.scala
@@ -24,7 +24,7 @@ class CountdownLatchBench extends Bench.ForkOnly(0):
         import kyo.*
 
         def iterate(l: Latch, n: Int): Unit < IO =
-            if n <= 0 then IO.unit
+            if n <= 0 then Kyo.unit
             else l.release.flatMap(_ => iterate(l, n - 1))
 
         for

--- a/kyo-bench/src/main/scala/kyo/bench/DeepBindBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/DeepBindBench.scala
@@ -8,7 +8,7 @@ class DeepBindBench extends Bench.SyncAndFork(()):
         import kyo.*
 
         def loop(i: Int): Unit < IO =
-            IO.unit.flatMap { _ =>
+            Kyo.unit.flatMap { _ =>
                 if i > depth then
                     ()
                 else

--- a/kyo-bench/src/main/scala/kyo/bench/EnqueueDequeueBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/EnqueueDequeueBench.scala
@@ -24,7 +24,7 @@ class EnqueueDequeueBench extends Bench.ForkOnly(()):
 
         def loop(c: Channel[Unit], i: Int): Unit < (Async & Abort[Closed]) =
             if i >= depth then
-                IO.unit
+                Kyo.unit
             else
                 c.put(()).flatMap(_ => c.take.flatMap(_ => loop(c, i + 1)))
 

--- a/kyo-bench/src/main/scala/kyo/bench/ForkChainedBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForkChainedBench.scala
@@ -26,7 +26,7 @@ class ForkChainedBench extends Bench.ForkOnly(0):
 
         def iterate(p: Promise[Nothing, Unit], n: Int): Unit < IO =
             if n <= 0 then p.complete(Result.unit).unit
-            else IO.unit.flatMap(_ => Async.run(iterate(p, n - 1)).unit)
+            else Kyo.unit.flatMap(_ => Async.run(iterate(p, n - 1)).unit)
 
         for
             p <- Promise.init[Nothing, Unit]

--- a/kyo-bench/src/main/scala/kyo/bench/PingPongBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/PingPongBench.scala
@@ -50,7 +50,7 @@ class PingPongBench extends Bench.ForkOnly(()):
                         _ <- Async.run(chan.put(()))
                         _ <- chan.take
                         n <- ref.decrementAndGet
-                        _ <- if n == 0 then promise.complete(Result.unit).unit else IO.unit
+                        _ <- if n == 0 then promise.complete(Result.unit).unit else Kyo.unit
                     yield ()
                 _ <- repeat(depth)(Async.run[Closed, Unit, Any](effect))
             yield ()

--- a/kyo-bench/src/main/scala/kyo/bench/RendezvousBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/RendezvousBench.scala
@@ -80,7 +80,7 @@ class RendezvousBench extends Bench.ForkOnly(10000 * (10000 + 1) / 2):
                     }
                 }
             else
-                IO.unit
+                Kyo.unit
 
         def consume(waiting: AtomicRef[Any], n: Int = 0, acc: Int = 0): Int < Async =
             if n <= depth then

--- a/kyo-bench/src/main/scala/kyo/bench/SchedulingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/SchedulingBench.scala
@@ -30,13 +30,13 @@ class SchedulingBench extends Bench.ForkOnly(1001000):
         import kyo.*
 
         def fiber(i: Int): Int < IO =
-            IO.unit.flatMap { _ =>
+            Kyo.unit.flatMap { _ =>
                 IO(i).flatMap { j =>
-                    IO.unit.flatMap { _ =>
+                    Kyo.unit.flatMap { _ =>
                         if j > depth then
-                            IO.unit.flatMap(_ => IO(j))
+                            Kyo.unit.flatMap(_ => IO(j))
                         else
-                            IO.unit.flatMap(_ => fiber(j + 1))
+                            Kyo.unit.flatMap(_ => fiber(j + 1))
                     }
                 }
             }

--- a/kyo-bench/src/main/scala/kyo/bench/SemaphoreBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/SemaphoreBench.scala
@@ -24,7 +24,7 @@ class SemaphoreBench extends Bench.ForkOnly(()):
 
         def loop(s: Meter, i: Int): Unit < (Async & Abort[Closed]) =
             if i >= depth then
-                IO.unit
+                Kyo.unit
             else
                 s.run(()).flatMap(_ => loop(s, i + 1))
 

--- a/kyo-core/jvm/src/main/scala/kyo/Path.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Path.scala
@@ -283,7 +283,7 @@ class Path private (val path: List[String]) derives CanEqual:
             (parentExists, createFolders) match
                 case (true, _)     => IO(JFiles.copy(toJava, to.toJava, opts*)).unit
                 case (false, true) => Path(toJava.getParent().toString).mkDir.andThen(IO(JFiles.copy(toJava, to.toJava, opts*)).unit)
-                case _             => IO.unit
+                case _             => ()
         }
     end copy
 

--- a/kyo-core/jvm/src/main/scala/kyo/Process.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Process.scala
@@ -192,7 +192,7 @@ object Process:
                             for
                                 _ <- Async.run(Resource.run(resources))
                             yield ()
-                        case _ => IO.unit
+                        case _ => Kyo.unit
                 yield process
 
             override def cwd(newCwd: Path)                   = self.copy(cwd = Some(newCwd))

--- a/kyo-core/shared/src/main/scala/kyo/IO.scala
+++ b/kyo-core/shared/src/main/scala/kyo/IO.scala
@@ -24,13 +24,6 @@ opaque type IO <: Abort[Nothing] = Abort[Nothing]
 
 object IO:
 
-    /** Creates a unit IO effect, representing a no-op side effect.
-      *
-      * @return
-      *   A unit value wrapped in an IO effect.
-      */
-    inline def unit: Unit < IO = ()
-
     /** Suspends a potentially side-effecting computation in an IO effect.
       *
       * This method allows you to lift any computation (including those with side effects) into the IO context, deferring its execution

--- a/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
@@ -201,7 +201,7 @@ class ResourceTest extends Test:
         case object TestException extends NoStackTrace
 
         "acquire fails" taggedAs jvmOnly in run {
-            val io = Resource.acquireRelease(IO[Int, Any](throw TestException))(_ => IO.unit)
+            val io = Resource.acquireRelease(IO[Int, Any](throw TestException))(_ => Kyo.unit)
             Resource.run(io)
                 .pipe(Async.runAndBlock(timeout))
                 .pipe(Abort.run(_))

--- a/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
@@ -27,8 +27,8 @@ object Kyo:
 
     /** Returns a pure effect that produces Unit.
       *
-      * This is exactly equivalent to `pure(())`, as both simply lift the Unit value into the effect context
-      * without introducing any effect suspension.
+      * This is exactly equivalent to `pure(())`, as both simply lift the Unit value into the effect context without introducing any effect
+      * suspension.
       *
       * @tparam S
       *   The effect context (can be Any)

--- a/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
@@ -12,6 +12,8 @@ object Kyo:
       * While pure values are automatically lifted into Kyo computations in most cases, this method can be useful in specific scenarios,
       * such as in if/else expressions, to help with type inference.
       *
+      * Note: This is a zero-cost operation that simply wraps the value in a Kyo computation type without introducing any effect suspension.
+      *
       * @tparam A
       *   The type of the value
       * @tparam S
@@ -19,10 +21,20 @@ object Kyo:
       * @param v
       *   The value to lift into the effect context
       * @return
-      *   A computation that produces the given value
+      *   A computation that directly produces the given value without suspension
       */
     inline def pure[A, S](inline v: A): A < S = v
 
+    /** Returns a pure effect that produces Unit.
+      *
+      * This is exactly equivalent to `pure(())`, as both simply lift the Unit value into the effect context
+      * without introducing any effect suspension.
+      *
+      * @tparam S
+      *   The effect context (can be Any)
+      * @return
+      *   A computation that directly produces Unit without suspension
+      */
     inline def unit[S]: Unit < S = ()
 
     /** Zips two effects into a tuple.

--- a/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
@@ -23,6 +23,8 @@ object Kyo:
       */
     inline def pure[A, S](inline v: A): A < S = v
 
+    inline def unit[S]: Unit < S = ()
+
     /** Zips two effects into a tuple.
       *
       * @param v1

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscriber.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscriber.scala
@@ -235,7 +235,7 @@ final private[kyo] class StreamSubscriber[V](
                     end if
                 case other =>
                     if state.compareAndSet(curState, other) then
-                        IO.unit
+                        Kyo.unit
                     else
                         handleInterupt()
             end match

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -74,7 +74,7 @@ final private[kyo] class StreamSubscription[V, Ctx](
                 fiber.onComplete {
                     case Result.Success(StreamComplete) => IO(subscriber.onComplete())
                     case Result.Panic(e)                => IO(subscriber.onError(e))
-                    case Result.Failure(StreamCanceled) => IO.unit
+                    case Result.Failure(StreamCanceled) => Kyo.unit
                 }.andThen(fiber)
             }
     end consume

--- a/kyo-stm/shared/src/main/scala/kyo/TTable.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TTable.scala
@@ -187,7 +187,7 @@ object TTable:
                         removeFromIndexes(id, prev.get)
                             .andThen(updateIndexes(id, record))
                     else
-                        Kyo.pure(())
+                        Kyo.unit
             yield prev
 
         def upsert(id: Id, record: Record[Fields])(using Frame) =
@@ -197,7 +197,7 @@ object TTable:
             for
                 record  <- store.get(id)
                 deleted <- store.remove(id)
-                _       <- if deleted.nonEmpty then removeFromIndexes(id, record.get) else Kyo.pure(())
+                _       <- if deleted.nonEmpty then removeFromIndexes(id, record.get) else Kyo.unit
             yield deleted
 
         def size(using Frame)     = store.size


### PR DESCRIPTION
This method was introduced before we had the `Kyo` companion object. It doesn't make much sense since I'd expect it to return a suspended computation given the pending `IO`. 