### PR TITLE
Avoid marking synthetic files as internal

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/internal/FindEnclosing.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/FindEnclosing.scala
@@ -11,9 +11,12 @@ private[kyo] object FindEnclosing:
     def isInternal(using Quotes): Boolean =
         val pos      = quotes.reflect.Position.ofMacroExpansion
         val fileName = pos.sourceFile.name
-        val path     = pos.sourceFile.path
-        val excluded = (path.contains("src/test/") && testFileSuffixes.exists(fileName.endsWith)) || fileName.endsWith("Bench.scala")
-        apply(sym => sym.fullName.startsWith("kyo") && !excluded).nonEmpty
+        if fileName.isEmpty || fileName.startsWith("<") then false // synthetic file, like scala-cli/repl
+        else
+            val path     = pos.sourceFile.path
+            val excluded = (path.contains("src/test/") && testFileSuffixes.exists(fileName.endsWith)) || fileName.endsWith("Bench.scala")
+            apply(sym => sym.fullName.startsWith("kyo") && !excluded).nonEmpty
+        end if
     end isInternal
 
     def apply(using Quotes)(predicate: quotes.reflect.Symbol => Boolean): Maybe[quotes.reflect.Symbol] =


### PR DESCRIPTION
Fixes #1286

### Problem
Synthetic files (scala repl, worksheet, etc) are currently triggering `FindEnclosing.isInternal`

### Solution
Manually exclude empty files and files starting with `<` - like `<repl>` from internal.

### Notes
I tested with a publishLocal, but not sure how robust that is. I can't think of a great way to test.