### PR TITLE
force compile error of discarded defer block

### DIFF
--- a/kyo-direct/shared/src/main/scala/kyo/Direct.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/Direct.scala
@@ -101,7 +101,7 @@ private def laterImpl[A: Type, S: Type](self: Expr[A < S])(using Quotes): Expr[A
     )
 end laterImpl
 
-private def impl[A: Type](body: Expr[A])(using Quotes): Expr[Any] =
+private def impl[A: Type](body: Expr[A])(using quotes: Quotes): Expr[Any] =
     import quotes.reflect.*
 
     Validate(body)

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -226,4 +226,14 @@ class HygieneTest extends Test:
             "`synchronized` blocks are not allowed inside a `defer` block."
         )
     }
+
+    "defer drop" in {
+        typeCheckFailure(
+            """
+                 val default: Unit < Abort[String] = ()
+                 val x: Unit < Emit[Int] = defer(default.now)
+                 
+               """.stripMargin
+        )("Cannot lift `Unit < kyo.Abort[scala.Predef.String]` to the required type (`Unit < ?`)")
+    }
 end HygieneTest

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -234,6 +234,6 @@ class HygieneTest extends Test:
                  val x: Unit < Emit[Int] = defer(default.now)
                  
                """.stripMargin
-        )("Cannot lift `Unit < kyo.Abort[scala.Predef.String]` to the required type (`Unit < ?`)")
+        )("Cannot lift `Unit < kyo.Abort[scala.Predef.String]` to the expected type (`Unit < ?`).")
     }
 end HygieneTest

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
@@ -39,7 +39,7 @@ object Log:
         ): Unit < IO =
             q.add(Entry(balance, account, amount, desc))
 
-        private[Log] def flushLoop(interval: Duration): Unit < Async = defer {
+        private[Log] def flushLoop(interval: Duration): Unit < (Async & Abort[Closed]) = defer {
             Async.sleep(interval).now
             val entries = q.drain.now
             append(entries).now

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -427,8 +427,6 @@ object `<`:
                 |Please remove the type constraint on Left Hand Side.
                 |More info : https://github.com/getkyo/kyo/issues/903""".stripMargin
         )
-
-        '{ ??? }
     end liftUnitImpl
 
     /** Converts a pure single-argument function to an effectful computation. */

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -422,7 +422,7 @@ object `<`:
     def liftUnitImpl[S1: Type, S2: Type](v: Expr[Unit < S1])(using quotes: Quotes): Expr[Unit < S2] =
         import quotes.reflect.*
         val source = TypeRepr.of[S1].show
-        report.error(
+        report.errorAndAbort(
             s"""Cannot lift `Unit < $source` to the required type (`Unit < ?`).
                 |Please remove the type constraint on Left Hand Side.
                 |More info : https://github.com/getkyo/kyo/issues/903""".stripMargin

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -423,9 +423,10 @@ object `<`:
         import quotes.reflect.*
         val source = TypeRepr.of[S1].show
         report.errorAndAbort(
-            s"""Cannot lift `Unit < $source` to the required type (`Unit < ?`).
-                |Please remove the type constraint on Left Hand Side.
-                |More info : https://github.com/getkyo/kyo/issues/903""".stripMargin
+            s"""Cannot lift `Unit < ${source}` to the expected type (`Unit < ?`).
+               |This may be due to an effect type mismatch.
+               |Consider removing or adjusting the type constraint on the left-hand side.
+               |More info : https://github.com/getkyo/kyo/issues/903""".stripMargin
         )
     end liftUnitImpl
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -419,7 +419,7 @@ object `<`:
 
     implicit inline def liftUnit[S1, S2](inline v: Unit < S1): Unit < S2 = ${ liftUnitImpl[S1, S2]('v) }
 
-    def liftUnitImpl[S1: Type, S2: Type](v: Expr[Unit < S1])(using quotes: Quotes): Expr[Unit < S2] =
+    private def liftUnitImpl[S1: Type, S2: Type](v: Expr[Unit < S1])(using quotes: Quotes): Expr[Unit < S2] =
         import quotes.reflect.*
         val source = TypeRepr.of[S1].show
         report.errorAndAbort(


### PR DESCRIPTION
#903 

### Problem
Due to https://github.com/scala/scala3/issues/23018, some defer block are silently transforming from 

```scala
val oups:Int < Abort[String] = Abort.fail("oups")

val x : Unit < Any = {
  defer:
    oups.now + 1
}
```

to 
```scala
val x: Unit < Any = {
  //discard
  kernel.`<`.lift(())
}
```
without any warning.

### Solution
make the compilation fail if we try to lift `Unit < A` into `Unit < B` without `B <:< A`.

