### PR TITLE
Stream handle method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1366,6 +1366,22 @@ val result: Chunk[String] < (Env[Config] & Async) =
     c.run
 ```
 
+To handle one or more effects used by a stream, you can pass effect transformations to the `handle` method. These will be applied to the underlying streaming effect.
+
+```scala
+import kyo.*
+
+case class Config(someConfig: String)
+
+val original: Stream[Int, Resource & Env[Config] & Abort[String] & Async] = Stream(1)
+
+val handled: Stream[Int, Async] = original.handle(
+    Resource.run(_),
+    Env.run(Config("some config"))(_),
+    Abort.run[String](_)
+)
+```
+
 The `Stream` effect is useful for processing large amounts of data in a memory-efficient manner, as it allows for lazy evaluation and only keeps a small portion of the data in memory at any given time. It's also composable, allowing you to build complex data processing pipelines by chaining stream operations.
 
 Note that a number of `Stream` methods (e.g., `map`, `filter`, `mapChunk`) are overloaded to provide different implementations for pure vs effectful transformations. This can make a big difference for performance, so take care that the functions you pass to these methods are typed to return pure values if they do not include effects. Unnecessarily lifting them to return `A < Any` will result in performance loss.

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -697,11 +697,13 @@ sealed abstract class Stream[V, -S] extends Serializable:
     )(using Frame): Stream[V1, S1] = Stream(f(emit).unit)
     end handle
 
+    /** Applies two transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, V1, S1](
         f1: A => B,
         f2: B => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f2(f1(emit)).unit)
 
+    /** Applies three transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, V1, S1](
         f1: A => B,
         f2: B => C,
@@ -709,6 +711,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
     )(using Frame): Stream[V1, S1] =
         Stream(f3(f2(f1(emit))).unit)
 
+    /** Applies four transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, V1, S1](
         f1: A => B,
         f2: B => C,
@@ -716,6 +719,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
         f4: D => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f4(f3(f2(f1(emit)))).unit)
 
+    /** Applies five transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, V1, S1](
         f1: A => B,
         f2: B => C,
@@ -724,6 +728,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
         f5: E => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f5(f4(f3(f2(f1(emit))))).unit)
 
+    /** Applies six transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, V1, S1](
         f1: A => B,
         f2: B => C,
@@ -733,6 +738,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
         f6: F => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f6(f5(f4(f3(f2(f1(emit)))))).unit)
 
+    /** Applies seven transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, V1, S1](
         f1: A => B,
         f2: B => C,
@@ -743,6 +749,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
         f7: G => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f7(f6(f5(f4(f3(f2(f1(emit))))))).unit)
 
+    /** Applies eight transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, H, V1, S1](
         f1: A => B,
         f2: B => C,
@@ -754,6 +761,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
         f8: H => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f8(f7(f6(f5(f4(f3(f2(f1(emit)))))))).unit)
 
+    /** Applies nine transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, H, I, V1, S1](
         f1: A => B,
         f2: B => C,
@@ -766,6 +774,7 @@ sealed abstract class Stream[V, -S] extends Serializable:
         f9: I => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f9(f8(f7(f6(f5(f4(f3(f2(f1(emit))))))))).unit)
 
+    /** Applies ten transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, H, I, J, V1, S1](
         f1: A => B,
         f2: B => C,

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -693,99 +693,99 @@ sealed abstract class Stream[V, -S] extends Serializable:
       *   A new stream based on the handled effect
       */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), V1, S1](
-        f: A => (Any < (Emit[Chunk[V1]] & S1))
+        f: (=> A) => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f(emit).unit)
     end handle
 
     /** Applies two transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, V1, S1](
-        f1: A => B,
-        f2: B => (Any < (Emit[Chunk[V1]] & S1))
+        f1: (=> A) => B,
+        f2: (=> B) => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f2(f1(emit)).unit)
 
     /** Applies three transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, V1, S1](
-        f1: A => B,
-        f2: B => C,
-        f3: C => (Any < (Emit[Chunk[V1]] & S1))
+        f1: (=> A) => B,
+        f2: (=> B) => C,
+        f3: (=> C) => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] =
         Stream(f3(f2(f1(emit))).unit)
 
     /** Applies four transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, V1, S1](
-        f1: A => B,
-        f2: B => C,
-        f3: C => D,
-        f4: D => (Any < (Emit[Chunk[V1]] & S1))
+        f1: (=> A) => B,
+        f2: (=> B) => C,
+        f3: (=> C) => D,
+        f4: (=> D) => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f4(f3(f2(f1(emit)))).unit)
 
     /** Applies five transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, V1, S1](
-        f1: A => B,
-        f2: B => C,
-        f3: C => D,
-        f4: D => E,
-        f5: E => (Any < (Emit[Chunk[V1]] & S1))
+        f1: (=> A) => B,
+        f2: (=> B) => C,
+        f3: (=> C) => D,
+        f4: (=> D) => E,
+        f5: (=> E) => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f5(f4(f3(f2(f1(emit))))).unit)
 
     /** Applies six transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, V1, S1](
-        f1: A => B,
-        f2: B => C,
-        f3: C => D,
-        f4: D => E,
-        f5: E => F,
-        f6: F => (Any < (Emit[Chunk[V1]] & S1))
+        f1: (=> A) => B,
+        f2: (=> B) => C,
+        f3: (=> C) => D,
+        f4: (=> D) => E,
+        f5: (=> E) => F,
+        f6: (=> F) => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f6(f5(f4(f3(f2(f1(emit)))))).unit)
 
     /** Applies seven transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, V1, S1](
-        f1: A => B,
-        f2: B => C,
-        f3: C => D,
-        f4: D => E,
-        f5: E => F,
-        f6: F => G,
-        f7: G => (Any < (Emit[Chunk[V1]] & S1))
+        f1: (=> A) => B,
+        f2: (=> B) => C,
+        f3: (=> C) => D,
+        f4: (=> D) => E,
+        f5: (=> E) => F,
+        f6: (=> F) => G,
+        f7: (=> G) => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f7(f6(f5(f4(f3(f2(f1(emit))))))).unit)
 
     /** Applies eight transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, H, V1, S1](
-        f1: A => B,
-        f2: B => C,
-        f3: C => D,
-        f4: D => E,
-        f5: E => F,
-        f6: F => G,
-        f7: G => H,
-        f8: H => (Any < (Emit[Chunk[V1]] & S1))
+        f1: (=> A) => B,
+        f2: (=> B) => C,
+        f3: (=> C) => D,
+        f4: (=> D) => E,
+        f5: (=> E) => F,
+        f6: (=> F) => G,
+        f7: (=> G) => H,
+        f8: (=> H) => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f8(f7(f6(f5(f4(f3(f2(f1(emit)))))))).unit)
 
     /** Applies nine transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, H, I, V1, S1](
-        f1: A => B,
-        f2: B => C,
-        f3: C => D,
-        f4: D => E,
-        f5: E => F,
-        f6: F => G,
-        f7: G => H,
-        f8: H => I,
-        f9: I => (Any < (Emit[Chunk[V1]] & S1))
+        f1: (=> A) => B,
+        f2: (=> B) => C,
+        f3: (=> C) => D,
+        f4: (=> D) => E,
+        f5: (=> E) => F,
+        f6: (=> F) => G,
+        f7: (=> G) => H,
+        f8: (=> H) => I,
+        f9: (=> I) => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f9(f8(f7(f6(f5(f4(f3(f2(f1(emit))))))))).unit)
 
     /** Applies ten transformations to this stream's underlying computation. */
     def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, H, I, J, V1, S1](
-        f1: A => B,
-        f2: B => C,
-        f3: C => D,
-        f4: D => E,
-        f5: E => F,
-        f6: F => G,
-        f7: G => H,
-        f8: H => I,
-        f9: I => J,
-        f10: J => (Any < (Emit[Chunk[V1]] & S1))
+        f1: (=> A) => B,
+        f2: (=> B) => C,
+        f3: (=> C) => D,
+        f4: (=> D) => E,
+        f5: (=> E) => F,
+        f6: (=> F) => G,
+        f7: (=> G) => H,
+        f8: (=> H) => I,
+        f9: (=> I) => J,
+        f10: (=> J) => (Any < (Emit[Chunk[V1]] & S1))
     )(using Frame): Stream[V1, S1] = Stream(f10(f9(f8(f7(f6(f5(f4(f3(f2(f1(emit)))))))))).unit)
 end Stream
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -663,6 +663,121 @@ sealed abstract class Stream[V, -S] extends Serializable:
       */
     def into[A, S2](sink: Sink[V, A, S2])(using Tag[Poll[Chunk[V]]], Tag[Emit[Chunk[V]]], Frame): A < (S & S2) =
         sink.drain(this)
+    end into
+
+    /** Applies a transformation to this stream's underlying computation. This provides a convenient way to handle effects included in the
+      * stream.
+      *
+      * For example, to ensure all resources close when the stream is evaluated:
+      * ```
+      * val original: Stream[Int, Resource & Async] = ???
+      * val withCleanup = original.handle(Resource.run)
+      * ```
+      *
+      * While `handle` can be used with any function that processes the underlying effect, its main purpose is to facilitate effect handling
+      * and composition of multiple handlers. The multi-parameter versions of `handle` enable chaining transformations in a readable
+      * sequential style.
+      *
+      * ```
+      * val original: Stream[Int, Resource & Abort[String] & Var[Int]] = ???
+      * val handled: Stream[Int, Any] = original.handle(
+      *   Resource.run,
+      *   Abort.run[String](_),
+      *   Var.run(20),
+      * )
+      * ```
+      *
+      * @param f
+      *   The transformation function to apply to the underlying effect
+      * @return
+      *   A new stream based on the handled effect
+      */
+    def handle[A >: (Unit < (Emit[Chunk[V]] & S)), V1, S1](
+        f: A => (Any < (Emit[Chunk[V1]] & S1))
+    )(using Frame): Stream[V1, S1] = Stream(f(emit).unit)
+    end handle
+
+    def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, V1, S1](
+        f1: A => B,
+        f2: B => (Any < (Emit[Chunk[V1]] & S1))
+    )(using Frame): Stream[V1, S1] = Stream(f2(f1(emit)).unit)
+
+    def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, V1, S1](
+        f1: A => B,
+        f2: B => C,
+        f3: C => (Any < (Emit[Chunk[V1]] & S1))
+    )(using Frame): Stream[V1, S1] =
+        Stream(f3(f2(f1(emit))).unit)
+
+    def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, V1, S1](
+        f1: A => B,
+        f2: B => C,
+        f3: C => D,
+        f4: D => (Any < (Emit[Chunk[V1]] & S1))
+    )(using Frame): Stream[V1, S1] = Stream(f4(f3(f2(f1(emit)))).unit)
+
+    def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, V1, S1](
+        f1: A => B,
+        f2: B => C,
+        f3: C => D,
+        f4: D => E,
+        f5: E => (Any < (Emit[Chunk[V1]] & S1))
+    )(using Frame): Stream[V1, S1] = Stream(f5(f4(f3(f2(f1(emit))))).unit)
+
+    def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, V1, S1](
+        f1: A => B,
+        f2: B => C,
+        f3: C => D,
+        f4: D => E,
+        f5: E => F,
+        f6: F => (Any < (Emit[Chunk[V1]] & S1))
+    )(using Frame): Stream[V1, S1] = Stream(f6(f5(f4(f3(f2(f1(emit)))))).unit)
+
+    def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, V1, S1](
+        f1: A => B,
+        f2: B => C,
+        f3: C => D,
+        f4: D => E,
+        f5: E => F,
+        f6: F => G,
+        f7: G => (Any < (Emit[Chunk[V1]] & S1))
+    )(using Frame): Stream[V1, S1] = Stream(f7(f6(f5(f4(f3(f2(f1(emit))))))).unit)
+
+    def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, H, V1, S1](
+        f1: A => B,
+        f2: B => C,
+        f3: C => D,
+        f4: D => E,
+        f5: E => F,
+        f6: F => G,
+        f7: G => H,
+        f8: H => (Any < (Emit[Chunk[V1]] & S1))
+    )(using Frame): Stream[V1, S1] = Stream(f8(f7(f6(f5(f4(f3(f2(f1(emit)))))))).unit)
+
+    def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, H, I, V1, S1](
+        f1: A => B,
+        f2: B => C,
+        f3: C => D,
+        f4: D => E,
+        f5: E => F,
+        f6: F => G,
+        f7: G => H,
+        f8: H => I,
+        f9: I => (Any < (Emit[Chunk[V1]] & S1))
+    )(using Frame): Stream[V1, S1] = Stream(f9(f8(f7(f6(f5(f4(f3(f2(f1(emit))))))))).unit)
+
+    def handle[A >: (Unit < (Emit[Chunk[V]] & S)), B, C, D, E, F, G, H, I, J, V1, S1](
+        f1: A => B,
+        f2: B => C,
+        f3: C => D,
+        f4: D => E,
+        f5: E => F,
+        f6: F => G,
+        f7: G => H,
+        f8: H => I,
+        f9: I => J,
+        f10: J => (Any < (Emit[Chunk[V1]] & S1))
+    )(using Frame): Stream[V1, S1] = Stream(f10(f9(f8(f7(f6(f5(f4(f3(f2(f1(emit)))))))))).unit)
 end Stream
 
 object Stream:


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

Addresses [discussion of resource handling on discord](https://discord.com/channels/1087005439859904574/1087005440623259681/1379902422419509338)

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

Handling stream effects is currently a little awkward. You have to apply a handler to the stream's `emit` effect and then construct a new Stream from the transformed effect. To handle resources within the scope of a stream, for instance, you would do:
```
val original: Stream[Int, Resource] = ???
val handled: Stream[Int, Any] = Stream(Resource.run(original.emit))
```

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

This PR adds a `handle` method to `Stream` similar to the `handle` method on `Pending`: it accepts one or more functions transforming the underlying emit effect, and constructs a new stream using the transformed effect. You can handle multiple effects as follows:

```
val original: Stream[Int, Resource & Var[Int] & Abort[String] = ???
val handled: Stream[Int, Any] = original.handle(
  Resource.run(_),
  Var.run(23)(_),
  Abort.run[String](_),
)
```

The functions are expected to evaluate to a `Emit[Chunked[V1]]` effect where `V1` need not be the same as the original `V` type. It does not have to evaluate to `Unit < ...`, as the implementation calls `.unit` to ensure it will be a valid streaming effect. This means you can pass `Abort.run[String](_)` without having to worry about the fact that the transformed effect will evaluate to `Result[Unit, String]`.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
