### PR TITLE
[prelude] rename Var.setAndThen to setWith

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Var.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Var.scala
@@ -90,7 +90,7 @@ object Var:
       * @return
       *   The result of the computation after setting the new value
       */
-    private[kyo] inline def setAndThen[V, A, S](inline value: V)(inline f: => A < S)(using
+    private[kyo] inline def setWith[V, A, S](inline value: V)(inline f: => A < S)(using
         inline tag: Tag[Var[V]],
         inline frame: Frame
     ): A < (Var[V] & S) =
@@ -215,7 +215,7 @@ object Var:
         def update[V](using Tag[Var[V]]): Isolate.Stateful[Var[V], Any] =
             new Base[V, Any]:
                 def restore[A: Flat, S2](v: (V, A) < S2)(using Frame) =
-                    v.map(Var.setAndThen(_)(_))
+                    v.map(Var.setWith(_)(_))
 
         /** Creates an isolate that merges Var values using a combination function.
           *
@@ -232,7 +232,7 @@ object Var:
         def merge[V](using Tag[Var[V]])[S](f: (V, V) => V < S): Isolate.Stateful[Var[V], S] =
             new Base[V, S]:
                 def restore[A: Flat, S2](v: (V, A) < S2)(using Frame) =
-                    Var.use[V](prev => v.map((state, r) => f(prev, state).map(Var.setAndThen(_)(r))))
+                    Var.use[V](prev => v.map((state, r) => f(prev, state).map(Var.setWith(_)(r))))
 
         /** Creates an isolate that keeps Var modifications local.
           *

--- a/kyo-prelude/shared/src/test/scala/kyo/VarTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/VarTest.scala
@@ -51,9 +51,9 @@ class VarTest extends Test:
         assert(r == (2, 3))
     }
 
-    "setAndThen" in {
+    "setWith" in {
         val result = Var.run(1) {
-            Var.setAndThen(2)(Var.use[Int](_ * 2))
+            Var.setWith(2)(Var.use[Int](_ * 2))
         }.eval
         assert(result == 4)
     }

--- a/kyo-stm/shared/src/main/scala/kyo/TRef.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TRef.scala
@@ -76,7 +76,7 @@ final private class TRefImpl[A] private[kyo] (initialState: Write[A])
                         else
                             // Append Read to the log and return value
                             val entry = Read(state.tid, state.value)
-                            Var.setAndThen(log.put(this, entry))(f(state.value))
+                            Var.setWith(log.put(this, entry))(f(state.value))
                         end if
                     }
             end match


### PR DESCRIPTION

### Problem

`Var.andThen` isn't following the pattern of other APIs with the `With` prefix to indicate that the method takes a continuation function.

### Solution

Update the name.
