### PR TITLE
Pipe variance

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Pipe.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Pipe.scala
@@ -216,7 +216,7 @@ sealed abstract class Pipe[-A, +B, -S] extends Serializable:
         Pipe:
             Poll.runEmit[Chunk[BB]](pollEmit)(pipe.pollEmit).unit
 
-    /** Join to a sink producing a new sink that transforms the stream prior to processing it.
+    /** Join to a sink producing a new sink that transforms a stream prior to processing it.
       *
       * @param sink
       *   Sink to prepend pipe to
@@ -237,7 +237,8 @@ sealed abstract class Pipe[-A, +B, -S] extends Serializable:
       * @return
       *   A new transformed stream
       */
-    def transform[AA <: A, S1](stream: Stream[AA, S1])(using
+    def transform[AA <: A, S1](stream: Stream[AA, S1])(
+        using
         emitTag: Tag[Emit[Chunk[AA]]],
         pollTag: Tag[Poll[Chunk[AA]]],
         fr: Frame
@@ -267,7 +268,8 @@ object Pipe:
 
     private val _empty = Pipe(())
 
-    def empty[A]: Pipe[A, A, Any] = _empty.asInstanceOf[Pipe[A, A, Any]]
+    /** A pipe that ignores the original stream and emits nothing * */
+    def empty[A, B]: Pipe[A, B, Any] = _empty
 
     /** A pipe that passes through the original stream without transforming it */
     def identity[A](using Tag[Emit[Chunk[A]]], Tag[Poll[Chunk[A]]], Frame): Pipe[A, A, Any] =

--- a/kyo-prelude/shared/src/main/scala/kyo/Pipe.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Pipe.scala
@@ -23,7 +23,7 @@ import scala.util.NotGiven
   * @tparam S
   *   The type of effects associated with the transformation
   */
-sealed abstract class Pipe[A, B, -S] extends Serializable:
+sealed abstract class Pipe[-A, +B, -S] extends Serializable:
 
     /** Returns the underlying effect that polls chunks of type A and emits chunks of type B */
     def pollEmit: Unit < (Poll[Chunk[A]] & Emit[Chunk[B]] & S)
@@ -35,9 +35,9 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   A pipe that accepts streams of the new element type
       */
-    def contramap[A1](f: A1 => A)(
+    def contramapPure[AA <: A, A1](f: A1 => AA)(
         using
-        t1: Tag[Poll[Chunk[A]]],
+        t1: Tag[Poll[Chunk[AA]]],
         t2: Tag[Poll[Chunk[A1]]],
         fr: Frame
     ): Pipe[A1, B, S] =
@@ -56,11 +56,10 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   A pipe that accepts streams of the new element type
       */
-    def contramap[A1, S1](f: A1 => A < S1)(
+    def contramap[AA <: A, A1, S1](f: A1 => AA < S1)(
         using
-        t1: Tag[Poll[Chunk[A]]],
+        t1: Tag[Poll[Chunk[AA]]],
         t2: Tag[Poll[Chunk[A1]]],
-        disc: Discriminator,
         fr: Frame
     ): Pipe[A1, B, S & S1] =
         Pipe:
@@ -81,9 +80,9 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   A pipe that accepts streams of the new element type
       */
-    def contramapChunk[A1](f: Chunk[A1] => Chunk[A])(
+    def contramapChunkPure[AA <: A, A1](f: Chunk[A1] => Chunk[AA])(
         using
-        t1: Tag[Poll[Chunk[A]]],
+        t1: Tag[Poll[Chunk[AA]]],
         t2: Tag[Poll[Chunk[A1]]],
         fr: Frame
     ): Pipe[A1, B, S] =
@@ -103,11 +102,10 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   A pipe that accepts streams of the new element type
       */
-    def contramapChunk[A1, S1](f: Chunk[A1] => Chunk[A] < S1)(
+    def contramapChunk[AA <: A, A1, S1](f: Chunk[A1] => Chunk[AA] < S1)(
         using
-        t1: Tag[Poll[Chunk[A]]],
+        t1: Tag[Poll[Chunk[AA]]],
         t2: Tag[Poll[Chunk[A1]]],
-        disc: Discriminator,
         fr: Frame
     ): Pipe[A1, B, S & S1] =
         Pipe:
@@ -129,9 +127,9 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   A new pipe with output stream transformed by the mapping function
       */
-    def map[B1](f: B => B1)(
+    def mapPure[BB >: B, B1](f: BB => B1)(
         using
-        t1: Tag[Emit[Chunk[B]]],
+        t1: Tag[Emit[Chunk[BB]]],
         t2: Tag[Emit[Chunk[B1]]],
         fr: Frame
     ): Pipe[A, B1, S] =
@@ -150,11 +148,10 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   A new pipe with output stream transformed by the mapping function
       */
-    def map[B1, S1](f: B => B1 < S1)(
+    def map[BB >: B, B1, S1](f: BB => B1 < S1)(
         using
-        t1: Tag[Emit[Chunk[B]]],
+        t1: Tag[Emit[Chunk[BB]]],
         t2: Tag[Emit[Chunk[B1]]],
-        disc: Discriminator,
         fr: Frame
     ): Pipe[A, B1, S & S1] =
         Pipe:
@@ -173,9 +170,9 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   A new pipe with output stream transformed by the mapping function
       */
-    def mapChunk[B1](f: Chunk[B] => Chunk[B1])(
+    def mapChunkPure[BB >: B, B1](f: Chunk[BB] => Chunk[B1])(
         using
-        t1: Tag[Emit[Chunk[B]]],
+        t1: Tag[Emit[Chunk[BB]]],
         t2: Tag[Emit[Chunk[B1]]],
         fr: Frame
     ): Pipe[A, B1, S] =
@@ -194,11 +191,10 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   A new pipe with output stream transformed by the mapping function
       */
-    def mapChunk[B1, S1](f: Chunk[B] => Chunk[B1] < S1)(
+    def mapChunk[BB >: B, B1, S1](f: Chunk[BB] => Chunk[B1] < S1)(
         using
-        t1: Tag[Emit[Chunk[B]]],
+        t1: Tag[Emit[Chunk[BB]]],
         t2: Tag[Emit[Chunk[B1]]],
-        disc: Discriminator,
         fr: Frame
     ): Pipe[A, B1, S & S1] =
         Pipe:
@@ -216,9 +212,9 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   New pipe that performs both transformations in sequence
       */
-    def join[C, S1](pipe: Pipe[B, C, S1])(using Tag[Emit[Chunk[B]]], Tag[Poll[Chunk[B]]], Frame): Pipe[A, C, S & S1] =
+    def join[BB >: B, C, S1](pipe: Pipe[BB, C, S1])(using Tag[Emit[Chunk[BB]]], Tag[Poll[Chunk[BB]]], Frame): Pipe[A, C, S & S1] =
         Pipe:
-            Poll.runEmit[Chunk[B]](pollEmit)(pipe.pollEmit).unit
+            Poll.runEmit[Chunk[BB]](pollEmit)(pipe.pollEmit).unit
 
     /** Join to a sink producing a new sink that transforms the stream prior to processing it.
       *
@@ -227,9 +223,9 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   New sink that transforms stream prior to processing it
       */
-    def join[C, S1](sink: Sink[B, C, S1])(using Tag[Emit[Chunk[B]]], Tag[Poll[Chunk[B]]], Frame): Sink[A, C, S & S1] =
+    def join[BB >: B, C, S1](sink: Sink[BB, C, S1])(using Tag[Emit[Chunk[BB]]], Tag[Poll[Chunk[BB]]], Frame): Sink[A, C, S & S1] =
         Sink:
-            Poll.runEmit[Chunk[B]](pollEmit)(sink.poll).map(_._2)
+            Poll.runEmit[Chunk[BB]](pollEmit)(sink.poll).map(_._2)
 
     /** Consume a stream to produce a new stream
       *
@@ -241,13 +237,13 @@ sealed abstract class Pipe[A, B, -S] extends Serializable:
       * @return
       *   A new transformed stream
       */
-    def transform[S1](stream: Stream[A, S1])(using
-        emitTag: Tag[Emit[Chunk[A]]],
-        pollTag: Tag[Poll[Chunk[A]]],
+    def transform[AA <: A, S1](stream: Stream[AA, S1])(using
+        emitTag: Tag[Emit[Chunk[AA]]],
+        pollTag: Tag[Poll[Chunk[AA]]],
         fr: Frame
     ): Stream[B, S & S1] =
         Stream:
-            Loop(stream.emit, pollEmit) { (emit, poll) =>
+            Loop(stream.emit, pollEmit: Unit < (Poll[Chunk[AA]] & Emit[Chunk[B]] & S)) { (emit, poll) =>
                 ArrowEffect.handleFirst(pollTag, poll)(
                     handle = [C] =>
                         (_, pollCont) =>
@@ -290,13 +286,12 @@ object Pipe:
       * @param f
       *   Pure function transforming stream elements
       */
-    def map[A](using
+    def mapPure[A](using
         Tag[A]
     )[B](f: A => B)(
         using
         Tag[Poll[Chunk[A]]],
         Tag[Emit[Chunk[B]]],
-        NotGiven[B <:< (Any < Nothing)],
         Frame
     ): Pipe[A, B, Any] =
         Pipe:
@@ -320,8 +315,6 @@ object Pipe:
         using
         Tag[Poll[Chunk[A]]],
         Tag[Emit[Chunk[B]]],
-        NotGiven[B <:< (Any < Nothing)],
-        Discriminator,
         Frame
     ): Pipe[A, B, S] =
         Pipe:
@@ -340,7 +333,7 @@ object Pipe:
       * @param f
       *   Pure function transforming stream chunks
       */
-    def mapChunk[A](using Tag[Poll[Chunk[A]]])[B](f: Chunk[A] => Chunk[B])(using Tag[Emit[Chunk[B]]], Frame): Pipe[A, B, Any] =
+    def mapChunkPure[A](using Tag[Poll[Chunk[A]]])[B](f: Chunk[A] => Chunk[B])(using Tag[Emit[Chunk[B]]], Frame): Pipe[A, B, Any] =
         Pipe:
             Loop.foreach:
                 Poll.andMap[Chunk[A]]:
@@ -358,7 +351,7 @@ object Pipe:
       */
     def mapChunk[A](using
         Tag[Poll[Chunk[A]]]
-    )[B, S](f: Chunk[A] => Chunk[B] < S)(using Tag[Emit[Chunk[B]]], Discriminator, Frame): Pipe[A, B, S] =
+    )[B, S](f: Chunk[A] => Chunk[B] < S)(using Tag[Emit[Chunk[B]]], Frame): Pipe[A, B, S] =
         Pipe:
             Loop.foreach:
                 Poll.andMap[Chunk[A]]:
@@ -416,7 +409,7 @@ object Pipe:
       * @param f
       *   Pure function determining whether to continue output stream based on input stream element
       */
-    def takeWhile[A](f: A => Boolean)(using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]], Frame): Pipe[A, A, Any] =
+    def takeWhilePure[A](using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]])(f: A => Boolean)(using Frame): Pipe[A, A, Any] =
         Pipe:
             Loop.foreach:
                 Poll.andMap[Chunk[A]]:
@@ -436,7 +429,7 @@ object Pipe:
       * @param f
       *   Effectful function determining whether to continue output stream based on input stream element
       */
-    def takeWhile[A](using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]])[S](f: A => Boolean < S)(using Discriminator, Frame): Pipe[A, A, S] =
+    def takeWhile[A](using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]])[S](f: A => Boolean < S)(using Frame): Pipe[A, A, S] =
         Pipe:
             Loop.foreach:
                 Poll.andMap[Chunk[A]]:
@@ -456,7 +449,7 @@ object Pipe:
       * @param f
       *   Pure function determining whether to continue skipping elements
       */
-    def dropWhile[A](f: A => Boolean)(using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]], Frame): Pipe[A, A, Any] =
+    def dropWhilePure[A](using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]])(f: A => Boolean)(using Frame): Pipe[A, A, Any] =
         Pipe:
             Loop(false): done =>
                 Poll.andMap[Chunk[A]]:
@@ -477,7 +470,7 @@ object Pipe:
       * @param f
       *   Effectful function determining whether to continue skipping elements
       */
-    def dropWhile[A](using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]])[S](f: A => Boolean < S)(using Discriminator, Frame): Pipe[A, A, S] =
+    def dropWhile[A](using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]])[S](f: A => Boolean < S)(using Frame): Pipe[A, A, S] =
         Pipe:
             Loop(false): done =>
                 Poll.andMap[Chunk[A]]:
@@ -498,7 +491,7 @@ object Pipe:
       * @param f
       *   Pure function determining whether to skip streaming element
       */
-    def filter[A](f: A => Boolean)(using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]], Frame): Pipe[A, A, Any] =
+    def filterPure[A](using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]])(f: A => Boolean)(using Frame): Pipe[A, A, Any] =
         Pipe:
             Loop.foreach:
                 Poll.andMap[Chunk[A]]:
@@ -516,7 +509,7 @@ object Pipe:
       * @param f
       *   Effectful function determining whether to skip streaming element
       */
-    def filter[A](using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]])[S](f: A => Boolean < S)(using Discriminator, Frame): Pipe[A, A, S] =
+    def filter[A](using Tag[Poll[Chunk[A]]], Tag[Emit[Chunk[A]]])[S](f: A => Boolean < S)(using Frame): Pipe[A, A, S] =
         Pipe:
             Loop.foreach:
                 Poll.andMap[Chunk[A]]:
@@ -534,7 +527,7 @@ object Pipe:
       * @param f
       *   Pure function converting input elements to optional output elements
       */
-    def collect[A](using Tag[Poll[Chunk[A]]])[B](f: A => Maybe[B])(using Tag[Emit[Chunk[B]]], Frame): Pipe[A, B, Any] =
+    def collectPure[A](using Tag[Poll[Chunk[A]]])[B](f: A => Maybe[B])(using Tag[Emit[Chunk[B]]], Frame): Pipe[A, B, Any] =
         Pipe:
             Loop.foreach:
                 Poll.andMap[Chunk[A]]:
@@ -552,7 +545,7 @@ object Pipe:
       * @param f
       *   Effectful function converting input elements to optional output elements
       */
-    def collect[A](using Tag[Poll[Chunk[A]]])[B, S](f: A => Maybe[B] < S)(using Tag[Emit[Chunk[B]]], Discriminator, Frame): Pipe[A, B, S] =
+    def collect[A](using Tag[Poll[Chunk[A]]])[B, S](f: A => Maybe[B] < S)(using Tag[Emit[Chunk[B]]], Frame): Pipe[A, B, S] =
         Pipe:
             Loop.foreach:
                 Poll.andMap[Chunk[A]]:
@@ -571,7 +564,7 @@ object Pipe:
       * @param f
       *   Pure function converting input elements to optional output elements
       */
-    def collectWhile[A](using Tag[Poll[Chunk[A]]])[B](f: A => Maybe[B])(using Tag[Emit[Chunk[B]]], Frame): Pipe[A, B, Any] =
+    def collectWhilePure[A](using Tag[Poll[Chunk[A]]])[B](f: A => Maybe[B])(using Tag[Emit[Chunk[B]]], Frame): Pipe[A, B, Any] =
         Pipe:
             Loop.foreach:
                 Poll.andMap[Chunk[A]]:
@@ -598,7 +591,7 @@ object Pipe:
       */
     def collectWhile[A](using
         Tag[Poll[Chunk[A]]]
-    )[B, S](f: A => Maybe[B] < S)(using Tag[Emit[Chunk[B]]], Discriminator, Frame): Pipe[A, B, S] =
+    )[B, S](f: A => Maybe[B] < S)(using Tag[Emit[Chunk[B]]], Frame): Pipe[A, B, S] =
         Pipe:
             Loop.foreach:
                 Poll.andMap[Chunk[A]]:

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -81,7 +81,7 @@ sealed abstract class Sink[-V, +A, -S] extends Serializable:
       * @return
       *   A sink that processes streams of the new element type
       */
-    final def contramap[VV <: V, V2](f: V2 => VV)(using
+    final def contramapPure[VV <: V, V2](f: V2 => VV)(using
         t1: Tag[Poll[Chunk[VV]]],
         t2: Tag[Poll[Chunk[V2]]],
         fr: Frame
@@ -105,7 +105,6 @@ sealed abstract class Sink[-V, +A, -S] extends Serializable:
     final def contramap[VV <: V, V2, S2](f: V2 => VV < S2)(using
         t1: Tag[Poll[Chunk[VV]]],
         t2: Tag[Poll[Chunk[V2]]],
-        d: Discriminator,
         fr: Frame
     ): Sink[V2, A, S & S2] =
         Sink:
@@ -130,7 +129,7 @@ sealed abstract class Sink[-V, +A, -S] extends Serializable:
       * @return
       *   A new sink that processes streams of the new element type
       */
-    final def contramapChunk[VV <: V, V2](f: Chunk[V2] => Chunk[VV])(using
+    final def contramapChunkPure[VV <: V, V2](f: Chunk[V2] => Chunk[VV])(using
         t1: Tag[Poll[Chunk[VV]]],
         t2: Tag[Poll[Chunk[V2]]],
         fr: Frame
@@ -155,7 +154,6 @@ sealed abstract class Sink[-V, +A, -S] extends Serializable:
     final def contramapChunk[VV <: V, V2, S2](f: Chunk[V2] => Chunk[VV] < S2)(using
         t1: Tag[Poll[Chunk[VV]]],
         t2: Tag[Poll[Chunk[V2]]],
-        d: Discriminator,
         fr: Frame
     ): Sink[V2, A, S & S2] =
         Sink:

--- a/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Sink.scala
@@ -217,6 +217,11 @@ object Sink:
         new Sink[V, A, S]:
             def poll: A < (Poll[Chunk[V]] & S) = v
 
+    private val _empty = Sink(())
+
+    /** A sink that does nothing: returns an empty (Unit) value without ever running the input stream * */
+    def empty[V]: Sink[V, Unit, Any] = _empty
+
     /** Construct a sink that runs a stream of element type `V` without producing any value.
       *
       * @return

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -680,8 +680,13 @@ sealed abstract class Stream[+V, -S] extends Serializable:
       * @return
       *   A new stream of transformed element type `A`
       */
-    def into[VV >: V, A, S2](pipe: Pipe[VV, A, S2])(using Tag[Poll[Chunk[VV]]], Tag[Emit[Chunk[VV]]], Frame): Stream[A, S & S2] =
-        pipe.transform(this)
+    def into[VV >: V, A, S2](pipe: Pipe[VV, A, S2])(
+        using
+        t1: Tag[Emit[Chunk[VV]]],
+        t2: Tag[Poll[Chunk[VV]]],
+        f: Frame
+    ): Stream[A, S & S2] =
+        pipe.transform(this)(using t1, t2, f)
 
     /** Process with a [[Sink]] of corresponding streaming element type.
       *

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -832,8 +832,10 @@ object Stream:
         new Stream[V, S]:
             def emit: Unit < (Emit[Chunk[V]] & S) = v
 
-    private val _empty           = Stream(())
-    def empty[V]: Stream[V, Any] = _empty.asInstanceOf[Stream[V, Any]]
+    private val _empty = Stream(())
+
+    /** A stream that emits no elements and does nothing * */
+    def empty[V]: Stream[V, Any] = _empty
 
     /** The default chunk size for streams. */
     inline def DefaultChunkSize: Int = 4096

--- a/kyo-prelude/shared/src/test/scala/kyo/PipeTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/PipeTest.scala
@@ -166,6 +166,42 @@ class PipeTest extends Test:
             }
         }
 
+        "takeWhilePure" - {
+            "take none" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.takeWhilePure[Int](_ < 0)).run.eval == Seq.empty
+                )
+            }
+
+            "take some" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3, 4, 5)).into(Pipe.takeWhilePure[Int](_ < 4)).run.eval ==
+                        Seq(1, 2, 3)
+                )
+            }
+
+            "take all" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.takeWhilePure[Int](_ < 10)).run.eval ==
+                        Seq(1, 2, 3)
+                )
+            }
+
+            "empty stream" in {
+                assert(
+                    Stream.init(Seq.empty[Int]).into(Pipe.takeWhilePure[Int](_ => true)).run.eval ==
+                        Seq.empty
+                )
+            }
+
+            "stack safety" in {
+                assert(
+                    Stream.init(Seq.fill(n)(1)).into(Pipe.takeWhilePure[Int](_ == 1)).run.eval ==
+                        Seq.fill(n)(1)
+                )
+            }
+        }
+
         "dropWhile" - {
             "drop none" in {
                 assert(
@@ -211,6 +247,43 @@ class PipeTest extends Test:
             }
         }
 
+        "dropWhilePure" - {
+            "drop none" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.dropWhilePure[Int](_ < 0)).run.eval ==
+                        Seq(1, 2, 3)
+                )
+            }
+
+            "drop some" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3, 4, 5)).into(Pipe.dropWhilePure[Int](_ < 4)).run.eval ==
+                        Seq(4, 5)
+                )
+            }
+
+            "drop all" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.dropWhilePure[Int](_ < 10)).run.eval ==
+                        Seq.empty
+                )
+            }
+
+            "empty stream" in {
+                assert(
+                    Stream.init(Seq.empty[Int]).into(Pipe.dropWhilePure[Int](_ => false)).run.eval ==
+                        Seq.empty
+                )
+            }
+
+            "stack safety" in {
+                assert(
+                    Stream.init(Seq.fill(n)(1) ++ Seq(2)).into(Pipe.dropWhilePure[Int](_ == 1)).run.eval ==
+                        Seq(2)
+                )
+            }
+        }
+
         "filter" - {
             "non-empty" in {
                 assert(
@@ -245,6 +318,36 @@ class PipeTest extends Test:
                 val result            = Var.run(false)(Stream.init(1 to n).into(Pipe.filter(predicate)).run).eval
                 assert(
                     result.size > 0 && result.forall(_ % 2 == 0) && result.forall(i => !(i % 3 == 0))
+                )
+            }
+        }
+
+        "filterPure" - {
+            "non-empty" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.filterPure[Int](_ % 2 == 0)).run.eval ==
+                        Seq(2)
+                )
+            }
+
+            "all in" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.filterPure[Int](_ => true)).run.eval ==
+                        Seq(1, 2, 3)
+                )
+            }
+
+            "all out" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.filterPure[Int](_ => false)).run.eval ==
+                        Seq.empty
+                )
+            }
+
+            "stack safety" in {
+                assert(
+                    Stream.init(1 to n).into(Pipe.filterPure[Int](_ % 2 == 0)).run.eval.size ==
+                        n / 2
                 )
             }
         }
@@ -284,6 +387,36 @@ class PipeTest extends Test:
                 val result = Var.run(false)(Stream.init(1 to 10).into(Pipe.collect(predicate)).run).eval
                 assert(
                     result == (1 to 10 by 2)
+                )
+            }
+        }
+
+        "collectPure" - {
+            "non-empty" in {
+                assert(
+                    Stream.init(Seq(None, Some(2), None)).into(Pipe.collectPure[Option[Int]](Maybe.fromOption(_))).run.eval ==
+                        Seq(2)
+                )
+            }
+
+            "all in" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.collectPure[Int](Present(_))).run.eval ==
+                        Seq(1, 2, 3)
+                )
+            }
+
+            "all out" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).collectPure(_ => Absent).run.eval ==
+                        Seq.empty
+                )
+            }
+
+            "stack safety" in {
+                assert(
+                    Stream.init(1 to n).into(Pipe.collectPure[Int](v => if v % 2 == 0 then Present(v) else Absent)).run.eval.size ==
+                        n / 2
                 )
             }
         }
@@ -336,6 +469,57 @@ class PipeTest extends Test:
             "stack safety" in {
                 assert(
                     Stream.init(Seq.fill(n)(1)).into(Pipe.collectWhile[Int](i => Present(i))).run.eval ==
+                        Seq.fill(n)(1)
+                )
+            }
+        }
+
+        "collectWhilePure" - {
+            "take none" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.collectWhilePure[Int](i =>
+                        if i < 0 then Present(i + 1) else Absent
+                    )).run.eval == Seq.empty
+                )
+            }
+
+            "take some" in {
+                assert(
+                    Stream.init(Seq(
+                        1, 2, 3, 4, 5
+                    )).into(Pipe.collectWhilePure[Int](i => if i < 4 then Present(i + 1) else Absent)).run.eval ==
+                        Seq(2, 3, 4)
+                )
+            }
+
+            "take some even if subsequent elements pass predicate" in {
+                assert(
+                    Stream.init(Seq(
+                        1, 2, 3, 4, 5
+                    )).into(Pipe.collectWhilePure[Int](i => if i != 4 then Present(i + 1) else Absent)).run.eval ==
+                        Seq(2, 3, 4)
+                )
+            }
+
+            "take all" in {
+                assert(
+                    Stream.init(Seq(
+                        1, 2, 3, 4, 5
+                    )).into(Pipe.collectWhilePure[Int](i => if i < 10 then Present(i + 1) else Absent)).run.eval ==
+                        Seq(2, 3, 4, 5, 6)
+                )
+            }
+
+            "empty stream" in {
+                assert(
+                    Stream.init(Seq.empty[Int]).into(Pipe.collectWhilePure[Int](i => Present(i + 1))).run.eval ==
+                        Seq.empty
+                )
+            }
+
+            "stack safety" in {
+                assert(
+                    Stream.init(Seq.fill(n)(1)).into(Pipe.collectWhilePure[Int](i => Present(i))).run.eval ==
                         Seq.fill(n)(1)
                 )
             }
@@ -424,6 +608,40 @@ class PipeTest extends Test:
             }
         }
 
+        "mapPure" - {
+            "double" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.mapPure[Int](_ * 2)).run.eval == Seq(2, 4, 6)
+                )
+            }
+
+            "to string" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.mapPure[Int](_.toString)).run.eval ==
+                        Seq("1", "2", "3")
+                )
+            }
+
+            "stack safety" in {
+                assert(
+                    Stream.init(Seq.fill(n)(1)).into(Pipe.mapPure[Int](_ + 1)).run.eval ==
+                        Seq.fill(n)(2)
+                )
+            }
+            "produce until" in {
+                var counter = 0
+                val result =
+                    Stream
+                        .init(0 until 100)
+                        .into(Pipe.mapPure[Int](_ => counter += 1))
+                        .take(0)
+                        .run
+                        .eval
+                assert(counter == 0)
+                assert(result.isEmpty)
+            }
+        }
+
         "mapChunk" - {
             "double" in {
                 assert(
@@ -462,6 +680,40 @@ class PipeTest extends Test:
                     Stream
                         .init(0 until 100)
                         .into(Pipe.mapChunk[Int](_.map(_ => counter += 1)))
+                        .take(0)
+                        .run
+                        .eval
+                assert(counter == 0)
+                assert(result.isEmpty)
+            }
+        }
+
+        "mapChunkPure" - {
+            "double" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.mapChunkPure[Int](_.take(2).map(_ * 2))).run.eval == Seq(2, 4)
+                )
+            }
+
+            "to string" in {
+                assert(
+                    Stream.init(Seq(1, 2, 3)).into(Pipe.mapChunkPure[Int](_.append(4).map(_.toString))).run.eval ==
+                        Seq("1", "2", "3", "4")
+                )
+            }
+
+            "stack safety" in {
+                assert(
+                    Stream.init(Seq.fill(n)(1)).into(Pipe.mapChunkPure[Int](_.map(_ + 1))).run.eval ==
+                        Seq.fill(n)(2)
+                )
+            }
+            "produce until" in {
+                var counter = 0
+                val result =
+                    Stream
+                        .init(0 until 100)
+                        .into(Pipe.mapChunkPure[Int](_.map(_ => counter += 1)))
                         .take(0)
                         .run
                         .eval
@@ -643,6 +895,13 @@ class PipeTest extends Test:
         }
     }
 
+    "contramapPure" in run {
+        val pipe   = Pipe.identity[Int].contramapPure((str: String) => str.length)
+        val stream = Stream.init(Seq("a", "be", "see"))
+        val result = stream.into(pipe).run.eval
+        assert(result == Seq(1, 2, 3))
+    }
+
     "contramapChunk" - {
         "pure" in run {
             val pipe   = Pipe.identity[Int].contramapChunk((chunk: Chunk[String]) => Chunk(chunk.size))
@@ -661,6 +920,13 @@ class PipeTest extends Test:
         }
     }
 
+    "contramapChunkPure" in run {
+        val pipe   = Pipe.identity[Int].contramapChunkPure((chunk: Chunk[String]) => Chunk(chunk.size))
+        val stream = Stream.init(Seq("a", "be", "see"))
+        val result = stream.into(pipe).run.eval
+        assert(result == Seq(3))
+    }
+
     "map" - {
         "pure" in run {
             val pipe   = Pipe.identity[String].map((str: String) => str.length)
@@ -675,6 +941,13 @@ class PipeTest extends Test:
             val result = Var.runTuple("")(stream.into(pipe).run).eval
             assert(result == ("abesee", Seq(1, 2, 3)))
         }
+    }
+
+    "mapPure" in run {
+        val pipe   = Pipe.identity[String].mapPure((str: String) => str.length)
+        val stream = Stream.init(Seq("a", "be", "see"))
+        val result = stream.into(pipe).run.eval
+        assert(result == Seq(1, 2, 3))
     }
 
     "mapChunk" - {
@@ -693,6 +966,13 @@ class PipeTest extends Test:
             val result = Var.runTuple("")(stream.into(pipe).run).eval
             assert(result == ("abesee", Seq(3)))
         }
+    }
+
+    "mapChunkPure" in run {
+        val pipe   = Pipe.identity[String].mapChunkPure((chunk: Chunk[String]) => Chunk(chunk.size))
+        val stream = Stream.init(Seq("a", "be", "see"))
+        val result = stream.into(pipe).run.eval
+        assert(result == Seq(3))
     }
 
     "join" - {

--- a/kyo-prelude/shared/src/test/scala/kyo/PipeTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/PipeTest.scala
@@ -731,7 +731,7 @@ class PipeTest extends Test:
             }
             "empty stream" in {
                 val stream = Stream
-                    .empty[Int]
+                    .empty
                     .into(Pipe.tap[Int](i => Var.update[Int](_ + i).unit))
                 assert(Var.runTuple(0)(stream.run).eval == (0, Seq()))
             }
@@ -746,7 +746,7 @@ class PipeTest extends Test:
             }
             "empty stream" in {
                 val stream = Stream
-                    .empty[Int]
+                    .empty
                     .into(Pipe.tapChunk[Int](c => Var.update[Int](_ + c.sum).unit))
                 assert(Var.runTuple(0)(stream.run).eval == (0, Seq()))
             }

--- a/kyo-prelude/shared/src/test/scala/kyo/SinkTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/SinkTest.scala
@@ -79,6 +79,14 @@ class SinkTest extends Test:
         }
     }
 
+    "contramapPure" in run {
+        val s1     = Sink.fold[Int, Int](0)(_ + _)
+        val s2     = s1.contramapPure((_: String).length)
+        val stream = Stream.init(Seq("a", "be", "see"))
+        val result = s2.drain(stream).eval
+        assert(result == 6)
+    }
+
     "contramapChunk" - {
         "pure" in run {
             val s1     = Sink.fold[Int, Int](0)(_ + _)
@@ -96,6 +104,14 @@ class SinkTest extends Test:
             val result = Var.runTuple(0)(s2.drain(stream)).eval
             assert(result == (1, 6))
         }
+    }
+
+    "contramapChunkPure" in run {
+        val s1     = Sink.fold[Int, Int](0)(_ + _)
+        val s2     = s1.contramapChunkPure((_: Chunk[String]).map(_.length))
+        val stream = Stream.init(Seq("a", "be", "see"))
+        val result = s2.drain(stream).eval
+        assert(result == 6)
     }
 
     "map" - {

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -9,7 +9,7 @@ class StreamTest extends Test:
 
     "empty" in {
         assert(
-            Stream.empty[Int].run.eval == Seq.empty
+            Stream.empty.run.eval == Seq.empty
         )
     }
 
@@ -941,8 +941,8 @@ class StreamTest extends Test:
         }
         "empty stream" in {
             val stream = Stream
-                .empty[Int]
-                .tap(i => Var.update[Int](_ + i).unit)
+                .empty
+                .tap((i: Int) => Var.update[Int](_ + i).unit)
             assert(Var.runTuple(0)(stream.run).eval == (0, Seq()))
         }
     }
@@ -956,8 +956,8 @@ class StreamTest extends Test:
         }
         "empty stream" in {
             val stream = Stream
-                .empty[Int]
-                .tapChunk(c => Var.update[Int](_ + c.sum).unit)
+                .empty
+                .tapChunk((c: Chunk[Int]) => Var.update[Int](_ + c.sum).unit)
             assert(Var.runTuple(0)(stream.run).eval == (0, Seq()))
         }
     }


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

Composability of `Pipe`, `Sink`, and `Stream` is improved vastly with variance in their streaming element types. Now that `Sink` and `Stream` have been updated, `Pipe` is all that's left.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Now that `Poll[V]` is covariant with `V` and `Emit[V]` is contravariant with `V`, `Pipe[A, B, S]` can be made contravariant with `A` and covariant with `B` simply by adding the variance and adding a type parameter narrowing and widening `A` and `B` respectively.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->

Also added `empty` methods to `Sink` and `Pipe`, and added scaladoc to all `empty` methods
