### PR TITLE
remove Ops classes

### DIFF
--- a/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Combinators.scala
@@ -419,7 +419,7 @@ extension [A, S, E](effect: A < (Abort[E] & S))
         fl2: Flat[B],
         fr: Frame
     ): B < (Abort[Nothing] & S & S1) =
-        Abort.fold(onSuccess, onFail)(effect)
+        Abort.fold[E](onSuccess, onFail)(effect)
 
     /** Recovers from an Abort failure by applying the provided function.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Retry.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Retry.scala
@@ -28,57 +28,39 @@ object Retry:
         Schedule.exponentialBackoff(initial = 100.millis, factor = 2, maxBackoff = 5.seconds)
             .jitter(0.2).take(3)
 
-    /** Provides retry operations for a specific error type. */
-    final class RetryOps[E >: Nothing](dummy: Unit) extends AnyVal:
-
-        /** Retries an operation using the default retry schedule.
-          *
-          * Uses [[defaultSchedule]] which implements exponential backoff with jitter. See [[defaultSchedule]] for the specific
-          * configuration.
-          *
-          * @param v
-          *   The operation to retry
-          * @return
-          *   The result of the operation, or an abort if all retries fail
-          */
-        def apply[A: Flat, S](v: => A < (Abort[E] & S))(using SafeClassTag[E], Frame): A < (Async & Abort[E] & S) =
-            apply(defaultSchedule)(v)
-
-        /** Retries an operation using a custom policy builder.
-          *
-          * @param builder
-          *   A function that modifies the default policy.
-          * @param v
-          *   The operation to retry.
-          * @return
-          *   The result of the operation, or an abort if all retries fail.
-          */
-        def apply[A: Flat, S](schedule: Schedule)(v: => A < (Abort[E] & S))(
-            using
-            SafeClassTag[E],
-            Frame
-        ): A < (Async & Abort[E] & S) =
-            Abort.run[E](v).map {
-                case Result.Success(value) => value
-                case result: Result.Failure[E] @unchecked =>
-                    Clock.now.map { now =>
-                        schedule.next(now).map { (delay, nextSchedule) =>
-                            Async.delay(delay)(Retry[E](nextSchedule)(v))
-                        }.getOrElse {
-                            Abort.error(result)
-                        }
-                    }
-                case panic: Result.Panic => Abort.error(panic)
-            }
-    end RetryOps
-
-    /** Creates a RetryOps instance for the specified error type.
+    /** Retries an operation using the default retry schedule.
       *
-      * @tparam E
-      *   The error type to handle in retries.
+      * Uses [[defaultSchedule]] which implements exponential backoff with jitter. See [[defaultSchedule]] for the specific configuration.
+      *
+      * @param v
+      *   The operation to retry
       * @return
-      *   A RetryOps instance for the specified error type.
+      *   The result of the operation, or an abort if all retries fail
       */
-    inline def apply[E >: Nothing]: RetryOps[E] = RetryOps(())
+    def apply[E: SafeClassTag](using Frame)[A: Flat, S](v: => A < (Abort[E] & S)): A < (Async & Abort[E] & S) =
+        apply(defaultSchedule)(v)
+
+    /** Retries an operation using a custom policy builder.
+      *
+      * @param builder
+      *   A function that modifies the default policy.
+      * @param v
+      *   The operation to retry.
+      * @return
+      *   The result of the operation, or an abort if all retries fail.
+      */
+    def apply[E: SafeClassTag](using Frame)[A: Flat, S](schedule: Schedule)(v: => A < (Abort[E] & S)): A < (Async & Abort[E] & S) =
+        Abort.run[E](v).map {
+            case Result.Success(value) => value
+            case result: Result.Failure[E] @unchecked =>
+                Clock.now.map { now =>
+                    schedule.next(now).map { (delay, nextSchedule) =>
+                        Async.delay(delay)(Retry[E](nextSchedule)(v))
+                    }.getOrElse {
+                        Abort.error(result)
+                    }
+                }
+            case panic: Result.Panic => Abort.error(panic)
+        }
 
 end Retry

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -123,88 +123,75 @@ object System:
     def let[A, S](system: System)(f: => A < S)(using Frame): A < S =
         local.let(system)(f)
 
-    class EnvOps[A](dummy: Unit) extends AnyVal:
-        /** Retrieves an environment variable.
-          *
-          * @param name
-          *   The name of the environment variable.
-          * @tparam E
-          *   The error type for parsing.
-          * @return
-          *   A `Maybe` containing the parsed value if it exists, or `Maybe.empty` otherwise.
-          */
-        def apply[E](name: String)(
-            using
-            parser: Parser[E, A],
-            frame: Frame,
-            reduce: Reducible[Abort[E]]
-        ): Maybe[A] < (reduce.SReduced & IO) =
-            reduce(local.use(_.env[E, A](name)))
+    /** Retrieves an environment variable.
+      *
+      * @param name
+      *   The name of the environment variable.
+      * @tparam E
+      *   The error type for parsing.
+      * @return
+      *   A `Maybe` containing the parsed value if it exists, or `Maybe.empty` otherwise.
+      */
+    def env[A](using Frame)[E](name: String)(using parser: Parser[E, A], reduce: Reducible[Abort[E]]): Maybe[A] < (reduce.SReduced & IO) =
+        reduce(local.use(_.env[E, A](name)))
 
-        /** Retrieves an environment variable with a default value.
-          *
-          * @param name
-          *   The name of the environment variable.
-          * @param default
-          *   The default value to use if the variable is not found.
-          * @tparam E
-          *   The error type for parsing.
-          * @return
-          *   The parsed value if it exists, or the default value otherwise.
-          */
-        def apply[E](name: String, default: => A)(
-            using
-            parser: Parser[E, A],
-            frame: Frame,
-            reduce: Reducible[Abort[E]]
-        ): A < (reduce.SReduced & IO) =
-            reduce(local.use(_.env[E, A](name).map(_.getOrElse(default))))
+    /** Retrieves an environment variable with a default value.
+      *
+      * @param name
+      *   The name of the environment variable.
+      * @param default
+      *   The default value to use if the variable is not found.
+      * @tparam E
+      *   The error type for parsing.
+      * @return
+      *   The parsed value if it exists, or the default value otherwise.
+      */
+    def env[A](using
+        Frame
+    )[E](name: String, default: => A)(
+        using
+        parser: Parser[E, A],
+        reduce: Reducible[Abort[E]]
+    ): A < (reduce.SReduced & IO) =
+        reduce(local.use(_.env[E, A](name).map(_.getOrElse(default))))
 
-    end EnvOps
+    /** Retrieves a system property.
+      *
+      * @param name
+      *   The name of the system property.
+      * @tparam E
+      *   The error type for parsing.
+      * @return
+      *   A `Maybe` containing the parsed value if it exists, or `Maybe.empty` otherwise.
+      */
+    def property[A](using
+        Frame
+    )[E](name: String)(
+        using
+        parser: Parser[E, A],
+        reduce: Reducible[Abort[E]]
+    ): Maybe[A] < (reduce.SReduced & IO) =
+        reduce(local.use(_.property[E, A](name)))
 
-    def env[A]: EnvOps[A] = EnvOps(())
-
-    class PropertyOps[A](dummy: Unit) extends AnyVal:
-
-        /** Retrieves a system property.
-          *
-          * @param name
-          *   The name of the system property.
-          * @tparam E
-          *   The error type for parsing.
-          * @return
-          *   A `Maybe` containing the parsed value if it exists, or `Maybe.empty` otherwise.
-          */
-        def apply[E](name: String)(
-            using
-            parser: Parser[E, A],
-            frame: Frame,
-            reduce: Reducible[Abort[E]]
-        ): Maybe[A] < (reduce.SReduced & IO) =
-            reduce(local.use(_.property[E, A](name)))
-
-        /** Retrieves a system property with a default value.
-          *
-          * @param name
-          *   The name of the system property.
-          * @param default
-          *   The default value to use if the property is not found.
-          * @tparam E
-          *   The error type for parsing.
-          * @return
-          *   The parsed value if it exists, or the default value otherwise.
-          */
-        def apply[E](name: String, default: => A)(
-            using
-            parser: Parser[E, A],
-            frame: Frame,
-            reduce: Reducible[Abort[E]]
-        ): A < (reduce.SReduced & IO) =
-            reduce(local.use(_.property[E, A](name).map(_.getOrElse(default))))
-
-    end PropertyOps
-
-    def property[A]: PropertyOps[A] = PropertyOps(())
+    /** Retrieves a system property with a default value.
+      *
+      * @param name
+      *   The name of the system property.
+      * @param default
+      *   The default value to use if the property is not found.
+      * @tparam E
+      *   The error type for parsing.
+      * @return
+      *   The parsed value if it exists, or the default value otherwise.
+      */
+    def property[A](using
+        Frame
+    )[E](name: String, default: => A)(
+        using
+        parser: Parser[E, A],
+        reduce: Reducible[Abort[E]]
+    ): A < (reduce.SReduced & IO) =
+        reduce(local.use(_.property[E, A](name).map(_.getOrElse(default))))
 
     /** Retrieves the system-dependent line separator string. */
     def lineSeparator(using Frame): String < IO = local.use(_.lineSeparator)

--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -116,188 +116,160 @@ object Abort:
             case false => value.map(fail)
         }
 
-    final class GetOps[E >: Nothing](dummy: Unit) extends AnyVal:
-
-        /** Lifts an Either into the Abort effect.
-          *
-          * @param either
-          *   The Either to lift
-          * @return
-          *   A computation that succeeds with the Right value or fails with the Left value
-          */
-        inline def apply[A](either: Either[E, A])(using inline frame: Frame): A < Abort[E] =
-            either match
-                case Right(value) => value
-                case Left(value)  => fail(value)
-
-        /** Lifts an Option into the Abort effect with Absent as the failure value.
-          *
-          * @param opt
-          *   The Option to lift
-          * @return
-          *   A computation that succeeds with the Some value or fails with Absent
-          */
-        inline def apply[A](opt: Option[A])(using inline frame: Frame): A < Abort[Absent] =
-            opt match
-                case None    => fail(Absent)
-                case Some(v) => v
-
-        /** Lifts a scala.util.Try into the Abort effect.
-          *
-          * @param e
-          *   The Try to lift
-          * @return
-          *   A computation that succeeds with the Success value or fails with the Failure exception
-          */
-        inline def apply[A](e: scala.util.Try[A])(using inline frame: Frame): A < Abort[Throwable] =
-            e match
-                case scala.util.Success(t) => t
-                case scala.util.Failure(v) => fail(v)
-
-        /** Lifts a Result into the Abort effect.
-          *
-          * @param r
-          *   The Result to lift
-          * @return
-          *   A computation that succeeds with the Success value or fails with the Failure value
-          */
-        inline def apply[E, A](r: Result[E, A])(using inline frame: Frame): A < Abort[E] =
-            r.foldError(identity, Abort.error)
-
-        /** Lifts a Maybe into the Abort effect.
-          *
-          * @param m
-          *   The Maybe to lift
-          * @return
-          *   A computation that succeeds with the Present value or fails with Absent
-          */
-        @targetName("maybe")
-        inline def apply[A](m: Maybe[A])(using inline frame: Frame): A < Abort[Absent] =
-            m.fold(fail(Absent))(identity)
-    end GetOps
-
-    /** Operations for lifting various types into the Abort effect.
+    /** Lifts an Either into the Abort effect.
       *
-      * @tparam E
-      *   The failure type of the Abort effect being run
+      * @param either
+      *   The Either to lift
+      * @return
+      *   A computation that succeeds with the Right value or fails with the Left value
       */
-    inline def get[E >: Nothing]: GetOps[E] = GetOps(())
+    inline def get[E](using inline frame: Frame)[A](either: Either[E, A]): A < Abort[E] =
+        either match
+            case Right(value) => value
+            case Left(value)  => fail(value)
 
-    final private class RunWithOps[E >: Nothing](dummy: Unit) extends AnyVal:
-        /** Runs an Abort effect, converting it to a Result.
-          *
-          * @param v
-          *   The computation to run
-          * @tparam A
-          *   The success type of the computation
-          * @tparam S
-          *   The effect type of the computation
-          * @tparam ER
-          *   Any remaining Abort effects after running this one
-          * @return
-          *   A Result containing either the success value or the failure value, wrapped in the remaining effects
-          */
-        inline def apply[A: Flat, S, ER, B, S2](
-            v: => A < (Abort[E | ER] & S)
-        )(
-            continue: Result[E, A] => B < S2
-        )(
-            using
-            frame: Frame,
-            ct: SafeClassTag[E],
-            reduce: Reducible[Abort[ER]]
-        ): B < (S & reduce.SReduced & S2) =
-            reduce {
-                ArrowEffect.handleCatching[
-                    Const[Error[E]],
-                    Const[Unit],
-                    Abort[E],
-                    Result[E, A],
-                    B,
-                    Abort[ER] & S,
-                    Abort[ER] & S,
-                    S2
-                ](
-                    erasedTag[E],
-                    v.map(Result.succeed[E, A](_))
-                )(
-                    accept = [C] =>
-                        input =>
-                            input.isPanic ||
-                                input.asInstanceOf[Error[Any]].failure.exists(ct.accepts),
-                    handle = [C] => (input, _) => input,
-                    recover =
-                        case ct(fail) if ct <:< SafeClassTag[Throwable] =>
-                            continue(Result.Failure(fail))
-                        case fail =>
-                            continue(Result.Panic(fail)),
-                    done = continue(_)
-                )
-            }
-    end RunWithOps
-
-    /** Runs an Abort effect. This operation handles the Abort effect, converting it into a Result type.
+    /** Lifts an Option into the Abort effect with Absent as the failure value.
+      *
+      * @param opt
+      *   The Option to lift
+      * @return
+      *   A computation that succeeds with the Some value or fails with Absent
       */
-    private inline def runWith[E]: RunWithOps[E] = RunWithOps(())
+    inline def get[A](opt: Option[A])(using inline frame: Frame): A < Abort[Absent] =
+        opt match
+            case None    => fail(Absent)
+            case Some(v) => v
 
-    final class RunOps[E >: Nothing](dummy: Unit) extends AnyVal:
-        /** Runs an Abort effect, converting it to a Result.
-          *
-          * @param v
-          *   The computation to run
-          * @tparam A
-          *   The success type of the computation
-          * @tparam S
-          *   The effect type of the computation
-          * @tparam ER
-          *   Any remaining Abort effects after running this one
-          * @return
-          *   A Result containing either the success value or the failure value, wrapped in the remaining effects
-          */
-        def apply[A: Flat, S, ER](v: => A < (Abort[E | ER] & S))(
-            using
-            frame: Frame,
-            ct: SafeClassTag[E],
-            reduce: Reducible[Abort[ER]]
-        ): Result[E, A] < (S & reduce.SReduced) =
-            runWith[E](v)(identity)
-        end apply
-    end RunOps
-
-    /** Runs an Abort effect. This operation handles the Abort effect, converting it into a Result type.
+    /** Lifts a scala.util.Try into the Abort effect.
+      *
+      * @param e
+      *   The Try to lift
+      * @return
+      *   A computation that succeeds with the Success value or fails with the Failure exception
       */
-    inline def run[E]: RunOps[E] = RunOps(())
+    inline def get[A](e: scala.util.Try[A])(using inline frame: Frame): A < Abort[Throwable] =
+        e match
+            case scala.util.Success(t) => t
+            case scala.util.Failure(v) => fail(v)
 
-    final class RunPartialOps[E >: Nothing](dummy: Unit) extends AnyVal:
-        /** Runs an Abort effect, converting it to a partial Result and leaving panic cases.
-          *
-          * @param v
-          *   The computation to run
-          * @tparam A
-          *   The success type of the computation
-          * @tparam S
-          *   The effect type of the computation
-          * @tparam ER
-          *   Any remaining Abort effects after running this one
-          * @return
-          *   A Result containing either the success value or the failure value, wrapped in the remaining effects
-          */
-        def apply[A: Flat, S, ER](v: => A < (Abort[E | ER] & S))(
-            using
-            frame: Frame,
-            ct: SafeClassTag[E],
-            f2: Flat[Result.Partial[E, A]]
-        ): Result.Partial[E, A] < (S & Abort[ER]) =
-            Abort.runWith[E](v):
-                case panic: Panic                    => Abort.error(panic)
-                case other: Partial[E, A] @unchecked => other
-
-    end RunPartialOps
-
-    /** Runs an Abort effect, handling only Success and Fail cases. This operation handles the Abort effect, converting it into Success or
-      * Fail.
+    /** Lifts a Result into the Abort effect.
+      *
+      * @param r
+      *   The Result to lift
+      * @return
+      *   A computation that succeeds with the Success value or fails with the Failure value
       */
-    inline def runPartial[E]: RunPartialOps[E] = RunPartialOps(())
+    inline def get[E](using inline frame: Frame)[A](r: Result[E, A]): A < Abort[E] =
+        r.foldError(identity, Abort.error)
+
+    /** Lifts a Maybe into the Abort effect.
+      *
+      * @param m
+      *   The Maybe to lift
+      * @return
+      *   A computation that succeeds with the Present value or fails with Absent
+      */
+    @targetName("maybe")
+    inline def get[A](m: Maybe[A])(using inline frame: Frame): A < Abort[Absent] =
+        m.fold(fail(Absent))(identity)
+
+    /** Runs an Abort effect, converting it to a Result.
+      *
+      * @param v
+      *   The computation to run
+      * @tparam A
+      *   The success type of the computation
+      * @tparam S
+      *   The effect type of the computation
+      * @tparam ER
+      *   Any remaining Abort effects after running this one
+      * @return
+      *   A Result containing either the success value or the failure value, wrapped in the remaining effects
+      */
+    inline def runWith[E](
+        using Frame
+    )[A: Flat, S, ER, B, S2](
+        v: => A < (Abort[E | ER] & S)
+    )(
+        continue: Result[E, A] => B < S2
+    )(
+        using
+        ct: SafeClassTag[E],
+        reduce: Reducible[Abort[ER]]
+    ): B < (S & reduce.SReduced & S2) =
+        reduce {
+            ArrowEffect.handleCatching[
+                Const[Error[E]],
+                Const[Unit],
+                Abort[E],
+                Result[E, A],
+                B,
+                Abort[ER] & S,
+                Abort[ER] & S,
+                S2
+            ](
+                erasedTag[E],
+                v.map(Result.succeed[E, A](_))
+            )(
+                accept = [C] =>
+                    input =>
+                        input.isPanic ||
+                            input.asInstanceOf[Error[Any]].failure.exists(ct.accepts),
+                handle = [C] => (input, _) => input,
+                recover =
+                    case ct(fail) if ct <:< SafeClassTag[Throwable] =>
+                        continue(Result.Failure(fail))
+                    case fail =>
+                        continue(Result.Panic(fail)),
+                done = continue(_)
+            )
+        }
+
+    /** Runs an Abort effect, converting it to a Result.
+      *
+      * @param v
+      *   The computation to run
+      * @tparam A
+      *   The success type of the computation
+      * @tparam S
+      *   The effect type of the computation
+      * @tparam ER
+      *   Any remaining Abort effects after running this one
+      * @return
+      *   A Result containing either the success value or the failure value, wrapped in the remaining effects
+      */
+    def run[E](
+        using Frame
+    )[A: Flat, S, ER](v: => A < (Abort[E | ER] & S))(
+        using
+        ct: SafeClassTag[E],
+        reduce: Reducible[Abort[ER]]
+    ): Result[E, A] < (S & reduce.SReduced) =
+        runWith[E](v)(identity)
+
+    /** Runs an Abort effect, converting it to a partial Result and leaving panic cases.
+      *
+      * @param v
+      *   The computation to run
+      * @tparam A
+      *   The success type of the computation
+      * @tparam S
+      *   The effect type of the computation
+      * @tparam ER
+      *   Any remaining Abort effects after running this one
+      * @return
+      *   A Result containing either the success value or the failure value, wrapped in the remaining effects
+      */
+    def runPartial[E](
+        using Frame
+    )[A: Flat, S, ER](v: => A < (Abort[E | ER] & S))(
+        using
+        ct: SafeClassTag[E],
+        f2: Flat[Result.Partial[E, A]]
+    ): Result.Partial[E, A] < (S & Abort[ER]) =
+        Abort.runWith[E](v):
+            case panic: Panic                    => Abort.error(panic)
+            case other: Partial[E, A] @unchecked => other
 
     /** Completely handles an Abort effect, converting it to a partial Result and throwing any Panic exceptions.
       *
@@ -323,61 +295,55 @@ object Abort:
             case Panic(thr)                      => throw thr
             case other: Partial[E, A] @unchecked => other
 
-    final class RecoverOps[E](dummy: Unit) extends AnyVal:
-
-        /** Recovers from an Abort failure by applying the provided function.
-          *
-          * This method allows you to handle failures in an Abort effect and potentially continue the computation with a new value. It only
-          * handles failures of type E and leaves panics unhandled (Abort[Nothing]).
-          *
-          * @param onFail
-          *   A function that takes the failure value of type E and returns a new computation
-          * @param v
-          *   The original computation that may fail
-          * @return
-          *   A computation that either succeeds with the original value or the recovered value
-          */
-        def apply[A: Flat, B: Flat, S, ER](onFail: E => B < S)(v: => A < (Abort[E | ER] & S))(
-            using
-            frame: Frame,
-            ct: SafeClassTag[E],
-            reduce: Reducible[Abort[ER]]
-        ): (A | B) < (S & reduce.SReduced & Abort[Nothing]) =
-            runWith[E](v):
-                case Success(a)   => a
-                case Failure(e)   => onFail(e)
-                case panic: Panic => Abort.error(panic)
-
-        /** Recovers from an Abort failure or panic by applying the provided functions.
-          *
-          * This method allows you to handle both failures and panics in an Abort effect. It provides separate handlers for failures of type
-          * E and for panics (Throwables).
-          *
-          * @param onFail
-          *   A function that takes the failure value of type E and returns a new computation
-          * @param onPanic
-          *   A function that takes a Throwable and returns a new computation
-          * @param v
-          *   The original computation that may fail or panic
-          * @return
-          *   A computation that either succeeds with the original value or the recovered value
-          */
-        def apply[A: Flat, B: Flat, S, ER](onFail: E => B < S, onPanic: Throwable => B < S)(v: => A < (Abort[E | ER] & S))(
-            using
-            frame: Frame,
-            ct: SafeClassTag[E],
-            reduce: Reducible[Abort[ER]]
-        ): (A | B) < (S & reduce.SReduced) =
-            runWith[E](v):
-                case Success(a) => a
-                case Failure(e) => onFail(e)
-                case Panic(thr) => onPanic(thr)
-        end apply
-    end RecoverOps
-
-    /** Provides recovery operations for Abort effects.
+    /** Recovers from an Abort failure by applying the provided function.
+      *
+      * This method allows you to handle failures in an Abort effect and potentially continue the computation with a new value. It only
+      * handles failures of type E and leaves panics unhandled (Abort[Nothing]).
+      *
+      * @param onFail
+      *   A function that takes the failure value of type E and returns a new computation
+      * @param v
+      *   The original computation that may fail
+      * @return
+      *   A computation that either succeeds with the original value or the recovered value
       */
-    inline def recover[E]: RecoverOps[E] = RecoverOps(())
+    def recover[E](
+        using Frame
+    )[A: Flat, B: Flat, S, ER](onFail: E => B < S)(v: => A < (Abort[E | ER] & S))(
+        using
+        ct: SafeClassTag[E],
+        reduce: Reducible[Abort[ER]]
+    ): (A | B) < (S & reduce.SReduced & Abort[Nothing]) =
+        runWith[E](v):
+            case Success(a)   => a
+            case Failure(e)   => onFail(e)
+            case panic: Panic => Abort.error(panic)
+
+    /** Recovers from an Abort failure or panic by applying the provided functions.
+      *
+      * This method allows you to handle both failures and panics in an Abort effect. It provides separate handlers for failures of type E
+      * and for panics (Throwables).
+      *
+      * @param onFail
+      *   A function that takes the failure value of type E and returns a new computation
+      * @param onPanic
+      *   A function that takes a Throwable and returns a new computation
+      * @param v
+      *   The original computation that may fail or panic
+      * @return
+      *   A computation that either succeeds with the original value or the recovered value
+      */
+    def recover[E](
+        using Frame
+    )[A: Flat, B: Flat, S, ER](onFail: E => B < S, onPanic: Throwable => B < S)(v: => A < (Abort[E | ER] & S))(
+        using
+        ct: SafeClassTag[E],
+        reduce: Reducible[Abort[ER]]
+    ): (A | B) < (S & reduce.SReduced) =
+        runWith[E](v):
+            case Success(a) => a
+            case Failure(e) => onFail(e)
+            case Panic(thr) => onPanic(thr)
 
     /** Recovers from an Abort failure by handling Failure cases with a provided function. Does not handle Panic cases, but throws
       * underlying exceptions.
@@ -400,66 +366,61 @@ object Abort:
             case Failure(e) => onFail(e)
             case Panic(thr) => throw thr
 
-    final case class FoldOps[E](dummy: Unit) extends AnyVal:
-        /** Recovers from an Abort failure by applying the provided function.
-          *
-          * This method allows you to handle failures in an Abort effect and potentially continue the computation with a new value. It only
-          * handles failures of type E and leaves panics unhandled (Abort[Nothing]).
-          *
-          * @param onSuccess
-          *   A function that takes the success value of type A and returns a new computation
-          * @param onFail
-          *   A function that takes the failure value of type E and returns a new computation
-          * @param v
-          *   The original computation that may fail
-          * @return
-          *   A computation that either succeeds with the original value or the recovered value
-          */
-        def apply[A: Flat, B: Flat, S, ER](onSuccess: A => B < S, onFail: E => B < S)(v: => A < (Abort[E | ER] & S))(
-            using
-            frame: Frame,
-            ct: SafeClassTag[E]
-        ): B < (S & Abort[ER]) =
-            runWith[E](v):
-                case Success(a)   => onSuccess(a)
-                case Failure(e)   => onFail(e)
-                case panic: Panic => Abort.error(panic)
-
-        /** Recovers from an Abort failure by applying the provided function.
-          *
-          * This method allows you to handle failures and panics in an Abort effect and potentially continue the computation with a new
-          * value.
-          *
-          * @param onSuccess
-          *   A function that takes the success value of type A and returns a new computation
-          * @param onFail
-          *   A function that takes the failure value of type E and returns a new computation
-          * @param onPanic
-          *   A function that takes the throwable panic value and returns a new computation
-          * @param v
-          *   The original computation that may fail
-          * @return
-          *   A computation that either succeeds with the original value or the recovered value
-          */
-        def apply[A: Flat, B: Flat, S, ER](
-            onSuccess: A => B < S,
-            onFail: E => B < S,
-            onPanic: Throwable => B < S
-        )(v: => A < (Abort[E | ER] & S))(
-            using
-            frame: Frame,
-            ct: SafeClassTag[E],
-            reduce: Reducible[Abort[ER]]
-        ): B < (S & reduce.SReduced) =
-            runWith[E](v):
-                case Success(a) => onSuccess(a)
-                case Failure(e) => onFail(e)
-                case Panic(thr) => onPanic(thr)
-    end FoldOps
-
-    /** Provides fold operations for Abort effects.
+    /** Recovers from an Abort failure by applying the provided function.
+      *
+      * This method allows you to handle failures in an Abort effect and potentially continue the computation with a new value. It only
+      * handles failures of type E and leaves panics unhandled (Abort[Nothing]).
+      *
+      * @param onSuccess
+      *   A function that takes the success value of type A and returns a new computation
+      * @param onFail
+      *   A function that takes the failure value of type E and returns a new computation
+      * @param v
+      *   The original computation that may fail
+      * @return
+      *   A computation that either succeeds with the original value or the recovered value
       */
-    inline def fold[E]: FoldOps[E] = FoldOps(())
+    def fold[E](
+        using Frame
+    )[A: Flat, B: Flat, S, ER](
+        onSuccess: A => B < S,
+        onFail: E => B < S
+    )(v: => A < (Abort[E | ER] & S))(using ct: SafeClassTag[E]): B < (S & Abort[ER]) =
+        runWith[E](v):
+            case Success(a)   => onSuccess(a)
+            case Failure(e)   => onFail(e)
+            case panic: Panic => Abort.error(panic)
+
+    /** Recovers from an Abort failure by applying the provided function.
+      *
+      * This method allows you to handle failures and panics in an Abort effect and potentially continue the computation with a new value.
+      *
+      * @param onSuccess
+      *   A function that takes the success value of type A and returns a new computation
+      * @param onFail
+      *   A function that takes the failure value of type E and returns a new computation
+      * @param onPanic
+      *   A function that takes the throwable panic value and returns a new computation
+      * @param v
+      *   The original computation that may fail
+      * @return
+      *   A computation that either succeeds with the original value or the recovered value
+      */
+    def fold[E](
+        using Frame
+    )[A: Flat, B: Flat, S, ER](
+        onSuccess: A => B < S,
+        onFail: E => B < S,
+        onPanic: Throwable => B < S
+    )(v: => A < (Abort[E | ER] & S))(
+        using
+        ct: SafeClassTag[E],
+        reduce: Reducible[Abort[ER]]
+    ): B < (S & reduce.SReduced) =
+        runWith[E](v):
+            case Success(a) => onSuccess(a)
+            case Failure(e) => onFail(e)
+            case Panic(thr) => onPanic(thr)
 
     /** Recovers from an Abort failure by applying the provided function.
       *
@@ -486,52 +447,44 @@ object Abort:
             case Failure(e) => onFail(e)
             case Panic(thr) => throw thr
 
-    final class CatchingOps[E <: Throwable](dummy: Unit) extends AnyVal:
-        /** Catches exceptions of type E and converts them to Abort failures.
-          *
-          * @param v
-          *   The computation to run and catch exceptions from
-          * @tparam A
-          *   The return type of the computation
-          * @tparam S
-          *   The effect type of the computation
-          * @return
-          *   A computation that may fail with an Abort[E] if an exception of type E is caught
-          */
-        def apply[A, S](v: => A < S)(
-            using
-            ct: SafeClassTag[E],
-            frame: Frame
-        ): A < (Abort[E] & S) =
-            Effect.catching(v) {
-                case ct(ex) => Abort.fail(ex)
-                case ex     => Abort.panic(ex)
-            }
-
-        /** Catches exceptions of type E, transforms and converts them to Abort failures.
-          *
-          * @param v
-          *   The computation to run and catch exceptions from
-          * @tparam A
-          *   The return type of the computation
-          * @tparam S
-          *   The effect type of the computation
-          * @return
-          *   A computation that may fail with an Abort[E1] if an exception of type E is caught
-          */
-        def apply[A, S, E1](f: E => E1)(v: => A < S)(
-            using
-            ct: SafeClassTag[E],
-            frame: Frame
-        ): A < (Abort[E1] & S) =
-            Effect.catching(v) {
-                case ct(ex) => Abort.fail(f(ex))
-                case ex     => Abort.panic(ex)
-            }
-    end CatchingOps
-
-    /** Catches exceptions and converts them to Abort failures. This is useful for integrating exception-based code with the Abort effect.
+    /** Catches exceptions of type E and converts them to Abort failures.
+      *
+      * @param v
+      *   The computation to run and catch exceptions from
+      * @tparam A
+      *   The return type of the computation
+      * @tparam S
+      *   The effect type of the computation
+      * @return
+      *   A computation that may fail with an Abort[E] if an exception of type E is caught
       */
-    inline def catching[E <: Throwable]: CatchingOps[E] = CatchingOps(())
+    def catching[E](
+        using Frame
+    )[A, S](v: => A < S)(using ct: SafeClassTag[E]): A < (Abort[E] & S) =
+        Effect.catching(v) {
+            case ct(ex) => Abort.fail(ex)
+            case ex     => Abort.panic(ex)
+        }
+
+    /** Catches exceptions of type E, transforms and converts them to Abort failures.
+      *
+      * @param v
+      *   The computation to run and catch exceptions from
+      * @tparam A
+      *   The return type of the computation
+      * @tparam S
+      *   The effect type of the computation
+      * @return
+      *   A computation that may fail with an Abort[E1] if an exception of type E is caught
+      */
+    def catching[E](
+        using Frame
+    )[A, S, E1](f: E => E1)(v: => A < S)(
+        using ct: SafeClassTag[E]
+    ): A < (Abort[E1] & S) =
+        Effect.catching(v) {
+            case ct(ex) => Abort.fail(f(ex))
+            case ex     => Abort.panic(ex)
+        }
 
 end Abort

--- a/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
@@ -61,128 +61,104 @@ object Emit:
     ): A < (S & Emit[V]) =
         ArrowEffect.suspendWith[Any](tag, value)(_ => f)
 
-    final class RunOps[V](dummy: Unit) extends AnyVal:
-        /** Runs an Emit effect, collecting all emitted values into a Chunk.
-          *
-          * @param v
-          *   The computation with Emit effect
-          * @return
-          *   A tuple of the collected values and the result of the computation
-          */
-        def apply[A: Flat, S](v: A < (Emit[V] & S))(using tag: Tag[Emit[V]], frame: Frame): (Chunk[V], A) < S =
-            ArrowEffect.handleState(tag, Chunk.empty[V], v)(
-                handle = [C] => (input, state, cont) => (state.append(input), cont(())),
-                done = (state, res) => (state, res)
-            )
-    end RunOps
+    /** Runs an Emit effect, collecting all emitted values into a Chunk.
+      *
+      * @param v
+      *   The computation with Emit effect
+      * @return
+      *   A tuple of the collected values and the result of the computation
+      */
+    def run[V](using Frame)[A: Flat, S](v: A < (Emit[V] & S))(using tag: Tag[Emit[V]]): (Chunk[V], A) < S =
+        ArrowEffect.handleState(tag, Chunk.empty[V], v)(
+            handle = [C] => (input, state, cont) => (state.append(input), cont(())),
+            done = (state, res) => (state, res)
+        )
 
-    inline def run[V >: Nothing]: RunOps[V] = RunOps(())
+    /** Runs an Emit effect, folding over the emitted values.
+      *
+      * @param acc
+      *   The initial accumulator value
+      * @param f
+      *   The folding function that takes the current accumulator and emitted value, and returns an updated accumulator
+      * @param v
+      *   The computation with Emit effect
+      * @return
+      *   A tuple of the final accumulator value and the result of the computation
+      */
+    def runFold[V](
+        using Frame
+    )[A, S, B: Flat, S2](acc: A)(f: (A, V) => A < S)(v: B < (Emit[V] & S2))(using tag: Tag[Emit[V]]): (A, B) < (S & S2) =
+        ArrowEffect.handleState(tag, acc, v)(
+            handle = [C] =>
+                (input, state, cont) =>
+                    f(state, input).map(a => (a, cont(()))),
+            done = (state, res) => (state, res)
+        )
 
-    final class RunFoldOps[V](dummy: Unit) extends AnyVal:
-        /** Runs an Emit effect, folding over the emitted values.
-          *
-          * @param acc
-          *   The initial accumulator value
-          * @param f
-          *   The folding function that takes the current accumulator and emitted value, and returns an updated accumulator
-          * @param v
-          *   The computation with Emit effect
-          * @return
-          *   A tuple of the final accumulator value and the result of the computation
-          */
-        def apply[A, S, B: Flat, S2](acc: A)(f: (A, V) => A < S)(v: B < (Emit[V] & S2))(
-            using
-            tag: Tag[Emit[V]],
-            frame: Frame
-        ): (A, B) < (S & S2) =
-            ArrowEffect.handleState(tag, acc, v)(
-                handle = [C] =>
-                    (input, state, cont) =>
-                        f(state, input).map(a => (a, cont(()))),
-                done = (state, res) => (state, res)
-            )
-    end RunFoldOps
+    /** Runs an Emit effect, discarding all emitted values.
+      *
+      * @param v
+      *   The computation with Emit effect
+      * @return
+      *   The result of the computation, discarding emitted values
+      */
+    def runDiscard[V](
+        using Frame
+    )[A: Flat, S](v: A < (Emit[V] & S))(using tag: Tag[Emit[V]]): A < S =
+        ArrowEffect.handle(tag, v)(
+            handle = [C] => (input, cont) => cont(())
+        )
 
-    inline def runFold[V >: Nothing]: RunFoldOps[V] = RunFoldOps(())
+    /** Runs an Emit effect, allowing custom handling of each emitted value.
+      *
+      * @param v
+      *   The computation with Emit effect
+      * @param f
+      *   A function to process each emitted value
+      * @return
+      *   The result of the computation
+      */
+    def runForeach[V](
+        using Frame
+    )[A: Flat, S, S2](v: A < (Emit[V] & S))(f: V => Any < S2)(using tag: Tag[Emit[V]]): A < (S & S2) =
+        ArrowEffect.handle(tag, v)(
+            [C] => (input, cont) => f(input).map(_ => cont(()))
+        )
 
-    final class RunDiscardOps[V](dummy: Unit) extends AnyVal:
-        /** Runs an Emit effect, discarding all emitted values.
-          *
-          * @param v
-          *   The computation with Emit effect
-          * @return
-          *   The result of the computation, discarding emitted values
-          */
-        def apply[A: Flat, S](v: A < (Emit[V] & S))(using tag: Tag[Emit[V]], frame: Frame): A < S =
-            ArrowEffect.handle(tag, v)(
-                handle = [C] => (input, cont) => cont(())
-            )
-    end RunDiscardOps
+    /** Runs an Emit effect, allowing custom handling of each emitted value with a boolean result determining whether to continue.
+      *
+      * @param v
+      *   The computation with Emit effect
+      * @param f
+      *   A function to process each emitted value
+      * @return
+      *   The result of the computation
+      */
+    def runWhile[V](using Frame)[A: Flat, S, S2](v: A < (Emit[V] & S))(f: V => Boolean < S2)(using tag: Tag[Emit[V]]): A < (S & S2) =
+        ArrowEffect.handleState(tag, true, v)(
+            [C] => (input, cond, cont) => if cond then f(input).map(c => (c, cont(()))) else (cond, cont(()))
+        )
 
-    inline def runDiscard[V >: Nothing]: RunDiscardOps[V] = RunDiscardOps(())
-
-    final class RunForeachOps[V](dummy: Unit) extends AnyVal:
-        /** Runs an Emit effect, allowing custom handling of each emitted value.
-          *
-          * @param v
-          *   The computation with Emit effect
-          * @param f
-          *   A function to process each emitted value
-          * @return
-          *   The result of the computation
-          */
-        def apply[A: Flat, S, S2](v: A < (Emit[V] & S))(f: V => Any < S2)(using tag: Tag[Emit[V]], frame: Frame): A < (S & S2) =
-            ArrowEffect.handle(tag, v)(
-                [C] => (input, cont) => f(input).map(_ => cont(()))
-            )
-    end RunForeachOps
-
-    inline def runForeach[V >: Nothing]: RunForeachOps[V] = RunForeachOps(())
-
-    final class RunWhileOps[V](dummy: Unit) extends AnyVal:
-        /** Runs an Emit effect, allowing custom handling of each emitted value with a boolean result determining whether to continue.
-          *
-          * @param v
-          *   The computation with Emit effect
-          * @param f
-          *   A function to process each emitted value
-          * @return
-          *   The result of the computation
-          */
-        def apply[A: Flat, S, S2](v: A < (Emit[V] & S))(f: V => Boolean < S2)(using tag: Tag[Emit[V]], frame: Frame): A < (S & S2) =
-            ArrowEffect.handleState(tag, true, v)(
-                [C] => (input, cond, cont) => if cond then f(input).map(c => (c, cont(()))) else (cond, cont(()))
-            )
-    end RunWhileOps
-
-    inline def runWhile[V >: Nothing]: RunWhileOps[V] = RunWhileOps(())
-
-    final class RunFirstOps[V](dummy: Unit) extends AnyVal:
-
-        /** Runs an Emit effect, capturing only the first emitted value and returning a continuation.
-          *
-          * @param v
-          *   The computation with Emit effect
-          * @return
-          *   A tuple containing:
-          *   - Maybe[V]: The first emitted value if any (None if no values were emitted)
-          *   - A continuation function that returns the remaining computation
-          */
-        def apply[A: Flat, S](v: A < (Emit[V] & S))(using tag: Tag[Emit[V]], frame: Frame): (Maybe[V], () => A < (Emit[V] & S)) < S =
-            ArrowEffect.handleFirst(tag, v)(
-                handle = [C] =>
-                    (input, cont) =>
-                        // Effect found, return the input an continuation
-                        (Maybe(input), () => cont(())),
-                done = r =>
-                    // Effect not found, return empty input and a placeholder continuation
-                    // that returns the result of the computation
-                    (Maybe.empty[V], () => r: A < (Emit[V] & S))
-            )
-        end apply
-    end RunFirstOps
-
-    inline def runFirst[V >: Nothing]: RunFirstOps[V] = RunFirstOps(())
+    /** Runs an Emit effect, capturing only the first emitted value and returning a continuation.
+      *
+      * @param v
+      *   The computation with Emit effect
+      * @return
+      *   A tuple containing:
+      *   - Maybe[V]: The first emitted value if any (None if no values were emitted)
+      *   - A continuation function that returns the remaining computation
+      */
+    def runFirst[V](using Frame)[A: Flat, S](v: A < (Emit[V] & S))(using tag: Tag[Emit[V]]): (Maybe[V], () => A < (Emit[V] & S)) < S =
+        ArrowEffect.handleFirst(tag, v)(
+            handle = [C] =>
+                (input, cont) =>
+                    // Effect found, return the input an continuation
+                    (Maybe(input), () => cont(())),
+            done = r =>
+                // Effect not found, return empty input and a placeholder continuation
+                // that returns the result of the computation
+                (Maybe.empty[V], () => r: A < (Emit[V] & S))
+        )
 
     object isolate:
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
@@ -52,92 +52,77 @@ object Poll:
     ): Maybe[V] < Poll[V] =
         ArrowEffect.suspend[Unit](tag, ())
 
-    final class ValuesOps[V](dummy: Unit) extends AnyVal:
-
-        /** Processes polled values with a function. Values are processed until n is reached or the stream completes.
-          *
-          * @param n
-          *   Maximum number of values to process
-          * @param f
-          *   Function to apply to each value
-          * @return
-          *   A computation that processes values until completion or limit reached
-          */
-        def apply[S](n: Int)(f: V => Any < S)(using tag: Tag[Poll[V]], frame: Frame): Unit < (Poll[V] & S) =
-            Loop.indexed { idx =>
-                if idx == n then Loop.done
-                else
-                    Poll.andMap[V] {
-                        case Present(v) => f(v).map(_ => Loop.continue(()))
-                        case Absent     => Loop.done
-                    }
-            }
-
-        /** Processes polled values with a function until the stream completes.
-          *
-          * @param f
-          *   Function to apply to each value
-          * @return
-          *   A computation that processes values until completion
-          */
-        def apply[S](f: V => Any < S)(using tag: Tag[Poll[V]], frame: Frame): Unit < (Poll[V] & S) =
-            Loop(()) { _ =>
+    /** Processes polled values with a function. Values are processed until n is reached or the stream completes.
+      *
+      * @param n
+      *   Maximum number of values to process
+      * @param f
+      *   Function to apply to each value
+      * @return
+      *   A computation that processes values until completion or limit reached
+      */
+    def values[V](using Frame)[S](n: Int)(f: V => Any < S)(using tag: Tag[Poll[V]]): Unit < (Poll[V] & S) =
+        Loop.indexed { idx =>
+            if idx == n then Loop.done
+            else
                 Poll.andMap[V] {
                     case Present(v) => f(v).map(_ => Loop.continue(()))
                     case Absent     => Loop.done
                 }
+        }
+
+    /** Processes polled values with a function until the stream completes.
+      *
+      * @param f
+      *   Function to apply to each value
+      * @return
+      *   A computation that processes values until completion
+      */
+    def values[V](using Frame)[S](f: V => Any < S)(using tag: Tag[Poll[V]]): Unit < (Poll[V] & S) =
+        Loop(()) { _ =>
+            Poll.andMap[V] {
+                case Present(v) => f(v).map(_ => Loop.continue(()))
+                case Absent     => Loop.done
             }
-    end ValuesOps
+        }
 
-    inline def values[V]: ValuesOps[V] = ValuesOps(())
+    /** Applies a function to the result of polling.
+      *
+      * @param f
+      *   Function to apply to the polled result
+      * @return
+      *   A computation that applies the function to the polled result
+      */
+    inline def andMap[V](
+        using inline frame: Frame
+    )[A, S](f: Maybe[V] => A < S)(
+        using inline tag: Tag[Poll[V]]
+    ): A < (Poll[V] & S) =
+        ArrowEffect.suspendWith[Unit](tag, ())(f)
 
-    final case class AndMapOps[V](dummy: Unit) extends AnyVal:
-
-        /** Applies a function to the result of polling.
-          *
-          * @param f
-          *   Function to apply to the polled result
-          * @return
-          *   A computation that applies the function to the polled result
-          */
-        inline def apply[A, S](f: Maybe[V] => A < S)(
-            using
-            inline tag: Tag[Poll[V]],
-            inline frame: Frame
-        ): A < (Poll[V] & S) =
-            ArrowEffect.suspendWith[Unit](tag, ())(f)
-    end AndMapOps
-
-    def andMap[V]: AndMapOps[V] = AndMapOps(())
-
-    final class FoldOps[V](dummy: Unit) extends AnyVal:
-
-        /** Folds over polled values with an accumulator.
-          *
-          * Processes values from the stream by combining them with an accumulator value. Continues until the stream ends, allowing stateful
-          * processing of the sequence.
-          *
-          * @param acc
-          *   Initial accumulator value
-          * @param f
-          *   Function to combine accumulator with each value
-          * @return
-          *   Final accumulator value after processing all values
-          */
-        def apply[A, S](acc: A)(f: (A, V) => A < S)(
-            using
-            tag: Tag[Poll[V]],
-            frame: Frame
-        ): A < (Poll[V] & S) =
-            Loop(acc) { state =>
-                Poll.andMap[V] {
-                    case Absent     => Loop.done(state)
-                    case Present(v) => f(state, v).map(Loop.continue(_))
-                }
+    /** Folds over polled values with an accumulator.
+      *
+      * Processes values from the stream by combining them with an accumulator value. Continues until the stream ends, allowing stateful
+      * processing of the sequence.
+      *
+      * @param acc
+      *   Initial accumulator value
+      * @param f
+      *   Function to combine accumulator with each value
+      * @return
+      *   Final accumulator value after processing all values
+      */
+    def fold[V](
+        using Frame
+    )[A, S](acc: A)(f: (A, V) => A < S)(
+        using tag: Tag[Poll[V]]
+    ): A < (Poll[V] & S) =
+        Loop(acc) { state =>
+            Poll.andMap[V] {
+                case Absent     => Loop.done(state)
+                case Present(v) => f(state, v).map(Loop.continue(_))
             }
-    end FoldOps
-
-    inline def fold[V]: FoldOps[V] = FoldOps(())
+        }
 
     /** Runs a Poll effect using the provided sequence of values.
       *
@@ -161,36 +146,29 @@ object Poll:
                 (unit, state, cont) => (state.drop(1), cont(state.headMaybe))
         )
 
-    final case class RunFirstOps[V](dummy: Unit) extends AnyVal:
-
-        /** Runs a Poll effect with a single input value, stopping after the first poll operation.
-          *
-          * This method provides a single input value to the Poll effect and stops after the first poll. It returns a continuation function
-          * that can process the Maybe[V] result of the poll
-          *
-          * @param v
-          *   The computation requiring Poll values
-          * @return
-          *   A tuple containing the acknowledgement and a continuation function that processes the poll result
-          */
-        def apply[A: Flat, S](v: A < (Poll[V] & S))(
-            using
-            tag: Tag[Poll[V]],
-            frame: Frame
-        ): Either[A, Maybe[V] => A < (Poll[V] & S)] < S =
-            ArrowEffect.handleFirst(tag, v)(
-                handle = [C] =>
-                    (input, cont) =>
-                        // Effect found, return the input an continuation
-                        Right(cont),
-                done = r =>
-                    // Effect not found, return empty input and a placeholder continuation
-                    // that returns the result of the computation
-                    Left(r)
-            )
-    end RunFirstOps
-
-    def runFirst[V]: RunFirstOps[V] = RunFirstOps(())
+    /** Runs a Poll effect with a single input value, stopping after the first poll operation.
+      *
+      * This method provides a single input value to the Poll effect and stops after the first poll. It returns a continuation function that
+      * can process the Maybe[V] result of the poll
+      *
+      * @param v
+      *   The computation requiring Poll values
+      * @return
+      *   A tuple containing the acknowledgement and a continuation function that processes the poll result
+      */
+    def runFirst[V](
+        using Frame
+    )[A: Flat, S](v: A < (Poll[V] & S))(using tag: Tag[Poll[V]]): Either[A, Maybe[V] => A < (Poll[V] & S)] < S =
+        ArrowEffect.handleFirst(tag, v)(
+            handle = [C] =>
+                (input, cont) =>
+                    // Effect found, return the input an continuation
+                    Right(cont),
+            done = r =>
+                // Effect not found, return empty input and a placeholder continuation
+                // that returns the result of the computation
+                Left(r)
+        )
 
     /** Connects an emitting source to a polling consumer with flow control.
       *

--- a/kyo-prelude/shared/src/main/scala/kyo/Var.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Var.scala
@@ -51,34 +51,23 @@ object Var:
     inline def get[V](using inline tag: Tag[Var[V]], inline frame: Frame): V < Var[V] =
         use[V](identity)
 
-    final class UseOps[V](dummy: Unit) extends AnyVal:
-        /** Invokes the provided function with the current value of the `Var`.
-          *
-          * @param f
-          *   The function to apply to the current value
-          * @tparam A
-          *   The return type of the function
-          * @tparam S
-          *   Additional effects in the function
-          * @return
-          *   The result of applying the function to the current value
-          */
-        inline def apply[A, S](inline f: V => A < S)(
-            using
-            inline tag: Tag[Var[V]],
-            inline frame: Frame
-        ): A < (Var[V] & S) =
-            ArrowEffect.suspendWith[V](tag, Get: Op[V])(f)
-    end UseOps
-
-    /** Creates a new UseOps instance for the given type V.
+    /** Invokes the provided function with the current value of the `Var`.
       *
-      * @tparam V
-      *   The type of the value stored in the Var
+      * @param f
+      *   The function to apply to the current value
+      * @tparam A
+      *   The return type of the function
+      * @tparam S
+      *   Additional effects in the function
       * @return
-      *   A new UseOps instance
+      *   The result of applying the function to the current value
       */
-    inline def use[V]: UseOps[V] = UseOps(())
+    inline def use[V](
+        using inline frame: Frame
+    )[A, S](inline f: V => A < S)(
+        using inline tag: Tag[Var[V]]
+    ): A < (Var[V] & S) =
+        ArrowEffect.suspendWith[V](tag, Get: Op[V])(f)
 
     /** Sets a new value and returns the previous one.
       *

--- a/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
@@ -35,7 +35,7 @@ object Routes:
       *   A NettyKyoServerBinding wrapped in an asynchronous effect
       */
     def run[A, S](server: NettyKyoServer)(v: Unit < (Routes & S))(using Frame): NettyKyoServerBinding < (Async & S) =
-        Emit.run[Route].apply[Unit, Async & S](v).map { (routes, _) =>
+        Emit.run[Route][Unit, Async & S](v).map { (routes, _) =>
             IO(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Async & S)
         }
     end run


### PR DESCRIPTION
### Problem

We used to use `Ops` classes to encode methods with multiple type parameter groups. The latest versions of the compiler include the new clause interleaving feature that provides a similar mechanism. I was initially reluctant to adopt it because I thought it could make it harder for people reading the codebase to understand the method signatures but there are important drawbacks with the current `Ops` classes:

- The scaladoc generation isn't great because there's the op builder method indirection
- Use of `pipe` with methods using `Ops` classes require an explicit function. For instance, `a.pipe(Abort.run)` doesn't compile but `a.pipe(Abort.run(_))` does.
- The noise of the `Ops` classes makes the code less readable

### Solution

Migrate the all `Ops` classes to clause interleaving. To have some consistency, I used the `Frame` as the implicit to separate type parameter groups since the compiler currently requires parameters between type parameter groups.

### Notes

- There are no changes to the method bodies nor scaladocs.