### PR TITLE
[data] introduce optimized override for Chunk.apply

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -549,17 +549,6 @@ object Chunk extends StrictOptimizedSeqFactory[Chunk]:
       */
     def empty[A]: Chunk[A] = Indexed.empty[A]
 
-    /** Creates a Chunk containing multiple elements.
-      *
-      * @tparam A
-      *   the type of elements in the Chunk
-      * @param values
-      *   the elements of the Chunk
-      * @return
-      *   a new Chunk with the elements
-      */
-    override def apply[A](values: A*): Chunk[A] = Indexed.from(values)
-
     /** Creates a Chunk from an Array of elements.
       *
       * @tparam A

--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -470,7 +470,7 @@ object Chunk extends StrictOptimizedSeqFactory[Chunk]:
           * @return
           *   a single value Chunk of type A
           */
-        def single[A](a: A): Indexed[A] = Single(a)
+        private[Chunk] def single[A](a: A): Indexed[A] = Single(a)
 
         def from[A](source: Array[A]): Indexed[A] =
             source.length match

--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -470,7 +470,7 @@ object Chunk extends StrictOptimizedSeqFactory[Chunk]:
           * @return
           *   a single value Chunk of type A
           */
-        def single[A](a: A): Single[A] = Single(a)
+        def single[A](a: A): Indexed[A] = Single(a)
 
         def from[A](source: Array[A]): Indexed[A] =
             source.length match
@@ -549,16 +549,16 @@ object Chunk extends StrictOptimizedSeqFactory[Chunk]:
       */
     def empty[A]: Chunk[A] = Indexed.empty[A]
 
-    /** Creates a Chunk containing exactly one element.
+    /** Creates a Chunk containing multiple elements.
       *
       * @tparam A
       *   the type of elements in the Chunk
-      * @param a
-      *   the single element
+      * @param values
+      *   the elements of the Chunk
       * @return
-      *   a new Chunk.Single containing the single element
+      *   a new Chunk with the elements
       */
-    def single[A](a: A): Chunk.Indexed[A] = Indexed.single(a)
+    override def apply[A](values: A*): Chunk[A] = Indexed.from(values)
 
     /** Creates a Chunk from an Array of elements.
       *

--- a/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
@@ -158,7 +158,7 @@ object Kyo:
             case 0 => Chunk.empty
             case 1 =>
                 val head = source.iterator.next()
-                f(head).map(Chunk.single(_))
+                f(head).map(Chunk(_))
             case _ =>
                 source match
                     case linearSeq: LinearSeq[A] =>
@@ -187,7 +187,7 @@ object Kyo:
             case 0 => Chunk.empty
             case 1 =>
                 val head = source.iterator.next()
-                f(0, head).map(Chunk.single(_))
+                f(0, head).map(Chunk(_))
             case _ =>
                 source match
                     case linearSeq: LinearSeq[A] =>
@@ -341,7 +341,7 @@ object Kyo:
     def collectAll[A, S](source: IterableOnce[A < S])(using Frame, Safepoint): Chunk[A] < S =
         source.knownSize match
             case 0 => Chunk.empty
-            case 1 => source.iterator.next().map(Chunk.single(_))
+            case 1 => source.iterator.next().map(Chunk(_))
             case _ =>
                 source match
                     case linearSeq: LinearSeq[A < S] =>


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem

We recently introduced the `Single` version of `Chunk`. It's under the `private[kyo]` internal object so it shouldn't leak to users. Also, we'd need to migrate all single-elements calls to `Chunk.apply` to `Chunk.single` to leverage the optimization, which isn't ideal.

### Solution

Don't expose `Single` in user-facing APIs and override `Chunk.apply` to create `Single` internally in case a single element is passed.
