### PR TITLE
migrate tests to use typeCheckFailure

### DIFF
--- a/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorTest.scala
@@ -173,7 +173,9 @@ class AbortCombinatorTest extends Test:
 
             "should not be callable on throwable abort" in {
                 val failure: Int < Abort[IllegalArgumentException] = 23
-                assertDoesNotCompile("failure.abortToThrowable")
+                typeCheckFailure("failure.abortToThrowable")(
+                    "value abortToThrowable is not a member of Int < kyo.Abort[IllegalArgumentException]"
+                )
             }
 
             "should convert empty choice to absent abort" in {

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -42,7 +42,9 @@ class AsyncTest extends Test:
             }
         }
         "non IO-based effect" in run {
-            assertDoesNotCompile("Async.run(Vars[Int].get)")
+            typeCheckFailure("Async.run(Var.get[Int])")(
+                "The computation you're trying to fork with Async has pending effects"
+            )
         }
     }
 
@@ -140,7 +142,9 @@ class AsyncTest extends Test:
 
     "race" - {
         "zero" in runNotJS {
-            assertDoesNotCompile("Async.race()")
+            typeCheckFailure("Async.race()")(
+                "None of the overloaded alternatives of method race in object Async"
+            )
         }
         "one" in runNotJS {
             Async.race(1).map { r =>

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -115,7 +115,9 @@ class FiberTest extends Test:
 
     "race" - {
         "zero" in runNotJS {
-            assertDoesNotCompile("Async.raceFiber()")
+            typeCheckFailure("Async.race()")(
+                "None of the overloaded alternatives of method race in object Async"
+            )
         }
         "one" in runNotJS {
             Fiber.race(Seq(1)).map(_.get).map { r =>

--- a/kyo-core/shared/src/test/scala/kyo/IOTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/IOTest.scala
@@ -109,9 +109,6 @@ class IOTest extends Test:
             }
             succeed
         }
-        "doesn't accept other pending effects" in {
-            assertDoesNotCompile("IO.Unsafe.run[Int < Options](Options.get(Some(1)))")
-        }
     }
 
     "ensure" - {
@@ -175,18 +172,22 @@ class IOTest extends Test:
         }
 
         "does not include wider Abort types" in {
-            assertDoesNotCompile("""
+            typeCheckFailure("""
                 val a: Int < Abort[String] = 1
                 val b: Int < IO            = a
-            """)
+            """)(
+                "Required: Int < kyo.IO"
+            )
         }
 
         "preserves Nothing as most specific error type" in {
-            assertDoesNotCompile("""
+            typeCheckFailure("""
                 val io: Int < IO = IO {
                     Abort.fail[String]("error")
                 }
-            """)
+            """)(
+                "Required: Int < kyo.IO"
+            )
         }
     }
 

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
@@ -104,17 +104,21 @@ class KyoAppTest extends Test:
     }
 
     "effect mismatch" taggedAs jvmOnly in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
             new KyoApp:
-                run(1: Int < Options)
-        """)
+                run(1: Int < Var[Int])
+        """)(
+            "Found:    Int < kyo.Var[Int]"
+        )
     }
 
     "indirect effect mismatch" taggedAs jvmOnly in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
             new KyoApp:
-                run(Choices.run(1: Int < Options))
-        """)
+                run(Choice.run(1: Int < Var[Int]))
+        """)(
+            "Found:    Int < kyo.Var[Int]"
+        )
     }
 
 end KyoAppTest

--- a/kyo-data/shared/src/main/scala/kyo/internal/BaseKyoDataTest.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/BaseKyoDataTest.scala
@@ -1,6 +1,8 @@
 package kyo.internal
 
+import kyo.Frame
 import kyo.Result
+import scala.compiletime
 import scala.compiletime.testing.typeCheckErrors
 import scala.util.Try
 
@@ -24,11 +26,11 @@ private[kyo] trait BaseKyoDataTest:
                 Result.panic(new RuntimeException("Compilation failed", cause))
     end typeCheck
 
-    transparent inline def typeCheckFailure(inline code: String)(inline error: String): Assertion =
+    transparent inline def typeCheckFailure(inline code: String)(inline expected: String)(using frame: Frame): Assertion =
         typeCheck(code) match
             case Result.Failure(errors) =>
-                if errors.contains(error) && !error.isEmpty() then assertionSuccess
-                else assertionFailure(s"Predicate not satisfied by $errors")
+                if errors.contains(expected) && !expected.isEmpty() then assertionSuccess
+                else assertionFailure(frame.render(Map("expected" -> expected, "actual" -> errors)))
             case Result.Panic(exception) => assertionFailure(exception.getMessage)
             case Result.Success(_)       => assertionFailure("Code type-checked successfully, expected a failure")
 

--- a/kyo-data/shared/src/test/scala/kyo/DurationTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/DurationTest.scala
@@ -41,16 +41,16 @@ class DurationTest extends Test:
         }
 
         "invalid conversion shouldn't compile" in {
-            assertDoesNotCompile("2.nano")
-            assertDoesNotCompile("2.micro")
-            assertDoesNotCompile("2.milli")
-            assertDoesNotCompile("2.second")
-            assertDoesNotCompile("2.minute")
-            assertDoesNotCompile("2.hour")
-            assertDoesNotCompile("2.day")
-            assertDoesNotCompile("2.week")
-            assertDoesNotCompile("2.month")
-            assertDoesNotCompile("2.year")
+            typeCheckFailure("2.nano")("please use `.nanos`")
+            typeCheckFailure("2.micro")("please use `.micros`")
+            typeCheckFailure("2.milli")("please use `.millis`")
+            typeCheckFailure("2.second")("please use `.seconds`")
+            typeCheckFailure("2.minute")("please use `.minutes`")
+            typeCheckFailure("2.hour")("please use `.hours`")
+            typeCheckFailure("2.day")("please use `.days`")
+            typeCheckFailure("2.week")("please use `.weeks`")
+            typeCheckFailure("2.month")("please use `.months`")
+            typeCheckFailure("2.year")("please use `.years`")
         }
 
         "equality" in {
@@ -100,7 +100,7 @@ class DurationTest extends Test:
         }
 
         "Long.to* shouldn't compile" in {
-            assertDoesNotCompile("Long.MaxValue.toNanos")
+            typeCheckFailure("Long.MaxValue.toNanos")("value toNanos is not a member of Long")
         }
     }
 

--- a/kyo-data/shared/src/test/scala/kyo/InstantTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/InstantTest.scala
@@ -200,8 +200,10 @@ class InstantTest extends Test:
         }
 
         "unsupported unit" in {
-            assertDoesNotCompile("instant.truncatedTo(Duration.Units.Weeks)")
-            assertDoesNotCompile("instant.truncatedTo(Duration.Units.Months)")
+            val instant = Instant.Min
+            val error   = "Required: kyo.Duration.Units & kyo.Duration.Truncatable"
+            typeCheckFailure("instant.truncatedTo(Duration.Units.Weeks)")(error)
+            typeCheckFailure("instant.truncatedTo(Duration.Units.Months)")(error)
         }
     }
 

--- a/kyo-data/shared/src/test/scala/kyo/RecordTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/RecordTest.scala
@@ -611,30 +611,32 @@ class RecordTest extends Test:
         "AsFields behavior" - {
             import Record.AsFields
 
+            val error = "No given instance of type kyo.AsFieldsInternal.HasAsField"
+
             "summoning AsFields instance" in {
-                assertDoesNotCompile("""
+                typeCheckFailure("""
                     summon[AsFields[Int & "name" ~ String & "age" ~ Int]]
-                """)
+                """)(error)
             }
 
             "AsFields with multiple raw types" in {
-                assertDoesNotCompile("""
+                typeCheckFailure("""
                     AsFields[Int & Boolean & "value" ~ String & String]
-                """)
+                """)(error)
             }
 
             "AsFields with duplicate field names" in {
-                assertDoesNotCompile("""
+                typeCheckFailure("""
                    AsFields[Int & "value" ~ String & "value" ~ Int]
-                """)
+                """)(error)
             }
 
             "compact with AsFields" in {
                 val record = ("name" ~ "test" & "age" ~ 42)
                     .asInstanceOf[Record[Int & "name" ~ String & "age" ~ Int]]
-                assertDoesNotCompile("""
+                typeCheckFailure("""
                     record.compact
-                """)
+                """)(error)
             }
         }
     }

--- a/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
@@ -197,18 +197,6 @@ class ResultTest extends Test:
         }
     }
 
-    "get" - {
-        "returns the value for Success" in {
-            assert(Result.succeed(1).getOrThrow == 1)
-        }
-        "can't be called for Failure" in {
-            assertDoesNotCompile("Result.error(ex).get")
-        }
-        "throws an exception for Panic" in {
-            assertThrows[Exception](Result.panic(ex).getOrThrow)
-        }
-    }
-
     "getOrElse" - {
         "returns the value for Success" in {
             assert(Result.succeed(1).getOrElse(0) == 1)
@@ -230,7 +218,7 @@ class ResultTest extends Test:
             assert(Result.succeed(1).getOrThrow == 1)
         }
         "doesn't compile for non-Throwable Failure" in {
-            assertDoesNotCompile("Result.fail(1).getOrThrow")
+            typeCheckFailure("Result.fail(1).getOrThrow")("value getOrThrow is not a member of kyo.Result")
         }
         "throws for Throwable Failure" in {
             assert(Result.catching[Exception](Result.fail(ex).getOrThrow) == Result.fail(ex))
@@ -418,7 +406,7 @@ class ResultTest extends Test:
 
     "exception" - {
         "only available if E is Throwable" in {
-            assertDoesNotCompile("Result.Failure(1).exception")
+            typeCheckFailure("Result.Failure(1).exception")("value exception is not a member of kyo.Result.Failure")
         }
         "from Failure" in {
             val ex = new Exception
@@ -453,7 +441,7 @@ class ResultTest extends Test:
             "fails to compile for non-Throwable error" in {
                 val failure: Result[String, Int] = Failure("Something went wrong")
                 val _                            = failure
-                assertDoesNotCompile("failure.toTry")
+                typeCheckFailure("failure.toTry")("value toTry is not a member of kyo.Result")
             }
         }
 

--- a/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
@@ -441,7 +441,7 @@ class ResultTest extends Test:
             "fails to compile for non-Throwable error" in {
                 val failure: Result[String, Int] = Failure("Something went wrong")
                 val _                            = failure
-                typeCheckFailure("failure.toTry")("value toTry is not a member of kyo.Result")
+                typeCheckFailure("failure.toTry")("Failure type must be a 'Throwable' to invoke 'toTry'. Found: 'String'")
             }
         }
 

--- a/kyo-data/shared/src/test/scala/kyo/SafeClassTagTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/SafeClassTagTest.scala
@@ -289,45 +289,48 @@ class SafeClassTagTest extends Test:
     }
 
     "unsupported" - {
+
+        val error = "This method requires a SafeClassTag"
+
         "generic types" - {
             "List[Int]" in {
-                assertDoesNotCompile("SafeClassTag[List[Int]]")
+                typeCheckFailure("SafeClassTag[List[Int]]")(error)
             }
 
             "Option[String]" in {
-                assertDoesNotCompile("SafeClassTag[Option[String]]")
+                typeCheckFailure("SafeClassTag[Option[String]]")(error)
             }
 
             "Map[String, Int]" in {
-                assertDoesNotCompile("SafeClassTag[Map[String, Int]]")
+                typeCheckFailure("SafeClassTag[Map[String, Int]]")(error)
             }
 
             "generic class" in {
                 class Generic[T]
-                assertDoesNotCompile("SafeClassTag[Generic[Int]]")
+                typeCheckFailure("SafeClassTag[Generic[Int]]")(error)
             }
 
             "generic trait" in {
                 trait GenericTrait[T]
-                assertDoesNotCompile("SafeClassTag[GenericTrait[String]]")
+                typeCheckFailure("SafeClassTag[GenericTrait[String]]")(error)
             }
         }
 
         "Null type" - {
             "Null" in {
-                assertDoesNotCompile("SafeClassTag[Null]")
+                typeCheckFailure("SafeClassTag[Null]")(error)
             }
 
             "Null in union" in {
-                assertDoesNotCompile("SafeClassTag[String | Null]")
+                typeCheckFailure("SafeClassTag[String | Null]")(error)
             }
 
             "Null in intersection" in {
-                assertDoesNotCompile("SafeClassTag[Any & Null]")
+                typeCheckFailure("SafeClassTag[Any & Null]")(error)
             }
 
             "Complex type with Null" in {
-                assertDoesNotCompile("SafeClassTag[(String | Int) & (Double | Null)]")
+                typeCheckFailure("SafeClassTag[(String | Int) & (Double | Null)]")(error)
             }
         }
     }

--- a/kyo-data/shared/src/test/scala/kyo/TagTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/TagTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.annotation.nowarn
 
-class TagTest extends AsyncFreeSpec with NonImplicitAssertions:
+class TagTest extends Test:
 
     inline def test[T1, T2](using k1: Tag[T1], i1: ITag[T1], k2: Tag[T2], i2: ITag[T2]): Unit =
         "T1 <:< T2" in {
@@ -221,11 +221,10 @@ class TagTest extends AsyncFreeSpec with NonImplicitAssertions:
     val test = new UnsupportedTest {}
 
     "unsupported types" in {
-        assertDoesNotCompile("Tag[Nothing]")
-        assertDoesNotCompile("Tag[UnsupportedTest#A]")
-        assertDoesNotCompile("Tag[UnsupportedTest.A]")
-        assertDoesNotCompile("Tag[String & Int]")
-        assertDoesNotCompile("Tag[String | Int]")
+        typeCheckFailure("Tag[Nothing]")("Tag cannot be created for Nothing as it has no values")
+        typeCheckFailure("Tag[UnsupportedTest#A]")("Please provide an implicit kyo.Tag[TagTest.this.UnsupportedTest#A] parameter")
+        typeCheckFailure("Tag[String & Int]")("Method doesn't accept intersection types. Found: scala.Predef.String & scala.Int")
+        typeCheckFailure("Tag[String | Int]")("Method doesn't accept union types. Found: scala.Predef.String | scala.Int.")
     }
 
     "show" - {
@@ -415,9 +414,9 @@ class TagTest extends AsyncFreeSpec with NonImplicitAssertions:
             trait A
             @nowarn
             trait B
-            assertDoesNotCompile("Union[A & B]")
-            assertDoesNotCompile("Union[A & B | A]")
-            assertDoesNotCompile("Union[A | B & A]")
+            typeCheckFailure("Union[A & B]")("Union tags don't support type intersections. Found: A & B")
+            typeCheckFailure("Union[A & B | A]")("Union tags don't support type intersections. Found: A & B")
+            typeCheckFailure("Union[A | B & A]")("Union tags don't support type intersections. Found: B & A")
         }
 
         "showTpe" - {
@@ -585,9 +584,9 @@ class TagTest extends AsyncFreeSpec with NonImplicitAssertions:
             trait A
             @nowarn
             trait B
-            assertDoesNotCompile("Intersection[A | B]")
-            assertDoesNotCompile("Intersection[A & B | A]")
-            assertDoesNotCompile("Intersection[A | B & A]")
+            typeCheckFailure("Intersection[A | B]")("Intersection tags don't support type unions. Found: A | B")
+            typeCheckFailure("Intersection[A & B | A]")("Intersection tags don't support type unions. Found: A & B | A")
+            typeCheckFailure("Intersection[A | B & A]")("Intersection tags don't support type unions. Found: A | B & A")
         }
 
         "showTpe" - {

--- a/kyo-data/shared/src/test/scala/kyo/TypeMapTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/TypeMapTest.scala
@@ -64,7 +64,7 @@ class TypeMapTest extends Test:
             assert(e.size == 4)
         }
         "distinct" in pendingUntilFixed {
-            typeCheckFailure("TypeMap(0, 0)")
+            typeCheckFailure("TypeMap(0, 0)")("should fail")
         }
     }
     "fatal" - {

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -3,56 +3,66 @@ package kyo
 import org.scalatest.Assertions
 import org.scalatest.freespec.AnyFreeSpec
 
-class HygieneTest extends AnyFreeSpec with Assertions:
+class HygieneTest extends Test:
 
     "use of var" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             var willFail = 1
             IO(1).now
           }
-        """)
+        """)(
+            "`var` declarations are not allowed inside a `defer` block."
+        )
     }
 
     "use of return" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             return 42
             IO(1).now
           }
-        """)
+        """)(
+            "Exception occurred while executing macro expansion"
+        )
     }
 
     "nested defer block" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             defer {
               IO(1).now
             }
           }
-        """)
+        """)(
+            "Effectful computations must explicitly use either .now or .later in a defer block."
+        )
     }
 
     "lazy val" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             lazy val x = 10
             IO(1).now
           }
-        """)
+        """)(
+            "`lazy val` and `object` declarations are not allowed inside a `defer` block."
+        )
     }
 
     "function containing await" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             def foo() = IO(1).now
             foo()
           }
-        """)
+        """)(
+            "Method definitions containing .now are not supported inside `defer` blocks."
+        )
     }
 
     "try/catch" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             try {
               IO(1).now
@@ -60,59 +70,71 @@ class HygieneTest extends AnyFreeSpec with Assertions:
               case _: Exception => IO(2).now
             }
           }
-        """)
+        """)(
+            "`try`/`catch` blocks are not supported inside `defer` blocks."
+        )
     }
 
     "class declaration" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             class A(val x: Int)
             IO(1).now
           }
-        """)
+        """)(
+            "`class` and `trait` declarations are not allowed inside `defer` blocks."
+        )
     }
 
     "object declaration" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             object A
             IO(1).now
           }
-        """)
+        """)(
+            "`class` and `trait` declarations are not allowed inside `defer` blocks."
+        )
     }
 
     "trait declaration" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             trait A
             IO(1).now
           }
-        """)
+        """)(
+            "`class` and `trait` declarations are not allowed inside `defer` blocks."
+        )
     }
 
     "for-comprehension" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             for {
               x <- IO(1).now
               y <- IO(2).now
             } yield x + y
           }
-        """)
+        """)(
+            "value flatMap is not a member of Int"
+        )
     }
 
     "try without catch or finally" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             try {
               IO(1).now
             }
           }
-        """)
+        """)(
+            "`try`/`catch` blocks are not supported inside `defer` blocks."
+        )
     }
 
     "try with only finally" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             try {
               IO(1).now
@@ -120,39 +142,47 @@ class HygieneTest extends AnyFreeSpec with Assertions:
               println("Cleanup")
             }
           }
-        """)
+        """)(
+            "`try`/`catch` blocks are not supported inside `defer` blocks."
+        )
     }
 
     "new instance with by-name parameter" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           class A(x: => String)
           defer {
               new A(IO("blah").now)
           }
-        """)
+        """)(
+            "Can't find AsyncShift (Found:    cps.runtime.CpsMonadSelfAsyncShift[[A] =>> A < kyo.IO"
+        )
     }
 
     "match expression without cases" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             IO(1).now match {}
           }
-        """)
+        """)(
+            "case' expected, but '}' found"
+        )
     }
 
     "for-comprehension without yield" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             for {
               x <- IO(1).now
               y <- IO(2).now
             } x + y
           }
-        """)
+        """)(
+            "value foreach is not a member of Int"
+        )
     }
 
     "nested functions" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             def outer() = {
               def inner() = IO(1).now
@@ -160,35 +190,43 @@ class HygieneTest extends AnyFreeSpec with Assertions:
             }
             outer()
           }
-        """)
+        """)(
+            "Method definitions containing .now are not supported inside `defer` blocks"
+        )
     }
 
     "lambdas with await" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
             val f = (x: Int) => IO(1).now + x
             f(10)
           }
-        """)
+        """)(
+            "async lambda can't be result of expression"
+        )
     }
 
     "throw" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
               if IO("foo").now == "bar" then
                   throw new Exception
               else
                   2
           }
-        """)
+        """)(
+            "`throw` expressions are not allowed inside a `defer` block."
+        )
     }
 
     "synchronized" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
           defer {
               val x = synchronized(1)
               IO(x).now
           }
-        """)
+        """)(
+            "`synchronized` blocks are not allowed inside a `defer` block."
+        )
     }
 end HygieneTest

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/BoundaryTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/BoundaryTest.scala
@@ -16,13 +16,15 @@ class BoundaryTest extends Test:
             assert(boundary.isInstanceOf[Boundary[TestEffect1 & TestEffect2, Any]])
         }
 
+        val error = "The computation you're trying to fork with Async has pending effects that aren't supported"
+
         "fails compilation for non-context effects" in {
-            assertDoesNotCompile("Boundary.derive[Int, Any]")
-            assertDoesNotCompile("Boundary.derive[String, Any]")
+            typeCheckFailure("Boundary.derive[Int, Any]")(error)
+            typeCheckFailure("Boundary.derive[String, Any]")(error)
         }
 
         "fails compilation for non-context effect traits" in {
-            assertDoesNotCompile("Boundary.derive[NotContextEffect, Any]")
+            typeCheckFailure("Boundary.derive[NotContextEffect, Any]")(error)
         }
     }
 

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/LoopTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/LoopTest.scala
@@ -667,10 +667,11 @@ class LoopTest extends Test:
         }
 
         "should not compile for non-Flat output types" in {
-            assertDoesNotCompile("implicitly[Flat[Loop.Outcome[Int, Int < Any]]]")
-            assertDoesNotCompile("implicitly[Flat[Loop.Outcome2[Int, String, Int < Any]]]")
-            assertDoesNotCompile("implicitly[Flat[Loop.Outcome3[Int, String, Boolean, Int < Any]]]")
-            assertDoesNotCompile("implicitly[Flat[Loop.Outcome4[Int, String, Boolean, Double, Int < Any]]]")
+            val error = "This error can be reported an unsupported pending effect is passed to a method"
+            typeCheckFailure("implicitly[Flat[Loop.Outcome[Int, Int < Any]]]")(error)
+            typeCheckFailure("implicitly[Flat[Loop.Outcome2[Int, String, Int < Any]]]")(error)
+            typeCheckFailure("implicitly[Flat[Loop.Outcome3[Int, String, Boolean, Int < Any]]]")(error)
+            typeCheckFailure("implicitly[Flat[Loop.Outcome4[Int, String, Boolean, Double, Int < Any]]]")(error)
         }
     }
 end LoopTest

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/PendingTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/PendingTest.scala
@@ -54,7 +54,7 @@ class PendingTest extends Test:
 
     "eval should not compile for pending effects" in {
         @nowarn("msg=unused") trait CustomEffect extends ArrowEffect[Const[Unit], Const[Unit]]
-        assertDoesNotCompile("val x: Int < CustomEffect = 5; x.eval")
+        typeCheckFailure("val x: Int < CustomEffect = 5; x.eval")("value eval is not a member of Int < CustomEffect")
     }
 
     "lift" - {
@@ -67,10 +67,10 @@ class PendingTest extends Test:
         "nested computation" - {
             "generic method effect mismatch" in {
                 @nowarn("msg=unused") def test1[A](v: A < Any) = v
-                assertDoesNotCompile("test1(effect)")
+                typeCheckFailure("test1(1: Int < TestEffect)")("Required: Any < Any")
             }
             "inference widening" in {
-                assertDoesNotCompile("val _: Int < Any < Any = (1: Int < Any)")
+                typeCheckFailure("val _: Int < Any < Any = (1: Int < Any)")("Required: Int < Any < Any")
             }
         }
 
@@ -109,18 +109,26 @@ class PendingTest extends Test:
                 val f3: (Int, Int, Int) => String < Any      = (_, _, _) => "test"
                 val f4: (Int, Int, Int, Int) => String < Any = (_, _, _, _) => "test"
                 discard(f1, f2, f3, f4)
-                assertDoesNotCompile("""
+                typeCheckFailure("""
                     val _: Int => String < Any < Any = f1
-                """)
-                assertDoesNotCompile("""
+                """)(
+                    "Required: Int => String < Any < Any"
+                )
+                typeCheckFailure("""
                     val _: (Int, Int) => String < Any < Any = f2
-                """)
-                assertDoesNotCompile("""
+                """)(
+                    "Required: (Int, Int) => String < Any < Any"
+                )
+                typeCheckFailure("""
                     val _: (Int, Int, Int) => String < Any < Any = f3
-                """)
-                assertDoesNotCompile("""
+                """)(
+                    "Required: (Int, Int, Int) => String < Any < Any"
+                )
+                typeCheckFailure("""
                     val _: (Int, Int, Int, Int) => String < Any < Any = f4
-                """)
+                """)(
+                    "Required: (Int, Int, Int, Int) => String < Any < Any"
+                )
             }
         }
     }
@@ -146,7 +154,9 @@ class PendingTest extends Test:
         }
 
         "doesn't accept nested computations" in {
-            assertDoesNotCompile("def test(x: Int < Any < Any) = x.evalNow")
+            typeCheckFailure("def test(x: Int < Any < Any) = x.evalNow")(
+                "Cannot prove 'kyo.kernel.Pending$package.<[scala.Int, scala.Any]' isn't nested"
+            )
         }
     }
 
@@ -243,14 +253,13 @@ class PendingTest extends Test:
     }
 
     "only 'flatten' is available for nested computations" in {
+        val error = "may contain a nested effect computation"
         def test[S](effect: Unit < S < S) =
-            assertDoesNotCompile("effect.map(_ => 1))")
-            assertDoesNotCompile("effect.andThen(1)")
-            assertDoesNotCompile("effect.flatMap(_ => 1)")
-            assertDoesNotCompile("effect.pipe(_ => 1)")
-            assertDoesNotCompile("effect.evalNow")
-            assertDoesNotCompile("effect.repeat(10)")
-            assertDoesNotCompile("effect.unit")
+            typeCheckFailure("effect.map(_ => 1))")(error)
+            typeCheckFailure("effect.andThen(1)")(error)
+            typeCheckFailure("effect.flatMap(_ => 1)")(error)
+            typeCheckFailure("effect.pipe(_ => 1)")(error)
+            typeCheckFailure("effect.unit")("value unit is not a member of Unit < S < S")
             effect.flatten
         end test
         def nest[T](v: T): T < Any =

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/WeakFlatTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/WeakFlatTest.scala
@@ -18,8 +18,9 @@ class WeakFlatTest extends Test:
     }
 
     "not compile for known Kyo types" in {
-        assertDoesNotCompile("implicitly[WeakFlat[Int < Any]]")
-        assertDoesNotCompile("implicitly[WeakFlat[String < Env[Int]]]")
+        val error = "may contain a nested effect computation"
+        typeCheckFailure("implicitly[WeakFlat[Int < Any]]")(error)
+        typeCheckFailure("implicitly[WeakFlat[String < Env[Int]]]")(error)
     }
 
     "compile for Unit and Nothing" in {
@@ -31,7 +32,7 @@ class WeakFlatTest extends Test:
     "work with type aliases" in {
         type MyAlias[A] = A
         implicitly[WeakFlat[MyAlias[Int]]]
-        assertDoesNotCompile("implicitly[WeakFlat[MyAlias[Int < Any]]]")
+        typeCheckFailure("implicitly[WeakFlat[MyAlias[Int < Any]]]")("may contain a nested effect computation")
         succeed
     }
 
@@ -54,7 +55,7 @@ class WeakFlatTest extends Test:
 
         42.weakMethod
         "hello".weakMethod
-        assertDoesNotCompile("(42: Int < Any).weakMethod")
+        typeCheckFailure("(42: Int < Any).weakMethod")("may contain a nested effect computation")
         succeed
     }
 
@@ -79,7 +80,7 @@ class WeakFlatTest extends Test:
         trait B
         type Intersection = A & B
         implicitly[WeakFlat[Intersection]]
-        assertDoesNotCompile("implicitly[WeakFlat[A & (B < Any)]]")
+        typeCheckFailure("implicitly[WeakFlat[A & (B < Any)]]")("may contain a nested effect computation.")
         succeed
     }
 end WeakFlatTest

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -826,7 +826,7 @@ class AbortsTest extends Test:
                 val ex          = new RuntimeException("Panic!")
                 val computation = Abort.panic(ex)
                 val recovered   = Abort.recover[CustomError](_ => 42)(computation)
-                assertDoesNotCompile("val _: Int < Any = recovered")
+                typeCheckFailure("val _: Int < Any = recovered")("Required: Int < Any")
             }
         }
 

--- a/kyo-prelude/shared/src/test/scala/kyo/EnvTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/EnvTest.scala
@@ -46,7 +46,9 @@ class EnvTest extends Test:
     }
 
     "intersection type env" in {
-        assertDoesNotCompile("Env.get[Int & Double]")
+        typeCheckFailure("Env.get[Int & Double]")(
+            "Method doesn't accept intersection types"
+        )
     }
 
     "reduce large intersection incrementally" in {
@@ -79,11 +81,13 @@ class EnvTest extends Test:
     }
 
     "invalid inference" in {
-        assertDoesNotCompile("""
+        typeCheckFailure("""
         def t1(v: Int < Env[Int & String]) =
             Env.run(1)(v)
         val _: Int < Any = t1(42)
-        """)
+        """)(
+            "Required: Int < Any"
+        )
     }
 
     "no transformations" in {

--- a/kyo-prelude/shared/src/test/scala/kyo/LayerTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/LayerTest.scala
@@ -244,7 +244,7 @@ class LayerTest extends Test:
             val b = Layer(true)
             val c = Layer(0)
             discard(a, b, c)
-            typeCheckFailure("""Layer.init[String](a, b, c)""")
+            typeCheckFailure("""Layer.init[String](a, b, c)""")("should fail")
         }
     }
     "runLayer" - {

--- a/kyo-stm/shared/src/test/scala/kyo/TTableTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TTableTest.scala
@@ -178,12 +178,16 @@ class TTableTest extends Test:
             "should not compile when querying non-indexed fields" in run {
                 for
                     table <- TTable.Indexed.init["name" ~ String & "age" ~ Int, "age" ~ Int]
-                yield assertDoesNotCompile("""table.query("name" ~ "Alice")""")
+                yield typeCheckFailure("""table.query("name" ~ "Alice")""")(
+                    "Cannot query on fields that are not indexed."
+                )
             }
 
             "should not compile when querying partially indexed fields" in run {
                 for table <- TTable.Indexed.init["name" ~ String & "age" ~ Int, "age" ~ Int]
-                yield assertDoesNotCompile("""table.query("name" ~ "Alice" & "age" ~ 30)""")
+                yield typeCheckFailure("""table.query("name" ~ "Alice" & "age" ~ 30)""")(
+                    "Cannot query on fields that are not indexed."
+                )
             }
         }
 


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->
The `assertDoesNotEqual` implementation provided by scalatest doesn't allow matching the error message, which is a source of tech debt as we change the code base. Tests might be continuing passing if we rename methods or types for example

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->
Migrate all tests from `assertDoesNotEqual` to `typeCheckFailure`
