### PR TITLE
[core] optimize Resource.run without resources

### DIFF
--- a/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
@@ -141,6 +141,10 @@ class ResourceTest extends Test:
             }
     }
 
+    "empty run" in run {
+        Resource.run("a").map(s => assert(s == "a"))
+    }
+
     "effectful acquireRelease" taggedAs jvmOnly in run {
         val io =
             for


### PR DESCRIPTION

### Problem

`Resources.run` forks a fiber to close resources but it isn't necessary if there are no resources to close.

### Solution

Complete the promise immediately if the queue is empty.
