### PR TITLE
[core] use call-by-name on IO.ensure

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/IO.scala
+++ b/kyo-core/shared/src/main/scala/kyo/IO.scala
@@ -58,7 +58,7 @@ object IO:
       * @tparam A
       *   The result type of the main computation.
       */
-    inline def ensure[A, S](inline f: => Any < IO)(v: A < S)(using inline frame: Frame): A < (IO & S) =
+    inline def ensure[A, S](inline f: => Any < IO)(v: => A < S)(using inline frame: Frame): A < (IO & S) =
         ensure(_ => f)(v)
 
     /** Ensures that a finalizer is run after the computation, regardless of success or failure.
@@ -80,7 +80,7 @@ object IO:
       * @return
       *   The result of the computation, with the finalizer guaranteed to run.
       */
-    inline def ensure[A, S](inline f: Maybe[Error[Any]] => Any < IO)(v: A < S)(using inline frame: Frame): A < (IO & S) =
+    inline def ensure[A, S](inline f: Maybe[Error[Any]] => Any < IO)(v: => A < S)(using inline frame: Frame): A < (IO & S) =
         Unsafe(Safepoint.ensure(ex => IO.Unsafe.evalOrThrow(f(ex)))(v))
 
     /** Retrieves a local value and applies a function that can perform side effects.

--- a/kyo-core/shared/src/test/scala/kyo/IOTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/IOTest.scala
@@ -129,6 +129,17 @@ class IOTest extends Test:
                 assert(called)
             }
         }
+        "call-by-name" in run {
+            var count       = 0
+            var countEnsure = 0
+
+            val io: Unit < IO =
+                IO.ensure({ countEnsure = countEnsure + 1 })({ count = count + 1 })
+
+            io.andThen(io).map: _ =>
+                assert(count == 2)
+                assert(countEnsure == 2)
+        }
     }
 
     "evalOrThrow" - {


### PR DESCRIPTION
Fix `IO.ensure(end)(body)` to use a call-by-name on `body`.

Fix #1228