### PR TITLE
[prelude] introduce Env.getAll/useAll + scaladoc improvements

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Layer.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Layer.scala
@@ -198,7 +198,7 @@ object Layer:
                         {
                             for
                                 leftResult  <- doRun(lhs)
-                                rightResult <- Env.runTypeMap(leftResult)(doRun(rhs))
+                                rightResult <- Env.runAll(leftResult)(doRun(rhs))
                             yield rightResult
                         }.asInstanceOf[Expected]
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Local.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Local.scala
@@ -5,17 +5,38 @@ import kyo.Tag
 import kyo.kernel.*
 import scala.annotation.nowarn
 
-/** Represents a local value that can be accessed and modified within a specific scope.
+/** Represents a context value with a default that can be modified within scopes.
   *
-  * Local provides a way to manage thread-local-like state in a functional manner. There are two types of locals: regular and isolated.
+  * `Local` provides functionality similar to thread-local variables in a functional context. Unlike `Env`, a `Local` value always has a
+  * default and doesn't create a pending effect that must be satisfied. This makes it more suitable for optional contextual values that can
+  * fall back to reasonable defaults when not explicitly provided.
   *
-  * Regular locals behave similarly to inheritable thread locals, where child fibers inherit the value from their parent fiber. Isolated
-  * locals, on the other hand, are similar to non-inheritable thread locals, where child fibers always start with the default value.
+  * Values in a `Local` can be temporarily modified within specific computation scopes using methods like `let` or `update`. These
+  * modifications only affect the specified scope and automatically revert when the computation exits that scope. This scoping behavior
+  * makes `Local` ideal for contextual information that varies within different parts of your application.
+  *
+  * `Local` comes in two variants: regular (inheritable) and non-inheritable. Regular locals pass their values across asynchronous
+  * boundaries, similar to inheritable thread locals, while non-inheritable locals do not, starting with the default value in new async
+  * contexts.
+  *
+  * This effect useful for managing request context information, tracing and logging context, temporary configuration overrides, and user or
+  * tenant context. Choose `Local` when you have context that always has a sensible default value and may need to be modified temporarily.
+  * For required dependencies that must be explicitly provided, `Env` would be the more appropriate choice.
   *
   * @tparam A
   *   The type of the local value
+  *
+  * @see
+  *   [[kyo.Local.init]], [[kyo.Local.initNoninheritable]] for creating Local instances
+  * @see
+  *   [[kyo.Local#get]], [[kyo.Local#use]] for retrieving values
+  * @see
+  *   [[kyo.Local#let]], [[kyo.Local#update]] for modifying values within scopes
+  * @see
+  *   [[kyo.Env]] for required dependencies without defaults
   */
 abstract class Local[A]:
+
     /** The default value for this Local. */
     def default: A
 


### PR DESCRIPTION
### Problem

The `Env` effect doesn't provide a way to obtain multiple values at once. Also, the scaladocs of `Env` and `Local` don't provide a good mental model for when to use the effects since they're similar

### Solution

Introduce `Env.getAll` and `Env.useAll` that allows the user to request multiple values via a type intersection, operating at the level of `TypeMap`. Additionally, improve the scaladocs of `Env` and `Local` to provide a better mental model regarding the effects.

### Notes

- I've renamed `runTypeMap` to `runAll` for consistency