### PR TITLE
mark classes as Serializable

### DIFF
--- a/kyo-cache/shared/src/main/scala/kyo/Cache.scala
+++ b/kyo-cache/shared/src/main/scala/kyo/Cache.scala
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit
   * @param store
   *   The underlying cache store
   */
-class Cache(private[kyo] val store: Store):
+class Cache(private[kyo] val store: Store) extends Serializable:
 
     /** Memoizes a function with a single argument.
       *

--- a/kyo-core/jvm/src/main/scala/kyo/Path.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Path.scala
@@ -21,7 +21,7 @@ import scala.io.*
 import scala.jdk.CollectionConverters.*
 import scala.jdk.StreamConverters.*
 
-final class Path private (val path: List[String]) derives CanEqual:
+final class Path private (val path: List[String]) extends Serializable derives CanEqual:
 
     def toJava: JPath               = Paths.get(path.mkString(File.separator))
     lazy val parts: List[Path.Part] = path

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -312,7 +312,7 @@ object Channel:
         IO.Unsafe(f(Unsafe.init(capacity, access)))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-    abstract class Unsafe[A]:
+    abstract class Unsafe[A] extends Serializable:
         def capacity: Int
         def size()(using AllowUnsafe): Result[Closed, Int]
 

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -131,7 +131,7 @@ object Clock:
 
     object Stopwatch:
         /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-        final class Unsafe(start: Duration, clock: Clock.Unsafe):
+        final class Unsafe(start: Duration, clock: Clock.Unsafe) extends Serializable:
             def elapsed()(using AllowUnsafe): Duration = clock.nowMonotonic() - start
             def safe: Stopwatch                        = Stopwatch(this)
         end Unsafe
@@ -161,7 +161,7 @@ object Clock:
 
     object Deadline:
         /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-        final class Unsafe(endInstant: Maybe[Instant], clock: Clock.Unsafe):
+        final class Unsafe(endInstant: Maybe[Instant], clock: Clock.Unsafe) extends Serializable:
 
             def timeLeft()(using AllowUnsafe): Duration =
                 endInstant.map(_ - clock.now()).getOrElse(Duration.Infinity)

--- a/kyo-core/shared/src/main/scala/kyo/Console.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Console.scala
@@ -242,7 +242,7 @@ object Console:
     def checkErrors(using Frame): Boolean < IO = IO.Unsafe.withLocal(local)(console => console.unsafe.checkErrors)
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-    abstract class Unsafe:
+    abstract class Unsafe extends Serializable:
         def readLine()(using AllowUnsafe): Result[IOException, String]
         def print(s: String)(using AllowUnsafe): Unit
         def printErr(s: String)(using AllowUnsafe): Unit

--- a/kyo-core/shared/src/main/scala/kyo/Log.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Log.scala
@@ -87,7 +87,7 @@ object Log extends LogPlatformSpecific:
         let(Log(Unsafe.ConsoleLogger(name, level)))(v)
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-    abstract class Unsafe:
+    abstract class Unsafe extends Serializable:
         def level: Level
 
         def trace(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -329,7 +329,7 @@ object Queue:
     end Unbounded
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-    abstract class Unsafe[A]:
+    abstract class Unsafe[A] extends Serializable:
         def capacity: Int
         def size()(using AllowUnsafe): Result[Closed, Int]
         def empty()(using AllowUnsafe): Result[Closed, Boolean]

--- a/kyo-core/shared/src/main/scala/kyo/Random.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Random.scala
@@ -24,7 +24,7 @@ import scala.annotation.tailrec
   * @see
   *   [[kyo.Random.withSeed]] For creating reproducible random sequences
   */
-abstract class Random:
+abstract class Random extends Serializable:
     def nextInt(using Frame): Int < IO
     def nextInt(exclusiveBound: Int)(using Frame): Int < IO
     def nextLong(using Frame): Long < IO
@@ -44,7 +44,7 @@ end Random
 object Random:
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-    abstract class Unsafe:
+    abstract class Unsafe extends Serializable:
         def nextInt()(using AllowUnsafe): Int
         def nextInt(exclusiveBound: Int)(using AllowUnsafe): Int
         def nextLong()(using AllowUnsafe): Long

--- a/kyo-core/shared/src/main/scala/kyo/Signal.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Signal.scala
@@ -28,7 +28,7 @@ import scala.annotation.tailrec
   * @tparam A
   *   The type of value contained in the signal. Must have an instance of `CanEqual[A, A]`
   */
-sealed abstract class Signal[A](using CanEqual[A, A]):
+sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
     self =>
 
     /** Retrieves the current value of the signal.

--- a/kyo-core/shared/src/main/scala/kyo/Stat.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Stat.scala
@@ -6,7 +6,7 @@ import kyo.stats.internal.TraceReceiver
 
 /** A counter for tracking numeric values that only increase.
   */
-abstract class Counter:
+abstract class Counter extends Serializable:
     /** The underlying unsafe counter implementation. */
     val unsafe: UnsafeCounter
 
@@ -29,7 +29,7 @@ end Counter
 
 /** A histogram for observing the distribution of values.
   */
-abstract class Histogram:
+abstract class Histogram extends Serializable:
     /** The underlying unsafe histogram implementation. */
     val unsafe: UnsafeHistogram
 
@@ -62,7 +62,7 @@ end Histogram
 
 /** A gauge for measuring a specific value that can go up and down.
   */
-abstract class Gauge:
+abstract class Gauge extends Serializable:
     /** The underlying unsafe gauge implementation. */
     val unsafe: UnsafeGauge
 
@@ -75,7 +75,7 @@ end Gauge
 
 /** A gauge that specifically measures counter-like values.
   */
-abstract class CounterGauge:
+abstract class CounterGauge extends Serializable:
     /** The underlying unsafe counter gauge implementation. */
     val unsafe: UnsafeCounterGauge
 
@@ -86,7 +86,7 @@ abstract class CounterGauge:
     def collect(using Frame): Long < IO
 end CounterGauge
 
-final class Stat(private val registryScope: StatsRegistry.Scope):
+final class Stat(private val registryScope: StatsRegistry.Scope) extends Serializable:
 
     /** Create a new Stat instance with an additional scope.
       * @param path

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -35,7 +35,7 @@ import java.time.format.DateTimeParseException
   * @see
   *   [[kyo.System.OS]] For supported operating system detection values
   */
-abstract class System:
+abstract class System extends Serializable:
     def unsafe: System.Unsafe
     def env[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & IO)
     def property[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & IO)
@@ -52,7 +52,7 @@ object System:
         case Linux, MacOS, Windows, BSD, Solaris, IBMI, AIX, Unknown
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-    abstract class Unsafe:
+    abstract class Unsafe extends Serializable:
         def env(name: String)(using AllowUnsafe): Maybe[String]
         def property(name: String)(using AllowUnsafe): Maybe[String]
         def lineSeparator()(using AllowUnsafe): String
@@ -203,7 +203,7 @@ object System:
     def operatingSystem(using Frame): OS < IO = local.use(_.operatingSystem)
 
     /** Abstract class for parsing string values into specific types. */
-    abstract class Parser[E, A]:
+    abstract class Parser[E, A] extends Serializable:
         /** Parses a string value into type A.
           *
           * @param s

--- a/kyo-core/shared/src/main/scala/kyo/internal/OSSignal.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/OSSignal.scala
@@ -4,7 +4,7 @@ package kyo.internal
   */
 private[kyo] object OsSignal extends OsSignalPlatformSpecific:
     /** A handler for signals. */
-    abstract class Handler:
+    abstract class Handler extends Serializable:
         def apply(signal: String, handle: => Unit): Unit
 
     object Handler:

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -8,7 +8,7 @@ import kyo.kernel.internal.Safepoint
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
-private[kyo] class IOPromise[+E, +A](init: State[E, A]) extends Safepoint.Interceptor:
+private[kyo] class IOPromise[+E, +A](init: State[E, A]) extends Safepoint.Interceptor with Serializable:
 
     @volatile private var state = init
 

--- a/kyo-core/shared/src/main/scala/kyo/stats/internal/TraceReceiver.scala
+++ b/kyo-core/shared/src/main/scala/kyo/stats/internal/TraceReceiver.scala
@@ -6,7 +6,7 @@ import kyo.stats.*
 import kyo.stats.Attributes
 import scala.jdk.CollectionConverters.*
 
-trait TraceReceiver:
+trait TraceReceiver extends Serializable:
 
     def startSpan(
         scope: List[String],

--- a/kyo-data/shared/src/main/scala/kyo/ChunkBuilder.scala
+++ b/kyo-data/shared/src/main/scala/kyo/ChunkBuilder.scala
@@ -11,7 +11,8 @@ import scala.reflect.ClassTag
   * @tparam A
   *   the type of elements in the Chunk being built
   */
-sealed abstract class ChunkBuilder[A] extends ReusableBuilder[A, Chunk.Indexed[A]]
+sealed abstract class ChunkBuilder[A] extends ReusableBuilder[A, Chunk.Indexed[A]] with Serializable
+
 object ChunkBuilder:
 
     /** Creates a new ChunkBuilder with no size hint.

--- a/kyo-data/shared/src/main/scala/kyo/Record.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Record.scala
@@ -145,7 +145,7 @@ object Record:
 
     given [Fields]: Flat[Record[Fields]] = Flat.unsafe.bypass
 
-    final infix class ~[Name <: String, Value] private ()
+    final infix class ~[Name <: String, Value] private () extends Serializable
 
     object `~`:
         given [Name <: String, Value](using CanEqual[Value, Value]): CanEqual[Name ~ Value, Name ~ Value] =

--- a/kyo-data/shared/src/main/scala/kyo/Render.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Render.scala
@@ -4,7 +4,7 @@ import scala.language.implicitConversions
 
 /** Provides Text representation of a type. Needed for customizing how to display opaque types as alternative to toString
   */
-abstract class Render[A]:
+abstract class Render[A] extends Serializable:
     def asText(value: A): Text
     final def asString(value: A): String = asText(value).show
 

--- a/kyo-data/shared/src/main/scala/kyo/Result.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Result.scala
@@ -192,7 +192,7 @@ object Result:
     end Success
 
     /** Represents an error in a Result. */
-    sealed abstract class Error[+E]:
+    sealed abstract class Error[+E] extends Serializable:
 
         /** Gets the error value or panic exception.
           *

--- a/kyo-data/shared/src/main/scala/kyo/Schedule.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Schedule.scala
@@ -8,7 +8,7 @@ import kyo.Duration
   * Schedule provides various combinators for creating complex scheduling policies. It can be used to define retry policies, periodic tasks,
   * or any other time-based scheduling logic.
   */
-sealed abstract class Schedule derives CanEqual:
+sealed abstract class Schedule extends Serializable derives CanEqual:
 
     /** Returns the next delay and the updated schedule.
       *

--- a/kyo-data/shared/src/main/scala/kyo/Text.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Text.scala
@@ -25,7 +25,7 @@ object Text:
     def empty: Text = ""
 
     /** Abstract class for character predicates used in Text operations */
-    abstract class Predicate:
+    abstract class Predicate extends Serializable:
         /** Tests if a character matches the predicate
           *
           * @param char
@@ -560,7 +560,7 @@ object Text:
 
     private[kyo] object internal:
 
-        sealed trait Op:
+        sealed trait Op extends Serializable:
             def isEmpty: Boolean
             def length: Int
             def charAt(index: Int): Char

--- a/kyo-data/shared/src/main/scala/kyo/internal/TypeIntersection.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/TypeIntersection.scala
@@ -13,7 +13,7 @@ import scala.quoted.*
   *   - Apply type constructors uniformly across all components
   *   - Collect type class instances for all component types
   */
-sealed abstract class TypeIntersection[A]:
+sealed abstract class TypeIntersection[A] extends Serializable:
 
     /** The tuple representation of the decomposed types.
       *

--- a/kyo-direct/shared/src/main/scala/kyo/Direct.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/Direct.scala
@@ -162,7 +162,8 @@ object directInternal:
     given Frame = Frame.internal
     class KyoCpsMonad[S]
         extends CpsMonadContext[[A] =>> A < S]
-        with CpsMonad[[A] =>> A < S]:
+        with CpsMonad[[A] =>> A < S]
+        with Serializable:
 
         type Context = KyoCpsMonad[S]
 

--- a/kyo-kernel/js/src/main/scala/kyo/kernel/internal/TracePool.scala
+++ b/kyo-kernel/js/src/main/scala/kyo/kernel/internal/TracePool.scala
@@ -6,7 +6,7 @@ private[kernel] object TracePool:
     inline def globalCapacity: Int = 0
     inline def localCapacity: Int  = 1024
 
-    abstract class Local:
+    abstract class Local extends Serializable:
         final private val pool = new Array[Trace](localCapacity)
         final private var size = 0
 

--- a/kyo-kernel/jvm/src/main/scala/kyo/kernel/internal/TracePool.scala
+++ b/kyo-kernel/jvm/src/main/scala/kyo/kernel/internal/TracePool.scala
@@ -29,7 +29,7 @@ private[kernel] object TracePool:
 
     private val global = new MpmcArrayQueue[Trace](globalCapacity)
 
-    abstract class Local:
+    abstract class Local extends Serializable:
         final private val pool = new Array[Trace](localCapacity)
         final private var size = 0
 

--- a/kyo-kernel/native/src/main/scala/kyo/kernel/internal/TracePool.scala
+++ b/kyo-kernel/native/src/main/scala/kyo/kernel/internal/TracePool.scala
@@ -10,7 +10,7 @@ private[kernel] object TracePool:
 
     private val global = new ConcurrentLinkedQueue[Trace]()
 
-    abstract class Local:
+    abstract class Local extends Serializable:
         final private val pool = new Array[Trace](localCapacity)
         final private var size = 0
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Effect.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Effect.scala
@@ -18,7 +18,7 @@ import scala.util.control.NonFatal
   *   - [[ArrowEffect]] for suspended computations involving input/output transformations.
   *   - [[ContextEffect]] for suspended computations requiring contextual values.
   */
-abstract class Effect private[kernel] ()
+abstract class Effect private[kernel] () extends Serializable
 
 object Effect:
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Effect.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Effect.scala
@@ -18,7 +18,7 @@ import scala.util.control.NonFatal
   *   - [[ArrowEffect]] for suspended computations involving input/output transformations.
   *   - [[ContextEffect]] for suspended computations requiring contextual values.
   */
-abstract class Effect private[kernel] () extends Serializable
+abstract class Effect private[kernel] ()
 
 object Effect:
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Isolate.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Isolate.scala
@@ -75,7 +75,7 @@ object Isolate:
       * @tparam Passthrough
       *   Additional effects that will remain pending after isolation
       */
-    sealed abstract class Contextual[Retain, -Passthrough]:
+    sealed abstract class Contextual[Retain, -Passthrough] extends Serializable:
 
         /** Runs a computation with transformed effects.
           *
@@ -173,7 +173,7 @@ object Isolate:
       * @tparam Passthrough
       *   Additional effects that will remain pending after isolation
       */
-    abstract class Stateful[Retain, -Passthrough]:
+    abstract class Stateful[Retain, -Passthrough] extends Serializable:
         self =>
 
         /** The type of state being managed */

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Loop.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Loop.scala
@@ -27,7 +27,7 @@ object Loop:
       * @tparam A
       *   The type of the single state value maintained between iterations
       */
-    abstract class Continue[A]:
+    abstract class Continue[A] extends Serializable:
         private[Loop] def _1: A
 
     /** Represents the state of two values to be carried forward to the next iteration.
@@ -37,7 +37,7 @@ object Loop:
       * @tparam B
       *   The type of the second state value
       */
-    abstract class Continue2[A, B]:
+    abstract class Continue2[A, B] extends Serializable:
         private[Loop] def _1: A
         private[Loop] def _2: B
 
@@ -50,7 +50,7 @@ object Loop:
       * @tparam C
       *   The type of the third state value
       */
-    abstract class Continue3[A, B, C]:
+    abstract class Continue3[A, B, C] extends Serializable:
         private[Loop] def _1: A
         private[Loop] def _2: B
         private[Loop] def _3: C
@@ -67,7 +67,7 @@ object Loop:
       * @tparam D
       *   The type of the fourth state value
       */
-    abstract class Continue4[A, B, C, D]:
+    abstract class Continue4[A, B, C, D] extends Serializable:
         private[Loop] def _1: A
         private[Loop] def _2: B
         private[Loop] def _3: C

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/KyoInternal.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/KyoInternal.scala
@@ -25,7 +25,7 @@ import kyo.kernel.ArrowEffect
   * @tparam S
   *   The type-level set of effects this computation may perform
   */
-sealed abstract private[kernel] class Kyo[+A, -S]
+sealed abstract private[kernel] class Kyo[+A, -S] extends Serializable
 
 /** Base class of suspended computations, separated from Kyo solely to hide its additional type parameters and to avoid variance checking.
   * Contains the actual storage and continuation machinery.

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Safepoint.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Safepoint.scala
@@ -16,7 +16,7 @@ import scala.util.control.NonFatal
   * This class is not meant to be used directly by user code, but rather serves as infrastructure for effect handlers and combinators. It's
   * a key part of ensuring effect execution remains practical and debuggable while maintaining good performance characteristics.
   */
-final class Safepoint private () extends Trace.Owner:
+final class Safepoint private () extends Trace.Owner with Serializable:
 
     private var state: State             = State.init()
     private var interceptor: Interceptor = null
@@ -43,6 +43,8 @@ final class Safepoint private () extends Trace.Owner:
         interceptor = newInterceptor
         state = state.withInterceptor(newInterceptor != null)
 
+    private def writeReplace() = Safepoint.Restore
+
     override def toString(): String =
         val currentState = state
         s"Safepoint(depth=${currentState.depth}, threadId=${currentState.threadId}, interceptor=${interceptor})"
@@ -50,6 +52,9 @@ final class Safepoint private () extends Trace.Owner:
 end Safepoint
 
 object Safepoint:
+
+    private[Safepoint] object Restore extends Serializable:
+        private def readResolve() = get
 
     implicit def get: Safepoint = local.get()
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Trace.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Trace.scala
@@ -22,7 +22,7 @@ import scala.util.control.NoStackTrace
 final private[kyo] class Trace(
     private[kernel] val frames: Array[Frame],
     private[kernel] var index: Int
-)
+) extends Serializable
 
 private[kyo] object Trace:
 

--- a/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
+++ b/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
@@ -267,7 +267,7 @@ object Memory:
     end Unsafe
 
     /** Defines how values of type A are laid out in memory. */
-    abstract class Layout[A]:
+    abstract class Layout[A] extends Serializable:
         inline def get(memory: Unsafe[A], offset: Long)(using AllowUnsafe): A
         inline def set(memory: Unsafe[A], offset: Long, value: A)(using AllowUnsafe): Unit
         def size: Long

--- a/kyo-prelude/shared/src/main/scala/kyo/Aspect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Aspect.scala
@@ -29,7 +29,7 @@ import Aspect.*
   */
 final class Aspect[Input[_], Output[_], S] private[kyo] (
     default: Cut[Input, Output, S]
-)(using Frame):
+)(using Frame) extends Serializable:
 
     /** Applies this aspect to transform a computation.
       *

--- a/kyo-prelude/shared/src/main/scala/kyo/Layer.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Layer.scala
@@ -36,7 +36,7 @@ import kyo.Tag
   * @see
   *   [[kyo.Env]], [[kyo.Memo]] for related effects that interact with layers
   */
-abstract class Layer[+Out, -S]:
+abstract class Layer[+Out, -S] extends Serializable:
     self =>
 
     /** Composes this layer with another layer that depends on the output of this layer.
@@ -294,7 +294,7 @@ object Layer:
 
         private given Frame = Frame.internal
 
-        class DoRun[Out, S]:
+        class DoRun[Out, S] extends Serializable:
             private val memo = Memo[Layer[Out, S], TypeMap[Out], S & Memo] { self =>
                 type Expected = TypeMap[Out] < (S & Memo)
                 self match

--- a/kyo-prelude/shared/src/main/scala/kyo/Local.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Local.scala
@@ -35,7 +35,7 @@ import scala.annotation.nowarn
   * @see
   *   [[kyo.Env]] for required dependencies without defaults
   */
-abstract class Local[A]:
+abstract class Local[A] extends Serializable:
 
     /** The default value for this Local. */
     def default: A

--- a/kyo-prelude/shared/src/main/scala/kyo/Memo.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Memo.scala
@@ -14,7 +14,7 @@ object Memo:
 
     // Used to ensure each memoized function
     // has a different key space
-    private[kyo] class MemoIdentity
+    private[kyo] class MemoIdentity extends Serializable
 
     private[kyo] case class Cache(map: Map[(Any, Any), Any]):
         def get[A](input: A, id: MemoIdentity): Maybe[Any] =

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -42,7 +42,7 @@ import scala.util.NotGiven
   * @see
   *   [[kyo.Poll]] for pull-based consumption with backpressure
   */
-sealed abstract class Stream[V, -S]:
+sealed abstract class Stream[V, -S] extends Serializable:
 
     /** Returns the effect that produces acknowledgments and emits chunks of values. */
     def emit: Unit < (Emit[Chunk[V]] & S)
@@ -622,7 +622,7 @@ object Stream:
 
     /** A dummy type that can be used as implicit evidence to help the compiler discriminate between overloaded methods.
       */
-    sealed class Dummy
+    sealed class Dummy extends Serializable
     object Dummy:
         given Dummy = new Dummy {}
 

--- a/kyo-stats-registry/js-native/src/main/scala/kyo/stats/internal/UnsafeHistogram.scala
+++ b/kyo-stats-registry/js-native/src/main/scala/kyo/stats/internal/UnsafeHistogram.scala
@@ -1,6 +1,6 @@
 package kyo.stats.internal
 
-class UnsafeHistogram(numberOfSignificantValueDigits: Int, highestToLowestValueRatio: Long) {
+class UnsafeHistogram(numberOfSignificantValueDigits: Int, highestToLowestValueRatio: Long) extends Serializable {
 
     val _ = (numberOfSignificantValueDigits, highestToLowestValueRatio)
 

--- a/kyo-stats-registry/jvm/src/main/scala/kyo/stats/internal/UnsafeHistogram.scala
+++ b/kyo-stats-registry/jvm/src/main/scala/kyo/stats/internal/UnsafeHistogram.scala
@@ -2,7 +2,7 @@ package kyo.stats.internal
 
 import org.HdrHistogram.ConcurrentDoubleHistogram as HdrHistogram
 
-class UnsafeHistogram(numberOfSignificantValueDigits: Int, highestToLowestValueRatio: Long) {
+class UnsafeHistogram(numberOfSignificantValueDigits: Int, highestToLowestValueRatio: Long) extends Serializable {
     private val hdr =
         new HdrHistogram(
             highestToLowestValueRatio,

--- a/kyo-stats-registry/shared/src/main/scala/kyo/stats/internal/StatsExporter.scala
+++ b/kyo-stats-registry/shared/src/main/scala/kyo/stats/internal/StatsExporter.scala
@@ -1,6 +1,6 @@
 package kyo.stats.internal
 
-abstract class StatsExporter {
+abstract class StatsExporter extends Serializable {
     def counter(path: List[String], description: String, delta: Long): Unit
     def histogram(path: List[String], description: String, summary: Summary): Unit
     def gauge(path: List[String], description: String, currentValue: Double): Unit

--- a/kyo-stats-registry/shared/src/main/scala/kyo/stats/internal/StatsRegistry.scala
+++ b/kyo-stats-registry/shared/src/main/scala/kyo/stats/internal/StatsRegistry.scala
@@ -9,7 +9,7 @@ object StatsRegistry {
 
     def scope(path: String*): Scope = new Scope(path.reverse.toList)
 
-    class Scope private[kyo] (reversePath: List[String]) {
+    class Scope private[kyo] (reversePath: List[String]) extends Serializable {
 
         def path: List[String] = reversePath.reverse
 
@@ -51,7 +51,7 @@ object StatsRegistry {
         val counterGauges  = new Store[UnsafeCounterGauge]
         lazy val exporters = Collections.newSetFromMap(new ConcurrentHashMap[StatsExporter, java.lang.Boolean])
 
-        class Store[A <: AnyRef] {
+        class Store[A <: AnyRef] extends Serializable {
             val map = new ConcurrentHashMap[List[String], (WeakReference[A], String)]
 
             @tailrec final def get(reversePath: List[String], description: String, init: => A): A = {

--- a/kyo-stats-registry/shared/src/main/scala/kyo/stats/internal/UnsafeCounter.scala
+++ b/kyo-stats-registry/shared/src/main/scala/kyo/stats/internal/UnsafeCounter.scala
@@ -2,7 +2,7 @@ package kyo.stats.internal
 
 import java.util.concurrent.atomic.LongAdder
 
-class UnsafeCounter {
+class UnsafeCounter extends Serializable {
     private var last  = 0L
     private val adder = new LongAdder
 

--- a/kyo-stats-registry/shared/src/main/scala/kyo/stats/internal/UnsafeGauge.scala
+++ b/kyo-stats-registry/shared/src/main/scala/kyo/stats/internal/UnsafeGauge.scala
@@ -1,10 +1,10 @@
 package kyo.stats.internal
 
-class UnsafeGauge(run: () => Double) {
+class UnsafeGauge(run: () => Double) extends Serializable {
     def collect(): Double = run()
 }
 
-class UnsafeCounterGauge(run: () => Long) {
+class UnsafeCounterGauge(run: () => Long) extends Serializable {
     private var last = 0L
     def collect(): Long = {
         val value = run()

--- a/kyo-stm/shared/src/main/scala/kyo/TRef.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TRef.scala
@@ -56,7 +56,8 @@ end TRef
   */
 final private class TRefImpl[A] private[kyo] (initialState: Write[A])
     extends AtomicInteger(0) // Atomic super class to keep the lock state
-    with TRef[A]:
+    with TRef[A]
+    with Serializable:
 
     @volatile private var currentState = initialState
 

--- a/kyo-stm/shared/src/main/scala/kyo/TRefLog.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TRefLog.scala
@@ -37,7 +37,7 @@ private[kyo] object TRefLog:
 
     val isolate = Var.isolate.update[TRefLog](using tag)
 
-    sealed abstract class Entry[A]:
+    sealed abstract class Entry[A] extends Serializable:
         def tid: Long
         def value: A
 


### PR DESCRIPTION

### Problem

We currently don't mark classes as `Serializable`, which prevents java serialiazation.

### Solution

I searched the codebase for class declarations to introduce the ones that were missing. I made an exception for `Fiber`/`IOTask` and classes using them since serializing the state of a running fiber would be problematic. Classes that hold fibers like `Meter` are also not marked.

### Notes

- Case classes are automatically marked as `Serializable`.
- `Safepoint` requires custom serialization to restore from the thread local
