### PR TITLE
rename Stream methods prefixed with run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,7 +1290,7 @@ val h: Chunk[Int] < Any =
 
 // Process stream elements without collecting results
 val i: Unit < Any =
-    a.runDiscard
+    a.discard
 
 // Fold over stream elements
 val j: Int < Any =
@@ -1929,7 +1929,7 @@ val lines: Stream[String, Resource & IO] =
 
 // Process the stream
 val result: Unit < (Resource & Console & Async & Abort[IOException]) =
-    lines.map(line => Console.printLine(line)).runDiscard
+    lines.map(line => Console.printLine(line)).discard
 
 // Walk a directory tree
 val tree: Stream[Path, IO] =
@@ -1937,7 +1937,7 @@ val tree: Stream[Path, IO] =
 
 // Process each file in the tree
 val processedTree: Unit < (Console & Async & Abort[IOException]) =
-    tree.map(file => file.read.map(content => Console.printLine(s"File: ${file}, Content: $content"))).runDiscard
+    tree.map(file => file.read.map(content => Console.printLine(s"File: ${file}, Content: $content"))).discard
 ```
 
 `Path` integrates with Kyo's `Stream` API, allowing for efficient processing of file contents using streams. The `sink` and `sinkLines` extension methods on `Stream` enable writing streams of data back to files.

--- a/README.md
+++ b/README.md
@@ -1294,11 +1294,11 @@ val i: Unit < Any =
 
 // Fold over stream elements
 val j: Int < Any =
-    a.runFold(0)(_ + _)
+    a.fold(0)(_ + _)
 
 // Process each element with side effects
 val k: Unit < (IO & Abort[IOException]) =
-    a.runForeach(Console.printLine(_))
+    a.foreach(Console.printLine(_))
 ```
 
 Streams can be combined with other effects, allowing for powerful and flexible data processing pipelines:

--- a/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
+++ b/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
@@ -144,7 +144,7 @@ object Topic:
 
                 // ensure publication is closed after use
                 IO.ensure(IO(publication.close())) {
-                    stream.runForeachChunk { messages =>
+                    stream.foreachChunk { messages =>
                         Retry[Backpressured](retrySchedule) {
                             IO {
                                 if !publication.isConnected() then backpressured

--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamBench.scala
@@ -20,7 +20,7 @@ class StreamBench extends ArenaBench.SyncAndFork(25000000):
         Stream.init(seq)
             .filter(_ % 2 == 0)
             .map(_ + 1)
-            .runFold(0)(_ + _)
+            .fold(0)(_ + _)
     end kyoBench
 
     def zioBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
@@ -18,7 +18,7 @@ class StreamIOBench extends ArenaBench.SyncAndFork(25000000):
         Stream.init(seq)
             .filter(v => IO(v % 2 == 0))
             .map(v => IO(v + 1))
-            .runFold(0)(_ + _)
+            .fold(0)(_ + _)
     end kyoBench
 
     def zioBench() =

--- a/kyo-core/jvm/src/main/scala/kyo/Path.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Path.scala
@@ -449,7 +449,7 @@ end Path
 extension [S](stream: Stream[Byte, S])
     def sink(path: Path)(using Frame): Unit < (Resource & IO & S) =
         Resource.acquireRelease(IO(FileChannel.open(path.toJava, StandardOpenOption.WRITE)))(ch => ch.close()).map { fileCh =>
-            stream.runForeachChunk(bytes =>
+            stream.foreachChunk(bytes =>
                 IO {
                     fileCh.write(ByteBuffer.wrap(bytes.toArray))
                     ()
@@ -462,7 +462,7 @@ extension [S](stream: Stream[String, S])
     @scala.annotation.targetName("stringSink")
     def sink(path: Path, charset: Codec = java.nio.charset.StandardCharsets.UTF_8)(using Frame): Unit < (Resource & IO & S) =
         Resource.acquireRelease(IO(FileChannel.open(path.toJava, StandardOpenOption.WRITE)))(ch => ch.close()).map { fileCh =>
-            stream.runForeach(s =>
+            stream.foreach(s =>
                 IO {
                     fileCh.write(ByteBuffer.wrap(s.getBytes))
                     ()
@@ -475,7 +475,7 @@ extension [S](stream: Stream[String, S])
         charset: Codec = java.nio.charset.StandardCharsets.UTF_8
     )(using Frame): Unit < (Resource & IO & S) =
         Resource.acquireRelease(FileChannel.open(path.toJava, StandardOpenOption.WRITE))(ch => ch.close()).map { fileCh =>
-            stream.runForeach(line =>
+            stream.foreach(line =>
                 IO {
                     fileCh.write(ByteBuffer.wrap(line.getBytes))
                     fileCh.write(ByteBuffer.wrap(JSystem.lineSeparator().getBytes))

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -194,11 +194,6 @@ sealed abstract class Stream[V, -S]:
                         f(input).andThen:
                             Emit.valueWith(input)(((), cont(())))
 
-    private def discard(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Stream[V, S] =
-        Stream(ArrowEffect.handle(tag, emit)(
-            [C] => (input, cont) => cont(())
-        ))
-
     /** Takes the first n elements from the stream.
       *
       * @param n

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -455,7 +455,7 @@ sealed abstract class Stream[V, -S]:
       * @return
       *   The final accumulated value
       */
-    def runFold[A](acc: A)(f: (A, V) => A)(using
+    def fold[A](acc: A)(f: (A, V) => A)(using
         tag: Tag[Emit[Chunk[V]]],
         frame: Frame
     ): A < S =

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -330,7 +330,7 @@ sealed abstract class Stream[V, -S]:
       * @return
       *   A unit effect that runs the stream without collecting results
       */
-    def runDiscard(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Unit < S =
+    def discard(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Unit < S =
         ArrowEffect.handle(tag, emit)(
             [C] => (input, cont) => cont(())
         )
@@ -342,8 +342,8 @@ sealed abstract class Stream[V, -S]:
       * @return
       *   A unit effect that runs the stream and applies f to each value
       */
-    def runForeach[S2](f: V => Unit < S2)(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Unit < (S & S2) =
-        runForeachChunk(c => Kyo.foreachDiscard(c)(f))
+    def foreach[S2](f: V => Unit < S2)(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Unit < (S & S2) =
+        foreachChunk(c => Kyo.foreachDiscard(c)(f))
 
     /** Runs the stream and applies the given function to each emitted chunk.
       *
@@ -352,7 +352,7 @@ sealed abstract class Stream[V, -S]:
       * @return
       *   A unit effect that runs the stream and applies f to each chunk
       */
-    def runForeachChunk[S2](f: Chunk[V] => Unit < S2)(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Unit < (S & S2) =
+    def foreachChunk[S2](f: Chunk[V] => Unit < S2)(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Unit < (S & S2) =
         ArrowEffect.handle(tag, emit)(
             [C] =>
                 (input, cont) =>
@@ -371,7 +371,7 @@ sealed abstract class Stream[V, -S]:
       * @return
       *   The final accumulated value
       */
-    def runFold[A, S2](acc: A)(f: (A, V) => A < S2)(using tag: Tag[Emit[Chunk[V]]], frame: Frame): A < (S & S2) =
+    def fold[A, S2](acc: A)(f: (A, V) => A < S2)(using tag: Tag[Emit[Chunk[V]]], frame: Frame): A < (S & S2) =
         ArrowEffect.handleState(tag, acc, emit)(
             handle = [C] =>
                 (input, state, cont) =>

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -679,40 +679,40 @@ class StreamTest extends Test:
         }
     }
 
-    "runDiscard" - {
+    "discard" - {
         "non-empty stream" in {
             assert(
                 Var.run(0) {
-                    Stream.init(0 until 100).map(i => Var.update[Int](_ + i)).runDiscard.andThen(Var.get[Int])
+                    Stream.init(0 until 100).map(i => Var.update[Int](_ + i)).discard.andThen(Var.get[Int])
                 }.eval == 4950
             )
         }
 
         "empty stream" in {
             assert(
-                Stream.init(Seq.empty[Int]).runDiscard.eval == ()
+                Stream.init(Seq.empty[Int]).discard.eval == ()
             )
         }
     }
 
-    "runForeach" - {
+    "foreach" - {
         "executes the function for each element" in run {
             var sum = 0
-            Stream.init(Seq(1, 2, 3, 4, 5)).runForeach(i => sum += i).map { _ =>
+            Stream.init(Seq(1, 2, 3, 4, 5)).foreach(i => sum += i).map { _ =>
                 assert(sum == 15)
             }
         }
 
         "works with empty stream" in run {
             var executed = false
-            Stream.init(Seq.empty[Int]).runForeach(_ => executed = true).map { _ =>
+            Stream.init(Seq.empty[Int]).foreach(_ => executed = true).map { _ =>
                 assert(!executed)
             }
         }
 
         "works with effects" in run {
             var sum = 0
-            Stream.init(Seq(1, 2, 3, 4, 5)).runForeach { i =>
+            Stream.init(Seq(1, 2, 3, 4, 5)).foreach { i =>
                 Env.use[Int] { multiplier =>
                     sum += i * multiplier
                 }
@@ -724,7 +724,7 @@ class StreamTest extends Test:
         "short-circuits on abort" in run {
             var sum = 0
             val result = Abort.run[String] {
-                Stream.init(Seq(1, 2, 3, 4, 5)).runForeach { i =>
+                Stream.init(Seq(1, 2, 3, 4, 5)).foreach { i =>
                     sum += i
                     if i >= 3 then Abort.fail("Reached 3")
                     else Abort.get(Right(()))
@@ -737,10 +737,10 @@ class StreamTest extends Test:
         }
     }
 
-    "runForeachChunk" - {
+    "foreachChunk" - {
         "executes the function for each chunk" in run {
             var sum = 0
-            Stream.init(Chunk(1, 2, 3, 4, 5)).runForeachChunk(chunk =>
+            Stream.init(Chunk(1, 2, 3, 4, 5)).foreachChunk(chunk =>
                 sum += chunk.foldLeft(0)(_ + _)
             ).map { _ =>
                 assert(sum == 15)
@@ -749,14 +749,14 @@ class StreamTest extends Test:
 
         "works with empty stream" in run {
             var executed = false
-            Stream.init(Chunk.empty[Int]).runForeachChunk(_ => executed = true).map { _ =>
+            Stream.init(Chunk.empty[Int]).foreachChunk(_ => executed = true).map { _ =>
                 assert(!executed)
             }
         }
 
         "works with effects" in run {
             var sum = 0
-            Stream.init(Chunk(1, 2, 3, 4, 5)).runForeachChunk { chunk =>
+            Stream.init(Chunk(1, 2, 3, 4, 5)).foreachChunk { chunk =>
                 Env.use[Int] { multiplier =>
                     sum += chunk.foldLeft(0)(_ + _) * multiplier
                 }
@@ -766,22 +766,22 @@ class StreamTest extends Test:
         }
     }
 
-    "runFold" - {
+    "fold" - {
         "sum" in {
             assert(
-                Stream.init(Seq(1, 2, 3)).runFold(0)(_ + _).eval == 6
+                Stream.init(Seq(1, 2, 3)).fold(0)(_ + _).eval == 6
             )
         }
 
         "concat" in {
             assert(
-                Stream.init(Seq("a", "b", "c")).runFold("")(_ + _).eval == "abc"
+                Stream.init(Seq("a", "b", "c")).fold("")(_ + _).eval == "abc"
             )
         }
 
         "early termination" in {
             val stream = Stream.init(Seq(1, 2, 3, 4, 5))
-            val folded = stream.runFold(0) { (acc, v) =>
+            val folded = stream.fold(0) { (acc, v) =>
                 if acc < 6 then acc + v else Abort.fail(())
             }
             assert(Abort.run[Unit](folded).eval.foldError(_ => true)(_ => false))
@@ -789,7 +789,7 @@ class StreamTest extends Test:
 
         "stack safety" in {
             assert(
-                Stream.init(Seq.fill(n)(1)).runFold(0)(_ + _).eval == n
+                Stream.init(Seq.fill(n)(1)).fold(0)(_ + _).eval == n
             )
         }
     }

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
@@ -51,7 +51,7 @@ object StreamPublisher:
             supervisor: Fiber.Promise[Nothing, Unit]
         ): Unit < (Async & Ctx) =
             Abort.recover[Closed](_ => supervisor.interrupt.unit)(
-                channel.stream().runForeach: subscriber =>
+                channel.stream().foreach: subscriber =>
                     for
                         subscription <- publisher.getSubscription(subscriber)
                         fiber        <- subscription.subscribe.andThen(subscription.consume)

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
@@ -22,7 +22,7 @@ abstract private class PublisherToSubscriberTest extends Test:
             _ = publisher.subscribe(subscriber)
             subscriberStream <- subscriber.stream
             (isSame, _) <- subscriberStream
-                .runFold(true -> 0) { case ((acc, expected), cur) =>
+                .fold(true -> 0) { case ((acc, expected), cur) =>
                     (acc && (expected == cur)) -> (expected + 1)
                 }
         yield assert(isSame)
@@ -44,7 +44,7 @@ abstract private class PublisherToSubscriberTest extends Test:
             subscriber <- streamSubscriber
             _ = publisher.subscribe(subscriber)
             subscriberStream <- subscriber.stream
-            result           <- Abort.run[Throwable](subscriberStream.runDiscard)
+            result           <- Abort.run[Throwable](subscriberStream.discard)
         yield result match
             case Result.Error(e: Throwable) => assert(e == TestError)
             case _                          => assert(false)
@@ -223,7 +223,7 @@ abstract private class PublisherToSubscriberTest extends Test:
                                 case _                       => promise.completeDiscard(Failure(TestError))
                         })))
                 }
-                _      <- Resource.run(subscriber.stream.map(_.take(10).runDiscard))
+                _      <- Resource.run(subscriber.stream.map(_.take(10).discard))
                 result <- promise.getResult
             yield assert(result == Success(()))
             end for

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/StreamSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/StreamSubscriberTest.scala
@@ -46,7 +46,7 @@ final class StreamSubscriberTest extends Test:
             subscriber <- StreamSubscriber[Int](BufferSize, EmitStrategy.Eager)
             subStream  <- subscriber.stream
             _ = publisher.subscribe(subscriber)
-            results <- subStream.take(StreamLength).runFold(0)(_ + _)
+            results <- subStream.take(StreamLength).fold(0)(_ + _)
         yield assert(results == (StreamLength >> 1) * (StreamLength + 1))
         end for
     }
@@ -57,7 +57,7 @@ final class StreamSubscriberTest extends Test:
             subscriber <- StreamSubscriber[Int](BufferSize, EmitStrategy.Buffer)
             subStream  <- subscriber.stream
             _ = publisher.subscribe(subscriber)
-            results <- subStream.take(StreamLength).runFold(0)(_ + _)
+            results <- subStream.take(StreamLength).fold(0)(_ + _)
         yield assert(results == (StreamLength >> 1) * (StreamLength + 1))
         end for
     }
@@ -72,8 +72,8 @@ final class StreamSubscriberTest extends Test:
             _ = publisher.subscribe(subscriber1)
             _ = publisher.subscribe(subscriber2)
             results <- Async.parallelUnbounded(List(
-                subStream1.take(StreamLength >> 1).runFold(0)(_ + _),
-                subStream2.take(StreamLength >> 1).runFold(0)(_ + _)
+                subStream1.take(StreamLength >> 1).fold(0)(_ + _),
+                subStream2.take(StreamLength >> 1).fold(0)(_ + _)
             ))
         yield
             assert(results.size == 2)


### PR DESCRIPTION

Fixes #1047

### Problem

Some of the methods in `Stream` have the `run` prefix, which was introduced to indicate that the `stream` will be fully handled and return a computation instead of a `Stream` instance. Renaming the `Stream` methods prefixed with `run` makes it easier to be found

### Solution

Rename the `Stream` methods



### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
