### PR TITLE
[build] disable test fork output to try fix Scala Steward

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,11 @@ lazy val `kyo-settings` = Seq(
     Test / testOptions += Tests.Argument("-oDG"),
     ThisBuild / versionScheme               := Some("early-semver"),
     libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % Test,
-    Test / javaOptions += "--add-opens=java.base/java.lang=ALL-UNNAMED"
+    Test / javaOptions += "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    Test / forkOptions := (Test / forkOptions).value
+        .withOutputStrategy(
+            OutputStrategy.CustomOutput(java.io.OutputStream.nullOutputStream)
+        )
 )
 
 Global / onLoad := {


### PR DESCRIPTION

### Problem

Scala Steward isn't working for the repo since Jan.

### Solution

I don't know if it's related but this PR introduces a config that is suggested in https://github.com/VirtusLab/scala-steward-repos/issues/98#issuecomment-2288919616. I'm not sure what the config supposed to do since I see the regular test logs locally but it seems worth trying.

