### PR TITLE
specialize >.lift for AnyVal and Unit

### DIFF
--- a/kyo-kernel/jvm/src/test/scala/kyo/kernel/BytecodeTest.scala
+++ b/kyo-kernel/jvm/src/test/scala/kyo/kernel/BytecodeTest.scala
@@ -32,7 +32,7 @@ class BytecodeTest extends Test:
 
     "map" in {
         val map = methodBytecodeSize[TestMap]
-        assert(map == Map("test" -> 26, "anonfun" -> 11, "mapLoop" -> 170))
+        assert(map == Map("test" -> 26, "anonfun" -> 11, "mapLoop" -> 158))
     }
 
     "handle" in {

--- a/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/Kyo.scala
@@ -42,7 +42,7 @@ object Kyo:
       * @return
       *   A computation that directly produces Unit without suspension
       */
-    inline def unit[S]: Unit < S = ()
+    inline def unit: Unit < Any = ()
 
     /** Zips two effects into a tuple.
       */

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -417,9 +417,13 @@ object `<`:
             case kyo: Kyo[?, ?] => Nested(kyo)
             case _              => v.asInstanceOf[A < S]
 
-    implicit inline def liftUnit[S1, S2](inline v: Unit < S1): Unit < S2 = ${ liftUnitImpl[S1, S2]('v) }
+    implicit inline def liftAnyVal[A <: AnyVal, S](inline v: A): A < S = v.asInstanceOf[A < S]
 
-    private def liftUnitImpl[S1: Type, S2: Type](v: Expr[Unit < S1])(using quotes: Quotes): Expr[Unit < S2] =
+    implicit inline def liftUnit[S](inline v: Unit): Unit < S = v.asInstanceOf[Unit < S]
+
+    implicit inline def abortCastUnit[S1, S2](inline v: Unit < S1): Unit < S2 = ${ abortCastUnitImpl[S1, S2]('v) }
+
+    private def abortCastUnitImpl[S1: Type, S2: Type](v: Expr[Unit < S1])(using quotes: Quotes): Expr[Unit < S2] =
         import quotes.reflect.*
         val source = TypeRepr.of[S1].show
         report.errorAndAbort(
@@ -428,7 +432,7 @@ object `<`:
                |Consider removing or adjusting the type constraint on the left-hand side.
                |More info : https://github.com/getkyo/kyo/issues/903""".stripMargin
         )
-    end liftUnitImpl
+    end abortCastUnitImpl
 
     /** Converts a pure single-argument function to an effectful computation. */
     implicit inline def liftPureFunction1[A1, B](inline f: A1 => B)(


### PR DESCRIPTION
Following https://github.com/getkyo/kyo/pull/1285 a lighter version.

- No visible compileTime increase
- Less bytecode on simple cases
