### PR TITLE
Stream broadcast

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -1,6 +1,7 @@
 package kyo
 
 import kyo.Async.defaultConcurrency
+import kyo.Result.Success
 import kyo.kernel.ArrowEffect
 
 object StreamCoreExtensions:
@@ -28,6 +29,41 @@ object StreamCoreExtensions:
                         else Loop.done
         Abort.run(emit).unit
     end emitMaybeElementsFromChannel
+
+    sealed trait StreamHub[A, E]:
+        def subscribe(using Frame): Stream[A, Abort[E] & Async] < (Resource & Async)
+
+    private case class StreamHubImpl[A, E](hub: Hub[Result.Partial[E, Chunk[A]]])(
+        using
+        Tag[Emit[Chunk[A]]],
+        Tag[Emit[Chunk[Chunk[A]]]]
+    ) extends StreamHub[A, E]:
+        def subscribe(using Frame): Stream[A, Abort[E] & Async] < (Resource & Async) =
+            Abort.runPartial[Closed](hub.listen).map:
+                case Result.Success(listener) =>
+                    Stream(listener.stream(1).map(Abort.get(_)).mapChunk(v => v.flattenChunk).emit)
+                case Result.Failure(e) => Abort.panic(e)
+
+        def consume[S](stream: Stream[A, Abort[E] & S & Async])(
+            using
+            Isolate.Contextual[S, IO],
+            Isolate.Stateful[S, Abort[E] & Async],
+            SafeClassTag[E],
+            Tag[Emit[Chunk[A]]],
+            Frame
+        ): Unit < (Async & S & Resource) =
+            Resource.acquireRelease(Async.run {
+                Abort.run[E](
+                    Abort.run[Closed](
+                        stream.foreachChunk(chunk => hub.put(Result.Success(chunk)))
+                    )
+                ).map:
+                    case Result.Success(_)       => ()
+                    case Result.Failure(e)       => hub.put(Result.Failure(e))
+                    case panic @ Result.Panic(e) => Abort.get(panic)
+            })(_.interrupt).unit
+
+    end StreamHubImpl
 
     extension (streamObj: Stream.type)
         /** Merges multiple streams asynchronously. Stream stops when all sources streams have completed.
@@ -532,6 +568,216 @@ object StreamCoreExtensions:
             frame: Frame
         ): Stream[V2, Abort[E] & Async & S & S2] =
             mapChunkParUnordered(Async.defaultConcurrency, defaultAsyncStreamBufferSize)(f)(using t1, t2, t3, i1, i2, ev, frame)
+
+        /** Broadcast streaming elements to two streams that can be evaluated in parallel.
+          *
+          * @param bufferSize
+          *   Size of underlying channel communicating streamed elements to broadcasted streams
+          * @return
+          *   2-tuple of broadcasted streams
+          */
+        def broadcast2(bufferSize: Int = defaultAsyncStreamBufferSize)(
+            using
+            i1: Isolate.Contextual[S, IO],
+            i2: Isolate.Stateful[S, Async],
+            t1: Tag[V],
+            t2: Tag[Emit[Chunk[V]]],
+            t3: Tag[Emit[Chunk[Chunk[V]]]],
+            t4: SafeClassTag[E],
+            fr: Frame
+        ): (Stream[V, Abort[E] & Async], Stream[V, Abort[E] & Resource & Async]) < (Resource & Async & S) =
+            broadcastDynamicWith(bufferSize) { streamHub =>
+                for
+                    s1 <- streamHub.subscribe
+                    s2 <- streamHub.subscribe
+                yield (s1, s2)
+            }(using i1, i2, t1, t2, t3, t4, fr)
+
+        /** Broadcast streaming elements to three streams that can be evaluated in parallel.
+          */
+        def broadcast3(bufferSize: Int = defaultAsyncStreamBufferSize)(
+            using
+            i1: Isolate.Contextual[S, IO],
+            i2: Isolate.Stateful[S, Async],
+            t1: Tag[V],
+            t2: Tag[Emit[Chunk[V]]],
+            t3: Tag[Emit[Chunk[Chunk[V]]]],
+            t4: SafeClassTag[E],
+            fr: Frame
+        ): (
+            Stream[V, Abort[E] & Async],
+            Stream[V, Abort[E] & Async],
+            Stream[V, Abort[E] & Async]
+        ) < (Resource & Async & S) =
+            broadcastDynamicWith(bufferSize) { streamHub =>
+                for
+                    s1 <- streamHub.subscribe
+                    s2 <- streamHub.subscribe
+                    s3 <- streamHub.subscribe
+                yield (s1, s2, s3)
+            }(using i1, i2, t1, t2, t3, t4, fr)
+
+        /** Broadcast streaming elements to four streams that can be evaluated in parallel.
+          */
+        def broadcast4(bufferSize: Int = defaultAsyncStreamBufferSize)(
+            using
+            i1: Isolate.Contextual[S, IO],
+            i2: Isolate.Stateful[S, Async],
+            t1: Tag[V],
+            t2: Tag[Emit[Chunk[V]]],
+            t3: Tag[Emit[Chunk[Chunk[V]]]],
+            t4: SafeClassTag[E],
+            fr: Frame
+        ): (
+            Stream[V, Abort[E] & Async],
+            Stream[V, Abort[E] & Async],
+            Stream[V, Abort[E] & Async],
+            Stream[V, Abort[E] & Async]
+        ) < (Resource & Async & S) =
+            broadcastDynamicWith(bufferSize) { streamHub =>
+                for
+                    s1 <- streamHub.subscribe
+                    s2 <- streamHub.subscribe
+                    s3 <- streamHub.subscribe
+                    s4 <- streamHub.subscribe
+                yield (s1, s2, s3, s4)
+            }(using i1, i2, t1, t2, t3, t4, fr)
+
+        /** Broadcast streaming elements to five streams that can be evaluated in parallel.
+          */
+        def broadcast5(bufferSize: Int = defaultAsyncStreamBufferSize)(
+            using
+            i1: Isolate.Contextual[S, IO],
+            i2: Isolate.Stateful[S, Async],
+            t1: Tag[V],
+            t2: Tag[Emit[Chunk[V]]],
+            t3: Tag[Emit[Chunk[Chunk[V]]]],
+            t4: SafeClassTag[E],
+            fr: Frame
+        ): (
+            Stream[V, Abort[E] & Async],
+            Stream[V, Abort[E] & Async],
+            Stream[V, Abort[E] & Async],
+            Stream[V, Abort[E] & Async],
+            Stream[V, Abort[E] & Async]
+        ) < (Resource & Async & S) =
+            broadcastDynamicWith(bufferSize) { streamHub =>
+                for
+                    s1 <- streamHub.subscribe
+                    s2 <- streamHub.subscribe
+                    s3 <- streamHub.subscribe
+                    s4 <- streamHub.subscribe
+                    s5 <- streamHub.subscribe
+                yield (s1, s2, s3, s4, s5)
+            }(using i1, i2, t1, t2, t3, t4, fr)
+
+        /** Broadcast streaming elements to a specified number of streams that can be evaluated in parallel.
+          *
+          * @param numStreams
+          *   Number of streams to broadcast the original stream to
+          * @param bufferSize
+          *   Size of underlying channel communicating streamed elements to broadcasted streams
+          * @return
+          *   Chunk of streams of length [[numStreams]] containing the broadcasted streams
+          */
+        def broadcastN(numStreams: Int, bufferSize: Int = defaultAsyncStreamBufferSize)(
+            using
+            i1: Isolate.Contextual[S, IO],
+            i2: Isolate.Stateful[S, Async],
+            t1: Tag[V],
+            t2: Tag[Emit[Chunk[V]]],
+            t3: Tag[Emit[Chunk[Chunk[V]]]],
+            t4: SafeClassTag[E],
+            fr: Frame
+        ): Chunk[Stream[V, Abort[E] & Resource & Async]] < (Resource & Async & S) =
+            broadcastDynamicWith(bufferSize) { streamHub =>
+                val builder = Chunk.newBuilder[Stream[V, Abort[E] & Resource & Async]]
+                Loop(numStreams): remaining =>
+                    if remaining <= 0 then
+                        IO(builder.result()).map(chunk => Loop.done(chunk))
+                    else
+                        streamHub.subscribe.map: stream =>
+                            IO(builder.addOne(stream)).andThen(Loop.continue(remaining - 1))
+            }(using i1, i2, t1, t2, t3, t4, fr)
+
+        /** Convert to a reusable stream that can be run multiple times in parallel to consume the same elements.
+          *
+          * @note
+          *   This method should only be used when it is not necessary for each evaluation of the stream to consume all the elements of the
+          *   original stream. Elements handled by all currently running instances of the stream prior to a subsequent runs will be lost. As
+          *   soon a single run commences, elements will start being pulled from the original stream and may be lost prior to subsequent
+          *   runs. To guarantee all runs handle the same elements, use [[broadcastDynamicWith]] or [[broadcastN]].
+          * @param bufferSize
+          *   Size of underlying channel communicating streamed elements to broadcasted stream
+          * @return
+          *   A resourceful, asynchronous effect producing a stream that can be run multiple times in parallel
+          */
+        def broadcasted(bufferSize: Int = defaultAsyncStreamBufferSize)(
+            using
+            i1: Isolate.Contextual[S, IO],
+            i2: Isolate.Stateful[S, Async],
+            t1: Tag[V],
+            t2: Tag[Emit[Chunk[V]]],
+            t3: Tag[Emit[Chunk[Chunk[V]]]],
+            t4: SafeClassTag[E],
+            fr: Frame
+        ): Stream[V, Abort[E] & Async & Resource] < (Resource & Async & S) =
+            broadcastDynamic(bufferSize).map: streamHub =>
+                Stream:
+                    streamHub.subscribe.map(_.emit)
+
+        /** Construct a [[StreamHub]] to broadcast copies of the original streams that may be handled in parallel.
+          *
+          * @note
+          *   This method should only be used when it is not necessary for each subscription to consume all the elements of the original
+          *   stream. Elements handled by all subscriptions prior to a subsequent subscription [[StreamHub]] will be lost. As soon a single
+          *   subscription is constructed and evaluated, elements will be pulled from the original stream, meaning that elements may be lost
+          *   between subscriptions. To guarantee all streams include the same elements, use [[broadcastDynamicWith]] or [[broadcastN]].
+          * @param bufferSize
+          *   Size of underlying channel communicating streamed elements to broadcasted stream
+          * @return
+          *   A resourceful, asynchronous effect producing a stream that can be run multiple times in parallel
+          */
+        def broadcastDynamic(bufferSize: Int = defaultAsyncStreamBufferSize)(
+            using
+            i1: Isolate.Contextual[S, IO],
+            i2: Isolate.Stateful[S, Async],
+            t1: Tag[V],
+            t2: Tag[Emit[Chunk[V]]],
+            t3: Tag[Emit[Chunk[Chunk[V]]]],
+            t4: SafeClassTag[E],
+            fr: Frame
+        ): StreamHub[V, E] < (Resource & Async & S) =
+            Hub.initWith[Result.Partial[E, Chunk[V]]](bufferSize): hub =>
+                val streamHub = StreamHubImpl(hub)
+                streamHub.consume(stream).andThen:
+                    streamHub
+        end broadcastDynamic
+
+        /** Use a [[StreamHub]] to broadcast copies of the original streams that may be handled in parallel. The original stream will not
+          * begin broadcasting to any subscribed streams prior to the completion of the effect produced by parameter [[fn]].
+          *
+          * @note
+          *   Do not await evaluation of subscribed streams within [[fn]].
+          * @param bufferSize
+          *   Size of underlying channel communicating streamed elements to broadcasted stream
+          * @return
+          *   A resourceful, asynchronous effect producing a stream that can be run multiple times in parallel
+          */
+        def broadcastDynamicWith[A, S1](bufferSize: Int)(fn: StreamHub[V, E] => A < S1)(
+            using
+            i1: Isolate.Contextual[S, IO],
+            i2: Isolate.Stateful[S, Async],
+            t1: Tag[V],
+            t2: Tag[Emit[Chunk[V]]],
+            t3: Tag[Emit[Chunk[Chunk[V]]]],
+            t4: SafeClassTag[E],
+            fr: Frame
+        ): A < (Resource & Async & S & S1) =
+            Hub.initWith[Result.Partial[E, Chunk[V]]](bufferSize): hub =>
+                val streamHub = StreamHubImpl(hub)
+                fn(streamHub).map: a =>
+                    streamHub.consume(stream).andThen(a)
 
     end extension
 end StreamCoreExtensions

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -569,7 +569,7 @@ object StreamCoreExtensions:
         ): Stream[V2, Abort[E] & Async & S & S2] =
             mapChunkParUnordered(Async.defaultConcurrency, defaultAsyncStreamBufferSize)(f)(using t1, t2, t3, i1, i2, ev, frame)
 
-        /** Broadcast streaming elements to two streams that can be evaluated in parallel.
+        /** Broadcast to two streams that can be evaluated in parallel.
           *
           * @param bufferSize
           *   Size of underlying channel communicating streamed elements to broadcasted streams
@@ -593,7 +593,7 @@ object StreamCoreExtensions:
                 yield (s1, s2)
             }(using i1, i2, t1, t2, t3, t4, fr)
 
-        /** Broadcast streaming elements to three streams that can be evaluated in parallel.
+        /** Broadcast to three streams that can be evaluated in parallel.
           */
         def broadcast3(bufferSize: Int = defaultAsyncStreamBufferSize)(
             using
@@ -617,7 +617,7 @@ object StreamCoreExtensions:
                 yield (s1, s2, s3)
             }(using i1, i2, t1, t2, t3, t4, fr)
 
-        /** Broadcast streaming elements to four streams that can be evaluated in parallel.
+        /** Broadcast to four streams that can be evaluated in parallel.
           */
         def broadcast4(bufferSize: Int = defaultAsyncStreamBufferSize)(
             using
@@ -643,7 +643,7 @@ object StreamCoreExtensions:
                 yield (s1, s2, s3, s4)
             }(using i1, i2, t1, t2, t3, t4, fr)
 
-        /** Broadcast streaming elements to five streams that can be evaluated in parallel.
+        /** Broadcast to five streams that can be evaluated in parallel.
           */
         def broadcast5(bufferSize: Int = defaultAsyncStreamBufferSize)(
             using
@@ -671,7 +671,7 @@ object StreamCoreExtensions:
                 yield (s1, s2, s3, s4, s5)
             }(using i1, i2, t1, t2, t3, t4, fr)
 
-        /** Broadcast streaming elements to a specified number of streams that can be evaluated in parallel.
+        /** Broadcast to a specified number of streams that can be evaluated in parallel.
           *
           * @param numStreams
           *   Number of streams to broadcast the original stream to

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -700,13 +700,13 @@ object StreamCoreExtensions:
                             IO(builder.addOne(stream)).andThen(Loop.continue(remaining - 1))
             }(using i1, i2, t1, t2, t3, t4, fr)
 
-        /** Convert to a reusable stream that can be run multiple times in parallel to consume the same elements.
+        /** Convert to a reusable stream that can be run multiple times in parallel to consume the same original elements.
           *
           * @note
-          *   This method should only be used when it is not necessary for each evaluation of the stream to consume all the elements of the
-          *   original stream. Elements handled by all currently running instances of the stream prior to a subsequent runs will be lost. As
-          *   soon a single run commences, elements will start being pulled from the original stream and may be lost prior to subsequent
-          *   runs. To guarantee all runs handle the same elements, use [[broadcastDynamicWith]] or [[broadcastN]].
+          *   This method should only be used when it is not necessary for each evaluation of the resulting stream to consume all the
+          *   elements of the original stream. Elements handled by all currently running instances of the stream prior to a subsequent runs
+          *   will be lost. As soon a single run commences, elements will start being pulled from the original stream and may be lost prior
+          *   to subsequent runs. To guarantee all runs handle the same elements, use [[broadcastDynamicWith]] or [[broadcast[N]]].
           * @param bufferSize
           *   Size of underlying channel communicating streamed elements to broadcasted stream
           * @return

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -601,7 +601,7 @@ object StreamCoreExtensions:
         ): Stream[V2, Abort[E] & Async & S & S2] =
             mapChunkParUnordered(Async.defaultConcurrency, defaultAsyncStreamBufferSize)(f)(using t1, t2, t3, i1, i2, ev, frame)
 
-        /** Broadcast to two streams that can be evaluated in parallel.
+        /** Broadcast to two streams that can be evaluated in parallel. Original stream begins to run as soon as either of the original streams does.
           *
           * @param bufferSize
           *   Size of underlying channel communicating streamed elements to broadcasted streams
@@ -732,7 +732,7 @@ object StreamCoreExtensions:
                             IO(builder.addOne(stream)).andThen(Loop.continue(remaining - 1))
             }(using i1, i2, t1, t2, t3, t4, fr)
 
-        /** Convert to a reusable stream that can be run multiple times in parallel to consume the same original elements.
+        /** Convert to a reusable stream that can be run multiple times in parallel to consume the same original elements. Original stream begins to run as soon as the broadcasted stream is run for the first time.
           *
           * @note
           *   This method should only be used when it is not necessary for each evaluation of the resulting stream to consume all the
@@ -758,7 +758,7 @@ object StreamCoreExtensions:
                 Stream:
                     streamHub.subscribe.map(_.emit)
 
-        /** Construct a [[StreamHub]] to broadcast copies of the original streams that may be handled in parallel.
+        /** Construct a [[StreamHub]] to broadcast copies of the original streams that may be handled in parallel. Original stream begins to run the first time any subscribed stream is run.
           *
           * @note
           *   This method should only be used when it is not necessary for each subscription to consume all the elements of the original
@@ -787,7 +787,7 @@ object StreamCoreExtensions:
         end broadcastDynamic
 
         /** Use a [[StreamHub]] to broadcast copies of the original streams that may be handled in parallel. The original stream will not
-          * begin broadcasting to any subscribed streams prior to the completion of the effect produced by parameter [[fn]].
+          * begin broadcasting to any subscribed streams prior to the completion of the effect produced by parameter [[fn]]. Original stream begins to run the first time any subscribed stream is run.
           *
           * @note
           *   Do not await evaluation of subscribed streams within [[fn]].
@@ -811,7 +811,7 @@ object StreamCoreExtensions:
                     streamHub.consume(stream).andThen(a)
 
         /** Use a [[StreamHub]] to broadcast copies of the original streams that may be handled in parallel. The original stream will not
-          * begin broadcasting to any subscribed streams prior to the completion of the effect produced by parameter [[fn]].
+          * begin broadcasting to any subscribed streams prior to the completion of the effect produced by parameter [[fn]]. Original stream begins to run the first time any subscribed stream is run.
           *
           * Uses a default buffer size.
           *

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -91,7 +91,7 @@ object StreamCoreExtensions:
             Resource.acquireRelease(Async.run {
                 Abort.run[E](
                     Abort.run[Closed](
-                        stream.foreachChunk(chunk => hub.put(Result.Success(Present(chunk))))
+                        latch.await.andThen(stream.foreachChunk(chunk => hub.put(Result.Success(Present(chunk)))))
                     )
                 ).map:
                     case Result.Success(_) =>

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -601,7 +601,8 @@ object StreamCoreExtensions:
         ): Stream[V2, Abort[E] & Async & S & S2] =
             mapChunkParUnordered(Async.defaultConcurrency, defaultAsyncStreamBufferSize)(f)(using t1, t2, t3, i1, i2, ev, frame)
 
-        /** Broadcast to two streams that can be evaluated in parallel. Original stream begins to run as soon as either of the original streams does.
+        /** Broadcast to two streams that can be evaluated in parallel. Original stream begins to run as soon as either of the original
+          * streams does.
           *
           * @param bufferSize
           *   Size of underlying channel communicating streamed elements to broadcasted streams
@@ -732,7 +733,8 @@ object StreamCoreExtensions:
                             IO(builder.addOne(stream)).andThen(Loop.continue(remaining - 1))
             }(using i1, i2, t1, t2, t3, t4, fr)
 
-        /** Convert to a reusable stream that can be run multiple times in parallel to consume the same original elements. Original stream begins to run as soon as the broadcasted stream is run for the first time.
+        /** Convert to a reusable stream that can be run multiple times in parallel to consume the same original elements. Original stream
+          * begins to run as soon as the broadcasted stream is run for the first time.
           *
           * @note
           *   This method should only be used when it is not necessary for each evaluation of the resulting stream to consume all the
@@ -758,7 +760,8 @@ object StreamCoreExtensions:
                 Stream:
                     streamHub.subscribe.map(_.emit)
 
-        /** Construct a [[StreamHub]] to broadcast copies of the original streams that may be handled in parallel. Original stream begins to run the first time any subscribed stream is run.
+        /** Construct a [[StreamHub]] to broadcast copies of the original streams that may be handled in parallel. Original stream begins to
+          * run the first time any subscribed stream is run.
           *
           * @note
           *   This method should only be used when it is not necessary for each subscription to consume all the elements of the original
@@ -787,7 +790,8 @@ object StreamCoreExtensions:
         end broadcastDynamic
 
         /** Use a [[StreamHub]] to broadcast copies of the original streams that may be handled in parallel. The original stream will not
-          * begin broadcasting to any subscribed streams prior to the completion of the effect produced by parameter [[fn]]. Original stream begins to run the first time any subscribed stream is run.
+          * begin broadcasting to any subscribed streams prior to the completion of the effect produced by parameter [[fn]]. Original stream
+          * begins to run the first time any subscribed stream is run.
           *
           * @note
           *   Do not await evaluation of subscribed streams within [[fn]].
@@ -811,7 +815,8 @@ object StreamCoreExtensions:
                     streamHub.consume(stream).andThen(a)
 
         /** Use a [[StreamHub]] to broadcast copies of the original streams that may be handled in parallel. The original stream will not
-          * begin broadcasting to any subscribed streams prior to the completion of the effect produced by parameter [[fn]]. Original stream begins to run the first time any subscribed stream is run.
+          * begin broadcasting to any subscribed streams prior to the completion of the effect produced by parameter [[fn]]. Original stream
+          * begins to run the first time any subscribed stream is run.
           *
           * Uses a default buffer size.
           *

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -302,7 +302,7 @@ class StreamCoreExtensionsTest extends Test:
             }
 
             "dynamic" - {
-                "broadcasted in unison" in run {
+                "broadcasted in unison" in runNotJS {
                     Channel.initWith[Maybe[Int]](1024): channel =>
                         val lazyStream = channel.streamUntilClosed(256).collectWhile(v => v)
                         lazyStream.broadcasted().map: reusableStream =>
@@ -331,7 +331,7 @@ class StreamCoreExtensionsTest extends Test:
                                 assert(res1 == Result.Failure("message") && res2 == Result.Failure("message"))
                 }
 
-                "broadcastDynamic in unison" in run {
+                "broadcastDynamic in unison" in runNotJS {
                     Channel.initWith[Maybe[Int]](1024): channel =>
                         val lazyStream = channel.streamUntilClosed(256).collectWhile(v => v)
                         lazyStream.broadcastDynamic().map: streamHub =>

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -263,8 +263,10 @@ class StreamCoreExtensionsTest extends Test:
                     Kyo.zip(streamHub.subscribe, streamHub.subscribe)
                 }.map:
                     case (s1, s2) =>
-                        Kyo.zip(s1.run, s2.run).map:
-                            case (c1, c2) => assert(c1 == c2 && c1 == (0 to 10))
+                        // Ensure boundary works
+                        Async.sleep(30.millis).andThen:
+                            Kyo.zip(s1.run, s2.run).map:
+                                case (c1, c2) => assert(c1 == c2 && c1 == (0 to 10))
             }
 
             "broadcast2" in run {

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -254,6 +254,67 @@ class StreamCoreExtensionsTest extends Test:
                 Choice.run(test).andThen(succeed)
             }
         }
+
+        "broadcast" - {
+            val stream = Stream.init(0 to 10)
+
+            "broadcastDynamicWith" in run {
+                stream.broadcastDynamicWith { streamHub =>
+                    Kyo.zip(streamHub.subscribe, streamHub.subscribe)
+                }.map:
+                    case (s1, s2) =>
+                        Kyo.zip(s1.run, s2.run).map:
+                            case (c1, c2) => assert(c1 == c2 && c1 == (0 to 10))
+            }
+
+            "broadcast2" in run {
+                stream.broadcast2().map:
+                    case (s1, s2) =>
+                        Kyo.zip(s1.run, s2.run).map:
+                            case (c1, c2) => assert(Set(c1, c2).size == 1 && c1 == (0 to 10))
+            }
+
+            "broadcast3" in run {
+                stream.broadcast3().map:
+                    case (s1, s2, s3) =>
+                        Kyo.zip(s1.run, s2.run, s3.run).map:
+                            case (c1, c2, c3) => assert(Set(c1, c2, c3).size == 1 && c1 == (0 to 10))
+            }
+
+            "broadcast4" in run {
+                stream.broadcast4().map:
+                    case (s1, s2, s3, s4) =>
+                        Kyo.zip(s1.run, s2.run, s3.run, s4.run).map:
+                            case (c1, c2, c3, c4) => assert(Set(c1, c2, c3, c4).size == 1 && c1 == (0 to 10))
+            }
+
+            "broadcast5" in run {
+                stream.broadcast5().map:
+                    case (s1, s2, s3, s4, s5) =>
+                        Kyo.zip(s1.run, s2.run, s3.run, s4.run, s5.run).map:
+                            case (c1, c2, c3, c4, c5) => assert(Set(c1, c2, c3, c4, c5).size == 1 && c1 == (0 to 10))
+            }
+
+            "broadcastN" in run {
+                stream.broadcastN(50).map: streamChunk =>
+                    Kyo.foreach(streamChunk)(_.run).map: resultChunks =>
+                        assert(resultChunks.size == 50 && resultChunks.toSet.size == 1 && resultChunks.headMaybe.contains(0 to 10))
+            }
+
+            "broadcasted" in run {
+                Channel.initWith[Maybe[Int]](1024): channel =>
+                    val lazyStream = channel.streamUntilClosed(256).collectWhile(v => v)
+                    lazyStream.broadcasted().map: reusableStream =>
+                        Latch.initWith(10): latch =>
+                            Async.run(Async.foreach(1 to 10)(_ => latch.release.andThen(reusableStream.run))).map: runFiber =>
+                                latch.await.andThen:
+                                    Async.run(Kyo.foreach(0 to 10)(i => channel.put(Present(i))).andThen(channel.put(Absent))).andThen:
+                                        runFiber.get.map: resultChunks =>
+                                            assert(
+                                                resultChunks.size == 10 && resultChunks.toSet.size == 1 && resultChunks.head == (0 to 10)
+                                            )
+            }
+        }
     }
 
 end StreamCoreExtensionsTest


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

Addresses #679 

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

There should be an easy way to broadcast streams.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Implemented a variety of `broadcast...` methods. The underlying approach was to make a `StreamHub`, simple wrapper of a `Hub` that communicates elements, failures, and end-of-stream to listeners. `StreamHub` is exposed in the `broadcastDynamic` and `broadcastDynamicWith` methods. Other broadcast methods use it under the hood.

`broadcast2` through `broadcast5` construct tuples of broadcasted streams from the original stream. These guarantee that all streams will consume all elements of the original.

`broadcastN` allows you to specify a number of streams and will construct a chunk of that size (this is based on ZIO's approach)

`broadcasted` generates a stream that subscribes to the hub each time its run so can be reused in parallel. Does not guarantee all elements will be streamed for each run.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
