### PR TITLE
Hub.init/initWith is Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -2440,13 +2440,13 @@ import kyo.*
 import kyo.Hub.Listener
 
 // Initialize a Hub with a buffer
-val a: Hub[Int] < IO =
+val a: Hub[Int] < (IO & Resource) =
     Hub.init[Int](3)
 
 // Hub provide APIs similar to
 // channels: size, offer, isEmpty,
 // isFull, putFiber, put
-val b: Boolean < (IO & Abort[Closed]) =
+val b: Boolean < (IO & Abort[Closed] & Resource) =
     a.map(_.offer(1))
 
 // But reading from hubs can only
@@ -2489,7 +2489,7 @@ val g: Int < (Async & Abort[Closed]) =
 // only include items pending in
 // the hub's buffer. The listener
 // buffers are discarded
-val h: Maybe[Seq[Int]] < IO =
+val h: Maybe[Seq[Int]] < (IO & Resource) =
     a.map(_.close)
 ```
 


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->
Fixes #1044 

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->
`Hub`s are initialized with a long-running fiber that should be cleaned up when the hub is no longer being used. This PR makes the initializing methods `init`, `initWith`, and all overloads `Resource` effects, where the finalizer calls `Hub#close`.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->
`Hub#initWith` uses `Resource.acquireRelease` to construct the `Hub` and calls `_.close.unit` as the finalizer.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->

