### PR TITLE
[core] Log: add support for outputting Text

### DIFF
--- a/kyo-core/jvm/src/main/scala/kyo/internal/LogPlatformSpecific.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/internal/LogPlatformSpecific.scala
@@ -4,6 +4,7 @@ import kyo.AllowUnsafe
 import kyo.Frame
 import kyo.Log
 import kyo.Log.Level
+import kyo.Text
 
 trait LogPlatformSpecific:
     val live: Log = Log(LogPlatformSpecific.Unsafe.SLF4J("kyo.logs"))
@@ -25,34 +26,34 @@ object LogPlatformSpecific:
                 else if logger.isErrorEnabled() then Level.error
                 else Level.silent
 
-            inline def trace(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
+            inline def trace(msg: => Text)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.trace.enabled(level) then logger.trace(s"[${frame.position.show}] $msg")
 
-            inline def trace(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
+            inline def trace(msg: => Text, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.trace.enabled(level) then logger.trace(s"[${frame.position.show}] $msg", t)
 
-            inline def debug(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
+            inline def debug(msg: => Text)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.debug.enabled(level) then logger.debug(s"[${frame.position.show}] $msg")
 
-            inline def debug(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
+            inline def debug(msg: => Text, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.debug.enabled(level) then logger.debug(s"[${frame.position.show}] $msg", t)
 
-            inline def info(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
+            inline def info(msg: => Text)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.info.enabled(level) then logger.info(s"[${frame.position.show}] $msg")
 
-            inline def info(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
+            inline def info(msg: => Text, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.info.enabled(level) then logger.info(s"[${frame.position.show}] $msg", t)
 
-            inline def warn(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
+            inline def warn(msg: => Text)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.warn.enabled(level) then logger.warn(s"[${frame.position.show}] $msg")
 
-            inline def warn(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
+            inline def warn(msg: => Text, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.warn.enabled(level) then logger.warn(s"[${frame.position.show}] $msg", t)
 
-            inline def error(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
+            inline def error(msg: => Text)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.error.enabled(level) then logger.error(s"[${frame.position.show}] $msg")
 
-            inline def error(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
+            inline def error(msg: => Text, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.error.enabled(level) then logger.error(s"[${frame.position.show}] $msg", t)
         end SLF4J
     end Unsafe

--- a/kyo-core/shared/src/main/scala/kyo/Log.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Log.scala
@@ -90,16 +90,16 @@ object Log extends LogPlatformSpecific:
     abstract class Unsafe extends Serializable:
         def level: Level
 
-        def trace(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit
-        def trace(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
-        def debug(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit
-        def debug(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
-        def info(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit
-        def info(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
-        def warn(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit
-        def warn(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
-        def error(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit
-        def error(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
+        def trace(msg: => Text)(using frame: Frame, allow: AllowUnsafe): Unit
+        def trace(msg: => Text, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
+        def debug(msg: => Text)(using frame: Frame, allow: AllowUnsafe): Unit
+        def debug(msg: => Text, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
+        def info(msg: => Text)(using frame: Frame, allow: AllowUnsafe): Unit
+        def info(msg: => Text, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
+        def warn(msg: => Text)(using frame: Frame, allow: AllowUnsafe): Unit
+        def warn(msg: => Text, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
+        def error(msg: => Text)(using frame: Frame, allow: AllowUnsafe): Unit
+        def error(msg: => Text, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit
 
         def safe: Log = Log(this)
     end Unsafe
@@ -107,62 +107,62 @@ object Log extends LogPlatformSpecific:
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
         case class ConsoleLogger(name: String, level: Level) extends Log.Unsafe:
-            inline def trace(msg: => String)(
+            inline def trace(msg: => Text)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
             ): Unit = if Level.trace.enabled(level) then println(s"TRACE $name -- [${frame.position.show}] $msg")
 
-            inline def trace(msg: => String, t: => Throwable)(
+            inline def trace(msg: => Text, t: => Throwable)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
             ): Unit = if Level.trace.enabled(level) then println(s"TRACE $name -- [${frame.position.show}] $msg $t")
 
-            inline def debug(msg: => String)(
+            inline def debug(msg: => Text)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
             ): Unit =
                 if Level.debug.enabled(level) then println(s"DEBUG $name -- [${frame.position.show}] $msg")
 
-            inline def debug(msg: => String, t: => Throwable)(
+            inline def debug(msg: => Text, t: => Throwable)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
             ): Unit = if Level.debug.enabled(level) then println(s"DEBUG $name -- [${frame.position.show}] $msg $t")
 
-            inline def info(msg: => String)(
+            inline def info(msg: => Text)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
             ): Unit = if Level.info.enabled(level) then println(s"INFO $name -- [${frame.position.show}] $msg")
 
-            inline def info(msg: => String, t: => Throwable)(
+            inline def info(msg: => Text, t: => Throwable)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
             ): Unit = if Level.info.enabled(level) then println(s"INFO $name -- [${frame.position.show}] $msg $t")
 
-            inline def warn(msg: => String)(
+            inline def warn(msg: => Text)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
             ): Unit = if Level.warn.enabled(level) then println(s"WARN $name -- [${frame.position.show}] $msg")
 
-            inline def warn(msg: => String, t: => Throwable)(
+            inline def warn(msg: => Text, t: => Throwable)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
             ): Unit = if Level.warn.enabled(level) then println(s"WARN $name -- [${frame.position.show}] $msg $t")
 
-            inline def error(msg: => String)(
+            inline def error(msg: => Text)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
             ): Unit = if Level.error.enabled(level) then println(s"ERROR $name -- [${frame.position.show}] $msg")
 
-            inline def error(msg: => String, t: => Throwable)(
+            inline def error(msg: => Text, t: => Throwable)(
                 using
                 frame: Frame,
                 allow: AllowUnsafe
@@ -188,7 +188,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message
       */
-    inline def trace(inline msg: => String)(using inline frame: Frame): Unit < IO =
+    inline def trace(inline msg: => Text)(using inline frame: Frame): Unit < IO =
         logWhen(Level.trace)(_.trace(msg))
 
     /** Logs a trace message with an exception.
@@ -200,7 +200,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message and exception
       */
-    inline def trace(inline msg: => String, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
+    inline def trace(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
         logWhen(Level.trace)(_.trace(msg, t))
 
     /** Logs a debug message.
@@ -210,7 +210,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message
       */
-    inline def debug(inline msg: => String)(using inline frame: Frame): Unit < IO =
+    inline def debug(inline msg: => Text)(using inline frame: Frame): Unit < IO =
         logWhen(Level.debug)(_.debug(msg))
 
     /** Logs a debug message with an exception.
@@ -222,7 +222,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message and exception
       */
-    inline def debug(inline msg: => String, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
+    inline def debug(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
         logWhen(Level.debug)(_.debug(msg, t))
 
     /** Logs an info message.
@@ -232,7 +232,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message
       */
-    inline def info(inline msg: => String)(using inline frame: Frame): Unit < IO =
+    inline def info(inline msg: => Text)(using inline frame: Frame): Unit < IO =
         logWhen(Level.info)(_.info(msg))
 
     /** Logs an info message with an exception.
@@ -244,7 +244,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message and exception
       */
-    inline def info(inline msg: => String, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
+    inline def info(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
         logWhen(Level.info)(_.info(msg, t))
 
     /** Logs a warning message.
@@ -254,7 +254,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message
       */
-    inline def warn(inline msg: => String)(using inline frame: Frame): Unit < IO =
+    inline def warn(inline msg: => Text)(using inline frame: Frame): Unit < IO =
         logWhen(Level.warn)(_.warn(msg))
 
     /** Logs a warning message with an exception.
@@ -266,7 +266,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message and exception
       */
-    inline def warn(inline msg: => String, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
+    inline def warn(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
         logWhen(Level.warn)(_.warn(msg, t))
 
     /** Logs an error message.
@@ -276,7 +276,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message
       */
-    inline def error(inline msg: => String)(using inline frame: Frame): Unit < IO =
+    inline def error(inline msg: => Text)(using inline frame: Frame): Unit < IO =
         logWhen(Level.error)(_.error(msg))
 
     /** Logs an error message with an exception.
@@ -288,7 +288,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message and exception
       */
-    inline def error(inline msg: => String, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
+    inline def error(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
         logWhen(Level.error)(_.error(msg, t))
 
 end Log

--- a/kyo-core/shared/src/test/scala/kyo/LogTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/LogTest.scala
@@ -42,13 +42,14 @@ class LogTest extends Test:
         scala.Console.withOut(new java.io.PrintStream(new java.io.OutputStream:
             override def write(b: Int): Unit = output.append(b.toChar))) {
             import AllowUnsafe.embrace.danger
+            val text: Text = "info message - hidden"
             IO.Unsafe.evalOrThrow {
                 for
                     _ <- Log.withConsoleLogger("test.logger", Log.Level.debug) {
                         for
                             _ <- Log.trace("won't show up")
                             _ <- Log.debug("test message")
-                            _ <- Log.info("info message")
+                            _ <- Log.info(text.dropRight(9))
                             _ <- Log.warn("warning", new Exception("test exception"))
                         yield ()
                     }


### PR DESCRIPTION
Fixes #1162 
### Problem
Users can't pass `Text` into `Log` methods.

### Solution
Change type signatures to accept `Text`.