### PR TITLE
Sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,9 +1379,9 @@ import kyo.*
 val countSink: Sink[Int, Int, Any] = Sink.count[Int]
 // add all integers in stream together
 val sumSink: Sink[Int, Int, Any] = Sink.fold(0)((a: Int, v: Int) => a + v)
-// zip combines sinks together, applying them to same stream elements in tandem, and
+// `zip` combines sinks together, applying them to same stream elements in tandem, and
 // producing a tuple of the output values of each sink.
-// map transforms the output value
+// `map` transforms the output value
 val averageSink: Sink[Int, Double, Any] = sumSink.zip(countSink).map { 
     case (sum, count) => sum / count
 }

--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,49 @@ The `Stream` effect is useful for processing large amounts of data in a memory-e
 
 Note that a number of `Stream` methods (e.g., `map`, `filter`, `mapChunk`) are overloaded to provide different implementations for pure vs effectful transformations. This can make a big difference for performance, so take care that the functions you pass to these methods are typed to return pure values if they do not include effects. Unnecessarily lifting them to return `A < Any` will result in performance loss.
 
+#### Sink: stream evaluation
+
+While typically it is sufficient to use the built-in methods on `Stream` to run streams and evaluate them to some value or outcome, it can also be useful to abstract the evaluation into a separate type that can be composed and manipulated separately from any actual stream. For this purpose, Kyo includes a `Sink[V, A, S]` type, inspired by ZIO's `ZSink`, which represents the processing of a stream of element type `V` into an output value of type `A` using effect types `S`.
+
+To run a stream into a sink, you can use `Stream#into` or `Sink#consume`
+
+All of the evaluation methods available on `Stream` are available as constructors for `Sink`s, e.g:
+
+```scala
+import kyo.*
+
+val stream = Stream.init(1 to 10)
+
+val collectValuesSink: Sink[Int, Chunk[Int], Any] = Sink.collect[Int]
+val collectedValues: Chunk[Int] < Any = stream.into(collectedValues)
+
+val printValuesSink: Sink[Int, Unit, IO] = Sink.foreach((v: Int) => Console.printLine(s"Value: $v"))
+val printedValues: Unit < IO = stream.into(printValuesSink)
+
+val sumValuesSink: Sink[Int, Int, Any] = Sink.fold(0)((a: Int, v: Int) => a + v)
+val summedValues: Int < Any = stream.into(sumValuesSink)
+```
+
+Sinks can then be combined and transformed to produce new sinks:
+
+```scala
+// built in sink to count elements in stream
+val countSink = Sink[Int, Int, Any] = Sink.count[Int]
+// add all integers in stream together
+val sumSink = Sink[Int, Int, Any] = Sink.fold(0)((a: Int, v: Int) => a + v)
+// zip combines sinks together, applying them to same stream elements in tandem, and
+// producing a tuple of the output values of each sink.
+// map transforms the output value
+val averageSink: Sink[Int, Double, Any] = sumSink.zip(countSink).map { 
+    case (sum, count) => sum / count
+}
+// contramap transforms the sink to consume a different stream type
+val avgStringLengthSink = averageSink.contramap((str: String) => str.length)
+
+val strings = Stream.init(Seq("one", "two", "three"))
+val avgStringLength: Double < Any = strings.into(avgStringLengthSink)
+```
+
 ### Var: Stateful Computations
 
 The `Var` effect allows for stateful computations, similar to the `State` monad. It enables the management of state within a computation in a purely functional manner.

--- a/README.md
+++ b/README.md
@@ -1361,7 +1361,7 @@ import kyo.*
 val stream = Stream.init(1 to 10)
 
 val collectValuesSink: Sink[Int, Chunk[Int], Any] = Sink.collect[Int]
-val collectedValues: Chunk[Int] < Any = stream.into(collectedValues)
+val collectedValues: Chunk[Int] < Any = stream.into(collectValuesSink)
 
 val printValuesSink: Sink[Int, Unit, IO] = Sink.foreach((v: Int) => Console.printLine(s"Value: $v"))
 val printedValues: Unit < IO = stream.into(printValuesSink)
@@ -1373,10 +1373,12 @@ val summedValues: Int < Any = stream.into(sumValuesSink)
 Sinks can then be combined and transformed to produce new sinks:
 
 ```scala
+import kyo.*
+
 // built in sink to count elements in stream
-val countSink = Sink[Int, Int, Any] = Sink.count[Int]
+val countSink: Sink[Int, Int, Any] = Sink.count[Int]
 // add all integers in stream together
-val sumSink = Sink[Int, Int, Any] = Sink.fold(0)((a: Int, v: Int) => a + v)
+val sumSink: Sink[Int, Int, Any] = Sink.fold(0)((a: Int, v: Int) => a + v)
 // zip combines sinks together, applying them to same stream elements in tandem, and
 // producing a tuple of the output values of each sink.
 // map transforms the output value

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -113,7 +113,7 @@ object IOTask:
         context: Context,
         finalizers: Finalizers = Finalizers.empty,
         runtime: Int = 0
-    )(using Frame): IOTask[Ctx, E, A] =
+    ): IOTask[Ctx, E, A] =
         val ctx = context
         val task =
             if ctx.isEmpty then

--- a/kyo-data/shared/src/main/scala/kyo/Discriminator.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Discriminator.scala
@@ -1,0 +1,9 @@
+package kyo
+
+/** A dummy class used to use to help the compiler distinguish between overloaded methods that have subtle type differences.
+  */
+sealed abstract class Discriminator {}
+
+object Discriminator:
+    private val cached  = new Discriminator {}
+    given Discriminator = cached

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -231,7 +231,7 @@ object Sink:
                 Poll.andMap[Chunk[V]]:
                     case Absent => Loop.done(currentChunk)
                     case Present(c) =>
-                        Loop.continue(currentChunk ++ c)
+                        Loop.continue(currentChunk.concat(c))
     end collect
 
     /** Construct a sink that counts streaming elements.

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -57,8 +57,14 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                             )
                         ,
                         done = a =>
-                            pollB.map: b =>
-                                Loop.done((a, b))
+                            ArrowEffect.handleFirst(tag, pollB)(
+                                handle = [C] =>
+                                    (_, contB) =>
+                                        contB(polledValue).map: b =>
+                                            Loop.done((a, b)),
+                                done = b =>
+                                    Loop.done((a, b))
+                            )
                     )
     end zip
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -103,7 +103,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
         ev: NotGiven[V2 <:< (Any < Nothing)],
-        d: Sink.Dummy,
+        d: Discriminator,
         fr: Frame
     ): Sink[V2, A, S & S2] =
         Sink:
@@ -156,7 +156,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
         ev: NotGiven[V2 <:< (Any < Nothing)],
-        d: Sink.Dummy,
+        d: Discriminator,
         fr: Frame
     ): Sink[V2, A, S & S2] =
         Sink:
@@ -446,11 +446,5 @@ object Sink:
     ): Sink[V, (A, B, C, D, E, F, G, H, I, J), S] =
         a.zip(zip(b, c, d, e, f, g, h, i, j)).map:
             case (a, tail) => a *: tail
-
-    /** A dummy type that can be used as implicit evidence to help the compiler discriminate between overloaded methods.
-      */
-    sealed class Dummy extends Serializable
-    object Dummy:
-        given Dummy = new Dummy {}
 
 end Sink

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -5,7 +5,6 @@ import kyo.kernel.ArrowEffect
 import kyo.kernel.internal.WeakFlat
 import scala.annotation.nowarn
 import scala.annotation.targetName
-import scala.util.NotGiven
 
 /** Processes a stream of type `V`, producing a value of type `A`.
   *
@@ -80,7 +79,6 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
     final def contramap[V2](f: V2 => V)(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
-        ev: NotGiven[V2 <:< (Any < Nothing)],
         fr: Frame
     ): Sink[V2, A, S] =
         Sink:
@@ -102,7 +100,6 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
     final def contramap[V2, S2](f: V2 => V < S2)(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
-        ev: NotGiven[V2 <:< (Any < Nothing)],
         d: Discriminator,
         fr: Frame
     ): Sink[V2, A, S & S2] =
@@ -128,7 +125,6 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
     final def contramapChunk[V2](f: Chunk[V2] => Chunk[V])(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
-        ev: NotGiven[V2 <:< (Any < Nothing)],
         fr: Frame
     ): Sink[V2, A, S] =
         Sink:
@@ -151,7 +147,6 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
     final def contramapChunk[V2, S2](f: Chunk[V2] => Chunk[V] < S2)(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
-        ev: NotGiven[V2 <:< (Any < Nothing)],
         d: Discriminator,
         fr: Frame
     ): Sink[V2, A, S & S2] =

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -144,7 +144,8 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                             ((), cont(maybeChunkV))
             )
 
-    /** Transform a sink to consume a stream of a different element type using an effectful mapping function that transforms streamed chunks.
+    /** Transform a sink to consume a stream of a different element type using an effectful mapping function that transforms streamed
+      * chunks.
       *
       * @param f
       *   Effectful function mapping chunks of new stream element type to chunks of the original stream element type

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -9,7 +9,8 @@ import scala.util.NotGiven
 
 /** Processes a stream of type `V`, producing a value of type `A`.
   *
-  * `Sink` provides an abstraction for running `Stream` s that can be composed and transformed in various ways.
+  * `Sink` provides a composable abstraction for processing `Stream` s. A `Sink[V, A, S]` can process a stream of type `Stream[V, S2]` to
+  * produce a value of type `A` using effects `S & S2`.
   *
   * @tparam V
   *   The type of values that this sink can process
@@ -23,9 +24,19 @@ import scala.util.NotGiven
   */
 sealed abstract class Sink[V, A, -S] extends Serializable:
 
-    /** Returns the effect that produces the output value from polling chunks of `V`s. */
+    /** Returns the effect that produces the output value `A` from polling chunks of `V`. */
     def poll: A < (Poll[Chunk[V]] & S)
 
+    /** Combine with another sink. Each element of the stream is processed in tandem by both sinks, producing a tuple of their result
+      * values.
+      *
+      * @note
+      *   Departure from the ZIO API, where `zip` composes ZSinks in sequence instead of in parallel
+      * @param other
+      *   Second sink to combine with
+      * @return
+      *   A new sink that produces a tuple of the outputs of the source sinks.
+      */
     def zip[B, S2](other: Sink[V, B, S2])(using Tag[V], Frame): Sink[V, (A, B), S & S2] =
         Sink:
             Loop((poll, other.poll)): (pollA, pollB) =>
@@ -46,6 +57,14 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                                     Loop.continue(nextA, nextB)
     end zip
 
+    /** Transform a sink to consume a stream of a different element type by providing a function to transform elements of the new type to
+      * the original element type.
+      *
+      * @param f
+      *   Function mapping new stream element type to original stream element type
+      * @return
+      *   A new sink that processes streams of the new element type
+      */
     def contramap[V2](f: V2 => V)(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
@@ -61,6 +80,14 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                             ((), cont(maybeChunkV))
             )
 
+    /** Transform a sink to consume a stream of a different element type by providing an effectful function to transform elements of the new
+      * type to the original element type.
+      *
+      * @param f
+      *   Effectful function mapping new stream element type to original stream element type
+      * @return
+      *   A new sink that processes streams of the new element type
+      */
     def contramap[V2, S2](f: V2 => V < S2)(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
@@ -84,6 +111,14 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                                     ((), cont(Present(chunk1)))
             )
 
+    /** Transform a sink to consume a stream of a different element type by providing a function to transform chunks of elements of the new
+      * type to chunks of the original element type.
+      *
+      * @param f
+      *   Function mapping chunks of new stream element type to chunks of the original stream element type
+      * @return
+      *   A new sink that processes streams of the new element type
+      */
     def contramapChunk[V2](f: Chunk[V2] => Chunk[V])(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
@@ -99,6 +134,14 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                             ((), cont(maybeChunkV))
             )
 
+    /** Transform a sink to consume a stream of a different element type by providing an effectful function to transform chunks of elements
+      * of the new type to chunks of the original element type.
+      *
+      * @param f
+      *   Effectful function mapping chunks of new stream element type to chunks of the original stream element type
+      * @return
+      *   A new sink that processes streams of the new element type
+      */
     def contramapChunk[V2, S2](f: Chunk[V2] => Chunk[V] < S2)(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
@@ -121,12 +164,29 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                                     ((), cont(Present(chunk1)))
             )
 
+    /** Transform a sink to produce a new output type by providing a function to transform the original result type.
+      *
+      * @param f
+      *   Function mapping the original output to a new output value
+      * @return
+      *   A new sink that processes the same kind of stream to produce a new output type
+      */
     def map[B, S2](f: A => (B < S2))(
         using fr: Frame
     ): Sink[V, B, S & S2] =
         Sink(poll.map((a: A) => f(a)))
     end map
 
+    /** Process a stream to produce an output
+      *
+      * @see
+      *   [[kyo.Stream.into]]
+      *
+      * @param stream
+      *   Stream to be processed
+      * @return
+      *   An effect generating an output value from elements consumed from the stream
+      */
     def consume[S2](stream: Stream[V, S2])(using Tag[V], Frame): A < (S & S2) =
         Poll.run(stream.emit)(poll).map(_._2)
 end Sink
@@ -137,6 +197,11 @@ object Sink:
         new Sink[V, A, S]:
             def poll: A < (Poll[Chunk[V]] & S) = v
 
+    /** Construct a sink that runs a stream of element type `V` without producing any value.
+      *
+      * @return
+      *   A sink that runs a stream without producing a value
+      */
     def drain[V](using Tag[V], Frame): Sink[V, Unit, Any] =
         Sink:
             Loop(()): _ =>
@@ -146,6 +211,11 @@ object Sink:
                         Loop.continue
     end drain
 
+    /** Construct a sink that accumulates all elements of a stream of type `V` into a chunk.
+      *
+      * @return
+      *   A sink that produces a chunk of all elements emitted by the source stream
+      */
     def collect[V](using Tag[V], Frame): Sink[V, Chunk[V], Any] =
         Sink:
             Loop(Chunk.empty[V]): currentChunk =>
@@ -155,6 +225,11 @@ object Sink:
                         Loop.continue(currentChunk ++ c)
     end collect
 
+    /** Construct a sink that counts streaming elements.
+      *
+      * @return
+      *   A sink that produces the count of all elements emitted by source stream
+      */
     def count[V](using Tag[V], Frame): Sink[V, Int, Any] =
         Sink:
             Loop(0): count =>
@@ -164,6 +239,13 @@ object Sink:
                         Loop.continue(count + chunk.size)
     end count
 
+    /** Construct a sink that applies an effectful function to each element of a stream, discarding all resulting values
+      *
+      * @param f
+      *   Effectful function with no result to apply to each streaming element
+      * @return
+      *   A sink that applies an effectful function to each element of the source stream
+      */
     def foreach[V, S](f: V => Unit < S)(using Tag[V], Frame): Sink[V, Unit, S] =
         Sink:
             Loop(()): _ =>
@@ -173,6 +255,13 @@ object Sink:
                         Kyo.foreachDiscard(c)(f).andThen(Loop.continue)
     end foreach
 
+    /** Construct a sink that applies an effectful function to each chunk of a stream, discarding all resulting values
+      *
+      * @param f
+      *   Effectful function with no result to apply to each streaming element
+      * @return
+      *   A sink that applies an effectful function to each chunk of the source stream
+      */
     def foreachChunk[V, S](f: Chunk[V] => Unit < S)(using Tag[V], Frame): Sink[V, Unit, S] =
         Sink:
             Loop(()): _ =>
@@ -182,6 +271,16 @@ object Sink:
                         f(c).andThen(Loop.continue)
     end foreachChunk
 
+    /** Construct a sink that applies a pure, stateful, aggregating function to streaming elements to generate a final value.
+      *
+      * @param acc
+      *   Initial state ("accumulator") to be updated by each streaming element
+      * @param f
+      *   Pure aggregating function to update the accumulator based on the accumulator's current value along with the current element
+      *   emitted by the source stream
+      * @return
+      *   A sink that processes a stream by updating an accumulator for each element of the stream
+      */
     def fold[A, V](acc: A)(f: (A, V) => A)(using
         t1: Tag[Emit[Chunk[V]]],
         t2: Tag[V],
@@ -195,6 +294,16 @@ object Sink:
                         Loop.continue(c.foldLeft(state)(f))
     end fold
 
+    /** Construct a sink that applies an effectful, stateful, aggregating function to streaming elements to generate a final value.
+      *
+      * @param acc
+      *   Initial state ("accumulator") to be updated by each streaming element
+      * @param f
+      *   Effectful aggregating function to update the accumulator based on the accumulator's current value along with the current element
+      *   emitted by the source stream
+      * @return
+      *   A sink that processes a stream by updating an accumulator for each element of the stream
+      */
     def foldKyo[A, V, S](acc: A)(f: (A, V) => A < S)(using
         t1: Tag[Emit[Chunk[V]]],
         t2: Tag[V],
@@ -209,13 +318,19 @@ object Sink:
                             Loop.continue(newState)
     end foldKyo
 
+    /** Combine two sinks, processing source stream in tandem.
+      */
     def zip[V, A, B, S](a: Sink[V, A, S], b: Sink[V, B, S])(using Tag[V], Frame): Sink[V, (A, B), S] =
         a.zip(b)
 
+    /** Combine three sinks, processing source stream in tandem.
+      */
     def zip[V, A, B, C, S](a: Sink[V, A, S], b: Sink[V, B, S], c: Sink[V, C, S])(using Tag[V], Frame): Sink[V, (A, B, C), S] =
         a.zip(zip(b, c)).map:
             case (a, tail) => a *: tail
 
+    /** Combine four sinks, processing source stream in tandem.
+      */
     def zip[V, A, B, C, D, S](a: Sink[V, A, S], b: Sink[V, B, S], c: Sink[V, C, S], d: Sink[V, D, S])(using
         Tag[V],
         Frame
@@ -223,6 +338,8 @@ object Sink:
         a.zip(zip(b, c, d)).map:
             case (a, tail) => a *: tail
 
+    /** Combine five sinks, processing source stream in tandem.
+      */
     def zip[V, A, B, C, D, E, S](a: Sink[V, A, S], b: Sink[V, B, S], c: Sink[V, C, S], d: Sink[V, D, S], e: Sink[V, E, S])(using
         Tag[V],
         Frame
@@ -230,6 +347,8 @@ object Sink:
         a.zip(zip(b, c, d, e)).map:
             case (a, tail) => a *: tail
 
+    /** Combine six sinks, processing source stream in tandem.
+      */
     def zip[V, A, B, C, D, E, F, S](
         a: Sink[V, A, S],
         b: Sink[V, B, S],
@@ -244,6 +363,8 @@ object Sink:
         a.zip(zip(b, c, d, e, f)).map:
             case (a, tail) => a *: tail
 
+    /** Combine seven sinks, processing source stream in tandem.
+      */
     def zip[V, A, B, C, D, E, F, G, S](
         a: Sink[V, A, S],
         b: Sink[V, B, S],
@@ -259,6 +380,8 @@ object Sink:
         a.zip(zip(b, c, d, e, f, g)).map:
             case (a, tail) => a *: tail
 
+    /** Combine eight sinks, processing source stream in tandem.
+      */
     def zip[V, A, B, C, D, E, F, G, H, S](
         a: Sink[V, A, S],
         b: Sink[V, B, S],
@@ -275,6 +398,8 @@ object Sink:
         a.zip(zip(b, c, d, e, f, g, h)).map:
             case (a, tail) => a *: tail
 
+    /** Combine nine sinks, processing source stream in tandem.
+      */
     def zip[V, A, B, C, D, E, F, G, H, I, S](
         a: Sink[V, A, S],
         b: Sink[V, B, S],
@@ -292,6 +417,8 @@ object Sink:
         a.zip(zip(b, c, d, e, f, g, h, i)).map:
             case (a, tail) => a *: tail
 
+    /** Combine ten sinks, processing source stream in tandem.
+      */
     def zip[V, A, B, C, D, E, F, G, H, I, J, S](
         a: Sink[V, A, S],
         b: Sink[V, B, S],

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -70,8 +70,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
 
     end zip
 
-    /** Transform a sink to consume a stream of a different element type by providing a function to transform elements of the new type to
-      * the original element type.
+    /** Transform a sink to consume a stream of a different element type using a pure mapping function.
       *
       * @param f
       *   Function mapping new stream element type to original stream element type
@@ -93,8 +92,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                             ((), cont(maybeChunkV))
             )
 
-    /** Transform a sink to consume a stream of a different element type by providing an effectful function to transform elements of the new
-      * type to the original element type.
+    /** Transform a sink to consume a stream of a different element type using an effectful mapping function.
       *
       * @param f
       *   Effectful function mapping new stream element type to original stream element type
@@ -124,8 +122,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                                     ((), cont(Present(chunk1)))
             )
 
-    /** Transform a sink to consume a stream of a different element type by providing a function to transform chunks of elements of the new
-      * type to chunks of the original element type.
+    /** Transform a sink to consume a stream of a different element type using a pure mapping function that transforms streamed chunks.
       *
       * @param f
       *   Function mapping chunks of new stream element type to chunks of the original stream element type
@@ -147,8 +144,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                             ((), cont(maybeChunkV))
             )
 
-    /** Transform a sink to consume a stream of a different element type by providing an effectful function to transform chunks of elements
-      * of the new type to chunks of the original element type.
+    /** Transform a sink to consume a stream of a different element type using an effectful mapping function that transforms streamed chunks.
       *
       * @param f
       *   Effectful function mapping chunks of new stream element type to chunks of the original stream element type
@@ -177,7 +173,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                                     ((), cont(Present(chunk1)))
             )
 
-    /** Transform a sink to produce a new output type by providing a function to transform the original result type.
+    /** Transform a sink to produce a new output type using a function that transforms the original stream's result.
       *
       * @param f
       *   Function mapping the original output to a new output value

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -1,0 +1,319 @@
+package kyo
+
+import kyo.Tag
+import kyo.kernel.ArrowEffect
+import kyo.kernel.internal.WeakFlat
+import scala.annotation.nowarn
+import scala.annotation.targetName
+import scala.util.NotGiven
+
+/** Processes a stream of type `V`, producing a value of type `A`.
+  *
+  * `Sink` provides an abstraction for running `Stream` s that can be composed and transformed in various ways.
+  *
+  * @tparam V
+  *   The type of values that this sink can process
+  * @tparam A
+  *   The type of the value generated when processing a stream of `V` s
+  * @tparam S
+  *   The type of effects used in processing the stream
+  *
+  * @see
+  *   [[kyo.Poll]] for the underlying pull-based consumption mechanism
+  */
+sealed abstract class Sink[V, A, -S] extends Serializable:
+
+    /** Returns the effect that produces the output value from polling chunks of `V`s. */
+    def poll: A < (Poll[Chunk[V]] & S)
+
+    def zip[B, S2](other: Sink[V, B, S2])(using Tag[V], Frame): Sink[V, (A, B), S & S2] =
+        Sink:
+            Loop((poll, other.poll)): (pollA, pollB) =>
+                Poll.andMap[Chunk[V]]: polledValue =>
+                    // TODO: use ArrowEffect.handleFirst directly to avoid Either
+                    Poll.runFirst(pollA).map:
+                        case Left(a) =>
+                            pollB.map: b =>
+                                Loop.done((a, b))
+                        case Right(fnA) =>
+                            val nextA = fnA(polledValue)
+                            Poll.runFirst(pollB).map:
+                                case Left(b) =>
+                                    nextA.map: a =>
+                                        Loop.done((a, b))
+                                case Right(fnB) =>
+                                    val nextB = fnB(polledValue)
+                                    Loop.continue(nextA, nextB)
+    end zip
+
+    def contramap[V2](f: V2 => V)(using
+        t1: Tag[Poll[Chunk[V]]],
+        t2: Tag[Poll[Chunk[V2]]],
+        ev: NotGiven[V2 <:< (Any < Nothing)],
+        fr: Frame
+    ): Sink[V2, A, S] =
+        Sink:
+            ArrowEffect.handleState(t1, (), poll)(
+                [C] =>
+                    (_, _, cont) =>
+                        Poll.andMap[Chunk[V2]]: maybeChunkV2 =>
+                            val maybeChunkV = maybeChunkV2.map(_.map(f))
+                            ((), cont(maybeChunkV))
+            )
+
+    def contramap[V2, S2](f: V2 => V < S2)(using
+        t1: Tag[Poll[Chunk[V]]],
+        t2: Tag[Poll[Chunk[V2]]],
+        ev: NotGiven[V2 <:< (Any < Nothing)],
+        d: Sink.Dummy,
+        fr: Frame
+    ): Sink[V2, A, S & S2] =
+        Sink:
+            ArrowEffect.handleState[Const[Unit], Const[Maybe[Chunk[V]]], Poll[Chunk[V]], Unit, A, A, S, S, S2 & Poll[Chunk[V2]]](
+                t1,
+                (),
+                poll
+            )(
+                [C] =>
+                    (_, _, cont) =>
+                        Poll.andMap[Chunk[V2]]:
+                            case Absent =>
+                                ((), cont(Absent))
+                            case Present(chunk2) =>
+                                Kyo.foreach(chunk2)(f).map: chunk1 =>
+                                    ((), cont(Present(chunk1)))
+            )
+
+    def contramapChunk[V2](f: Chunk[V2] => Chunk[V])(using
+        t1: Tag[Poll[Chunk[V]]],
+        t2: Tag[Poll[Chunk[V2]]],
+        ev: NotGiven[V2 <:< (Any < Nothing)],
+        fr: Frame
+    ): Sink[V2, A, S] =
+        Sink:
+            ArrowEffect.handleState(t1, (), poll)(
+                [C] =>
+                    (_, _, cont) =>
+                        Poll.andMap[Chunk[V2]]: maybeChunkV2 =>
+                            val maybeChunkV = maybeChunkV2.map(f)
+                            ((), cont(maybeChunkV))
+            )
+
+    def contramapChunk[V2, S2](f: Chunk[V2] => Chunk[V] < S2)(using
+        t1: Tag[Poll[Chunk[V]]],
+        t2: Tag[Poll[Chunk[V2]]],
+        ev: NotGiven[V2 <:< (Any < Nothing)],
+        d: Sink.Dummy,
+        fr: Frame
+    ): Sink[V2, A, S & S2] =
+        Sink:
+            ArrowEffect.handleState[Const[Unit], Const[Maybe[Chunk[V]]], Poll[Chunk[V]], Unit, A, A, S, S, S2 & Poll[Chunk[V2]]](
+                t1,
+                (),
+                poll
+            )(
+                [C] =>
+                    (_, _, cont) =>
+                        Poll.andMap[Chunk[V2]]:
+                            case Absent => ((), cont(Absent))
+                            case Present(chunk2) =>
+                                f(chunk2).map: chunk1 =>
+                                    ((), cont(Present(chunk1)))
+            )
+
+    def map[B, S2](f: A => (B < S2))(
+        using fr: Frame
+    ): Sink[V, B, S & S2] =
+        Sink(poll.map((a: A) => f(a)))
+    end map
+
+    def consume[S2](stream: Stream[V, S2])(using Tag[V], Frame): A < (S & S2) =
+        Poll.run(stream.emit)(poll).map(_._2)
+end Sink
+
+object Sink:
+    @nowarn("msg=anonymous")
+    inline def apply[V, A, S](inline v: => A < (Poll[Chunk[V]] & S)): Sink[V, A, S] =
+        new Sink[V, A, S]:
+            def poll: A < (Poll[Chunk[V]] & S) = v
+
+    def drain[V](using Tag[V], Frame): Sink[V, Unit, Any] =
+        Sink:
+            Loop(()): _ =>
+                Poll.andMap[Chunk[V]]:
+                    case Absent => Loop.done
+                    case Present(_) =>
+                        Loop.continue
+    end drain
+
+    def collect[V](using Tag[V], Frame): Sink[V, Chunk[V], Any] =
+        Sink:
+            Loop(Chunk.empty[V]): currentChunk =>
+                Poll.andMap[Chunk[V]]:
+                    case Absent => Loop.done(currentChunk)
+                    case Present(c) =>
+                        Loop.continue(currentChunk ++ c)
+    end collect
+
+    def count[V](using Tag[V], Frame): Sink[V, Int, Any] =
+        Sink:
+            Loop(0): count =>
+                Poll.andMap[Chunk[V]]:
+                    case Absent => Loop.done(count)
+                    case Present(chunk) =>
+                        Loop.continue(count + chunk.size)
+    end count
+
+    def foreach[V, S](f: V => Unit < S)(using Tag[V], Frame): Sink[V, Unit, S] =
+        Sink:
+            Loop(()): _ =>
+                Poll.andMap[Chunk[V]]:
+                    case Absent => Loop.done
+                    case Present(c) =>
+                        Kyo.foreachDiscard(c)(f).andThen(Loop.continue)
+    end foreach
+
+    def foreachChunk[V, S](f: Chunk[V] => Unit < S)(using Tag[V], Frame): Sink[V, Unit, S] =
+        Sink:
+            Loop(()): _ =>
+                Poll.andMap[Chunk[V]]:
+                    case Absent => Loop.done
+                    case Present(c) =>
+                        f(c).andThen(Loop.continue)
+    end foreachChunk
+
+    def fold[A, V](acc: A)(f: (A, V) => A)(using
+        t1: Tag[Emit[Chunk[V]]],
+        t2: Tag[V],
+        frame: Frame
+    ): Sink[V, A, Any] =
+        Sink:
+            Loop(acc): state =>
+                Poll.andMap[Chunk[V]]:
+                    case Absent => Loop.done(state)
+                    case Present(c) =>
+                        Loop.continue(c.foldLeft(state)(f))
+    end fold
+
+    def foldKyo[A, V, S](acc: A)(f: (A, V) => A < S)(using
+        t1: Tag[Emit[Chunk[V]]],
+        t2: Tag[V],
+        frame: Frame
+    ): Sink[V, A, S] =
+        Sink:
+            Loop(acc): state =>
+                Poll.andMap[Chunk[V]]:
+                    case Absent => Loop.done(state)
+                    case Present(c) =>
+                        Kyo.foldLeft(c)(state)(f).map: newState =>
+                            Loop.continue(newState)
+    end foldKyo
+
+    def zip[V, A, B, S](a: Sink[V, A, S], b: Sink[V, B, S])(using Tag[V], Frame): Sink[V, (A, B), S] =
+        a.zip(b)
+
+    def zip[V, A, B, C, S](a: Sink[V, A, S], b: Sink[V, B, S], c: Sink[V, C, S])(using Tag[V], Frame): Sink[V, (A, B, C), S] =
+        a.zip(zip(b, c)).map:
+            case (a, tail) => a *: tail
+
+    def zip[V, A, B, C, D, S](a: Sink[V, A, S], b: Sink[V, B, S], c: Sink[V, C, S], d: Sink[V, D, S])(using
+        Tag[V],
+        Frame
+    ): Sink[V, (A, B, C, D), S] =
+        a.zip(zip(b, c, d)).map:
+            case (a, tail) => a *: tail
+
+    def zip[V, A, B, C, D, E, S](a: Sink[V, A, S], b: Sink[V, B, S], c: Sink[V, C, S], d: Sink[V, D, S], e: Sink[V, E, S])(using
+        Tag[V],
+        Frame
+    ): Sink[V, (A, B, C, D, E), S] =
+        a.zip(zip(b, c, d, e)).map:
+            case (a, tail) => a *: tail
+
+    def zip[V, A, B, C, D, E, F, S](
+        a: Sink[V, A, S],
+        b: Sink[V, B, S],
+        c: Sink[V, C, S],
+        d: Sink[V, D, S],
+        e: Sink[V, E, S],
+        f: Sink[V, F, S]
+    )(using
+        Tag[V],
+        Frame
+    ): Sink[V, (A, B, C, D, E, F), S] =
+        a.zip(zip(b, c, d, e, f)).map:
+            case (a, tail) => a *: tail
+
+    def zip[V, A, B, C, D, E, F, G, S](
+        a: Sink[V, A, S],
+        b: Sink[V, B, S],
+        c: Sink[V, C, S],
+        d: Sink[V, D, S],
+        e: Sink[V, E, S],
+        f: Sink[V, F, S],
+        g: Sink[V, G, S]
+    )(using
+        Tag[V],
+        Frame
+    ): Sink[V, (A, B, C, D, E, F, G), S] =
+        a.zip(zip(b, c, d, e, f, g)).map:
+            case (a, tail) => a *: tail
+
+    def zip[V, A, B, C, D, E, F, G, H, S](
+        a: Sink[V, A, S],
+        b: Sink[V, B, S],
+        c: Sink[V, C, S],
+        d: Sink[V, D, S],
+        e: Sink[V, E, S],
+        f: Sink[V, F, S],
+        g: Sink[V, G, S],
+        h: Sink[V, H, S]
+    )(using
+        Tag[V],
+        Frame
+    ): Sink[V, (A, B, C, D, E, F, G, H), S] =
+        a.zip(zip(b, c, d, e, f, g, h)).map:
+            case (a, tail) => a *: tail
+
+    def zip[V, A, B, C, D, E, F, G, H, I, S](
+        a: Sink[V, A, S],
+        b: Sink[V, B, S],
+        c: Sink[V, C, S],
+        d: Sink[V, D, S],
+        e: Sink[V, E, S],
+        f: Sink[V, F, S],
+        g: Sink[V, G, S],
+        h: Sink[V, H, S],
+        i: Sink[V, I, S]
+    )(using
+        Tag[V],
+        Frame
+    ): Sink[V, (A, B, C, D, E, F, G, H, I), S] =
+        a.zip(zip(b, c, d, e, f, g, h, i)).map:
+            case (a, tail) => a *: tail
+
+    def zip[V, A, B, C, D, E, F, G, H, I, J, S](
+        a: Sink[V, A, S],
+        b: Sink[V, B, S],
+        c: Sink[V, C, S],
+        d: Sink[V, D, S],
+        e: Sink[V, E, S],
+        f: Sink[V, F, S],
+        g: Sink[V, G, S],
+        h: Sink[V, H, S],
+        i: Sink[V, I, S],
+        j: Sink[V, J, S]
+    )(using
+        Tag[V],
+        Frame
+    ): Sink[V, (A, B, C, D, E, F, G, H, I, J), S] =
+        a.zip(zip(b, c, d, e, f, g, h, i, j)).map:
+            case (a, tail) => a *: tail
+
+    /** A dummy type that can be used as implicit evidence to help the compiler discriminate between overloaded methods.
+      */
+    sealed class Dummy extends Serializable
+    object Dummy:
+        given Dummy = new Dummy {}
+
+end Sink

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -37,7 +37,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that produces a tuple of the outputs of the source sinks.
       */
-    def zip[B, S2](other: Sink[V, B, S2])(using tag: Tag[Poll[Chunk[V]]], f: Frame): Sink[V, (A, B), S & S2] =
+    final def zip[B, S2](other: Sink[V, B, S2])(using tag: Tag[Poll[Chunk[V]]], f: Frame): Sink[V, (A, B), S & S2] =
         Sink:
             Loop((poll, other.poll)): (pollA, pollB) =>
                 ArrowEffect.handleFirst(tag, pollA)(
@@ -77,7 +77,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that processes streams of the new element type
       */
-    def contramap[V2](f: V2 => V)(using
+    final def contramap[V2](f: V2 => V)(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
         ev: NotGiven[V2 <:< (Any < Nothing)],
@@ -99,7 +99,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that processes streams of the new element type
       */
-    def contramap[V2, S2](f: V2 => V < S2)(using
+    final def contramap[V2, S2](f: V2 => V < S2)(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
         ev: NotGiven[V2 <:< (Any < Nothing)],
@@ -129,7 +129,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that processes streams of the new element type
       */
-    def contramapChunk[V2](f: Chunk[V2] => Chunk[V])(using
+    final def contramapChunk[V2](f: Chunk[V2] => Chunk[V])(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
         ev: NotGiven[V2 <:< (Any < Nothing)],
@@ -152,7 +152,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that processes streams of the new element type
       */
-    def contramapChunk[V2, S2](f: Chunk[V2] => Chunk[V] < S2)(using
+    final def contramapChunk[V2, S2](f: Chunk[V2] => Chunk[V] < S2)(using
         t1: Tag[Poll[Chunk[V]]],
         t2: Tag[Poll[Chunk[V2]]],
         ev: NotGiven[V2 <:< (Any < Nothing)],
@@ -181,7 +181,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that processes the same kind of stream to produce a new output type
       */
-    def map[B, S2](f: A => (B < S2))(
+    final def map[B, S2](f: A => (B < S2))(
         using fr: Frame
     ): Sink[V, B, S & S2] =
         Sink(poll.map((a: A) => f(a)))
@@ -197,7 +197,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   An effect generating an output value from elements consumed from the stream
       */
-    def consume[S2](stream: Stream[V, S2])(using Tag[V], Frame): A < (S & S2) =
+    final def consume[S2](stream: Stream[V, S2])(using Tag[V], Frame): A < (S & S2) =
         Poll.run(stream.emit)(poll).map(_._2)
 end Sink
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -625,6 +625,9 @@ sealed abstract class Stream[V, -S] extends Serializable:
     end splitAt
 
     /** Process with a [[Sink]] of corresponding streaming element type.
+      * 
+      * @see
+      *   [[kyo.Sink.consume]]
       *
       * @param sink
       *   Sink to process stream with

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -99,7 +99,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
         using
         tagV: Tag[Emit[Chunk[V]]],
         tagV2: Tag[Emit[Chunk[V2]]],
-        discr: Stream.Dummy,
+        discr: Discriminator,
         frame: Frame
     ): Stream[V2, S] =
         Stream[V2, S](ArrowEffect.handleState(tagV, (), emit)(
@@ -269,7 +269,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
       */
     def takeWhile(f: V => Boolean)(using
         tag: Tag[Emit[Chunk[V]]],
-        discr: Stream.Dummy,
+        discr: Discriminator,
         frame: Frame
     ): Stream[V, S] =
         Stream[V, S](ArrowEffect.handleState(tag, true, emit)(
@@ -341,7 +341,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
 
     def filter(f: V => Boolean)(using
         tag: Tag[Emit[Chunk[V]]],
-        discr: Stream.Dummy,
+        discr: Discriminator,
         frame: Frame
     ): Stream[V, S] =
         Stream[V, S](ArrowEffect.handleState(tag, (), emit)(
@@ -375,7 +375,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
     def collect[V2](f: V => Maybe[V2])(using
         tag: Tag[Emit[Chunk[V]]],
         t2: Tag[Emit[Chunk[V2]]],
-        discr: Stream.Dummy,
+        discr: Discriminator,
         frame: Frame
     ): Stream[V2, S] =
         Stream[V2, S](ArrowEffect.handleState(tag, (), emit)(
@@ -416,7 +416,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
     def collectWhile[V2](f: V => Maybe[V2])(using
         tag: Tag[Emit[Chunk[V]]],
         t2: Tag[Emit[Chunk[V2]]],
-        discr: Stream.Dummy,
+        discr: Discriminator,
         frame: Frame
     ): Stream[V2, S] =
         Stream[V2, S](ArrowEffect.handleState(tag, (), emit)(
@@ -733,11 +733,5 @@ object Stream:
                         end if
                     }
                 }
-
-    /** A dummy type that can be used as implicit evidence to help the compiler discriminate between overloaded methods.
-      */
-    sealed class Dummy extends Serializable
-    object Dummy:
-        given Dummy = new Dummy {}
 
 end Stream

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -625,7 +625,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
     end splitAt
 
     /** Process with a [[Sink]] of corresponding streaming element type.
-      * 
+      *
       * @see
       *   [[kyo.Sink.consume]]
       *

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -623,6 +623,16 @@ sealed abstract class Stream[V, -S] extends Serializable:
                 end match
         )
     end splitAt
+
+    /** Process with a [[Sink]] of corresponding streaming element type.
+      *
+      * @param sink
+      *   Sink to process stream with
+      * @return
+      *   An effect producing a value of sink's output type `A`
+      */
+    def into[A, S2](sink: Sink[V, A, S2])(using Tag[V], Frame): A < (S & S2) =
+        sink.consume(this)
 end Stream
 
 object Stream:

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -635,7 +635,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
       *   An effect producing a value of sink's output type `A`
       */
     def into[A, S2](sink: Sink[V, A, S2])(using Tag[V], Frame): A < (S & S2) =
-        sink.consume(this)
+        sink.drain(this)
 end Stream
 
 object Stream:

--- a/kyo-prelude/shared/src/test/scala/kyo/SinkTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/SinkTest.scala
@@ -3,8 +3,8 @@ package kyo
 class SinkTest extends Test:
 
     "sinks" - {
-        "drain" in run {
-            val sink = Sink.drain[Int]
+        "discard" in run {
+            val sink = Sink.discard[Int]
             val stream = Stream:
                 Var.get[Int].map: init =>
                     Loop(init): i =>
@@ -13,49 +13,49 @@ class SinkTest extends Test:
                             Emit.valueWith(Chunk(i)):
                                 Var.update[Int](_ + 1).map: next =>
                                     Loop.continue(next)
-            val result = Var.runTuple(0)(sink.consume(stream)).eval
+            val result = Var.runTuple(0)(sink.drain(stream)).eval
             assert(result == (6, ()))
         }
 
         "collect" in run {
             val sink   = Sink.collect[Int]
             val stream = Stream.init(0 to 5)
-            val result = sink.consume(stream).eval
+            val result = sink.drain(stream).eval
             assert(result == (0 to 5))
         }
 
         "count" in run {
             val sink   = Sink.count[Int]
             val stream = Stream.init(0 to 5)
-            val result = sink.consume(stream).eval
+            val result = sink.drain(stream).eval
             assert(result == 6)
         }
 
         "foreach" in run {
             val sink   = Sink.foreach((i: Int) => Var.update[List[Int]](i :: _).unit)
             val stream = Stream.init(0 to 5)
-            val result = Var.runTuple(Nil)(sink.consume(stream)).eval
+            val result = Var.runTuple(Nil)(sink.drain(stream)).eval
             assert(result == ((5 to 0 by -1), ()))
         }
 
         "foreachChunk" in run {
             val sink   = Sink.foreachChunk((ch: Chunk[Int]) => Var.update[List[Chunk[Int]]](ch :: _).unit)
             val stream = Stream.init(0 to 1).concat(Stream.init(2 to 3)).concat(Stream.init(4 to 5))
-            val result = Var.runTuple(Nil)(sink.consume(stream)).eval
+            val result = Var.runTuple(Nil)(sink.drain(stream)).eval
             assert(result == (List(Chunk(4, 5), Chunk(2, 3), Chunk(0, 1)), ()))
         }
 
         "fold" in run {
             val sink   = Sink.fold(0)((a: Int, v: String) => a + v.length)
             val stream = Stream.init(Seq("a", "be", "see"))
-            val result = sink.consume(stream).eval
+            val result = sink.drain(stream).eval
             assert(result == 6)
         }
 
         "foldKyo" in run {
             val sink   = Sink.foldKyo(0)((a: Int, v: String) => Var.update[String](_ + v).andThen(a + v.length))
             val stream = Stream.init(Seq("a", "be", "see"))
-            val result = Var.runTuple("")(sink.consume(stream)).eval
+            val result = Var.runTuple("")(sink.drain(stream)).eval
             assert(result == ("abesee", 6))
         }
     }
@@ -65,7 +65,7 @@ class SinkTest extends Test:
             val s1     = Sink.fold[Int, Int](0)(_ + _)
             val s2     = s1.contramap((_: String).length)
             val stream = Stream.init(Seq("a", "be", "see"))
-            val result = s2.consume(stream).eval
+            val result = s2.drain(stream).eval
             assert(result == 6)
         }
 
@@ -74,7 +74,7 @@ class SinkTest extends Test:
             val s2 = s1.contramap: (str: String) =>
                 Var.update[Int](_ + 1).andThen(str.length)
             val stream = Stream.init(Seq("a", "be", "see"))
-            val result = Var.runTuple(0)(s2.consume(stream)).eval
+            val result = Var.runTuple(0)(s2.drain(stream)).eval
             assert(result == (3, 6))
         }
     }
@@ -84,7 +84,7 @@ class SinkTest extends Test:
             val s1     = Sink.fold[Int, Int](0)(_ + _)
             val s2     = s1.contramapChunk((_: Chunk[String]).map(_.length))
             val stream = Stream.init(Seq("a", "be", "see"))
-            val result = s2.consume(stream).eval
+            val result = s2.drain(stream).eval
             assert(result == 6)
         }
 
@@ -93,7 +93,7 @@ class SinkTest extends Test:
             val s2 = s1.contramapChunk: (ch: Chunk[String]) =>
                 Var.update[Int](_ + 1).andThen(ch.map(_.length))
             val stream = Stream.init(Seq("a", "be", "see"))
-            val result = Var.runTuple(0)(s2.consume(stream)).eval
+            val result = Var.runTuple(0)(s2.drain(stream)).eval
             assert(result == (1, 6))
         }
     }
@@ -103,7 +103,7 @@ class SinkTest extends Test:
             val s1     = Sink.fold[Int, Int](0)(_ + _)
             val s2     = s1.map(_.toString)
             val stream = Stream.init(1 to 4)
-            val result = s2.consume(stream).eval
+            val result = s2.drain(stream).eval
             assert(result == "10")
         }
 
@@ -112,7 +112,7 @@ class SinkTest extends Test:
             val s2 = s1.map: i =>
                 Var.update[Int](_ + 1).andThen(i.toString)
             val stream = Stream.init(1 to 4)
-            val result = Var.runTuple(0)(s2.consume(stream)).eval
+            val result = Var.runTuple(0)(s2.drain(stream)).eval
             assert(result == (1, "10"))
         }
     }
@@ -123,9 +123,9 @@ class SinkTest extends Test:
             val s2     = Sink.foldKyo[Int, Int, Var[Int]](0)((a, v) => Var.get[Int].map(i => a + v - i))
             val zipped = s1.zip(s2)
             val stream = Stream.init(0 to 5)
-            val res1   = Var.run(3)(s1.consume(stream)).eval
-            val res2   = Var.run(3)(s2.consume(stream)).eval
-            val result = Var.run(3)(zipped.consume(stream)).eval
+            val res1   = Var.run(3)(s1.drain(stream)).eval
+            val res2   = Var.run(3)(s2.drain(stream)).eval
+            val result = Var.run(3)(zipped.drain(stream)).eval
             assert(result == (res1, res2))
         }
 
@@ -142,7 +142,7 @@ class SinkTest extends Test:
             val s10    = s9.map(_ + 1)
             val zipped = Sink.zip(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10)
             val stream = Stream.init(0 to 5)
-            val result = zipped.consume(stream).eval
+            val result = zipped.drain(stream).eval
             assert(result == (15, 16, 17, 18, 19, 20, 21, 22, 23, 24))
         }
 
@@ -158,7 +158,7 @@ class SinkTest extends Test:
             val s2     = Sink.fold(0)((acc: Int, v: Int) => acc + v)
             val zipped = s1.zip(s2)
             val stream = Stream.init(0 to 5).rechunk(1)
-            val result = zipped.consume(stream).eval
+            val result = zipped.drain(stream).eval
             assert(result == (3, 15))
         }
     }

--- a/kyo-prelude/shared/src/test/scala/kyo/SinkTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/SinkTest.scala
@@ -1,0 +1,150 @@
+package kyo
+
+class SinkTest extends Test:
+
+    "sinks" - {
+        "drain" in run {
+            val sink = Sink.drain[Int]
+            val stream = Stream:
+                Var.get[Int].map: init =>
+                    Loop(init): i =>
+                        if i > 5 then Loop.done
+                        else
+                            Emit.valueWith(Chunk(i)):
+                                Var.update[Int](_ + 1).map: next =>
+                                    Loop.continue(next)
+            val result = Var.runTuple(0)(sink.consume(stream)).eval
+            assert(result == (6, ()))
+        }
+
+        "collect" in run {
+            val sink   = Sink.collect[Int]
+            val stream = Stream.init(0 to 5)
+            val result = sink.consume(stream).eval
+            assert(result == (0 to 5))
+        }
+
+        "count" in run {
+            val sink   = Sink.count[Int]
+            val stream = Stream.init(0 to 5)
+            val result = sink.consume(stream).eval
+            assert(result == 6)
+        }
+
+        "foreach" in run {
+            val sink   = Sink.foreach((i: Int) => Var.update[List[Int]](i :: _).unit)
+            val stream = Stream.init(0 to 5)
+            val result = Var.runTuple(Nil)(sink.consume(stream)).eval
+            assert(result == ((5 to 0 by -1), ()))
+        }
+
+        "foreachChunk" in run {
+            val sink   = Sink.foreachChunk((ch: Chunk[Int]) => Var.update[List[Chunk[Int]]](ch :: _).unit)
+            val stream = Stream.init(0 to 1).concat(Stream.init(2 to 3)).concat(Stream.init(4 to 5))
+            val result = Var.runTuple(Nil)(sink.consume(stream)).eval
+            assert(result == (List(Chunk(4, 5), Chunk(2, 3), Chunk(0, 1)), ()))
+        }
+
+        "fold" in run {
+            val sink   = Sink.fold(0)((a: Int, v: String) => a + v.length)
+            val stream = Stream.init(Seq("a", "be", "see"))
+            val result = sink.consume(stream).eval
+            assert(result == 6)
+        }
+
+        "foldKyo" in run {
+            val sink   = Sink.foldKyo(0)((a: Int, v: String) => Var.update[String](_ + v).andThen(a + v.length))
+            val stream = Stream.init(Seq("a", "be", "see"))
+            val result = Var.runTuple("")(sink.consume(stream)).eval
+            assert(result == ("abesee", 6))
+        }
+    }
+
+    "contramap" - {
+        "pure" in run {
+            val s1     = Sink.fold[Int, Int](0)(_ + _)
+            val s2     = s1.contramap((_: String).length)
+            val stream = Stream.init(Seq("a", "be", "see"))
+            val result = s2.consume(stream).eval
+            assert(result == 6)
+        }
+
+        "effectful" in run {
+            val s1 = Sink.fold[Int, Int](0)(_ + _)
+            val s2 = s1.contramap: (str: String) =>
+                Var.update[Int](_ + 1).andThen(str.length)
+            val stream = Stream.init(Seq("a", "be", "see"))
+            val result = Var.runTuple(0)(s2.consume(stream)).eval
+            assert(result == (3, 6))
+        }
+    }
+
+    "contramapChunk" - {
+        "pure" in run {
+            val s1     = Sink.fold[Int, Int](0)(_ + _)
+            val s2     = s1.contramapChunk((_: Chunk[String]).map(_.length))
+            val stream = Stream.init(Seq("a", "be", "see"))
+            val result = s2.consume(stream).eval
+            assert(result == 6)
+        }
+
+        "effectful" in run {
+            val s1 = Sink.fold[Int, Int](0)(_ + _)
+            val s2 = s1.contramapChunk: (ch: Chunk[String]) =>
+                Var.update[Int](_ + 1).andThen(ch.map(_.length))
+            val stream = Stream.init(Seq("a", "be", "see"))
+            val result = Var.runTuple(0)(s2.consume(stream)).eval
+            assert(result == (1, 6))
+        }
+    }
+
+    "map" - {
+        "pure" in run {
+            val s1     = Sink.fold[Int, Int](0)(_ + _)
+            val s2     = s1.map(_.toString)
+            val stream = Stream.init(1 to 4)
+            val result = s2.consume(stream).eval
+            assert(result == "10")
+        }
+
+        "effectful" in run {
+            val s1 = Sink.fold[Int, Int](0)(_ + _)
+            val s2 = s1.map: i =>
+                Var.update[Int](_ + 1).andThen(i.toString)
+            val stream = Stream.init(1 to 4)
+            val result = Var.runTuple(0)(s2.consume(stream)).eval
+            assert(result == (1, "10"))
+        }
+    }
+
+    "zip" - {
+        "x2" in {
+            val s1     = Sink.foldKyo[Int, Int, Var[Int]](0)((a, v) => Var.get[Int].map(i => a + v + i))
+            val s2     = Sink.foldKyo[Int, Int, Var[Int]](0)((a, v) => Var.get[Int].map(i => a + v - i))
+            val zipped = s1.zip(s2)
+            val stream = Stream.init(0 to 5)
+            val res1   = Var.run(3)(s1.consume(stream)).eval
+            val res2   = Var.run(3)(s2.consume(stream)).eval
+            val result = Var.run(3)(zipped.consume(stream)).eval
+            assert(result == (res1, res2))
+        }
+
+        "x10" in {
+            val s1     = Sink.fold[Int, Int](0)(_ + _)
+            val s2     = s1.map(_ + 1)
+            val s3     = s2.map(_ + 1)
+            val s4     = s3.map(_ + 1)
+            val s5     = s4.map(_ + 1)
+            val s6     = s5.map(_ + 1)
+            val s7     = s6.map(_ + 1)
+            val s8     = s7.map(_ + 1)
+            val s9     = s8.map(_ + 1)
+            val s10    = s9.map(_ + 1)
+            val zipped = Sink.zip(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10)
+            val stream = Stream.init(0 to 5)
+            val result = zipped.consume(stream).eval
+            assert(result == (15, 16, 17, 18, 19, 20, 21, 22, 23, 24))
+        }
+    }
+
+end SinkTest


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

Addresses #1124 

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

It would be useful to have an abstraction for processing streams similar to ZIO's `ZSink`

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Added a `Sink[V, A, S]` type, which is a wrapper of `A < (Poll[Chunk[V]] & S)`, as discussed in #1124 

Combinators:
- `contramap`
- `contramapChunk`
- `map`
- `zip`

Constructors:
- `drain`
- `collect`
- `count`
- `fold`
- `foldKyo`
- `foreach`
- `foreachChunk`

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->

I have not included any facility for "leftover" streams as discussed in #1124 as this has turned out to be substantially more complicated than I thought. Basically, since `Stream` and `Sink` emit and poll chunks of values respectively, remaining chunks would have to be re-emitted after being handled by the `poll` function in order to support sinks that terminate early.

This would break the symmetry of `Stream` and `Poll`, however, and would make methods like `contramap` impossible. For the time being, I recommend treating `Sink` as total. If there is desire for partial sinks, we can revisit. I personally have never used sinks partially and so don't have a good sense of need for them.


