### PR TITLE
[data] introduce Environment and improve KyoException

### DIFF
--- a/kyo-core/jvm/src/main/scala/kyo/StreamCompression.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/StreamCompression.scala
@@ -11,12 +11,7 @@ import scala.annotation.tailrec
 
 object StreamCompression:
 
-    final class StreamCompressionException(reason: String | Throwable)(using Frame) extends KyoException(
-            message = reason match
-                case string: String => Text(string)
-                case _: Throwable   => null,
-            cause = reason
-        )
+    final class StreamCompressionException(cause: Text | Throwable)(using Frame) extends KyoException("", cause)
 
     enum CompressionLevel(val value: Int) derives CanEqual:
         case Default         extends CompressionLevel(-1)

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -24,7 +24,7 @@ class KyoException private[kyo] (message: Text = "", cause: Text | Throwable = "
                 case _: Throwable           => Absent
                 case cause: Text @unchecked => Maybe(cause)
 
-        if Environment.isDevelopment() then
+        if Environment.isDevelopment then
             val msg = frame.render(("⚠️ KyoException".red.bold :: Maybe(message).toList ::: detail.toList).map(_.show)*)
             s"\n$msg\n"
         else

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -2,17 +2,14 @@ package kyo
 
 import kyo.*
 import kyo.Ansi.*
+import kyo.internal.Environment
 import scala.util.control.NoStackTrace
 
-class KyoException private[kyo] (
-    message: Text | Null = null,
-    cause: Text | Throwable | Null = null
-)(using val frame: Frame) extends Exception(
-        Option(message) match
-            case Some(message) => message.toString;
-            case _             => null,
+class KyoException private[kyo] (message: Text = "", cause: Text | Throwable = "")(using val frame: Frame)
+    extends Exception(
+        message.toString,
         cause match
-            case cause: Throwable => cause;
+            case cause: Throwable => cause
             case _                => null
     ) with NoStackTrace:
 
@@ -27,8 +24,12 @@ class KyoException private[kyo] (
                 case _: Throwable           => Absent
                 case cause: Text @unchecked => Maybe(cause)
 
-        val msg = frame.render(("⚠️ KyoException".red.bold :: Maybe(message).toList ::: detail.toList).map(_.show)*)
-        s"\n$msg\n"
+        if Environment.isDevelopment() then
+            val msg = frame.render(("⚠️ KyoException".red.bold :: Maybe(message).toList ::: detail.toList).map(_.show)*)
+            s"\n$msg\n"
+        else
+            detail.map(_.toString).getOrElse(null)
+        end if
     end getMessage
 
 end KyoException

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -1,35 +1,70 @@
 package kyo
 
+import KyoException.maxMessageLength
 import kyo.*
 import kyo.Ansi.*
 import kyo.internal.Environment
 import scala.util.control.NoStackTrace
 
-class KyoException private[kyo] (message: Text = "", cause: Text | Throwable = "")(using val frame: Frame)
-    extends Exception(
+/** Kyo's base exception class that provides enhanced error reporting and context.
+  *
+  * The exception's behavior changes based on the environment:
+  *   - In development: Provides detailed, ANSI-colored error messages with context
+  *   - In production: Returns minimal error messages for cleaner logs
+  *
+  * @param message
+  *   The primary error message
+  * @param cause
+  *   Either a Text explanation or a Throwable that caused this exception
+  * @param frame
+  *   Implicit Frame providing context about where the exception was created
+  */
+class KyoException private[kyo] (
+    message: Text = "",
+    cause: Text | Throwable = ""
+)(using val frame: Frame) extends Exception(
         message.toString,
         cause match
             case cause: Throwable => cause
             case _                => null
     ) with NoStackTrace:
 
+    /** Returns the underlying cause of this exception. Overriding this method is important for performance since the method is synchronized
+      * in the super classes.
+      *
+      * @return
+      *   The Throwable cause if one was provided, null otherwise
+      */
     override def getCause(): Throwable =
         cause match
             case cause: Throwable => cause
             case _                => null
 
+    /** Formats and returns the exception message.
+      *
+      * In production mode, returns only the cause message if present, or null if no cause message was provided.
+      *
+      * @return
+      *   The formatted exception message
+      */
     override def getMessage(): String =
         val detail =
             cause match
                 case _: Throwable           => Absent
-                case cause: Text @unchecked => Maybe(cause)
+                case cause: Text @unchecked => Maybe(cause.take(maxMessageLength))
 
         if Environment.isDevelopment then
-            val msg = frame.render(("⚠️ KyoException".red.bold :: Maybe(message).toList ::: detail.toList).map(_.show)*)
+            val msg = frame.render(
+                ("⚠️ KyoException".red.bold :: Maybe(message).toList ::: detail.toList)
+                    .map(_.show)*
+            )
             s"\n$msg\n"
         else
             detail.map(_.toString).getOrElse(null)
         end if
     end getMessage
-
 end KyoException
+
+object KyoException:
+    /** Maximum length for error messages to prevent excessive output. */
+    val maxMessageLength = 1000

--- a/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
@@ -6,7 +6,7 @@ package kyo.internal
   * verbosity of error messages and debugging information in Kyo's implementations.
   *
   * The development mode can be controlled in two ways:
-  *   1. Explicitly via the system property "-Dkyo.development-mode.enable=true"
+  *   1. Explicitly via the system property "-Dkyo.development=true"
   *   2. Automatically by detecting SBT in the classpath
   * }}}
   */
@@ -16,7 +16,7 @@ private[kyo] object Environment:
       *
       * This method checks the following conditions in order:
       *
-      *   1. If system property "kyo.development-mode.enable" exists:
+      *   1. If system property "kyo.development" exists:
       *      - Returns true if the property value is "true" (case insensitive)
       *      - Returns false if the property value is anything else
       *   2. If the property doesn't exist:
@@ -29,9 +29,10 @@ private[kyo] object Environment:
     val isDevelopment: Boolean = inferIsDevelopment()
 
     private[internal] def inferIsDevelopment(): Boolean =
-        sys.props.get("kyo.development-mode.enable").flatMap(_.toBooleanOption) match
+        sys.props.get("kyo.development").map(_.toLowerCase) match
             case Some("true") => true
             case Some(_)      => false
-            case _            => sys.props.get("java.class.path").exists(_.contains("org.scala-sbt"))
+            case None =>
+                sys.props.get("java.class.path").exists(_.contains("org.scala-sbt"))
 
 end Environment

--- a/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
@@ -8,7 +8,6 @@ package kyo.internal
   * The development mode can be controlled in two ways:
   *   1. Explicitly via the system property "-Dkyo.development=true"
   *   2. Automatically by detecting SBT in the classpath
-  * }}}
   */
 private[kyo] object Environment:
 

--- a/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
@@ -1,0 +1,11 @@
+package kyo.internal
+
+object Environment:
+
+    def isDevelopment(): Boolean =
+        sys.props.get("kyo.development-mode.enable").map(_.toLowerCase) match
+            case Some("true") => true
+            case Some(_)      => false
+            case _            => sys.props.get("java.class.path").exists(_.contains("org.scala-sbt"))
+
+end Environment

--- a/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
@@ -29,7 +29,7 @@ private[kyo] object Environment:
     val isDevelopment: Boolean = inferIsDevelopment()
 
     private[internal] def inferIsDevelopment(): Boolean =
-        sys.props.get("kyo.development-mode.enable").map(_.toLowerCase) match
+        sys.props.get("kyo.development-mode.enable").flatMap(_.toBooleanOption) match
             case Some("true") => true
             case Some(_)      => false
             case _            => sys.props.get("java.class.path").exists(_.contains("org.scala-sbt"))

--- a/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
@@ -1,7 +1,31 @@
 package kyo.internal
 
+/** Environment detection utility.
+  *
+  * Provides functionality to detect whether the JVM is running in a development environment. This information is used to control the
+  * verbosity of error messages and debugging information in Kyo's implementations.
+  *
+  * The development mode can be controlled in two ways:
+  *   1. Explicitly via the system property "-Dkyo.development-mode.enable=true"
+  *   2. Automatically by detecting SBT in the classpath
+  * }}}
+  */
 object Environment:
 
+    /** Determines if the execution is a development environment.
+      *
+      * This method checks the following conditions in order:
+      *
+      *   1. If system property "kyo.development-mode.enable" exists:
+      *      - Returns true if the property value is "true" (case insensitive)
+      *      - Returns false if the property value is anything else
+      *   2. If the property doesn't exist:
+      *      - Returns true if SBT is detected in the classpath (contains "org.scala-sbt")
+      *      - Returns false otherwise
+      *
+      * @return
+      *   true if running in a development environment, false otherwise
+      */
     def isDevelopment(): Boolean =
         sys.props.get("kyo.development-mode.enable").map(_.toLowerCase) match
             case Some("true") => true

--- a/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/Environment.scala
@@ -10,7 +10,7 @@ package kyo.internal
   *   2. Automatically by detecting SBT in the classpath
   * }}}
   */
-object Environment:
+private[kyo] object Environment:
 
     /** Determines if the execution is a development environment.
       *
@@ -26,7 +26,9 @@ object Environment:
       * @return
       *   true if running in a development environment, false otherwise
       */
-    def isDevelopment(): Boolean =
+    val isDevelopment: Boolean = inferIsDevelopment()
+
+    private[internal] def inferIsDevelopment(): Boolean =
         sys.props.get("kyo.development-mode.enable").map(_.toLowerCase) match
             case Some("true") => true
             case Some(_)      => false

--- a/kyo-data/shared/src/test/scala/kyo/internal/EnvironmentTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/internal/EnvironmentTest.scala
@@ -1,0 +1,28 @@
+package kyo.internal
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class EnvironmentTest extends AnyFreeSpec with Matchers:
+
+    "infers as development" - {
+        "if running in sbt or metals, which should be the case in this test execution" in {
+            assert(Environment.inferIsDevelopment())
+        }
+        "if system property is enabled, which should be the case in this test execution" in {
+            System.setProperty("kyo.development", "true")
+            assert(Environment.inferIsDevelopment())
+        }
+    }
+
+    "doesn't infer as development" - {
+        "if system property is false" in {
+            System.setProperty("kyo.development", "false")
+            assert(!Environment.inferIsDevelopment())
+        }
+        "if system property is invalid" in {
+            System.setProperty("kyo.development", "blah")
+            assert(!Environment.inferIsDevelopment())
+        }
+    }
+end EnvironmentTest

--- a/kyo-data/shared/src/test/scala/kyo/internal/EnvironmentTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/internal/EnvironmentTest.scala
@@ -6,9 +6,6 @@ import org.scalatest.matchers.should.Matchers
 class EnvironmentTest extends AnyFreeSpec with Matchers:
 
     "infers as development" - {
-        "if running in sbt or metals, which should be the case in this test execution" in {
-            assert(Environment.inferIsDevelopment())
-        }
         "if system property is enabled, which should be the case in this test execution" in {
             System.setProperty("kyo.development", "true")
             assert(Environment.inferIsDevelopment())


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->
`KyoException` is too verbose in production environments. It's designed to improve the development experience by showing errors with the `Frame` information but, in a production environment, the overhead to log failures can significantly contribute to performance degradation.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->
Introduce `Environment` that enables the verbose mode only if the user explicitly enables the development mode or sbt entries are present in the classpath, which should be the case for Kyo development environments since we recommend both sbt and metals. The risk of false positives seems low since the check is strict.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
I've also improved `KyoException` because I noticed a `NullPointerException`.
