### PR TITLE
Include Timeout Duration in Timeout Exception

### DIFF
--- a/kyo-caliban/src/test/scala/kyo/Test.scala
+++ b/kyo-caliban/src/test/scala/kyo/Test.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with BaseKyoKernelTest[Any] with NonImplicitAssertions:
 
-    def run(v: Future[Assertion] < Any): Future[Assertion] = v.eval
+    def run(v: Future[Assertion] < Any)(using Frame): Future[Assertion] = v.eval
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -188,7 +188,7 @@ object Async:
     def timeout[E, A, S](
         using isolate: Isolate.Stateful[S, Abort[E] & Async]
     )(after: Duration)(v: => A < (Abort[E] & Async & S))(using frame: Frame): A < (Abort[E | Timeout] & Async & S) =
-        if after == Duration.Zero then Abort.fail(Timeout())
+        if after == Duration.Zero then Abort.fail(Timeout(Present(after)))
         else if !after.isFinite then v
         else
             isolate.capture { state =>
@@ -196,7 +196,7 @@ object Async:
                     Clock.use { clock =>
                         IO.Unsafe {
                             val sleepFiber = clock.unsafe.sleep(after)
-                            sleepFiber.onComplete(_ => discard(task.unsafe.interrupt(Result.Failure(Timeout()))))
+                            sleepFiber.onComplete(_ => discard(task.unsafe.interrupt(Result.Failure(Timeout(Present(after))))))
                             task.unsafe.onComplete(_ => discard(sleepFiber.interrupt()))
                             isolate.restore(task.get)
                         }

--- a/kyo-core/shared/src/main/scala/kyo/Timeout.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Timeout.scala
@@ -1,3 +1,4 @@
 package kyo
 
-class Timeout()(using Frame) extends KyoException(t"Computation has timed out.")
+final class Timeout(duration: Maybe[Duration] = Absent)(using Frame)
+    extends KyoException("Computation has timed out" + duration.fold("")(" after " + _.show))

--- a/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
@@ -4,7 +4,7 @@ import kyo.*
 import scala.concurrent.Future
 
 private[kyo] trait BaseKyoCoreTest extends BaseKyoKernelTest[Abort[Any] & Async & Resource]:
-    def run(v: Future[Assertion] < (Abort[Any] & Async & Resource)): Future[Assertion] =
+    def run(v: Future[Assertion] < (Abort[Any] & Async & Resource))(using Frame): Future[Assertion] =
         import AllowUnsafe.embrace.danger
         v.handle(
             Resource.run,

--- a/kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala
@@ -8,42 +8,42 @@ import scala.concurrent.Future
 
 private[kyo] trait BaseKyoKernelTest[S] extends BaseKyoDataTest:
 
-    def run(v: Future[Assertion] < S): Future[Assertion]
+    def run(v: Future[Assertion] < S)(using Frame): Future[Assertion]
 
     @targetName("runAssertion")
-    def run(v: Assertion < S): Future[Assertion] = run(v.map(Future.successful(_)))
+    def run(v: Assertion < S)(using Frame): Future[Assertion] = run(v.map(Future.successful(_)))
 
     @targetName("runJVMAssertion")
-    def runJVM(v: => Assertion < S): Future[Assertion] = runJVM(v.map(Future.successful(_)))
+    def runJVM(v: => Assertion < S)(using Frame): Future[Assertion] = runJVM(v.map(Future.successful(_)))
 
     @targetName("runJSAssertion")
-    def runJS(v: => Assertion < S): Future[Assertion] = runJS(v.map(Future.successful(_)))
+    def runJS(v: => Assertion < S)(using Frame): Future[Assertion] = runJS(v.map(Future.successful(_)))
 
     @targetName("runNotJSAssertion")
-    def runNotJS(v: => Assertion < S): Future[Assertion] = runNotJS(v.map(Future.successful(_)))
+    def runNotJS(v: => Assertion < S)(using Frame): Future[Assertion] = runNotJS(v.map(Future.successful(_)))
 
     @targetName("runNativeAssertion")
-    def runNative(v: => Assertion < S): Future[Assertion] = runNative(v.map(Future.successful(_)))
+    def runNative(v: => Assertion < S)(using Frame): Future[Assertion] = runNative(v.map(Future.successful(_)))
 
-    def runJVM(v: => Future[Assertion] < S): Future[Assertion] =
+    def runJVM(v: => Future[Assertion] < S)(using Frame): Future[Assertion] =
         if Platform.isJVM then
             run(v)
         else
             Future.successful(assertionSuccess)
 
-    def runJS(v: => Future[Assertion] < S): Future[Assertion] =
+    def runJS(v: => Future[Assertion] < S)(using Frame): Future[Assertion] =
         if Platform.isJS then
             run(v)
         else
             Future.successful(assertionSuccess)
 
-    def runNotJS(v: => Future[Assertion] < S): Future[Assertion] =
+    def runNotJS(v: => Future[Assertion] < S)(using Frame): Future[Assertion] =
         if !Platform.isJS then
             run(v)
         else
             Future.successful(assertionSuccess)
 
-    def runNative(v: => Future[Assertion] < S): Future[Assertion] =
+    def runNative(v: => Future[Assertion] < S)(using Frame): Future[Assertion] =
         if Platform.isNative then
             run(v)
         else

--- a/kyo-kernel/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/Test.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoKernelTest[Any]:
 
-    def run(v: Future[Assertion] < Any): Future[Assertion] = v.eval
+    def run(v: Future[Assertion] < Any)(using Frame): Future[Assertion] = v.eval
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-prelude/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/Test.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoKernelTest[Abort[Throwable]]:
 
-    def run(v: Future[Assertion] < Abort[Throwable]): Future[Assertion] =
+    def run(v: Future[Assertion] < Abort[Throwable])(using Frame): Future[Assertion] =
         Abort.run(v).eval.getOrThrow
 
     type Assertion = org.scalatest.Assertion


### PR DESCRIPTION
### Problem
This PR aims to solve 2 problems:
1. it's currently impossible to debug test timeouts, as they always point to `Async.timeout(timeout),` in `BaseKyoCoreTest`
2. If you stack timeouts or have any non-trivial indirection, it can be tricky to figure out how long an effect took.

### Solution
- To solve problem 1, all testing methods needed to propagate a `Frame`. Now the test that is failing is correctly rendered.
- To solve problem 2, I added an argument in the constructor to capture a Duration. It's optional as some timeouts (Deadline) may not have a duration.

### Example
A failing test:
```
[info] - ordered runs *** FAILED *** (2 seconds, 13 milliseconds)
[info]   kyo.Fiber$package$Fiber$Interrupted: [2m   │ ──────────────────────────────
[info]    │ // KyoAppTest.scala:39:55 kyo.KyoAppTest._$_$$anon ?
[info]    │ ──────────────────────────────
[info] 38 │ val app = new KyoApp:
[info] 39 │     run { Async.delay(2.seconds)(IO(x += 1)) }📍
[info] 40 │     run { Async.delay(10.millis)(IO(x += 2)) }
[info]    │ ──────────────────────────────
[info]    │ ⚠️ KyoException
[info]    │ 
[info]    │ Fiber interrupted at KyoAppTest.scala:39:55
[info]    │ ──────────────────────────────
[info]   ...
```