### PR TITLE
[core] improve IO suspension naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Kyo also offers an `andThen` method for more fluent code, combining two computat
 import kyo.*
 
 val a: Unit < Sync =
-    Sync(println("hello"))
+    Sync.defer(println("hello"))
 
 val b: String < Sync =
     a.andThen("test")
@@ -365,7 +365,7 @@ import kyo.*
 val a: String < (Abort[Exception] & Sync) =
     direct {
         val b: String =
-            Sync("hello").now
+            Sync.defer("hello").now
         val c: String =
             Abort.get(Right("world")).now
         b + " " + c
@@ -373,7 +373,7 @@ val a: String < (Abort[Exception] & Sync) =
 
 // Equivalent desugared
 val b: String < (Abort[Exception] & Sync) =
-    Sync("hello").map { b =>
+    Sync.defer("hello").map { b =>
         Abort.get(Right("world")).map { c =>
             b + " " + c
         }
@@ -392,12 +392,12 @@ val a: Int < Sync =
     direct {
         // Incorrect usage of a '<' value
         // without '.now' or '.later'
-        Sync(println(42))
+        Sync.defer(println(42))
         42
     }
 ```
 
-> Note: In the absence of effectful hygiene, the side effect `Sync(println(42))` would be overlooked and never executed. With the hygiene in place, such code results in a compilation error.
+> Note: In the absence of effectful hygiene, the side effect `Sync.defer(println(42))` would be overlooked and never executed. With the hygiene in place, such code results in a compilation error.
 
 The `.now` operator is used when you need the effect's result immediately, while `.later` is an advanced operation that preserves the effect without sequencing it:
 
@@ -406,22 +406,22 @@ import kyo.*
 
 // Using .now for immediate sequencing
 val immediate = direct {
-    val x: Int = Sync(1).now      // Get result here
-    val y: Int = Sync(2).now      // Then get this result
+    val x: Int = Sync.defer(1).now      // Get result here
+    val y: Int = Sync.defer(2).now      // Then get this result
     x + y                       // Use both results
 }
 
 // Using .later for preserved effects
 val preserved = direct {
-    val effect1: Int < Sync = Sync(1).later   // Effect preserved
-    val effect2: Int < Sync = Sync(2).later   // Effect preserved
+    val effect1: Int < Sync = Sync.defer(1).later   // Effect preserved
+    val effect2: Int < Sync = Sync.defer(2).later   // Effect preserved
     effect1.now + effect2.now             // Sequence effects
 }
 
 // Combining both approaches
 val combined = direct {
-    val effect1: Int < Sync = Sync(1).later   // Effect preserved
-    val effect2: Int = Sync(2).now          // Effect sequenced
+    val effect1: Int < Sync = Sync.defer(1).later   // Effect preserved
+    val effect2: Int = Sync.defer(2).now          // Effect sequenced
     effect1.now + effect2                 // Combine results
 }
 ```
@@ -436,26 +436,26 @@ direct {
     val a: Int = 5
 
     // Effectful value
-    val b: Int = Sync(10).now
+    val b: Int = Sync.defer(10).now
 
     // Control flow
     val c: String =
-        if Sync(true).now then "True branch" else "False branch"
+        if Sync.defer(true).now then "True branch" else "False branch"
 
     // Logical operations
     val d: Boolean =
-        Sync(true).now && Sync(false).now
+        Sync.defer(true).now && Sync.defer(false).now
 
     val e: Boolean =
-        Sync(true).now || Sync(true).now
+        Sync.defer(true).now || Sync.defer(true).now
 
     // Loop (for demonstration; this loop
     // won't execute its body)
-    while Sync(false).now do "Looping"
+    while Sync.defer(false).now do "Looping"
 
     // Pattern matching
     val matchResult: String =
-        Sync(1).now match
+        Sync.defer(1).now match
             case 1 => "One"
             case _ => "Other"
 }
@@ -521,7 +521,7 @@ import kyo.*
 
 // An example computation
 val a: Int < Sync =
-    Sync(Math.cos(42).toInt)
+    Sync.defer(Math.cos(42).toInt)
 
 // Avoid! Run the application with a timeout
 val b: Result[Throwable, Int] =
@@ -635,7 +635,7 @@ def writeBytes = 1 // placeholder
 
 // 'apply' is used to suspend side effects
 val a: Int < Sync =
-    Sync(writeBytes)
+    Sync.defer(writeBytes)
 ```
 
 Users shouldn't typically handle the `Sync` effect directly since it triggers the execution of side effects, which breaks referential transparency. Prefer `KyoApp` instead.
@@ -646,7 +646,7 @@ In some specific cases where Kyo isn't used as the main effect system of an appl
 import kyo.*
 
 val a: Int < Sync =
-    Sync(42)
+    Sync.defer(42)
 
 // ** Avoid 'Sync.Unsafe.run', use 'KyoApp' instead. **
 val b: Int < Abort[Nothing] =
@@ -735,19 +735,19 @@ trait Logger:
 val dbLayer: Layer[Database, Any] =
     Layer {
         new Database:
-            def query = Sync("DB result")
+            def query = Sync.defer("DB result")
     }
 
 val cacheLayer: Layer[Cache, Any] =
     Layer {
         new Cache:
-            def get = Sync(42)
+            def get = Sync.defer(42)
     }
 
 val loggerLayer: Layer[Logger, Any] =
     Layer {
         new Logger:
-            def log(msg: String) = Sync(println(msg))
+            def log(msg: String) = Sync.defer(println(msg))
     }
 
 // The `Layer.init` method provides a way to create a layer from multiple sub-layers, automatically 
@@ -800,7 +800,7 @@ trait EmailService:
 // Define layers
 val dbLayer: Layer[Database, Sync] = Layer {
     new Database:
-        def query = Sync("DB result")
+        def query = Sync.defer("DB result")
 }
 
 val userServiceLayer: Layer[UserService, Env[Database] & Sync] =
@@ -812,7 +812,7 @@ val userServiceLayer: Layer[UserService, Env[Database] & Sync] =
 val emailServiceLayer: Layer[EmailService, Sync] = Layer {
     new EmailService:
         def sendEmail(to: String, content: String) =
-            Sync(println(s"Email sent to $to: $content"))
+            Sync.defer(println(s"Email sent to $to: $content"))
 }
 
 // Example of `to`: Output of dbLayer is used as input for userServiceLayer
@@ -898,7 +898,7 @@ val b: Int < Async =
 // Example method to execute a function on a database
 def withDb[T](f: Database => T < Async): T < (Resource & Async) =
     // Initializes the database ('new Database' is a placeholder)
-    Sync(new Database).map { db =>
+    Sync.defer(new Database).map { db =>
         // Registers `db.close` to be finalized
         Resource.ensure(db.close).andThen {
             // Invokes the function
@@ -930,7 +930,7 @@ val source1 = Batch.sourceSeq[Int, String, Any] { seq =>
 // Using 'Batch.sourceMap' for processing the entire sequence at once, returning a 'Map'
 val source2 = Batch.sourceMap[Int, String, Sync] { seq =>
     // Source functions can perform arbitrary effects like 'Sync' before returning the results
-    Sync {
+    Sync.defer {
         seq.map(i => i -> i.toString).toMap
     }
 }
@@ -939,7 +939,7 @@ val source2 = Batch.sourceMap[Int, String, Sync] { seq =>
 // This is a more generic method that allows effects for each of the inputs
 val source3 = Batch.source[Int, String, Sync] { seq =>
     val map = seq.map { i =>
-        i -> Sync((i * 2).toString)
+        i -> Sync.defer((i * 2).toString)
     }.toMap
     (i: Int) => map(i)
 }
@@ -981,7 +981,7 @@ import kyo.*
 
 // Correct usage: reusing the source
 val source = Batch.sourceSeq[Int, Int, Sync] { seq => 
-    Sync(seq.map(_ * 2))
+    Sync.defer(seq.map(_ * 2))
 }
 
 val goodBatch = for
@@ -993,8 +993,8 @@ yield c
 // Incorrect usage: creating new sources inline
 val badBatch = for
     a <- Batch.eval(1 to 1000)
-    b <- Batch.sourceSeq[Int, Int, Sync](seq => Sync(seq.map(_ * 2)))(a)  // This won't be batched
-    c <- Batch.sourceSeq[Int, Int, Sync](seq => Sync(seq.map(_ * 2)))(b)  // This also won't be batched
+    b <- Batch.sourceSeq[Int, Int, Sync](seq => Sync.defer(seq.map(_ * 2)))(a)  // This won't be batched
+    c <- Batch.sourceSeq[Int, Int, Sync](seq => Sync.defer(seq.map(_ * 2)))(b)  // This also won't be batched
 yield c
 ```
 
@@ -1063,7 +1063,7 @@ val b: Int < Any =
 val d: Int < Sync =
     Loop(1)(i =>
         if i < 5 then
-            Sync(println(s"Iteration: $i")).map(_ => Loop.continue(i + 1))
+            Sync.defer(println(s"Iteration: $i")).map(_ => Loop.continue(i + 1))
         else
             Loop.done(i)
     )
@@ -1352,7 +1352,7 @@ case class Config(someConfig: String)
 // Stream with Sync effect
 val a: Stream[String, Sync] =
     Stream.init(Seq("file1.txt", "file2.txt"))
-        .map(fileName => Sync(scala.io.Source.fromFile(fileName).mkString))
+        .map(fileName => Sync.defer(scala.io.Source.fromFile(fileName).mkString))
 
 // Stream with Abort effect
 val b: Stream[Int, Abort[NumberFormatException]] =
@@ -1699,7 +1699,7 @@ val authCut =
             (input, cont) =>
                 input.metadata.get("auth-token") match
                     case Some("valid-token") => cont(input)
-                    case _                   => Sync(Response(input.value, status = 401))
+                    case _                   => Sync.defer(Response(input.value, status = 401))
     )
 
 // Add logging via another Cut
@@ -1751,7 +1751,7 @@ val a: Unit < Check =
 // Checks can be composed with other effects
 val b: Int < (Check & Sync) =
     for
-        value <- Sync(42)
+        value <- Sync.defer(42)
         _     <- Check.require(value > 0, "Value is positive")
     yield value
 
@@ -1854,7 +1854,7 @@ import kyo.*
 // An example computation to
 // be scheduled
 val a: Unit < Sync =
-    Sync(())
+    Sync.defer(())
 
 // Recurring task with a delay between
 // executions
@@ -2034,7 +2034,7 @@ val stats2: Stat =
 
 // Some example computation
 val a: Int < Sync =
-    Sync(42)
+    Sync.defer(42)
 
 // Trace the execution of the
 // `a` example computation
@@ -2218,7 +2218,7 @@ import kyo.*
 
 // An example computation
 val a: Int < Sync =
-    Sync(Math.cos(42).toInt)
+    Sync.defer(Math.cos(42).toInt)
 
 // There are method overloadings for up to four
 // parallel computations. Parameters taken by
@@ -2246,7 +2246,7 @@ import kyo.*
 
 // An example computation
 val a: Int < Sync =
-    Sync(Math.cos(42).toInt)
+    Sync.defer(Math.cos(42).toInt)
 
 // There are method overloadings for up to four
 // computations. Parameters taken by reference
@@ -2855,14 +2855,14 @@ import kyo.debug.*
 // and the result (or exception) of the computation
 val a: Int < Sync =
     Debug {
-        Sync(42)
+        Sync.defer(42)
     }
 
 // Similar to `apply`, but also prints intermediate steps
 // of the computation, providing a trace of execution
 val b: Int < Sync =
     Debug.trace {
-        Sync(41).map(_ + 1)
+        Sync.defer(41).map(_ + 1)
     }
 
 // Allows printing of specific values along with their 
@@ -2870,7 +2870,7 @@ val b: Int < Sync =
 // The return type of 'values' is 'Unit', not an effectful
 // computation.
 val c: Unit < Sync =
-    Sync {
+    Sync.defer {
         val x = 42
         val y = "Hello"
         Debug.values(x, y)
@@ -3209,7 +3209,7 @@ val a: Int < Async =
         fun = cache.memo { (v: String) =>
             // Note how the implementation
             // can use other effects
-            Sync(v.toInt)
+            Sync.defer(v.toInt)
         }
 
         // Use the function
@@ -3356,7 +3356,7 @@ import zio.{Fiber => _, *}
 val a: Int < (Abort[Nothing] & Async) =
     for
         v1 <- ZIOs.get(ZIO.succeed(21))
-        v2 <- Sync(21)
+        v2 <- Sync.defer(21)
         v3 <- Fiber.run(-42).map(_.get)
     yield v1 + v2 + v3
 
@@ -3364,7 +3364,7 @@ val a: Int < (Abort[Nothing] & Async) =
 val b: Int < (Abort[Nothing] & Async) =
     for
         f1 <- ZIOs.get(ZIO.succeed(21).fork)
-        f2 <- Fiber.run(Sync(21))
+        f2 <- Fiber.run(Sync.defer(21))
         v1 <- ZIOs.get(f1.join)
         v2 <- f2.get
     yield v1 + v2
@@ -3375,7 +3375,7 @@ val c: Int < (Abort[Nothing] & Async) =
 
 // Transforming Kyo effects within ZIO effects
 val d: Task[Int] =
-    ZIOs.run(Sync(21).map(_ * 2))
+    ZIOs.run(Sync.defer(21).map(_ * 2))
 ```
 
 > Note: Support for ZIO environments (`R` in `ZIO[R, E, A]`) is currently in development. Once implemented, it will be possible to use ZIO effects with environments directly within Kyo computations.
@@ -3408,7 +3408,7 @@ import cats.effect.kernel.Outcome.Succeeded
 val a: Int < (Abort[Nothing] & Async) =
     for
         v1 <- Cats.get(CatsIO.pure(21))
-        v2 <- Sync(21)
+        v2 <- Sync.defer(21)
         v3 <- Fiber.run(-42).map(_.get)
     yield v1 + v2 + v3
 
@@ -3416,7 +3416,7 @@ val a: Int < (Abort[Nothing] & Async) =
 val b: Int < (Abort[Nothing] & Async) =
     for
         f1 <- Cats.get(CatsIO.pure(21).start)
-        f2 <- Fiber.run(Sync(21))
+        f2 <- Fiber.run(Sync.defer(21))
         v1 <- Cats.get(f1.joinWith(CatsIO(99)))
         v2 <- f2.get
     yield v1 + v2
@@ -3427,7 +3427,7 @@ val c: Int < (Abort[Nothing] & Async) =
 
 // Transforming Kyo effects within Cats Effect Sync:
 val d: CatsIO[Int] =
-    Cats.run(Sync(21).map(_ * 2))
+    Cats.run(Sync.defer(21).map(_ * 2))
 ```
 
 ### Resolvers: GraphQL Server via Caliban

--- a/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
+++ b/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
@@ -61,7 +61,7 @@ object Topic:
       *   The computation result within Async context
       */
     def run[A, S](v: A < (Topic & S))(using Frame): A < (Async & S) =
-        Sync {
+        Sync.io {
             val driver = MediaDriver.launchEmbedded()
             Sync.ensure(driver.close()) {
                 run(driver)(v)
@@ -81,7 +81,7 @@ object Topic:
       *   The computation result within Async context
       */
     def run[A, S](driver: MediaDriver)(v: A < (Topic & S))(using Frame): A < (Async & S) =
-        Sync {
+        Sync.io {
             val aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName()))
             Sync.ensure(aeron.close()) {
                 run(aeron)(v)
@@ -133,7 +133,7 @@ object Topic:
         etag: Tag[Emit[Chunk[A]]]
     ): Unit < (Topic & S & Abort[Closed | Backpressured] & Async) =
         Env.use[Aeron] { aeron =>
-            Sync {
+            Sync.io {
                 // register the publication with Aeron using type's hash as stream ID
                 val publication = aeron.addPublication(aeronUri, tag.hash.abs)
 
@@ -144,10 +144,10 @@ object Topic:
                 val backpressured = Abort.fail(Backpressured())
 
                 // ensure publication is closed after use
-                Sync.ensure(Sync(publication.close())) {
+                Sync.ensure(Sync.io(publication.close())) {
                     stream.foreachChunk { messages =>
                         Retry[Backpressured](retrySchedule) {
-                            Sync {
+                            Sync.io {
                                 if !publication.isConnected() then backpressured
                                 else
                                     // serialize messages with type tag for runtime verification
@@ -204,7 +204,7 @@ object Topic:
     )(using tag: Tag[A], etag: Tag[Emit[Chunk[A]]], frame: Frame): Stream[A, Topic & Abort[Backpressured] & Async] =
         Stream {
             Env.use[Aeron] { aeron =>
-                Sync {
+                Sync.io {
                     // register subscription with Aeron using type's hash as stream ID
                     val subscription = aeron.addSubscription(aeronUri, tag.hash.abs)
 
@@ -223,10 +223,10 @@ object Topic:
                         )
 
                     // ensure subscription is closed after use
-                    Sync.ensure(Sync(subscription.close())) {
+                    Sync.ensure(Sync.io(subscription.close())) {
                         def loop(): Unit < (Emit[Chunk[A]] & Async & Abort[Backpressured]) =
                             Retry[Backpressured](retrySchedule) {
-                                Sync {
+                                Sync.io {
                                     if !subscription.isConnected() then backpressured
                                     else
                                         // clear previous result before polling

--- a/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
+++ b/kyo-aeron/jvm/src/main/scala/kyo/Topic.scala
@@ -61,7 +61,7 @@ object Topic:
       *   The computation result within Async context
       */
     def run[A, S](v: A < (Topic & S))(using Frame): A < (Async & S) =
-        Sync.io {
+        Sync.defer {
             val driver = MediaDriver.launchEmbedded()
             Sync.ensure(driver.close()) {
                 run(driver)(v)
@@ -81,7 +81,7 @@ object Topic:
       *   The computation result within Async context
       */
     def run[A, S](driver: MediaDriver)(v: A < (Topic & S))(using Frame): A < (Async & S) =
-        Sync.io {
+        Sync.defer {
             val aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName()))
             Sync.ensure(aeron.close()) {
                 run(aeron)(v)
@@ -133,7 +133,7 @@ object Topic:
         etag: Tag[Emit[Chunk[A]]]
     ): Unit < (Topic & S & Abort[Closed | Backpressured] & Async) =
         Env.use[Aeron] { aeron =>
-            Sync.io {
+            Sync.defer {
                 // register the publication with Aeron using type's hash as stream ID
                 val publication = aeron.addPublication(aeronUri, tag.hash.abs)
 
@@ -144,10 +144,10 @@ object Topic:
                 val backpressured = Abort.fail(Backpressured())
 
                 // ensure publication is closed after use
-                Sync.ensure(Sync.io(publication.close())) {
+                Sync.ensure(Sync.defer(publication.close())) {
                     stream.foreachChunk { messages =>
                         Retry[Backpressured](retrySchedule) {
-                            Sync.io {
+                            Sync.defer {
                                 if !publication.isConnected() then backpressured
                                 else
                                     // serialize messages with type tag for runtime verification
@@ -204,7 +204,7 @@ object Topic:
     )(using tag: Tag[A], etag: Tag[Emit[Chunk[A]]], frame: Frame): Stream[A, Topic & Abort[Backpressured] & Async] =
         Stream {
             Env.use[Aeron] { aeron =>
-                Sync.io {
+                Sync.defer {
                     // register subscription with Aeron using type's hash as stream ID
                     val subscription = aeron.addSubscription(aeronUri, tag.hash.abs)
 
@@ -223,10 +223,10 @@ object Topic:
                         )
 
                     // ensure subscription is closed after use
-                    Sync.ensure(Sync.io(subscription.close())) {
+                    Sync.ensure(Sync.defer(subscription.close())) {
                         def loop(): Unit < (Emit[Chunk[A]] & Async & Abort[Backpressured]) =
                             Retry[Backpressured](retrySchedule) {
-                                Sync.io {
+                                Sync.defer {
                                     if !subscription.isConnected() then backpressured
                                     else
                                         // clear previous result before polling

--- a/kyo-bench/src/main/scala/kyo/bench/arena/BlockingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/BlockingBench.scala
@@ -10,7 +10,7 @@ class BlockingBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        Sync.io(block())
+        Sync.defer(block())
     end kyoBenchFiber
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/BlockingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/BlockingBench.scala
@@ -10,7 +10,7 @@ class BlockingBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        Sync(block())
+        Sync.io(block())
     end kyoBenchFiber
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/BlockingContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/BlockingContentionBench.scala
@@ -12,7 +12,7 @@ class BlockingContentionBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        Async.fill(concurrency, concurrency)(Sync.io(block())).unit
+        Async.fill(concurrency, concurrency)(Sync.defer(block())).unit
     end kyoBenchFiber
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/BlockingContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/BlockingContentionBench.scala
@@ -12,7 +12,7 @@ class BlockingContentionBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        Async.fill(concurrency, concurrency)(Sync(block())).unit
+        Async.fill(concurrency, concurrency)(Sync.io(block())).unit
     end kyoBenchFiber
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/CollectBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/CollectBench.scala
@@ -4,7 +4,7 @@ class CollectBench extends ArenaBench.SyncAndFork(Seq.fill(1000)(1)):
 
     val count = 1000
 
-    val kyoTasks  = List.fill(count)(kyo.Sync(1))
+    val kyoTasks  = List.fill(count)(kyo.Sync.io(1))
     val catsTasks = List.fill(count)(cats.effect.IO(1))
     val zioTasks  = List.fill(count)(zio.ZIO.succeed(1))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/CollectBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/CollectBench.scala
@@ -4,7 +4,7 @@ class CollectBench extends ArenaBench.SyncAndFork(Seq.fill(1000)(1)):
 
     val count = 1000
 
-    val kyoTasks  = List.fill(count)(kyo.Sync.io(1))
+    val kyoTasks  = List.fill(count)(kyo.Sync.defer(1))
     val catsTasks = List.fill(count)(cats.effect.IO(1))
     val zioTasks  = List.fill(count)(zio.ZIO.succeed(1))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/CollectParBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/CollectParBench.scala
@@ -3,7 +3,7 @@ package kyo.bench.arena
 class CollectParBench extends ArenaBench.ForkOnly(Seq.fill(1000)(1)):
 
     val count     = 1000
-    val kyoTasks  = List.fill(count)(kyo.Sync(1))
+    val kyoTasks  = List.fill(count)(kyo.Sync.io(1))
     val catsTasks = List.fill(count)(cats.effect.IO(1))
     val zioTasks  = List.fill(count)(zio.ZIO.succeed(1))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/CollectParBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/CollectParBench.scala
@@ -3,7 +3,7 @@ package kyo.bench.arena
 class CollectParBench extends ArenaBench.ForkOnly(Seq.fill(1000)(1)):
 
     val count     = 1000
-    val kyoTasks  = List.fill(count)(kyo.Sync.io(1))
+    val kyoTasks  = List.fill(count)(kyo.Sync.defer(1))
     val catsTasks = List.fill(count)(cats.effect.IO(1))
     val zioTasks  = List.fill(count)(zio.ZIO.succeed(1))
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/DeepBindMapBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/DeepBindMapBench.scala
@@ -8,10 +8,10 @@ class DeepBindMapBench extends ArenaBench.SyncAndFork(10001):
         import kyo.*
 
         def loop(i: Int): Int < Sync =
-            Sync.io {
+            Sync.defer {
                 if i > depth then i
                 else
-                    Sync.io(i + 11)
+                    Sync.defer(i + 11)
                         .map(_ - 1)
                         .map(_ - 1)
                         .map(_ - 1)

--- a/kyo-bench/src/main/scala/kyo/bench/arena/DeepBindMapBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/DeepBindMapBench.scala
@@ -8,10 +8,10 @@ class DeepBindMapBench extends ArenaBench.SyncAndFork(10001):
         import kyo.*
 
         def loop(i: Int): Int < Sync =
-            Sync {
+            Sync.io {
                 if i > depth then i
                 else
-                    Sync(i + 11)
+                    Sync.io(i + 11)
                         .map(_ - 1)
                         .map(_ - 1)
                         .map(_ - 1)

--- a/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindBench.scala
@@ -8,10 +8,10 @@ class NarrowBindBench extends ArenaBench.SyncAndFork(10000):
         import kyo.*
 
         def loop(i: Int): Int < Sync =
-            if i < depth then Sync.io(i + 1).flatMap(loop)
-            else Sync.io(i)
+            if i < depth then Sync.defer(i + 1).flatMap(loop)
+            else Sync.defer(i)
 
-        Sync.io(0).flatMap(loop)
+        Sync.defer(0).flatMap(loop)
     end kyoBench
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindBench.scala
@@ -8,10 +8,10 @@ class NarrowBindBench extends ArenaBench.SyncAndFork(10000):
         import kyo.*
 
         def loop(i: Int): Int < Sync =
-            if i < depth then Sync(i + 1).flatMap(loop)
-            else Sync(i)
+            if i < depth then Sync.io(i + 1).flatMap(loop)
+            else Sync.io(i)
 
-        Sync(0).flatMap(loop)
+        Sync.io(0).flatMap(loop)
     end kyoBench
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindMapBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindMapBench.scala
@@ -9,11 +9,11 @@ class NarrowBindMapBench extends ArenaBench.SyncAndFork(10000):
 
         def loop(i: Int): Int < Sync =
             if i < depth then
-                Sync.io(i + 11).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1)
+                Sync.defer(i + 11).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1)
                     .map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(loop)
-            else Sync.io(i)
+            else Sync.defer(i)
 
-        Sync.io(0).flatMap(loop)
+        Sync.defer(0).flatMap(loop)
     end kyoBench
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindMapBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/NarrowBindMapBench.scala
@@ -9,11 +9,11 @@ class NarrowBindMapBench extends ArenaBench.SyncAndFork(10000):
 
         def loop(i: Int): Int < Sync =
             if i < depth then
-                Sync(i + 11).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1)
+                Sync.io(i + 11).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1)
                     .map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(_ - 1).map(loop)
-            else Sync(i)
+            else Sync.io(i)
 
-        Sync(0).flatMap(loop)
+        Sync.io(0).flatMap(loop)
     end kyoBench
 
     def catsBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SchedulingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SchedulingBench.scala
@@ -31,10 +31,10 @@ class SchedulingBench extends ArenaBench.ForkOnly(1001000):
 
         def fiber(i: Int): Int < Sync =
             Kyo.unit.flatMap { _ =>
-                Sync.io(i).flatMap { j =>
+                Sync.defer(i).flatMap { j =>
                     Kyo.unit.flatMap { _ =>
                         if j > depth then
-                            Kyo.unit.flatMap(_ => Sync.io(j))
+                            Kyo.unit.flatMap(_ => Sync.defer(j))
                         else
                             Kyo.unit.flatMap(_ => fiber(j + 1))
                     }

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SchedulingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SchedulingBench.scala
@@ -31,10 +31,10 @@ class SchedulingBench extends ArenaBench.ForkOnly(1001000):
 
         def fiber(i: Int): Int < Sync =
             Kyo.unit.flatMap { _ =>
-                Sync(i).flatMap { j =>
+                Sync.io(i).flatMap { j =>
                     Kyo.unit.flatMap { _ =>
                         if j > depth then
-                            Kyo.unit.flatMap(_ => Sync(j))
+                            Kyo.unit.flatMap(_ => Sync.io(j))
                         else
                             Kyo.unit.flatMap(_ => fiber(j + 1))
                     }

--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
@@ -16,8 +16,8 @@ class StreamIOBench extends ArenaBench.SyncAndFork(25000000):
     def kyoBench() =
         import kyo.*
         Stream.init(seq)
-            .filter(v => Sync.io(v % 2 == 0))
-            .map(v => Sync.io(v + 1))
+            .filter(v => Sync.defer(v % 2 == 0))
+            .map(v => Sync.defer(v + 1))
             .fold(0)(_ + _)
     end kyoBench
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/StreamIOBench.scala
@@ -16,8 +16,8 @@ class StreamIOBench extends ArenaBench.SyncAndFork(25000000):
     def kyoBench() =
         import kyo.*
         Stream.init(seq)
-            .filter(v => Sync(v % 2 == 0))
-            .map(v => Sync(v + 1))
+            .filter(v => Sync.io(v % 2 == 0))
+            .map(v => Sync.io(v + 1))
             .fold(0)(_ + _)
     end kyoBench
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SuspensionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SuspensionBench.scala
@@ -16,12 +16,12 @@ class SuspensionBench extends ArenaBench.SyncAndFork(()):
     def kyoBench() =
         import kyo.*
 
-        Sync.io(())
-            .flatMap(_ => Sync.io(())).map(_ => ()).flatMap(_ => Sync.io(())).map(_ => ())
-            .flatMap(_ => Sync.io(())).map(_ => ()).flatMap(_ => Sync.io(())).map(_ => ())
-            .flatMap(_ => Sync.io(())).map(_ => ()).flatMap(_ => Sync.io(())).map(_ => ())
-            .flatMap(_ => Sync.io(())).map(_ => ()).flatMap(_ => Sync.io(())).map(_ => ())
-            .flatMap(_ => Sync.io(())).map(_ => ()).flatMap(_ => Sync.io(())).map(_ => ())
+        Sync.defer(())
+            .flatMap(_ => Sync.defer(())).map(_ => ()).flatMap(_ => Sync.defer(())).map(_ => ())
+            .flatMap(_ => Sync.defer(())).map(_ => ()).flatMap(_ => Sync.defer(())).map(_ => ())
+            .flatMap(_ => Sync.defer(())).map(_ => ()).flatMap(_ => Sync.defer(())).map(_ => ())
+            .flatMap(_ => Sync.defer(())).map(_ => ()).flatMap(_ => Sync.defer(())).map(_ => ())
+            .flatMap(_ => Sync.defer(())).map(_ => ()).flatMap(_ => Sync.defer(())).map(_ => ())
     end kyoBench
 
     def zioBench() =

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SuspensionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SuspensionBench.scala
@@ -16,12 +16,12 @@ class SuspensionBench extends ArenaBench.SyncAndFork(()):
     def kyoBench() =
         import kyo.*
 
-        Sync(())
-            .flatMap(_ => Sync(())).map(_ => ()).flatMap(_ => Sync(())).map(_ => ())
-            .flatMap(_ => Sync(())).map(_ => ()).flatMap(_ => Sync(())).map(_ => ())
-            .flatMap(_ => Sync(())).map(_ => ()).flatMap(_ => Sync(())).map(_ => ())
-            .flatMap(_ => Sync(())).map(_ => ()).flatMap(_ => Sync(())).map(_ => ())
-            .flatMap(_ => Sync(())).map(_ => ()).flatMap(_ => Sync(())).map(_ => ())
+        Sync.io(())
+            .flatMap(_ => Sync.io(())).map(_ => ()).flatMap(_ => Sync.io(())).map(_ => ())
+            .flatMap(_ => Sync.io(())).map(_ => ()).flatMap(_ => Sync.io(())).map(_ => ())
+            .flatMap(_ => Sync.io(())).map(_ => ()).flatMap(_ => Sync.io(())).map(_ => ())
+            .flatMap(_ => Sync.io(())).map(_ => ()).flatMap(_ => Sync.io(())).map(_ => ())
+            .flatMap(_ => Sync.io(())).map(_ => ()).flatMap(_ => Sync.io(())).map(_ => ())
     end kyoBench
 
     def zioBench() =

--- a/kyo-cache/shared/src/main/scala/kyo/Cache.scala
+++ b/kyo-cache/shared/src/main/scala/kyo/Cache.scala
@@ -35,13 +35,13 @@ class Cache(private[kyo] val store: Store) extends Serializable:
         (v: A) =>
             Promise.initWith[Throwable, B] { p =>
                 val key = (this, v)
-                Sync[B, Async & S] {
+                Sync.io {
                     val p2 = store.get(key, _ => p.asInstanceOf[Promise[Nothing, Any]])
                     if p.equals(p2) then
                         Sync.ensure {
                             p.interrupt.map {
                                 case true =>
-                                    Sync(store.invalidate(key))
+                                    Sync.io(store.invalidate(key))
                                 case false =>
                                     ()
                             }
@@ -51,7 +51,7 @@ class Cache(private[kyo] val store: Store) extends Serializable:
                                     p.complete(Result.Success(v))
                                         .andThen(v)
                                 case r =>
-                                    Sync(store.invalidate(key))
+                                    Sync.io(store.invalidate(key))
                                         .andThen(p.complete(r))
                                         .andThen(r.getOrThrow)
                             }
@@ -225,7 +225,7 @@ object Cache:
       *   A new Cache instance wrapped in an Sync effect
       */
     def init(f: Builder => Builder)(using Frame): Cache < Sync =
-        Sync {
+        Sync.io {
             new Cache(
                 f(new Builder(Caffeine.newBuilder())).b
                     .build[Any, Promise[Nothing, Any]]()

--- a/kyo-caliban/src/main/scala/kyo/Resolvers.scala
+++ b/kyo-caliban/src/main/scala/kyo/Resolvers.scala
@@ -118,7 +118,7 @@ object Resolvers:
         for
             interpreter <- v
             endpoints = interpreter.serverEndpoints[R, NoStreams](NoStreams).map(convertEndpoint(_, runtime))
-            bindings <- Sync.io(server.addEndpoints(endpoints).start())
+            bindings <- Sync.defer(server.addEndpoints(endpoints).start())
         yield bindings
 
     /** Creates an HttpInterpreter from a GraphQL API.

--- a/kyo-caliban/src/main/scala/kyo/Resolvers.scala
+++ b/kyo-caliban/src/main/scala/kyo/Resolvers.scala
@@ -118,7 +118,7 @@ object Resolvers:
         for
             interpreter <- v
             endpoints = interpreter.serverEndpoints[R, NoStreams](NoStreams).map(convertEndpoint(_, runtime))
-            bindings <- Sync(server.addEndpoints(endpoints).start())
+            bindings <- Sync.io(server.addEndpoints(endpoints).start())
         yield bindings
 
     /** Creates an HttpInterpreter from a GraphQL API.

--- a/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
+++ b/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
@@ -101,13 +101,13 @@ class CatsTest extends Test:
 
         def kyoLoop(started: CountDownLatch, done: CountDownLatch): Unit < Sync =
             def loop(i: Int): Unit < Sync =
-                Sync {
+                Sync.defer {
                     if i == 0 then
-                        Sync(started.countDown()).andThen(loop(i + 1))
+                        Sync.defer(started.countDown()).andThen(loop(i + 1))
                     else
                         loop(i + 2)
                 }
-            Sync.ensure(Sync(done.countDown()))(loop(0))
+            Sync.ensure(Sync.defer(done.countDown()))(loop(0))
         end kyoLoop
 
         def catsLoop(started: CountDownLatch, done: CountDownLatch): CatsIO[Unit] =
@@ -202,10 +202,10 @@ class CatsTest extends Test:
                     val panic   = Result.Panic(new Exception)
                     for
                         f <- Fiber.run(Cats.get(catsLoop(started, done)))
-                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt(panic)
                         r <- f.getResult
-                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r == panic)
                     end for
                 }
@@ -220,10 +220,10 @@ class CatsTest extends Test:
                         yield ()
                     for
                         f <- Fiber.run(v)
-                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }
@@ -238,10 +238,10 @@ class CatsTest extends Test:
                     end parallelEffect
                     for
                         f <- Fiber.run(parallelEffect)
-                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }
@@ -256,10 +256,10 @@ class CatsTest extends Test:
                     end raceEffect
                     for
                         f <- Fiber.run(raceEffect)
-                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -118,7 +118,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that manages the resource lifecycle using Resource and Sync effects
       */
     def fromAutoCloseable[A <: AutoCloseable, S](closeable: => A < S)(using Frame): A < (S & Resource & Sync) =
-        acquireRelease(closeable)(c => Sync(c.close()))
+        acquireRelease(closeable)(c => Sync.io(c.close()))
 
     /** Creates an effect from an Either[E, A] and handles Left[E] to Abort[E].
       *
@@ -383,7 +383,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that suspends the given effect
       */
     def suspend[A, S](effect: => A < S)(using Frame): A < (S & Sync) =
-        Sync(effect)
+        Sync.io(effect)
 
     /** Suspends an effect using Sync and handles any exceptions that occur to Abort[Throwable].
       *
@@ -393,7 +393,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that suspends the given effect and handles any exceptions that occur to Abort[Throwable]
       */
     def suspendAttempt[A, S](effect: => A < S)(using Frame): A < (S & Sync & Abort[Throwable]) =
-        Sync(Abort.catching[Throwable](effect))
+        Sync.io(Abort.catching[Throwable](effect))
 
     /** Traverses a sequence of effects and collects the results.
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -118,7 +118,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that manages the resource lifecycle using Resource and Sync effects
       */
     def fromAutoCloseable[A <: AutoCloseable, S](closeable: => A < S)(using Frame): A < (S & Resource & Sync) =
-        acquireRelease(closeable)(c => Sync.io(c.close()))
+        acquireRelease(closeable)(c => Sync.defer(c.close()))
 
     /** Creates an effect from an Either[E, A] and handles Left[E] to Abort[E].
       *
@@ -383,7 +383,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that suspends the given effect
       */
     def suspend[A, S](effect: => A < S)(using Frame): A < (S & Sync) =
-        Sync.io(effect)
+        Sync.defer(effect)
 
     /** Suspends an effect using Sync and handles any exceptions that occur to Abort[Throwable].
       *
@@ -393,7 +393,7 @@ extension (kyoObject: Kyo.type)
       *   An effect that suspends the given effect and handles any exceptions that occur to Abort[Throwable]
       */
     def suspendAttempt[A, S](effect: => A < S)(using Frame): A < (S & Sync & Abort[Throwable]) =
-        Sync.io(Abort.catching[Throwable](effect))
+        Sync.defer(Abort.catching[Throwable](effect))
 
     /** Traverses a sequence of effects and collects the results.
       *

--- a/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
@@ -58,11 +58,11 @@ class AbortCombinatorsTest extends Test:
 
             "should construct from an Sync" in {
                 import AllowUnsafe.embrace.danger
-                val effect = Kyo.attempt(Sync(throw new Exception("failure")))
+                val effect = Kyo.attempt(Sync.io(throw new Exception("failure")))
                 assert(Sync.Unsafe.evalOrThrow(
                     Abort.run[Throwable](effect)
                 ).failure.get.getMessage == "failure")
-                val effect1 = Kyo.attempt(Sync(1))
+                val effect1 = Kyo.attempt(Sync.io(1))
                 assert(Sync.Unsafe.evalOrThrow(
                     Abort.run[Throwable](effect1)
                 ).getOrElse(-1) == 1)

--- a/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AbortCombinatorsTest.scala
@@ -58,11 +58,11 @@ class AbortCombinatorsTest extends Test:
 
             "should construct from an Sync" in {
                 import AllowUnsafe.embrace.danger
-                val effect = Kyo.attempt(Sync.io(throw new Exception("failure")))
+                val effect = Kyo.attempt(Sync.defer(throw new Exception("failure")))
                 assert(Sync.Unsafe.evalOrThrow(
                     Abort.run[Throwable](effect)
                 ).failure.get.getMessage == "failure")
-                val effect1 = Kyo.attempt(Sync.io(1))
+                val effect1 = Kyo.attempt(Sync.defer(1))
                 assert(Sync.Unsafe.evalOrThrow(
                     Abort.run[Throwable](effect1)
                 ).getOrElse(-1) == 1)

--- a/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorsTest.scala
@@ -28,7 +28,7 @@ class ChoiceCombinatorTest extends Test:
         "iteration" - {
             "should iterate using foreach" in run {
                 var state             = 0
-                def effectFor(i: Int) = Sync.io { state += i; state }
+                def effectFor(i: Int) = Sync.defer { state += i; state }
                 val effect            = Kyo.foreach(1 to 10)(effectFor)
                 assert(state == 0)
                 effect.map { result =>
@@ -41,7 +41,7 @@ class ChoiceCombinatorTest extends Test:
             "should iterate using collect" in run {
                 var state = 0
                 val effect = Kyo.collect(1 to 10) { i =>
-                    Sync.io(Maybe.when(i % 2 == 0) { { state += i; i * 2 } })
+                    Sync.defer(Maybe.when(i % 2 == 0) { { state += i; i * 2 } })
                 }
                 assert(state == 0)
                 effect.map { result =>
@@ -52,7 +52,7 @@ class ChoiceCombinatorTest extends Test:
 
             "should iterate using traverse" in run {
                 var state   = 0
-                val effects = (1 to 10).map(i => Sync.io { state += i; state })
+                val effects = (1 to 10).map(i => Sync.defer { state += i; state })
                 val effect  = Kyo.traverse(effects)
                 assert(state == 0)
                 effect.map { result =>
@@ -63,7 +63,7 @@ class ChoiceCombinatorTest extends Test:
 
             "should iterate using traverseDiscard" in run {
                 var state   = 0
-                val effects = (1 to 10).map(i => Sync.io { state += i; state })
+                val effects = (1 to 10).map(i => Sync.defer { state += i; state })
                 val effect  = Kyo.traverseDiscard(effects)
                 assert(state == 0)
                 effect.map { result =>

--- a/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ChoiceCombinatorsTest.scala
@@ -28,7 +28,7 @@ class ChoiceCombinatorTest extends Test:
         "iteration" - {
             "should iterate using foreach" in run {
                 var state             = 0
-                def effectFor(i: Int) = Sync { state += i; state }
+                def effectFor(i: Int) = Sync.io { state += i; state }
                 val effect            = Kyo.foreach(1 to 10)(effectFor)
                 assert(state == 0)
                 effect.map { result =>
@@ -41,7 +41,7 @@ class ChoiceCombinatorTest extends Test:
             "should iterate using collect" in run {
                 var state = 0
                 val effect = Kyo.collect(1 to 10) { i =>
-                    Sync(Maybe.when(i % 2 == 0) { { state += i; i * 2 } })
+                    Sync.io(Maybe.when(i % 2 == 0) { { state += i; i * 2 } })
                 }
                 assert(state == 0)
                 effect.map { result =>
@@ -52,7 +52,7 @@ class ChoiceCombinatorTest extends Test:
 
             "should iterate using traverse" in run {
                 var state   = 0
-                val effects = (1 to 10).map(i => Sync { state += i; state })
+                val effects = (1 to 10).map(i => Sync.io { state += i; state })
                 val effect  = Kyo.traverse(effects)
                 assert(state == 0)
                 effect.map { result =>
@@ -63,7 +63,7 @@ class ChoiceCombinatorTest extends Test:
 
             "should iterate using traverseDiscard" in run {
                 var state   = 0
-                val effects = (1 to 10).map(i => Sync { state += i; state })
+                val effects = (1 to 10).map(i => Sync.io { state += i; state })
                 val effect  = Kyo.traverseDiscard(effects)
                 assert(state == 0)
                 effect.map { result =>

--- a/kyo-combinators/shared/src/test/scala/kyo/FiberCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/FiberCombinatorsTest.scala
@@ -47,7 +47,7 @@ class FiberCombinatorsTest extends Test:
             }
 
             "should construct from traversePar" in run {
-                val effect = Kyo.traversePar(Seq(Sync(1), Sync(2), Sync(3)))
+                val effect = Kyo.traversePar(Seq(Sync.defer(1), Sync.defer(2), Sync.defer(3)))
                 Fiber.run(effect).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v => assert(v == Seq(1, 2, 3)))
                 }
@@ -95,8 +95,8 @@ class FiberCombinatorsTest extends Test:
 
         "zip par" - {
             "should zip right par" in run {
-                val e1     = Sync(1)
-                val e2     = Sync(2)
+                val e1     = Sync.defer(1)
+                val e2     = Sync.defer(2)
                 val effect = e1 &> e2
                 Fiber.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v =>
@@ -106,8 +106,8 @@ class FiberCombinatorsTest extends Test:
             }
 
             "should zip left par" in run {
-                val e1     = Sync(1)
-                val e2     = Sync(2)
+                val e1     = Sync.defer(1)
+                val e2     = Sync.defer(2)
                 val effect = e1 <& e2
                 Fiber.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v =>
@@ -117,8 +117,8 @@ class FiberCombinatorsTest extends Test:
             }
 
             "should zip par" in run {
-                val e1     = Sync(1)
-                val e2     = Sync(2)
+                val e1     = Sync.defer(1)
+                val e2     = Sync.defer(2)
                 val effect = e1 <&> e2
                 Fiber.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v =>

--- a/kyo-combinators/shared/src/test/scala/kyo/KyoCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/KyoCombinatorsTest.scala
@@ -8,13 +8,13 @@ class KyoCombinatorsTest extends Test:
 
         "debug" - {
             "with string value" in run {
-                val effect = Sync("Hello World")
+                val effect = Sync.defer("Hello World")
                 effect.map { handled =>
                     assert(handled == "Hello World")
                 }
             }
             "with integer value" in run {
-                val effect = Sync(42)
+                val effect = Sync.defer(42)
                 effect.map { handled =>
                     assert(handled == 42)
                 }
@@ -23,13 +23,13 @@ class KyoCombinatorsTest extends Test:
 
         "debug(prefix)" - {
             "with boolean value" in run {
-                val effect = Sync(true)
+                val effect = Sync.defer(true)
                 effect.map { handled =>
                     assert(handled == true)
                 }
             }
             "with string value" in run {
-                val effect = Sync("test")
+                val effect = Sync.defer("test")
                 effect.map { handled =>
                     assert(handled == "test")
                 }
@@ -38,14 +38,14 @@ class KyoCombinatorsTest extends Test:
 
         "discard" - {
             "with integer value" in run {
-                val effect          = Sync(23)
+                val effect          = Sync.defer(23)
                 val effectDiscarded = effect.unit
                 effectDiscarded.map { handled =>
                     assert(handled == ())
                 }
             }
             "with string value" in run {
-                val effect          = Sync("hello")
+                val effect          = Sync.defer("hello")
                 val effectDiscarded = effect.unit
                 effectDiscarded.map { handled =>
                     assert(handled == ())
@@ -55,16 +55,16 @@ class KyoCombinatorsTest extends Test:
 
         "*>" - {
             "with string values" in run {
-                val eff1   = Sync("hello")
-                val eff2   = Sync("world")
+                val eff1   = Sync.defer("hello")
+                val eff2   = Sync.defer("world")
                 val zipped = eff1 *> eff2
                 zipped.map { handled =>
                     assert(handled == "world")
                 }
             }
             "with mixed types" in run {
-                val eff1   = Sync(42)
-                val eff2   = Sync("answer")
+                val eff1   = Sync.defer(42)
+                val eff2   = Sync.defer("answer")
                 val zipped = eff1 *> eff2
                 zipped.map { handled =>
                     assert(handled == "answer")
@@ -74,16 +74,16 @@ class KyoCombinatorsTest extends Test:
 
         "<*" - {
             "with string values" in run {
-                val eff1   = Sync("hello")
-                val eff2   = Sync("world")
+                val eff1   = Sync.defer("hello")
+                val eff2   = Sync.defer("world")
                 val zipped = eff1 <* eff2
                 zipped.map { handled =>
                     assert(handled == "hello")
                 }
             }
             "with mixed types" in run {
-                val eff1   = Sync("answer")
-                val eff2   = Sync(42)
+                val eff1   = Sync.defer("answer")
+                val eff2   = Sync.defer(42)
                 val zipped = eff1 <* eff2
                 zipped.map { handled =>
                     assert(handled == "answer")
@@ -93,16 +93,16 @@ class KyoCombinatorsTest extends Test:
 
         "<*>" - {
             "with string values" in run {
-                val eff1   = Sync("hello")
-                val eff2   = Sync("world")
+                val eff1   = Sync.defer("hello")
+                val eff2   = Sync.defer("world")
                 val zipped = eff1 <*> eff2
                 zipped.map { handled =>
                     assert(handled == ("hello", "world"))
                 }
             }
             "with mixed types" in run {
-                val eff1   = Sync(42)
-                val eff2   = Sync("answer")
+                val eff1   = Sync.defer(42)
+                val eff2   = Sync.defer("answer")
                 val zipped = eff1 <*> eff2
                 zipped.map { handled =>
                     assert(handled == (42, "answer"))
@@ -113,10 +113,10 @@ class KyoCombinatorsTest extends Test:
         "when" - {
             "condition is false" in run {
                 var state: Boolean = false
-                val toggleState = Sync {
+                val toggleState = Sync.defer {
                     state = !state
                 }
-                val getState   = Sync(state)
+                val getState   = Sync.defer(state)
                 val effectWhen = (toggleState *> getState).when(getState)
                 effectWhen.map { handledEffectWhen =>
                     assert(handledEffectWhen == Absent)
@@ -124,10 +124,10 @@ class KyoCombinatorsTest extends Test:
             }
             "condition is true" in run {
                 var state: Boolean = true
-                val toggleState = Sync {
+                val toggleState = Sync.defer {
                     state = !state
                 }
-                val getState   = Sync(state)
+                val getState   = Sync.defer(state)
                 val effectWhen = (toggleState *> getState).when(getState)
                 effectWhen.map { handledEffectWhen =>
                     assert(handledEffectWhen == Present(false))
@@ -137,7 +137,7 @@ class KyoCombinatorsTest extends Test:
 
         "unless" - {
             "condition is true" in run {
-                val effect = Sync("value").unless(Env.get[Boolean])
+                val effect = Sync.defer("value").unless(Env.get[Boolean])
                 Env.run(true) {
                     effect
                 }.map { result =>
@@ -145,7 +145,7 @@ class KyoCombinatorsTest extends Test:
                 }
             }
             "condition is false" in run {
-                val effect = Sync("value").unless(Env.get[Boolean])
+                val effect = Sync.defer("value").unless(Env.get[Boolean])
                 Env.run(false) {
                     effect
                 }.map { result =>
@@ -156,13 +156,13 @@ class KyoCombinatorsTest extends Test:
 
         "tap" - {
             "with integer value" in run {
-                val effect: Int < Sync = Sync(42).tap(v => assert(42 == v))
+                val effect: Int < Sync = Sync.defer(42).tap(v => assert(42 == v))
                 effect.map { handled =>
                     assert(handled == 42)
                 }
             }
             "with string value" in run {
-                val effect: String < Sync = Sync("test").tap(v => assert("test" == v))
+                val effect: String < Sync = Sync.defer("test").tap(v => assert("test" == v))
                 effect.map { handled =>
                     assert(handled == "test")
                 }
@@ -171,13 +171,13 @@ class KyoCombinatorsTest extends Test:
 
         "delay" - {
             "with short delay" in run {
-                val effect = Sync(42).delay(1.millis)
+                val effect = Sync.defer(42).delay(1.millis)
                 Fiber.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v => assert(v == 42))
                 }
             }
             "with zero delay" in run {
-                val effect = Sync("test").delay(0.millis)
+                val effect = Sync.defer("test").delay(0.millis)
                 Fiber.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v => assert(v == "test"))
                 }
@@ -188,7 +188,7 @@ class KyoCombinatorsTest extends Test:
             "repeat with fixed number" - {
                 "repeat 3 times" in run {
                     var count  = 0
-                    val effect = Sync { count += 1; count }.repeat(3)
+                    val effect = Sync.defer { count += 1; count }.repeat(3)
                     effect.map { handled =>
                         assert(handled == 4)
                         assert(count == 4)
@@ -196,7 +196,7 @@ class KyoCombinatorsTest extends Test:
                 }
                 "repeat 0 times" in run {
                     var count  = 0
-                    val effect = Sync { count += 1; count }.repeat(0)
+                    val effect = Sync.defer { count += 1; count }.repeat(0)
                     effect.map { handled =>
                         assert(handled == 1)
                         assert(count == 1)
@@ -208,7 +208,7 @@ class KyoCombinatorsTest extends Test:
                 "repeat with custom policy" in run {
                     var count    = 0
                     val schedule = Schedule.repeat(3)
-                    val effect   = Sync { count += 1; count }.repeatAtInterval(schedule)
+                    val effect   = Sync.defer { count += 1; count }.repeatAtInterval(schedule)
                     Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map { v =>
                             assert(v == 4)
@@ -222,7 +222,7 @@ class KyoCombinatorsTest extends Test:
                 "repeat with exponential backoff" in run {
                     var count   = 0
                     val backoff = (i: Int) => Math.pow(2, i).toLong.millis
-                    val effect  = Sync { count += 1; count }.repeatAtInterval(backoff, 3)
+                    val effect  = Sync.defer { count += 1; count }.repeatAtInterval(backoff, 3)
                     Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map { v =>
                             assert(v == 4)
@@ -237,14 +237,14 @@ class KyoCombinatorsTest extends Test:
             "repeatWhile with simple condition" - {
                 "condition becomes false" in run {
                     var count  = 0
-                    val effect = Sync { count += 1; count }.repeatWhile(_ < 3)
+                    val effect = Sync.defer { count += 1; count }.repeatWhile(_ < 3)
                     Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }
                 "condition is initially false" in run {
                     var count  = 5
-                    val effect = Sync { count += 1; count }.repeatWhile(_ < 3)
+                    val effect = Sync.defer { count += 1; count }.repeatWhile(_ < 3)
                     Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 6))
                     }
@@ -254,7 +254,7 @@ class KyoCombinatorsTest extends Test:
             "repeatWhile with condition and duration" - {
                 "condition becomes false with delay" in run {
                     var count  = 0
-                    val effect = Sync { count += 1; count }.repeatWhile((v, i) => (v < 3, 10.millis))
+                    val effect = Sync.defer { count += 1; count }.repeatWhile((v, i) => (v < 3, 10.millis))
                     Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
@@ -266,14 +266,14 @@ class KyoCombinatorsTest extends Test:
             "repeatUntil with simple condition" - {
                 "condition becomes true" in run {
                     var count  = 0
-                    val effect = Sync { count += 1; count }.repeatUntil(_ == 3)
+                    val effect = Sync.defer { count += 1; count }.repeatUntil(_ == 3)
                     Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }
                 "condition is initially true" in run {
                     var count  = 0
-                    val effect = Sync { count += 1; count }.repeatUntil(_ => true)
+                    val effect = Sync.defer { count += 1; count }.repeatUntil(_ => true)
                     Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 1))
                     }
@@ -283,7 +283,7 @@ class KyoCombinatorsTest extends Test:
             "repeatUntil with condition and duration" - {
                 "condition becomes true with delay" in run {
                     var count  = 0
-                    val effect = Sync { count += 1; count }.repeatUntil((v, i) => (v == 3, 10.millis))
+                    val effect = Sync.defer { count += 1; count }.repeatUntil((v, i) => (v == 3, 10.millis))
                     Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
@@ -293,7 +293,7 @@ class KyoCombinatorsTest extends Test:
 
         "unpanic" - {
             "with throwable" in run {
-                val effect: Nothing < (Abort[Throwable] & Sync)     = Sync { Abort.fail(Exception("failure")) }
+                val effect: Nothing < (Abort[Throwable] & Sync)     = Sync.defer { Abort.fail(Exception("failure")) }
                 val panicked: Nothing < Sync                        = effect.orPanic
                 val unpanicked: Nothing < (Abort[Throwable] & Sync) = panicked.unpanic
                 Abort.run[Throwable](unpanicked).map: handled =>
@@ -303,7 +303,7 @@ class KyoCombinatorsTest extends Test:
             }
 
             "with non-throwable failure" in run {
-                val effect: Nothing < (Abort[String] & Sync)        = Sync { Abort.fail("failure") }
+                val effect: Nothing < (Abort[String] & Sync)        = Sync.defer { Abort.fail("failure") }
                 val panicked: Nothing < Sync                        = effect.orPanic
                 val unpanicked: Nothing < (Abort[Throwable] & Sync) = panicked.unpanic
                 Abort.run[Throwable](unpanicked).map: handled =>
@@ -313,8 +313,8 @@ class KyoCombinatorsTest extends Test:
 
         "ensuring" in run {
             var finalizerCalled                          = false
-            def ensure: Unit < (Sync & Abort[Throwable]) = Sync { finalizerCalled = true }
-            Resource.run(Sync(()).ensuring(ensure))
+            def ensure: Unit < (Sync & Abort[Throwable]) = Sync.defer { finalizerCalled = true }
+            Resource.run(Sync.defer(()).ensuring(ensure))
                 .andThen(assert(finalizerCalled))
         }
 
@@ -322,7 +322,7 @@ class KyoCombinatorsTest extends Test:
             var error: Maybe[Error[Any]] = Absent
             given [A]: CanEqual[A, A]    = CanEqual.derived
 
-            val ensure: Maybe[Error[Any]] => Unit < (Sync & Abort[Throwable]) = ex => Sync { error = ex }
+            val ensure: Maybe[Error[Any]] => Unit < (Sync & Abort[Throwable]) = ex => Sync.defer { error = ex }
             Abort.fail("failure").ensuringError(ensure).handle(Resource.run, Abort.run(_)).andThen {
                 assert(error == Result.fail("failure"))
             }

--- a/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -10,7 +10,7 @@ abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abo
     final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         val currentAsync: Unit < (Async & Abort[Throwable]) =
-            Abort.run(handle(v)).map(result => Sync.io(onResult(result)).andThen(Abort.get(result)).unit)
+            Abort.run(handle(v)).map(result => Sync.defer(onResult(result)).andThen(Abort.get(result)).unit)
         maybePreviousAsync = maybePreviousAsync match
             case Absent                 => Present(currentAsync)
             case Present(previousAsync) => Present(previousAsync.map(_ => currentAsync))

--- a/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -10,7 +10,7 @@ abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abo
     final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         val currentAsync: Unit < (Async & Abort[Throwable]) =
-            Abort.run(handle(v)).map(result => Sync(onResult(result)).andThen(Abort.get(result)).unit)
+            Abort.run(handle(v)).map(result => Sync.io(onResult(result)).andThen(Abort.get(result)).unit)
         maybePreviousAsync = maybePreviousAsync match
             case Absent                 => Present(currentAsync)
             case Present(previousAsync) => Present(previousAsync.map(_ => currentAsync))

--- a/kyo-core/jvm/src/main/scala/kyo/Path.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Path.scala
@@ -29,10 +29,10 @@ final class Path private (val path: List[String]) extends Serializable derives C
     /** Methods to read files completely
       */
     def read(using Frame): String < Sync =
-        Sync(JFiles.readString(toJava))
+        Sync.io(JFiles.readString(toJava))
 
     def read(charset: Charset)(using Frame): String < Sync =
-        Sync(JFiles.readString(toJava, charset))
+        Sync.io(JFiles.readString(toJava, charset))
 
     def readAll(extension: String)(using Frame): Seq[(String, String)] < Sync =
         list(extension).map { paths =>
@@ -45,21 +45,21 @@ final class Path private (val path: List[String]) extends Serializable derives C
         }
 
     def readBytes(using Frame): Array[Byte] < Sync =
-        Sync(JFiles.readAllBytes(toJava))
+        Sync.io(JFiles.readAllBytes(toJava))
 
     def readLines(using Frame): List[String] < Sync =
-        Sync(JFiles.readAllLines(toJava).asScala.toList)
+        Sync.io(JFiles.readAllLines(toJava).asScala.toList)
 
     def readLines(
         charSet: Charset = java.nio.charset.StandardCharsets.UTF_8
     )(using Frame): List[String] < Sync =
-        Sync(JFiles.readAllLines(toJava, charSet).asScala.toList)
+        Sync.io(JFiles.readAllLines(toJava, charSet).asScala.toList)
 
     /** Methods to append and write to files
       */
 
     private inline def append(createFolders: Boolean)(inline f: (JPath, Seq[OpenOption]) => JPath)(using Frame): Unit < Sync =
-        Sync {
+        Sync.io {
             if createFolders then
                 discard(f(toJava, Seq(StandardOpenOption.APPEND, StandardOpenOption.CREATE)))
             else if javaExists(toJava.getParent()) then
@@ -82,7 +82,7 @@ final class Path private (val path: List[String]) extends Serializable derives C
         append(createFolders)((path, options) => Files.write(toJava, value.asJava, options*))
 
     private inline def write(createFolders: Boolean)(inline f: (JPath, Seq[OpenOption]) => JPath)(using Frame): Unit < Sync =
-        Sync {
+        Sync.io {
             if createFolders then
                 discard(f(toJava, Seq(StandardOpenOption.WRITE, StandardOpenOption.CREATE)))
             else if javaExists(toJava.getParent()) then
@@ -112,7 +112,7 @@ final class Path private (val path: List[String]) extends Serializable derives C
     def readStream(charset: Charset = java.nio.charset.StandardCharsets.UTF_8)(using Frame): Stream[String, Resource & Sync] =
         readLoop[String, Array[Byte], (FileChannel, ByteBuffer)](
             (FileChannel.open(toJava, StandardOpenOption.READ), ByteBuffer.allocate(2048)),
-            ch => Sync(ch._1.close()),
+            ch => Sync.io(ch._1.close()),
             readOnceBytes,
             arr => Chunk(new String(arr, charset))
         )
@@ -121,7 +121,7 @@ final class Path private (val path: List[String]) extends Serializable derives C
       */
     def readLinesStream(charset: Charset = java.nio.charset.StandardCharsets.UTF_8)(using Frame): Stream[String, Resource & Sync] =
         readLoop[String, String, BufferedReader](
-            Sync(JFiles.newBufferedReader(toJava, Charset.defaultCharset())),
+            Sync.io(JFiles.newBufferedReader(toJava, Charset.defaultCharset())),
             reader => reader.close(),
             readOnceLines,
             line => Chunk(line)
@@ -131,20 +131,20 @@ final class Path private (val path: List[String]) extends Serializable derives C
       */
     def readBytesStream(using Frame): Stream[Byte, Resource & Sync] =
         readLoop[Byte, Array[Byte], (FileChannel, ByteBuffer)](
-            Sync(FileChannel.open(toJava, StandardOpenOption.READ), ByteBuffer.allocate(2048)),
+            Sync.io(FileChannel.open(toJava, StandardOpenOption.READ), ByteBuffer.allocate(2048)),
             ch => ch._1.close(),
             readOnceBytes,
             arr => Chunk.from(arr.toSeq)
         )
 
     private def readOnceLines(reader: BufferedReader)(using Frame) =
-        Sync {
+        Sync.io {
             val line = reader.readLine()
             if line == null then Maybe.empty else Maybe(line)
         }
 
     private def readOnceBytes(res: (FileChannel, ByteBuffer))(using Frame) =
-        Sync {
+        Sync.io {
             val (fileChannel, buf) = res
             val bytesRead          = fileChannel.read(buf)
             if bytesRead < 1 then Maybe.empty
@@ -192,12 +192,12 @@ final class Path private (val path: List[String]) extends Serializable derives C
     /** List contents of path
       */
     def list(using Frame): IndexedSeq[Path] < Sync =
-        Sync(JFiles.list(toJava).toScala(LazyList).toIndexedSeq).map(_.map(path => Path(path.toString)))
+        Sync.io(JFiles.list(toJava).toScala(LazyList).toIndexedSeq).map(_.map(path => Path(path.toString)))
 
     /** List contents of path with given extension
       */
     def list(extension: String)(using Frame): IndexedSeq[Path] < Sync =
-        Sync(JFiles.list(toJava).toScala(LazyList).filter(path =>
+        Sync.io(JFiles.list(toJava).toScala(LazyList).filter(path =>
             path.getFileName().toString().split('.').toList.lastOption.getOrElse("") == extension
         ).toIndexedSeq.map(path => Path(path.toString)))
 
@@ -210,9 +210,9 @@ final class Path private (val path: List[String]) extends Serializable derives C
       */
     def exists(followLinks: Boolean)(using Frame): Boolean < Sync =
         val path = toJava
-        if path == null then Sync(false)
-        else if followLinks then Sync(JFiles.exists(path))
-        else Sync(JFiles.exists(path, LinkOption.NOFOLLOW_LINKS))
+        if path == null then Sync.io(false)
+        else if followLinks then Sync.io(JFiles.exists(path))
+        else Sync.io(JFiles.exists(path, LinkOption.NOFOLLOW_LINKS))
     end exists
 
     private def javaExists(jPath: JPath): Boolean =
@@ -222,32 +222,32 @@ final class Path private (val path: List[String]) extends Serializable derives C
     /** Returns if the path represents a directory
       */
     def isDir(using Frame): Boolean < Sync =
-        Sync(JFiles.isDirectory(toJava))
+        Sync.io(JFiles.isDirectory(toJava))
 
     /** Returns if the path represents a file
       */
     def isFile(using Frame): Boolean < Sync =
-        Sync(JFiles.isRegularFile(toJava))
+        Sync.io(JFiles.isRegularFile(toJava))
 
     /** Returns if the path represents a symbolic link
       */
     def isLink(using Frame): Boolean < Sync =
-        Sync(JFiles.isSymbolicLink(toJava))
+        Sync.io(JFiles.isSymbolicLink(toJava))
 
     /** Creates a directory in this path
       */
     def mkDir(using Frame): Unit < Sync =
-        Sync(javaExists(toJava.getParent())).map { parentsExist =>
-            if parentsExist == true then Sync(JFiles.createDirectory(toJava))
-            else Sync(JFiles.createDirectories(toJava))
+        Sync.io(javaExists(toJava.getParent())).map { parentsExist =>
+            if parentsExist == true then Sync.io(JFiles.createDirectory(toJava))
+            else Sync.io(JFiles.createDirectories(toJava))
         }.unit
 
     /** Creates a directory in this path
       */
     def mkFile(using Frame): Unit < Sync =
-        Sync(javaExists(toJava.getParent())).map { parentsExist =>
-            if parentsExist == true then Sync(JFiles.createDirectory(toJava))
-            else Sync(JFiles.createDirectories(toJava))
+        Sync.io(javaExists(toJava.getParent())).map { parentsExist =>
+            if parentsExist == true then Sync.io(JFiles.createDirectory(toJava))
+            else Sync.io(JFiles.createDirectories(toJava))
         }.unit
     end mkFile
 
@@ -262,10 +262,10 @@ final class Path private (val path: List[String]) extends Serializable derives C
         val opts = (if atomicMove then List(StandardCopyOption.ATOMIC_MOVE) else Nil) ++ (if replaceExisting then
                                                                                               List(StandardCopyOption.REPLACE_EXISTING)
                                                                                           else Nil)
-        Sync(javaExists(toJava.getParent())).map { parentExists =>
+        Sync.io(javaExists(toJava.getParent())).map { parentExists =>
             (parentExists, createFolders) match
-                case (true, _)     => Sync(JFiles.move(toJava, to.toJava, opts*)).unit
-                case (false, true) => Path(toJava.getParent().toString).mkDir.andThen(Sync(JFiles.move(toJava, to.toJava, opts*)).unit)
+                case (true, _)     => Sync.io(JFiles.move(toJava, to.toJava, opts*)).unit
+                case (false, true) => Path(toJava.getParent().toString).mkDir.andThen(Sync.io(JFiles.move(toJava, to.toJava, opts*)).unit)
                 case _             => ()
         }
     end move
@@ -283,10 +283,10 @@ final class Path private (val path: List[String]) extends Serializable derives C
         val opts = (if followLinks then List.empty[CopyOption] else List[CopyOption](LinkOption.NOFOLLOW_LINKS)) ++
             (if copyAttributes then List[CopyOption](StandardCopyOption.COPY_ATTRIBUTES) else List.empty[CopyOption]) ++
             (if replaceExisting then List[CopyOption](StandardCopyOption.REPLACE_EXISTING) else List.empty[CopyOption])
-        Sync(javaExists(toJava.getParent())).map { parentExists =>
+        Sync.io(javaExists(toJava.getParent())).map { parentExists =>
             (parentExists, createFolders) match
-                case (true, _)     => Sync(JFiles.copy(toJava, to.toJava, opts*)).unit
-                case (false, true) => Path(toJava.getParent().toString).mkDir.andThen(Sync(JFiles.copy(toJava, to.toJava, opts*)).unit)
+                case (true, _)     => Sync.io(JFiles.copy(toJava, to.toJava, opts*)).unit
+                case (false, true) => Path(toJava.getParent().toString).mkDir.andThen(Sync.io(JFiles.copy(toJava, to.toJava, opts*)).unit)
                 case _             => ()
         }
     end copy
@@ -299,7 +299,7 @@ final class Path private (val path: List[String]) extends Serializable derives C
     /** Removes this path if it is empty
       */
     def remove(checkExists: Boolean)(using Frame): Boolean < Sync =
-        Sync {
+        Sync.io {
             if checkExists then
                 JFiles.delete(toJava)
                 true
@@ -310,7 +310,7 @@ final class Path private (val path: List[String]) extends Serializable derives C
     /** Removes this path and all its contents
       */
     def removeAll(using Frame): Unit < Sync =
-        Sync {
+        Sync.io {
             val path = toJava
             if javaExists(path) then
                 val visitor = new SimpleFileVisitor[JPath]:
@@ -334,7 +334,7 @@ final class Path private (val path: List[String]) extends Serializable derives C
     /** Creates a stream of the contents of this path with given depth
       */
     def walk(maxDepth: Int)(using Frame): Stream[Path, Sync] =
-        Stream.init(Sync(JFiles.walk(toJava).toScala(LazyList).map(path => Path(path.toString))))
+        Stream.init(Sync.io(JFiles.walk(toJava).toScala(LazyList).map(path => Path(path.toString))))
 
     override def hashCode(): Int =
         val prime  = 31
@@ -382,7 +382,7 @@ object Path:
     )
 
     def basePaths(using Frame): BasePaths < Sync =
-        Sync {
+        Sync.io {
             val dirs = BaseDirectories.get()
             BasePaths(
                 Path(dirs.cacheDir),
@@ -409,7 +409,7 @@ object Path:
     )
 
     def userPaths(using Frame): UserPaths < Sync =
-        Sync {
+        Sync.io {
             val dirs = UserDirectories.get()
             UserPaths(
                 Path(dirs.homeDir),
@@ -436,7 +436,7 @@ object Path:
     )
 
     def projectPaths(qualifier: String, organization: String, application: String)(using Frame): ProjectPaths < Sync =
-        Sync {
+        Sync.io {
             val dirs = ProjectDirectories.from(qualifier, organization, application)
             ProjectPaths(
                 Path(dirs.projectPath),
@@ -453,9 +453,9 @@ end Path
 
 extension [S](stream: Stream[Byte, S])
     def sink(path: Path)(using Frame): Unit < (Resource & Sync & S) =
-        Resource.acquireRelease(Sync(FileChannel.open(path.toJava, StandardOpenOption.WRITE)))(ch => ch.close()).map { fileCh =>
+        Resource.acquireRelease(Sync.io(FileChannel.open(path.toJava, StandardOpenOption.WRITE)))(ch => ch.close()).map { fileCh =>
             stream.foreachChunk(bytes =>
-                Sync {
+                Sync.io {
                     fileCh.write(ByteBuffer.wrap(bytes.toArray))
                     ()
                 }
@@ -466,9 +466,9 @@ end extension
 extension [S](stream: Stream[String, S])
     @scala.annotation.targetName("stringSink")
     def sink(path: Path, charset: Codec = java.nio.charset.StandardCharsets.UTF_8)(using Frame): Unit < (Resource & Sync & S) =
-        Resource.acquireRelease(Sync(FileChannel.open(path.toJava, StandardOpenOption.WRITE)))(ch => ch.close()).map { fileCh =>
+        Resource.acquireRelease(Sync.io(FileChannel.open(path.toJava, StandardOpenOption.WRITE)))(ch => ch.close()).map { fileCh =>
             stream.foreach(s =>
-                Sync {
+                Sync.io {
                     fileCh.write(ByteBuffer.wrap(s.getBytes))
                     ()
                 }
@@ -481,7 +481,7 @@ extension [S](stream: Stream[String, S])
     )(using Frame): Unit < (Resource & Sync & S) =
         Resource.acquireRelease(FileChannel.open(path.toJava, StandardOpenOption.WRITE))(ch => ch.close()).map { fileCh =>
             stream.foreach(line =>
-                Sync {
+                Sync.io {
                     fileCh.write(ByteBuffer.wrap(line.getBytes))
                     fileCh.write(ByteBuffer.wrap(JSystem.lineSeparator().getBytes))
                     ()

--- a/kyo-core/jvm/src/main/scala/kyo/Process.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Process.scala
@@ -18,13 +18,13 @@ case class Process(private val process: JProcess):
     def stdin: OutputStream                                                 = process.getOutputStream
     def stdout: InputStream                                                 = process.getInputStream
     def stderr: InputStream                                                 = process.getErrorStream
-    def waitFor(using Frame): Int < Sync                                    = Sync.io(process.waitFor())
-    def waitFor(timeout: Long, unit: TimeUnit)(using Frame): Boolean < Sync = Sync.io(process.waitFor(timeout, unit))
-    def exitValue(using Frame): Int < Sync                                  = Sync.io(process.exitValue())
-    def destroy(using Frame): Unit < Sync                                   = Sync.io(process.destroy())
-    def destroyForcibly(using Frame): JProcess < Sync                       = Sync.io(process.destroyForcibly())
-    def isAlive(using Frame): Boolean < Sync                                = Sync.io(process.isAlive())
-    def pid(using Frame): Long < Sync                                       = Sync.io(process.pid())
+    def waitFor(using Frame): Int < Sync                                    = Sync.defer(process.waitFor())
+    def waitFor(timeout: Long, unit: TimeUnit)(using Frame): Boolean < Sync = Sync.defer(process.waitFor(timeout, unit))
+    def exitValue(using Frame): Int < Sync                                  = Sync.defer(process.exitValue())
+    def destroy(using Frame): Unit < Sync                                   = Sync.defer(process.destroy())
+    def destroyForcibly(using Frame): JProcess < Sync                       = Sync.defer(process.destroyForcibly())
+    def isAlive(using Frame): Boolean < Sync                                = Sync.defer(process.isAlive())
+    def pid(using Frame): Long < Sync                                       = Sync.defer(process.pid())
 end Process
 
 object Process:
@@ -39,7 +39,7 @@ object Process:
           * command, use `spawn` or use directly `jvm.spawn`.
           */
         def command(clazz: Class[?], args: List[String] = Nil)(using Frame): Process.Command < Sync =
-            Sync.io {
+            Sync.defer {
                 val javaHome  = JSystem.getProperty("java.home") + File.separator + "bin" + File.separator + "java"
                 val classPath = JSystem.getProperty("java.class.path")
                 val command   = javaHome :: "-cp" :: classPath :: clazz.getName().init :: args
@@ -167,7 +167,7 @@ object Process:
             self =>
             override def spawn(using Frame): Process < Sync =
                 for
-                    process <- Sync.io {
+                    process <- Sync.defer {
                         val builder = new ProcessBuilder(command*)
 
                         builder.redirectErrorStream(redirectErrorStream)
@@ -214,7 +214,7 @@ object Process:
         case class Piped(commands: List[Simple]) extends Command:
             self =>
             def spawnAll(using Frame): List[Process] < Sync =
-                if commands.isEmpty then Sync.io(List.empty)
+                if commands.isEmpty then Sync.defer(List.empty)
                 else
                     commands.tail.foldLeft(commands.head.spawn.map(p => (p :: Nil, p.stdout))) { case (acc, nextCommand) =>
                         for

--- a/kyo-core/jvm/src/main/scala/kyo/Process.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Process.scala
@@ -18,13 +18,13 @@ case class Process(private val process: JProcess):
     def stdin: OutputStream                                                 = process.getOutputStream
     def stdout: InputStream                                                 = process.getInputStream
     def stderr: InputStream                                                 = process.getErrorStream
-    def waitFor(using Frame): Int < Sync                                    = Sync(process.waitFor())
-    def waitFor(timeout: Long, unit: TimeUnit)(using Frame): Boolean < Sync = Sync(process.waitFor(timeout, unit))
-    def exitValue(using Frame): Int < Sync                                  = Sync(process.exitValue())
-    def destroy(using Frame): Unit < Sync                                   = Sync(process.destroy())
-    def destroyForcibly(using Frame): JProcess < Sync                       = Sync(process.destroyForcibly())
-    def isAlive(using Frame): Boolean < Sync                                = Sync(process.isAlive())
-    def pid(using Frame): Long < Sync                                       = Sync(process.pid())
+    def waitFor(using Frame): Int < Sync                                    = Sync.io(process.waitFor())
+    def waitFor(timeout: Long, unit: TimeUnit)(using Frame): Boolean < Sync = Sync.io(process.waitFor(timeout, unit))
+    def exitValue(using Frame): Int < Sync                                  = Sync.io(process.exitValue())
+    def destroy(using Frame): Unit < Sync                                   = Sync.io(process.destroy())
+    def destroyForcibly(using Frame): JProcess < Sync                       = Sync.io(process.destroyForcibly())
+    def isAlive(using Frame): Boolean < Sync                                = Sync.io(process.isAlive())
+    def pid(using Frame): Long < Sync                                       = Sync.io(process.pid())
 end Process
 
 object Process:
@@ -39,7 +39,7 @@ object Process:
           * command, use `spawn` or use directly `jvm.spawn`.
           */
         def command(clazz: Class[?], args: List[String] = Nil)(using Frame): Process.Command < Sync =
-            Sync {
+            Sync.io {
                 val javaHome  = JSystem.getProperty("java.home") + File.separator + "bin" + File.separator + "java"
                 val classPath = JSystem.getProperty("java.class.path")
                 val command   = javaHome :: "-cp" :: classPath :: clazz.getName().init :: args
@@ -167,7 +167,7 @@ object Process:
             self =>
             override def spawn(using Frame): Process < Sync =
                 for
-                    process <- Sync {
+                    process <- Sync.io {
                         val builder = new ProcessBuilder(command*)
 
                         builder.redirectErrorStream(redirectErrorStream)
@@ -214,7 +214,7 @@ object Process:
         case class Piped(commands: List[Simple]) extends Command:
             self =>
             def spawnAll(using Frame): List[Process] < Sync =
-                if commands.isEmpty then Sync(List.empty)
+                if commands.isEmpty then Sync.io(List.empty)
                 else
                     commands.tail.foldLeft(commands.head.spawn.map(p => (p :: Nil, p.stdout))) { case (acc, nextCommand) =>
                         for

--- a/kyo-core/jvm/src/main/scala/kyo/StreamCompression.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/StreamCompression.scala
@@ -153,44 +153,44 @@ object StreamCompression:
         ): Unit < (Resource & Sync & Emit[Chunk[Byte]] & Ctx) =
             Loop(DeflateState.Initialize):
                 case DeflateState.Initialize =>
-                    Resource.acquireRelease(Sync.io {
+                    Resource.acquireRelease(Sync.defer {
                         val deflater = new Deflater(compressionLevel.value, noWrap)
                         deflater.setStrategy(strategy.value)
                         deflater
                     }) { deflater =>
-                        Sync.io(deflater.end())
+                        Sync.defer(deflater.end())
                     }.map { deflater =>
                         Loop.continue(DeflateState.DeflateInput(deflater, stream.emit))
                     }
                 case DeflateState.DeflateInput(deflater, emit) =>
                     Emit.runFirst(emit).map {
                         case Present(bytes) -> cont =>
-                            Sync.io(deflater.setInput(toUnboxByteArray(bytes))).andThen(Loop.continue(DeflateState.PullDeflater(
+                            Sync.defer(deflater.setInput(toUnboxByteArray(bytes))).andThen(Loop.continue(DeflateState.PullDeflater(
                                 deflater,
                                 Present(cont),
                                 Chunk.empty[Byte]
                             )))
                         case _ =>
-                            Sync.io(deflater.finish()).andThen(Loop.continue(DeflateState.PullDeflater(
+                            Sync.defer(deflater.finish()).andThen(Loop.continue(DeflateState.PullDeflater(
                                 deflater,
                                 Absent,
                                 Chunk.empty[Byte]
                             )))
                     }
                 case DeflateState.PullDeflater(deflater, maybeEmitFn, chunk) =>
-                    Sync.io(new Array[Byte](bufferSize)).map: buffer =>
-                        Sync.io(deflater.deflate(buffer, 0, buffer.length, flushMode.value))
+                    Sync.defer(new Array[Byte](bufferSize)).map: buffer =>
+                        Sync.defer(deflater.deflate(buffer, 0, buffer.length, flushMode.value))
                             .map:
                                 case 0 =>
                                     Loop.continue(DeflateState.EmitDeflated(deflater, maybeEmitFn, chunk))
                                 case size =>
-                                    Sync.io(chunk.concat(fromUnboxByteArray(buffer, size)))
+                                    Sync.defer(chunk.concat(fromUnboxByteArray(buffer, size)))
                                         .map(nextChunk => Loop.continue(DeflateState.PullDeflater(deflater, maybeEmitFn, nextChunk)))
                 case DeflateState.EmitDeflated(deflater, maybeEmitFn, chunk) =>
                     Emit.valueWith(chunk):
                         maybeEmitFn match
                             case Present(emitFn) => Loop.continue(DeflateState.DeflateInput(deflater, emitFn()))
-                            case Absent          => Sync.io(deflater.end()).andThen(Loop.done)
+                            case Absent          => Sync.defer(deflater.end()).andThen(Loop.done)
         end emit
 
         Stream(emit(stream, bufferSize, compressionLevel, strategy, flushMode, noWrap))
@@ -233,17 +233,17 @@ object StreamCompression:
             strategy: CompressionStrategy,
             flushMode: FlushMode
         ): Unit < (Resource & Sync & Emit[Chunk[Byte]] & Ctx) =
-            val bufferIO = Sync.io(new Array[Byte](bufferSize))
+            val bufferIO = Sync.defer(new Array[Byte](bufferSize))
 
             Loop(GZipState.Initialize):
                 case GZipState.Initialize =>
-                    Resource.acquireRelease(Sync.io {
+                    Resource.acquireRelease(Sync.defer {
                         val deflater = new Deflater(compressionLevel.value, true)
                         val crc32    = new CRC32()
                         deflater.setStrategy(strategy.value)
                         deflater -> crc32
                     }) { (deflater, crc32) =>
-                        Sync.io {
+                        Sync.defer {
                             deflater.end()
                             crc32.reset()
                         }
@@ -251,7 +251,7 @@ object StreamCompression:
                         Loop.continue(GZipState.SendHeader(deflater, crc32))
                     }
                 case GZipState.SendHeader(deflater, crc32) =>
-                    Sync.io {
+                    Sync.defer {
                         // no MTIME timestamp, unknown OS
                         Chunk(
                             0x1f, // ID1: Identification 1
@@ -276,12 +276,12 @@ object StreamCompression:
                 case GZipState.DeflateInput(deflater, crc32, emit) =>
                     Emit.runFirst(emit).map {
                         case Present(bytes) -> cont =>
-                            Sync.io {
+                            Sync.defer {
                                 crc32.update(toUnboxByteArray(bytes))
                                 deflater.setInput(toUnboxByteArray(bytes))
                             }.andThen(Loop.continue(GZipState.PullDeflater(deflater, crc32, Present(cont), Chunk.empty[Byte])))
                         case _ =>
-                            Sync.io(deflater.finish()).andThen(Loop.continue(GZipState.PullDeflater(
+                            Sync.defer(deflater.finish()).andThen(Loop.continue(GZipState.PullDeflater(
                                 deflater,
                                 crc32,
                                 Absent,
@@ -290,10 +290,10 @@ object StreamCompression:
                     }
                 case GZipState.PullDeflater(deflater, crc32, maybeEmitFn, chunk) =>
                     bufferIO.map: buffer =>
-                        Sync.io(deflater.deflate(buffer, 0, buffer.length, flushMode.value))
+                        Sync.defer(deflater.deflate(buffer, 0, buffer.length, flushMode.value))
                             .map:
                                 case 0 => Loop.continue(GZipState.EmitDeflated(deflater, crc32, maybeEmitFn, chunk))
-                                case size => Sync.io(chunk.concat(fromUnboxByteArray(buffer, size)))
+                                case size => Sync.defer(chunk.concat(fromUnboxByteArray(buffer, size)))
                                         .map(nextChunk => Loop.continue(GZipState.PullDeflater(deflater, crc32, maybeEmitFn, nextChunk)))
                 case GZipState.EmitDeflated(deflater, crc32, maybeEmitFn, chunk) =>
                     Emit.valueWith(chunk):
@@ -301,7 +301,7 @@ object StreamCompression:
                             case Present(emitFn) => Loop.continue(GZipState.DeflateInput(deflater, crc32, emitFn()))
                             case Absent          => Loop.continue(GZipState.SendTrailer(deflater, crc32))
                 case GZipState.SendTrailer(deflater, crc32) =>
-                    Sync.io {
+                    Sync.defer {
                         val crcValue  = crc32.getValue
                         val bytesRead = deflater.getBytesRead()
                         val trailer = Chunk(
@@ -335,7 +335,7 @@ object StreamCompression:
         Frame
     ) =
 
-        val bufferIO = Sync.io(new Array[Byte](bufferSize))
+        val bufferIO = Sync.defer(new Array[Byte](bufferSize))
 
         enum InflateState derives CanEqual:
             case Initialize                                                               extends InflateState
@@ -356,18 +356,18 @@ object StreamCompression:
             Loop(InflateState.Initialize):
                 case InflateState.Initialize =>
                     Resource
-                        .acquireRelease(Sync.io(new Inflater(noWrap)))(inflater => Sync.io(inflater.end()))
+                        .acquireRelease(Sync.defer(new Inflater(noWrap)))(inflater => Sync.defer(inflater.end()))
                         .map: inflater =>
                             Loop.continue(InflateState.InflateInput(inflater, stream.emit))
                 case InflateState.InflateInput(inflater, emit) =>
                     Emit.runFirst(emit).map:
                         case Present(bytes) -> emitFn =>
-                            Sync.io(inflater.setInput(toUnboxByteArray(bytes)))
+                            Sync.defer(inflater.setInput(toUnboxByteArray(bytes)))
                                 .andThen(
                                     Loop.continue(InflateState.PullInflater(inflater, Present(emitFn), bytes))
                                 )
                         case _ =>
-                            Sync.io(Loop.continue(InflateState.PullInflater(inflater, Absent, Chunk.empty)))
+                            Sync.defer(Loop.continue(InflateState.PullInflater(inflater, Absent, Chunk.empty)))
                 case InflateState.PullInflater(inflater, maybeEmitFn, bytes) =>
                     if inflater.finished then
                         val leftOver = inflater.getRemaining match
@@ -377,7 +377,7 @@ object StreamCompression:
                             maybeEmitFn match
                                 case Present(emitFn) =>
                                     Resource
-                                        .acquireRelease(Sync.io(new Inflater(noWrap)))(inflater => Sync.io(inflater.end()))
+                                        .acquireRelease(Sync.defer(new Inflater(noWrap)))(inflater => Sync.defer(inflater.end()))
                                         .map: inflater =>
                                             Loop.continue(InflateState.InflateInput(inflater, emitFn()))
                                 case Absent =>
@@ -467,7 +467,7 @@ object StreamCompression:
         ): (Chunk[Byte], CRC32, Unit < (Emit[Chunk[Byte]] & Ctx)) => Loop.Outcome[GunzipState, Unit] < (Resource & Sync) =
             (bytes: Chunk[Byte], headerCrc32: CRC32, emit: Unit < (Emit[Chunk[Byte]] & Ctx)) =>
                 if hasExtra then
-                    Sync.io(Loop.continue(GunzipState.ParseHeaderExtra(
+                    Sync.defer(Loop.continue(GunzipState.ParseHeaderExtra(
                         bytes,
                         headerCrc32,
                         checkCrc16,
@@ -475,7 +475,7 @@ object StreamCompression:
                         emit
                     )))
                 else if commentsToSkip > 0 then
-                    Sync.io(Loop.continue(GunzipState.SkipComments(
+                    Sync.defer(Loop.continue(GunzipState.SkipComments(
                         bytes,
                         headerCrc32,
                         checkCrc16,
@@ -483,18 +483,18 @@ object StreamCompression:
                         emit
                     )))
                 else if checkCrc16 then
-                    Sync.io(Loop.continue(GunzipState.CheckCrc16(
+                    Sync.defer(Loop.continue(GunzipState.CheckCrc16(
                         bytes,
                         headerCrc32,
                         emit
                     )))
                 else
-                    Resource.acquireRelease(Sync.io {
+                    Resource.acquireRelease(Sync.defer {
                         val inflater     = new Inflater(true)
                         val contentCrc32 = new CRC32()
                         inflater -> contentCrc32
                     })((inflater, contentCrc32) =>
-                        Sync.io {
+                        Sync.defer {
                             inflater.end()
                             contentCrc32.reset()
                         }
@@ -514,7 +514,7 @@ object StreamCompression:
         ): Unit < (Resource & Sync & Abort[StreamCompressionException] & Ctx & Emit[Chunk[Byte]]) =
             Loop(GunzipState.Initialize):
                 case GunzipState.Initialize =>
-                    Resource.acquireRelease(Sync.io(new CRC32()))(headerCrc32 => Sync.io(headerCrc32.reset()))
+                    Resource.acquireRelease(Sync.defer(new CRC32()))(headerCrc32 => Sync.defer(headerCrc32.reset()))
                         .map: headerCrc32 =>
                             Loop.continue(GunzipState.ParseHeader(Chunk.empty, headerCrc32, stream.emit))
                 case GunzipState.ParseHeader(accBytes, headerCrc32, emit) =>
@@ -658,14 +658,14 @@ object StreamCompression:
                     if leftOver.isEmpty then
                         Emit.runFirst(emit).map:
                             case Present(bytes) -> emitFn =>
-                                Sync.io(inflater.setInput(toUnboxByteArray(bytes)))
+                                Sync.defer(inflater.setInput(toUnboxByteArray(bytes)))
                                     .andThen(
                                         Loop.continue(GunzipState.PullInflater(inflater, contentCrc32, Present(emitFn), bytes))
                                     )
                             case _ =>
                                 Loop.continue(GunzipState.PullInflater(inflater, contentCrc32, Absent, Chunk.empty))
                     else
-                        Sync.io(inflater.setInput(toUnboxByteArray(leftOver)))
+                        Sync.defer(inflater.setInput(toUnboxByteArray(leftOver)))
                             .andThen(
                                 Loop.continue(GunzipState.PullInflater(inflater, contentCrc32, Present(() => emit), leftOver))
                             )
@@ -684,12 +684,12 @@ object StreamCompression:
                                 case Absent =>
                                     Loop.continue(GunzipState.CheckTrailer(Chunk.empty, inflater, contentCrc32, Absent))
                     else
-                        Sync.io(new Array[Byte](bufferSize)).map: buffer =>
+                        Sync.defer(new Array[Byte](bufferSize)).map: buffer =>
                             Abort
                                 .catching[DataFormatException](dfe => StreamCompressionException(dfe))(inflater.inflate(buffer))
                                 .map(read => fromUnboxByteArray(buffer, read))
                                 .map(inflated =>
-                                    Sync.io(contentCrc32.update(toUnboxByteArray(inflated))).andThen(
+                                    Sync.defer(contentCrc32.update(toUnboxByteArray(inflated))).andThen(
                                         Emit.valueWith(inflated)(
                                             Loop.continue(GunzipState.PullInflater(inflater, contentCrc32, maybeEmitFn, bytes))
                                         )
@@ -731,7 +731,7 @@ object StreamCompression:
                         else
                             maybeEmitFn match
                                 case Present(emitFn) =>
-                                    Resource.acquireRelease(Sync.io(new CRC32()))(headerCrc32 => Sync.io(headerCrc32.reset()))
+                                    Resource.acquireRelease(Sync.defer(new CRC32()))(headerCrc32 => Sync.defer(headerCrc32.reset()))
                                         .map: headerCrc32 =>
                                             Loop.continue(GunzipState.ParseHeader(rest, headerCrc32, emitFn()))
                                 case Absent =>

--- a/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
@@ -17,7 +17,7 @@ class PathTest extends Test:
         JFiles.delete(Paths.get(name))
 
     def useFile(name: String, text: String) =
-        Resource.acquireRelease(Sync.io(createFile(name, text)))(_ => Sync.io(destroyFile(name)))
+        Resource.acquireRelease(Sync.defer(createFile(name, text)))(_ => Sync.defer(destroyFile(name)))
 
     "read and write files" - {
         "read file as string" in run {
@@ -176,10 +176,10 @@ class PathTest extends Test:
             val stream = Stream.init(Chunk[Byte](115, 111, 109, 101, 32, 116, 101, 120, 116))
             val file   = Path(name)
             for
-                _   <- Sync.io(createFile(name, ""))
+                _   <- Sync.defer(createFile(name, ""))
                 _   <- stream.sink(file)
                 res <- file.read
-                _   <- Sync.io(destroyFile(name))
+                _   <- Sync.defer(destroyFile(name))
             yield assert(res == "some text")
             end for
 
@@ -190,10 +190,10 @@ class PathTest extends Test:
             val stream = Stream.init(Chunk("some text", "more text"))
             val file   = Path(name)
             for
-                _   <- Sync.io(createFile(name, ""))
+                _   <- Sync.defer(createFile(name, ""))
                 _   <- stream.sinkLines(file)
                 res <- file.readLines
-                _   <- Sync.io(destroyFile(name))
+                _   <- Sync.defer(destroyFile(name))
             yield assert(res == List("some text", "more text"))
             end for
         }
@@ -344,49 +344,49 @@ class PathTest extends Test:
         "cache" in run {
             for
                 kyoPath <- Path.basePaths.map(_.cache)
-                libPath <- Sync.io(BaseDirectories.get().cacheDir)
+                libPath <- Sync.defer(BaseDirectories.get().cacheDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "config" in run {
             for
                 kyoPath <- Path.basePaths.map(_.config)
-                libPath <- Sync.io(BaseDirectories.get().configDir)
+                libPath <- Sync.defer(BaseDirectories.get().configDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "data" in run {
             for
                 kyoPath <- Path.basePaths.map(_.data)
-                libPath <- Sync.io(BaseDirectories.get().dataDir)
+                libPath <- Sync.defer(BaseDirectories.get().dataDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "dataLocal" in run {
             for
                 kyoPath <- Path.basePaths.map(_.dataLocal)
-                libPath <- Sync.io(BaseDirectories.get().dataLocalDir)
+                libPath <- Sync.defer(BaseDirectories.get().dataLocalDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "executable" in run {
             for
                 kyoPath <- Path.basePaths.map(_.executable)
-                libPath <- Sync.io(BaseDirectories.get().executableDir)
+                libPath <- Sync.defer(BaseDirectories.get().executableDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "preference" in run {
             for
                 kyoPath <- Path.basePaths.map(_.preference)
-                libPath <- Sync.io(BaseDirectories.get().preferenceDir)
+                libPath <- Sync.defer(BaseDirectories.get().preferenceDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "runtime" in run {
             for
                 kyoPath <- Path.basePaths.map(_.runtime)
-                libPath <- Sync.io(BaseDirectories.get().runtimeDir)
+                libPath <- Sync.defer(BaseDirectories.get().runtimeDir)
             yield assert(kyoPath == Path(libPath))
         }
     }
@@ -395,70 +395,70 @@ class PathTest extends Test:
         "home" in run {
             for
                 kyoPath <- Path.userPaths.map(_.home)
-                libPath <- Sync.io(UserDirectories.get().homeDir)
+                libPath <- Sync.defer(UserDirectories.get().homeDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "audio" in run {
             for
                 kyoPath <- Path.userPaths.map(_.audio)
-                libPath <- Sync.io(UserDirectories.get().audioDir)
+                libPath <- Sync.defer(UserDirectories.get().audioDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "desktop" in run {
             for
                 kyoPath <- Path.userPaths.map(_.desktop)
-                libPath <- Sync.io(UserDirectories.get().desktopDir)
+                libPath <- Sync.defer(UserDirectories.get().desktopDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "document" in run {
             for
                 kyoPath <- Path.userPaths.map(_.document)
-                libPath <- Sync.io(UserDirectories.get().documentDir)
+                libPath <- Sync.defer(UserDirectories.get().documentDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "download" in run {
             for
                 kyoPath <- Path.userPaths.map(_.download)
-                libPath <- Sync.io(UserDirectories.get().downloadDir)
+                libPath <- Sync.defer(UserDirectories.get().downloadDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "font" in run {
             for
                 kyoPath <- Path.userPaths.map(_.font)
-                libPath <- Sync.io(UserDirectories.get().fontDir)
+                libPath <- Sync.defer(UserDirectories.get().fontDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "picture" in run {
             for
                 kyoPath <- Path.userPaths.map(_.picture)
-                libPath <- Sync.io(UserDirectories.get().pictureDir)
+                libPath <- Sync.defer(UserDirectories.get().pictureDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "public" in run {
             for
                 kyoPath <- Path.userPaths.map(_.public)
-                libPath <- Sync.io(UserDirectories.get().publicDir)
+                libPath <- Sync.defer(UserDirectories.get().publicDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "template" in run {
             for
                 kyoPath <- Path.userPaths.map(_.template)
-                libPath <- Sync.io(UserDirectories.get().templateDir)
+                libPath <- Sync.defer(UserDirectories.get().templateDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "video" in run {
             for
                 kyoPath <- Path.userPaths.map(_.video)
-                libPath <- Sync.io(UserDirectories.get().videoDir)
+                libPath <- Sync.defer(UserDirectories.get().videoDir)
             yield assert(kyoPath == Path(libPath))
         }
     }
@@ -470,49 +470,49 @@ class PathTest extends Test:
         "path" in run {
             for
                 kyoPath <- testProject.map(_.path)
-                libPath <- Sync.io(libProject.projectPath)
+                libPath <- Sync.defer(libProject.projectPath)
             yield assert(kyoPath == Path(libPath))
         }
 
         "cache" in run {
             for
                 kyoPath <- testProject.map(_.cache)
-                libPath <- Sync.io(libProject.cacheDir)
+                libPath <- Sync.defer(libProject.cacheDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "config" in run {
             for
                 kyoPath <- testProject.map(_.config)
-                libPath <- Sync.io(libProject.configDir)
+                libPath <- Sync.defer(libProject.configDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "data" in run {
             for
                 kyoPath <- testProject.map(_.data)
-                libPath <- Sync.io(libProject.dataDir)
+                libPath <- Sync.defer(libProject.dataDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "dataLocal" in run {
             for
                 kyoPath <- testProject.map(_.dataLocal)
-                libPath <- Sync.io(libProject.dataLocalDir)
+                libPath <- Sync.defer(libProject.dataLocalDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "preference" in run {
             for
                 kyoPath <- testProject.map(_.preference)
-                libPath <- Sync.io(libProject.preferenceDir)
+                libPath <- Sync.defer(libProject.preferenceDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "runtime" in run {
             for
                 kyoPath <- testProject.map(_.runtime)
-                libPath <- Sync.io(libProject.runtimeDir)
+                libPath <- Sync.defer(libProject.runtimeDir)
             yield assert(kyoPath == Path(libPath))
         }
     }

--- a/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
@@ -17,7 +17,7 @@ class PathTest extends Test:
         JFiles.delete(Paths.get(name))
 
     def useFile(name: String, text: String) =
-        Resource.acquireRelease(Sync(createFile(name, text)))(_ => Sync(destroyFile(name)))
+        Resource.acquireRelease(Sync.io(createFile(name, text)))(_ => Sync.io(destroyFile(name)))
 
     "read and write files" - {
         "read file as string" in run {
@@ -176,10 +176,10 @@ class PathTest extends Test:
             val stream = Stream.init(Chunk[Byte](115, 111, 109, 101, 32, 116, 101, 120, 116))
             val file   = Path(name)
             for
-                _   <- Sync(createFile(name, ""))
+                _   <- Sync.io(createFile(name, ""))
                 _   <- stream.sink(file)
                 res <- file.read
-                _   <- Sync(destroyFile(name))
+                _   <- Sync.io(destroyFile(name))
             yield assert(res == "some text")
             end for
 
@@ -190,10 +190,10 @@ class PathTest extends Test:
             val stream = Stream.init(Chunk("some text", "more text"))
             val file   = Path(name)
             for
-                _   <- Sync(createFile(name, ""))
+                _   <- Sync.io(createFile(name, ""))
                 _   <- stream.sinkLines(file)
                 res <- file.readLines
-                _   <- Sync(destroyFile(name))
+                _   <- Sync.io(destroyFile(name))
             yield assert(res == List("some text", "more text"))
             end for
         }
@@ -344,49 +344,49 @@ class PathTest extends Test:
         "cache" in run {
             for
                 kyoPath <- Path.basePaths.map(_.cache)
-                libPath <- Sync(BaseDirectories.get().cacheDir)
+                libPath <- Sync.io(BaseDirectories.get().cacheDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "config" in run {
             for
                 kyoPath <- Path.basePaths.map(_.config)
-                libPath <- Sync(BaseDirectories.get().configDir)
+                libPath <- Sync.io(BaseDirectories.get().configDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "data" in run {
             for
                 kyoPath <- Path.basePaths.map(_.data)
-                libPath <- Sync(BaseDirectories.get().dataDir)
+                libPath <- Sync.io(BaseDirectories.get().dataDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "dataLocal" in run {
             for
                 kyoPath <- Path.basePaths.map(_.dataLocal)
-                libPath <- Sync(BaseDirectories.get().dataLocalDir)
+                libPath <- Sync.io(BaseDirectories.get().dataLocalDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "executable" in run {
             for
                 kyoPath <- Path.basePaths.map(_.executable)
-                libPath <- Sync(BaseDirectories.get().executableDir)
+                libPath <- Sync.io(BaseDirectories.get().executableDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "preference" in run {
             for
                 kyoPath <- Path.basePaths.map(_.preference)
-                libPath <- Sync(BaseDirectories.get().preferenceDir)
+                libPath <- Sync.io(BaseDirectories.get().preferenceDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "runtime" in run {
             for
                 kyoPath <- Path.basePaths.map(_.runtime)
-                libPath <- Sync(BaseDirectories.get().runtimeDir)
+                libPath <- Sync.io(BaseDirectories.get().runtimeDir)
             yield assert(kyoPath == Path(libPath))
         }
     }
@@ -395,70 +395,70 @@ class PathTest extends Test:
         "home" in run {
             for
                 kyoPath <- Path.userPaths.map(_.home)
-                libPath <- Sync(UserDirectories.get().homeDir)
+                libPath <- Sync.io(UserDirectories.get().homeDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "audio" in run {
             for
                 kyoPath <- Path.userPaths.map(_.audio)
-                libPath <- Sync(UserDirectories.get().audioDir)
+                libPath <- Sync.io(UserDirectories.get().audioDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "desktop" in run {
             for
                 kyoPath <- Path.userPaths.map(_.desktop)
-                libPath <- Sync(UserDirectories.get().desktopDir)
+                libPath <- Sync.io(UserDirectories.get().desktopDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "document" in run {
             for
                 kyoPath <- Path.userPaths.map(_.document)
-                libPath <- Sync(UserDirectories.get().documentDir)
+                libPath <- Sync.io(UserDirectories.get().documentDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "download" in run {
             for
                 kyoPath <- Path.userPaths.map(_.download)
-                libPath <- Sync(UserDirectories.get().downloadDir)
+                libPath <- Sync.io(UserDirectories.get().downloadDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "font" in run {
             for
                 kyoPath <- Path.userPaths.map(_.font)
-                libPath <- Sync(UserDirectories.get().fontDir)
+                libPath <- Sync.io(UserDirectories.get().fontDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "picture" in run {
             for
                 kyoPath <- Path.userPaths.map(_.picture)
-                libPath <- Sync(UserDirectories.get().pictureDir)
+                libPath <- Sync.io(UserDirectories.get().pictureDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "public" in run {
             for
                 kyoPath <- Path.userPaths.map(_.public)
-                libPath <- Sync(UserDirectories.get().publicDir)
+                libPath <- Sync.io(UserDirectories.get().publicDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "template" in run {
             for
                 kyoPath <- Path.userPaths.map(_.template)
-                libPath <- Sync(UserDirectories.get().templateDir)
+                libPath <- Sync.io(UserDirectories.get().templateDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "video" in run {
             for
                 kyoPath <- Path.userPaths.map(_.video)
-                libPath <- Sync(UserDirectories.get().videoDir)
+                libPath <- Sync.io(UserDirectories.get().videoDir)
             yield assert(kyoPath == Path(libPath))
         }
     }
@@ -470,49 +470,49 @@ class PathTest extends Test:
         "path" in run {
             for
                 kyoPath <- testProject.map(_.path)
-                libPath <- Sync(libProject.projectPath)
+                libPath <- Sync.io(libProject.projectPath)
             yield assert(kyoPath == Path(libPath))
         }
 
         "cache" in run {
             for
                 kyoPath <- testProject.map(_.cache)
-                libPath <- Sync(libProject.cacheDir)
+                libPath <- Sync.io(libProject.cacheDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "config" in run {
             for
                 kyoPath <- testProject.map(_.config)
-                libPath <- Sync(libProject.configDir)
+                libPath <- Sync.io(libProject.configDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "data" in run {
             for
                 kyoPath <- testProject.map(_.data)
-                libPath <- Sync(libProject.dataDir)
+                libPath <- Sync.io(libProject.dataDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "dataLocal" in run {
             for
                 kyoPath <- testProject.map(_.dataLocal)
-                libPath <- Sync(libProject.dataLocalDir)
+                libPath <- Sync.io(libProject.dataLocalDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "preference" in run {
             for
                 kyoPath <- testProject.map(_.preference)
-                libPath <- Sync(libProject.preferenceDir)
+                libPath <- Sync.io(libProject.preferenceDir)
             yield assert(kyoPath == Path(libPath))
         }
 
         "runtime" in run {
             for
                 kyoPath <- testProject.map(_.runtime)
-                libPath <- Sync(libProject.runtimeDir)
+                libPath <- Sync.io(libProject.runtimeDir)
             yield assert(kyoPath == Path(libPath))
         }
     }

--- a/kyo-core/jvm/src/test/scala/kyo/StreamCompressionTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/StreamCompressionTest.scala
@@ -79,70 +79,70 @@ class StreamCompressionTest extends Test:
     "deflate/inflate" - {
         "inflate please wrap" in run {
             for
-                inStream <- Sync(Stream.init(
+                inStream <- Sync.io(Stream.init(
                     Chunk.from(Array[Byte](120, -100, -53, -52, 75, -53, 73, 44, 73, 85, 40, -56, 73, 77, 44, 78, 85, 40, 47, 74, 44, 0, 0,
                         73, -20, 7, 88))
                 ))
-                outStream <- Sync(inStream.inflate())
+                outStream <- Sync.io(inStream.inflate())
                 bytes     <- outStream.run.map(toUnboxByteArray)
-                string    <- Sync(new String(bytes, StandardCharsets.UTF_8))
+                string    <- Sync.io(new String(bytes, StandardCharsets.UTF_8))
             yield assert(string == "inflate please wrap")
         }
 
         "inflate please nowrap" in run {
             for
-                inStream <- Sync(Stream.init(
+                inStream <- Sync.io(Stream.init(
                     Chunk.from(Array[Byte](-53, -52, 75, -53, 73, 44, 73, 85, 40, -56, 73, 77, 44, 78, 85, -56, -53, 47, 47, 74, 44, 0, 0))
                 ))
-                outStream <- Sync(inStream.inflate(noWrap = true))
+                outStream <- Sync.io(inStream.inflate(noWrap = true))
                 bytes     <- outStream.run.map(toUnboxByteArray)
-                string    <- Sync(new String(bytes, StandardCharsets.UTF_8))
+                string    <- Sync.io(new String(bytes, StandardCharsets.UTF_8))
             yield assert(string == "inflate please nowrap")
         }
 
         "short stream" in run {
             for
-                inStream <- Sync(Stream.init(Chunk.from(getBytes(shortText))))
+                inStream <- Sync.io(Stream.init(Chunk.from(getBytes(shortText))))
                 inChunk  <- inStream.run
-                deflatedStream <- Sync {
+                deflatedStream <- Sync.io {
                     val deflatedChunk = jdkDeflate(inChunk, new Deflater(CompressionLevel.Default.value, false))
                     Stream.init(deflatedChunk)
                 }
-                inflatedStream <- Sync(deflatedStream.inflate(noWrap = false))
+                inflatedStream <- Sync.io(deflatedStream.inflate(noWrap = false))
                 bytes          <- inflatedStream.run.map(toUnboxByteArray)
-                string         <- Sync(new String(bytes, StandardCharsets.UTF_8))
+                string         <- Sync.io(new String(bytes, StandardCharsets.UTF_8))
             yield assert(string == shortText)
         }
 
         "stream of two deflated inputs" in run {
             for
-                inStream1 <- Sync(Stream.init(Chunk.from(getBytes(shortText))))
+                inStream1 <- Sync.io(Stream.init(Chunk.from(getBytes(shortText))))
                 inChunk1  <- inStream1.run
-                deflatedStream1 <- Sync {
+                deflatedStream1 <- Sync.io {
                     val deflatedChunk = jdkDeflate(inChunk1, new Deflater(CompressionLevel.Default.value, false))
                     Stream.init(deflatedChunk)
                 }
-                inStream2 <- Sync(Stream.init(Chunk.from(getBytes(otherShortText))))
+                inStream2 <- Sync.io(Stream.init(Chunk.from(getBytes(otherShortText))))
                 inChunk2  <- inStream2.run
-                deflatedStream2 <- Sync {
+                deflatedStream2 <- Sync.io {
                     val deflatedChunk = jdkDeflate(inChunk2, new Deflater(CompressionLevel.Default.value, false))
                     Stream.init(deflatedChunk)
                 }
-                inflatedStream <- Sync(deflatedStream1.concat(deflatedStream2).inflate(noWrap = false))
+                inflatedStream <- Sync.io(deflatedStream1.concat(deflatedStream2).inflate(noWrap = false))
                 bytes          <- inflatedStream.run.map(toUnboxByteArray)
-                string         <- Sync(new String(bytes, StandardCharsets.UTF_8))
+                string         <- Sync.io(new String(bytes, StandardCharsets.UTF_8))
             yield assert(string == shortText ++ otherShortText)
         }
 
         "inflate input (deflated larger than inflated)" in runJVM {
             for
-                inStream <- Sync(Stream.init(
+                inStream <- Sync.io(Stream.init(
                     Chunk.from(getBytes("꒔諒ᇂ즆ᰃ遇ኼ㎐만咘똠ᯈ䕍쏮쿻ࣇ㦲䷱瘫椪⫐褽睌쨘꛹騏蕾☦余쒧꺠ܝ猸b뷈埣ꂓ琌ཬ隖㣰忢鐮橀쁚誅렌폓㖅ꋹ켗餪庺Đ懣㫍㫌굦뢲䅦苮Ѣқ闭䮚ū﫣༶漵>껆拦휬콯耙腒䔖돆圹Ⲷ曩ꀌ㒈")),
                     1
                 ))
-                deflatedStream <- Sync(inStream.deflate(noWrap = false))
+                deflatedStream <- Sync.io(inStream.deflate(noWrap = false))
                 byteChunk      <- deflatedStream.run
-                expected <- Sync {
+                expected <- Sync.io {
                     val bos = new ByteArrayOutputStream()
                     val ios = new InflaterOutputStream(bos, new Inflater(false))
                     ios.write(toUnboxByteArray(byteChunk), 0, byteChunk.length)
@@ -153,64 +153,64 @@ class StreamCompressionTest extends Test:
                     ios.close()
                     inflatedBytes
                 }
-                inflatedStream <- Sync(deflatedStream.inflate(noWrap = false))
+                inflatedStream <- Sync.io(deflatedStream.inflate(noWrap = false))
                 result         <- inflatedStream.run
             yield assert(expected == result)
         }
 
         "long input, buffer smaller than chunks" in run {
             for
-                inStream <- Sync(Stream.init(
+                inStream <- Sync.io(Stream.init(
                     Chunk.from(getBytes(longText)),
                     64
                 ))
                 inChunk <- inStream.run
-                deflatedStream <- Sync {
+                deflatedStream <- Sync.io {
                     val deflatedChunk = jdkDeflate(inChunk, new Deflater(CompressionLevel.Default.value, false))
                     Stream.init(deflatedChunk)
                 }
-                inflatedStream <- Sync(deflatedStream.inflate(bufferSize = 8, noWrap = false))
+                inflatedStream <- Sync.io(deflatedStream.inflate(bufferSize = 8, noWrap = false))
                 bytes          <- inflatedStream.run.map(toUnboxByteArray)
-                string         <- Sync(new String(bytes, StandardCharsets.UTF_8))
+                string         <- Sync.io(new String(bytes, StandardCharsets.UTF_8))
             yield assert(string == longText)
         }
 
         "long input, chunks smaller then buffer" in run {
             for
-                inStream <- Sync(Stream.init(
+                inStream <- Sync.io(Stream.init(
                     Chunk.from(getBytes(longText)),
                     8
                 ))
                 inChunk <- inStream.run
-                deflatedStream <- Sync {
+                deflatedStream <- Sync.io {
                     val deflatedChunk = jdkDeflate(inChunk, new Deflater(CompressionLevel.Default.value, false))
                     Stream.init(deflatedChunk)
                 }
-                inflatedStream <- Sync(deflatedStream.inflate(bufferSize = 64, noWrap = false))
+                inflatedStream <- Sync.io(deflatedStream.inflate(bufferSize = 64, noWrap = false))
                 bytes          <- inflatedStream.run.map(toUnboxByteArray)
-                string         <- Sync(new String(bytes, StandardCharsets.UTF_8))
+                string         <- Sync.io(new String(bytes, StandardCharsets.UTF_8))
             yield assert(string == longText)
         }
 
         "long input, nowrap = true" in run {
             for
-                inStream <- Sync(Stream.init(Chunk.from(getBytes(longText))))
+                inStream <- Sync.io(Stream.init(Chunk.from(getBytes(longText))))
                 inChunk  <- inStream.run
-                deflatedStream <- Sync {
+                deflatedStream <- Sync.io {
                     val deflatedChunk = jdkDeflate(inChunk, new Deflater(CompressionLevel.BestCompression.value, true))
                     Stream.init(deflatedChunk)
                 }
-                inflatedStream <- Sync(deflatedStream.inflate(noWrap = true))
+                inflatedStream <- Sync.io(deflatedStream.inflate(noWrap = true))
                 bytes          <- inflatedStream.run.map(toUnboxByteArray)
-                string         <- Sync(new String(bytes, StandardCharsets.UTF_8))
+                string         <- Sync.io(new String(bytes, StandardCharsets.UTF_8))
             yield assert(string == longText)
         }
 
         "fail early if header is corrupted" in run {
             Abort.run(
                 for
-                    inStream       <- Sync(Stream.init(Chunk[Byte](1, 2, 3, 4, 5)))
-                    inflatedStream <- Sync(inStream.inflate())
+                    inStream       <- Sync.io(Stream.init(Chunk[Byte](1, 2, 3, 4, 5)))
+                    inflatedStream <- Sync.io(inStream.inflate())
                     _              <- inflatedStream.run
                 yield ()
             ).map: result =>
@@ -221,12 +221,12 @@ class StreamCompressionTest extends Test:
 
         "inflate nowrap: remaining = 0 but not all was pulled" in run {
             for
-                deflatedStream <- Sync {
+                deflatedStream <- Sync.io {
                     val deflatedChunk =
                         jdkDeflate(inflateRandomExampleThatFailed, new Deflater(CompressionLevel.BestCompression.value, true))
                     Stream.init(deflatedChunk)
                 }
-                inflatedStream <- Sync(deflatedStream.inflate(noWrap = true))
+                inflatedStream <- Sync.io(deflatedStream.inflate(noWrap = true))
                 resultChunk    <- inflatedStream.run
             yield assert(resultChunk == inflateRandomExampleThatFailed)
         }
@@ -234,9 +234,9 @@ class StreamCompressionTest extends Test:
         "deflate and then inflate" in run {
             val longTextChunk = Chunk.from(getBytes(longText))
             for
-                inStream       <- Sync(Stream.init(longTextChunk))
-                deflatedStream <- Sync(inStream.deflate(noWrap = true))
-                inflatedStream <- Sync(deflatedStream.inflate(noWrap = true))
+                inStream       <- Sync.io(Stream.init(longTextChunk))
+                deflatedStream <- Sync.io(inStream.deflate(noWrap = true))
+                inflatedStream <- Sync.io(deflatedStream.inflate(noWrap = true))
                 byteChunk      <- inflatedStream.run
             yield assert(byteChunk == longTextChunk)
             end for
@@ -249,8 +249,8 @@ class StreamCompressionTest extends Test:
                 | “College Hall (is) the oldest building in continuous use for Educational purposes west of the Rocky Mountains. Here were educated men and women who have won recognition throughout the world in all the learned professions.”""".stripMargin
             ))
             for
-                inStream       <- Sync(Stream.init(uncompressed))
-                deflatedStream <- Sync(inStream.deflate(compressionLevel = CompressionLevel.BestCompression))
+                inStream       <- Sync.io(Stream.init(uncompressed))
+                deflatedStream <- Sync.io(inStream.deflate(compressionLevel = CompressionLevel.BestCompression))
                 deflatedChunk  <- deflatedStream.run
             yield assert(deflatedChunk.length < uncompressed.length)
             end for
@@ -266,10 +266,10 @@ class StreamCompressionTest extends Test:
                     | She knew her mom would enter her room at any minute, and she could pretend that she hadn't heard any of the previous yelling.""".stripMargin
             ))
             for
-                inStream       <- Sync(Stream.init(input))
-                deflatedStream <- Sync(inStream.deflate())
+                inStream       <- Sync.io(Stream.init(input))
+                deflatedStream <- Sync.io(inStream.deflate())
                 deflatedChunk  <- deflatedStream.run
-                inflatedChunk  <- Sync(jdkInflate(deflatedChunk, new Inflater(false)))
+                inflatedChunk  <- Sync.io(jdkInflate(deflatedChunk, new Inflater(false)))
             yield assert(inflatedChunk == input)
             end for
         }
@@ -283,10 +283,10 @@ class StreamCompressionTest extends Test:
                     | A decision had to be made and the wrong choice could signal the end of the pack.""".stripMargin
             ))
             for
-                inStream       <- Sync(Stream.init(input))
-                deflatedStream <- Sync(inStream.deflate(noWrap = true))
+                inStream       <- Sync.io(Stream.init(input))
+                deflatedStream <- Sync.io(inStream.deflate(noWrap = true))
                 deflatedChunk  <- deflatedStream.run
-                inflatedChunk  <- Sync(jdkInflate(deflatedChunk, new Inflater(true)))
+                inflatedChunk  <- Sync.io(jdkInflate(deflatedChunk, new Inflater(true)))
             yield assert(inflatedChunk == input)
             end for
         }
@@ -303,24 +303,24 @@ class StreamCompressionTest extends Test:
                     | Stormi is a dog I love.""".stripMargin
             ))
             for
-                inStream         <- Sync(Stream.init(input))
-                deflatedStream   <- Sync(inStream.deflate(bufferSize = 1))
+                inStream         <- Sync.io(Stream.init(input))
+                deflatedStream   <- Sync.io(inStream.deflate(bufferSize = 1))
                 deflatedChunk    <- deflatedStream.run
-                jdkDeflatedChunk <- Sync(jdkDeflate(input, new Deflater(StreamCompression.CompressionLevel.Default.value, false)))
-                inflatedStream   <- Sync(deflatedStream.inflate(bufferSize = 1))
+                jdkDeflatedChunk <- Sync.io(jdkDeflate(input, new Deflater(StreamCompression.CompressionLevel.Default.value, false)))
+                inflatedStream   <- Sync.io(deflatedStream.inflate(bufferSize = 1))
                 inflatedChunk    <- inflatedStream.run
-                jdkInflatedChunk <- Sync(jdkInflate(jdkDeflatedChunk, new Inflater(false)))
+                jdkInflatedChunk <- Sync.io(jdkInflate(jdkDeflatedChunk, new Inflater(false)))
             yield assert(deflatedChunk == jdkDeflatedChunk && inflatedChunk == jdkInflatedChunk)
             end for
         }
 
         "deflate empty bytes" in run {
             for
-                inStream       <- Sync(Stream.empty[Byte])
-                deflatedStream <- Sync(inStream.deflate())
+                inStream       <- Sync.io(Stream.empty[Byte])
+                deflatedStream <- Sync.io(inStream.deflate())
                 deflatedChunk  <- deflatedStream.run
                 jdkDeflatedChunk <-
-                    Sync(jdkDeflate(Chunk.empty[Byte], new Deflater(StreamCompression.CompressionLevel.Default.value, false)))
+                    Sync.io(jdkDeflate(Chunk.empty[Byte], new Deflater(StreamCompression.CompressionLevel.Default.value, false)))
             yield assert(deflatedChunk == jdkDeflatedChunk)
             end for
         }
@@ -330,47 +330,47 @@ class StreamCompressionTest extends Test:
         "short stream" in run {
             val shortTextChunk = Chunk.from(getBytes(shortText))
             for
-                jdkGzippedStream <- Sync {
+                jdkGzippedStream <- Sync.io {
                     val gzipByte = jdkGzip(shortTextChunk, syncFlush = true)
                     Stream.init(gzipByte)
                 }
-                gunzippedStream <- Sync(jdkGzippedStream.gunzip())
+                gunzippedStream <- Sync.io(jdkGzippedStream.gunzip())
                 gunzippedChunk  <- gunzippedStream.run
-                string          <- Sync(new String(toUnboxByteArray(gunzippedChunk), StandardCharsets.UTF_8))
+                string          <- Sync.io(new String(toUnboxByteArray(gunzippedChunk), StandardCharsets.UTF_8))
             yield assert(string == shortText)
             end for
         }
 
         "stream of two gzipped inputs" in run {
             for
-                inStream1 <- Sync(Stream.init(Chunk.from(getBytes(shortText))))
+                inStream1 <- Sync.io(Stream.init(Chunk.from(getBytes(shortText))))
                 inChunk1  <- inStream1.run
-                jdkGzippedStream1 <- Sync {
+                jdkGzippedStream1 <- Sync.io {
                     val gzipByte = jdkGzip(inChunk1, syncFlush = true)
                     Stream.init(gzipByte)
                 }
-                inStream2 <- Sync(Stream.init(Chunk.from(getBytes(otherShortText))))
+                inStream2 <- Sync.io(Stream.init(Chunk.from(getBytes(otherShortText))))
                 inChunk2  <- inStream2.run
-                jdkGzippedStream2 <- Sync {
+                jdkGzippedStream2 <- Sync.io {
                     val gzipByte = jdkGzip(inChunk2, syncFlush = true)
                     Stream.init(gzipByte)
                 }
-                gunzippedStream <- Sync(jdkGzippedStream1.concat(jdkGzippedStream2).gunzip())
+                gunzippedStream <- Sync.io(jdkGzippedStream1.concat(jdkGzippedStream2).gunzip())
                 bytes           <- gunzippedStream.run.map(toUnboxByteArray)
-                string          <- Sync(new String(bytes, StandardCharsets.UTF_8))
+                string          <- Sync.io(new String(bytes, StandardCharsets.UTF_8))
             yield assert(string == shortText ++ otherShortText)
         }
 
         "long stream, no sync flush" in run {
             val longTextChunk = Chunk.from(getBytes(longText))
             for
-                jdkGzippedStream <- Sync {
+                jdkGzippedStream <- Sync.io {
                     val gzipByte = jdkGzip(longTextChunk, syncFlush = false)
                     Stream.init(gzipByte)
                 }
-                gunzippedStream <- Sync(jdkGzippedStream.gunzip())
+                gunzippedStream <- Sync.io(jdkGzippedStream.gunzip())
                 gunzippedChunk  <- gunzippedStream.run
-                string          <- Sync(new String(toUnboxByteArray(gunzippedChunk), StandardCharsets.UTF_8))
+                string          <- Sync.io(new String(toUnboxByteArray(gunzippedChunk), StandardCharsets.UTF_8))
             yield assert(string == longText)
             end for
         }
@@ -399,24 +399,24 @@ class StreamCompressionTest extends Test:
             end crc16
             val totalHeader = Chunk.from(header ++ headerExtra ++ comment ++ fileName ++ crc16)
             for
-                jdkGzippedStream <- Sync {
+                jdkGzippedStream <- Sync.io {
                     val gzipByte        = jdkGzip(Chunk.from(getBytes(shortText)), syncFlush = false)
                     val withTotalHeader = totalHeader.concat(gzipByte.drop(10))
                     Stream.init(withTotalHeader)
                 }
-                gunzippedStream <- Sync(jdkGzippedStream.gunzip())
+                gunzippedStream <- Sync.io(jdkGzippedStream.gunzip())
                 gunzippedChunk  <- gunzippedStream.run
-                string          <- Sync(new String(toUnboxByteArray(gunzippedChunk), StandardCharsets.UTF_8))
+                string          <- Sync.io(new String(toUnboxByteArray(gunzippedChunk), StandardCharsets.UTF_8))
             yield assert(string == shortText)
             end for
         }
 
         "gzip empty bytes" in run {
             for
-                inStream     <- Sync(Stream.empty[Byte])
-                gzipStream   <- Sync(inStream.gzip())
+                inStream     <- Sync.io(Stream.empty[Byte])
+                gzipStream   <- Sync.io(inStream.gzip())
                 gzipChunk    <- gzipStream.run
-                jdkGzipChunk <- Sync(jdkGzip(Chunk.empty[Byte], syncFlush = false))
+                jdkGzipChunk <- Sync.io(jdkGzip(Chunk.empty[Byte], syncFlush = false))
             yield assert(gzipChunk == jdkGzipChunk)
             end for
         }
@@ -424,9 +424,9 @@ class StreamCompressionTest extends Test:
         "gzip and then gunzip" in run {
             val longTextChunk = Chunk.from(getBytes(longText))
             for
-                inStream     <- Sync(Stream.init(longTextChunk))
-                gzipStream   <- Sync(inStream.gzip())
-                gunzipStream <- Sync(gzipStream.gunzip())
+                inStream     <- Sync.io(Stream.init(longTextChunk))
+                gzipStream   <- Sync.io(inStream.gzip())
+                gunzipStream <- Sync.io(gzipStream.gunzip())
                 byteChunk    <- gunzipStream.run
             yield assert(byteChunk == longTextChunk)
             end for
@@ -441,8 +441,8 @@ class StreamCompressionTest extends Test:
                    |Love may not always be a ray of sunshine.
                    |That is unless they were referring to how the sun can burn.""".stripMargin))
             for
-                inStream   <- Sync(Stream.init(uncompressed))
-                gzipStream <- Sync(inStream.gzip(bufferSize = 2048))
+                inStream   <- Sync.io(Stream.init(uncompressed))
+                gzipStream <- Sync.io(inStream.gzip(bufferSize = 2048))
                 gzipChunk  <- gzipStream.run
             yield assert(gzipChunk.length < uncompressed.length)
             end for
@@ -456,13 +456,13 @@ class StreamCompressionTest extends Test:
                     | And instead of an answer, you are simply left with a question. Why?""".stripMargin
             ))
             for
-                inStream       <- Sync(Stream.init(input))
-                gzipStream     <- Sync(inStream.gzip(bufferSize = 1))
+                inStream       <- Sync.io(Stream.init(input))
+                gzipStream     <- Sync.io(inStream.gzip(bufferSize = 1))
                 gzipChunk      <- gzipStream.run
-                jdkGzipChunk   <- Sync(jdkGzip(input, true))
-                gunzipStream   <- Sync(gzipStream.gunzip(bufferSize = 1))
+                jdkGzipChunk   <- Sync.io(jdkGzip(input, true))
+                gunzipStream   <- Sync.io(gzipStream.gunzip(bufferSize = 1))
                 gunzipChunk    <- gunzipStream.run
-                jdkGunzipChunk <- Sync(jdkGunzip(jdkGzipChunk))
+                jdkGunzipChunk <- Sync.io(jdkGunzip(jdkGzipChunk))
             yield assert(gzipChunk == jdkGzipChunk && gunzipChunk == jdkGunzipChunk)
             end for
         }

--- a/kyo-core/shared/src/main/scala/kyo/Admission.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Admission.scala
@@ -46,7 +46,7 @@ object Admission:
       *   The computation result if admitted, or Rejected if the task is rejected
       */
     def run[A, S](key: String)(v: A < S)(using frame: Frame): A < (Sync & S & Abort[Rejected]) =
-        Sync.io {
+        Sync.defer {
             if Scheduler.get.reject(key) then Abort.fail(Rejected())
             else v
         }
@@ -71,7 +71,7 @@ object Admission:
       *   The computation result if admitted, or Rejected if the task is rejected
       */
     def run[A, S](key: Int)(v: A < S)(using frame: Frame): A < (Sync & S & Abort[Rejected]) =
-        Sync.io {
+        Sync.defer {
             if Scheduler.get.reject(key) then Abort.fail(Rejected())
             else v
         }
@@ -94,7 +94,7 @@ object Admission:
       *   The computation result if admitted, or Rejected if the task is rejected
       */
     def run[A, S](v: A < S)(using frame: Frame): A < (Sync & S & Abort[Rejected]) =
-        Sync.io {
+        Sync.defer {
             if Scheduler.get.reject() then Abort.fail(Rejected())
             else v
         }
@@ -118,7 +118,7 @@ object Admission:
       *   true if the task should be rejected, false if it can be accepted
       */
     def reject()(using Frame): Boolean < Sync =
-        Sync.io(Scheduler.get.reject())
+        Sync.defer(Scheduler.get.reject())
 
     /** Tests if a task with the given string key should be rejected based on current system conditions.
       *
@@ -144,7 +144,7 @@ object Admission:
       *   true if the task should be rejected, false if it can be accepted
       */
     def reject(key: String)(using Frame): Boolean < Sync =
-        Sync.io(Scheduler.get.reject(key))
+        Sync.defer(Scheduler.get.reject(key))
 
     /** Tests if a task with the given integer key should be rejected based on current system conditions.
       *
@@ -170,6 +170,6 @@ object Admission:
       *   true if the task should be rejected, false if it can be accepted
       */
     def reject(key: Int)(using Frame): Boolean < Sync =
-        Sync.io(Scheduler.get.reject(key))
+        Sync.defer(Scheduler.get.reject(key))
 
 end Admission

--- a/kyo-core/shared/src/main/scala/kyo/Admission.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Admission.scala
@@ -46,7 +46,7 @@ object Admission:
       *   The computation result if admitted, or Rejected if the task is rejected
       */
     def run[A, S](key: String)(v: A < S)(using frame: Frame): A < (Sync & S & Abort[Rejected]) =
-        Sync {
+        Sync.io {
             if Scheduler.get.reject(key) then Abort.fail(Rejected())
             else v
         }
@@ -71,7 +71,7 @@ object Admission:
       *   The computation result if admitted, or Rejected if the task is rejected
       */
     def run[A, S](key: Int)(v: A < S)(using frame: Frame): A < (Sync & S & Abort[Rejected]) =
-        Sync {
+        Sync.io {
             if Scheduler.get.reject(key) then Abort.fail(Rejected())
             else v
         }
@@ -94,7 +94,7 @@ object Admission:
       *   The computation result if admitted, or Rejected if the task is rejected
       */
     def run[A, S](v: A < S)(using frame: Frame): A < (Sync & S & Abort[Rejected]) =
-        Sync {
+        Sync.io {
             if Scheduler.get.reject() then Abort.fail(Rejected())
             else v
         }
@@ -118,7 +118,7 @@ object Admission:
       *   true if the task should be rejected, false if it can be accepted
       */
     def reject()(using Frame): Boolean < Sync =
-        Sync(Scheduler.get.reject())
+        Sync.io(Scheduler.get.reject())
 
     /** Tests if a task with the given string key should be rejected based on current system conditions.
       *
@@ -144,7 +144,7 @@ object Admission:
       *   true if the task should be rejected, false if it can be accepted
       */
     def reject(key: String)(using Frame): Boolean < Sync =
-        Sync(Scheduler.get.reject(key))
+        Sync.io(Scheduler.get.reject(key))
 
     /** Tests if a task with the given integer key should be rejected based on current system conditions.
       *
@@ -170,6 +170,6 @@ object Admission:
       *   true if the task should be rejected, false if it can be accepted
       */
     def reject(key: Int)(using Frame): Boolean < Sync =
-        Sync(Scheduler.get.reject(key))
+        Sync.io(Scheduler.get.reject(key))
 
 end Admission

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -93,8 +93,8 @@ object Async extends AsyncPlatformSpecific:
       * @return
       *   The suspended computation wrapped in an Async effect
       */
-    inline def io[A, S](inline v: => A < S)(using inline frame: Frame): A < (Async & S) =
-        Sync.io(v)
+    inline def defer[A, S](inline v: => A < S)(using inline frame: Frame): A < (Async & S) =
+        Sync.defer(v)
 
     /** Runs an asynchronous computation with interrupt masking.
       *
@@ -761,7 +761,7 @@ object Async extends AsyncPlatformSpecific:
                         else
                             loop()
                         end if
-            Kyo.lift(Sync.io(loop()))
+            Kyo.lift(Sync.defer(loop()))
         }
 
     /** Converts a Future to an asynchronous computation.

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -69,7 +69,7 @@ object Async extends AsyncPlatformSpecific:
         Sync.Unsafe.evalOrThrow(System.property[Int]("kyo.async.concurrency.default", Runtime.getRuntime().availableProcessors() * 2))
     end defaultConcurrency
 
-    /** Convenience method for suspending computations in an Async effect.
+    /** Convenience method for suspending side effects in an Async effect.
       *
       * While Sync is specifically designed to suspend side effects without handling asynchronicity, Async provides both side effect
       * suspension and asynchronous execution capabilities (fibers, async scheduling). Since Async includes Sync in its effect set, this
@@ -93,8 +93,8 @@ object Async extends AsyncPlatformSpecific:
       * @return
       *   The suspended computation wrapped in an Async effect
       */
-    inline def apply[A, S](inline v: => A < S)(using inline frame: Frame): A < (Async & S) =
-        Sync(v)
+    inline def io[A, S](inline v: => A < S)(using inline frame: Frame): A < (Async & S) =
+        Sync.io(v)
 
     /** Runs an asynchronous computation with interrupt masking.
       *
@@ -761,7 +761,7 @@ object Async extends AsyncPlatformSpecific:
                         else
                             loop()
                         end if
-            Kyo.lift(Sync(loop()))
+            Kyo.lift(Sync.io(loop()))
         }
 
     /** Converts a Future to an asynchronous computation.

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -334,7 +334,7 @@ object Clock:
                     def set(now: Instant) = set(now, 100.millis)
 
                     def set(now: Instant, wallClockDelay: Duration) =
-                        Sync {
+                        Sync.io {
                             current = now
                             tick()
                             Clock.live.unsafe.sleep(wallClockDelay).safe.get
@@ -343,7 +343,7 @@ object Clock:
                     def advance(duration: Duration) = advance(duration, duration.min(100.millis))
 
                     def advance(duration: Duration, wallClockDelay: Duration) =
-                        Sync {
+                        Sync.io {
                             current = current + duration
                             tick()
                             Clock.live.unsafe.sleep(wallClockDelay).safe.get

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -334,7 +334,7 @@ object Clock:
                     def set(now: Instant) = set(now, 100.millis)
 
                     def set(now: Instant, wallClockDelay: Duration) =
-                        Sync.io {
+                        Sync.defer {
                             current = now
                             tick()
                             Clock.live.unsafe.sleep(wallClockDelay).safe.get
@@ -343,7 +343,7 @@ object Clock:
                     def advance(duration: Duration) = advance(duration, duration.min(100.millis))
 
                     def advance(duration: Duration, wallClockDelay: Duration) =
-                        Sync.io {
+                        Sync.defer {
                             current = current + duration
                             tick()
                             Clock.live.unsafe.sleep(wallClockDelay).safe.get

--- a/kyo-core/shared/src/main/scala/kyo/Console.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Console.scala
@@ -184,7 +184,7 @@ object Console:
                         stdErr.append(s + "\n")
                         ()
             let(Console(proxy))(v)
-                .map(r => Sync.io((Out(stdOut.toString(), stdErr.toString()), r)))
+                .map(r => Sync.defer((Out(stdOut.toString(), stdErr.toString()), r)))
         }
 
     /** Reads a line from the console.

--- a/kyo-core/shared/src/main/scala/kyo/Console.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Console.scala
@@ -184,7 +184,7 @@ object Console:
                         stdErr.append(s + "\n")
                         ()
             let(Console(proxy))(v)
-                .map(r => Sync((Out(stdOut.toString(), stdErr.toString()), r)))
+                .map(r => Sync.io((Out(stdOut.toString(), stdErr.toString()), r)))
         }
 
     /** Reads a line from the console.

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -300,7 +300,7 @@ object Fiber:
           * @return
           *   The number of waiters on this Fiber
           */
-        def waiters(using Frame): Int < Sync = Sync.io(self.asPromise.waiters())
+        def waiters(using Frame): Int < Sync = Sync.defer(self.asPromise.waiters())
 
         /** Polls the Fiber for a result without blocking.
           *
@@ -569,7 +569,7 @@ object Fiber:
                     val safepoint = Safepoint.get
                     isolate.runInternal { (trace, context) =>
                         foreach(iterable) { (idx, v) =>
-                            val fiber = IOTask(Sync.io(f(idx, v)), safepoint.copyTrace(trace), context)
+                            val fiber = IOTask(Sync.defer(f(idx, v)), safepoint.copyTrace(trace), context)
                             state.interrupts(fiber)
                             fiber.onComplete(state(idx, _))
                         }
@@ -664,7 +664,7 @@ object Fiber:
           *   The result of applying the function
           */
         inline def initWith[E, A](using inline frame: Frame)[B, S](inline f: Promise[E, A] => B < S): B < (S & Sync) =
-            Sync.io(f(IOPromise()))
+            Sync.defer(f(IOPromise()))
 
         extension [E, A](self: Promise[E, A])
             /** Completes the Promise with a result.

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -300,7 +300,7 @@ object Fiber:
           * @return
           *   The number of waiters on this Fiber
           */
-        def waiters(using Frame): Int < Sync = Sync(self.asPromise.waiters())
+        def waiters(using Frame): Int < Sync = Sync.io(self.asPromise.waiters())
 
         /** Polls the Fiber for a result without blocking.
           *
@@ -569,7 +569,7 @@ object Fiber:
                     val safepoint = Safepoint.get
                     isolate.runInternal { (trace, context) =>
                         foreach(iterable) { (idx, v) =>
-                            val fiber = IOTask(Sync(f(idx, v)), safepoint.copyTrace(trace), context)
+                            val fiber = IOTask(Sync.io(f(idx, v)), safepoint.copyTrace(trace), context)
                             state.interrupts(fiber)
                             fiber.onComplete(state(idx, _))
                         }
@@ -664,7 +664,7 @@ object Fiber:
           *   The result of applying the function
           */
         inline def initWith[E, A](using inline frame: Frame)[B, S](inline f: Promise[E, A] => B < S): B < (S & Sync) =
-            Sync(f(IOPromise()))
+            Sync.io(f(IOPromise()))
 
         extension [E, A](self: Promise[E, A])
             /** Completes the Promise with a result.

--- a/kyo-core/shared/src/main/scala/kyo/Hub.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Hub.scala
@@ -96,7 +96,7 @@ final class Hub[A] private[kyo] (
     def close(using frame: Frame): Maybe[Seq[A]] < Sync =
         fiber.interruptDiscard(Result.Failure(Closed("Hub", initFrame))).andThen {
             ch.close.map { r =>
-                Sync.io {
+                Sync.defer {
                     val l = Chunk.fromNoCopy(listeners.toArray()).asInstanceOf[Chunk[Listener[A]]]
                     discard(listeners.removeIf(_ => true)) // clear is not available in Scala Native
                     Kyo.foreachDiscard(l)(_.child.close.unit).andThen(r)
@@ -164,7 +164,7 @@ final class Hub[A] private[kyo] (
                     closed.map {
                         case true =>
                             // race condition
-                            Sync.io {
+                            Sync.defer {
                                 discard(listeners.remove(listener))
                                 fail
                             }
@@ -176,7 +176,7 @@ final class Hub[A] private[kyo] (
     end listen
 
     private[kyo] def remove(listener: Listener[A])(using Frame): Unit < Sync =
-        Sync.io {
+        Sync.defer {
             discard(listeners.remove(listener))
         }
 end Hub

--- a/kyo-core/shared/src/main/scala/kyo/Hub.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Hub.scala
@@ -96,7 +96,7 @@ final class Hub[A] private[kyo] (
     def close(using frame: Frame): Maybe[Seq[A]] < Sync =
         fiber.interruptDiscard(Result.Failure(Closed("Hub", initFrame))).andThen {
             ch.close.map { r =>
-                Sync {
+                Sync.io {
                     val l = Chunk.fromNoCopy(listeners.toArray()).asInstanceOf[Chunk[Listener[A]]]
                     discard(listeners.removeIf(_ => true)) // clear is not available in Scala Native
                     Kyo.foreachDiscard(l)(_.child.close.unit).andThen(r)
@@ -164,7 +164,7 @@ final class Hub[A] private[kyo] (
                     closed.map {
                         case true =>
                             // race condition
-                            Sync {
+                            Sync.io {
                                 discard(listeners.remove(listener))
                                 fail
                             }
@@ -176,7 +176,7 @@ final class Hub[A] private[kyo] (
     end listen
 
     private[kyo] def remove(listener: Listener[A])(using Frame): Unit < Sync =
-        Sync {
+        Sync.io {
             discard(listeners.remove(listener))
         }
 end Hub

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -378,7 +378,7 @@ object Meter:
             }
         end close
 
-        final def closed(using Frame) = Sync.io(state.get() == Int.MinValue)
+        final def closed(using Frame) = Sync.defer(state.get() == Int.MinValue)
 
         @tailrec final protected def release(): Boolean =
             val st = state.get()

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -378,7 +378,7 @@ object Meter:
             }
         end close
 
-        final def closed(using Frame) = Sync(state.get() == Int.MinValue)
+        final def closed(using Frame) = Sync.io(state.get() == Int.MinValue)
 
         @tailrec final protected def release(): Boolean =
             val st = state.get()

--- a/kyo-core/shared/src/main/scala/kyo/Random.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Random.scala
@@ -173,7 +173,7 @@ object Random:
       *   The result of the effect execution with the seeded Random instance.
       */
     def withSeed[A, S](seed: Int)(v: A < S)(using Frame): A < (S & Sync) =
-        Sync.io(Random(Random.Unsafe(new java.util.Random(seed)))).map(let(_)(v))
+        Sync.defer(Random(Random.Unsafe(new java.util.Random(seed)))).map(let(_)(v))
 
     /** Gets the current Random instance from the local context.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Random.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Random.scala
@@ -173,7 +173,7 @@ object Random:
       *   The result of the effect execution with the seeded Random instance.
       */
     def withSeed[A, S](seed: Int)(v: A < S)(using Frame): A < (S & Sync) =
-        Sync(Random(Random.Unsafe(new java.util.Random(seed)))).map(let(_)(v))
+        Sync.io(Random(Random.Unsafe(new java.util.Random(seed)))).map(let(_)(v))
 
     /** Gets the current Random instance from the local context.
       *

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -78,7 +78,7 @@ object Resource:
       *   The acquired resource wrapped in Resource, Sync, and S effects.
       */
     def acquireRelease[A, S](acquire: => A < S)(release: A => Any < (Async & Abort[Throwable]))(using Frame): A < (Resource & Sync & S) =
-        Sync {
+        Sync.io {
             acquire.map { resource =>
                 ensure(release(resource)).andThen(resource)
             }

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -78,7 +78,7 @@ object Resource:
       *   The acquired resource wrapped in Resource, Sync, and S effects.
       */
     def acquireRelease[A, S](acquire: => A < S)(release: A => Any < (Async & Abort[Throwable]))(using Frame): A < (Resource & Sync & S) =
-        Sync.io {
+        Sync.defer {
             acquire.map { resource =>
                 ensure(release(resource)).andThen(resource)
             }

--- a/kyo-core/shared/src/main/scala/kyo/Stat.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Stat.scala
@@ -111,9 +111,9 @@ final class Stat(private val registryScope: StatsRegistry.Scope) extends Seriali
     ): Counter =
         new Counter:
             val unsafe                    = registryScope.counter(name, description)
-            def get(using Frame)          = Sync(unsafe.get())
-            def inc(using Frame)          = Sync(unsafe.inc())
-            def add(v: Long)(using Frame) = Sync(unsafe.add(v))
+            def get(using Frame)          = Sync.io(unsafe.get())
+            def inc(using Frame)          = Sync.io(unsafe.inc())
+            def add(v: Long)(using Frame) = Sync.io(unsafe.add(v))
 
     /** Initialize a new Histogram.
       * @param name
@@ -129,10 +129,10 @@ final class Stat(private val registryScope: StatsRegistry.Scope) extends Seriali
     ): Histogram =
         new Histogram:
             val unsafe                                    = registryScope.histogram(name, description)
-            def observe(v: Double)(using Frame)           = Sync(unsafe.observe(v))
-            def observe(v: Long)(using Frame)             = Sync(unsafe.observe(v))
-            def count(using Frame)                        = Sync(unsafe.count())
-            def valueAtPercentile(v: Double)(using Frame) = Sync(unsafe.valueAtPercentile(v))
+            def observe(v: Double)(using Frame)           = Sync.io(unsafe.observe(v))
+            def observe(v: Long)(using Frame)             = Sync.io(unsafe.observe(v))
+            def count(using Frame)                        = Sync.io(unsafe.count())
+            def valueAtPercentile(v: Double)(using Frame) = Sync.io(unsafe.valueAtPercentile(v))
 
     /** Initialize a new Gauge.
       * @param name
@@ -150,7 +150,7 @@ final class Stat(private val registryScope: StatsRegistry.Scope) extends Seriali
     )(f: => Double): Gauge =
         new Gauge:
             val unsafe               = registryScope.gauge(name, description)(f)
-            def collect(using Frame) = Sync(unsafe.collect())
+            def collect(using Frame) = Sync.io(unsafe.collect())
 
     /** Initialize a new CounterGauge.
       * @param name
@@ -168,7 +168,7 @@ final class Stat(private val registryScope: StatsRegistry.Scope) extends Seriali
     )(f: => Long): CounterGauge =
         new CounterGauge:
             val unsafe               = registryScope.counterGauge(name, description)(f)
-            def collect(using Frame) = Sync(f)
+            def collect(using Frame) = Sync.io(f)
 
     /** Trace a span of execution.
       * @param name

--- a/kyo-core/shared/src/main/scala/kyo/Stat.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Stat.scala
@@ -111,9 +111,9 @@ final class Stat(private val registryScope: StatsRegistry.Scope) extends Seriali
     ): Counter =
         new Counter:
             val unsafe                    = registryScope.counter(name, description)
-            def get(using Frame)          = Sync.io(unsafe.get())
-            def inc(using Frame)          = Sync.io(unsafe.inc())
-            def add(v: Long)(using Frame) = Sync.io(unsafe.add(v))
+            def get(using Frame)          = Sync.defer(unsafe.get())
+            def inc(using Frame)          = Sync.defer(unsafe.inc())
+            def add(v: Long)(using Frame) = Sync.defer(unsafe.add(v))
 
     /** Initialize a new Histogram.
       * @param name
@@ -129,10 +129,10 @@ final class Stat(private val registryScope: StatsRegistry.Scope) extends Seriali
     ): Histogram =
         new Histogram:
             val unsafe                                    = registryScope.histogram(name, description)
-            def observe(v: Double)(using Frame)           = Sync.io(unsafe.observe(v))
-            def observe(v: Long)(using Frame)             = Sync.io(unsafe.observe(v))
-            def count(using Frame)                        = Sync.io(unsafe.count())
-            def valueAtPercentile(v: Double)(using Frame) = Sync.io(unsafe.valueAtPercentile(v))
+            def observe(v: Double)(using Frame)           = Sync.defer(unsafe.observe(v))
+            def observe(v: Long)(using Frame)             = Sync.defer(unsafe.observe(v))
+            def count(using Frame)                        = Sync.defer(unsafe.count())
+            def valueAtPercentile(v: Double)(using Frame) = Sync.defer(unsafe.valueAtPercentile(v))
 
     /** Initialize a new Gauge.
       * @param name
@@ -150,7 +150,7 @@ final class Stat(private val registryScope: StatsRegistry.Scope) extends Seriali
     )(f: => Double): Gauge =
         new Gauge:
             val unsafe               = registryScope.gauge(name, description)(f)
-            def collect(using Frame) = Sync.io(unsafe.collect())
+            def collect(using Frame) = Sync.defer(unsafe.collect())
 
     /** Initialize a new CounterGauge.
       * @param name
@@ -168,7 +168,7 @@ final class Stat(private val registryScope: StatsRegistry.Scope) extends Seriali
     )(f: => Long): CounterGauge =
         new CounterGauge:
             val unsafe               = registryScope.counterGauge(name, description)(f)
-            def collect(using Frame) = Sync.io(f)
+            def collect(using Frame) = Sync.defer(f)
 
     /** Trace a span of execution.
       * @param name

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -158,13 +158,13 @@ object StreamCoreExtensions:
             Tag[Emit[Chunk[V]]],
             Frame
         ): Stream[V, Sync] =
-            val stream: Stream[V, Sync] < Sync = Sync.io:
+            val stream: Stream[V, Sync] < Sync = Sync.defer:
                 val it      = v
                 val size    = chunkSize max 1
                 val builder = ChunkBuilder.init[V]
 
                 val pull: Chunk[V] < Sync =
-                    Sync.io:
+                    Sync.defer:
                         var count = 0
                         while count < size && it.hasNext do
                             builder.addOne(it.next())
@@ -178,7 +178,7 @@ object StreamCoreExtensions:
                             case Result.Success(chunk) if chunk.isEmpty => Loop.done
                             case Result.Success(chunk)                  => Emit.valueWith(chunk)(Loop.continue)
                             case Result.Panic(throwable) =>
-                                Sync.io:
+                                Sync.defer:
                                     val lastElements: Chunk[V] = builder.result()
                                     Emit.valueWith(lastElements)(Abort.panic(throwable))
 
@@ -206,13 +206,13 @@ object StreamCoreExtensions:
                     "\n - `fromIteratorCatching[E = Throwable]` catches all Exceptions as `Failure`."
             ) notNothing: NotGiven[E =:= Nothing]
         ): Stream[V, Sync & Abort[E]] =
-            val stream: Stream[V, (Sync & Abort[E])] < Sync = Sync.io:
+            val stream: Stream[V, (Sync & Abort[E])] < Sync = Sync.defer:
                 val it      = v
                 val size    = chunkSize max 1
                 val builder = ChunkBuilder.init[V]
 
                 val pull: Chunk[V] < (Sync & Abort[E]) =
-                    Sync.io:
+                    Sync.defer:
                         Abort.catching[E]:
                             var count = 0
                             while count < size && it.hasNext do
@@ -227,7 +227,7 @@ object StreamCoreExtensions:
                             case Result.Success(chunk) if chunk.isEmpty => Loop.done
                             case Result.Success(chunk)                  => Emit.valueWith(chunk)(Loop.continue)
                             case error: Result.Error[E] @unchecked =>
-                                Sync.io:
+                                Sync.defer:
                                     val lastElements: Chunk[V] = builder.result()
                                     Emit.valueWith(lastElements)(Abort.error(error))
 
@@ -838,10 +838,10 @@ object StreamCoreExtensions:
                 val builder = Chunk.newBuilder[Stream[V, Abort[E] & Resource & Async]]
                 Loop(numStreams): remaining =>
                     if remaining <= 0 then
-                        Sync.io(builder.result()).map(chunk => Loop.done(chunk))
+                        Sync.defer(builder.result()).map(chunk => Loop.done(chunk))
                     else
                         streamHub.subscribe.map: stream =>
-                            Sync.io(builder.addOne(stream)).andThen(Loop.continue(remaining - 1))
+                            Sync.defer(builder.addOne(stream)).andThen(Loop.continue(remaining - 1))
             }(using i1, i2, t1, t2, t3, t4, fr)
 
         /** Convert to a reusable stream that can be run multiple times in parallel to consume the same original elements. Original stream

--- a/kyo-core/shared/src/main/scala/kyo/Sync.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Sync.scala
@@ -47,7 +47,7 @@ object Sync:
       * @return
       *   The suspended computation wrapped in an Sync effect.
       */
-    inline def apply[A, S](inline f: Safepoint ?=> A < S)(using inline frame: Frame): A < (Sync & S) =
+    inline def io[A, S](inline f: Safepoint ?=> A < S)(using inline frame: Frame): A < (Sync & S) =
         Effect.deferInline(f)
 
     /** Ensures that a finalizer is run after the main computation, regardless of success or failure.
@@ -94,10 +94,10 @@ object Sync:
       * This is the preferred way to access a local value when you need to perform side effects with it. Common use cases include accessing
       * loggers, configuration, or request-scoped values that you need to use in computations that produce side effects.
       *
-      * While `local.get.map(v => Sync(f(v)))` would also work, this method is more direct since both Sync and Local use the same underlying
-      * mechanism to handle effects. Under the hood, accessing a local value and performing Sync operations both use the same type of
-      * suspension, the kernel's internal `Defer` effect. This means we can safely combine them without creating unnecessary layers of
-      * suspension.
+      * While `local.get.map(v => Sync.io(f(v)))` would also work, this method is more direct since both Sync and Local use the same
+      * underlying mechanism to handle effects. Under the hood, accessing a local value and performing Sync operations both use the same
+      * type of suspension, the kernel's internal `Defer` effect. This means we can safely combine them without creating unnecessary layers
+      * of suspension.
       *
       * @param local
       *   The local value to access

--- a/kyo-core/shared/src/main/scala/kyo/Sync.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Sync.scala
@@ -47,7 +47,7 @@ object Sync:
       * @return
       *   The suspended computation wrapped in an Sync effect.
       */
-    inline def io[A, S](inline f: Safepoint ?=> A < S)(using inline frame: Frame): A < (Sync & S) =
+    inline def defer[A, S](inline f: Safepoint ?=> A < S)(using inline frame: Frame): A < (Sync & S) =
         Effect.deferInline(f)
 
     /** Ensures that a finalizer is run after the main computation, regardless of success or failure.
@@ -94,7 +94,7 @@ object Sync:
       * This is the preferred way to access a local value when you need to perform side effects with it. Common use cases include accessing
       * loggers, configuration, or request-scoped values that you need to use in computations that produce side effects.
       *
-      * While `local.get.map(v => Sync.io(f(v)))` would also work, this method is more direct since both Sync and Local use the same
+      * While `local.get.map(v => Sync.defer(f(v)))` would also work, this method is more direct since both Sync and Local use the same
       * underlying mechanism to handle effects. Under the hood, accessing a local value and performing Sync operations both use the same
       * type of suspension, the kernel's internal `Defer` effect. This means we can safely combine them without creating unnecessary layers
       * of suspension.

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -61,7 +61,7 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
                                             this.interrupts(input)
                                             input.onComplete { r =>
                                                 this.removeInterrupt(input)
-                                                curr = Sync.io(cont(r.asInstanceOf[Result[Nothing, C]]))
+                                                curr = Sync.defer(cont(r.asInstanceOf[Result[Nothing, C]]))
                                                 Scheduler.get.schedule(this)
                                             }
                                             nullResult

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -61,7 +61,7 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
                                             this.interrupts(input)
                                             input.onComplete { r =>
                                                 this.removeInterrupt(input)
-                                                curr = Sync(cont(r.asInstanceOf[Result[Nothing, C]]))
+                                                curr = Sync.io(cont(r.asInstanceOf[Result[Nothing, C]]))
                                                 Scheduler.get.schedule(this)
                                             }
                                             nullResult

--- a/kyo-core/shared/src/main/scala/kyo/stats/internal/Span.scala
+++ b/kyo-core/shared/src/main/scala/kyo/stats/internal/Span.scala
@@ -8,10 +8,10 @@ import scala.annotation.tailrec
 final case class Span(unsafe: Span.Unsafe):
 
     def end(using Frame): Unit < Sync =
-        Sync(unsafe.end())
+        Sync.io(unsafe.end())
 
     def event(name: String, a: Attributes)(using Frame): Unit < Sync =
-        Sync(unsafe.event(name, a))
+        Sync.io(unsafe.event(name, a))
 end Span
 
 object Span:

--- a/kyo-core/shared/src/main/scala/kyo/stats/internal/Span.scala
+++ b/kyo-core/shared/src/main/scala/kyo/stats/internal/Span.scala
@@ -8,10 +8,10 @@ import scala.annotation.tailrec
 final case class Span(unsafe: Span.Unsafe):
 
     def end(using Frame): Unit < Sync =
-        Sync.io(unsafe.end())
+        Sync.defer(unsafe.end())
 
     def event(name: String, a: Attributes)(using Frame): Unit < Sync =
-        Sync.io(unsafe.event(name, a))
+        Sync.defer(unsafe.event(name, a))
 end Span
 
 object Span:

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -29,7 +29,7 @@ class AsyncTest extends Test:
         "nested" in runNotJS {
             val t1 = Thread.currentThread()
             for
-                t2 <- Fiber.run(Sync(Fiber.run(Thread.currentThread()).map(_.get))).map(_.get)
+                t2 <- Fiber.run(Sync.defer(Fiber.run(Thread.currentThread()).map(_.get))).map(_.get)
             yield assert(t1 ne t2)
         }
 
@@ -50,17 +50,17 @@ class AsyncTest extends Test:
 
     "sleep" in run {
         for
-            start <- Sync(java.lang.System.currentTimeMillis())
+            start <- Sync.defer(java.lang.System.currentTimeMillis())
             _     <- Async.sleep(10.millis)
-            end   <- Sync(java.lang.System.currentTimeMillis())
+            end   <- Sync.defer(java.lang.System.currentTimeMillis())
         yield assert(end - start >= 8)
     }
 
     "delay" in run {
         for
-            start <- Sync(java.lang.System.currentTimeMillis())
+            start <- Sync.defer(java.lang.System.currentTimeMillis())
             res   <- Async.delay(5.millis)(42)
-            end   <- Sync(java.lang.System.currentTimeMillis())
+            end   <- Sync.defer(java.lang.System.currentTimeMillis())
         yield
             assert(end - start >= 4)
             assert(res == 42)
@@ -158,7 +158,7 @@ class AsyncTest extends Test:
             val ac = new JAtomicInteger(0)
             val bc = new JAtomicInteger(0)
             def loop(i: Int, s: String): String < Sync =
-                Sync {
+                Sync.defer {
                     if i > 0 then
                         if s.equals("a") then ac.incrementAndGet()
                         else bc.incrementAndGet()
@@ -215,7 +215,7 @@ class AsyncTest extends Test:
             val ac = new JAtomicInteger(0)
             val bc = new JAtomicInteger(0)
             def loop(i: Int, s: String): String < Sync =
-                Sync {
+                Sync.defer {
                     if i > 0 then
                         if s.equals("a") then ac.incrementAndGet()
                         else bc.incrementAndGet()
@@ -231,12 +231,12 @@ class AsyncTest extends Test:
         }
         "three arguments" in run {
             for
-                (v1, v2, v3) <- Async.zip(Sync(1), Sync(2), Sync(3))
+                (v1, v2, v3) <- Async.zip(Sync.defer(1), Sync.defer(2), Sync.defer(3))
             yield assert(v1 == 1 && v2 == 2 && v3 == 3)
         }
         "four arguments" in run {
             for
-                (v1, v2, v3, v4) <- Async.zip(Sync(1), Sync(2), Sync(3), Sync(4))
+                (v1, v2, v3, v4) <- Async.zip(Sync.defer(1), Sync.defer(2), Sync.defer(3), Sync.defer(4))
             yield assert(v1 == 1 && v2 == 2 && v3 == 3 && v4 == 4)
         }
     }
@@ -280,7 +280,7 @@ class AsyncTest extends Test:
             val io1: (JAtomicInteger & Closeable, Set[Int]) < (Resource & Async) =
                 for
                     r  <- Resource.acquire(resource1)
-                    v1 <- Sync(r.incrementAndGet())
+                    v1 <- Sync.defer(r.incrementAndGet())
                     v2 <- Fiber.run(r.incrementAndGet()).map(_.get)
                 yield (r, Set(v1, v2))
             Resource.run(io1).map {
@@ -315,7 +315,7 @@ class AsyncTest extends Test:
             val io1: Set[Int] < (Resource & Async) =
                 for
                     r  <- Resource.acquire(resource1)
-                    v1 <- Sync(r.incrementAndGet())
+                    v1 <- Sync.defer(r.incrementAndGet())
                     v2 <- Fiber.run(r.incrementAndGet()).map(_.get)
                     v3 <- Resource.run(Resource.acquire(resource2).map(_.incrementAndGet()))
                 yield Set(v1, v2, v3)
@@ -858,13 +858,13 @@ class AsyncTest extends Test:
         "sequence" - {
             "delegates to Fiber.gather" in run {
                 for
-                    result <- Async.gather(Seq(Sync(1), Sync(2), Sync(3)))
+                    result <- Async.gather(Seq(Sync.defer(1), Sync.defer(2), Sync.defer(3)))
                 yield assert(result == Chunk(1, 2, 3))
             }
 
             "with max limit delegates to Fiber.gather" in run {
                 for
-                    result <- Async.gather(2)(Seq(Sync(1), Sync(2), Sync(3)))
+                    result <- Async.gather(2)(Seq(Sync.defer(1), Sync.defer(2), Sync.defer(3)))
                 yield
                     assert(result.size == 2)
                     assert(result.forall(Seq(1, 2, 3).contains))
@@ -874,13 +874,13 @@ class AsyncTest extends Test:
         "varargs" - {
             "delegates to sequence-based gather" in run {
                 for
-                    result <- Async.gather(Sync(1), Sync(2), Sync(3))
+                    result <- Async.gather(Sync.defer(1), Sync.defer(2), Sync.defer(3))
                 yield assert(result == Chunk(1, 2, 3))
             }
 
             "with max limit delegates to sequence-based gather" in run {
                 for
-                    result <- Async.gather(2)(Sync(1), Sync(2), Sync(3))
+                    result <- Async.gather(2)(Sync.defer(1), Sync.defer(2), Sync.defer(3))
                 yield
                     assert(result.size == 2)
                     assert(result.forall(Seq(1, 2, 3).contains))
@@ -1281,7 +1281,7 @@ class AsyncTest extends Test:
     "apply" - {
         "suspends computation" in run {
             var counter = 0
-            val computation = Async {
+            val computation = Async.defer {
                 counter += 1
                 counter
             }
@@ -1304,7 +1304,7 @@ class AsyncTest extends Test:
                 done    <- Latch.init(1)
                 fiber <- Fiber.run {
                     started.release.andThen {
-                        Async { executed = true }.andThen {
+                        Async.defer { executed = true }.andThen {
                             done.release
                         }
                     }
@@ -1320,15 +1320,15 @@ class AsyncTest extends Test:
         "executes nine computations in parallel" in run {
             for
                 result <- Async.zip(
-                    Sync(1),
-                    Sync(2),
-                    Sync(3),
-                    Sync(4),
-                    Sync(5),
-                    Sync(6),
-                    Sync(7),
-                    Sync(8),
-                    Sync(9)
+                    Sync.defer(1),
+                    Sync.defer(2),
+                    Sync.defer(3),
+                    Sync.defer(4),
+                    Sync.defer(5),
+                    Sync.defer(6),
+                    Sync.defer(7),
+                    Sync.defer(8),
+                    Sync.defer(9)
                 )
             yield assert(result == (1, 2, 3, 4, 5, 6, 7, 8, 9))
         }
@@ -1336,16 +1336,16 @@ class AsyncTest extends Test:
         "executes ten computations in parallel" in run {
             for
                 result <- Async.zip(
-                    Sync(1),
-                    Sync(2),
-                    Sync(3),
-                    Sync(4),
-                    Sync(5),
-                    Sync(6),
-                    Sync(7),
-                    Sync(8),
-                    Sync(9),
-                    Sync(10)
+                    Sync.defer(1),
+                    Sync.defer(2),
+                    Sync.defer(3),
+                    Sync.defer(4),
+                    Sync.defer(5),
+                    Sync.defer(6),
+                    Sync.defer(7),
+                    Sync.defer(8),
+                    Sync.defer(9),
+                    Sync.defer(10)
                 )
             yield assert(result == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
         }

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -514,7 +514,7 @@ class ChannelTest extends Test:
         "Sync" in run {
             for
                 channel <- Channel.init[Int < Sync](2)
-                _       <- channel.put(Sync.io(42))
+                _       <- channel.put(Sync.defer(42))
                 result  <- channel.take.flatten
             yield assert(result == 42)
         }

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -514,7 +514,7 @@ class ChannelTest extends Test:
         "Sync" in run {
             for
                 channel <- Channel.init[Int < Sync](2)
-                _       <- channel.put(Sync(42))
+                _       <- channel.put(Sync.io(42))
                 result  <- channel.take.flatten
             yield assert(result == 42)
         }

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -133,7 +133,7 @@ class FiberTest extends Test:
         }
         "n" in run {
             def loop(i: Int, s: String): String < (Abort[String] & Sync) =
-                Sync.io {
+                Sync.defer {
                     if i == 80 && s == "a" then
                         Abort.fail("Loser")
                     else if i <= 0 then s
@@ -158,7 +158,7 @@ class FiberTest extends Test:
             }
             "n" in run {
                 def loop(i: Int, s: String): String < (Abort[String] & Sync) =
-                    Sync.io {
+                    Sync.defer {
                         if i == 80 && s == "a" then
                             Abort.fail("Winner")
                         else if i <= 0 then s
@@ -247,7 +247,7 @@ class FiberTest extends Test:
 
         "small collection + Sync" in run {
             for
-                fiber  <- Fiber.foreachIndexed(Seq(1, 2, 3))((idx, v) => Sync.io((idx, v)))
+                fiber  <- Fiber.foreachIndexed(Seq(1, 2, 3))((idx, v) => Sync.defer((idx, v)))
                 result <- fiber.get
             yield assert(result == Seq((0, 1), (1, 2), (2, 3)))
         }
@@ -255,7 +255,7 @@ class FiberTest extends Test:
         "error propagation" in run {
             val error = new Exception("test error")
             for
-                fiber <- Sync.io {
+                fiber <- Sync.defer {
                     def task(idx: Int, v: Int): Int < (Sync & Async & Abort[Throwable]) =
                         if v == 3 then Abort.fail(error)
                         else v
@@ -424,7 +424,7 @@ class FiberTest extends Test:
             var completed = false
             val fiber     = Fiber.success(42)
             for
-                _ <- fiber.onComplete(_ => Sync.io { completed = true })
+                _ <- fiber.onComplete(_ => Sync.defer { completed = true })
             yield assert(completed)
             end for
         }
@@ -433,7 +433,7 @@ class FiberTest extends Test:
             var completed = Maybe.empty[Result[Any, Int]]
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onComplete(v => Sync.io { completed = Maybe(v) })
+                _     <- fiber.onComplete(v => Sync.defer { completed = Maybe(v) })
                 notCompletedYet = completed
                 _ <- fiber.complete(Result.succeed(42))
                 completedAfterWait = completed
@@ -449,7 +449,7 @@ class FiberTest extends Test:
             var interrupted = false
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onInterrupt(_ => Sync.io { interrupted = true })
+                _     <- fiber.onInterrupt(_ => Sync.defer { interrupted = true })
                 _     <- fiber.interrupt
             yield assert(interrupted)
             end for
@@ -459,7 +459,7 @@ class FiberTest extends Test:
             var interrupted = false
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onInterrupt(_ => Sync.io { interrupted = true })
+                _     <- fiber.onInterrupt(_ => Sync.defer { interrupted = true })
                 _     <- fiber.complete(Result.succeed(42))
                 _     <- fiber.get
             yield assert(!interrupted)
@@ -470,9 +470,9 @@ class FiberTest extends Test:
             var count = 0
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onInterrupt(_ => Sync.io { count += 1 })
-                _     <- fiber.onInterrupt(_ => Sync.io { count += 1 })
-                _     <- fiber.onInterrupt(_ => Sync.io { count += 1 })
+                _     <- fiber.onInterrupt(_ => Sync.defer { count += 1 })
+                _     <- fiber.onInterrupt(_ => Sync.defer { count += 1 })
+                _     <- fiber.onInterrupt(_ => Sync.defer { count += 1 })
                 _     <- fiber.interrupt
             yield assert(count == 3)
             end for
@@ -707,7 +707,7 @@ class FiberTest extends Test:
         "collects all successful results" in run {
             Loop.repeat(repeats) {
                 for
-                    fiber  <- Fiber.gather(3)(Seq(Sync.io(1), Sync.io(2), Sync.io(3)))
+                    fiber  <- Fiber.gather(3)(Seq(Sync.defer(1), Sync.defer(2), Sync.defer(3)))
                     result <- fiber.get
                 yield
                     assert(result == Chunk(1, 2, 3))
@@ -718,7 +718,7 @@ class FiberTest extends Test:
         "with max limit" in run {
             val seq = Seq(1, 2, 3)
             for
-                fiber  <- Fiber.gather(2)(seq.map(Sync.io(_)))
+                fiber  <- Fiber.gather(2)(seq.map(Sync.defer(_)))
                 result <- fiber.get
             yield
                 assert(result.distinct.size == 2)
@@ -728,7 +728,7 @@ class FiberTest extends Test:
 
         "handles max=0" in run {
             for
-                fiber  <- Fiber.gather(0)(Seq(Sync.io(1), Sync.io(2), Sync.io(3)))
+                fiber  <- Fiber.gather(0)(Seq(Sync.defer(1), Sync.defer(2), Sync.defer(3)))
                 result <- fiber.get
             yield assert(result.isEmpty)
         }
@@ -739,7 +739,7 @@ class FiberTest extends Test:
                 fiber <- Fiber.gather(1)(Seq(
                     Abort.fail[Exception](error),
                     Abort.fail[Exception](error),
-                    Sync.io(3)
+                    Sync.defer(3)
                 ))
                 result <- fiber.get
             yield assert(result == Chunk(3))
@@ -748,7 +748,7 @@ class FiberTest extends Test:
 
         "handles negative max" in run {
             for
-                fiber  <- Fiber.gather(-1)(Seq(Sync.io(1), Sync.io(2), Sync.io(3)))
+                fiber  <- Fiber.gather(-1)(Seq(Sync.defer(1), Sync.defer(2), Sync.defer(3)))
                 result <- fiber.get
             yield assert(result.isEmpty)
         }
@@ -756,7 +756,7 @@ class FiberTest extends Test:
         "handles max > size" in run {
             val seq = Seq(1, 2, 3)
             for
-                fiber  <- Fiber.gather(10)(seq.map(Sync.io(_)))
+                fiber  <- Fiber.gather(10)(seq.map(Sync.defer(_)))
                 result <- fiber.get
             yield assert(result == Chunk(1, 2, 3))
             end for
@@ -766,9 +766,9 @@ class FiberTest extends Test:
             val error = new Exception("test error")
             for
                 fiber <- Fiber.gather(10)(Seq(
-                    Sync.io(1),
+                    Sync.defer(1),
                     Abort.fail[Exception](error),
-                    Sync.io(3)
+                    Sync.defer(3)
                 ))
                 result <- fiber.get
             yield assert(result == Chunk(1, 3))
@@ -811,9 +811,9 @@ class FiberTest extends Test:
         "filters out failures" in run {
             for
                 fiber <- Fiber.gather(3)(Seq(
-                    Sync.io(1),
+                    Sync.defer(1),
                     Abort.fail[Exception](error),
-                    Sync.io(3)
+                    Sync.defer(3)
                 ))
                 result <- fiber.get
             yield assert(result == Chunk(1, 3))
@@ -886,10 +886,10 @@ class FiberTest extends Test:
         "max limit with failures" in run {
             for
                 fiber <- Fiber.gather(2)(Seq(
-                    Sync.io(1),
+                    Sync.defer(1),
                     Abort.fail[Exception](error),
-                    Sync.io(3),
-                    Sync.io(4)
+                    Sync.defer(3),
+                    Sync.defer(4)
                 ))
                 result <- fiber.get
             yield

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -133,7 +133,7 @@ class FiberTest extends Test:
         }
         "n" in run {
             def loop(i: Int, s: String): String < (Abort[String] & Sync) =
-                Sync {
+                Sync.io {
                     if i == 80 && s == "a" then
                         Abort.fail("Loser")
                     else if i <= 0 then s
@@ -158,7 +158,7 @@ class FiberTest extends Test:
             }
             "n" in run {
                 def loop(i: Int, s: String): String < (Abort[String] & Sync) =
-                    Sync {
+                    Sync.io {
                         if i == 80 && s == "a" then
                             Abort.fail("Winner")
                         else if i <= 0 then s
@@ -247,7 +247,7 @@ class FiberTest extends Test:
 
         "small collection + Sync" in run {
             for
-                fiber  <- Fiber.foreachIndexed(Seq(1, 2, 3))((idx, v) => Sync((idx, v)))
+                fiber  <- Fiber.foreachIndexed(Seq(1, 2, 3))((idx, v) => Sync.io((idx, v)))
                 result <- fiber.get
             yield assert(result == Seq((0, 1), (1, 2), (2, 3)))
         }
@@ -255,7 +255,7 @@ class FiberTest extends Test:
         "error propagation" in run {
             val error = new Exception("test error")
             for
-                fiber <- Sync {
+                fiber <- Sync.io {
                     def task(idx: Int, v: Int): Int < (Sync & Async & Abort[Throwable]) =
                         if v == 3 then Abort.fail(error)
                         else v
@@ -424,7 +424,7 @@ class FiberTest extends Test:
             var completed = false
             val fiber     = Fiber.success(42)
             for
-                _ <- fiber.onComplete(_ => Sync { completed = true })
+                _ <- fiber.onComplete(_ => Sync.io { completed = true })
             yield assert(completed)
             end for
         }
@@ -433,7 +433,7 @@ class FiberTest extends Test:
             var completed = Maybe.empty[Result[Any, Int]]
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onComplete(v => Sync { completed = Maybe(v) })
+                _     <- fiber.onComplete(v => Sync.io { completed = Maybe(v) })
                 notCompletedYet = completed
                 _ <- fiber.complete(Result.succeed(42))
                 completedAfterWait = completed
@@ -449,7 +449,7 @@ class FiberTest extends Test:
             var interrupted = false
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onInterrupt(_ => Sync { interrupted = true })
+                _     <- fiber.onInterrupt(_ => Sync.io { interrupted = true })
                 _     <- fiber.interrupt
             yield assert(interrupted)
             end for
@@ -459,7 +459,7 @@ class FiberTest extends Test:
             var interrupted = false
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onInterrupt(_ => Sync { interrupted = true })
+                _     <- fiber.onInterrupt(_ => Sync.io { interrupted = true })
                 _     <- fiber.complete(Result.succeed(42))
                 _     <- fiber.get
             yield assert(!interrupted)
@@ -470,9 +470,9 @@ class FiberTest extends Test:
             var count = 0
             for
                 fiber <- Promise.init[Nothing, Int]
-                _     <- fiber.onInterrupt(_ => Sync { count += 1 })
-                _     <- fiber.onInterrupt(_ => Sync { count += 1 })
-                _     <- fiber.onInterrupt(_ => Sync { count += 1 })
+                _     <- fiber.onInterrupt(_ => Sync.io { count += 1 })
+                _     <- fiber.onInterrupt(_ => Sync.io { count += 1 })
+                _     <- fiber.onInterrupt(_ => Sync.io { count += 1 })
                 _     <- fiber.interrupt
             yield assert(count == 3)
             end for
@@ -707,7 +707,7 @@ class FiberTest extends Test:
         "collects all successful results" in run {
             Loop.repeat(repeats) {
                 for
-                    fiber  <- Fiber.gather(3)(Seq(Sync(1), Sync(2), Sync(3)))
+                    fiber  <- Fiber.gather(3)(Seq(Sync.io(1), Sync.io(2), Sync.io(3)))
                     result <- fiber.get
                 yield
                     assert(result == Chunk(1, 2, 3))
@@ -718,7 +718,7 @@ class FiberTest extends Test:
         "with max limit" in run {
             val seq = Seq(1, 2, 3)
             for
-                fiber  <- Fiber.gather(2)(seq.map(Sync(_)))
+                fiber  <- Fiber.gather(2)(seq.map(Sync.io(_)))
                 result <- fiber.get
             yield
                 assert(result.distinct.size == 2)
@@ -728,7 +728,7 @@ class FiberTest extends Test:
 
         "handles max=0" in run {
             for
-                fiber  <- Fiber.gather(0)(Seq(Sync(1), Sync(2), Sync(3)))
+                fiber  <- Fiber.gather(0)(Seq(Sync.io(1), Sync.io(2), Sync.io(3)))
                 result <- fiber.get
             yield assert(result.isEmpty)
         }
@@ -739,7 +739,7 @@ class FiberTest extends Test:
                 fiber <- Fiber.gather(1)(Seq(
                     Abort.fail[Exception](error),
                     Abort.fail[Exception](error),
-                    Sync(3)
+                    Sync.io(3)
                 ))
                 result <- fiber.get
             yield assert(result == Chunk(3))
@@ -748,7 +748,7 @@ class FiberTest extends Test:
 
         "handles negative max" in run {
             for
-                fiber  <- Fiber.gather(-1)(Seq(Sync(1), Sync(2), Sync(3)))
+                fiber  <- Fiber.gather(-1)(Seq(Sync.io(1), Sync.io(2), Sync.io(3)))
                 result <- fiber.get
             yield assert(result.isEmpty)
         }
@@ -756,7 +756,7 @@ class FiberTest extends Test:
         "handles max > size" in run {
             val seq = Seq(1, 2, 3)
             for
-                fiber  <- Fiber.gather(10)(seq.map(Sync(_)))
+                fiber  <- Fiber.gather(10)(seq.map(Sync.io(_)))
                 result <- fiber.get
             yield assert(result == Chunk(1, 2, 3))
             end for
@@ -766,9 +766,9 @@ class FiberTest extends Test:
             val error = new Exception("test error")
             for
                 fiber <- Fiber.gather(10)(Seq(
-                    Sync(1),
+                    Sync.io(1),
                     Abort.fail[Exception](error),
-                    Sync(3)
+                    Sync.io(3)
                 ))
                 result <- fiber.get
             yield assert(result == Chunk(1, 3))
@@ -811,9 +811,9 @@ class FiberTest extends Test:
         "filters out failures" in run {
             for
                 fiber <- Fiber.gather(3)(Seq(
-                    Sync(1),
+                    Sync.io(1),
                     Abort.fail[Exception](error),
-                    Sync(3)
+                    Sync.io(3)
                 ))
                 result <- fiber.get
             yield assert(result == Chunk(1, 3))
@@ -886,10 +886,10 @@ class FiberTest extends Test:
         "max limit with failures" in run {
             for
                 fiber <- Fiber.gather(2)(Seq(
-                    Sync(1),
+                    Sync.io(1),
                     Abort.fail[Exception](error),
-                    Sync(3),
-                    Sync(4)
+                    Sync.io(3),
+                    Sync.io(4)
                 ))
                 result <- fiber.get
             yield

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
@@ -27,7 +27,7 @@ class KyoAppTest extends Test:
                 run { ref.getAndIncrement }
                 run { ref.getAndIncrement }
 
-            _    <- Sync.io(app.main(Array.empty))
+            _    <- Sync.defer(app.main(Array.empty))
             runs <- ref.get
         yield assert(runs == 3)
     }
@@ -36,10 +36,10 @@ class KyoAppTest extends Test:
         val x       = new ListBuffer[Int]
         val promise = scala.concurrent.Promise[Assertion]()
         val app = new KyoApp:
-            run { Async.delay(10.millis)(Sync.io(x += 1)) }
-            run { Async.delay(10.millis)(Sync.io(x += 2)) }
-            run { Async.delay(10.millis)(Sync.io(x += 3)) }
-            run { Sync.io(promise.complete(Try(assert(x.toList == List(1, 2, 3))))) }
+            run { Async.delay(10.millis)(Sync.defer(x += 1)) }
+            run { Async.delay(10.millis)(Sync.defer(x += 2)) }
+            run { Async.delay(10.millis)(Sync.defer(x += 3)) }
+            run { Sync.defer(promise.complete(Try(assert(x.toList == List(1, 2, 3))))) }
         app.main(Array.empty)
         promise.future
     }

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
@@ -27,7 +27,7 @@ class KyoAppTest extends Test:
                 run { ref.getAndIncrement }
                 run { ref.getAndIncrement }
 
-            _    <- Sync(app.main(Array.empty))
+            _    <- Sync.io(app.main(Array.empty))
             runs <- ref.get
         yield assert(runs == 3)
     }
@@ -36,10 +36,10 @@ class KyoAppTest extends Test:
         val x       = new ListBuffer[Int]
         val promise = scala.concurrent.Promise[Assertion]()
         val app = new KyoApp:
-            run { Async.delay(10.millis)(Sync(x += 1)) }
-            run { Async.delay(10.millis)(Sync(x += 2)) }
-            run { Async.delay(10.millis)(Sync(x += 3)) }
-            run { Sync(promise.complete(Try(assert(x.toList == List(1, 2, 3))))) }
+            run { Async.delay(10.millis)(Sync.io(x += 1)) }
+            run { Async.delay(10.millis)(Sync.io(x += 2)) }
+            run { Async.delay(10.millis)(Sync.io(x += 3)) }
+            run { Sync.io(promise.complete(Try(assert(x.toList == List(1, 2, 3))))) }
         app.main(Array.empty)
         promise.future
     }

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -385,7 +385,7 @@ class QueueTest extends Test:
         "Sync" in runNotNative {
             for
                 queue  <- Queue.init[Int < Sync](2)
-                _      <- queue.offer(Sync(42))
+                _      <- queue.offer(Sync.io(42))
                 result <- queue.poll.map(_.get)
             yield assert(result == 42)
         }

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -385,7 +385,7 @@ class QueueTest extends Test:
         "Sync" in runNotNative {
             for
                 queue  <- Queue.init[Int < Sync](2)
-                _      <- queue.offer(Sync.io(42))
+                _      <- queue.offer(Sync.defer(42))
                 result <- queue.poll.map(_.get)
             yield assert(result == 42)
         }

--- a/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
@@ -156,7 +156,7 @@ class ResourceTest extends Test:
         case object TestException extends NoStackTrace
 
         "acquire fails" in run {
-            val io = Resource.acquireRelease(Sync[Int, Any](throw TestException))(_ => ())
+            val io = Resource.acquireRelease(Sync.io[Int, Any](throw TestException))(_ => ())
             Resource.run(io)
                 .handle(Abort.run)
                 .map {
@@ -168,8 +168,8 @@ class ResourceTest extends Test:
         "release fails" in run {
             var acquired = false
             var released = false
-            val io = Resource.acquireRelease(Sync { acquired = true; "resource" }) { _ =>
-                Sync {
+            val io = Resource.acquireRelease(Sync.io { acquired = true; "resource" }) { _ =>
+                Sync.io {
                     released = true
                     throw TestException
                 }
@@ -184,7 +184,7 @@ class ResourceTest extends Test:
 
         "ensure fails" in run {
             var ensureCalled = false
-            val io           = Resource.ensure(Sync { ensureCalled = true; throw TestException })
+            val io           = Resource.ensure(Sync.io { ensureCalled = true; throw TestException })
             Resource.run(io)
                 .map(_ => assert(ensureCalled))
 
@@ -211,7 +211,7 @@ class ResourceTest extends Test:
         "cleans up resources in parallel" in run {
             Latch.init(3).map { latch =>
                 def makeResource(id: Int) =
-                    Resource.acquireRelease(Sync(id))(_ => latch.release)
+                    Resource.acquireRelease(Sync.io(id))(_ => latch.release)
 
                 val resources = Kyo.foreach(1 to 3)(makeResource)
 
@@ -227,7 +227,7 @@ class ResourceTest extends Test:
         "respects parallelism limit" in run {
             AtomicInt.init.map { counter =>
                 def makeResource(id: Int) =
-                    Resource.acquireRelease(Sync(id)) { _ =>
+                    Resource.acquireRelease(Sync.io(id)) { _ =>
                         for
                             current <- counter.getAndIncrement
                             _       <- Async.sleep(1.millis)
@@ -297,7 +297,7 @@ class ResourceTest extends Test:
                     _ <- Resource.ensure {
                         Async.sleep(25.millis).andThen { secondFinalizerCalled = true }
                     }
-                    _ <- Sync(Abort.fail("Fail after acquiring resources"))
+                    _ <- Sync.io(Abort.fail("Fail after acquiring resources"))
                 yield ()
 
             Resource.run(io)

--- a/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
@@ -156,7 +156,7 @@ class ResourceTest extends Test:
         case object TestException extends NoStackTrace
 
         "acquire fails" in run {
-            val io = Resource.acquireRelease(Sync.io[Int, Any](throw TestException))(_ => ())
+            val io = Resource.acquireRelease(Sync.defer[Int, Any](throw TestException))(_ => ())
             Resource.run(io)
                 .handle(Abort.run)
                 .map {
@@ -168,8 +168,8 @@ class ResourceTest extends Test:
         "release fails" in run {
             var acquired = false
             var released = false
-            val io = Resource.acquireRelease(Sync.io { acquired = true; "resource" }) { _ =>
-                Sync.io {
+            val io = Resource.acquireRelease(Sync.defer { acquired = true; "resource" }) { _ =>
+                Sync.defer {
                     released = true
                     throw TestException
                 }
@@ -184,7 +184,7 @@ class ResourceTest extends Test:
 
         "ensure fails" in run {
             var ensureCalled = false
-            val io           = Resource.ensure(Sync.io { ensureCalled = true; throw TestException })
+            val io           = Resource.ensure(Sync.defer { ensureCalled = true; throw TestException })
             Resource.run(io)
                 .map(_ => assert(ensureCalled))
 
@@ -211,7 +211,7 @@ class ResourceTest extends Test:
         "cleans up resources in parallel" in run {
             Latch.init(3).map { latch =>
                 def makeResource(id: Int) =
-                    Resource.acquireRelease(Sync.io(id))(_ => latch.release)
+                    Resource.acquireRelease(Sync.defer(id))(_ => latch.release)
 
                 val resources = Kyo.foreach(1 to 3)(makeResource)
 
@@ -227,7 +227,7 @@ class ResourceTest extends Test:
         "respects parallelism limit" in run {
             AtomicInt.init.map { counter =>
                 def makeResource(id: Int) =
-                    Resource.acquireRelease(Sync.io(id)) { _ =>
+                    Resource.acquireRelease(Sync.defer(id)) { _ =>
                         for
                             current <- counter.getAndIncrement
                             _       <- Async.sleep(1.millis)
@@ -297,7 +297,7 @@ class ResourceTest extends Test:
                     _ <- Resource.ensure {
                         Async.sleep(25.millis).andThen { secondFinalizerCalled = true }
                     }
-                    _ <- Sync.io(Abort.fail("Fail after acquiring resources"))
+                    _ <- Sync.defer(Abort.fail("Fail after acquiring resources"))
                 yield ()
 
             Resource.run(io)

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -133,7 +133,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12, par, Int.MaxValue)
-                        s2 = stream.mapPar(par, buf)(i => Sync.io(i + 1))
+                        s2 = stream.mapPar(par, buf)(i => Sync.defer(i + 1))
                         res <- s2.run
                     yield assert(
                         res == (2 to 13)
@@ -168,7 +168,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
-                        s2 = stream.mapParUnordered(par, buf)(i => Sync.io(i + 1))
+                        s2 = stream.mapParUnordered(par, buf)(i => Sync.defer(i + 1))
                         res <- s2.run
                     yield assert(
                         res.toSet == (2 to 13).toSet
@@ -205,7 +205,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
-                        s2 = stream.mapChunkPar(par, buf)(c => Sync.io(c.map(_ + 1)))
+                        s2 = stream.mapChunkPar(par, buf)(c => Sync.defer(c.map(_ + 1)))
                         res <- s2.run
                     yield assert(
                         res == (2 to 13)
@@ -447,7 +447,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
-                        s2 = stream.mapChunkParUnordered(par, buf)(c => Sync.io(c.map(_ + 1)))
+                        s2 = stream.mapChunkParUnordered(par, buf)(c => Sync.defer(c.map(_ + 1)))
                         res <- s2.run
                     yield assert(
                         res.toSet == (2 to 13).toSet

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -133,7 +133,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12, par, Int.MaxValue)
-                        s2 = stream.mapPar(par, buf)(i => Sync(i + 1))
+                        s2 = stream.mapPar(par, buf)(i => Sync.io(i + 1))
                         res <- s2.run
                     yield assert(
                         res == (2 to 13)
@@ -168,7 +168,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
-                        s2 = stream.mapParUnordered(par, buf)(i => Sync(i + 1))
+                        s2 = stream.mapParUnordered(par, buf)(i => Sync.io(i + 1))
                         res <- s2.run
                     yield assert(
                         res.toSet == (2 to 13).toSet
@@ -205,7 +205,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
-                        s2 = stream.mapChunkPar(par, buf)(c => Sync(c.map(_ + 1)))
+                        s2 = stream.mapChunkPar(par, buf)(c => Sync.io(c.map(_ + 1)))
                         res <- s2.run
                     yield assert(
                         res == (2 to 13)
@@ -447,7 +447,7 @@ class StreamCoreExtensionsTest extends Test:
                     for
                         par <- Choice.eval(1, 2, 4, Async.defaultConcurrency, 1024)
                         buf <- Choice.eval(1, 4, 5, 8, 12)
-                        s2 = stream.mapChunkParUnordered(par, buf)(c => Sync(c.map(_ + 1)))
+                        s2 = stream.mapChunkParUnordered(par, buf)(c => Sync.io(c.map(_ + 1)))
                         res <- s2.run
                     yield assert(
                         res.toSet == (2 to 13).toSet

--- a/kyo-core/shared/src/test/scala/kyo/SyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SyncTest.scala
@@ -9,7 +9,7 @@ class SyncTest extends Test:
         "execution" in run {
             var called = false
             val v =
-                Sync.io {
+                Sync.defer {
                     called = true
                     1
                 }
@@ -24,7 +24,7 @@ class SyncTest extends Test:
             var called = false
             val v =
                 Env.get[Int].map { i =>
-                    Sync.io {
+                    Sync.defer {
                         called = true
                         i
                     }
@@ -44,10 +44,10 @@ class SyncTest extends Test:
             def fail: Int = throw ex
 
             val ios = List(
-                Sync.io(fail),
-                Sync.io(fail).map(_ + 1),
-                Sync.io(1).map(_ => fail),
-                Sync.io(Sync.io(1)).map(_ => fail)
+                Sync.defer(fail),
+                Sync.defer(fail).map(_ + 1),
+                Sync.defer(1).map(_ => fail),
+                Sync.defer(Sync.defer(1)).map(_ => fail)
             )
             ios.foreach { io =>
                 assert(Try(Sync.Unsafe.evalOrThrow(io)) == Try(fail))
@@ -57,7 +57,7 @@ class SyncTest extends Test:
         "stack-safe" in run {
             val frames = 10000
             def loop(i: Int): Int < Sync =
-                Sync.io {
+                Sync.defer {
                     if i < frames then
                         loop(i + 1)
                     else
@@ -72,7 +72,7 @@ class SyncTest extends Test:
         "execution" in run {
             var called = false
             val v: Int < Sync =
-                Sync.io {
+                Sync.defer {
                     called = true
                     1
                 }
@@ -85,7 +85,7 @@ class SyncTest extends Test:
         "stack-safe" in run {
             val frames = 100000
             def loop(i: Int): Assertion < Sync =
-                Sync.io {
+                Sync.defer {
                     if i < frames then
                         loop(i + 1)
                     else
@@ -99,10 +99,10 @@ class SyncTest extends Test:
             def fail: Int = throw ex
 
             val ios = List(
-                Sync.io(fail),
-                Sync.io(fail).map(_ + 1),
-                Sync.io(1).map(_ => fail),
-                Sync.io(Sync.io(1)).map(_ => fail)
+                Sync.defer(fail),
+                Sync.defer(fail).map(_ + 1),
+                Sync.defer(1).map(_ => fail),
+                Sync.defer(Sync.defer(1)).map(_ => fail)
             )
             ios.foreach { io =>
                 assert(Try(Sync.Unsafe.evalOrThrow(io)) == Try(fail))
@@ -123,7 +123,7 @@ class SyncTest extends Test:
             val ex     = new Exception
             var called = false
             Abort.run[Any](Sync.ensure { called = true } {
-                Sync.io[Int, Any](throw ex)
+                Sync.defer[Int, Any](throw ex)
             }).map { result =>
                 assert(result == Result.panic(ex))
                 assert(called)
@@ -145,13 +145,13 @@ class SyncTest extends Test:
     "evalOrThrow" - {
         import AllowUnsafe.embrace.danger
         "success" in run {
-            val result = Sync.Unsafe.evalOrThrow(Sync.io(42))
+            val result = Sync.Unsafe.evalOrThrow(Sync.defer(42))
             assert(result == 42)
         }
 
         "throws exceptions" in run {
             val ex = new Exception("test error")
-            val io = Sync.io[Int, Any](throw ex)
+            val io = Sync.defer[Int, Any](throw ex)
 
             val caught = intercept[Exception] {
                 Sync.Unsafe.evalOrThrow(io)
@@ -161,7 +161,7 @@ class SyncTest extends Test:
 
         "propagates nested exceptions" in run {
             val ex = new Exception("nested error")
-            val io = Sync.io(Sync.io(throw ex))
+            val io = Sync.defer(Sync.defer(throw ex))
 
             val caught = intercept[Exception] {
                 Sync.Unsafe.evalOrThrow(io)
@@ -170,7 +170,7 @@ class SyncTest extends Test:
         }
 
         "works with mapped values" in run {
-            val result = Sync.Unsafe.evalOrThrow(Sync.io(21).map(_ * 2))
+            val result = Sync.Unsafe.evalOrThrow(Sync.defer(21).map(_ * 2))
             assert(result == 42)
         }
     }
@@ -193,7 +193,7 @@ class SyncTest extends Test:
 
         "preserves Nothing as most specific error type" in {
             typeCheckFailure("""
-                val io: Int < Sync = Sync.io {
+                val io: Int < Sync = Sync.defer {
                     Abort.fail[String]("error")
                 }
             """)(

--- a/kyo-core/shared/src/test/scala/kyo/SyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SyncTest.scala
@@ -9,7 +9,7 @@ class SyncTest extends Test:
         "execution" in run {
             var called = false
             val v =
-                Sync {
+                Sync.io {
                     called = true
                     1
                 }
@@ -24,7 +24,7 @@ class SyncTest extends Test:
             var called = false
             val v =
                 Env.get[Int].map { i =>
-                    Sync {
+                    Sync.io {
                         called = true
                         i
                     }
@@ -44,10 +44,10 @@ class SyncTest extends Test:
             def fail: Int = throw ex
 
             val ios = List(
-                Sync(fail),
-                Sync(fail).map(_ + 1),
-                Sync(1).map(_ => fail),
-                Sync(Sync(1)).map(_ => fail)
+                Sync.io(fail),
+                Sync.io(fail).map(_ + 1),
+                Sync.io(1).map(_ => fail),
+                Sync.io(Sync.io(1)).map(_ => fail)
             )
             ios.foreach { io =>
                 assert(Try(Sync.Unsafe.evalOrThrow(io)) == Try(fail))
@@ -57,7 +57,7 @@ class SyncTest extends Test:
         "stack-safe" in run {
             val frames = 10000
             def loop(i: Int): Int < Sync =
-                Sync {
+                Sync.io {
                     if i < frames then
                         loop(i + 1)
                     else
@@ -72,7 +72,7 @@ class SyncTest extends Test:
         "execution" in run {
             var called = false
             val v: Int < Sync =
-                Sync {
+                Sync.io {
                     called = true
                     1
                 }
@@ -85,7 +85,7 @@ class SyncTest extends Test:
         "stack-safe" in run {
             val frames = 100000
             def loop(i: Int): Assertion < Sync =
-                Sync {
+                Sync.io {
                     if i < frames then
                         loop(i + 1)
                     else
@@ -99,10 +99,10 @@ class SyncTest extends Test:
             def fail: Int = throw ex
 
             val ios = List(
-                Sync(fail),
-                Sync(fail).map(_ + 1),
-                Sync(1).map(_ => fail),
-                Sync(Sync(1)).map(_ => fail)
+                Sync.io(fail),
+                Sync.io(fail).map(_ + 1),
+                Sync.io(1).map(_ => fail),
+                Sync.io(Sync.io(1)).map(_ => fail)
             )
             ios.foreach { io =>
                 assert(Try(Sync.Unsafe.evalOrThrow(io)) == Try(fail))
@@ -123,7 +123,7 @@ class SyncTest extends Test:
             val ex     = new Exception
             var called = false
             Abort.run[Any](Sync.ensure { called = true } {
-                Sync[Int, Any](throw ex)
+                Sync.io[Int, Any](throw ex)
             }).map { result =>
                 assert(result == Result.panic(ex))
                 assert(called)
@@ -145,13 +145,13 @@ class SyncTest extends Test:
     "evalOrThrow" - {
         import AllowUnsafe.embrace.danger
         "success" in run {
-            val result = Sync.Unsafe.evalOrThrow(Sync(42))
+            val result = Sync.Unsafe.evalOrThrow(Sync.io(42))
             assert(result == 42)
         }
 
         "throws exceptions" in run {
             val ex = new Exception("test error")
-            val io = Sync[Int, Any](throw ex)
+            val io = Sync.io[Int, Any](throw ex)
 
             val caught = intercept[Exception] {
                 Sync.Unsafe.evalOrThrow(io)
@@ -161,7 +161,7 @@ class SyncTest extends Test:
 
         "propagates nested exceptions" in run {
             val ex = new Exception("nested error")
-            val io = Sync(Sync(throw ex))
+            val io = Sync.io(Sync.io(throw ex))
 
             val caught = intercept[Exception] {
                 Sync.Unsafe.evalOrThrow(io)
@@ -170,7 +170,7 @@ class SyncTest extends Test:
         }
 
         "works with mapped values" in run {
-            val result = Sync.Unsafe.evalOrThrow(Sync(21).map(_ * 2))
+            val result = Sync.Unsafe.evalOrThrow(Sync.io(21).map(_ * 2))
             assert(result == 42)
         }
     }
@@ -193,7 +193,7 @@ class SyncTest extends Test:
 
         "preserves Nothing as most specific error type" in {
             typeCheckFailure("""
-                val io: Int < Sync = Sync {
+                val io: Int < Sync = Sync.io {
                     Abort.fail[String]("error")
                 }
             """)(

--- a/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
@@ -86,13 +86,13 @@ class SystemTest extends Test:
         val customSystem = new System:
             def unsafe: Unsafe = ???
             def env[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync) =
-                Sync(Maybe("custom_env").asInstanceOf[Maybe[A]])
+                Sync.io(Maybe("custom_env").asInstanceOf[Maybe[A]])
             def property[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync) =
-                Sync(Maybe("custom_property").asInstanceOf[Maybe[A]])
-            def lineSeparator(using Frame): String < Sync = Sync("custom_separator")
-            def userName(using Frame): String < Sync      = Sync("custom_user")
-            def userHome(using Frame): String < Sync      = Sync("custom_home")
-            def operatingSystem(using Frame): OS < Sync   = Sync(OS.AIX)
+                Sync.io(Maybe("custom_property").asInstanceOf[Maybe[A]])
+            def lineSeparator(using Frame): String < Sync = Sync.io("custom_separator")
+            def userName(using Frame): String < Sync      = Sync.io("custom_user")
+            def userHome(using Frame): String < Sync      = Sync.io("custom_home")
+            def operatingSystem(using Frame): OS < Sync   = Sync.io(OS.AIX)
 
         for
             env       <- System.let(customSystem)(System.env[String]("ANY"))

--- a/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
@@ -86,13 +86,13 @@ class SystemTest extends Test:
         val customSystem = new System:
             def unsafe: Unsafe = ???
             def env[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync) =
-                Sync.io(Maybe("custom_env").asInstanceOf[Maybe[A]])
+                Sync.defer(Maybe("custom_env").asInstanceOf[Maybe[A]])
             def property[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync) =
-                Sync.io(Maybe("custom_property").asInstanceOf[Maybe[A]])
-            def lineSeparator(using Frame): String < Sync = Sync.io("custom_separator")
-            def userName(using Frame): String < Sync      = Sync.io("custom_user")
-            def userHome(using Frame): String < Sync      = Sync.io("custom_home")
-            def operatingSystem(using Frame): OS < Sync   = Sync.io(OS.AIX)
+                Sync.defer(Maybe("custom_property").asInstanceOf[Maybe[A]])
+            def lineSeparator(using Frame): String < Sync = Sync.defer("custom_separator")
+            def userName(using Frame): String < Sync      = Sync.defer("custom_user")
+            def userHome(using Frame): String < Sync      = Sync.defer("custom_home")
+            def operatingSystem(using Frame): OS < Sync   = Sync.defer(OS.AIX)
 
         for
             env       <- System.let(customSystem)(System.env[String]("ANY"))

--- a/kyo-direct/shared/src/main/scala/kyo/Direct.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/Direct.scala
@@ -64,8 +64,8 @@ private def nowImpl[A: Type, S: Type](self: Expr[A < S])(using Quotes): Expr[A] 
            |
            |${highlight("""
            |direct {
-           |  val x = Sync.io(1).now     // Get result here
-           |  val y = Sync.io(2).now     // Then get this result
+           |  val x = Sync.defer(1).now     // Get result here
+           |  val y = Sync.defer(2).now     // Then get this result
            |  x + y                 // Use both results
            |}""".stripMargin)}
            |""".stripMargin,
@@ -85,8 +85,8 @@ private def laterImpl[A: Type, S: Type](self: Expr[A < S])(using Quotes): Expr[A
            |${highlight("""
            |// Example: Preserve effects for composition
            |def combination = direct {
-           |  val effect1 = Sync.io(1).later   // Effect preserved
-           |  val effect2 = Sync.io(2).later   // Effect preserved
+           |  val effect1 = Sync.defer(1).later   // Effect preserved
+           |  val effect2 = Sync.defer(2).later   // Effect preserved
            |  (effect1, effect2)          // Return tuple of effects
            |}
            |

--- a/kyo-direct/shared/src/main/scala/kyo/Direct.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/Direct.scala
@@ -64,8 +64,8 @@ private def nowImpl[A: Type, S: Type](self: Expr[A < S])(using Quotes): Expr[A] 
            |
            |${highlight("""
            |direct {
-           |  val x = Sync(1).now     // Get result here
-           |  val y = Sync(2).now     // Then get this result
+           |  val x = Sync.io(1).now     // Get result here
+           |  val y = Sync.io(2).now     // Then get this result
            |  x + y                 // Use both results
            |}""".stripMargin)}
            |""".stripMargin,
@@ -85,8 +85,8 @@ private def laterImpl[A: Type, S: Type](self: Expr[A < S])(using Quotes): Expr[A
            |${highlight("""
            |// Example: Preserve effects for composition
            |def combination = direct {
-           |  val effect1 = Sync(1).later   // Effect preserved
-           |  val effect2 = Sync(2).later   // Effect preserved
+           |  val effect1 = Sync.io(1).later   // Effect preserved
+           |  val effect2 = Sync.io(2).later   // Effect preserved
            |  (effect1, effect2)          // Return tuple of effects
            |}
            |

--- a/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
@@ -157,7 +157,7 @@ private[kyo] object Validate:
                             |direct {
                             |    val value = counter.get.now    // OK - get value first
                             |    val incr = value + 1           // OK - pure operation
-                            |    Sync(incr).now                   // OK - single .now
+                            |    Sync.io(incr).now                   // OK - single .now
                             |}""".stripMargin)}""".stripMargin
                         )
                 }
@@ -172,16 +172,16 @@ private[kyo] object Validate:
                        |${bold("1. Use .now when you need the effect's result immediately:")}
                        |${highlight("""
                        |direct {
-                       |  val x: Int = Sync(1).now      // Get result here
-                       |  val y: Int = x + Sync(2).now  // Use result in next computation
+                       |  val x: Int = Sync.io(1).now      // Get result here
+                       |  val y: Int = x + Sync.io(2).now  // Use result in next computation
                        |  y * 2                       // Use final result
                        |}""".stripMargin)}
                        |
                        |${bold("2. Use .later (advanced) when you want to preserve the effect:")}
                        |${highlight("""
                        |direct {
-                       |  val x: Int < Sync = Sync(1).later    // Keep effect for later
-                       |  val y: Int < Sync = Sync(2).later    // Keep another effect
+                       |  val x: Int < Sync = Sync.io(1).later    // Keep effect for later
+                       |  val y: Int < Sync = Sync.io(2).later    // Keep another effect
                        |  x.now + y.now                    // Sequence effects
                        |}""".stripMargin)}
                        |""".stripMargin
@@ -209,13 +209,13 @@ private[kyo] object Validate:
                     |${highlight("""
                     |// Instead of lazy declarations in direct:
                     |direct {
-                    |  lazy val x = Sync(1).now  // NOT OK - lazy val
+                    |  lazy val x = Sync.io(1).now  // NOT OK - lazy val
                     |  object A               // NOT OK - object
                     |  x + 1
                     |}
                     |
                     |// Define outside direct:
-                    |lazy val x = Sync(1)       // OK - outside
+                    |lazy val x = Sync.io(1)       // OK - outside
                     |object A                 // OK - outside
                     |
                     |// Use inside direct:
@@ -241,13 +241,13 @@ private[kyo] object Validate:
                        |${highlight("""
                        |// Instead of method in direct:
                        |direct {
-                       |  def process(x: Int) = Sync(x).now  // NOT OK
+                       |  def process(x: Int) = Sync.io(x).now  // NOT OK
                        |  process(10)
                        |}
                        |
                        |// Define outside:
                        |def process(x: Int): Int < Sync = direct {
-                       |  Sync(x).now
+                       |  Sync.io(x).now
                        |}
                        |
                        |direct {
@@ -265,7 +265,7 @@ private[kyo] object Validate:
                        |// Instead of try/catch:
                        |direct {
                        |  try {
-                       |    Sync(1).now    // NOT OK
+                       |    Sync.io(1).now    // NOT OK
                        |  } catch {
                        |    case e => handleError(e)
                        |  }
@@ -273,7 +273,7 @@ private[kyo] object Validate:
                        |
                        |// Define the effectful computation:
                        |def computation = direct {
-                       |  Sync(1).now
+                       |  Sync.io(1).now
                        |}
                        |
                        |// Handle the effect direct block:
@@ -323,14 +323,14 @@ private[kyo] object Validate:
                     |direct {
                     |  if condition then
                     |    throw new Exception("error")  // NOT OK - throws exception
-                    |  Sync(1).now
+                    |  Sync.io(1).now
                     |}
                     |
                     |// Use Abort effect:
                     |direct {
                     |  if condition then
                     |    Abort.fail("error").now       // OK - proper error handling
-                    |  else Sync(1).now
+                    |  else Sync.io(1).now
                     |}""".stripMargin)}""".stripMargin
                 )
 

--- a/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
@@ -157,7 +157,7 @@ private[kyo] object Validate:
                             |direct {
                             |    val value = counter.get.now    // OK - get value first
                             |    val incr = value + 1           // OK - pure operation
-                            |    Sync.io(incr).now                   // OK - single .now
+                            |    Sync.defer(incr).now                   // OK - single .now
                             |}""".stripMargin)}""".stripMargin
                         )
                 }
@@ -172,16 +172,16 @@ private[kyo] object Validate:
                        |${bold("1. Use .now when you need the effect's result immediately:")}
                        |${highlight("""
                        |direct {
-                       |  val x: Int = Sync.io(1).now      // Get result here
-                       |  val y: Int = x + Sync.io(2).now  // Use result in next computation
+                       |  val x: Int = Sync.defer(1).now      // Get result here
+                       |  val y: Int = x + Sync.defer(2).now  // Use result in next computation
                        |  y * 2                       // Use final result
                        |}""".stripMargin)}
                        |
                        |${bold("2. Use .later (advanced) when you want to preserve the effect:")}
                        |${highlight("""
                        |direct {
-                       |  val x: Int < Sync = Sync.io(1).later    // Keep effect for later
-                       |  val y: Int < Sync = Sync.io(2).later    // Keep another effect
+                       |  val x: Int < Sync = Sync.defer(1).later    // Keep effect for later
+                       |  val y: Int < Sync = Sync.defer(2).later    // Keep another effect
                        |  x.now + y.now                    // Sequence effects
                        |}""".stripMargin)}
                        |""".stripMargin
@@ -209,13 +209,13 @@ private[kyo] object Validate:
                     |${highlight("""
                     |// Instead of lazy declarations in direct:
                     |direct {
-                    |  lazy val x = Sync.io(1).now  // NOT OK - lazy val
+                    |  lazy val x = Sync.defer(1).now  // NOT OK - lazy val
                     |  object A               // NOT OK - object
                     |  x + 1
                     |}
                     |
                     |// Define outside direct:
-                    |lazy val x = Sync.io(1)       // OK - outside
+                    |lazy val x = Sync.defer(1)       // OK - outside
                     |object A                 // OK - outside
                     |
                     |// Use inside direct:
@@ -241,13 +241,13 @@ private[kyo] object Validate:
                        |${highlight("""
                        |// Instead of method in direct:
                        |direct {
-                       |  def process(x: Int) = Sync.io(x).now  // NOT OK
+                       |  def process(x: Int) = Sync.defer(x).now  // NOT OK
                        |  process(10)
                        |}
                        |
                        |// Define outside:
                        |def process(x: Int): Int < Sync = direct {
-                       |  Sync.io(x).now
+                       |  Sync.defer(x).now
                        |}
                        |
                        |direct {
@@ -265,7 +265,7 @@ private[kyo] object Validate:
                        |// Instead of try/catch:
                        |direct {
                        |  try {
-                       |    Sync.io(1).now    // NOT OK
+                       |    Sync.defer(1).now    // NOT OK
                        |  } catch {
                        |    case e => handleError(e)
                        |  }
@@ -273,7 +273,7 @@ private[kyo] object Validate:
                        |
                        |// Define the effectful computation:
                        |def computation = direct {
-                       |  Sync.io(1).now
+                       |  Sync.defer(1).now
                        |}
                        |
                        |// Handle the effect direct block:
@@ -323,14 +323,14 @@ private[kyo] object Validate:
                     |direct {
                     |  if condition then
                     |    throw new Exception("error")  // NOT OK - throws exception
-                    |  Sync.io(1).now
+                    |  Sync.defer(1).now
                     |}
                     |
                     |// Use Abort effect:
                     |direct {
                     |  if condition then
                     |    Abort.fail("error").now       // OK - proper error handling
-                    |  else Sync.io(1).now
+                    |  else Sync.defer(1).now
                     |}""".stripMargin)}""".stripMargin
                 )
 

--- a/kyo-direct/shared/src/test/scala/kyo/BlockTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/BlockTest.scala
@@ -8,29 +8,29 @@ class BlockTest extends AnyFreeSpec with Assertions:
 
     "assigned run" - {
         "only" in {
-            val i = Sync(1)
+            val i = Sync.io(1)
             runLiftTest(1) {
                 val v = i.now
                 v
             }
         }
         "followed by pure expression" in {
-            val i = Sync(1)
+            val i = Sync.io(1)
             runLiftTest(2) {
                 val v = i.now
                 v + 1
             }
         }
         "followed by impure expression" in {
-            val i = Sync(1)
-            val j = Sync(2)
+            val i = Sync.io(1)
+            val j = Sync.io(2)
             runLiftTest(3) {
                 val v = i.now
                 v + j.now
             }
         }
         "nested" in {
-            val i = Sync(1)
+            val i = Sync.io(1)
             runLiftTest(3) {
                 val v =
                     val r = i.now
@@ -41,21 +41,21 @@ class BlockTest extends AnyFreeSpec with Assertions:
     }
     "unassigned run" - {
         "only" in {
-            val i = Sync(1)
+            val i = Sync.io(1)
             runLiftTest(1) {
                 i.now
             }
         }
         "followed by pure expression" in {
-            val i = Sync(1)
+            val i = Sync.io(1)
             runLiftTest(2) {
                 i.now
                 2
             }
         }
         "followed by impure expression" in {
-            val i = Sync(1)
-            val j = Sync(2)
+            val i = Sync.io(1)
+            val j = Sync.io(2)
             runLiftTest(2) {
                 i.now
                 j.now
@@ -76,7 +76,7 @@ class BlockTest extends AnyFreeSpec with Assertions:
             }
         }
         "followed by impure expression" in {
-            val i = Sync(1)
+            val i = Sync.io(1)
             def a = 2
             runLiftTest(1) {
                 a
@@ -84,8 +84,8 @@ class BlockTest extends AnyFreeSpec with Assertions:
             }
         }
         "using previous defers" in {
-            val i = Sync(1)
-            val j = Sync(2)
+            val i = Sync.io(1)
+            val j = Sync.io(2)
             runLiftTest(3) {
                 val v = i.now
                 v + j.now
@@ -94,14 +94,14 @@ class BlockTest extends AnyFreeSpec with Assertions:
         "using external function" in {
             def a(i: Int, s: String) = i + s.toInt
             runLiftTest(4) {
-                Sync(a(1, "2")).now + a(0, "1")
+                Sync.io(a(1, "2")).now + a(0, "1")
             }
         }
     }
     "complex" - {
         "tuple val pattern" in {
             runLiftTest(3) {
-                val (a, b) = (Sync(1).now, Sync(2).now)
+                val (a, b) = (Sync.io(1).now, Sync.io(2).now)
                 a + b
             }
         }
@@ -109,11 +109,11 @@ class BlockTest extends AnyFreeSpec with Assertions:
             runLiftTest((1, 2, 3)) {
                 val x = 1
                 (
-                    Sync(x).now, {
-                        val a = Sync(2).now
+                    Sync.io(x).now, {
+                        val a = Sync.io(2).now
                         a
                     },
-                    Sync(3).now
+                    Sync.io(3).now
                 )
             }
         }

--- a/kyo-direct/shared/src/test/scala/kyo/BlockTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/BlockTest.scala
@@ -8,29 +8,29 @@ class BlockTest extends AnyFreeSpec with Assertions:
 
     "assigned run" - {
         "only" in {
-            val i = Sync.io(1)
+            val i = Sync.defer(1)
             runLiftTest(1) {
                 val v = i.now
                 v
             }
         }
         "followed by pure expression" in {
-            val i = Sync.io(1)
+            val i = Sync.defer(1)
             runLiftTest(2) {
                 val v = i.now
                 v + 1
             }
         }
         "followed by impure expression" in {
-            val i = Sync.io(1)
-            val j = Sync.io(2)
+            val i = Sync.defer(1)
+            val j = Sync.defer(2)
             runLiftTest(3) {
                 val v = i.now
                 v + j.now
             }
         }
         "nested" in {
-            val i = Sync.io(1)
+            val i = Sync.defer(1)
             runLiftTest(3) {
                 val v =
                     val r = i.now
@@ -41,21 +41,21 @@ class BlockTest extends AnyFreeSpec with Assertions:
     }
     "unassigned run" - {
         "only" in {
-            val i = Sync.io(1)
+            val i = Sync.defer(1)
             runLiftTest(1) {
                 i.now
             }
         }
         "followed by pure expression" in {
-            val i = Sync.io(1)
+            val i = Sync.defer(1)
             runLiftTest(2) {
                 i.now
                 2
             }
         }
         "followed by impure expression" in {
-            val i = Sync.io(1)
-            val j = Sync.io(2)
+            val i = Sync.defer(1)
+            val j = Sync.defer(2)
             runLiftTest(2) {
                 i.now
                 j.now
@@ -76,7 +76,7 @@ class BlockTest extends AnyFreeSpec with Assertions:
             }
         }
         "followed by impure expression" in {
-            val i = Sync.io(1)
+            val i = Sync.defer(1)
             def a = 2
             runLiftTest(1) {
                 a
@@ -84,8 +84,8 @@ class BlockTest extends AnyFreeSpec with Assertions:
             }
         }
         "using previous defers" in {
-            val i = Sync.io(1)
-            val j = Sync.io(2)
+            val i = Sync.defer(1)
+            val j = Sync.defer(2)
             runLiftTest(3) {
                 val v = i.now
                 v + j.now
@@ -94,14 +94,14 @@ class BlockTest extends AnyFreeSpec with Assertions:
         "using external function" in {
             def a(i: Int, s: String) = i + s.toInt
             runLiftTest(4) {
-                Sync.io(a(1, "2")).now + a(0, "1")
+                Sync.defer(a(1, "2")).now + a(0, "1")
             }
         }
     }
     "complex" - {
         "tuple val pattern" in {
             runLiftTest(3) {
-                val (a, b) = (Sync.io(1).now, Sync.io(2).now)
+                val (a, b) = (Sync.defer(1).now, Sync.defer(2).now)
                 a + b
             }
         }
@@ -109,11 +109,11 @@ class BlockTest extends AnyFreeSpec with Assertions:
             runLiftTest((1, 2, 3)) {
                 val x = 1
                 (
-                    Sync.io(x).now, {
-                        val a = Sync.io(2).now
+                    Sync.defer(x).now, {
+                        val a = Sync.defer(2).now
                         a
                     },
-                    Sync.io(3).now
+                    Sync.defer(3).now
                 )
             }
         }

--- a/kyo-direct/shared/src/test/scala/kyo/BooleanTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/BooleanTest.scala
@@ -19,51 +19,51 @@ class BooleanTest extends AnyFreeSpec with Assertions:
         "pure/impure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    True && Sync(True).now
+                    True && Sync.io(True).now
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    True && Sync(False).now
+                    True && Sync.io(False).now
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    False && Sync(NotExpected).now
+                    False && Sync.io(NotExpected).now
                 }
             }
         }
         "impure/pure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    Sync(True).now && True
+                    Sync.io(True).now && True
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    Sync(True).now && False
+                    Sync.io(True).now && False
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    Sync(False).now && NotExpected
+                    Sync.io(False).now && NotExpected
                 }
             }
         }
         "impure/impure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    Sync(True).now && Sync(True).now
+                    Sync.io(True).now && Sync.io(True).now
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    Sync(True).now && Sync(False).now
+                    Sync.io(True).now && Sync.io(False).now
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    Sync(False).now && Sync(NotExpected).now
+                    Sync.io(False).now && Sync.io(NotExpected).now
                 }
             }
         }
@@ -77,51 +77,51 @@ class BooleanTest extends AnyFreeSpec with Assertions:
         "pure/impure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    False || Sync(False).now
+                    False || Sync.io(False).now
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    False || Sync(True).now
+                    False || Sync.io(True).now
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    True || Sync(NotExpected).now
+                    True || Sync.io(NotExpected).now
                 }
             }
         }
         "impure/pure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    Sync(False).now || False
+                    Sync.io(False).now || False
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    Sync(False).now || True
+                    Sync.io(False).now || True
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    Sync(True).now || NotExpected
+                    Sync.io(True).now || NotExpected
                 }
             }
         }
         "impure/impure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    Sync(False).now || Sync(False).now
+                    Sync.io(False).now || Sync.io(False).now
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    Sync(False).now || Sync(True).now
+                    Sync.io(False).now || Sync.io(True).now
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    Sync(True).now || Sync(NotExpected).now
+                    Sync.io(True).now || Sync.io(NotExpected).now
                 }
             }
         }

--- a/kyo-direct/shared/src/test/scala/kyo/BooleanTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/BooleanTest.scala
@@ -19,51 +19,51 @@ class BooleanTest extends AnyFreeSpec with Assertions:
         "pure/impure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    True && Sync.io(True).now
+                    True && Sync.defer(True).now
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    True && Sync.io(False).now
+                    True && Sync.defer(False).now
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    False && Sync.io(NotExpected).now
+                    False && Sync.defer(NotExpected).now
                 }
             }
         }
         "impure/pure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    Sync.io(True).now && True
+                    Sync.defer(True).now && True
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    Sync.io(True).now && False
+                    Sync.defer(True).now && False
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    Sync.io(False).now && NotExpected
+                    Sync.defer(False).now && NotExpected
                 }
             }
         }
         "impure/impure" - {
             "True/True" in {
                 runLiftTest(True) {
-                    Sync.io(True).now && Sync.io(True).now
+                    Sync.defer(True).now && Sync.defer(True).now
                 }
             }
             "True/False" in {
                 runLiftTest(False) {
-                    Sync.io(True).now && Sync.io(False).now
+                    Sync.defer(True).now && Sync.defer(False).now
                 }
             }
             "False/NotExpected" in {
                 runLiftTest(False) {
-                    Sync.io(False).now && Sync.io(NotExpected).now
+                    Sync.defer(False).now && Sync.defer(NotExpected).now
                 }
             }
         }
@@ -77,51 +77,51 @@ class BooleanTest extends AnyFreeSpec with Assertions:
         "pure/impure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    False || Sync.io(False).now
+                    False || Sync.defer(False).now
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    False || Sync.io(True).now
+                    False || Sync.defer(True).now
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    True || Sync.io(NotExpected).now
+                    True || Sync.defer(NotExpected).now
                 }
             }
         }
         "impure/pure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    Sync.io(False).now || False
+                    Sync.defer(False).now || False
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    Sync.io(False).now || True
+                    Sync.defer(False).now || True
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    Sync.io(True).now || NotExpected
+                    Sync.defer(True).now || NotExpected
                 }
             }
         }
         "impure/impure" - {
             "False/False" in {
                 runLiftTest(False) {
-                    Sync.io(False).now || Sync.io(False).now
+                    Sync.defer(False).now || Sync.defer(False).now
                 }
             }
             "False/True" in {
                 runLiftTest(True) {
-                    Sync.io(False).now || Sync.io(True).now
+                    Sync.defer(False).now || Sync.defer(True).now
                 }
             }
             "True/NotExpected" in {
                 runLiftTest(True) {
-                    Sync.io(True).now || Sync.io(NotExpected).now
+                    Sync.defer(True).now || Sync.defer(NotExpected).now
                 }
             }
         }

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -6,7 +6,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             var willFail = 1
-            Sync(1).now
+            Sync.io(1).now
           }
         """)(
             "`var` declarations are not allowed inside a `direct` block."
@@ -17,7 +17,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             return 42
-            Sync(1).now
+            Sync.io(1).now
           }
         """)(
             "Exception occurred while executing macro expansion"
@@ -28,7 +28,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             direct {
-              Sync(1).now
+              Sync.io(1).now
             }
           }
         """)(
@@ -40,7 +40,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             lazy val x = 10
-            Sync(1).now
+            Sync.io(1).now
           }
         """)(
             "`lazy val` and `object` declarations are not allowed inside a `direct` block."
@@ -50,7 +50,7 @@ class HygieneTest extends Test:
     "function containing await" in {
         typeCheckFailure("""
           direct {
-            def foo() = Sync(1).now
+            def foo() = Sync.io(1).now
             foo()
           }
         """)(
@@ -62,9 +62,9 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             try {
-              Sync(1).now
+              Sync.io(1).now
             } catch {
-              case _: Exception => Sync(2).now
+              case _: Exception => Sync.io(2).now
             }
           }
         """)(
@@ -76,7 +76,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             class A(val x: Int)
-            Sync(1).now
+            Sync.io(1).now
           }
         """)(
             "`class` and `trait` declarations are not allowed inside `direct` blocks."
@@ -87,7 +87,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             object A
-            Sync(1).now
+            Sync.io(1).now
           }
         """)(
             "`class` and `trait` declarations are not allowed inside `direct` blocks."
@@ -98,7 +98,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             trait A
-            Sync(1).now
+            Sync.io(1).now
           }
         """)(
             "`class` and `trait` declarations are not allowed inside `direct` blocks."
@@ -109,8 +109,8 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             for {
-              x <- Sync(1).now
-              y <- Sync(2).now
+              x <- Sync.io(1).now
+              y <- Sync.io(2).now
             } yield x + y
           }
         """)(
@@ -122,7 +122,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             try {
-              Sync(1).now
+              Sync.io(1).now
             }
           }
         """)(
@@ -134,7 +134,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             try {
-              Sync(1).now
+              Sync.io(1).now
             } finally {
               println("Cleanup")
             }
@@ -148,7 +148,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           class A(x: => String)
           direct {
-              new A(Sync("blah").now)
+              new A(Sync.io("blah").now)
           }
         """)(
             "Can't find AsyncShift (Found:    cps.runtime.CpsMonadSelfAsyncShift[[A] =>> A < kyo.Sync"
@@ -158,7 +158,7 @@ class HygieneTest extends Test:
     "match expression without cases" in {
         typeCheckFailure("""
           direct {
-            Sync(1).now match {}
+            Sync.io(1).now match {}
           }
         """)(
             "case' expected, but '}' found"
@@ -169,8 +169,8 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             for {
-              x <- Sync(1).now
-              y <- Sync(2).now
+              x <- Sync.io(1).now
+              y <- Sync.io(2).now
             } x + y
           }
         """)(
@@ -182,7 +182,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             def outer() = {
-              def inner() = Sync(1).now
+              def inner() = Sync.io(1).now
               inner()
             }
             outer()
@@ -195,7 +195,7 @@ class HygieneTest extends Test:
     "lambdas with await" in {
         typeCheckFailure("""
           direct {
-            val f = (x: Int) => Sync(1).now + x
+            val f = (x: Int) => Sync.io(1).now + x
             f(10)
           }
         """)(
@@ -206,7 +206,7 @@ class HygieneTest extends Test:
     "throw" in {
         typeCheckFailure("""
           direct {
-              if Sync("foo").now == "bar" then
+              if Sync.io("foo").now == "bar" then
                   throw new Exception
               else
                   2
@@ -220,7 +220,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
               val x = synchronized(1)
-              Sync(x).now
+              Sync.io(x).now
           }
         """)(
             "`synchronized` blocks are not allowed inside a `direct` block."
@@ -228,17 +228,19 @@ class HygieneTest extends Test:
     }
 
     "nested var" in {
-        typeCheckFailure("""direct {{var x = 1; Sync(x)}.now}""")("`var` declarations are not allowed inside a `direct` block.")
+        typeCheckFailure("""direct {{var x = 1; Sync.io(x)}.now}""")("`var` declarations are not allowed inside a `direct` block.")
     }
 
     "nested nested var" in {
-        typeCheckFailure("""direct {{val y = 1;{var x = 1; Sync(x)}}.now}""")("`var` declarations are not allowed inside a `direct` block.")
+        typeCheckFailure("""direct {{val y = 1;{var x = 1; Sync.io(x)}}.now}""")(
+            "`var` declarations are not allowed inside a `direct` block."
+        )
     }
 
     "nested now in def" in {
         typeCheckFailure("""
              direct {
-               val i = Sync(1).later
+               val i = Sync.io(1).later
                def f =  i.now > 0
                f
              }""")("Method definitions containing .now are not supported inside `direct` blocks.")

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -6,7 +6,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             var willFail = 1
-            Sync.io(1).now
+            Sync.defer(1).now
           }
         """)(
             "`var` declarations are not allowed inside a `direct` block."
@@ -17,7 +17,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             return 42
-            Sync.io(1).now
+            Sync.defer(1).now
           }
         """)(
             "Exception occurred while executing macro expansion"
@@ -28,7 +28,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             direct {
-              Sync.io(1).now
+              Sync.defer(1).now
             }
           }
         """)(
@@ -40,7 +40,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             lazy val x = 10
-            Sync.io(1).now
+            Sync.defer(1).now
           }
         """)(
             "`lazy val` and `object` declarations are not allowed inside a `direct` block."
@@ -50,7 +50,7 @@ class HygieneTest extends Test:
     "function containing await" in {
         typeCheckFailure("""
           direct {
-            def foo() = Sync.io(1).now
+            def foo() = Sync.defer(1).now
             foo()
           }
         """)(
@@ -62,9 +62,9 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             try {
-              Sync.io(1).now
+              Sync.defer(1).now
             } catch {
-              case _: Exception => Sync.io(2).now
+              case _: Exception => Sync.defer(2).now
             }
           }
         """)(
@@ -76,7 +76,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             class A(val x: Int)
-            Sync.io(1).now
+            Sync.defer(1).now
           }
         """)(
             "`class` and `trait` declarations are not allowed inside `direct` blocks."
@@ -87,7 +87,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             object A
-            Sync.io(1).now
+            Sync.defer(1).now
           }
         """)(
             "`class` and `trait` declarations are not allowed inside `direct` blocks."
@@ -98,7 +98,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             trait A
-            Sync.io(1).now
+            Sync.defer(1).now
           }
         """)(
             "`class` and `trait` declarations are not allowed inside `direct` blocks."
@@ -109,8 +109,8 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             for {
-              x <- Sync.io(1).now
-              y <- Sync.io(2).now
+              x <- Sync.defer(1).now
+              y <- Sync.defer(2).now
             } yield x + y
           }
         """)(
@@ -122,7 +122,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             try {
-              Sync.io(1).now
+              Sync.defer(1).now
             }
           }
         """)(
@@ -134,7 +134,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             try {
-              Sync.io(1).now
+              Sync.defer(1).now
             } finally {
               println("Cleanup")
             }
@@ -148,7 +148,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           class A(x: => String)
           direct {
-              new A(Sync.io("blah").now)
+              new A(Sync.defer("blah").now)
           }
         """)(
             "Can't find AsyncShift (Found:    cps.runtime.CpsMonadSelfAsyncShift[[A] =>> A < kyo.Sync"
@@ -158,7 +158,7 @@ class HygieneTest extends Test:
     "match expression without cases" in {
         typeCheckFailure("""
           direct {
-            Sync.io(1).now match {}
+            Sync.defer(1).now match {}
           }
         """)(
             "case' expected, but '}' found"
@@ -169,8 +169,8 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             for {
-              x <- Sync.io(1).now
-              y <- Sync.io(2).now
+              x <- Sync.defer(1).now
+              y <- Sync.defer(2).now
             } x + y
           }
         """)(
@@ -182,7 +182,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
             def outer() = {
-              def inner() = Sync.io(1).now
+              def inner() = Sync.defer(1).now
               inner()
             }
             outer()
@@ -195,7 +195,7 @@ class HygieneTest extends Test:
     "lambdas with await" in {
         typeCheckFailure("""
           direct {
-            val f = (x: Int) => Sync.io(1).now + x
+            val f = (x: Int) => Sync.defer(1).now + x
             f(10)
           }
         """)(
@@ -206,7 +206,7 @@ class HygieneTest extends Test:
     "throw" in {
         typeCheckFailure("""
           direct {
-              if Sync.io("foo").now == "bar" then
+              if Sync.defer("foo").now == "bar" then
                   throw new Exception
               else
                   2
@@ -220,7 +220,7 @@ class HygieneTest extends Test:
         typeCheckFailure("""
           direct {
               val x = synchronized(1)
-              Sync.io(x).now
+              Sync.defer(x).now
           }
         """)(
             "`synchronized` blocks are not allowed inside a `direct` block."
@@ -228,11 +228,11 @@ class HygieneTest extends Test:
     }
 
     "nested var" in {
-        typeCheckFailure("""direct {{var x = 1; Sync.io(x)}.now}""")("`var` declarations are not allowed inside a `direct` block.")
+        typeCheckFailure("""direct {{var x = 1; Sync.defer(x)}.now}""")("`var` declarations are not allowed inside a `direct` block.")
     }
 
     "nested nested var" in {
-        typeCheckFailure("""direct {{val y = 1;{var x = 1; Sync.io(x)}}.now}""")(
+        typeCheckFailure("""direct {{val y = 1;{var x = 1; Sync.defer(x)}}.now}""")(
             "`var` declarations are not allowed inside a `direct` block."
         )
     }
@@ -240,7 +240,7 @@ class HygieneTest extends Test:
     "nested now in def" in {
         typeCheckFailure("""
              direct {
-               val i = Sync.io(1).later
+               val i = Sync.defer(1).later
                def f =  i.now > 0
                f
              }""")("Method definitions containing .now are not supported inside `direct` blocks.")

--- a/kyo-direct/shared/src/test/scala/kyo/IfTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/IfTest.scala
@@ -9,22 +9,22 @@ class IfTest extends AnyFreeSpec with Assertions:
     "unlifted condition / ifelse" - {
         "pure / pure" in {
             runLiftTest(2) {
-                if Sync.io(1).now == 1 then 2 else 3
+                if Sync.defer(1).now == 1 then 2 else 3
             }
         }
         "pure / impure" in {
             runLiftTest(2) {
-                if Sync.io(1).now == 1 then Sync.io(2).now else 3
+                if Sync.defer(1).now == 1 then Sync.defer(2).now else 3
             }
         }
         "impure / pure" in {
             runLiftTest(1) {
-                Sync.io(1).now
+                Sync.defer(1).now
             }
         }
         "impure / impure" in {
             runLiftTest(3) {
-                if Sync.io(1).now == 2 then Sync.io(2).now else Sync.io(3).now
+                if Sync.defer(1).now == 2 then Sync.defer(2).now else Sync.defer(3).now
             }
         }
     }
@@ -36,17 +36,17 @@ class IfTest extends AnyFreeSpec with Assertions:
         }
         "pure / impure" in {
             runLiftTest(2) {
-                if 1 == 1 then Sync.io(2).now else 3
+                if 1 == 1 then Sync.defer(2).now else 3
             }
         }
         "impure / pure" in {
             runLiftTest(2) {
-                if 1 == 1 then 2 else Sync.io(3).now
+                if 1 == 1 then 2 else Sync.defer(3).now
             }
         }
         "impure / impure" in {
             runLiftTest(3) {
-                if 1 == 2 then Sync.io(2).now else Sync.io(3).now
+                if 1 == 2 then Sync.defer(2).now else Sync.defer(3).now
             }
         }
     }

--- a/kyo-direct/shared/src/test/scala/kyo/IfTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/IfTest.scala
@@ -9,22 +9,22 @@ class IfTest extends AnyFreeSpec with Assertions:
     "unlifted condition / ifelse" - {
         "pure / pure" in {
             runLiftTest(2) {
-                if Sync(1).now == 1 then 2 else 3
+                if Sync.io(1).now == 1 then 2 else 3
             }
         }
         "pure / impure" in {
             runLiftTest(2) {
-                if Sync(1).now == 1 then Sync(2).now else 3
+                if Sync.io(1).now == 1 then Sync.io(2).now else 3
             }
         }
         "impure / pure" in {
             runLiftTest(1) {
-                Sync(1).now
+                Sync.io(1).now
             }
         }
         "impure / impure" in {
             runLiftTest(3) {
-                if Sync(1).now == 2 then Sync(2).now else Sync(3).now
+                if Sync.io(1).now == 2 then Sync.io(2).now else Sync.io(3).now
             }
         }
     }
@@ -36,17 +36,17 @@ class IfTest extends AnyFreeSpec with Assertions:
         }
         "pure / impure" in {
             runLiftTest(2) {
-                if 1 == 1 then Sync(2).now else 3
+                if 1 == 1 then Sync.io(2).now else 3
             }
         }
         "impure / pure" in {
             runLiftTest(2) {
-                if 1 == 1 then 2 else Sync(3).now
+                if 1 == 1 then 2 else Sync.io(3).now
             }
         }
         "impure / impure" in {
             runLiftTest(3) {
-                if 1 == 2 then Sync(2).now else Sync(3).now
+                if 1 == 2 then Sync.io(2).now else Sync.io(3).now
             }
         }
     }

--- a/kyo-direct/shared/src/test/scala/kyo/PatMatchTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PatMatchTest.scala
@@ -112,7 +112,7 @@ class PatMatchTest extends AnyFreeSpec with Assertions:
     "misc" - {
         "val patmatch" in {
             runLiftTest(1) {
-                val Some(a) = Sync.io(Some(1)).now
+                val Some(a) = Sync.defer(Some(1)).now
                 a
             }
         }

--- a/kyo-direct/shared/src/test/scala/kyo/PatMatchTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PatMatchTest.scala
@@ -112,7 +112,7 @@ class PatMatchTest extends AnyFreeSpec with Assertions:
     "misc" - {
         "val patmatch" in {
             runLiftTest(1) {
-                val Some(a) = Sync(Some(1)).now
+                val Some(a) = Sync.io(Some(1)).now
                 a
             }
         }

--- a/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
@@ -307,7 +307,7 @@ class PreludeTest extends Test:
         "poll with fold" in run {
             val effect = Poll.fold[Int](0) { (acc, v) =>
                 direct {
-                    Sync(acc).now + v
+                    Sync.io(acc).now + v
                 }
             }
 

--- a/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PreludeTest.scala
@@ -307,7 +307,7 @@ class PreludeTest extends Test:
         "poll with fold" in run {
             val effect = Poll.fold[Int](0) { (acc, v) =>
                 direct {
-                    Sync.io(acc).now + v
+                    Sync.defer(acc).now + v
                 }
             }
 

--- a/kyo-direct/shared/src/test/scala/kyo/ShiftTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/ShiftTest.scala
@@ -51,7 +51,7 @@ class ShiftTest extends AnyFreeSpec with Assertions:
 
         val forReference = direct:
             def innerF(i: Int) = i + 1
-            Sync(innerF(1)).now
+            Sync.io(innerF(1)).now
 
     }
 

--- a/kyo-direct/shared/src/test/scala/kyo/ShiftTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/ShiftTest.scala
@@ -51,7 +51,7 @@ class ShiftTest extends AnyFreeSpec with Assertions:
 
         val forReference = direct:
             def innerF(i: Int) = i + 1
-            Sync.io(innerF(1)).now
+            Sync.defer(innerF(1)).now
 
     }
 

--- a/kyo-direct/shared/src/test/scala/kyo/WhileTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/WhileTest.scala
@@ -34,8 +34,8 @@ class WhileTest extends Test:
 
         direct {
             while i < 3 do
-                Sync(incrementA()).now
-                Sync(incrementB()).now
+                Sync.io(incrementA()).now
+                Sync.io(incrementB()).now
                 ()
             end while
             assert(i == 4)
@@ -79,7 +79,7 @@ class WhileTest extends Test:
                 val counter = AtomicInt.init(0).now
                 while counter.get.now < 3 do
                     val current = counter.incrementAndGet.now
-                    Sync(results += current).now
+                    Sync.io(results += current).now
                     ()
                 end while
                 val finalCount = counter.get.now
@@ -132,10 +132,10 @@ class WhileTest extends Test:
                 val counter = AtomicInt.init(0).now
                 while counter.get.now < 5 do
                     val current = counter.incrementAndGet.now
-                    if Sync(current % 2 == 1).now then
+                    if Sync.io(current % 2 == 1).now then
                         () // Skip odd numbers
                     else
-                        Sync { evens += current }.now
+                        Sync.io { evens += current }.now
                         ()
                     end if
                 end while
@@ -154,7 +154,7 @@ class WhileTest extends Test:
                     val counter = AtomicInt.init(0).now
                     while counter.get.now < 5 do
                         val op = s"op${counter.get.now}"
-                        Sync { operations += op }.now
+                        Sync.io { operations += op }.now
                         val current = counter.incrementAndGet.now
                         if current == 2 then
                             Abort.fail(s"Error at $current").now

--- a/kyo-direct/shared/src/test/scala/kyo/WhileTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/WhileTest.scala
@@ -34,8 +34,8 @@ class WhileTest extends Test:
 
         direct {
             while i < 3 do
-                Sync.io(incrementA()).now
-                Sync.io(incrementB()).now
+                Sync.defer(incrementA()).now
+                Sync.defer(incrementB()).now
                 ()
             end while
             assert(i == 4)
@@ -79,7 +79,7 @@ class WhileTest extends Test:
                 val counter = AtomicInt.init(0).now
                 while counter.get.now < 3 do
                     val current = counter.incrementAndGet.now
-                    Sync.io(results += current).now
+                    Sync.defer(results += current).now
                     ()
                 end while
                 val finalCount = counter.get.now
@@ -132,10 +132,10 @@ class WhileTest extends Test:
                 val counter = AtomicInt.init(0).now
                 while counter.get.now < 5 do
                     val current = counter.incrementAndGet.now
-                    if Sync.io(current % 2 == 1).now then
+                    if Sync.defer(current % 2 == 1).now then
                         () // Skip odd numbers
                     else
-                        Sync.io { evens += current }.now
+                        Sync.defer { evens += current }.now
                         ()
                     end if
                 end while
@@ -154,7 +154,7 @@ class WhileTest extends Test:
                     val counter = AtomicInt.init(0).now
                     while counter.get.now < 5 do
                         val op = s"op${counter.get.now}"
-                        Sync.io { operations += op }.now
+                        Sync.defer { operations += op }.now
                         val current = counter.incrementAndGet.now
                         if current == 2 then
                             Abort.fail(s"Error at $current").now

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Index.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Index.scala
@@ -31,7 +31,7 @@ object Index:
     val init: Index < (Env[DB.Config] & Sync) = direct {
         val cfg  = Env.get[DB.Config].now
         val file = open(cfg.workingDir + "/index.dat").now
-        Sync(Live(file)).now
+        Sync.io(Live(file)).now
     }
 
     final class Live(file: FileChannel) extends Index:
@@ -57,7 +57,7 @@ object Index:
         private val buffers = ThreadLocal.withInitial(() => Buffers())
 
         def transaction(account: Int, amount: Int, desc: String) =
-            Sync {
+            Sync.io {
                 val descChars  = this.descChars(desc)
                 val limit      = limits(account)
                 val offset     = address + (account * paddedEntrySize)
@@ -106,7 +106,7 @@ object Index:
         end descChars
 
         def statement(account: Int) =
-            Sync {
+            Sync.io {
                 val limit     = limits(account)
                 val offset    = address + (account * paddedEntrySize)
                 val statement = this.buffers.get().statement
@@ -173,7 +173,7 @@ object Index:
     end Live
 
     private def open(filePath: String) =
-        Sync {
+        Sync.io {
             FileChannel
                 .open(
                     Paths.get(filePath),

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Index.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Index.scala
@@ -31,7 +31,7 @@ object Index:
     val init: Index < (Env[DB.Config] & Sync) = direct {
         val cfg  = Env.get[DB.Config].now
         val file = open(cfg.workingDir + "/index.dat").now
-        Sync.io(Live(file)).now
+        Sync.defer(Live(file)).now
     }
 
     final class Live(file: FileChannel) extends Index:
@@ -57,7 +57,7 @@ object Index:
         private val buffers = ThreadLocal.withInitial(() => Buffers())
 
         def transaction(account: Int, amount: Int, desc: String) =
-            Sync.io {
+            Sync.defer {
                 val descChars  = this.descChars(desc)
                 val limit      = limits(account)
                 val offset     = address + (account * paddedEntrySize)
@@ -106,7 +106,7 @@ object Index:
         end descChars
 
         def statement(account: Int) =
-            Sync.io {
+            Sync.defer {
                 val limit     = limits(account)
                 val offset    = address + (account * paddedEntrySize)
                 val statement = this.buffers.get().statement
@@ -173,7 +173,7 @@ object Index:
     end Live
 
     private def open(filePath: String) =
-        Sync.io {
+        Sync.defer {
             FileChannel
                 .open(
                     Paths.get(filePath),

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
@@ -22,7 +22,7 @@ object Log:
     val init: Log < (Env[DB.Config] & Sync) = direct {
         val cfg = Env.get[DB.Config].now
         val q   = Queue.Unbounded.init[Entry](Access.MultiProducerSingleConsumer).now
-        val log = Sync(Live(cfg.workingDir + "/log.dat", q)).now
+        val log = Sync.defer(Live(cfg.workingDir + "/log.dat", q)).now
         val _   = Fiber.run(log.flushLoop(cfg.flushInterval)).now
         log
     }
@@ -47,7 +47,7 @@ object Log:
         }
 
         private def append(entries: Seq[Entry]) =
-            Sync {
+            Sync.defer {
                 if entries.nonEmpty then
                     val str =
                         entries.map { e =>

--- a/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
+++ b/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
@@ -188,9 +188,9 @@ object Memory:
           *   The result of the operation
           */
         def run[A, S](f: A < (Arena & S))(using Frame): A < (Sync & S) =
-            Sync.io {
+            Sync.defer {
                 val arena = JArena.ofShared()
-                Sync.ensure(Sync.io(arena.close))(Env.run(arena)(f))
+                Sync.ensure(Sync.defer(arena.close))(Env.run(arena)(f))
             }
 
         given isolate: Isolate.Contextual[Arena, Sync] = Isolate.Contextual.derive[Arena, Sync]

--- a/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
+++ b/kyo-offheap/shared/src/main/scala/kyo/Memory.scala
@@ -188,9 +188,9 @@ object Memory:
           *   The result of the operation
           */
         def run[A, S](f: A < (Arena & S))(using Frame): A < (Sync & S) =
-            Sync {
+            Sync.io {
                 val arena = JArena.ofShared()
-                Sync.ensure(Sync(arena.close))(Env.run(arena)(f))
+                Sync.ensure(Sync.io(arena.close))(Env.run(arena)(f))
             }
 
         given isolate: Isolate.Contextual[Arena, Sync] = Isolate.Contextual.derive[Arena, Sync]

--- a/kyo-playwright/shared/src/main/scala/kyo/Browser.scala
+++ b/kyo-playwright/shared/src/main/scala/kyo/Browser.scala
@@ -48,7 +48,7 @@ object Browser:
       *   The result of the operations
       */
     def run[A, S](timeout: Duration)(v: A < (Browser & S))(using Frame): A < (Sync & S) =
-        Sync.io {
+        Sync.defer {
             val playwright = Playwright.create()
             Sync.ensure(playwright.close) {
                 run(playwright.chromium().launch().newPage(), timeout)(v)
@@ -67,7 +67,7 @@ object Browser:
       *   The result of the operations
       */
     def run[A, S](page: Page, timeout: Duration = defaultTimeout)(v: A < (Browser & S))(using Frame): A < (Sync & S) =
-        Sync.io {
+        Sync.defer {
             page.setDefaultTimeout(timeout.toMillis.toDouble)
             page.setDefaultNavigationTimeout(timeout.toMillis.toDouble)
 
@@ -76,7 +76,7 @@ object Browser:
                     (input, cont) =>
                         for
                             _ <- Log.debug(s"Browser: Executing $input")
-                            r <- Sync.io(cont(input.unsafeRun(page)))
+                            r <- Sync.defer(cont(input.unsafeRun(page)))
                             _ <- Log.debug(s"Browser: Done $input")
                         yield r
             )

--- a/kyo-playwright/shared/src/main/scala/kyo/Browser.scala
+++ b/kyo-playwright/shared/src/main/scala/kyo/Browser.scala
@@ -48,7 +48,7 @@ object Browser:
       *   The result of the operations
       */
     def run[A, S](timeout: Duration)(v: A < (Browser & S))(using Frame): A < (Sync & S) =
-        Sync {
+        Sync.io {
             val playwright = Playwright.create()
             Sync.ensure(playwright.close) {
                 run(playwright.chromium().launch().newPage(), timeout)(v)
@@ -67,7 +67,7 @@ object Browser:
       *   The result of the operations
       */
     def run[A, S](page: Page, timeout: Duration = defaultTimeout)(v: A < (Browser & S))(using Frame): A < (Sync & S) =
-        Sync {
+        Sync.io {
             page.setDefaultTimeout(timeout.toMillis.toDouble)
             page.setDefaultNavigationTimeout(timeout.toMillis.toDouble)
 
@@ -76,7 +76,7 @@ object Browser:
                     (input, cont) =>
                         for
                             _ <- Log.debug(s"Browser: Executing $input")
-                            r <- Sync(cont(input.unsafeRun(page)))
+                            r <- Sync.io(cont(input.unsafeRun(page)))
                             _ <- Log.debug(s"Browser: Done $input")
                         yield r
             )

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -27,7 +27,7 @@ final private[kyo] class StreamSubscription[V, S](
         discard(requestChannel.close())
     end cancel
 
-    private[interop] def subscribe(using Frame): Unit < Sync = Sync.io(subscriber.onSubscribe(this))
+    private[interop] def subscribe(using Frame): Unit < Sync = Sync.defer(subscriber.onSubscribe(this))
 
     private[interop] def poll(using Tag[Poll[Chunk[V]]], Frame): StreamComplete < (Async & Poll[Chunk[V]] & Abort[StreamCanceled]) =
         def loopPoll(requesting: Long): (Chunk[V] | StreamComplete) < (Sync & Poll[Chunk[V]]) =
@@ -35,22 +35,22 @@ final private[kyo] class StreamSubscription[V, S](
                 Poll.andMap:
                     case Present(values) =>
                         if values.size <= requesting then
-                            Sync.io(values.foreach(subscriber.onNext(_)))
+                            Sync.defer(values.foreach(subscriber.onNext(_)))
                                 .andThen(Loop.continue(requesting - values.size))
                         else
-                            Sync.io(values.take(requesting.intValue).foreach(subscriber.onNext(_)))
+                            Sync.defer(values.take(requesting.intValue).foreach(subscriber.onNext(_)))
                                 .andThen(Loop.done(values.drop(requesting.intValue)))
                     case Absent =>
-                        Sync.io(Loop.done(StreamComplete))
+                        Sync.defer(Loop.done(StreamComplete))
 
         Loop[Chunk[V], StreamComplete, Async & Poll[Chunk[V]] & Abort[StreamCanceled]](Chunk.empty[V]): leftOver =>
             Abort.run[Closed](requestChannel.safe.take).map:
                 case Result.Success(requesting) =>
                     if requesting <= leftOver.size then
-                        Sync.io(leftOver.take(requesting.intValue).foreach(subscriber.onNext(_)))
+                        Sync.defer(leftOver.take(requesting.intValue).foreach(subscriber.onNext(_)))
                             .andThen(Loop.continue(leftOver.drop(requesting.intValue)))
                     else
-                        Sync.io(leftOver.foreach(subscriber.onNext(_)))
+                        Sync.defer(leftOver.foreach(subscriber.onNext(_)))
                             .andThen(loopPoll(requesting - leftOver.size))
                             .map {
                                 case nextLeftOver: Chunk[V] => Loop.continue(nextLeftOver)
@@ -68,8 +68,8 @@ final private[kyo] class StreamSubscription[V, S](
         Fiber.run[StreamCanceled, StreamComplete, S](Poll.runEmit(stream.emit)(poll).map(_._2))
             .map { fiber =>
                 fiber.onComplete {
-                    case Result.Success(StreamComplete) => Sync.io(subscriber.onComplete())
-                    case Result.Panic(e)                => Sync.io(subscriber.onError(e))
+                    case Result.Success(StreamComplete) => Sync.defer(subscriber.onComplete())
+                    case Result.Panic(e)                => Sync.defer(subscriber.onError(e))
                     case Result.Failure(StreamCanceled) => Kyo.unit
                 }.andThen(fiber)
             }

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -27,7 +27,7 @@ final private[kyo] class StreamSubscription[V, S](
         discard(requestChannel.close())
     end cancel
 
-    private[interop] def subscribe(using Frame): Unit < Sync = Sync(subscriber.onSubscribe(this))
+    private[interop] def subscribe(using Frame): Unit < Sync = Sync.io(subscriber.onSubscribe(this))
 
     private[interop] def poll(using Tag[Poll[Chunk[V]]], Frame): StreamComplete < (Async & Poll[Chunk[V]] & Abort[StreamCanceled]) =
         def loopPoll(requesting: Long): (Chunk[V] | StreamComplete) < (Sync & Poll[Chunk[V]]) =
@@ -35,22 +35,22 @@ final private[kyo] class StreamSubscription[V, S](
                 Poll.andMap:
                     case Present(values) =>
                         if values.size <= requesting then
-                            Sync(values.foreach(subscriber.onNext(_)))
+                            Sync.io(values.foreach(subscriber.onNext(_)))
                                 .andThen(Loop.continue(requesting - values.size))
                         else
-                            Sync(values.take(requesting.intValue).foreach(subscriber.onNext(_)))
+                            Sync.io(values.take(requesting.intValue).foreach(subscriber.onNext(_)))
                                 .andThen(Loop.done(values.drop(requesting.intValue)))
                     case Absent =>
-                        Sync(Loop.done(StreamComplete))
+                        Sync.io(Loop.done(StreamComplete))
 
         Loop[Chunk[V], StreamComplete, Async & Poll[Chunk[V]] & Abort[StreamCanceled]](Chunk.empty[V]): leftOver =>
             Abort.run[Closed](requestChannel.safe.take).map:
                 case Result.Success(requesting) =>
                     if requesting <= leftOver.size then
-                        Sync(leftOver.take(requesting.intValue).foreach(subscriber.onNext(_)))
+                        Sync.io(leftOver.take(requesting.intValue).foreach(subscriber.onNext(_)))
                             .andThen(Loop.continue(leftOver.drop(requesting.intValue)))
                     else
-                        Sync(leftOver.foreach(subscriber.onNext(_)))
+                        Sync.io(leftOver.foreach(subscriber.onNext(_)))
                             .andThen(loopPoll(requesting - leftOver.size))
                             .map {
                                 case nextLeftOver: Chunk[V] => Loop.continue(nextLeftOver)
@@ -68,8 +68,8 @@ final private[kyo] class StreamSubscription[V, S](
         Fiber.run[StreamCanceled, StreamComplete, S](Poll.runEmit(stream.emit)(poll).map(_._2))
             .map { fiber =>
                 fiber.onComplete {
-                    case Result.Success(StreamComplete) => Sync(subscriber.onComplete())
-                    case Result.Panic(e)                => Sync(subscriber.onError(e))
+                    case Result.Success(StreamComplete) => Sync.io(subscriber.onComplete())
+                    case Result.Panic(e)                => Sync.io(subscriber.onError(e))
                     case Result.Failure(StreamCanceled) => Kyo.unit
                 }.andThen(fiber)
             }

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/package.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/package.scala
@@ -18,7 +18,7 @@ package object flow:
     ): Stream[T, Async] < (Resource & Sync) =
         for
             subscriber <- StreamSubscriber[T](bufferSize, emitStrategy)
-            _          <- Sync(publisher.subscribe(subscriber))
+            _          <- Sync.io(publisher.subscribe(subscriber))
             stream     <- subscriber.stream
         yield stream
 

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/package.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/package.scala
@@ -18,7 +18,7 @@ package object flow:
     ): Stream[T, Async] < (Resource & Sync) =
         for
             subscriber <- StreamSubscriber[T](bufferSize, emitStrategy)
-            _          <- Sync.io(publisher.subscribe(subscriber))
+            _          <- Sync.defer(publisher.subscribe(subscriber))
             stream     <- subscriber.stream
         yield stream
 

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/CancellationTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/CancellationTest.scala
@@ -24,7 +24,7 @@ final class CancellationTest extends Test:
                 for
                     flag         <- AtomicBoolean.init(false)
                     subscription <- StreamSubscription.subscribe(stream, new Sub(flag))
-                    _            <- Sync.io(program(subscription))
+                    _            <- Sync.defer(program(subscription))
                 yield Loop.continue(index - 1)
             end if
         }

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/CancellationTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/CancellationTest.scala
@@ -24,7 +24,7 @@ final class CancellationTest extends Test:
                 for
                     flag         <- AtomicBoolean.init(false)
                     subscription <- StreamSubscription.subscribe(stream, new Sub(flag))
-                    _            <- Sync(program(subscription))
+                    _            <- Sync.io(program(subscription))
                 yield Loop.continue(index - 1)
             end if
         }

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
@@ -35,7 +35,7 @@ abstract private class PublisherToSubscriberTest extends Test:
             .range(0, 10, 1, 1)
             .map { int =>
                 if int < 5 then
-                    Sync.io(int)
+                    Sync.defer(int)
                 else
                     Abort.panic(TestError)
             }
@@ -104,7 +104,7 @@ abstract private class PublisherToSubscriberTest extends Test:
             def emit(counter: AtomicInt): Unit < (Emit[Chunk[Int]] & Sync) =
                 counter.getAndIncrement.map: value =>
                     if value >= MaxStreamLength then
-                        Sync.io(())
+                        Sync.defer(())
                     else
                         Emit.valueWith(Chunk(value))(emit(counter))
                     end if
@@ -161,7 +161,7 @@ abstract private class PublisherToSubscriberTest extends Test:
             def emit(counter: AtomicInt): Unit < (Emit[Chunk[Int]] & Sync) =
                 counter.getAndIncrement.map: value =>
                     if value >= MaxStreamLength then
-                        Sync.io(())
+                        Sync.defer(())
                     else
                         Emit.valueWith(Chunk(value))(emit(counter))
                     end if

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
@@ -35,7 +35,7 @@ abstract private class PublisherToSubscriberTest extends Test:
             .range(0, 10, 1, 1)
             .map { int =>
                 if int < 5 then
-                    Sync(int)
+                    Sync.io(int)
                 else
                     Abort.panic(TestError)
             }
@@ -104,7 +104,7 @@ abstract private class PublisherToSubscriberTest extends Test:
             def emit(counter: AtomicInt): Unit < (Emit[Chunk[Int]] & Sync) =
                 counter.getAndIncrement.map: value =>
                     if value >= MaxStreamLength then
-                        Sync(())
+                        Sync.io(())
                     else
                         Emit.valueWith(Chunk(value))(emit(counter))
                     end if
@@ -161,7 +161,7 @@ abstract private class PublisherToSubscriberTest extends Test:
             def emit(counter: AtomicInt): Unit < (Emit[Chunk[Int]] & Sync) =
                 counter.getAndIncrement.map: value =>
                     if value >= MaxStreamLength then
-                        Sync(())
+                        Sync.io(())
                     else
                         Emit.valueWith(Chunk(value))(emit(counter))
                     end if

--- a/kyo-stats-otel/shared/src/main/scala/kyo/stats/otel/OTelTraceReceiver.scala
+++ b/kyo-stats-otel/shared/src/main/scala/kyo/stats/otel/OTelTraceReceiver.scala
@@ -19,7 +19,7 @@ class OTelTraceReceiver extends TraceReceiver {
         parent: Maybe[Span],
         attributes: Attributes
     )(implicit frame: Frame): Span < Sync =
-        Sync.io {
+        Sync.defer {
             val b =
                 otel.getTracer(scope.mkString("_"))
                     .spanBuilder(name)

--- a/kyo-stats-otel/shared/src/main/scala/kyo/stats/otel/OTelTraceReceiver.scala
+++ b/kyo-stats-otel/shared/src/main/scala/kyo/stats/otel/OTelTraceReceiver.scala
@@ -19,7 +19,7 @@ class OTelTraceReceiver extends TraceReceiver {
         parent: Maybe[Span],
         attributes: Attributes
     )(implicit frame: Frame): Span < Sync =
-        Sync {
+        Sync.io {
             val b =
                 otel.getTracer(scope.mkString("_"))
                     .spanBuilder(name)

--- a/kyo-stm/shared/src/test/scala/kyo/TRefLogTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TRefLogTest.scala
@@ -13,7 +13,7 @@ class TTRefLogTest extends Test:
         }
 
         "put" in run {
-            Sync.io {
+            Sync.defer {
                 val ref   = new TRefImpl[Int](Write(0, 0))
                 val entry = Write(1, 42)
                 val log   = TRefLog.empty.put(ref, entry)
@@ -24,7 +24,7 @@ class TTRefLogTest extends Test:
         }
 
         "get" in run {
-            Sync.io {
+            Sync.defer {
                 val ref   = new TRefImpl[Int](Write(0, 0))
                 val entry = Write(1, 42)
                 val log   = TRefLog.empty.put(ref, entry)
@@ -34,7 +34,7 @@ class TTRefLogTest extends Test:
         }
 
         "toSeq" in run {
-            Sync.io {
+            Sync.defer {
                 val ref1   = new TRefImpl[Int](Write(0, 0))
                 val ref2   = new TRefImpl[Int](Write(0, 0))
                 val entry1 = Write(1, 42)

--- a/kyo-stm/shared/src/test/scala/kyo/TRefLogTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TRefLogTest.scala
@@ -13,7 +13,7 @@ class TTRefLogTest extends Test:
         }
 
         "put" in run {
-            Sync {
+            Sync.io {
                 val ref   = new TRefImpl[Int](Write(0, 0))
                 val entry = Write(1, 42)
                 val log   = TRefLog.empty.put(ref, entry)
@@ -24,7 +24,7 @@ class TTRefLogTest extends Test:
         }
 
         "get" in run {
-            Sync {
+            Sync.io {
                 val ref   = new TRefImpl[Int](Write(0, 0))
                 val entry = Write(1, 42)
                 val log   = TRefLog.empty.put(ref, entry)
@@ -34,7 +34,7 @@ class TTRefLogTest extends Test:
         }
 
         "toSeq" in run {
-            Sync {
+            Sync.io {
                 val ref1   = new TRefImpl[Int](Write(0, 0))
                 val ref2   = new TRefImpl[Int](Write(0, 0))
                 val entry1 = Write(1, 42)

--- a/kyo-sttp/jvm/src/test/scala/kyo/RequestsLiveTest.scala
+++ b/kyo-sttp/jvm/src/test/scala/kyo/RequestsLiveTest.scala
@@ -35,7 +35,7 @@ class RequestsLiveTest extends Test:
         response: Try[String],
         port: Int = 8000
     ): Int < (Sync & Resource) =
-        Sync {
+        Sync.io {
 
             import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
             import java.io.OutputStream
@@ -64,6 +64,6 @@ class RequestsLiveTest extends Test:
             server.setExecutor(null)
             server.start()
             Resource.ensure(server.stop(0))
-                .andThen(Sync(server.getAddress.getPort()))
+                .andThen(Sync.io(server.getAddress.getPort()))
         }
 end RequestsLiveTest

--- a/kyo-sttp/jvm/src/test/scala/kyo/RequestsLiveTest.scala
+++ b/kyo-sttp/jvm/src/test/scala/kyo/RequestsLiveTest.scala
@@ -35,7 +35,7 @@ class RequestsLiveTest extends Test:
         response: Try[String],
         port: Int = 8000
     ): Int < (Sync & Resource) =
-        Sync.io {
+        Sync.defer {
 
             import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
             import java.io.OutputStream
@@ -64,6 +64,6 @@ class RequestsLiveTest extends Test:
             server.setExecutor(null)
             server.start()
             Resource.ensure(server.stop(0))
-                .andThen(Sync.io(server.getAddress.getPort()))
+                .andThen(Sync.defer(server.getAddress.getPort()))
         }
 end RequestsLiveTest

--- a/kyo-sttp/native/src/main/scala/kyo/PlatformBackend.scala
+++ b/kyo-sttp/native/src/main/scala/kyo/PlatformBackend.scala
@@ -10,7 +10,7 @@ object PlatformBackend:
             def send[A](r: Request[A, Any]) =
                 given Frame = Frame.internal
                 def call    = r.send(b)
-                Abort.run[Throwable](Sync(call))
+                Abort.run[Throwable](Sync.io(call))
                     .map(_.foldError(identity, ex => Abort.fail(FailedRequest(ex.failureOrPanic))))
             end send
 end PlatformBackend

--- a/kyo-sttp/native/src/main/scala/kyo/PlatformBackend.scala
+++ b/kyo-sttp/native/src/main/scala/kyo/PlatformBackend.scala
@@ -10,7 +10,7 @@ object PlatformBackend:
             def send[A](r: Request[A, Any]) =
                 given Frame = Frame.internal
                 def call    = r.send(b)
-                Abort.run[Throwable](Sync.io(call))
+                Abort.run[Throwable](Sync.defer(call))
                     .map(_.foldError(identity, ex => Abort.fail(FailedRequest(ex.failureOrPanic))))
             end send
 end PlatformBackend

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -36,16 +36,16 @@ class KyoSttpMonad extends MonadAsyncError[M]:
         }
 
     def error[A](t: Throwable) =
-        Sync.io(throw t)
+        Sync.defer(throw t)
 
     def unit[A](t: A) =
         t
 
     override def eval[A](t: => A) =
-        Sync.io(t)
+        Sync.defer(t)
 
     override def suspend[A](t: => M[A]) =
-        Sync.io(t)
+        Sync.defer(t)
 
     def async[A](register: (Either[Throwable, A] => Unit) => Canceler): M[A] =
         Sync.Unsafe {

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -36,16 +36,16 @@ class KyoSttpMonad extends MonadAsyncError[M]:
         }
 
     def error[A](t: Throwable) =
-        Sync(throw t)
+        Sync.io(throw t)
 
     def unit[A](t: A) =
         t
 
     override def eval[A](t: => A) =
-        Sync(t)
+        Sync.io(t)
 
     override def suspend[A](t: => M[A]) =
-        Sync(t)
+        Sync.io(t)
 
     def async[A](register: (Either[Throwable, A] => Unit) => Canceler): M[A] =
         Sync.Unsafe {

--- a/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
@@ -7,25 +7,25 @@ import sttp.monad.Canceler
 class KyoSttpMonadTest extends Test:
 
     "map" in run {
-        KyoSttpMonad.map(Sync.io(1))(_ + 1).map(r => assert(r == 2))
+        KyoSttpMonad.map(Sync.defer(1))(_ + 1).map(r => assert(r == 2))
     }
 
     "flatMap" in run {
-        KyoSttpMonad.flatMap(Sync.io(1))(v => Sync.io(v + 1)).map(r => assert(r == 2))
+        KyoSttpMonad.flatMap(Sync.defer(1))(v => Sync.defer(v + 1)).map(r => assert(r == 2))
     }
 
     "handleError" - {
         "ok" in run {
-            KyoSttpMonad.handleError(Sync.io(1))(_ => 2).map(r => assert(r == 1))
+            KyoSttpMonad.handleError(Sync.defer(1))(_ => 2).map(r => assert(r == 1))
         }
         "nok" in run {
-            KyoSttpMonad.handleError(Sync.io(throw new Exception))(_ => 2).map(r => assert(r == 2))
+            KyoSttpMonad.handleError(Sync.defer(throw new Exception))(_ => 2).map(r => assert(r == 2))
         }
     }
 
     "ensure" in run {
         var calls = 0
-        KyoSttpMonad.ensure(Sync.io(1), Sync.io(calls += 1)).map { r =>
+        KyoSttpMonad.ensure(Sync.defer(1), Sync.defer(calls += 1)).map { r =>
             assert(r == 1)
             assert(calls == 1)
         }

--- a/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
@@ -7,25 +7,25 @@ import sttp.monad.Canceler
 class KyoSttpMonadTest extends Test:
 
     "map" in run {
-        KyoSttpMonad.map(Sync(1))(_ + 1).map(r => assert(r == 2))
+        KyoSttpMonad.map(Sync.io(1))(_ + 1).map(r => assert(r == 2))
     }
 
     "flatMap" in run {
-        KyoSttpMonad.flatMap(Sync(1))(v => Sync(v + 1)).map(r => assert(r == 2))
+        KyoSttpMonad.flatMap(Sync.io(1))(v => Sync.io(v + 1)).map(r => assert(r == 2))
     }
 
     "handleError" - {
         "ok" in run {
-            KyoSttpMonad.handleError(Sync(1))(_ => 2).map(r => assert(r == 1))
+            KyoSttpMonad.handleError(Sync.io(1))(_ => 2).map(r => assert(r == 1))
         }
         "nok" in run {
-            KyoSttpMonad.handleError(Sync(throw new Exception))(_ => 2).map(r => assert(r == 2))
+            KyoSttpMonad.handleError(Sync.io(throw new Exception))(_ => 2).map(r => assert(r == 2))
         }
     }
 
     "ensure" in run {
         var calls = 0
-        KyoSttpMonad.ensure(Sync(1), Sync(calls += 1)).map { r =>
+        KyoSttpMonad.ensure(Sync.io(1), Sync.io(calls += 1)).map { r =>
             assert(r == 1)
             assert(calls == 1)
         }

--- a/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
@@ -36,7 +36,7 @@ object Routes:
       */
     def run[A, S](server: NettyKyoServer)(v: Unit < (Routes & S))(using Frame): NettyKyoServerBinding < (Async & S) =
         Emit.run[Route][Unit, Nothing, Async & S](v).map { (routes, _) =>
-            Sync(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Async & S)
+            Sync.io(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Async & S)
         }
     end run
 

--- a/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
@@ -36,7 +36,7 @@ object Routes:
       */
     def run[A, S](server: NettyKyoServer)(v: Unit < (Routes & S))(using Frame): NettyKyoServerBinding < (Async & S) =
         Emit.run[Route][Unit, Nothing, Async & S](v).map { (routes, _) =>
-            Sync.io(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Async & S)
+            Sync.defer(server.addEndpoints(routes.toSeq.map(_.endpoint).toList).start()): NettyKyoServerBinding < (Async & S)
         }
     end run
 

--- a/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
@@ -7,7 +7,7 @@ import kyo.*
 object KyoUtil:
     def nettyChannelFutureToScala(nettyFuture: ChannelFuture)(using Frame): Channel < Async =
         Promise.initWith[Nothing, Channel] { p =>
-            p.onComplete(_ => Sync.io(discard(nettyFuture.cancel(true)))).andThen {
+            p.onComplete(_ => Sync.defer(discard(nettyFuture.cancel(true)))).andThen {
                 nettyFuture.addListener((future: ChannelFuture) =>
                     discard {
                         import AllowUnsafe.embrace.danger
@@ -21,7 +21,7 @@ object KyoUtil:
 
     def nettyFutureToScala[A](f: io.netty.util.concurrent.Future[A])(using Frame): A < Async =
         Promise.initWith[Nothing, A] { p =>
-            p.onComplete(_ => Sync.io(discard(f.cancel(true)))).andThen {
+            p.onComplete(_ => Sync.defer(discard(f.cancel(true)))).andThen {
                 f.addListener((future: io.netty.util.concurrent.Future[A]) =>
                     discard {
                         import AllowUnsafe.embrace.danger

--- a/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/internal/KyoUtil.scala
@@ -7,7 +7,7 @@ import kyo.*
 object KyoUtil:
     def nettyChannelFutureToScala(nettyFuture: ChannelFuture)(using Frame): Channel < Async =
         Promise.initWith[Nothing, Channel] { p =>
-            p.onComplete(_ => Sync(discard(nettyFuture.cancel(true)))).andThen {
+            p.onComplete(_ => Sync.io(discard(nettyFuture.cancel(true)))).andThen {
                 nettyFuture.addListener((future: ChannelFuture) =>
                     discard {
                         import AllowUnsafe.embrace.danger
@@ -21,7 +21,7 @@ object KyoUtil:
 
     def nettyFutureToScala[A](f: io.netty.util.concurrent.Future[A])(using Frame): A < Async =
         Promise.initWith[Nothing, A] { p =>
-            p.onComplete(_ => Sync(discard(f.cancel(true)))).andThen {
+            p.onComplete(_ => Sync.io(discard(f.cancel(true)))).andThen {
                 f.addListener((future: io.netty.util.concurrent.Future[A]) =>
                     discard {
                         import AllowUnsafe.embrace.danger

--- a/kyo-zio-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
+++ b/kyo-zio-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
@@ -11,12 +11,12 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
                     assertCompletes
                 },
                 test("IOs Succeed") {
-                    Sync.io(assertCompletes)
+                    Sync.defer(assertCompletes)
                 }
             ),
             suite("failing!")(
                 test("Sync fail") {
-                    Sync.io(throw new Exception("Fail!")).map(_ => assertCompletes)
+                    Sync.defer(throw new Exception("Fail!")).map(_ => assertCompletes)
                 },
                 test("Sync Succeed") {
                     Abort.fail[Throwable](new RuntimeException("Abort!")).map(_ => assertCompletes)
@@ -43,7 +43,7 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
                 ),
                 test("checkKyo")(
                     check(Gen.boolean) { b =>
-                        Sync.io(assertTrue(b == b))
+                        Sync.defer(assertTrue(b == b))
                     }
                 )
             )

--- a/kyo-zio-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
+++ b/kyo-zio-test/shared/src/test/scala/kyo/test/KyoSpecDefaultSpec.scala
@@ -11,12 +11,12 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
                     assertCompletes
                 },
                 test("IOs Succeed") {
-                    Sync(assertCompletes)
+                    Sync.io(assertCompletes)
                 }
             ),
             suite("failing!")(
                 test("Sync fail") {
-                    Sync(throw new Exception("Fail!")).map(_ => assertCompletes)
+                    Sync.io(throw new Exception("Fail!")).map(_ => assertCompletes)
                 },
                 test("Sync Succeed") {
                     Abort.fail[Throwable](new RuntimeException("Abort!")).map(_ => assertCompletes)
@@ -43,7 +43,7 @@ object KyoSpecDefaultSpec extends KyoSpecDefault:
                 ),
                 test("checkKyo")(
                     check(Gen.boolean) { b =>
-                        Sync(assertTrue(b == b))
+                        Sync.io(assertTrue(b == b))
                     }
                 )
             )

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -135,13 +135,13 @@ class ZIOsTest extends Test:
 
         def kyoLoop(started: CountDownLatch, done: CountDownLatch): Unit < Sync =
             def loop(i: Int): Unit < Sync =
-                Sync {
+                Sync.defer {
                     if i == 0 then
-                        Sync(started.countDown()).andThen(loop(i + 1))
+                        Sync.defer(started.countDown()).andThen(loop(i + 1))
                     else
                         loop(i + 1)
                 }
-            Sync.ensure(Sync(done.countDown()))(loop(0))
+            Sync.ensure(Sync.defer(done.countDown()))(loop(0))
         end kyoLoop
 
         def zioLoop(started: CountDownLatch, done: CountDownLatch): Task[Unit] =
@@ -236,10 +236,10 @@ class ZIOsTest extends Test:
                     val panic   = Result.Panic(new Exception)
                     for
                         f <- Fiber.run(ZIOs.get(zioLoop(started, done)))
-                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt(panic)
                         r <- f.getResult
-                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r == panic)
                     end for
                 }
@@ -254,10 +254,10 @@ class ZIOsTest extends Test:
                         yield ()
                     for
                         f <- Fiber.run(v)
-                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }
@@ -272,10 +272,10 @@ class ZIOsTest extends Test:
                     end parallelEffect
                     for
                         f <- Fiber.run(parallelEffect)
-                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }
@@ -290,10 +290,10 @@ class ZIOsTest extends Test:
                     end raceEffect
                     for
                         f <- Fiber.run(raceEffect)
-                        _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
-                        _ <- Sync(done.await(100, TimeUnit.MILLISECONDS))
+                        _ <- Sync.defer(done.await(100, TimeUnit.MILLISECONDS))
                     yield assert(r.isPanic)
                     end for
                 }

--- a/kyo-zio/shared/src/test/scala/kyo/ZLayersTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZLayersTest.scala
@@ -107,7 +107,7 @@ class ZLayersTest extends Test:
 
     ".run" - {
         "Sync" in runZIO {
-            val klayer: Layer[TestService, Sync] = Layer(Sync.io(TestServiceImpl(0)))
+            val klayer: Layer[TestService, Sync] = Layer(Sync.defer(TestServiceImpl(0)))
 
             val zlayer = ZLayers.run(klayer)
 

--- a/kyo-zio/shared/src/test/scala/kyo/ZLayersTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZLayersTest.scala
@@ -107,7 +107,7 @@ class ZLayersTest extends Test:
 
     ".run" - {
         "Sync" in runZIO {
-            val klayer: Layer[TestService, Sync] = Layer(Sync(TestServiceImpl(0)))
+            val klayer: Layer[TestService, Sync] = Layer(Sync.io(TestServiceImpl(0)))
 
             val zlayer = ZLayers.run(klayer)
 


### PR DESCRIPTION

### Problem

Since the renaming of `IO` to `Sync`, its `apply` method doesn't seem as intuitive anymore since it doesn't indicate suspension of side effects. Also, `Async.apply` is confusing because it's meant to suspend side effects but it can give the impression that it'll run the computation concurrently. 

### Solution

Rename the `apply` method of both `Sync` and `Async` to `io` since it's a common naming to indicate side effects.

