### PR TITLE
Abort: remove usage of erased Tags

### DIFF
--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -1272,7 +1272,7 @@ class AbortTest extends Test:
         }
 
         "generic" in {
-            def test[A](a: A): Nothing < Abort[A] =
+            def test[A](a: A)(using Tag[Abort[a.type]]): Nothing < Abort[A] =
                 Abort.literal.fail(a)
 
             val result                  = test(1)


### PR DESCRIPTION
Related to #1247

### Problem
Erased tags are leftover from earlier limitations with splicing and subtype checking of tags.

### Solution
Require tag evidences in all Abort methods.

### Notes
I think we should consider making less arguments/methods inline in Abort. Perhaps just the most common cases need to be inline. This will help prevent large bytecode sizes.