### PR TITLE
[combinator] update `ensuring` to accept `Abort[Throwable]`

### DIFF
--- a/kyo-combinators/shared/src/main/scala/kyo/KyoCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/KyoCombinators.scala
@@ -1,5 +1,6 @@
 package kyo
 
+import kyo.Result.Error
 import kyo.debug.Debug
 import kyo.kernel.ArrowEffect
 import scala.annotation.tailrec
@@ -237,7 +238,20 @@ extension [A, S](effect: A < S)
       * @return
       *   An effect that executes the finalizer after this effect
       */
-    def ensuring(finalizer: => Any < Async)(using Frame): A < (S & Resource & Sync) =
+    def ensuring(finalizer: => Any < (Async & Abort[Throwable]))(using Frame): A < (S & Resource & Sync) =
+        Resource.ensure(finalizer).andThen(effect)
+
+    /** Ensures that the specified finalizer is executed after this effect, whether it succeeds or fails. The finalizer will execute when
+      * the Resource effect is handled.
+      *
+      * If the effect fails, the error is propagated as a `Present`. If the effect succeeds, the 'error' will be `Absent`.
+      *
+      * @param finalizer
+      *   The finalizer to execute after this effect
+      * @return
+      *   An effect that executes the finalizer after this effect
+      */
+    def ensuringError(finalizer: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using Frame): A < (S & Resource & Sync) =
         Resource.ensure(finalizer).andThen(effect)
 
 end extension


### PR DESCRIPTION
### Problem
kyo-combinators `ensuring` should accept the same effects as `Resource.ensuring`. It was also missing the variant that propagate the optional error forward.

### Solution
Update the signature of `kyo-cominator`'s ensuring. 
