### PR TITLE
[scheduler] add example of using Scheduler from Java

### DIFF
--- a/kyo-scheduler/jvm/src/test/java/examples/JavaSchedulerTest.java
+++ b/kyo-scheduler/jvm/src/test/java/examples/JavaSchedulerTest.java
@@ -1,0 +1,38 @@
+package examples;
+
+import kyo.scheduler.Scheduler;
+import kyo.scheduler.Task;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class JavaSchedulerTest {
+
+    public static void main(String[] args) throws Exception {
+        forks();
+    }
+
+    private static void forks() throws Exception {
+        Scheduler scheduler = Scheduler.get();
+
+        AtomicReference<String> threadName = new AtomicReference<>("");
+        CountDownLatch latch = new CountDownLatch(1);
+
+        scheduler.schedule(Task.apply(() -> {
+            threadName.set(Thread.currentThread().getName());
+            latch.countDown();
+        }));
+
+        if (!latch.await(1, TimeUnit.SECONDS)) {
+            throw new Exception("Task did not complete in time");
+        }
+
+        if (!threadName.get().contains("kyo")) {
+            throw new Exception("Task did not run on kyo thread, ran on: " + threadName.get());
+        } else {
+            System.out.println("Task ran on thread: " + threadName.get());
+        }
+    }
+}


### PR DESCRIPTION
### Problem
The Scheduler is currently published as a Scala module, so I suspect users may not realize that it's available for other JVM applications.

#1111 

### Solution
Add an example test in Java to make sure our APIs are always accessible from Java - not depending on Scala specific features.