### PR TITLE
Channel stream optimistic drain

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/ChannelBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ChannelBench.scala
@@ -1,0 +1,33 @@
+package kyo.bench
+
+import kyo.*
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+import scala.compiletime.uninitialized
+import scala.reflect.ClassTag
+import scala.util.Random
+
+class ChannelBench extends BaseBench:
+
+    import AllowUnsafe.embrace.danger
+
+    var size: Int = 1024
+
+    @Param(Array("1", "2", "4", "8"))
+    var maxChunkSize: Int = uninitialized
+
+    def intFillFn: Int = Random.nextInt()
+
+    @Benchmark def streamChunks() =
+        val x =
+            for
+                channel <- Channel.init[Int](size)
+                _       <- channel.putBatch(Seq.fill(size)(intFillFn))
+                _       <- Async.run(channel.closeAwaitEmpty)
+                count   <- channel.streamUntilClosed(maxChunkSize).into(Sink.count)
+            yield count
+        val count = IO.Unsafe.evalOrThrow(Async.run(x).flatMap(_.block(Duration.Infinity))).getOrThrow
+        assert(count == size, s"Expected $size, got $count")
+    end streamChunks
+
+end ChannelBench


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

When the producer is faster than a stream consumer (at least in terms of frequency of calls to put and emit, not necessarily overall throughput), the consumer will call take and drain and perform an unnecessary `Chunk.concat`.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Optimistically call `drainUpTo` and only if it is non-empty then call `take`.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->

Whenever the steam consumer blocks it will always emit a single element before draining the rest. This eliminates all `Chunk.concat` but the chunk sizes will be less consistent. If the consumer cares about this then they should call `rechunk`.

Here are the results of running the benchmark with both the old and new implementations:
```
[info] Benchmark                                      (maxChunkSize)   Mode  Cnt       Score       Error   Units
[info] ChannelBench.streamChunks                                   1  thrpt    5    1567.323 ±    46.675   ops/s
[info] ChannelBench.streamChunks:gc.alloc.rate                     1  thrpt    5    1203.317 ±    35.884  MB/sec
[info] ChannelBench.streamChunks:gc.alloc.rate.norm                1  thrpt    5  805148.166 ±     1.308    B/op
[info] ChannelBench.streamChunks:gc.count                          1  thrpt    5      10.000              counts
[info] ChannelBench.streamChunks:gc.time                           1  thrpt    5       7.000                  ms
[info] ChannelBench.streamChunks                                   2  thrpt    5    1629.221 ±    16.583   ops/s
[info] ChannelBench.streamChunks:gc.alloc.rate                     2  thrpt    5    1066.309 ±    10.867  MB/sec
[info] ChannelBench.streamChunks:gc.alloc.rate.norm                2  thrpt    5  686372.088 ±     1.475    B/op
[info] ChannelBench.streamChunks:gc.count                          2  thrpt    5       9.000              counts
[info] ChannelBench.streamChunks:gc.time                           2  thrpt    5       6.000                  ms
[info] ChannelBench.streamChunks                                   4  thrpt    5    2943.928 ±    38.511   ops/s
[info] ChannelBench.streamChunks:gc.alloc.rate                     4  thrpt    5    1116.141 ±    14.647  MB/sec
[info] ChannelBench.streamChunks:gc.alloc.rate.norm                4  thrpt    5  397602.393 ±     0.091    B/op
[info] ChannelBench.streamChunks:gc.count                          4  thrpt    5      10.000              counts
[info] ChannelBench.streamChunks:gc.time                           4  thrpt    5       6.000                  ms
[info] ChannelBench.streamChunks                                   8  thrpt    5    5059.374 ±   285.300   ops/s
[info] ChannelBench.streamChunks:gc.alloc.rate                     8  thrpt    5    1192.789 ±    63.451  MB/sec
[info] ChannelBench.streamChunks:gc.alloc.rate.norm                8  thrpt    5  247251.451 ±   942.549    B/op
[info] ChannelBench.streamChunks:gc.count                          8  thrpt    5      10.000              counts
[info] ChannelBench.streamChunks:gc.time                           8  thrpt    5       6.000                  ms
[info] ChannelBench.streamChunks2                                  1  thrpt    5    1582.921 ±    38.449   ops/s
[info] ChannelBench.streamChunks2:gc.alloc.rate                    1  thrpt    5    1216.563 ±    20.005  MB/sec
[info] ChannelBench.streamChunks2:gc.alloc.rate.norm               1  thrpt    5  806003.443 ±  7173.520    B/op
[info] ChannelBench.streamChunks2:gc.count                         1  thrpt    5      10.000              counts
[info] ChannelBench.streamChunks2:gc.time                          1  thrpt    5       6.000                  ms
[info] ChannelBench.streamChunks2                                  2  thrpt    5    2792.484 ±    39.788   ops/s
[info] ChannelBench.streamChunks2:gc.alloc.rate                    2  thrpt    5    1226.608 ±    64.519  MB/sec
[info] ChannelBench.streamChunks2:gc.alloc.rate.norm               2  thrpt    5  460646.177 ± 20508.503    B/op
[info] ChannelBench.streamChunks2:gc.count                         2  thrpt    5      10.000              counts
[info] ChannelBench.streamChunks2:gc.time                          2  thrpt    5       7.000                  ms
[info] ChannelBench.streamChunks2                                  4  thrpt    5    4841.032 ±    77.556   ops/s
[info] ChannelBench.streamChunks2:gc.alloc.rate                    4  thrpt    5    1280.094 ±    20.254  MB/sec
[info] ChannelBench.streamChunks2:gc.alloc.rate.norm               4  thrpt    5  277303.186 ±   744.321    B/op
[info] ChannelBench.streamChunks2:gc.count                         4  thrpt    5      11.000              counts
[info] ChannelBench.streamChunks2:gc.time                          4  thrpt    5       7.000                  ms
[info] ChannelBench.streamChunks2                                  8  thrpt    5    7295.941 ±   416.986   ops/s
[info] ChannelBench.streamChunks2:gc.alloc.rate                    8  thrpt    5    1322.592 ±    74.115  MB/sec
[info] ChannelBench.streamChunks2:gc.alloc.rate.norm               8  thrpt    5  190108.108 ±   278.695    B/op
[info] ChannelBench.streamChunks2:gc.count                         8  thrpt    5      11.000              counts
[info] ChannelBench.streamChunks2:gc.time                          8  thrpt    5       8.000                  ms
[info] Benchmark result is saved to jmh-result.json
```
`ChannelBench.streamChunks` was the old implementation. `ChannelBench.streamChunks2` is the new one.