### PR TITLE
Add reproducer for 'Stream.groupedWithin' closing resources

### DIFF
--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -678,6 +678,18 @@ class StreamCoreExtensionsTest extends Test:
                     yield assert(result.flatten == (1 to 10))
                 }.andThen(succeed)
             }
+
+            "resource" in run {
+                pending
+                class TestResource(var closes: Int = 0) extends java.io.Closeable:
+                    def close() = closes += 1
+
+                val stream        = Stream(Resource.acquire(TestResource()).map(r => Emit.value(Chunk(r))))
+                val groupedWithin = stream.groupedWithin(3, Duration.Infinity)
+                groupedWithin.run.map: grouped =>
+                    stream.run.map: streamResult =>
+                        assert(grouped.flatten.head.closes == streamResult.head.closes)
+            }
         }
     }
 


### PR DESCRIPTION
### Problem
groupedWithin (and other operators) shouldn't close open stream resources.

### Solution
For now, simply reproduce the issue. I plan to followup with some changes to resource.