### PR TITLE
fix and enable JS tests

### DIFF
--- a/kyo-actor/shared/src/test/scala/kyo/ActorTest.scala
+++ b/kyo-actor/shared/src/test/scala/kyo/ActorTest.scala
@@ -328,10 +328,10 @@ class ActorTest extends Test:
                         }
                     }
                 }
-                _       <- actor.send(1)
-                result  <- Abort.run(actor.await)
-                cleaned <- resourceCleaned.get
-            yield assert(cleaned && result == Result.fail(TestError))
+                _      <- actor.send(1)
+                result <- Abort.run(actor.await)
+                _      <- untilTrue(resourceCleaned.get)
+            yield assert(result == Result.fail(TestError))
             end for
         }
     }

--- a/kyo-actor/shared/src/test/scala/kyo/ActorTest.scala
+++ b/kyo-actor/shared/src/test/scala/kyo/ActorTest.scala
@@ -156,7 +156,7 @@ class ActorTest extends Test:
                 assert(events.contains("child2 cleaned up"))
         }
 
-        "child actors are cleaned up when parent fails" in runNotJS {
+        "child actors are cleaned up when parent fails" in run {
             case object ParentError
 
             for
@@ -278,7 +278,7 @@ class ActorTest extends Test:
         }
     }
 
-    "graceful shutdown" in runNotJS {
+    "graceful shutdown" in run {
         for
             started   <- Latch.init(1)
             exit      <- Latch.init(1)
@@ -317,7 +317,7 @@ class ActorTest extends Test:
             yield assert(cleaned)
         }
 
-        "cleans up resources on error" in runNotJS {
+        "cleans up resources on error" in run {
             case object TestError
             for
                 resourceCleaned <- AtomicBoolean.init(false)
@@ -540,7 +540,7 @@ class ActorTest extends Test:
 
     "multiple receive calls" - {
 
-        "combines receiveMax and receiveAll" in runNotJS {
+        "combines receiveMax and receiveAll" in run {
             for
                 results <- Queue.Unbounded.init[String]()
                 actor <- Actor.run {

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -157,6 +157,30 @@ object Async:
       */
     def never[E, A](using Frame): A < Async = Fiber.never[Nothing, A].get
 
+    /** Yields control to the scheduler, allowing other fibers to execute.
+      *
+      * Primarily useful in JavaScript environments for CPU-intensive loops without async operations, as JS lacks automatic preemption. On
+      * JVM/Native platforms, this is less necessary since they use automatic time-slice preemption between threads.
+      *
+      * @return
+      *   Unit wrapped in an Async effect
+      */
+    def yieldNow(using Frame): Unit < Async =
+        Async.run(()).map(_.get)
+
+    /** Yields control to the scheduler and then executes the provided computation.
+      *
+      * Recommended for JavaScript environments to prevent event loop starvation in CPU-intensive operations. On JVM/Native platforms,
+      * automatic preemption makes this less critical.
+      *
+      * @param f
+      *   The computation to execute after yielding
+      * @return
+      *   The result of the computation wrapped in an Async effect
+      */
+    def yieldWith[A, S](f: => A < S)(using Frame): A < (Async & S) =
+        Async.run(()).map(_.use(_ => f))
+
     /** Delays execution of a computation by a specified duration.
       *
       * @param d

--- a/kyo-core/shared/src/main/scala/kyo/Atomic.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Atomic.scala
@@ -1,5 +1,7 @@
 package kyo
 
+import scala.annotation.nowarn
+
 /** A thread-safe atomic integer with effect-based operations.
   *
   * AtomicInt provides a wrapper around platform-specific atomic integer implementations (such as java.util.concurrent.atomic.AtomicInteger
@@ -181,9 +183,11 @@ object AtomicInt:
             inline def getAndDecrement()(using inline allow: AllowUnsafe): Int                       = self.getAndDecrement()
             inline def getAndAdd(v: Int)(using inline allow: AllowUnsafe): Int                       = self.getAndAdd(v)
             inline def addAndGet(v: Int)(using inline allow: AllowUnsafe): Int                       = self.addAndGet(v)
-            inline def getAndUpdate(inline f: Int => Int)(using inline allow: AllowUnsafe): Int      = self.getAndUpdate(f(_))
-            inline def updateAndGet(inline f: Int => Int)(using inline allow: AllowUnsafe): Int      = self.updateAndGet(f(_))
-            inline def safe: AtomicInt                                                               = AtomicInt(self)
+            @nowarn("msg=anonymous")
+            inline def getAndUpdate(inline f: Int => Int)(using inline allow: AllowUnsafe): Int = self.getAndUpdate(f(_))
+            @nowarn("msg=anonymous")
+            inline def updateAndGet(inline f: Int => Int)(using inline allow: AllowUnsafe): Int = self.updateAndGet(f(_))
+            inline def safe: AtomicInt                                                          = AtomicInt(self)
         end extension
     end Unsafe
 end AtomicInt
@@ -370,9 +374,11 @@ object AtomicLong:
             inline def getAndDecrement()(using inline allow: AllowUnsafe): Long                        = self.getAndDecrement()
             inline def getAndAdd(v: Long)(using inline allow: AllowUnsafe): Long                       = self.getAndAdd(v)
             inline def addAndGet(v: Long)(using inline allow: AllowUnsafe): Long                       = self.addAndGet(v)
-            inline def getAndUpdate(inline f: Long => Long)(using inline allow: AllowUnsafe): Long     = self.getAndUpdate(f(_))
-            inline def updateAndGet(inline f: Long => Long)(using inline allow: AllowUnsafe): Long     = self.updateAndGet(f(_))
-            inline def safe: AtomicLong                                                                = AtomicLong(self)
+            @nowarn("msg=anonymous")
+            inline def getAndUpdate(inline f: Long => Long)(using inline allow: AllowUnsafe): Long = self.getAndUpdate(f(_))
+            @nowarn("msg=anonymous")
+            inline def updateAndGet(inline f: Long => Long)(using inline allow: AllowUnsafe): Long = self.updateAndGet(f(_))
+            inline def safe: AtomicLong                                                            = AtomicLong(self)
         end extension
     end Unsafe
 end AtomicLong
@@ -624,9 +630,11 @@ object AtomicRef:
             inline def lazySet(v: A)(using inline allow: AllowUnsafe): Unit                      = self.lazySet(v)
             inline def getAndSet(v: A)(using inline allow: AllowUnsafe): A                       = self.getAndSet(v)
             inline def compareAndSet(curr: A, next: A)(using inline allow: AllowUnsafe): Boolean = self.compareAndSet(curr, next)
-            inline def getAndUpdate(inline f: A => A)(using inline allow: AllowUnsafe): A        = self.getAndUpdate(f(_))
-            inline def updateAndGet(inline f: A => A)(using inline allow: AllowUnsafe): A        = self.updateAndGet(f(_))
-            inline def safe: AtomicRef[A]                                                        = AtomicRef(self)
+            @nowarn("msg=anonymous")
+            inline def getAndUpdate(inline f: A => A)(using inline allow: AllowUnsafe): A = self.getAndUpdate(f(_))
+            @nowarn("msg=anonymous")
+            inline def updateAndGet(inline f: A => A)(using inline allow: AllowUnsafe): A = self.updateAndGet(f(_))
+            inline def safe: AtomicRef[A]                                                 = AtomicRef(self)
         end extension
     end Unsafe
 end AtomicRef

--- a/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
@@ -18,4 +18,15 @@ private[kyo] trait BaseKyoCoreTest extends BaseKyoKernelTest[Abort[Any] & Async 
             IO.Unsafe.evalOrThrow
         )
     end run
+
+    def untilTrue[S](f: => Boolean < S): Unit < (Async & S) =
+        Abort.recover(Abort.panic) {
+            Retry[AssertionError](Schedule.fixed(10.millis)) {
+                f.map {
+                    case false => throw new AssertionError("untilTrue condition failed")
+                    case true  =>
+                }
+            }
+        }
+    end untilTrue
 end BaseKyoCoreTest

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -107,8 +107,8 @@ class AsyncTest extends Test:
 
     "interrupt" - {
 
-        def loop(ref: AtomicInt): Unit < IO =
-            ref.incrementAndGet.map(_ => loop(ref))
+        def loop(ref: AtomicInt): Unit < Async =
+            Async.yieldWith(ref.incrementAndGet.map(_ => loop(ref)))
 
         def runLoop(started: Latch, done: Latch) =
             Resource.run {
@@ -117,7 +117,7 @@ class AsyncTest extends Test:
                 }
             }
 
-        "one fiber" in runNotJS {
+        "one fiber" in run {
             for
                 started     <- Latch.init(1)
                 done        <- Latch.init(1)
@@ -127,7 +127,7 @@ class AsyncTest extends Test:
                 _           <- done.await
             yield assert(interrupted)
         }
-        "multiple fibers" in runNotJS {
+        "multiple fibers" in run {
             for
                 started      <- Latch.init(3)
                 done         <- Latch.init(3)
@@ -144,21 +144,21 @@ class AsyncTest extends Test:
     }
 
     "race" - {
-        "zero" in runNotJS {
+        "zero" in run {
             typeCheckFailure("Async.race()")(
                 "None of the overloaded alternatives of method race in object Async"
             )
         }
-        "one" in runNotJS {
+        "one" in run {
             Async.race(1).map { r =>
                 assert(r == 1)
             }
         }
-        "multiple" in runNotJS {
+        "multiple" in run {
             val ac = new JAtomicInteger(0)
             val bc = new JAtomicInteger(0)
-            def loop(i: Int, s: String): String < IO =
-                IO {
+            def loop(i: Int, s: String): String < Async =
+                Async.yieldNow.andThen {
                     if i > 0 then
                         if s.equals("a") then ac.incrementAndGet()
                         else bc.incrementAndGet()
@@ -172,7 +172,7 @@ class AsyncTest extends Test:
                 assert(bc.get() <= Int.MaxValue)
             }
         }
-        "waits for the first success" in runNotJS {
+        "waits for the first success" in run {
             val ex = new Exception
             Async.race(
                 Async.sleep(1.milli).andThen(42),
@@ -181,7 +181,7 @@ class AsyncTest extends Test:
                 assert(r == 42)
             }
         }
-        "returns the last failure if all fibers fail" in runNotJS {
+        "returns the last failure if all fibers fail" in run {
             val ex1 = new Exception
             val ex2 = new Exception
             val race =
@@ -193,7 +193,7 @@ class AsyncTest extends Test:
                 r => assert(r == Result.panic(ex1))
             }
         }
-        "never" in runNotJS {
+        "never" in run {
             Async.race(Async.never, 1).map { r =>
                 assert(r == 1)
             }
@@ -249,23 +249,24 @@ class AsyncTest extends Test:
         yield assert(v1 + v2 + v3 + l.sum == 15)
     }
 
-    "interrupt" in runNotJS {
-        def loop(ref: AtomicInt): Unit < IO =
-            ref.incrementAndGet.map(_ => loop(ref))
+    "interrupt" in run {
+        def loop(ref: AtomicInt): Unit < Async =
+            Async.yieldWith(ref.incrementAndGet.map(_ => loop(ref)))
 
-        def task(l: Latch): Unit < Async =
-            Resource.run[Unit, IO] {
-                Resource.ensure(l.release).map { _ =>
-                    AtomicInt.init(0).map(loop)
+        def task(started: Latch, done: Latch): Unit < Async =
+            Resource.run {
+                Resource.ensure(done.release).map { _ =>
+                    started.release.andThen(AtomicInt.init(0).map(loop))
                 }
             }
 
         for
-            l           <- Latch.init(1)
-            fiber       <- Async.run(task(l))
-            _           <- Async.sleep(10.millis)
+            started     <- Latch.init(1)
+            done        <- Latch.init(1)
+            fiber       <- Async.run(task(started, done))
+            _           <- started.await
             interrupted <- fiber.interrupt(panic)
-            _           <- l.await
+            _           <- done.await
         yield assert(interrupted)
         end for
     }
@@ -543,14 +544,12 @@ class AsyncTest extends Test:
             yield assert(result == 42)
         }
 
-        "interrupts computation" in runNotJS {
+        "interrupts computation" in run {
             for
-                flag  <- AtomicBoolean.init(false)
-                fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onInterrupt(_ => flag.set(true))
-                // TODO Boundary inference issue
-                v = Async.timeout(1.millis)(fiber.get)
-                result <- Async.run(v)
+                flag   <- AtomicBoolean.init(false)
+                fiber  <- Promise.init[Nothing, Int]
+                _      <- fiber.onInterrupt(_ => flag.set(true))
+                result <- Async.run(Async.timeout(1.millis)(fiber.get))
                 result <- fiber.getResult
                 _      <- untilTrue(flag.get)
             yield assert(result.isFailure)
@@ -1378,6 +1377,38 @@ class AsyncTest extends Test:
                 waiters <- fiber.waiters
                 _       <- exit.release
             yield assert(waiters == 1)
+        }
+    }
+
+    "yield" - {
+        "yieldNow suspends and resumes execution" in run {
+            for
+                counter <- AtomicInt.init(0)
+                result  <- Async.yieldNow.andThen(counter.incrementAndGet)
+                count   <- counter.get
+            yield
+                assert(result == 1)
+                assert(count == 1)
+        }
+
+        "yieldWith executes computation after yielding" in run {
+            for
+                counter <- AtomicInt.init(0)
+                result  <- Async.yieldWith(counter.incrementAndGet)
+                count   <- counter.get
+            yield
+                assert(result == 1)
+                assert(count == 1)
+        }
+
+        "stack safety with multiple yields" in run {
+            def loop(i: Int): Int < Async =
+                if i <= 0 then 0
+                else Async.yieldNow.andThen(loop(i - 1).map(_ + 1))
+
+            loop(1000).map { result =>
+                assert(result == 1000)
+            }
         }
     }
 

--- a/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
@@ -29,7 +29,7 @@ class BarrierTest extends Test:
         yield succeed
     }
 
-    "await + fibers" in runNotJS {
+    "await + fibers" in run {
         for
             barrier <- Barrier.init(1)
             _       <- Async.run(barrier.await)
@@ -37,14 +37,14 @@ class BarrierTest extends Test:
         yield succeed
     }
 
-    "await(2) + fibers" in runNotJS {
+    "await(2) + fibers" in run {
         for
             barrier <- Barrier.init(2)
             _       <- Async.zip(barrier.await, barrier.await)
         yield succeed
     }
 
-    "contention" in runNotJS {
+    "contention" in run {
         for
             barrier <- Barrier.init(1000)
             _       <- Async.fill(1000, 1000)(barrier.await)

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -114,17 +114,17 @@ class FiberTest extends Test:
     }
 
     "race" - {
-        "zero" in runNotJS {
+        "zero" in run {
             typeCheckFailure("Async.race()")(
                 "None of the overloaded alternatives of method race in object Async"
             )
         }
-        "one" in runNotJS {
+        "one" in run {
             Fiber.race(Seq(1)).map(_.get).map { r =>
                 assert(r == 1)
             }
         }
-        "n" in runNotJS {
+        "n" in run {
             val ac = new JAtomicInteger(0)
             val bc = new JAtomicInteger(0)
             def loop(i: Int, s: String): String < IO =
@@ -143,7 +143,7 @@ class FiberTest extends Test:
             }
         }
         "interrupts losers" - {
-            "promise + plain value" in runNotJS {
+            "promise + plain value" in run {
                 for
                     latch   <- Latch.init(1)
                     promise <- Promise.init[Nothing, Int]
@@ -152,7 +152,7 @@ class FiberTest extends Test:
                     _       <- latch.await
                 yield assert(result == 42)
             }
-            "promise + delayed" in runNotJS {
+            "promise + delayed" in run {
                 for
                     latch   <- Latch.init(1)
                     promise <- Promise.init[Nothing, Int]
@@ -161,7 +161,7 @@ class FiberTest extends Test:
                     _       <- latch.await
                 yield assert(result == 42)
             }
-            "slow + fast" in runNotJS {
+            "slow + fast" in run {
                 for
                     adder <- LongAdder.init
                     result <-
@@ -716,7 +716,7 @@ class FiberTest extends Test:
             end for
         }
 
-        "preserves original order" in runNotJS {
+        "preserves original order" in run {
             for
                 fiber <- Fiber.gather(10)(Seq(
                     Async.delay(3.millis)(1),
@@ -727,7 +727,7 @@ class FiberTest extends Test:
             yield assert(result == Chunk(1, 2, 3))
         }
 
-        "preserves original order with max limit" in runNotJS {
+        "preserves original order with max limit" in run {
             for
                 fiber <- Fiber.gather(2)(Seq(
                     Async.delay(100.millis)(1),
@@ -738,7 +738,7 @@ class FiberTest extends Test:
             yield assert(result == Chunk(2, 3))
         }
 
-        "handles concurrent completions" in runNotJS {
+        "handles concurrent completions" in run {
             for
                 latch  <- Latch.init(1)
                 fiber  <- Fiber.gather(20)(Seq.fill(20)(latch.await.andThen(42)))
@@ -761,7 +761,7 @@ class FiberTest extends Test:
             end for
         }
 
-        "handles mixed success/failure with exact max" in runNotJS {
+        "handles mixed success/failure with exact max" in run {
             val error = new Exception("test error")
             for
                 fiber <- Fiber.gather(2)(Seq(
@@ -778,7 +778,7 @@ class FiberTest extends Test:
             end for
         }
 
-        "handles race conditions in counter updates" in runNotJS {
+        "handles race conditions in counter updates" in run {
             Loop.repeat(repeats) {
                 for
                     latch1 <- Latch.init(1)
@@ -797,7 +797,7 @@ class FiberTest extends Test:
             }.andThen(succeed)
         }
 
-        "race conditions in error propagation" in runNotJS {
+        "race conditions in error propagation" in run {
             Loop.repeat(50) {
                 for
                     latch <- Latch.init(1)
@@ -853,7 +853,7 @@ class FiberTest extends Test:
             }.andThen(succeed)
         }
 
-        "interrupts all child fibers" in runNotJS {
+        "interrupts all child fibers" in run {
             Loop.repeat(repeats) {
                 for
                     interruptCount <- AtomicInt.init
@@ -877,7 +877,7 @@ class FiberTest extends Test:
             }.andThen(succeed)
         }
 
-        "interrupts remaining fibers when max results reached" in runNotJS {
+        "interrupts remaining fibers when max results reached" in run {
             Loop.repeat(repeats) {
                 for
                     interruptCount <- AtomicInt.init

--- a/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
@@ -38,7 +38,7 @@ class LatchTest extends Test:
         yield succeed
     }
 
-    "countDown + fibers + await" in runNotJS {
+    "countDown + fibers + await" in run {
         for
             latch <- Latch.init(1)
             _     <- Async.run(latch.release)
@@ -46,7 +46,7 @@ class LatchTest extends Test:
         yield succeed
     }
 
-    "countDown(2) + fibers + await" in runNotJS {
+    "countDown(2) + fibers + await" in run {
         for
             latch <- Latch.init(2)
             _     <- Async.zip(latch.release, latch.release)
@@ -54,7 +54,7 @@ class LatchTest extends Test:
         yield succeed
     }
 
-    "contention" in runNotJS {
+    "contention" in run {
         for
             latch <- Latch.init(1000)
             _     <- Async.fill(1000, 1000)(latch.release)

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -3,19 +3,19 @@ package kyo
 class MeterTest extends Test:
 
     "mutex" - {
-        "ok" in runNotJS {
+        "ok" in run {
             for
                 t <- Meter.initMutex
                 v <- t.run(2)
             yield assert(v == 2)
         }
 
-        "run" in runNotJS {
+        "run" in run {
             for
                 t  <- Meter.initMutex
                 p  <- Promise.init[Nothing, Int]
                 b1 <- Promise.init[Nothing, Unit]
-                f1 <- Async.run(t.run(b1.complete(Result.unit).map(_ => p.block(Duration.Infinity))))
+                f1 <- Async.run(t.run(b1.complete(Result.unit).map(_ => p.getResult)))
                 _  <- b1.get
                 a1 <- t.availablePermits
                 w1 <- t.pendingWaiters
@@ -34,12 +34,12 @@ class MeterTest extends Test:
             yield assert(a1 == 0 && w1 == 0 && !d1 && !d2 && a2 == 0 && w2 == 1 && v1 == Result.succeed(1) && v2 == 2 && a3 == 1 && w3 == 0)
         }
 
-        "tryRun" in runNotJS {
+        "tryRun" in run {
             for
                 sem <- Meter.initMutex
                 p   <- Promise.init[Nothing, Int]
                 b1  <- Promise.init[Nothing, Unit]
-                f1  <- Async.run(sem.tryRun(b1.complete(Result.unit).map(_ => p.block(Duration.Infinity))))
+                f1  <- Async.run(sem.tryRun(b1.complete(Result.unit).map(_ => p.getResult)))
                 _   <- b1.get
                 a1  <- sem.availablePermits
                 w1  <- sem.pendingWaiters
@@ -52,7 +52,7 @@ class MeterTest extends Test:
     }
 
     "semaphore" - {
-        "ok" in runNotJS {
+        "ok" in run {
             for
                 t  <- Meter.initSemaphore(2)
                 v1 <- t.run(2)
@@ -60,15 +60,15 @@ class MeterTest extends Test:
             yield assert(v1 == 2 && v2 == 3)
         }
 
-        "run" in runNotJS {
+        "run" in run {
             for
                 t  <- Meter.initSemaphore(2)
                 p  <- Promise.init[Nothing, Int]
                 b1 <- Promise.init[Nothing, Unit]
-                f1 <- Async.run(t.run(b1.complete(Result.unit).map(_ => p.block(Duration.Infinity))))
+                f1 <- Async.run(t.run(b1.complete(Result.unit).map(_ => p.getResult)))
                 _  <- b1.get
                 b2 <- Promise.init[Nothing, Unit]
-                f2 <- Async.run(t.run(b2.complete(Result.unit).map(_ => p.block(Duration.Infinity))))
+                f2 <- Async.run(t.run(b2.complete(Result.unit).map(_ => p.getResult)))
                 _  <- b2.get
                 a1 <- t.availablePermits
                 w1 <- t.pendingWaiters
@@ -90,17 +90,17 @@ class MeterTest extends Test:
                 v1 == Result.succeed(1) && v2 == Result.succeed(1) && v3 == 2 && a3 == 2 && w3 == 0)
         }
 
-        "tryRun" in runNotJS {
+        "tryRun" in run {
             for
                 sem <- Meter.initSemaphore(2)
                 p   <- Promise.init[Nothing, Int]
                 b1  <- Promise.init[Nothing, Unit]
-                f1  <- Async.run(sem.tryRun(b1.complete(Result.unit).map(_ => p.block(Duration.Infinity))))
+                f1  <- Async.run(sem.tryRun(b1.complete(Result.unit).map(_ => p.getResult)))
                 _   <- b1.get
                 a1  <- sem.availablePermits
                 w1  <- sem.pendingWaiters
                 b2  <- Promise.init[Nothing, Unit]
-                f2  <- Async.run(sem.tryRun(b2.complete(Result.unit).map(_ => p.block(Duration.Infinity))))
+                f2  <- Async.run(sem.tryRun(b2.complete(Result.unit).map(_ => p.getResult)))
                 _   <- b2.get
                 a2  <- sem.availablePermits
                 w2  <- sem.pendingWaiters
@@ -190,19 +190,19 @@ class MeterTest extends Test:
     }
 
     def loop(meter: Meter, counter: AtomicInt): Unit < (Async & Abort[Closed]) =
-        meter.run(counter.incrementAndGet).map(_ => loop(meter, counter))
+        Async.yieldWith(meter.run(counter.incrementAndGet).map(_ => loop(meter, counter)))
 
     val panic = Result.Panic(new Exception)
 
     "rate limiter" - {
-        "ok" in runNotJS {
+        "ok" in run {
             for
                 t  <- Meter.initRateLimiter(2, 1.milli)
                 v1 <- t.run(2)
                 v2 <- t.run(3)
             yield assert(v1 == 2 && v2 == 3)
         }
-        "one loop" in runNotJS {
+        "one loop" in run {
             for
                 meter   <- Meter.initRateLimiter(10, 1.milli)
                 counter <- AtomicInt.init(0)
@@ -212,7 +212,7 @@ class MeterTest extends Test:
                 v1      <- counter.get
             yield assert(v1 >= 2 && v1 <= 200)
         }
-        "two loops" in runNotJS {
+        "two loops" in run {
             for
                 meter   <- Meter.initRateLimiter(10, 1.milli)
                 counter <- AtomicInt.init(0)
@@ -224,7 +224,7 @@ class MeterTest extends Test:
                 v1      <- counter.get
             yield assert(v1 >= 2 && v1 <= 200)
         }
-        "replenish doesn't overflow" in runNotJS {
+        "replenish doesn't overflow" in run {
             for
                 meter     <- Meter.initRateLimiter(5, 5.millis)
                 _         <- Async.sleep(32.millis)
@@ -235,7 +235,7 @@ class MeterTest extends Test:
 
     "pipeline" - {
 
-        "run" in runNotJS {
+        "run" in run {
             for
                 meter   <- Meter.pipeline(Meter.initRateLimiter(2, 1.milli), Meter.initMutex)
                 counter <- AtomicInt.init(0)
@@ -248,22 +248,19 @@ class MeterTest extends Test:
             yield assert(v1 >= 0 && v1 < 200)
         }
 
-        "tryRun" in runNotJS {
+        "tryRun" in run {
             for
-                meter   <- Meter.pipeline(Meter.initRateLimiter(2, 100.millis), Meter.initMutex)
-                counter <- AtomicInt.init(0)
-                f1      <- Async.run(loop(meter, counter))
-                _       <- Async.sleep(5.millis)
-                _       <- untilTrue(meter.availablePermits.map(_ == 0))
-                r       <- meter.tryRun(())
-                _       <- f1.interrupt(panic)
-            yield assert(r.isEmpty)
+                meter <- Meter.pipeline(Meter.initRateLimiter(2, 10.millis), Meter.initMutex)
+                f1    <- Async.run(meter.run(Async.never))
+                _     <- untilTrue(meter.tryRun(()).map(_.isEmpty))
+                _     <- f1.interrupt(panic)
+            yield succeed
         }
     }
 
     "reentrancy" - {
         "mutex" - {
-            "reentrant by default" in runNotJS {
+            "reentrant by default" in run {
                 for
                     mutex <- Meter.initMutex
                     result <- mutex.run {
@@ -274,7 +271,7 @@ class MeterTest extends Test:
                 yield assert(result == 42)
             }
 
-            "non-reentrant" in runNotJS {
+            "non-reentrant" in run {
                 for
                     meter  <- Meter.initMutex(reentrant = false)
                     p      <- Promise.init[Nothing, Int]
@@ -286,7 +283,7 @@ class MeterTest extends Test:
                 yield assert(!done && result.isPanic)
             }
 
-            "nested forked fiber can't reenter" in runNotJS {
+            "nested forked fiber can't reenter" in run {
                 for
                     meter <- Meter.initMutex
                     (done, result) <- meter.run {
@@ -305,7 +302,7 @@ class MeterTest extends Test:
         }
 
         "semaphore" - {
-            "reentrant by default" in runNotJS {
+            "reentrant by default" in run {
                 for
                     sem <- Meter.initSemaphore(1)
                     result <- sem.run {
@@ -316,7 +313,7 @@ class MeterTest extends Test:
                 yield assert(result == 42)
             }
 
-            "non-reentrant" in runNotJS {
+            "non-reentrant" in run {
                 for
                     meter  <- Meter.initSemaphore(1, reentrant = false)
                     p      <- Promise.init[Nothing, Int]
@@ -328,7 +325,7 @@ class MeterTest extends Test:
                 yield assert(!done && result.isPanic)
             }
 
-            "nested forked fiber can't reenter" in runNotJS {
+            "nested forked fiber can't reenter" in run {
                 for
                     meter <- Meter.initSemaphore(1)
                     (done, result) <- meter.run {
@@ -347,7 +344,7 @@ class MeterTest extends Test:
         }
 
         "rate limiter" - {
-            "reentrant by default" in runNotJS {
+            "reentrant by default" in run {
                 for
                     rateLimiter <- Meter.initRateLimiter(1, 60.seconds)
                     result <- rateLimiter.run {
@@ -358,7 +355,7 @@ class MeterTest extends Test:
                 yield assert(result == 42)
             }
 
-            "non-reentrant" in runNotJS {
+            "non-reentrant" in run {
                 for
                     meter  <- Meter.initRateLimiter(1, 60.seconds, reentrant = false)
                     p      <- Promise.init[Nothing, Int]
@@ -370,7 +367,7 @@ class MeterTest extends Test:
                 yield assert(!done && result.isPanic)
             }
 
-            "nested forked fiber can't reenter" in runNotJS {
+            "nested forked fiber can't reenter" in run {
                 for
                     meter <- Meter.initRateLimiter(1, 60.seconds)
                     (done, result) <- meter.run {
@@ -389,7 +386,7 @@ class MeterTest extends Test:
         }
 
         "pipeline" - {
-            "reentrant when all components are reentrant" in runNotJS {
+            "reentrant when all components are reentrant" in run {
                 for
                     mutex       <- Meter.initMutex
                     sem         <- Meter.initSemaphore(1)
@@ -403,7 +400,7 @@ class MeterTest extends Test:
                 yield assert(result == 42)
             }
 
-            "non-reentrant when any component is non-reentrant" in runNotJS {
+            "non-reentrant when any component is non-reentrant" in run {
                 for
                     mutex       <- Meter.initMutex
                     sem         <- Meter.initSemaphore(1, reentrant = false)
@@ -420,7 +417,7 @@ class MeterTest extends Test:
                 yield assert(!done && result.isPanic)
             }
 
-            "nested forked fiber can't reenter" in runNotJS {
+            "nested forked fiber can't reenter" in run {
                 for
                     mutex       <- Meter.initMutex
                     sem         <- Meter.initSemaphore(1)

--- a/kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala
@@ -49,20 +49,6 @@ private[kyo] trait BaseKyoKernelTest[S] extends BaseKyoDataTest:
         else
             Future.successful(assertionSuccess)
 
-    def untilTrue[S](f: => Boolean < S): Boolean < S =
-        def now: Duration = System.currentTimeMillis().millis
-        val start         = now
-        def loop(): Boolean < S =
-            if now - start > timeout then
-                throw new TimeoutException
-            else
-                f.map {
-                    case true  => true
-                    case false => loop()
-                }
-        loop()
-    end untilTrue
-
     def timeout =
         if Platform.isDebugEnabled then
             Duration.Infinity


### PR DESCRIPTION
Fixes #1138

### Problem

We have tests disabled in JS because they require multiple threads.

### Solution

Fix tests to avoid hot loops hogging the JS thread.
