### PR TITLE
'Discarding' methods accept `Any` instead of `Unit`

### DIFF
--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -265,7 +265,7 @@ extension [A, S](effect: A < S)
       * @return
       *   An effect that executes the finalizer after this effect
       */
-    def ensuring(finalizer: => Unit < Async)(using Frame): A < (S & Resource & IO) =
+    def ensuring(finalizer: => Any < Async)(using Frame): A < (S & Resource & IO) =
         Resource.ensure(finalizer).andThen(effect)
 
 end extension

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -17,7 +17,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that manages the resource lifecycle using Resource and IO effects
       */
-    def acquireRelease[A, S](acquire: => A < S)(release: A => Unit < Async)(using Frame): A < (S & Resource & IO) =
+    def acquireRelease[A, S](acquire: => A < S)(release: A => Any < Async)(using Frame): A < (S & Resource & IO) =
         Resource.acquireRelease(acquire)(release)
 
     /** Adds a finalizer to the current effect using Resource.
@@ -27,7 +27,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that ensures the finalizer is executed when the effect is completed
       */
-    def addFinalizer(finalizer: => Unit < Async)(using Frame): Unit < (Resource & IO) =
+    def addFinalizer(finalizer: => Any < Async)(using Frame): Unit < (Resource & IO) =
         Resource.ensure(finalizer)
 
     /** Creates an asynchronous effect that can be completed by the given register function.
@@ -37,7 +37,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that can be completed by the given register function
       */
-    def async[A](register: (A < Async => Unit) => Unit < Async)(
+    def async[A](register: (A < Async => Unit) => Any < Async)(
         using
         Flat[A],
         Frame

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -320,7 +320,7 @@ object Clock:
       * @return
       *   A Fiber that can be used to control or interrupt the recurring task
       */
-    def repeatWithDelay[E, S](delay: Duration)(f: => Unit < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
+    def repeatWithDelay[E, S](delay: Duration)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
         repeatWithDelay(Duration.Zero, delay)(f)
 
     /** Repeatedly executes a task with a fixed delay between completions, starting after an initial delay.
@@ -338,9 +338,9 @@ object Clock:
         startAfter: Duration,
         delay: Duration
     )(
-        f: => Unit < (Async & Abort[E])
+        f: => Any < (Async & Abort[E])
     )(using Frame): Fiber[E, Unit] < IO =
-        repeatWithDelay(startAfter, delay, ())(_ => f)
+        repeatWithDelay(startAfter, delay, ())(_ => f.unit)
 
     /** Repeatedly executes a task with a fixed delay between completions, maintaining state between executions.
       *
@@ -375,8 +375,8 @@ object Clock:
       * @return
       *   A Fiber that can be used to control or interrupt the recurring task
       */
-    def repeatWithDelay[E, S](delaySchedule: Schedule)(f: => Unit < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
-        repeatWithDelay(delaySchedule, ())(_ => f)
+    def repeatWithDelay[E, S](delaySchedule: Schedule)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
+        repeatWithDelay(delaySchedule, ())(_ => f.unit)
 
     /** Repeatedly executes a task with delays determined by a custom schedule, maintaining state between executions.
       *
@@ -422,7 +422,7 @@ object Clock:
       * @return
       *   A Fiber that can be used to control or interrupt the recurring task
       */
-    def repeatAtInterval[E, S](interval: Duration)(f: => Unit < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
+    def repeatAtInterval[E, S](interval: Duration)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
         repeatAtInterval(Duration.Zero, interval)(f)
 
     /** Repeatedly executes a task at fixed time intervals, starting after an initial delay.
@@ -440,9 +440,9 @@ object Clock:
         startAfter: Duration,
         interval: Duration
     )(
-        f: => Unit < (Async & Abort[E])
+        f: => Any < (Async & Abort[E])
     )(using Frame): Fiber[E, Unit] < IO =
-        repeatAtInterval(startAfter, interval, ())(_ => f)
+        repeatAtInterval(startAfter, interval, ())(_ => f.unit)
 
     /** Repeatedly executes a task at fixed time intervals, maintaining state between executions.
       *
@@ -477,8 +477,8 @@ object Clock:
       * @return
       *   A Fiber that can be used to control or interrupt the recurring task
       */
-    def repeatAtInterval[E, S](intervalSchedule: Schedule)(f: => Unit < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
-        repeatAtInterval(intervalSchedule, ())(_ => f)
+    def repeatAtInterval[E, S](intervalSchedule: Schedule)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
+        repeatAtInterval(intervalSchedule, ())(_ => f.unit)
 
     /** Repeatedly executes a task with intervals determined by a custom schedule, maintaining state between executions.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -134,9 +134,9 @@ object Fiber extends FiberPlatformSpecific:
           * @param f
           *   The callback function
           */
-        def onComplete[E2 >: E, A2 >: A](f: Result[E2, A2] => Unit < IO)(using Frame): Unit < IO =
+        def onComplete[E2 >: E, A2 >: A](f: Result[E2, A2] => Any < IO)(using Frame): Unit < IO =
             import AllowUnsafe.embrace.danger
-            IO(self.onComplete(r => IO.Unsafe.evalOrThrow(f(r))))
+            IO(self.onComplete(r => IO.Unsafe.evalOrThrow(f(r).unit)))
 
         /** Registers a callback to be called when the Fiber is interrupted.
           *
@@ -148,9 +148,9 @@ object Fiber extends FiberPlatformSpecific:
           * @return
           *   A unit value wrapped in IO, representing the registration of the callback
           */
-        def onInterrupt(f: Result.Error[E] => Unit < IO)(using Frame): Unit < IO =
+        def onInterrupt(f: Result.Error[E] => Any < IO)(using Frame): Unit < IO =
             import AllowUnsafe.embrace.danger
-            IO(self.onInterrupt(r => IO.Unsafe.evalOrThrow(f(r))))
+            IO(self.onInterrupt(r => IO.Unsafe.evalOrThrow(f(r).unit)))
 
         /** Blocks until the Fiber completes or the timeout is reached.
           *

--- a/kyo-core/shared/src/main/scala/kyo/IO.scala
+++ b/kyo-core/shared/src/main/scala/kyo/IO.scala
@@ -61,8 +61,8 @@ object IO:
       * @return
       *   The result of the main computation, with the finalizer guaranteed to run.
       */
-    def ensure[A, S](f: => Unit < IO)(v: A < S)(using frame: Frame): A < (IO & S) =
-        Unsafe(Safepoint.ensure(IO.Unsafe.evalOrThrow(f))(v))
+    def ensure[A, S](f: => Any < IO)(v: A < S)(using frame: Frame): A < (IO & S) =
+        Unsafe(Safepoint.ensure(IO.Unsafe.evalOrThrow(f.unit))(v))
 
     /** Retrieves a local value and applies a function that can perform side effects.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Log.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Log.scala
@@ -170,12 +170,12 @@ object Log extends LogPlatformSpecific:
         end ConsoleLogger
     end Unsafe
 
-    private inline def logWhen(inline level: Level)(inline doLog: Log => Unit < IO)(using
+    private inline def logWhen(inline level: Level)(inline doLog: Log => Any < IO)(using
         inline frame: Frame
     ): Unit < IO =
         IO.Unsafe.withLocal(local) { log =>
             if level.enabled(log.level) then
-                doLog(log)
+                doLog(log).unit
             else
                 (
             )

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -26,9 +26,9 @@ object Resource:
       * @return
       *   A unit value wrapped in Resource and IO effects.
       */
-    def ensure(v: => Unit < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & IO) =
+    def ensure(v: => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & IO) =
         ContextEffect.suspendWith(Tag[Resource]) { finalizer =>
-            Abort.run(finalizer.queue.offer(IO(v))).map {
+            Abort.run(finalizer.queue.offer(IO(v.unit))).map {
                 case Result.Success(_) => ()
                 case _ =>
                     throw new Closed(
@@ -51,7 +51,7 @@ object Resource:
       * @return
       *   The acquired resource wrapped in Resource, IO, and S effects.
       */
-    def acquireRelease[A, S](acquire: A < S)(release: A => Unit < (Async & Abort[Throwable]))(using Frame): A < (Resource & IO & S) =
+    def acquireRelease[A, S](acquire: A < S)(release: A => Any < (Async & Abort[Throwable]))(using Frame): A < (Resource & IO & S) =
         acquire.map { resource =>
             ensure(release(resource)).andThen(resource)
         }

--- a/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
@@ -150,10 +150,10 @@ object Kyo:
       * @return
       *   A new effect that produces Unit
       */
-    def foreachDiscard[A, B, S](seq: Seq[A])(f: Safepoint ?=> A => Unit < S)(using Frame, Safepoint): Unit < S =
+    def foreachDiscard[A, B, S](seq: Seq[A])(f: Safepoint ?=> A => Any < S)(using Frame, Safepoint): Unit < S =
         seq.knownSize match
             case 0 =>
-            case 1 => f(seq(0))
+            case 1 => f(seq(0)).unit
             case _ =>
                 seq match
                     case seq: List[A] =>

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Loop.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Loop.scala
@@ -572,9 +572,9 @@ object Loop:
       * @return
       *   Unit after completing all iterations
       */
-    inline def repeat[S](n: Int)(inline run: Safepoint ?=> Unit < S)(using inline _frame: Frame, safepoint: Safepoint): Unit < S =
+    inline def repeat[S](n: Int)(inline run: Safepoint ?=> Any < S)(using inline _frame: Frame, safepoint: Safepoint): Unit < S =
         @nowarn("msg=anonymous")
-        @tailrec def loop(i: Int)(v: Unit < S)(using Safepoint): Unit < S =
+        @tailrec def loop(i: Int)(v: Any < S)(using Safepoint): Unit < S =
             if i > n then ()
             else
                 v match
@@ -600,9 +600,9 @@ object Loop:
       * @return
       *   Nothing, as this loop runs forever unless interrupted
       */
-    inline def forever[S](inline run: Safepoint ?=> Unit < S)(using inline _frame: Frame, safepoint: Safepoint): Unit < S =
+    inline def forever[S](inline run: Safepoint ?=> Any < S)(using inline _frame: Frame, safepoint: Safepoint): Unit < S =
         @nowarn("msg=anonymous")
-        @tailrec def loop(v: Unit < S)(using Safepoint): Unit < S =
+        @tailrec def loop(v: Any < S)(using Safepoint): Unit < S =
             v match
                 case kyo: KyoSuspend[IX, OX, EX, Any, Unit, S] @unchecked =>
                     new KyoContinue[IX, OX, EX, Any, Unit, S](kyo):

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Safepoint.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Safepoint.scala
@@ -146,11 +146,12 @@ object Safepoint:
     end ensuring
 
     @nowarn("msg=anonymous")
-    private[kyo] inline def ensure[A, S](inline f: => Unit)(inline v: => A < S)(using safepoint: Safepoint, inline _frame: Frame): A < S =
+    private[kyo] inline def ensure[A, S](inline f: => Any)(inline v: => A < S)(using safepoint: Safepoint, inline _frame: Frame): A < S =
         // ensures the function is called once even if an
         // interceptor executes it multiple times
         val ensure = new Ensure:
-            def run: Unit = f
+            def run: Unit =
+                val _ = f
 
         def ensureLoop(v: A < S)(using safepoint: Safepoint): A < S =
             v match

--- a/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
@@ -111,9 +111,9 @@ object Emit:
           * @return
           *   The result of the computation
           */
-        def apply[A: Flat, S, S2](v: A < (Emit[V] & S))(f: V => Unit < S2)(using tag: Tag[Emit[V]], frame: Frame): A < (S & S2) =
+        def apply[A: Flat, S, S2](v: A < (Emit[V] & S))(f: V => Any < S2)(using tag: Tag[Emit[V]], frame: Frame): A < (S & S2) =
             ArrowEffect.handle(tag, v)(
-                [C] => (input, cont) => f(input).map(cont)
+                [C] => (input, cont) => f(input).map(_ => cont(()))
             )
     end RunForeachOps
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
@@ -45,12 +45,12 @@ object Poll:
           * @return
           *   A computation that processes values until completion or limit reached
           */
-        def apply[S](n: Int)(f: V => Unit < S)(using tag: Tag[Poll[V]], frame: Frame): Unit < (Poll[V] & S) =
+        def apply[S](n: Int)(f: V => Any < S)(using tag: Tag[Poll[V]], frame: Frame): Unit < (Poll[V] & S) =
             Loop.indexed { idx =>
                 if idx == n then Loop.done
                 else
                     Poll.andMap[V] {
-                        case Present(v) => f(v).map(Loop.continue)
+                        case Present(v) => f(v).map(_ => Loop.continue(()))
                         case Absent     => Loop.done
                     }
             }
@@ -62,10 +62,10 @@ object Poll:
           * @return
           *   A computation that processes values until completion
           */
-        def apply[S](f: V => Unit < S)(using tag: Tag[Poll[V]], frame: Frame): Unit < (Poll[V] & S) =
+        def apply[S](f: V => Any < S)(using tag: Tag[Poll[V]], frame: Frame): Unit < (Poll[V] & S) =
             Loop(()) { _ =>
                 Poll.andMap[V] {
-                    case Present(v) => f(v).map(Loop.continue)
+                    case Present(v) => f(v).map(_ => Loop.continue(()))
                     case Absent     => Loop.done
                 }
             }

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -163,7 +163,7 @@ sealed abstract class Stream[V, -S]:
       * @return
       *   A new stream runs f while emitting values
       */
-    def tap[S1](f: V => Unit < S1)(
+    def tap[S1](f: V => Any < S1)(
         using
         tag: Tag[Emit[Chunk[V]]],
         frame: Frame
@@ -182,7 +182,7 @@ sealed abstract class Stream[V, -S]:
       * @return
       *   A new stream runs f while emitting chunks
       */
-    def tapChunk[S1](f: Chunk[V] => Unit < S1)(
+    def tapChunk[S1](f: Chunk[V] => Any < S1)(
         using
         tag: Tag[Emit[Chunk[V]]],
         frame: Frame
@@ -421,7 +421,7 @@ sealed abstract class Stream[V, -S]:
       * @return
       *   A unit effect that runs the stream and applies f to each value
       */
-    def foreach[S2](f: V => Unit < S2)(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Unit < (S & S2) =
+    def foreach[S2](f: V => Any < S2)(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Unit < (S & S2) =
         foreachChunk(c => Kyo.foreachDiscard(c)(f))
 
     /** Runs the stream and applies the given function to each emitted chunk.
@@ -431,7 +431,7 @@ sealed abstract class Stream[V, -S]:
       * @return
       *   A unit effect that runs the stream and applies f to each chunk
       */
-    def foreachChunk[S2](f: Chunk[V] => Unit < S2)(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Unit < (S & S2) =
+    def foreachChunk[S2](f: Chunk[V] => Any < S2)(using tag: Tag[Emit[Chunk[V]]], frame: Frame): Unit < (S & S2) =
         ArrowEffect.handle(tag, emit)(
             [C] =>
                 (input, cont) =>


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->
Fixes #1067 

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->
A lot of methods accept effects that are only used for their side-effects and thus typically have a result type of `Unit`. This requires users to frequently append `.unit` to the effects they pass to these methods. This PR changes all such methods to accept effects in the form `Any < S` to remove the need for this boilerplate.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->
Public discarding methods now accept `Any < S` effects and then convert them to `Unit < S` using `.unit` prior to using them. Generally it is hard to avoid calling `.unit` since these effects are typically passed to methods that require a `Flat` result (`Any` is not guaranteed to be flat.)

Here are the methods that have changed:
- kyo-combinators/Combinators
  - `ensuring` 
- kyo-combinators/Constructors
  - `Kyo.acquireRelease`
  - `Kyo.addFinalizer`
  - `Kyo.async`
- kyo-core/Clock
  - `Clock.repeat...`
- kyo-core/Fiber
  - `onComplete`
  - `onInterrupt`
- kyo-core/scheduler/IOPromise
  - `onComplete`
  - `onInterrupt`
- kyo-core/IO
  - `IO.ensure`
- kyo-core/Resource
  - `Resource.ensure`
  - `Resource.acquireRelease`
- kyo-core/Log
  - `Log.logWhen`
- kyo-kernal/Kyo
  - `Kyo.foreachDiscard`
- kyo-kernal/Loop
  - `repeat`
  - `forever` 
- kyo-kernal/Safepoint
  - `Safepoint.ensure` 
- kyo-prelude/Emit
  - `Emit.runForeach`
- kyo-prelude/Poll
  - `Poll.apply`
- kyo-prelude/Stream
  - `Stream.tap`
  - `Stream.tapChunk`
  - `Stream.foreach`
  - `Stream.foreachChunk`

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
