### PR TITLE
Resource: avoid leaking `Queue` based Finalizer details

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import java.io.Closeable
 import kyo.Tag
 import kyo.kernel.ContextEffect
 
@@ -36,9 +35,53 @@ import kyo.kernel.ContextEffect
 sealed trait Resource extends ContextEffect[Resource.Finalizer]
 
 object Resource:
-
     /** Represents a finalizer for a resource. */
-    case class Finalizer(createdAt: Frame, queue: Queue.Unbounded[Unit < (Async & Abort[Throwable])])
+    sealed abstract class Finalizer:
+        def ensure(v: => Any < (Async & Abort[Throwable]))(using Frame): Unit < IO
+
+    object Finalizer:
+        sealed abstract class Closeable extends Finalizer:
+            def close(using Frame): Unit < IO
+            def await(using Frame): Unit < Async
+
+        object Closeable:
+            object Unsafe:
+                def init(parallelism: Int)(using frame: Frame, u: AllowUnsafe): Closeable =
+                    new Closeable:
+                        val queue   = Queue.Unbounded.Unsafe.init[Unit < (Async & Abort[Throwable])](Access.MultiProducerSingleConsumer)
+                        val promise = Promise.Unsafe.init[Nothing, Unit]().safe
+
+                        def ensure(v: => Any < (Async & Abort[Throwable]))(using Frame): Unit < IO =
+                            IO.Unsafe {
+                                if queue.offer(IO(v.unit)).isFailure then
+                                    Abort.panic(new Closed(
+                                        "Finalizer",
+                                        frame,
+                                        "This finalizer is already closed. This may happen if a background fiber escapes the scope of a 'Resource.run' call."
+                                    ))
+                                else ()
+                            }
+                        end ensure
+
+                        def close(using Frame): Unit < IO =
+                            IO.Unsafe {
+                                queue.close() match
+                                    case Absent =>
+                                        Abort.panic(new Closed("Resource finalizer queue already closed.", frame))
+                                    case Present(tasks) =>
+                                        Async.foreachDiscard(tasks, parallelism) { task =>
+                                            Abort.run[Throwable](task)
+                                                .map(_.foldError(_ => (), ex => Log.error("Resource finalizer failed", ex.exception)))
+                                        }
+                                            .handle(Async.run[Nothing, Unit, Any])
+                                            .map(promise.becomeDiscard)
+                            }
+
+                        def await(using Frame): Unit < Async = promise.get
+                end init
+            end Unsafe
+        end Closeable
+    end Finalizer
 
     /** Ensures that the given effect is executed when the resource is released.
       *
@@ -50,18 +93,7 @@ object Resource:
       *   A unit value wrapped in Resource and IO effects.
       */
     def ensure(v: => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & IO) =
-        ContextEffect.suspendWith(Tag[Resource]) { finalizer =>
-            Abort.run(finalizer.queue.offer(IO(v.unit))).map {
-                case Result.Success(_) => ()
-                case _ =>
-                    throw new Closed(
-                        "Finalizer",
-                        finalizer.createdAt,
-                        "The finalizer queue is already closed. This may happen if " +
-                            "a background fiber escapes the scope of a 'Resource.run' call."
-                    )
-            }
-        }
+        ContextEffect.suspendWith(Tag[Resource])(_.ensure(IO(v.unit)))
 
     /** Acquires a resource and provides a release function.
       *
@@ -88,7 +120,7 @@ object Resource:
       * @return
       *   The acquired Closeable resource wrapped in Resource, IO, and S effects.
       */
-    def acquire[A <: Closeable, S](resource: A < S)(using Frame): A < (Resource & IO & S) =
+    def acquire[A <: java.io.Closeable, S](resource: A < S)(using Frame): A < (Resource & IO & S) =
         acquireRelease(resource)(r => IO(r.close()))
 
     /** Runs a resource-managed effect with default parallelism of 1.
@@ -122,26 +154,11 @@ object Resource:
       *   The result of the effect wrapped in Async and S effects.
       */
     def run[A, S](closeParallelism: Int)(v: A < (Resource & S))(using frame: Frame): A < (Async & S) =
-        Queue.Unbounded.initWith[Unit < (Async & Abort[Throwable])](Access.MultiProducerSingleConsumer) { q =>
-            Promise.initWith[Nothing, Unit] { p =>
-                val finalizer = Finalizer(frame, q)
-                def close: Unit < IO =
-                    q.close.map {
-                        case Absent =>
-                            bug("Resource finalizer queue already closed.")
-                        case Present(tasks) =>
-                            Async.foreach(tasks, closeParallelism) { task =>
-                                Abort.run[Throwable](task)
-                                    .map(_.foldError(_ => (), ex => Log.error("Resource finalizer failed", ex.exception)))
-                            }
-                                .unit
-                                .handle(Async.run[Nothing, Unit, Any])
-                                .map(p.becomeDiscard)
-                    }
-                ContextEffect.handle(Tag[Resource], finalizer, _ => finalizer)(v)
-                    .handle(IO.ensure(close))
-                    .map(result => p.get.andThen(result))
-            }
+        IO.Unsafe {
+            val closeable = Finalizer.Closeable.Unsafe.init(closeParallelism)
+            ContextEffect.handle(Tag[Resource], closeable, _ => closeable)(v)
+                .handle(IO.ensure(closeable.close))
+                .map(result => closeable.await.andThen(result))
         }
 
     given Isolate.Contextual[Resource, Any] = Isolate.Contextual.derive[Resource, Any]

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -53,7 +53,7 @@ object Resource:
 
                         def ensure(v: => Any < (Async & Abort[Throwable]))(using Frame): Unit < IO =
                             IO.Unsafe {
-                                if queue.offer(IO(v.unit)).isError then
+                                if !queue.offer(IO(v.unit)).contains(true) then
                                     Abort.panic(new Closed(
                                         "Finalizer",
                                         frame,


### PR DESCRIPTION
### Problem
`Finalizer` could be implemented a number of ways. Exposing the `Queue` makes the implementation hard to change. Additionally, this makes it more complex when we support hierarchical scopes in #1131.

### Solution
Use an `abstract class`, exposing only the necessary behaviors. In a followup, I will work towards a rename to `Scope` (optional?), then adding support for `Scope.fork` or some similar naming. 