### PR TITLE
make `typeCheck`, `typeCheckFailure` methods transparent

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/internal/BaseKyoDataTest.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/BaseKyoDataTest.scala
@@ -15,7 +15,7 @@ private[kyo] trait BaseKyoDataTest:
     given [A, B]: CanEqual[Either[A, B], Either[A, B]] = CanEqual.derived
     given CanEqual[Throwable, Throwable]               = CanEqual.derived
 
-    inline def typeCheck(inline code: String): Result[String, Unit] =
+    transparent inline def typeCheck(inline code: String): Result[String, Unit] =
         try
             val errors = typeCheckErrors(code)
             if errors.isEmpty then Result.unit else Result.fail(errors.iterator.map(_.message).mkString("\n"))
@@ -24,7 +24,7 @@ private[kyo] trait BaseKyoDataTest:
                 Result.panic(new RuntimeException("Compilation failed", cause))
     end typeCheck
 
-    inline def typeCheckFailure(inline code: String)(inline error: String): Assertion =
+    transparent inline def typeCheckFailure(inline code: String)(inline error: String): Assertion =
         typeCheck(code) match
             case Result.Failure(errors) =>
                 if errors.contains(error) && !error.isEmpty() then assertionSuccess

--- a/kyo-data/shared/src/test/scala/kyo/RecordTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/RecordTest.scala
@@ -96,17 +96,17 @@ class RecordTest extends Test:
         }
 
         "incorrect type access should not compile" in {
-            assertDoesNotCompile("""
+            typeCheckFailure("""
                 val record = "name" ~ "Bob"
                 val name: Int = record.name
-            """)
+            """)("""Invalid field access: ("name" : String)""")
         }
 
         "non-existent field access should not compile" in {
-            assertDoesNotCompile("""
+            typeCheckFailure("""
                 val record = "name" ~ "Bob"
                 val city = record.city
-            """)
+            """)("""Invalid field access: ("city" : String)""")
         }
     }
 
@@ -278,9 +278,9 @@ class RecordTest extends Test:
                 "name" ~ "Frank" & "age" ~ 40
             val compacted = record.compact
             assert(compacted.size == 1)
-            assertDoesNotCompile("""
+            typeCheckFailure("""
                 compacted.age
-            """)
+            """)("""Invalid field access: ("age" : String)""")
         }
     }
 
@@ -365,9 +365,9 @@ class RecordTest extends Test:
         }
 
         "preserves type safety" in {
-            assertDoesNotCompile("""
+            typeCheckFailure("""
                 val partial: Record["name" ~ String] = "age" ~ 30
-            """)
+            """)("""Required: kyo.Record[("name" : String) ~ String]""")
         }
 
         "allows multiple upcasts" in {
@@ -427,9 +427,9 @@ class RecordTest extends Test:
             val record1 = "name" ~ "Alice" & "age" ~ 30
             val record2 = "name" ~ "Alice" & "years" ~ 30
 
-            assertDoesNotCompile("""
+            typeCheckFailure("""
                 assert(record1 != record2)
-            """)
+            """)("""cannot be compared with == or !=""")
         }
 
         "not compile when fields lack CanEqual" in {
@@ -438,9 +438,9 @@ class RecordTest extends Test:
             val record1: Record["test" ~ NoEqual] = "test" ~ NoEqual(1)
             val record2                           = "test" ~ NoEqual(1)
 
-            assertDoesNotCompile("""
+            typeCheckFailure("""
                 assert(record1 == record2)
-            """)
+            """)("""cannot be compared with == or !=""")
         }
 
         "subtype equality" - {
@@ -556,16 +556,16 @@ class RecordTest extends Test:
 
             "cannot call methods that take malformed types" in {
                 def takesMalformed(r: MalformedRecord): String = r.name
-                assertDoesNotCompile("""
+                typeCheckFailure("""
                     takesMalformed("name" ~ "test" & "age" ~ 42)
-                """)
+                """)("""Required: kyo.Record[Int & ("age" : String) ~ Int]""")
             }
 
             "cannot return malformed types" in {
-                assertDoesNotCompile("""
+                typeCheckFailure("""
                     def returnsMalformed(): MalformedRecord =
                         "name" ~ "test" & "age" ~ 42
-                """)
+                """)("""Required: kyo.Record[Int & ("age" : String) ~ Int]""")
             }
         }
 

--- a/kyo-data/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-data/shared/src/test/scala/kyo/Test.scala
@@ -1,28 +1,12 @@
 package kyo
 
-import org.scalatest.Assertion
+import kyo.internal.BaseKyoDataTest
 import org.scalatest.NonImplicitAssertions
+import org.scalatest.Succeeded
 import org.scalatest.freespec.AsyncFreeSpec
-import scala.compiletime.testing.typeCheckErrors
-import scala.util.Try
 
-abstract class Test extends AsyncFreeSpec with NonImplicitAssertions:
-    given tryCanEqual[A]: CanEqual[Try[A], Try[A]]                   = CanEqual.derived
-    given eitherCanEqual[A, B]: CanEqual[Either[A, B], Either[A, B]] = CanEqual.derived
-    given throwableCanEqual: CanEqual[Throwable, Throwable]          = CanEqual.derived
-
-    inline def typeCheck(inline code: String): Result[String, Unit] =
-        try
-            val errors = typeCheckErrors(code)
-            if errors.isEmpty then Result.unit else Result.fail(errors.iterator.map(_.message).mkString("\n"))
-        catch
-            case cause: Throwable =>
-                Result.panic(new RuntimeException("Compilation failed", cause))
-    end typeCheck
-
-    inline def typeCheckFailure(inline code: String)(inline predicate: String => Boolean): Assertion =
-        typeCheck(code) match
-            case Result.Failure(errors)  => if predicate(errors) then succeed else fail(s"Predicate not satisfied by $errors")
-            case Result.Panic(exception) => fail(exception.getMessage)
-            case Result.Success(_)       => fail("Code type-checked successfully, expected a failure")
+abstract class Test extends AsyncFreeSpec, NonImplicitAssertions, BaseKyoDataTest:
+    override type Assertion = org.scalatest.Assertion
+    override val assertionSuccess: Assertion              = Succeeded
+    override def assertionFailure(msg: String): Assertion = fail(msg)
 end Test

--- a/kyo-kernel/shared/src/test/scala/kyo/KyoTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/KyoTest.scala
@@ -362,22 +362,22 @@ class KyoTest extends Test:
 
     "flat check" - {
 
-        val noGivenInstance = "No given instance of type kyo.Flat"
+        val noGivenError = "No given instance of type kyo.Flat"
 
         "pending type" in {
             typeCheckFailure("implicitly[Flat[Int < Any]]")("Cannot prove 'kyo.kernel.Pending$package.<[scala.Int, scala.Any]'")
-            typeCheckFailure("implicitly[Flat[Int < Options]]")(noGivenInstance)
+            typeCheckFailure("implicitly[Flat[Int < Options]]")(noGivenError)
             typeCheckFailure("implicitly[Flat[Int < Nothing]]")("Cannot prove 'kyo.kernel.Pending$package.<[scala.Int, scala.Nothing]'")
         }
 
         "nested" in {
-            typeCheckFailure("implicitly[Flat[Int < IOs < IOs]]")(noGivenInstance)
-            typeCheckFailure("implicitly[Flat[Any < IOs < IOs]]")(noGivenInstance)
+            typeCheckFailure("implicitly[Flat[Int < IOs < IOs]]")(noGivenError)
+            typeCheckFailure("implicitly[Flat[Any < IOs < IOs]]")(noGivenError)
         }
 
         "nested w/ mismatch" in {
-            typeCheckFailure("implicitly[Flat[Int < Options < IOs]]")(noGivenInstance)
-            typeCheckFailure("implicitly[Flat[Int < IOs < Options]]")(noGivenInstance)
+            typeCheckFailure("implicitly[Flat[Int < Options < IOs]]")(noGivenError)
+            typeCheckFailure("implicitly[Flat[Int < IOs < Options]]")(noGivenError)
         }
 
         "generic" in {
@@ -387,13 +387,13 @@ class KyoTest extends Test:
         }
 
         "generic pending" in {
-            typeCheckFailure("def f[A] = implicitly[Flat[A < Options]]")(noGivenInstance)
+            typeCheckFailure("def f[A] = implicitly[Flat[A < Options]]")(noGivenError)
             typeCheckFailure("def f[A] = implicitly[Flat[A < Any]]")("Cannot prove 'kyo.kernel.Pending$package.<[A, scala.Any]'")
         }
 
         "any" in {
             typeCheckFailure("implicitly[Flat[Any]]")("Cannot prove 'scala.Any' isn't nested")
-            typeCheckFailure("implicitly[Flat[Any < IOs]]")(noGivenInstance)
+            typeCheckFailure("implicitly[Flat[Any < IOs]]")(noGivenError)
         }
     }
 end KyoTest

--- a/kyo-kernel/shared/src/test/scala/kyo/KyoTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/KyoTest.scala
@@ -362,37 +362,38 @@ class KyoTest extends Test:
 
     "flat check" - {
 
-        val error = "No given instance of type kyo.Flat"
+        val noGivenInstance = "No given instance of type kyo.Flat"
 
         "pending type" in {
-            typeCheckFailure("implicitly[Flat[Int < Any]]")(error)
-            typeCheckFailure("implicitly[Flat[Int < Options]]")(error)
-            typeCheckFailure("implicitly[Flat[Int < Nothing]]")(error)
+            typeCheckFailure("implicitly[Flat[Int < Any]]")("Cannot prove 'kyo.kernel.Pending$package.<[scala.Int, scala.Any]'")
+            typeCheckFailure("implicitly[Flat[Int < Options]]")(noGivenInstance)
+            typeCheckFailure("implicitly[Flat[Int < Nothing]]")("Cannot prove 'kyo.kernel.Pending$package.<[scala.Int, scala.Nothing]'")
         }
 
         "nested" in {
-            typeCheckFailure("implicitly[Flat[Int < IOs < IOs]]")(error)
-            typeCheckFailure("implicitly[Flat[Any < IOs < IOs]]")(error)
+            typeCheckFailure("implicitly[Flat[Int < IOs < IOs]]")(noGivenInstance)
+            typeCheckFailure("implicitly[Flat[Any < IOs < IOs]]")(noGivenInstance)
         }
 
         "nested w/ mismatch" in {
-            typeCheckFailure("implicitly[Flat[Int < Options < IOs]]")(error)
-            typeCheckFailure("implicitly[Flat[Int < IOs < Options]]")(error)
+            typeCheckFailure("implicitly[Flat[Int < Options < IOs]]")(noGivenInstance)
+            typeCheckFailure("implicitly[Flat[Int < IOs < Options]]")(noGivenInstance)
         }
 
         "generic" in {
+            val error = "Cannot prove 'A' isn't nested"
             typeCheckFailure("def f[A] = implicitly[Flat[A]]")(error)
             typeCheckFailure("def f[A] = implicitly[Flat[A | Int]]")(error)
         }
 
         "generic pending" in {
-            typeCheckFailure("def f[A] = implicitly[Flat[A < Options]]")(error)
-            typeCheckFailure("def f[A] = implicitly[Flat[A < Any]]")(error)
+            typeCheckFailure("def f[A] = implicitly[Flat[A < Options]]")(noGivenInstance)
+            typeCheckFailure("def f[A] = implicitly[Flat[A < Any]]")("Cannot prove 'kyo.kernel.Pending$package.<[A, scala.Any]'")
         }
 
         "any" in {
-            typeCheckFailure("implicitly[Flat[Any]]")(error)
-            typeCheckFailure("implicitly[Flat[Any < IOs]]")(error)
+            typeCheckFailure("implicitly[Flat[Any]]")("Cannot prove 'scala.Any' isn't nested")
+            typeCheckFailure("implicitly[Flat[Any < IOs]]")(noGivenInstance)
         }
     }
 end KyoTest


### PR DESCRIPTION
Closes https://github.com/getkyo/kyo/issues/1033

minimized example why `transparent` helps:
https://scastie.scala-lang.org/road21/1CxBjcGMRdGfeVDg09jjdg
