### PR TITLE
[data] Chunk optimizations

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/ChunkBuilder.scala
+++ b/kyo-data/shared/src/main/scala/kyo/ChunkBuilder.scala
@@ -1,6 +1,10 @@
 package kyo
 
+import java.util.ArrayDeque
+import scala.annotation.nowarn
+import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuilder
+import scala.collection.mutable.Builder
 import scala.collection.mutable.ReusableBuilder
 import scala.reflect.ClassTag
 
@@ -11,9 +15,61 @@ import scala.reflect.ClassTag
   * @tparam A
   *   the type of elements in the Chunk being built
   */
-sealed abstract class ChunkBuilder[A] extends ReusableBuilder[A, Chunk.Indexed[A]] with Serializable
+sealed class ChunkBuilder[A] extends ReusableBuilder[A, Chunk.Indexed[A]] with Serializable:
+    private var builder = Maybe.empty[ArrayDeque[A]]
+
+    final override def addOne(elem: A): this.type =
+        builder match
+            case Absent =>
+                val buffer = ChunkBuilder.acquireBuffer[A]()
+                buffer.add(elem)
+                builder = Present(buffer)
+            case Present(buffer) =>
+                discard(buffer.add(elem))
+        end match
+        this
+    end addOne
+
+    override def addAll(elems: IterableOnce[A]): this.type =
+        elems match
+            case elems: Chunk[A] =>
+                elems.foreach(addOne)
+            case _ =>
+                val it = elems.iterator
+                @tailrec def loop(): Unit =
+                    if it.hasNext then
+                        addOne(it.next())
+                        loop()
+                loop()
+        end match
+        this
+    end addAll
+
+    final override def clear(): Unit = builder.foreach(_.clear())
+
+    final override def result(): Chunk.Indexed[A] =
+        val chunk = builder.fold(Chunk.Indexed.empty[A])(b => Chunk.fromNoCopy(b.toArray.asInstanceOf[Array[A]]))
+        builder.foreach(ChunkBuilder.releaseBuffer)
+        builder = Absent
+        chunk
+    end result
+
+    final override def knownSize: Int = builder.fold(0)(_.size)
+
+    override def toString(): String =
+        s"ChunkBuilder(size = $knownSize)"
+end ChunkBuilder
 
 object ChunkBuilder:
+
+    private val bufferCache = ThreadLocal.withInitial(() => new ArrayDeque[ArrayDeque[?]])
+
+    private[kyo] def acquireBuffer[A](): ArrayDeque[A] =
+        Maybe(bufferCache.get().poll()).getOrElse(new ArrayDeque).asInstanceOf[ArrayDeque[A]]
+
+    private[kyo] def releaseBuffer(buffer: ArrayDeque[?]): Unit =
+        buffer.clear()
+        discard(bufferCache.get().add(buffer))
 
     /** Creates a new ChunkBuilder with no size hint.
       *
@@ -22,50 +78,12 @@ object ChunkBuilder:
       * @return
       *   a new ChunkBuilder instance
       */
-    def init[A]: ChunkBuilder[A] = init(0)
+    def init[A]: ChunkBuilder[A] =
+        new ChunkBuilder[A]
 
-    /** Creates a new ChunkBuilder with a size hint.
-      *
-      * @tparam A
-      *   the type of elements in the Chunk to be built
-      * @param hint
-      *   the expected number of elements to be added
-      * @return
-      *   a new ChunkBuilder instance
-      */
-    def init[A](hint: Int): ChunkBuilder[A] =
-        new ChunkBuilder[A]:
-            var builder = Maybe.empty[ArrayBuilder[A]]
-            var _hint   = hint
+    @nowarn("msg=anonymous")
+    inline def initTransform[A, B](inline f: (ChunkBuilder[B], A) => Unit): (A => Unit) & ChunkBuilder[B] =
+        new ChunkBuilder[B] with Function1[A, Unit]:
+            def apply(elem: A): Unit = f(this, elem)
 
-            override def addOne(elem: A): this.type =
-                builder match
-                    case Absent =>
-                        val arr = ArrayBuilder.make[A](using ClassTag.Any.asInstanceOf[ClassTag[A]])
-                        if _hint > 0 then arr.sizeHint(_hint)
-                        arr.addOne(elem)
-                        builder = Maybe(arr)
-                    case Present(arr) => discard(arr.addOne(elem))
-                end match
-                this
-            end addOne
-
-            override def sizeHint(n: Int): Unit =
-                _hint = n
-                builder.foreach(_.sizeHint(n))
-
-            override def clear(): Unit = builder.foreach(_.clear())
-
-            override def result(): Chunk.Indexed[A] =
-                val chunk = builder.fold(Chunk.Indexed.empty[A])(b => Chunk.fromNoCopy(b.result()))
-                builder.foreach(_.clear())
-                chunk
-            end result
-
-            override def knownSize: Int = builder.fold(0)(_.knownSize)
-
-            override def toString(): String =
-                if _hint > 0 then s"ChunkBuilder(size = $knownSize, hint = $_hint)"
-                else s"ChunkBuilder(size = $knownSize)"
-    end init
 end ChunkBuilder

--- a/kyo-data/shared/src/main/scala/kyo/ChunkBuilder.scala
+++ b/kyo-data/shared/src/main/scala/kyo/ChunkBuilder.scala
@@ -62,7 +62,9 @@ end ChunkBuilder
 
 object ChunkBuilder:
 
-    private val bufferCache = ThreadLocal.withInitial(() => new ArrayDeque[ArrayDeque[?]])
+    private val bufferCache =
+        new ThreadLocal[ArrayDeque[ArrayDeque[?]]]:
+            override def initialValue() = new ArrayDeque[ArrayDeque[?]]
 
     private[kyo] def acquireBuffer[A](): ArrayDeque[A] =
         Maybe(bufferCache.get().poll()).getOrElse(new ArrayDeque).asInstanceOf[ArrayDeque[A]]

--- a/kyo-data/shared/src/test/scala/kyo/ChunkBuilderTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ChunkBuilderTest.scala
@@ -17,7 +17,7 @@ class ChunkBuilderTest extends Test:
         }
 
         "clear" in {
-            val builder = ChunkBuilder.init[Boolean](10)
+            val builder = ChunkBuilder.init[Boolean]
             builder.addOne(true)
             builder.clear()
             assert(builder.knownSize == 0)
@@ -35,28 +35,27 @@ class ChunkBuilderTest extends Test:
         }
 
         "hint" in {
-            val builder = ChunkBuilder.init[Int](1000)
+            val builder = ChunkBuilder.init[Int]
             (0 until 1000).foreach(builder.addOne)
             assert(builder.result().length == 1000)
         }
 
         "knownSize" in {
-            val builder = ChunkBuilder.init[Int](20)
+            val builder = ChunkBuilder.init[Int]
             assert(builder.knownSize == 0)
             (0 until 10).foreach(builder.addOne)
             assert(builder.knownSize == 10)
         }
 
         "toString" in {
-            assert(ChunkBuilder.init[Int](10).toString() == "ChunkBuilder(size = 0, hint = 10)")
             assert(ChunkBuilder.init[Int].toString() == "ChunkBuilder(size = 0)")
             val builder = ChunkBuilder.init[Int]
             builder.sizeHint(1)
-            assert(builder.toString() == "ChunkBuilder(size = 0, hint = 1)")
+            assert(builder.toString() == "ChunkBuilder(size = 0)")
             val hinted = ChunkBuilder.init[Int]
             hinted.addOne(1)
             hinted.sizeHint(2)
-            assert(hinted.toString() == "ChunkBuilder(size = 1, hint = 2)")
+            assert(hinted.toString() == "ChunkBuilder(size = 1)")
         }
     }
 end ChunkBuilderTest


### PR DESCRIPTION
### Problem

The overhead of the default Scala collection methods with `Chunk` is the main bottleneck in `StreamBench`.

### Solution

- Introduce a thread-local cache in `ChunkBuilder` to reuse buffers instead of having to allocate and grow them dynamically, which introduces allocations. 
- Introduce an optimized `foreach` similar to `copyTo` allowing traversal without allocations besides the allocation of the function parameter
- Override other methods like `map` and `filter` to use the optimized `foreach`. To avoid having to allocate the `ChunkBuilder` + the function to call `foreach`, I've introduced `ChunkBuilder.initTransform` that merges the function implementation in the same allocation as `ChunkBuilder`.

