### PR TITLE
Correct path separator split. Fixes #1106.

### DIFF
--- a/kyo-core/jvm/src/main/scala/kyo/Path.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Path.scala
@@ -14,6 +14,7 @@ import java.nio.file.*
 import java.nio.file.Files as JFiles
 import java.nio.file.Path as JPath
 import java.nio.file.attribute.BasicFileAttributes
+import java.util.regex.Pattern
 import kyo.*
 import kyo.Tag
 import scala.io.*
@@ -364,7 +365,7 @@ object Path:
         }
         val javaPath       = if flattened.isEmpty then Paths.get("") else Paths.get(flattened.head, flattened.tail*)
         val normalizedPath = javaPath.normalize().toString
-        if normalizedPath.isEmpty then empty else new Path(normalizedPath.split(File.separator).toList)
+        if normalizedPath.isEmpty then empty else new Path(normalizedPath.split(Pattern.quote(File.separator)).toList)
     end apply
 
     def apply(path: Part*): Path =


### PR DESCRIPTION
### Problem
On Windows paths are not correctly splitted, when created from String, because path separator is not correctly escaped. More details in #1106.

### Solution
`File.separator` has to be correctly used for pattern matching regex, `Pattern.quote(File.separator)`
