### PR TITLE
[core] move fromCompletionStage from Fiber to Async

### DIFF
--- a/kyo-core/js/src/main/scala/kyo/internal/AsyncPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/internal/AsyncPlatformSpecific.scala
@@ -1,0 +1,3 @@
+package kyo.internal
+
+trait AsyncPlatformSpecific

--- a/kyo-core/js/src/main/scala/kyo/internal/FiberPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/internal/FiberPlatformSpecific.scala
@@ -1,3 +1,0 @@
-package kyo.internal
-
-trait FiberPlatformSpecific

--- a/kyo-core/jvm/src/main/scala/kyo/internal/AsyncPlatformSpecific.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/internal/AsyncPlatformSpecific.scala
@@ -4,6 +4,10 @@ import java.util.concurrent.CompletionStage
 import kyo.*
 
 trait AsyncPlatformSpecific:
+
+    def fromFuture[A](cs: CompletionStage[A])(using Frame): A < Async =
+        fromCompletionStage(cs)
+
     def fromCompletionStage[A](cs: CompletionStage[A])(using Frame): A < Async =
         IO.Unsafe {
             val p = Promise.Unsafe.init[Nothing, A]()

--- a/kyo-core/jvm/src/main/scala/kyo/internal/AsyncPlatformSpecific.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/internal/AsyncPlatformSpecific.scala
@@ -3,17 +3,14 @@ package kyo.internal
 import java.util.concurrent.CompletionStage
 import kyo.*
 
-trait FiberPlatformSpecific:
+trait AsyncPlatformSpecific:
     def fromCompletionStage[A](cs: CompletionStage[A])(using Frame): A < Async =
-        fromCompletionStageFiber(cs).map(_.get)
-
-    def fromCompletionStageFiber[A](cs: CompletionStage[A])(using Frame): Fiber[Nothing, A] < IO =
         IO.Unsafe {
             val p = Promise.Unsafe.init[Nothing, A]()
             cs.whenComplete { (success, error) =>
                 if error == null then p.completeDiscard(Result.succeed(success))
                 else p.completeDiscard(Result.panic(error))
             }
-            p.safe
+            p.safe.get
         }
-end FiberPlatformSpecific
+end AsyncPlatformSpecific

--- a/kyo-core/jvm/src/test/scala/kyo/internal/AsyncPlatformSpecificTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/internal/AsyncPlatformSpecificTest.scala
@@ -3,12 +3,12 @@ package kyo.internal
 import java.util.concurrent.*
 import kyo.*
 
-class FiberPlatformSpecificTest extends Test:
+class AsyncPlatformSpecificTest extends Test:
 
     "completionStage to Fiber" in runJVM {
         val cf = new CompletableFuture[Int]()
         cf.completeOnTimeout(42, 1, TimeUnit.MICROSECONDS)
-        val res = Fiber.fromCompletionStage(cf)
+        val res = Async.fromCompletionStage(cf)
         res.map(v => assert(v == 42))
     }
-end FiberPlatformSpecificTest
+end AsyncPlatformSpecificTest

--- a/kyo-core/jvm/src/test/scala/kyo/internal/AsyncPlatformSpecificTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/internal/AsyncPlatformSpecificTest.scala
@@ -11,4 +11,11 @@ class AsyncPlatformSpecificTest extends Test:
         val res = Async.fromCompletionStage(cf)
         res.map(v => assert(v == 42))
     }
+
+    "fromFuture with CompletionStage" in runJVM {
+        val cf = new CompletableFuture[Int]()
+        cf.completeOnTimeout(42, 1, TimeUnit.MICROSECONDS)
+        val res = Async.fromFuture(cf)
+        res.map(v => assert(v == 42))
+    }
 end AsyncPlatformSpecificTest

--- a/kyo-core/native/src/main/scala/kyo/internal/AsyncPlatformSpecific.scala
+++ b/kyo-core/native/src/main/scala/kyo/internal/AsyncPlatformSpecific.scala
@@ -1,0 +1,3 @@
+package kyo.internal
+
+trait AsyncPlatformSpecific

--- a/kyo-core/native/src/main/scala/kyo/internal/FiberPlatformSpecific.scala
+++ b/kyo-core/native/src/main/scala/kyo/internal/FiberPlatformSpecific.scala
@@ -1,3 +1,0 @@
-package kyo.internal
-
-trait FiberPlatformSpecific

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -2,6 +2,7 @@ package kyo
 
 import kyo.Result.Panic
 import kyo.Tag
+import kyo.internal.AsyncPlatformSpecific
 import kyo.kernel.*
 import kyo.scheduler.*
 import scala.annotation.tailrec
@@ -40,7 +41,7 @@ import scala.util.control.NonFatal
   */
 opaque type Async <: (IO & Async.Join) = Async.Join & IO
 
-object Async:
+object Async extends AsyncPlatformSpecific:
 
     /** Default concurrency level for collection operations.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -4,7 +4,6 @@ export Fiber.Promise
 import java.lang.invoke.VarHandle
 import java.util.Arrays
 import kyo.Result.Panic
-import kyo.internal.FiberPlatformSpecific
 import kyo.kernel.*
 import kyo.kernel.internal.*
 import kyo.scheduler.*
@@ -38,7 +37,7 @@ import scala.util.control.NoStackTrace
   */
 opaque type Fiber[+E, +A] = IOPromiseBase[E, A]
 
-object Fiber extends FiberPlatformSpecific:
+object Fiber:
 
     private val _unit  = IOPromise(Result.unit).mask()
     private val _never = IOPromise[Nothing, Unit]().mask()

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -1028,7 +1028,7 @@ class ChannelTest extends Test:
                     latch.await.andThen(channel.close)
                 )
                 _        <- latch.release
-                _        <- channel.drain
+                _        <- Abort.run(channel.drain)
                 result1  <- closeAwaitEmptyFiber.get
                 result2  <- closeFiber.get
                 isClosed <- channel.closed


### PR DESCRIPTION
### Problem

`Fiber` is a low-level effect with complex semantics for newcomers. Its functionality is essential for integrations and more low-level code but `Async` provides better usability and covers a majority of use cases. For this reason, `Fiber`'s API has become more limited over time and we don't even provide common combinators like `race` for it since the same functionality can be achieved via `Async` combinators and `Async.run` to obtain a `Fiber`. I hadn't noticed that `fromCompletionStage` is still in `Fiber` and using an old method naming pattern with a `Fiber` suffix.

### Solution

Move the method to `Async` and remove `fromCompletionStageFiber`.

