### PR TITLE
Enable Scala Native compilation (tests are still off)

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Build JS
       run: sbt '+kyoJS/test'
 
-    # - name: Build Native
-    #   run: sbt '+kyoNative/test'
+    - name: Build Native
+      run: sbt '+kyoNative/Test/compile' # test

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Build JS
       run: sbt '+kyoJS/testQuick'
 
-    # - name: Build Native
-    #   run: sbt '+kyoNative/testQuick'
+    - name: Build Native
+      run: sbt '+kyoNative/Test/compile' # testQuick


### PR DESCRIPTION
Relates to issue
 * https://github.com/getkyo/kyo/pull/1063

Hello @fwbrasil , I see that Scala Native got disabled. It sucks that SN tests were causing issues, but oh well, such is life with bleeding edge tech, like SN.
But if it were only tests which had problems, does that mean that we could still keep SN compilation?

If we keep SN compilation in CI, we could prevent potential incompatibilities from getting merged.
