### PR TITLE
[improvement] var args to Choice.eval (fixes #1216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,7 +996,7 @@ import kyo.*
 // Note how 'get' takes a 'Seq[T]'
 // and returns a 'T < Choice'
 val a: Int < Choice =
-    Choice.eval(Seq(1, 2, 3, 4))
+    Choice.eval(1, 2, 3, 4)
 
 // 'dropIf' discards the current element if
 // a condition is not met. Produces a 'Seq(1, 2)'

--- a/kyo-combinators/shared/src/main/scala/kyo/AbortCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AbortCombinators.scala
@@ -462,7 +462,9 @@ class ForAbortOps[A, S, E, E1 <: E](effect: A < (Abort[E] & S)) extends AnyVal:
         reduce: Reducible[Abort[ER]],
         frame: Frame
     ): A < (S & reduce.SReduced & Choice) =
-        Abort.run[E1](effect.asInstanceOf[A < (Abort[E1 | ER] & S)]).map(e => Choice.eval(e.foldError(List(_), _ => Nil)*))
+        Abort.run[E1](effect.asInstanceOf[A < (Abort[E1 | ER] & S)]).map(result =>
+            result.foldError(value => Choice.eval(value), _ => Choice.drop)
+        )
 
     /** Translates the partial Abort[E1] effect to an Abort[Absent] effect in case of failure.
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/AbortCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AbortCombinators.scala
@@ -71,7 +71,7 @@ extension [A, S, E](effect: A < (Abort[E] & S))
         ct: SafeClassTag[E],
         fr: Frame
     ): A < (S & Choice) =
-        effect.result.map(e => Choice.eval(e.foldError(List(_), _ => Nil)*))
+        effect.result.map(result => result.foldError(value => Choice.eval(value), _ => Choice.drop))
 
     /** Translates the Abort[E] effect to an Abort[Absent] effect in case of failure.
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/AbortCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AbortCombinators.scala
@@ -71,7 +71,7 @@ extension [A, S, E](effect: A < (Abort[E] & S))
         ct: SafeClassTag[E],
         fr: Frame
     ): A < (S & Choice) =
-        effect.result.map(e => Choice.eval(e.foldError(List(_), _ => Nil)))
+        effect.result.map(e => Choice.eval(e.foldError(List(_), _ => Nil)*))
 
     /** Translates the Abort[E] effect to an Abort[Absent] effect in case of failure.
       *
@@ -462,7 +462,7 @@ class ForAbortOps[A, S, E, E1 <: E](effect: A < (Abort[E] & S)) extends AnyVal:
         reduce: Reducible[Abort[ER]],
         frame: Frame
     ): A < (S & reduce.SReduced & Choice) =
-        Abort.run[E1](effect.asInstanceOf[A < (Abort[E1 | ER] & S)]).map(e => Choice.eval(e.foldError(List(_), _ => Nil)))
+        Abort.run[E1](effect.asInstanceOf[A < (Abort[E1 | ER] & S)]).map(e => Choice.eval(e.foldError(List(_), _ => Nil)*))
 
     /** Translates the partial Abort[E1] effect to an Abort[Absent] effect in case of failure.
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
@@ -31,7 +31,7 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToAbsent(using Frame): A < (Choice & Abort[Absent] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.fail(Absent)
-            case other              => Choice.evalFromSeq(other)
+            case other              => Choice.evalSeq(other)
 
     /** Handles dropped Choice effects as NoSuchElementException aborts
       *
@@ -41,7 +41,7 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToThrowable(using Frame): A < (Choice & Abort[NoSuchElementException] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.catching(Chunk.empty.head)
-            case other              => Choice.evalFromSeq(other)
+            case other              => Choice.evalSeq(other)
 
     /** Handles dropped Choice effects as Aborts of a specified instance of E
       *
@@ -53,6 +53,6 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToFailure[E](error: => E)(using Frame): A < (Choice & Abort[E] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.fail(error)
-            case other              => Choice.evalFromSeq(other)
+            case other              => Choice.evalSeq(other)
 
 end extension

--- a/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
@@ -31,7 +31,7 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToAbsent(using Frame): A < (Choice & Abort[Absent] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.fail(Absent)
-            case other              => Choice.eval(other)
+            case other              => Choice.eval(other*)
 
     /** Handles dropped Choice effects as NoSuchElementException aborts
       *
@@ -41,7 +41,7 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToThrowable(using Frame): A < (Choice & Abort[NoSuchElementException] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.catching(Chunk.empty.head)
-            case other              => Choice.eval(other)
+            case other              => Choice.eval(other*)
 
     /** Handles dropped Choice effects as Aborts of a specified instance of E
       *
@@ -53,6 +53,6 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToFailure[E](error: => E)(using Frame): A < (Choice & Abort[E] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.fail(error)
-            case other              => Choice.eval(other)
+            case other              => Choice.eval(other*)
 
 end extension

--- a/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
@@ -31,7 +31,7 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToAbsent(using Frame): A < (Choice & Abort[Absent] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.fail(Absent)
-            case other              => Choice.eval(other*)
+            case other              => Choice.evalFromSeq(other)
 
     /** Handles dropped Choice effects as NoSuchElementException aborts
       *
@@ -41,7 +41,7 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToThrowable(using Frame): A < (Choice & Abort[NoSuchElementException] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.catching(Chunk.empty.head)
-            case other              => Choice.eval(other*)
+            case other              => Choice.evalFromSeq(other)
 
     /** Handles dropped Choice effects as Aborts of a specified instance of E
       *
@@ -53,6 +53,6 @@ extension [A, S](effect: A < (S & Choice))
     def choiceDropToFailure[E](error: => E)(using Frame): A < (Choice & Abort[E] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.fail(error)
-            case other              => Choice.eval(other*)
+            case other              => Choice.evalFromSeq(other)
 
 end extension

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -188,7 +188,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that attempts to run the given effect and handles the sequence to Choice.
       */
     def fromSeq[A](sequence: Seq[A])(using Frame): A < Choice =
-        Choice.eval(sequence)
+        Choice.eval(sequence*)
 
     /** Creates an effect from a Try[A] and handles the Try to Abort[Throwable].
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -188,7 +188,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that attempts to run the given effect and handles the sequence to Choice.
       */
     def fromSeq[A](sequence: Seq[A])(using Frame): A < Choice =
-        Choice.evalFromSeq(sequence)
+        Choice.evalSeq(sequence)
 
     /** Creates an effect from a Try[A] and handles the Try to Abort[Throwable].
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -188,7 +188,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that attempts to run the given effect and handles the sequence to Choice.
       */
     def fromSeq[A](sequence: Seq[A])(using Frame): A < Choice =
-        Choice.eval(sequence*)
+        Choice.evalFromSeq(sequence)
 
     /** Creates an effect from a Try[A] and handles the Try to Abort[Throwable].
       *

--- a/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
@@ -307,12 +307,12 @@ class AbortCombinatorsTest extends Test:
             }
 
             "should convert empty choice to absent abort" in {
-                val failure: Int < Choice                     = Choice.eval(Seq())
+                val failure: Int < Choice                     = Choice.eval()
                 val converted: Int < (Choice & Abort[Absent]) = failure.choiceDropToAbsent
                 val handled                                   = Abort.run(Choice.run(converted))
                 assert(handled.eval == Result.fail(Absent))
 
-                val success: Int < Choice                      = Choice.eval(Seq(23))
+                val success: Int < Choice                      = Choice.eval(23)
                 val converted2: Int < (Choice & Abort[Absent]) = success.choiceDropToAbsent
                 val handled2                                   = Abort.run(Choice.run(converted2))
                 assert(handled2.eval == Result.succeed(Chunk(23)))

--- a/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorsTest.scala
@@ -12,14 +12,14 @@ class ChoiceCombinatorTest extends Test:
 
         "handle" - {
             "should handle" in {
-                val effect: Int < Choice = Choice.eval(Seq(1, 2, 3))
+                val effect: Int < Choice = Choice.eval(1, 2, 3)
                 assert(effect.handleChoice.eval == Seq(1, 2, 3))
             }
         }
 
         "filter" - {
             "should filter" in {
-                val effect: Int < Choice = Choice.eval(Seq(1, 2, 3))
+                val effect: Int < Choice = Choice.eval(1, 2, 3)
                 val filteredEffect       = effect.filterChoice(_ < 3)
                 assert(filteredEffect.handleChoice.eval == Seq(1, 2))
             }

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -543,7 +543,7 @@ class ChannelTest extends Test:
 
         "offer and close" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -573,7 +573,7 @@ class ChannelTest extends Test:
 
         "offer and poll" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -593,7 +593,7 @@ class ChannelTest extends Test:
 
         "put and take" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 putFiber <- Async.run(
@@ -612,7 +612,7 @@ class ChannelTest extends Test:
 
         "offer to full channel during close" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 _       <- Kyo.foreach(1 to size)(i => channel.offer(i))
                 latch   <- Latch.init(1)
@@ -639,7 +639,7 @@ class ChannelTest extends Test:
 
         "concurrent close attempts" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -667,7 +667,7 @@ class ChannelTest extends Test:
 
         "offer, poll, put, take, and close" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -707,7 +707,7 @@ class ChannelTest extends Test:
 
         "putBatch and take" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
@@ -730,7 +730,7 @@ class ChannelTest extends Test:
 
         "putBatch and takeExactly" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
@@ -1011,7 +1011,7 @@ class ChannelTest extends Test:
 
         "race between closeAwaitEmpty and close" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 _       <- Kyo.foreach(1 to (size min 5))(i => channel.put(i))
                 latch   <- Latch.init(1)
@@ -1036,7 +1036,7 @@ class ChannelTest extends Test:
 
         "two producers calling closeAwaitEmpty" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
@@ -1076,7 +1076,7 @@ class ChannelTest extends Test:
 
         "producer calling closeAwaitEmpty and another calling close" in run {
             (for
-                size    <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 

--- a/kyo-core/shared/src/test/scala/kyo/HubTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/HubTest.scala
@@ -247,7 +247,7 @@ class HubTest extends Test:
 
         "concurrent listeners and close" in run {
             (for
-                size  <- Choice.eval(Seq(1, 2, 10, 100))
+                size  <- Choice.eval(1, 2, 10, 100)
                 hub   <- Hub.init[Int](size)
                 latch <- Latch.init(1)
                 listenerFiber <- Async.run(

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -119,7 +119,7 @@ class MeterTest extends Test:
 
             "run" in run {
                 (for
-                    size    <- Choice.eval(Seq(1, 2, 3, 50, 100))
+                    size    <- Choice.eval(1, 2, 3, 50, 100)
                     meter   <- Meter.initSemaphore(size)
                     counter <- AtomicInt.init(0)
                     results <-
@@ -139,7 +139,7 @@ class MeterTest extends Test:
 
             "close" in run {
                 (for
-                    size    <- Choice.eval(Seq(1, 2, 3, 50, 100))
+                    size    <- Choice.eval(1, 2, 3, 50, 100)
                     meter   <- Meter.initSemaphore(size)
                     latch   <- Latch.init(1)
                     counter <- AtomicInt.init(0)
@@ -166,7 +166,7 @@ class MeterTest extends Test:
 
             "with interruptions" in runJVM {
                 (for
-                    size    <- Choice.eval(Seq(1, 2, 3, 50, 100))
+                    size    <- Choice.eval(1, 2, 3, 50, 100)
                     meter   <- Meter.initSemaphore(size)
                     started <- Latch.init(100)
                     latch   <- Latch.init(1)

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -234,7 +234,7 @@ class QueueTest extends Test:
 
         "offer and close" in run {
             (for
-                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -260,7 +260,7 @@ class QueueTest extends Test:
 
         "offer and poll" in run {
             (for
-                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -280,7 +280,7 @@ class QueueTest extends Test:
 
         "offer to full queue during close" in run {
             (for
-                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 _     <- Kyo.foreach(1 to size)(i => queue.offer(i))
                 latch <- Latch.init(1)
@@ -303,7 +303,7 @@ class QueueTest extends Test:
 
         "concurrent close attempts" in run {
             (for
-                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -327,7 +327,7 @@ class QueueTest extends Test:
 
         "offer, poll and close" in run {
             (for
-                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
                 offerFiber <- Async.run(
@@ -500,7 +500,7 @@ class QueueTest extends Test:
 
         "race between closeAwaitEmpty and close" in run {
             (for
-                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 _     <- Kyo.foreach(1 to (size min 5))(i => queue.offer(i))
                 latch <- Latch.init(1)
@@ -525,7 +525,7 @@ class QueueTest extends Test:
 
         "two producers calling closeAwaitEmpty" in run {
             (for
-                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
 
@@ -564,7 +564,7 @@ class QueueTest extends Test:
 
         "producer calling closeAwaitEmpty and another calling close" in run {
             (for
-                size  <- Choice.eval(Seq(0, 1, 2, 10, 100))
+                size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
 

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -6,7 +6,7 @@ class StreamCoreExtensionsTest extends Test:
         "collectAll" in run {
             Choice.run {
                 for
-                    size <- Choice.eval(Seq(0, 1, 32, 100))
+                    size <- Choice.eval(0, 1, 32, 100)
                     s1     = Stream.init(0 to 99 by 3)
                     s2     = Stream.init(1 to 99 by 3)
                     s3     = Stream.init(2 to 99 by 3)
@@ -19,7 +19,7 @@ class StreamCoreExtensionsTest extends Test:
         "collectAllHalting" in runNotJS {
             Choice.run {
                 for
-                    size <- Choice.eval(Seq(0, 1, 32, 1024))
+                    size <- Choice.eval(0, 1, 32, 1024)
                     s1     = Stream(Loop.forever(Emit.value(Chunk(100))))
                     s2     = Stream.init(0 to 50)
                     merged = Stream.collectAllHalting(Seq(s1, s2), size)
@@ -51,8 +51,8 @@ class StreamCoreExtensionsTest extends Test:
             "should halt if non-halting side completes" in run {
                 Choice.run {
                     for
-                        size <- Choice.eval(Seq(0, 1, 32, 1024))
-                        left <- Choice.eval(Seq(true, false))
+                        size <- Choice.eval(0, 1, 32, 1024)
+                        left <- Choice.eval(true, false)
                         s1     = Stream.init(0 to 50)
                         s2     = Stream(Loop.forever(Emit.value(Chunk(100))))
                         merged = if left then s1.mergeHaltingLeft(s2, size) else s2.mergeHaltingRight(s1, size)
@@ -69,8 +69,8 @@ class StreamCoreExtensionsTest extends Test:
                 val s2 = Stream.init(s2Set.toSeq)
                 Choice.run {
                     for
-                        size <- Choice.eval(Seq(0, 1, 32, 1024))
-                        left <- Choice.eval(Seq(true, false))
+                        size <- Choice.eval(0, 1, 32, 1024)
+                        left <- Choice.eval(true, false)
                         // Make sure we get case where all three values of s2 have been consumed (not guaranteed)
                         assertion <- Loop(Set.empty[Int]) { lastRes =>
                             if s2Set.subsetOf(lastRes) then
@@ -112,8 +112,8 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.eval(Seq(1, 2, 4, Async.defaultConcurrency, Int.MaxValue))
-                        buf <- Choice.eval(Seq(1, 4, 5, 8, 12, par, Int.MaxValue))
+                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, Int.MaxValue)
+                        buf <- Choice.eval(1, 4, 5, 8, 12, par, Int.MaxValue)
                         s2 = stream.mapPar(par, buf)(i => IO(i + 1))
                         res <- s2.run
                     yield assert(
@@ -129,7 +129,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4)
                 val test =
                     for
-                        par <- Choice.eval(Seq(2, 4, Async.defaultConcurrency))
+                        par <- Choice.eval(2, 4, Async.defaultConcurrency)
                         s2 = stream.mapPar(par)(i => if i == 1 then Async.sleep(10.millis).andThen(i + 1) else i + 1)
                         res <- s2.run
                     yield assert(
@@ -147,8 +147,8 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.eval(Seq(1, 2, 4, Async.defaultConcurrency))
-                        buf <- Choice.eval(Seq(1, 4, 5, 8, 12))
+                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency)
+                        buf <- Choice.eval(1, 4, 5, 8, 12)
                         s2 = stream.mapParUnordered(par, buf)(i => IO(i + 1))
                         res <- s2.run
                     yield assert(
@@ -164,7 +164,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4)
                 val test =
                     for
-                        par <- Choice.eval(Seq(2, 4, Async.defaultConcurrency))
+                        par <- Choice.eval(2, 4, Async.defaultConcurrency)
                         s2 = stream.mapParUnordered(par)(i => if i == 1 then Async.sleep(10.millis).andThen(i + 1) else i + 1)
                         res <- s2.run
                     yield assert(
@@ -184,8 +184,8 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.eval(Seq(1, 2, 4, Async.defaultConcurrency))
-                        buf <- Choice.eval(Seq(1, 4, 5, 8, 12))
+                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency)
+                        buf <- Choice.eval(1, 4, 5, 8, 12)
                         s2 = stream.mapChunkPar(par, buf)(c => IO(c.map(_ + 1)))
                         res <- s2.run
                     yield assert(
@@ -202,7 +202,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8))
                 val test =
                     for
-                        par <- Choice.eval(Seq(2, 4, Async.defaultConcurrency))
+                        par <- Choice.eval(2, 4, Async.defaultConcurrency)
                         s2 =
                             stream.mapChunkPar(par)(c => if c.head == 1 then Async.sleep(10.millis).andThen(c.map(_ + 1)) else c.map(_ + 1))
                         res <- s2.run
@@ -221,8 +221,8 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.eval(Seq(1, 2, 4, Async.defaultConcurrency))
-                        buf <- Choice.eval(Seq(1, 4, 5, 8, 12))
+                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency)
+                        buf <- Choice.eval(1, 4, 5, 8, 12)
                         s2 = stream.mapChunkParUnordered(par, buf)(c => IO(c.map(_ + 1)))
                         res <- s2.run
                     yield assert(
@@ -238,7 +238,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8))
                 val test =
                     for
-                        par <- Choice.eval(Seq(2, 4, Async.defaultConcurrency))
+                        par <- Choice.eval(2, 4, Async.defaultConcurrency)
                         s2 =
                             stream.mapChunkParUnordered(par)(c =>
                                 if c.head == 1 then Async.sleep(10.millis).andThen(c.map(_ + 1)) else c.map(_ + 1)

--- a/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
@@ -193,8 +193,8 @@ class PreludeTest extends Test:
         "basic choices" in run {
             val effect =
                 defer {
-                    val x = Choice.eval(Seq(1, 2, 3)).now
-                    val y = Choice.eval(Seq("a", "b")).now
+                    val x = Choice.eval(1, 2, 3).now
+                    val y = Choice.eval("a", "b").now
                     s"$x$y"
                 }
 
@@ -206,8 +206,8 @@ class PreludeTest extends Test:
         "choice with conditions" in run {
             val effect =
                 defer {
-                    val x = Choice.eval(Seq(1, -2, -3)).now
-                    val y = Choice.eval(Seq("ab", "cde")).now
+                    val x = Choice.eval(1, -2, -3).now
+                    val y = Choice.eval("ab", "cde").now
                     if x > 0 then y.length * x
                     else y.length
                 }
@@ -220,7 +220,7 @@ class PreludeTest extends Test:
         "choice with filtering" in run {
             val effect =
                 defer {
-                    val x = Choice.eval(Seq(1, 2, 3, 4)).now
+                    val x = Choice.eval(1, 2, 3, 4).now
                     Choice.dropIf(x % 2 == 0).now
                     x
                 }
@@ -358,8 +358,8 @@ class PreludeTest extends Test:
     }
 
     "Choice" in run {
-        val x = Choice.eval(Seq(1, -2, -3))
-        val y = Choice.eval(Seq("ab", "cde"))
+        val x = Choice.eval(1, -2, -3)
+        val y = Choice.eval("ab", "cde")
 
         val v: Int < Choice =
             defer {
@@ -376,8 +376,8 @@ class PreludeTest extends Test:
     }
 
     "Choice + filter" in run {
-        val x = Choice.eval(Seq(1, -2, -3))
-        val y = Choice.eval(Seq("ab", "cde"))
+        val x = Choice.eval(1, -2, -3)
+        val y = Choice.eval("ab", "cde")
 
         val v: Int < Choice =
             defer {

--- a/kyo-direct/shared/src/test/scala/kyo/ShiftTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/ShiftTest.scala
@@ -283,7 +283,7 @@ class ShiftMethodSupportTest extends AnyFreeSpec with Assertions:
                     val result = Choice.run(
                         defer:
                             Coll("x", "y").map(str =>
-                                Choice.eval(List(true, false))
+                                Choice.eval(true, false)
                                     .map(b => if b then str.toUpperCase else str).now
                             )
                     ).eval
@@ -298,7 +298,7 @@ class ShiftMethodSupportTest extends AnyFreeSpec with Assertions:
                 "collect" in {
                     val effects =
                         Coll("x", "y").map { str =>
-                            Choice.eval(List(true, false)).map(b =>
+                            Choice.eval(true, false).map(b =>
                                 if b then str.toUpperCase else str
                             )
                         }
@@ -313,7 +313,7 @@ class ShiftMethodSupportTest extends AnyFreeSpec with Assertions:
 
                 "flatMap" in {
                     val effects = defer:
-                        val tf = Choice.eval(List(true, false)).later
+                        val tf = Choice.eval(true, false).later
                         Coll("x", "y").flatMap(str1 =>
                             val pred1 = tf.now
                             Coll("z").map(str2 =>
@@ -338,7 +338,7 @@ class ShiftMethodSupportTest extends AnyFreeSpec with Assertions:
                 "foldLeft" in {
                     val result = Choice.run(
                         defer:
-                            Coll(1, 1).foldLeft(0)((acc, _) => Choice.eval(List(0, 1)).map(n => acc + n).now)
+                            Coll(1, 1).foldLeft(0)((acc, _) => Choice.eval(0, 1).map(n => acc + n).now)
                     ).eval
 
                     assert(result.contains(0))

--- a/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
@@ -32,15 +32,29 @@ sealed trait Choice extends ArrowEffect[Seq, Id]
 
 object Choice:
 
-    /** Introduces a choice point by selecting values from a sequence.
+    /** Introduces a non-deterministic choice over a variadic list of values.
+      *
+      * @param a*
+      *   Zero or more candidate values to choose from.
+      * @return
+      *   A computation that represent multiple paths, one for each input value.
+      * @example
+      *   {{{Choice.eval(1, 2, 3)}}}
+      */
+    inline def eval[A](a: A*)(using inline frame: Frame): A < Choice =
+        ArrowEffect.suspend[A](Tag[Choice], a)
+
+    /** Introduces a non-deterministic choice over a sequence of values.
       *
       * @param seq
-      *   The sequence of possible values
+      *   A sequence of candidate values to choose from.
       * @return
-      *   A computation that represents the selection of values from the sequence
+      *   A computation that represent multiple paths, one for each input value.
+      * @example
+      *   {{{Choice.evalFromSeq(Seq("a", "b", "c"))}}}
       */
-    inline def eval[A](seq: A*)(using inline frame: Frame): A < Choice =
-        ArrowEffect.suspend[A](Tag[Choice], seq)
+    inline def evalFromSeq[A](seq: Seq[A])(using inline frame: Frame): A < Choice =
+        eval(seq*)
 
     /** Evaluates a function for each value in a sequence, introducing multiple computation paths.
       *

--- a/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
@@ -39,7 +39,7 @@ object Choice:
       * @return
       *   A computation that represents the selection of values from the sequence
       */
-    inline def eval[A](seq: Seq[A])(using inline frame: Frame): A < Choice =
+    inline def eval[A](seq: A*)(using inline frame: Frame): A < Choice =
         ArrowEffect.suspend[A](Tag[Choice], seq)
 
     /** Evaluates a function for each value in a sequence, introducing multiple computation paths.

--- a/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Choice.scala
@@ -42,7 +42,7 @@ object Choice:
       *   {{{Choice.eval(1, 2, 3)}}}
       */
     inline def eval[A](a: A*)(using inline frame: Frame): A < Choice =
-        ArrowEffect.suspend[A](Tag[Choice], a)
+        evalSeq(a)
 
     /** Introduces a non-deterministic choice over a sequence of values.
       *
@@ -53,8 +53,8 @@ object Choice:
       * @example
       *   {{{Choice.evalFromSeq(Seq("a", "b", "c"))}}}
       */
-    inline def evalFromSeq[A](seq: Seq[A])(using inline frame: Frame): A < Choice =
-        eval(seq*)
+    inline def evalSeq[A](seq: Seq[A])(using inline frame: Frame): A < Choice =
+        ArrowEffect.suspend[A](Tag[Choice], seq)
 
     /** Evaluates a function for each value in a sequence, introducing multiple computation paths.
       *

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -1316,7 +1316,7 @@ class AbortTest extends Test:
             val local = Local.init("default")
             val combined = Kyo.lift {
                 local.let("custom") {
-                    Choice.eval(Seq(1, 2)).flatMap { n =>
+                    Choice.eval(1, 2).flatMap { n =>
                         if n % 2 == 0 then n * 10
                         else Abort.fail(s"odd: $n")
                     }

--- a/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
@@ -60,8 +60,8 @@ class DebugTest extends Test:
         Debug.trace {
             Choice.run {
                 for
-                    x <- Choice.eval(Seq(1, 2, 3))
-                    y <- Choice.eval(Seq(4, 5, 6))
+                    x <- Choice.eval(1, 2, 3)
+                    y <- Choice.eval(4, 5, 6)
                 yield x + y
             }
         }
@@ -183,7 +183,7 @@ class DebugTest extends Test:
         "with Choice" in
             testOutput(
                 "DebugTest.scala:65:28",
-                "List(4, 5, 6)",
+                "(4, 5, 6)",
                 "DebugTest.scala:65:28",
                 "6",
                 "DebugTest.scala:66:14",

--- a/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
@@ -551,11 +551,11 @@ class STMTest extends Test:
     "Concurrency" - {
 
         val repeats = 10
-        val sizes   = Seq(1, 10, 100, 1000)
+        val sizes   = Choice.eval(1, 10, 100, 1000)
 
         "concurrent updates" in runNotJS {
             (for
-                size  <- Choice.eval(sizes)
+                size  <- sizes
                 ref   <- TRef.init(0)
                 _     <- Async.fill(size, size)(STM.run(ref.update(_ + 1)))
                 value <- STM.run(ref.get)
@@ -566,7 +566,7 @@ class STMTest extends Test:
 
         "concurrent reads and writes" in runNotJS {
             (for
-                size  <- Choice.eval(sizes)
+                size  <- sizes
                 ref   <- TRef.init(0)
                 latch <- Latch.init(1)
                 writeFiber <- Async.run(
@@ -586,7 +586,7 @@ class STMTest extends Test:
 
         "concurrent nested transactions" in runNotJS {
             (for
-                size <- Choice.eval(sizes)
+                size <- sizes
                 ref  <- TRef.init(0)
                 _ <- Async.fill(size, size) {
                     STM.run {

--- a/kyo-stm/shared/src/test/scala/kyo/TChunkTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TChunkTest.scala
@@ -189,7 +189,7 @@ class TChunkTest extends Test:
 
         "concurrent modifications" in runNotJS {
             (for
-                size     <- Choice.eval(Seq(1, 10, 100))
+                size     <- Choice.eval(1, 10, 100)
                 chunk    <- TChunk.init[Int]()
                 _        <- Async.foreach(1 to size, size)(i => STM.run(chunk.append(i)))
                 snapshot <- STM.run(chunk.snapshot)
@@ -203,7 +203,7 @@ class TChunkTest extends Test:
 
         "concurrent filtering" in runNotJS {
             (for
-                size  <- Choice.eval(Seq(1, 10, 100))
+                size  <- Choice.eval(1, 10, 100)
                 chunk <- TChunk.init[Int]()
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => chunk.append(i))
@@ -222,7 +222,7 @@ class TChunkTest extends Test:
 
         "concurrent slice operations" in runNotJS {
             (for
-                size  <- Choice.eval(Seq(1, 10, 100))
+                size  <- Choice.eval(1, 10, 100)
                 chunk <- TChunk.init[Int]()
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => chunk.append(i))
@@ -246,7 +246,7 @@ class TChunkTest extends Test:
 
         "concurrent compaction" in runNotJS {
             (for
-                size  <- Choice.eval(Seq(1, 10, 100))
+                size  <- Choice.eval(1, 10, 100)
                 chunk <- TChunk.init[Int]()
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => chunk.append(i))

--- a/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
@@ -371,7 +371,7 @@ class TMapTest extends Test:
 
         "concurrent modifications" in runNotJS {
             (for
-                size     <- Choice.eval(Seq(1, 10, 100))
+                size     <- Choice.eval(1, 10, 100)
                 map      <- STM.run(TMap.init[Int, Int]())
                 _        <- Async.foreach(1 to size, size)(i => STM.run(map.put(i, i)))
                 snapshot <- STM.run(map.snapshot)
@@ -385,7 +385,7 @@ class TMapTest extends Test:
 
         "concurrent reads and writes" in runNotJS {
             (for
-                size  <- Choice.eval(Seq(1, 10, 100))
+                size  <- Choice.eval(1, 10, 100)
                 map   <- STM.run(TMap.init[Int, Int]())
                 latch <- Latch.init(1)
 
@@ -420,7 +420,7 @@ class TMapTest extends Test:
 
         "concurrent updates" in runNotJS {
             (for
-                size <- Choice.eval(Seq(1, 10, 100))
+                size <- Choice.eval(1, 10, 100)
                 map  <- STM.run(TMap.init[Int, Int]())
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => map.put(i, 1))
@@ -443,7 +443,7 @@ class TMapTest extends Test:
 
         "concurrent removals" in runNotJS {
             (for
-                size <- Choice.eval(Seq(1, 10, 100))
+                size <- Choice.eval(1, 10, 100)
                 map  <- STM.run(TMap.init[Int, Int]())
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => map.put(i, i))
@@ -459,7 +459,7 @@ class TMapTest extends Test:
 
         "concurrent bulk operations" in runNotJS {
             (for
-                size <- Choice.eval(Seq(1, 10, 100))
+                size <- Choice.eval(1, 10, 100)
                 map  <- STM.run(TMap.init[Int, Int]())
                 _ <- STM.run {
                     Kyo.foreachDiscard((1 to size))(i => map.put(i, i))


### PR DESCRIPTION
`Choice.eval` can be used as a var args. (cf #1216)


---

- [x] check if we need to create another method for seq.
- [x] update documentation