### PR TITLE
[direct] rename defer to direct

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/ForeachBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ForeachBench.scala
@@ -30,31 +30,31 @@ class ForeachBench extends BaseBench:
 
     @Benchmark def deferChunk(bh: Blackhole) =
         val asVal = intChunk
-        val prg   = defer(asVal.map(i => f(i).now).size)
+        val prg   = direct(asVal.map(i => f(i).now).size)
         bh.consume(prg.eval)
     end deferChunk
 
     @Benchmark def deferSeq(bh: Blackhole) =
         val asVal: Seq[Int] = intChunk
-        val prg             = defer(asVal.map(i => f(i).now).size)
+        val prg             = direct(asVal.map(i => f(i).now).size)
         bh.consume(prg.eval)
     end deferSeq
 
     @Benchmark def deferVector(bh: Blackhole) =
         val asVal = intVec
-        val prg   = defer(asVal.map(i => f(i).now).size)
+        val prg   = direct(asVal.map(i => f(i).now).size)
         bh.consume(prg.eval)
     end deferVector
 
     @Benchmark def deferVectorAsSeq(bh: Blackhole) =
         val asVal: Seq[Int] = intVec
-        val prg             = defer(asVal.map(i => f(i).now).size)
+        val prg             = direct(asVal.map(i => f(i).now).size)
         bh.consume(prg.eval)
     end deferVectorAsSeq
 
     @Benchmark def deferIterable(bh: Blackhole) =
         val asVal: Iterable[Int] = intChunk
-        val prg                  = defer(asVal.map(i => f(i).now).size)
+        val prg                  = direct(asVal.map(i => f(i).now).size)
         bh.consume(prg.eval)
     end deferIterable
 

--- a/kyo-direct/shared/src/main/scala/kyo/Direct.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/Direct.scala
@@ -15,7 +15,7 @@ import scala.quoted.*
   * The `.later` operation is an advanced feature that gives more control over effect sequencing, but requires a deeper understanding of
   * effect composition.
   *
-  * The `defer` block is desugared into regular monadic composition using Kyo's monadic bind (`map`).
+  * The `direct` block is desugared into regular monadic composition using Kyo's monadic bind (`map`).
   *
   * @tparam A
   *   The type of the value returned by the deferred block
@@ -24,32 +24,32 @@ import scala.quoted.*
   * @return
   *   A value of type `A < S`, where `S` represents the combined effects of all operations
   */
-transparent inline def defer[A](inline f: A) = ${ impl[A]('f) }
+transparent inline def direct[A](inline f: A) = ${ impl[A]('f) }
 
 extension [A, S](inline self: A < S)
 
     /** Sequences an effect immediately, making its result available for use.
       *
-      * Must be used within a `defer` block. This operation tells the direct syntax to execute the effect at this point in the computation,
+      * Must be used within a `direct` block. This operation tells the direct syntax to execute the effect at this point in the computation,
       * allowing you to use its result in subsequent operations.
       *
       * @return
       *   The unwrapped value of type `A` from the effect
       * @throws RuntimeException
-      *   if used outside a `defer` block
+      *   if used outside a `direct` block
       */
     inline def now: A = ${ nowImpl('self) }
 
     /** Preserves an effect without immediate sequencing (advanced API).
       *
-      * Must be used within a `defer` block. This advanced operation preserves the effect in its wrapped form without sequencing it,
+      * Must be used within a `direct` block. This advanced operation preserves the effect in its wrapped form without sequencing it,
       * providing more control over effect composition. Use this when building reusable effect combinations or when explicit control over
       * effect sequencing is needed.
       *
       * @return
       *   The preserved effect of type `A < S`
       * @throws RuntimeException
-      *   if used outside a `defer` block
+      *   if used outside a `direct` block
       */
     inline def later: A < S = ${ laterImpl('self) }
 end extension
@@ -57,13 +57,13 @@ end extension
 private def nowImpl[A: Type, S: Type](self: Expr[A < S])(using Quotes): Expr[A] =
     import quotes.reflect.*
     report.errorAndAbort(
-        s"""${".now".cyan} must be used within a ${"`defer`".yellow} block.
+        s"""${".now".cyan} must be used within a ${"`direct`".yellow} block.
            |
            |${".now".cyan} tells the system to sequence this effect at this point in the computation. Use it when you need 
            |the effect's result for your next computation:
            |
            |${highlight("""
-           |defer {
+           |direct {
            |  val x = IO(1).now     // Get result here
            |  val y = IO(2).now     // Then get this result  
            |  x + y                 // Use both results
@@ -76,7 +76,7 @@ end nowImpl
 private def laterImpl[A: Type, S: Type](self: Expr[A < S])(using Quotes): Expr[A < S] =
     import quotes.reflect.*
     report.errorAndAbort(
-        s"""${".later".cyan} must be used within a ${"`defer`".yellow} block.
+        s"""${".later".cyan} must be used within a ${"`direct`".yellow} block.
            |
            |${".later".cyan} is an advanced operation that preserves an effect without sequencing it. This gives you more 
            |control but requires understanding effect composition. Use it when building reusable effect combinations 
@@ -84,13 +84,13 @@ private def laterImpl[A: Type, S: Type](self: Expr[A < S])(using Quotes): Expr[A
            |
            |${highlight("""
            |// Example: Preserve effects for composition
-           |def combination = defer {
+           |def combination = direct {
            |  val effect1 = IO(1).later   // Effect preserved
            |  val effect2 = IO(2).later   // Effect preserved
            |  (effect1, effect2)          // Return tuple of effects
            |}
            |
-           |defer {
+           |direct {
            |  val (e1, e2) = combination.now  // Get both effects
            |  e1.now + e2.now                 // Sequence them here
            |}""".stripMargin)}

--- a/kyo-direct/shared/src/main/scala/kyo/TestSupport.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/TestSupport.scala
@@ -5,7 +5,7 @@ import scala.language.experimental.macros
 object TestSupport:
     transparent inline def runLiftTest[A, B](inline expected: A)(inline body: B): Unit =
         import AllowUnsafe.embrace.danger
-        val actual: B = IO.Unsafe.evalOrThrow(defer(body).asInstanceOf[B < IO])
+        val actual: B = IO.Unsafe.evalOrThrow(direct(body).asInstanceOf[B < IO])
         if !expected.equals(actual) then
             throw new AssertionError("Expected " + expected + " but got " + actual)
     end runLiftTest

--- a/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
@@ -110,33 +110,33 @@ private[kyo] object Validate:
                     case tree @ Apply(TypeApply(Ident("now" | "later"), _), _) =>
                         fail(
                             tree,
-                            s"""${".now".cyan} and ${".later".cyan} can only be used directly inside a ${"`defer`".yellow} block.
+                            s"""${".now".cyan} and ${".later".cyan} can only be used directly inside a ${"`direct`".yellow} block.
                             |
-                            |Common mistake: You may have forgotten to wrap an effectful computation in ${"`defer`".yellow}:
+                            |Common mistake: You may have forgotten to wrap an effectful computation in ${"`direct`".yellow}:
                             |${highlight("""
-                            |// Missing defer when handling effects:
-                            |val result = Emit.run {      // NOT OK - missing defer
+                            |// Missing direct when handling effects:
+                            |val result = Emit.run {      // NOT OK - missing direct
                             |    Emit.value(1).now
                             |    Emit.value(2).now
                             |}
                             |
-                            |// Correctly wrapped in defer:
+                            |// Correctly wrapped in direct:
                             |val result = Emit.run {
-                            |    defer {                  // OK - effects wrapped in defer
+                            |    direct {                  // OK - effects wrapped in direct
                             |        Emit.value(1).now
                             |        Emit.value(2).now
                             |    }
                             |}""")}
                             |
-                            |If you're seeing this inside a ${"`defer`".yellow} block, you may have nested ${".now".cyan}/${".later".cyan} calls:
+                            |If you're seeing this inside a ${"`direct`".yellow} block, you may have nested ${".now".cyan}/${".later".cyan} calls:
                             |${highlight("""
                             |// Instead of nested .now:
-                            |defer {
+                            |direct {
                             |    (counter.get.now + 1).now     // NOT OK - nested .now
                             |}
                             |
                             |// Store intermediate results:
-                            |defer {
+                            |direct {
                             |    val value = counter.get.now    // OK - get value first
                             |    val incr = value + 1           // OK - pure operation
                             |    IO(incr).now                   // OK - single .now
@@ -147,13 +147,13 @@ private[kyo] object Validate:
             case tree: Term if tree.tpe.typeSymbol.name == "<" =>
                 fail(
                     tree,
-                    s"""Effectful computations must explicitly use either ${".now".cyan} or ${".later".cyan} in a ${"defer".yellow} block.
+                    s"""Effectful computations must explicitly use either ${".now".cyan} or ${".later".cyan} in a ${"direct".yellow} block.
                        |
                        |You have two options:
                        |
                        |${bold("1. Use .now when you need the effect's result immediately:")}
                        |${highlight("""
-                       |defer {
+                       |direct {
                        |  val x: Int = IO(1).now      // Get result here
                        |  val y: Int = x + IO(2).now  // Use result in next computation
                        |  y * 2                       // Use final result
@@ -161,7 +161,7 @@ private[kyo] object Validate:
                        |
                        |${bold("2. Use .later (advanced) when you want to preserve the effect:")}
                        |${highlight("""
-                       |defer {
+                       |direct {
                        |  val x: Int < IO = IO(1).later    // Keep effect for later
                        |  val y: Int < IO = IO(2).later    // Keep another effect
                        |  x.now + y.now                    // Sequence effects
@@ -172,7 +172,7 @@ private[kyo] object Validate:
             case tree @ ValDef(_, _, _) if tree.symbol.flags.is(Flags.Mutable) =>
                 fail(
                     tree,
-                    s"""${"`var`".yellow} declarations are not allowed inside a ${"`defer`".yellow} block.
+                    s"""${"`var`".yellow} declarations are not allowed inside a ${"`direct`".yellow} block.
                        |
                        |Mutable state can lead to unexpected behavior with effects. Instead, use proper state management tools:
                        |
@@ -185,30 +185,30 @@ private[kyo] object Validate:
             case tree @ ValDef(_, _, _) if tree.symbol.flags.is(Flags.Lazy) =>
                 fail(
                     tree,
-                    s"""${"`lazy val`".yellow} and ${"`object`".yellow} declarations are not allowed inside a ${"`defer`".yellow} block.
+                    s"""${"`lazy val`".yellow} and ${"`object`".yellow} declarations are not allowed inside a ${"`direct`".yellow} block.
                     |
-                    |These interfere with effect sequencing. Define them outside the defer block:
+                    |These interfere with effect sequencing. Define them outside the direct block:
                     |${highlight("""
-                    |// Instead of lazy declarations in defer:
-                    |defer {
+                    |// Instead of lazy declarations in direct:
+                    |direct {
                     |  lazy val x = IO(1).now  // NOT OK - lazy val
                     |  object A               // NOT OK - object
                     |  x + 1
                     |}
                     |
-                    |// Define outside defer:
+                    |// Define outside direct:
                     |lazy val x = IO(1)       // OK - outside
                     |object A                 // OK - outside
                     |
-                    |// Use inside defer:
-                    |defer {
+                    |// Use inside direct:
+                    |direct {
                     |  val result = x.now     // OK - proper sequencing
                     |  A.method.now
                     |}""".stripMargin)}
                     |
                     |For expensive computations needing caching, consider ${"`Async.memoize`".cyan}:
                     |${highlight("""
-                    |defer {
+                    |direct {
                     |  val memoized = Async.memoize(expensiveComputation).now
                     |  memoized().now  // First computes, then caches
                     |}""".stripMargin)}""".stripMargin.stripMargin
@@ -217,22 +217,22 @@ private[kyo] object Validate:
             case tree @ DefDef(_, _, _, Some(body)) if !pure(body) =>
                 fail(
                     tree,
-                    s"""Method definitions containing ${".now".cyan} are not supported inside ${"`defer`".yellow} blocks.
+                    s"""Method definitions containing ${".now".cyan} are not supported inside ${"`direct`".yellow} blocks.
                        |
-                       |Define methods outside defer blocks:
+                       |Define methods outside direct blocks:
                        |${highlight("""
-                       |// Instead of method in defer:
-                       |defer {
+                       |// Instead of method in direct:
+                       |direct {
                        |  def process(x: Int) = IO(x).now  // NOT OK
                        |  process(10)
                        |}
                        |
                        |// Define outside:
-                       |def process(x: Int): Int < IO = defer {
+                       |def process(x: Int): Int < IO = direct {
                        |  IO(x).now
                        |}
                        |
-                       |defer {
+                       |direct {
                        |  process(10).now  // OK
                        |}""".stripMargin)}""".stripMargin
                 )
@@ -240,12 +240,12 @@ private[kyo] object Validate:
             case tree @ Try(_, _, _) =>
                 fail(
                     tree,
-                    s"""${"`try`".yellow}/${"`catch`".yellow} blocks are not supported inside ${"`defer`".yellow} blocks.
+                    s"""${"`try`".yellow}/${"`catch`".yellow} blocks are not supported inside ${"`direct`".yellow} blocks.
                        |
-                       |Use error handling effects instead. You can handle each effect in a separate defer block:
+                       |Use error handling effects instead. You can handle each effect in a separate direct block:
                        |${highlight("""
                        |// Instead of try/catch:
-                       |defer {
+                       |direct {
                        |  try {
                        |    IO(1).now    // NOT OK
                        |  } catch {
@@ -254,12 +254,12 @@ private[kyo] object Validate:
                        |}
                        |
                        |// Define the effectful computation:
-                       |def computation = defer {
+                       |def computation = direct {
                        |  IO(1).now
                        |}
                        |
-                       |// Handle the effect defer block:
-                       |defer {
+                       |// Handle the effect direct block:
+                       |direct {
                        |  Abort.run(computation).now match {
                        |    case Result.Success(v) => v
                        |    case Result.Failure(e) => handleError(e)
@@ -274,42 +274,42 @@ private[kyo] object Validate:
             case tree @ ClassDef(_, _, _, _, _) =>
                 fail(
                     tree,
-                    s"""${"`class`".yellow} and ${"`trait`".yellow} declarations are not allowed inside ${"`defer`".yellow} blocks.
+                    s"""${"`class`".yellow} and ${"`trait`".yellow} declarations are not allowed inside ${"`direct`".yellow} blocks.
                         |
-                        |Define them outside defer blocks:
+                        |Define them outside direct blocks:
                         |${highlight("""
-                        |// Instead of declarations in defer:
-                        |defer {
+                        |// Instead of declarations in direct:
+                        |direct {
                         |  class MyClass(x: Int)    // NOT OK
                         |  trait MyTrait            // NOT OK
                         |  new MyClass(10)
                         |}
                         |
                         |// Define outside:
-                        |class MyClass(x: Int)      // OK - outside defer
-                        |trait MyTrait              // OK - outside defer
+                        |class MyClass(x: Int)      // OK - outside direct
+                        |trait MyTrait              // OK - outside direct
                         |
-                        |defer {
-                        |  new MyClass(10)          // OK - usage in defer
+                        |direct {
+                        |  new MyClass(10)          // OK - usage in direct
                         |}""".stripMargin)}""".stripMargin
                 )
 
             case tree @ Apply(Ident("throw"), _) =>
                 fail(
                     tree,
-                    s"""${"`throw`".yellow} expressions are not allowed inside a ${"`defer`".yellow} block.
+                    s"""${"`throw`".yellow} expressions are not allowed inside a ${"`direct`".yellow} block.
                     |
                     |Exception throwing can break effect sequencing. Use error handling effects instead:
                     |${highlight("""
                     |// Instead of throw:
-                    |defer {
+                    |direct {
                     |  if condition then
                     |    throw new Exception("error")  // NOT OK - throws exception
                     |  IO(1).now
                     |}
                     |
                     |// Use Abort effect:
-                    |defer {
+                    |direct {
                     |  if condition then
                     |    Abort.fail("error").now       // OK - proper error handling
                     |  else IO(1).now
@@ -319,7 +319,7 @@ private[kyo] object Validate:
             case tree @ Select(_, "synchronized") =>
                 fail(
                     tree,
-                    s"""${"`synchronized`".yellow} blocks are not allowed inside a ${"`defer`".yellow} block.
+                    s"""${"`synchronized`".yellow} blocks are not allowed inside a ${"`direct`".yellow} block.
                        |
                        |Synchronization can lead to deadlocks with effects. Instead, use proper concurrency primitives:
                        |
@@ -332,7 +332,7 @@ private[kyo] object Validate:
             case tree @ Select(_, _) if tree.symbol.flags.is(Flags.Mutable) =>
                 fail(
                     tree,
-                    s"""Mutable field access is not allowed inside a ${"`defer`".yellow} block.
+                    s"""Mutable field access is not allowed inside a ${"`direct`".yellow} block.
                     |
                     |Mutable state can lead to race conditions. Use proper state management instead:
                     |

--- a/kyo-direct/shared/src/test/scala/kyo/CoreTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/CoreTest.scala
@@ -4,7 +4,7 @@ class CoreTest extends Test:
 
     "atomic operations" - {
         "AtomicInt" in run {
-            defer {
+            direct {
                 val counter = AtomicInt.init(0).now
                 counter.incrementAndGet.now
                 counter.incrementAndGet.now
@@ -14,7 +14,7 @@ class CoreTest extends Test:
         }
 
         "AtomicRef" in run {
-            defer {
+            direct {
                 val ref = AtomicRef.init("initial").now
                 ref.set("updated").now
                 assert(ref.get.now == "updated")
@@ -24,7 +24,7 @@ class CoreTest extends Test:
 
     "clock operations" - {
         "sleep and timeout" in run {
-            defer {
+            direct {
                 val start = Clock.now.now
                 Async.sleep(5.millis).now
                 val elapsed = Clock.now.now - start
@@ -33,7 +33,7 @@ class CoreTest extends Test:
         }
 
         "deadline" in run {
-            defer {
+            direct {
                 val deadline = Clock.deadline(1.second).now
                 assert(!deadline.isOverdue.now)
                 assert(deadline.timeLeft.now <= 1.second)
@@ -43,7 +43,7 @@ class CoreTest extends Test:
 
     "queue operations" - {
         "basic queue" in run {
-            defer {
+            direct {
                 val queue = Queue.init[Int](3).now
                 assert(queue.offer(1).now)
                 assert(queue.offer(2).now)
@@ -53,7 +53,7 @@ class CoreTest extends Test:
         }
 
         "unbounded queue" in run {
-            defer {
+            direct {
                 val queue = Queue.Unbounded.init[Int]().now
                 queue.add(1).now
                 queue.add(2).now
@@ -65,7 +65,7 @@ class CoreTest extends Test:
 
     "random operations" - {
         "basic random" in run {
-            defer {
+            direct {
                 val r1 = Random.nextInt(10).now
                 val r2 = Random.nextInt(10).now
                 assert(r1 >= 0 && r1 < 10)
@@ -74,9 +74,9 @@ class CoreTest extends Test:
         }
 
         "with seed" in run {
-            defer {
+            direct {
                 val results1 = Random.withSeed(42) {
-                    defer {
+                    direct {
                         val a = Random.nextInt(100).now
                         val b = Random.nextInt(100).now
                         (a, b)
@@ -84,7 +84,7 @@ class CoreTest extends Test:
                 }.now
 
                 val results2 = Random.withSeed(42) {
-                    defer {
+                    direct {
                         val a = Random.nextInt(100).now
                         val b = Random.nextInt(100).now
                         (a, b)
@@ -98,7 +98,7 @@ class CoreTest extends Test:
 
     "console operations" in run {
         Console.withOut {
-            defer {
+            direct {
                 Console.printLine("test output").now
             }
         }.map { case (output, _) =>
@@ -109,11 +109,11 @@ class CoreTest extends Test:
 
     "meter operations" - {
         "semaphore" in run {
-            defer {
+            direct {
                 val sem = Meter.initSemaphore(2).now
                 assert(sem.availablePermits.now == 2)
                 sem.run {
-                    defer {
+                    direct {
                         assert(sem.availablePermits.now == 1)
                     }
                 }.now
@@ -122,11 +122,11 @@ class CoreTest extends Test:
         }
 
         "mutex" in run {
-            defer {
+            direct {
                 val mutex = Meter.initMutex.now
                 assert(mutex.availablePermits.now == 1)
                 mutex.run {
-                    defer {
+                    direct {
                         assert(mutex.availablePermits.now == 0)
                     }
                 }.now
@@ -136,7 +136,7 @@ class CoreTest extends Test:
     }
 
     "channel operations" in run {
-        defer {
+        direct {
             val channel = Channel.init[Int](2).now
             assert(channel.offer(1).now)
             assert(channel.offer(2).now)
@@ -148,20 +148,20 @@ class CoreTest extends Test:
     }
 
     "barrier operations" in run {
-        defer {
+        direct {
             val barrier = Barrier.init(2).now
             assert(barrier.pending.now == 2)
 
             // Start two fibers that will wait at the barrier
             val fiber1 = Async.run {
-                defer {
+                direct {
                     barrier.await.now
                     true
                 }
             }.now
 
             val fiber2 = Async.run {
-                defer {
+                direct {
                     barrier.await.now
                     true
                 }
@@ -175,14 +175,14 @@ class CoreTest extends Test:
     }
 
     "latch operations" in run {
-        defer {
+        direct {
             val latch = Latch.init(2).now
             assert(latch.pending.now == 2)
             latch.release.now
             assert(latch.pending.now == 1)
             latch.release.now
             val awaited = Async.run {
-                defer {
+                direct {
                     latch.await.now
                     true
                 }

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -4,18 +4,18 @@ class HygieneTest extends Test:
 
     "use of var" in {
         typeCheckFailure("""
-          defer {
+          direct {
             var willFail = 1
             IO(1).now
           }
         """)(
-            "`var` declarations are not allowed inside a `defer` block."
+            "`var` declarations are not allowed inside a `direct` block."
         )
     }
 
     "use of return" in {
         typeCheckFailure("""
-          defer {
+          direct {
             return 42
             IO(1).now
           }
@@ -24,43 +24,43 @@ class HygieneTest extends Test:
         )
     }
 
-    "nested defer block" in {
+    "nested direct block" in {
         typeCheckFailure("""
-          defer {
-            defer {
+          direct {
+            direct {
               IO(1).now
             }
           }
         """)(
-            "Effectful computations must explicitly use either .now or .later in a defer block."
+            "Effectful computations must explicitly use either .now or .later in a direct block."
         )
     }
 
     "lazy val" in {
         typeCheckFailure("""
-          defer {
+          direct {
             lazy val x = 10
             IO(1).now
           }
         """)(
-            "`lazy val` and `object` declarations are not allowed inside a `defer` block."
+            "`lazy val` and `object` declarations are not allowed inside a `direct` block."
         )
     }
 
     "function containing await" in {
         typeCheckFailure("""
-          defer {
+          direct {
             def foo() = IO(1).now
             foo()
           }
         """)(
-            "Method definitions containing .now are not supported inside `defer` blocks."
+            "Method definitions containing .now are not supported inside `direct` blocks."
         )
     }
 
     "try/catch" in {
         typeCheckFailure("""
-          defer {
+          direct {
             try {
               IO(1).now
             } catch {
@@ -68,46 +68,46 @@ class HygieneTest extends Test:
             }
           }
         """)(
-            "`try`/`catch` blocks are not supported inside `defer` blocks."
+            "`try`/`catch` blocks are not supported inside `direct` blocks."
         )
     }
 
     "class declaration" in {
         typeCheckFailure("""
-          defer {
+          direct {
             class A(val x: Int)
             IO(1).now
           }
         """)(
-            "`class` and `trait` declarations are not allowed inside `defer` blocks."
+            "`class` and `trait` declarations are not allowed inside `direct` blocks."
         )
     }
 
     "object declaration" in {
         typeCheckFailure("""
-          defer {
+          direct {
             object A
             IO(1).now
           }
         """)(
-            "`class` and `trait` declarations are not allowed inside `defer` blocks."
+            "`class` and `trait` declarations are not allowed inside `direct` blocks."
         )
     }
 
     "trait declaration" in {
         typeCheckFailure("""
-          defer {
+          direct {
             trait A
             IO(1).now
           }
         """)(
-            "`class` and `trait` declarations are not allowed inside `defer` blocks."
+            "`class` and `trait` declarations are not allowed inside `direct` blocks."
         )
     }
 
     "for-comprehension" in {
         typeCheckFailure("""
-          defer {
+          direct {
             for {
               x <- IO(1).now
               y <- IO(2).now
@@ -120,19 +120,19 @@ class HygieneTest extends Test:
 
     "try without catch or finally" in {
         typeCheckFailure("""
-          defer {
+          direct {
             try {
               IO(1).now
             }
           }
         """)(
-            "`try`/`catch` blocks are not supported inside `defer` blocks."
+            "`try`/`catch` blocks are not supported inside `direct` blocks."
         )
     }
 
     "try with only finally" in {
         typeCheckFailure("""
-          defer {
+          direct {
             try {
               IO(1).now
             } finally {
@@ -140,14 +140,14 @@ class HygieneTest extends Test:
             }
           }
         """)(
-            "`try`/`catch` blocks are not supported inside `defer` blocks."
+            "`try`/`catch` blocks are not supported inside `direct` blocks."
         )
     }
 
     "new instance with by-name parameter" in {
         typeCheckFailure("""
           class A(x: => String)
-          defer {
+          direct {
               new A(IO("blah").now)
           }
         """)(
@@ -157,7 +157,7 @@ class HygieneTest extends Test:
 
     "match expression without cases" in {
         typeCheckFailure("""
-          defer {
+          direct {
             IO(1).now match {}
           }
         """)(
@@ -167,7 +167,7 @@ class HygieneTest extends Test:
 
     "for-comprehension without yield" in {
         typeCheckFailure("""
-          defer {
+          direct {
             for {
               x <- IO(1).now
               y <- IO(2).now
@@ -180,7 +180,7 @@ class HygieneTest extends Test:
 
     "nested functions" in {
         typeCheckFailure("""
-          defer {
+          direct {
             def outer() = {
               def inner() = IO(1).now
               inner()
@@ -188,60 +188,60 @@ class HygieneTest extends Test:
             outer()
           }
         """)(
-            "Method definitions containing .now are not supported inside `defer` blocks"
+            "Method definitions containing .now are not supported inside `direct` blocks"
         )
     }
 
     "lambdas with await" in {
         typeCheckFailure("""
-          defer {
+          direct {
             val f = (x: Int) => IO(1).now + x
             f(10)
           }
         """)(
-            "Method definitions containing .now are not supported inside `defer` blocks."
+            "Method definitions containing .now are not supported inside `direct` blocks."
         )
     }
 
     "throw" in {
         typeCheckFailure("""
-          defer {
+          direct {
               if IO("foo").now == "bar" then
                   throw new Exception
               else
                   2
           }
         """)(
-            "`throw` expressions are not allowed inside a `defer` block."
+            "`throw` expressions are not allowed inside a `direct` block."
         )
     }
 
     "synchronized" in {
         typeCheckFailure("""
-          defer {
+          direct {
               val x = synchronized(1)
               IO(x).now
           }
         """)(
-            "`synchronized` blocks are not allowed inside a `defer` block."
+            "`synchronized` blocks are not allowed inside a `direct` block."
         )
     }
 
     "nested var" in {
-        typeCheckFailure("""defer {{var x = 1; IO(x)}.now}""")("`var` declarations are not allowed inside a `defer` block.")
+        typeCheckFailure("""direct {{var x = 1; IO(x)}.now}""")("`var` declarations are not allowed inside a `direct` block.")
     }
 
     "nested nested var" in {
-        typeCheckFailure("""defer {{val y = 1;{var x = 1; IO(x)}}.now}""")("`var` declarations are not allowed inside a `defer` block.")
+        typeCheckFailure("""direct {{val y = 1;{var x = 1; IO(x)}}.now}""")("`var` declarations are not allowed inside a `direct` block.")
     }
 
     "nested now in def" in {
         typeCheckFailure("""
-             defer {
+             direct {
                val i = IO(1).later
                def f =  i.now > 0
                f
-             }""")("Method definitions containing .now are not supported inside `defer` blocks.")
+             }""")("Method definitions containing .now are not supported inside `direct` blocks.")
     }
 
     "asyncShift explicit .later" in {
@@ -249,16 +249,16 @@ class HygieneTest extends Test:
             """
               val default:Int < Any = 2
               val value = scala.util.Try(1)
-              defer(value.getOrElse(default))
+              direct(value.getOrElse(default))
              """
-        )("Effectful computations must explicitly use either .now or .later in a defer block.")
+        )("Effectful computations must explicitly use either .now or .later in a direct block.")
     }
 
-    "defer drop" in {
+    "direct drop" in {
         typeCheckFailure(
             """
                  val default: Unit < Abort[String] = ()
-                 val x: Unit < Emit[Int] = defer(default.now)
+                 val x: Unit < Emit[Int] = direct(default.now)
                  
                """.stripMargin
         )("Cannot lift `Unit < kyo.Abort[scala.Predef.String]` to the expected type (`Unit < ?`).")
@@ -267,7 +267,7 @@ class HygieneTest extends Test:
     "opaque types issue #993" in {
         val maybe1: Maybe[Int] < IO = Maybe(1)
         val maybe0: Maybe[Int]      = Maybe(0)
-        defer:
+        direct:
             maybe1.now.fold(2)(_ + 1)
             maybe1.now.contains(1)
             maybe0.contains(1)

--- a/kyo-direct/shared/src/test/scala/kyo/PatMatchTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PatMatchTest.scala
@@ -9,14 +9,14 @@ class PatMatchTest extends AnyFreeSpec with Assertions:
         "without guards" - {
             "pure cases" in {
                 runLiftTest(3) {
-                    defer("b").now match
+                    direct("b").now match
                         case "a" => 2
                         case "b" => 3
                 }
             }
             "pure cases with val" in {
                 runLiftTest(3) {
-                    val v = defer("b").now
+                    val v = direct("b").now
                     v match
                         case "a" => 2
                         case "b" => 3
@@ -24,39 +24,39 @@ class PatMatchTest extends AnyFreeSpec with Assertions:
             }
             "pure/impure cases" in {
                 runLiftTest(2) {
-                    defer("a").now match
-                        case "a" => defer(2).now
+                    direct("a").now match
+                        case "a" => direct(2).now
                         case "b" => 3
                 }
             }
             "impure cases" in {
                 runLiftTest(3) {
-                    defer("b").now match
-                        case "a" => defer(2).now
-                        case "b" => defer(3).now
+                    direct("b").now match
+                        case "a" => direct(2).now
+                        case "b" => direct(3).now
                 }
             }
         }
         "with guards" - {
             "pure cases" in {
                 runLiftTest(3) {
-                    defer("b").now match
+                    direct("b").now match
                         case s if s == "a" => 2
                         case "b"           => 3
                 }
             }
             "pure/impure cases" in {
                 runLiftTest(2) {
-                    defer("a").now match
-                        case "a"           => defer(2).now
+                    direct("a").now match
+                        case "a"           => direct(2).now
                         case s if s == "b" => 3
                 }
             }
             "impure cases" in {
                 runLiftTest(2) {
-                    defer("b").now match
-                        case s if "1".toInt == 1 => defer(2).now
-                        case "b"                 => defer(3).now
+                    direct("b").now match
+                        case s if "1".toInt == 1 => direct(2).now
+                        case "b"                 => direct(3).now
                 }
             }
         }
@@ -72,16 +72,16 @@ class PatMatchTest extends AnyFreeSpec with Assertions:
             }
             "pure/impure cases" in {
                 runLiftTest(2) {
-                    defer("a").now match
-                        case "a" => defer(2).now
+                    direct("a").now match
+                        case "a" => direct(2).now
                         case "b" => 3
                 }
             }
             "impure cases" in {
                 runLiftTest(3) {
                     ("b": String) match
-                        case "a" => defer(2).now
-                        case "b" => defer(3).now
+                        case "a" => direct(2).now
+                        case "b" => direct(3).now
                 }
             }
         }
@@ -95,16 +95,16 @@ class PatMatchTest extends AnyFreeSpec with Assertions:
             }
             "pure/impure cases" in {
                 runLiftTest(2) {
-                    defer("a").now match
-                        case "a"           => defer(2).now
+                    direct("a").now match
+                        case "a"           => direct(2).now
                         case s if s == "b" => 3
                 }
             }
             "impure cases" in {
                 runLiftTest(2) {
                     "b" match
-                        case s if "1".toInt == 1 => defer(2).now
-                        case "b"                 => defer(3).now
+                        case s if "1".toInt == 1 => direct(2).now
+                        case "b"                 => direct(3).now
                 }
             }
         }

--- a/kyo-direct/shared/src/test/scala/kyo/WhileTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/WhileTest.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable.ArrayBuffer
 class WhileTest extends Test:
 
     "atomic counter" in run {
-        defer {
+        direct {
             val counter = AtomicInt.init(0).now
             while counter.get.now < 3 do
                 counter.incrementAndGet.now
@@ -32,7 +32,7 @@ class WhileTest extends Test:
             i
         end incrementB
 
-        defer {
+        direct {
             while i < 3 do
                 IO(incrementA()).now
                 IO(incrementB()).now
@@ -46,7 +46,7 @@ class WhileTest extends Test:
 
     "effectful condition" - {
         "simple condition" in run {
-            defer {
+            direct {
                 val counter = AtomicInt.init(0).now
                 while counter.get.now < 5 do
                     counter.incrementAndGet.now
@@ -56,7 +56,7 @@ class WhileTest extends Test:
         }
 
         "compound condition" in run {
-            defer {
+            direct {
                 val counter1 = AtomicInt.init(0).now
                 val counter2 = AtomicInt.init(10).now
                 while counter1.get.now < 5 && counter2.get.now > 5 do
@@ -75,7 +75,7 @@ class WhileTest extends Test:
     "nested effects" - {
         "in condition and body" in run {
             val results = ArrayBuffer[Int]()
-            defer {
+            direct {
                 val counter = AtomicInt.init(0).now
                 while counter.get.now < 3 do
                     val current = counter.incrementAndGet.now
@@ -89,10 +89,10 @@ class WhileTest extends Test:
         }
 
         "with abort effect" in run {
-            defer {
+            direct {
                 val counter = AtomicInt.init(0).now
                 val result = Abort.run {
-                    defer {
+                    direct {
                         while counter.get.now < 2 do
                             if counter.get.now >= 5 then
                                 Abort.fail("Too high").now
@@ -109,10 +109,10 @@ class WhileTest extends Test:
 
     "complex control flow" - {
         "break using abort" in run {
-            defer {
+            direct {
                 val counter = AtomicInt.init(0).now
                 val result = Abort.run {
-                    defer {
+                    direct {
                         while true do
                             val current = counter.incrementAndGet.now
                             if current >= 3 then
@@ -128,7 +128,7 @@ class WhileTest extends Test:
 
         "continue pattern" in run {
             val evens = ArrayBuffer[Int]()
-            defer {
+            direct {
                 val counter = AtomicInt.init(0).now
                 while counter.get.now < 5 do
                     val current = counter.incrementAndGet.now
@@ -148,9 +148,9 @@ class WhileTest extends Test:
 
     "error handling" in run {
         val operations = ArrayBuffer[String]()
-        defer {
+        direct {
             val result = Abort.run {
-                defer {
+                direct {
                     val counter = AtomicInt.init(0).now
                     while counter.get.now < 5 do
                         val op = s"op${counter.get.now}"

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/api/Endpoints.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/api/Endpoints.scala
@@ -11,7 +11,7 @@ import zio.json.JsonEncoder
 
 object Endpoints:
 
-    val init: Unit < (Env[Handler] & Routes) = defer {
+    val init: Unit < (Env[Handler] & Routes) = direct {
 
         val handler = Env.get[Handler].now
 

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/api/Handler.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/api/Handler.scala
@@ -20,7 +20,7 @@ end Handler
 
 object Handler:
 
-    val init: Handler < Env[DB] = defer {
+    val init: Handler < Env[DB] = direct {
         Live(Env.get[DB].now)
     }
 
@@ -29,7 +29,7 @@ object Handler:
         private val notFound            = Abort.fail[StatusCode](StatusCode.NotFound)
         private val unprocessableEntity = Abort.fail[StatusCode](StatusCode.UnprocessableEntity)
 
-        def transaction(account: Int, request: Transaction) = defer {
+        def transaction(account: Int, request: Transaction) = direct {
             import request.*
             // validations
             if account < 0 || account > 5 then notFound.now
@@ -54,7 +54,7 @@ object Handler:
             end match
         }
 
-        def statement(account: Int) = defer {
+        def statement(account: Int) = direct {
             // validations
             if account < 0 || account > 5 then notFound.now
             else ()

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/api/Server.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/api/Server.scala
@@ -13,7 +13,7 @@ object Server extends KyoApp:
 
     run {
 
-        defer {
+        direct {
             val port = System.property[Int]("PORT", 9999).now
 
             val dbConfig =

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/DB.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/DB.scala
@@ -24,7 +24,7 @@ object DB:
         flushInterval: Duration
     )
 
-    val init: DB < (Env[Config] & IO) = defer {
+    val init: DB < (Env[Config] & IO) = direct {
         val index = Index.init.now
         val log   = db.Log.init.now
         Live(index, log)

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Index.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Index.scala
@@ -28,7 +28,7 @@ end Index
 
 object Index:
 
-    val init: Index < (Env[DB.Config] & IO) = defer {
+    val init: Index < (Env[DB.Config] & IO) = direct {
         val cfg  = Env.get[DB.Config].now
         val file = open(cfg.workingDir + "/index.dat").now
         IO(Live(file)).now

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
@@ -19,7 +19,7 @@ object Log:
 
     case class Entry(balance: Int, account: Int, amount: Int, desc: String)
 
-    val init: Log < (Env[DB.Config] & IO) = defer {
+    val init: Log < (Env[DB.Config] & IO) = direct {
         val cfg = Env.get[DB.Config].now
         val q   = Queue.Unbounded.init[Entry](Access.MultiProducerSingleConsumer).now
         val log = IO(Live(cfg.workingDir + "/log.dat", q)).now
@@ -39,7 +39,7 @@ object Log:
         ): Unit < IO =
             q.add(Entry(balance, account, amount, desc))
 
-        private[Log] def flushLoop(interval: Duration): Unit < (Async & Abort[Closed]) = defer {
+        private[Log] def flushLoop(interval: Duration): Unit < (Async & Abort[Closed]) = direct {
             Async.sleep(interval).now
             val entries = q.drain.now
             append(entries).now


### PR DESCRIPTION
Following a discussion on discord: https://discord.com/channels/1087005439859904574/1245754417840394313/1376094723823108106 

Rename `defer` to `direct`:
```scala
defer:
  e.now + 1
```
```scala
direct:
  e.now + 1
```  

