### PR TITLE
periodic cleanup of unused imports

### DIFF
--- a/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
+++ b/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
@@ -7,9 +7,6 @@ import io.aeron.driver.MediaDriver
 import io.aeron.logbuffer.BufferClaim
 import io.aeron.logbuffer.Header
 import org.agrona.DirectBuffer
-import scala.annotation.implicitNotFound
-import scala.annotation.targetName
-import scala.compiletime.*
 import upickle.default.*
 
 /** High-performance publish-subscribe messaging for local and distributed systems.

--- a/kyo-aeron/jvm/src/test/scala/kyo/Test.scala
+++ b/kyo-aeron/jvm/src/test/scala/kyo/Test.scala
@@ -6,7 +6,6 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-aeron/jvm/src/test/scala/kyo/TopicTest.scala
+++ b/kyo-aeron/jvm/src/test/scala/kyo/TopicTest.scala
@@ -2,7 +2,6 @@ package kyo
 
 import java.net.DatagramSocket
 import java.net.InetSocketAddress
-import kyo.debug.Debug
 
 class TopicTest extends Test:
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/BroadFlatMapBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/BroadFlatMapBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench.arena
 
-import org.openjdk.jmh.annotations.*
-
 class BroadFlatMapBench extends ArenaBench.SyncAndFork(BigInt(610)):
 
     val depth = 15

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkChainedBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkChainedBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench.arena
 
-import org.openjdk.jmh.annotations.*
-
 class ForkChainedBench extends ArenaBench.ForkOnly(0):
 
     val depth = 10000

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench.arena
 
-import org.openjdk.jmh.annotations.*
-
 class ForkJoinBench extends ArenaBench.ForkOnly(()):
 
     val depth = 10000

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinContentionBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench.arena
 
-import org.openjdk.jmh.annotations.*
-
 class ForkJoinContentionBench extends ArenaBench.ForkOnly(()):
 
     val depth     = 1000

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkManyBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkManyBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench.arena
 
-import org.openjdk.jmh.annotations.*
-
 class ForkManyBench extends ArenaBench.ForkOnly(0):
 
     val depth = 10000

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkSpawnBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkSpawnBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench.arena
 
-import org.openjdk.jmh.annotations.*
-
 class ForkSpawnBench extends ArenaBench.ForkOnly(()):
 
     val depth = 5

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ProducerConsumerBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ProducerConsumerBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench.arena
 
-import org.openjdk.jmh.annotations.Benchmark
-
 class ProducerConsumerBench extends ArenaBench.ForkOnly(()):
 
     val depth = 10000

--- a/kyo-bench/src/main/scala/kyo/bench/arena/Registry.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/Registry.scala
@@ -4,6 +4,9 @@ import java.io.BufferedReader
 import java.io.File
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Collectors
 import scala.jdk.CollectionConverters.*
 
 object Registry:

--- a/kyo-bench/src/main/scala/kyo/bench/arena/RendezvousBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/RendezvousBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench.arena
 
-import org.openjdk.jmh.annotations.*
-
 class RendezvousBench extends ArenaBench.ForkOnly(10000 * (10000 + 1) / 2):
 
     given canEqualNull[A]: CanEqual[A, A | Null] = CanEqual.derived

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SemaphoreBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SemaphoreBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench.arena
 
-import org.openjdk.jmh.annotations.Benchmark
-
 class SemaphoreBench extends ArenaBench.ForkOnly(()):
 
     val depth = 10000

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SemaphoreContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SemaphoreContentionBench.scala
@@ -1,7 +1,5 @@
 package kyo.bench.arena
 
-import org.openjdk.jmh.annotations.*
-
 class SemaphoreContentionBench extends ArenaBench.ForkOnly(()):
 
     val permits   = 10

--- a/kyo-bench/src/main/scala/kyo/bench/arena/TestHttpServer.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/TestHttpServer.scala
@@ -13,7 +13,6 @@ import java.io.PrintStream
 import java.io.PrintWriter
 import java.net.HttpURLConnection
 import java.net.URL
-import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 import scala.util.control.NonFatal

--- a/kyo-cache/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-cache/shared/src/test/scala/kyo/Test.scala
@@ -3,10 +3,8 @@ package kyo
 import kyo.internal.BaseKyoCoreTest
 import kyo.kernel.Platform
 import org.scalatest.NonImplicitAssertions
-import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-cats/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-cats/shared/src/test/scala/kyo/Test.scala
@@ -3,10 +3,8 @@ package kyo
 import kyo.internal.BaseKyoCoreTest
 import kyo.kernel.Platform
 import org.scalatest.NonImplicitAssertions
-import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-combinators/shared/src/test/scala/kyo/EmitCombinatorTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EmitCombinatorTest.scala
@@ -1,8 +1,5 @@
 package kyo
 
-import scala.concurrent.Future
-import scala.util.Try
-
 class EmitCombinatorTest extends Test:
 
     given ce[A, B]: CanEqual[A, B] = CanEqual.canEqualAny

--- a/kyo-combinators/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/Test.scala
@@ -6,7 +6,6 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-core/jvm/src/main/scala/kyo/scheduler/IOPromisePlatformSpecific.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/scheduler/IOPromisePlatformSpecific.scala
@@ -1,7 +1,6 @@
 package kyo.scheduler
 
 import java.lang.invoke.MethodHandles
-import java.lang.invoke.VarHandle
 import kyo.Present
 import kyo.scheduler.IOPromise.State
 

--- a/kyo-core/jvm/src/test/scala/kyo/StreamCompressionTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/StreamCompressionTest.scala
@@ -2,10 +2,8 @@ package kyo
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
-import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.util.zip.CRC32
-import java.util.zip.DataFormatException
 import java.util.zip.Deflater
 import java.util.zip.DeflaterInputStream
 import java.util.zip.GZIPInputStream

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -1,10 +1,8 @@
 package kyo
 
-import java.io.CharArrayReader
 import org.jctools.queues.MpmcUnboundedXaddArrayQueue
 import scala.annotation.tailrec
 import scala.util.NotGiven
-import scala.util.boundary
 
 /** A channel for communicating between fibers.
   *

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -1,7 +1,6 @@
 package kyo.scheduler
 
 import IOPromise.*
-import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.LockSupport
 import kyo.*
 import kyo.Result.Error

--- a/kyo-core/shared/src/test/scala/kyo/ConsoleTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ConsoleTest.scala
@@ -1,10 +1,8 @@
 package kyo
 
-import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.OutputStream
 import java.io.PrintStream
-import java.io.StringWriter
 
 class ConsoleTest extends Test:
 

--- a/kyo-core/shared/src/test/scala/kyo/IOTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/IOTest.scala
@@ -239,7 +239,6 @@ class IOTest extends Test:
     }
 
     "Unsafe.withLocal" - {
-        import AllowUnsafe.embrace.danger
 
         def unsafeOperation(value: Int)(using unsafe: AllowUnsafe): Int =
             value * 2

--- a/kyo-core/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-core/shared/src/test/scala/kyo/Test.scala
@@ -6,7 +6,6 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-data/shared/src/main/scala/kyo/Record.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Record.scala
@@ -10,7 +10,6 @@ import scala.compiletime.summonInline
 import scala.deriving.Mirror
 import scala.language.dynamics
 import scala.language.implicitConversions
-import scala.util.NotGiven
 
 /** A type-safe, immutable record structure that maps field names to values. Records solve the common need to work with flexible key-value
   * structures while maintaining type safety at compile time. Unlike traditional maps or case classes, Records allow dynamic field

--- a/kyo-data/shared/src/main/scala/kyo/Render.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Render.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import scala.annotation.nowarn
 import scala.language.implicitConversions
 
 /** Provides Text representation of a type. Needed for customizing how to display opaque types as alternative to toString

--- a/kyo-data/shared/src/main/scala/kyo/Result.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Result.scala
@@ -2,7 +2,6 @@ package kyo
 
 import Result.*
 import scala.annotation.implicitNotFound
-import scala.annotation.targetName
 import scala.util.Try
 import scala.util.control.NonFatal
 

--- a/kyo-data/shared/src/main/scala/kyo/internal/TypeIntersection.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/TypeIntersection.scala
@@ -1,9 +1,6 @@
 package kyo.internal
 
 import TypeIntersection.*
-import scala.annotation.implicitNotFound
-import scala.compiletime.erasedValue
-import scala.compiletime.summonAll
 import scala.compiletime.summonInline
 import scala.quoted.*
 

--- a/kyo-data/shared/src/test/scala/kyo/RecordTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/RecordTest.scala
@@ -1,7 +1,6 @@
 package kyo
 
 import Record.Field
-import kyo.Record.AsRecord.FieldsOf
 import kyo.internal.TypeIntersection
 
 class RecordTest extends Test:
@@ -609,25 +608,23 @@ class RecordTest extends Test:
         }
 
         "AsFields behavior" - {
-            import Record.AsFields
-
             val error = "No given instance of type kyo.AsFieldsInternal.HasAsField"
 
             "summoning AsFields instance" in {
                 typeCheckFailure("""
-                    summon[AsFields[Int & "name" ~ String & "age" ~ Int]]
+                    summon[Record.AsFields[Int & "name" ~ String & "age" ~ Int]]
                 """)(error)
             }
 
             "AsFields with multiple raw types" in {
                 typeCheckFailure("""
-                    AsFields[Int & Boolean & "value" ~ String & String]
+                    Record.AsFields[Int & Boolean & "value" ~ String & String]
                 """)(error)
             }
 
             "AsFields with duplicate field names" in {
                 typeCheckFailure("""
-                   AsFields[Int & "value" ~ String & "value" ~ Int]
+                   Record.AsFields[Int & "value" ~ String & "value" ~ Int]
                 """)(error)
             }
 

--- a/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ResultTest.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import java.io.IOException
 import kyo.Result
 import kyo.Result.*
 import scala.util.Try

--- a/kyo-data/shared/src/test/scala/kyo/TagTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/TagTest.scala
@@ -4,8 +4,6 @@ import izumi.reflect.Tag as ITag
 import kyo.*
 import kyo.Tag.Intersection
 import kyo.Tag.Union
-import org.scalatest.NonImplicitAssertions
-import org.scalatest.freespec.AsyncFreeSpec
 import scala.annotation.nowarn
 
 class TagTest extends Test:

--- a/kyo-direct/shared/src/main/scala/kyo/Validate.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/Validate.scala
@@ -2,7 +2,6 @@ package kyo
 
 import kyo.Ansi.*
 import scala.quoted.*
-import scala.util.control.NonFatal
 
 private[kyo] object Validate:
     def apply(expr: Expr[Any])(using Quotes): Unit =

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -1,8 +1,5 @@
 package kyo
 
-import org.scalatest.Assertions
-import org.scalatest.freespec.AnyFreeSpec
-
 class HygieneTest extends Test:
 
     "use of var" in {

--- a/kyo-direct/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/Test.scala
@@ -6,7 +6,6 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-kernel/jvm/src/test/scala/kyo/kernel/internal/TracePoolConcurrencyTest.scala
+++ b/kyo-kernel/jvm/src/test/scala/kyo/kernel/internal/TracePoolConcurrencyTest.scala
@@ -1,11 +1,7 @@
 package kyo.kernel.internal
 
 import java.util.concurrent.Executors
-import kyo.Frame
-import kyo.Tagged.*
 import kyo.Test
-import kyo.discard
-import scala.concurrent.Future
 
 class TracePoolConcurrencyTest extends Test:
 

--- a/kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala
@@ -5,7 +5,6 @@ import kyo.*
 import kyo.kernel.Platform
 import scala.annotation.targetName
 import scala.concurrent.Future
-import scala.util.Try
 
 private[kyo] trait BaseKyoKernelTest[S] extends BaseKyoDataTest:
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Isolate.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Isolate.scala
@@ -1,12 +1,8 @@
 package kyo.kernel
 
 import kyo.Ansi.*
-import kyo.Const
 import kyo.Flat
 import kyo.Frame
-import kyo.Maybe
-import kyo.Tag
-import kyo.internal.TypeIntersection
 import kyo.kernel.internal.*
 import scala.annotation.nowarn
 import scala.quoted.*

--- a/kyo-kernel/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/Test.scala
@@ -2,13 +2,11 @@ package kyo
 
 import kyo.internal.BaseKyoKernelTest
 import kyo.kernel.Platform
-import org.scalatest.Assertion
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.compiletime.testing.typeCheckErrors
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.util.Try
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoKernelTest[Any]:
 

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/TracePoolTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/TracePoolTest.scala
@@ -1,11 +1,8 @@
 package kyo.kernel.internal
 
-import java.util.concurrent.Executors
 import kyo.Frame
 import kyo.Tagged.*
 import kyo.Test
-import kyo.discard
-import scala.concurrent.Future
 
 class TracePoolTest extends Test:
 

--- a/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
+++ b/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
@@ -1,10 +1,7 @@
 package kyo
 
 import java.lang.foreign.{Arena as JArena, *}
-import scala.annotation.implicitNotFound
 import scala.annotation.tailrec
-import scala.deriving.Mirror
-import scala.math.Numeric.Implicits.infixNumericOps
 
 /** Memory provides a safe, effect-tracked interface for off-heap memory management.
   *

--- a/kyo-offheap/shared/src/test/scala/kyo/MemoryTest.scala
+++ b/kyo-offheap/shared/src/test/scala/kyo/MemoryTest.scala
@@ -1,8 +1,6 @@
 package kyo
 
-import kyo.Emit.valueWith
 import kyo.Memory.Unsafe
-import kyo.internal.LayerMacros.Validated.succeed
 
 class MemoryTest extends Test:
 

--- a/kyo-offheap/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-offheap/shared/src/test/scala/kyo/Test.scala
@@ -6,7 +6,6 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-prelude/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/Test.scala
@@ -2,13 +2,11 @@ package kyo
 
 import kyo.internal.BaseKyoKernelTest
 import kyo.kernel.Platform
-import org.scalatest.Assertion
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.compiletime.testing.typeCheckErrors
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.util.Try
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoKernelTest[Abort[Throwable]]:
 

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -4,8 +4,6 @@ import StreamSubscription.*
 import java.util.concurrent.Flow.*
 import kyo.*
 import kyo.kernel.ArrowEffect
-import kyo.scheduler.IOPromise
-import kyo.scheduler.IOTask
 
 final private[kyo] class StreamSubscription[V, S](
     private val stream: Stream[V, S & IO],

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/Test.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/Test.scala
@@ -6,7 +6,6 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
@@ -1,7 +1,6 @@
 package kyo.interop.flow
 
 import kyo.*
-import kyo.Duration
 import kyo.Result.Failure
 import kyo.Result.Success
 import kyo.interop.flow.StreamSubscriber.EmitStrategy

--- a/kyo-scheduler-pekko/jvm/src/test/scala/kyo/scheduler/KyoExecutorServiceConfiguratorTest.scala
+++ b/kyo-scheduler-pekko/jvm/src/test/scala/kyo/scheduler/KyoExecutorServiceConfiguratorTest.scala
@@ -1,13 +1,11 @@
 package kyo.scheduler
 
 import com.typesafe.config.ConfigFactory
-import java.util.concurrent.CountDownLatch
 import org.apache.pekko.actor.Actor
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.actor.Props
 import org.apache.pekko.pattern.ask
 import org.apache.pekko.testkit.TestKit
-import org.apache.pekko.testkit.TestProbe
 import org.apache.pekko.util.Timeout
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.NonImplicitAssertions
@@ -15,7 +13,6 @@ import org.scalatest.freespec.AnyFreeSpecLike
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.concurrent.Promise
 import scala.concurrent.duration.*
 
 class KyoExecutorServiceConfiguratorTest

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -18,7 +18,6 @@ import kyo.scheduler.top.Reporter
 import kyo.scheduler.top.Status
 import kyo.scheduler.util.Flag
 import kyo.scheduler.util.LoomSupport
-import kyo.scheduler.util.Singleton
 import kyo.scheduler.util.Threads
 import kyo.scheduler.util.XSRandom
 import scala.annotation.nowarn

--- a/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/SchedulerTest.scala
+++ b/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/SchedulerTest.scala
@@ -2,8 +2,6 @@ package kyo.scheduler
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
 import kyo.scheduler.util.Threads
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.concurrent.Eventually.*

--- a/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/SchedulerSingletonTest.scala
+++ b/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/SchedulerSingletonTest.scala
@@ -3,7 +3,6 @@ package kyo.scheduler
 import java.net.URL
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit

--- a/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/util/SingletonTest.scala
+++ b/kyo-scheduler/jvm/src/test/scala/kyo/scheduler/util/SingletonTest.scala
@@ -4,12 +4,10 @@ import java.net.URL
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AnyFreeSpec
-import scala.util.Random
 
 class TestInstance(val value: Int)
 class TestSingleton extends Singleton[TestInstance] {

--- a/kyo-stats-otel/shared/src/test/scala/kyo/stats/otel/Test.scala
+++ b/kyo-stats-otel/shared/src/test/scala/kyo/stats/otel/Test.scala
@@ -6,7 +6,6 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest {
 

--- a/kyo-stm/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/Test.scala
@@ -6,7 +6,6 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-sttp/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/Test.scala
@@ -6,7 +6,6 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-tapir/shared/src/test/scala/kyo/server/Test.scala
+++ b/kyo-tapir/shared/src/test/scala/kyo/server/Test.scala
@@ -6,7 +6,6 @@ import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 

--- a/kyo-zio/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/Test.scala
@@ -3,10 +3,8 @@ package kyo
 import kyo.internal.BaseKyoCoreTest
 import kyo.kernel.Platform
 import org.scalatest.NonImplicitAssertions
-import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 


### PR DESCRIPTION

### Problem

We can't enable the compiler option to warn unused imports due to increased compilation times

### Solution

Periodic cleanup of the codebase with the flag enabled.

