### PR TITLE
[build] disable Scala Native

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Build JS
       run: sbt '+kyoJS/test'
 
-    - name: Build Native
-      run: sbt '+kyoNative/test'
+    # - name: Build Native
+    #   run: sbt '+kyoNative/test'

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Build JS
       run: sbt '+kyoJS/testQuick'
 
-    - name: Build Native
-      run: sbt '+kyoNative/testQuick'
+    # - name: Build Native
+    #   run: sbt '+kyoNative/testQuick'


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->
We've been having consistent issues with the Scala Native build timing out. I've been debugging this issue for some time and trying several changes but I haven't had success so far. It seems related to concurrency issues in Scala Native's test runner.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->
Since this is significantly affecting Kyo's development, I think we we could disable the native build for now. I'll dust off an old linux box I have to try to reproduce it locally.
