### PR TITLE
fix: NPE when enriching exceptions

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -85,7 +85,7 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
         if isNull(curr) || !isPending() then
             finalizers.run()
             finalizers = Finalizers.empty
-            if !isNull(trace) then
+            if trace ne null then
                 safepoint.releaseTrace(trace)
                 trace = null.asInstanceOf[Trace]
             curr = nullResult

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Trace.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Trace.scala
@@ -33,9 +33,10 @@ private[kyo] object Trace:
         final private var index  = 0
 
         private[kernel] inline def pushFrame(frame: Frame): Unit =
-            val idx = this.index
-            frames(idx & (maxTraceFrames - 1)) = frame
-            this.index = idx + 1
+            if frame ne null then
+                val idx = this.index
+                frames(idx & (maxTraceFrames - 1)) = frame
+                this.index = idx + 1
         end pushFrame
 
         final private[kernel] def saveTrace(): Trace =
@@ -104,8 +105,12 @@ private[kyo] object Trace:
                     if idx < size then
                         val curr = frames((start + idx) & (maxTraceFrames - 1))
                         ordered(idx) = curr
-                        val snippetSize = curr.snippetShort.size
-                        parse(idx + 1, if snippetSize > maxSnippetSize then snippetSize else maxSnippetSize)
+                        if curr ne null then
+                            val snippetSize = curr.snippetShort.size
+                            parse(idx + 1, if snippetSize > maxSnippetSize then snippetSize else maxSnippetSize)
+                        else
+                            parse(idx + 1, maxSnippetSize)
+                        end if
                     else
                         maxSnippetSize + 1
                 val toPad = parse(0, 0)
@@ -115,7 +120,7 @@ private[kyo] object Trace:
                         case (acc, curr) =>
                             acc match
                                 case `curr` :: tail => acc
-                                case _              => curr :: acc
+                                case _              => if curr ne null then curr :: acc else acc
                     }.map { frame =>
                         StackTraceElement(
                             frame.snippetShort.reverse.padTo(toPad, ' ').reverse + " @ " + frame.className,

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/TraceTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/TraceTest.scala
@@ -138,6 +138,13 @@ class TraceTest extends Test:
         }
     }
 
+    "bug #1172 null frames" in {
+        val safepoint = Safepoint.get // Trace.Owner
+        safepoint.pushFrame(null.asInstanceOf[Frame])
+        safepoint.enrich(new Exception)
+        succeed
+    }
+
     def assertTrace[A](f: => A, expected: String) =
         try
             f

--- a/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
@@ -751,5 +751,33 @@ class STMTest extends Test:
             assert(result == Result.fail(ex))
         }
     }
+    "bug #1172" in runJVM {
+        Abort.run { // trap non-fatal exceptions (AssertionError)
+            for
+                // initially they contain equal values:
+                r1 <- STM.run(TRef.init("a"))
+                r2 <- STM.run(TRef.init("a"))
+                txn1 =
+                    for
+                        v1 <- r1.get
+                        v2 <- r2.get
+                        // we only write equal values:
+                        _ <- r1.set(v1 + "1")
+                        _ <- r2.set(v2 + "1")
+                    yield ()
+                txn2 = r1.get.map { v1 =>
+                    r2.get.map { v2 =>
+                        if v1 == v2 then
+                            ()
+                        else
+                            // observed non-equal values:
+                            throw new AssertionError(s"${v1} != ${v2}") // <- fails here
+                    }
+                }
+                once = Async.zip(STM.run(STM.defaultRetrySchedule.forever)(txn1), STM.run(STM.defaultRetrySchedule.forever)(txn2))
+                _ <- Async.foreachDiscard(1 to 100000, concurrency = 8) { _ => once }
+            yield succeed
+        }.map(_.getOrElse(succeed))
+    }
 
 end STMTest


### PR DESCRIPTION
### Problem
When enriching exceptions, null frames could cause a NPE. See bug #1172 

### Solution
Check for null frames when initially pushed, as well as when building the saved trace.

### Notes
There is probably an issue with `IOTask` pushing null traces, but I wasn't able to minimize it quickly. This should be slightly more robust as even if users accidentally push null frames somehow there is protection.


