### PR TITLE
[core] channel.pendingPuts/pendingTakes + fix flaky tests

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -74,6 +74,28 @@ object Channel:
           */
         def size(using Frame): Int < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.size()))
 
+        /** Returns the number of fibers currently waiting to put values into the channel.
+          *
+          * This method provides visibility into the backpressure state of the channel by counting how many producer fibers are currently
+          * suspended waiting for space to become available. A non-zero value indicates that producers are being throttled due to the
+          * channel being full.
+          *
+          * @return
+          *   The number of fibers waiting to put values into the channel
+          */
+        def pendingPuts(using Frame): Int < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.pendingPuts()))
+
+        /** Returns the number of fibers currently waiting to take values from the channel.
+          *
+          * This method provides visibility into the consumer demand state of the channel by counting how many consumer fibers are currently
+          * suspended waiting for values to become available. A non-zero value indicates that consumers are waiting for producers to add
+          * values.
+          *
+          * @return
+          *   The number of fibers waiting to take values from the channel
+          */
+        def pendingTakes(using Frame): Int < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.pendingTakes()))
+
         /** Attempts to offer an element to the channel without blocking.
           *
           * @param value
@@ -310,6 +332,8 @@ object Channel:
     sealed abstract class Unsafe[A] extends Serializable:
         def capacity: Int
         def size()(using AllowUnsafe, Frame): Result[Closed, Int]
+        def pendingPuts()(using AllowUnsafe, Frame): Result[Closed, Int]
+        def pendingTakes()(using AllowUnsafe, Frame): Result[Closed, Int]
 
         def offer(value: A)(using AllowUnsafe, Frame): Result[Closed, Boolean]
         def offerAll(values: Seq[A])(using AllowUnsafe, Frame): Result[Closed, Chunk[A]]
@@ -409,6 +433,9 @@ object Channel:
             def capacity = 0
 
             def size()(using AllowUnsafe, Frame) = succeedIfOpen(0)
+
+            def pendingPuts()(using AllowUnsafe, Frame)  = succeedIfOpen(puts.size())
+            def pendingTakes()(using AllowUnsafe, Frame) = succeedIfOpen(takes.size())
 
             def offer(value: A)(using AllowUnsafe, Frame) =
                 Maybe(takes.poll()) match
@@ -585,6 +612,9 @@ object Channel:
             val queue = Queue.Unsafe.init[A](capacity, access)
 
             def size()(using AllowUnsafe, Frame) = queue.size()
+
+            def pendingPuts()(using AllowUnsafe, Frame)  = queue.size().map(_ => puts.size())
+            def pendingTakes()(using AllowUnsafe, Frame) = queue.size().map(_ => (takes.size()))
 
             def offer(value: A)(using AllowUnsafe, Frame) =
                 val result = queue.offer(value)

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -314,11 +314,10 @@ class ChannelTest extends Test:
         "should consider pending puts" in run {
             for
                 c         <- Channel.init[Int](2)
-                l         <- Latch.init(3)
-                _         <- Async.run(l.release.andThen(c.put(1)))
-                _         <- Async.run(l.release.andThen(c.put(2)))
-                _         <- Async.run(l.release.andThen(c.put(3)))
-                _         <- l.await
+                _         <- Async.run(c.put(1))
+                _         <- Async.run(c.put(2))
+                _         <- Async.run(c.put(3))
+                _         <- untilTrue(c.pendingPuts.map(_ == 1))
                 result    <- c.drain
                 finalSize <- c.size
             yield assert(result.sorted == Chunk(1, 2, 3) && finalSize == 0)
@@ -326,15 +325,14 @@ class ChannelTest extends Test:
         }
         "should consider pending puts - zero capacity" in run {
             for
-                c      <- Channel.init[Int](0)
-                l      <- Latch.init(3)
-                _      <- Async.run(l.release.andThen(c.put(1)))
-                _      <- Async.run(l.release.andThen(c.put(2)))
-                _      <- Async.run(l.release.andThen(c.put(3)))
-                _      <- l.await
-                result <- c.drain
-                _      <- untilTrue(c.size.map(_ == 0))
-            yield assert(result.sorted == Chunk(1, 2, 3))
+                c         <- Channel.init[Int](0)
+                _         <- Async.run(c.put(1))
+                _         <- Async.run(c.put(2))
+                _         <- Async.run(c.put(3))
+                _         <- untilTrue(c.pendingPuts.map(_ == 3))
+                result    <- c.drain
+                finalSize <- c.size
+            yield assert(result.sorted == Chunk(1, 2, 3) && finalSize == 0)
             end for
         }
         "race with close" in run {
@@ -390,32 +388,28 @@ class ChannelTest extends Test:
             yield assert(r == Seq(1, 2) && s == 2)
         }
         "should consider pending puts" in run {
-            import AllowUnsafe.embrace.danger
-            IO.Unsafe.evalOrThrow {
-                for
-                    c         <- Channel.init[Int](2)
-                    _         <- Async.run(c.put(1))
-                    _         <- Async.run(c.put(2))
-                    _         <- Async.run(c.put(3))
-                    _         <- Async.run(c.put(4))
-                    result    <- c.drainUpTo(3)
-                    finalSize <- c.size
-                yield assert(result == Chunk(1, 2, 3) && finalSize == 1)
-            }
+            for
+                c         <- Channel.init[Int](2)
+                _         <- Async.run(c.put(1))
+                _         <- Async.run(c.put(2))
+                _         <- Async.run(c.put(3))
+                _         <- Async.run(c.put(4))
+                _         <- untilTrue(c.pendingPuts.map(_ == 2))
+                result    <- c.drainUpTo(3)
+                finalSize <- c.size
+            yield assert(result == Chunk(1, 2, 3) && finalSize == 1)
         }
         "should consider pending puts - zero capacity" in run {
-            import AllowUnsafe.embrace.danger
-            IO.Unsafe.evalOrThrow {
-                for
-                    c         <- Channel.init[Int](0)
-                    _         <- Async.run(c.put(1))
-                    _         <- Async.run(c.put(2))
-                    _         <- Async.run(c.put(3))
-                    _         <- Async.run(c.put(4))
-                    result    <- c.drainUpTo(3)
-                    finalSize <- c.size
-                yield assert(result == Chunk(1, 2, 3) && finalSize == 0)
-            }
+            for
+                c         <- Channel.init[Int](0)
+                _         <- Async.run(c.put(1))
+                _         <- Async.run(c.put(2))
+                _         <- Async.run(c.put(3))
+                _         <- Async.run(c.put(4))
+                _         <- untilTrue(c.pendingPuts.map(_ == 4))
+                result    <- c.drainUpTo(3)
+                finalSize <- c.size
+            yield assert(result == Chunk(1, 2, 3) && finalSize == 0)
         }
         "race with close" in run {
             verifyRaceDrainWithClose(2, _.drainUpTo(2), _.close)
@@ -1117,6 +1111,57 @@ class ChannelTest extends Test:
             )
                 .handle(Choice.run, _.unit, Loop.repeat(10))
                 .andThen(succeed)
+        }
+    }
+
+    "pendingPuts and pendingTakes" - {
+        "should return 0 for empty channel" in run {
+            for
+                c     <- Channel.init[Int](2)
+                puts  <- c.pendingPuts
+                takes <- c.pendingTakes
+            yield assert(puts == 0 && takes == 0)
+        }
+
+        "should count pending puts when channel is full" in run {
+            for
+                c     <- Channel.init[Int](2)
+                _     <- c.put(1)
+                _     <- c.put(2)
+                f1    <- Async.run(c.put(3))
+                f2    <- Async.run(c.put(4))
+                _     <- Async.sleep(10.millis)
+                puts  <- c.pendingPuts
+                takes <- c.pendingTakes
+                _     <- c.take
+                _     <- c.take
+                _     <- f1.get
+                _     <- f2.get
+            yield assert(puts == 2 && takes == 0)
+        }
+
+        "should count pending takes when channel is empty" in run {
+            for
+                c     <- Channel.init[Int](2)
+                f1    <- Async.run(c.take)
+                f2    <- Async.run(c.take)
+                _     <- Async.sleep(10.millis)
+                puts  <- c.pendingPuts
+                takes <- c.pendingTakes
+                _     <- c.put(1)
+                _     <- c.put(2)
+                _     <- f1.get
+                _     <- f2.get
+            yield assert(puts == 0 && takes == 2)
+        }
+
+        "should fail when channel is closed" in run {
+            for
+                c     <- Channel.init[Int](2)
+                _     <- c.close
+                puts  <- Abort.run(c.pendingPuts)
+                takes <- Abort.run(c.pendingTakes)
+            yield assert(puts.isFailure && takes.isFailure)
         }
     }
 


### PR DESCRIPTION

### Problem

We have a few flaky channel tests due to the necessity of having pending puts in some scenarios. Currently, there isn't an easy way to inspect if the number of pending operations, which can be used to fix the flakiness.

### Solution

Introduce `pendingPuts` and `pendingTakes`. Fix the flaky tests using them.

### Notes

I'll wait for the build to pass and merge to fix the build. Please feel free to provide feedback after merge and I'll address it!