### PR TITLE
Fix/993

### DIFF
--- a/kyo-direct/shared/src/main/scala/kyo/Direct.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/Direct.scala
@@ -151,11 +151,11 @@ private def impl[A: Type](body: Expr[A])(using quotes: Quotes): Expr[Any] =
                     args0
                 ),
                 args1
-            ) if t.tpe <:< TypeRepr.of[Maybe[Any]] =>
+            ) if t.tpe.typeSymbol.flags.is(Flags.Opaque) =>
 
             val newVal: Symbol = Symbol.newVal(
                 Symbol.spliceOwner,
-                freshName("genKyoOpaque"),
+                freshName("opaqueAlias"),
                 t.tpe,
                 Flags.Private,
                 Symbol.noSymbol

--- a/kyo-direct/shared/src/main/scala/kyo/Direct.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/Direct.scala
@@ -125,7 +125,7 @@ private def impl[A: Type](body: Expr[A])(using quotes: Quotes): Expr[Any] =
         loop(l, Nil)
     end flatten
 
-    val pending =
+    val pending: TypeRepr =
         flatten(effects) match
             case Nil =>
                 TypeRepr.of[Any]
@@ -133,10 +133,46 @@ private def impl[A: Type](body: Expr[A])(using quotes: Quotes): Expr[Any] =
                 effects.reduce((a, b) => AndType(a, b))
     end pending
 
+    var genSym = 0
+    def freshName(name: String): String =
+        genSym = genSym + 1
+        s"${name}_N$genSym"
+
+    val preparedBody = Trees.transform(body.asTerm) {
+        case Apply(
+                Apply(
+                    TypeApply(
+                        Apply(
+                            ta: TypeApply,
+                            List(a @ Apply(TypeApply(Ident("now"), List(t, s)), List(_)))
+                        ),
+                        types0
+                    ),
+                    args0
+                ),
+                args1
+            ) if t.tpe <:< TypeRepr.of[Maybe[Any]] =>
+
+            val newVal: Symbol = Symbol.newVal(
+                Symbol.spliceOwner,
+                freshName("genKyoOpaque"),
+                t.tpe,
+                Flags.Private,
+                Symbol.noSymbol
+            )
+            Block(
+                List(ValDef(newVal, Some(a))),
+                Apply(
+                    Apply(TypeApply(Apply(ta, List(Ident(newVal.termRef))), types0), args0),
+                    args1
+                )
+            )
+    }
+
     pending.asType match
         case '[s] =>
             val transformedBody =
-                Trees.transform(body.asTerm) {
+                Trees.transform(preparedBody) {
                     case Apply(TypeApply(Ident("now"), List(t, s2)), List(qual)) =>
                         (t.tpe.asType, s2.tpe.asType) match
                             case ('[t], '[s2]) => '{

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -237,7 +237,7 @@ class HygieneTest extends Test:
         )("Cannot lift `Unit < kyo.Abort[scala.Predef.String]` to the expected type (`Unit < ?`).")
     }
 
-    "issue 993" in {
+    "opaque types issue #993" in {
         val maybe1: Maybe[Int] < IO = Maybe(1)
         val maybe0: Maybe[Int]      = Maybe(0)
         defer:

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -237,12 +237,13 @@ class HygieneTest extends Test:
         )("Cannot lift `Unit < kyo.Abort[scala.Predef.String]` to the expected type (`Unit < ?`).")
     }
 
-    "993" in {
+    "issue 993" in {
         val maybe1: Maybe[Int] < IO = Maybe(1)
-        defer(maybe1.now)
-
-        // SHOuLD COMPILE
-        /*  defer(maybe1.now.contains(1))*/
+        val maybe0: Maybe[Int]      = Maybe(0)
+        defer:
+            maybe1.now.fold(2)(_ + 1)
+            maybe1.now.contains(1)
+            maybe0.contains(1)
 
         assertionSuccess
     }

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -236,4 +236,14 @@ class HygieneTest extends Test:
                """.stripMargin
         )("Cannot lift `Unit < kyo.Abort[scala.Predef.String]` to the expected type (`Unit < ?`).")
     }
+
+    "993" in {
+        val maybe1: Maybe[Int] < IO = Maybe(1)
+        defer(maybe1.now)
+
+        // SHOuLD COMPILE
+        /*  defer(maybe1.now.contains(1))*/
+
+        assertionSuccess
+    }
 end HygieneTest


### PR DESCRIPTION
On #993 

### Problem

cannot use constructs like:
```scala
val maybe: Maybe[Int] < IO = 1
defer: 
  maybe.now.contains(1)

```
without a compiler panic.

### Solution
more macros to turn this block into
```scala
defer: 
  val TEMP = maybe.now
  TEMP.contains(1)
```