### PR TITLE
[core] Channel/Queue closeAndWaitEmpty

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -210,6 +210,18 @@ object Channel:
           */
         def close(using Frame): Maybe[Seq[A]] < IO = IO.Unsafe(self.close())
 
+        /** Closes the channel and asynchronously waits until it's empty.
+          * 
+          * This method closes the channel to new elements and returns a fiber that completes
+          * when all elements have been consumed. Unlike the regular `close` method, this
+          * allows consumers to process all remaining elements before considering the channel
+          * fully closed.
+          *
+          * @return
+          *   true if the channel was successfully closed and emptied, false if it was already closed
+          */
+        def closeAwaitEmpty(using Frame): Boolean < Async = IO.Unsafe(self.closeAwaitEmpty().safe.get)
+
         /** Checks if the channel is closed.
           *
           * @return
@@ -327,6 +339,7 @@ object Channel:
         def drain()(using AllowUnsafe): Result[Closed, Chunk[A]]
         def drainUpTo(max: Int)(using AllowUnsafe): Result[Closed, Chunk[A]]
         def close()(using Frame, AllowUnsafe): Maybe[Seq[A]]
+        def closeAwaitEmpty()(using Frame, AllowUnsafe): Fiber.Unsafe[Nothing, Boolean]
 
         def empty()(using AllowUnsafe): Result[Closed, Boolean]
         def full()(using AllowUnsafe): Result[Closed, Boolean]
@@ -494,6 +507,9 @@ object Channel:
                     Present(Chunk.empty)
             end close
 
+            def closeAwaitEmpty()(using Frame, AllowUnsafe) =
+                Fiber.Unsafe.init(Result.succeed(close().isDefined))
+
             def empty()(using AllowUnsafe)  = asResult(true)
             def full()(using AllowUnsafe)   = asResult(true)
             def closed()(using AllowUnsafe) = isClosed.get()
@@ -638,6 +654,12 @@ object Channel:
                     flush()
                     backlog
                 }
+
+            def closeAwaitEmpty()(using frame: Frame, allow: AllowUnsafe) =
+                val r = queue.closeAwaitEmpty()
+                r.onComplete(_ => flush())
+                r
+            end closeAwaitEmpty
 
             def empty()(using AllowUnsafe)  = queue.empty()
             def full()(using AllowUnsafe)   = queue.full()

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -121,6 +121,18 @@ object Queue:
           */
         def close(using Frame): Maybe[Seq[A]] < IO = IO.Unsafe(self.close())
 
+        /** Closes the queue and asynchronously waits until it's empty.
+          * 
+          * This method closes the queue to new elements and returns a fiber that completes
+          * when all elements have been consumed. Unlike the regular `close` method, this
+          * allows consumers to process all remaining elements before considering the queue
+          * fully closed.
+          *
+          * @return
+          *   true if the queue was successfully closed and emptied, false if it was already closed
+          */
+        def closeAwaitEmpty(using Frame): Boolean < Async = IO.Unsafe(self.closeAwaitEmpty().safe.get)
+
         /** Checks if the queue is closed.
           *
           * @return
@@ -279,18 +291,19 @@ object Queue:
                 allow: AllowUnsafe
             ): Unsafe[A] =
                 new Unsafe[A]:
-                    val underlying                             = Queue.Unsafe.init[A](_capacity, access)
-                    def capacity                               = _capacity
-                    def size()(using AllowUnsafe)              = underlying.size()
-                    def empty()(using AllowUnsafe)             = underlying.empty()
-                    def full()(using AllowUnsafe)              = underlying.full().map(_ => false)
-                    def offer(v: A)(using AllowUnsafe)         = underlying.offer(v).map(_ => true)
-                    def poll()(using AllowUnsafe)              = underlying.poll()
-                    def drainUpTo(max: Int)(using AllowUnsafe) = underlying.drainUpTo(max)
-                    def peek()(using AllowUnsafe)              = underlying.peek()
-                    def drain()(using AllowUnsafe)             = underlying.drain()
-                    def close()(using Frame, AllowUnsafe)      = underlying.close()
-                    def closed()(using AllowUnsafe): Boolean   = underlying.closed()
+                    val underlying                                  = Queue.Unsafe.init[A](_capacity, access)
+                    def capacity                                    = _capacity
+                    def size()(using AllowUnsafe)                   = underlying.size()
+                    def empty()(using AllowUnsafe)                  = underlying.empty()
+                    def full()(using AllowUnsafe)                   = underlying.full().map(_ => false)
+                    def offer(v: A)(using AllowUnsafe)              = underlying.offer(v).map(_ => true)
+                    def poll()(using AllowUnsafe)                   = underlying.poll()
+                    def drainUpTo(max: Int)(using AllowUnsafe)      = underlying.drainUpTo(max)
+                    def peek()(using AllowUnsafe)                   = underlying.peek()
+                    def drain()(using AllowUnsafe)                  = underlying.drain()
+                    def close()(using Frame, AllowUnsafe)           = underlying.close()
+                    def closeAwaitEmpty()(using Frame, AllowUnsafe) = underlying.closeAwaitEmpty()
+                    def closed()(using AllowUnsafe): Boolean        = underlying.closed()
                 end new
             end initDropping
 
@@ -316,12 +329,13 @@ object Queue:
                         end loop
                         loop(v)
                     end offer
-                    def poll()(using AllowUnsafe)              = underlying.poll()
-                    def drainUpTo(max: Int)(using AllowUnsafe) = underlying.drainUpTo(max)
-                    def peek()(using AllowUnsafe)              = underlying.peek()
-                    def drain()(using AllowUnsafe)             = underlying.drain()
-                    def close()(using Frame, AllowUnsafe)      = underlying.close()
-                    def closed()(using AllowUnsafe): Boolean   = underlying.closed()
+                    def poll()(using AllowUnsafe)                   = underlying.poll()
+                    def drainUpTo(max: Int)(using AllowUnsafe)      = underlying.drainUpTo(max)
+                    def peek()(using AllowUnsafe)                   = underlying.peek()
+                    def drain()(using AllowUnsafe)                  = underlying.drain()
+                    def close()(using Frame, AllowUnsafe)           = underlying.close()
+                    def closeAwaitEmpty()(using Frame, AllowUnsafe) = underlying.closeAwaitEmpty()
+                    def closed()(using AllowUnsafe): Boolean        = underlying.closed()
                 end new
             end initSliding
         end Unsafe
@@ -339,6 +353,7 @@ object Queue:
         def peek()(using AllowUnsafe): Result[Closed, Maybe[A]]
         def drain()(using AllowUnsafe): Result[Closed, Chunk[A]]
         def close()(using Frame, AllowUnsafe): Maybe[Seq[A]]
+        def closeAwaitEmpty()(using Frame, AllowUnsafe): Fiber.Unsafe[Nothing, Boolean]
         def closed()(using AllowUnsafe): Boolean
         final def safe: Queue[A] = this
     end Unsafe
@@ -346,35 +361,76 @@ object Queue:
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     object Unsafe:
 
+        private enum State derives CanEqual:
+            case Open
+            case HalfClosed(p: Promise.Unsafe[Nothing, Boolean], r: Result.Error[Closed])
+            case FullyClosed(r: Result.Error[Closed])
+        end State
+
         sealed abstract private class Closeable[A](initFrame: Frame) extends Unsafe[A]:
             import AllowUnsafe.embrace.danger
-            final protected val _closed = AtomicRef.Unsafe.init(Maybe.empty[Result.Error[Closed]])
+            final private val state = AtomicRef.Unsafe.init[State](State.Open)
 
             final def close()(using frame: Frame, allow: AllowUnsafe) =
                 val fail = Result.Failure(Closed("Queue", initFrame))
-                Maybe.when(_closed.compareAndSet(Maybe.empty, Maybe(fail)))(_drain())
+                Maybe.when(state.compareAndSet(State.Open, State.FullyClosed(fail)))(_drain())
             end close
 
-            final def closed()(using AllowUnsafe) = _closed.get().isDefined
+            final def closeAwaitEmpty()(using frame: Frame, allow: AllowUnsafe): Fiber.Unsafe[Nothing, Boolean] =
+                val fail = Result.Failure(Closed("Queue", initFrame))
+                val p    = Promise.Unsafe.init[Nothing, Boolean]()
+                if state.compareAndSet(State.Open, State.HalfClosed(p, fail)) then
+                    handleHalfOpen()
+                    p
+                else
+                    Fiber.Unsafe.init(Result.succeed(false))
+                end if
+            end closeAwaitEmpty
+
+            final def closed()(using AllowUnsafe) =
+                state.get().isInstanceOf[State.FullyClosed]
 
             final def drainUpTo(max: Int)(using AllowUnsafe): Result[Closed, Chunk[A]] = op(_drain(Maybe.Present(max)))
 
             final def drain()(using AllowUnsafe): Result[Closed, Chunk[A]] = op(_drain())
 
             protected def _drain(max: Maybe[Int] = Maybe.Absent): Chunk[A]
+            protected def _isEmpty(): Boolean
+
+            private def opClosed: Maybe[Result.Error[Closed]] =
+                state.get() match
+                    case State.FullyClosed(r) => Present(r)
+                    case _                    => Absent
 
             protected inline def op[A](inline f: => A): Result[Closed, A] =
-                _closed.get().getOrElse(Result(f))
+                opClosed.getOrElse {
+                    val r = Result(f)
+                    handleHalfOpen()
+                    r
+                }
+
+            private def offerClosed: Maybe[Result.Error[Closed]] =
+                state.get() match
+                    case State.Open             => Absent
+                    case State.HalfClosed(_, r) => Present(r)
+                    case State.FullyClosed(r)   => Present(r)
 
             protected inline def offerOp[A](inline f: => Boolean, inline raceRepair: => Boolean): Result[Closed, Boolean] =
-                _closed.get().getOrElse {
+                offerClosed.getOrElse {
                     val result = f
-                    if result && _closed.get().isDefined then
+                    if result && closed() then
                         Result(raceRepair)
                     else
                         Result(result)
                     end if
                 }
+
+            private def handleHalfOpen(): Unit =
+                state.get() match
+                    case s: State.HalfClosed if _isEmpty() && state.compareAndSet(s, State.FullyClosed(s.r)) =>
+                        s.p.completeDiscard(Result.succeed(true))
+                    case _ =>
+
         end Closeable
 
         def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using
@@ -392,6 +448,7 @@ object Queue:
                         def poll()(using AllowUnsafe)              = op(Maybe.empty)
                         def peek()(using AllowUnsafe)              = op(Maybe.empty)
                         def _drain(max: Maybe[Int] = Maybe.Absent) = Chunk.empty
+                        def _isEmpty()                             = true
                 case 1 =>
                     new Closeable[A](initFrame):
                         private val state              = AtomicRef.Unsafe.init(Maybe.empty[A])
@@ -407,6 +464,7 @@ object Queue:
                             max.fold(
                                 state.getAndSet(Maybe.empty).fold(Chunk.empty)(Chunk(_))
                             )(m => if m <= 0 then Chunk.empty else state.getAndSet(Maybe.empty).fold(Chunk.empty)(Chunk(_)))
+                        def _isEmpty() = state.get().isEmpty
                 case Int.MaxValue =>
                     Unbounded.Unsafe.init(access).safe
                 case _ =>
@@ -455,6 +513,7 @@ object Queue:
                     loop(0)
                     b.result()
                 end _drain
+                protected def _isEmpty() = q.isEmpty()
 
     end Unsafe
 

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -924,4 +924,63 @@ class ChannelTest extends Test:
         }
     }
 
+    "closeAwaitEmpty" - {
+        "returns true when channel is already empty" in run {
+            for
+                c      <- Channel.init[Int](10)
+                result <- c.closeAwaitEmpty
+            yield assert(result)
+        }
+
+        "returns true when channel becomes empty after closing" in run {
+            for
+                c      <- Channel.init[Int](10)
+                _      <- c.put(1)
+                _      <- c.put(2)
+                fiber  <- Async.run(c.closeAwaitEmpty)
+                _      <- c.take
+                _      <- c.take
+                result <- fiber.get
+            yield assert(result)
+        }
+
+        "returns false if channel is already closed" in run {
+            for
+                c      <- Channel.init[Int](10)
+                _      <- c.close
+                result <- c.closeAwaitEmpty
+            yield assert(!result)
+        }
+
+        "concurrent taking and waiting" in run {
+            for
+                c      <- Channel.init[Int](10)
+                _      <- Kyo.foreach(1 to 5)(i => c.put(i))
+                fiber  <- Async.run(c.closeAwaitEmpty)
+                _      <- Async.foreach(1 to 5)(_ => c.take)
+                result <- fiber.get
+            yield assert(result)
+        }
+
+        "zero capacity channel" in run {
+            for
+                c      <- Channel.init[Int](0)
+                result <- c.closeAwaitEmpty
+            yield assert(result)
+        }
+
+        "should discard new takes" in run {
+            for
+                c      <- Channel.init[Int](2)
+                _      <- c.put(1)
+                _      <- c.put(2)
+                fiber  <- Async.run(c.closeAwaitEmpty)
+                _      <- c.take
+                _      <- c.take
+                take   <- Abort.run(c.take)
+                result <- fiber.get
+            yield assert(result && take.isFailure)
+        }
+    }
+
 end ChannelTest


### PR DESCRIPTION
Fixes #721

### Problem

`Queue` and `Channel` don't offer a way to close them only after all pending items are consumed. This is an important limitation in producer/consumer scenarios where the producer has has finished processing but it needs to wait for consumers to drain the queue or channel before closing it.

### Solution

Introduce `Channel.closeAndWaitEmpty` and `Queue.closeAndWaitEmpty`

