### PR TITLE
Frame: prevent expansion in `src/main` for Test files

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
@@ -19,7 +19,7 @@ private[kyo] trait BaseKyoCoreTest extends BaseKyoKernelTest[Abort[Any] & Async 
         )
     end run
 
-    def untilTrue[S](f: => Boolean < S): Unit < (Async & S) =
+    def untilTrue[S](f: => Boolean < S)(using Frame): Unit < (Async & S) =
         Abort.recover(Abort.panic) {
             Retry[AssertionError](Schedule.fixed(10.millis)) {
                 f.map {

--- a/kyo-data/shared/src/main/scala/kyo/internal/FindEnclosing.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/FindEnclosing.scala
@@ -6,12 +6,14 @@ import scala.quoted.*
 
 private[kyo] object FindEnclosing:
 
-    private val allowKyoFileSuffixes = Set("Test.scala", "Spec.scala", "Bench.scala")
+    private val testFileSuffixes = Set("Test.scala", "Spec.scala")
 
     def isInternal(using Quotes): Boolean =
         val pos      = quotes.reflect.Position.ofMacroExpansion
         val fileName = pos.sourceFile.name
-        apply(sym => sym.fullName.startsWith("kyo") && !allowKyoFileSuffixes.exists(fileName.endsWith)).nonEmpty
+        val path     = pos.sourceFile.path
+        val excluded = (path.contains("src/test/") && testFileSuffixes.exists(fileName.endsWith)) || fileName.endsWith("Bench.scala")
+        apply(sym => sym.fullName.startsWith("kyo") && !excluded).nonEmpty
     end isInternal
 
     def apply(using Quotes)(predicate: quotes.reflect.Symbol => Boolean): Maybe[quotes.reflect.Symbol] =


### PR DESCRIPTION
### Problem
Frame should not be expanded in any testing framework we provide or base test traits we use internally.

### Solution
Only consider test file names if the path contains `src/test`