### PR TITLE
remove: dependency `com.lihaoyi:pprint`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -279,7 +279,6 @@ lazy val `kyo-data` =
         .in(file("kyo-data"))
         .settings(
             `kyo-settings`,
-            libraryDependencies += "com.lihaoyi" %%% "pprint"        % "0.9.0",
             libraryDependencies += "dev.zio"     %%% "izumi-reflect" % "3.0.2" % Test
         )
         .jvmSettings(mimaCheck(false))

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -46,8 +46,8 @@ object KyoApp:
 
         protected def exit(code: Int): Unit = kernel.Platform.exit(code)
 
-        protected def onResult(result: Result[Any, Any]): Unit =
-            if !result.exists(().equals(_)) then println(pprint.apply(result).plainText)
+        protected def onResult[E, A](result: Result[E, A])(using Render[Result[E, A]]): Unit =
+            if !result.exists(().equals(_)) then println(result.show)
             result match
                 case Error(e: Throwable) => throw e
                 case Error(_)            => exit(1)


### PR DESCRIPTION
### Problem
Kyo should ideally be zero dependency to ensure companies are able to adopt it. Plus all the other downsides...

### Solution
Use `Render` to print the output of the KyoApp.
