### PR TITLE
[core] implement `Async.raceFirst`

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -213,6 +213,9 @@ object Async extends AsyncPlatformSpecific:
       * WARNING: Executes all computations concurrently without bounds. Use with caution on large sequences to avoid resource exhaustion. On
       * platforms supporting parallel execution (like JVM), computations may run in parallel.
       *
+      * Note: Unlike `raceFirst`, this method will only complete when a successful computation completes. If all computations fail, it will
+      * wait for the last failure. If some fail while others never complete, it will wait indefinitely for a success.
+      *
       * @param seq
       *   The sequence of computations to race
       * @return
@@ -230,6 +233,9 @@ object Async extends AsyncPlatformSpecific:
     end race
 
     /** Races two or more computations and returns the result of the first successful computation to complete.
+      *
+      * Note: Unlike `race`, this method will only complete when a successful computation completes. If all computations fail, it will wait
+      * for the last failure. If some fail while others never complete, it will wait indefinitely for a success.
       *
       * @param first
       *   The first computation
@@ -254,6 +260,10 @@ object Async extends AsyncPlatformSpecific:
       * WARNING: Executes all computations concurrently without bounds. Use with caution on large sequences to avoid resource exhaustion. On
       * platforms supporting parallel execution (like JVM), computations may run in parallel.
       *
+      * Note: Unlike `race`, this method will complete as soon as any computation completes, regardless of whether it succeeded or failed.
+      * For example, if one computation fails while another never completes, this method will return the failure, interrupting the other
+      * computation(s).
+      *
       * @param seq
       *   The sequence of computations to race
       * @return
@@ -272,6 +282,10 @@ object Async extends AsyncPlatformSpecific:
 
     /** Races two or more computations and returns the result of the first to complete. When one computation completes, all other
       * computations are interrupted.
+      *
+      * Note: Unlike `race`, this method will complete as soon as any computation completes, regardless of whether it succeeded or failed.
+      * For example, if one computation fails while another never completes, this method will return the failure, interrupting the other
+      * computation(s).
       *
       * @param first
       *   The first computation

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -207,8 +207,8 @@ object Async extends AsyncPlatformSpecific:
         end if
     end timeout
 
-    /** Races multiple computations and returns the result of the first to complete. When one computation completes, all other computations
-      * are interrupted.
+    /** Races multiple computations and returns the result of the first successful computation to complete. When one computation succeeds,
+      * all other computations are interrupted.
       *
       * WARNING: Executes all computations concurrently without bounds. Use with caution on large sequences to avoid resource exhaustion. On
       * platforms supporting parallel execution (like JVM), computations may run in parallel.
@@ -216,7 +216,7 @@ object Async extends AsyncPlatformSpecific:
       * @param seq
       *   The sequence of computations to race
       * @return
-      *   The result of the first computation to complete
+      *   The result of the first successful computation to complete
       */
     def race[E, A, S](
         using isolate: Isolate.Stateful[S, Abort[E] & Async]
@@ -229,14 +229,14 @@ object Async extends AsyncPlatformSpecific:
         }
     end race
 
-    /** Races two or more computations and returns the result of the first to complete.
+    /** Races two or more computations and returns the result of the first successful computation to complete.
       *
       * @param first
       *   The first computation
       * @param rest
       *   The rest of the computations
       * @return
-      *   The result of the first computation to complete
+      *   The result of the first successful computation to complete
       */
     def race[E, A, S](
         using Isolate.Stateful[S, Abort[E] & Async]
@@ -247,6 +247,47 @@ object Async extends AsyncPlatformSpecific:
         using frame: Frame
     ): A < (Abort[E] & Async & S) =
         race[E, A, S](first +: rest)
+
+    /** Races multiple computations and returns the result of the first to complete. When one computation completes, all other computations
+      * are interrupted.
+      *
+      * WARNING: Executes all computations concurrently without bounds. Use with caution on large sequences to avoid resource exhaustion. On
+      * platforms supporting parallel execution (like JVM), computations may run in parallel.
+      *
+      * @param seq
+      *   The sequence of computations to race
+      * @return
+      *   The result of the first computation to complete
+      */
+    def raceFirst[E, A, S](
+        using isolate: Isolate.Stateful[S, Abort[E] & Async]
+    )(iterable: Iterable[A < (Abort[E] & Async & S)])(
+        using frame: Frame
+    ): A < (Abort[E] & Async & S) =
+        require(iterable.nonEmpty, "Can't race an empty collection.")
+        isolate.capture { state =>
+            Fiber.raceFirst(iterable.map(isolate.isolate(state, _))).map(fiber => isolate.restore(fiber.get))
+        }
+    end raceFirst
+
+    /** Races two or more computations and returns the result of the first to complete. When one computation completes, all other
+      * computations are interrupted.
+      *
+      * @param first
+      *   The first computation
+      * @param rest
+      *   The rest of the computations
+      * @return
+      */
+    def raceFirst[E, A, S](
+        using Isolate.Stateful[S, Abort[E] & Async]
+    )(
+        first: A < (Abort[E] & Async & S),
+        rest: A < (Abort[E] & Async & S)*
+    )(
+        using frame: Frame
+    ): A < (Abort[E] & Async & S) =
+        raceFirst[E, A, S](first +: rest)
 
     /** Concurrently executes two or more computations and collects their successful results.
       *
@@ -337,8 +378,8 @@ object Async extends AsyncPlatformSpecific:
 
     /** Executes a sequence of computations with indexed access, using bounded concurrency.
       *
-      * @param seq
-      *   The sequence of elements to process
+      * @param iterable
+      *   The collection of elements to process
       * @param concurrency
       *   Maximum number of concurrent computations (defaults to [[defaultConcurrency]])
       * @param f
@@ -372,8 +413,8 @@ object Async extends AsyncPlatformSpecific:
 
     /** Executes a sequence of computations using bounded concurrency.
       *
-      * @param seq
-      *   The sequence of elements to process
+      * @param iterable
+      *   The collection of elements to process
       * @param concurrency
       *   Maximum number of concurrent computations (defaults to [[defaultConcurrency]])
       * @param f
@@ -390,8 +431,8 @@ object Async extends AsyncPlatformSpecific:
 
     /** Executes a sequence of computations in parallel, discarding the results.
       *
-      * @param seq
-      *   The sequence of elements to process
+      * @param iterable
+      *   The collection of elements to process
       * @param concurrency
       *   Maximum number of concurrent computations (defaults to defaultConcurrency)
       * @param f
@@ -406,8 +447,8 @@ object Async extends AsyncPlatformSpecific:
 
     /** Filters elements from a sequence using bounded concurrency.
       *
-      * @param seq
-      *   The sequence to filter
+      * @param iterable
+      *   The collection to filter
       * @param concurrency
       *   Maximum number of concurrent predicate evaluations (defaults to [[defaultConcurrency]])
       * @param f
@@ -424,8 +465,8 @@ object Async extends AsyncPlatformSpecific:
 
     /** Transforms and filters elements from a sequence using bounded concurrency.
       *
-      * @param seq
-      *   The sequence to process
+      * @param iterable
+      *   The collection to process
       * @param concurrency
       *   Maximum number of concurrent evaluations (defaults to [[defaultConcurrency]])
       * @param f
@@ -442,8 +483,8 @@ object Async extends AsyncPlatformSpecific:
 
     /** Executes a sequence of computations using bounded concurrency.
       *
-      * @param seq
-      *   The sequence of computations to execute
+      * @param iterable
+      *   The collection of computations to execute
       * @param concurrency
       *   Maximum number of concurrent computations (defaults to [[defaultConcurrency]])
       * @return
@@ -458,8 +499,8 @@ object Async extends AsyncPlatformSpecific:
 
     /** Executes a sequence of computations in parallel, discarding their results.
       *
-      * @param seq
-      *   The sequence of computations to execute
+      * @param iterable
+      *   The collection of computations to execute
       * @param concurrency
       *   Maximum number of concurrent computations (defaults to defaultConcurrency)
       */


### PR DESCRIPTION
### Problem
`Async.race` completes on the the first success or the last failure. In certain cases, this is undesirable. For example racing a potentially failing computation with a promise that may never complete. The resulting computation will hang indefinitely.

### Solution
Create a new specialized `Race[E, A]` class extending `IOPromise` in `Fiber`. This will be used to implement customization of Race state without additional overhead of a separate class. This PR adds support for `Success` (existing) and `First` (new).