### PR TITLE
[build] limit concurrency to only build the last commit of PRs

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: build


### PR DESCRIPTION
### Problem

PRs trigger a new build on each push, which is typically unnecessary and incurs into costs and overall longer build times sine we have a single dedicated runner.

### Solution

Limit the concurrency of PR builds so only the latest commit is built and builds for previous commits are automatically cancelled.
