### PR TITLE
[stm] add TRef.toString

### DIFF
--- a/kyo-stm/shared/src/main/scala/kyo/TRef.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TRef.scala
@@ -148,6 +148,14 @@ final private class TRefImpl[A] private[kyo] (initialState: Write[A])
                 super.set(0)
         end match
     end unlock
+
+    override def toString() =
+        val lockState = get() match
+            case 0            => "free"
+            case Int.MaxValue => "writer"
+            case i            => s"$i readers"
+        s"TRef(state=$currentState, lock=$lockState)"
+    end toString
 end TRefImpl
 
 object TRef:


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem

While debugging https://github.com/getkyo/kyo/issues/1158, I had some trouble to understand the state of `TRefLog` due to the default `toString` of `TRef` being inherited from `AtomicInteger`, which just prints the atomic int value (lock state).

### Solution

Introduce a custom `toString` showing the state of the `TRef`.
