### PR TITLE
[core] fix interrupts leak

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -273,6 +273,13 @@ object Fiber extends FiberPlatformSpecific:
           */
         def waiters(using Frame): Int < IO = IO(self.waiters())
 
+        /** Polls the Fiber for a result without blocking.
+          *
+          * @return
+          *   Maybe containing the Result if the Fiber is done, or Absent if still pending
+          */
+        def poll(using Frame): Maybe[Result[E, A]] < IO = IO(self.poll())
+
     end extension
 
     case class Interrupted(at: Frame)
@@ -571,6 +578,8 @@ object Fiber extends FiberPlatformSpecific:
             def safe: Fiber[E, A] = self
 
             def waiters()(using AllowUnsafe): Int = self.waiters()
+
+            def poll()(using AllowUnsafe): Maybe[Result[E, A]] = self.poll()
         end extension
     end Unsafe
 
@@ -642,6 +651,13 @@ object Fiber extends FiberPlatformSpecific:
               */
             def waiters(using Frame): Int < IO = IO(self.waiters())
 
+            /** Polls the Promise for a result without blocking.
+              *
+              * @return
+              *   Maybe containing the Result if the Promise is done, or Absent if still pending
+              */
+            def poll(using Frame): Maybe[Result[E, A]] < IO = IO(self.poll())
+
         end extension
 
         opaque type Unsafe[+E, +A] <: Fiber.Unsafe[E, A] = IOPromise[E, A]
@@ -665,6 +681,7 @@ object Fiber extends FiberPlatformSpecific:
                 def becomeDiscard[E2 <: E, A2 <: A](other: Fiber[E2, A2])(using AllowUnsafe): Unit = discard(self.become(other))
                 def safe: Promise[E, A]                                                            = self
                 def waiters()(using AllowUnsafe): Int                                              = self.waiters()
+                def poll()(using AllowUnsafe): Maybe[Result[E, A]]                                 = self.poll()
             end extension
         end Unsafe
     end Promise

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -263,6 +263,16 @@ object Fiber extends FiberPlatformSpecific:
 
         def unsafe: Fiber.Unsafe[E, A] = self
 
+        /** Gets the number of waiters on this Fiber.
+          *
+          * This method returns the count of callbacks and other fibers waiting for this fiber to complete. Primarily useful for debugging
+          * and monitoring purposes.
+          *
+          * @return
+          *   The number of waiters on this Fiber
+          */
+        def waiters(using Frame): Int < IO = IO(self.waiters())
+
     end extension
 
     case class Interrupted(at: Frame)
@@ -559,6 +569,8 @@ object Fiber extends FiberPlatformSpecific:
             end mapResult
 
             def safe: Fiber[E, A] = self
+
+            def waiters()(using AllowUnsafe): Int = self.waiters()
         end extension
     end Unsafe
 
@@ -619,6 +631,17 @@ object Fiber extends FiberPlatformSpecific:
             def becomeDiscard[E2 <: E, A2 <: A](other: Fiber[E2, A2])(using Frame): Unit < IO = IO(discard(self.become(other)))
 
             def unsafe: Unsafe[E, A] = self
+
+            /** Gets the number of waiters on this Promise.
+              *
+              * This method returns the count of callbacks and other fibers waiting for this promise to complete. Primarily useful for
+              * debugging and monitoring purposes.
+              *
+              * @return
+              *   The number of waiters on this Promise
+              */
+            def waiters(using Frame): Int < IO = IO(self.waiters())
+
         end extension
 
         opaque type Unsafe[+E, +A] <: Fiber.Unsafe[E, A] = IOPromise[E, A]
@@ -641,6 +664,7 @@ object Fiber extends FiberPlatformSpecific:
                 def become[E2 <: E, A2 <: A](other: Fiber[E2, A2])(using AllowUnsafe): Boolean     = self.become(other)
                 def becomeDiscard[E2 <: E, A2 <: A](other: Fiber[E2, A2])(using AllowUnsafe): Unit = discard(self.become(other))
                 def safe: Promise[E, A]                                                            = self
+                def waiters()(using AllowUnsafe): Int                                              = self.waiters()
             end extension
         end Unsafe
     end Promise

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.locks.LockSupport
 import kyo.*
 import kyo.Result.Error
 import kyo.kernel.internal.Safepoint
-import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
@@ -276,7 +275,6 @@ private[kyo] object IOPromise:
         def removeInterrupt(other: IOPromise[?, ?]): Pending[E, A]
         def run[E2 >: E, A2 >: A](v: Result[E2, A2]): Pending[E2, A2]
 
-        @nowarn("msg=anonymous")
         final def onComplete(f: Result[E, A] => Any): Pending[E, A] =
             new Pending[E, A]:
                 def waiters: Int = self.waiters + 1
@@ -302,7 +300,6 @@ private[kyo] object IOPromise:
                 def run[E2 >: E, A2 >: A](v: Result[E2, A2]) =
                     self
 
-        @nowarn("msg=anonymous")
         def onInterrupt(f: Error[E] => Any): Pending[E, A] =
             new Pending[E, A]:
                 def interrupt[E2 >: E](error: Error[E2]) =

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -42,6 +42,11 @@ private[kyo] class IOPromise[+E, +A](init: State[E, A]) extends Safepoint.Interc
         doneLoop(this)
     end done
 
+    final def poll(): Maybe[Result[E, A]] =
+        this.state match
+            case _: (Pending[?, ?] | Linked[?, ?]) => Absent
+            case r                                 => Present(r.asInstanceOf[Result[E, A]])
+
     final protected def isPending(): Boolean =
         state.isInstanceOf[Pending[?, ?]]
 
@@ -57,6 +62,18 @@ private[kyo] class IOPromise[+E, +A](init: State[E, A]) extends Safepoint.Interc
                     discard(other.interrupt(Result.Panic(Interrupt())))
         interruptsLoop(this)
     end interrupts
+
+    final def removeInterrupt(other: IOPromise[?, ?])(using frame: Frame): Unit =
+        @tailrec def removeInterruptLoop(promise: IOPromise[E, A]): Unit =
+            promise.state match
+                case p: Pending[E, A] @unchecked =>
+                    if !promise.compareAndSet(p, p.removeInterrupt(other)) then
+                        removeInterruptLoop(promise)
+                case l: Linked[E, A] @unchecked =>
+                    removeInterruptLoop(l.p)
+                case _ =>
+        removeInterruptLoop(this)
+    end removeInterrupt
 
     final def mask(): IOPromise[E, A] =
         val p = new IOPromise[E, A]:
@@ -120,7 +137,7 @@ private[kyo] class IOPromise[+E, +A](init: State[E, A]) extends Safepoint.Interc
         becomeLoop(other.compress())
     end become
 
-    inline def onComplete(inline f: Result[E, A] => Any): Unit =
+    def onComplete(f: Result[E, A] => Any): Unit =
         @tailrec def onCompleteLoop(promise: IOPromise[E, A]): Unit =
             promise.state match
                 case p: Pending[E, A] @unchecked =>
@@ -133,7 +150,7 @@ private[kyo] class IOPromise[+E, +A](init: State[E, A]) extends Safepoint.Interc
         onCompleteLoop(this)
     end onComplete
 
-    inline def onInterrupt(inline f: Error[E] => Any): Unit =
+    def onInterrupt(f: Error[E] => Any): Unit =
         @tailrec def onInterruptLoop(promise: IOPromise[E, A]): Unit =
             promise.state match
                 case p: Pending[E, A] @unchecked =>
@@ -173,6 +190,18 @@ private[kyo] class IOPromise[+E, +A](init: State[E, A]) extends Safepoint.Interc
                     false
         completeLoop()
     end complete
+
+    def waiters(): Int =
+        @tailrec def waitersLoop(promise: IOPromise[?, ?]): Int =
+            promise.state match
+                case p: Pending[?, ?] =>
+                    p.waiters
+                case l: Linked[?, ?] =>
+                    waitersLoop(l.p)
+                case _ =>
+                    0
+        waitersLoop(this)
+    end waiters
 
     final def block(deadline: Clock.Deadline.Unsafe)(using frame: Frame): Result[E | Timeout, A] =
         def blockLoop(promise: IOPromise[E, A]): Result[E | Timeout, A] =
@@ -237,15 +266,18 @@ private[kyo] object IOPromise:
 
         def waiters: Int
         def interrupt[E2 >: E](v: Error[E2]): Pending[E, A]
+        def removeInterrupt(other: IOPromise[?, ?]): Pending[E, A]
         def run[E2 >: E, A2 >: A](v: Result[E2, A2]): Pending[E2, A2]
 
         @nowarn("msg=anonymous")
-        inline def onComplete(inline f: Result[E, A] => Any): Pending[E, A] =
+        final def onComplete(f: Result[E, A] => Any): Pending[E, A] =
             new Pending[E, A]:
                 def waiters: Int = self.waiters + 1
                 def interrupt[E2 >: E](error: Error[E2]) =
                     eval(discard(f(error.asInstanceOf[Error[E]])))
                     self
+                def removeInterrupt(other: IOPromise[?, ?]) =
+                    self.removeInterrupt(other).onComplete(f)
                 def run[E2 >: E, A2 >: A](v: Result[E2, A2]) =
                     eval(discard(f(v.asInstanceOf[Result[E, A]])))
                     self
@@ -256,16 +288,21 @@ private[kyo] object IOPromise:
                 def interrupt[E2 >: E](error: Error[E2]) =
                     discard(p.interrupt(error.asInstanceOf[Error[E]]))
                     self
+                def removeInterrupt(other: IOPromise[?, ?]) =
+                    if p eq other then self
+                    else self.removeInterrupt(other).interrupts(p)
                 def waiters: Int = self.waiters + 1
                 def run[E2 >: E, A2 >: A](v: Result[E2, A2]) =
                     self
 
         @nowarn("msg=anonymous")
-        inline def onInterrupt(inline f: Error[E] => Any): Pending[E, A] =
+        def onInterrupt(f: Error[E] => Any): Pending[E, A] =
             new Pending[E, A]:
                 def interrupt[E2 >: E](error: Error[E2]) =
                     eval(discard(f(error.asInstanceOf[Error[E]])))
                     self
+                def removeInterrupt(other: IOPromise[?, ?]) =
+                    self.removeInterrupt(other).onInterrupt(f)
                 def waiters: Int = self.waiters + 1
                 def run[E2 >: E, A2 >: A](v: Result[E2, A2]) =
                     self
@@ -282,9 +319,15 @@ private[kyo] object IOPromise:
                     case _ if (p eq Pending.Empty) => tail
                     case p: Pending[E, A]          => interruptLoop(p.interrupt(error), error)
 
+            @tailrec def removeInterruptsLoop(p: Pending[E, A], other: IOPromise[?, ?]): Pending[E2, A2] =
+                p match
+                    case _ if (p eq Pending.Empty) => tail
+                    case p: Pending[E, A]          => removeInterruptsLoop(p.removeInterrupt(other), other)
+
             new Pending[E2, A2]:
                 def waiters: Int                               = self.waiters + tail.waiters
                 def interrupt[E2 >: E](error: Error[E2])       = interruptLoop(self, error.asInstanceOf[Error[E]])
+                def removeInterrupt(other: IOPromise[?, ?])    = removeInterruptsLoop(self, other)
                 def run[E3 >: E2, A3 >: A2](v: Result[E3, A3]) = runLoop(self, v)
             end new
         end merge
@@ -312,9 +355,10 @@ private[kyo] object IOPromise:
     object Pending:
         def apply[E, A](): Pending[E, A] = Empty.asInstanceOf[Pending[E, A]]
         case object Empty extends Pending[Nothing, Nothing]:
-            def waiters: Int                           = 0
-            def interrupt[E2 >: Nothing](v: Error[E2]) = this
-            def run[E2, A2](v: Result[E2, A2])         = this
+            def waiters: Int                            = 0
+            def interrupt[E2 >: Nothing](v: Error[E2])  = this
+            def removeInterrupt(other: IOPromise[?, ?]) = this
+            def run[E2, A2](v: Result[E2, A2])          = this
         end Empty
     end Pending
 

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -1362,6 +1362,7 @@ class AsyncTest extends Test:
                 }
                 _       <- done.await
                 waiters <- fiber.waiters
+                _       <- exit.release
             yield assert(waiters == 1)
         }
         "with delay" in run {
@@ -1375,6 +1376,7 @@ class AsyncTest extends Test:
                 }
                 _       <- done.await
                 waiters <- fiber.waiters
+                _       <- exit.release
             yield assert(waiters == 1)
         }
     }

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -1348,4 +1348,35 @@ class AsyncTest extends Test:
         }
     }
 
+    "fiber with multiple children" - {
+        "immediate" in run {
+            for
+                done <- Latch.init(1)
+                exit <- Latch.init(1)
+                fiber <- Async.run {
+                    Kyo.fill(100) {
+                        Promise.init[Nothing, Int].map { p2 =>
+                            p2.completeDiscard(Result.succeed(1)).andThen(p2.get)
+                        }
+                    }.andThen(done.release).andThen(exit.await)
+                }
+                _       <- done.await
+                waiters <- fiber.waiters
+            yield assert(waiters == 1)
+        }
+        "with delay" in run {
+            for
+                done <- Latch.init(1)
+                exit <- Latch.init(1)
+                fiber <- Async.run {
+                    Kyo.fill(100) {
+                        Async.sleep(1.nanos)
+                    }.andThen(done.release).andThen(exit.await)
+                }
+                _       <- done.await
+                waiters <- fiber.waiters
+            yield assert(waiters == 1)
+        }
+    }
+
 end AsyncTest


### PR DESCRIPTION
Fixes #1122

### Problem

When a parent `Fiber` is executing and encounters a new child `Fiber` to be waited on, the parent needs to register a callback to propagate interrupts to the child in case there's an interrupt during the waiting. The issue is that, once the child fiber finishes and the parent resumes, the interrupt callback for the child isn't necessary anymore but it stays in the pending list until the parent fully completes execution. This leads to a memory leak when a parent fiber handles many children during its execution.

### Solution

When the parent fiber resumes execution, remove the interrupt callback for the completed child.

### Notes

I've also included a fast-path optimization: if the child fiber is already completed, the parent resumes execution immeditely without suspending. There's a performance penalty with this change due to the removal of a few `inline`s in `IOPromise` that should be easily offset with this additional optimization.