### PR TITLE
Avoid `.unit` where possible

### DIFF
--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
@@ -55,7 +55,7 @@ object StreamPublisher:
                     for
                         subscription <- publisher.getSubscription(subscriber)
                         fiber        <- subscription.subscribe.andThen(subscription.consume)
-                        _            <- supervisor.onInterrupt(_ => fiber.interrupt(Result.Panic(Interrupt())).unit)
+                        _            <- supervisor.onInterrupt(_ => fiber.interrupt(Result.Panic(Interrupt())))
                     yield ()
             )
 
@@ -73,8 +73,8 @@ object StreamPublisher:
                             case Result.Success(true) => ()
                             case _                    => discardSubscriber(subscriber)
             }
-            supervisor <- Resource.acquireRelease(Fiber.Promise.init[Nothing, Unit])(_.interrupt.unit)
-            _          <- Resource.acquireRelease(Async._run(consumeChannel(publisher, channel, supervisor)))(_.interrupt.unit)
+            supervisor <- Resource.acquireRelease(Fiber.Promise.init[Nothing, Unit])(_.interrupt)
+            _          <- Resource.acquireRelease(Async._run(consumeChannel(publisher, channel, supervisor)))(_.interrupt)
         yield publisher
         end for
     end apply

--- a/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
@@ -35,7 +35,7 @@ object Routes:
       *   A NettyKyoServerBinding wrapped in an asynchronous effect
       */
     def run[A, S](server: NettyKyoServer)(v: Unit < (Routes & S))(using Frame): NettyKyoServerBinding < (Async & S) =
-        Emit.run[Route][Unit, Async & S](v).map { (routes, _) =>
+        Emit.run[Route].apply[Unit, Async & S](v).map { (routes, _) =>
             IO(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Async & S)
         }
     end run

--- a/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
@@ -35,7 +35,7 @@ object Routes:
       *   A NettyKyoServerBinding wrapped in an asynchronous effect
       */
     def run[A, S](server: NettyKyoServer)(v: Unit < (Routes & S))(using Frame): NettyKyoServerBinding < (Async & S) =
-        Emit.run[Route].apply[Unit, Async & S](v).map { (routes, _) =>
+        Emit.run[Route][Unit, Async & S](v).map { (routes, _) =>
             IO(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Async & S)
         }
     end run
@@ -63,7 +63,7 @@ object Routes:
                         }
                 )
             )
-        ).unit
+        )
 
     /** Adds a new route to the collection, starting from a PublicEndpoint.
       *
@@ -89,6 +89,6 @@ object Routes:
       *   Unit wrapped in Routes effect
       */
     def collect(init: (Unit < Routes)*)(using Frame): Unit < Routes =
-        Kyo.collect(init).unit
+        Kyo.collectDiscard(init)
 
 end Routes

--- a/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServerInterpreter.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServerInterpreter.scala
@@ -47,7 +47,7 @@ object NettyKyoServerInterpreter:
                 else
                     f
             import AllowUnsafe.embrace.danger
-            IO.Unsafe.evalOrThrow(Async.run(exec).unit)
+            val _ = IO.Unsafe.evalOrThrow(Async.run(exec))
         end apply
     end KyoRunAsync
 end NettyKyoServerInterpreter

--- a/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
@@ -7,7 +7,7 @@ import kyo.*
 object KyoUtil:
     def nettyChannelFutureToScala(nettyFuture: ChannelFuture)(using Frame): Channel < Async =
         Promise.initWith[Nothing, Channel] { p =>
-            p.onComplete(_ => IO(nettyFuture.cancel(true)).unit).andThen {
+            p.onComplete(_ => IO(discard(nettyFuture.cancel(true)))).andThen {
                 nettyFuture.addListener((future: ChannelFuture) =>
                     discard {
                         import AllowUnsafe.embrace.danger
@@ -21,7 +21,7 @@ object KyoUtil:
 
     def nettyFutureToScala[A](f: io.netty.util.concurrent.Future[A])(using Frame): A < Async =
         Promise.initWith[Nothing, A] { p =>
-            p.onComplete(_ => IO(f.cancel(true)).unit).andThen {
+            p.onComplete(_ => IO(discard(f.cancel(true)))).andThen {
                 f.addListener((future: io.netty.util.concurrent.Future[A]) =>
                     discard {
                         import AllowUnsafe.embrace.danger


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
`.unit` should be avoided where it's possible to discard non-unit values without an additional suspension.

### Solution
- use `IO(discard(_))` - should we make this a function?