### PR TITLE
[data] optimize Maybe.collect

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Maybe.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Maybe.scala
@@ -324,14 +324,8 @@ object Maybe:
           *   a new Maybe containing the result of the partial function if defined and applicable, or Absent otherwise
           */
         inline def collect[B](pf: PartialFunction[A, B]): Maybe[B] =
-            if !isEmpty then
-                val value = get
-                if pf.isDefinedAt(value) then
-                    pf(value)
-                else
-                    Absent
-                end if
-            else Absent
+            if isEmpty then Absent
+            else pf.applyOrElse(get, constAbsent)
 
         /** Returns this Maybe if defined, or an alternative Maybe if empty.
           *
@@ -445,5 +439,7 @@ object Maybe:
                 else
                     new PresentAbsent(depth)
         end PresentAbsent
+
+        def constAbsent(ignored: Any): Absent = Absent
     end internal
 end Maybe


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
The current implementation of `Maybe.collect` checks if the partial function is defined on the input value before calling it. This can be sub-optimal, as it causes a double evaluation of pattern matchers and guards in the partial function (once on the call to `pf.isDefinedAt(value)` and once on the application `pf(value)`. 

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->
Using the `applyOrElse` method allows optimized implementations of `PartialFuncion`, such as partial function literals (mentioned in https://github.com/scala/scala/blob/780d80c714354871bc5972045926b7ccd042e102/src/library/scala/PartialFunction.scala#L194)  to avoid double evaluations of guards.