### PR TITLE
fix: Path#readAll

### DIFF
--- a/kyo-core/jvm/src/main/scala/kyo/Process.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Process.scala
@@ -1,6 +1,9 @@
 package kyo
 
-import java.io.*
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
 import java.lang.Process as JProcess
 import java.lang.ProcessBuilder.Redirect
 import java.lang.System as JSystem

--- a/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
@@ -81,6 +81,19 @@ class PathTest extends Test:
             succeed
         }
 
+        "readAll" in run {
+            val first  = "first.txt"
+            val second = "second.txt"
+            val text   = "text content"
+            val root   = Path()
+            for
+                _ <- useFile(first, text)
+                _ <- useFile(second, text)
+                v <- root.readAll("txt")
+            yield assert(v == List(first -> text, second -> text))
+            end for
+        }
+
         "append to file from string" in run {
             val name = "read-file-string.txt"
             val text = "some text"


### PR DESCRIPTION
### Problem
#1084 

### Solution
> The index parameter is the index of the name element to return. The element that is closest to the root in the directory hierarchy has index 0. The element that is farthest from the root has index [count](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html#getNameCount--)-1.

This will only capture files farthest from the root. We may want to produce a tree structure of some kind later.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
