### PR TITLE
Creates a stream by repeatedly calling a lazily evaluated function

### DIFF
--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -60,6 +60,35 @@ class StreamTest extends Test:
         }
     }
 
+    "repeatPresent" - {
+        var i = 0
+
+        def reads: Maybe[Chunk[Int]] =
+            val r = i match
+                case 0 => Maybe.Present(Chunk(1, 2, 3))
+                case 1 => Maybe.Present(Chunk.empty[Int])
+                case 2 => Maybe.Present(Chunk(4, 5, 6))
+                case 3 => Maybe.Present(Chunk(7))
+                case _ => Maybe.Absent
+            i += 1
+            r
+        end reads
+
+        "absent" in {
+            assert(Stream.repeatPresent(Maybe.empty[Chunk[Int]]).run.eval == Seq.empty)
+        }
+
+        "present default resize" in {
+            i = 0
+            assert(Stream.repeatPresent(reads).run.eval == Seq(1, 2, 3, 4, 5, 6, 7))
+        }
+
+        "present resize to 1" in {
+            i = 0
+            assert(Stream.repeatPresent(reads, 1).run.eval == Seq(1, 2, 3, 4, 5, 6, 7))
+        }
+    }
+
     "range" - {
         "empty" in {
             assert(Stream.range(0, 0).run.eval == Seq.empty)

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -1,7 +1,5 @@
 package kyo
 
-import zio.test.laws.GenF.chunk
-
 class StreamTest extends Test:
 
     val n = 100000


### PR DESCRIPTION
Creates a stream by repeatedly calling a lazily evaluated function, until the return is absent.

<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->
Stream emit an effect until some end state offers no more values.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->
repeatPresent is a factory method in the Stream class that creates a stream by repeatedly calling a function until it returns an absent value
1. Create a stream from a function that may return values multiple times
2. Automatically terminate the stream when the function returns an absent value
3. Control the chunk size of emitted values for performance optimization


### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
