### PR TITLE
Stream and Pipe benchmarks

### DIFF
--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamPipeBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamPipeBench.scala
@@ -19,14 +19,14 @@ class StreamPipeBench extends BaseBench:
             .eval
     end mapPureStreamBench
 
-    // @Benchmark
-    // def mapPureStreamAbstractBench() =
-    //     import kyo.*
-    //     Stream.init(seq)
-    //         .mapAbstractPure(_ + 1)
-    //         .fold(0)(_ + _)
-    //         .eval
-    // end mapPureStreamAbstractBench
+    @Benchmark
+    def mapPureStreamAbstractBench() =
+        import kyo.*
+        Stream.init(seq)
+            .mapAbstractPure(_ + 1)
+            .fold(0)(_ + _)
+            .eval
+    end mapPureStreamAbstractBench
 
     @Benchmark
     def mapPurePipeBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamPipeBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamPipeBench.scala
@@ -1,0 +1,196 @@
+package kyo.bench.arena
+
+import WarmupJITProfile.*
+import kyo.AllowUnsafe
+import kyo.bench.BaseBench
+import org.openjdk.jmh.annotations.*
+
+class StreamPipeBench extends BaseBench:
+    val seq = (0 until 10000).toVector
+
+    import AllowUnsafe.embrace.danger
+
+    @Benchmark
+    def mapPureStreamBench() =
+        import kyo.*
+        Stream.init(seq)
+            .mapPure(_ + 1)
+            .fold(0)(_ + _)
+            .eval
+    end mapPureStreamBench
+
+    // @Benchmark
+    // def mapPureStreamAbstractBench() =
+    //     import kyo.*
+    //     Stream.init(seq)
+    //         .mapAbstractPure(_ + 1)
+    //         .fold(0)(_ + _)
+    //         .eval
+    // end mapPureStreamAbstractBench
+
+    @Benchmark
+    def mapPurePipeBench() =
+        import kyo.*
+        Stream.init(seq)
+            .into(Pipe.mapPure((_: Int) + 1))
+            .fold(0)(_ + _)
+            .eval
+    end mapPurePipeBench
+
+    @Benchmark
+    def mapPurePipeAbstractBench() =
+        import kyo.*
+        Stream.init(seq)
+            .into(Pipe.mapAbstractPure((_: Int) + 1))
+            .fold(0)(_ + _)
+            .eval
+    end mapPurePipeAbstractBench
+
+    @Benchmark
+    def mapKyoStreamBench() =
+        import kyo.*
+        Stream.init(seq)
+            .map(v => Sync(v + 1))
+            .fold(0)(_ + _)
+            .handle(Sync.Unsafe.evalOrThrow)
+    end mapKyoStreamBench
+
+    @Benchmark
+    def mapKyoStreamAbstractBench() =
+        import kyo.*
+        Stream.init(seq)
+            .mapAbstract(v => Sync(v + 1))
+            .fold(0)(_ + _)
+            .handle(Sync.Unsafe.evalOrThrow)
+    end mapKyoStreamAbstractBench
+
+    @Benchmark
+    def mapKyoPipeBench() =
+        import kyo.*
+        Stream.init(seq)
+            .into(Pipe.map((v: Int) => Sync(v + 1)))
+            .fold(0)(_ + _)
+            .handle(Sync.Unsafe.evalOrThrow)
+    end mapKyoPipeBench
+
+    @Benchmark
+    def mapKyoPipeAbstractBench() =
+        import kyo.*
+        Stream.init(seq)
+            .into(Pipe.mapAbstract((v: Int) => Sync(v + 1)))
+            .fold(0)(_ + _)
+            .handle(Sync.Unsafe.evalOrThrow)
+    end mapKyoPipeAbstractBench
+
+    @Benchmark
+    def filterPureStreamBench() =
+        import kyo.*
+        Stream.init(seq)
+            .filterPure(_ % 2 == 0)
+            .fold(0)(_ + _)
+            .eval
+    end filterPureStreamBench
+
+    @Benchmark
+    def filterPureStreamAbstractBench() =
+        import kyo.*
+        Stream.init(seq)
+            .filterAbstractPure(_ % 2 == 0)
+            .fold(0)(_ + _)
+            .eval
+    end filterPureStreamAbstractBench
+
+    @Benchmark
+    def filterPurePipeBench() =
+        import kyo.*
+        Stream.init(seq)
+            .into(Pipe.filterPure((_: Int) % 2 == 0))
+            .fold(0)(_ + _)
+            .eval
+    end filterPurePipeBench
+
+    @Benchmark
+    def filterPurePipeAbstractBench() =
+        import kyo.*
+        Stream.init(seq)
+            .into(Pipe.filterAbstractPure((_: Int) % 2 == 0))
+            .fold(0)(_ + _)
+            .eval
+    end filterPurePipeAbstractBench
+
+    @Benchmark
+    def filterKyoStreamBench() =
+        import kyo.*
+        Stream.init(seq)
+            .filter(v => Sync(v % 2 == 0))
+            .fold(0)(_ + _)
+            .handle(Sync.Unsafe.evalOrThrow)
+    end filterKyoStreamBench
+
+    @Benchmark
+    def filterKyoStreamAbstractBench() =
+        import kyo.*
+        Stream.init(seq)
+            .filterAbstract(v => Sync(v % 2 == 0))
+            .fold(0)(_ + _)
+            .handle(Sync.Unsafe.evalOrThrow)
+    end filterKyoStreamAbstractBench
+
+    @Benchmark
+    def filterKyoPipeBench() =
+        import kyo.*
+        Stream.init(seq)
+            .into(Pipe.filter((v: Int) => Sync(v % 2 == 0)))
+            .fold(0)(_ + _)
+            .handle(Sync.Unsafe.evalOrThrow)
+    end filterKyoPipeBench
+
+    @Benchmark
+    def filterKyoPipAbstractBench() =
+        import kyo.*
+        Stream.init(seq)
+            .into(Pipe.filterAbstract((v: Int) => Sync(v % 2 == 0)))
+            .fold(0)(_ + _)
+            .handle(Sync.Unsafe.evalOrThrow)
+    end filterKyoPipAbstractBench
+
+    @Benchmark
+    def filterMapVarStreamBench() =
+        import kyo.*
+        Stream.init(seq)
+            .filter(v => Var.get[Int].map(i => ((i + v) % 2 > -1)))
+            .map(v => Var.update[Int](_ + 1).map(i => v + i))
+            .fold(0)(_ + _)
+            .handle(Var.run(0), Sync.Unsafe.evalOrThrow)
+    end filterMapVarStreamBench
+
+    @Benchmark
+    def filterMapVarStreamAbstractBench() =
+        import kyo.*
+        Stream.init(seq)
+            .filterAbstract(v => Var.get[Int].map(i => ((i + v) % 2 > -1)))
+            .mapAbstract(v => Var.update[Int](_ + 1).map(i => v + i))
+            .fold(0)(_ + _)
+            .handle(Var.run(0), Sync.Unsafe.evalOrThrow)
+    end filterMapVarStreamAbstractBench
+
+    @Benchmark
+    def filterMapVarPipeBench() =
+        import kyo.*
+        Stream.init(seq)
+            .into(Pipe.filter((v: Int) => Var.get[Int].map(i => ((i + v) % 2 > -1))))
+            .into(Pipe.map((v: Int) => Var.update[Int](_ + 1).map(i => v + i)))
+            .fold(0)(_ + _)
+            .handle(Var.run(0), Sync.Unsafe.evalOrThrow)
+    end filterMapVarPipeBench
+
+    @Benchmark
+    def filterMapVarPipeAbstractBench() =
+        import kyo.*
+        Stream.init(seq)
+            .into(Pipe.filterAbstract((v: Int) => Var.get[Int].map(i => ((i + v) % 2 > -1))))
+            .into(Pipe.mapAbstract((v: Int) => Var.update[Int](_ + 1).map(i => v + i)))
+            .fold(0)(_ + _)
+            .handle(Var.run(0), Sync.Unsafe.evalOrThrow)
+    end filterMapVarPipeAbstractBench
+end StreamPipeBench

--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamPipeBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamPipeBench.scala
@@ -146,13 +146,13 @@ class StreamPipeBench extends BaseBench:
     end filterKyoPipeBench
 
     @Benchmark
-    def filterKyoPipAbstractBench() =
+    def filterKyoPipeAbstractBench() =
         import kyo.*
         Stream.init(seq)
             .into(Pipe.filterAbstract((v: Int) => Sync(v % 2 == 0)))
             .fold(0)(_ + _)
             .handle(Sync.Unsafe.evalOrThrow)
-    end filterKyoPipAbstractBench
+    end filterKyoPipeAbstractBench
 
     @Benchmark
     def filterMapVarStreamBench() =

--- a/kyo-prelude/shared/src/main/scala/kyo/StreamTransformations.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/StreamTransformations.scala
@@ -1,0 +1,39 @@
+package kyo
+
+private[kyo] object StreamTransformations:
+    inline def handleMap[V1, B, V2, S, S2](chunk: Chunk[V1], cont: => B < S)(f: V1 => V2 < S2)(using
+        Tag[Emit[Chunk[V2]]],
+        Frame
+    ): B < (S & S2 & Emit[Chunk[V2]]) =
+        Kyo.foreach(chunk)(f).map: newChunk =>
+            if newChunk.isEmpty then cont
+            else Emit.valueWith(newChunk)(cont)
+
+    inline def handleMapPure[V1, B, V2, S](chunk: Chunk[V1], cont: => B < S)(f: V1 => V2)(using
+        Tag[Emit[Chunk[V2]]],
+        Frame
+    ): B < (S & Emit[Chunk[V2]]) =
+        val newChunk = chunk.map(f)
+        if newChunk.isEmpty then cont
+        else Emit.valueWith(newChunk)(cont)
+    end handleMapPure
+
+    inline def handleFilter[V1, B, S, S2](chunk: Chunk[V1], cont: => B < S)(f: V1 => Boolean < S2)(
+        using
+        Tag[Emit[Chunk[V1]]],
+        Frame
+    ): B < (S & S2 & Emit[Chunk[V1]]) =
+        Kyo.filter(chunk)(f).map: newChunk =>
+            if newChunk.isEmpty then cont
+            else Emit.valueWith(newChunk)(cont)
+
+    inline def handleFilterPure[V1, B, S](chunk: Chunk[V1], cont: => B < S)(f: V1 => Boolean)(
+        using
+        Tag[Emit[Chunk[V1]]],
+        Frame
+    ): B < (S & Emit[Chunk[V1]]) =
+        val newChunk = chunk.filter(f)
+        if newChunk.isEmpty then cont
+        else Emit.valueWith(newChunk)(cont)
+    end handleFilterPure
+end StreamTransformations


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

Addresses concerns raised in #1166 (see discussion [here](https://github.com/getkyo/kyo/pull/1166#discussion_r2067717465))

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

`Pipe` currently reimplements a bunch of the same functionality as `Stream` in a slightly different way. We need to figure out whether to maintain parallel implementations (in which case we would probably try to abstract the tests to a single reusable suite), have `Stream` use `Pipe` for its transformation method implementations, find some other way to reuse code between the two types, or rethink `Pipe` entirely.

What choice we make will depend largely on performance.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

This PR (not meant to be merged in its current form) has some benchmarks for basic stream transformations on both `Stream` and `Pipe` (`map`, `mapPure`, `filter`, and `filterPure`). Results running locally on a macbook pro are posted below.

It also includes a POC attempt to abstract the common logic from `Stream` and `Pipe` methods. Both types essentially do the same thing, but one uses `ArrowEffect.handleLoop` and the other just uses `Loop` + `Poll.andMap`. I've added a `StreamTransformations` object that includes `handleMap`, `handleMapPure`, `handleFilter`, and `handleFilterPure` which can be used within `ArrowEffect.handleLoop` or `Loop`/`Poll.andMap` to provide a common implementation.

"Abstract" versions of filter and pure methods are included in the benchmark to see how abstracting the logic affects performance.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
