### PR TITLE
[core] Async.fillIndexed

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -485,7 +485,28 @@ object Async:
     )(n: Int, concurrency: Int = defaultConcurrency)(
         f: => A < (Abort[E] & Async & S)
     )(using Frame): Chunk[A] < (Abort[E] & Async & S) =
-        foreach(0 until n, concurrency)(_ => f)
+        fillIndexed(n, concurrency)(_ => f)
+
+    /** Repeats a computation n times in parallel with index access.
+      *
+      * Similar to `fill`, but provides the current index to the computation function. This is useful when the computation needs to know
+      * which iteration it's processing.
+      *
+      * @param n
+      *   Number of times to repeat the computation
+      * @param concurrency
+      *   Maximum number of concurrent computations (defaults to [[defaultConcurrency]])
+      * @param f
+      *   Function that takes the current index (0 to n-1) and returns a computation
+      * @return
+      *   Chunk containing results of all iterations in index order
+      */
+    def fillIndexed[E, A: Flat, S](
+        using isolate: Isolate.Stateful[S, Abort[E] & Async]
+    )(n: Int, concurrency: Int = defaultConcurrency)(
+        f: Int => A < (Abort[E] & Async & S)
+    )(using Frame): Chunk[A] < (Abort[E] & Async & S) =
+        foreach(0 until n, concurrency)(f)
 
     /** Executes two computations in parallel and returns their results as a tuple.
       */

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -1147,6 +1147,24 @@ class AsyncTest extends Test:
         }
     }
 
+    "fillIndexed" - {
+        "creates n computations with index access" in run {
+            for
+                results <- Async.fillIndexed(5) { i =>
+                    i * 2
+                }
+            yield assert(results == Chunk(0, 2, 4, 6, 8))
+        }
+
+        "handles empty input" in run {
+            for
+                results <- Async.fillIndexed(0) { i =>
+                    fail(s"Should not be called with i=$i")
+                }
+            yield assert(results.isEmpty)
+        }
+    }
+
     "memoize" - {
         "caches successful results" in run {
             for


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem

`Async.foreach(0 until n)(idx => ...)` is a common pattern to repeat a computation with an index.

### Solution

Add `Async.fillIndexed`.
