### PR TITLE
[offheap] disable scaladoc generation to fix build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -342,7 +342,10 @@ lazy val `kyo-offheap` =
         .dependsOn(`kyo-core`)
         .settings(`kyo-settings`)
         .jvmSettings(mimaCheck(false))
-        .nativeSettings(`native-settings`)
+        .nativeSettings(
+            `native-settings`,
+            Compile / doc / sources := Seq.empty
+        )
 
 lazy val `kyo-direct` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform)

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -756,7 +756,7 @@ class AsyncTest extends Test:
                             f(1),
                             f(1)
                         ),
-                        2
+                        3
                     ),
                     f(1)
                 )


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem

The `release` workflow in main is failing because scaladoc generation of the `kyo-offheapNative` project fails with a compiler crash.

### Solution

I've tried to fix the issue again without success so, as a workaround, this PR disables scaladoc generation for the module but only for Native. Given that we direct users to the JVM scaladocs, it shouldn't be an issue.