### PR TITLE
[kernel] rename `pipe` to `handle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ val b: String < IO =
     a.andThen("test")
 ```
 
-The `pipe` method allows for chaining effect handlers without nesting parentheses. It's particularly useful when dealing with multiple effects.
+The `handle` method allows for chaining effect handlers without nesting parentheses. It's particularly useful when dealing with multiple effects.
 
 ```scala
 import kyo.*
@@ -196,23 +196,23 @@ val a: Int < (Abort[String] & Env[Int]) =
         e <- Env.get[Int]
     yield v + e
 
-// Handle effects using `pipe`
+// Handle effects using `handle`
 val b: Result[String, Int] =
-    a.pipe(Abort.run(_))   // Handle Abort
-     .pipe(Env.run(10))    // Handle Env
+    a.handle(Abort.run(_))   // Handle Abort
+     .handle(Env.run(10))    // Handle Env
      .eval                 // Evaluate the computation
 
-// Equivalent without `pipe`
+// Equivalent without `handle`
 val c: Result[String, Int] =
     Env.run(10)(Abort.run(a)).eval
 
-// `pipe` also supports multiple functions
+// `handle` also supports multiple functions
 val d: Result[String, Int] =
-    a.pipe(Abort.run(_), Env.run(10)).eval
+    a.handle(Abort.run(_), Env.run(10)).eval
 
 // Mixing effect handling, 'map' transformation, and 'eval'
 val e: Int =
-    a.pipe(
+    a.handle(
         Abort.run(_),
         Env.run(10),
         _.map(_.getOrElse(24)), // Convert Result to Int

--- a/kyo-actor/shared/src/main/scala/kyo/Actor.scala
+++ b/kyo-actor/shared/src/main/scala/kyo/Actor.scala
@@ -304,7 +304,7 @@ object Actor:
                         case Right(cont) =>
                             mailbox.take.map(v => Loop.continue(cont(Maybe(v))))
                     }
-                }.pipe(
+                }.handle(
                     IO.ensure(mailbox.close), // Ensure mailbox cleanup by closing it when the actor completes or fails
                     Env.run(_subject),        // Provide the actor's Subject to the environment so it can be accessed via Actor.self
                     Resource.run,             // Close used resources

--- a/kyo-cats/shared/src/main/scala/kyo/Cats.scala
+++ b/kyo-cats/shared/src/main/scala/kyo/Cats.scala
@@ -47,7 +47,7 @@ object Cats:
                         Some(CatsIO(fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))).void)
                     }
                 }
-            }.pipe(IO.Unsafe.evalOrThrow)
+            }.handle(IO.Unsafe.evalOrThrow)
         }
     end run
 end Cats

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -732,7 +732,7 @@ object Async:
                                         promise.completeDiscard(r)
                                         Abort.get(r)
                                     }
-                                }.pipe(IO.ensure {
+                                }.handle(IO.ensure {
                                     IO.Unsafe {
                                         if !promise.done() then
                                             ref.set(Absent)

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -135,11 +135,11 @@ object Resource:
                                     .map(_.foldError(_ => (), ex => Log.error("Resource finalizer failed", ex.exception)))
                             }
                                 .unit
-                                .pipe(Async.run[Nothing, Unit, Any])
+                                .handle(Async.run[Nothing, Unit, Any])
                                 .map(p.becomeDiscard)
                     }
                 ContextEffect.handle(Tag[Resource], finalizer, _ => finalizer)(v)
-                    .pipe(IO.ensure(close))
+                    .handle(IO.ensure(close))
                     .map(result => p.get.andThen(result))
             }
         }

--- a/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
@@ -6,7 +6,7 @@ import scala.concurrent.Future
 private[kyo] trait BaseKyoCoreTest extends BaseKyoKernelTest[Abort[Any] & Async & Resource]:
     def run(v: Future[Assertion] < (Abort[Any] & Async & Resource)): Future[Assertion] =
         import AllowUnsafe.embrace.danger
-        v.pipe(
+        v.handle(
             Resource.run,
             Abort.recover[Any] {
                 case ex: Throwable => throw ex

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -70,9 +70,9 @@ class AsyncTest extends Test:
 
         "timeout" in runNotJS {
             Async.sleep(1.day).andThen(1)
-                .pipe(Async.timeout(10.millis))
-                .pipe(Async.runAndBlock(Duration.Infinity))
-                .pipe(Abort.run[Timeout](_))
+                .handle(Async.timeout(10.millis))
+                .handle(Async.runAndBlock(Duration.Infinity))
+                .handle(Abort.run[Timeout](_))
                 .map {
                     case Result.Failure(_: Timeout) => succeed
                     case v                          => fail(v.toString())
@@ -81,8 +81,8 @@ class AsyncTest extends Test:
 
         "block timeout" in runNotJS {
             Async.sleep(1.day).andThen(1)
-                .pipe(Async.runAndBlock(10.millis))
-                .pipe(Abort.run[Timeout](_))
+                .handle(Async.runAndBlock(10.millis))
+                .handle(Abort.run[Timeout](_))
                 .map {
                     case Result.Failure(_: Timeout) => succeed
                     case v                          => fail(v.toString())
@@ -91,8 +91,8 @@ class AsyncTest extends Test:
 
         "multiple fibers timeout" in runNotJS {
             Kyo.fill(100)(Async.sleep(1.milli)).andThen(1)
-                .pipe(Async.runAndBlock(10.millis))
-                .pipe(Abort.run[Timeout](_))
+                .handle(Async.runAndBlock(10.millis))
+                .handle(Abort.run[Timeout](_))
                 .map {
                     case Result.Failure(_: Timeout) => succeed
                     case v                          => fail(v.toString())

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -70,10 +70,11 @@ class AsyncTest extends Test:
 
         "timeout" in runNotJS {
             Async.sleep(1.day).andThen(1)
-                .handle(Async.timeout(10.millis))
-                .handle(Async.runAndBlock(Duration.Infinity))
-                .handle(Abort.run[Timeout])
-                .map {
+                .handle(
+                    Async.timeout(10.millis),
+                    Async.runAndBlock(Duration.Infinity),
+                    Abort.run[Timeout]
+                ).map {
                     case Result.Failure(_: Timeout) => succeed
                     case v                          => fail(v.toString())
                 }
@@ -81,9 +82,10 @@ class AsyncTest extends Test:
 
         "block timeout" in runNotJS {
             Async.sleep(1.day).andThen(1)
-                .handle(Async.runAndBlock(10.millis))
-                .handle(Abort.run[Timeout])
-                .map {
+                .handle(
+                    Async.runAndBlock(10.millis),
+                    Abort.run[Timeout]
+                ).map {
                     case Result.Failure(_: Timeout) => succeed
                     case v                          => fail(v.toString())
                 }
@@ -91,9 +93,10 @@ class AsyncTest extends Test:
 
         "multiple fibers timeout" in runNotJS {
             Kyo.fill(100)(Async.sleep(1.milli)).andThen(1)
-                .handle(Async.runAndBlock(10.millis))
-                .handle(Abort.run[Timeout])
-                .map {
+                .handle(
+                    Async.runAndBlock(10.millis),
+                    Abort.run[Timeout]
+                ).map {
                     case Result.Failure(_: Timeout) => succeed
                     case v                          => fail(v.toString())
                 }

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -72,7 +72,7 @@ class AsyncTest extends Test:
             Async.sleep(1.day).andThen(1)
                 .handle(Async.timeout(10.millis))
                 .handle(Async.runAndBlock(Duration.Infinity))
-                .handle(Abort.run[Timeout](_))
+                .handle(Abort.run[Timeout])
                 .map {
                     case Result.Failure(_: Timeout) => succeed
                     case v                          => fail(v.toString())
@@ -82,7 +82,7 @@ class AsyncTest extends Test:
         "block timeout" in runNotJS {
             Async.sleep(1.day).andThen(1)
                 .handle(Async.runAndBlock(10.millis))
-                .handle(Abort.run[Timeout](_))
+                .handle(Abort.run[Timeout])
                 .map {
                     case Result.Failure(_: Timeout) => succeed
                     case v                          => fail(v.toString())
@@ -92,7 +92,7 @@ class AsyncTest extends Test:
         "multiple fibers timeout" in runNotJS {
             Kyo.fill(100)(Async.sleep(1.milli)).andThen(1)
                 .handle(Async.runAndBlock(10.millis))
-                .handle(Abort.run[Timeout](_))
+                .handle(Abort.run[Timeout])
                 .map {
                     case Result.Failure(_: Timeout) => succeed
                     case v                          => fail(v.toString())

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -555,7 +555,7 @@ class ChannelTest extends Test:
                 assert(drained.isFailure)
                 assert(isClosed)
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -575,7 +575,7 @@ class ChannelTest extends Test:
                 polled      <- pollFiber.get
                 channelSize <- channel.size
             yield assert(offered.count(_.contains(true)) == polled.count(_.toMaybe.flatten.isDefined) + channelSize))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -594,7 +594,7 @@ class ChannelTest extends Test:
                 puts  <- putFiber.get
                 takes <- takeFiber.get
             yield assert(puts.count(_.isSuccess) == takes.count(_.isSuccess) && takes.flatMap(_.toMaybe.toList).toSet == (1 to 100).toSet))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -617,7 +617,7 @@ class ChannelTest extends Test:
                 assert(offered.count(_.contains(true)) == backlog.get.size - size)
                 assert(isClosed)
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -641,7 +641,7 @@ class ChannelTest extends Test:
                 assert(backlog.flatMap(_.toList.flatten).size == offered.count(_.contains(true)))
                 assert(isClosed)
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -677,7 +677,7 @@ class ChannelTest extends Test:
                 assert(totalOffered - totalTaken == backlog.get.size)
                 assert(isClosed)
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -700,7 +700,7 @@ class ChannelTest extends Test:
                 takeRes   <- takeFiber.get
                 finalSize <- channel.size
             yield assert(putRes.flatten.toSet == takeRes.toSet))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -725,7 +725,7 @@ class ChannelTest extends Test:
                 takeRes   <- takeFiber.get
                 finalSize <- channel.size
             yield assert(putRes.flatten.toSet == takeRes.flatten.toSet))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 

--- a/kyo-core/shared/src/test/scala/kyo/HubTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/HubTest.scala
@@ -241,7 +241,7 @@ class HubTest extends Test:
                 assert(subs1.count(_.isSuccess) == pubs.count(_.isSuccess))
                 assert(subs2.count(_.isSuccess) == pubs.count(_.isSuccess))
                 assert(subs3.count(_.isSuccess) == pubs.count(_.isSuccess))
-            ).pipe(Choice.run, _.unit, Loop.repeat(repeats))
+            ).handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -260,7 +260,7 @@ class HubTest extends Test:
                 listeners  <- listenerFiber.get
                 backlog    <- closeFiber.get
                 isClosed   <- hub.closed
-            yield assert(isClosed)).pipe(Choice.run, _.unit, Loop.repeat(repeats))
+            yield assert(isClosed)).handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -133,7 +133,7 @@ class MeterTest extends Test:
                     assert(count == 100)
                     assert(permits == size)
                 )
-                    .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                    .handle(Choice.run, _.unit, Loop.repeat(repeats))
                     .andThen(succeed)
             }
 
@@ -160,7 +160,7 @@ class MeterTest extends Test:
                     assert(count <= 100)
                     assert(available.isFailure)
                 )
-                    .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                    .handle(Choice.run, _.unit, Loop.repeat(repeats))
                     .andThen(succeed)
             }
 
@@ -185,7 +185,7 @@ class MeterTest extends Test:
                     completed   <- Kyo.foreach(runFibers)(_.getResult)
                     count       <- counter.get
                 yield assert(interrupted.count(identity) + completed.count(_.isSuccess) == 100))
-                    .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                    .handle(Choice.run, _.unit, Loop.repeat(repeats))
                     .andThen(succeed)
             }
         }

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -254,7 +254,7 @@ class QueueTest extends Test:
                 assert(drained.isFailure)
                 assert(isClosed)
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -274,7 +274,7 @@ class QueueTest extends Test:
                 polled  <- pollFiber.get
                 left    <- queue.size
             yield assert(offered.count(_.contains(true)) == polled.count(_.toMaybe.flatten.isDefined) + left))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -297,7 +297,7 @@ class QueueTest extends Test:
                 assert(offered.count(_.contains(true)) == backlog.get.size - size)
                 assert(isClosed)
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -321,7 +321,7 @@ class QueueTest extends Test:
                 assert(backlog.flatMap(_.toList.flatten).size == offered.count(_.contains(true)))
                 assert(isClosed)
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -347,7 +347,7 @@ class QueueTest extends Test:
                 assert(offered.count(_.contains(true)) - polled.count(_.toMaybe.flatten.isDefined) == backlog.get.size)
                 assert(isClosed)
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
     }

--- a/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
@@ -55,7 +55,7 @@ class ResourceTest extends Test:
         assert(r2.acquires == 0)
         Async.runAndBlock(timeout)(r)
             .handle(Env.run(1))
-            .handle(Abort.run(_))
+            .handle(Abort.run)
             .handle(IO.Unsafe.evalOrThrow)
         assert(r1.closes == 1)
         assert(r2.closes == 0)
@@ -116,7 +116,7 @@ class ResourceTest extends Test:
         assert(r2.acquires == 0)
         r.handle(Env.run(3))
             .handle(Async.runAndBlock(timeout))
-            .handle(Abort.run(_))
+            .handle(Abort.run)
             .handle(IO.Unsafe.evalOrThrow)
         assert(r1.closes == 1)
         assert(r2.closes == 1)
@@ -146,7 +146,7 @@ class ResourceTest extends Test:
                 r
         io.handle(Resource.run)
             .handle(Async.runAndBlock(timeout))
-            .handle(Abort.run(_))
+            .handle(Abort.run)
             .map { finalizedResource =>
                 finalizedResource.foldError(_.closes.get.map(i => assert(i == 1)), _ => ???)
             }
@@ -159,7 +159,7 @@ class ResourceTest extends Test:
             Resource.ensure(Async.run(closes += 1).map(_.get).unit)
                 .handle(Resource.run)
                 .handle(Async.runAndBlock(timeout))
-                .handle(Abort.run(_))
+                .handle(Abort.run)
                 .map { _ =>
                     assert(closes == 1)
                 }
@@ -178,8 +178,8 @@ class ResourceTest extends Test:
             Resource.acquireRelease(acquire)(release)
                 .handle(Resource.run)
                 .handle(Async.runAndBlock(timeout))
-                .handle(Abort.run[Timeout](_))
-                .handle(Abort.run[Absent](_))
+                .handle(Abort.run[Timeout])
+                .handle(Abort.run[Absent])
                 .map { _ =>
                     assert(closes == 1)
                 }
@@ -190,7 +190,7 @@ class ResourceTest extends Test:
             Resource.acquire(Async.run(r).map(_.get))
                 .handle(Resource.run)
                 .handle(Async.runAndBlock(timeout))
-                .handle(Abort.run(_))
+                .handle(Abort.run)
                 .map { _ =>
                     assert(r.closes == 1)
                 }
@@ -204,7 +204,7 @@ class ResourceTest extends Test:
             val io = Resource.acquireRelease(IO[Int, Any](throw TestException))(_ => Kyo.unit)
             Resource.run(io)
                 .handle(Async.runAndBlock(timeout))
-                .handle(Abort.run(_))
+                .handle(Abort.run)
                 .map {
                     case Result.Panic(t) => assert(t eq TestException)
                     case _               => fail("Expected panic")
@@ -222,7 +222,7 @@ class ResourceTest extends Test:
             }
             Resource.run(io)
                 .handle(Async.runAndBlock(timeout))
-                .handle(Abort.run(_))
+                .handle(Abort.run)
                 .map { _ =>
                     assert(acquired && released)
                 }

--- a/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
@@ -30,7 +30,7 @@ class ResourceTest extends Test:
         val r1 = TestResource(1)
         val r2 = TestResource(2)
         Resource.acquire(r1()).map(_ => assert(r1.closes == 0))
-            .pipe(Resource.run)
+            .handle(Resource.run)
             .map { _ =>
                 assert(r1.closes == 1)
                 assert(r2.closes == 0)
@@ -47,16 +47,16 @@ class ResourceTest extends Test:
             Resource.acquire(r1()).map { _ =>
                 assert(r1.closes == 0)
                 Env.get[Int]
-            }.pipe(Resource.run)
-                .pipe(IO.Unsafe.run)
+            }.handle(Resource.run)
+                .handle(IO.Unsafe.run)
         assert(r1.closes == 0)
         assert(r2.closes == 0)
         assert(r1.acquires == 1)
         assert(r2.acquires == 0)
         Async.runAndBlock(timeout)(r)
-            .pipe(Env.run(1))
-            .pipe(Abort.run(_))
-            .pipe(IO.Unsafe.evalOrThrow)
+            .handle(Env.run(1))
+            .handle(Abort.run(_))
+            .handle(IO.Unsafe.evalOrThrow)
         assert(r1.closes == 1)
         assert(r2.closes == 0)
         assert(r1.acquires == 1)
@@ -67,7 +67,7 @@ class ResourceTest extends Test:
         val r1 = TestResource(1)
         val r2 = TestResource(2)
         Resource.acquire(r1()).map(_ => Resource.acquire(r2()))
-            .pipe(Resource.run)
+            .handle(Resource.run)
             .map { _ =>
                 assert(r1.closes == 1)
                 assert(r2.closes == 1)
@@ -86,7 +86,7 @@ class ResourceTest extends Test:
                 r2 <- Resource.acquire(r2())
                 i2 = r2.id * 5
             yield i1 + i2
-        io.pipe(Resource.run)
+        io.handle(Resource.run)
             .map { r =>
                 assert(r == 13)
                 assert(r1.closes == 1)
@@ -108,16 +108,16 @@ class ResourceTest extends Test:
                 i2 <- Env.get[Int].map(_ * r2.id)
             yield i1 + i2
         val r =
-            io.pipe(Resource.run)
-                .pipe(IO.Unsafe.run)
+            io.handle(Resource.run)
+                .handle(IO.Unsafe.run)
         assert(r1.closes == 0)
         assert(r2.closes == 0)
         assert(r1.acquires == 1)
         assert(r2.acquires == 0)
-        r.pipe(Env.run(3))
-            .pipe(Async.runAndBlock(timeout))
-            .pipe(Abort.run(_))
-            .pipe(IO.Unsafe.evalOrThrow)
+        r.handle(Env.run(3))
+            .handle(Async.runAndBlock(timeout))
+            .handle(Abort.run(_))
+            .handle(IO.Unsafe.evalOrThrow)
         assert(r1.closes == 1)
         assert(r2.closes == 1)
         assert(r1.acquires == 1)
@@ -127,8 +127,8 @@ class ResourceTest extends Test:
     "nested" in run {
         val r1 = TestResource(1)
         Resource.acquire(r1())
-            .pipe(Resource.run)
-            .pipe(Resource.run)
+            .handle(Resource.run)
+            .handle(Resource.run)
             .map { r =>
                 assert(r == r1)
                 assert(r1.acquires == 1)
@@ -144,9 +144,9 @@ class ResourceTest extends Test:
             yield
                 assert(closeCount == 0)
                 r
-        io.pipe(Resource.run)
-            .pipe(Async.runAndBlock(timeout))
-            .pipe(Abort.run(_))
+        io.handle(Resource.run)
+            .handle(Async.runAndBlock(timeout))
+            .handle(Abort.run(_))
             .map { finalizedResource =>
                 finalizedResource.foldError(_.closes.get.map(i => assert(i == 1)), _ => ???)
             }
@@ -157,9 +157,9 @@ class ResourceTest extends Test:
         "ensure" taggedAs jvmOnly in run {
             var closes = 0
             Resource.ensure(Async.run(closes += 1).map(_.get).unit)
-                .pipe(Resource.run)
-                .pipe(Async.runAndBlock(timeout))
-                .pipe(Abort.run(_))
+                .handle(Resource.run)
+                .handle(Async.runAndBlock(timeout))
+                .handle(Abort.run(_))
                 .map { _ =>
                     assert(closes == 1)
                 }
@@ -176,10 +176,10 @@ class ResourceTest extends Test:
                     closes += 1
                 }.map(_.get)
             Resource.acquireRelease(acquire)(release)
-                .pipe(Resource.run)
-                .pipe(Async.runAndBlock(timeout))
-                .pipe(Abort.run[Timeout](_))
-                .pipe(Abort.run[Absent](_))
+                .handle(Resource.run)
+                .handle(Async.runAndBlock(timeout))
+                .handle(Abort.run[Timeout](_))
+                .handle(Abort.run[Absent](_))
                 .map { _ =>
                     assert(closes == 1)
                 }
@@ -188,9 +188,9 @@ class ResourceTest extends Test:
         "acquire" taggedAs jvmOnly in run {
             val r = TestResource(1)
             Resource.acquire(Async.run(r).map(_.get))
-                .pipe(Resource.run)
-                .pipe(Async.runAndBlock(timeout))
-                .pipe(Abort.run(_))
+                .handle(Resource.run)
+                .handle(Async.runAndBlock(timeout))
+                .handle(Abort.run(_))
                 .map { _ =>
                     assert(r.closes == 1)
                 }
@@ -203,8 +203,8 @@ class ResourceTest extends Test:
         "acquire fails" taggedAs jvmOnly in run {
             val io = Resource.acquireRelease(IO[Int, Any](throw TestException))(_ => Kyo.unit)
             Resource.run(io)
-                .pipe(Async.runAndBlock(timeout))
-                .pipe(Abort.run(_))
+                .handle(Async.runAndBlock(timeout))
+                .handle(Abort.run(_))
                 .map {
                     case Result.Panic(t) => assert(t eq TestException)
                     case _               => fail("Expected panic")
@@ -221,8 +221,8 @@ class ResourceTest extends Test:
                 }
             }
             Resource.run(io)
-                .pipe(Async.runAndBlock(timeout))
-                .pipe(Abort.run(_))
+                .handle(Async.runAndBlock(timeout))
+                .handle(Abort.run(_))
                 .map { _ =>
                     assert(acquired && released)
                 }
@@ -262,7 +262,7 @@ class ResourceTest extends Test:
                 val resources = Kyo.foreach(1 to 3)(makeResource)
 
                 for
-                    close <- Async.run(resources.pipe(Resource.run(3)))
+                    close <- Async.run(resources.handle(Resource.run(3)))
                     _     <- latch.await
                     ids   <- close.get
                 yield assert(ids == (1 to 3))
@@ -286,7 +286,7 @@ class ResourceTest extends Test:
                 val resources = Kyo.foreach(1 to 10)(makeResource)
 
                 for
-                    close <- Async.run(resources.pipe(Resource.run(3)))
+                    close <- Async.run(resources.handle(Resource.run(3)))
                     ids   <- close.get
                 yield assert(ids == (1 to 10))
                 end for

--- a/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
@@ -241,7 +241,7 @@ class SignalTest extends Test:
                 _   <- Async.fill(10, 10)(ref.updateAndGet(_ + 1))
                 v   <- ref.get
             yield assert(v == 10))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -268,7 +268,7 @@ class SignalTest extends Test:
                 writeResults <- writers.get
                 finalValue   <- ref.get
             yield assert(readResults.forall(_ == 10) && writeResults.forall(_ == 10) && finalValue == 10))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -24,6 +24,17 @@ import scala.language.implicitConversions
   * The pending type has a single fundamental operation - the monadic bind, which is exposed as both `map` and `flatMap` (for
   * for-comprehension support). Plain values are automatically lifted into the effect context, which means `map` can serve as both `map` and
   * `flatMap`. This allows writing effectful code typically without having to distinguish map from flatMap or manually lifting values.
+  *
+  * Effects are typically handled using their specific `run` methods, such as `Abort.run(computation)` or `Env.run(config)(computation)`.
+  * Each effect provides its own handling mechanism that processes the computation and removes that effect from the type signature.
+  *
+  * The `handle` method offers an alternative approach that enables passing a computation to one or more transformation functions. For
+  * example, instead of `Abort.run(computation)`, one can write `computation.handle(Abort.run)`. The multi-parameter version enables
+  * chaining transformations: `computation.handle(Abort.run, Env.run(config))`. This can be useful when composing multiple effect handlers.
+  *
+  * Beyond effect handlers, `handle` can be used with any function that takes a computation as input. For example,
+  * `computation.handle(Abort.run, _.map(_ + 1))` handles `Abort` and then applies a transformation. While `handle` supports arbitrary
+  * functions, it is primarily designed for effect handling .
   */
 opaque type <[+A, -S] = A | Kyo[A, S]
 
@@ -121,64 +132,111 @@ object `<`:
             unitLoop(v)
         end unit
 
-        /** Applies a sequence of transformations to this computation.
+        /** Applies a transformation to this computation.
+          *
+          * The `handle` method provides a convenient way to pass a computation to a transformation function. It's primarily designed for
+          * effect handling, allowing a more fluent API style compared to the traditional approach of passing the computation to a handler
+          * function.
+          *
+          * For example, instead of:
+          * ```
+          * Env.run(1)(Abort.run(computation))
+          * ```
+          * You can write:
+          * ```
+          * computation.handle(Abort.run, Env.run(1))
+          * ```
+          *
+          * While `handle` can be used with any function that processes a computation, its main purpose is to facilitate effect handling and
+          * composition of multiple handlers. The multi-parameter versions of `handle` enable chaining transformations in a readable
+          * sequential style.
+          *
+          * @param f
+          *   The transformation function to apply
+          * @return
+          *   The result of applying the transformation
           */
-        inline def pipe[B](inline f: (=> A < S) => B)(
+        inline def handle[B](inline f: (=> A < S) => B)(
             using inline flat: WeakFlat[A]
         ): B =
-            def pipe1 = v
-            f(pipe1)
-        end pipe
+            def handle1 = v
+            f(handle1)
+        end handle
 
-        /** Applies a sequence of transformations to this computation.
+        /** Applies two transformations to this computation in sequence.
+          *
+          * Enables chaining multiple effect handlers or transformations in a readable sequential style.
+          *
+          * @return
+          *   The result after applying both transformations
           */
-        inline def pipe[B, C](
+        inline def handle[B, C](
             inline f1: A < S => B,
             inline f2: (=> B) => C
         )(using inline flat: WeakFlat[A]): C =
-            def pipe2 = v.pipe(f1)
-            f2(pipe2)
-        end pipe
+            def handle2 = v.handle(f1)
+            f2(handle2)
+        end handle
 
-        /** Applies a sequence of transformations to this computation.
+        /** Applies three transformations to this computation in sequence.
+          *
+          * Enables chaining multiple effect handlers or transformations in a readable sequential style.
+          *
+          * @return
+          *   The result after applying all transformations in sequence
           */
-        inline def pipe[B, C, D](
+        inline def handle[B, C, D](
             inline f1: A < S => B,
             inline f2: (=> B) => C,
             inline f3: (=> C) => D
         )(using inline flat: WeakFlat[A]): D =
-            def pipe3 = v.pipe(f1, f2)
-            f3(pipe3)
-        end pipe
+            def handle3 = v.handle(f1, f2)
+            f3(handle3)
+        end handle
 
-        /** Applies a sequence of transformations to this computation.
+        /** Applies four transformations to this computation in sequence.
+          *
+          * Enables chaining multiple effect handlers or transformations in a readable sequential style.
+          *
+          * @return
+          *   The result after applying all transformations in sequence
           */
-        inline def pipe[B, C, D, E](
+        inline def handle[B, C, D, E](
             inline f1: A < S => B,
             inline f2: (=> B) => C,
             inline f3: (=> C) => D,
             inline f4: (=> D) => E
         )(using inline flat: WeakFlat[A]): E =
-            def pipe4 = v.pipe(f1, f2, f3)
-            f4(pipe4)
-        end pipe
+            def handle4 = v.handle(f1, f2, f3)
+            f4(handle4)
+        end handle
 
-        /** Applies a sequence of transformations to this computation.
+        /** Applies five transformations to this computation in sequence.
+          *
+          * Enables chaining multiple effect handlers or transformations in a readable sequential style.
+          *
+          * @return
+          *   The result after applying all transformations in sequence
           */
-        inline def pipe[B, C, D, E, F](
+        inline def handle[B, C, D, E, F](
             inline f1: A < S => B,
             inline f2: (=> B) => C,
             inline f3: (=> C) => D,
             inline f4: (=> D) => E,
             inline f5: (=> E) => F
         )(using inline flat: WeakFlat[A]): F =
-            def pipe5 = v.pipe(f1, f2, f3, f4)
-            f5(pipe5)
-        end pipe
+            def handle5 = v.handle(f1, f2, f3, f4)
+            f5(handle5)
+        end handle
 
-        /** Applies a sequence of transformations to this computation.
+        /** Applies six transformations to this computation in sequence.
+          *
+          * Enables chaining multiple effect handlers or transformations in a readable sequential style.
+          *
+          * @return
+          *   The result after applying all transformations in sequence
           */
-        inline def pipe[B, C, D, E, F, G](
+        inline def handle[B, C, D, E, F, G](
             inline f1: A < S => B,
             inline f2: (=> B) => C,
             inline f3: (=> C) => D,
@@ -186,13 +244,13 @@ object `<`:
             inline f5: (=> E) => F,
             inline f6: (=> F) => G
         )(using inline flat: WeakFlat[A]): G =
-            def pipe6 = v.pipe(f1, f2, f3, f4, f5)
-            f6(pipe6)
-        end pipe
+            def handle6 = v.handle(f1, f2, f3, f4, f5)
+            f6(handle6)
+        end handle
 
         /** Applies a sequence of transformations to this computation.
           */
-        inline def pipe[B, C, D, E, F, G, H](
+        inline def handle[B, C, D, E, F, G, H](
             inline f1: A < S => B,
             inline f2: (=> B) => C,
             inline f3: (=> C) => D,
@@ -201,13 +259,13 @@ object `<`:
             inline f6: (=> F) => G,
             inline f7: (=> G) => H
         )(using inline flat: WeakFlat[A]): H =
-            def pipe7 = v.pipe(f1, f2, f3, f4, f5, f6)
-            f7(pipe7)
-        end pipe
+            def handle7 = v.handle(f1, f2, f3, f4, f5, f6)
+            f7(handle7)
+        end handle
 
         /** Applies a sequence of transformations to this computation.
           */
-        inline def pipe[B, C, D, E, F, G, H, I](
+        inline def handle[B, C, D, E, F, G, H, I](
             inline f1: A < S => B,
             inline f2: (=> B) => C,
             inline f3: (=> C) => D,
@@ -217,13 +275,13 @@ object `<`:
             inline f7: (=> G) => H,
             inline f8: (=> H) => I
         )(using inline flat: WeakFlat[A]): I =
-            def pipe8 = v.pipe(f1, f2, f3, f4, f5, f6, f7)
-            f8(pipe8)
-        end pipe
+            def handle8 = v.handle(f1, f2, f3, f4, f5, f6, f7)
+            f8(handle8)
+        end handle
 
         /** Applies a sequence of transformations to this computation.
           */
-        inline def pipe[B, C, D, E, F, G, H, I, J](
+        inline def handle[B, C, D, E, F, G, H, I, J](
             inline f1: A < S => B,
             inline f2: (=> B) => C,
             inline f3: (=> C) => D,
@@ -234,13 +292,13 @@ object `<`:
             inline f8: (=> H) => I,
             inline f9: (=> I) => J
         )(using inline flat: WeakFlat[A]): J =
-            def pipe9 = v.pipe(f1, f2, f3, f4, f5, f6, f7, f8)
-            f9(pipe9)
-        end pipe
+            def handle9 = v.handle(f1, f2, f3, f4, f5, f6, f7, f8)
+            f9(handle9)
+        end handle
 
         /** Applies a sequence of transformations to this computation.
           */
-        inline def pipe[B, C, D, E, F, G, H, I, J, K](
+        inline def handle[B, C, D, E, F, G, H, I, J, K](
             inline f1: A < S => B,
             inline f2: (=> B) => C,
             inline f3: (=> C) => D,
@@ -252,9 +310,9 @@ object `<`:
             inline f9: (=> I) => J,
             inline f10: (=> J) => K
         )(using inline flat: WeakFlat[A]): K =
-            def pipe10 = v.pipe(f1, f2, f3, f4, f5, f6, f7, f8, f9)
-            f10(pipe10)
-        end pipe
+            def handle10 = v.handle(f1, f2, f3, f4, f5, f6, f7, f8, f9)
+            f10(handle10)
+        end handle
 
         private[kyo] inline def evalNow(using inline flat: Flat[A]): Maybe[A] =
             v match

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/PendingTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/PendingTest.scala
@@ -160,29 +160,29 @@ class PendingTest extends Test:
         }
     }
 
-    "pipe" - {
+    "handle" - {
         "applies a function to a pure value" in {
-            val result = (5: Int < Any).pipe(_.map(_ + 1))
+            val result = (5: Int < Any).handle(_.map(_ + 1))
             assert(result.eval == 6)
         }
 
         "applies a function to an effectful value" in {
             val effect: Int < TestEffect = TestEffect(1)
-            val result                   = effect.pipe(v => TestEffect.run(v))
+            val result                   = effect.handle(v => TestEffect.run(v))
             assert(result.eval == 2)
         }
 
         "allows chaining of operations" in {
             val effect: Int < TestEffect = TestEffect(1)
             val result = effect
-                .pipe(v => v.map(_ * 2))
-                .pipe(v => TestEffect.run(v))
+                .handle(v => v.map(_ * 2))
+                .handle(v => TestEffect.run(v))
             assert(result.eval == 4)
         }
 
         "works with functions that return effects" in {
             val effect: Int < TestEffect = TestEffect(1)
-            val result = effect.pipe { v =>
+            val result = effect.handle { v =>
                 TestEffect.run(v).map { x =>
                     TestEffect.run(TestEffect(1))
                 }
@@ -192,17 +192,17 @@ class PendingTest extends Test:
 
         "works with identity function" in {
             val effect: Int < TestEffect = TestEffect(1)
-            val result                   = effect.pipe(identity)
+            val result                   = effect.handle(identity)
             assert(TestEffect.run(result).eval == 2)
         }
 
         "can produce a value instead of a computation" in {
-            val result: Int = TestEffect(1).pipe(TestEffect.run).pipe(_.eval)
+            val result: Int = TestEffect(1).handle(TestEffect.run).handle(_.eval)
             assert(result == 2)
         }
 
         "works with two functions" in {
-            val result = (5: Int < Any).pipe(
+            val result = (5: Int < Any).handle(
                 _.map(_ + 1),
                 _.map(_ * 2)
             )
@@ -210,7 +210,7 @@ class PendingTest extends Test:
         }
 
         "works with three functions" in {
-            val result = (5: Int < Any).pipe(
+            val result = (5: Int < Any).handle(
                 _.map(_ + 1),
                 _.map(_ * 2),
                 _.map(_.toString)
@@ -219,7 +219,7 @@ class PendingTest extends Test:
         }
 
         "works with four functions" in {
-            val result = (5: Int < Any).pipe(
+            val result = (5: Int < Any).handle(
                 _.map(_ + 1),
                 _.map(_ * 2),
                 _.map(_.toString),
@@ -229,7 +229,7 @@ class PendingTest extends Test:
         }
 
         "works with five functions" in {
-            val result = (5: Int < Any).pipe(
+            val result = (5: Int < Any).handle(
                 _.map(_ + 1),
                 _.map(_ * 2),
                 _.map(_.toString),
@@ -240,7 +240,7 @@ class PendingTest extends Test:
         }
 
         "works with six functions" in {
-            val result = (5: Int < Any).pipe(
+            val result = (5: Int < Any).handle(
                 _.map(_ + 1),
                 _.map(_ * 2),
                 _.map(_.toString),
@@ -252,7 +252,7 @@ class PendingTest extends Test:
         }
 
         "works with seven functions" in {
-            val result = (5: Int < Any).pipe(
+            val result = (5: Int < Any).handle(
                 _.map(_ + 1),
                 _.map(_ * 2),
                 _.map(_.toString),
@@ -265,7 +265,7 @@ class PendingTest extends Test:
         }
 
         "works with eight functions" in {
-            val result = (5: Int < Any).pipe(
+            val result = (5: Int < Any).handle(
                 _.map(_ + 1),
                 _.map(_ * 2),
                 _.map(_.toString),
@@ -279,7 +279,7 @@ class PendingTest extends Test:
         }
 
         "works with nine functions" in {
-            val result = (5: Int < Any).pipe(
+            val result = (5: Int < Any).handle(
                 _.map(_ + 1),
                 _.map(_ * 2),
                 _.map(_.toString),
@@ -294,7 +294,7 @@ class PendingTest extends Test:
         }
 
         "works with ten functions" in {
-            val result = (5: Int < Any).pipe(
+            val result = (5: Int < Any).handle(
                 _.map(_ + 1),
                 _.map(_ * 2),
                 _.map(_.toString),
@@ -316,7 +316,7 @@ class PendingTest extends Test:
             typeCheckFailure("effect.map(_ => 1))")(error)
             typeCheckFailure("effect.andThen(1)")(error)
             typeCheckFailure("effect.flatMap(_ => 1)")(error)
-            typeCheckFailure("effect.pipe(_ => 1)")(error)
+            typeCheckFailure("effect.handle(_ => 1)")(error)
             typeCheckFailure("effect.unit")("value unit is not a member of Unit < S < S")
             effect.flatten
         end test

--- a/kyo-monix/shared/src/main/scala/kyo/Monix.scala
+++ b/kyo-monix/shared/src/main/scala/kyo/Monix.scala
@@ -57,7 +57,7 @@ object Monix:
                     cb(r.toEither)
                 }
                 Task(discard(fiber.unsafe.interrupt()))
-            }.pipe(IO.Unsafe.evalOrThrow)
+            }.handle(IO.Unsafe.evalOrThrow)
         }
 
 end Monix

--- a/kyo-prelude/shared/src/main/scala/kyo/Parse.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Parse.scala
@@ -714,7 +714,7 @@ object Parse:
         Tag[Emit[Chunk[A]]]
     ): Stream[A, S & S2 & Abort[ParseFailed]] =
         Stream {
-            input.emit.pipe {
+            input.emit.handle {
                 // Maintains a running buffer of text and repeatedly attempts parsing
                 Emit.runFold[Chunk[Text]](Text.empty) {
                     (acc: Text, curr: Chunk[Text]) =>

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -1178,25 +1178,25 @@ class AbortTest extends Test:
             }
         }
 
-        "with pipe operator" - {
+        "with handle operator" - {
             case class CustomError(message: String) derives CanEqual
 
             "recovers from failures" in {
                 val computation: Int < Abort[CustomError] = Abort.fail(CustomError("Failed"))
-                val result                                = computation.pipe(Abort.recover[CustomError](_ => 42))
+                val result                                = computation.handle(Abort.recover[CustomError](_ => 42))
                 assert(Abort.run(result).eval == Result.succeed(42))
             }
 
             "doesn't affect successful computations" in {
                 val computation: Int < Abort[CustomError] = 10
-                val result                                = computation.pipe(Abort.recover[CustomError](_ => 42))
+                val result                                = computation.handle(Abort.recover[CustomError](_ => 42))
                 assert(Abort.run(result).eval == Result.succeed(10))
             }
 
             "can be chained with other operations" in {
                 val computation: Int < Abort[CustomError] = Abort.fail(CustomError("Failed"))
                 val result = computation
-                    .pipe(Abort.recover[CustomError](_ => 42))
+                    .handle(Abort.recover[CustomError](_ => 42))
                     .map(_ * 2)
 
                 assert(Abort.run(result).eval == Result.succeed(84))
@@ -1205,7 +1205,7 @@ class AbortTest extends Test:
             "works with onPanic" in {
                 val ex                                    = new RuntimeException("Panic!")
                 val computation: Int < Abort[CustomError] = Abort.panic(ex)
-                val result = computation.pipe(Abort.recover[CustomError](
+                val result = computation.handle(Abort.recover[CustomError](
                     onFail = _ => 42,
                     onPanic = _ => -1
                 ))

--- a/kyo-prelude/shared/src/test/scala/kyo/LayerTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/LayerTest.scala
@@ -226,7 +226,7 @@ class LayerTest extends Test:
                 assert(grandchild.parent.age == 10)
 
                 assert(env.size == 1)
-            }.pipe(Memo.run)
+            }.handle(Memo.run)
         }
         "effects" in run {
             class A

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -724,7 +724,7 @@ class StreamTest extends Test:
                 Env.use[Int] { multiplier =>
                     sum += i * multiplier
                 }
-            }.pipe(Env.run(2)).map { _ =>
+            }.handle(Env.run(2)).map { _ =>
                 assert(sum == 30)
             }
         }
@@ -768,7 +768,7 @@ class StreamTest extends Test:
                 Env.use[Int] { multiplier =>
                     sum += chunk.foldLeft(0)(_ + _) * multiplier
                 }
-            }.pipe(Env.run(2)).map { _ =>
+            }.handle(Env.run(2)).map { _ =>
                 assert(sum == 30)
             }
         }

--- a/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
@@ -13,12 +13,12 @@ class DebugTest extends Test:
         Env.run(10) {
             val x = Env.use[Int](_ + 1)
             val y = Env.use[Int](_ * 2)
-            val z = Kyo.zip(x, y).map(_ + _).pipe(Debug(_))
+            val z = Kyo.zip(x, y).map(_ + _).handle(Debug)
             z
         }
 
     def pipeComputation =
-        Env.use[Int](_ + 1).pipe(Env.run(10)).pipe(Debug(_))
+        Env.use[Int](_ + 1).handle(Env.run(10)).handle(Debug)
 
     def nestedDebugComputation = Debug(Debug(42))
 
@@ -102,15 +102,15 @@ class DebugTest extends Test:
 
         "with effects" in
             testOutput(
-                "DebugTest.scala:16:59",
+                "DebugTest.scala:16:61",
                 "31"
             ) {
                 effectsComputation.eval
             }
 
-        "with pipe" in
+        "with handle" in
             testOutput(
-                "DebugTest.scala:21:60",
+                "DebugTest.scala:21:64",
                 "11"
             ) {
                 pipeComputation.eval

--- a/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
@@ -13,12 +13,12 @@ class DebugTest extends Test:
         Env.run(10) {
             val x = Env.use[Int](_ + 1)
             val y = Env.use[Int](_ * 2)
-            val z = Kyo.zip(x, y).map(_ + _).handle(Debug)
+            val z = Kyo.zip(x, y).map(_ + _).handle(Debug(_))
             z
         }
 
-    def pipeComputation =
-        Env.use[Int](_ + 1).handle(Env.run(10)).handle(Debug)
+    def handleComputation =
+        Env.use[Int](_ + 1).handle(Env.run(10), Debug(_))
 
     def nestedDebugComputation = Debug(Debug(42))
 
@@ -108,12 +108,12 @@ class DebugTest extends Test:
                 effectsComputation.eval
             }
 
-        "with handle" in
+        "with pipe" in
             testOutput(
-                "DebugTest.scala:21:64",
+                "DebugTest.scala:21:57",
                 "11"
             ) {
-                pipeComputation.eval
+                handleComputation.eval
             }
 
         "nested Debug calls" in

--- a/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
@@ -503,7 +503,7 @@ class STMTest extends Test:
                 _     <- Async.fill(size, size)(STM.run(ref.update(_ + 1)))
                 value <- STM.run(ref.get)
             yield assert(value == size))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -523,7 +523,7 @@ class STMTest extends Test:
                 reads <- readFiber.get
                 value <- STM.run(ref.get)
             yield assert(value == size && reads.forall(_ <= size)))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -546,7 +546,7 @@ class STMTest extends Test:
                 }
                 value <- STM.run(ref.get)
             yield assert(value == size * 2))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -576,7 +576,7 @@ class STMTest extends Test:
                 }
                 finalStates <- Kyo.collectAll(forks.map(fork => STM.run(fork.get)))
             yield assert(finalStates.forall(identity)))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -626,7 +626,7 @@ class STMTest extends Test:
                 assert(final2 >= 0)
                 assert(final3 >= 0)
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -678,7 +678,7 @@ class STMTest extends Test:
                 assert(final2 >= 0)
                 assert(final3 >= 0)
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
     }

--- a/kyo-stm/shared/src/test/scala/kyo/TChunkTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TChunkTest.scala
@@ -197,7 +197,7 @@ class TChunkTest extends Test:
                 snapshot.length == size &&
                     snapshot.toSet == (1 to size).toSet
             ))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -216,7 +216,7 @@ class TChunkTest extends Test:
                 snapshot.forall(_ % 2 == 0) &&
                     snapshot.length == size / 2
             ))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -240,7 +240,7 @@ class TChunkTest extends Test:
                 snapshot.length <= size / 2 &&
                     snapshot.toSet.subsetOf((1 to size).toSet)
             ))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -260,7 +260,7 @@ class TChunkTest extends Test:
                     snapshot.length == size &&
                     snapshot.toSet == (1 to size).toSet
             ))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
     }

--- a/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
@@ -379,7 +379,7 @@ class TMapTest extends Test:
                 snapshot.size == size &&
                     snapshot.forall((k, v) => k == v && k >= 1 && k <= size)
             ))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -414,7 +414,7 @@ class TMapTest extends Test:
                 assert(snapshot.forall((k, v) => v == k * 2))
                 assert(reads.forall(maybeVal => maybeVal.isEmpty || maybeVal.exists(_ % 2 == 0)))
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -437,7 +437,7 @@ class TMapTest extends Test:
                 snapshot.size == size &&
                     snapshot.forall((_, v) => v == 11) // Initial 1 + 10 increments
             ))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -453,7 +453,7 @@ class TMapTest extends Test:
                 )
                 snapshot <- STM.run(map.snapshot)
             yield assert(snapshot.isEmpty))
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
 
@@ -480,7 +480,7 @@ class TMapTest extends Test:
                 assert(snapshot.forall((_, v) => v % 2 == 0))
                 assert(sums.forall(_ == snapshot.values.sum))
             )
-                .pipe(Choice.run, _.unit, Loop.repeat(repeats))
+                .handle(Choice.run, _.unit, Loop.repeat(repeats))
                 .andThen(succeed)
         }
     }

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -67,7 +67,7 @@ object ZIOs:
                         fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))
                     })
                 }
-            }.pipe(IO.Unsafe.evalOrThrow)
+            }.handle(IO.Unsafe.evalOrThrow)
         }
     end run
 


### PR DESCRIPTION

### Problem

The `pipe` method is convenient for effect handling but I think using it for arbitrary transformations isn't very intuitive. 

### Solution

Rename `pipe` to `handle` to more clearly indicate that the method is meant to be used for effect handling. It still supports arbitrary transformations but the scaladocs are also updated to indicate that it's meant primarily for effect handling.
