### PR TITLE
[prelude] Abort with literal types

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -487,4 +487,72 @@ object Abort:
             case ex     => Abort.panic(ex)
         }
 
+    /** Provides methods for working with literal error values in Abort effects.
+      *
+      * The literal namespace ensures that error types are preserved as singleton types rather than being widened to their base types. This
+      * is particularly useful when you want to maintain precise type information about specific error values.
+      *
+      * For example:
+      * ```scala
+      * val error1 = Abort.fail("error")         // Nothing < Abort[String]
+      * val error2 = Abort.literal.fail("error") // Nothing < Abort["error"]
+      * ```
+      */
+    object literal:
+        /** Fails the computation with a literal value, preserving its singleton type.
+          *
+          * Unlike [[kyo.Abort.fail]], this method preserves the exact literal type of the failure value.
+          *
+          * @param value
+          *   The literal failure value
+          * @return
+          *   A computation that immediately fails with the given literal value, preserving its exact type
+          */
+        inline def fail[V <: Singleton](inline value: V)(using inline frame: Frame): Nothing < Abort[V] =
+            Abort.fail(value)
+
+        /** Fails the computation if the condition is true, using a literal failure value.
+          *
+          * @param b
+          *   The condition to check
+          * @param value
+          *   The literal failure value to use if the condition is true
+          * @return
+          *   A unit computation that may fail with the literal value if the condition is true
+          */
+        inline def when[V <: Singleton, S](b: Boolean < S)(inline value: V)(using inline frame: Frame): Unit < (Abort[V] & S) =
+            Abort.when(b)(value)
+
+        /** Fails the computation if the condition is false, using a literal failure value.
+          *
+          * @param b
+          *   The condition to check
+          * @param value
+          *   The literal failure value to use if the condition is false
+          * @return
+          *   A unit computation that may fail with the literal value if the condition is false
+          */
+        inline def unless[V <: Singleton, S](b: Boolean < S)(inline value: V)(using inline frame: Frame): Unit < (Abort[V] & S) =
+            Abort.unless(b)(value)
+
+        /** Ensures a condition is met before returning the provided result, using a literal failure value.
+          *
+          * @param cond
+          *   The condition to check
+          * @param result
+          *   The result to return if the condition is true
+          * @param value
+          *   The literal failure value to use if the condition is false
+          * @tparam A
+          *   The type of the result
+          * @return
+          *   A computation that succeeds with the result if the condition is true, or fails with the literal value if it's false
+          */
+        inline def ensuring[V <: Singleton, A, S](cond: Boolean < S, result: => A < S)(inline value: V)(using
+            inline frame: Frame
+        ): A < (Abort[V] & S) =
+            Abort.ensuring(cond, result)(value)
+
+    end literal
+
 end Abort

--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -553,6 +553,13 @@ object Abort:
         ): A < (Abort[V] & S) =
             Abort.ensuring(cond, result)(value)
 
+        /** Runs an Abort effect with a literal error type, preserving the singleton type in the Result.
+          */
+        inline def run[V <: Singleton](
+            using Frame
+        )[A: Flat, S](v: => A < (Abort[V] & S)): Result[V, A] < S =
+            Abort.run(v)
+
     end literal
 
 end Abort

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -1216,13 +1216,15 @@ class AbortTest extends Test:
 
     "literal" - {
         "string" in {
-            val result: Nothing < Abort["FAIL!"] = Abort.literal.fail("FAIL!")
-            val _: Nothing < Abort[String]       = result
+            val result                      = Abort.literal.fail("FAIL!")
+            val _: Nothing < Abort["FAIL!"] = result
+            val _: Nothing < Abort[String]  = result
             assert(Abort.run(result).eval == Result.fail("FAIL!"))
         }
 
         "numeric" in {
-            val result: Nothing < Abort[-1] = Abort.literal.fail(-1)
+            val result                 = Abort.literal.fail(-1)
+            val _: Nothing < Abort[-1] = result
             assert(Abort.run(result).eval == Result.fail(-1))
         }
 
@@ -1230,7 +1232,8 @@ class AbortTest extends Test:
             def divide(a: Int, b: Int): Int < Abort["Division by zero"] =
                 Abort.literal.ensuring(b != 0, a / b)("Division by zero")
 
-            val result: Int < Abort["Division by zero"] = divide(1, 0)
+            val result                             = divide(1, 0)
+            val _: Int < Abort["Division by zero"] = result
             assert(Abort.run(result).eval == Result.fail("Division by zero"))
             assert(Abort.run(divide(1, 1)).eval == Result.succeed(1))
         }
@@ -1239,7 +1242,8 @@ class AbortTest extends Test:
             def unless(b: Boolean): Unit < Abort["BOOM"] =
                 Abort.literal.unless(b)("BOOM")
 
-            val result: Unit < Abort["BOOM"] = unless(false)
+            val result                  = unless(false)
+            val _: Unit < Abort["BOOM"] = result
             assert(Abort.run(result).eval == Result.fail("BOOM"))
             assert(Abort.run(unless(true)).eval == Result.unit)
         }
@@ -1248,20 +1252,22 @@ class AbortTest extends Test:
             def when(b: Boolean): Unit < Abort["TOO_BIG"] =
                 Abort.literal.when(b)("TOO_BIG")
 
-            val result: Unit < Abort["TOO_BIG"] = when(false)
+            val result                     = when(false)
+            val _: Unit < Abort["TOO_BIG"] = result
             assert(Abort.run(result).eval == Result.unit)
             assert(Abort.run(when(true)).eval == Result.fail("TOO_BIG"))
         }
 
         "effects" in {
             val result = Env.run(15) {
-                Abort.run {
+                Abort.literal.run {
                     for
                         x <- Env.get[Int]
                         _ <- Abort.literal.when(x > 10)("TOO_BIG")
                     yield x
                 }
             }.eval
+            val _: Result["TOO_BIG", Int] = result
             assert(result == Result.fail("TOO_BIG"))
         }
 
@@ -1269,13 +1275,14 @@ class AbortTest extends Test:
             def test[A](a: A): Nothing < Abort[A] =
                 Abort.literal.fail(a)
 
-            val result: Int < Abort[Int] = test(1)
+            val result                  = test(1)
+            val _: Nothing < Abort[Int] = result
             assert(Abort.run(result).eval == Result.fail(1))
         }
 
         "union" in {
-            val result: Nothing < Abort["FAIL!" | "FAIL2!"] = Abort.literal.fail("FAIL!")
-            val _: Nothing < Abort["FAIL!" | "FAIL2!"]      = result
+            val result                                 = Abort.literal.fail("FAIL!")
+            val _: Nothing < Abort["FAIL!" | "FAIL2!"] = result
             assert(Abort.run(result).eval == Result.fail("FAIL!"))
         }
     }


### PR DESCRIPTION
Fixes #739 

### Problem
With `Abort.fail`, manual type annotations are required to write expressions that fail with literal types.

### Solution
Add an object `literal` to `Abort` to enable failing with literal types, namely Strings.

### Notes
The functions will degrade to non-literal behavior in a generic scope.
