### PR TITLE
Stream variance

### DIFF
--- a/kyo-aeron/jvm/src/test/scala/kyo/TopicTest.scala
+++ b/kyo-aeron/jvm/src/test/scala/kyo/TopicTest.scala
@@ -128,7 +128,7 @@ class TopicTest extends Test:
                             slowFiber <-
                                 Async.run(started.release.andThen(
                                     Topic.stream[Message](uri)
-                                        .map(r => Async.delay(1.millis)(r))
+                                        .mapKyo(r => Async.delay(1.millis)(r))
                                         .take(messages.size)
                                         .run
                                 ))
@@ -259,7 +259,7 @@ class TopicTest extends Test:
                         failingFiber <- Async.run(
                             started.release.andThen(
                                 Topic.stream[Message](uri)
-                                    .map(_ => Abort.fail("Planned failure"): Message < Abort[String])
+                                    .mapKyo(_ => Abort.fail("Planned failure"): Message < Abort[String])
                                     .take(messageCount)
                                     .run
                             )

--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamBench.scala
@@ -18,7 +18,7 @@ class StreamBench extends ArenaBench.SyncAndFork(25000000):
     def kyoBench() =
         import kyo.*
         Stream.init(seq)
-            .filter(_ % 2 == 0)
+            .filter[Int](_ % 2 == 0)
             .map(_ + 1)
             .fold(0)(_ + _)
     end kyoBench

--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
@@ -16,8 +16,8 @@ class StreamIOBench extends ArenaBench.SyncAndFork(25000000):
     def kyoBench() =
         import kyo.*
         Stream.init(seq)
-            .filter[Int, IO](v => IO(v % 2 == 0))
-            .map(v => IO(v + 1))
+            .filterKyo(v => IO(v % 2 == 0))
+            .mapKyo(v => IO(v + 1))
             .fold(0)(_ + _)
     end kyoBench
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
@@ -16,7 +16,7 @@ class StreamIOBench extends ArenaBench.SyncAndFork(25000000):
     def kyoBench() =
         import kyo.*
         Stream.init(seq)
-            .filter(v => IO(v % 2 == 0))
+            .filter[Int, IO](v => IO(v % 2 == 0))
             .map(v => IO(v + 1))
             .fold(0)(_ + _)
     end kyoBench

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -780,7 +780,7 @@ class ChannelTest extends Test:
             for
                 c <- Channel.init[Int](4)
                 _ <- Kyo.foreach(1 to 4)(c.put)
-                stream = c.stream(1).mapChunk(Chunk(_)).take(4)
+                stream = c.stream(1).mapChunk[Int, Chunk[Int]](Chunk(_)).take(4)
                 r <- stream.run
                 s <- c.size
             yield assert(r == Chunk(Chunk(1), Chunk(2), Chunk(3), Chunk(4)) && s == 0)
@@ -790,7 +790,7 @@ class ChannelTest extends Test:
             for
                 c <- Channel.init[Int](4)
                 _ <- Kyo.foreach(1 to 4)(c.put)
-                stream = c.stream().mapChunk(ch => Chunk(ch)).take(1)
+                stream = c.stream().mapChunk[Int, Chunk[Int]](ch => Chunk(ch)).take(1)
                 v <- stream.run
                 s <- c.size
             yield assert(v == Chunk(Chunk(1, 2, 3, 4)) && s == 0)
@@ -800,7 +800,7 @@ class ChannelTest extends Test:
             for
                 c <- Channel.init[Int](4)
                 _ <- Kyo.foreach(1 to 4)(c.put)
-                stream = c.stream(2).mapChunk(ch => Chunk(ch)).take(2)
+                stream = c.stream(2).mapChunk[Int, Chunk[Int]](ch => Chunk(ch)).take(2)
                 v <- stream.run
                 s <- c.size
             yield assert(v == Chunk(Chunk(1, 2), Chunk(3, 4)) && s == 0)
@@ -810,7 +810,7 @@ class ChannelTest extends Test:
             for
                 c  <- Channel.init[Int](4)
                 bg <- Async.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
-                stream = c.stream().take(20).mapChunk(ch => Chunk(ch))
+                stream = c.stream().take(20).mapChunk[Int, Chunk[Int]](ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
             yield assert(v.flattenChunk == Chunk.from(0 until 20))
@@ -820,7 +820,7 @@ class ChannelTest extends Test:
             for
                 c  <- Channel.init[Int](4)
                 bg <- Async.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
-                stream = c.stream(2).take(20).mapChunk(ch => Chunk(ch))
+                stream = c.stream(2).take(20).mapChunk[Int, Chunk[Int]](ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
             yield assert(v.flattenChunk == Chunk.from(0 until 20) && v.forall(_.size <= 2))
@@ -830,7 +830,7 @@ class ChannelTest extends Test:
             for
                 c  <- Channel.init[Int](3)
                 bg <- Async.run(Kyo.foreach(0 to 8)(c.put).andThen(c.close))
-                stream = c.stream().mapChunk(ch => Chunk(ch))
+                stream = c.stream().mapChunk[Int, Chunk[Int]](ch => Chunk(ch))
                 v <- Abort.run(stream.run)
             yield v match
                 case Result.Success(v)         => fail(s"Stream succeeded unexpectedly: ${v}")
@@ -842,7 +842,7 @@ class ChannelTest extends Test:
             for
                 c  <- Channel.init[Int](9)
                 bg <- Async.run(Loop(0)(i => c.putBatch(Chunk(i, i + 1, i + 2)).andThen(Loop.continue(i + 3))))
-                stream = c.stream(3).take(15).mapChunk(ch => Chunk(ch))
+                stream = c.stream(3).take(15).mapChunk[Int, Chunk[Int]](ch => Chunk(ch))
                 res <- stream.run
                 _   <- bg.interrupt
             yield
@@ -877,7 +877,7 @@ class ChannelTest extends Test:
             for
                 c <- Channel.init[Int](4)
                 _ <- Kyo.foreach(1 to 4)(c.put)
-                stream = c.streamUntilClosed(1).mapChunk(Chunk(_)).take(4)
+                stream = c.streamUntilClosed(1).mapChunk[Int, Chunk[Int]](Chunk(_)).take(4)
                 r <- stream.run
                 s <- c.size
             yield assert(r == Chunk(Chunk(1), Chunk(2), Chunk(3), Chunk(4)) && s == 0)
@@ -887,7 +887,7 @@ class ChannelTest extends Test:
             for
                 c <- Channel.init[Int](4)
                 _ <- Kyo.foreach(1 to 4)(c.put)
-                stream = c.streamUntilClosed().mapChunk(ch => Chunk(ch)).take(1)
+                stream = c.streamUntilClosed().mapChunk[Int, Chunk[Int]](ch => Chunk(ch)).take(1)
                 v <- stream.run
                 s <- c.size
             yield assert(v == Chunk(Chunk(1, 2, 3, 4)) && s == 0)
@@ -897,7 +897,7 @@ class ChannelTest extends Test:
             for
                 c <- Channel.init[Int](4)
                 _ <- Kyo.foreach(1 to 4)(c.put)
-                stream = c.streamUntilClosed(2).mapChunk(ch => Chunk(ch)).take(2)
+                stream = c.streamUntilClosed(2).mapChunk[Int, Chunk[Int]](ch => Chunk(ch)).take(2)
                 v <- stream.run
                 s <- c.size
             yield assert(v == Chunk(Chunk(1, 2), Chunk(3, 4)) && s == 0)
@@ -907,7 +907,7 @@ class ChannelTest extends Test:
             for
                 c  <- Channel.init[Int](4)
                 bg <- Async.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
-                stream = c.streamUntilClosed().take(20).mapChunk(ch => Chunk(ch))
+                stream = c.streamUntilClosed().take(20).mapChunk[Int, Chunk[Int]](ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
             yield assert(v.flattenChunk == Chunk.from(0 until 20))
@@ -917,7 +917,7 @@ class ChannelTest extends Test:
             for
                 c  <- Channel.init[Int](4)
                 bg <- Async.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
-                stream = c.streamUntilClosed(2).take(20).mapChunk(ch => Chunk(ch))
+                stream = c.streamUntilClosed(2).take(20).mapChunk[Int, Chunk[Int]](ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
             yield assert(v.flattenChunk == Chunk.from(0 until 20) && v.forall(_.size <= 2))

--- a/kyo-core/shared/src/test/scala/kyo/HubTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/HubTest.scala
@@ -184,7 +184,7 @@ class HubTest extends Test:
             for
                 h <- Hub.init[Int](4)
                 l <- h.listen
-                f <- Async.run(l.stream(2).mapChunk(Chunk(_)).take(2).run)
+                f <- Async.run(l.stream(2).mapChunk[Int, Chunk[Int]](Chunk(_)).take(2).run)
                 _ <- h.putBatch(1 to 4)
                 r <- f.get
             yield assert(r.forall(_.size <= 2))

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -257,7 +257,7 @@ class StreamCoreExtensionsTest extends Test:
                     val it = Iterator("a", "b", "c")
 
                     val stream: Stream[String, IO & Choice] =
-                        Stream.fromIterator(it, bufferSize).map: str =>
+                        Stream.fromIterator(it, bufferSize).mapKyo: str =>
                             Choice.eval(true, false).map:
                                 case true  => str.toUpperCase
                                 case false => str

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -47,6 +47,18 @@ class StreamCoreExtensionsTest extends Test:
     }
 
     "combinator" - {
+        "variance" in run {
+            val intStream = Stream.init(Chunk(1, 2, 3))
+            val strStream = Stream.init(Chunk("one", "two", "three"))
+
+            val merged = intStream.merge(strStream)
+
+            given CanEqual[Int | String, Int | String] = CanEqual.derived
+
+            merged.run.map: resultChunk =>
+                assert(resultChunk.toSet == Set(1, 2, 3, "one", "two", "three"))
+        }
+
         "mergeHaltingLeft/Right" - {
             "should halt if non-halting side completes" in run {
                 Choice.run {

--- a/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
@@ -339,7 +339,7 @@ class PreludeTest extends Test:
                 direct {
                     val env = Env.get[Int].now
                     val stream = Stream.init(1 to 3)
-                        .map { x =>
+                        .mapKyo { x =>
                             direct {
                                 val value = Var.get[Int].now
                                 Var.update[Int](_ + x).now

--- a/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
@@ -34,6 +34,7 @@ import kyo.kernel.*
 sealed trait Emit[-V] extends ArrowEffect[Const[V], Const[Unit]]
 
 object Emit:
+    given eliminateEmit: Reducible.Eliminable[Emit[Nothing]] with {}
 
     /** Emits a single value.
       *
@@ -86,11 +87,15 @@ object Emit:
       * @return
       *   A tuple of the collected values and the result of the computation
       */
-    def run[V](using Frame)[A, S](v: A < (Emit[V] & S))(using tag: Tag[Emit[V]]): (Chunk[V], A) < S =
-        ArrowEffect.handleLoop(tag, Chunk.empty[V], v)(
-            handle = [C] => (input, state, cont) => Loop.continue(state.append(input), cont(())),
-            done = (state, res) => (state, res)
-        )
+    def run[V](using
+        tag: Tag[Emit[V]],
+        fr: Frame
+    )[A, VR, S](v: A < (Emit[V] & Emit[VR] & S))(using reduce: Reducible[Emit[VR]]): (Chunk[V], A) < (reduce.SReduced & S) =
+        reduce:
+            ArrowEffect.handleLoop(tag, Chunk.empty[V], v)(
+                handle = [C] => (input, state, cont) => Loop.continue(state.append(input), cont(())),
+                done = (state, res) => (state, res)
+            )
 
     /** Runs an Emit effect, folding over the emitted values.
       *
@@ -105,13 +110,17 @@ object Emit:
       */
     def runFold[V](
         using Frame
-    )[A, S, B, S2](acc: A)(f: (A, V) => A < S)(v: B < (Emit[V] & S2))(using tag: Tag[Emit[V]]): (A, B) < (S & S2) =
-        ArrowEffect.handleLoop(tag, acc, v)(
-            handle = [C] =>
-                (input, state, cont) =>
-                    f(state, input).map(a => Loop.continue(a, cont(()))),
-            done = (state, res) => (state, res)
-        )
+    )[A, S, VR, B, S2](acc: A)(f: (A, V) => A < S)(v: B < (Emit[V] & Emit[VR] & S2))(using
+        tag: Tag[Emit[V]],
+        reduce: Reducible[Emit[VR]]
+    ): (A, B) < (reduce.SReduced & S & S2) =
+        reduce:
+            ArrowEffect.handleLoop(tag, acc, v)(
+                handle = [C] =>
+                    (input, state, cont) =>
+                        f(state, input).map(a => Loop.continue(a, cont(()))),
+                done = (state, res) => (state, res)
+            )
 
     /** Runs an Emit effect, discarding all emitted values.
       *
@@ -122,10 +131,11 @@ object Emit:
       */
     def runDiscard[V](
         using Frame
-    )[A, S](v: A < (Emit[V] & S))(using tag: Tag[Emit[V]]): A < S =
-        ArrowEffect.handle(tag, v)(
-            handle = [C] => (input, cont) => cont(())
-        )
+    )[A, VR, S](v: A < (Emit[V] & Emit[VR] & S))(using tag: Tag[Emit[V]], reduce: Reducible[Emit[VR]]): A < (reduce.SReduced & S) =
+        reduce:
+            ArrowEffect.handle(tag, v)(
+                handle = [C] => (input, cont) => cont(())
+            )
 
     /** Runs an Emit effect, allowing custom handling of each emitted value.
       *
@@ -138,10 +148,14 @@ object Emit:
       */
     def runForeach[V](
         using Frame
-    )[A, S, S2](v: A < (Emit[V] & S))(f: V => Any < S2)(using tag: Tag[Emit[V]]): A < (S & S2) =
-        ArrowEffect.handle(tag, v)(
-            [C] => (input, cont) => f(input).map(_ => cont(()))
-        )
+    )[A, VR, S, S2](v: A < (Emit[V] & Emit[VR] & S))(f: V => Any < S2)(using
+        tag: Tag[Emit[V]],
+        reduce: Reducible[Emit[VR]]
+    ): A < (reduce.SReduced & S & S2) =
+        reduce[A, S & S2]:
+            ArrowEffect.handle(tag, v)(
+                [C] => (input, cont) => f(input).map(_ => cont(()))
+            )
 
     /** Runs an Emit effect, allowing custom handling of each emitted value with a boolean result determining whether to continue.
       *
@@ -152,15 +166,21 @@ object Emit:
       * @return
       *   The result of the computation
       */
-    def runWhile[V](using Frame)[A, S, S2](v: A < (Emit[V] & S))(f: V => Boolean < S2)(using tag: Tag[Emit[V]]): A < (S & S2) =
-        ArrowEffect.handleLoop(tag, true, v)(
-            [C] =>
-                (input, cond, cont) =>
-                    if cond then
-                        f(input).map(c => Loop.continue(c, cont(())))
-                    else
-                        Loop.continue(cond, cont(()))
-        )
+    def runWhile[V](using
+        Frame
+    )[A, VR, S, S2](v: A < (Emit[V] & Emit[VR] & S))(f: V => Boolean < S2)(using
+        tag: Tag[Emit[V]],
+        reduce: Reducible[Emit[VR]]
+    ): A < (reduce.SReduced & S & S2) =
+        reduce:
+            ArrowEffect.handleLoop(tag, true, v)(
+                [C] =>
+                    (input, cond, cont) =>
+                        if cond then
+                            f(input).map(c => Loop.continue(c, cont(())))
+                        else
+                            Loop.continue(cond, cont(()))
+            )
 
     /** Runs an Emit effect, capturing only the first emitted value and returning a continuation.
       *
@@ -171,17 +191,23 @@ object Emit:
       *   - Maybe[V]: The first emitted value if any (None if no values were emitted)
       *   - A continuation function that returns the remaining computation
       */
-    def runFirst[V](using Frame)[A, S](v: A < (Emit[V] & S))(using tag: Tag[Emit[V]]): (Maybe[V], () => A < (Emit[V] & S)) < S =
-        ArrowEffect.handleFirst(tag, v)(
-            handle = [C] =>
-                (input, cont) =>
-                    // Effect found, return the input an continuation
-                    (Maybe(input), () => cont(())),
-            done = r =>
-                // Effect not found, return empty input and a placeholder continuation
-                // that returns the result of the computation
-                (Maybe.empty[V], () => r: A < (Emit[V] & S))
-        )
+    def runFirst[V](using
+        Frame
+    )[A, VR, S](v: A < (Emit[V] & Emit[VR] & S))(using
+        tag: Tag[Emit[V]],
+        reduce: Reducible[Emit[VR]]
+    ): (Maybe[V], () => A < (Emit[V | VR] & S)) < (reduce.SReduced & S) =
+        reduce:
+            ArrowEffect.handleFirst(tag, v)(
+                handle = [C] =>
+                    (input, cont) =>
+                        // Effect found, return the input an continuation
+                        (Maybe(input), () => cont(())),
+                done = r =>
+                    // Effect not found, return empty input and a placeholder continuation
+                    // that returns the result of the computation
+                    (Maybe.empty[V], () => r: A < (Emit[V] & S))
+            )
 
     object isolate:
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Emit.scala
@@ -31,7 +31,7 @@ import kyo.kernel.*
   * @see
   *   [[kyo.Stream]] for higher-level streaming operations (preferred for most use cases)
   */
-sealed trait Emit[V] extends ArrowEffect[Const[V], Const[Unit]]
+sealed trait Emit[-V] extends ArrowEffect[Const[V], Const[Unit]]
 
 object Emit:
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
@@ -39,6 +39,7 @@ import kyo.kernel.ArrowEffect
 sealed trait Poll[+V] extends ArrowEffect[Const[Unit], Const[Maybe[V]]]
 
 object Poll:
+    given eliminatePoll: Reducible.Eliminable[Poll[Any]] with {}
 
     /** Attempts to poll a single value.
       *
@@ -135,15 +136,17 @@ object Poll:
       * @return
       *   The result of running the Poll computation with the provided values
       */
-    def run[V, A, S](inputs: Chunk[V])(v: A < (Poll[V] & S))(
+    def run[V](inputs: Chunk[V])[A, VR, S](v: A < (Poll[V] & Poll[VR] & S))(
         using
         tag: Tag[Poll[V]],
+        reduce: Reducible[Poll[VR]],
         frame: Frame
-    ): A < S =
-        ArrowEffect.handleLoop(tag, inputs, v)(
-            [C] =>
-                (unit, state, cont) => Loop.continue(state.drop(1), cont(state.headMaybe))
-        )
+    ): A < (reduce.SReduced & S) =
+        reduce:
+            ArrowEffect.handleLoop(tag, inputs, v)(
+                [C] =>
+                    (unit, state, cont) => Loop.continue(state.drop(1), cont(state.headMaybe))
+            )
 
     /** Runs a Poll effect with a single input value, stopping after the first poll operation.
       *
@@ -157,17 +160,21 @@ object Poll:
       */
     def runFirst[V](
         using Frame
-    )[A, S](v: A < (Poll[V] & S))(using tag: Tag[Poll[V]]): Either[A, Maybe[V] => A < (Poll[V] & S)] < S =
-        ArrowEffect.handleFirst(tag, v)(
-            handle = [C] =>
-                (input, cont) =>
-                    // Effect found, return the input an continuation
-                    Right(cont),
-            done = r =>
-                // Effect not found, return empty input and a placeholder continuation
-                // that returns the result of the computation
-                Left(r)
-        )
+    )[A, VR, S](v: A < (Poll[V] & Poll[VR] & S))(using
+        tag: Tag[Poll[V]],
+        reduce: Reducible[Poll[VR]]
+    ): Either[A, Maybe[V] => A < (Poll[V & VR] & S)] < (reduce.SReduced & S) =
+        reduce:
+            ArrowEffect.handleFirst(tag, v)(
+                handle = [C] =>
+                    (input, cont) =>
+                        // Effect found, return the input an continuation
+                        Right(cont),
+                done = r =>
+                    // Effect not found, return empty input and a placeholder continuation
+                    // that returns the result of the computation
+                    Left(r)
+            )
 
     /** Connects an emitting source to a polling consumer with flow control.
       *
@@ -187,39 +194,45 @@ object Poll:
       * @return
       *   A tuple containing results from both the emitter and poller
       */
-    def run[V, A, B, S, S2](emit: A < (Emit[V] & S))(poll: B < (Poll[V] & S2))(
+    def run[V](
         using
         emitTag: Tag[Emit[V]],
-        pollTag: Tag[Poll[V]],
+        pollTag: Tag[Poll[V]]
+    )[A, B, VRE, VRP, S, S2](emit: A < (Emit[V] & Emit[VRE] & S))(poll: B < (Poll[V] & Poll[VRP] & S2))(
+        using
+        reduceEmit: Reducible[Emit[VRE]],
+        reducePoll: Reducible[Poll[VRP]],
         frame: Frame
-    ): (A, B) < (S & S2) =
-        // Start by handling the first emission
-        Loop(emit, poll) { (emit, poll) =>
-            ArrowEffect.handleFirst(emitTag, emit)(
-                handle = [C] =>
-                    (emitted, emitCont) =>
-                        // Once we have an emitted value, handle the first poll operation
-                        // This creates the demand-driven cycle between emit and poll
-                        ArrowEffect.handleFirst(pollTag, poll)(
-                            handle = [C2] =>
-                                (_, pollCont) =>
-                                    // Continue the emit-poll cycle:
-                                    // 1. Pass the ack back to emitter to control flow
-                                    // 2. Pass the emitted value to poller for consumption
-                                    // 3. Recursively continue the cycle
-                                    Loop.continue(emitCont(()), pollCont(Maybe(emitted))),
-                            // Poll.run(emitCont(ack))(pollCont(Maybe(emitted))),
-                            done = b =>
-                                // Poller completed early (e.g., received all needed values)
-                                // Discard remaining emit operations
-                                Emit.runDiscard(emitCont(())).map(a => Loop.done((a, b)))
-                    ),
-                done = a =>
-                    // Emitter completed (no more values to emit)
-                    // Run remaining poll operations with empty chunk to signal completion
-                    Poll.run(Chunk.empty)(poll).map(b => Loop.done((a, b)))
-            )
-        }
+    ): (A, B) < (reduceEmit.SReduced & reducePoll.SReduced & S & S2) =
+        reduceEmit:
+            reducePoll:
+                // Start by handling the first emission
+                Loop(emit, poll) { (emit, poll) =>
+                    ArrowEffect.handleFirst(emitTag, emit)(
+                        handle = [C] =>
+                            (emitted, emitCont) =>
+                                // Once we have an emitted value, handle the first poll operation
+                                // This creates the demand-driven cycle between emit and poll
+                                ArrowEffect.handleFirst(pollTag, poll)(
+                                    handle = [C2] =>
+                                        (_, pollCont) =>
+                                            // Continue the emit-poll cycle:
+                                            // 1. Pass the ack back to emitter to control flow
+                                            // 2. Pass the emitted value to poller for consumption
+                                            // 3. Recursively continue the cycle
+                                            Loop.continue(emitCont(()), pollCont(Maybe(emitted))),
+                                    // Poll.run(emitCont(ack))(pollCont(Maybe(emitted))),
+                                    done = b =>
+                                        // Poller completed early (e.g., received all needed values)
+                                        // Discard remaining emit operations
+                                        Emit.runDiscard[V](emitCont(())).map(a => Loop.done((a, b)))
+                            ),
+                        done = a =>
+                            // Emitter completed (no more values to emit)
+                            // Run remaining poll operations with empty chunk to signal completion
+                            Poll.run[V](Chunk.empty)(poll).map(b => Loop.done((a, b)))
+                    )
+                }
     end run
 
 end Poll

--- a/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Poll.scala
@@ -36,7 +36,7 @@ import kyo.kernel.ArrowEffect
   * @see
   *   [[kyo.Stream]] for higher-level streaming operations
   */
-sealed trait Poll[V] extends ArrowEffect[Const[Unit], Const[Maybe[V]]]
+sealed trait Poll[+V] extends ArrowEffect[Const[Unit], Const[Maybe[V]]]
 
 object Poll:
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -21,7 +21,7 @@ import scala.annotation.targetName
   * @see
   *   [[kyo.Poll]] for the underlying pull-based consumption mechanism
   */
-sealed abstract class Sink[V, A, -S] extends Serializable:
+sealed abstract class Sink[-V, +A, -S] extends Serializable:
 
     /** Returns the effect that produces the output value `A` from polling chunks of `V`. */
     def poll: A < (Poll[Chunk[V]] & S)
@@ -36,13 +36,14 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that produces a tuple of the outputs of the source sinks.
       */
-    final def zip[B, S2](other: Sink[V, B, S2])(using tag: Tag[Poll[Chunk[V]]], f: Frame): Sink[V, (A, B), S & S2] =
+    final def zip[VV <: V, B, S2](other: Sink[VV, B, S2])(using tag: Tag[Poll[Chunk[VV]]], f: Frame): Sink[VV, (A, B), S & S2] =
+        val pollVV: A < (Poll[Chunk[VV]] & S) = poll
         Sink:
-            Loop((poll, other.poll)): (pollA, pollB) =>
+            Loop((pollVV, other.poll)): (pollA, pollB) =>
                 ArrowEffect.handleFirst(tag, pollA)(
                     handle = [C] =>
                         (_, contA) =>
-                            Poll.andMap[Chunk[V]]: polledValue =>
+                            Poll.andMap[Chunk[VV]]: polledValue =>
                                 val nextA = contA(polledValue)
                                 ArrowEffect.handleFirst(tag, pollB)(
                                     handle = [C] =>
@@ -59,7 +60,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
                         ArrowEffect.handleFirst(tag, pollB)(
                             handle = [C] =>
                                 (_, contB) =>
-                                    Poll.andMap[Chunk[V]]: polledValue =>
+                                    Poll.andMap[Chunk[VV]]: polledValue =>
                                         contB(polledValue).map: b =>
                                             Loop.done((a, b)),
                             done = b =>
@@ -76,13 +77,13 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that processes streams of the new element type
       */
-    final def contramap[V2](f: V2 => V)(using
-        t1: Tag[Poll[Chunk[V]]],
+    final def contramap[VV <: V, V2](f: V2 => VV)(using
+        t1: Tag[Poll[Chunk[VV]]],
         t2: Tag[Poll[Chunk[V2]]],
         fr: Frame
     ): Sink[V2, A, S] =
         Sink:
-            ArrowEffect.handleLoop(t1, poll)(
+            ArrowEffect.handleLoop(t1, poll: A < (Poll[Chunk[VV]] & S))(
                 [C] =>
                     (_, cont) =>
                         Poll.andMap[Chunk[V2]]: maybeChunkV2 =>
@@ -97,14 +98,15 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that processes streams of the new element type
       */
-    final def contramap[V2, S2](f: V2 => V < S2)(using
-        t1: Tag[Poll[Chunk[V]]],
+    final def contramap[VV <: V, V2, S2](f: V2 => VV < S2)(
+        using
+        t1: Tag[Poll[Chunk[VV]]],
         t2: Tag[Poll[Chunk[V2]]],
         d: Discriminator,
         fr: Frame
     ): Sink[V2, A, S & S2] =
         Sink:
-            ArrowEffect.handleLoop[Const[Unit], Const[Maybe[Chunk[V]]], Poll[Chunk[V]], A, S, S2 & Poll[Chunk[V2]]](t1, poll)(
+            ArrowEffect.handleLoop[Const[Unit], Const[Maybe[Chunk[VV]]], Poll[Chunk[VV]], A, S, S2 & Poll[Chunk[V2]]](t1, poll)(
                 [C] =>
                     (_, cont) =>
                         Poll.andMap[Chunk[V2]]:
@@ -122,13 +124,13 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that processes streams of the new element type
       */
-    final def contramapChunk[V2](f: Chunk[V2] => Chunk[V])(using
-        t1: Tag[Poll[Chunk[V]]],
+    final def contramapChunk[VV <: V, V2](f: Chunk[V2] => Chunk[VV])(using
+        t1: Tag[Poll[Chunk[VV]]],
         t2: Tag[Poll[Chunk[V2]]],
         fr: Frame
     ): Sink[V2, A, S] =
         Sink:
-            ArrowEffect.handleLoop[Const[Unit], Const[Maybe[Chunk[V]]], Poll[Chunk[V]], A, S, Poll[Chunk[V2]]](t1, poll)(
+            ArrowEffect.handleLoop[Const[Unit], Const[Maybe[Chunk[VV]]], Poll[Chunk[VV]], A, S, Poll[Chunk[V2]]](t1, poll)(
                 [C] =>
                     (_, cont) =>
                         Poll.andMap[Chunk[V2]]: maybeChunkV2 =>
@@ -144,14 +146,14 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   A new sink that processes streams of the new element type
       */
-    final def contramapChunk[V2, S2](f: Chunk[V2] => Chunk[V] < S2)(using
-        t1: Tag[Poll[Chunk[V]]],
+    final def contramapChunk[VV <: V, V2, S2](f: Chunk[V2] => Chunk[VV] < S2)(using
+        t1: Tag[Poll[Chunk[VV]]],
         t2: Tag[Poll[Chunk[V2]]],
         d: Discriminator,
         fr: Frame
     ): Sink[V2, A, S & S2] =
         Sink:
-            ArrowEffect.handleLoop[Const[Unit], Const[Maybe[Chunk[V]]], Poll[Chunk[V]], A, S, S2 & Poll[Chunk[V2]]](t1, poll)(
+            ArrowEffect.handleLoop[Const[Unit], Const[Maybe[Chunk[VV]]], Poll[Chunk[VV]], A, S, S2 & Poll[Chunk[V2]]](t1, poll)(
                 [C] =>
                     (_, cont) =>
                         Poll.andMap[Chunk[V2]]:
@@ -184,7 +186,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       * @return
       *   An effect generating an output value from elements consumed from the stream
       */
-    final def drain[S2](stream: Stream[V, S2])(using Tag[Poll[Chunk[V]]], Tag[Emit[Chunk[V]]], Frame): A < (S & S2) =
+    final def drain[VV <: V, S2](stream: Stream[VV, S2])(using Tag[Poll[Chunk[VV]]], Tag[Emit[Chunk[VV]]], Frame): A < (S & S2) =
         Poll.run(stream.emit)(poll).map(_._2)
 end Sink
 

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -698,7 +698,7 @@ sealed abstract class Stream[+V, -S] extends Serializable:
       *   An effect producing a value of sink's output type `A`
       */
     def into[VV >: V, A, S2](sink: Sink[VV, A, S2])(using Tag[Poll[Chunk[VV]]], Tag[Emit[Chunk[VV]]], Frame): A < (S & S2) =
-        sink.drain(this)
+        sink.drain[VV, S](this)
     end into
 
     /** Applies a transformation to this stream's underlying computation. This provides a convenient way to handle effects included in the

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -57,8 +57,6 @@ sealed abstract class Stream[+V, -S] extends Serializable:
     def concat[VV >: V, S2](other: Stream[VV, S2])(using Frame): Stream[VV, S & S2] =
         Stream(emit.map(_ => other.emit))
 
-    val derp: List[Int] = ???
-
     /** Transforms each value in the stream using the given pure function.
       *
       * @param f
@@ -312,7 +310,10 @@ sealed abstract class Stream[+V, -S] extends Serializable:
       * @return
       *   A new stream containing elements that satisfy the predicate
       */
-    def takeWhile[VV >: V, S2](f: VV => Boolean < S2)(using tag: Tag[Emit[Chunk[VV]]], frame: Frame): Stream[VV, S & S2] =
+    def takeWhile[VV >: V, S2](f: VV => Boolean < S2)(using
+        tag: Tag[Emit[Chunk[VV]]],
+        frame: Frame
+    ): Stream[VV, S & S2] =
         Stream(
             ArrowEffect.handleLoop(tag, true, emit)(
                 [C] =>

--- a/kyo-prelude/shared/src/test/scala/kyo/ChoiceTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/ChoiceTest.scala
@@ -232,7 +232,7 @@ class ChoiceTest extends Test:
             val stream      = Choice.runStream(computation)
 
             val result = stream
-                .filter(_ % 2 == 1)
+                .filter[Int](_ % 2 == 1)
                 .map(_ * 10)
                 .run.eval
 

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -285,7 +285,7 @@ class StreamTest extends Test:
 
         "with effects" in {
             val stream = Stream.init(Seq(1, 2, 3, 4, 5))
-            val taken = stream.takeWhile[Int, Var[Int]] { v =>
+            val taken = stream.takeWhileKyo { v =>
                 Var.update[Int](_ + 1).map(_ < 4)
             }.run
             assert(Var.runTuple(0)(taken).eval == (4, Seq(1, 2, 3)))
@@ -330,7 +330,7 @@ class StreamTest extends Test:
 
         "with effects" in {
             val stream = Stream.init(Seq(1, 2, 3, 4, 5))
-            val dropped = stream.dropWhile { v =>
+            val dropped = stream.dropWhileKyo { v =>
                 Var.update[Int](_ + 1).map(_ < 3)
             }.run
             assert(Var.runTuple(0)(dropped).eval == (3, Seq(3, 4, 5)))
@@ -375,7 +375,7 @@ class StreamTest extends Test:
 
         "with effects" in {
             def predicate(i: Int) = Var.get[Boolean].map(b => Var.set(!b).andThen(b && !(i % 3 == 0)))
-            val result            = Var.run(false)(Stream.init(1 to n).filter(predicate).run).eval
+            val result            = Var.run(false)(Stream.init(1 to n).filterKyo(predicate).run).eval
             assert(
                 result.size > 0 && result.forall(_ % 2 == 0) && result.forall(i => !(i % 3 == 0))
             )
@@ -414,7 +414,7 @@ class StreamTest extends Test:
         "with effects" in {
             def predicate(v: Int) =
                 Var.update[Boolean](!_).map(if _ then Present(v) else Absent)
-            val result = Var.run(false)(Stream.init(1 to 10).collect(predicate).run).eval
+            val result = Var.run(false)(Stream.init(1 to 10).collectKyo(predicate).run).eval
             assert(
                 result == (1 to 10 by 2)
             )
@@ -458,7 +458,7 @@ class StreamTest extends Test:
 
         "with effects" in {
             val stream = Stream.init(Seq(1, 2, 3, 4, 5))
-            val collected = stream.collectWhile[Int, Int, Var[Boolean]] { v =>
+            val collected = stream.collectWhileKyo { v =>
                 Var.update[Boolean](!_).map(if _ then Present(v * 2) else Absent)
             }.run
             assert(Var.run(false)(collected).eval == Seq(2))
@@ -525,13 +525,13 @@ class StreamTest extends Test:
 
         "with effects" in {
             val stream      = Stream.init(Seq(1, 2, 3))
-            val transformed = stream.map(v => Env.use[Int](v * _)).run
+            val transformed = stream.mapKyo(v => Env.use[Int](v * _)).run
             assert(Env.run(2)(transformed).eval == Seq(2, 4, 6))
         }
 
         "with failures" in {
             val stream      = Stream.init(Seq("1", "2", "abc", "3"))
-            val transformed = stream.map(v => Abort.catching[NumberFormatException](v.toInt)).run
+            val transformed = stream.mapKyo(v => Abort.catching[NumberFormatException](v.toInt)).run
             assert(Abort.run(transformed).eval.isFailure)
         }
 
@@ -571,14 +571,14 @@ class StreamTest extends Test:
 
         "with effects" in {
             val stream      = Stream.init(Seq(1, 2, 3))
-            val transformed = stream.mapChunk[Int, Int, Env[Int]](v => Env.use[Int](i => v.map(_ * i))).run
+            val transformed = stream.mapChunkKyo(v => Env.use[Int](i => v.map(_ * i))).run
             assert(Env.run(2)(transformed).eval == Seq(2, 4, 6))
         }
 
         "with failures" in {
             val stream = Stream.init(Seq("1", "2", "abc", "3"))
             val transformed =
-                stream.mapChunk[String, Int, Abort[NumberFormatException]](c => Abort.catching[NumberFormatException](c.map(_.toInt))).run
+                stream.mapChunkKyo(c => Abort.catching[NumberFormatException](c.map(_.toInt))).run
             assert(Abort.run(transformed).eval.isFailure)
         }
 
@@ -618,7 +618,7 @@ class StreamTest extends Test:
         "nested effects" in {
             val result = Env.run(10) {
                 Stream.init(Seq(1, 2, 3))
-                    .flatMap(i => Stream.init(Seq(i, i + 1)).map(j => Env.use[Int](_ + j)))
+                    .flatMap(i => Stream.init(Seq(i, i + 1)).mapKyo(j => Env.use[Int](_ + j)))
                     .run
             }
             assert(result.eval == Seq(11, 12, 12, 13, 13, 14))
@@ -788,7 +788,7 @@ class StreamTest extends Test:
         }
 
         "with effects" in {
-            val stream = Stream.range(0, 100).map(i => Env.use[Int](_ + i)).rechunk(48)
+            val stream = Stream.range(0, 100).mapKyo(i => Env.use[Int](_ + i)).rechunk(48)
             val result = Env.run(10)(stream.run).eval
             val chunks = Env.run(10)(chunkSizes(stream)).eval
             assert(result == (10 until 110))
@@ -822,7 +822,7 @@ class StreamTest extends Test:
         "non-empty stream" in {
             assert(
                 Var.run(0) {
-                    Stream.init(0 until 100).map(i => Var.update[Int](_ + i)).discard.andThen(Var.get[Int])
+                    Stream.init(0 until 100).mapKyo(i => Var.update[Int](_ + i)).discard.andThen(Var.get[Int])
                 }.eval == 4950
             )
         }
@@ -1012,7 +1012,7 @@ class StreamTest extends Test:
             val result = Env.run(10) {
                 Stream.init(Seq(1, 2, 3))
                     .flatMap(i =>
-                        Stream.init(Seq(i, i + 1)).map { j =>
+                        Stream.init(Seq(i, i + 1)).mapKyo { j =>
                             sum += j
                             Env.use[Int](env => if sum > env then Abort.fail("Sum too large") else j)
                         }
@@ -1031,7 +1031,7 @@ class StreamTest extends Test:
                     if counter % 2 == 0 then
                         Abort.fail(s"Even counter: $counter")
                     else
-                        Stream.init(Seq(n, n * 10)).map { m =>
+                        Stream.init(Seq(n, n * 10)).mapKyo { m =>
                             if m > 20 then Abort.fail(s"Value too large: $m")
                             else Env.use[Int](_ + m)
                         }
@@ -1046,7 +1046,7 @@ class StreamTest extends Test:
             val stream = Stream.init(Chunk(1, 2, 3, 4, 5))
             val result = Abort.run[String] {
                 Var.run(0) {
-                    stream.mapChunk[Int, Int, Var[Int] & Abort[String]] { chunk =>
+                    stream.mapChunkKyo { chunk =>
                         Var.update[Int](_ + chunk.size).map { newState =>
                             if newState > 3 then Abort.fail(s"State too high: $newState")
                             else chunk.map(_ * newState)
@@ -1131,18 +1131,18 @@ class StreamTest extends Test:
 
         maintains(
             (_.map(identity[Int]), "map"),
-            (_.map(Kyo.lift[Int, Any]), "map (kyo)"),
-            (_.mapChunk(identity[Chunk[Int]]), "mapChunk"),
-            (_.mapChunk(Kyo.lift[Chunk[Int], Any]), "mapChunk (kyo)"),
+            (_.mapKyo(Kyo.lift), "map (kyo)"),
+            (_.mapChunk(identity), "mapChunk"),
+            (_.mapChunkKyo(Kyo.lift), "mapChunk (kyo)"),
             (_.tap(identity), "tap"),
             (_.tapChunk(identity), "tapChunk"),
             (_.take(Int.MaxValue), "take"),
-            (_.takeWhile[Int](_ => true), "takeWhile"),
-            (_.takeWhile[Int, Any](_ => Kyo.lift(true)), "takeWhile (kyo)"),
+            (_.takeWhile(_ => true), "takeWhile"),
+            (_.takeWhileKyo(_ => Kyo.lift(true)), "takeWhile (kyo)"),
             (_.dropWhile(_ => false), "dropWhile"),
-            (_.dropWhile(_ => Kyo.lift(false)), "dropWhile (kyo)"),
-            (_.filter[Int](_ => true), "filter"),
-            (_.filter[Int, Any](_ => Kyo.lift(true)), "filter (kyo)"),
+            (_.dropWhileKyo(_ => Kyo.lift(false)), "dropWhile (kyo)"),
+            (_.filter(_ => true), "filter"),
+            (_.filterKyo(_ => Kyo.lift(true)), "filter (kyo)"),
             (_.changes, "changes"),
             (_.rechunk(chunkSize), "rechunk"),
             (_.flatMapChunk(c => Stream.init(c)), "flatMapChunk")

--- a/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
@@ -162,7 +162,7 @@ class DebugTest extends Test:
 
         "with Stream JVM" taggedAs jvmOnly in
             testOutput(
-                "DebugTest.scala:55:36",
+                "DebugTest.scala:55:41",
                 "()",
                 "DebugTest.scala:57:10",
                 "Seq(6)"

--- a/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/debug/DebugTest.scala
@@ -51,8 +51,8 @@ class DebugTest extends Test:
     def streamComputation =
         Debug.trace {
             Stream.init(1 to 5)
-                .map(_ * 2)
-                .filter(_ % 3 == 0)
+                .map[Int, Int](_ * 2)
+                .filter[Int](_ % 3 == 0)
                 .run
         }
 

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
@@ -33,7 +33,7 @@ abstract private class PublisherToSubscriberTest extends Test:
         pending
         val inputStream: Stream[Int, IO] = Stream
             .range(0, 10, 1, 1)
-            .map { int =>
+            .mapKyo { int =>
                 if int < 5 then
                     IO(int)
                 else

--- a/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
@@ -35,7 +35,7 @@ object Routes:
       *   A NettyKyoServerBinding wrapped in an asynchronous effect
       */
     def run[A, S](server: NettyKyoServer)(v: Unit < (Routes & S))(using Frame): NettyKyoServerBinding < (Async & S) =
-        Emit.run[Route][Unit, Async & S](v).map { (routes, _) =>
+        Emit.run[Route](v).map { (routes, _) =>
             IO(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Async & S)
         }
     end run


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

The lack of variance in `Stream` is a problem for DX.
- It is difficult to merge streams of different types
- When defining streams using `Emit`, you have to explicitly set the type to the desired supertype

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Made `Emit[V]` contravariant with `V`, made `Poll[V]` covariant with `V`, made `Stream[V, S]` covariant with `V`.

Added partial handling to `Emit`. You can construct a `Emit[Int | String]` effect and then handle the `Int` or `String` emissions separately. (Haven't added this to `Poll` yet.)

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->

As a result of the covariance in `Stream`, I have had to lift a lot of the `V` parameters to `VV >: V`. This has apparently made it too difficult for the compiler to distinguish between our pure/effectful method overloads. Accordingly, I have added explicit `---Kyo` variants of each method. This solves the compiler issue, but I think it is also a better approach in the long run. Since we now support nested effects, there's no reason a user shouldn't be able to emit an effect (which was impossible, or very difficult, before), and now the user can be more assured that pure values aren't being lifted without their knowing.
