### PR TITLE
[offheap] reintroduce inlining

### DIFF
--- a/kyo-offheap/native/src/main/java/lang/foreign/MemorySegment.scala
+++ b/kyo-offheap/native/src/main/java/lang/foreign/MemorySegment.scala
@@ -177,23 +177,23 @@ object ValueLayout:
     trait OfFloat   extends ValueLayout
     trait OfDouble  extends ValueLayout
 
-    case object JAVA_BOOLEAN extends OfBoolean:
+    val JAVA_BOOLEAN = new OfBoolean:
         val byteSize = sizeOf[CBool]
-    case object JAVA_BYTE extends OfByte:
+    val JAVA_BYTE = new OfByte:
         val byteSize = sizeOf[Byte]
-    case object JAVA_CHAR extends OfChar:
+    val JAVA_CHAR = new OfChar:
         val byteSize = sizeOf[CChar]
-    case object JAVA_SHORT extends OfShort:
+    val JAVA_SHORT = new OfShort:
         val byteSize = sizeOf[CShort]
-    case object JAVA_INT extends OfInt:
+    val JAVA_INT = new OfInt:
         val byteSize = sizeOf[CInt]
-    case object JAVA_LONG extends OfLong:
+    val JAVA_LONG = new OfLong:
         val byteSize = sizeOf[CLong]
-    case object JAVA_FLOAT extends OfFloat:
+    val JAVA_FLOAT = new OfFloat:
         val byteSize = sizeOf[CFloat]
-    case object JAVA_DOUBLE extends OfDouble:
+    val JAVA_DOUBLE = new OfDouble:
         val byteSize = sizeOf[CDouble]
-    case object ADDRESS extends AddressLayout:
+    val ADDRESS = new AddressLayout:
         val byteSize = sizeOf[Ptr[Byte]]
 end ValueLayout
 

--- a/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
+++ b/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
@@ -59,7 +59,7 @@ object Memory:
       * @return
       *   The result of applying f to the new memory segment
       */
-    def initWith[A: Layout as l](size: Int)[B, S](f: Memory[A] => B < S)(using frame: Frame): B < (Arena & S) =
+    def initWith[A: Layout as l](size: Int)[B, S](f: Memory[A] => B < S)(using Frame): B < (Arena & S) =
         Arena.use { arena =>
             IO.Unsafe(f(arena.allocate(l.size * size)))
         }
@@ -73,7 +73,7 @@ object Memory:
           * @return
           *   The element at the specified index
           */
-        def get(index: Int)(using Frame): A < Arena =
+        inline def get(index: Int)(using inline frame: Frame): A < Arena =
             IO.Unsafe {
                 // TODO inference issue without the val
                 val x = Unsafe.get(self)(index)
@@ -88,7 +88,7 @@ object Memory:
           * @param value
           *   The value to write
           */
-        def set(index: Int, value: A)(using Frame): Unit < Arena =
+        inline def set(index: Int, value: A)(using inline frame: Frame): Unit < Arena =
             IO.Unsafe(Unsafe.set(self)(index, value))
 
         /** Fills the entire memory segment with the specified value.
@@ -96,7 +96,7 @@ object Memory:
           * @param value
           *   The value to fill with
           */
-        def fill(value: A)(using frame: Frame): Unit < Arena =
+        inline def fill(value: A)(using inline frame: Frame): Unit < Arena =
             IO.Unsafe(Unsafe.fill(self)(value))
 
         /** Folds over all elements in the memory segment.
@@ -108,7 +108,7 @@ object Memory:
           * @return
           *   The final accumulated value
           */
-        def fold[B](zero: B)(f: (B, A) => B)(using Frame): B < Arena =
+        inline def fold[B](zero: B)(f: (B, A) => B)(using inline frame: Frame): B < Arena =
             IO.Unsafe(Unsafe.fold(self)(zero)(f))
 
         /** Finds the index of the first element satisfying the predicate.
@@ -118,7 +118,7 @@ object Memory:
           * @return
           *   The index wrapped in Maybe, or Absent if not found
           */
-        def findIndex(p: A => Boolean)(using Frame): Maybe[Int] < Arena =
+        inline def findIndex(p: A => Boolean)(using inline frame: Frame): Maybe[Int] < Arena =
             IO.Unsafe(Unsafe.findIndex(self)(p))
 
         /** Checks if any element satisfies the predicate.
@@ -128,7 +128,7 @@ object Memory:
           * @return
           *   true if any element satisfies the predicate
           */
-        def exists(p: A => Boolean)(using Frame): Boolean < Arena =
+        inline def exists(p: A => Boolean)(using inline frame: Frame): Boolean < Arena =
             IO.Unsafe(Unsafe.exists(self)(p))
 
         /** Creates a view of a portion of this memory segment.
@@ -208,13 +208,13 @@ object Memory:
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         extension [A: Layout as l](self: Unsafe[A])
-            def get(index: Int)(using AllowUnsafe): A =
+            inline def get(index: Int)(using AllowUnsafe): A =
                 l.get(self, index * l.size)
 
-            def set(index: Int, value: A)(using AllowUnsafe): Unit =
+            inline def set(index: Int, value: A)(using AllowUnsafe): Unit =
                 l.set(self, index * l.size, value)
 
-            def fill(value: A)(using AllowUnsafe): Unit =
+            inline def fill(value: A)(using AllowUnsafe): Unit =
                 val len = size
                 @tailrec def loop(i: Int): Unit =
                     if i < len then
@@ -223,7 +223,7 @@ object Memory:
                 loop(0)
             end fill
 
-            def fold[B](z: B)(f: (B, A) => B)(using AllowUnsafe): B =
+            inline def fold[B](z: B)(inline f: (B, A) => B)(using AllowUnsafe): B =
                 val len = size
                 @tailrec def loop(i: Int, acc: B): B =
                     if i < len then
@@ -232,7 +232,7 @@ object Memory:
                 loop(0, z)
             end fold
 
-            def findIndex(f: A => Boolean)(using AllowUnsafe): Maybe[Int] =
+            inline def findIndex(inline f: A => Boolean)(using AllowUnsafe): Maybe[Int] =
                 val len = size
                 @tailrec def loop(i: Int): Maybe[Int] =
                     if i < len then
@@ -242,7 +242,7 @@ object Memory:
                 loop(0)
             end findIndex
 
-            def exists(f: A => Boolean)(using AllowUnsafe): Boolean =
+            inline def exists(inline f: A => Boolean)(using AllowUnsafe): Boolean =
                 findIndex(f) match
                     case Present(_) => true
                     case Absent     => false
@@ -268,8 +268,8 @@ object Memory:
 
     /** Defines how values of type A are laid out in memory. */
     abstract class Layout[A]:
-        def get(memory: Unsafe[A], offset: Long)(using AllowUnsafe): A
-        def set(memory: Unsafe[A], offset: Long, value: A)(using AllowUnsafe): Unit
+        inline def get(memory: Unsafe[A], offset: Long)(using AllowUnsafe): A
+        inline def set(memory: Unsafe[A], offset: Long, value: A)(using AllowUnsafe): Unit
         def size: Long
     end Layout
 
@@ -278,49 +278,49 @@ object Memory:
         import ValueLayout.*
 
         given Layout[Byte] with
-            def get(memory: Unsafe[Byte], offset: Long)(using AllowUnsafe): Byte =
+            inline def get(memory: Unsafe[Byte], offset: Long)(using AllowUnsafe): Byte =
                 memory.get(JAVA_BYTE, offset)
-            def set(memory: Unsafe[Byte], offset: Long, value: Byte)(using AllowUnsafe): Unit =
+            inline def set(memory: Unsafe[Byte], offset: Long, value: Byte)(using AllowUnsafe): Unit =
                 memory.set(JAVA_BYTE, offset, value)
             def size = JAVA_BYTE.byteSize
         end given
 
         given Layout[Short] with
-            def get(memory: Unsafe[Short], offset: Long)(using AllowUnsafe): Short =
+            inline def get(memory: Unsafe[Short], offset: Long)(using AllowUnsafe): Short =
                 memory.get(JAVA_SHORT, offset)
-            def set(memory: Unsafe[Short], offset: Long, value: Short)(using AllowUnsafe): Unit =
+            inline def set(memory: Unsafe[Short], offset: Long, value: Short)(using AllowUnsafe): Unit =
                 memory.set(JAVA_SHORT, offset, value)
             def size = JAVA_SHORT.byteSize
         end given
 
         given Layout[Int] with
-            def get(memory: Unsafe[Int], offset: Long)(using AllowUnsafe): Int =
+            inline def get(memory: Unsafe[Int], offset: Long)(using AllowUnsafe): Int =
                 memory.get(JAVA_INT, offset)
-            def set(memory: Unsafe[Int], offset: Long, value: Int)(using AllowUnsafe): Unit =
+            inline def set(memory: Unsafe[Int], offset: Long, value: Int)(using AllowUnsafe): Unit =
                 memory.set(JAVA_INT, offset, value)
             def size = JAVA_INT.byteSize
         end given
 
         given Layout[Long] with
-            def get(memory: Unsafe[Long], offset: Long)(using AllowUnsafe): Long =
+            inline def get(memory: Unsafe[Long], offset: Long)(using AllowUnsafe): Long =
                 memory.get(JAVA_LONG, offset)
-            def set(memory: Unsafe[Long], offset: Long, value: Long)(using AllowUnsafe): Unit =
+            inline def set(memory: Unsafe[Long], offset: Long, value: Long)(using AllowUnsafe): Unit =
                 memory.set(JAVA_LONG, offset, value)
             def size = JAVA_LONG.byteSize
         end given
 
         given Layout[Float] with
-            def get(memory: Unsafe[Float], offset: Long)(using AllowUnsafe): Float =
+            inline def get(memory: Unsafe[Float], offset: Long)(using AllowUnsafe): Float =
                 memory.get(JAVA_FLOAT, offset)
-            def set(memory: Unsafe[Float], offset: Long, value: Float)(using AllowUnsafe): Unit =
+            inline def set(memory: Unsafe[Float], offset: Long, value: Float)(using AllowUnsafe): Unit =
                 memory.set(JAVA_FLOAT, offset, value)
             def size = JAVA_FLOAT.byteSize
         end given
 
         given Layout[Double] with
-            def get(memory: Unsafe[Double], offset: Long)(using AllowUnsafe): Double =
+            inline def get(memory: Unsafe[Double], offset: Long)(using AllowUnsafe): Double =
                 memory.get(JAVA_DOUBLE, offset)
-            def set(memory: Unsafe[Double], offset: Long, value: Double)(using AllowUnsafe): Unit =
+            inline def set(memory: Unsafe[Double], offset: Long, value: Double)(using AllowUnsafe): Unit =
                 memory.set(JAVA_DOUBLE, offset, value)
             def size = JAVA_DOUBLE.byteSize
         end given


### PR DESCRIPTION

### Problem

The `release` workflow is failing in main since https://github.com/getkyo/kyo/pull/1072 got merged. The compiler for some reason has trouble to generate scaladocs after the `inline` keywords were removed.

### Solution

I've tried to understand why the compiler was having trouble with scaladocs but the error messages don't show any meaningful information. I've decided to reintroduce inlining to check if the scaladoc generation would work but it actually continues failing but I think the change still makes sense.
