### PR TITLE
Use Effect.defer instead of Effect.catching

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -454,11 +454,8 @@ object Abort:
       */
     def catching[E](
         using Frame
-    )[A, S](v: => A < S)(using ct: SafeClassTag[E]): A < (Abort[E] & S) =
-        Effect.catching(v) {
-            case ct(ex) => Abort.fail(ex)
-            case ex     => Abort.panic(ex)
-        }
+    )[A, S](v: => A < S): A < (Abort[E] & S) =
+        Effect.defer(v)
 
     /** Catches exceptions of type E, transforms and converts them to Abort failures.
       *
@@ -476,10 +473,10 @@ object Abort:
     )[A, S, E1](f: E => E1)(v: => A < S)(
         using ct: SafeClassTag[E]
     ): A < (Abort[E1] & S) =
-        Effect.catching(v) {
-            case ct(ex) => Abort.fail(f(ex))
-            case ex     => Abort.panic(ex)
-        }
+        runWith[E](v):
+            case Success(a)  => a
+            case Failure(ex) => Abort.fail(f(ex))
+            case Panic(p)    => Abort.panic(p)
 
     /** Provides methods for working with literal error values in Abort effects.
       *


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

I was looking at the implementation for `Abort` and noticed that [`catching`](https://github.com/getkyo/kyo/blob/c67d64bab66bf152e0b4bfbf6d22eb555925e63b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala#L444-L461) uses [`Effect.catching`](https://github.com/getkyo/kyo/blob/c67d64bab66bf152e0b4bfbf6d22eb555925e63b/kyo-kernel/shared/src/main/scala/kyo/kernel/Effect.scala#L25-L62) whereas [`runWith`](https://github.com/getkyo/kyo/blob/c67d64bab66bf152e0b4bfbf6d22eb555925e63b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala#L176-L226) uses [`ArrowEffect.handleCatching`](https://github.com/getkyo/kyo/blob/c67d64bab66bf152e0b4bfbf6d22eb555925e63b/kyo-kernel/shared/src/main/scala/kyo/kernel/ArrowEffect.scala#L436-L480). `runWith` has to catch the failures because it may have been widened from some other suspended computation. This means that it is redundant to have the effect catch the error as part of the suspended computation since it is going to catch it when the effect is handled anyway.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

I replaced `Effect.catching` with `Effect.defer` in the simple `catching`.

In the overload of `catching` which maps the failure I changed it to use `runWith` like `recover` etc. I think this method was missing tests so I added some minimal ones.

I was wondering whether `Effect.catching` could be removed but it is still being used by `Debug` and `KyoSttpMonad`. Perhaps they could use `Abort` instead but I didn't bother looking at that yet but I can if it is worth it.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
