### PR TITLE
[core] Stream.fromIteratorCatching

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -89,7 +89,7 @@ object StreamCoreExtensions:
                         builder.result()
 
                 Stream:
-                    Loop.indexed: _ =>
+                    Loop.foreach:
                         pull.map:
                             case chunk if chunk.isEmpty => Loop.done
                             case chunk                  => Emit.valueWith(chunk)(Loop.continue)
@@ -133,7 +133,7 @@ object StreamCoreExtensions:
                             builder.result()
 
                 Stream:
-                    Loop.indexed: _ =>
+                    Loop.foreach:
                         Abort.run(pull).map:
                             case Result.Success(chunk) if chunk.isEmpty => Loop.done
                             case Result.Success(chunk)                  => Emit.valueWith(chunk)(Loop.continue)

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -116,9 +116,10 @@ object StreamCoreExtensions:
             tag: Tag[Emit[Chunk[V]]],
             ct: SafeClassTag[E],
             @implicitNotFound(
-                "Missing type param on `fromIteratorCatching[E = SomeException](iterator, chunkSize)`." +
-                    "\n - Cannot catch Exceptions using `E = Nothing`." +
-                    "\n - `fromIteratorCatching[E = Throwable]` catches all Exceptions."
+                "Missing *explicit* type param on `fromIteratorCatching[E = SomeException](iterator, chunkSize)`." +
+                    "\n - Cannot catch Exceptions as `Failure[E]` using `E = Nothing`, they are turned into `Panic`." +
+                    "\n       If you need this behaviour, use `fromIterator(iterator, chunkSize)` directly." +
+                    "\n - `fromIteratorCatching[E = Throwable]` catches all Exceptions as `Failure`."
             ) notNothing: NotGiven[E =:= Nothing]
         ): Stream[V, IO & Abort[E]] =
             val stream: Stream[V, (IO & Abort[E])] < IO = IO:

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -361,7 +361,9 @@ class StreamCoreExtensionsTest extends Test:
                         case i => i
                     })
 
-                    typeCheckFailure("Stream.fromIteratorCatching(it, chunkSize)")("Cannot catch Exceptions using `E = Nothing`")
+                    typeCheckFailure("Stream.fromIteratorCatching(it, chunkSize)")(
+                        "Cannot catch Exceptions as `Failure[E]` using `E = Nothing`, they are turned into `Panic`"
+                    )
                 }
 
                 "catching specific exception after values" in run {

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -337,6 +337,15 @@ class StreamCoreExtensionsTest extends Test:
                         assert(chunk == Chunk(0, 1, 2, 42))
                 }
 
+                "compile error" in run {
+                    val it = Iterator.tabulate(5)({
+                        case 3 => throw new RuntimeException("fail")
+                        case i => i
+                    })
+
+                    typeCheckFailure("Stream.fromIteratorCatching(it, chunkSize)")("Cannot catch Exceptions using `E = Nothing`")
+                }
+
                 "catching specific exception after values" in run {
                     class Oups(val value: Int) extends RuntimeException("fail")
 

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -335,7 +335,6 @@ class StreamCoreExtensionsTest extends Test:
 
                     errorTo42.run.map: chunk =>
                         assert(chunk == Chunk(0, 1, 2, 42))
-
                 }
 
                 "catching specific exception after values" in run {

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -217,7 +217,7 @@ class StreamCoreExtensionsTest extends Test:
         }
 
         def fromIteratorTests(chunkSize: Int): Unit =
-            s"bufferSize = $chunkSize" - {
+            s"chunkSize = $chunkSize" - {
                 "basic" in run {
                     val it     = Iterator(1, 2, 3, 4, 5)
                     val stream = Stream.fromIterator(it, chunkSize)

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -216,29 +216,29 @@ class StreamCoreExtensionsTest extends Test:
             }
         }
 
-        def fromIteratorTests(bufferSize: Int): Unit =
-            s"bufferSize = $bufferSize" - {
+        def fromIteratorTests(chunkSize: Int): Unit =
+            s"bufferSize = $chunkSize" - {
                 "basic" in run {
                     val it     = Iterator(1, 2, 3, 4, 5)
-                    val stream = Stream.fromIterator(it, bufferSize)
+                    val stream = Stream.fromIterator(it, chunkSize)
                     stream.run.map(res => assert(res == Chunk(1, 2, 3, 4, 5)))
                 }
 
                 "call by name" in run {
 
-                    val stream = Stream.fromIterator(Iterator(1, 2, 3, 4, 5), bufferSize)
+                    val stream = Stream.fromIterator(Iterator(1, 2, 3, 4, 5), chunkSize)
                     stream.run.map(res => assert(res == Chunk(1, 2, 3, 4, 5)))
                 }
 
                 "empty iterator" in run {
                     val it     = Iterator.empty
-                    val stream = Stream.fromIterator(it, bufferSize)
+                    val stream = Stream.fromIterator(it, chunkSize)
                     stream.run.map(res => assert(res.isEmpty))
                 }
 
                 "reuse same stream" in run {
                     val it     = Iterator(1, 2, 3)
-                    val stream = Stream.fromIterator(it, bufferSize)
+                    val stream = Stream.fromIterator(it, chunkSize)
                     for
                         first  <- stream.run
                         second <- stream.run
@@ -249,7 +249,7 @@ class StreamCoreExtensionsTest extends Test:
                 "large iterator" in run {
                     val size   = 10000
                     val it     = Iterator.from(0).take(size)
-                    val stream = Stream.fromIterator(it, bufferSize)
+                    val stream = Stream.fromIterator(it, chunkSize)
                     stream.run.map(res => assert(res == Chunk.from(0 until size)))
                 }
 
@@ -257,7 +257,7 @@ class StreamCoreExtensionsTest extends Test:
                     val it = Iterator("a", "b", "c")
 
                     val stream: Stream[String, IO & Choice] =
-                        Stream.fromIterator(it, bufferSize).map: str =>
+                        Stream.fromIterator(it, chunkSize).rechunk(10).map: str =>
                             Choice.eval(true, false).map:
                                 case true  => str.toUpperCase
                                 case false => str
@@ -272,6 +272,125 @@ class StreamCoreExtensionsTest extends Test:
 
         "fromIterator" - {
             Seq(0, 1, 4, 32, 1024).foreach(fromIteratorTests)
+        }
+
+        def fromIteratorCatchingTests(chunkSize: Int): Unit =
+            s"bufferSize = $chunkSize" - {
+
+                "basic" in run {
+                    val it     = Iterator(1, 2, 3, 4, 5)
+                    val stream = Stream.fromIteratorCatching[Throwable](it, chunkSize)
+                    stream.run.map(res => assert(res == Chunk(1, 2, 3, 4, 5)))
+                }
+
+                "call by name" in run {
+                    val stream = Stream.fromIteratorCatching[Throwable](Iterator(1, 2, 3, 4, 5), chunkSize)
+                    stream.run.map(res => assert(res == Chunk(1, 2, 3, 4, 5)))
+                }
+
+                "empty iterator" in run {
+                    val it     = Iterator.empty
+                    val stream = Stream.fromIteratorCatching[Throwable](it, chunkSize)
+                    stream.run.map(res => assert(res.isEmpty))
+                }
+
+                "reuse same stream" in run {
+                    val it     = Iterator(1, 2, 3)
+                    val stream = Stream.fromIteratorCatching[Throwable](it, chunkSize)
+                    for
+                        first  <- stream.run
+                        second <- stream.run
+                    yield assert((first, second) == (Chunk(1, 2, 3), Chunk.empty))
+                    end for
+                }
+
+                "large iterator" in run {
+                    val size   = 9999
+                    val it     = Iterator.from(0).take(size)
+                    val stream = Stream.fromIteratorCatching[Throwable](it, chunkSize)
+                    stream.run.map(res => assert(res == Chunk.from(0 until size)))
+                }
+
+                "lazy" in run {
+                    val it = Iterator.tabulate(5)({
+                        case 3 => throw new RuntimeException("fail")
+                        case i => i
+                    })
+
+                    val stream = Stream.fromIteratorCatching[Throwable](it, chunkSize min 3)
+
+                    stream.take(3).run.map: chunk =>
+                        assert(chunk == Chunk(0, 1, 2))
+                }
+
+                "catching exception after values" in run {
+                    val it = Iterator.tabulate(5)({
+                        case 3 => throw new RuntimeException("fail")
+                        case i => i
+                    })
+
+                    val stream = Stream.fromIteratorCatching[Throwable](it, chunkSize)
+
+                    val errorTo42 = stream.handle(Abort.recoverOrThrow(e => Emit.value(Chunk(42))))
+
+                    errorTo42.run.map: chunk =>
+                        assert(chunk == Chunk(0, 1, 2, 42))
+
+                }
+
+                "catching specific exception after values" in run {
+                    class Oups(val value: Int) extends RuntimeException("fail")
+
+                    val it = Iterator.tabulate(5)({
+                        case 3 => throw new Oups(42)
+                        case i => i
+                    })
+
+                    val stream = Stream.fromIteratorCatching[Oups](it, chunkSize).handle(Abort.recoverOrThrow((e: Oups) =>
+                        Emit.value(Chunk(e.value))
+                    ))
+
+                    stream.run.map: chunk =>
+                        assert(chunk == Chunk(0, 1, 2, 42))
+                }
+
+                "catching specific exception, panic" in run {
+                    class Oups(val value: Int) extends RuntimeException("fail")
+
+                    val it = Iterator.tabulate(5)({
+                        case 3 => throw new RuntimeException("fail")
+                        case i => i
+                    })
+
+                    val stream = Stream.fromIteratorCatching[Oups](it, chunkSize).handle(Abort.recoverOrThrow((e: Oups) =>
+                        Emit.value(Chunk(e.value))
+                    ))
+
+                    Abort.run(stream.run).map({
+                        case Result.Panic(_) => succeed
+                        case _               => fail("should not be caught")
+
+                    })
+                }
+
+                "map with Choice" in run {
+                    val it = Iterator("a", "b", "c")
+                    val stream: Stream[String, IO & Choice & Abort[Throwable]] =
+                        Stream.fromIteratorCatching[Throwable](it, chunkSize).rechunk(10).map: str =>
+                            Choice.eval(true, false).map:
+                                case true  => str.toUpperCase
+                                case false => str
+
+                    Choice.run(stream.run).map: allCombinations =>
+                        assert(allCombinations.size == 8)
+                        assert(allCombinations.contains(Chunk("a", "B", "c")))
+
+                }
+
+            }
+
+        "fromIteratorCatching" - {
+            Seq(0, 1, 4, 32, 1024).foreach(fromIteratorCatchingTests)
         }
 
         "mapChunkParUnordered" - {


### PR DESCRIPTION
follow-up of https://github.com/getkyo/kyo/pull/1222


* add `Stream.fromIteratorCatching[E]`
* rewrite `Stream.fromIterator` to use `Stream.fromIteratorCatching`


Note: previous implementation on `fromIterator` was passing the test on `Choice`, because `Stream.repeatPresent` is rechunking. `Choice` over map of impure/effectful construction is still on open subject (not for long).
