### PR TITLE
Rename IO to Sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,8 +145,8 @@ If you want to contribute a new method like `S.newMethod` or `s.newMethod`, feel
 | Subproject        | Use For                                                 |
 | ----------------- | ------------------------------------------------------- |
 | `kyo-data`        | Data structures (`Chunk`, `Maybe`, `Result`, etc.)      |
-| `kyo-prelude`     | Effect types without `IO` (`Abort`, `Env`, `Var`, etc.) |
-| `kyo-core`        | Methods requiring `IO`, `Async`, or `Resource`          |
+| `kyo-prelude`     | Effect types without `Sync` (`Abort`, `Env`, `Var`, etc.) |
+| `kyo-core`        | Methods requiring `Sync`, `Async`, or `Resource`          |
 | `kyo-combinators` | Extensions or composition helpers                       |
 
 Add corresponding tests in the same subproject.
@@ -154,12 +154,12 @@ Add corresponding tests in the same subproject.
 **Example:**\
 A new `Stream.fromSomething` method:
 
-- If it uses `IO`: place it in `kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala`
+- If it uses `Sync`: place it in `kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala`
 - If it doesn't: place it in `kyo-prelude/shared/src/main/scala/kyo/Stream.scala`
 
 ### Tips
 
-- Prefer [`call-by-name`](https://docs.scala-lang.org/tour/by-name-parameters.html) (`body: => A < S`) for deferred evaluation **when lifting to IO**. This works because `IO` is the final effect to be handled, allowing proper suspension of side effects. This does not apply to other effects.
+- Prefer [`call-by-name`](https://docs.scala-lang.org/tour/by-name-parameters.html) (`body: => A < S`) for deferred evaluation **when lifting to Sync**. This works because `Sync` is the final effect to be handled, allowing proper suspension of side effects. This does not apply to other effects.
 
 - Use [`inline`](https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html) only when beneficial in performance-sensitive APIs. Excessive use may increase compilation times.
 

--- a/README.md
+++ b/README.md
@@ -3386,7 +3386,7 @@ The `Cats` effect provides seamless integration between Kyo and the Cats Effect 
 
 ```scala
 import kyo.*
-import cats.effect.Sync as CatsIO
+import cats.effect.IO as CatsIO
 
 // Use the 'get' method to extract a 'Sync' effect from Cats Effect:
 val a: Int < (Abort[Throwable] & Async) =
@@ -3401,7 +3401,7 @@ Kyo and Cats effects can be seamlessly mixed and matched within computations, al
 
 ```scala
 import kyo.*
-import cats.effect.Sync as CatsIO
+import cats.effect.IO as CatsIO
 import cats.effect.kernel.Outcome.Succeeded
 
 // Note how Cats includes the Sync, Async, and Abort[Nothing] effects:

--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ val a: Int < IO =
 
 Users shouldn't typically handle the `IO` effect directly since it triggers the execution of side effects, which breaks referential transparency. Prefer `KyoApp` instead.
 
-In some specific cases where Kyo isn't used as the main effect system of an application, it might be necessary to handle the IO effect directly. However, this requires explicit acknowledgment of the unsafe nature of the operation using `AllowUnsafe.embrace.danger`. The `run` method can only be used if `IO` is the only pending effect.
+In some specific cases where Kyo isn't used as the main effect system of an application, it might be necessary to handle the Sync effect directly. However, this requires explicit acknowledgment of the unsafe nature of the operation using `AllowUnsafe.embrace.danger`. The `run` method can only be used if `IO` is the only pending effect.
 
 ```scala
 import kyo.*
@@ -1349,7 +1349,7 @@ import kyo.*
 
 case class Config(someConfig: String)
 
-// Stream with IO effect
+// Stream with Sync effect
 val a: Stream[String, IO] =
     Stream.init(Seq("file1.txt", "file2.txt"))
         .map(fileName => IO(scala.io.Source.fromFile(fileName).mkString))

--- a/kyo-actor/shared/src/main/scala/kyo/Subject.scala
+++ b/kyo-actor/shared/src/main/scala/kyo/Subject.scala
@@ -40,7 +40,7 @@ sealed abstract class Subject[A]:
       * @return
       *   true if the message was successfully sent, false if the recipient couldn't accept it immediately
       */
-    def trySend(message: A)(using Frame): Boolean < (IO & Abort[Closed])
+    def trySend(message: A)(using Frame): Boolean < (Sync & Abort[Closed])
 
     /** Sends a message and waits for a response.
       *
@@ -171,7 +171,7 @@ object Subject:
       */
     inline def init[A](
         inline send: Frame ?=> A => Unit < (Async & Abort[Closed]),
-        inline trySend: Frame ?=> A => Boolean < (IO & Abort[Closed])
+        inline trySend: Frame ?=> A => Boolean < (Sync & Abort[Closed])
     ): Subject[A] =
         _init(send, trySend)
 
@@ -179,7 +179,7 @@ object Subject:
     // Indirection to avoid parameter shaddowing
     private inline def _init[A](
         inline _send: Frame ?=> A => Unit < (Async & Abort[Closed]),
-        inline _trySend: Frame ?=> A => Boolean < (IO & Abort[Closed])
+        inline _trySend: Frame ?=> A => Boolean < (Sync & Abort[Closed])
     ): Subject[A] =
         new Subject[A]:
             def send(message: A)(using Frame)    = _send(message)

--- a/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
+++ b/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
@@ -61,9 +61,9 @@ object Topic:
       *   The computation result within Async context
       */
     def run[A, S](v: A < (Topic & S))(using Frame): A < (Async & S) =
-        IO {
+        Sync {
             val driver = MediaDriver.launchEmbedded()
-            IO.ensure(driver.close()) {
+            Sync.ensure(driver.close()) {
                 run(driver)(v)
             }
         }
@@ -81,9 +81,9 @@ object Topic:
       *   The computation result within Async context
       */
     def run[A, S](driver: MediaDriver)(v: A < (Topic & S))(using Frame): A < (Async & S) =
-        IO {
+        Sync {
             val aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName()))
-            IO.ensure(aeron.close()) {
+            Sync.ensure(aeron.close()) {
                 run(aeron)(v)
             }
         }
@@ -133,7 +133,7 @@ object Topic:
         etag: Tag[Emit[Chunk[A]]]
     ): Unit < (Topic & S & Abort[Closed | Backpressured] & Async) =
         Env.use[Aeron] { aeron =>
-            IO {
+            Sync {
                 // register the publication with Aeron using type's hash as stream ID
                 val publication = aeron.addPublication(aeronUri, tag.hash.abs)
 
@@ -144,10 +144,10 @@ object Topic:
                 val backpressured = Abort.fail(Backpressured())
 
                 // ensure publication is closed after use
-                IO.ensure(IO(publication.close())) {
+                Sync.ensure(Sync(publication.close())) {
                     stream.foreachChunk { messages =>
                         Retry[Backpressured](retrySchedule) {
-                            IO {
+                            Sync {
                                 if !publication.isConnected() then backpressured
                                 else
                                     // serialize messages with type tag for runtime verification
@@ -204,7 +204,7 @@ object Topic:
     )(using tag: Tag[A], etag: Tag[Emit[Chunk[A]]], frame: Frame): Stream[A, Topic & Abort[Backpressured] & Async] =
         Stream {
             Env.use[Aeron] { aeron =>
-                IO {
+                Sync {
                     // register subscription with Aeron using type's hash as stream ID
                     val subscription = aeron.addSubscription(aeronUri, tag.hash.abs)
 
@@ -223,10 +223,10 @@ object Topic:
                         )
 
                     // ensure subscription is closed after use
-                    IO.ensure(IO(subscription.close())) {
+                    Sync.ensure(Sync(subscription.close())) {
                         def loop(): Unit < (Emit[Chunk[A]] & Async & Abort[Backpressured]) =
                             Retry[Backpressured](retrySchedule) {
-                                IO {
+                                Sync {
                                     if !subscription.isConnected() then backpressured
                                     else
                                         // clear previous result before polling

--- a/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
+++ b/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
@@ -53,7 +53,7 @@ object Topic:
 
     /** Handles Topic with an embedded Aeron MediaDriver.
       *
-      * Creates and manages the lifecycle of an embedded MediaDriver, ensuring proper cleanup through IO.ensure.
+      * Creates and manages the lifecycle of an embedded MediaDriver, ensuring proper cleanup through Sync.ensure.
       *
       * @param v
       *   The computation requiring Topic capabilities

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ArenaBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ArenaBench.scala
@@ -37,7 +37,7 @@ object ArenaBench:
     abstract class Base[A](expectedResult: A) extends ArenaBench[A](expectedResult):
         def zioBench(): zio.UIO[A]
         def kyoBenchFiber(): kyo.<[A, kyo.Async & kyo.Abort[Throwable]] = kyoBench()
-        def kyoBench(): kyo.<[A, kyo.IO]
+        def kyoBench(): kyo.<[A, kyo.Sync]
         def catsBench(): cats.effect.IO[A]
     end Base
 
@@ -47,7 +47,7 @@ object ArenaBench:
         def forkKyo(warmup: KyoForkWarmup): A =
             import kyo.*
             import AllowUnsafe.embrace.danger
-            IO.Unsafe.evalOrThrow(Async.run(kyoBenchFiber()).flatMap(_.block(Duration.Infinity))).getOrThrow
+            Sync.Unsafe.evalOrThrow(Async.run(kyoBenchFiber()).flatMap(_.block(Duration.Infinity))).getOrThrow
         end forkKyo
 
         @Benchmark
@@ -68,7 +68,7 @@ object ArenaBench:
         @Benchmark
         def syncKyo(warmup: KyoSyncWarmup): A =
             import kyo.AllowUnsafe.embrace.danger
-            kyo.IO.Unsafe.evalOrThrow(kyoBench())
+            kyo.Sync.Unsafe.evalOrThrow(kyoBench())
         end syncKyo
 
         @Benchmark

--- a/kyo-bench/src/main/scala/kyo/bench/arena/BlockingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/BlockingBench.scala
@@ -10,7 +10,7 @@ class BlockingBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        IO(block())
+        Sync(block())
     end kyoBenchFiber
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/BlockingContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/BlockingContentionBench.scala
@@ -12,7 +12,7 @@ class BlockingContentionBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        Async.fill(concurrency, concurrency)(IO(block())).unit
+        Async.fill(concurrency, concurrency)(Sync(block())).unit
     end kyoBenchFiber
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/BroadFlatMapBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/BroadFlatMapBench.scala
@@ -18,7 +18,7 @@ class BroadFlatMapBench extends ArenaBench.SyncAndFork(BigInt(610)):
     def kyoBench() =
         import kyo.*
 
-        def kyoFib(n: Int): BigInt < IO =
+        def kyoFib(n: Int): BigInt < Sync =
             if n <= 1 then BigInt(n)
             else kyoFib(n - 1).flatMap(a => kyoFib(n - 2).flatMap(b => a + b))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/CollectBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/CollectBench.scala
@@ -4,7 +4,7 @@ class CollectBench extends ArenaBench.SyncAndFork(Seq.fill(1000)(1)):
 
     val count = 1000
 
-    val kyoTasks  = List.fill(count)(kyo.IO(1))
+    val kyoTasks  = List.fill(count)(kyo.Sync(1))
     val catsTasks = List.fill(count)(cats.effect.IO(1))
     val zioTasks  = List.fill(count)(zio.ZIO.succeed(1))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/CollectParBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/CollectParBench.scala
@@ -3,7 +3,7 @@ package kyo.bench.arena
 class CollectParBench extends ArenaBench.ForkOnly(Seq.fill(1000)(1)):
 
     val count     = 1000
-    val kyoTasks  = List.fill(count)(kyo.IO(1))
+    val kyoTasks  = List.fill(count)(kyo.Sync(1))
     val catsTasks = List.fill(count)(cats.effect.IO(1))
     val zioTasks  = List.fill(count)(zio.ZIO.succeed(1))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/CountdownLatchBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/CountdownLatchBench.scala
@@ -23,7 +23,7 @@ class CountdownLatchBench extends ArenaBench.ForkOnly(0):
     override def kyoBenchFiber() =
         import kyo.*
 
-        def iterate(l: Latch, n: Int): Unit < IO =
+        def iterate(l: Latch, n: Int): Unit < Sync =
             if n <= 0 then Kyo.unit
             else l.release.flatMap(_ => iterate(l, n - 1))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/DeepBindBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/DeepBindBench.scala
@@ -7,7 +7,7 @@ class DeepBindBench extends ArenaBench.SyncAndFork(()):
     def kyoBench() =
         import kyo.*
 
-        def loop(i: Int): Unit < IO =
+        def loop(i: Int): Unit < Sync =
             Kyo.unit.flatMap { _ =>
                 if i > depth then
                     ()

--- a/kyo-bench/src/main/scala/kyo/bench/arena/DeepBindMapBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/DeepBindMapBench.scala
@@ -7,11 +7,11 @@ class DeepBindMapBench extends ArenaBench.SyncAndFork(10001):
     def kyoBench() =
         import kyo.*
 
-        def loop(i: Int): Int < IO =
-            IO {
+        def loop(i: Int): Int < Sync =
+            Sync {
                 if i > depth then i
                 else
-                    IO(i + 11)
+                    Sync(i + 11)
                         .map(_ - 1)
                         .map(_ - 1)
                         .map(_ - 1)

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkChainedBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkChainedBench.scala
@@ -22,7 +22,7 @@ class ForkChainedBench extends ArenaBench.ForkOnly(0):
     override def kyoBenchFiber() =
         import kyo.*
 
-        def iterate(p: Promise[Nothing, Unit], n: Int): Unit < IO =
+        def iterate(p: Promise[Nothing, Unit], n: Int): Unit < Sync =
             if n <= 0 then p.complete(Result.unit).unit
             else Kyo.unit.flatMap(_ => Async.run(iterate(p, n - 1)).unit)
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkManyBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkManyBench.scala
@@ -26,7 +26,7 @@ class ForkManyBench extends ArenaBench.ForkOnly(0):
     override def kyoBenchFiber() =
         import kyo.*
 
-        def repeat[A](n: Int)(io: A < IO): A < IO =
+        def repeat[A](n: Int)(io: A < Sync): A < Sync =
             if n <= 1 then io
             else io.flatMap(_ => repeat(n - 1)(io))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkSpawnBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkSpawnBench.scala
@@ -31,7 +31,7 @@ class ForkSpawnBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        def repeat[A](n: Int)(io: A < IO): A < IO =
+        def repeat[A](n: Int)(io: A < Sync): A < Sync =
             if n <= 1 then io
             else io.flatMap(_ => repeat(n - 1)(io))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/LoggingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/LoggingBench.scala
@@ -7,7 +7,7 @@ class LoggingBench extends ArenaBench.SyncAndFork(()):
     def kyoBench() =
         import kyo.*
 
-        def loop(i: Int): Unit < IO =
+        def loop(i: Int): Unit < Sync =
             if i > depth then
                 ()
             else

--- a/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindBench.scala
@@ -7,11 +7,11 @@ class NarrowBindBench extends ArenaBench.SyncAndFork(10000):
     def kyoBench() =
         import kyo.*
 
-        def loop(i: Int): Int < IO =
-            if i < depth then IO(i + 1).flatMap(loop)
-            else IO(i)
+        def loop(i: Int): Int < Sync =
+            if i < depth then Sync(i + 1).flatMap(loop)
+            else Sync(i)
 
-        IO(0).flatMap(loop)
+        Sync(0).flatMap(loop)
     end kyoBench
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindMapBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindMapBench.scala
@@ -7,13 +7,13 @@ class NarrowBindMapBench extends ArenaBench.SyncAndFork(10000):
     def kyoBench() =
         import kyo.*
 
-        def loop(i: Int): Int < IO =
+        def loop(i: Int): Int < Sync =
             if i < depth then
-                IO(i + 11).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1)
+                Sync(i + 11).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1)
                     .map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(loop)
-            else IO(i)
+            else Sync(i)
 
-        IO(0).flatMap(loop)
+        Sync(0).flatMap(loop)
     end kyoBench
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/RandomBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/RandomBench.scala
@@ -15,7 +15,7 @@ class RandomBench extends ArenaBench.SyncAndFork(()):
                 _ <- Random.nextFloat
             yield ()
 
-        def loop(i: Int): Unit < IO =
+        def loop(i: Int): Unit < Sync =
             if i > depth then
                 ()
             else

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SchedulingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SchedulingBench.scala
@@ -29,12 +29,12 @@ class SchedulingBench extends ArenaBench.ForkOnly(1001000):
     override def kyoBenchFiber() =
         import kyo.*
 
-        def fiber(i: Int): Int < IO =
+        def fiber(i: Int): Int < Sync =
             Kyo.unit.flatMap { _ =>
-                IO(i).flatMap { j =>
+                Sync(i).flatMap { j =>
                     Kyo.unit.flatMap { _ =>
                         if j > depth then
-                            Kyo.unit.flatMap(_ => IO(j))
+                            Kyo.unit.flatMap(_ => Sync(j))
                         else
                             Kyo.unit.flatMap(_ => fiber(j + 1))
                     }

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SemaphoreContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SemaphoreContentionBench.scala
@@ -34,7 +34,7 @@ class SemaphoreContentionBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        def repeat[A](n: Int)(io: A < IO): A < IO =
+        def repeat[A](n: Int)(io: A < Sync): A < Sync =
             if n <= 1 then io
             else io.flatMap(_ => repeat(n - 1)(io))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
@@ -16,8 +16,8 @@ class StreamIOBench extends ArenaBench.SyncAndFork(25000000):
     def kyoBench() =
         import kyo.*
         Stream.init(seq)
-            .filter(v => IO(v % 2 == 0))
-            .map(v => IO(v + 1))
+            .filter(v => Sync(v % 2 == 0))
+            .map(v => Sync(v + 1))
             .fold(0)(_ + _)
     end kyoBench
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SuspensionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SuspensionBench.scala
@@ -16,12 +16,12 @@ class SuspensionBench extends ArenaBench.SyncAndFork(()):
     def kyoBench() =
         import kyo.*
 
-        IO(())
-            .flatMap(_ => IO(())).map(_ => ()).flatMap(_ => IO(())).map(_ => ())
-            .flatMap(_ => IO(())).map(_ => ()).flatMap(_ => IO(())).map(_ => ())
-            .flatMap(_ => IO(())).map(_ => ()).flatMap(_ => IO(())).map(_ => ())
-            .flatMap(_ => IO(())).map(_ => ()).flatMap(_ => IO(())).map(_ => ())
-            .flatMap(_ => IO(())).map(_ => ()).flatMap(_ => IO(())).map(_ => ())
+        Sync(())
+            .flatMap(_ => Sync(())).map(_ => ()).flatMap(_ => Sync(())).map(_ => ())
+            .flatMap(_ => Sync(())).map(_ => ()).flatMap(_ => Sync(())).map(_ => ())
+            .flatMap(_ => Sync(())).map(_ => ()).flatMap(_ => Sync(())).map(_ => ())
+            .flatMap(_ => Sync(())).map(_ => ()).flatMap(_ => Sync(())).map(_ => ())
+            .flatMap(_ => Sync(())).map(_ => ()).flatMap(_ => Sync(())).map(_ => ())
     end kyoBench
 
     def zioBench() =

--- a/kyo-cache/shared/src/main/scala/kyo/Cache.scala
+++ b/kyo-cache/shared/src/main/scala/kyo/Cache.scala
@@ -222,7 +222,7 @@ object Cache:
       * @param f
       *   A function that configures the Cache using a Builder
       * @return
-      *   A new Cache instance wrapped in an IO effect
+      *   A new Cache instance wrapped in an Sync effect
       */
     def init(f: Builder => Builder)(using Frame): Cache < Sync =
         Sync {

--- a/kyo-cache/shared/src/main/scala/kyo/Cache.scala
+++ b/kyo-cache/shared/src/main/scala/kyo/Cache.scala
@@ -35,13 +35,13 @@ class Cache(private[kyo] val store: Store) extends Serializable:
         (v: A) =>
             Promise.initWith[Throwable, B] { p =>
                 val key = (this, v)
-                IO[B, Async & S] {
+                Sync[B, Async & S] {
                     val p2 = store.get(key, _ => p.asInstanceOf[Promise[Nothing, Any]])
                     if p.equals(p2) then
-                        IO.ensure {
+                        Sync.ensure {
                             p.interrupt.map {
                                 case true =>
-                                    IO(store.invalidate(key))
+                                    Sync(store.invalidate(key))
                                 case false =>
                                     ()
                             }
@@ -51,7 +51,7 @@ class Cache(private[kyo] val store: Store) extends Serializable:
                                     p.complete(Result.Success(v))
                                         .andThen(v)
                                 case r =>
-                                    IO(store.invalidate(key))
+                                    Sync(store.invalidate(key))
                                         .andThen(p.complete(r))
                                         .andThen(r.getOrThrow)
                             }
@@ -224,8 +224,8 @@ object Cache:
       * @return
       *   A new Cache instance wrapped in an IO effect
       */
-    def init(f: Builder => Builder)(using Frame): Cache < IO =
-        IO {
+    def init(f: Builder => Builder)(using Frame): Cache < Sync =
+        Sync {
             new Cache(
                 f(new Builder(Caffeine.newBuilder())).b
                     .build[Any, Promise[Nothing, Any]]()

--- a/kyo-caliban/src/main/scala/kyo/Resolvers.scala
+++ b/kyo-caliban/src/main/scala/kyo/Resolvers.scala
@@ -118,7 +118,7 @@ object Resolvers:
         for
             interpreter <- v
             endpoints = interpreter.serverEndpoints[R, NoStreams](NoStreams).map(convertEndpoint(_, runtime))
-            bindings <- IO(server.addEndpoints(endpoints).start())
+            bindings <- Sync(server.addEndpoints(endpoints).start())
         yield bindings
 
     /** Creates an HttpInterpreter from a GraphQL API.

--- a/kyo-caliban/src/test/scala/kyo/ResolversTest.scala
+++ b/kyo-caliban/src/test/scala/kyo/ResolversTest.scala
@@ -28,7 +28,7 @@ class ResolverTest extends Test:
         k1: Int < Abort[Throwable],
         k2: Int < Async,
         k3: Int < (Abort[Throwable] & Async),
-        k4: Int < IO,
+        k4: Int < Sync,
         k5: Int < Async
     ) derives Schema.SemiAuto
 

--- a/kyo-cats/shared/src/main/scala/kyo/Cats.scala
+++ b/kyo-cats/shared/src/main/scala/kyo/Cats.scala
@@ -16,7 +16,7 @@ object Cats:
       *   A Kyo effect that, when run, will execute the cats.effect.IO
       */
     def get[A](io: => CatsIO[A])(using Frame): A < (Abort[Nothing] & Async) =
-        IO.Unsafe {
+        Sync.Unsafe {
             import cats.effect.unsafe.implicits.global
             val p                = Promise.Unsafe.init[Nothing, A]()
             val (future, cancel) = io.unsafeToFutureCancelable()
@@ -47,7 +47,7 @@ object Cats:
                         Some(CatsIO(fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))).void)
                     }
                 }
-            }.handle(IO.Unsafe.evalOrThrow)
+            }.handle(Sync.Unsafe.evalOrThrow)
         }
     end run
 end Cats

--- a/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
+++ b/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
@@ -99,15 +99,15 @@ class CatsTest extends Test:
 
     "interrupts" - {
 
-        def kyoLoop(started: CountDownLatch, done: CountDownLatch): Unit < IO =
-            def loop(i: Int): Unit < IO =
-                IO {
+        def kyoLoop(started: CountDownLatch, done: CountDownLatch): Unit < Sync =
+            def loop(i: Int): Unit < Sync =
+                Sync {
                     if i == 0 then
-                        IO(started.countDown()).andThen(loop(i + 1))
+                        Sync(started.countDown()).andThen(loop(i + 1))
                     else
                         loop(i + 2)
                 }
-            IO.ensure(IO(done.countDown()))(loop(0))
+            Sync.ensure(Sync(done.countDown()))(loop(0))
         end kyoLoop
 
         def catsLoop(started: CountDownLatch, done: CountDownLatch): CatsIO[Unit] =
@@ -202,10 +202,10 @@ class CatsTest extends Test:
                     val panic   = Result.Panic(new Exception)
                     for
                         f <- Async.run(Cats.get(catsLoop(started, done)))
-                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt(panic)
                         r <- f.getResult
-                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r == panic)
                     end for
                 }
@@ -220,10 +220,10 @@ class CatsTest extends Test:
                         yield ()
                     for
                         f <- Async.run(v)
-                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }
@@ -238,10 +238,10 @@ class CatsTest extends Test:
                     end parallelEffect
                     for
                         f <- Async.run(parallelEffect)
-                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }
@@ -256,10 +256,10 @@ class CatsTest extends Test:
                     end raceEffect
                     for
                         f <- Async.run(raceEffect)
-                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }

--- a/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
@@ -15,7 +15,7 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
       */
     inline def fork(
         using frame: Frame
-    ): Fiber[E, A] < (IO & Ctx) =
+    ): Fiber[E, A] < (Sync & Ctx) =
         Async.run(effect)
 
     /** Forks this computation using the Async effect and returns its result as a `Fiber[E, A]`, managed by the Resource effect. Unlike
@@ -27,7 +27,7 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
       */
     inline def forkScoped(
         using frame: Frame
-    ): Fiber[E, A] < (IO & Ctx & Resource) =
+    ): Fiber[E, A] < (Sync & Ctx & Resource) =
         Kyo.acquireRelease(Async.run(effect))(_.interrupt.unit)
 
     /** Performs this computation and then the next one in parallel, discarding the result of this computation.
@@ -40,8 +40,8 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
     @targetName("zipRightPar")
     def &>[A1, E1, Ctx1](
         using
-        s: Isolate.Contextual[Ctx, IO],
-        s2: Isolate.Contextual[Ctx1, IO]
+        s: Isolate.Contextual[Ctx, Sync],
+        s2: Isolate.Contextual[Ctx1, Sync]
     )(next: A1 < (Abort[E1] & Async & Ctx1))(
         using
         r: Reducible[Abort[E]],
@@ -65,8 +65,8 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
     @targetName("zipLeftPar")
     def <&[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
         using
-        s: Isolate.Contextual[Ctx, IO],
-        s2: Isolate.Contextual[Ctx1, IO]
+        s: Isolate.Contextual[Ctx, Sync],
+        s2: Isolate.Contextual[Ctx1, Sync]
     )(
         using
         r: Reducible[Abort[E]],
@@ -90,8 +90,8 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
     @targetName("zipPar")
     def <&>[A1, E1, Ctx1](
         using
-        s: Isolate.Contextual[Ctx, IO],
-        s2: Isolate.Contextual[Ctx1, IO]
+        s: Isolate.Contextual[Ctx, Sync],
+        s2: Isolate.Contextual[Ctx1, Sync]
     )(next: A1 < (Abort[E1] & Async & Ctx1))(
         using
         r: Reducible[Abort[E]],

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -375,7 +375,7 @@ extension (kyoObject: Kyo.type)
     def sleep(duration: Duration)(using Frame): Unit < Async =
         Async.sleep(duration)
 
-    /** Suspends an effect using IO.
+    /** Suspends an effect using Sync.
       *
       * @param effect
       *   The effect to suspend
@@ -385,7 +385,7 @@ extension (kyoObject: Kyo.type)
     def suspend[A, S](effect: => A < S)(using Frame): A < (S & Sync) =
         Sync(effect)
 
-    /** Suspends an effect using IO and handles any exceptions that occur to Abort[Throwable].
+    /** Suspends an effect using Sync and handles any exceptions that occur to Abort[Throwable].
       *
       * @param effect
       *   The effect to suspend

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -17,7 +17,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that manages the resource lifecycle using Resource and IO effects
       */
-    def acquireRelease[A, S](acquire: => A < S)(release: A => Any < Async)(using Frame): A < (S & Resource & IO) =
+    def acquireRelease[A, S](acquire: => A < S)(release: A => Any < Async)(using Frame): A < (S & Resource & Sync) =
         Resource.acquireRelease(acquire)(release)
 
     /** Adds a finalizer to the current effect using Resource.
@@ -27,7 +27,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that ensures the finalizer is executed when the effect is completed
       */
-    def addFinalizer(finalizer: => Any < Async)(using Frame): Unit < (Resource & IO) =
+    def addFinalizer(finalizer: => Any < Async)(using Frame): Unit < (Resource & Sync) =
         Resource.ensure(finalizer)
 
     /** Creates an asynchronous effect that can be completed by the given register function.
@@ -46,7 +46,7 @@ extension (kyoObject: Kyo.type)
                     effFiber.map(_.onComplete(a => promise.completeDiscard(a)))
                 val updatePromiseIO = Async.run(updatePromise).unit
                 import AllowUnsafe.embrace.danger
-                IO.Unsafe.evalOrThrow(updatePromiseIO)
+                Sync.Unsafe.evalOrThrow(updatePromiseIO)
             _ <- register(registerFn)
             a <- promise.get
         yield a
@@ -117,8 +117,8 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that manages the resource lifecycle using Resource and IO effects
       */
-    def fromAutoCloseable[A <: AutoCloseable, S](closeable: => A < S)(using Frame): A < (S & Resource & IO) =
-        acquireRelease(closeable)(c => IO(c.close()))
+    def fromAutoCloseable[A <: AutoCloseable, S](closeable: => A < S)(using Frame): A < (S & Resource & Sync) =
+        acquireRelease(closeable)(c => Sync(c.close()))
 
     /** Creates an effect from an Either[E, A] and handles Left[E] to Abort[E].
       *
@@ -207,7 +207,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that logs the message to the console
       */
-    inline def logInfo(inline message: => String): Unit < IO =
+    inline def logInfo(inline message: => String): Unit < Sync =
         Log.info(message)
 
     /** Logs an informational message to the console with an error.
@@ -219,7 +219,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that logs the message and error to the console
       */
-    inline def logInfo(inline message: => String, inline err: => Throwable): Unit < IO =
+    inline def logInfo(inline message: => String, inline err: => Throwable): Unit < Sync =
         Log.info(message, err)
 
     /** Logs a warning message to the console.
@@ -229,7 +229,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that logs the message to the console
       */
-    inline def logWarn(inline message: => String): Unit < IO =
+    inline def logWarn(inline message: => String): Unit < Sync =
         Log.warn(message)
 
     /** Logs a warning message to the console with an error.
@@ -241,7 +241,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that logs the message and error to the console
       */
-    inline def logWarn[S, S1](inline message: => String, inline err: => Throwable): Unit < IO =
+    inline def logWarn[S, S1](inline message: => String, inline err: => Throwable): Unit < Sync =
         Log.warn(message, err)
 
     /** Logs a debug message to the console.
@@ -251,7 +251,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that logs the message to the console
       */
-    inline def logDebug(inline message: => String): Unit < IO =
+    inline def logDebug(inline message: => String): Unit < Sync =
         Log.debug(message)
 
     /** Logs a debug message to the console with an error.
@@ -263,7 +263,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that logs the message and error to the console
       */
-    inline def logDebug(inline message: => String, inline err: => Throwable): Unit < IO =
+    inline def logDebug(inline message: => String, inline err: => Throwable): Unit < Sync =
         Log.debug(message, err)
 
     /** Logs an error message to the console.
@@ -273,7 +273,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that logs the message to the console
       */
-    inline def logError(inline message: => String): Unit < IO =
+    inline def logError(inline message: => String): Unit < Sync =
         Log.error(message)
 
     /** Logs an error message to the console with an error.
@@ -285,7 +285,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that logs the message and error to the console
       */
-    inline def logError(inline message: => String, inline err: => Throwable): Unit < IO =
+    inline def logError(inline message: => String, inline err: => Throwable): Unit < Sync =
         Log.error(message, err)
 
     /** Logs a trace message to the console.
@@ -295,7 +295,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that logs the message to the console
       */
-    inline def logTrace(inline message: => String): Unit < IO =
+    inline def logTrace(inline message: => String): Unit < Sync =
         Log.trace(message)
 
     /** Logs a trace message to the console with an error.
@@ -307,7 +307,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that logs the message and error to the console
       */
-    inline def logTrace(inline message: => String, inline err: Throwable): Unit < IO =
+    inline def logTrace(inline message: => String, inline err: Throwable): Unit < Sync =
         Log.trace(message, err)
 
     /** Creates an effect that never completes using Async.
@@ -382,8 +382,8 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that suspends the given effect
       */
-    def suspend[A, S](effect: => A < S)(using Frame): A < (S & IO) =
-        IO(effect)
+    def suspend[A, S](effect: => A < S)(using Frame): A < (S & Sync) =
+        Sync(effect)
 
     /** Suspends an effect using IO and handles any exceptions that occur to Abort[Throwable].
       *
@@ -392,8 +392,8 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that suspends the given effect and handles any exceptions that occur to Abort[Throwable]
       */
-    def suspendAttempt[A, S](effect: => A < S)(using Frame): A < (S & IO & Abort[Throwable]) =
-        IO(Abort.catching[Throwable](effect))
+    def suspendAttempt[A, S](effect: => A < S)(using Frame): A < (S & Sync & Abort[Throwable]) =
+        Sync(Abort.catching[Throwable](effect))
 
     /** Traverses a sequence of effects and collects the results.
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -15,7 +15,7 @@ extension (kyoObject: Kyo.type)
       * @param release
       *   The effect to release the resource
       * @return
-      *   An effect that manages the resource lifecycle using Resource and IO effects
+      *   An effect that manages the resource lifecycle using Resource and Sync effects
       */
     def acquireRelease[A, S](acquire: => A < S)(release: A => Any < Async)(using Frame): A < (S & Resource & Sync) =
         Resource.acquireRelease(acquire)(release)
@@ -115,7 +115,7 @@ extension (kyoObject: Kyo.type)
       * @param closeable
       *   The AutoCloseable resource to create an effect from
       * @return
-      *   An effect that manages the resource lifecycle using Resource and IO effects
+      *   An effect that manages the resource lifecycle using Resource and Sync effects
       */
     def fromAutoCloseable[A <: AutoCloseable, S](closeable: => A < S)(using Frame): A < (S & Resource & Sync) =
         acquireRelease(closeable)(c => Sync(c.close()))
@@ -339,7 +339,7 @@ extension (kyoObject: Kyo.type)
       * @param resource
       *   The resource to create a scoped effect from
       * @return
-      *   An effect that manages the resource lifecycle using Resource and IO effects
+      *   An effect that manages the resource lifecycle using Resource and Sync effects
       */
     def scoped[A, S](resource: => A < (S & Resource))(using Frame): A < (Async & S) =
         Resource.run(resource)

--- a/kyo-combinators/shared/src/main/scala/kyo/KyoCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/KyoCombinators.scala
@@ -237,7 +237,7 @@ extension [A, S](effect: A < S)
       * @return
       *   An effect that executes the finalizer after this effect
       */
-    def ensuring(finalizer: => Any < Async)(using Frame): A < (S & Resource & IO) =
+    def ensuring(finalizer: => Any < Async)(using Frame): A < (S & Resource & Sync) =
         Resource.ensure(finalizer).andThen(effect)
 
 end extension

--- a/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
@@ -50,7 +50,7 @@ class AbortCombinatorsTest extends Test:
                 assert(Abort.run[Throwable](effect1).eval.getOrElse(-1) == 1)
             }
 
-            "should construct from an IO" in {
+            "should construct from an Sync" in {
                 import AllowUnsafe.embrace.danger
                 val effect = Kyo.attempt(Sync(throw new Exception("failure")))
                 assert(Sync.Unsafe.evalOrThrow(

--- a/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
@@ -52,12 +52,12 @@ class AbortCombinatorsTest extends Test:
 
             "should construct from an IO" in {
                 import AllowUnsafe.embrace.danger
-                val effect = Kyo.attempt(IO(throw new Exception("failure")))
-                assert(IO.Unsafe.evalOrThrow(
+                val effect = Kyo.attempt(Sync(throw new Exception("failure")))
+                assert(Sync.Unsafe.evalOrThrow(
                     Abort.run[Throwable](effect)
                 ).failure.get.getMessage == "failure")
-                val effect1 = Kyo.attempt(IO(1))
-                assert(IO.Unsafe.evalOrThrow(
+                val effect1 = Kyo.attempt(Sync(1))
+                assert(Sync.Unsafe.evalOrThrow(
                     Abort.run[Throwable](effect1)
                 ).getOrElse(-1) == 1)
             }

--- a/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorsTest.scala
@@ -28,7 +28,7 @@ class ChoiceCombinatorTest extends Test:
         "iteration" - {
             "should iterate using foreach" in run {
                 var state             = 0
-                def effectFor(i: Int) = IO { state += i; state }
+                def effectFor(i: Int) = Sync { state += i; state }
                 val effect            = Kyo.foreach(1 to 10)(effectFor)
                 assert(state == 0)
                 effect.map { result =>
@@ -41,7 +41,7 @@ class ChoiceCombinatorTest extends Test:
             "should iterate using collect" in run {
                 var state = 0
                 val effect = Kyo.collect(1 to 10) { i =>
-                    IO(Maybe.when(i % 2 == 0) { { state += i; i * 2 } })
+                    Sync(Maybe.when(i % 2 == 0) { { state += i; i * 2 } })
                 }
                 assert(state == 0)
                 effect.map { result =>
@@ -52,7 +52,7 @@ class ChoiceCombinatorTest extends Test:
 
             "should iterate using traverse" in run {
                 var state   = 0
-                val effects = (1 to 10).map(i => IO { state += i; state })
+                val effects = (1 to 10).map(i => Sync { state += i; state })
                 val effect  = Kyo.traverse(effects)
                 assert(state == 0)
                 effect.map { result =>
@@ -63,7 +63,7 @@ class ChoiceCombinatorTest extends Test:
 
             "should iterate using traverseDiscard" in run {
                 var state   = 0
-                val effects = (1 to 10).map(i => IO { state += i; state })
+                val effects = (1 to 10).map(i => Sync { state += i; state })
                 val effect  = Kyo.traverseDiscard(effects)
                 assert(state == 0)
                 effect.map { result =>

--- a/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
@@ -138,7 +138,7 @@ class ConstructorsTest extends Test:
         }
 
         "suspend" - {
-            "should suspend an effect using IO" in run {
+            "should suspend an effect using Sync" in run {
                 var executed = false
                 val effect = Kyo.suspend {
                     executed = true

--- a/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
@@ -158,8 +158,8 @@ class ConstructorsTest extends Test:
                 val successEffect = Kyo.suspendAttempt(42)
                 val failureEffect = Kyo.suspendAttempt(throw new Exception("Error"))
 
-                val successResult = IO.Unsafe.evalOrThrow(Abort.run[Throwable](successEffect))
-                val failureResult = IO.Unsafe.evalOrThrow(Abort.run[Throwable](failureEffect))
+                val successResult = Sync.Unsafe.evalOrThrow(Abort.run[Throwable](successEffect))
+                val failureResult = Sync.Unsafe.evalOrThrow(Abort.run[Throwable](failureEffect))
 
                 assert(successResult == Result.succeed(42))
                 assert(failureResult.isInstanceOf[Result.Failure[?]])

--- a/kyo-combinators/shared/src/test/scala/kyo/EnvCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/EnvCombinatorsTest.scala
@@ -73,7 +73,7 @@ class EnvCombinatorsTest extends Test:
                             layerInt,
                             layerBool
                         )
-                val _: Int < (IO & Memo) = handled
+                val _: Int < (Sync & Memo) = handled
                 Memo.run(handled).map { result =>
                     assert(result == 23)
                 }

--- a/kyo-combinators/shared/src/test/scala/kyo/FiberCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/FiberCombinatorsTest.scala
@@ -47,7 +47,7 @@ class FiberCombinatorsTest extends Test:
             }
 
             "should construct from traversePar" in run {
-                val effect = Kyo.traversePar(Seq(IO(1), IO(2), IO(3)))
+                val effect = Kyo.traversePar(Seq(Sync(1), Sync(2), Sync(3)))
                 Async.run(effect).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v => assert(v == Seq(1, 2, 3)))
                 }
@@ -95,8 +95,8 @@ class FiberCombinatorsTest extends Test:
 
         "zip par" - {
             "should zip right par" in run {
-                val e1     = IO(1)
-                val e2     = IO(2)
+                val e1     = Sync(1)
+                val e2     = Sync(2)
                 val effect = e1 &> e2
                 Async.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v =>
@@ -106,8 +106,8 @@ class FiberCombinatorsTest extends Test:
             }
 
             "should zip left par" in run {
-                val e1     = IO(1)
-                val e2     = IO(2)
+                val e1     = Sync(1)
+                val e2     = Sync(2)
                 val effect = e1 <& e2
                 Async.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v =>
@@ -117,8 +117,8 @@ class FiberCombinatorsTest extends Test:
             }
 
             "should zip par" in run {
-                val e1     = IO(1)
-                val e2     = IO(2)
+                val e1     = Sync(1)
+                val e2     = Sync(2)
                 val effect = e1 <&> e2
                 Async.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v =>

--- a/kyo-combinators/shared/src/test/scala/kyo/KyoCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/KyoCombinatorsTest.scala
@@ -6,13 +6,13 @@ class KyoCombinatorsTest extends Test:
 
         "debug" - {
             "with string value" in run {
-                val effect = IO("Hello World")
+                val effect = Sync("Hello World")
                 effect.map { handled =>
                     assert(handled == "Hello World")
                 }
             }
             "with integer value" in run {
-                val effect = IO(42)
+                val effect = Sync(42)
                 effect.map { handled =>
                     assert(handled == 42)
                 }
@@ -21,13 +21,13 @@ class KyoCombinatorsTest extends Test:
 
         "debug(prefix)" - {
             "with boolean value" in run {
-                val effect = IO(true)
+                val effect = Sync(true)
                 effect.map { handled =>
                     assert(handled == true)
                 }
             }
             "with string value" in run {
-                val effect = IO("test")
+                val effect = Sync("test")
                 effect.map { handled =>
                     assert(handled == "test")
                 }
@@ -36,14 +36,14 @@ class KyoCombinatorsTest extends Test:
 
         "discard" - {
             "with integer value" in run {
-                val effect          = IO(23)
+                val effect          = Sync(23)
                 val effectDiscarded = effect.unit
                 effectDiscarded.map { handled =>
                     assert(handled == ())
                 }
             }
             "with string value" in run {
-                val effect          = IO("hello")
+                val effect          = Sync("hello")
                 val effectDiscarded = effect.unit
                 effectDiscarded.map { handled =>
                     assert(handled == ())
@@ -53,16 +53,16 @@ class KyoCombinatorsTest extends Test:
 
         "*>" - {
             "with string values" in run {
-                val eff1   = IO("hello")
-                val eff2   = IO("world")
+                val eff1   = Sync("hello")
+                val eff2   = Sync("world")
                 val zipped = eff1 *> eff2
                 zipped.map { handled =>
                     assert(handled == "world")
                 }
             }
             "with mixed types" in run {
-                val eff1   = IO(42)
-                val eff2   = IO("answer")
+                val eff1   = Sync(42)
+                val eff2   = Sync("answer")
                 val zipped = eff1 *> eff2
                 zipped.map { handled =>
                     assert(handled == "answer")
@@ -72,16 +72,16 @@ class KyoCombinatorsTest extends Test:
 
         "<*" - {
             "with string values" in run {
-                val eff1   = IO("hello")
-                val eff2   = IO("world")
+                val eff1   = Sync("hello")
+                val eff2   = Sync("world")
                 val zipped = eff1 <* eff2
                 zipped.map { handled =>
                     assert(handled == "hello")
                 }
             }
             "with mixed types" in run {
-                val eff1   = IO("answer")
-                val eff2   = IO(42)
+                val eff1   = Sync("answer")
+                val eff2   = Sync(42)
                 val zipped = eff1 <* eff2
                 zipped.map { handled =>
                     assert(handled == "answer")
@@ -91,16 +91,16 @@ class KyoCombinatorsTest extends Test:
 
         "<*>" - {
             "with string values" in run {
-                val eff1   = IO("hello")
-                val eff2   = IO("world")
+                val eff1   = Sync("hello")
+                val eff2   = Sync("world")
                 val zipped = eff1 <*> eff2
                 zipped.map { handled =>
                     assert(handled == ("hello", "world"))
                 }
             }
             "with mixed types" in run {
-                val eff1   = IO(42)
-                val eff2   = IO("answer")
+                val eff1   = Sync(42)
+                val eff2   = Sync("answer")
                 val zipped = eff1 <*> eff2
                 zipped.map { handled =>
                     assert(handled == (42, "answer"))
@@ -111,10 +111,10 @@ class KyoCombinatorsTest extends Test:
         "when" - {
             "condition is false" in run {
                 var state: Boolean = false
-                val toggleState = IO {
+                val toggleState = Sync {
                     state = !state
                 }
-                val getState   = IO(state)
+                val getState   = Sync(state)
                 val effectWhen = (toggleState *> getState).when(getState)
                 effectWhen.map { handledEffectWhen =>
                     assert(handledEffectWhen == Absent)
@@ -122,10 +122,10 @@ class KyoCombinatorsTest extends Test:
             }
             "condition is true" in run {
                 var state: Boolean = true
-                val toggleState = IO {
+                val toggleState = Sync {
                     state = !state
                 }
-                val getState   = IO(state)
+                val getState   = Sync(state)
                 val effectWhen = (toggleState *> getState).when(getState)
                 effectWhen.map { handledEffectWhen =>
                     assert(handledEffectWhen == Present(false))
@@ -135,7 +135,7 @@ class KyoCombinatorsTest extends Test:
 
         "unless" - {
             "condition is true" in run {
-                val effect = IO("value").unless(Env.get[Boolean])
+                val effect = Sync("value").unless(Env.get[Boolean])
                 Env.run(true) {
                     effect
                 }.map { result =>
@@ -143,7 +143,7 @@ class KyoCombinatorsTest extends Test:
                 }
             }
             "condition is false" in run {
-                val effect = IO("value").unless(Env.get[Boolean])
+                val effect = Sync("value").unless(Env.get[Boolean])
                 Env.run(false) {
                     effect
                 }.map { result =>
@@ -154,13 +154,13 @@ class KyoCombinatorsTest extends Test:
 
         "tap" - {
             "with integer value" in run {
-                val effect: Int < IO = IO(42).tap(v => assert(42 == v))
+                val effect: Int < Sync = Sync(42).tap(v => assert(42 == v))
                 effect.map { handled =>
                     assert(handled == 42)
                 }
             }
             "with string value" in run {
-                val effect: String < IO = IO("test").tap(v => assert("test" == v))
+                val effect: String < Sync = Sync("test").tap(v => assert("test" == v))
                 effect.map { handled =>
                     assert(handled == "test")
                 }
@@ -169,13 +169,13 @@ class KyoCombinatorsTest extends Test:
 
         "delay" - {
             "with short delay" in run {
-                val effect = IO(42).delay(1.millis)
+                val effect = Sync(42).delay(1.millis)
                 Async.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v => assert(v == 42))
                 }
             }
             "with zero delay" in run {
-                val effect = IO("test").delay(0.millis)
+                val effect = Sync("test").delay(0.millis)
                 Async.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v => assert(v == "test"))
                 }
@@ -186,7 +186,7 @@ class KyoCombinatorsTest extends Test:
             "repeat with fixed number" - {
                 "repeat 3 times" in run {
                     var count  = 0
-                    val effect = IO { count += 1; count }.repeat(3)
+                    val effect = Sync { count += 1; count }.repeat(3)
                     effect.map { handled =>
                         assert(handled == 4)
                         assert(count == 4)
@@ -194,7 +194,7 @@ class KyoCombinatorsTest extends Test:
                 }
                 "repeat 0 times" in run {
                     var count  = 0
-                    val effect = IO { count += 1; count }.repeat(0)
+                    val effect = Sync { count += 1; count }.repeat(0)
                     effect.map { handled =>
                         assert(handled == 1)
                         assert(count == 1)
@@ -206,7 +206,7 @@ class KyoCombinatorsTest extends Test:
                 "repeat with custom policy" in run {
                     var count    = 0
                     val schedule = Schedule.repeat(3)
-                    val effect   = IO { count += 1; count }.repeatAtInterval(schedule)
+                    val effect   = Sync { count += 1; count }.repeatAtInterval(schedule)
                     Async.run(effect).map(_.toFuture).map { handled =>
                         handled.map { v =>
                             assert(v == 4)
@@ -220,7 +220,7 @@ class KyoCombinatorsTest extends Test:
                 "repeat with exponential backoff" in run {
                     var count   = 0
                     val backoff = (i: Int) => Math.pow(2, i).toLong.millis
-                    val effect  = IO { count += 1; count }.repeatAtInterval(backoff, 3)
+                    val effect  = Sync { count += 1; count }.repeatAtInterval(backoff, 3)
                     Async.run(effect).map(_.toFuture).map { handled =>
                         handled.map { v =>
                             assert(v == 4)
@@ -235,14 +235,14 @@ class KyoCombinatorsTest extends Test:
             "repeatWhile with simple condition" - {
                 "condition becomes false" in run {
                     var count  = 0
-                    val effect = IO { count += 1; count }.repeatWhile(_ < 3)
+                    val effect = Sync { count += 1; count }.repeatWhile(_ < 3)
                     Async.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }
                 "condition is initially false" in run {
                     var count  = 5
-                    val effect = IO { count += 1; count }.repeatWhile(_ < 3)
+                    val effect = Sync { count += 1; count }.repeatWhile(_ < 3)
                     Async.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 6))
                     }
@@ -252,7 +252,7 @@ class KyoCombinatorsTest extends Test:
             "repeatWhile with condition and duration" - {
                 "condition becomes false with delay" in run {
                     var count  = 0
-                    val effect = IO { count += 1; count }.repeatWhile((v, i) => (v < 3, 10.millis))
+                    val effect = Sync { count += 1; count }.repeatWhile((v, i) => (v < 3, 10.millis))
                     Async.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
@@ -264,14 +264,14 @@ class KyoCombinatorsTest extends Test:
             "repeatUntil with simple condition" - {
                 "condition becomes true" in run {
                     var count  = 0
-                    val effect = IO { count += 1; count }.repeatUntil(_ == 3)
+                    val effect = Sync { count += 1; count }.repeatUntil(_ == 3)
                     Async.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }
                 "condition is initially true" in run {
                     var count  = 0
-                    val effect = IO { count += 1; count }.repeatUntil(_ => true)
+                    val effect = Sync { count += 1; count }.repeatUntil(_ => true)
                     Async.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 1))
                     }
@@ -281,7 +281,7 @@ class KyoCombinatorsTest extends Test:
             "repeatUntil with condition and duration" - {
                 "condition becomes true with delay" in run {
                     var count  = 0
-                    val effect = IO { count += 1; count }.repeatUntil((v, i) => (v == 3, 10.millis))
+                    val effect = Sync { count += 1; count }.repeatUntil((v, i) => (v == 3, 10.millis))
                     Async.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
@@ -291,9 +291,9 @@ class KyoCombinatorsTest extends Test:
 
         "unpanic" - {
             "with throwable" in run {
-                val effect: Nothing < (Abort[Throwable] & IO)     = IO { Abort.fail(Exception("failure")) }
-                val panicked: Nothing < IO                        = effect.orPanic
-                val unpanicked: Nothing < (Abort[Throwable] & IO) = panicked.unpanic
+                val effect: Nothing < (Abort[Throwable] & Sync)     = Sync { Abort.fail(Exception("failure")) }
+                val panicked: Nothing < Sync                        = effect.orPanic
+                val unpanicked: Nothing < (Abort[Throwable] & Sync) = panicked.unpanic
                 Abort.run[Throwable](unpanicked).map: handled =>
                     val msg = handled.failure.collect:
                         case thr: Throwable => thr.getMessage()
@@ -301,9 +301,9 @@ class KyoCombinatorsTest extends Test:
             }
 
             "with non-throwable failure" in run {
-                val effect: Nothing < (Abort[String] & IO)        = IO { Abort.fail("failure") }
-                val panicked: Nothing < IO                        = effect.orPanic
-                val unpanicked: Nothing < (Abort[Throwable] & IO) = panicked.unpanic
+                val effect: Nothing < (Abort[String] & Sync)        = Sync { Abort.fail("failure") }
+                val panicked: Nothing < Sync                        = effect.orPanic
+                val unpanicked: Nothing < (Abort[Throwable] & Sync) = panicked.unpanic
                 Abort.run[Throwable](unpanicked).map: handled =>
                     assert(handled == Result.Failure(PanicException("failure")))
             }
@@ -311,7 +311,7 @@ class KyoCombinatorsTest extends Test:
 
         "ensuring" in run {
             var finalizerCalled = false
-            Resource.run(IO(()).ensuring(IO { finalizerCalled = true }))
+            Resource.run(Sync(()).ensuring(Sync { finalizerCalled = true }))
                 .andThen(assert(finalizerCalled))
         }
     }

--- a/kyo-combinators/shared/src/test/scala/kyo/ResourceCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ResourceCombinatorsTest.scala
@@ -7,15 +7,15 @@ class ResourceCombinatorsTest extends Test:
     "construct" - {
         "should construct a resource with acquireRelease" in run {
             var state = 0
-            val acquire = IO {
-                (i: Int) => IO { state = i }
+            val acquire = Sync {
+                (i: Int) => Sync { state = i }
             }
             val resource = Kyo.acquireRelease(acquire)(_(0))
-            val effect: Int < (Resource & IO) =
+            val effect: Int < (Resource & Sync) =
                 for
                     setter <- resource
                     _      <- setter(50)
-                    result <- IO(state)
+                    result <- Sync(state)
                 yield result
             assert(state == 0)
             val handledResources: Int < Async = Resource.run(effect)
@@ -30,7 +30,7 @@ class ResourceCombinatorsTest extends Test:
 
         "should construct a resource using addFinalizer" in run {
             var state  = 0
-            val effect = Kyo.addFinalizer(IO { state = 100 })
+            val effect = Kyo.addFinalizer(Sync { state = 100 })
             Async.run(Resource.run(effect)).map(_.toFuture).map { handled =>
                 for
                     ass1 <- handled

--- a/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -10,7 +10,7 @@ abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abo
     final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         val currentAsync: Unit < (Async & Abort[Throwable]) =
-            Abort.run(handle(v)).map(result => IO(onResult(result)).andThen(Abort.get(result)).unit)
+            Abort.run(handle(v)).map(result => Sync(onResult(result)).andThen(Abort.get(result)).unit)
         maybePreviousAsync = maybePreviousAsync match
             case Absent                 => Present(currentAsync)
             case Present(previousAsync) => Present(previousAsync.map(_ => currentAsync))
@@ -19,7 +19,7 @@ abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abo
                 val race = Async.race(fiber.get, previousAsync)
                 Async.timeout(timeout)(race)
             }
-            val _ = IO.Unsafe.evalOrThrow(Async.run(racedAsyncIO))
+            val _ = Sync.Unsafe.evalOrThrow(Async.run(racedAsyncIO))
         }.toList
     end run
 

--- a/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -5,7 +5,7 @@ abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abo
     final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         initCode = initCode.appended(() =>
-            val result = IO.Unsafe.evalOrThrow(Abort.run(Async.runAndBlock(timeout)(handle(v))))
+            val result = Sync.Unsafe.evalOrThrow(Abort.run(Async.runAndBlock(timeout)(handle(v))))
             onResult(result)
         )
     end run

--- a/kyo-core/jvm/src/main/scala/kyo/Path.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Path.scala
@@ -28,13 +28,13 @@ final class Path private (val path: List[String]) extends Serializable derives C
 
     /** Methods to read files completely
       */
-    def read(using Frame): String < IO =
-        IO(JFiles.readString(toJava))
+    def read(using Frame): String < Sync =
+        Sync(JFiles.readString(toJava))
 
-    def read(charset: Charset)(using Frame): String < IO =
-        IO(JFiles.readString(toJava, charset))
+    def read(charset: Charset)(using Frame): String < Sync =
+        Sync(JFiles.readString(toJava, charset))
 
-    def readAll(extension: String)(using Frame): Seq[(String, String)] < IO =
+    def readAll(extension: String)(using Frame): Seq[(String, String)] < Sync =
         list(extension).map { paths =>
             Kyo.foreach(paths) { p =>
                 p.read.map { content =>
@@ -44,22 +44,22 @@ final class Path private (val path: List[String]) extends Serializable derives C
             }
         }
 
-    def readBytes(using Frame): Array[Byte] < IO =
-        IO(JFiles.readAllBytes(toJava))
+    def readBytes(using Frame): Array[Byte] < Sync =
+        Sync(JFiles.readAllBytes(toJava))
 
-    def readLines(using Frame): List[String] < IO =
-        IO(JFiles.readAllLines(toJava).asScala.toList)
+    def readLines(using Frame): List[String] < Sync =
+        Sync(JFiles.readAllLines(toJava).asScala.toList)
 
     def readLines(
         charSet: Charset = java.nio.charset.StandardCharsets.UTF_8
-    )(using Frame): List[String] < IO =
-        IO(JFiles.readAllLines(toJava, charSet).asScala.toList)
+    )(using Frame): List[String] < Sync =
+        Sync(JFiles.readAllLines(toJava, charSet).asScala.toList)
 
     /** Methods to append and write to files
       */
 
-    private inline def append(createFolders: Boolean)(inline f: (JPath, Seq[OpenOption]) => JPath)(using Frame): Unit < IO =
-        IO {
+    private inline def append(createFolders: Boolean)(inline f: (JPath, Seq[OpenOption]) => JPath)(using Frame): Unit < Sync =
+        Sync {
             if createFolders then
                 discard(f(toJava, Seq(StandardOpenOption.APPEND, StandardOpenOption.CREATE)))
             else if javaExists(toJava.getParent()) then
@@ -68,21 +68,21 @@ final class Path private (val path: List[String]) extends Serializable derives C
 
     /** Appends a String to this path.
       */
-    def append(value: String, createFolders: Boolean = true)(using Frame): Unit < IO =
+    def append(value: String, createFolders: Boolean = true)(using Frame): Unit < Sync =
         append(createFolders)((path, options) => Files.writeString(toJava, value, options*))
 
     /** Appends a Bytes Array to this path.
       */
-    def appendBytes(value: Array[Byte], createFolders: Boolean = true)(using Frame): Unit < IO =
+    def appendBytes(value: Array[Byte], createFolders: Boolean = true)(using Frame): Unit < Sync =
         append(createFolders)((path, options) => Files.write(toJava, value, options*))
 
     /** Appends lines of String to this path.
       */
-    def appendLines(value: List[String], createFolders: Boolean = true)(using Frame): Unit < IO =
+    def appendLines(value: List[String], createFolders: Boolean = true)(using Frame): Unit < Sync =
         append(createFolders)((path, options) => Files.write(toJava, value.asJava, options*))
 
-    private inline def write(createFolders: Boolean)(inline f: (JPath, Seq[OpenOption]) => JPath)(using Frame): Unit < IO =
-        IO {
+    private inline def write(createFolders: Boolean)(inline f: (JPath, Seq[OpenOption]) => JPath)(using Frame): Unit < Sync =
+        Sync {
             if createFolders then
                 discard(f(toJava, Seq(StandardOpenOption.WRITE, StandardOpenOption.CREATE)))
             else if javaExists(toJava.getParent()) then
@@ -91,17 +91,17 @@ final class Path private (val path: List[String]) extends Serializable derives C
 
     /** Writes a String to this path.
       */
-    def write(value: String, createFolders: Boolean = true)(using Frame): Unit < IO =
+    def write(value: String, createFolders: Boolean = true)(using Frame): Unit < Sync =
         write(createFolders)((path, options) => Files.writeString(toJava, value, options*))
 
     /** Writes a Bytes Array to this path.
       */
-    def writeBytes(value: Array[Byte], createFolders: Boolean = true)(using Frame): Unit < IO =
+    def writeBytes(value: Array[Byte], createFolders: Boolean = true)(using Frame): Unit < Sync =
         write(createFolders)((path, options) => Files.write(toJava, value, options*))
 
     /** Writes lines of String to this path.
       */
-    def writeLines(value: List[String], createFolders: Boolean = true)(using Frame): Unit < IO =
+    def writeLines(value: List[String], createFolders: Boolean = true)(using Frame): Unit < Sync =
         write(createFolders)((path, options) => Files.write(toJava, value.asJava, options*))
 
     /** Methods to read files into Stream
@@ -109,19 +109,19 @@ final class Path private (val path: List[String]) extends Serializable derives C
 
     /** Reads a file returning its contents as a Stream of Strings
       */
-    def readStream(charset: Charset = java.nio.charset.StandardCharsets.UTF_8)(using Frame): Stream[String, Resource & IO] =
+    def readStream(charset: Charset = java.nio.charset.StandardCharsets.UTF_8)(using Frame): Stream[String, Resource & Sync] =
         readLoop[String, Array[Byte], (FileChannel, ByteBuffer)](
             (FileChannel.open(toJava, StandardOpenOption.READ), ByteBuffer.allocate(2048)),
-            ch => IO(ch._1.close()),
+            ch => Sync(ch._1.close()),
             readOnceBytes,
             arr => Chunk(new String(arr, charset))
         )
 
     /** Reads a file returning its contents as a Stream of Lines
       */
-    def readLinesStream(charset: Charset = java.nio.charset.StandardCharsets.UTF_8)(using Frame): Stream[String, Resource & IO] =
+    def readLinesStream(charset: Charset = java.nio.charset.StandardCharsets.UTF_8)(using Frame): Stream[String, Resource & Sync] =
         readLoop[String, String, BufferedReader](
-            IO(JFiles.newBufferedReader(toJava, Charset.defaultCharset())),
+            Sync(JFiles.newBufferedReader(toJava, Charset.defaultCharset())),
             reader => reader.close(),
             readOnceLines,
             line => Chunk(line)
@@ -129,22 +129,22 @@ final class Path private (val path: List[String]) extends Serializable derives C
 
     /** Reads a file returning its contents as a Stream of Bytes
       */
-    def readBytesStream(using Frame): Stream[Byte, Resource & IO] =
+    def readBytesStream(using Frame): Stream[Byte, Resource & Sync] =
         readLoop[Byte, Array[Byte], (FileChannel, ByteBuffer)](
-            IO(FileChannel.open(toJava, StandardOpenOption.READ), ByteBuffer.allocate(2048)),
+            Sync(FileChannel.open(toJava, StandardOpenOption.READ), ByteBuffer.allocate(2048)),
             ch => ch._1.close(),
             readOnceBytes,
             arr => Chunk.from(arr.toSeq)
         )
 
     private def readOnceLines(reader: BufferedReader)(using Frame) =
-        IO {
+        Sync {
             val line = reader.readLine()
             if line == null then Maybe.empty else Maybe(line)
         }
 
     private def readOnceBytes(res: (FileChannel, ByteBuffer))(using Frame) =
-        IO {
+        Sync {
             val (fileChannel, buf) = res
             val bytesRead          = fileChannel.read(buf)
             if bytesRead < 1 then Maybe.empty
@@ -157,12 +157,12 @@ final class Path private (val path: List[String]) extends Serializable derives C
         }
 
     private def readLoop[A, ReadTpe, Res](
-        acquire: Res < IO,
+        acquire: Res < Sync,
         release: Res => Unit < Async,
-        readOnce: Res => Maybe[ReadTpe] < IO,
+        readOnce: Res => Maybe[ReadTpe] < Sync,
         writeOnce: ReadTpe => Chunk[A]
-    )(using Tag[Emit[Chunk[A]]], Frame): Stream[A, Resource & IO] =
-        Stream[A, Resource & IO] {
+    )(using Tag[Emit[Chunk[A]]], Frame): Stream[A, Resource & Sync] =
+        Stream[A, Resource & Sync] {
             Resource.acquireRelease(acquire)(release).map { res =>
                 readOnce(res).map { state =>
                     Loop(state) {
@@ -180,7 +180,7 @@ final class Path private (val path: List[String]) extends Serializable derives C
 
     /** Truncates the content of this file
       */
-    def truncate(size: Long)(using Frame): FileChannel < (Resource & IO) =
+    def truncate(size: Long)(using Frame): FileChannel < (Resource & Sync) =
         Resource
             .acquireRelease(FileChannel.open(toJava, StandardOpenOption.WRITE))(ch => ch.close())
             .map { ch =>
@@ -191,28 +191,28 @@ final class Path private (val path: List[String]) extends Serializable derives C
 
     /** List contents of path
       */
-    def list(using Frame): IndexedSeq[Path] < IO =
-        IO(JFiles.list(toJava).toScala(LazyList).toIndexedSeq).map(_.map(path => Path(path.toString)))
+    def list(using Frame): IndexedSeq[Path] < Sync =
+        Sync(JFiles.list(toJava).toScala(LazyList).toIndexedSeq).map(_.map(path => Path(path.toString)))
 
     /** List contents of path with given extension
       */
-    def list(extension: String)(using Frame): IndexedSeq[Path] < IO =
-        IO(JFiles.list(toJava).toScala(LazyList).filter(path =>
+    def list(extension: String)(using Frame): IndexedSeq[Path] < Sync =
+        Sync(JFiles.list(toJava).toScala(LazyList).filter(path =>
             path.getFileName().toString().split('.').toList.lastOption.getOrElse("") == extension
         ).toIndexedSeq.map(path => Path(path.toString)))
 
     /** Returns if the path exists
       */
-    def exists(using Frame): Boolean < IO =
+    def exists(using Frame): Boolean < Sync =
         exists(true)
 
     /** Returns if the path exists
       */
-    def exists(followLinks: Boolean)(using Frame): Boolean < IO =
+    def exists(followLinks: Boolean)(using Frame): Boolean < Sync =
         val path = toJava
-        if path == null then IO(false)
-        else if followLinks then IO(JFiles.exists(path))
-        else IO(JFiles.exists(path, LinkOption.NOFOLLOW_LINKS))
+        if path == null then Sync(false)
+        else if followLinks then Sync(JFiles.exists(path))
+        else Sync(JFiles.exists(path, LinkOption.NOFOLLOW_LINKS))
     end exists
 
     private def javaExists(jPath: JPath): Boolean =
@@ -221,33 +221,33 @@ final class Path private (val path: List[String]) extends Serializable derives C
 
     /** Returns if the path represents a directory
       */
-    def isDir(using Frame): Boolean < IO =
-        IO(JFiles.isDirectory(toJava))
+    def isDir(using Frame): Boolean < Sync =
+        Sync(JFiles.isDirectory(toJava))
 
     /** Returns if the path represents a file
       */
-    def isFile(using Frame): Boolean < IO =
-        IO(JFiles.isRegularFile(toJava))
+    def isFile(using Frame): Boolean < Sync =
+        Sync(JFiles.isRegularFile(toJava))
 
     /** Returns if the path represents a symbolic link
       */
-    def isLink(using Frame): Boolean < IO =
-        IO(JFiles.isSymbolicLink(toJava))
+    def isLink(using Frame): Boolean < Sync =
+        Sync(JFiles.isSymbolicLink(toJava))
 
     /** Creates a directory in this path
       */
-    def mkDir(using Frame): Unit < IO =
-        IO(javaExists(toJava.getParent())).map { parentsExist =>
-            if parentsExist == true then IO(JFiles.createDirectory(toJava))
-            else IO(JFiles.createDirectories(toJava))
+    def mkDir(using Frame): Unit < Sync =
+        Sync(javaExists(toJava.getParent())).map { parentsExist =>
+            if parentsExist == true then Sync(JFiles.createDirectory(toJava))
+            else Sync(JFiles.createDirectories(toJava))
         }.unit
 
     /** Creates a directory in this path
       */
-    def mkFile(using Frame): Unit < IO =
-        IO(javaExists(toJava.getParent())).map { parentsExist =>
-            if parentsExist == true then IO(JFiles.createDirectory(toJava))
-            else IO(JFiles.createDirectories(toJava))
+    def mkFile(using Frame): Unit < Sync =
+        Sync(javaExists(toJava.getParent())).map { parentsExist =>
+            if parentsExist == true then Sync(JFiles.createDirectory(toJava))
+            else Sync(JFiles.createDirectories(toJava))
         }.unit
     end mkFile
 
@@ -258,14 +258,14 @@ final class Path private (val path: List[String]) extends Serializable derives C
         replaceExisting: Boolean = false,
         atomicMove: Boolean = false,
         createFolders: Boolean = true
-    )(using Frame): Unit < IO =
+    )(using Frame): Unit < Sync =
         val opts = (if atomicMove then List(StandardCopyOption.ATOMIC_MOVE) else Nil) ++ (if replaceExisting then
                                                                                               List(StandardCopyOption.REPLACE_EXISTING)
                                                                                           else Nil)
-        IO(javaExists(toJava.getParent())).map { parentExists =>
+        Sync(javaExists(toJava.getParent())).map { parentExists =>
             (parentExists, createFolders) match
-                case (true, _)     => IO(JFiles.move(toJava, to.toJava, opts*)).unit
-                case (false, true) => Path(toJava.getParent().toString).mkDir.andThen(IO(JFiles.move(toJava, to.toJava, opts*)).unit)
+                case (true, _)     => Sync(JFiles.move(toJava, to.toJava, opts*)).unit
+                case (false, true) => Path(toJava.getParent().toString).mkDir.andThen(Sync(JFiles.move(toJava, to.toJava, opts*)).unit)
                 case _             => ()
         }
     end move
@@ -279,27 +279,27 @@ final class Path private (val path: List[String]) extends Serializable derives C
         copyAttributes: Boolean = false,
         createFolders: Boolean = true,
         mergeFolders: Boolean = false
-    )(using Frame): Unit < IO =
+    )(using Frame): Unit < Sync =
         val opts = (if followLinks then List.empty[CopyOption] else List[CopyOption](LinkOption.NOFOLLOW_LINKS)) ++
             (if copyAttributes then List[CopyOption](StandardCopyOption.COPY_ATTRIBUTES) else List.empty[CopyOption]) ++
             (if replaceExisting then List[CopyOption](StandardCopyOption.REPLACE_EXISTING) else List.empty[CopyOption])
-        IO(javaExists(toJava.getParent())).map { parentExists =>
+        Sync(javaExists(toJava.getParent())).map { parentExists =>
             (parentExists, createFolders) match
-                case (true, _)     => IO(JFiles.copy(toJava, to.toJava, opts*)).unit
-                case (false, true) => Path(toJava.getParent().toString).mkDir.andThen(IO(JFiles.copy(toJava, to.toJava, opts*)).unit)
+                case (true, _)     => Sync(JFiles.copy(toJava, to.toJava, opts*)).unit
+                case (false, true) => Path(toJava.getParent().toString).mkDir.andThen(Sync(JFiles.copy(toJava, to.toJava, opts*)).unit)
                 case _             => ()
         }
     end copy
 
     /** Removes this path if it is empty
       */
-    def remove(using Frame): Boolean < IO =
+    def remove(using Frame): Boolean < Sync =
         remove(false)
 
     /** Removes this path if it is empty
       */
-    def remove(checkExists: Boolean)(using Frame): Boolean < IO =
-        IO {
+    def remove(checkExists: Boolean)(using Frame): Boolean < Sync =
+        Sync {
             if checkExists then
                 JFiles.delete(toJava)
                 true
@@ -309,8 +309,8 @@ final class Path private (val path: List[String]) extends Serializable derives C
 
     /** Removes this path and all its contents
       */
-    def removeAll(using Frame): Unit < IO =
-        IO {
+    def removeAll(using Frame): Unit < Sync =
+        Sync {
             val path = toJava
             if javaExists(path) then
                 val visitor = new SimpleFileVisitor[JPath]:
@@ -328,13 +328,13 @@ final class Path private (val path: List[String]) extends Serializable derives C
 
     /** Creates a stream of the contents of this path with maximum depth
       */
-    def walk(using Frame): Stream[Path, IO] =
+    def walk(using Frame): Stream[Path, Sync] =
         walk(Int.MaxValue)
 
     /** Creates a stream of the contents of this path with given depth
       */
-    def walk(maxDepth: Int)(using Frame): Stream[Path, IO] =
-        Stream.init(IO(JFiles.walk(toJava).toScala(LazyList).map(path => Path(path.toString))))
+    def walk(maxDepth: Int)(using Frame): Stream[Path, Sync] =
+        Stream.init(Sync(JFiles.walk(toJava).toScala(LazyList).map(path => Path(path.toString))))
 
     override def hashCode(): Int =
         val prime  = 31
@@ -381,8 +381,8 @@ object Path:
         runtime: Path
     )
 
-    def basePaths(using Frame): BasePaths < IO =
-        IO {
+    def basePaths(using Frame): BasePaths < Sync =
+        Sync {
             val dirs = BaseDirectories.get()
             BasePaths(
                 Path(dirs.cacheDir),
@@ -408,8 +408,8 @@ object Path:
         video: Path
     )
 
-    def userPaths(using Frame): UserPaths < IO =
-        IO {
+    def userPaths(using Frame): UserPaths < Sync =
+        Sync {
             val dirs = UserDirectories.get()
             UserPaths(
                 Path(dirs.homeDir),
@@ -435,8 +435,8 @@ object Path:
         runtime: Path
     )
 
-    def projectPaths(qualifier: String, organization: String, application: String)(using Frame): ProjectPaths < IO =
-        IO {
+    def projectPaths(qualifier: String, organization: String, application: String)(using Frame): ProjectPaths < Sync =
+        Sync {
             val dirs = ProjectDirectories.from(qualifier, organization, application)
             ProjectPaths(
                 Path(dirs.projectPath),
@@ -452,10 +452,10 @@ object Path:
 end Path
 
 extension [S](stream: Stream[Byte, S])
-    def sink(path: Path)(using Frame): Unit < (Resource & IO & S) =
-        Resource.acquireRelease(IO(FileChannel.open(path.toJava, StandardOpenOption.WRITE)))(ch => ch.close()).map { fileCh =>
+    def sink(path: Path)(using Frame): Unit < (Resource & Sync & S) =
+        Resource.acquireRelease(Sync(FileChannel.open(path.toJava, StandardOpenOption.WRITE)))(ch => ch.close()).map { fileCh =>
             stream.foreachChunk(bytes =>
-                IO {
+                Sync {
                     fileCh.write(ByteBuffer.wrap(bytes.toArray))
                     ()
                 }
@@ -465,10 +465,10 @@ end extension
 
 extension [S](stream: Stream[String, S])
     @scala.annotation.targetName("stringSink")
-    def sink(path: Path, charset: Codec = java.nio.charset.StandardCharsets.UTF_8)(using Frame): Unit < (Resource & IO & S) =
-        Resource.acquireRelease(IO(FileChannel.open(path.toJava, StandardOpenOption.WRITE)))(ch => ch.close()).map { fileCh =>
+    def sink(path: Path, charset: Codec = java.nio.charset.StandardCharsets.UTF_8)(using Frame): Unit < (Resource & Sync & S) =
+        Resource.acquireRelease(Sync(FileChannel.open(path.toJava, StandardOpenOption.WRITE)))(ch => ch.close()).map { fileCh =>
             stream.foreach(s =>
-                IO {
+                Sync {
                     fileCh.write(ByteBuffer.wrap(s.getBytes))
                     ()
                 }
@@ -478,10 +478,10 @@ extension [S](stream: Stream[String, S])
     def sinkLines(
         path: Path,
         charset: Codec = java.nio.charset.StandardCharsets.UTF_8
-    )(using Frame): Unit < (Resource & IO & S) =
+    )(using Frame): Unit < (Resource & Sync & S) =
         Resource.acquireRelease(FileChannel.open(path.toJava, StandardOpenOption.WRITE))(ch => ch.close()).map { fileCh =>
             stream.foreach(line =>
-                IO {
+                Sync {
                     fileCh.write(ByteBuffer.wrap(line.getBytes))
                     fileCh.write(ByteBuffer.wrap(JSystem.lineSeparator().getBytes))
                     ()

--- a/kyo-core/jvm/src/main/scala/kyo/StreamCompression.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/StreamCompression.scala
@@ -72,7 +72,7 @@ object StreamCompression:
             tag: Tag[Emit[Chunk[Byte]]],
             frame: Frame,
             ev: A <:< Byte
-        ): Stream[Byte, Resource & IO & Ctx] =
+        ): Stream[Byte, Resource & Sync & Ctx] =
             deflateStream(stream.map(ev.apply), bufferSize, compressionLevel, strategy, flushMode, noWrap)
         end deflate
 
@@ -84,7 +84,7 @@ object StreamCompression:
             tag: Tag[Emit[Chunk[Byte]]],
             frame: Frame,
             ev: A <:< Byte
-        ): Stream[Byte, IO & Resource & Ctx & Abort[StreamCompressionException]] =
+        ): Stream[Byte, Sync & Resource & Ctx & Abort[StreamCompressionException]] =
             inflateStream(stream.map(ev.apply), bufferSize, noWrap)
         end inflate
 
@@ -98,7 +98,7 @@ object StreamCompression:
             tag: Tag[Emit[Chunk[Byte]]],
             frame: Frame,
             ev: A <:< Byte
-        ): Stream[Byte, Resource & IO & Ctx] =
+        ): Stream[Byte, Resource & Sync & Ctx] =
             gzipStream(stream.map(ev.apply), bufferSize, compressionLevel, strategy, flushMode)
         end gzip
 
@@ -109,7 +109,7 @@ object StreamCompression:
             tag: Tag[Emit[Chunk[Byte]]],
             frame: Frame,
             ev: A <:< Byte
-        ): Stream[Byte, IO & Resource & Ctx & Abort[StreamCompressionException]] =
+        ): Stream[Byte, Sync & Resource & Ctx & Abort[StreamCompressionException]] =
             gunzipStream(stream.map(ev.apply), bufferSize)
         end gunzip
     end extension
@@ -150,47 +150,47 @@ object StreamCompression:
             using
             Tag[Emit[Chunk[Byte]]],
             Frame
-        ): Unit < (Resource & IO & Emit[Chunk[Byte]] & Ctx) =
+        ): Unit < (Resource & Sync & Emit[Chunk[Byte]] & Ctx) =
             Loop(DeflateState.Initialize):
                 case DeflateState.Initialize =>
-                    Resource.acquireRelease(IO {
+                    Resource.acquireRelease(Sync {
                         val deflater = new Deflater(compressionLevel.value, noWrap)
                         deflater.setStrategy(strategy.value)
                         deflater
                     }) { deflater =>
-                        IO(deflater.end())
+                        Sync(deflater.end())
                     }.map { deflater =>
                         Loop.continue(DeflateState.DeflateInput(deflater, stream.emit))
                     }
                 case DeflateState.DeflateInput(deflater, emit) =>
                     Emit.runFirst(emit).map {
                         case Present(bytes) -> cont =>
-                            IO(deflater.setInput(toUnboxByteArray(bytes))).andThen(Loop.continue(DeflateState.PullDeflater(
+                            Sync(deflater.setInput(toUnboxByteArray(bytes))).andThen(Loop.continue(DeflateState.PullDeflater(
                                 deflater,
                                 Present(cont),
                                 Chunk.empty[Byte]
                             )))
                         case _ =>
-                            IO(deflater.finish()).andThen(Loop.continue(DeflateState.PullDeflater(
+                            Sync(deflater.finish()).andThen(Loop.continue(DeflateState.PullDeflater(
                                 deflater,
                                 Absent,
                                 Chunk.empty[Byte]
                             )))
                     }
                 case DeflateState.PullDeflater(deflater, maybeEmitFn, chunk) =>
-                    IO(new Array[Byte](bufferSize)).map: buffer =>
-                        IO(deflater.deflate(buffer, 0, buffer.length, flushMode.value))
+                    Sync(new Array[Byte](bufferSize)).map: buffer =>
+                        Sync(deflater.deflate(buffer, 0, buffer.length, flushMode.value))
                             .map:
                                 case 0 =>
                                     Loop.continue(DeflateState.EmitDeflated(deflater, maybeEmitFn, chunk))
                                 case size =>
-                                    IO(chunk.concat(fromUnboxByteArray(buffer, size)))
+                                    Sync(chunk.concat(fromUnboxByteArray(buffer, size)))
                                         .map(nextChunk => Loop.continue(DeflateState.PullDeflater(deflater, maybeEmitFn, nextChunk)))
                 case DeflateState.EmitDeflated(deflater, maybeEmitFn, chunk) =>
                     Emit.valueWith(chunk):
                         maybeEmitFn match
                             case Present(emitFn) => Loop.continue(DeflateState.DeflateInput(deflater, emitFn()))
-                            case Absent          => IO(deflater.end()).andThen(Loop.done)
+                            case Absent          => Sync(deflater.end()).andThen(Loop.done)
         end emit
 
         Stream(emit(stream, bufferSize, compressionLevel, strategy, flushMode, noWrap))
@@ -206,7 +206,7 @@ object StreamCompression:
         using
         tag: Tag[Emit[Chunk[Byte]]],
         _frame: Frame
-    ): Stream[Byte, Resource & IO & Ctx] =
+    ): Stream[Byte, Resource & Sync & Ctx] =
         enum GZipState derives CanEqual:
             case Initialize                                                                             extends GZipState
             case SendHeader(delfater: Deflater, crc32: CRC32)                                           extends GZipState
@@ -232,18 +232,18 @@ object StreamCompression:
             compressionLevel: CompressionLevel,
             strategy: CompressionStrategy,
             flushMode: FlushMode
-        ): Unit < (Resource & IO & Emit[Chunk[Byte]] & Ctx) =
-            val bufferIO = IO(new Array[Byte](bufferSize))
+        ): Unit < (Resource & Sync & Emit[Chunk[Byte]] & Ctx) =
+            val bufferIO = Sync(new Array[Byte](bufferSize))
 
             Loop(GZipState.Initialize):
                 case GZipState.Initialize =>
-                    Resource.acquireRelease(IO {
+                    Resource.acquireRelease(Sync {
                         val deflater = new Deflater(compressionLevel.value, true)
                         val crc32    = new CRC32()
                         deflater.setStrategy(strategy.value)
                         deflater -> crc32
                     }) { (deflater, crc32) =>
-                        IO {
+                        Sync {
                             deflater.end()
                             crc32.reset()
                         }
@@ -251,7 +251,7 @@ object StreamCompression:
                         Loop.continue(GZipState.SendHeader(deflater, crc32))
                     }
                 case GZipState.SendHeader(deflater, crc32) =>
-                    IO {
+                    Sync {
                         // no MTIME timestamp, unknown OS
                         Chunk(
                             0x1f, // ID1: Identification 1
@@ -276,19 +276,24 @@ object StreamCompression:
                 case GZipState.DeflateInput(deflater, crc32, emit) =>
                     Emit.runFirst(emit).map {
                         case Present(bytes) -> cont =>
-                            IO {
+                            Sync {
                                 crc32.update(toUnboxByteArray(bytes))
                                 deflater.setInput(toUnboxByteArray(bytes))
                             }.andThen(Loop.continue(GZipState.PullDeflater(deflater, crc32, Present(cont), Chunk.empty[Byte])))
                         case _ =>
-                            IO(deflater.finish()).andThen(Loop.continue(GZipState.PullDeflater(deflater, crc32, Absent, Chunk.empty[Byte])))
+                            Sync(deflater.finish()).andThen(Loop.continue(GZipState.PullDeflater(
+                                deflater,
+                                crc32,
+                                Absent,
+                                Chunk.empty[Byte]
+                            )))
                     }
                 case GZipState.PullDeflater(deflater, crc32, maybeEmitFn, chunk) =>
                     bufferIO.map: buffer =>
-                        IO(deflater.deflate(buffer, 0, buffer.length, flushMode.value))
+                        Sync(deflater.deflate(buffer, 0, buffer.length, flushMode.value))
                             .map:
                                 case 0 => Loop.continue(GZipState.EmitDeflated(deflater, crc32, maybeEmitFn, chunk))
-                                case size => IO(chunk.concat(fromUnboxByteArray(buffer, size)))
+                                case size => Sync(chunk.concat(fromUnboxByteArray(buffer, size)))
                                         .map(nextChunk => Loop.continue(GZipState.PullDeflater(deflater, crc32, maybeEmitFn, nextChunk)))
                 case GZipState.EmitDeflated(deflater, crc32, maybeEmitFn, chunk) =>
                     Emit.valueWith(chunk):
@@ -296,7 +301,7 @@ object StreamCompression:
                             case Present(emitFn) => Loop.continue(GZipState.DeflateInput(deflater, crc32, emitFn()))
                             case Absent          => Loop.continue(GZipState.SendTrailer(deflater, crc32))
                 case GZipState.SendTrailer(deflater, crc32) =>
-                    IO {
+                    Sync {
                         val crcValue  = crc32.getValue
                         val bytesRead = deflater.getBytesRead()
                         val trailer = Chunk(
@@ -330,7 +335,7 @@ object StreamCompression:
         Frame
     ) =
 
-        val bufferIO = IO(new Array[Byte](bufferSize))
+        val bufferIO = Sync(new Array[Byte](bufferSize))
 
         enum InflateState derives CanEqual:
             case Initialize                                                               extends InflateState
@@ -347,22 +352,22 @@ object StreamCompression:
             using
             Tag[Emit[Chunk[Byte]]],
             Frame
-        ): Unit < (Resource & IO & Abort[StreamCompressionException] & Ctx & Emit[Chunk[Byte]]) =
+        ): Unit < (Resource & Sync & Abort[StreamCompressionException] & Ctx & Emit[Chunk[Byte]]) =
             Loop(InflateState.Initialize):
                 case InflateState.Initialize =>
                     Resource
-                        .acquireRelease(IO(new Inflater(noWrap)))(inflater => IO(inflater.end()))
+                        .acquireRelease(Sync(new Inflater(noWrap)))(inflater => Sync(inflater.end()))
                         .map: inflater =>
                             Loop.continue(InflateState.InflateInput(inflater, stream.emit))
                 case InflateState.InflateInput(inflater, emit) =>
                     Emit.runFirst(emit).map:
                         case Present(bytes) -> emitFn =>
-                            IO(inflater.setInput(toUnboxByteArray(bytes)))
+                            Sync(inflater.setInput(toUnboxByteArray(bytes)))
                                 .andThen(
                                     Loop.continue(InflateState.PullInflater(inflater, Present(emitFn), bytes))
                                 )
                         case _ =>
-                            IO(Loop.continue(InflateState.PullInflater(inflater, Absent, Chunk.empty)))
+                            Sync(Loop.continue(InflateState.PullInflater(inflater, Absent, Chunk.empty)))
                 case InflateState.PullInflater(inflater, maybeEmitFn, bytes) =>
                     if inflater.finished then
                         val leftOver = inflater.getRemaining match
@@ -372,7 +377,7 @@ object StreamCompression:
                             maybeEmitFn match
                                 case Present(emitFn) =>
                                     Resource
-                                        .acquireRelease(IO(new Inflater(noWrap)))(inflater => IO(inflater.end()))
+                                        .acquireRelease(Sync(new Inflater(noWrap)))(inflater => Sync(inflater.end()))
                                         .map: inflater =>
                                             Loop.continue(InflateState.InflateInput(inflater, emitFn()))
                                 case Absent =>
@@ -459,10 +464,10 @@ object StreamCompression:
             checkCrc16: Boolean
         )(
             using Frame
-        ): (Chunk[Byte], CRC32, Unit < (Emit[Chunk[Byte]] & Ctx)) => Loop.Outcome[GunzipState, Unit] < (Resource & IO) =
+        ): (Chunk[Byte], CRC32, Unit < (Emit[Chunk[Byte]] & Ctx)) => Loop.Outcome[GunzipState, Unit] < (Resource & Sync) =
             (bytes: Chunk[Byte], headerCrc32: CRC32, emit: Unit < (Emit[Chunk[Byte]] & Ctx)) =>
                 if hasExtra then
-                    IO(Loop.continue(GunzipState.ParseHeaderExtra(
+                    Sync(Loop.continue(GunzipState.ParseHeaderExtra(
                         bytes,
                         headerCrc32,
                         checkCrc16,
@@ -470,7 +475,7 @@ object StreamCompression:
                         emit
                     )))
                 else if commentsToSkip > 0 then
-                    IO(Loop.continue(GunzipState.SkipComments(
+                    Sync(Loop.continue(GunzipState.SkipComments(
                         bytes,
                         headerCrc32,
                         checkCrc16,
@@ -478,18 +483,18 @@ object StreamCompression:
                         emit
                     )))
                 else if checkCrc16 then
-                    IO(Loop.continue(GunzipState.CheckCrc16(
+                    Sync(Loop.continue(GunzipState.CheckCrc16(
                         bytes,
                         headerCrc32,
                         emit
                     )))
                 else
-                    Resource.acquireRelease(IO {
+                    Resource.acquireRelease(Sync {
                         val inflater     = new Inflater(true)
                         val contentCrc32 = new CRC32()
                         inflater -> contentCrc32
                     })((inflater, contentCrc32) =>
-                        IO {
+                        Sync {
                             inflater.end()
                             contentCrc32.reset()
                         }
@@ -506,10 +511,10 @@ object StreamCompression:
             using
             Tag[Chunk[Byte]],
             Frame
-        ): Unit < (Resource & IO & Abort[StreamCompressionException] & Ctx & Emit[Chunk[Byte]]) =
+        ): Unit < (Resource & Sync & Abort[StreamCompressionException] & Ctx & Emit[Chunk[Byte]]) =
             Loop(GunzipState.Initialize):
                 case GunzipState.Initialize =>
-                    Resource.acquireRelease(IO(new CRC32()))(headerCrc32 => IO(headerCrc32.reset()))
+                    Resource.acquireRelease(Sync(new CRC32()))(headerCrc32 => Sync(headerCrc32.reset()))
                         .map: headerCrc32 =>
                             Loop.continue(GunzipState.ParseHeader(Chunk.empty, headerCrc32, stream.emit))
                 case GunzipState.ParseHeader(accBytes, headerCrc32, emit) =>
@@ -653,14 +658,14 @@ object StreamCompression:
                     if leftOver.isEmpty then
                         Emit.runFirst(emit).map:
                             case Present(bytes) -> emitFn =>
-                                IO(inflater.setInput(toUnboxByteArray(bytes)))
+                                Sync(inflater.setInput(toUnboxByteArray(bytes)))
                                     .andThen(
                                         Loop.continue(GunzipState.PullInflater(inflater, contentCrc32, Present(emitFn), bytes))
                                     )
                             case _ =>
                                 Loop.continue(GunzipState.PullInflater(inflater, contentCrc32, Absent, Chunk.empty))
                     else
-                        IO(inflater.setInput(toUnboxByteArray(leftOver)))
+                        Sync(inflater.setInput(toUnboxByteArray(leftOver)))
                             .andThen(
                                 Loop.continue(GunzipState.PullInflater(inflater, contentCrc32, Present(() => emit), leftOver))
                             )
@@ -679,12 +684,12 @@ object StreamCompression:
                                 case Absent =>
                                     Loop.continue(GunzipState.CheckTrailer(Chunk.empty, inflater, contentCrc32, Absent))
                     else
-                        IO(new Array[Byte](bufferSize)).map: buffer =>
+                        Sync(new Array[Byte](bufferSize)).map: buffer =>
                             Abort
                                 .catching[DataFormatException](dfe => StreamCompressionException(dfe))(inflater.inflate(buffer))
                                 .map(read => fromUnboxByteArray(buffer, read))
                                 .map(inflated =>
-                                    IO(contentCrc32.update(toUnboxByteArray(inflated))).andThen(
+                                    Sync(contentCrc32.update(toUnboxByteArray(inflated))).andThen(
                                         Emit.valueWith(inflated)(
                                             Loop.continue(GunzipState.PullInflater(inflater, contentCrc32, maybeEmitFn, bytes))
                                         )
@@ -726,7 +731,7 @@ object StreamCompression:
                         else
                             maybeEmitFn match
                                 case Present(emitFn) =>
-                                    Resource.acquireRelease(IO(new CRC32()))(headerCrc32 => IO(headerCrc32.reset()))
+                                    Resource.acquireRelease(Sync(new CRC32()))(headerCrc32 => Sync(headerCrc32.reset()))
                                         .map: headerCrc32 =>
                                             Loop.continue(GunzipState.ParseHeader(rest, headerCrc32, emitFn()))
                                 case Absent =>

--- a/kyo-core/jvm/src/main/scala/kyo/internal/AsyncPlatformSpecific.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/internal/AsyncPlatformSpecific.scala
@@ -9,7 +9,7 @@ trait AsyncPlatformSpecific:
         fromCompletionStage(cs)
 
     def fromCompletionStage[A](cs: CompletionStage[A])(using Frame): A < Async =
-        IO.Unsafe {
+        Sync.Unsafe {
             val p = Promise.Unsafe.init[Nothing, A]()
             cs.whenComplete { (success, error) =>
                 if error == null then p.completeDiscard(Result.succeed(success))

--- a/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
@@ -17,7 +17,7 @@ class PathTest extends Test:
         JFiles.delete(Paths.get(name))
 
     def useFile(name: String, text: String) =
-        Resource.acquireRelease(IO(createFile(name, text)))(_ => IO(destroyFile(name)))
+        Resource.acquireRelease(Sync(createFile(name, text)))(_ => Sync(destroyFile(name)))
 
     "read and write files" - {
         "read file as string" in run {
@@ -176,10 +176,10 @@ class PathTest extends Test:
             val stream = Stream.init(Chunk[Byte](115, 111, 109, 101, 32, 116, 101, 120, 116))
             val file   = Path(name)
             for
-                _   <- IO(createFile(name, ""))
+                _   <- Sync(createFile(name, ""))
                 _   <- stream.sink(file)
                 res <- file.read
-                _   <- IO(destroyFile(name))
+                _   <- Sync(destroyFile(name))
             yield assert(res == "some text")
             end for
 
@@ -190,10 +190,10 @@ class PathTest extends Test:
             val stream = Stream.init(Chunk("some text", "more text"))
             val file   = Path(name)
             for
-                _   <- IO(createFile(name, ""))
+                _   <- Sync(createFile(name, ""))
                 _   <- stream.sinkLines(file)
                 res <- file.readLines
-                _   <- IO(destroyFile(name))
+                _   <- Sync(destroyFile(name))
             yield assert(res == List("some text", "more text"))
             end for
         }
@@ -344,49 +344,49 @@ class PathTest extends Test:
         "cache" in run {
             for
                 kyoPath <- Path.basePaths.map(_.cache)
-                libPath <- IO(BaseDirectories.get().cacheDir)
+                libPath <- Sync(BaseDirectories.get().cacheDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "config" in run {
             for
                 kyoPath <- Path.basePaths.map(_.config)
-                libPath <- IO(BaseDirectories.get().configDir)
+                libPath <- Sync(BaseDirectories.get().configDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "data" in run {
             for
                 kyoPath <- Path.basePaths.map(_.data)
-                libPath <- IO(BaseDirectories.get().dataDir)
+                libPath <- Sync(BaseDirectories.get().dataDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "dataLocal" in run {
             for
                 kyoPath <- Path.basePaths.map(_.dataLocal)
-                libPath <- IO(BaseDirectories.get().dataLocalDir)
+                libPath <- Sync(BaseDirectories.get().dataLocalDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "executable" in run {
             for
                 kyoPath <- Path.basePaths.map(_.executable)
-                libPath <- IO(BaseDirectories.get().executableDir)
+                libPath <- Sync(BaseDirectories.get().executableDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "preference" in run {
             for
                 kyoPath <- Path.basePaths.map(_.preference)
-                libPath <- IO(BaseDirectories.get().preferenceDir)
+                libPath <- Sync(BaseDirectories.get().preferenceDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "runtime" in run {
             for
                 kyoPath <- Path.basePaths.map(_.runtime)
-                libPath <- IO(BaseDirectories.get().runtimeDir)
+                libPath <- Sync(BaseDirectories.get().runtimeDir)
             yield assert(kyoPath == Path(libPath))
         }
     }
@@ -395,70 +395,70 @@ class PathTest extends Test:
         "home" in run {
             for
                 kyoPath <- Path.userPaths.map(_.home)
-                libPath <- IO(UserDirectories.get().homeDir)
+                libPath <- Sync(UserDirectories.get().homeDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "audio" in run {
             for
                 kyoPath <- Path.userPaths.map(_.audio)
-                libPath <- IO(UserDirectories.get().audioDir)
+                libPath <- Sync(UserDirectories.get().audioDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "desktop" in run {
             for
                 kyoPath <- Path.userPaths.map(_.desktop)
-                libPath <- IO(UserDirectories.get().desktopDir)
+                libPath <- Sync(UserDirectories.get().desktopDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "document" in run {
             for
                 kyoPath <- Path.userPaths.map(_.document)
-                libPath <- IO(UserDirectories.get().documentDir)
+                libPath <- Sync(UserDirectories.get().documentDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "download" in run {
             for
                 kyoPath <- Path.userPaths.map(_.download)
-                libPath <- IO(UserDirectories.get().downloadDir)
+                libPath <- Sync(UserDirectories.get().downloadDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "font" in run {
             for
                 kyoPath <- Path.userPaths.map(_.font)
-                libPath <- IO(UserDirectories.get().fontDir)
+                libPath <- Sync(UserDirectories.get().fontDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "picture" in run {
             for
                 kyoPath <- Path.userPaths.map(_.picture)
-                libPath <- IO(UserDirectories.get().pictureDir)
+                libPath <- Sync(UserDirectories.get().pictureDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "public" in run {
             for
                 kyoPath <- Path.userPaths.map(_.public)
-                libPath <- IO(UserDirectories.get().publicDir)
+                libPath <- Sync(UserDirectories.get().publicDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "template" in run {
             for
                 kyoPath <- Path.userPaths.map(_.template)
-                libPath <- IO(UserDirectories.get().templateDir)
+                libPath <- Sync(UserDirectories.get().templateDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "video" in run {
             for
                 kyoPath <- Path.userPaths.map(_.video)
-                libPath <- IO(UserDirectories.get().videoDir)
+                libPath <- Sync(UserDirectories.get().videoDir)
             yield assert(kyoPath == Path(libPath))
         }
     }
@@ -470,49 +470,49 @@ class PathTest extends Test:
         "path" in run {
             for
                 kyoPath <- testProject.map(_.path)
-                libPath <- IO(libProject.projectPath)
+                libPath <- Sync(libProject.projectPath)
             yield assert(kyoPath == Path(libPath))
         }
 
         "cache" in run {
             for
                 kyoPath <- testProject.map(_.cache)
-                libPath <- IO(libProject.cacheDir)
+                libPath <- Sync(libProject.cacheDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "config" in run {
             for
                 kyoPath <- testProject.map(_.config)
-                libPath <- IO(libProject.configDir)
+                libPath <- Sync(libProject.configDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "data" in run {
             for
                 kyoPath <- testProject.map(_.data)
-                libPath <- IO(libProject.dataDir)
+                libPath <- Sync(libProject.dataDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "dataLocal" in run {
             for
                 kyoPath <- testProject.map(_.dataLocal)
-                libPath <- IO(libProject.dataLocalDir)
+                libPath <- Sync(libProject.dataLocalDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "preference" in run {
             for
                 kyoPath <- testProject.map(_.preference)
-                libPath <- IO(libProject.preferenceDir)
+                libPath <- Sync(libProject.preferenceDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "runtime" in run {
             for
                 kyoPath <- testProject.map(_.runtime)
-                libPath <- IO(libProject.runtimeDir)
+                libPath <- Sync(libProject.runtimeDir)
             yield assert(kyoPath == Path(libPath))
         }
     }

--- a/kyo-core/shared/src/main/scala/kyo/Adder.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Adder.scala
@@ -36,7 +36,7 @@ final case class LongAdder private (unsafe: LongAdder.Unsafe):
       * @return
       *   Unit
       */
-    inline def add(v: Long)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.add(v))
+    inline def add(v: Long)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.add(v))
 
     /** Decrements the sum by one.
       *
@@ -45,7 +45,7 @@ final case class LongAdder private (unsafe: LongAdder.Unsafe):
       * @return
       *   Unit
       */
-    inline def decrement(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.decrement())
+    inline def decrement(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.decrement())
 
     /** Increments the sum by one.
       *
@@ -54,7 +54,7 @@ final case class LongAdder private (unsafe: LongAdder.Unsafe):
       * @return
       *   Unit
       */
-    inline def increment(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.increment())
+    inline def increment(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.increment())
 
     /** Returns the current sum.
       *
@@ -64,7 +64,7 @@ final case class LongAdder private (unsafe: LongAdder.Unsafe):
       * @return
       *   The current sum
       */
-    inline def get(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.get())
+    inline def get(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.get())
 
     /** Resets the sum to zero.
       *
@@ -73,7 +73,7 @@ final case class LongAdder private (unsafe: LongAdder.Unsafe):
       * @return
       *   Unit
       */
-    inline def reset(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.reset())
+    inline def reset(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.reset())
 
     /** Returns the current sum and resets it to zero.
       *
@@ -83,7 +83,7 @@ final case class LongAdder private (unsafe: LongAdder.Unsafe):
       * @return
       *   The sum before reset,
       */
-    inline def sumThenReset(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.sumThenReset())
+    inline def sumThenReset(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.sumThenReset())
 
 end LongAdder
 
@@ -94,7 +94,7 @@ object LongAdder:
       * @return
       *   A new LongAdder
       */
-    def init(using frame: Frame): LongAdder < IO = initWith(identity)
+    def init(using frame: Frame): LongAdder < Sync = initWith(identity)
 
     /** Uses a new LongAdder.
       * @param f
@@ -102,8 +102,8 @@ object LongAdder:
       * @return
       *   The result of applying the function
       */
-    inline def initWith[A, S](inline f: LongAdder => A < S)(using inline frame: Frame): A < (IO & S) =
-        IO.Unsafe(f(LongAdder(Unsafe.init())))
+    inline def initWith[A, S](inline f: LongAdder => A < S)(using inline frame: Frame): A < (Sync & S) =
+        Sync.Unsafe(f(LongAdder(Unsafe.init())))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.LongAdder
@@ -158,7 +158,7 @@ final case class DoubleAdder private (unsafe: DoubleAdder.Unsafe):
       * @return
       *   Unit
       */
-    inline def add(v: Double)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.add(v))
+    inline def add(v: Double)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.add(v))
 
     /** Returns the current sum.
       *
@@ -168,7 +168,7 @@ final case class DoubleAdder private (unsafe: DoubleAdder.Unsafe):
       * @return
       *   The current sum
       */
-    inline def get(using inline frame: Frame): Double < IO = IO.Unsafe(unsafe.get())
+    inline def get(using inline frame: Frame): Double < Sync = Sync.Unsafe(unsafe.get())
 
     /** Resets the sum to zero.
       *
@@ -177,7 +177,7 @@ final case class DoubleAdder private (unsafe: DoubleAdder.Unsafe):
       * @return
       *   Unit
       */
-    inline def reset(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.reset())
+    inline def reset(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.reset())
 
     /** Returns the current sum and resets it to zero.
       *
@@ -187,7 +187,7 @@ final case class DoubleAdder private (unsafe: DoubleAdder.Unsafe):
       * @return
       *   The sum before reset,
       */
-    inline def sumThenReset(using inline frame: Frame): Double < IO = IO.Unsafe(unsafe.sumThenReset())
+    inline def sumThenReset(using inline frame: Frame): Double < Sync = Sync.Unsafe(unsafe.sumThenReset())
 
 end DoubleAdder
 
@@ -198,7 +198,7 @@ object DoubleAdder:
       * @return
       *   A new DoubleAdder
       */
-    def init(using Frame): DoubleAdder < IO = initWith(identity)
+    def init(using Frame): DoubleAdder < Sync = initWith(identity)
 
     /** Uses a new DoubleAdder.
       * @param f
@@ -206,8 +206,8 @@ object DoubleAdder:
       * @return
       *   The result of applying the function
       */
-    inline def initWith[A, S](inline f: DoubleAdder => A < S)(using inline frame: Frame): A < (IO & S) =
-        IO.Unsafe(f(DoubleAdder(Unsafe.init())))
+    inline def initWith[A, S](inline f: DoubleAdder => A < S)(using inline frame: Frame): A < (Sync & S) =
+        Sync.Unsafe(f(DoubleAdder(Unsafe.init())))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = j.DoubleAdder

--- a/kyo-core/shared/src/main/scala/kyo/Admission.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Admission.scala
@@ -45,8 +45,8 @@ object Admission:
       * @return
       *   The computation result if admitted, or Rejected if the task is rejected
       */
-    def run[A, S](key: String)(v: A < S)(using frame: Frame): A < (IO & S & Abort[Rejected]) =
-        IO {
+    def run[A, S](key: String)(v: A < S)(using frame: Frame): A < (Sync & S & Abort[Rejected]) =
+        Sync {
             if Scheduler.get.reject(key) then Abort.fail(Rejected())
             else v
         }
@@ -70,8 +70,8 @@ object Admission:
       * @return
       *   The computation result if admitted, or Rejected if the task is rejected
       */
-    def run[A, S](key: Int)(v: A < S)(using frame: Frame): A < (IO & S & Abort[Rejected]) =
-        IO {
+    def run[A, S](key: Int)(v: A < S)(using frame: Frame): A < (Sync & S & Abort[Rejected]) =
+        Sync {
             if Scheduler.get.reject(key) then Abort.fail(Rejected())
             else v
         }
@@ -93,8 +93,8 @@ object Admission:
       * @return
       *   The computation result if admitted, or Rejected if the task is rejected
       */
-    def run[A, S](v: A < S)(using frame: Frame): A < (IO & S & Abort[Rejected]) =
-        IO {
+    def run[A, S](v: A < S)(using frame: Frame): A < (Sync & S & Abort[Rejected]) =
+        Sync {
             if Scheduler.get.reject() then Abort.fail(Rejected())
             else v
         }
@@ -117,8 +117,8 @@ object Admission:
       * @return
       *   true if the task should be rejected, false if it can be accepted
       */
-    def reject()(using Frame): Boolean < IO =
-        IO(Scheduler.get.reject())
+    def reject()(using Frame): Boolean < Sync =
+        Sync(Scheduler.get.reject())
 
     /** Tests if a task with the given string key should be rejected based on current system conditions.
       *
@@ -143,8 +143,8 @@ object Admission:
       * @return
       *   true if the task should be rejected, false if it can be accepted
       */
-    def reject(key: String)(using Frame): Boolean < IO =
-        IO(Scheduler.get.reject(key))
+    def reject(key: String)(using Frame): Boolean < Sync =
+        Sync(Scheduler.get.reject(key))
 
     /** Tests if a task with the given integer key should be rejected based on current system conditions.
       *
@@ -169,7 +169,7 @@ object Admission:
       * @return
       *   true if the task should be rejected, false if it can be accepted
       */
-    def reject(key: Int)(using Frame): Boolean < IO =
-        IO(Scheduler.get.reject(key))
+    def reject(key: Int)(using Frame): Boolean < Sync =
+        Sync(Scheduler.get.reject(key))
 
 end Admission

--- a/kyo-core/shared/src/main/scala/kyo/AllowUnsafe.scala
+++ b/kyo-core/shared/src/main/scala/kyo/AllowUnsafe.scala
@@ -10,8 +10,8 @@ Options (in order of preference):
 1. Receive an implicit AllowUnsafe parameter
    def myFunction(implicit allow: AllowUnsafe) = // unsafe code here
 
-2. Suspend the operation with IO
-   IO.Unsafe { // unsafe code here }
+2. Suspend the operation with Sync
+   Sync.Unsafe { // unsafe code here }
 
 3. Import implicit evidence (last resort)
    import AllowUnsafe.embrace.danger

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -12,13 +12,14 @@ import scala.util.control.NonFatal
 
 /** Asynchronous computation effect.
   *
-  * While IO handles pure effect suspension, Async provides the complete toolkit for concurrent programming - managing fibers, scheduling,
-  * and execution control. It includes IO in its effect set, making it a unified solution for both synchronous and asynchronous operations.
+  * While Sync handles pure effect suspension, Async provides the complete toolkit for concurrent programming - managing fibers, scheduling,
+  * and execution control. It includes Sync in its effect set, making it a unified solution for both synchronous and asynchronous
+  * operations.
   *
   * This separation, enabled by Kyo's algebraic effect system, is reflected in the codebase's design: the presence of Async in pending
-  * effects signals that a computation may park or involve fiber scheduling, contrasting with IO-only operations that run to completion.
+  * effects signals that a computation may park or involve fiber scheduling, contrasting with Sync-only operations that run to completion.
   *
-  * Most application code can work exclusively with Async, with the IO/Async distinction becoming relevant primarily in library code or
+  * Most application code can work exclusively with Async, with the Sync/Async distinction becoming relevant primarily in library code or
   * performance-critical sections where precise control over execution characteristics is needed.
   *
   * Note: For collection operations, Async provides concurrent execution variants of the `Kyo` companion object sequential operations. These
@@ -26,7 +27,7 @@ import scala.util.control.NonFatal
   * can be overridden per operation when needed. On platforms like the JVM, these operations may execute in parallel using multiple threads.
   * On single-threaded platforms like JavaScript, operations will be interleaved concurrently but not execute in parallel.
   *
-  * This effect includes IO in its effect set to handle both async and sync execution in a single effect.
+  * This effect includes Sync in its effect set to handle both async and sync execution in a single effect.
   *
   * @see
   *   [[Async.run]] for executing asynchronous computations and obtaining a Fiber
@@ -58,7 +59,7 @@ object Async extends AsyncPlatformSpecific:
       * ```
       *
       * Consider adjusting this based on:
-      *   - Nature of operations (CPU vs IO bound)
+      *   - Nature of operations (CPU vs Sync bound)
       *   - Available system resources
       *   - Specific performance requirements
       *
@@ -72,8 +73,8 @@ object Async extends AsyncPlatformSpecific:
 
     /** Convenience method for suspending computations in an Async effect.
       *
-      * While IO is specifically designed to suspend side effects without handling asynchronicity, Async provides both side effect
-      * suspension and asynchronous execution capabilities (fibers, async scheduling). Since Async includes IO in its effect set, this
+      * While Sync is specifically designed to suspend side effects without handling asynchronicity, Async provides both side effect
+      * suspension and asynchronous execution capabilities (fibers, async scheduling). Since Async includes Sync in its effect set, this
       * method allows users to work with a single unified effect that handles both concerns.
       *
       * Note that this method only suspends the computation - it does not fork execution into a new fiber. For concurrent execution, use

--- a/kyo-core/shared/src/main/scala/kyo/Atomic.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Atomic.scala
@@ -19,7 +19,7 @@ final case class AtomicInt private (unsafe: AtomicInt.Unsafe):
       * @return
       *   The current integer value
       */
-    inline def get(using inline frame: Frame): Int < IO = use(identity)
+    inline def get(using inline frame: Frame): Int < Sync = use(identity)
 
     /** Uses the current value with a transformation function.
       * @param f
@@ -27,20 +27,20 @@ final case class AtomicInt private (unsafe: AtomicInt.Unsafe):
       * @return
       *   The result of applying the function to the current value
       */
-    inline def use[A, S](inline f: Int => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.Unsafe(f(unsafe.get()))
+    inline def use[A, S](inline f: Int => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.Unsafe(f(unsafe.get()))
 
     /** Sets to the given value.
       * @param v
       *   The new value
       */
-    inline def set(v: Int)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.set(v))
+    inline def set(v: Int)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.set(v))
 
     /** Eventually sets to the given value.
       * @param v
       *   The new value
       */
-    inline def lazySet(v: Int)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.lazySet(v))
+    inline def lazySet(v: Int)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.lazySet(v))
 
     /** Atomically sets to the given value and returns the old value.
       * @param v
@@ -48,7 +48,7 @@ final case class AtomicInt private (unsafe: AtomicInt.Unsafe):
       * @return
       *   The previous value
       */
-    inline def getAndSet(v: Int)(using inline frame: Frame): Int < IO = IO.Unsafe(unsafe.getAndSet(v))
+    inline def getAndSet(v: Int)(using inline frame: Frame): Int < Sync = Sync.Unsafe(unsafe.getAndSet(v))
 
     /** Atomically sets the value to the given updated value if the current value is equal to the expected value.
       * @param curr
@@ -58,31 +58,32 @@ final case class AtomicInt private (unsafe: AtomicInt.Unsafe):
       * @return
       *   true if successful, false otherwise
       */
-    inline def compareAndSet(curr: Int, next: Int)(using inline frame: Frame): Boolean < IO = IO.Unsafe(unsafe.compareAndSet(curr, next))
+    inline def compareAndSet(curr: Int, next: Int)(using inline frame: Frame): Boolean < Sync =
+        Sync.Unsafe(unsafe.compareAndSet(curr, next))
 
     /** Atomically increments the current value and returns the updated value.
       * @return
       *   The updated value
       */
-    inline def incrementAndGet(using inline frame: Frame): Int < IO = IO.Unsafe(unsafe.incrementAndGet())
+    inline def incrementAndGet(using inline frame: Frame): Int < Sync = Sync.Unsafe(unsafe.incrementAndGet())
 
     /** Atomically decrements the current value and returns the updated value.
       * @return
       *   The updated value
       */
-    inline def decrementAndGet(using inline frame: Frame): Int < IO = IO.Unsafe(unsafe.decrementAndGet())
+    inline def decrementAndGet(using inline frame: Frame): Int < Sync = Sync.Unsafe(unsafe.decrementAndGet())
 
     /** Atomically increments the current value and returns the old value.
       * @return
       *   The previous value
       */
-    inline def getAndIncrement(using inline frame: Frame): Int < IO = IO.Unsafe(unsafe.getAndIncrement())
+    inline def getAndIncrement(using inline frame: Frame): Int < Sync = Sync.Unsafe(unsafe.getAndIncrement())
 
     /** Atomically decrements the current value and returns the old value.
       * @return
       *   The previous value
       */
-    inline def getAndDecrement(using inline frame: Frame): Int < IO = IO.Unsafe(unsafe.getAndDecrement())
+    inline def getAndDecrement(using inline frame: Frame): Int < Sync = Sync.Unsafe(unsafe.getAndDecrement())
 
     /** Atomically adds the given value to the current value and returns the old value.
       * @param v
@@ -90,7 +91,7 @@ final case class AtomicInt private (unsafe: AtomicInt.Unsafe):
       * @return
       *   The previous value
       */
-    inline def getAndAdd(v: Int)(using inline frame: Frame): Int < IO = IO.Unsafe(unsafe.getAndAdd(v))
+    inline def getAndAdd(v: Int)(using inline frame: Frame): Int < Sync = Sync.Unsafe(unsafe.getAndAdd(v))
 
     /** Atomically adds the given value to the current value and returns the updated value.
       * @param v
@@ -98,7 +99,7 @@ final case class AtomicInt private (unsafe: AtomicInt.Unsafe):
       * @return
       *   The updated value
       */
-    inline def addAndGet(v: Int)(using inline frame: Frame): Int < IO = IO.Unsafe(unsafe.addAndGet(v))
+    inline def addAndGet(v: Int)(using inline frame: Frame): Int < Sync = Sync.Unsafe(unsafe.addAndGet(v))
 
     /** Atomically updates the current value using the given function and returns the old value.
       * @param f
@@ -106,7 +107,7 @@ final case class AtomicInt private (unsafe: AtomicInt.Unsafe):
       * @return
       *   The previous value
       */
-    inline def getAndUpdate(inline f: Int => Int)(using inline frame: Frame): Int < IO = IO.Unsafe(unsafe.getAndUpdate(f))
+    inline def getAndUpdate(inline f: Int => Int)(using inline frame: Frame): Int < Sync = Sync.Unsafe(unsafe.getAndUpdate(f))
 
     /** Atomically updates the current value using the given function and returns the updated value.
       * @param f
@@ -114,7 +115,7 @@ final case class AtomicInt private (unsafe: AtomicInt.Unsafe):
       * @return
       *   The updated value
       */
-    inline def updateAndGet(inline f: Int => Int)(using inline frame: Frame): Int < IO = IO.Unsafe(unsafe.updateAndGet(f))
+    inline def updateAndGet(inline f: Int => Int)(using inline frame: Frame): Int < Sync = Sync.Unsafe(unsafe.updateAndGet(f))
 
     /** Returns a string representation of the current value.
       * @return
@@ -130,7 +131,7 @@ object AtomicInt:
       * @return
       *   A new AtomicInt instance initialized to 0
       */
-    def init(using Frame): AtomicInt < IO = initWith(0)(identity)
+    def init(using Frame): AtomicInt < Sync = initWith(0)(identity)
 
     /** Creates a new AtomicInt with the given initial value.
       * @param v
@@ -138,7 +139,7 @@ object AtomicInt:
       * @return
       *   A new AtomicInt instance
       */
-    def init(initialValue: Int)(using Frame): AtomicInt < IO = initWith(initialValue)(identity)
+    def init(initialValue: Int)(using Frame): AtomicInt < Sync = initWith(initialValue)(identity)
 
     /** Uses a new AtomicInt with initial value 0 in the given function.
       * @param f
@@ -146,7 +147,7 @@ object AtomicInt:
       * @return
       *   The result of applying the function
       */
-    inline def initWith[A, S](inline f: AtomicInt => A < S)(using inline frame: Frame): A < (S & IO) =
+    inline def initWith[A, S](inline f: AtomicInt => A < S)(using inline frame: Frame): A < (S & Sync) =
         initWith(0)(f)
 
     /** Uses a new AtomicInt with the given initial value in the function.
@@ -157,8 +158,8 @@ object AtomicInt:
       * @return
       *   The result of applying the function
       */
-    inline def initWith[A, S](initialValue: Int)(inline f: AtomicInt => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.Unsafe(f(AtomicInt(Unsafe.init(initialValue))))
+    inline def initWith[A, S](initialValue: Int)(inline f: AtomicInt => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.Unsafe(f(AtomicInt(Unsafe.init(initialValue))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = java.util.concurrent.atomic.AtomicInteger
@@ -206,7 +207,7 @@ final case class AtomicLong private (unsafe: AtomicLong.Unsafe):
       * @return
       *   The current long value
       */
-    inline def get(using inline frame: Frame): Long < IO = use(identity)
+    inline def get(using inline frame: Frame): Long < Sync = use(identity)
 
     /** Uses the current value with a transformation function.
       * @param f
@@ -214,20 +215,20 @@ final case class AtomicLong private (unsafe: AtomicLong.Unsafe):
       * @return
       *   The result of applying the function to the current value
       */
-    inline def use[A, S](inline f: Long => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.Unsafe(f(unsafe.get()))
+    inline def use[A, S](inline f: Long => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.Unsafe(f(unsafe.get()))
 
     /** Sets to the given value.
       * @param v
       *   The new value
       */
-    inline def set(v: Long)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.set(v))
+    inline def set(v: Long)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.set(v))
 
     /** Eventually sets to the given value.
       * @param v
       *   The new value
       */
-    inline def lazySet(v: Long)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.lazySet(v))
+    inline def lazySet(v: Long)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.lazySet(v))
 
     /** Atomically sets to the given value and returns the old value.
       * @param v
@@ -235,7 +236,7 @@ final case class AtomicLong private (unsafe: AtomicLong.Unsafe):
       * @return
       *   The previous value
       */
-    inline def getAndSet(v: Long)(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.getAndSet(v))
+    inline def getAndSet(v: Long)(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.getAndSet(v))
 
     /** Atomically sets the value to the given updated value if the current value is equal to the expected value.
       * @param curr
@@ -245,32 +246,32 @@ final case class AtomicLong private (unsafe: AtomicLong.Unsafe):
       * @return
       *   true if successful, false otherwise
       */
-    inline def compareAndSet(curr: Long, next: Long)(using inline frame: Frame): Boolean < IO =
-        IO.Unsafe(unsafe.compareAndSet(curr, next))
+    inline def compareAndSet(curr: Long, next: Long)(using inline frame: Frame): Boolean < Sync =
+        Sync.Unsafe(unsafe.compareAndSet(curr, next))
 
     /** Atomically increments the current value and returns the updated value.
       * @return
       *   The updated value
       */
-    inline def incrementAndGet(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.incrementAndGet())
+    inline def incrementAndGet(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.incrementAndGet())
 
     /** Atomically decrements the current value and returns the updated value.
       * @return
       *   The updated value
       */
-    inline def decrementAndGet(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.decrementAndGet())
+    inline def decrementAndGet(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.decrementAndGet())
 
     /** Atomically increments the current value and returns the old value.
       * @return
       *   The previous value
       */
-    inline def getAndIncrement(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.getAndIncrement())
+    inline def getAndIncrement(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.getAndIncrement())
 
     /** Atomically decrements the current value and returns the old value.
       * @return
       *   The previous value
       */
-    inline def getAndDecrement(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.getAndDecrement())
+    inline def getAndDecrement(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.getAndDecrement())
 
     /** Atomically adds the given value to the current value and returns the old value.
       * @param v
@@ -278,7 +279,7 @@ final case class AtomicLong private (unsafe: AtomicLong.Unsafe):
       * @return
       *   The previous value
       */
-    inline def getAndAdd(v: Long)(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.getAndAdd(v))
+    inline def getAndAdd(v: Long)(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.getAndAdd(v))
 
     /** Atomically adds the given value to the current value and returns the updated value.
       * @param v
@@ -286,7 +287,7 @@ final case class AtomicLong private (unsafe: AtomicLong.Unsafe):
       * @return
       *   The updated value
       */
-    inline def addAndGet(v: Long)(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.addAndGet(v))
+    inline def addAndGet(v: Long)(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.addAndGet(v))
 
     /** Atomically updates the current value using the given function and returns the old value.
       * @param f
@@ -294,7 +295,7 @@ final case class AtomicLong private (unsafe: AtomicLong.Unsafe):
       * @return
       *   The previous value
       */
-    inline def getAndUpdate(inline f: Long => Long)(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.getAndUpdate(f(_)))
+    inline def getAndUpdate(inline f: Long => Long)(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.getAndUpdate(f(_)))
 
     /** Atomically updates the current value using the given function and returns the updated value.
       * @param f
@@ -302,7 +303,7 @@ final case class AtomicLong private (unsafe: AtomicLong.Unsafe):
       * @return
       *   The updated value
       */
-    inline def updateAndGet(inline f: Long => Long)(using inline frame: Frame): Long < IO = IO.Unsafe(unsafe.updateAndGet(f(_)))
+    inline def updateAndGet(inline f: Long => Long)(using inline frame: Frame): Long < Sync = Sync.Unsafe(unsafe.updateAndGet(f(_)))
 
     /** Returns a string representation of the current value.
       * @return
@@ -318,7 +319,7 @@ object AtomicLong:
       * @return
       *   A new AtomicLong instance initialized to 0
       */
-    def init(using Frame): AtomicLong < IO = init(0)
+    def init(using Frame): AtomicLong < Sync = init(0)
 
     /** Creates a new AtomicLong with the given initial value.
       * @param initialValue
@@ -326,7 +327,7 @@ object AtomicLong:
       * @return
       *   A new AtomicLong instance
       */
-    def init(initialValue: Long)(using Frame): AtomicLong < IO =
+    def init(initialValue: Long)(using Frame): AtomicLong < Sync =
         initWith(initialValue)(identity)
 
     /** Uses a new AtomicLong with initial value 0 in the given function.
@@ -335,7 +336,7 @@ object AtomicLong:
       * @return
       *   The result of applying the function
       */
-    inline def initWith[A, S](inline f: AtomicLong => A < S)(using inline frame: Frame): A < (S & IO) =
+    inline def initWith[A, S](inline f: AtomicLong => A < S)(using inline frame: Frame): A < (S & Sync) =
         initWith(0)(f)
 
     /** Uses a new AtomicLong with the given initial value in the function.
@@ -346,8 +347,8 @@ object AtomicLong:
       * @return
       *   The result of applying the function
       */
-    inline def initWith[A, S](initialValue: Long)(inline f: AtomicLong => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.Unsafe(f(AtomicLong(Unsafe.init(initialValue))))
+    inline def initWith[A, S](initialValue: Long)(inline f: AtomicLong => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.Unsafe(f(AtomicLong(Unsafe.init(initialValue))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = java.util.concurrent.atomic.AtomicLong
@@ -393,7 +394,7 @@ final case class AtomicBoolean private (unsafe: AtomicBoolean.Unsafe):
       * @return
       *   The current boolean value
       */
-    inline def get(using inline frame: Frame): Boolean < IO = use(identity)
+    inline def get(using inline frame: Frame): Boolean < Sync = use(identity)
 
     /** Uses the current value with a transformation function.
       * @param f
@@ -401,20 +402,20 @@ final case class AtomicBoolean private (unsafe: AtomicBoolean.Unsafe):
       * @return
       *   The result of applying the function to the current value
       */
-    inline def use[A, S](inline f: Boolean => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.Unsafe(f(unsafe.get()))
+    inline def use[A, S](inline f: Boolean => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.Unsafe(f(unsafe.get()))
 
     /** Sets to the given value.
       * @param v
       *   The new value
       */
-    inline def set(v: Boolean)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.set(v))
+    inline def set(v: Boolean)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.set(v))
 
     /** Eventually sets to the given value.
       * @param v
       *   The new value
       */
-    inline def lazySet(v: Boolean)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.lazySet(v))
+    inline def lazySet(v: Boolean)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.lazySet(v))
 
     /** Atomically sets to the given value and returns the old value.
       * @param v
@@ -422,7 +423,7 @@ final case class AtomicBoolean private (unsafe: AtomicBoolean.Unsafe):
       * @return
       *   The previous value
       */
-    inline def getAndSet(v: Boolean)(using inline frame: Frame): Boolean < IO = IO.Unsafe(unsafe.getAndSet(v))
+    inline def getAndSet(v: Boolean)(using inline frame: Frame): Boolean < Sync = Sync.Unsafe(unsafe.getAndSet(v))
 
     /** Atomically sets the value to the given updated value if the current value is equal to the expected value.
       * @param curr
@@ -432,8 +433,8 @@ final case class AtomicBoolean private (unsafe: AtomicBoolean.Unsafe):
       * @return
       *   true if successful, false otherwise
       */
-    inline def compareAndSet(curr: Boolean, next: Boolean)(using inline frame: Frame): Boolean < IO =
-        IO.Unsafe(unsafe.compareAndSet(curr, next))
+    inline def compareAndSet(curr: Boolean, next: Boolean)(using inline frame: Frame): Boolean < Sync =
+        Sync.Unsafe(unsafe.compareAndSet(curr, next))
 
     /** Returns a string representation of the current value.
       * @return
@@ -449,7 +450,7 @@ object AtomicBoolean:
       * @return
       *   A new AtomicBoolean instance initialized to false
       */
-    def init(using Frame): AtomicBoolean < IO = init(false)
+    def init(using Frame): AtomicBoolean < Sync = init(false)
 
     /** Creates a new AtomicBoolean with the given initial value.
       * @param initialValue
@@ -457,7 +458,7 @@ object AtomicBoolean:
       * @return
       *   A new AtomicBoolean instance
       */
-    def init(initialValue: Boolean)(using Frame): AtomicBoolean < IO =
+    def init(initialValue: Boolean)(using Frame): AtomicBoolean < Sync =
         initWith(initialValue)(identity)
 
     /** Uses a new AtomicBoolean with initial value false in the given function.
@@ -466,7 +467,7 @@ object AtomicBoolean:
       * @return
       *   The result of applying the function
       */
-    inline def initWith[A, S](inline f: AtomicBoolean => A < S)(using inline frame: Frame): A < (S & IO) =
+    inline def initWith[A, S](inline f: AtomicBoolean => A < S)(using inline frame: Frame): A < (S & Sync) =
         initWith(false)(f)
 
     /** Uses a new AtomicBoolean with the given initial value in the function.
@@ -477,8 +478,8 @@ object AtomicBoolean:
       * @return
       *   The result of applying the function
       */
-    inline def initWith[A, S](initialValue: Boolean)(inline f: AtomicBoolean => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.Unsafe(f(AtomicBoolean(Unsafe.init(initialValue))))
+    inline def initWith[A, S](initialValue: Boolean)(inline f: AtomicBoolean => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.Unsafe(f(AtomicBoolean(Unsafe.init(initialValue))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     opaque type Unsafe = java.util.concurrent.atomic.AtomicBoolean
@@ -519,7 +520,7 @@ final case class AtomicRef[A] private (unsafe: AtomicRef.Unsafe[A]):
       * @return
       *   The current value
       */
-    inline def get(using inline frame: Frame): A < IO = use(identity)
+    inline def get(using inline frame: Frame): A < Sync = use(identity)
 
     /** Uses the current value with a transformation function.
       * @param f
@@ -527,20 +528,20 @@ final case class AtomicRef[A] private (unsafe: AtomicRef.Unsafe[A]):
       * @return
       *   The result of applying the function to the current value
       */
-    inline def use[B, S](inline f: A => B < S)(using inline frame: Frame): B < (S & IO) =
-        IO.Unsafe(f(unsafe.get()))
+    inline def use[B, S](inline f: A => B < S)(using inline frame: Frame): B < (S & Sync) =
+        Sync.Unsafe(f(unsafe.get()))
 
     /** Sets to the given value.
       * @param v
       *   The new value
       */
-    inline def set(v: A)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.set(v))
+    inline def set(v: A)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.set(v))
 
     /** Eventually sets to the given value.
       * @param v
       *   The new value
       */
-    inline def lazySet(v: A)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.lazySet(v))
+    inline def lazySet(v: A)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.lazySet(v))
 
     /** Atomically sets to the given value and returns the old value.
       * @param v
@@ -548,7 +549,7 @@ final case class AtomicRef[A] private (unsafe: AtomicRef.Unsafe[A]):
       * @return
       *   The previous value
       */
-    inline def getAndSet(v: A)(using inline frame: Frame): A < IO = IO.Unsafe(unsafe.getAndSet(v))
+    inline def getAndSet(v: A)(using inline frame: Frame): A < Sync = Sync.Unsafe(unsafe.getAndSet(v))
 
     /** Atomically sets the value to the given updated value if the current value is equal to the expected value.
       * @param curr
@@ -558,7 +559,7 @@ final case class AtomicRef[A] private (unsafe: AtomicRef.Unsafe[A]):
       * @return
       *   true if successful, false otherwise
       */
-    inline def compareAndSet(curr: A, next: A)(using inline frame: Frame): Boolean < IO = IO.Unsafe(unsafe.compareAndSet(curr, next))
+    inline def compareAndSet(curr: A, next: A)(using inline frame: Frame): Boolean < Sync = Sync.Unsafe(unsafe.compareAndSet(curr, next))
 
     /** Atomically updates the current value using the given function and returns the old value.
       * @param f
@@ -566,7 +567,7 @@ final case class AtomicRef[A] private (unsafe: AtomicRef.Unsafe[A]):
       * @return
       *   The previous value
       */
-    inline def getAndUpdate(inline f: A => A)(using inline frame: Frame): A < IO = IO.Unsafe(unsafe.getAndUpdate(f(_)))
+    inline def getAndUpdate(inline f: A => A)(using inline frame: Frame): A < Sync = Sync.Unsafe(unsafe.getAndUpdate(f(_)))
 
     /** Atomically updates the current value using the given function and returns the updated value.
       * @param f
@@ -574,7 +575,7 @@ final case class AtomicRef[A] private (unsafe: AtomicRef.Unsafe[A]):
       * @return
       *   The updated value
       */
-    inline def updateAndGet(inline f: A => A)(using inline frame: Frame): A < IO = IO.Unsafe(unsafe.updateAndGet(f(_)))
+    inline def updateAndGet(inline f: A => A)(using inline frame: Frame): A < Sync = Sync.Unsafe(unsafe.updateAndGet(f(_)))
 
     /** Returns a string representation of the current value.
       * @return
@@ -594,7 +595,7 @@ object AtomicRef:
       * @tparam A
       *   The type of the referenced value
       */
-    def init[A](initialValue: A)(using Frame): AtomicRef[A] < IO =
+    def init[A](initialValue: A)(using Frame): AtomicRef[A] < Sync =
         initWith(initialValue)(identity)
 
     /** Uses a new AtomicRef with the given initial value in the function.
@@ -607,8 +608,8 @@ object AtomicRef:
       * @tparam A
       *   The type of the referenced value
       */
-    inline def initWith[A, B, S](initialValue: A)(inline f: AtomicRef[A] => B < S)(using inline frame: Frame): B < (S & IO) =
-        IO.Unsafe(f(AtomicRef(Unsafe.init(initialValue))))
+    inline def initWith[A, B, S](initialValue: A)(inline f: AtomicRef[A] => B < S)(using inline frame: Frame): B < (S & Sync) =
+        Sync.Unsafe(f(AtomicRef(Unsafe.init(initialValue))))
 
     opaque type Unsafe[A] = java.util.concurrent.atomic.AtomicReference[A]
 

--- a/kyo-core/shared/src/main/scala/kyo/Barrier.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Barrier.scala
@@ -26,14 +26,14 @@ final case class Barrier private (unsafe: Barrier.Unsafe):
       * @return
       *   Unit
       */
-    def await(using Frame): Unit < Async = IO.Unsafe(unsafe.await().safe.get)
+    def await(using Frame): Unit < Async = Sync.Unsafe(unsafe.await().safe.get)
 
     /** Returns the number of parties still waiting at the barrier.
       *
       * @return
       *   The number of waiting parties
       */
-    def pending(using Frame): Int < IO = IO.Unsafe(unsafe.pending())
+    def pending(using Frame): Int < Sync = Sync.Unsafe(unsafe.pending())
 
 end Barrier
 
@@ -46,7 +46,7 @@ object Barrier:
       * @return
       *   A new Barrier instance
       */
-    def init(parties: Int)(using Frame): Barrier < IO = initWith(parties)(identity)
+    def init(parties: Int)(using Frame): Barrier < Sync = initWith(parties)(identity)
 
     /** Uses a new Barrier with the provided number of parties.
       * @param parties
@@ -56,8 +56,8 @@ object Barrier:
       * @return
       *   The result of applying the function
       */
-    inline def initWith[A, S](parties: Int)(inline f: Barrier => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.Unsafe(f(Barrier(Unsafe.init(parties))))
+    inline def initWith[A, S](parties: Int)(inline f: Barrier => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.Unsafe(f(Barrier(Unsafe.init(parties))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     sealed abstract class Unsafe:

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -72,7 +72,7 @@ object Channel:
           * @return
           *   The number of elements currently in the channel
           */
-        def size(using Frame): Int < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.size()))
+        def size(using Frame): Int < (Abort[Closed] & Sync) = Sync.Unsafe(Abort.get(self.size()))
 
         /** Returns the number of fibers currently waiting to put values into the channel.
           *
@@ -83,7 +83,7 @@ object Channel:
           * @return
           *   The number of fibers waiting to put values into the channel
           */
-        def pendingPuts(using Frame): Int < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.pendingPuts()))
+        def pendingPuts(using Frame): Int < (Abort[Closed] & Sync) = Sync.Unsafe(Abort.get(self.pendingPuts()))
 
         /** Returns the number of fibers currently waiting to take values from the channel.
           *
@@ -94,7 +94,7 @@ object Channel:
           * @return
           *   The number of fibers waiting to take values from the channel
           */
-        def pendingTakes(using Frame): Int < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.pendingTakes()))
+        def pendingTakes(using Frame): Int < (Abort[Closed] & Sync) = Sync.Unsafe(Abort.get(self.pendingTakes()))
 
         /** Attempts to offer an element to the channel without blocking.
           *
@@ -103,21 +103,21 @@ object Channel:
           * @return
           *   true if the element was added to the channel, false otherwise
           */
-        def offer(value: A)(using Frame): Boolean < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.offer(value)))
+        def offer(value: A)(using Frame): Boolean < (Abort[Closed] & Sync) = Sync.Unsafe(Abort.get(self.offer(value)))
 
         /** Offers an element to the channel without returning a result.
           *
           * @param v
           *   The element to offer
           */
-        def offerDiscard(value: A)(using Frame): Unit < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.offer(value).unit))
+        def offerDiscard(value: A)(using Frame): Unit < (Abort[Closed] & Sync) = Sync.Unsafe(Abort.get(self.offer(value).unit))
 
         /** Attempts to poll an element from the channel without blocking.
           *
           * @return
           *   Maybe containing the polled element, or empty if the channel is empty
           */
-        def poll(using Frame): Maybe[A] < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.poll()))
+        def poll(using Frame): Maybe[A] < (Abort[Closed] & Sync) = Sync.Unsafe(Abort.get(self.poll()))
 
         /** Puts an element into the channel, asynchronously blocking if necessary.
           *
@@ -125,7 +125,7 @@ object Channel:
           *   The element to put
           */
         def put(value: A)(using Frame): Unit < (Abort[Closed] & Async) =
-            IO.Unsafe {
+            Sync.Unsafe {
                 self.offer(value).foldError(
                     {
                         case true  => ()
@@ -143,9 +143,9 @@ object Channel:
         def putBatch(values: Seq[A])(using Frame): Unit < (Abort[Closed] & Async) =
             if values.isEmpty then ()
             else if self.capacity == 0 then
-                IO.Unsafe(self.putBatchFiber(values).safe.get)
+                Sync.Unsafe(self.putBatchFiber(values).safe.get)
             else
-                IO.Unsafe {
+                Sync.Unsafe {
                     self.offerAll(values) match
                         case Result.Success(remaining) =>
                             if remaining.isEmpty then ()
@@ -162,7 +162,7 @@ object Channel:
           *   The taken element
           */
         def take(using Frame): A < (Abort[Closed] & Async) =
-            IO.Unsafe {
+            Sync.Unsafe {
                 self.poll().foldError(
                     {
                         case Present(value) => value
@@ -200,21 +200,21 @@ object Channel:
           * @return
           *   A sequence containing all elements that were in the channel
           */
-        def drain(using Frame): Chunk[A] < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.drain()))
+        def drain(using Frame): Chunk[A] < (Abort[Closed] & Sync) = Sync.Unsafe(Abort.get(self.drain()))
 
         /** Takes up to [[max]] elements from the channel.
           *
           * @return
           *   a sequence of up to [[max]] elements that were in the channel.
           */
-        def drainUpTo(max: Int)(using Frame): Chunk[A] < (IO & Abort[Closed]) = IO.Unsafe(Abort.get(self.drainUpTo(max)))
+        def drainUpTo(max: Int)(using Frame): Chunk[A] < (Sync & Abort[Closed]) = Sync.Unsafe(Abort.get(self.drainUpTo(max)))
 
         /** Closes the channel.
           *
           * @return
           *   A sequence of remaining elements
           */
-        def close(using Frame): Maybe[Seq[A]] < IO = IO.Unsafe(self.close())
+        def close(using Frame): Maybe[Seq[A]] < Sync = Sync.Unsafe(self.close())
 
         /** Closes the channel and asynchronously waits until it's empty.
           *
@@ -225,28 +225,28 @@ object Channel:
           * @return
           *   true if the channel was successfully closed and emptied, false if it was already closed
           */
-        def closeAwaitEmpty(using Frame): Boolean < Async = IO.Unsafe(self.closeAwaitEmpty().safe.get)
+        def closeAwaitEmpty(using Frame): Boolean < Async = Sync.Unsafe(self.closeAwaitEmpty().safe.get)
 
         /** Checks if the channel is closed.
           *
           * @return
           *   true if the channel is closed, false otherwise
           */
-        def closed(using Frame): Boolean < IO = IO.Unsafe(self.closed())
+        def closed(using Frame): Boolean < Sync = Sync.Unsafe(self.closed())
 
         /** Checks if the channel is empty.
           *
           * @return
           *   true if the channel is empty, false otherwise
           */
-        def empty(using Frame): Boolean < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.empty()))
+        def empty(using Frame): Boolean < (Abort[Closed] & Sync) = Sync.Unsafe(Abort.get(self.empty()))
 
         /** Checks if the channel is full.
           *
           * @return
           *   true if the channel is full, false otherwise
           */
-        def full(using Frame): Boolean < (Abort[Closed] & IO) = IO.Unsafe(Abort.get(self.full()))
+        def full(using Frame): Boolean < (Abort[Closed] & Sync) = Sync.Unsafe(Abort.get(self.full()))
 
         private def emitChunks(maxChunkSize: Int = Int.MaxValue)(
             using
@@ -314,7 +314,7 @@ object Channel:
       * @warning
       *   The actual capacity may be larger than the specified capacity due to rounding.
       */
-    def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Channel[A] < IO =
+    def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Channel[A] < Sync =
         initWith[A](capacity, access)(identity)
 
     /** Uses a new Channel with the provided configuration.
@@ -325,8 +325,8 @@ object Channel:
       */
     inline def initWith[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](
         inline f: Channel[A] => B < S
-    )(using inline frame: Frame): B < (S & IO) =
-        IO.Unsafe(f(Unsafe.init(capacity, access)))
+    )(using inline frame: Frame): B < (S & Sync) =
+        Sync.Unsafe(f(Unsafe.init(capacity, access)))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     sealed abstract class Unsafe[A] extends Serializable:

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -64,7 +64,7 @@ final case class Clock(unsafe: Clock.Unsafe):
       * @see
       *   [[nowMonotonic]] for measuring elapsed time between events
       */
-    def now(using Frame): Instant < IO = IO.Unsafe(unsafe.now())
+    def now(using Frame): Instant < Sync = Sync.Unsafe(unsafe.now())
 
     /** Gets the current monotonic time as a Duration.
       *
@@ -86,14 +86,14 @@ final case class Clock(unsafe: Clock.Unsafe):
       * @see
       *   [[now]] for calendar time/date operations
       */
-    def nowMonotonic(using Frame): Duration < IO = IO.Unsafe(unsafe.nowMonotonic())
+    def nowMonotonic(using Frame): Duration < Sync = Sync.Unsafe(unsafe.nowMonotonic())
 
     /** Creates a new stopwatch.
       *
       * @return
       *   A new Stopwatch instance
       */
-    def stopwatch(using Frame): Clock.Stopwatch < IO = IO.Unsafe(unsafe.stopwatch().safe)
+    def stopwatch(using Frame): Clock.Stopwatch < Sync = Sync.Unsafe(unsafe.stopwatch().safe)
 
     /** Creates a new deadline with the specified duration.
       *
@@ -102,12 +102,12 @@ final case class Clock(unsafe: Clock.Unsafe):
       * @return
       *   A new Deadline instance
       */
-    def deadline(duration: Duration)(using Frame): Clock.Deadline < IO = IO.Unsafe(unsafe.deadline(duration).safe)
+    def deadline(duration: Duration)(using Frame): Clock.Deadline < Sync = Sync.Unsafe(unsafe.deadline(duration).safe)
 
-    private[kyo] def sleep(duration: Duration)(using Frame): Fiber[Nothing, Unit] < IO =
+    private[kyo] def sleep(duration: Duration)(using Frame): Fiber[Nothing, Unit] < Sync =
         if duration == Duration.Zero then Fiber.unit
         else if !duration.isFinite then Fiber.never
-        else IO.Unsafe(unsafe.sleep(duration).safe)
+        else Sync.Unsafe(unsafe.sleep(duration).safe)
 end Clock
 
 /** Companion object for creating and managing Clock instances. */
@@ -126,7 +126,7 @@ object Clock:
           * @return
           *   The elapsed time as a Duration
           */
-        def elapsed(using Frame): Duration < IO = IO.Unsafe(unsafe.elapsed())
+        def elapsed(using Frame): Duration < Sync = Sync.Unsafe(unsafe.elapsed())
     end Stopwatch
 
     object Stopwatch:
@@ -149,14 +149,14 @@ object Clock:
           * @return
           *   The remaining time as a Duration
           */
-        def timeLeft(using Frame): Duration < IO = IO.Unsafe(unsafe.timeLeft())
+        def timeLeft(using Frame): Duration < Sync = Sync.Unsafe(unsafe.timeLeft())
 
         /** Checks if the deadline is overdue.
           *
           * @return
           *   A boolean indicating if the deadline is overdue
           */
-        def isOverdue(using Frame): Boolean < IO = IO.Unsafe(unsafe.isOverdue())
+        def isOverdue(using Frame): Boolean < Sync = Sync.Unsafe(unsafe.isOverdue())
     end Deadline
 
     object Deadline:
@@ -223,10 +223,10 @@ object Clock:
       * @return
       *   The result of running the effect with scaled time
       */
-    def withTimeShift[A, S](factor: Double)(v: => A < S)(using Frame): A < (IO & S) =
+    def withTimeShift[A, S](factor: Double)(v: => A < S)(using Frame): A < (Sync & S) =
         if factor == 1 then v
         else
-            IO.Unsafe.withLocal(local) { clock =>
+            Sync.Unsafe.withLocal(local) { clock =>
                 val shifted =
                     new Unsafe:
                         val underlying  = clock.unsafe
@@ -310,8 +310,8 @@ object Clock:
       * @return
       *   The result of running the effect with controlled time
       */
-    def withTimeControl[A, S](f: TimeControl => A < S)(using Frame): A < (IO & S) =
-        IO.Unsafe {
+    def withTimeControl[A, S](f: TimeControl => A < S)(using Frame): A < (Sync & S) =
+        Sync.Unsafe {
             val controlled =
                 new Unsafe with TimeControl:
                     @volatile var current = Instant.Epoch
@@ -334,7 +334,7 @@ object Clock:
                     def set(now: Instant) = set(now, 100.millis)
 
                     def set(now: Instant, wallClockDelay: Duration) =
-                        IO {
+                        Sync {
                             current = now
                             tick()
                             Clock.live.unsafe.sleep(wallClockDelay).safe.get
@@ -343,7 +343,7 @@ object Clock:
                     def advance(duration: Duration) = advance(duration, duration.min(100.millis))
 
                     def advance(duration: Duration, wallClockDelay: Duration) =
-                        IO {
+                        Sync {
                             current = current + duration
                             tick()
                             Clock.live.unsafe.sleep(wallClockDelay).safe.get
@@ -374,8 +374,8 @@ object Clock:
       * @return
       *   The current time
       */
-    def now(using Frame): Instant < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.now())
+    def now(using Frame): Instant < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.now())
 
     /** Gets the current monotonic time using the local Clock instance. Unlike `now`, this is guaranteed to be strictly monotonic and
       * suitable for measuring elapsed time.
@@ -386,19 +386,19 @@ object Clock:
       * @return
       *   The current monotonic time as a Duration since system start
       */
-    def nowMonotonic(using Frame): Duration < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nowMonotonic())
+    def nowMonotonic(using Frame): Duration < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nowMonotonic())
 
-    private[kyo] def sleep(duration: Duration)(using Frame): Fiber[Nothing, Unit] < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.sleep(duration).safe)
+    private[kyo] def sleep(duration: Duration)(using Frame): Fiber[Nothing, Unit] < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.sleep(duration).safe)
 
     /** Creates a new stopwatch using the local Clock instance.
       *
       * @return
       *   A new Stopwatch instance
       */
-    def stopwatch(using Frame): Stopwatch < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.stopwatch().safe)
+    def stopwatch(using Frame): Stopwatch < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.stopwatch().safe)
 
     /** Creates a new deadline with the specified duration using the local Clock instance.
       *
@@ -407,8 +407,8 @@ object Clock:
       * @return
       *   A new Deadline instance
       */
-    def deadline(duration: Duration)(using Frame): Deadline < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.deadline(duration).safe)
+    def deadline(duration: Duration)(using Frame): Deadline < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.deadline(duration).safe)
 
     /** Repeatedly executes a task with a fixed delay between completions.
       *
@@ -422,7 +422,7 @@ object Clock:
       * @return
       *   A Fiber that can be used to control or interrupt the recurring task
       */
-    def repeatWithDelay[E, S](delay: Duration)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
+    def repeatWithDelay[E, S](delay: Duration)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < Sync =
         repeatWithDelay(Duration.Zero, delay)(f)
 
     /** Repeatedly executes a task with a fixed delay between completions, starting after an initial delay.
@@ -441,7 +441,7 @@ object Clock:
         delay: Duration
     )(
         f: => Any < (Async & Abort[E])
-    )(using Frame): Fiber[E, Unit] < IO =
+    )(using Frame): Fiber[E, Unit] < Sync =
         repeatWithDelay(startAfter, delay, ())(_ => f.unit)
 
     /** Repeatedly executes a task with a fixed delay between completions, maintaining state between executions.
@@ -465,7 +465,7 @@ object Clock:
         state: A
     )(
         f: A => A < (Async & Abort[E])
-    )(using Frame): Fiber[E, A] < IO =
+    )(using Frame): Fiber[E, A] < Sync =
         repeatWithDelay(Schedule.delay(startAfter).andThen(Schedule.fixed(delay)), state)(f)
 
     /** Repeatedly executes a task with delays determined by a custom schedule.
@@ -477,7 +477,7 @@ object Clock:
       * @return
       *   A Fiber that can be used to control or interrupt the recurring task
       */
-    def repeatWithDelay[E, S](delaySchedule: Schedule)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
+    def repeatWithDelay[E, S](delaySchedule: Schedule)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < Sync =
         repeatWithDelay(delaySchedule, ())(_ => f.unit)
 
     /** Repeatedly executes a task with delays determined by a custom schedule, maintaining state between executions.
@@ -498,7 +498,7 @@ object Clock:
         state: A
     )(
         f: A => A < (Async & Abort[E])
-    )(using Frame): Fiber[E, A] < IO =
+    )(using Frame): Fiber[E, A] < Sync =
         Async.run {
             Clock.use { clock =>
                 Loop(state, delaySchedule) { (state, schedule) =>
@@ -524,7 +524,7 @@ object Clock:
       * @return
       *   A Fiber that can be used to control or interrupt the recurring task
       */
-    def repeatAtInterval[E, S](interval: Duration)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
+    def repeatAtInterval[E, S](interval: Duration)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < Sync =
         repeatAtInterval(Duration.Zero, interval)(f)
 
     /** Repeatedly executes a task at fixed time intervals, starting after an initial delay.
@@ -543,7 +543,7 @@ object Clock:
         interval: Duration
     )(
         f: => Any < (Async & Abort[E])
-    )(using Frame): Fiber[E, Unit] < IO =
+    )(using Frame): Fiber[E, Unit] < Sync =
         repeatAtInterval(startAfter, interval, ())(_ => f.unit)
 
     /** Repeatedly executes a task at fixed time intervals, maintaining state between executions.
@@ -567,7 +567,7 @@ object Clock:
         state: A
     )(
         f: A => A < (Async & Abort[E])
-    )(using Frame): Fiber[E, A] < IO =
+    )(using Frame): Fiber[E, A] < Sync =
         repeatAtInterval(Schedule.delay(startAfter).andThen(Schedule.fixed(interval)), state)(f)
 
     /** Repeatedly executes a task with intervals determined by a custom schedule.
@@ -579,7 +579,7 @@ object Clock:
       * @return
       *   A Fiber that can be used to control or interrupt the recurring task
       */
-    def repeatAtInterval[E, S](intervalSchedule: Schedule)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < IO =
+    def repeatAtInterval[E, S](intervalSchedule: Schedule)(f: => Any < (Async & Abort[E]))(using Frame): Fiber[E, Unit] < Sync =
         repeatAtInterval(intervalSchedule, ())(_ => f.unit)
 
     /** Repeatedly executes a task with intervals determined by a custom schedule, maintaining state between executions.
@@ -600,7 +600,7 @@ object Clock:
         state: A
     )(
         f: A => A < (Async & Abort[E])
-    )(using Frame): Fiber[E, A] < IO =
+    )(using Frame): Fiber[E, A] < Sync =
         Async.run {
             Clock.use { clock =>
                 clock.now.map { now =>

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -28,7 +28,7 @@ import scala.collection.mutable.PriorityQueue
   * `Clock.withTimeControl` and `Clock.withTimeShift` for precise temporal control during tests.
   *
   * All time-related operations in Clock are effect-based, properly tracking side effects in the type system. Operations like `now` and
-  * `nowMonotonic` are wrapped in IO effects, while time-suspending operations like `sleep` are wrapped in Async effects.
+  * `nowMonotonic` are wrapped in Sync effects, while time-suspending operations like `sleep` are wrapped in Async effects.
   *
   * The scheduling methods offer different execution patterns: `repeatWithDelay` waits for a specified duration after each task completes
   * before executing again (ensuring a minimum gap between executions), while `repeatAtInterval` aims to execute tasks at fixed time

--- a/kyo-core/shared/src/main/scala/kyo/Console.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Console.scala
@@ -22,48 +22,48 @@ final case class Console(unsafe: Console.Unsafe):
       * @return
       *   A String representing the line read from the console.
       */
-    def readLine(using Frame): String < (IO & Abort[IOException]) = IO.Unsafe(Abort.get(unsafe.readLine()))
+    def readLine(using Frame): String < (Sync & Abort[IOException]) = Sync.Unsafe(Abort.get(unsafe.readLine()))
 
     /** Prints a string to the console without a newline.
       *
       * @param s
       *   The string to print.
       */
-    def print(s: Text)(using Frame): Unit < IO = IO.Unsafe(unsafe.print(s.show))
+    def print(s: Text)(using Frame): Unit < Sync = Sync.Unsafe(unsafe.print(s.show))
 
     /** Prints a string to the console's error stream without a newline.
       *
       * @param s
       *   The string to print to the error stream.
       */
-    def printErr(s: Text)(using Frame): Unit < IO = IO.Unsafe(unsafe.printErr(s.show))
+    def printErr(s: Text)(using Frame): Unit < Sync = Sync.Unsafe(unsafe.printErr(s.show))
 
     /** Prints a string to the console followed by a newline.
       *
       * @param s
       *   The string to print.
       */
-    def println(s: Text)(using Frame): Unit < IO = IO.Unsafe(unsafe.printLine(s.show))
+    def println(s: Text)(using Frame): Unit < Sync = Sync.Unsafe(unsafe.printLine(s.show))
 
     /** Prints a string to the console's error stream followed by a newline.
       *
       * @param s
       *   The string to print to the error stream.
       */
-    def printLineErr(s: Text)(using Frame): Unit < IO = IO.Unsafe(unsafe.printLineErr(s.show))
+    def printLineErr(s: Text)(using Frame): Unit < Sync = Sync.Unsafe(unsafe.printLineErr(s.show))
 
     /** Checks if an error occurred in the console output or error streams.
       *
       * @return
       *   True if an error occurred, false otherwise.
       */
-    def checkErrors(using Frame): Boolean < IO = IO.Unsafe(unsafe.checkErrors)
+    def checkErrors(using Frame): Boolean < Sync = Sync.Unsafe(unsafe.checkErrors)
 
     /** Flushes the console output streams.
       *
       * This method ensures that any buffered output is written to the console.
       */
-    def flush(using Frame): Unit < IO = IO.Unsafe(unsafe.flush())
+    def flush(using Frame): Unit < Sync = Sync.Unsafe(unsafe.flush())
 end Console
 
 /** Companion object for Console, providing utility methods and a live implementation.
@@ -134,8 +134,8 @@ object Console:
       * @return
       *   The result of the computation with IO effects.
       */
-    def withIn[A, S](lines: Iterable[String])(v: A < S)(using Frame): A < (IO & S) =
-        IO.withLocal(local) { console =>
+    def withIn[A, S](lines: Iterable[String])(v: A < S)(using Frame): A < (Sync & S) =
+        Sync.withLocal(local) { console =>
             val it = lines.iterator
             val proxy =
                 new Proxy(console.unsafe):
@@ -165,8 +165,8 @@ object Console:
       * @return
       *   A tuple containing the captured output (Out) and the computation result.
       */
-    def withOut[A, S](v: A < S)(using Frame): (Out, A) < (IO & S) =
-        IO.withLocal(local) { console =>
+    def withOut[A, S](v: A < S)(using Frame): (Out, A) < (Sync & S) =
+        Sync.withLocal(local) { console =>
             val stdOut = new StringBuffer
             val stdErr = new StringBuffer
             val proxy =
@@ -184,7 +184,7 @@ object Console:
                         stdErr.append(s + "\n")
                         ()
             let(Console(proxy))(v)
-                .map(r => IO((Out(stdOut.toString(), stdErr.toString()), r)))
+                .map(r => Sync((Out(stdOut.toString(), stdErr.toString()), r)))
         }
 
     /** Reads a line from the console.
@@ -192,8 +192,8 @@ object Console:
       * @return
       *   A String representing the line read from the console.
       */
-    def readLine(using Frame): String < (IO & Abort[IOException]) =
-        IO.Unsafe.withLocal(local)(console => Abort.get(console.unsafe.readLine()))
+    def readLine(using Frame): String < (Sync & Abort[IOException]) =
+        Sync.Unsafe.withLocal(local)(console => Abort.get(console.unsafe.readLine()))
 
     private def toString(v: Any)(using Frame): String =
         v match
@@ -207,39 +207,39 @@ object Console:
       * @param v
       *   The value to print.
       */
-    def print[A](v: A)(using Frame): Unit < IO =
-        IO.Unsafe.withLocal(local)(console => console.unsafe.print(toString(v)))
+    def print[A](v: A)(using Frame): Unit < Sync =
+        Sync.Unsafe.withLocal(local)(console => console.unsafe.print(toString(v)))
 
     /** Prints a value to the console's error stream without a newline.
       *
       * @param v
       *   The value to print to the error stream.
       */
-    def printErr[A](v: A)(using Frame): Unit < IO =
-        IO.Unsafe.withLocal(local)(console => console.unsafe.printErr(toString(v)))
+    def printErr[A](v: A)(using Frame): Unit < Sync =
+        Sync.Unsafe.withLocal(local)(console => console.unsafe.printErr(toString(v)))
 
     /** Prints a value to the console followed by a newline.
       *
       * @param v
       *   The value to print.
       */
-    def printLine[A](v: A)(using Frame): Unit < IO =
-        IO.Unsafe.withLocal(local)(console => console.unsafe.printLine(toString(v)))
+    def printLine[A](v: A)(using Frame): Unit < Sync =
+        Sync.Unsafe.withLocal(local)(console => console.unsafe.printLine(toString(v)))
 
     /** Prints a value to the console's error stream followed by a newline.
       *
       * @param v
       *   The value to print to the error stream.
       */
-    def printLineErr[A](v: A)(using Frame): Unit < IO =
-        IO.Unsafe.withLocal(local)(console => console.unsafe.printLineErr(toString(v)))
+    def printLineErr[A](v: A)(using Frame): Unit < Sync =
+        Sync.Unsafe.withLocal(local)(console => console.unsafe.printLineErr(toString(v)))
 
     /** Checks if an error occurred in the console output or error streams.
       *
       * @return
       *   True if an error occurred, false otherwise.
       */
-    def checkErrors(using Frame): Boolean < IO = IO.Unsafe.withLocal(local)(console => console.unsafe.checkErrors)
+    def checkErrors(using Frame): Boolean < Sync = Sync.Unsafe.withLocal(local)(console => console.unsafe.checkErrors)
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe extends Serializable:

--- a/kyo-core/shared/src/main/scala/kyo/Console.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Console.scala
@@ -132,7 +132,7 @@ object Console:
       * @tparam S
       *   The type of effects in the computation.
       * @return
-      *   The result of the computation with IO effects.
+      *   The result of the computation with Sync effects.
       */
     def withIn[A, S](lines: Iterable[String])(v: A < S)(using Frame): A < (Sync & S) =
         Sync.withLocal(local) { console =>

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -165,7 +165,7 @@ object Fiber:
           * @param f
           *   The callback function to be executed on interruption
           * @return
-          *   A unit value wrapped in IO, representing the registration of the callback
+          *   A unit value wrapped in Sync, representing the registration of the callback
           */
         def onInterrupt(f: Result.Error[E] => Any < Sync)(using Frame): Unit < Sync =
             Sync.Unsafe(Unsafe.onInterrupt(self)(r => Sync.Unsafe.evalOrThrow(f(r).unit)))

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -75,7 +75,7 @@ object KyoApp:
         def runAndBlock[A](timeout: Duration)(
             v: A < (Async & Resource & Abort[Throwable])
         )(using Frame, AllowUnsafe): Result[Throwable, A] =
-            Abort.run(IO.Unsafe.run(Async.runAndBlock(timeout)(Resource.run(v)))).eval
+            Abort.run(Sync.Unsafe.run(Async.runAndBlock(timeout)(Resource.run(v)))).eval
     end Unsafe
 
 end KyoApp

--- a/kyo-core/shared/src/main/scala/kyo/Latch.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Latch.scala
@@ -28,14 +28,14 @@ final case class Latch private (unsafe: Latch.Unsafe):
     /** Decrements the count of the latch, releasing it if the count reaches zero.
       *
       * @return
-      *   Unit wrapped in an IO effect
+      *   Unit wrapped in an Sync effect
       */
     def release(using Frame): Unit < Sync = Sync.Unsafe(unsafe.release())
 
     /** Returns the current count of the latch.
       *
       * @return
-      *   The current count wrapped in an IO effect
+      *   The current count wrapped in an Sync effect
       */
     def pending(using Frame): Int < Sync = Sync.Unsafe(unsafe.pending())
 
@@ -49,7 +49,7 @@ object Latch:
       * @param count
       *   The initial count for the latch
       * @return
-      *   A new Latch instance wrapped in an IO effect
+      *   A new Latch instance wrapped in an Sync effect
       */
     def init(count: Int)(using Frame): Latch < Sync =
         initWith(count)(identity)

--- a/kyo-core/shared/src/main/scala/kyo/Latch.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Latch.scala
@@ -23,21 +23,21 @@ final case class Latch private (unsafe: Latch.Unsafe):
       * @return
       *   Unit wrapped in an Async effect
       */
-    def await(using Frame): Unit < Async = IO.Unsafe(unsafe.await().safe.get)
+    def await(using Frame): Unit < Async = Sync.Unsafe(unsafe.await().safe.get)
 
     /** Decrements the count of the latch, releasing it if the count reaches zero.
       *
       * @return
       *   Unit wrapped in an IO effect
       */
-    def release(using Frame): Unit < IO = IO.Unsafe(unsafe.release())
+    def release(using Frame): Unit < Sync = Sync.Unsafe(unsafe.release())
 
     /** Returns the current count of the latch.
       *
       * @return
       *   The current count wrapped in an IO effect
       */
-    def pending(using Frame): Int < IO = IO.Unsafe(unsafe.pending())
+    def pending(using Frame): Int < Sync = Sync.Unsafe(unsafe.pending())
 
 end Latch
 
@@ -51,7 +51,7 @@ object Latch:
       * @return
       *   A new Latch instance wrapped in an IO effect
       */
-    def init(count: Int)(using Frame): Latch < IO =
+    def init(count: Int)(using Frame): Latch < Sync =
         initWith(count)(identity)
 
     /** Uses a new Latch with the provided count.
@@ -62,8 +62,8 @@ object Latch:
       * @return
       *   The result of applying the function
       */
-    inline def initWith[A, S](count: Int)(inline f: Latch => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.Unsafe(f(Latch(Unsafe.init(count))))
+    inline def initWith[A, S](count: Int)(inline f: Latch => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.Unsafe(f(Latch(Unsafe.init(count))))
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     sealed abstract class Unsafe:

--- a/kyo-core/shared/src/main/scala/kyo/Log.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Log.scala
@@ -185,7 +185,7 @@ object Log extends LogPlatformSpecific:
       * @param msg
       *   The message to log
       * @return
-      *   An IO effect that logs the message
+      *   An Sync effect that logs the message
       */
     inline def trace(inline msg: => Text)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.trace)(_.trace(msg))
@@ -197,7 +197,7 @@ object Log extends LogPlatformSpecific:
       * @param t
       *   The exception to log
       * @return
-      *   An IO effect that logs the message and exception
+      *   An Sync effect that logs the message and exception
       */
     inline def trace(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.trace)(_.trace(msg, t))
@@ -207,7 +207,7 @@ object Log extends LogPlatformSpecific:
       * @param msg
       *   The message to log
       * @return
-      *   An IO effect that logs the message
+      *   An Sync effect that logs the message
       */
     inline def debug(inline msg: => Text)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.debug)(_.debug(msg))
@@ -219,7 +219,7 @@ object Log extends LogPlatformSpecific:
       * @param t
       *   The exception to log
       * @return
-      *   An IO effect that logs the message and exception
+      *   An Sync effect that logs the message and exception
       */
     inline def debug(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.debug)(_.debug(msg, t))
@@ -229,7 +229,7 @@ object Log extends LogPlatformSpecific:
       * @param msg
       *   The message to log
       * @return
-      *   An IO effect that logs the message
+      *   An Sync effect that logs the message
       */
     inline def info(inline msg: => Text)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.info)(_.info(msg))
@@ -241,7 +241,7 @@ object Log extends LogPlatformSpecific:
       * @param t
       *   The exception to log
       * @return
-      *   An IO effect that logs the message and exception
+      *   An Sync effect that logs the message and exception
       */
     inline def info(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.info)(_.info(msg, t))
@@ -251,7 +251,7 @@ object Log extends LogPlatformSpecific:
       * @param msg
       *   The message to log
       * @return
-      *   An IO effect that logs the message
+      *   An Sync effect that logs the message
       */
     inline def warn(inline msg: => Text)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.warn)(_.warn(msg))
@@ -263,7 +263,7 @@ object Log extends LogPlatformSpecific:
       * @param t
       *   The exception to log
       * @return
-      *   An IO effect that logs the message and exception
+      *   An Sync effect that logs the message and exception
       */
     inline def warn(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.warn)(_.warn(msg, t))
@@ -273,7 +273,7 @@ object Log extends LogPlatformSpecific:
       * @param msg
       *   The message to log
       * @return
-      *   An IO effect that logs the message
+      *   An Sync effect that logs the message
       */
     inline def error(inline msg: => Text)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.error)(_.error(msg))
@@ -285,7 +285,7 @@ object Log extends LogPlatformSpecific:
       * @param t
       *   The exception to log
       * @return
-      *   An IO effect that logs the message and exception
+      *   An Sync effect that logs the message and exception
       */
     inline def error(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.error)(_.error(msg, t))

--- a/kyo-core/shared/src/main/scala/kyo/Log.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Log.scala
@@ -3,19 +3,19 @@ package kyo
 import kyo.internal.LogPlatformSpecific
 
 final case class Log(unsafe: Log.Unsafe):
-    def level: Log.Level                                                        = unsafe.level
-    inline def trace(inline msg: => Text)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.trace(msg))
-    inline def trace(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
-        IO.Unsafe(unsafe.trace(msg, t))
-    inline def debug(inline msg: => Text)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.debug(msg))
-    inline def debug(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
-        IO.Unsafe(unsafe.debug(msg, t))
-    inline def info(inline msg: => Text)(using inline frame: Frame): Unit < IO                         = IO.Unsafe(unsafe.info(msg))
-    inline def info(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO = IO.Unsafe(unsafe.info(msg, t))
-    inline def warn(inline msg: => Text)(using inline frame: Frame): Unit < IO                         = IO.Unsafe(unsafe.warn(msg))
-    inline def warn(inline msg: => Text, t: => Throwable)(using inline frame: Frame): Unit < IO        = IO.Unsafe(unsafe.warn(msg, t))
-    inline def error(inline msg: => Text)(using inline frame: Frame): Unit < IO                        = IO.Unsafe(unsafe.error(msg))
-    inline def error(inline msg: => Text, t: => Throwable)(using inline frame: Frame): Unit < IO       = IO.Unsafe(unsafe.error(msg, t))
+    def level: Log.Level                                                          = unsafe.level
+    inline def trace(inline msg: => Text)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.trace(msg))
+    inline def trace(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
+        Sync.Unsafe(unsafe.trace(msg, t))
+    inline def debug(inline msg: => Text)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.debug(msg))
+    inline def debug(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
+        Sync.Unsafe(unsafe.debug(msg, t))
+    inline def info(inline msg: => Text)(using inline frame: Frame): Unit < Sync                         = Sync.Unsafe(unsafe.info(msg))
+    inline def info(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync = Sync.Unsafe(unsafe.info(msg, t))
+    inline def warn(inline msg: => Text)(using inline frame: Frame): Unit < Sync                         = Sync.Unsafe(unsafe.warn(msg))
+    inline def warn(inline msg: => Text, t: => Throwable)(using inline frame: Frame): Unit < Sync        = Sync.Unsafe(unsafe.warn(msg, t))
+    inline def error(inline msg: => Text)(using inline frame: Frame): Unit < Sync                        = Sync.Unsafe(unsafe.error(msg))
+    inline def error(inline msg: => Text, t: => Throwable)(using inline frame: Frame): Unit < Sync       = Sync.Unsafe(unsafe.error(msg, t))
 end Log
 
 /** Logging utility object for Kyo applications. */
@@ -169,10 +169,10 @@ object Log extends LogPlatformSpecific:
         end ConsoleLogger
     end Unsafe
 
-    private inline def logWhen(inline level: Level)(inline doLog: Log => Unit < IO)(using
+    private inline def logWhen(inline level: Level)(inline doLog: Log => Unit < Sync)(using
         inline frame: Frame
-    ): Unit < IO =
-        IO.Unsafe.withLocal(local) { log =>
+    ): Unit < Sync =
+        Sync.Unsafe.withLocal(local) { log =>
             if level.enabled(log.level) then
                 doLog(log)
             else
@@ -187,7 +187,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message
       */
-    inline def trace(inline msg: => Text)(using inline frame: Frame): Unit < IO =
+    inline def trace(inline msg: => Text)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.trace)(_.trace(msg))
 
     /** Logs a trace message with an exception.
@@ -199,7 +199,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message and exception
       */
-    inline def trace(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
+    inline def trace(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.trace)(_.trace(msg, t))
 
     /** Logs a debug message.
@@ -209,7 +209,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message
       */
-    inline def debug(inline msg: => Text)(using inline frame: Frame): Unit < IO =
+    inline def debug(inline msg: => Text)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.debug)(_.debug(msg))
 
     /** Logs a debug message with an exception.
@@ -221,7 +221,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message and exception
       */
-    inline def debug(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
+    inline def debug(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.debug)(_.debug(msg, t))
 
     /** Logs an info message.
@@ -231,7 +231,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message
       */
-    inline def info(inline msg: => Text)(using inline frame: Frame): Unit < IO =
+    inline def info(inline msg: => Text)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.info)(_.info(msg))
 
     /** Logs an info message with an exception.
@@ -243,7 +243,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message and exception
       */
-    inline def info(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
+    inline def info(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.info)(_.info(msg, t))
 
     /** Logs a warning message.
@@ -253,7 +253,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message
       */
-    inline def warn(inline msg: => Text)(using inline frame: Frame): Unit < IO =
+    inline def warn(inline msg: => Text)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.warn)(_.warn(msg))
 
     /** Logs a warning message with an exception.
@@ -265,7 +265,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message and exception
       */
-    inline def warn(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
+    inline def warn(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.warn)(_.warn(msg, t))
 
     /** Logs an error message.
@@ -275,7 +275,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message
       */
-    inline def error(inline msg: => Text)(using inline frame: Frame): Unit < IO =
+    inline def error(inline msg: => Text)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.error)(_.error(msg))
 
     /** Logs an error message with an exception.
@@ -287,7 +287,7 @@ object Log extends LogPlatformSpecific:
       * @return
       *   An IO effect that logs the message and exception
       */
-    inline def error(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < IO =
+    inline def error(inline msg: => Text, inline t: => Throwable)(using inline frame: Frame): Unit < Sync =
         logWhen(Level.error)(_.error(msg, t))
 
 end Log

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -54,21 +54,21 @@ object Queue:
           * @return
           *   the current size of the queue
           */
-        def size(using Frame): Int < (IO & Abort[Closed]) = IO.Unsafe(Abort.get(self.size()))
+        def size(using Frame): Int < (Sync & Abort[Closed]) = Sync.Unsafe(Abort.get(self.size()))
 
         /** Checks if the queue is empty.
           *
           * @return
           *   true if the queue is empty, false otherwise
           */
-        def empty(using Frame): Boolean < (IO & Abort[Closed]) = IO.Unsafe(Abort.get(self.empty()))
+        def empty(using Frame): Boolean < (Sync & Abort[Closed]) = Sync.Unsafe(Abort.get(self.empty()))
 
         /** Checks if the queue is full.
           *
           * @return
           *   true if the queue is full, false otherwise
           */
-        def full(using Frame): Boolean < (IO & Abort[Closed]) = IO.Unsafe(Abort.get(self.full()))
+        def full(using Frame): Boolean < (Sync & Abort[Closed]) = Sync.Unsafe(Abort.get(self.full()))
 
         /** Offers an element to the queue.
           *
@@ -77,49 +77,49 @@ object Queue:
           * @return
           *   true if the element was added, false if the queue is full or closed
           */
-        def offer(v: A)(using Frame): Boolean < (IO & Abort[Closed]) = IO.Unsafe(Abort.get(self.offer(v)))
+        def offer(v: A)(using Frame): Boolean < (Sync & Abort[Closed]) = Sync.Unsafe(Abort.get(self.offer(v)))
 
         /** Offers an element to the queue and discards the result
           *
           * @param v
           *   the element to offer
           */
-        def offerDiscard(v: A)(using Frame): Unit < (IO & Abort[Closed]) = IO.Unsafe(Abort.get(self.offer(v).unit))
+        def offerDiscard(v: A)(using Frame): Unit < (Sync & Abort[Closed]) = Sync.Unsafe(Abort.get(self.offer(v).unit))
 
         /** Polls an element from the queue.
           *
           * @return
           *   Maybe containing the polled element, or empty if the queue is empty
           */
-        def poll(using Frame): Maybe[A] < (IO & Abort[Closed]) = IO.Unsafe(Abort.get(self.poll()))
+        def poll(using Frame): Maybe[A] < (Sync & Abort[Closed]) = Sync.Unsafe(Abort.get(self.poll()))
 
         /** Peeks at the first element in the queue without removing it.
           *
           * @return
           *   Maybe containing the first element, or empty if the queue is empty
           */
-        def peek(using Frame): Maybe[A] < (IO & Abort[Closed]) = IO.Unsafe(Abort.get(self.peek()))
+        def peek(using Frame): Maybe[A] < (Sync & Abort[Closed]) = Sync.Unsafe(Abort.get(self.peek()))
 
         /** Drains all elements from the queue.
           *
           * @return
           *   a sequence of all elements in the queue
           */
-        def drain(using Frame): Chunk[A] < (IO & Abort[Closed]) = IO.Unsafe(Abort.get(self.drain()))
+        def drain(using Frame): Chunk[A] < (Sync & Abort[Closed]) = Sync.Unsafe(Abort.get(self.drain()))
 
         /** Takes up to [[max]] elements from the queue.
           *
           * @return
           *   a sequence of up to [[max]] elements from the queue.
           */
-        def drainUpTo(max: Int)(using Frame): Chunk[A] < (IO & Abort[Closed]) = IO.Unsafe(Abort.get(self.drainUpTo(max)))
+        def drainUpTo(max: Int)(using Frame): Chunk[A] < (Sync & Abort[Closed]) = Sync.Unsafe(Abort.get(self.drainUpTo(max)))
 
         /** Closes the queue and returns any remaining elements.
           *
           * @return
           *   a sequence of remaining elements
           */
-        def close(using Frame): Maybe[Seq[A]] < IO = IO.Unsafe(self.close())
+        def close(using Frame): Maybe[Seq[A]] < Sync = Sync.Unsafe(self.close())
 
         /** Closes the queue and asynchronously waits until it's empty.
           *
@@ -131,14 +131,14 @@ object Queue:
           *   true if the queue was successfully closed and emptied, false if it was already closed or another closeAwaitEmpty is already
           *   running.
           */
-        def closeAwaitEmpty(using Frame): Boolean < Async = IO.Unsafe(self.closeAwaitEmpty().safe.get)
+        def closeAwaitEmpty(using Frame): Boolean < Async = Sync.Unsafe(self.closeAwaitEmpty().safe.get)
 
         /** Checks if the queue is closed.
           *
           * @return
           *   true if the queue is closed, false otherwise
           */
-        def closed(using Frame): Boolean < IO = IO.Unsafe(self.closed())
+        def closed(using Frame): Boolean < Sync = Sync.Unsafe(self.closed())
 
         /** Returns the unsafe version of the queue.
           *
@@ -163,7 +163,7 @@ object Queue:
       * @warning
       *   The actual capacity may be larger than the specified capacity due to rounding.
       */
-    def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Queue[A] < IO =
+    def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Queue[A] < Sync =
         initWith[A](capacity, access)(identity)
 
     /** Uses a new Queue with the provided count.
@@ -178,8 +178,8 @@ object Queue:
       */
     inline def initWith[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](inline f: Queue[A] => B < S)(
         using inline frame: Frame
-    ): B < (IO & S) =
-        IO.Unsafe(f(Unsafe.init(capacity, access)))
+    ): B < (Sync & S) =
+        Sync.Unsafe(f(Unsafe.init(capacity, access)))
 
     /** An unbounded queue that can grow indefinitely.
       *
@@ -195,7 +195,7 @@ object Queue:
               * @param value
               *   the element to add
               */
-            def add(value: A)(using Frame): Unit < IO = IO.Unsafe(Unsafe.add(self)(value))
+            def add(value: A)(using Frame): Unit < Sync = Sync.Unsafe(Unsafe.add(self)(value))
 
             def unsafe: Unsafe[A] = self
         end extension
@@ -209,7 +209,7 @@ object Queue:
           * @return
           *   a new Unbounded Queue instance
           */
-        def init[A](access: Access = Access.MultiProducerMultiConsumer, chunkSize: Int = 8)(using Frame): Unbounded[A] < IO =
+        def init[A](access: Access = Access.MultiProducerMultiConsumer, chunkSize: Int = 8)(using Frame): Unbounded[A] < Sync =
             initWith[A](access, chunkSize)(identity)
 
         /** Uses a new unbounded Queue with the provided count.
@@ -225,8 +225,8 @@ object Queue:
             chunkSize: Int = 8
         )[B, S](inline f: Unbounded[A] => B < S)(
             using inline frame: Frame
-        ): B < (IO & S) =
-            IO.Unsafe(f(Unsafe.init(access, chunkSize)))
+        ): B < (Sync & S) =
+            Sync.Unsafe(f(Unsafe.init(access, chunkSize)))
 
         /** Initializes a new dropping queue with the specified capacity and access pattern.
           *
@@ -242,8 +242,8 @@ object Queue:
           * @warning
           *   The actual capacity may be larger than the specified capacity due to rounding.
           */
-        def initDropping[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Unbounded[A] < IO =
-            IO.Unsafe(Unsafe.initDropping(capacity, access))
+        def initDropping[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Unbounded[A] < Sync =
+            Sync.Unsafe(Unsafe.initDropping(capacity, access))
 
         /** Initializes a new sliding queue with the specified capacity and access pattern.
           *
@@ -259,8 +259,8 @@ object Queue:
           * @warning
           *   The actual capacity may be larger than the specified capacity due to rounding.
           */
-        def initSliding[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Unbounded[A] < IO =
-            IO.Unsafe(Unsafe.initSliding(capacity, access))
+        def initSliding[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Unbounded[A] < Sync =
+            Sync.Unsafe(Unsafe.initSliding(capacity, access))
 
         /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
         opaque type Unsafe[A] <: Queue.Unsafe[A] = Queue[A]

--- a/kyo-core/shared/src/main/scala/kyo/Random.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Random.scala
@@ -25,19 +25,19 @@ import scala.annotation.tailrec
   *   [[kyo.Random.withSeed]] For creating reproducible random sequences
   */
 abstract class Random extends Serializable:
-    def nextInt(using Frame): Int < IO
-    def nextInt(exclusiveBound: Int)(using Frame): Int < IO
-    def nextLong(using Frame): Long < IO
-    def nextDouble(using Frame): Double < IO
-    def nextBoolean(using Frame): Boolean < IO
-    def nextFloat(using Frame): Float < IO
-    def nextGaussian(using Frame): Double < IO
-    def nextValue[A](seq: Seq[A])(using Frame): A < IO
-    def nextValues[A](length: Int, seq: Seq[A])(using Frame): Seq[A] < IO
-    def nextStringAlphanumeric(length: Int)(using Frame): String < IO
-    def nextString(length: Int, chars: Seq[Char])(using Frame): String < IO
-    def nextBytes(length: Int)(using Frame): Seq[Byte] < IO
-    def shuffle[A](seq: Seq[A])(using Frame): Seq[A] < IO
+    def nextInt(using Frame): Int < Sync
+    def nextInt(exclusiveBound: Int)(using Frame): Int < Sync
+    def nextLong(using Frame): Long < Sync
+    def nextDouble(using Frame): Double < Sync
+    def nextBoolean(using Frame): Boolean < Sync
+    def nextFloat(using Frame): Float < Sync
+    def nextGaussian(using Frame): Double < Sync
+    def nextValue[A](seq: Seq[A])(using Frame): A < Sync
+    def nextValues[A](length: Int, seq: Seq[A])(using Frame): Seq[A] < Sync
+    def nextStringAlphanumeric(length: Int)(using Frame): String < Sync
+    def nextString(length: Int, chars: Seq[Char])(using Frame): String < Sync
+    def nextBytes(length: Int)(using Frame): Seq[Byte] < Sync
+    def shuffle[A](seq: Seq[A])(using Frame): Seq[A] < Sync
     def unsafe: Random.Unsafe
 end Random
 
@@ -118,24 +118,24 @@ object Random:
       */
     def apply(u: Unsafe): Random =
         new Random:
-            def nextInt(using Frame)                      = IO.Unsafe(u.nextInt())
-            def nextInt(exclusiveBound: Int)(using Frame) = IO.Unsafe(u.nextInt(exclusiveBound))
-            def nextLong(using Frame)                     = IO.Unsafe(u.nextLong())
-            def nextDouble(using Frame)                   = IO.Unsafe(u.nextDouble())
-            def nextBoolean(using Frame)                  = IO.Unsafe(u.nextBoolean())
-            def nextFloat(using Frame)                    = IO.Unsafe(u.nextFloat())
-            def nextGaussian(using Frame)                 = IO.Unsafe(u.nextGaussian())
-            def nextValue[A](seq: Seq[A])(using Frame)    = IO.Unsafe(u.nextValue[A](seq))
+            def nextInt(using Frame)                      = Sync.Unsafe(u.nextInt())
+            def nextInt(exclusiveBound: Int)(using Frame) = Sync.Unsafe(u.nextInt(exclusiveBound))
+            def nextLong(using Frame)                     = Sync.Unsafe(u.nextLong())
+            def nextDouble(using Frame)                   = Sync.Unsafe(u.nextDouble())
+            def nextBoolean(using Frame)                  = Sync.Unsafe(u.nextBoolean())
+            def nextFloat(using Frame)                    = Sync.Unsafe(u.nextFloat())
+            def nextGaussian(using Frame)                 = Sync.Unsafe(u.nextGaussian())
+            def nextValue[A](seq: Seq[A])(using Frame)    = Sync.Unsafe(u.nextValue[A](seq))
             def nextValues[A](length: Int, seq: Seq[A])(using Frame) =
-                IO.Unsafe(u.nextValues(length, seq))
+                Sync.Unsafe(u.nextValues(length, seq))
             def nextStringAlphanumeric(length: Int)(using Frame) =
-                IO.Unsafe(u.nextStringAlphanumeric(length))
+                Sync.Unsafe(u.nextStringAlphanumeric(length))
             def nextString(length: Int, chars: Seq[Char])(using Frame) =
-                IO.Unsafe(u.nextString(length, chars))
+                Sync.Unsafe(u.nextString(length, chars))
             def nextBytes(length: Int)(using Frame) =
-                IO.Unsafe(u.nextBytes(length))
+                Sync.Unsafe(u.nextBytes(length))
             def shuffle[A](seq: Seq[A])(using Frame) =
-                IO.Unsafe(u.shuffle(seq))
+                Sync.Unsafe(u.shuffle(seq))
             def unsafe: Unsafe = u
 
     /** A live instance of Random using the default java.util.Random. */
@@ -156,7 +156,7 @@ object Random:
       * @return
       *   The result of the effect execution.
       */
-    def let[A, S](r: Random)(v: A < S)(using Frame): A < (S & IO) =
+    def let[A, S](r: Random)(v: A < S)(using Frame): A < (S & Sync) =
         local.let(r)(v)
 
     /** Executes the given effect with a new Random instance initialized with the specified seed.
@@ -172,8 +172,8 @@ object Random:
       * @return
       *   The result of the effect execution with the seeded Random instance.
       */
-    def withSeed[A, S](seed: Int)(v: A < S)(using Frame): A < (S & IO) =
-        IO(Random(Random.Unsafe(new java.util.Random(seed)))).map(let(_)(v))
+    def withSeed[A, S](seed: Int)(v: A < S)(using Frame): A < (S & Sync) =
+        Sync(Random(Random.Unsafe(new java.util.Random(seed)))).map(let(_)(v))
 
     /** Gets the current Random instance from the local context.
       *
@@ -193,7 +193,7 @@ object Random:
       * @return
       *   The result of executing the function with the current Random instance.
       */
-    def use[A, S](f: Random => A < S)(using Frame): A < (S & IO) =
+    def use[A, S](f: Random => A < S)(using Frame): A < (S & Sync) =
         local.use(f)
 
     /** Generates a random integer.
@@ -201,8 +201,8 @@ object Random:
       * @return
       *   A random Int value.
       */
-    def nextInt(using Frame): Int < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextInt())
+    def nextInt(using Frame): Int < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextInt())
 
     /** Generates a random integer between 0 (inclusive) and the specified bound (exclusive).
       *
@@ -211,48 +211,48 @@ object Random:
       * @return
       *   A random Int value within the specified range.
       */
-    def nextInt(exclusiveBound: Int)(using Frame): Int < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextInt(exclusiveBound))
+    def nextInt(exclusiveBound: Int)(using Frame): Int < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextInt(exclusiveBound))
 
     /** Generates a random long integer.
       *
       * @return
       *   A random Long value.
       */
-    def nextLong(using Frame): Long < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextLong())
+    def nextLong(using Frame): Long < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextLong())
 
     /** Generates a random double between 0.0 (inclusive) and 1.0 (exclusive).
       *
       * @return
       *   A random Double value between 0.0 and 1.0.
       */
-    def nextDouble(using Frame): Double < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextDouble())
+    def nextDouble(using Frame): Double < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextDouble())
 
     /** Generates a random boolean value.
       *
       * @return
       *   A random Boolean value.
       */
-    def nextBoolean(using Frame): Boolean < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextBoolean())
+    def nextBoolean(using Frame): Boolean < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextBoolean())
 
     /** Generates a random float between 0.0 (inclusive) and 1.0 (exclusive).
       *
       * @return
       *   A random Float value between 0.0 and 1.0.
       */
-    def nextFloat(using Frame): Float < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextFloat())
+    def nextFloat(using Frame): Float < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextFloat())
 
     /** Generates a random double from a Gaussian distribution with mean 0.0 and standard deviation 1.0.
       *
       * @return
       *   A random Double value from a Gaussian distribution.
       */
-    def nextGaussian(using Frame): Double < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextGaussian())
+    def nextGaussian(using Frame): Double < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextGaussian())
 
     /** Selects a random element from the given sequence.
       *
@@ -263,8 +263,8 @@ object Random:
       * @return
       *   A randomly selected element from the sequence.
       */
-    def nextValue[A](seq: Seq[A])(using Frame): A < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextValue(seq): A)
+    def nextValue[A](seq: Seq[A])(using Frame): A < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextValue(seq): A)
 
     /** Generates a sequence of random elements from the given sequence.
       *
@@ -277,8 +277,8 @@ object Random:
       * @return
       *   A new sequence of randomly selected elements.
       */
-    def nextValues[A](length: Int, seq: Seq[A])(using Frame): Seq[A] < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextValues(length, seq))
+    def nextValues[A](length: Int, seq: Seq[A])(using Frame): Seq[A] < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextValues(length, seq))
 
     /** Generates a random alphanumeric string of the specified length.
       *
@@ -287,8 +287,8 @@ object Random:
       * @return
       *   A random alphanumeric String of the specified length.
       */
-    def nextStringAlphanumeric(length: Int)(using Frame): String < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextStringAlphanumeric(length))
+    def nextStringAlphanumeric(length: Int)(using Frame): String < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextStringAlphanumeric(length))
 
     /** Generates a random string of the specified length using the given character sequence and the current Random instance.
       *
@@ -299,8 +299,8 @@ object Random:
       * @return
       *   A random String of the specified length.
       */
-    def nextString(length: Int, chars: Seq[Char])(using Frame): String < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextString(length, chars))
+    def nextString(length: Int, chars: Seq[Char])(using Frame): String < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextString(length, chars))
 
     /** Generates a sequence of random bytes.
       *
@@ -309,8 +309,8 @@ object Random:
       * @return
       *   A Seq[Byte] of random bytes.
       */
-    def nextBytes(length: Int)(using Frame): Seq[Byte] < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.nextBytes(length))
+    def nextBytes(length: Int)(using Frame): Seq[Byte] < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.nextBytes(length))
 
     /** Shuffles the elements of the given sequence randomly.
       *
@@ -321,7 +321,7 @@ object Random:
       * @return
       *   A new sequence with the elements shuffled randomly.
       */
-    def shuffle[A](seq: Seq[A])(using Frame): Seq[A] < IO =
-        IO.Unsafe.withLocal(local)(_.unsafe.shuffle(seq))
+    def shuffle[A](seq: Seq[A])(using Frame): Seq[A] < Sync =
+        Sync.Unsafe.withLocal(local)(_.unsafe.shuffle(seq))
 
 end Random

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -47,7 +47,7 @@ object Resource:
       * @return
       *   A unit value wrapped in Resource and IO effects.
       */
-    inline def ensure(inline v: => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & IO) =
+    inline def ensure(inline v: => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & Sync) =
         ContextEffect.suspendWith(Tag[Resource])(_.ensure(_ => v))
 
     /** Ensures that the given effect is executed when the resource is released, with information about the computation's outcome.
@@ -63,7 +63,7 @@ object Resource:
       * @return
       *   A unit value wrapped in Resource and IO effects.
       */
-    inline def ensure(inline f: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & IO) =
+    inline def ensure(inline f: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & Sync) =
         ContextEffect.suspendWith(Tag[Resource])(_.ensure(f))
 
     /** Acquires a resource and provides a release function.
@@ -77,8 +77,8 @@ object Resource:
       * @return
       *   The acquired resource wrapped in Resource, IO, and S effects.
       */
-    def acquireRelease[A, S](acquire: => A < S)(release: A => Any < (Async & Abort[Throwable]))(using Frame): A < (Resource & IO & S) =
-        IO {
+    def acquireRelease[A, S](acquire: => A < S)(release: A => Any < (Async & Abort[Throwable]))(using Frame): A < (Resource & Sync & S) =
+        Sync {
             acquire.map { resource =>
                 ensure(release(resource)).andThen(resource)
             }
@@ -93,7 +93,7 @@ object Resource:
       * @return
       *   The acquired Closeable resource wrapped in Resource, IO, and S effects.
       */
-    def acquire[A <: java.io.Closeable, S](resource: => A < S)(using Frame): A < (Resource & IO & S) =
+    def acquire[A <: java.io.Closeable, S](resource: => A < S)(using Frame): A < (Resource & Sync & S) =
         acquireRelease(resource)(_.close())
 
     /** Runs a resource-managed effect with default parallelism of 1.
@@ -127,11 +127,11 @@ object Resource:
       *   The result of the effect wrapped in Async and S effects.
       */
     def run[A, S](closeParallelism: Int)(v: A < (Resource & S))(using frame: Frame): A < (Async & S) =
-        IO.Unsafe {
+        Sync.Unsafe {
             val finalizer = Finalizer.Awaitable.Unsafe.init(closeParallelism)
             ContextEffect.handle(Tag[Resource], finalizer, _ => finalizer)(v)
                 .handle(
-                    IO.ensure(finalizer.close),
+                    Sync.ensure(finalizer.close),
                     Abort.run[Any]
                 ).map { result =>
                     finalizer
@@ -145,11 +145,11 @@ object Resource:
 
     /** Represents a finalizer for a resource. */
     sealed abstract class Finalizer:
-        def ensure(v: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using Frame): Unit < IO
+        def ensure(v: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using Frame): Unit < Sync
 
     object Finalizer:
         sealed abstract class Awaitable extends Finalizer:
-            def close(ex: Maybe[Error[Any]])(using Frame): Unit < IO
+            def close(ex: Maybe[Error[Any]])(using Frame): Unit < Sync
             def await(using Frame): Unit < Async
 
         object Awaitable:
@@ -161,8 +161,8 @@ object Resource:
                         )
                         val promise = Promise.Unsafe.init[Nothing, Unit]().safe
 
-                        def ensure(v: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using Frame): Unit < IO =
-                            IO.Unsafe {
+                        def ensure(v: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using Frame): Unit < Sync =
+                            Sync.Unsafe {
                                 if !queue.offer(v).contains(true) then
                                     Abort.panic(new Closed(
                                         "Finalizer",
@@ -173,8 +173,8 @@ object Resource:
                             }
                         end ensure
 
-                        def close(ex: Maybe[Error[Any]])(using Frame): Unit < IO =
-                            IO.Unsafe {
+                        def close(ex: Maybe[Error[Any]])(using Frame): Unit < Sync =
+                            Sync.Unsafe {
                                 queue.close() match
                                     case Absent => ()
                                     case Present(tasks) =>

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -45,7 +45,7 @@ object Resource:
       * @param frame
       *   The implicit Frame for context.
       * @return
-      *   A unit value wrapped in Resource and IO effects.
+      *   A unit value wrapped in Resource and Sync effects.
       */
     inline def ensure(inline v: => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & Sync) =
         ContextEffect.suspendWith(Tag[Resource])(_.ensure(_ => v))
@@ -61,7 +61,7 @@ object Resource:
       * @param frame
       *   The implicit Frame for context.
       * @return
-      *   A unit value wrapped in Resource and IO effects.
+      *   A unit value wrapped in Resource and Sync effects.
       */
     inline def ensure(inline f: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & Sync) =
         ContextEffect.suspendWith(Tag[Resource])(_.ensure(f))

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -75,7 +75,7 @@ object Resource:
       * @param frame
       *   The implicit Frame for context.
       * @return
-      *   The acquired resource wrapped in Resource, IO, and S effects.
+      *   The acquired resource wrapped in Resource, Sync, and S effects.
       */
     def acquireRelease[A, S](acquire: => A < S)(release: A => Any < (Async & Abort[Throwable]))(using Frame): A < (Resource & Sync & S) =
         Sync {
@@ -91,7 +91,7 @@ object Resource:
       * @param frame
       *   The implicit Frame for context.
       * @return
-      *   The acquired Closeable resource wrapped in Resource, IO, and S effects.
+      *   The acquired Closeable resource wrapped in Resource, Sync, and S effects.
       */
     def acquire[A <: java.io.Closeable, S](resource: => A < S)(using Frame): A < (Resource & Sync & S) =
         acquireRelease(resource)(_.close())

--- a/kyo-core/shared/src/main/scala/kyo/Signal.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Signal.scala
@@ -39,7 +39,7 @@ sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
       * @return
       *   The current value of type A
       */
-    final def current(using Frame): A < IO = currentWith(identity)
+    final def current(using Frame): A < Sync = currentWith(identity)
 
     /** Retrieves and transforms the current value of the signal.
       *
@@ -51,7 +51,7 @@ sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
       * @return
       *   The transformed value wrapped in combined effects S & IO
       */
-    def currentWith[B, S](f: A => B < S)(using Frame): B < (S & IO)
+    def currentWith[B, S](f: A => B < S)(using Frame): B < (S & Sync)
 
     /** Waits for and returns the next value change in the signal.
       *
@@ -155,7 +155,7 @@ object Signal:
         frame: Frame,
         @implicitNotFound(missingCanEqual)
         canEqual: CanEqual[A, A]
-    ): SignalRef[A] < IO =
+    ): SignalRef[A] < Sync =
         initRefWith[A](initial)(identity)
 
     /** Creates a new mutable signal reference with an initial value and applies a transformation function.
@@ -181,8 +181,8 @@ object Signal:
         frame: Frame,
         @implicitNotFound(missingCanEqual)
         canEqual: CanEqual[A, A]
-    ): B < (S & IO) =
-        IO.Unsafe(f(new SignalRef(SignalRef.Unsafe.init(initial))))
+    ): B < (S & Sync) =
+        Sync.Unsafe(f(new SignalRef(SignalRef.Unsafe.init(initial))))
 
     /** Creates a new immutable signal with a constant value.
       *
@@ -249,7 +249,7 @@ object Signal:
       */
     @nowarn("msg=anonymous")
     inline def initRaw[A](
-        inline currentWith: [B, S] => (A => B < S) => B < (S & IO),
+        inline currentWith: [B, S] => (A => B < S) => B < (S & Sync),
         inline nextWith: [B, S] => (A => B < S) => B < (S & Async)
     )(
         using
@@ -282,7 +282,7 @@ object Signal:
       */
     @nowarn("msg=anonymous")
     inline def initRawWith[A](
-        inline currentWith: [B, S] => (A => B < S) => B < (S & IO),
+        inline currentWith: [B, S] => (A => B < S) => B < (S & Sync),
         inline nextWith: [B, S] => (A => B < S) => B < (S & Async)
     )[B, S](f: Signal[A] => B < S)(
         using
@@ -295,7 +295,7 @@ object Signal:
     // Separated from initRaw to avoid name conflicts between parameters and Signal members
     @nowarn("msg=anonymous")
     private inline def _initRaw[A](
-        inline _currentWith: [B, S] => (A => B < S) => B < (S & IO),
+        inline _currentWith: [B, S] => (A => B < S) => B < (S & Sync),
         inline _nextWith: [B, S] => (A => B < S) => B < (S & Async)
     )(
         using
@@ -303,7 +303,7 @@ object Signal:
         canEqual: CanEqual[A, A]
     ): Signal[A] =
         new Signal[A]:
-            def currentWith[B, S](f: A => B < S)(using frame: Frame): B < (S & IO) =
+            def currentWith[B, S](f: A => B < S)(using frame: Frame): B < (S & Sync) =
                 _currentWith(f)
             def nextWith[B, S](f: A => B < S)(using frame: Frame): B < (S & Async) =
                 _nextWith(f)
@@ -320,9 +320,9 @@ object Signal:
       */
     final class SignalRef[A] private[Signal] (_unsafe: SignalRef.Unsafe[A])(using CanEqual[A, A]) extends Signal[A]:
 
-        def currentWith[B, S](f: A => B < S)(using Frame) = IO.Unsafe(f(unsafe.get()))
+        def currentWith[B, S](f: A => B < S)(using Frame) = Sync.Unsafe(f(unsafe.get()))
 
-        def nextWith[B, S](f: A => B < S)(using Frame) = IO.Unsafe(unsafe.next().safe.use(f))
+        def nextWith[B, S](f: A => B < S)(using Frame) = Sync.Unsafe(unsafe.next().safe.use(f))
 
         /** Retrieves the current value of the reference.
           *
@@ -331,7 +331,7 @@ object Signal:
           * @return
           *   The current value
           */
-        def get(using Frame): A < IO = use(identity)
+        def get(using Frame): A < Sync = use(identity)
 
         /** Retrieves and transforms the current value of the reference.
           *
@@ -343,7 +343,7 @@ object Signal:
           * @return
           *   The transformed value wrapped in combined effects S & IO
           */
-        inline def use[B, S](inline f: A => B < S)(using Frame): B < (S & IO) = IO.Unsafe(f(_unsafe.get()))
+        inline def use[B, S](inline f: A => B < S)(using Frame): B < (S & Sync) = Sync.Unsafe(f(_unsafe.get()))
 
         /** Sets the reference to a new value.
           *
@@ -352,7 +352,7 @@ object Signal:
           * @param value
           *   The new value to set
           */
-        def set(value: A)(using Frame): Unit < IO = IO.Unsafe(_unsafe.set(value))
+        def set(value: A)(using Frame): Unit < Sync = Sync.Unsafe(_unsafe.set(value))
 
         /** Updates the reference's value and returns the previous value.
           *
@@ -361,8 +361,8 @@ object Signal:
           * @return
           *   The previous value
           */
-        def getAndSet(value: A)(using Frame): A < IO =
-            IO.Unsafe(_unsafe.getAndSet(value))
+        def getAndSet(value: A)(using Frame): A < Sync =
+            Sync.Unsafe(_unsafe.getAndSet(value))
 
         /** Atomically sets the value to the given updated value if the current value equals the expected value.
           *
@@ -373,8 +373,8 @@ object Signal:
           * @return
           *   True if successful, false otherwise
           */
-        def compareAndSet(curr: A, next: A)(using Frame): Boolean < IO =
-            IO.Unsafe(_unsafe.compareAndSet(curr, next))
+        def compareAndSet(curr: A, next: A)(using Frame): Boolean < Sync =
+            Sync.Unsafe(_unsafe.compareAndSet(curr, next))
 
         /** Atomically updates the current value using the provided function and returns the previous value.
           *
@@ -383,8 +383,8 @@ object Signal:
           * @return
           *   The previous value
           */
-        def getAndUpdate(f: A => A)(using Frame): A < IO =
-            IO.Unsafe(_unsafe.getAndUpdate(f))
+        def getAndUpdate(f: A => A)(using Frame): A < Sync =
+            Sync.Unsafe(_unsafe.getAndUpdate(f))
 
         /** Atomically updates the current value using the provided function and returns the new value.
           *
@@ -393,8 +393,8 @@ object Signal:
           * @return
           *   The new value
           */
-        def updateAndGet(f: A => A)(using Frame): A < IO =
-            IO.Unsafe(_unsafe.updateAndGet(f))
+        def updateAndGet(f: A => A)(using Frame): A < Sync =
+            Sync.Unsafe(_unsafe.updateAndGet(f))
 
         def unsafe: SignalRef.Unsafe[A] = _unsafe
     end SignalRef

--- a/kyo-core/shared/src/main/scala/kyo/Signal.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Signal.scala
@@ -49,7 +49,7 @@ sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
       * @param f
       *   The transformation function to apply to the current value
       * @return
-      *   The transformed value wrapped in combined effects S & IO
+      *   The transformed value wrapped in combined effects S & Sync
       */
     def currentWith[B, S](f: A => B < S)(using Frame): B < (S & Sync)
 
@@ -341,7 +341,7 @@ object Signal:
           * @param f
           *   The transformation function to apply to the current value
           * @return
-          *   The transformed value wrapped in combined effects S & IO
+          *   The transformed value wrapped in combined effects S & Sync
           */
         inline def use[B, S](inline f: A => B < S)(using Frame): B < (S & Sync) = Sync.Unsafe(f(_unsafe.get()))
 

--- a/kyo-core/shared/src/main/scala/kyo/Stat.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Stat.scala
@@ -12,7 +12,7 @@ abstract class Counter extends Serializable:
 
     /** Get the current value of the counter.
       * @return
-      *   The current count as a Long, wrapped in IO
+      *   The current count as a Long, wrapped in Sync
       */
     def get(using Frame): Long < Sync
 
@@ -47,7 +47,7 @@ abstract class Histogram extends Serializable:
 
     /** Get the total count of observations.
       * @return
-      *   The count as a Long, wrapped in IO
+      *   The count as a Long, wrapped in Sync
       */
     def count(using Frame): Long < Sync
 
@@ -55,7 +55,7 @@ abstract class Histogram extends Serializable:
       * @param v
       *   The percentile (0.0 to 100.0)
       * @return
-      *   The value at the given percentile, wrapped in IO
+      *   The value at the given percentile, wrapped in Sync
       */
     def valueAtPercentile(v: Double)(using Frame): Double < Sync
 end Histogram
@@ -68,7 +68,7 @@ abstract class Gauge extends Serializable:
 
     /** Collect the current value of the gauge.
       * @return
-      *   The current value as a Double, wrapped in IO
+      *   The current value as a Double, wrapped in Sync
       */
     def collect(using Frame): Double < Sync
 end Gauge
@@ -81,7 +81,7 @@ abstract class CounterGauge extends Serializable:
 
     /** Collect the current value of the counter gauge.
       * @return
-      *   The current value as a Long, wrapped in IO
+      *   The current value as a Long, wrapped in Sync
       */
     def collect(using Frame): Long < Sync
 end CounterGauge
@@ -178,7 +178,7 @@ final class Stat(private val registryScope: StatsRegistry.Scope) extends Seriali
       * @param v
       *   The computation to trace
       * @return
-      *   The result of the computation, wrapped in IO
+      *   The result of the computation, wrapped in Sync
       */
     def traceSpan[A, S](
         name: String,
@@ -197,7 +197,7 @@ object Stat:
       * @param v
       *   The computation to trace
       * @return
-      *   The result of the computation, wrapped in IO
+      *   The result of the computation, wrapped in Sync
       */
     def traceListen[A, S](receiver: TraceReceiver)(v: A < S)(using Frame): A < (Sync & S) =
         traceReceiver.use { curr =>

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -202,14 +202,14 @@ object StreamCoreExtensions:
                     "\n       If you need this behaviour, use `fromIterator(iterator, chunkSize)` directly." +
                     "\n - `fromIteratorCatching[E = Throwable]` catches all Exceptions as `Failure`."
             ) notNothing: NotGiven[E =:= Nothing]
-        ): Stream[V, IO & Abort[E]] =
-            val stream: Stream[V, (IO & Abort[E])] < IO = IO:
+        ): Stream[V, Sync & Abort[E]] =
+            val stream: Stream[V, (Sync & Abort[E])] < Sync = Sync:
                 val it      = v
                 val size    = chunkSize max 1
                 val builder = ChunkBuilder.init[V]
 
-                val pull: Chunk[V] < (IO & Abort[E]) =
-                    IO:
+                val pull: Chunk[V] < (Sync & Abort[E]) =
+                    Sync:
                         Abort.catching[E]:
                             var count = 0
                             while count < size && it.hasNext do
@@ -224,7 +224,7 @@ object StreamCoreExtensions:
                             case Result.Success(chunk) if chunk.isEmpty => Loop.done
                             case Result.Success(chunk)                  => Emit.valueWith(chunk)(Loop.continue)
                             case error: Result.Error[E] @unchecked =>
-                                IO:
+                                Sync:
                                     val lastElements: Chunk[V] = builder.result()
                                     Emit.valueWith(lastElements)(Abort.error(error))
 

--- a/kyo-core/shared/src/main/scala/kyo/Sync.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Sync.scala
@@ -7,34 +7,34 @@ import kyo.kernel.internal.Safepoint
 
 /** Pure suspension of side effects.
   *
-  * Unlike traditional monadic IO types that combine effect suspension and async execution, Kyo leverages algebraic effects to cleanly
-  * separate these concerns. IO focuses solely on suspending side effects, while async execution (fibers, scheduling) is handled by the
+  * Unlike traditional monadic Sync types that combine effect suspension and async execution, Kyo leverages algebraic effects to cleanly
+  * separate these concerns. Sync focuses solely on suspending side effects, while async execution (fibers, scheduling) is handled by the
   * Async effect.
   *
-  * This separation enables an important design principle in Kyo's codebase: methods that only declare IO in their pending effects are run
+  * This separation enables an important design principle in Kyo's codebase: methods that only declare Sync in their pending effects are run
   * to completion without parking or locking. This property, combined with Kyo's lock-free primitives, makes it easier to reason about
   * performance characteristics and identify potential async operations in the code.
   *
-  * IO is implemented as a type-level marker rather than a full ArrowEffect for performance. Since Effect.defer is only evaluated by the
+  * Sync is implemented as a type-level marker rather than a full ArrowEffect for performance. Since Effect.defer is only evaluated by the
   * Pending type's "eval" method, which can only handle computations without pending effects, side effects are properly deferred. This
-  * ensures they can only be executed after an IO.run call, even though it is a purely type-level operation.
+  * ensures they can only be executed after an Sync.run call, even though it is a purely type-level operation.
   *
-  * Like Async includes IO, this effect includes Abort[Nothing] to represent potential panics (untracked, unexpected exceptions).
+  * Like Async includes Sync, this effect includes Abort[Nothing] to represent potential panics (untracked, unexpected exceptions).
   */
 opaque type Sync <: Abort[Nothing] = Abort[Nothing]
 
-@deprecated
+@deprecated("use `Sync`", "0.19.1")
 type IO = Sync
 
-@deprecated
+@deprecated("use `Sync`", "0.19.1")
 val IO = Sync
 
 object Sync:
 
-    /** Suspends a potentially side-effecting computation in an IO effect.
+    /** Suspends a potentially side-effecting computation in an Sync effect.
       *
-      * This method allows you to lift any computation (including those with side effects) into the IO context, deferring its execution
-      * until the IO is run.
+      * This method allows you to lift any computation (including those with side effects) into the Sync context, deferring its execution
+      * until the Sync is run.
       *
       * @param f
       *   The computation to suspend, potentially containing side effects.
@@ -45,7 +45,7 @@ object Sync:
       * @tparam S
       *   Additional effects in the computation.
       * @return
-      *   The suspended computation wrapped in an IO effect.
+      *   The suspended computation wrapped in an Sync effect.
       */
     inline def apply[A, S](inline f: Safepoint ?=> A < S)(using inline frame: Frame): A < (Sync & S) =
         Effect.deferInline(f)
@@ -94,8 +94,8 @@ object Sync:
       * This is the preferred way to access a local value when you need to perform side effects with it. Common use cases include accessing
       * loggers, configuration, or request-scoped values that you need to use in computations that produce side effects.
       *
-      * While `local.get.map(v => IO(f(v)))` would also work, this method is more direct since both IO and Local use the same underlying
-      * mechanism to handle effects. Under the hood, accessing a local value and performing IO operations both use the same type of
+      * While `local.get.map(v => Sync(f(v)))` would also work, this method is more direct since both Sync and Local use the same underlying
+      * mechanism to handle effects. Under the hood, accessing a local value and performing Sync operations both use the same type of
       * suspension, the kernel's internal `Defer` effect. This means we can safely combine them without creating unnecessary layers of
       * suspension.
       *
@@ -104,7 +104,7 @@ object Sync:
       * @param f
       *   Function that can perform side effects with the local value
       * @return
-      *   An IO effect containing the result of applying the function
+      *   An Sync effect containing the result of applying the function
       */
     def withLocal[A, B, S](local: Local[A])(f: A => B < S)(using Frame): B < (S & Sync) =
         local.use(f)
@@ -120,41 +120,41 @@ object Sync:
         def withLocal[A, B, S](local: Local[A])(f: AllowUnsafe ?=> A => B < S)(using Frame): B < (S & Sync) =
             local.use(f(using AllowUnsafe.embrace.danger))
 
-        /** Evaluates an IO effect that may throw exceptions, converting any thrown exceptions into the final result.
+        /** Evaluates an Sync effect that may throw exceptions, converting any thrown exceptions into the final result.
           *
-          * WARNING: This is a low-level API that should be used with caution. It forcefully evaluates the IO effect and will throw any
+          * WARNING: This is a low-level API that should be used with caution. It forcefully evaluates the Sync effect and will throw any
           * encountered exceptions rather than handling them in a purely functional way.
           *
           * @param v
-          *   The IO effect to evaluate, which may contain throwable errors
+          *   The Sync effect to evaluate, which may contain throwable errors
           * @param frame
           *   Implicit frame for the computation
           * @return
-          *   The result of evaluating the IO effect, throwing any encountered exceptions
+          *   The result of evaluating the Sync effect, throwing any encountered exceptions
           * @throws Throwable
           *   If the evaluation results in an error
           */
         def evalOrThrow[A](v: A < (Sync & Abort[Throwable]))(using Frame, AllowUnsafe): A =
             Abort.run(v).eval.getOrThrow
 
-        /** Runs an IO effect, evaluating it and its side effects.
+        /** Runs an Sync effect, evaluating it and its side effects.
           *
           * WARNING: This is a low-level, unsafe API. It should be used with caution and only when absolutely necessary. This method
-          * executes the IO effect and any associated side effects right away, potentially breaking referential transparency and making it
+          * executes the Sync effect and any associated side effects right away, potentially breaking referential transparency and making it
           * harder to reason about the code's behavior.
           *
-          * In most cases, prefer higher-level, safer APIs for managing IO effects.
+          * In most cases, prefer higher-level, safer APIs for managing Sync effects.
           *
           * @param v
-          *   The IO effect to run.
+          *   The Sync effect to run.
           * @param frame
           *   Implicit frame for the computation.
           * @tparam A
-          *   The result type of the IO effect.
+          *   The result type of the Sync effect.
           * @tparam S
           *   Additional effects in the computation.
           * @return
-          *   The result of the IO effect after executing its side effects.
+          *   The result of the Sync effect after executing its side effects.
           */
         def run[E, A, S](v: => A < (Sync & Abort[E] & S))(using Frame, AllowUnsafe): A < (S & Abort[E]) =
             v

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -11,7 +11,7 @@ import java.time.format.DateTimeParseException
   * System provides an effect-based API for interacting with the host environment, offering structured access to environment variables,
   * system properties, and platform-specific information.
   *
-  * The API follows Kyo's effect model with IO-wrapped operations and features strongly-typed parsing capabilities through the Parser type
+  * The API follows Kyo's effect model with Sync-wrapped operations and features strongly-typed parsing capabilities through the Parser type
   * class. This allows for safe, composable interactions with the system environment while maintaining proper effect tracking.
   *
   * Key features:

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -37,11 +37,11 @@ import java.time.format.DateTimeParseException
   */
 abstract class System extends Serializable:
     def unsafe: System.Unsafe
-    def env[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & IO)
-    def property[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & IO)
-    def lineSeparator(using Frame): String < IO
-    def userName(using Frame): String < IO
-    def operatingSystem(using Frame): System.OS < IO
+    def env[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync)
+    def property[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync)
+    def lineSeparator(using Frame): String < Sync
+    def userName(using Frame): String < Sync
+    def operatingSystem(using Frame): System.OS < Sync
 end System
 
 /** Companion object for System, containing utility methods and type classes. */
@@ -63,22 +63,22 @@ object System:
 
     def apply(u: Unsafe): System =
         new System:
-            def env[E, A](name: String)(using p: Parser[E, A], frame: Frame): Maybe[A] < (Abort[E] & IO) =
-                IO.Unsafe {
+            def env[E, A](name: String)(using p: Parser[E, A], frame: Frame): Maybe[A] < (Abort[E] & Sync) =
+                Sync.Unsafe {
                     u.env(name) match
                         case Absent     => Absent
                         case Present(v) => Abort.get(p(v).map(Maybe(_)))
                 }
-            def property[E, A](name: String)(using p: Parser[E, A], frame: Frame): Maybe[A] < (Abort[E] & IO) =
-                IO.Unsafe {
+            def property[E, A](name: String)(using p: Parser[E, A], frame: Frame): Maybe[A] < (Abort[E] & Sync) =
+                Sync.Unsafe {
                     u.property(name) match
                         case Absent     => Absent
                         case Present(v) => Abort.get(p(v).map(Maybe(_)))
                 }
-            def lineSeparator(using Frame): String < IO = IO.Unsafe(u.lineSeparator())
-            def userName(using Frame): String < IO      = IO.Unsafe(u.userName())
-            def operatingSystem(using Frame): OS < IO   = IO.Unsafe(u.operatingSystem())
-            def unsafe: Unsafe                          = u
+            def lineSeparator(using Frame): String < Sync = Sync.Unsafe(u.lineSeparator())
+            def userName(using Frame): String < Sync      = Sync.Unsafe(u.userName())
+            def operatingSystem(using Frame): OS < Sync   = Sync.Unsafe(u.operatingSystem())
+            def unsafe: Unsafe                            = u
 
     private val local = Local.init(live)
 
@@ -132,7 +132,7 @@ object System:
       * @return
       *   A `Maybe` containing the parsed value if it exists, or `Maybe.empty` otherwise.
       */
-    def env[A](using Frame)[E](name: String)(using parser: Parser[E, A], reduce: Reducible[Abort[E]]): Maybe[A] < (reduce.SReduced & IO) =
+    def env[A](using Frame)[E](name: String)(using parser: Parser[E, A], reduce: Reducible[Abort[E]]): Maybe[A] < (reduce.SReduced & Sync) =
         reduce(local.use(_.env[E, A](name)))
 
     /** Retrieves an environment variable with a default value.
@@ -152,7 +152,7 @@ object System:
         using
         parser: Parser[E, A],
         reduce: Reducible[Abort[E]]
-    ): A < (reduce.SReduced & IO) =
+    ): A < (reduce.SReduced & Sync) =
         reduce(local.use(_.env[E, A](name).map(_.getOrElse(default))))
 
     /** Retrieves a system property.
@@ -170,7 +170,7 @@ object System:
         using
         parser: Parser[E, A],
         reduce: Reducible[Abort[E]]
-    ): Maybe[A] < (reduce.SReduced & IO) =
+    ): Maybe[A] < (reduce.SReduced & Sync) =
         reduce(local.use(_.property[E, A](name)))
 
     /** Retrieves a system property with a default value.
@@ -190,17 +190,17 @@ object System:
         using
         parser: Parser[E, A],
         reduce: Reducible[Abort[E]]
-    ): A < (reduce.SReduced & IO) =
+    ): A < (reduce.SReduced & Sync) =
         reduce(local.use(_.property[E, A](name).map(_.getOrElse(default))))
 
     /** Retrieves the system-dependent line separator string. */
-    def lineSeparator(using Frame): String < IO = local.use(_.lineSeparator)
+    def lineSeparator(using Frame): String < Sync = local.use(_.lineSeparator)
 
     /** Retrieves the user name of the current user. */
-    def userName(using Frame): String < IO = local.use(_.userName)
+    def userName(using Frame): String < Sync = local.use(_.userName)
 
     /** Retrieves the current operating system. */
-    def operatingSystem(using Frame): OS < IO = local.use(_.operatingSystem)
+    def operatingSystem(using Frame): OS < Sync = local.use(_.operatingSystem)
 
     /** Abstract class for parsing string values into specific types. */
     sealed abstract class Parser[E, A] extends Serializable:

--- a/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
@@ -15,7 +15,7 @@ private[kyo] trait BaseKyoCoreTest extends BaseKyoKernelTest[Abort[Any] & Async 
             Async.timeout(timeout),
             Async.run,
             _.map(_.toFuture).map(_.flatten),
-            IO.Unsafe.evalOrThrow
+            Sync.Unsafe.evalOrThrow
         )
     end run
 

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -61,7 +61,7 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
                                             this.interrupts(input)
                                             input.onComplete { r =>
                                                 this.removeInterrupt(input)
-                                                curr = IO(cont(r.asInstanceOf[Result[Nothing, C]]))
+                                                curr = Sync(cont(r.asInstanceOf[Result[Nothing, C]]))
                                                 Scheduler.get.schedule(this)
                                             }
                                             nullResult

--- a/kyo-core/shared/src/main/scala/kyo/stats/internal/Span.scala
+++ b/kyo-core/shared/src/main/scala/kyo/stats/internal/Span.scala
@@ -7,11 +7,11 @@ import scala.annotation.tailrec
 
 final case class Span(unsafe: Span.Unsafe):
 
-    def end(using Frame): Unit < IO =
-        IO(unsafe.end())
+    def end(using Frame): Unit < Sync =
+        Sync(unsafe.end())
 
-    def event(name: String, a: Attributes)(using Frame): Unit < IO =
-        IO(unsafe.event(name, a))
+    def event(name: String, a: Attributes)(using Frame): Unit < Sync =
+        Sync(unsafe.event(name, a))
 end Span
 
 object Span:
@@ -62,12 +62,12 @@ object Span:
         scope: List[String],
         name: String,
         attributes: Attributes = Attributes.empty
-    )(v: => A < S)(using Frame): A < (IO & S) =
+    )(v: => A < S)(using Frame): A < (Sync & S) =
         currentSpan.use { parent =>
             receiver
                 .startSpan(scope, name, parent, attributes)
                 .map { child =>
-                    IO.ensure(child.end) {
+                    Sync.ensure(child.end) {
                         currentSpan.let(Maybe(child))(v)
                     }
                 }

--- a/kyo-core/shared/src/main/scala/kyo/stats/internal/TraceReceiver.scala
+++ b/kyo-core/shared/src/main/scala/kyo/stats/internal/TraceReceiver.scala
@@ -13,7 +13,7 @@ trait TraceReceiver extends Serializable:
         name: String,
         parent: Maybe[Span] = Maybe.empty,
         attributes: Attributes = Attributes.empty
-    )(using Frame): Span < IO
+    )(using Frame): Span < Sync
 end TraceReceiver
 
 object TraceReceiver:

--- a/kyo-core/shared/src/test/scala/Issue1232.scala
+++ b/kyo-core/shared/src/test/scala/Issue1232.scala
@@ -3,10 +3,10 @@ package example
 import kyo.*
 
 class Issue1232 extends Test:
-    "IO.ensure" in run {
+    "Sync.ensure" in run {
         val result = typeCheck("""
           def hello: Unit = ()
-          val io = IO.ensure(hello)(1)""")
+          val io = Sync.ensure(hello)(1)""")
 
         assert(result == Result.succeed(()))
     }

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -29,7 +29,7 @@ class AsyncTest extends Test:
         "nested" in runNotJS {
             val t1 = Thread.currentThread()
             for
-                t2 <- Async.run(IO(Async.run(Thread.currentThread()).map(_.get))).map(_.get)
+                t2 <- Async.run(Sync(Async.run(Thread.currentThread()).map(_.get))).map(_.get)
             yield assert(t1 ne t2)
         }
 
@@ -50,17 +50,17 @@ class AsyncTest extends Test:
 
     "sleep" in run {
         for
-            start <- IO(java.lang.System.currentTimeMillis())
+            start <- Sync(java.lang.System.currentTimeMillis())
             _     <- Async.sleep(10.millis)
-            end   <- IO(java.lang.System.currentTimeMillis())
+            end   <- Sync(java.lang.System.currentTimeMillis())
         yield assert(end - start >= 8)
     }
 
     "delay" in run {
         for
-            start <- IO(java.lang.System.currentTimeMillis())
+            start <- Sync(java.lang.System.currentTimeMillis())
             res   <- Async.delay(5.millis)(42)
-            end   <- IO(java.lang.System.currentTimeMillis())
+            end   <- Sync(java.lang.System.currentTimeMillis())
         yield
             assert(end - start >= 4)
             assert(res == 42)
@@ -107,7 +107,7 @@ class AsyncTest extends Test:
 
     "interrupt" - {
 
-        def loop(ref: AtomicInt): Unit < IO =
+        def loop(ref: AtomicInt): Unit < Sync =
             ref.incrementAndGet.map(_ => loop(ref))
 
         def runLoop(started: Latch, done: Latch) =
@@ -157,8 +157,8 @@ class AsyncTest extends Test:
         "multiple" in run {
             val ac = new JAtomicInteger(0)
             val bc = new JAtomicInteger(0)
-            def loop(i: Int, s: String): String < IO =
-                IO {
+            def loop(i: Int, s: String): String < Sync =
+                Sync {
                     if i > 0 then
                         if s.equals("a") then ac.incrementAndGet()
                         else bc.incrementAndGet()
@@ -214,8 +214,8 @@ class AsyncTest extends Test:
         "n" in run {
             val ac = new JAtomicInteger(0)
             val bc = new JAtomicInteger(0)
-            def loop(i: Int, s: String): String < IO =
-                IO {
+            def loop(i: Int, s: String): String < Sync =
+                Sync {
                     if i > 0 then
                         if s.equals("a") then ac.incrementAndGet()
                         else bc.incrementAndGet()
@@ -231,12 +231,12 @@ class AsyncTest extends Test:
         }
         "three arguments" in run {
             for
-                (v1, v2, v3) <- Async.zip(IO(1), IO(2), IO(3))
+                (v1, v2, v3) <- Async.zip(Sync(1), Sync(2), Sync(3))
             yield assert(v1 == 1 && v2 == 2 && v3 == 3)
         }
         "four arguments" in run {
             for
-                (v1, v2, v3, v4) <- Async.zip(IO(1), IO(2), IO(3), IO(4))
+                (v1, v2, v3, v4) <- Async.zip(Sync(1), Sync(2), Sync(3), Sync(4))
             yield assert(v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4)
         }
     }
@@ -280,7 +280,7 @@ class AsyncTest extends Test:
             val io1: (JAtomicInteger & Closeable, Set[Int]) < (Resource & Async) =
                 for
                     r  <- Resource.acquire(resource1)
-                    v1 <- IO(r.incrementAndGet())
+                    v1 <- Sync(r.incrementAndGet())
                     v2 <- Async.run(r.incrementAndGet()).map(_.get)
                 yield (r, Set(v1, v2))
             Resource.run(io1).map {
@@ -315,7 +315,7 @@ class AsyncTest extends Test:
             val io1: Set[Int] < (Resource & Async) =
                 for
                     r  <- Resource.acquire(resource1)
-                    v1 <- IO(r.incrementAndGet())
+                    v1 <- Sync(r.incrementAndGet())
                     v2 <- Async.run(r.incrementAndGet()).map(_.get)
                     v3 <- Resource.run(Resource.acquire(resource2).map(_.incrementAndGet()))
                 yield Set(v1, v2, v3)
@@ -413,8 +413,8 @@ class AsyncTest extends Test:
     "boundary inference with Abort" - {
         "same failures" in {
             val v: Int < Abort[Int]                            = 1
-            val _: Fiber[Int, Int] < IO                        = Async.run(v)
-            val _: Int < (Abort[Int | Timeout] & IO)           = Async.runAndBlock(1.second)(v)
+            val _: Fiber[Int, Int] < Sync                      = Async.run(v)
+            val _: Int < (Abort[Int | Timeout] & Sync)         = Async.runAndBlock(1.second)(v)
             val _: Int < (Abort[Int] & Async)                  = Async.mask(v)
             val _: Int < (Abort[Int | Timeout] & Async)        = Async.timeout(1.second)(v)
             val _: Int < (Abort[Int] & Async)                  = Async.race(Seq(v))
@@ -427,8 +427,8 @@ class AsyncTest extends Test:
         }
         "additional failure" in {
             val v: Int < Abort[Int]                                     = 1
-            val _: Fiber[Int | String, Int] < IO                        = Async.run(v)
-            val _: Int < (Abort[Int | Timeout | String] & IO)           = Async.runAndBlock(1.second)(v)
+            val _: Fiber[Int | String, Int] < Sync                      = Async.run(v)
+            val _: Int < (Abort[Int | Timeout | String] & Sync)         = Async.runAndBlock(1.second)(v)
             val _: Int < (Abort[Int | String] & Async)                  = Async.mask(v)
             val _: Int < (Abort[Int | Timeout | String] & Async)        = Async.timeout(1.second)(v)
             val _: Int < (Abort[Int | String] & Async)                  = Async.race(Seq(v))
@@ -443,16 +443,16 @@ class AsyncTest extends Test:
             "run" in {
                 val v: Int < Abort[Int] = 1
 
-                val _: Fiber[Nothing, Fiber[Int, Int]] < IO  = Async.run(Async.run(v))
-                val _: Fiber[Int | Timeout, Int] < IO        = Async.run(Async.runAndBlock(1.second)(v))
-                val _: Fiber[Int, Int] < IO                  = Async.run(Async.mask(v))
-                val _: Fiber[Int | Timeout, Int] < IO        = Async.run(Async.timeout(1.second)(v))
-                val _: Fiber[Int, Int] < IO                  = Async.run(Async.race(Seq(v)))
-                val _: Fiber[Int, Int] < IO                  = Async.run(Async.race(v, v))
-                val x: Fiber[Int, Seq[Int]] < IO             = Async.run(Async.collectAll(Seq(v)))
-                val _: Fiber[Int, (Int, Int)] < IO           = Async.run(Async.zip(v, v))
-                val _: Fiber[Int, (Int, Int, Int)] < IO      = Async.run(Async.zip(v, v, v))
-                val _: Fiber[Int, (Int, Int, Int, Int)] < IO = Async.run(Async.zip(v, v, v, v))
+                val _: Fiber[Nothing, Fiber[Int, Int]] < Sync  = Async.run(Async.run(v))
+                val _: Fiber[Int | Timeout, Int] < Sync        = Async.run(Async.runAndBlock(1.second)(v))
+                val _: Fiber[Int, Int] < Sync                  = Async.run(Async.mask(v))
+                val _: Fiber[Int | Timeout, Int] < Sync        = Async.run(Async.timeout(1.second)(v))
+                val _: Fiber[Int, Int] < Sync                  = Async.run(Async.race(Seq(v)))
+                val _: Fiber[Int, Int] < Sync                  = Async.run(Async.race(v, v))
+                val x: Fiber[Int, Seq[Int]] < Sync             = Async.run(Async.collectAll(Seq(v)))
+                val _: Fiber[Int, (Int, Int)] < Sync           = Async.run(Async.zip(v, v))
+                val _: Fiber[Int, (Int, Int, Int)] < Sync      = Async.run(Async.zip(v, v, v))
+                val _: Fiber[Int, (Int, Int, Int, Int)] < Sync = Async.run(Async.zip(v, v, v, v))
                 succeed
             }
 
@@ -508,12 +508,12 @@ class AsyncTest extends Test:
             "runAndBlock" in {
                 val v: Int < Abort[Int] = 1
 
-                val _: Fiber[Int, Int] < (Abort[Timeout] & IO)  = Async.runAndBlock(1.second)(Async.run(v))
-                val _: Int < (Abort[Int | Timeout] & IO)        = Async.runAndBlock(1.second)(Async.runAndBlock(1.second)(v))
-                val _: Int < (Abort[Int | Timeout] & IO)        = Async.runAndBlock(1.second)(Async.mask(v))
-                val _: Int < (Abort[Int | Timeout] & IO)        = Async.runAndBlock(1.second)(Async.timeout(1.second)(v))
-                val _: Int < (Abort[Int | Timeout] & IO)        = Async.runAndBlock(1.second)(Async.race(v, v))
-                val _: (Int, Int) < (Abort[Int | Timeout] & IO) = Async.runAndBlock(1.second)(Async.zip(v, v))
+                val _: Fiber[Int, Int] < (Abort[Timeout] & Sync)  = Async.runAndBlock(1.second)(Async.run(v))
+                val _: Int < (Abort[Int | Timeout] & Sync)        = Async.runAndBlock(1.second)(Async.runAndBlock(1.second)(v))
+                val _: Int < (Abort[Int | Timeout] & Sync)        = Async.runAndBlock(1.second)(Async.mask(v))
+                val _: Int < (Abort[Int | Timeout] & Sync)        = Async.runAndBlock(1.second)(Async.timeout(1.second)(v))
+                val _: Int < (Abort[Int | Timeout] & Sync)        = Async.runAndBlock(1.second)(Async.race(v, v))
+                val _: (Int, Int) < (Abort[Int | Timeout] & Sync) = Async.runAndBlock(1.second)(Async.zip(v, v))
                 succeed
             }
         }
@@ -641,7 +641,7 @@ class AsyncTest extends Test:
 
         "sequence larger than parallelism" in run {
             AtomicInt.init.map { counter =>
-                def task(i: Int): Int < (IO & Async) =
+                def task(i: Int): Int < (Sync & Async) =
                     for
                         current <- counter.getAndIncrement
                         _       <- Async.sleep(1.millis)
@@ -661,7 +661,7 @@ class AsyncTest extends Test:
 
         "parallelism of 1 executes sequentially" in run {
             AtomicInt.init.map { counter =>
-                def task(i: Int): Int < (IO & Async) =
+                def task(i: Int): Int < (Sync & Async) =
                     for
                         current <- counter.getAndIncrement
                         _       <- Async.sleep(1.millis)
@@ -858,13 +858,13 @@ class AsyncTest extends Test:
         "sequence" - {
             "delegates to Fiber.gather" in run {
                 for
-                    result <- Async.gather(Seq(IO(1), IO(2), IO(3)))
+                    result <- Async.gather(Seq(Sync(1), Sync(2), Sync(3)))
                 yield assert(result == Chunk(1, 2, 3))
             }
 
             "with max limit delegates to Fiber.gather" in run {
                 for
-                    result <- Async.gather(2)(Seq(IO(1), IO(2), IO(3)))
+                    result <- Async.gather(2)(Seq(Sync(1), Sync(2), Sync(3)))
                 yield
                     assert(result.size == 2)
                     assert(result.forall(Seq(1, 2, 3).contains))
@@ -874,13 +874,13 @@ class AsyncTest extends Test:
         "varargs" - {
             "delegates to sequence-based gather" in run {
                 for
-                    result <- Async.gather(IO(1), IO(2), IO(3))
+                    result <- Async.gather(Sync(1), Sync(2), Sync(3))
                 yield assert(result == Chunk(1, 2, 3))
             }
 
             "with max limit delegates to sequence-based gather" in run {
                 for
-                    result <- Async.gather(2)(IO(1), IO(2), IO(3))
+                    result <- Async.gather(2)(Sync(1), Sync(2), Sync(3))
                 yield
                     assert(result.size == 2)
                     assert(result.forall(Seq(1, 2, 3).contains))
@@ -1104,16 +1104,16 @@ class AsyncTest extends Test:
         }
         "with nested eval" in run {
             import AllowUnsafe.embrace.danger
-            val task = IO.Unsafe.evalOrThrow(Async.run(Async.delay(100.millis)(42)))
+            val task = Sync.Unsafe.evalOrThrow(Async.run(Async.delay(100.millis)(42)))
             Async.run(task).map(_.get).map(_.get).map { result =>
                 assert(result == 42)
             }
         }
         "with multiple nested evals" in run {
             import AllowUnsafe.embrace.danger
-            val innerTask  = IO.Unsafe.evalOrThrow(Async.run(Async.delay(100.millis)(42)))
-            val middleTask = IO.Unsafe.evalOrThrow(Async.run(innerTask))
-            val outerTask  = IO.Unsafe.evalOrThrow(Async.run(middleTask))
+            val innerTask  = Sync.Unsafe.evalOrThrow(Async.run(Async.delay(100.millis)(42)))
+            val middleTask = Sync.Unsafe.evalOrThrow(Async.run(innerTask))
+            val outerTask  = Sync.Unsafe.evalOrThrow(Async.run(middleTask))
             Async.run(outerTask).map(_.get).map(_.get).map(_.get).map(_.get).map { result =>
                 assert(result == 42)
             }
@@ -1122,7 +1122,7 @@ class AsyncTest extends Test:
             import AllowUnsafe.embrace.danger
             Async.run {
                 Async.delay(100.millis) {
-                    IO.Unsafe.evalOrThrow(Async.run(42)).get
+                    Sync.Unsafe.evalOrThrow(Async.run(42)).get
                 }
             }.map(_.get).map { result =>
                 assert(result == 42)
@@ -1130,11 +1130,11 @@ class AsyncTest extends Test:
         }
         "with interleaved evals and delays" in run {
             import AllowUnsafe.embrace.danger
-            val task1 = IO.Unsafe.evalOrThrow(Async.run(Async.delay(100.millis)(1)))
+            val task1 = Sync.Unsafe.evalOrThrow(Async.run(Async.delay(100.millis)(1)))
             val task2 = Async.delay(100.millis) {
-                IO.Unsafe.evalOrThrow(Async.run(task1)).get
+                Sync.Unsafe.evalOrThrow(Async.run(task1)).get
             }
-            val task3 = IO.Unsafe.evalOrThrow(Async.run(task2))
+            val task3 = Sync.Unsafe.evalOrThrow(Async.run(task2))
             Async.run(task3).map(_.get).map(_.get).map(_.get).map { result =>
                 assert(result == 1)
             }
@@ -1258,7 +1258,7 @@ class AsyncTest extends Test:
                 sleeping <- Latch.init(1)
                 done     <- Latch.init(1)
                 memoized <- Async.memoize {
-                    IO.ensure(done.release) {
+                    Sync.ensure(done.release) {
                         for
                             _     <- started.release
                             _     <- Async.sleep(50.millis)
@@ -1320,15 +1320,15 @@ class AsyncTest extends Test:
         "executes nine computations in parallel" in run {
             for
                 result <- Async.zip(
-                    IO(1),
-                    IO(2),
-                    IO(3),
-                    IO(4),
-                    IO(5),
-                    IO(6),
-                    IO(7),
-                    IO(8),
-                    IO(9)
+                    Sync(1),
+                    Sync(2),
+                    Sync(3),
+                    Sync(4),
+                    Sync(5),
+                    Sync(6),
+                    Sync(7),
+                    Sync(8),
+                    Sync(9)
                 )
             yield assert(result == (1, 2, 3, 4, 5, 6, 7, 8, 9))
         }
@@ -1336,16 +1336,16 @@ class AsyncTest extends Test:
         "executes ten computations in parallel" in run {
             for
                 result <- Async.zip(
-                    IO(1),
-                    IO(2),
-                    IO(3),
-                    IO(4),
-                    IO(5),
-                    IO(6),
-                    IO(7),
-                    IO(8),
-                    IO(9),
-                    IO(10)
+                    Sync(1),
+                    Sync(2),
+                    Sync(3),
+                    Sync(4),
+                    Sync(5),
+                    Sync(6),
+                    Sync(7),
+                    Sync(8),
+                    Sync(9),
+                    Sync(10)
                 )
             yield assert(result == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
         }

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -33,7 +33,7 @@ class AsyncTest extends Test:
             yield assert(t1 ne t2)
         }
 
-        "with IO-based effects" - {
+        "with Sync-based effects" - {
             "Resource" in run {
                 var closes = 0
                 val a      = Resource.ensure(closes += 1).andThen(42)
@@ -41,7 +41,7 @@ class AsyncTest extends Test:
                 Resource.run(b.map(_.get.map(v => assert(v == 42))))
             }
         }
-        "non IO-based effect" in run {
+        "non Sync-based effect" in run {
             typeCheckFailure("Async.run(Var.get[Int])")(
                 "This operation requires Contextual isolation for effects"
             )

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -511,7 +511,7 @@ class ChannelTest extends Test:
     }
 
     "Kyo computations" - {
-        "IO" in run {
+        "Sync" in run {
             for
                 channel <- Channel.init[Int < Sync](2)
                 _       <- channel.put(Sync(42))

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -513,15 +513,15 @@ class ChannelTest extends Test:
     "Kyo computations" - {
         "IO" in run {
             for
-                channel <- Channel.init[Int < IO](2)
-                _       <- channel.put(IO(42))
+                channel <- Channel.init[Int < Sync](2)
+                _       <- channel.put(Sync(42))
                 result  <- channel.take.flatten
             yield assert(result == 42)
         }
         "AtomicBoolean" in run {
             for
                 flag    <- AtomicBoolean.init(false)
-                channel <- Channel.init[Int < IO](2)
+                channel <- Channel.init[Int < Sync](2)
                 _       <- channel.put(flag.set(true).andThen(42))
                 before  <- flag.get
                 result  <- channel.take.flatten
@@ -1167,7 +1167,7 @@ class ChannelTest extends Test:
 
     private def verifyRaceDrainWithClose(
         capacity: Int,
-        drain: Channel[Int] => Any < (Abort[Closed] & IO),
+        drain: Channel[Int] => Any < (Abort[Closed] & Sync),
         close: Channel[Int] => (Any < Async)
     ) =
         for

--- a/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
@@ -56,7 +56,7 @@ class ClockTest extends Test:
             Clock.withTimeControl { control =>
                 for
                     clock     <- Clock.get
-                    stopwatch <- IO.Unsafe(clock.unsafe.stopwatch())
+                    stopwatch <- Sync.Unsafe(clock.unsafe.stopwatch())
                     _         <- control.advance(5.seconds)
                 yield assert(stopwatch.elapsed() == 5.seconds)
                 end for
@@ -102,7 +102,7 @@ class ClockTest extends Test:
             Clock.withTimeControl { control =>
                 for
                     clock    <- Clock.get
-                    deadline <- IO.Unsafe(clock.unsafe.deadline(10.seconds))
+                    deadline <- Sync.Unsafe(clock.unsafe.deadline(10.seconds))
                     _        <- control.advance(3.seconds)
                 yield assert(deadline.timeLeft() == 7.seconds)
             }
@@ -113,7 +113,7 @@ class ClockTest extends Test:
             Clock.withTimeControl { control =>
                 for
                     deadline <- Clock.deadline(5.seconds)
-                    _        <- IO.Unsafe(assert(!deadline.unsafe.isOverdue()))
+                    _        <- Sync.Unsafe(assert(!deadline.unsafe.isOverdue()))
                     _        <- control.advance(6.seconds)
                 yield assert(deadline.unsafe.isOverdue())
             }

--- a/kyo-core/shared/src/test/scala/kyo/ConsoleTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ConsoleTest.scala
@@ -44,7 +44,7 @@ class ConsoleTest extends Test:
         scala.Console.withOut(buffer) {
             import AllowUnsafe.embrace.danger
             val (r1, r2) =
-                IO.Unsafe.evalOrThrow {
+                Sync.Unsafe.evalOrThrow {
                     for
                         r1 <- Abort.run(Console.print("test"))
                         r2 <- Abort.run(Console.checkErrors)
@@ -61,7 +61,7 @@ class ConsoleTest extends Test:
         scala.Console.withErr(buffer) {
             import AllowUnsafe.embrace.danger
             val (r1, r2) =
-                IO.Unsafe.evalOrThrow {
+                Sync.Unsafe.evalOrThrow {
                     for
                         r1 <- Abort.run(Console.printErr("test"))
                         r2 <- Abort.run(Console.checkErrors)
@@ -81,7 +81,7 @@ class ConsoleTest extends Test:
                 override def write(b: Int): Unit = error.append(b.toChar))) {
                 import AllowUnsafe.embrace.danger
                 val (r1, r2, r3, r4) =
-                    IO.Unsafe.evalOrThrow {
+                    Sync.Unsafe.evalOrThrow {
                         for
                             r1 <- Abort.run(Console.print("test"))
                             r2 <- Abort.run(Console.printLine(" message"))

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -245,7 +245,7 @@ class FiberTest extends Test:
             yield assert(result == Seq())
         }
 
-        "small collection + IO" in run {
+        "small collection + Sync" in run {
             for
                 fiber  <- Fiber.foreachIndexed(Seq(1, 2, 3))((idx, v) => Sync((idx, v)))
                 result <- fiber.get

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -132,8 +132,8 @@ class FiberTest extends Test:
             }
         }
         "n" in run {
-            def loop(i: Int, s: String): String < (Abort[String] & IO) =
-                IO {
+            def loop(i: Int, s: String): String < (Abort[String] & Sync) =
+                Sync {
                     if i == 80 && s == "a" then
                         Abort.fail("Loser")
                     else if i <= 0 then s
@@ -157,8 +157,8 @@ class FiberTest extends Test:
                 }
             }
             "n" in run {
-                def loop(i: Int, s: String): String < (Abort[String] & IO) =
-                    IO {
+                def loop(i: Int, s: String): String < (Abort[String] & Sync) =
+                    Sync {
                         if i == 80 && s == "a" then
                             Abort.fail("Winner")
                         else if i <= 0 then s
@@ -247,7 +247,7 @@ class FiberTest extends Test:
 
         "small collection + IO" in run {
             for
-                fiber  <- Fiber.foreachIndexed(Seq(1, 2, 3))((idx, v) => IO((idx, v)))
+                fiber  <- Fiber.foreachIndexed(Seq(1, 2, 3))((idx, v) => Sync((idx, v)))
                 result <- fiber.get
             yield assert(result == Seq((0, 1), (1, 2), (2, 3)))
         }
@@ -255,8 +255,8 @@ class FiberTest extends Test:
         "error propagation" in run {
             val error = new Exception("test error")
             for
-                fiber <- IO {
-                    def task(idx: Int, v: Int): Int < (IO & Async & Abort[Throwable]) =
+                fiber <- Sync {
+                    def task(idx: Int, v: Int): Int < (Sync & Async & Abort[Throwable]) =
                         if v == 3 then Abort.fail(error)
                         else v
 
@@ -424,7 +424,7 @@ class FiberTest extends Test:
             var completed = false
             val fiber     = Fiber.success(42)
             for
-                _ <- fiber.onComplete(_ => IO { completed = true })
+                _ <- fiber.onComplete(_ => Sync { completed = true })
             yield assert(completed)
             end for
         }
@@ -433,7 +433,7 @@ class FiberTest extends Test:
             var completed = Maybe.empty[Result[Any, Int]]
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onComplete(v => IO { completed = Maybe(v) })
+                _     <- fiber.onComplete(v => Sync { completed = Maybe(v) })
                 notCompletedYet = completed
                 _ <- fiber.complete(Result.succeed(42))
                 completedAfterWait = completed
@@ -449,7 +449,7 @@ class FiberTest extends Test:
             var interrupted = false
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onInterrupt(_ => IO { interrupted = true })
+                _     <- fiber.onInterrupt(_ => Sync { interrupted = true })
                 _     <- fiber.interrupt
             yield assert(interrupted)
             end for
@@ -459,7 +459,7 @@ class FiberTest extends Test:
             var interrupted = false
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onInterrupt(_ => IO { interrupted = true })
+                _     <- fiber.onInterrupt(_ => Sync { interrupted = true })
                 _     <- fiber.complete(Result.succeed(42))
                 _     <- fiber.get
             yield assert(!interrupted)
@@ -470,9 +470,9 @@ class FiberTest extends Test:
             var count = 0
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onInterrupt(_ => IO { count += 1 })
-                _     <- fiber.onInterrupt(_ => IO { count += 1 })
-                _     <- fiber.onInterrupt(_ => IO { count += 1 })
+                _     <- fiber.onInterrupt(_ => Sync { count += 1 })
+                _     <- fiber.onInterrupt(_ => Sync { count += 1 })
+                _     <- fiber.onInterrupt(_ => Sync { count += 1 })
                 _     <- fiber.interrupt
             yield assert(count == 3)
             end for
@@ -680,15 +680,15 @@ class FiberTest extends Test:
 
     "boundary inference with Abort" - {
         "same failures" in {
-            val v: Int < Abort[Int]          = 1
-            val _: Fiber[Int, Int] < IO      = Fiber.race(Seq(v))
-            val _: Fiber[Int, Seq[Int]] < IO = Fiber.foreachIndexed(Seq(v))((_, v) => v)
+            val v: Int < Abort[Int]            = 1
+            val _: Fiber[Int, Int] < Sync      = Fiber.race(Seq(v))
+            val _: Fiber[Int, Seq[Int]] < Sync = Fiber.foreachIndexed(Seq(v))((_, v) => v)
             succeed
         }
         "additional failure" in {
-            val v: Int < Abort[Int]                   = 1
-            val _: Fiber[Int | String, Int] < IO      = Fiber.race(Seq(v))
-            val _: Fiber[Int | String, Seq[Int]] < IO = Fiber.foreachIndexed(Seq(v))((_, v) => v)
+            val v: Int < Abort[Int]                     = 1
+            val _: Fiber[Int | String, Int] < Sync      = Fiber.race(Seq(v))
+            val _: Fiber[Int | String, Seq[Int]] < Sync = Fiber.foreachIndexed(Seq(v))((_, v) => v)
             succeed
         }
     }
@@ -707,7 +707,7 @@ class FiberTest extends Test:
         "collects all successful results" in run {
             Loop.repeat(repeats) {
                 for
-                    fiber  <- Fiber.gather(3)(Seq(IO(1), IO(2), IO(3)))
+                    fiber  <- Fiber.gather(3)(Seq(Sync(1), Sync(2), Sync(3)))
                     result <- fiber.get
                 yield
                     assert(result == Chunk(1, 2, 3))
@@ -718,7 +718,7 @@ class FiberTest extends Test:
         "with max limit" in run {
             val seq = Seq(1, 2, 3)
             for
-                fiber  <- Fiber.gather(2)(seq.map(IO(_)))
+                fiber  <- Fiber.gather(2)(seq.map(Sync(_)))
                 result <- fiber.get
             yield
                 assert(result.distinct.size == 2)
@@ -728,7 +728,7 @@ class FiberTest extends Test:
 
         "handles max=0" in run {
             for
-                fiber  <- Fiber.gather(0)(Seq(IO(1), IO(2), IO(3)))
+                fiber  <- Fiber.gather(0)(Seq(Sync(1), Sync(2), Sync(3)))
                 result <- fiber.get
             yield assert(result.isEmpty)
         }
@@ -739,7 +739,7 @@ class FiberTest extends Test:
                 fiber <- Fiber.gather(1)(Seq(
                     Abort.fail[Exception](error),
                     Abort.fail[Exception](error),
-                    IO(3)
+                    Sync(3)
                 ))
                 result <- fiber.get
             yield assert(result == Chunk(3))
@@ -748,7 +748,7 @@ class FiberTest extends Test:
 
         "handles negative max" in run {
             for
-                fiber  <- Fiber.gather(-1)(Seq(IO(1), IO(2), IO(3)))
+                fiber  <- Fiber.gather(-1)(Seq(Sync(1), Sync(2), Sync(3)))
                 result <- fiber.get
             yield assert(result.isEmpty)
         }
@@ -756,7 +756,7 @@ class FiberTest extends Test:
         "handles max > size" in run {
             val seq = Seq(1, 2, 3)
             for
-                fiber  <- Fiber.gather(10)(seq.map(IO(_)))
+                fiber  <- Fiber.gather(10)(seq.map(Sync(_)))
                 result <- fiber.get
             yield assert(result == Chunk(1, 2, 3))
             end for
@@ -766,9 +766,9 @@ class FiberTest extends Test:
             val error = new Exception("test error")
             for
                 fiber <- Fiber.gather(10)(Seq(
-                    IO(1),
+                    Sync(1),
                     Abort.fail[Exception](error),
-                    IO(3)
+                    Sync(3)
                 ))
                 result <- fiber.get
             yield assert(result == Chunk(1, 3))
@@ -811,9 +811,9 @@ class FiberTest extends Test:
         "filters out failures" in run {
             for
                 fiber <- Fiber.gather(3)(Seq(
-                    IO(1),
+                    Sync(1),
                     Abort.fail[Exception](error),
-                    IO(3)
+                    Sync(3)
                 ))
                 result <- fiber.get
             yield assert(result == Chunk(1, 3))
@@ -886,10 +886,10 @@ class FiberTest extends Test:
         "max limit with failures" in run {
             for
                 fiber <- Fiber.gather(2)(Seq(
-                    IO(1),
+                    Sync(1),
                     Abort.fail[Exception](error),
-                    IO(3),
-                    IO(4)
+                    Sync(3),
+                    Sync(4)
                 ))
                 result <- fiber.get
             yield

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
@@ -27,7 +27,7 @@ class KyoAppTest extends Test:
                 run { ref.getAndIncrement }
                 run { ref.getAndIncrement }
 
-            _    <- IO(app.main(Array.empty))
+            _    <- Sync(app.main(Array.empty))
             runs <- ref.get
         yield assert(runs == 3)
     }
@@ -36,10 +36,10 @@ class KyoAppTest extends Test:
         val x       = new ListBuffer[Int]
         val promise = scala.concurrent.Promise[Assertion]()
         val app = new KyoApp:
-            run { Async.delay(10.millis)(IO(x += 1)) }
-            run { Async.delay(10.millis)(IO(x += 2)) }
-            run { Async.delay(10.millis)(IO(x += 3)) }
-            run { IO(promise.complete(Try(assert(x.toList == List(1, 2, 3))))) }
+            run { Async.delay(10.millis)(Sync(x += 1)) }
+            run { Async.delay(10.millis)(Sync(x += 2)) }
+            run { Async.delay(10.millis)(Sync(x += 3)) }
+            run { Sync(promise.complete(Try(assert(x.toList == List(1, 2, 3))))) }
         app.main(Array.empty)
         promise.future
     }

--- a/kyo-core/shared/src/test/scala/kyo/LogTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/LogTest.scala
@@ -43,7 +43,7 @@ class LogTest extends Test:
             override def write(b: Int): Unit = output.append(b.toChar))) {
             import AllowUnsafe.embrace.danger
             val text: Text = "info message - hidden"
-            IO.Unsafe.evalOrThrow {
+            Sync.Unsafe.evalOrThrow {
                 for
                     _ <- Log.withConsoleLogger("test.logger", Log.Level.debug) {
                         for

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -382,7 +382,7 @@ class QueueTest extends Test:
     end if
 
     "Kyo computations" - {
-        "IO" in run {
+        "Sync" in run {
             for
                 queue  <- Queue.init[Int < Sync](2)
                 _      <- queue.offer(Sync(42))

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -384,15 +384,15 @@ class QueueTest extends Test:
     "Kyo computations" - {
         "IO" in run {
             for
-                queue  <- Queue.init[Int < IO](2)
-                _      <- queue.offer(IO(42))
+                queue  <- Queue.init[Int < Sync](2)
+                _      <- queue.offer(Sync(42))
                 result <- queue.poll.map(_.get)
             yield assert(result == 42)
         }
         "AtomicBoolean" in run {
             for
                 flag   <- AtomicBoolean.init(false)
-                queue  <- Queue.init[Int < IO](2)
+                queue  <- Queue.init[Int < Sync](2)
                 _      <- queue.offer(flag.set(true).andThen(42))
                 before <- flag.get
                 result <- queue.poll.map(_.get)

--- a/kyo-core/shared/src/test/scala/kyo/StatTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StatTest.scala
@@ -9,13 +9,13 @@ class StatTest extends Test:
         val histogram    = stat.initHistogram("a")
         val gauge        = stat.initGauge("a")(1)
         val counterGauge = stat.initCounterGauge("a")(1)
-        IO.Unsafe.evalOrThrow(counter.add(1))
-        IO.Unsafe.evalOrThrow(histogram.observe(1))
-        assert(IO.Unsafe.evalOrThrow(counter.get) == 1)
-        assert(IO.Unsafe.evalOrThrow(histogram.count) == 1)
-        assert(IO.Unsafe.evalOrThrow(gauge.collect) == 1)
-        assert(IO.Unsafe.evalOrThrow(counterGauge.collect) == 1)
+        Sync.Unsafe.evalOrThrow(counter.add(1))
+        Sync.Unsafe.evalOrThrow(histogram.observe(1))
+        assert(Sync.Unsafe.evalOrThrow(counter.get) == 1)
+        assert(Sync.Unsafe.evalOrThrow(histogram.count) == 1)
+        assert(Sync.Unsafe.evalOrThrow(gauge.collect) == 1)
+        assert(Sync.Unsafe.evalOrThrow(counterGauge.collect) == 1)
         val v = new Object
-        assert(IO.Unsafe.evalOrThrow(stat.traceSpan("a")(v)) eq v)
+        assert(Sync.Unsafe.evalOrThrow(stat.traceSpan("a")(v)) eq v)
     }
 end StatTest

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -133,7 +133,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12, par, Int.MaxValue)
-                        s2 = stream.mapPar(par, buf)(i => IO(i + 1))
+                        s2 = stream.mapPar(par, buf)(i => Sync(i + 1))
                         res <- s2.run
                     yield assert(
                         res == (2 to 13)
@@ -168,7 +168,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
-                        s2 = stream.mapParUnordered(par, buf)(i => IO(i + 1))
+                        s2 = stream.mapParUnordered(par, buf)(i => Sync(i + 1))
                         res <- s2.run
                     yield assert(
                         res.toSet == (2 to 13).toSet
@@ -205,7 +205,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
-                        s2 = stream.mapChunkPar(par, buf)(c => IO(c.map(_ + 1)))
+                        s2 = stream.mapChunkPar(par, buf)(c => Sync(c.map(_ + 1)))
                         res <- s2.run
                     yield assert(
                         res == (2 to 13)
@@ -275,7 +275,7 @@ class StreamCoreExtensionsTest extends Test:
                 "map with Choice" in run {
                     val it = Iterator("a", "b", "c")
 
-                    val stream: Stream[String, IO & Choice] =
+                    val stream: Stream[String, Sync & Choice] =
                         Stream.fromIterator(it, chunkSize).rechunk(10).map: str =>
                             Choice.eval(true, false).map:
                                 case true  => str.toUpperCase
@@ -422,7 +422,7 @@ class StreamCoreExtensionsTest extends Test:
 
                 "map with Choice" in run {
                     val it = Iterator("a", "b", "c")
-                    val stream: Stream[String, IO & Choice & Abort[Throwable]] =
+                    val stream: Stream[String, Sync & Choice & Abort[Throwable]] =
                         Stream.fromIteratorCatching[Throwable](it, chunkSize).rechunk(10).map: str =>
                             Choice.eval(true, false).map:
                                 case true  => str.toUpperCase
@@ -447,7 +447,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
-                        s2 = stream.mapChunkParUnordered(par, buf)(c => IO(c.map(_ + 1)))
+                        s2 = stream.mapChunkParUnordered(par, buf)(c => Sync(c.map(_ + 1)))
                         res <- s2.run
                     yield assert(
                         res.toSet == (2 to 13).toSet

--- a/kyo-core/shared/src/test/scala/kyo/SyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SyncTest.scala
@@ -176,7 +176,7 @@ class SyncTest extends Test:
     }
 
     "abort" - {
-        "IO includes Abort[Nothing]" in {
+        "Sync includes Abort[Nothing]" in {
             val a: Int < Abort[Nothing] = 1
             val b: Int < Sync           = a
             succeed
@@ -185,19 +185,19 @@ class SyncTest extends Test:
         "does not include wider Abort types" in {
             typeCheckFailure("""
                 val a: Int < Abort[String] = 1
-                val b: Int < IO            = a
+                val b: Int < Sync            = a
             """)(
-                "Required: Int < kyo.IO"
+                "Required: Int < kyo.Sync"
             )
         }
 
         "preserves Nothing as most specific error type" in {
             typeCheckFailure("""
-                val io: Int < IO = IO {
+                val io: Int < Sync = Sync {
                     Abort.fail[String]("error")
                 }
             """)(
-                "Required: Int < kyo.IO"
+                "Required: Int < kyo.Sync"
             )
         }
     }

--- a/kyo-core/shared/src/test/scala/kyo/SyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SyncTest.scala
@@ -3,13 +3,13 @@ package kyo
 import org.scalatest.compatible.Assertion
 import scala.util.Try
 
-class IOTest extends Test:
+class SyncTest extends Test:
 
     "lazyRun" - {
         "execution" in run {
             var called = false
             val v =
-                IO {
+                Sync {
                     called = true
                     1
                 }
@@ -24,13 +24,13 @@ class IOTest extends Test:
             var called = false
             val v =
                 Env.get[Int].map { i =>
-                    IO {
+                    Sync {
                         called = true
                         i
                     }
                 }
             assert(!called)
-            val v2 = IO.Unsafe.run(v)
+            val v2 = Sync.Unsafe.run(v)
             assert(!called)
             assert(
                 Abort.run(Env.run(1)(v2)).eval ==
@@ -44,20 +44,20 @@ class IOTest extends Test:
             def fail: Int = throw ex
 
             val ios = List(
-                IO(fail),
-                IO(fail).map(_ + 1),
-                IO(1).map(_ => fail),
-                IO(IO(1)).map(_ => fail)
+                Sync(fail),
+                Sync(fail).map(_ + 1),
+                Sync(1).map(_ => fail),
+                Sync(Sync(1)).map(_ => fail)
             )
             ios.foreach { io =>
-                assert(Try(IO.Unsafe.evalOrThrow(io)) == Try(fail))
+                assert(Try(Sync.Unsafe.evalOrThrow(io)) == Try(fail))
             }
             succeed
         }
         "stack-safe" in run {
             val frames = 10000
-            def loop(i: Int): Int < IO =
-                IO {
+            def loop(i: Int): Int < Sync =
+                Sync {
                     if i < frames then
                         loop(i + 1)
                     else
@@ -71,8 +71,8 @@ class IOTest extends Test:
     "run" - {
         "execution" in run {
             var called = false
-            val v: Int < IO =
-                IO {
+            val v: Int < Sync =
+                Sync {
                     called = true
                     1
                 }
@@ -84,8 +84,8 @@ class IOTest extends Test:
         }
         "stack-safe" in run {
             val frames = 100000
-            def loop(i: Int): Assertion < IO =
-                IO {
+            def loop(i: Int): Assertion < Sync =
+                Sync {
                     if i < frames then
                         loop(i + 1)
                     else
@@ -99,13 +99,13 @@ class IOTest extends Test:
             def fail: Int = throw ex
 
             val ios = List(
-                IO(fail),
-                IO(fail).map(_ + 1),
-                IO(1).map(_ => fail),
-                IO(IO(1)).map(_ => fail)
+                Sync(fail),
+                Sync(fail).map(_ + 1),
+                Sync(1).map(_ => fail),
+                Sync(Sync(1)).map(_ => fail)
             )
             ios.foreach { io =>
-                assert(Try(IO.Unsafe.evalOrThrow(io)) == Try(fail))
+                assert(Try(Sync.Unsafe.evalOrThrow(io)) == Try(fail))
             }
             succeed
         }
@@ -114,7 +114,7 @@ class IOTest extends Test:
     "ensure" - {
         "success" in run {
             var called = false
-            IO.ensure { called = true }(1).map { result =>
+            Sync.ensure { called = true }(1).map { result =>
                 assert(result == 1)
                 assert(called)
             }
@@ -122,8 +122,8 @@ class IOTest extends Test:
         "failure" in run {
             val ex     = new Exception
             var called = false
-            Abort.run[Any](IO.ensure { called = true } {
-                IO[Int, Any](throw ex)
+            Abort.run[Any](Sync.ensure { called = true } {
+                Sync[Int, Any](throw ex)
             }).map { result =>
                 assert(result == Result.panic(ex))
                 assert(called)
@@ -133,8 +133,8 @@ class IOTest extends Test:
             var count       = 0
             var countEnsure = 0
 
-            val io: Unit < IO =
-                IO.ensure({ countEnsure = countEnsure + 1 })({ count = count + 1 })
+            val io: Unit < Sync =
+                Sync.ensure({ countEnsure = countEnsure + 1 })({ count = count + 1 })
 
             io.andThen(io).map: _ =>
                 assert(count == 2)
@@ -145,32 +145,32 @@ class IOTest extends Test:
     "evalOrThrow" - {
         import AllowUnsafe.embrace.danger
         "success" in run {
-            val result = IO.Unsafe.evalOrThrow(IO(42))
+            val result = Sync.Unsafe.evalOrThrow(Sync(42))
             assert(result == 42)
         }
 
         "throws exceptions" in run {
             val ex = new Exception("test error")
-            val io = IO[Int, Any](throw ex)
+            val io = Sync[Int, Any](throw ex)
 
             val caught = intercept[Exception] {
-                IO.Unsafe.evalOrThrow(io)
+                Sync.Unsafe.evalOrThrow(io)
             }
             assert(caught == ex)
         }
 
         "propagates nested exceptions" in run {
             val ex = new Exception("nested error")
-            val io = IO(IO(throw ex))
+            val io = Sync(Sync(throw ex))
 
             val caught = intercept[Exception] {
-                IO.Unsafe.evalOrThrow(io)
+                Sync.Unsafe.evalOrThrow(io)
             }
             assert(caught == ex)
         }
 
         "works with mapped values" in run {
-            val result = IO.Unsafe.evalOrThrow(IO(21).map(_ * 2))
+            val result = Sync.Unsafe.evalOrThrow(Sync(21).map(_ * 2))
             assert(result == 42)
         }
     }
@@ -178,7 +178,7 @@ class IOTest extends Test:
     "abort" - {
         "IO includes Abort[Nothing]" in {
             val a: Int < Abort[Nothing] = 1
-            val b: Int < IO             = a
+            val b: Int < Sync           = a
             succeed
         }
 
@@ -207,7 +207,7 @@ class IOTest extends Test:
             val local      = Local.init("test")
             var sideEffect = ""
 
-            IO.withLocal(local) { value =>
+            Sync.withLocal(local) { value =>
                 sideEffect = value
                 value.length
             }.map { result =>
@@ -221,7 +221,7 @@ class IOTest extends Test:
             var captured = ""
 
             local.let("modified") {
-                IO.withLocal(local) { value =>
+                Sync.withLocal(local) { value =>
                     captured = value
                     value.toUpperCase
                 }
@@ -236,7 +236,7 @@ class IOTest extends Test:
             var executed = false
 
             val computation =
-                IO.withLocal(local) { value =>
+                Sync.withLocal(local) { value =>
                     executed = true
                     value
                 }
@@ -258,7 +258,7 @@ class IOTest extends Test:
             val local      = Local.init(42)
             var sideEffect = 0
 
-            IO.Unsafe.withLocal(local) { value =>
+            Sync.Unsafe.withLocal(local) { value =>
                 sideEffect = unsafeOperation(value)
                 sideEffect
             }.map { result =>
@@ -272,7 +272,7 @@ class IOTest extends Test:
             var captured = 0
 
             local.let(20) {
-                IO.Unsafe.withLocal(local) { value =>
+                Sync.Unsafe.withLocal(local) { value =>
                     captured = unsafeOperation(value)
                     value + 1
                 }
@@ -288,11 +288,11 @@ class IOTest extends Test:
 
             val computation =
                 for
-                    v1 <- IO.Unsafe.withLocal(local) { value =>
+                    v1 <- Sync.Unsafe.withLocal(local) { value =>
                         steps = unsafeOperation(value) :: steps
                         value * 2
                     }
-                    v2 <- IO.Unsafe {
+                    v2 <- Sync.Unsafe {
                         steps = v1 :: steps
                         v1 + 1
                     }
@@ -305,4 +305,4 @@ class IOTest extends Test:
         }
     }
 
-end IOTest
+end SyncTest

--- a/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
@@ -85,14 +85,14 @@ class SystemTest extends Test:
     "custom System implementation" in run {
         val customSystem = new System:
             def unsafe: Unsafe = ???
-            def env[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & IO) =
-                IO(Maybe("custom_env").asInstanceOf[Maybe[A]])
-            def property[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & IO) =
-                IO(Maybe("custom_property").asInstanceOf[Maybe[A]])
-            def lineSeparator(using Frame): String < IO = IO("custom_separator")
-            def userName(using Frame): String < IO      = IO("custom_user")
-            def userHome(using Frame): String < IO      = IO("custom_home")
-            def operatingSystem(using Frame): OS < IO   = IO(OS.AIX)
+            def env[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync) =
+                Sync(Maybe("custom_env").asInstanceOf[Maybe[A]])
+            def property[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync) =
+                Sync(Maybe("custom_property").asInstanceOf[Maybe[A]])
+            def lineSeparator(using Frame): String < Sync = Sync("custom_separator")
+            def userName(using Frame): String < Sync      = Sync("custom_user")
+            def userHome(using Frame): String < Sync      = Sync("custom_home")
+            def operatingSystem(using Frame): OS < Sync   = Sync(OS.AIX)
 
         for
             env       <- System.let(customSystem)(System.env[String]("ANY"))

--- a/kyo-core/shared/src/test/scala/kyo/scheduler/SyncPromiseTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/scheduler/SyncPromiseTest.scala
@@ -4,7 +4,7 @@ import kyo.*
 import org.scalatest.compatible.Assertion
 import scala.annotation.tailrec
 
-class IOPromiseTest extends Test:
+class SyncPromiseTest extends Test:
 
     def deadline(after: Duration = timeout) =
         import AllowUnsafe.embrace.danger
@@ -1015,4 +1015,4 @@ class IOPromiseTest extends Test:
         }
     }
 
-end IOPromiseTest
+end SyncPromiseTest

--- a/kyo-core/shared/src/test/scala/kyo/stats/internal/TraceReceiverTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/stats/internal/TraceReceiverTest.scala
@@ -30,7 +30,7 @@ class TraceReceiverTest extends Test:
             name: String,
             parent: Maybe[Span],
             attributes: Attributes
-        )(using Frame): Span < IO =
+        )(using Frame): Span < Sync =
             spanStarted = true
             Span.noop
         end startSpan

--- a/kyo-direct/shared/src/main/scala/kyo/Direct.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/Direct.scala
@@ -64,8 +64,8 @@ private def nowImpl[A: Type, S: Type](self: Expr[A < S])(using Quotes): Expr[A] 
            |
            |${highlight("""
            |direct {
-           |  val x = IO(1).now     // Get result here
-           |  val y = IO(2).now     // Then get this result  
+           |  val x = Sync(1).now     // Get result here
+           |  val y = Sync(2).now     // Then get this result
            |  x + y                 // Use both results
            |}""".stripMargin)}
            |""".stripMargin,
@@ -85,8 +85,8 @@ private def laterImpl[A: Type, S: Type](self: Expr[A < S])(using Quotes): Expr[A
            |${highlight("""
            |// Example: Preserve effects for composition
            |def combination = direct {
-           |  val effect1 = IO(1).later   // Effect preserved
-           |  val effect2 = IO(2).later   // Effect preserved
+           |  val effect1 = Sync(1).later   // Effect preserved
+           |  val effect2 = Sync(2).later   // Effect preserved
            |  (effect1, effect2)          // Return tuple of effects
            |}
            |

--- a/kyo-direct/shared/src/main/scala/kyo/TestSupport.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/TestSupport.scala
@@ -5,7 +5,7 @@ import scala.language.experimental.macros
 object TestSupport:
     transparent inline def runLiftTest[A, B](inline expected: A)(inline body: B): Unit =
         import AllowUnsafe.embrace.danger
-        val actual: B = IO.Unsafe.evalOrThrow(direct(body).asInstanceOf[B < IO])
+        val actual: B = Sync.Unsafe.evalOrThrow(direct(body).asInstanceOf[B < Sync])
         if !expected.equals(actual) then
             throw new AssertionError("Expected " + expected + " but got " + actual)
     end runLiftTest

--- a/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
@@ -157,7 +157,7 @@ private[kyo] object Validate:
                             |direct {
                             |    val value = counter.get.now    // OK - get value first
                             |    val incr = value + 1           // OK - pure operation
-                            |    IO(incr).now                   // OK - single .now
+                            |    Sync(incr).now                   // OK - single .now
                             |}""".stripMargin)}""".stripMargin
                         )
                 }
@@ -172,16 +172,16 @@ private[kyo] object Validate:
                        |${bold("1. Use .now when you need the effect's result immediately:")}
                        |${highlight("""
                        |direct {
-                       |  val x: Int = IO(1).now      // Get result here
-                       |  val y: Int = x + IO(2).now  // Use result in next computation
+                       |  val x: Int = Sync(1).now      // Get result here
+                       |  val y: Int = x + Sync(2).now  // Use result in next computation
                        |  y * 2                       // Use final result
                        |}""".stripMargin)}
                        |
                        |${bold("2. Use .later (advanced) when you want to preserve the effect:")}
                        |${highlight("""
                        |direct {
-                       |  val x: Int < IO = IO(1).later    // Keep effect for later
-                       |  val y: Int < IO = IO(2).later    // Keep another effect
+                       |  val x: Int < Sync = Sync(1).later    // Keep effect for later
+                       |  val y: Int < Sync = Sync(2).later    // Keep another effect
                        |  x.now + y.now                    // Sequence effects
                        |}""".stripMargin)}
                        |""".stripMargin
@@ -209,13 +209,13 @@ private[kyo] object Validate:
                     |${highlight("""
                     |// Instead of lazy declarations in direct:
                     |direct {
-                    |  lazy val x = IO(1).now  // NOT OK - lazy val
+                    |  lazy val x = Sync(1).now  // NOT OK - lazy val
                     |  object A               // NOT OK - object
                     |  x + 1
                     |}
                     |
                     |// Define outside direct:
-                    |lazy val x = IO(1)       // OK - outside
+                    |lazy val x = Sync(1)       // OK - outside
                     |object A                 // OK - outside
                     |
                     |// Use inside direct:
@@ -241,13 +241,13 @@ private[kyo] object Validate:
                        |${highlight("""
                        |// Instead of method in direct:
                        |direct {
-                       |  def process(x: Int) = IO(x).now  // NOT OK
+                       |  def process(x: Int) = Sync(x).now  // NOT OK
                        |  process(10)
                        |}
                        |
                        |// Define outside:
-                       |def process(x: Int): Int < IO = direct {
-                       |  IO(x).now
+                       |def process(x: Int): Int < Sync = direct {
+                       |  Sync(x).now
                        |}
                        |
                        |direct {
@@ -265,7 +265,7 @@ private[kyo] object Validate:
                        |// Instead of try/catch:
                        |direct {
                        |  try {
-                       |    IO(1).now    // NOT OK
+                       |    Sync(1).now    // NOT OK
                        |  } catch {
                        |    case e => handleError(e)
                        |  }
@@ -273,7 +273,7 @@ private[kyo] object Validate:
                        |
                        |// Define the effectful computation:
                        |def computation = direct {
-                       |  IO(1).now
+                       |  Sync(1).now
                        |}
                        |
                        |// Handle the effect direct block:
@@ -323,14 +323,14 @@ private[kyo] object Validate:
                     |direct {
                     |  if condition then
                     |    throw new Exception("error")  // NOT OK - throws exception
-                    |  IO(1).now
+                    |  Sync(1).now
                     |}
                     |
                     |// Use Abort effect:
                     |direct {
                     |  if condition then
                     |    Abort.fail("error").now       // OK - proper error handling
-                    |  else IO(1).now
+                    |  else Sync(1).now
                     |}""".stripMargin)}""".stripMargin
                 )
 

--- a/kyo-direct/shared/src/test/scala/kyo/BlockTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/BlockTest.scala
@@ -8,29 +8,29 @@ class BlockTest extends AnyFreeSpec with Assertions:
 
     "assigned run" - {
         "only" in {
-            val i = IO(1)
+            val i = Sync(1)
             runLiftTest(1) {
                 val v = i.now
                 v
             }
         }
         "followed by pure expression" in {
-            val i = IO(1)
+            val i = Sync(1)
             runLiftTest(2) {
                 val v = i.now
                 v + 1
             }
         }
         "followed by impure expression" in {
-            val i = IO(1)
-            val j = IO(2)
+            val i = Sync(1)
+            val j = Sync(2)
             runLiftTest(3) {
                 val v = i.now
                 v + j.now
             }
         }
         "nested" in {
-            val i = IO(1)
+            val i = Sync(1)
             runLiftTest(3) {
                 val v =
                     val r = i.now
@@ -41,21 +41,21 @@ class BlockTest extends AnyFreeSpec with Assertions:
     }
     "unassigned run" - {
         "only" in {
-            val i = IO(1)
+            val i = Sync(1)
             runLiftTest(1) {
                 i.now
             }
         }
         "followed by pure expression" in {
-            val i = IO(1)
+            val i = Sync(1)
             runLiftTest(2) {
                 i.now
                 2
             }
         }
         "followed by impure expression" in {
-            val i = IO(1)
-            val j = IO(2)
+            val i = Sync(1)
+            val j = Sync(2)
             runLiftTest(2) {
                 i.now
                 j.now
@@ -76,7 +76,7 @@ class BlockTest extends AnyFreeSpec with Assertions:
             }
         }
         "followed by impure expression" in {
-            val i = IO(1)
+            val i = Sync(1)
             def a = 2
             runLiftTest(1) {
                 a
@@ -84,8 +84,8 @@ class BlockTest extends AnyFreeSpec with Assertions:
             }
         }
         "using previous defers" in {
-            val i = IO(1)
-            val j = IO(2)
+            val i = Sync(1)
+            val j = Sync(2)
             runLiftTest(3) {
                 val v = i.now
                 v + j.now
@@ -94,14 +94,14 @@ class BlockTest extends AnyFreeSpec with Assertions:
         "using external function" in {
             def a(i: Int, s: String) = i + s.toInt
             runLiftTest(4) {
-                IO(a(1, "2")).now + a(0, "1")
+                Sync(a(1, "2")).now + a(0, "1")
             }
         }
     }
     "complex" - {
         "tuple val pattern" in {
             runLiftTest(3) {
-                val (a, b) = (IO(1).now, IO(2).now)
+                val (a, b) = (Sync(1).now, Sync(2).now)
                 a + b
             }
         }
@@ -109,11 +109,11 @@ class BlockTest extends AnyFreeSpec with Assertions:
             runLiftTest((1, 2, 3)) {
                 val x = 1
                 (
-                    IO(x).now, {
-                        val a = IO(2).now
+                    Sync(x).now, {
+                        val a = Sync(2).now
                         a
                     },
-                    IO(3).now
+                    Sync(3).now
                 )
             }
         }

--- a/kyo-direct/shared/src/test/scala/kyo/BooleanTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/BooleanTest.scala
@@ -19,51 +19,51 @@ class BooleanTest extends AnyFreeSpec with Assertions:
         "pure/impure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    True && IO(True).now
+                    True && Sync(True).now
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    True && IO(False).now
+                    True && Sync(False).now
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    False && IO(NotExpected).now
+                    False && Sync(NotExpected).now
                 }
             }
         }
         "impure/pure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    IO(True).now && True
+                    Sync(True).now && True
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    IO(True).now && False
+                    Sync(True).now && False
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    IO(False).now && NotExpected
+                    Sync(False).now && NotExpected
                 }
             }
         }
         "impure/impure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    IO(True).now && IO(True).now
+                    Sync(True).now && Sync(True).now
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    IO(True).now && IO(False).now
+                    Sync(True).now && Sync(False).now
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    IO(False).now && IO(NotExpected).now
+                    Sync(False).now && Sync(NotExpected).now
                 }
             }
         }
@@ -77,51 +77,51 @@ class BooleanTest extends AnyFreeSpec with Assertions:
         "pure/impure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    False || IO(False).now
+                    False || Sync(False).now
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    False || IO(True).now
+                    False || Sync(True).now
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    True || IO(NotExpected).now
+                    True || Sync(NotExpected).now
                 }
             }
         }
         "impure/pure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    IO(False).now || False
+                    Sync(False).now || False
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    IO(False).now || True
+                    Sync(False).now || True
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    IO(True).now || NotExpected
+                    Sync(True).now || NotExpected
                 }
             }
         }
         "impure/impure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    IO(False).now || IO(False).now
+                    Sync(False).now || Sync(False).now
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    IO(False).now || IO(True).now
+                    Sync(False).now || Sync(True).now
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    IO(True).now || IO(NotExpected).now
+                    Sync(True).now || Sync(NotExpected).now
                 }
             }
         }

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -265,8 +265,8 @@ class HygieneTest extends Test:
     }
 
     "opaque types issue #993" in {
-        val maybe1: Maybe[Int] < IO = Maybe(1)
-        val maybe0: Maybe[Int]      = Maybe(0)
+        val maybe1: Maybe[Int] < Sync = Maybe(1)
+        val maybe0: Maybe[Int]        = Maybe(0)
         direct:
             maybe1.now.fold(2)(_ + 1)
             maybe1.now.contains(1)

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -6,7 +6,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             var willFail = 1
-            IO(1).now
+            Sync(1).now
           }
         """)(
             "`var` declarations are not allowed inside a `direct` block."
@@ -17,7 +17,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             return 42
-            IO(1).now
+            Sync(1).now
           }
         """)(
             "Exception occurred while executing macro expansion"
@@ -28,7 +28,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             direct {
-              IO(1).now
+              Sync(1).now
             }
           }
         """)(
@@ -40,7 +40,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             lazy val x = 10
-            IO(1).now
+            Sync(1).now
           }
         """)(
             "`lazy val` and `object` declarations are not allowed inside a `direct` block."
@@ -50,7 +50,7 @@ class HygieneTest extends Test:
     "function containing await" in {
         typeCheckFailure("""
           direct {
-            def foo() = IO(1).now
+            def foo() = Sync(1).now
             foo()
           }
         """)(
@@ -62,9 +62,9 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             try {
-              IO(1).now
+              Sync(1).now
             } catch {
-              case _: Exception => IO(2).now
+              case _: Exception => Sync(2).now
             }
           }
         """)(
@@ -76,7 +76,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             class A(val x: Int)
-            IO(1).now
+            Sync(1).now
           }
         """)(
             "`class` and `trait` declarations are not allowed inside `direct` blocks."
@@ -87,7 +87,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             object A
-            IO(1).now
+            Sync(1).now
           }
         """)(
             "`class` and `trait` declarations are not allowed inside `direct` blocks."
@@ -98,7 +98,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             trait A
-            IO(1).now
+            Sync(1).now
           }
         """)(
             "`class` and `trait` declarations are not allowed inside `direct` blocks."
@@ -109,8 +109,8 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             for {
-              x <- IO(1).now
-              y <- IO(2).now
+              x <- Sync(1).now
+              y <- Sync(2).now
             } yield x + y
           }
         """)(
@@ -122,7 +122,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             try {
-              IO(1).now
+              Sync(1).now
             }
           }
         """)(
@@ -134,7 +134,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             try {
-              IO(1).now
+              Sync(1).now
             } finally {
               println("Cleanup")
             }
@@ -148,17 +148,17 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           class A(x: => String)
           direct {
-              new A(IO("blah").now)
+              new A(Sync("blah").now)
           }
         """)(
-            "Can't find AsyncShift (Found:    cps.runtime.CpsMonadSelfAsyncShift[[A] =>> A < kyo.IO"
+            "Can't find AsyncShift (Found:    cps.runtime.CpsMonadSelfAsyncShift[[A] =>> A < kyo.Sync"
         )
     }
 
     "match expression without cases" in {
         typeCheckFailure("""
           direct {
-            IO(1).now match {}
+            Sync(1).now match {}
           }
         """)(
             "case' expected, but '}' found"
@@ -169,8 +169,8 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             for {
-              x <- IO(1).now
-              y <- IO(2).now
+              x <- Sync(1).now
+              y <- Sync(2).now
             } x + y
           }
         """)(
@@ -182,7 +182,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             def outer() = {
-              def inner() = IO(1).now
+              def inner() = Sync(1).now
               inner()
             }
             outer()
@@ -195,7 +195,7 @@ class HygieneTest extends Test:
     "lambdas with await" in {
         typeCheckFailure("""
           direct {
-            val f = (x: Int) => IO(1).now + x
+            val f = (x: Int) => Sync(1).now + x
             f(10)
           }
         """)(
@@ -206,7 +206,7 @@ class HygieneTest extends Test:
     "throw" in {
         typeCheckFailure("""
           direct {
-              if IO("foo").now == "bar" then
+              if Sync("foo").now == "bar" then
                   throw new Exception
               else
                   2
@@ -220,7 +220,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
               val x = synchronized(1)
-              IO(x).now
+              Sync(x).now
           }
         """)(
             "`synchronized` blocks are not allowed inside a `direct` block."
@@ -228,17 +228,17 @@ class HygieneTest extends Test:
     }
 
     "nested var" in {
-        typeCheckFailure("""direct {{var x = 1; IO(x)}.now}""")("`var` declarations are not allowed inside a `direct` block.")
+        typeCheckFailure("""direct {{var x = 1; Sync(x)}.now}""")("`var` declarations are not allowed inside a `direct` block.")
     }
 
     "nested nested var" in {
-        typeCheckFailure("""direct {{val y = 1;{var x = 1; IO(x)}}.now}""")("`var` declarations are not allowed inside a `direct` block.")
+        typeCheckFailure("""direct {{val y = 1;{var x = 1; Sync(x)}}.now}""")("`var` declarations are not allowed inside a `direct` block.")
     }
 
     "nested now in def" in {
         typeCheckFailure("""
              direct {
-               val i = IO(1).later
+               val i = Sync(1).later
                def f =  i.now > 0
                f
              }""")("Method definitions containing .now are not supported inside `direct` blocks.")

--- a/kyo-direct/shared/src/test/scala/kyo/IfTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/IfTest.scala
@@ -9,22 +9,22 @@ class IfTest extends AnyFreeSpec with Assertions:
     "unlifted condition / ifelse" - {
         "pure / pure" in {
             runLiftTest(2) {
-                if IO(1).now == 1 then 2 else 3
+                if Sync(1).now == 1 then 2 else 3
             }
         }
         "pure / impure" in {
             runLiftTest(2) {
-                if IO(1).now == 1 then IO(2).now else 3
+                if Sync(1).now == 1 then Sync(2).now else 3
             }
         }
         "impure / pure" in {
             runLiftTest(1) {
-                IO(1).now
+                Sync(1).now
             }
         }
         "impure / impure" in {
             runLiftTest(3) {
-                if IO(1).now == 2 then IO(2).now else IO(3).now
+                if Sync(1).now == 2 then Sync(2).now else Sync(3).now
             }
         }
     }
@@ -36,17 +36,17 @@ class IfTest extends AnyFreeSpec with Assertions:
         }
         "pure / impure" in {
             runLiftTest(2) {
-                if 1 == 1 then IO(2).now else 3
+                if 1 == 1 then Sync(2).now else 3
             }
         }
         "impure / pure" in {
             runLiftTest(2) {
-                if 1 == 1 then 2 else IO(3).now
+                if 1 == 1 then 2 else Sync(3).now
             }
         }
         "impure / impure" in {
             runLiftTest(3) {
-                if 1 == 2 then IO(2).now else IO(3).now
+                if 1 == 2 then Sync(2).now else Sync(3).now
             }
         }
     }

--- a/kyo-direct/shared/src/test/scala/kyo/PatMatchTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PatMatchTest.scala
@@ -112,7 +112,7 @@ class PatMatchTest extends AnyFreeSpec with Assertions:
     "misc" - {
         "val patmatch" in {
             runLiftTest(1) {
-                val Some(a) = IO(Some(1)).now
+                val Some(a) = Sync(Some(1)).now
                 a
             }
         }

--- a/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
@@ -307,7 +307,7 @@ class PreludeTest extends Test:
         "poll with fold" in run {
             val effect = Poll.fold[Int](0) { (acc, v) =>
                 direct {
-                    IO(acc).now + v
+                    Sync(acc).now + v
                 }
             }
 

--- a/kyo-direct/shared/src/test/scala/kyo/ShiftTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/ShiftTest.scala
@@ -51,7 +51,7 @@ class ShiftTest extends AnyFreeSpec with Assertions:
 
         val forReference = direct:
             def innerF(i: Int) = i + 1
-            IO(innerF(1)).now
+            Sync(innerF(1)).now
 
     }
 

--- a/kyo-direct/shared/src/test/scala/kyo/WhileTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/WhileTest.scala
@@ -34,8 +34,8 @@ class WhileTest extends Test:
 
         direct {
             while i < 3 do
-                IO(incrementA()).now
-                IO(incrementB()).now
+                Sync(incrementA()).now
+                Sync(incrementB()).now
                 ()
             end while
             assert(i == 4)
@@ -79,7 +79,7 @@ class WhileTest extends Test:
                 val counter = AtomicInt.init(0).now
                 while counter.get.now < 3 do
                     val current = counter.incrementAndGet.now
-                    IO(results += current).now
+                    Sync(results += current).now
                     ()
                 end while
                 val finalCount = counter.get.now
@@ -132,10 +132,10 @@ class WhileTest extends Test:
                 val counter = AtomicInt.init(0).now
                 while counter.get.now < 5 do
                     val current = counter.incrementAndGet.now
-                    if IO(current % 2 == 1).now then
+                    if Sync(current % 2 == 1).now then
                         () // Skip odd numbers
                     else
-                        IO { evens += current }.now
+                        Sync { evens += current }.now
                         ()
                     end if
                 end while
@@ -154,7 +154,7 @@ class WhileTest extends Test:
                     val counter = AtomicInt.init(0).now
                     while counter.get.now < 5 do
                         val op = s"op${counter.get.now}"
-                        IO { operations += op }.now
+                        Sync { operations += op }.now
                         val current = counter.incrementAndGet.now
                         if current == 2 then
                             Abort.fail(s"Error at $current").now

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/api/Handler.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/api/Handler.scala
@@ -14,7 +14,7 @@ trait Handler:
 
     def statement(
         account: Int
-    ): Statement < (Abort[StatusCode] & IO)
+    ): Statement < (Abort[StatusCode] & Sync)
 
 end Handler
 

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
@@ -11,7 +11,7 @@ trait Log:
         account: Int,
         amount: Int,
         desc: String
-    ): Unit < IO
+    ): Unit < Sync
 
 end Log
 
@@ -19,10 +19,10 @@ object Log:
 
     case class Entry(balance: Int, account: Int, amount: Int, desc: String)
 
-    val init: Log < (Env[DB.Config] & IO) = direct {
+    val init: Log < (Env[DB.Config] & Sync) = direct {
         val cfg = Env.get[DB.Config].now
         val q   = Queue.Unbounded.init[Entry](Access.MultiProducerSingleConsumer).now
-        val log = IO(Live(cfg.workingDir + "/log.dat", q)).now
+        val log = Sync(Live(cfg.workingDir + "/log.dat", q)).now
         val _   = Async.run(log.flushLoop(cfg.flushInterval)).now
         log
     }
@@ -36,7 +36,7 @@ object Log:
             account: Int,
             amount: Int,
             desc: String
-        ): Unit < IO =
+        ): Unit < Sync =
             q.add(Entry(balance, account, amount, desc))
 
         private[Log] def flushLoop(interval: Duration): Unit < (Async & Abort[Closed]) = direct {
@@ -47,7 +47,7 @@ object Log:
         }
 
         private def append(entries: Seq[Entry]) =
-            IO {
+            Sync {
                 if entries.nonEmpty then
                     val str =
                         entries.map { e =>

--- a/kyo-offheap/shared/src/test/scala/kyo/MemoryTest.scala
+++ b/kyo-offheap/shared/src/test/scala/kyo/MemoryTest.scala
@@ -121,7 +121,7 @@ class MemoryTest extends Test:
             Arena.run {
                 for
                     mem <- Memory.init[Int](5)
-                    v <- IO.Unsafe {
+                    v <- Sync.Unsafe {
                         val unsafe: Unsafe[Int] = mem.unsafe
                         unsafe.set(0, 42)
                         unsafe.get(0)
@@ -134,7 +134,7 @@ class MemoryTest extends Test:
             Arena.run {
                 for
                     mem <- Memory.init[Int](5)
-                    (v0, v4) <- IO.Unsafe {
+                    (v0, v4) <- Sync.Unsafe {
                         val unsafe = mem.unsafe
                         unsafe.fill(42)
                         (unsafe.get(0), unsafe.get(4))
@@ -147,7 +147,7 @@ class MemoryTest extends Test:
             Arena.run {
                 for
                     mem <- Memory.init[Int](3)
-                    v <- IO.Unsafe {
+                    v <- Sync.Unsafe {
                         val unsafe = mem.unsafe
                         unsafe.set(0, 1)
                         unsafe.set(1, 2)

--- a/kyo-playwright/shared/src/main/scala/kyo/Image.scala
+++ b/kyo-playwright/shared/src/main/scala/kyo/Image.scala
@@ -21,7 +21,7 @@ final case class Image private (data: Array[Byte]):
       * @return
       *   Unit wrapped in IO effect
       */
-    def writeFileBinary(path: String)(using Frame): Unit < IO =
+    def writeFileBinary(path: String)(using Frame): Unit < Sync =
         writeFileBinary(Path(path))
 
     /** Writes the image to a file in binary format.
@@ -31,7 +31,7 @@ final case class Image private (data: Array[Byte]):
       * @return
       *   Unit wrapped in IO effect
       */
-    def writeFileBinary(path: Path)(using Frame): Unit < IO =
+    def writeFileBinary(path: Path)(using Frame): Unit < Sync =
         path.writeBytes(binary.unsafeArray)
 
     /** Writes the image to a file in base64 format.
@@ -41,7 +41,7 @@ final case class Image private (data: Array[Byte]):
       * @return
       *   Unit wrapped in IO effect
       */
-    def writeFileBase64(path: String)(using Frame): Unit < IO =
+    def writeFileBase64(path: String)(using Frame): Unit < Sync =
         writeFileBase64(Path(path))
 
     /** Writes the image to a file in base64 format.
@@ -51,7 +51,7 @@ final case class Image private (data: Array[Byte]):
       * @return
       *   Unit wrapped in IO effect
       */
-    def writeFileBase64(path: Path)(using Frame): Unit < IO =
+    def writeFileBase64(path: Path)(using Frame): Unit < Sync =
         path.write(base64)
 
     /** Converts the image data to an immutable array of bytes.

--- a/kyo-playwright/shared/src/main/scala/kyo/Image.scala
+++ b/kyo-playwright/shared/src/main/scala/kyo/Image.scala
@@ -19,7 +19,7 @@ final case class Image private (data: Array[Byte]):
       * @param path
       *   The file path as a string
       * @return
-      *   Unit wrapped in IO effect
+      *   Unit wrapped in Sync effect
       */
     def writeFileBinary(path: String)(using Frame): Unit < Sync =
         writeFileBinary(Path(path))
@@ -29,7 +29,7 @@ final case class Image private (data: Array[Byte]):
       * @param path
       *   The file path as a Path object
       * @return
-      *   Unit wrapped in IO effect
+      *   Unit wrapped in Sync effect
       */
     def writeFileBinary(path: Path)(using Frame): Unit < Sync =
         path.writeBytes(binary.unsafeArray)
@@ -39,7 +39,7 @@ final case class Image private (data: Array[Byte]):
       * @param path
       *   The file path as a string
       * @return
-      *   Unit wrapped in IO effect
+      *   Unit wrapped in Sync effect
       */
     def writeFileBase64(path: String)(using Frame): Unit < Sync =
         writeFileBase64(Path(path))
@@ -49,7 +49,7 @@ final case class Image private (data: Array[Byte]):
       * @param path
       *   The file path as a Path object
       * @return
-      *   Unit wrapped in IO effect
+      *   Unit wrapped in Sync effect
       */
     def writeFileBase64(path: Path)(using Frame): Unit < Sync =
         path.write(base64)

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -6,11 +6,11 @@ import kyo.*
 import kyo.kernel.ArrowEffect
 
 final private[kyo] class StreamSubscription[V, S](
-    private val stream: Stream[V, S & IO],
+    private val stream: Stream[V, S & Sync],
     subscriber: Subscriber[? >: V]
 )(
     using
-    Isolate.Contextual[S, IO],
+    Isolate.Contextual[S, Sync],
     AllowUnsafe,
     Frame
 ) extends Subscription:
@@ -27,30 +27,30 @@ final private[kyo] class StreamSubscription[V, S](
         discard(requestChannel.close())
     end cancel
 
-    private[interop] def subscribe(using Frame): Unit < IO = IO(subscriber.onSubscribe(this))
+    private[interop] def subscribe(using Frame): Unit < Sync = Sync(subscriber.onSubscribe(this))
 
     private[interop] def poll(using Tag[Poll[Chunk[V]]], Frame): StreamComplete < (Async & Poll[Chunk[V]] & Abort[StreamCanceled]) =
-        def loopPoll(requesting: Long): (Chunk[V] | StreamComplete) < (IO & Poll[Chunk[V]]) =
-            Loop[Long, Chunk[V] | StreamComplete, IO & Poll[Chunk[V]]](requesting): requesting =>
+        def loopPoll(requesting: Long): (Chunk[V] | StreamComplete) < (Sync & Poll[Chunk[V]]) =
+            Loop[Long, Chunk[V] | StreamComplete, Sync & Poll[Chunk[V]]](requesting): requesting =>
                 Poll.andMap:
                     case Present(values) =>
                         if values.size <= requesting then
-                            IO(values.foreach(subscriber.onNext(_)))
+                            Sync(values.foreach(subscriber.onNext(_)))
                                 .andThen(Loop.continue(requesting - values.size))
                         else
-                            IO(values.take(requesting.intValue).foreach(subscriber.onNext(_)))
+                            Sync(values.take(requesting.intValue).foreach(subscriber.onNext(_)))
                                 .andThen(Loop.done(values.drop(requesting.intValue)))
                     case Absent =>
-                        IO(Loop.done(StreamComplete))
+                        Sync(Loop.done(StreamComplete))
 
         Loop[Chunk[V], StreamComplete, Async & Poll[Chunk[V]] & Abort[StreamCanceled]](Chunk.empty[V]): leftOver =>
             Abort.run[Closed](requestChannel.safe.take).map:
                 case Result.Success(requesting) =>
                     if requesting <= leftOver.size then
-                        IO(leftOver.take(requesting.intValue).foreach(subscriber.onNext(_)))
+                        Sync(leftOver.take(requesting.intValue).foreach(subscriber.onNext(_)))
                             .andThen(Loop.continue(leftOver.drop(requesting.intValue)))
                     else
-                        IO(leftOver.foreach(subscriber.onNext(_)))
+                        Sync(leftOver.foreach(subscriber.onNext(_)))
                             .andThen(loopPoll(requesting - leftOver.size))
                             .map {
                                 case nextLeftOver: Chunk[V] => Loop.continue(nextLeftOver)
@@ -64,12 +64,12 @@ final private[kyo] class StreamSubscription[V, S](
         Tag[Emit[Chunk[V]]],
         Tag[Poll[Chunk[V]]],
         Frame
-    ): Fiber[StreamCanceled, StreamComplete] < (IO & S) =
+    ): Fiber[StreamCanceled, StreamComplete] < (Sync & S) =
         Async.run[StreamCanceled, StreamComplete, S](Poll.runEmit(stream.emit)(poll).map(_._2))
             .map { fiber =>
                 fiber.onComplete {
-                    case Result.Success(StreamComplete) => IO(subscriber.onComplete())
-                    case Result.Panic(e)                => IO(subscriber.onError(e))
+                    case Result.Success(StreamComplete) => Sync(subscriber.onComplete())
+                    case Result.Panic(e)                => Sync(subscriber.onError(e))
                     case Result.Failure(StreamCanceled) => Kyo.unit
                 }.andThen(fiber)
             }
@@ -85,30 +85,30 @@ object StreamSubscription:
     case object StreamCanceled
 
     def subscribe[V, S](
-        using Isolate.Contextual[S, IO]
+        using Isolate.Contextual[S, Sync]
     )(
-        stream: Stream[V, S & IO],
+        stream: Stream[V, S & Sync],
         subscriber: Subscriber[? >: V]
     )(
         using
         Frame,
         Tag[Emit[Chunk[V]]],
         Tag[Poll[Chunk[V]]]
-    ): StreamSubscription[V, S] < (IO & S & Resource) =
+    ): StreamSubscription[V, S] < (Sync & S & Resource) =
         for
-            subscription <- IO.Unsafe(new StreamSubscription[V, S](stream, subscriber))
+            subscription <- Sync.Unsafe(new StreamSubscription[V, S](stream, subscriber))
             _            <- subscription.subscribe
             _            <- Resource.acquireRelease(subscription.consume)(_.interrupt.unit)
         yield subscription
 
     object Unsafe:
         def subscribe[V, S](
-            using Isolate.Contextual[S, IO]
+            using Isolate.Contextual[S, Sync]
         )(
-            stream: Stream[V, S & IO],
+            stream: Stream[V, S & Sync],
             subscriber: Subscriber[? >: V]
         )(
-            subscribeCallback: (Fiber[StreamCanceled, StreamComplete] < (IO & S)) => Unit
+            subscribeCallback: (Fiber[StreamCanceled, StreamComplete] < (Sync & S)) => Unit
         )(
             using
             AllowUnsafe,

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/package.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/package.scala
@@ -15,36 +15,36 @@ package object flow:
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Stream[T, Async] < (Resource & IO) =
+    ): Stream[T, Async] < (Resource & Sync) =
         for
             subscriber <- StreamSubscriber[T](bufferSize, emitStrategy)
-            _          <- IO(publisher.subscribe(subscriber))
+            _          <- Sync(publisher.subscribe(subscriber))
             stream     <- subscriber.stream
         yield stream
 
     @nowarn("msg=anonymous")
     def subscribeToStream[T, S](
-        using Isolate.Contextual[S, IO]
+        using Isolate.Contextual[S, Sync]
     )(
-        stream: Stream[T, S & IO],
+        stream: Stream[T, S & Sync],
         subscriber: Subscriber[? >: T]
     )(
         using
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Subscription < (Resource & IO & S) =
+    ): Subscription < (Resource & Sync & S) =
         StreamSubscription.subscribe(stream, subscriber)
 
     def streamToPublisher[T, S](
-        using Isolate.Contextual[S, IO]
+        using Isolate.Contextual[S, Sync]
     )(
-        stream: Stream[T, S & IO]
+        stream: Stream[T, S & Sync]
     )(
         using
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Publisher[T] < (Resource & IO & S) = StreamPublisher[T, S](stream)
+    ): Publisher[T] < (Resource & Sync & S) = StreamPublisher[T, S](stream)
 
 end flow

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/reactive-streams/package.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/reactive-streams/package.scala
@@ -16,21 +16,21 @@ package object reactivestreams:
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Stream[T, Async] < (Resource & IO) =
+    ): Stream[T, Async] < (Resource & Sync) =
         flow.fromPublisher(FlowAdapters.toFlowPublisher(publisher), bufferSize, emitStrategy)
 
     @nowarn("msg=anonymous")
     def subscribeToStream[T, S](
-        using Isolate.Contextual[S, IO]
+        using Isolate.Contextual[S, Sync]
     )(
-        stream: Stream[T, S & IO],
+        stream: Stream[T, S & Sync],
         subscriber: Subscriber[? >: T]
     )(
         using
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Subscription < (Resource & IO & S) =
+    ): Subscription < (Resource & Sync & S) =
         flow.subscribeToStream(stream, FlowAdapters.toFlowSubscriber(subscriber)).map { subscription =>
             new Subscription:
                 override def request(n: Long): Unit = subscription.request(n)
@@ -38,15 +38,15 @@ package object reactivestreams:
         }
 
     def streamToPublisher[T, S](
-        using Isolate.Contextual[S, IO]
+        using Isolate.Contextual[S, Sync]
     )(
-        stream: Stream[T, S & IO]
+        stream: Stream[T, S & Sync]
     )(
         using
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Publisher[T] < (Resource & IO & S) = flow.streamToPublisher(stream).map { publisher =>
+    ): Publisher[T] < (Resource & Sync & S) = flow.streamToPublisher(stream).map { publisher =>
         FlowAdapters.toPublisher(publisher)
     }
 end reactivestreams

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/package.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/package.scala
@@ -5,7 +5,7 @@ import kyo.*
 import kyo.interop.flow.*
 
 object StreamReactiveStreamsExtensions:
-    extension [T, S](stream: Stream[T, S & IO])(using Isolate.Contextual[S, IO])
+    extension [T, S](stream: Stream[T, S & Sync])(using Isolate.Contextual[S, Sync])
         def subscribe(
             subscriber: Subscriber[? >: T]
         )(
@@ -13,7 +13,7 @@ object StreamReactiveStreamsExtensions:
             Frame,
             Tag[Emit[Chunk[T]]],
             Tag[Poll[Chunk[T]]]
-        ): Subscription < (Resource & IO & S) =
+        ): Subscription < (Resource & Sync & S) =
             subscribeToStream(stream, subscriber)
 
         def toPublisher(
@@ -21,7 +21,7 @@ object StreamReactiveStreamsExtensions:
             Frame,
             Tag[Emit[Chunk[T]]],
             Tag[Poll[Chunk[T]]]
-        ): Publisher[T] < (Resource & IO & S) =
+        ): Publisher[T] < (Resource & Sync & S) =
             streamToPublisher(stream)
     end extension
 end StreamReactiveStreamsExtensions

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/CancellationTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/CancellationTest.scala
@@ -6,9 +6,9 @@ import kyo.*
 final class CancellationTest extends Test:
     final class Sub[A](b: AtomicBoolean) extends Subscriber[A]:
         import AllowUnsafe.embrace.danger
-        def onNext(t: A)                 = IO.Unsafe.evalOrThrow(b.set(true))
-        def onComplete()                 = IO.Unsafe.evalOrThrow(b.set(true))
-        def onError(e: Throwable)        = IO.Unsafe.evalOrThrow(b.set(true))
+        def onNext(t: A)                 = Sync.Unsafe.evalOrThrow(b.set(true))
+        def onComplete()                 = Sync.Unsafe.evalOrThrow(b.set(true))
+        def onError(e: Throwable)        = Sync.Unsafe.evalOrThrow(b.set(true))
         def onSubscribe(s: Subscription) = ()
     end Sub
 
@@ -16,7 +16,7 @@ final class CancellationTest extends Test:
 
     val attempts = 100
 
-    def testStreamSubscription(clue: String)(program: Subscription => Unit): Unit < (IO & Resource) =
+    def testStreamSubscription(clue: String)(program: Subscription => Unit): Unit < (Sync & Resource) =
         Loop(attempts) { index =>
             if index <= 0 then
                 Loop.done
@@ -24,7 +24,7 @@ final class CancellationTest extends Test:
                 for
                     flag         <- AtomicBoolean.init(false)
                     subscription <- StreamSubscription.subscribe(stream, new Sub(flag))
-                    _            <- IO(program(subscription))
+                    _            <- Sync(program(subscription))
                 yield Loop.continue(index - 1)
             end if
         }

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamPublisherTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamPublisherTest.scala
@@ -27,7 +27,7 @@ final class StreamPublisherTest extends PublisherVerification[Int](new TestEnvir
                 StreamPublisher.Unsafe(
                     createStream(n.toInt),
                     subscribeCallback = fiber =>
-                        discard(IO.Unsafe.evalOrThrow(Async.runAndBlock(Duration.Infinity)(fiber)))
+                        discard(Sync.Unsafe.evalOrThrow(Async.runAndBlock(Duration.Infinity)(fiber)))
                 )
             )
         end if
@@ -39,7 +39,7 @@ final class StreamPublisherTest extends PublisherVerification[Int](new TestEnvir
                 createStream(),
                 subscribeCallback = fiber =>
                     val asynced = Async.runAndBlock(Duration.Infinity)(fiber)
-                    val result  = IO.Unsafe.evalOrThrow(asynced)
+                    val result  = Sync.Unsafe.evalOrThrow(asynced)
                     discard(result.unsafe.interrupt())
             )
         )

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamSubscriberTest.scala
@@ -26,7 +26,7 @@ class StreamSubscriberTest extends SubscriberWhiteboxVerification[Int](new TestE
             .map: s =>
                 new WhiteboxSubscriber(s, p)
 
-        IO.Unsafe.evalOrThrow(streamSubscriber)
+        Sync.Unsafe.evalOrThrow(streamSubscriber)
     end createSubscriber
 
     def createElement(i: Int): Int = counter.getAndIncrement
@@ -56,7 +56,7 @@ final class WhiteboxSubscriber[V](
         probe.registerOnSubscribe(
             new SubscriberPuppet:
                 override def triggerRequest(elements: Long): Unit =
-                    val computation: Unit < IO = Loop(elements) { remaining =>
+                    val computation: Unit < Sync = Loop(elements) { remaining =>
                         if remaining <= 0 then
                             Loop.done
                         else
@@ -64,7 +64,7 @@ final class WhiteboxSubscriber[V](
                                 Loop.continue(remaining - accepted)
                             }
                     }
-                    discard(IO.Unsafe.evalOrThrow(computation))
+                    discard(Sync.Unsafe.evalOrThrow(computation))
                 end triggerRequest
 
                 override def signalCancel(): Unit =
@@ -108,12 +108,12 @@ final class SubscriberBlackboxSpec extends SubscriberBlackboxVerification[Int](n
             .map:
                 case 0 => StreamSubscriber[Int](bufferSize = 16, EmitStrategy.Buffer)
                 case 1 => StreamSubscriber[Int](bufferSize = 16, EmitStrategy.Eager)
-        new StreamSubscriberWrapper(IO.Unsafe.evalOrThrow(streamSubscriber))
+        new StreamSubscriberWrapper(Sync.Unsafe.evalOrThrow(streamSubscriber))
     end createSubscriber
 
     override def triggerRequest(s: Subscriber[? >: Int]): Unit =
-        val computation: Long < IO = s.asInstanceOf[StreamSubscriberWrapper[Int]].streamSubscriber.request
-        discard(IO.Unsafe.evalOrThrow(computation))
+        val computation: Long < Sync = s.asInstanceOf[StreamSubscriberWrapper[Int]].streamSubscriber.request
+        discard(Sync.Unsafe.evalOrThrow(computation))
 
     def createElement(i: Int): Int = counter.incrementAndGet()
 end SubscriberBlackboxSpec

--- a/kyo-stats-otel/shared/src/main/scala/kyo/stats/otel/OTelTraceReceiver.scala
+++ b/kyo-stats-otel/shared/src/main/scala/kyo/stats/otel/OTelTraceReceiver.scala
@@ -18,8 +18,8 @@ class OTelTraceReceiver extends TraceReceiver {
         name: String,
         parent: Maybe[Span],
         attributes: Attributes
-    )(implicit frame: Frame): Span < IO =
-        IO {
+    )(implicit frame: Frame): Span < Sync =
+        Sync {
             val b =
                 otel.getTracer(scope.mkString("_"))
                     .spanBuilder(name)

--- a/kyo-stm/shared/src/main/scala/kyo/STM.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/STM.scala
@@ -100,7 +100,7 @@ object STM:
                         Abort.recoverError[E] { error =>
                             // Retry arbitrary E failures in case the transaction is inconsistent
                             Var.use[TRefLog] { log =>
-                                IO.Unsafe {
+                                Sync.Unsafe {
                                     if !commit(tid, log, probe = true) then
                                         // The ref log shows inconsistency, retry the transaction
                                         Abort.fail(FailedTransaction(Present(error)))
@@ -112,7 +112,7 @@ object STM:
                         },
                         Var.runTuple(TRefLog.empty)
                     ).map { (log, result) =>
-                        IO.Unsafe {
+                        Sync.Unsafe {
                             if !commit(tid, log) then
                                 Abort.fail(FailedTransaction())
                             else

--- a/kyo-stm/shared/src/main/scala/kyo/TChunk.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TChunk.scala
@@ -15,7 +15,7 @@ object TChunk:
       * @return
       *   a new empty transactional chunk
       */
-    def init[A](using Frame): TChunk[A] < IO =
+    def init[A](using Frame): TChunk[A] < Sync =
         init(Chunk.empty[A])
 
     /** Creates a new TChunk containing the provided values.
@@ -25,7 +25,7 @@ object TChunk:
       * @return
       *   A new TChunk containing the values, within the IO effect
       */
-    def init[A](values: A*)(using Frame): TChunk[A] < IO =
+    def init[A](values: A*)(using Frame): TChunk[A] < Sync =
         init(Chunk.from(values))
 
     /** Creates a new TChunk from an existing Chunk.
@@ -35,7 +35,7 @@ object TChunk:
       * @return
       *   A new TChunk containing the chunk, within the IO effect
       */
-    def init[A](chunk: Chunk[A])(using Frame): TChunk[A] < IO =
+    def init[A](chunk: Chunk[A])(using Frame): TChunk[A] < Sync =
         initWith(chunk)(identity)
 
     /** Creates a new TChunk and immediately applies a function to it.
@@ -50,7 +50,7 @@ object TChunk:
       * @return
       *   The result of applying the function to the new TChunk, within combined IO and S effects
       */
-    inline def initWith[A, B, S](chunk: Chunk[A])(inline f: TChunk[A] => B < S)(using inline frame: Frame): B < (IO & S) =
+    inline def initWith[A, B, S](chunk: Chunk[A])(inline f: TChunk[A] => B < S)(using inline frame: Frame): B < (Sync & S) =
         TRef.initWith(chunk)(f)
 
     private def useRef[A, B, S](ref: TRef[A], f: A => B < S)(using Frame) = ref.use(f(_))

--- a/kyo-stm/shared/src/main/scala/kyo/TChunk.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TChunk.scala
@@ -23,7 +23,7 @@ object TChunk:
       * @param values
       *   The initial values to store in the chunk
       * @return
-      *   A new TChunk containing the values, within the IO effect
+      *   A new TChunk containing the values, within the Sync effect
       */
     def init[A](values: A*)(using Frame): TChunk[A] < Sync =
         init(Chunk.from(values))
@@ -33,7 +33,7 @@ object TChunk:
       * @param chunk
       *   The initial chunk to wrap
       * @return
-      *   A new TChunk containing the chunk, within the IO effect
+      *   A new TChunk containing the chunk, within the Sync effect
       */
     def init[A](chunk: Chunk[A])(using Frame): TChunk[A] < Sync =
         initWith(chunk)(identity)

--- a/kyo-stm/shared/src/main/scala/kyo/TChunk.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TChunk.scala
@@ -48,7 +48,7 @@ object TChunk:
       * @param f
       *   The function to apply to the newly created TChunk
       * @return
-      *   The result of applying the function to the new TChunk, within combined IO and S effects
+      *   The result of applying the function to the new TChunk, within combined Sync and S effects
       */
     inline def initWith[A, B, S](chunk: Chunk[A])(inline f: TChunk[A] => B < S)(using inline frame: Frame): B < (Sync & S) =
         TRef.initWith(chunk)(f)

--- a/kyo-stm/shared/src/main/scala/kyo/TID.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TID.scala
@@ -9,8 +9,8 @@ private[kyo] object TID:
 
     def next(using AllowUnsafe): Long = nextTid.incrementAndGet()
 
-    inline def useNew[A, S](inline f: Long => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.Unsafe {
+    inline def useNew[A, S](inline f: Long => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.Unsafe {
             val tid = nextTid.incrementAndGet()
             tidLocal.let(tid)(f(tid))
         }
@@ -18,11 +18,11 @@ private[kyo] object TID:
     inline def useIO[A, S](inline f: Long => A < S)(using inline frame: Frame): A < S =
         tidLocal.use(f(_))
 
-    inline def useIOUnsafe[A, S](inline f: AllowUnsafe ?=> Long => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.Unsafe.withLocal(tidLocal)(f(_))
+    inline def useIOUnsafe[A, S](inline f: AllowUnsafe ?=> Long => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.Unsafe.withLocal(tidLocal)(f(_))
 
-    inline def useIORequired[A, S](inline f: Long => A < S)(using inline frame: Frame): A < (S & IO) =
-        IO.withLocal(tidLocal) {
+    inline def useIORequired[A, S](inline f: Long => A < S)(using inline frame: Frame): A < (S & Sync) =
+        Sync.withLocal(tidLocal) {
             case -1L => bug("STM operation attempted outside of STM.run - this should be impossible due to effect typing")
             case tid => f(tid)
         }

--- a/kyo-stm/shared/src/main/scala/kyo/TMap.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TMap.scala
@@ -22,7 +22,7 @@ object TMap:
     /** Creates a new empty TMap.
       *
       * @return
-      *   A new empty TMap within the IO effect
+      *   A new empty TMap within the Sync effect
       */
     def init[K, V](using Frame): TMap[K, V] < Sync =
         TRef.init(Map.empty)
@@ -32,7 +32,7 @@ object TMap:
       * @param entries
       *   The initial key-value pairs to store in the map
       * @return
-      *   A new TMap containing the entries, within the IO effect
+      *   A new TMap containing the entries, within the Sync effect
       */
     def init[K, V](entries: (K, V)*)(using Frame): TMap[K, V] < Sync =
         initWith(entries*)(identity)
@@ -42,7 +42,7 @@ object TMap:
       * @param map
       *   The initial map to wrap
       * @return
-      *   A new TMap containing the map entries, within the IO effect
+      *   A new TMap containing the map entries, within the Sync effect
       */
     def init[K, V](map: Map[K, V])(using Frame): TMap[K, V] < Sync =
         init(map.toSeq*)

--- a/kyo-stm/shared/src/main/scala/kyo/TMap.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TMap.scala
@@ -57,7 +57,7 @@ object TMap:
       * @param f
       *   The function to apply to the newly created TMap
       * @return
-      *   The result of applying the function to the new TMap, within combined IO and S effects
+      *   The result of applying the function to the new TMap, within combined Sync and S effects
       */
     inline def initWith[K, V](inline entries: (K, V)*)[A, S](inline f: TMap[K, V] => A < S)(
         using inline frame: Frame

--- a/kyo-stm/shared/src/main/scala/kyo/TMap.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TMap.scala
@@ -24,7 +24,7 @@ object TMap:
       * @return
       *   A new empty TMap within the IO effect
       */
-    def init[K, V](using Frame): TMap[K, V] < IO =
+    def init[K, V](using Frame): TMap[K, V] < Sync =
         TRef.init(Map.empty)
 
     /** Creates a new TMap containing the provided key-value pairs.
@@ -34,7 +34,7 @@ object TMap:
       * @return
       *   A new TMap containing the entries, within the IO effect
       */
-    def init[K, V](entries: (K, V)*)(using Frame): TMap[K, V] < IO =
+    def init[K, V](entries: (K, V)*)(using Frame): TMap[K, V] < Sync =
         initWith(entries*)(identity)
 
     /** Creates a new TMap from an existing Map.
@@ -44,7 +44,7 @@ object TMap:
       * @return
       *   A new TMap containing the map entries, within the IO effect
       */
-    def init[K, V](map: Map[K, V])(using Frame): TMap[K, V] < IO =
+    def init[K, V](map: Map[K, V])(using Frame): TMap[K, V] < Sync =
         init(map.toSeq*)
 
     /** Creates a new TMap and immediately applies a function to it.
@@ -61,7 +61,7 @@ object TMap:
       */
     inline def initWith[K, V](inline entries: (K, V)*)[A, S](inline f: TMap[K, V] => A < S)(
         using inline frame: Frame
-    ): TMap[K, V] < (IO & S) =
+    ): TMap[K, V] < (Sync & S) =
         TID.useIOUnsafe { tid =>
             val trefs =
                 entries.foldLeft(Map.empty[K, TRef[V]]) {

--- a/kyo-stm/shared/src/main/scala/kyo/TRef.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TRef.scala
@@ -180,7 +180,7 @@ object TRef:
       * @param f
       *   The function to apply to the newly created TRef
       * @return
-      *   The result of applying the function to the new TRef, within combined IO and S effects
+      *   The result of applying the function to the new TRef, within combined Sync and S effects
       */
     inline def initWith[A, B, S](inline value: A)(inline f: TRef[A] => B < S)(using inline frame: Frame): B < (Sync & S) =
         TID.useIOUnsafe { tid =>

--- a/kyo-stm/shared/src/main/scala/kyo/TRef.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TRef.scala
@@ -165,7 +165,7 @@ object TRef:
       * @param value
       *   The initial value to store in the reference
       * @return
-      *   A new TRef containing the value, within the IO effect
+      *   A new TRef containing the value, within the Sync effect
       */
     def init[A](value: A)(using Frame): TRef[A] < Sync =
         initWith(value)(identity)

--- a/kyo-stm/shared/src/main/scala/kyo/TRef.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TRef.scala
@@ -167,7 +167,7 @@ object TRef:
       * @return
       *   A new TRef containing the value, within the IO effect
       */
-    def init[A](value: A)(using Frame): TRef[A] < IO =
+    def init[A](value: A)(using Frame): TRef[A] < Sync =
         initWith(value)(identity)
 
     /** Creates a new TRef and immediately applies a function to it.
@@ -182,7 +182,7 @@ object TRef:
       * @return
       *   The result of applying the function to the new TRef, within combined IO and S effects
       */
-    inline def initWith[A, B, S](inline value: A)(inline f: TRef[A] => B < S)(using inline frame: Frame): B < (IO & S) =
+    inline def initWith[A, B, S](inline value: A)(inline f: TRef[A] => B < S)(using inline frame: Frame): B < (Sync & S) =
         TID.useIOUnsafe { tid =>
             f(TRef.Unsafe.init(tid, value))
         }

--- a/kyo-stm/shared/src/main/scala/kyo/TSchedule.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TSchedule.scala
@@ -32,7 +32,7 @@ object TSchedule:
       * @param f
       *   The function to apply to the newly created TSchedule
       * @return
-      *   The result of applying the function to the new TSchedule, within combined IO and S effects
+      *   The result of applying the function to the new TSchedule, within combined Sync and S effects
       */
     inline def initWith[A, S](schedule: Schedule)(inline f: TSchedule => A < S)(using Frame): A < (Sync & S) =
         Clock.now.map(now => TRef.initWith(schedule.next(now))(f))

--- a/kyo-stm/shared/src/main/scala/kyo/TSchedule.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TSchedule.scala
@@ -17,7 +17,7 @@ object TSchedule:
       * @param schedule
       *   The initial schedule to wrap
       * @return
-      *   A new TSchedule containing the schedule, within the IO effect
+      *   A new TSchedule containing the schedule, within the Sync effect
       */
     def init(schedule: Schedule)(using Frame): TSchedule < Sync =
         initWith(schedule)(identity)

--- a/kyo-stm/shared/src/main/scala/kyo/TSchedule.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TSchedule.scala
@@ -19,7 +19,7 @@ object TSchedule:
       * @return
       *   A new TSchedule containing the schedule, within the IO effect
       */
-    def init(schedule: Schedule)(using Frame): TSchedule < IO =
+    def init(schedule: Schedule)(using Frame): TSchedule < Sync =
         initWith(schedule)(identity)
 
     /** Creates a new TSchedule and immediately applies a function to it.
@@ -34,7 +34,7 @@ object TSchedule:
       * @return
       *   The result of applying the function to the new TSchedule, within combined IO and S effects
       */
-    inline def initWith[A, S](schedule: Schedule)(inline f: TSchedule => A < S)(using Frame): A < (IO & S) =
+    inline def initWith[A, S](schedule: Schedule)(inline f: TSchedule => A < S)(using Frame): A < (Sync & S) =
         Clock.now.map(now => TRef.initWith(schedule.next(now))(f))
 
     extension (self: TSchedule)

--- a/kyo-stm/shared/src/main/scala/kyo/TTable.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TTable.scala
@@ -111,7 +111,7 @@ object TTable:
       * @tparam Fields
       *   The record structure for the table
       * @return
-      *   A new TTable instance within the IO effect
+      *   A new TTable instance within the Sync effect
       */
     def init[Fields: AsFields](using Frame): TTable[Fields] < Sync =
         for
@@ -284,7 +284,7 @@ object TTable:
           * @tparam Indexes
           *   The subset of fields that should be indexed
           * @return
-          *   A new Indexed table instance within the IO effect
+          *   A new Indexed table instance within the Sync effect
           */
         def init[Fields: AsFields as fields, Indexes >: Fields: AsFields as indexFields](using Frame): Indexed[Fields, Indexes] < Sync =
             for

--- a/kyo-stm/shared/src/main/scala/kyo/TTable.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TTable.scala
@@ -113,7 +113,7 @@ object TTable:
       * @return
       *   A new TTable instance within the IO effect
       */
-    def init[Fields: AsFields](using Frame): TTable[Fields] < IO =
+    def init[Fields: AsFields](using Frame): TTable[Fields] < Sync =
         for
             nextId <- TRef.init(0)
             store  <- TMap.init[Int, Record[Fields]]
@@ -286,7 +286,7 @@ object TTable:
           * @return
           *   A new Indexed table instance within the IO effect
           */
-        def init[Fields: AsFields as fields, Indexes >: Fields: AsFields as indexFields](using Frame): Indexed[Fields, Indexes] < IO =
+        def init[Fields: AsFields as fields, Indexes >: Fields: AsFields as indexFields](using Frame): Indexed[Fields, Indexes] < Sync =
             for
                 table <- TTable.init[Fields]
                 indexes <-

--- a/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
@@ -790,7 +790,7 @@ class STMTest extends Test:
     "bug #925" in runJVM {
         def unsafeToFuture[A](a: => A < (Async & Abort[Throwable])): Future[A] =
             import kyo.AllowUnsafe.embrace.danger
-            IO.Unsafe.evalOrThrow(
+            Sync.Unsafe.evalOrThrow(
                 Async.run(a).map(_.toFuture)
             )
         end unsafeToFuture

--- a/kyo-stm/shared/src/test/scala/kyo/TRefLogTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TRefLogTest.scala
@@ -13,7 +13,7 @@ class TTRefLogTest extends Test:
         }
 
         "put" in run {
-            IO {
+            Sync {
                 val ref   = new TRefImpl[Int](Write(0, 0))
                 val entry = Write(1, 42)
                 val log   = TRefLog.empty.put(ref, entry)
@@ -24,7 +24,7 @@ class TTRefLogTest extends Test:
         }
 
         "get" in run {
-            IO {
+            Sync {
                 val ref   = new TRefImpl[Int](Write(0, 0))
                 val entry = Write(1, 42)
                 val log   = TRefLog.empty.put(ref, entry)
@@ -34,7 +34,7 @@ class TTRefLogTest extends Test:
         }
 
         "toSeq" in run {
-            IO {
+            Sync {
                 val ref1   = new TRefImpl[Int](Write(0, 0))
                 val ref2   = new TRefImpl[Int](Write(0, 0))
                 val entry1 = Write(1, 42)

--- a/kyo-sttp/jvm/src/test/scala/kyo/RequestsLiveTest.scala
+++ b/kyo-sttp/jvm/src/test/scala/kyo/RequestsLiveTest.scala
@@ -34,8 +34,8 @@ class RequestsLiveTest extends Test:
         endpointPath: String,
         response: Try[String],
         port: Int = 8000
-    ): Int < (IO & Resource) =
-        IO {
+    ): Int < (Sync & Resource) =
+        Sync {
 
             import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
             import java.io.OutputStream
@@ -64,6 +64,6 @@ class RequestsLiveTest extends Test:
             server.setExecutor(null)
             server.start()
             Resource.ensure(server.stop(0))
-                .andThen(IO(server.getAddress.getPort()))
+                .andThen(Sync(server.getAddress.getPort()))
         }
 end RequestsLiveTest

--- a/kyo-sttp/native/src/main/scala/kyo/PlatformBackend.scala
+++ b/kyo-sttp/native/src/main/scala/kyo/PlatformBackend.scala
@@ -10,7 +10,7 @@ object PlatformBackend:
             def send[A](r: Request[A, Any]) =
                 given Frame = Frame.internal
                 def call    = r.send(b)
-                Abort.run[Throwable](IO(call))
+                Abort.run[Throwable](Sync(call))
                     .map(_.foldError(identity, ex => Abort.fail(FailedRequest(ex.failureOrPanic))))
             end send
 end PlatformBackend

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -32,23 +32,23 @@ class KyoSttpMonad extends MonadAsyncError[M]:
         Promise.initWith[Nothing, Unit] { p =>
             def run =
                 Async.run(e).map(p.become).unit
-            IO.ensure(run)(f).map(r => p.get.andThen(r))
+            Sync.ensure(run)(f).map(r => p.get.andThen(r))
         }
 
     def error[A](t: Throwable) =
-        IO(throw t)
+        Sync(throw t)
 
     def unit[A](t: A) =
         t
 
     override def eval[A](t: => A) =
-        IO(t)
+        Sync(t)
 
     override def suspend[A](t: => M[A]) =
-        IO(t)
+        Sync(t)
 
     def async[A](register: (Either[Throwable, A] => Unit) => Canceler): M[A] =
-        IO.Unsafe {
+        Sync.Unsafe {
             val p = Promise.Unsafe.init[Nothing, A]()
             val canceller =
                 register {

--- a/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
@@ -7,25 +7,25 @@ import sttp.monad.Canceler
 class KyoSttpMonadTest extends Test:
 
     "map" in run {
-        KyoSttpMonad.map(IO(1))(_ + 1).map(r => assert(r == 2))
+        KyoSttpMonad.map(Sync(1))(_ + 1).map(r => assert(r == 2))
     }
 
     "flatMap" in run {
-        KyoSttpMonad.flatMap(IO(1))(v => IO(v + 1)).map(r => assert(r == 2))
+        KyoSttpMonad.flatMap(Sync(1))(v => Sync(v + 1)).map(r => assert(r == 2))
     }
 
     "handleError" - {
         "ok" in run {
-            KyoSttpMonad.handleError(IO(1))(_ => 2).map(r => assert(r == 1))
+            KyoSttpMonad.handleError(Sync(1))(_ => 2).map(r => assert(r == 1))
         }
         "nok" in run {
-            KyoSttpMonad.handleError(IO(throw new Exception))(_ => 2).map(r => assert(r == 2))
+            KyoSttpMonad.handleError(Sync(throw new Exception))(_ => 2).map(r => assert(r == 2))
         }
     }
 
     "ensure" in run {
         var calls = 0
-        KyoSttpMonad.ensure(IO(1), IO(calls += 1)).map { r =>
+        KyoSttpMonad.ensure(Sync(1), Sync(calls += 1)).map { r =>
             assert(r == 1)
             assert(calls == 1)
         }

--- a/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
@@ -36,7 +36,7 @@ object Routes:
       */
     def run[A, S](server: NettyKyoServer)(v: Unit < (Routes & S))(using Frame): NettyKyoServerBinding < (Async & S) =
         Emit.run[Route][Unit, Nothing, Async & S](v).map { (routes, _) =>
-            IO(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Async & S)
+            Sync(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Async & S)
         }
     end run
 

--- a/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServer.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServer.scala
@@ -80,10 +80,10 @@ case class NettyKyoServer(
         block: () => KyoSttpMonad.M[ServerResponse[NettyResponse]]
     ): (Future[ServerResponse[NettyResponse]], () => Future[Unit]) =
         import AllowUnsafe.embrace.danger
-        val fiber  = IO.Unsafe.evalOrThrow(Async.run(block()))
-        val future = IO.Unsafe.evalOrThrow(fiber.toFuture)
+        val fiber  = Sync.Unsafe.evalOrThrow(Async.run(block()))
+        val future = Sync.Unsafe.evalOrThrow(fiber.toFuture)
         val cancel = () =>
-            val _ = IO.Unsafe.evalOrThrow(fiber.interrupt)
+            val _ = Sync.Unsafe.evalOrThrow(fiber.interrupt)
             Future.unit
         (future, cancel)
     end unsafeRunAsync

--- a/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServerInterpreter.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServerInterpreter.scala
@@ -47,7 +47,7 @@ object NettyKyoServerInterpreter:
                 else
                     f
             import AllowUnsafe.embrace.danger
-            val _ = IO.Unsafe.evalOrThrow(Async.run(exec))
+            val _ = Sync.Unsafe.evalOrThrow(Async.run(exec))
         end apply
     end KyoRunAsync
 end NettyKyoServerInterpreter

--- a/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
@@ -7,7 +7,7 @@ import kyo.*
 object KyoUtil:
     def nettyChannelFutureToScala(nettyFuture: ChannelFuture)(using Frame): Channel < Async =
         Promise.initWith[Nothing, Channel] { p =>
-            p.onComplete(_ => IO(discard(nettyFuture.cancel(true)))).andThen {
+            p.onComplete(_ => Sync(discard(nettyFuture.cancel(true)))).andThen {
                 nettyFuture.addListener((future: ChannelFuture) =>
                     discard {
                         import AllowUnsafe.embrace.danger
@@ -21,7 +21,7 @@ object KyoUtil:
 
     def nettyFutureToScala[A](f: io.netty.util.concurrent.Future[A])(using Frame): A < Async =
         Promise.initWith[Nothing, A] { p =>
-            p.onComplete(_ => IO(discard(f.cancel(true)))).andThen {
+            p.onComplete(_ => Sync(discard(f.cancel(true)))).andThen {
                 f.addListener((future: io.netty.util.concurrent.Future[A]) =>
                     discard {
                         import AllowUnsafe.embrace.danger

--- a/kyo-zio-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
+++ b/kyo-zio-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
@@ -15,10 +15,10 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
                 }
             ),
             suite("failing!")(
-                test("IO fail") {
+                test("Sync fail") {
                     Sync(throw new Exception("Fail!")).map(_ => assertCompletes)
                 },
-                test("IO Succeed") {
+                test("Sync Succeed") {
                     Abort.fail[Throwable](new RuntimeException("Abort!")).map(_ => assertCompletes)
                 },
                 test("Async.delay") {

--- a/kyo-zio-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
+++ b/kyo-zio-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
@@ -11,12 +11,12 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
                     assertCompletes
                 },
                 test("IOs Succeed") {
-                    IO(assertCompletes)
+                    Sync(assertCompletes)
                 }
             ),
             suite("failing!")(
                 test("IO fail") {
-                    IO(throw new Exception("Fail!")).map(_ => assertCompletes)
+                    Sync(throw new Exception("Fail!")).map(_ => assertCompletes)
                 },
                 test("IO Succeed") {
                     Abort.fail[Throwable](new RuntimeException("Abort!")).map(_ => assertCompletes)
@@ -43,7 +43,7 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
                 ),
                 test("checkKyo")(
                     check(Gen.boolean) { b =>
-                        IO(assertTrue(b == b))
+                        Sync(assertTrue(b == b))
                     }
                 )
             )

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -17,7 +17,7 @@ object ZIOs:
       *   A Kyo effect that, when run, will execute the zio.ZIO
       */
     def get[E, A](v: => ZIO[Any, E, A])(using f: Frame, t: zio.Trace): A < (Abort[E] & Async) =
-        IO.Unsafe {
+        Sync.Unsafe {
             Unsafe.unsafely {
                 given ce: CanEqual[E, E] = CanEqual.derived
                 val p                    = Promise.Unsafe.init[E, A]()
@@ -67,7 +67,7 @@ object ZIOs:
                         fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))
                     })
                 }
-            }.handle(IO.Unsafe.evalOrThrow)
+            }.handle(Sync.Unsafe.evalOrThrow)
         }
     end run
 

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -132,15 +132,15 @@ class ZIOsTest extends Test:
 
     "interrupts" - {
 
-        def kyoLoop(started: CountDownLatch, done: CountDownLatch): Unit < IO =
-            def loop(i: Int): Unit < IO =
-                IO {
+        def kyoLoop(started: CountDownLatch, done: CountDownLatch): Unit < Sync =
+            def loop(i: Int): Unit < Sync =
+                Sync {
                     if i == 0 then
-                        IO(started.countDown()).andThen(loop(i + 1))
+                        Sync(started.countDown()).andThen(loop(i + 1))
                     else
                         loop(i + 1)
                 }
-            IO.ensure(IO(done.countDown()))(loop(0))
+            Sync.ensure(Sync(done.countDown()))(loop(0))
         end kyoLoop
 
         def zioLoop(started: CountDownLatch, done: CountDownLatch): Task[Unit] =
@@ -235,10 +235,10 @@ class ZIOsTest extends Test:
                     val panic   = Result.Panic(new Exception)
                     for
                         f <- Async.run(ZIOs.get(zioLoop(started, done)))
-                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt(panic)
                         r <- f.getResult
-                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r == panic)
                     end for
                 }
@@ -253,10 +253,10 @@ class ZIOsTest extends Test:
                         yield ()
                     for
                         f <- Async.run(v)
-                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }
@@ -271,10 +271,10 @@ class ZIOsTest extends Test:
                     end parallelEffect
                     for
                         f <- Async.run(parallelEffect)
-                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }
@@ -289,10 +289,10 @@ class ZIOsTest extends Test:
                     end raceEffect
                     for
                         f <- Async.run(raceEffect)
-                        _ <- IO(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- IO(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }


### PR DESCRIPTION

Proposition from @johnhungerford. 


---

- [x] basic rename
- [x] update Readme.md



-----

Reasoning
---

# Why Rename `IO` to `Sync` in Kyo?

## Motivation

The proposed change renames the `IO` effect in Kyo to `Sync`. This aligns better with Kyo’s goals of clarity, approachability, and a modern design that avoids unnecessary historical baggage from functional programming traditions.

---

## ✅ Benefits of Renaming to `Sync`

| Criterion                        | IO                         | Sync                         |
|----------------------------------|-----------------------------|------------------------------|
| **Clarity**                      | Suggests I/O operations     | Clearly indicates synchronous suspension |
| **Symmetry with `Async`**        | No                         | Yes                          |
| **Pedagogical Simplicity**       | Requires FP background      | Self-explanatory             |
| **Naming Semantics**             | Historical (Haskell/CE/ZIO) | Descriptive, intuitive       |
| **Effect Nature**                | Ambiguous (I/O vs memory)   | Explicit: suspended sync side-effects |
| **Learning Curve**               | Steeper for non-FP devs     | Lower, clearer mental model  |
| **Consistency**                  | Inherited                   | Aligns with Kyo’s direction  |

---

## ❌ Downsides

- **Longer name**: `Sync` has 4 characters vs `IO`'s 2.
- **Migration**: Requires updating existing codebases and documentation.
- **Community inertia**: Familiarity with `IO` from FP libraries (ZIO, Cats Effect, etc.).

---

## Counterpoints

- **Length**: `Sync` is still shorter than `Async`.
- **Community familiarity**: Only relevant for those with prior FP exposure, whereas Kyo aims to be beginner-friendly.
- **Migration path**: A deprecation alias (`type IO = Sync`) can ease the transition (e.g., in version `0.20`).

---

## Summary

Renaming `IO` to `Sync` enhances conceptual clarity, aligns with `Async`, and avoids misleading implications about the effect’s purpose. It's a pragmatic move to modernize terminology and improve approachability for a broader audience.

**Recommendation**:  
→ Proceed with `Sync` as the canonical name.  
→ Provide a deprecated `IO` alias temporarily for transition.
