### PR TITLE
Covariant Poll

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -185,7 +185,7 @@ sealed abstract class Sink[V, A, -S] extends Serializable:
       *   An effect generating an output value from elements consumed from the stream
       */
     final def drain[S2](stream: Stream[V, S2])(using Tag[Poll[Chunk[V]]], Tag[Emit[Chunk[V]]], Frame): A < (S & S2) =
-        Poll.run(stream.emit)(poll).map(_._2)
+        Poll.runEmit(stream.emit)(poll).map(_._2)
 end Sink
 
 object Sink:

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -65,7 +65,7 @@ final private[kyo] class StreamSubscription[V, S](
         Tag[Poll[Chunk[V]]],
         Frame
     ): Fiber[StreamCanceled, StreamComplete] < (IO & S) =
-        Async.run[StreamCanceled, StreamComplete, S](Poll.run(stream.emit)(poll).map(_._2))
+        Async.run[StreamCanceled, StreamComplete, S](Poll.runEmit(stream.emit)(poll).map(_._2))
             .map { fiber =>
                 fiber.onComplete {
                     case Result.Success(StreamComplete) => IO(subscriber.onComplete())


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

While `Poll` does not need variance for `Stream`, now that `Emit[V]` is contravariant with `V`, it makes sense to make `Poll` covariant with `V`. This will allow us to have variance in `Pipe` and `Sink`.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Made `Poll[V]` contravariant with `V` and made all handling methods support partial handling like in `Emit`.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->

Renamed the `run` overload that runs `Poll` effects against `Emit` effects to `runEmit` since the variance led to type inference issues.
