### PR TITLE
Zero-capacity channel

### DIFF
--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -326,7 +326,7 @@ class ChannelTest extends Test:
                 yield assert(result == Chunk(1, 2, 3) && finalSize == 0)
             }
         }
-        "should consider pending puts - zero capacity" in pendingUntilFixed {
+        "should consider pending puts - zero capacity" in run {
             import AllowUnsafe.embrace.danger
             IO.Unsafe.evalOrThrow {
                 for
@@ -338,7 +338,6 @@ class ChannelTest extends Test:
                     finalSize <- c.size
                 yield assert(result == Chunk(1, 2, 3) && finalSize == 0)
             }
-            ()
         }
     }
     "drainUpTo" - {
@@ -397,7 +396,7 @@ class ChannelTest extends Test:
                 yield assert(result == Chunk(1, 2, 3) && finalSize == 1)
             }
         }
-        "should consider pending puts - zero capacity" in pendingUntilFixed {
+        "should consider pending puts - zero capacity" in run {
             import AllowUnsafe.embrace.danger
             IO.Unsafe.evalOrThrow {
                 for
@@ -410,7 +409,6 @@ class ChannelTest extends Test:
                     finalSize <- c.size
                 yield assert(result == Chunk(1, 2, 3) && finalSize == 0)
             }
-            ()
         }
     }
     "close" - {
@@ -684,7 +682,7 @@ class ChannelTest extends Test:
         "putBatch and take" in run {
             (for
                 size    <- Choice.get(Seq(0, 1, 2, 10, 100))
-                channel <- Channel.init[Int](size)
+                channel <- Channel.init[Int](0)
                 latch   <- Latch.init(1)
 
                 putFiber <- Async.run(


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

Addresses #987 

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

Zero-capacity channels did not function properly since the default implementation expected to be able to offer to and pull from the intermediate queue directly.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Updated `Channel.Unsafe.init` to return a separate implementation of `Channel.Unsafe` when `_capacity == 0`. This new implementation has no `queue`. It's behavior is subtly different in the following ways:
1. Channel closure is tracked by an atomic boolean instead of being tied to the underlying queue (which doesn't exist)
2. Offer and poll interacts with the `puts` and `takes` queues directly
3. flush() handles only two cases: (a) channel is closed, and (b) `puts` and `takes` are both non-empty

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
