### PR TITLE
Add `Async.yieldNow`

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -38,7 +38,7 @@ import scala.util.control.NonFatal
   * @see
   *   [[Async.foreach]], [[Async.collect]], and their variants for concurrent collection processing with bounded concurrency
   */
-opaque type Async <: (IO & Async.Join) = Async.Join & IO
+opaque type Async <: (IO & Async.Join & Async.Yield) = Async.Join & Async.Yield & IO
 
 object Async:
 
@@ -772,10 +772,14 @@ object Async:
 
     sealed trait Join extends ArrowEffect[IOPromise[?, *], Result[Nothing, *]]
 
+    sealed trait Yield extends ArrowEffect[Const[Unit], Const[Unit]]
+
     private[kyo] def getResult[E, A](v: IOPromise[E, A])(using Frame): Result[E, A] < Async =
         ArrowEffect.suspend[A](Tag[Join], v)
 
     private[kyo] def useResult[E, A, B, S](v: IOPromise[E, A])(f: Result[E, A] => B < S)(using Frame): B < (S & Async) =
         ArrowEffect.suspendWith[A](Tag[Join], v)(f)
+
+    def yieldNow(using Frame): Unit < Async = ArrowEffect.suspend[Unit](Tag[Yield], ())
 
 end Async

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -38,7 +38,7 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
         try
             val next: A < (Ctx & Async & Abort[E]) =
                 Isolate.restoring(trace, this) {
-                    ArrowEffect.handlePartial(erasedAbortTag, Tag[Async.Join], curr, context)(
+                    ArrowEffect.handlePartial(erasedAbortTag, Tag[Async.Join], Tag[Async.Yield], curr, context)(
                         stop =
                             shouldPreempt() || (deadline != Long.MaxValue && clock.currentMillis() > deadline),
                         [C] =>
@@ -64,7 +64,9 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
                                                 Scheduler.get.schedule(this)
                                             }
                                             nullResult
-                            }
+                            },
+                        [C] =>
+                            (_, cont) => IO(cont(()))
                     )
                 }
             if !isNull(next) then


### PR DESCRIPTION
### Problem
Other effect systems has a special effect that yield the current task, stopping it from its current execution and send it back to the scheduler.

### Solution
Add a `yieldNow` feature for `Async`, which will yield the current task

### Notes
This is a result of my learning & understanding of the current scheduler, so it can be wrong, or unnecessary. Feel free to close in that case.
