### PR TITLE
Fix channel drain close race

### DIFF
--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -1136,7 +1136,7 @@ class ChannelTest extends Test:
                         c     <- ref.get
                         _     <- c.put(1)
                         empty <- c.empty
-                        _ <-
+                        _     <-
                             // If it is empty then it could be that the consumer is in the middle of
                             // draining. Attempt to close the channel right before the consumer
                             // checks for more items.
@@ -1157,9 +1157,9 @@ class ChannelTest extends Test:
             result <- Abort.run {
                 Async.fill(100_000, concurrency = 1) {
                     for
-                        c     <- ref.get
+                        c             <- ref.get
                         closedOrEmpty <- Abort.recover[Closed](_ => true)(c.empty)
-                        _     <- if closedOrEmpty then Kyo.unit else drain(c)
+                        _             <- if closedOrEmpty then Kyo.unit else drain(c)
                     yield ()
                 }
             }


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

Given:
- A channel.
- A producer that puts items into the channel.
- The produce closes the channel either:
  1) when it is empty via `close` or,
  2) using `closeAwaitEmpty`.
- A consumer that reads from the channel optimistically using `drain` and,
- if empty, the consumer uses `take` to block until there are new items or the channel is closed.

Then:
- There is a race condition where the consumer is in the middle of draining,
- the channel is not empty,
- the producer closes the channel,
- the consumer returns `Closed` rather than the items drained so far,
- and so items are effectively lost from the end of the channel.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

If draining encounters a `Failure[Closed]` and items have been drained, then returns those items.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->

This is a little tricky to reproduce as it relies on timing. For whatever reason it was fairly reliable to reproduce when running all the gRPC tests.

I had asked about this and @fwbrasil had said:
> I'd say the behavior for the draining operations are expected since they just obtain the values but don't guarantee that new items won't arrive. The trouble is the closing since the pending backlog in this case is returned to the producer given it's the one to call close. The returned backlog to the producer should contain the missing message.

#1191 was an attempt to resolve this although unfortunately it does not (although it does make other parts of the above pattern much easier to implement).

With this change, it still doesn't guarantee that new items won't arrive. The guarantee is that if it wasn't closed when drain was first called (really when the underlying queue drain is first called) then it will always return a success.