### PR TITLE
[core] add Stream's `unfoldKyo`

### DIFF
--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -44,6 +44,15 @@ class StreamTest extends Test:
             assert(size(301, 100) == Chunk(100, 100, 100, 1))
             assert(size(5, 0) == Chunk(1, 1, 1, 1, 1))
         }
+
+        "unfoldKyo" in {
+            val stream = Stream.unfoldKyo(0) {
+                case v: Int if v < 10 => Present(v -> (v + 1))
+                case _                => Absent
+            }
+
+            assert(stream.run.eval == Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+        }
     }
 
     "initChunk" - {

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -46,12 +46,17 @@ class StreamTest extends Test:
         }
 
         "unfoldKyo" in {
-            val stream = Stream.unfoldKyo(0) {
-                case v: Int if v < 10 => Present(v -> (v + 1))
-                case _                => Absent
-            }
+            val stream = Stream.unfoldKyo(0): cur =>
+                for
+                    fromVar <- Var.get[Int]
+                    _       <- Var.update[Int](_ + cur)
+                yield
+                    if cur < 10 then
+                        Present(fromVar -> (cur + 1))
+                    else
+                        Absent
 
-            assert(stream.run.eval == Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+            assert(Var.run(1)(stream.run).eval == Seq(1, 1, 2, 4, 7, 11, 16, 22, 29, 37))
         }
     }
 


### PR DESCRIPTION
### Solution
This PR introduce some method for `Stream[V, S]`
- [x] `duplicate`: which duplicate into `n` copies which respect to the original stream mutability
- [x] `unfoldKyo`: repeatedly build a `Stream[V, S]` using an effect
