### PR TITLE
Reimplement parallel map functions without state

### DIFF
--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -112,7 +112,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, Int.MaxValue)
+                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12, par, Int.MaxValue)
                         s2 = stream.mapPar(par, buf)(i => IO(i + 1))
                         res <- s2.run
@@ -129,7 +129,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4)
                 val test =
                     for
-                        par <- Choice.eval(2, 4, Async.defaultConcurrency)
+                        par <- Choice.eval(2, 4, Async.defaultConcurrency, 1024)
                         s2 = stream.mapPar(par)(i => if i == 1 then Async.sleep(10.millis).andThen(i + 1) else i + 1)
                         res <- s2.run
                     yield assert(
@@ -147,7 +147,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency)
+                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
                         s2 = stream.mapParUnordered(par, buf)(i => IO(i + 1))
                         res <- s2.run
@@ -164,7 +164,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4)
                 val test =
                     for
-                        par <- Choice.eval(2, 4, Async.defaultConcurrency)
+                        par <- Choice.eval(2, 4, Async.defaultConcurrency, 1024)
                         s2 = stream.mapParUnordered(par)(i => if i == 1 then Async.sleep(10.millis).andThen(i + 1) else i + 1)
                         res <- s2.run
                     yield assert(
@@ -184,7 +184,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency)
+                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
                         s2 = stream.mapChunkPar(par, buf)(c => IO(c.map(_ + 1)))
                         res <- s2.run
@@ -202,7 +202,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8))
                 val test =
                     for
-                        par <- Choice.eval(2, 4, Async.defaultConcurrency)
+                        par <- Choice.eval(2, 4, Async.defaultConcurrency, 1024)
                         s2 =
                             stream.mapChunkPar(par)(c => if c.head == 1 then Async.sleep(10.millis).andThen(c.map(_ + 1)) else c.map(_ + 1))
                         res <- s2.run
@@ -221,7 +221,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
-                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency)
+                        par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
                         s2 = stream.mapChunkParUnordered(par, buf)(c => IO(c.map(_ + 1)))
                         res <- s2.run
@@ -238,7 +238,7 @@ class StreamCoreExtensionsTest extends Test:
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8))
                 val test =
                     for
-                        par <- Choice.eval(2, 4, Async.defaultConcurrency)
+                        par <- Choice.eval(2, 4, Async.defaultConcurrency, 1024)
                         s2 =
                             stream.mapChunkParUnordered(par)(c =>
                                 if c.head == 1 then Async.sleep(10.millis).andThen(c.map(_ + 1)) else c.map(_ + 1)

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -180,7 +180,7 @@ class StreamCoreExtensionsTest extends Test:
 
         "mapChunkPar" - {
             "should map all chunks preserving order" in run {
-                pending
+                // pending
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8)).concat(Stream.init(9 to 12))
                 val test =
                     for
@@ -198,7 +198,7 @@ class StreamCoreExtensionsTest extends Test:
             }
 
             "should preserve order when first transformation is delayed" in run {
-                pending
+                // pending
                 val stream = Stream.init(1 to 4).concat(Stream.init(5 to 8))
                 val test =
                     for


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

Fixes #1192 

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

`mapChunkPar` tests were flaky due to the use of `SignalRef`

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Use a channel of size `parallel` instead to limit concurrency.

Also reimplemented `mapPar`, `mapParUnordered`, and `mapChunkParUnordered` similarly without state (they were using `AtomicRef`). I think they are a bit easier to understand this way, and are more consistent with each other now.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
