### PR TITLE
[build] split JVM/JS/Native CI steps to separate Jobs

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,6 +12,12 @@ jobs:
   build:
     runs-on: build
     timeout-minutes: 30
+    strategy:
+      matrix:
+        target:
+          - { name: "JVM", command: "sbt '+kyoJVM/testQuick'" }
+          - { name: "JS", command: "sbt '+kyoJS/testQuick'" }
+          - { name: "Native", command: "sbt '+kyoNative/Test/compile'" }
     env:
       JAVA_OPTS: -Xms15G -Xmx15G -Xss10M -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS:  -Xms15G -Xmx15G -Xss10M -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
@@ -27,11 +33,5 @@ jobs:
       with:
         java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz
 
-    - name: Build JVM
-      run: sbt '+kyoJVM/testQuick'
-
-    - name: Build JS
-      run: sbt '+kyoJS/testQuick'
-
-    - name: Build Native
-      run: sbt '+kyoNative/Test/compile' # testQuick
+    - name: Build ${{ matrix.target.name }}
+      run: ${{ matrix.target.command }}


### PR DESCRIPTION
### Problem
The CI can take upwards of 30 minutes sequentially, which is annoying for trying to quickly iterate or solve an issue in non-JVM platform.

### Solution
Run the CI tasks in separate jobs so they run in parallel.
