### PR TITLE
[prelude] Choice.runStream + Emit.valueWhen + refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,7 +973,7 @@ import kyo.*
 // Note how 'get' takes a 'Seq[T]'
 // and returns a 'T < Choice'
 val a: Int < Choice =
-    Choice.get(Seq(1, 2, 3, 4))
+    Choice.eval(Seq(1, 2, 3, 4))
 
 // 'dropIf' discards the current element if
 // a condition is not met. Produces a 'Seq(1, 2)'

--- a/kyo-combinators/shared/src/main/scala/kyo/AbortCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AbortCombinators.scala
@@ -71,7 +71,7 @@ extension [A, S, E](effect: A < (Abort[E] & S))
         ct: SafeClassTag[E],
         fr: Frame
     ): A < (S & Choice) =
-        effect.result.map(e => Choice.get(e.foldError(List(_), _ => Nil)))
+        effect.result.map(e => Choice.eval(e.foldError(List(_), _ => Nil)))
 
     /** Translates the Abort[E] effect to an Abort[Absent] effect in case of failure.
       *
@@ -462,7 +462,7 @@ class ForAbortOps[A, S, E, E1 <: E](effect: A < (Abort[E] & S)) extends AnyVal:
         reduce: Reducible[Abort[ER]],
         frame: Frame
     ): A < (S & reduce.SReduced & Choice) =
-        Abort.run[E1](effect.asInstanceOf[A < (Abort[E1 | ER] & S)]).map(e => Choice.get(e.foldError(List(_), _ => Nil)))
+        Abort.run[E1](effect.asInstanceOf[A < (Abort[E1 | ER] & S)]).map(e => Choice.eval(e.foldError(List(_), _ => Nil)))
 
     /** Translates the partial Abort[E1] effect to an Abort[Absent] effect in case of failure.
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
@@ -31,7 +31,7 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToAbsent(using Frame): A < (Choice & Abort[Absent] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.fail(Absent)
-            case other              => Choice.get(other)
+            case other              => Choice.eval(other)
 
     /** Handles dropped Choice effects as NoSuchElementException aborts
       *
@@ -41,7 +41,7 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToThrowable(using Frame): A < (Choice & Abort[NoSuchElementException] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.catching(Chunk.empty.head)
-            case other              => Choice.get(other)
+            case other              => Choice.eval(other)
 
     /** Handles dropped Choice effects as Aborts of a specified instance of E
       *
@@ -53,6 +53,6 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToFailure[E](error: => E)(using Frame): A < (Choice & Abort[E] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.fail(error)
-            case other              => Choice.get(other)
+            case other              => Choice.eval(other)
 
 end extension

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -188,7 +188,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that attempts to run the given effect and handles the sequence to Choice.
       */
     def fromSeq[A](sequence: Seq[A])(using Frame): A < Choice =
-        Choice.get(sequence)
+        Choice.eval(sequence)
 
     /** Creates an effect from a Try[A] and handles the Try to Abort[Throwable].
       *

--- a/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
@@ -307,12 +307,12 @@ class AbortCombinatorsTest extends Test:
             }
 
             "should convert empty choice to absent abort" in {
-                val failure: Int < Choice                     = Choice.get(Seq())
+                val failure: Int < Choice                     = Choice.eval(Seq())
                 val converted: Int < (Choice & Abort[Absent]) = failure.choiceDropToAbsent
                 val handled                                   = Abort.run(Choice.run(converted))
                 assert(handled.eval == Result.fail(Absent))
 
-                val success: Int < Choice                      = Choice.get(Seq(23))
+                val success: Int < Choice                      = Choice.eval(Seq(23))
                 val converted2: Int < (Choice & Abort[Absent]) = success.choiceDropToAbsent
                 val handled2                                   = Abort.run(Choice.run(converted2))
                 assert(handled2.eval == Result.succeed(Chunk(23)))

--- a/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorsTest.scala
@@ -12,14 +12,14 @@ class ChoiceCombinatorTest extends Test:
 
         "handle" - {
             "should handle" in {
-                val effect: Int < Choice = Choice.get(Seq(1, 2, 3))
+                val effect: Int < Choice = Choice.eval(Seq(1, 2, 3))
                 assert(effect.handleChoice.eval == Seq(1, 2, 3))
             }
         }
 
         "filter" - {
             "should filter" in {
-                val effect: Int < Choice = Choice.get(Seq(1, 2, 3))
+                val effect: Int < Choice = Choice.eval(Seq(1, 2, 3))
                 val filteredEffect       = effect.filterChoice(_ < 3)
                 assert(filteredEffect.handleChoice.eval == Seq(1, 2))
             }

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -531,7 +531,7 @@ class ChannelTest extends Test:
 
         "offer and close" in run {
             (for
-                size    <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -561,7 +561,7 @@ class ChannelTest extends Test:
 
         "offer and poll" in run {
             (for
-                size    <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -581,7 +581,7 @@ class ChannelTest extends Test:
 
         "put and take" in run {
             (for
-                size    <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 putFiber <- Async.run(
@@ -600,7 +600,7 @@ class ChannelTest extends Test:
 
         "offer to full channel during close" in run {
             (for
-                size    <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 channel <- Channel.init[Int](size)
                 _       <- Kyo.foreach(1 to size)(i => channel.offer(i))
                 latch   <- Latch.init(1)
@@ -627,7 +627,7 @@ class ChannelTest extends Test:
 
         "concurrent close attempts" in run {
             (for
-                size    <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -655,7 +655,7 @@ class ChannelTest extends Test:
 
         "offer, poll, put, take, and close" in run {
             (for
-                size    <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -695,7 +695,7 @@ class ChannelTest extends Test:
 
         "putBatch and take" in run {
             (for
-                size    <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
@@ -718,7 +718,7 @@ class ChannelTest extends Test:
 
         "putBatch and takeExactly" in run {
             (for
-                size    <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 

--- a/kyo-core/shared/src/test/scala/kyo/HubTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/HubTest.scala
@@ -247,7 +247,7 @@ class HubTest extends Test:
 
         "concurrent listeners and close" in run {
             (for
-                size  <- Choice.get(Seq(1, 2, 10, 100))
+                size  <- Choice.eval(Seq(1, 2, 10, 100))
                 hub   <- Hub.init[Int](size)
                 latch <- Latch.init(1)
                 listenerFiber <- Async.run(

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -119,7 +119,7 @@ class MeterTest extends Test:
 
             "run" in run {
                 (for
-                    size    <- Choice.get(Seq(1, 2, 3, 50, 100))
+                    size    <- Choice.eval(Seq(1, 2, 3, 50, 100))
                     meter   <- Meter.initSemaphore(size)
                     counter <- AtomicInt.init(0)
                     results <-
@@ -139,7 +139,7 @@ class MeterTest extends Test:
 
             "close" in run {
                 (for
-                    size    <- Choice.get(Seq(1, 2, 3, 50, 100))
+                    size    <- Choice.eval(Seq(1, 2, 3, 50, 100))
                     meter   <- Meter.initSemaphore(size)
                     latch   <- Latch.init(1)
                     counter <- AtomicInt.init(0)
@@ -166,7 +166,7 @@ class MeterTest extends Test:
 
             "with interruptions" in runJVM {
                 (for
-                    size    <- Choice.get(Seq(1, 2, 3, 50, 100))
+                    size    <- Choice.eval(Seq(1, 2, 3, 50, 100))
                     meter   <- Meter.initSemaphore(size)
                     started <- Latch.init(100)
                     latch   <- Latch.init(1)

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -234,7 +234,7 @@ class QueueTest extends Test:
 
         "offer and close" in run {
             (for
-                size  <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -260,7 +260,7 @@ class QueueTest extends Test:
 
         "offer and poll" in run {
             (for
-                size  <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -280,7 +280,7 @@ class QueueTest extends Test:
 
         "offer to full queue during close" in run {
             (for
-                size  <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 queue <- Queue.init[Int](size)
                 _     <- Kyo.foreach(1 to size)(i => queue.offer(i))
                 latch <- Latch.init(1)
@@ -303,7 +303,7 @@ class QueueTest extends Test:
 
         "concurrent close attempts" in run {
             (for
-                size  <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -327,7 +327,7 @@ class QueueTest extends Test:
 
         "offer, poll and close" in run {
             (for
-                size  <- Choice.get(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -6,7 +6,7 @@ class StreamCoreExtensionsTest extends Test:
         "collectAll" in run {
             Choice.run {
                 for
-                    size <- Choice.get(Seq(0, 1, 32, 100))
+                    size <- Choice.eval(Seq(0, 1, 32, 100))
                     s1     = Stream.init(0 to 99 by 3)
                     s2     = Stream.init(1 to 99 by 3)
                     s3     = Stream.init(2 to 99 by 3)
@@ -19,7 +19,7 @@ class StreamCoreExtensionsTest extends Test:
         "collectAllHalting" in runNotJS {
             Choice.run {
                 for
-                    size <- Choice.get(Seq(0, 1, 32, 1024))
+                    size <- Choice.eval(Seq(0, 1, 32, 1024))
                     s1     = Stream(Loop.forever(Emit.value(Chunk(100))))
                     s2     = Stream.init(0 to 50)
                     merged = Stream.collectAllHalting(Seq(s1, s2), size)
@@ -51,8 +51,8 @@ class StreamCoreExtensionsTest extends Test:
             "should halt if non-halting side completes" in run {
                 Choice.run {
                     for
-                        size <- Choice.get(Seq(0, 1, 32, 1024))
-                        left <- Choice.get(Seq(true, false))
+                        size <- Choice.eval(Seq(0, 1, 32, 1024))
+                        left <- Choice.eval(Seq(true, false))
                         s1     = Stream.init(0 to 50)
                         s2     = Stream(Loop.forever(Emit.value(Chunk(100))))
                         merged = if left then s1.mergeHaltingLeft(s2, size) else s2.mergeHaltingRight(s1, size)
@@ -69,8 +69,8 @@ class StreamCoreExtensionsTest extends Test:
                 val s2 = Stream.init(s2Set.toSeq)
                 Choice.run {
                     for
-                        size <- Choice.get(Seq(0, 1, 32, 1024))
-                        left <- Choice.get(Seq(true, false))
+                        size <- Choice.eval(Seq(0, 1, 32, 1024))
+                        left <- Choice.eval(Seq(true, false))
                         // Make sure we get case where all three values of s2 have been consumed (not guaranteed)
                         assertion <- Loop(Set.empty[Int]) { lastRes =>
                             if s2Set.subsetOf(lastRes) then
@@ -112,8 +112,8 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.get(Seq(1, 2, 4, Async.defaultConcurrency, Int.MaxValue))
-                        buf <- Choice.get(Seq(1, 4, 5, 8, 12, par, Int.MaxValue))
+                        par <- Choice.eval(Seq(1, 2, 4, Async.defaultConcurrency, Int.MaxValue))
+                        buf <- Choice.eval(Seq(1, 4, 5, 8, 12, par, Int.MaxValue))
                         s2 = stream.mapPar(par, buf)(i => IO(i + 1))
                         res <- s2.run
                     yield assert(
@@ -129,7 +129,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4)
                 val test =
                     for
-                        par <- Choice.get(Seq(2, 4, Async.defaultConcurrency))
+                        par <- Choice.eval(Seq(2, 4, Async.defaultConcurrency))
                         s2 = stream.mapPar(par)(i => if i == 1 then Async.sleep(10.millis).andThen(i + 1) else i + 1)
                         res <- s2.run
                     yield assert(
@@ -147,8 +147,8 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.get(Seq(1, 2, 4, Async.defaultConcurrency))
-                        buf <- Choice.get(Seq(1, 4, 5, 8, 12))
+                        par <- Choice.eval(Seq(1, 2, 4, Async.defaultConcurrency))
+                        buf <- Choice.eval(Seq(1, 4, 5, 8, 12))
                         s2 = stream.mapParUnordered(par, buf)(i => IO(i + 1))
                         res <- s2.run
                     yield assert(
@@ -164,7 +164,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4)
                 val test =
                     for
-                        par <- Choice.get(Seq(2, 4, Async.defaultConcurrency))
+                        par <- Choice.eval(Seq(2, 4, Async.defaultConcurrency))
                         s2 = stream.mapParUnordered(par)(i => if i == 1 then Async.sleep(10.millis).andThen(i + 1) else i + 1)
                         res <- s2.run
                     yield assert(
@@ -183,8 +183,8 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.get(Seq(1, 2, 4, Async.defaultConcurrency))
-                        buf <- Choice.get(Seq(1, 4, 5, 8, 12))
+                        par <- Choice.eval(Seq(1, 2, 4, Async.defaultConcurrency))
+                        buf <- Choice.eval(Seq(1, 4, 5, 8, 12))
                         s2 = stream.mapChunkPar(par, buf)(c => IO(c.map(_ + 1)))
                         res <- s2.run
                     yield assert(
@@ -200,7 +200,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8))
                 val test =
                     for
-                        par <- Choice.get(Seq(2, 4, Async.defaultConcurrency))
+                        par <- Choice.eval(Seq(2, 4, Async.defaultConcurrency))
                         s2 =
                             stream.mapChunkPar(par)(c => if c.head == 1 then Async.sleep(10.millis).andThen(c.map(_ + 1)) else c.map(_ + 1))
                         res <- s2.run
@@ -219,8 +219,8 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.get(Seq(1, 2, 4, Async.defaultConcurrency))
-                        buf <- Choice.get(Seq(1, 4, 5, 8, 12))
+                        par <- Choice.eval(Seq(1, 2, 4, Async.defaultConcurrency))
+                        buf <- Choice.eval(Seq(1, 4, 5, 8, 12))
                         s2 = stream.mapChunkParUnordered(par, buf)(c => IO(c.map(_ + 1)))
                         res <- s2.run
                     yield assert(
@@ -236,7 +236,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8))
                 val test =
                     for
-                        par <- Choice.get(Seq(2, 4, Async.defaultConcurrency))
+                        par <- Choice.eval(Seq(2, 4, Async.defaultConcurrency))
                         s2 =
                             stream.mapChunkParUnordered(par)(c =>
                                 if c.head == 1 then Async.sleep(10.millis).andThen(c.map(_ + 1)) else c.map(_ + 1)

--- a/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
@@ -193,8 +193,8 @@ class PreludeTest extends Test:
         "basic choices" in run {
             val effect =
                 defer {
-                    val x = Choice.get(Seq(1, 2, 3)).now
-                    val y = Choice.get(Seq("a", "b")).now
+                    val x = Choice.eval(Seq(1, 2, 3)).now
+                    val y = Choice.eval(Seq("a", "b")).now
                     s"$x$y"
                 }
 
@@ -206,8 +206,8 @@ class PreludeTest extends Test:
         "choice with conditions" in run {
             val effect =
                 defer {
-                    val x = Choice.get(Seq(1, -2, -3)).now
-                    val y = Choice.get(Seq("ab", "cde")).now
+                    val x = Choice.eval(Seq(1, -2, -3)).now
+                    val y = Choice.eval(Seq("ab", "cde")).now
                     if x > 0 then y.length * x
                     else y.length
                 }
@@ -220,7 +220,7 @@ class PreludeTest extends Test:
         "choice with filtering" in run {
             val effect =
                 defer {
-                    val x = Choice.get(Seq(1, 2, 3, 4)).now
+                    val x = Choice.eval(Seq(1, 2, 3, 4)).now
                     Choice.dropIf(x % 2 == 0).now
                     x
                 }
@@ -358,8 +358,8 @@ class PreludeTest extends Test:
     }
 
     "Choice" in run {
-        val x = Choice.get(Seq(1, -2, -3))
-        val y = Choice.get(Seq("ab", "cde"))
+        val x = Choice.eval(Seq(1, -2, -3))
+        val y = Choice.eval(Seq("ab", "cde"))
 
         val v: Int < Choice =
             defer {
@@ -376,8 +376,8 @@ class PreludeTest extends Test:
     }
 
     "Choice + filter" in run {
-        val x = Choice.get(Seq(1, -2, -3))
-        val y = Choice.get(Seq("ab", "cde"))
+        val x = Choice.eval(Seq(1, -2, -3))
+        val y = Choice.eval(Seq("ab", "cde"))
 
         val v: Int < Choice =
             defer {

--- a/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
@@ -36,7 +36,7 @@ object Choice:
       * @return
       *   A computation that represents the selection of values from the sequence
       */
-    inline def get[A](seq: Seq[A])(using inline frame: Frame): A < Choice =
+    inline def eval[A](seq: Seq[A])(using inline frame: Frame): A < Choice =
         ArrowEffect.suspend[A](Tag[Choice], seq)
 
     /** Evaluates a function for each value in a sequence, introducing multiple computation paths.
@@ -48,7 +48,7 @@ object Choice:
       * @return
       *   A computation that represents multiple paths, one for each input value
       */
-    inline def eval[A, B, S](seq: Seq[A])(inline f: A => B < S)(using inline frame: Frame): B < (Choice & S) =
+    inline def evalWith[A, B, S](seq: Seq[A])(inline f: A => B < S)(using inline frame: Frame): B < (Choice & S) =
         seq match
             case Seq(head) => f(head)
             case seq       => ArrowEffect.suspendWith[A](Tag[Choice], seq)(f)

--- a/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
@@ -45,6 +45,24 @@ object Emit:
     inline def value[V](inline value: V)(using inline tag: Tag[Emit[V]], inline frame: Frame): Unit < Emit[V] =
         ArrowEffect.suspend[Any](tag, value)
 
+    /** Emits a single value when a condition is true.
+      *
+      * @param cond
+      *   The condition that determines whether to emit the value
+      * @param value
+      *   The value to emit if the condition is true
+      * @return
+      *   An effect that emits the given value if the condition is true, otherwise does nothing
+      */
+    inline def valueWhen[V, S](cond: Boolean < S)(inline value: V)(using
+        inline tag: Tag[Emit[V]],
+        inline frame: Frame
+    ): Unit < (Emit[V] & S) =
+        cond.map {
+            case false => ()
+            case true  => Emit.value(value)
+        }
+
     /** Emits a single value and maps the resulting Ack.
       *
       * @param value

--- a/kyo-prelude/shared/src/main/scala/kyo/Parse.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Parse.scala
@@ -139,7 +139,7 @@ object Parse:
       *   Result from the single successful parser, fails if zero or multiple parsers succeed
       */
     def anyOf[A, S](seq: (A < (Parse & S))*)(using Frame): A < (Parse & S) =
-        Choice.eval(seq)(identity)
+        Choice.evalWith(seq)(identity)
 
     private def firstOf[A, S](seq: Seq[() => A < (Parse & S)])(using Frame): A < (Parse & S) =
         Loop(seq) {

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -1316,7 +1316,7 @@ class AbortTest extends Test:
             val local = Local.init("default")
             val combined = Kyo.lift {
                 local.let("custom") {
-                    Choice.get(Seq(1, 2)).flatMap { n =>
+                    Choice.eval(Seq(1, 2)).flatMap { n =>
                         if n % 2 == 0 then n * 10
                         else Abort.fail(s"odd: $n")
                     }

--- a/kyo-prelude/shared/src/test/scala/kyo/ChoiceTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/ChoiceTest.scala
@@ -6,51 +6,51 @@ class ChoiceTest extends Test:
 
     "eval with a single choice" in {
         assert(
-            Choice.run(Choice.eval(Seq(1))(i => (i + 1))).eval == Seq(2)
+            Choice.run(Choice.evalWith(Seq(1))(i => (i + 1))).eval == Seq(2)
         )
     }
 
     "eval with multiple choices" in {
         assert(
-            Choice.run(Choice.eval(Seq(1, 2, 3))(i => (i + 1))).eval == Seq(2, 3, 4)
+            Choice.run(Choice.evalWith(Seq(1, 2, 3))(i => (i + 1))).eval == Seq(2, 3, 4)
         )
     }
 
     "nested eval" in {
         assert(
-            Choice.run(Choice.eval(Seq(1, 2, 3))(i =>
-                Choice.get(Seq(i * 10, i * 100))
+            Choice.run(Choice.evalWith(Seq(1, 2, 3))(i =>
+                Choice.eval(Seq(i * 10, i * 100))
             )).eval == Seq(10, 100, 20, 200, 30, 300)
         )
     }
 
     "drop" in {
         assert(
-            Choice.run(Choice.eval(Seq(1, 2, 3))(i =>
-                if i < 2 then Choice.drop else Choice.get(Seq(i * 10, i * 100))
+            Choice.run(Choice.evalWith(Seq(1, 2, 3))(i =>
+                if i < 2 then Choice.drop else Choice.eval(Seq(i * 10, i * 100))
             )).eval == Seq(20, 200, 30, 300)
         )
     }
 
     "filter" in {
         assert(
-            Choice.run(Choice.eval(Seq(1, 2, 3))(i =>
-                Choice.dropIf(i < 2).map(_ => Choice.get(Seq(i * 10, i * 100)))
+            Choice.run(Choice.evalWith(Seq(1, 2, 3))(i =>
+                Choice.dropIf(i < 2).map(_ => Choice.eval(Seq(i * 10, i * 100)))
             )).eval == Seq(20, 200, 30, 300)
         )
     }
 
     "empty choices" in {
         assert(
-            Choice.run(Choice.eval(Seq.empty[Int])(_ => 42)).eval == Seq.empty[Int]
+            Choice.run(Choice.evalWith(Seq.empty[Int])(_ => 42)).eval == Seq.empty[Int]
         )
     }
 
     "nested drop" in {
         assert(
             Choice.run(
-                Choice.eval(Seq(1, 2, 3))(i =>
-                    Choice.eval(Seq(i * 10, i * 100))(j =>
+                Choice.evalWith(Seq(1, 2, 3))(i =>
+                    Choice.evalWith(Seq(i * 10, i * 100))(j =>
                         if j > 100 then Choice.drop else j
                     )
                 )
@@ -61,9 +61,9 @@ class ChoiceTest extends Test:
     "nested filter" in {
         assert(
             Choice.run(
-                Choice.eval(Seq(1, 2, 3))(i =>
+                Choice.evalWith(Seq(1, 2, 3))(i =>
                     Choice.dropIf(i % 2 != 0).map(_ =>
-                        Choice.eval(Seq(i * 10, i * 100))(j =>
+                        Choice.evalWith(Seq(i * 10, i * 100))(j =>
                             Choice.dropIf(j >= 300).map(_ => j)
                         )
                     )
@@ -76,7 +76,7 @@ class ChoiceTest extends Test:
         val largeChoice = Seq.range(0, 100000)
         try
             assert(
-                Choice.run(Choice.get(largeChoice)).eval == largeChoice
+                Choice.run(Choice.eval(largeChoice)).eval == largeChoice
             )
         catch
             case ex: StackOverflowError => fail()
@@ -85,9 +85,9 @@ class ChoiceTest extends Test:
 
     "large number of suspensions" taggedAs notNative in pendingUntilFixed {
         // https://github.com/getkyo/kyo/issues/208
-        var v = Choice.get(Seq(1))
+        var v = Choice.eval(Seq(1))
         for _ <- 0 until 100000 do
-            v = v.map(_ => Choice.get(Seq(1)))
+            v = v.map(_ => Choice.eval(Seq(1)))
         try
             assert(
                 Choice.run(v).eval == Seq(1)
@@ -102,7 +102,7 @@ class ChoiceTest extends Test:
         "foreach" in {
             val result = Choice.run(
                 Kyo.foreach(List("x", "y")) { str =>
-                    Choice.get(List(true, false)).map(b =>
+                    Choice.eval(List(true, false)).map(b =>
                         if b then str.toUpperCase else str
                     )
                 }
@@ -118,7 +118,7 @@ class ChoiceTest extends Test:
         "collect" in {
             val effects =
                 List("x", "y").map { str =>
-                    Choice.get(List(true, false)).map(b =>
+                    Choice.eval(List(true, false)).map(b =>
                         if b then str.toUpperCase else str
                     )
                 }
@@ -134,7 +134,7 @@ class ChoiceTest extends Test:
         "foldLeft" in {
             val result = Choice.run(
                 Kyo.foldLeft(List(1, 1))(0) { (acc, _) =>
-                    Choice.get(List(0, 1)).map(n => acc + n)
+                    Choice.eval(List(0, 1)).map(n => acc + n)
                 }
             ).eval
 
@@ -147,7 +147,7 @@ class ChoiceTest extends Test:
         "foreach - array" in {
             val result = Choice.run(
                 Kyo.foreach(Array("x", "y")) { str =>
-                    Choice.get(Seq(true, false)).map(b =>
+                    Choice.eval(Seq(true, false)).map(b =>
                         if b then str.toUpperCase else str
                     )
                 }
@@ -163,7 +163,7 @@ class ChoiceTest extends Test:
         "collect - array" in {
             val effects =
                 Array("x", "y").map { str =>
-                    Choice.get(Seq(true, false)).map(b =>
+                    Choice.eval(Seq(true, false)).map(b =>
                         if b then str.toUpperCase else str
                     )
                 }
@@ -179,7 +179,7 @@ class ChoiceTest extends Test:
         "foldLeft - array" in {
             val result = Choice.run(
                 Kyo.foldLeft(Array(1, 1))(0) { (acc, _) =>
-                    Choice.get(Seq(0, 1)).map(n => acc + n)
+                    Choice.eval(Seq(0, 1)).map(n => acc + n)
                 }
             ).eval
 

--- a/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
@@ -60,8 +60,8 @@ class DebugTest extends Test:
         Debug.trace {
             Choice.run {
                 for
-                    x <- Choice.get(Seq(1, 2, 3))
-                    y <- Choice.get(Seq(4, 5, 6))
+                    x <- Choice.eval(Seq(1, 2, 3))
+                    y <- Choice.eval(Seq(4, 5, 6))
                 yield x + y
             }
         }

--- a/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
@@ -555,7 +555,7 @@ class STMTest extends Test:
 
         "concurrent updates" in runNotJS {
             (for
-                size  <- Choice.get(sizes)
+                size  <- Choice.eval(sizes)
                 ref   <- TRef.init(0)
                 _     <- Async.fill(size, size)(STM.run(ref.update(_ + 1)))
                 value <- STM.run(ref.get)
@@ -566,7 +566,7 @@ class STMTest extends Test:
 
         "concurrent reads and writes" in runNotJS {
             (for
-                size  <- Choice.get(sizes)
+                size  <- Choice.eval(sizes)
                 ref   <- TRef.init(0)
                 latch <- Latch.init(1)
                 writeFiber <- Async.run(
@@ -586,7 +586,7 @@ class STMTest extends Test:
 
         "concurrent nested transactions" in runNotJS {
             (for
-                size <- Choice.get(sizes)
+                size <- Choice.eval(sizes)
                 ref  <- TRef.init(0)
                 _ <- Async.fill(size, size) {
                     STM.run {

--- a/kyo-stm/shared/src/test/scala/kyo/TChunkTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TChunkTest.scala
@@ -189,7 +189,7 @@ class TChunkTest extends Test:
 
         "concurrent modifications" in runNotJS {
             (for
-                size     <- Choice.get(Seq(1, 10, 100))
+                size     <- Choice.eval(Seq(1, 10, 100))
                 chunk    <- TChunk.init[Int]()
                 _        <- Async.foreach(1 to size, size)(i => STM.run(chunk.append(i)))
                 snapshot <- STM.run(chunk.snapshot)
@@ -203,7 +203,7 @@ class TChunkTest extends Test:
 
         "concurrent filtering" in runNotJS {
             (for
-                size  <- Choice.get(Seq(1, 10, 100))
+                size  <- Choice.eval(Seq(1, 10, 100))
                 chunk <- TChunk.init[Int]()
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => chunk.append(i))
@@ -222,7 +222,7 @@ class TChunkTest extends Test:
 
         "concurrent slice operations" in runNotJS {
             (for
-                size  <- Choice.get(Seq(1, 10, 100))
+                size  <- Choice.eval(Seq(1, 10, 100))
                 chunk <- TChunk.init[Int]()
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => chunk.append(i))
@@ -246,7 +246,7 @@ class TChunkTest extends Test:
 
         "concurrent compaction" in runNotJS {
             (for
-                size  <- Choice.get(Seq(1, 10, 100))
+                size  <- Choice.eval(Seq(1, 10, 100))
                 chunk <- TChunk.init[Int]()
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => chunk.append(i))

--- a/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
@@ -371,7 +371,7 @@ class TMapTest extends Test:
 
         "concurrent modifications" in runNotJS {
             (for
-                size     <- Choice.get(Seq(1, 10, 100))
+                size     <- Choice.eval(Seq(1, 10, 100))
                 map      <- STM.run(TMap.init[Int, Int]())
                 _        <- Async.foreach(1 to size, size)(i => STM.run(map.put(i, i)))
                 snapshot <- STM.run(map.snapshot)
@@ -385,7 +385,7 @@ class TMapTest extends Test:
 
         "concurrent reads and writes" in runNotJS {
             (for
-                size  <- Choice.get(Seq(1, 10, 100))
+                size  <- Choice.eval(Seq(1, 10, 100))
                 map   <- STM.run(TMap.init[Int, Int]())
                 latch <- Latch.init(1)
 
@@ -420,7 +420,7 @@ class TMapTest extends Test:
 
         "concurrent updates" in runNotJS {
             (for
-                size <- Choice.get(Seq(1, 10, 100))
+                size <- Choice.eval(Seq(1, 10, 100))
                 map  <- STM.run(TMap.init[Int, Int]())
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => map.put(i, 1))
@@ -443,7 +443,7 @@ class TMapTest extends Test:
 
         "concurrent removals" in runNotJS {
             (for
-                size <- Choice.get(Seq(1, 10, 100))
+                size <- Choice.eval(Seq(1, 10, 100))
                 map  <- STM.run(TMap.init[Int, Int]())
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => map.put(i, i))
@@ -459,7 +459,7 @@ class TMapTest extends Test:
 
         "concurrent bulk operations" in runNotJS {
             (for
-                size <- Choice.get(Seq(1, 10, 100))
+                size <- Choice.eval(Seq(1, 10, 100))
                 map  <- STM.run(TMap.init[Int, Int]())
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => map.put(i, i))


### PR DESCRIPTION
### Problem

`Choice.get` follows the API patterns of the early days of the project and only provides a handler to evaluate all alternatives

### Solution

Rename `Choice.get` to `Choice.eval` and `Choice.eval` to `Choice.evalWith`. Introduce `Choice.runStream`.

### Notes

I've also added `Emit.valueWhen` used in `runStream`
