### PR TITLE
[build] attempt to enable Native tests again

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -30,4 +30,4 @@ jobs:
       run: sbt '+kyoJS/test'
 
     - name: Build Native
-      run: sbt '+kyoNative/Test/compile' # test
+      run: sbt '+kyoNative/test'

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -34,4 +34,4 @@ jobs:
       run: sbt '+kyoJS/testQuick'
 
     - name: Build Native
-      run: sbt '+kyoNative/Test/compile' # testQuick
+      run: sbt '+kyoNative/testQuick' 


### PR DESCRIPTION

### Problem

We disabled the Scala Native tests some time ago. It's a problem since we might not catch potential issues with changes.

### Solution

I couldn't identify why we were seeing timeouts before but I did a quick test in main and the build passed. I think we can try again and see how it goes.

