### PR TITLE
[core] use `Render` to print `Result` of KyoApp

### DIFF
--- a/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -2,7 +2,7 @@ package kyo
 
 abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abort[Throwable]]:
 
-    final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame): Unit =
+    final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         initCode = initCode.appended(() =>
             val result = IO.Unsafe.evalOrThrow(Abort.run(Async.runAndBlock(timeout)(handle(v))))

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -42,12 +42,12 @@ object KyoApp:
             for proc <- initCode do proc()
         end main
 
-        protected def run[A](v: => A < S)(using Frame): Unit
+        protected def run[A](v: => A < S)(using Frame, Render[A]): Unit
 
-        protected def exit(code: Int): Unit = kernel.Platform.exit(code)
+        protected def exit(code: Int)(using AllowUnsafe): Unit = kernel.Platform.exit(code)
 
-        protected def onResult(result: Result[Any, Any]): Unit =
-            if !result.exists(().equals(_)) then println(pprint.apply(result).plainText)
+        protected def onResult[E, A](result: Result[E, A])(using Render[Result[E, A]], AllowUnsafe): Unit =
+            if !result.exists(().equals(_)) then println(result.show)
             result match
                 case Error(e: Throwable) => throw e
                 case Error(_)            => exit(1)

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
@@ -79,7 +79,7 @@ class KyoAppTest extends Test:
     "exit on error" taggedAs jvmOnly in {
         var exitCode = -1
         def app(fail: Boolean): KyoApp = new KyoApp:
-            override def exit(code: Int): Unit = exitCode = code
+            override def exit(code: Int)(using AllowUnsafe): Unit = exitCode = code
             run(Abort.when(fail)(new IllegalArgumentException("Aborts!")))
         val result = Result.catching[IllegalArgumentException](app(fail = true).main(Array.empty))
         assert(result.isFailure)

--- a/kyo-kernel/native/src/main/scala/kyo/kernel/Platform.scala
+++ b/kyo-kernel/native/src/main/scala/kyo/kernel/Platform.scala
@@ -9,5 +9,5 @@ object Platform:
     val isJS: Boolean                      = false
     val isNative: Boolean                  = true
     val isDebugEnabled: Boolean            = false
-    def exit(code: Int): Unit              = java.lang.System.exit(code)
+    def exit(code: Int)(using AllowUnsafe): Unit = java.lang.System.exit(code)
 end Platform


### PR DESCRIPTION
### Problem
`pprint` currently only shows the value inside the `Result.Success` as it's an opaque type.

### Solution
Use `Render[Result[E, A]]` to print the value. This also enables users to provide a `Render[A]`, customizing the output.

### Notes
- I also added `AllowUnsafe` evidence to `exit` as users shouldn't accidentally call that method.