### PR TITLE
Mark abstract classes as sealed

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -312,7 +312,7 @@ object Channel:
         IO.Unsafe(f(Unsafe.init(capacity, access)))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-    abstract class Unsafe[A] extends Serializable:
+    sealed abstract class Unsafe[A] extends Serializable:
         def capacity: Int
         def size()(using AllowUnsafe): Result[Closed, Int]
 

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -582,7 +582,7 @@ object Clock:
         }
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-    abstract class Unsafe:
+    sealed abstract class Unsafe:
 
         def now()(using AllowUnsafe): Instant
 

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -28,7 +28,7 @@ import scala.annotation.tailrec
   * @see
   *   [[kyo.Meter.pipeline]] For combining multiple meters into a composite control
   */
-abstract class Meter:
+abstract class Meter private[kyo] ():
     self =>
 
     /** Runs an effect after acquiring a permit.

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -268,7 +268,7 @@ object Meter:
 
     private val acquiredMeters = Local.initNoninheritable(Set.empty[Meter])
 
-    abstract private class Base(permits: Int, reentrant: Boolean)(using initFrame: Frame, allow: AllowUnsafe) extends Meter:
+    sealed abstract private class Base(permits: Int, reentrant: Boolean)(using initFrame: Frame, allow: AllowUnsafe) extends Meter:
 
         // MinValue => closed
         // >= 0     => # of permits

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -329,7 +329,7 @@ object Queue:
     end Unbounded
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
-    abstract class Unsafe[A] extends Serializable:
+    sealed abstract class Unsafe[A] extends Serializable:
         def capacity: Int
         def size()(using AllowUnsafe): Result[Closed, Int]
         def empty()(using AllowUnsafe): Result[Closed, Boolean]
@@ -347,7 +347,7 @@ object Queue:
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
 
-        abstract private class Closeable[A](initFrame: Frame) extends Unsafe[A]:
+        sealed abstract private class Closeable[A](initFrame: Frame) extends Unsafe[A]:
             import AllowUnsafe.embrace.danger
             final protected val _closed = AtomicRef.Unsafe.init(Maybe.empty[Result.Error[Closed]])
 

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -203,7 +203,7 @@ object System:
     def operatingSystem(using Frame): OS < IO = local.use(_.operatingSystem)
 
     /** Abstract class for parsing string values into specific types. */
-    abstract class Parser[E, A] extends Serializable:
+    sealed abstract class Parser[E, A] extends Serializable:
         /** Parses a string value into type A.
           *
           * @param s

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOPromise.scala
@@ -265,9 +265,9 @@ private[kyo] object IOPromise:
 
     type State[+E, +A] = Result[E, A] | Pending[E, A] | Linked[E, A]
 
-    case class Linked[+E, +A](p: IOPromise[E, A])
+    final case class Linked[+E, +A](p: IOPromise[E, A])
 
-    abstract class Pending[+E, +A]:
+    sealed abstract class Pending[+E, +A]:
         self =>
 
         def waiters: Int

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Loop.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Loop.scala
@@ -27,7 +27,7 @@ object Loop:
       * @tparam A
       *   The type of the single state value maintained between iterations
       */
-    abstract class Continue[A] extends Serializable:
+    sealed abstract class Continue[A] extends Serializable:
         private[Loop] def _1: A
 
     /** Represents the state of two values to be carried forward to the next iteration.
@@ -37,7 +37,7 @@ object Loop:
       * @tparam B
       *   The type of the second state value
       */
-    abstract class Continue2[A, B] extends Serializable:
+    sealed abstract class Continue2[A, B] extends Serializable:
         private[Loop] def _1: A
         private[Loop] def _2: B
 
@@ -50,7 +50,7 @@ object Loop:
       * @tparam C
       *   The type of the third state value
       */
-    abstract class Continue3[A, B, C] extends Serializable:
+    sealed abstract class Continue3[A, B, C] extends Serializable:
         private[Loop] def _1: A
         private[Loop] def _2: B
         private[Loop] def _3: C
@@ -67,7 +67,7 @@ object Loop:
       * @tparam D
       *   The type of the fourth state value
       */
-    abstract class Continue4[A, B, C, D] extends Serializable:
+    sealed abstract class Continue4[A, B, C, D] extends Serializable:
         private[Loop] def _1: A
         private[Loop] def _2: B
         private[Loop] def _3: C

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Safepoint.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Safepoint.scala
@@ -128,7 +128,7 @@ object Safepoint:
         immediate(p)(loop(v))
     end propagating
 
-    abstract private[kyo] class Ensure extends AtomicBoolean with Function0[Unit]:
+    sealed abstract private[kyo] class Ensure extends AtomicBoolean with Function0[Unit]:
         def run: Unit
         final def apply(): Unit =
             if compareAndSet(false, true) then

--- a/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
+++ b/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
@@ -267,7 +267,7 @@ object Memory:
     end Unsafe
 
     /** Defines how values of type A are laid out in memory. */
-    abstract class Layout[A] extends Serializable:
+    sealed abstract class Layout[A] extends Serializable:
         inline def get(memory: Unsafe[A], offset: Long)(using AllowUnsafe): A
         inline def set(memory: Unsafe[A], offset: Long, value: A)(using AllowUnsafe): Unit
         def size: Long

--- a/kyo-prelude/shared/src/main/scala/kyo/Local.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Local.scala
@@ -118,7 +118,7 @@ object Local:
         sealed private[kyo] trait State               extends ContextEffect[Map[Local[?], AnyRef]]
         sealed private[kyo] trait NoninheritableState extends ContextEffect[Map[Local[?], AnyRef]] with ContextEffect.Noninheritable
 
-        abstract class Base[A, E <: ContextEffect[Map[Local[?], AnyRef]]] extends Local[A]:
+        sealed abstract class Base[A, E <: ContextEffect[Map[Local[?], AnyRef]]] extends Local[A]:
 
             def tag: Tag[E]
 

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscriber.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscriber.scala
@@ -266,7 +266,7 @@ end StreamSubscriber
 
 object StreamSubscriber:
 
-    abstract private[flow] class SubscriberDone
+    sealed abstract private[flow] class SubscriberDone
     private[flow] case object SubscriberDone extends SubscriberDone
 
     enum EmitStrategy derives CanEqual:


### PR DESCRIPTION
### Problem
Unsealed abstract classes enable for anyone to extend, potentially leading to unsafe/incorrect implementations.

### Solution
Mark all internal/Unsafe classes as sealed where possible. Note: I think `Meter` should also be sealed, but we had a test abusing the extension - not sure how often people will be creating custom meters.