### PR TITLE
restrict lift to avoid lifting Abort.type and others

### DIFF
--- a/kyo-kernel/jvm/src/test/scala/kyo/kernel/BytecodeTest.scala
+++ b/kyo-kernel/jvm/src/test/scala/kyo/kernel/BytecodeTest.scala
@@ -32,12 +32,12 @@ class BytecodeTest extends Test:
 
     "map" in {
         val map = methodBytecodeSize[TestMap]
-        assert(map == Map("test" -> 26, "anonfun" -> 11, "mapLoop" -> 170))
+        assert(map == Map("test" -> 26, "anonfun" -> 11, "mapLoop" -> 158))
     }
 
     "handle" in {
         val map = methodBytecodeSize[TestHandle]
-        assert(map == Map("test" -> 26, "anonfun" -> 8, "handleLoop" -> 273))
+        assert(map == Map("test" -> 26, "anonfun" -> 8, "handleLoop" -> 267))
     }
 
     def methodBytecodeSize[A](using ct: ClassTag[A]): Map[String, Int] =

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -5,9 +5,6 @@ import kyo.kernel.internal.*
 import scala.annotation.nowarn
 import scala.annotation.tailrec
 import scala.language.implicitConversions
-import scala.quoted.Expr
-import scala.quoted.Quotes
-import scala.quoted.Type
 
 /** Represents a computation that may perform effects before producing a value.
   *
@@ -412,23 +409,11 @@ object `<`:
       * @return
       *   A computation in the effect context
       */
-    implicit def lift[A: WeakFlat, S](v: A): A < S =
-        v match
-            case kyo: Kyo[?, ?] => Nested(kyo)
-            case _              => v.asInstanceOf[A < S]
+    implicit inline def lift[A: WeakFlat, S](inline v: A): A < S = Lift.lift(v)
 
-    implicit inline def liftUnit[S1, S2](inline v: Unit < S1): Unit < S2 = ${ liftUnitImpl[S1, S2]('v) }
-
-    private def liftUnitImpl[S1: Type, S2: Type](v: Expr[Unit < S1])(using quotes: Quotes): Expr[Unit < S2] =
-        import quotes.reflect.*
-        val source = TypeRepr.of[S1].show
-        report.errorAndAbort(
-            s"""Cannot lift `Unit < ${source}` to the expected type (`Unit < ?`).
-               |This may be due to an effect type mismatch.
-               |Consider removing or adjusting the type constraint on the left-hand side.
-               |More info : https://github.com/getkyo/kyo/issues/903""".stripMargin
-        )
-    end liftUnitImpl
+    /** guard to avoid silent discard of provided Unit < S1, over a required Unit < S2
+      */
+    implicit inline def liftUnit[S1, S2](inline v: Unit < S1): Unit < S2 = Lift.liftUnit(v)
 
     /** Converts a pure single-argument function to an effectful computation. */
     implicit inline def liftPureFunction1[A1, B](inline f: A1 => B)(

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Lift.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Lift.scala
@@ -1,0 +1,55 @@
+package kyo.kernel.internal
+
+import kyo.kernel.<
+import kyo.kernel.internal.*
+import scala.annotation.nowarn
+import scala.quoted.*
+
+object Lift:
+
+    inline def liftUnit[S1, S2](inline v: Unit < S1): Unit < S2 = ${ liftUnitImpl[S1, S2]('v) }
+
+    def liftUnitImpl[S1: Type, S2: Type](v: Expr[Unit < S1])(using quotes: Quotes): Expr[Unit < S2] =
+        import quotes.reflect.*
+        val source = TypeRepr.of[S1].show
+        report.errorAndAbort(
+            s"""Cannot lift `Unit < ${source}` to the expected type (`Unit < ?`).
+               |This may be due to an effect type mismatch.
+               |Consider removing or adjusting the type constraint on the left-hand side.
+               |More info : https://github.com/getkyo/kyo/issues/903""".stripMargin
+        )
+    end liftUnitImpl
+
+    inline def lift[A: WeakFlat, S](inline v: A): A < S = ${ liftMacro[A, S]('v) }
+
+    def liftMacro[A: Type, S: Type](v: Expr[A])(using Quotes): Expr[A < S] =
+        import quotes.reflect.*
+
+        val tpe = TypeRepr.of[A].dealias
+        val sym = tpe.typeSymbol
+
+        def isTrivialType: Boolean =
+            tpe match
+                case _: ConstantType => true
+                case _ =>
+                    sym.fullName match
+                        case "scala.Unit" => true
+                        case "scala.Int" | "scala.Long" | "scala.Double"
+                            | "scala.Float" | "scala.Short" | "scala.Byte"
+                            | "scala.Char" | "scala.Boolean" => true
+                        case _ => false
+
+        if isTrivialType then
+            '{ $v.asInstanceOf[A < S] }
+        else if sym.flags.is(Flags.Module) && sym.fullName.startsWith("kyo.") then
+            report.error(s"Cannot lift object of type `${sym.fullName}.type` into `${sym.name}.type < S`")
+            '{ ??? }
+        else
+            '{
+                $v match
+                    case kyo: Kyo[?, ?] => Nested(kyo)
+                    case _              => $v.asInstanceOf[A < S]
+            }
+        end if
+    end liftMacro
+end Lift


### PR DESCRIPTION
When working with kyo-combinators, as a user we are proposed to lift anything which lead to the IDE proposing:

```scala
Abort.foldAbort

//with foldAbort from AbortCombinators:

def foldAbort[B, S1](
        onSuccess: A => B < S1,
        onFail: E => B < S1
    )(
        using
        ct: SafeClassTag[E],
        fr: Frame
    ): B < (Abort[Nothing] & S & S1) =
        Abort.fold[E](onSuccess, onFail)(effect)
```

This PR makes those construct invalid, and try to improve the developper experience.

---

There is a reduction of generated bytecode (not by a lot), but complety remove calls on trivial types.