### PR TITLE
[core] fix for #1232

### DIFF
--- a/kyo-core/shared/src/test/scala/Issue1232.scala
+++ b/kyo-core/shared/src/test/scala/Issue1232.scala
@@ -1,0 +1,13 @@
+package example
+
+import kyo.*
+
+class Issue1232 extends Test:
+    "IO.ensure" in run {
+        val result = typeCheck("""
+          def hello: Unit = ()
+          val io = IO.ensure(hello)(1)""")
+
+        assert(result == Result.succeed(()))
+    }
+end Issue1232

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Safepoint.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Safepoint.scala
@@ -11,6 +11,7 @@ import kyo.Result.Panic
 import kyo.isNull
 import kyo.kernel.*
 import scala.annotation.nowarn
+import scala.annotation.publicInBinary
 import scala.util.control.NonFatal
 
 /** Provides runtime safety guarantees and debugging capabilities for effect execution.
@@ -133,7 +134,7 @@ object Safepoint:
         immediate(p)(loop(v))
     end propagating
 
-    sealed abstract private[kyo] class Ensure
+    sealed abstract class Ensure @publicInBinary private[kyo] ()
         extends AtomicBoolean
         with Function1[Maybe[Error[Any]], Unit]:
 


### PR DESCRIPTION
Fix for #1232, changing the visibility of `Ensure`

---

```
[info] Issue1232:
[info] - IO.ensure *** FAILED *** (321 milliseconds)
[info]   Failure("class Ensure cannot be accessed as a member of (Safepoint$_this :
[info]     ($proxy10 : kyo.kernel.internal.Safepoint.type{type State = Long})) from anonymous class Safepoint$_this.Ensure {...}.
[info]     private[kyo] class Ensure can only be accessed from package kyo.") did not equal <(), the Unit value> (Issue1232.scala:11)
```
---
~I have no idea how to solve that, this doesn't work:~
Solved thanks to @hearnadam 
```diff
       * @tparam A
       *   The result type of the main computation.
       */
-    inline def ensure[A, S](inline f: => Any < IO)(v: A < S)(using inline frame: Frame): A < (IO & S) =
+    inline def ensure[A, S](inline f: Safepoint ?=> Any < IO)(v: A < S)(using inline frame: Frame): A < (IO & S) =
         ensure(_ => f)(v)

+    @targetName("ensureWithError")
     inline def ensure[A, S](inline f: Maybe[Error[Any]] => Any < IO)(v: A < S)(using inline frame: Frame): A < (IO & S) =
``` 

