### PR TITLE
[build] update dotty-cps-async

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -361,7 +361,7 @@ lazy val `kyo-direct` =
         .dependsOn(`kyo-core`)
         .settings(
             `kyo-settings`,
-            libraryDependencies += "com.github.rssh" %%% "dotty-cps-async" % "0.9.23"
+            libraryDependencies += "io.github.dotty-cps-async" %%% "dotty-cps-async" % "1.0.0"
         )
         .jvmSettings(mimaCheck(false))
         .nativeSettings(`native-settings`)


### PR DESCRIPTION

### Problem

I missed the new version of `dotty-cps-async` in https://github.com/getkyo/kyo/pull/1146 because the project is using a different org id now.

### Solution

Update the dependency.