### PR TITLE
[kernel] enable Loop.foreach to return a value

### DIFF
--- a/kyo-actor/shared/src/main/scala/kyo/Actor.scala
+++ b/kyo-actor/shared/src/main/scala/kyo/Actor.scala
@@ -215,7 +215,7 @@ object Actor:
       *   An effect representing the message processing loop
       */
     def receiveLoop[A: Tag](using Frame)[S](f: A => Loop.Outcome[Unit, Unit] < S): Unit < (Context[A] & S) =
-        Loop(()) { _ =>
+        Loop.foreach {
             Poll.one[A].map {
                 case Absent     => Loop.done
                 case Present(v) => f(v)

--- a/kyo-combinators/shared/src/main/scala/kyo/AbortCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AbortCombinators.scala
@@ -303,7 +303,7 @@ extension [A, S, E](effect: A < (Abort[E] & S))
       *   A computation that produces the result of this computation with Async and no Abort[E]
       */
     def retryForever(using SafeClassTag[E], Frame): A < S =
-        Loop(()): _ =>
+        Loop.foreach:
             Abort.fold[E](
                 (result: A) => Loop.done[Unit, A](result),
                 _ => Loop.continue,
@@ -592,7 +592,7 @@ class ForAbortOps[A, S, E, E1 <: E](effect: A < (Abort[E] & S)) extends AnyVal:
         Frame
     ): A < (S & Abort[ER]) =
         val retypedEffect = effect.asInstanceOf[A < (S & Abort[E1 | ER])]
-        Loop(()): _ =>
+        Loop.foreach:
             Abort.fold[E1](
                 (result: A) => Loop.done[Unit, A](result),
                 _ => Loop.continue,

--- a/kyo-combinators/shared/src/main/scala/kyo/KyoCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/KyoCombinators.scala
@@ -124,7 +124,7 @@ extension [A, S](effect: A < S)
       *   A computation that produces the result of the last successful execution before the condition becomes false
       */
     def repeatWhile[S1](fn: A => Boolean < S1)(using Frame): A < (S & S1) =
-        Loop(()): _ =>
+        Loop.foreach:
             effect.map: a =>
                 fn(a).map: test =>
                     if test then Loop.continue
@@ -156,7 +156,7 @@ extension [A, S](effect: A < S)
       *   A computation that produces the result of the first execution where the condition becomes true
       */
     def repeatUntil[S1](fn: A => Boolean < S1)(using Frame): A < (S & S1 & Async) =
-        Loop(()): _ =>
+        Loop.foreach:
             effect.map: a =>
                 fn(a).map: test =>
                     if test then Loop.done(a)

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -238,9 +238,9 @@ object Channel:
         ): Unit < (Emit[Chunk[A]] & Abort[Closed] & Async) =
             if maxChunkSize <= 0 then ()
             else if maxChunkSize == 1 then
-                Loop(()): _ =>
+                Loop.foreach:
                     Channel.take(self).map: v =>
-                        Emit.valueWith(Chunk(v))(Loop.continue(()))
+                        Emit.valueWith(Chunk(v))(Loop.continue)
             else
                 val drainEffect =
                     if maxChunkSize == Int.MaxValue then Channel.drain(self)
@@ -248,7 +248,7 @@ object Channel:
                 Loop[Unit, Unit, Abort[Closed] & Async & Emit[Chunk[A]]](()): _ =>
                     Channel.take(self).map: a =>
                         drainEffect.map: chunk =>
-                            Emit.valueWith(Chunk(a).concat(chunk))(Loop.continue(()))
+                            Emit.valueWith(Chunk(a).concat(chunk))(Loop.continue)
 
         /** Stream elements from channel, optionally specifying a maximum chunk size. In the absence of [[maxChunkSize]], chunk sizes will
           * be limited only by channel capacity or the number of elements in the channel at a given time. (Chunks can still be larger than

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -6,7 +6,7 @@ object StreamCoreExtensions:
     val DefaultCollectBufferSize = 1024
 
     private def emitMaybeChunksFromChannel[V](channel: Channel[Maybe[Chunk[V]]])(using Tag[V], Frame) =
-        val emit = Loop(()): _ =>
+        val emit = Loop.foreach:
             channel.take.map:
                 case Absent => Loop.done
                 case Present(c) =>

--- a/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
@@ -254,7 +254,7 @@ class SignalTest extends Test:
                     ))
                 writers <-
                     Async.run(Async.fill(10, 10)(
-                        Loop(()) { _ =>
+                        Loop.foreach {
                             ref.get.map { v =>
                                 if v < 10 then
                                     ref.compareAndSet(v, v + 1).andThen(Loop.continue)

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Loop.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Loop.scala
@@ -539,19 +539,18 @@ object Loop:
       * @return
       *   Unit after the loop completes
       */
-    inline def foreach[S](inline run: Safepoint ?=> Outcome[Unit, Unit] < S)(using inline _frame: Frame, safepoint: Safepoint): Unit < S =
+    inline def foreach[A, S](inline run: Safepoint ?=> Outcome[Unit, A] < S)(using inline _frame: Frame, safepoint: Safepoint): A < S =
         @nowarn("msg=anonymous")
-        @tailrec def loop(v: Outcome[Unit, Unit] < S)(using Safepoint): Unit < S =
+        @tailrec def loop(v: Outcome[Unit, A] < S)(using Safepoint): A < S =
             v match
                 case next: Continue[Unit] @unchecked =>
                     loop(run)
-                case kyo: KyoSuspend[IX, OX, EX, Any, Outcome[Unit, Unit], S] @unchecked =>
-                    new KyoContinue[IX, OX, EX, Any, Unit, S](kyo):
+                case kyo: KyoSuspend[IX, OX, EX, Any, Outcome[Unit, A], S] @unchecked =>
+                    new KyoContinue[IX, OX, EX, Any, A, S](kyo):
                         def frame = _frame
                         def apply(v: OX[Any], context: Context)(using Safepoint) =
                             loop(kyo(v, context))
-                case res =>
-                    ()
+                case res => res.asInstanceOf[A]
         loop(Loop.continue)
     end foreach
 

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/LoopTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/LoopTest.scala
@@ -367,33 +367,33 @@ class LoopTest extends Test:
     "indexed without input" - {
         "with a single iteration" in {
             assert(
-                Loop.indexed(idx => if idx < 1 then Loop.continue(()) else Loop.done(idx)).eval == 1
+                Loop.indexed(idx => if idx < 1 then Loop.continue else Loop.done(idx)).eval == 1
             )
         }
 
         "with multiple iterations" in {
             assert(
-                Loop.indexed(idx => if idx < 5 then Loop.continue(()) else Loop.done(idx)).eval == 5
+                Loop.indexed(idx => if idx < 5 then Loop.continue else Loop.done(idx)).eval == 5
             )
         }
 
         "with no iterations" in {
             assert(
-                Loop.indexed(idx => if idx < 0 then Loop.continue(()) else Loop.done(idx)).eval == 0
+                Loop.indexed(idx => if idx < 0 then Loop.continue else Loop.done(idx)).eval == 0
             )
         }
 
         "stack safety" in {
             val largeNumber = 100000
             assert(
-                Loop.indexed(idx => if idx < largeNumber then Loop.continue(()) else Loop.done(idx)).eval == largeNumber
+                Loop.indexed(idx => if idx < largeNumber then Loop.continue else Loop.done(idx)).eval == largeNumber
             )
         }
 
         "suspend" in {
             val result = Loop.indexed(idx =>
                 if idx < 5 then
-                    Effect.defer(Loop.continue(()))
+                    Effect.defer(Loop.continue)
                 else
                     Effect.defer(Loop.done(idx))
             )
@@ -572,7 +572,7 @@ class LoopTest extends Test:
             var counter = 0
             Loop.foreach {
                 counter += 1
-                if counter < 1 then Loop.continue(()) else Loop.done
+                if counter < 1 then Loop.continue else Loop.done
             }.eval
             assert(counter == 1)
         }
@@ -581,7 +581,7 @@ class LoopTest extends Test:
             var sum = 0
             Loop.foreach {
                 sum += 1
-                if sum < 10 then Loop.continue(()) else Loop.done
+                if sum < 10 then Loop.continue else Loop.done
             }.eval
             assert(sum == 10)
         }
@@ -600,7 +600,7 @@ class LoopTest extends Test:
             val largeNumber = 100000
             Loop.foreach {
                 counter += 1
-                if counter < largeNumber then Loop.continue(()) else Loop.done
+                if counter < largeNumber then Loop.continue else Loop.done
             }.eval
             assert(counter == largeNumber)
         }
@@ -610,13 +610,20 @@ class LoopTest extends Test:
             val result = Loop.foreach {
                 effect += "A"
                 if effect.length < 3 then
-                    Effect.defer(Loop.continue(()))
+                    Effect.defer(Loop.continue)
                 else
                     Effect.defer(Loop.done)
                 end if
             }
             result.eval
             assert(effect == "AAA")
+        }
+
+        "returns" in {
+            val result = Loop.foreach {
+                Effect.defer(Loop.done(1))
+            }
+            assert(result.eval == 1)
         }
     }
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
@@ -66,7 +66,7 @@ object Poll:
             if idx == n then Loop.done
             else
                 Poll.andMap[V] {
-                    case Present(v) => f(v).map(_ => Loop.continue(()))
+                    case Present(v) => f(v).map(_ => Loop.continue)
                     case Absent     => Loop.done
                 }
         }
@@ -79,12 +79,11 @@ object Poll:
       *   A computation that processes values until completion
       */
     def values[V](using Frame)[S](f: V => Any < S)(using tag: Tag[Poll[V]]): Unit < (Poll[V] & S) =
-        Loop(()) { _ =>
+        Loop.foreach:
             Poll.andMap[V] {
-                case Present(v) => f(v).map(_ => Loop.continue(()))
+                case Present(v) => f(v).map(_ => Loop.continue)
                 case Absent     => Loop.done
             }
-        }
 
     /** Applies a function to the result of polling.
       *

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -673,12 +673,11 @@ object Stream:
         frame: Frame
     ): Stream[V, S] =
         Stream[V, S]:
-            Loop(()) { _ =>
+            Loop.foreach:
                 v.map {
                     case Maybe.Present(seq) => Emit.valueWith(Chunk.from(seq))(Loop.continue)
                     case Maybe.Absent       => Emit.valueWith(Chunk.empty[V])(Loop.done)
                 }
-            }
         .rechunk(chunkSize)
 
     /** Creates a stream of integers from start (inclusive) to end (exclusive).

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscriber.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscriber.scala
@@ -245,12 +245,12 @@ final private[kyo] class StreamSubscriber[V](
 
     private[interop] def emit(using Frame, Tag[Emit[Chunk[V]]]): Unit < (Emit[Chunk[V]] & Async) =
         Emit.valueWith(Chunk.empty) {
-            Loop(()) { _ =>
+            Loop.foreach {
                 await
                     .map {
-                        case true => request.andThen(Loop.continue(()))
+                        case true => request.andThen(Loop.continue)
                         case false => poll.map {
-                                case Result.Success(nextChunk)  => Emit.value(nextChunk).andThen(Loop.continue(()))
+                                case Result.Success(nextChunk)  => Emit.value(nextChunk).andThen(Loop.continue)
                                 case Result.Error(e: Throwable) => Abort.panic(e)
                                 case _                          => Loop.done
                             }


### PR DESCRIPTION
### Problem
I noticed several loops in the codebase written as `Loop(()) { _ =>` which is not very readable. In one of the cases, we need to return a value, which was not possible with `Loop.foreach`

### Solution
Change `Loop.foreach` to enable returning a value in `done`.
