### PR TITLE
Pass single transformation to handle by-value

### DIFF
--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -175,9 +175,8 @@ object `<`:
           * @return
           *   The result of applying the transformation
           */
-        inline def handle[B](inline f: (=> A < S) => B): B =
-            def handle1 = v
-            f(handle1)
+        inline def handle[B](inline f: A < S => B): B =
+            f(v)
         end handle
 
         /** Applies two transformations to this computation in sequence.


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

During some more spelunking I realised that the first transformation passed to the single `handle` function was being passed by-name unnecessarily. The other `handle` functions already take it by-value.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Pass the first transformation by-value.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
