### PR TITLE
[direct][stream] add stream support in direct

### DIFF
--- a/kyo-direct/shared/src/main/scala/kyo/internal/AsyncShift.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/AsyncShift.scala
@@ -186,6 +186,15 @@ class StreamAsyncShift[V, S] extends AsyncShift[Stream[V, S]]:
         monad match
             case _: KyoCpsMonad[?] => monad.pure(stream.map(a => f(a)).asInstanceOf[Stream[V2, S]])
     end map
+
+    def filter[F[_]](stream: Stream[V, S], monad: CpsMonad[F])(f: V => F[Boolean])(using
+        tag: Tag[Emit[Chunk[V]]],
+        discr: Discriminator,
+        frame: Frame
+    ): F[Stream[V, S]] =
+        monad match
+            case _: KyoCpsMonad[?] => monad.pure(stream.filter(f).asInstanceOf[Stream[V, S]])
+
 end StreamAsyncShift
 
 class ChunkAsyncShift[A](using Frame) extends KyoSeqAsyncShift[A, Chunk, Chunk[A]]

--- a/kyo-direct/shared/src/main/scala/kyo/internal/AsyncShift.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/AsyncShift.scala
@@ -7,7 +7,6 @@ import kyo.*
 import kyo.kernel.internal.Safepoint
 import scala.annotation.targetName
 import scala.collection.IterableOps
-import scala.util.NotGiven
 
 trait asyncShiftLowPriorityImplicit1:
 

--- a/kyo-direct/shared/src/main/scala/kyo/internal/AsyncShift.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/AsyncShift.scala
@@ -21,7 +21,6 @@ object asyncShift extends asyncShiftLowPriorityImplicit1:
     transparent inline given shiftedChunk[A]: ChunkAsyncShift[A] = new ChunkAsyncShift[A]
     transparent inline given shiftedMaybe: MaybeAsyncShift       = new MaybeAsyncShift
     transparent inline given shiftedResult: ResultAsyncShift     = new ResultAsyncShift
-    transparent inline given shitferStream[V, S]: StreamAsyncShift[V, S] = new StreamAsyncShift
 
 end asyncShift
 
@@ -175,27 +174,6 @@ class MaybeAsyncShift(using Frame) extends AsyncShift[Maybe.type]:
                     case Maybe.Absent     => ifEmpty()
 
 end MaybeAsyncShift
-
-class StreamAsyncShift[V, S] extends AsyncShift[Stream[V, S]]:
-    def map[F[_], V2](stream: Stream[V, S], monad: CpsMonad[F])(f: V => F[V2])(using
-        t1: Tag[Emit[Chunk[V]]],
-        t2: Tag[Emit[Chunk[V2]]],
-        ev: NotGiven[V2 <:< (Any < Nothing)],
-        fr: Frame
-    ): F[Stream[V2, S]] =
-        monad match
-            case _: KyoCpsMonad[?] => monad.pure(stream.map(a => f(a)).asInstanceOf[Stream[V2, S]])
-    end map
-
-    def filter[F[_]](stream: Stream[V, S], monad: CpsMonad[F])(f: V => F[Boolean])(using
-        tag: Tag[Emit[Chunk[V]]],
-        discr: Discriminator,
-        frame: Frame
-    ): F[Stream[V, S]] =
-        monad match
-            case _: KyoCpsMonad[?] => monad.pure(stream.filter(f).asInstanceOf[Stream[V, S]])
-
-end StreamAsyncShift
 
 class ChunkAsyncShift[A](using Frame) extends KyoSeqAsyncShift[A, Chunk, Chunk[A]]
 

--- a/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
@@ -63,7 +63,8 @@ private[kyo] object Validate:
                     qualifier.tpe <:< TypeRepr.of[Option[?]] |
                     qualifier.tpe <:< TypeRepr.of[scala.util.Try[?]] |
                     qualifier.tpe <:< TypeRepr.of[Either[?, ?]] |
-                    qualifier.tpe <:< TypeRepr.of[Either.LeftProjection[?, ?]]
+                    qualifier.tpe <:< TypeRepr.of[Either.LeftProjection[?, ?]] |
+                    qualifier.tpe <:< TypeRepr.of[kyo.Stream[?, ?]]
 
             inline def validName: Boolean = validMethodNamesForAsyncShift.contains(methodName)
 

--- a/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
@@ -154,6 +154,9 @@ private[kyo] object Validate:
                 skipDive(argGroup0)
                 skipDive(argGroup1)
 
+            // direct: in direct:
+            case Inlined(Some(Apply(TypeApply(Ident("direct"), _), _)), _, _) =>
+
             case Apply(TypeApply(Ident("now" | "later"), _), List(qual)) =>
                 @tailrec
                 def dive(qual: Tree): Unit =

--- a/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
@@ -117,15 +117,14 @@ private[kyo] object Validate:
                         })
 
                         if hasNow then
-                            fail(
-                                body,
+                            report.errorAndAbort(
                                 """
                                   |Calling `.now` inside a lazy structure breaks effect handling, and allow for escaping behavior.
                                   |You have two options:
                                   | - calling .now before building the structure :
                                   |     def f(x: Int): Int < S
                                   |     direct:
-                                  |        y = f(1).now
+                                  |        val y = f(1).now
                                   |        stream.map(x => x + y)
                                   |
                                   | - using the effect
@@ -133,7 +132,8 @@ private[kyo] object Validate:
                                   |     direct:
                                   |       stream.map(x => f(x + 1))
                                   |
-                                  |""".stripMargin
+                                  |""".stripMargin,
+                                body.pos
                             )
                         else
                             body match

--- a/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
@@ -1,0 +1,34 @@
+package kyo
+
+import kyo.internal.BaseKyoCoreTest
+import org.scalatest.Assertions
+import org.scalatest.freespec.AnyFreeSpec
+import scala.collection.IterableOps
+import scala.util.Try
+
+class StreamTest extends Test:
+
+    "Stream" - {
+        "map" in run {
+            val stream = Stream.init(Seq(1, 2, 3))
+
+            def f(i: Int): Int < Var[Int] =
+                Var.update[Int](_ + i)
+
+            val newStream1: Stream[Int, Any] < Var[Int] = direct:
+                stream.map(x => f(x).now)
+
+            val newStream2: Stream[Int, Var[Int]] < Any = direct:
+                stream.map(x => f(x).later)
+
+            def check(stream: Stream[Int, Var[Int]] < Var[Int], expected: Chunk[Int]) =
+                Var.run(0):
+                    Stream.unwrap(stream).run.map: chunk =>
+                        assert(chunk == expected)
+
+            check(newStream1, Chunk(1, 3, 6))
+            check(newStream2, Chunk(1, 3, 6))
+
+        }
+    }
+end StreamTest

--- a/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
@@ -1,11 +1,5 @@
 package kyo
 
-import kyo.internal.BaseKyoCoreTest
-import org.scalatest.Assertions
-import org.scalatest.freespec.AnyFreeSpec
-import scala.collection.IterableOps
-import scala.util.Try
-
 class StreamTest extends Test:
 
     "Stream" - {
@@ -29,6 +23,27 @@ class StreamTest extends Test:
             check(newStream1, Chunk(1, 3, 6))
             check(newStream2, Chunk(1, 3, 6))
 
+        }
+
+        "filter" in run {
+            val stream = Stream.init(Seq(1, 2, 3))
+
+            def f(i: Int): Boolean < Var[Int] =
+                Var.update[Int](_ + i).map(_ % 2 == 0)
+
+            val newStream1: Stream[Int, Any] < Var[Int] = direct:
+                stream.filter(x => f(x).now)
+
+            val newStream2: Stream[Int, Var[Int]] < Any = direct:
+                stream.filter(x => f(x).later)
+
+            def check(stream: Stream[Int, Var[Int]] < Var[Int], expected: Chunk[Int]) =
+                Var.run(0):
+                    Stream.unwrap(stream).run.map: chunk =>
+                        assert(chunk == expected)
+
+            check(newStream1, Chunk(3))
+            check(newStream2, Chunk(3))
         }
     }
 end StreamTest

--- a/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
@@ -10,10 +10,20 @@ class StreamTest extends Test:
                 Var.update[Int](_ + i)
 
             val newStream1: Stream[Int, Any] < Var[Int] = direct:
-                stream.map(x => f(x).now)
+                stream.map(x => f(x).now) //TODO don't support .now
 
             val newStream2: Stream[Int, Var[Int]] < Any = direct:
-                stream.map(x => f(x).later)
+                stream.map(x => f(x).later) //TODO remove .later
+
+            val newStream3 = direct:
+                stream.map(x =>
+                    direct:
+                        f(x).now + 1
+                    .later //TODO remove .later
+                )
+
+            val x = direct:
+                direct(1 + 1).now
 
             def check(stream: Stream[Int, Var[Int]] < Var[Int], expected: Chunk[Int]) =
                 Var.run(0):

--- a/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
@@ -2,6 +2,11 @@ package kyo
 
 class StreamTest extends Test:
 
+    def check(stream: Stream[Int, Var[Int]] < Var[Int], expected: Chunk[Int]): Assertion < Any =
+        Var.run(0):
+            Stream.unwrap(stream).run.map: chunk =>
+                assert(chunk == expected)
+
     "Stream" - {
         "map" in run {
             val stream = Stream.init(Seq(1, 2, 3))
@@ -14,22 +19,19 @@ class StreamTest extends Test:
             )("Effectful computations must explicitly use either .now or .later in a direct block.")
 
             val newStream2: Stream[Int, Var[Int]] < Any = direct:
-                stream.map(x => f(x).later) // TODO remove .later
+                stream.map(x => f(x))
+
+            val newStream2_1: Stream[Int, Var[Int]] < Any = direct:
+                stream.map(f)
 
             val newStream3 = direct:
                 stream.map(x =>
                     direct:
                         f(x).now + 1
-                    .later // TODO remove .later
                 )
 
             val x = direct:
                 direct(1 + 1).now
-
-            def check(stream: Stream[Int, Var[Int]] < Var[Int], expected: Chunk[Int]) =
-                Var.run(0):
-                    Stream.unwrap(stream).run.map: chunk =>
-                        assert(chunk == expected)
 
             check(newStream2, Chunk(1, 3, 6))
 
@@ -47,11 +49,6 @@ class StreamTest extends Test:
 
             val newStream2: Stream[Int, Var[Int]] < Any = direct:
                 stream.filter(x => f(x).later)
-
-            def check(stream: Stream[Int, Var[Int]] < Var[Int], expected: Chunk[Int]) =
-                Var.run(0):
-                    Stream.unwrap(stream).run.map: chunk =>
-                        assert(chunk == expected)
 
             check(newStream2, Chunk(3))
         }

--- a/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
@@ -14,9 +14,10 @@ class StreamTest extends Test:
             def f(i: Int): Int < Var[Int] =
                 Var.update[Int](_ + i)
 
+            val magicStream = stream
             typeCheckFailure(
-                """val newStream1: Stream[Int, Any] < Var[Int] = direct(stream.map(x => f(x).now))""".stripMargin
-            )("Effectful computations must explicitly use either .now or .later in a direct block.")
+                """val newStream1: Stream[Int, Any] < Var[Int] = direct(magicStream.map(x => f(x).now))""".stripMargin
+            )("Calling `.now` inside a lazy structure breaks effect handling, and allow for escaping behavior.")
 
             val newStream2: Stream[Int, Var[Int]] < Any = direct:
                 stream.map(x => f(x))
@@ -45,7 +46,7 @@ class StreamTest extends Test:
 
             typeCheckFailure(
                 """val newStream1: Stream[Int, Any] < Var[Int] = direct(stream.filter(x => f(x).now))"""
-            )("Effectful computations must explicitly use either .now or .later in a direct block.")
+            )("Calling `.now` inside a lazy structure breaks effect handling, and allow for escaping behavior.")
 
             val newStream2: Stream[Int, Var[Int]] < Any = direct:
                 stream.filter(x => f(x).later)

--- a/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/StreamTest.scala
@@ -9,17 +9,18 @@ class StreamTest extends Test:
             def f(i: Int): Int < Var[Int] =
                 Var.update[Int](_ + i)
 
-            val newStream1: Stream[Int, Any] < Var[Int] = direct:
-                stream.map(x => f(x).now) //TODO don't support .now
+            typeCheckFailure(
+                """val newStream1: Stream[Int, Any] < Var[Int] = direct(stream.map(x => f(x).now))""".stripMargin
+            )("Effectful computations must explicitly use either .now or .later in a direct block.")
 
             val newStream2: Stream[Int, Var[Int]] < Any = direct:
-                stream.map(x => f(x).later) //TODO remove .later
+                stream.map(x => f(x).later) // TODO remove .later
 
             val newStream3 = direct:
                 stream.map(x =>
                     direct:
                         f(x).now + 1
-                    .later //TODO remove .later
+                    .later // TODO remove .later
                 )
 
             val x = direct:
@@ -30,7 +31,6 @@ class StreamTest extends Test:
                     Stream.unwrap(stream).run.map: chunk =>
                         assert(chunk == expected)
 
-            check(newStream1, Chunk(1, 3, 6))
             check(newStream2, Chunk(1, 3, 6))
 
         }
@@ -41,8 +41,9 @@ class StreamTest extends Test:
             def f(i: Int): Boolean < Var[Int] =
                 Var.update[Int](_ + i).map(_ % 2 == 0)
 
-            val newStream1: Stream[Int, Any] < Var[Int] = direct:
-                stream.filter(x => f(x).now)
+            typeCheckFailure(
+                """val newStream1: Stream[Int, Any] < Var[Int] = direct(stream.filter(x => f(x).now))"""
+            )("Effectful computations must explicitly use either .now or .later in a direct block.")
 
             val newStream2: Stream[Int, Var[Int]] < Any = direct:
                 stream.filter(x => f(x).later)
@@ -52,7 +53,6 @@ class StreamTest extends Test:
                     Stream.unwrap(stream).run.map: chunk =>
                         assert(chunk == expected)
 
-            check(newStream1, Chunk(3))
             check(newStream2, Chunk(3))
         }
     }


### PR DESCRIPTION
https://github.com/getkyo/kyo/issues/1221 add support for streams

Forms:

```scala
direct:
  stream.map(x => f(x).now)
```
* could be valid if unwraped. -> compile error

---

```scala
direct:
    stream.map(f)
```
* should be supported without a compile error

---

```scala
direct:
    stream.map(x => f(x).later)
```
* should be supported without a compile error

---

```scala
direct:
   stream.map(x => direct(f(x).now + 1))
```
* should be supported without a compile error   
       
        


