### PR TITLE
[core] move Async.run* to Fiber

### DIFF
--- a/README.md
+++ b/README.md
@@ -2202,7 +2202,7 @@ import kyo.*
 // taken by reference and automatically
 // suspended with 'Sync'
 val a: Fiber[Nothing, Int] < Sync =
-    Async.run(Math.cos(42).toInt)
+    Fiber.run(Math.cos(42).toInt)
 
 // It's possible to "extract" the value of a
 // 'Fiber' via the 'get' method. This is also
@@ -2342,17 +2342,17 @@ import kyo.*
 
 // An example computation with fibers
 val a: Int < Async =
-    Async.run(Math.cos(42).toInt).map(_.get)
+    Fiber.run(Math.cos(42).toInt).map(_.get)
 
 // Avoid handling 'Async' directly
 val b: Fiber[Nothing, Int] < Sync =
-    Async.run(a)
+    Fiber.run(a)
 
 // The 'runAndBlock' method accepts
 // arbitrary pending effects but relies
 // on thread blocking and requires a timeout
 val c: Int < (Abort[Timeout] & Sync) =
-    Async.runAndBlock(5.seconds)(a)
+    Fiber.runAndBlock(5.seconds)(a)
 ```
 
 > Note: Handling the `Async` effect doesn't break referential transparency as with `Sync` but its usage is not trivial due to the limitations of the pending effects. Prefer `KyoApp` instead.
@@ -2373,7 +2373,7 @@ val b: Boolean < Sync =
 // Fullfil the promise with
 // another fiber
 val c: Boolean < Sync =
-    a.map(fiber => Async.run(1).map(fiber.become(_)))
+    a.map(fiber => Fiber.run(1).map(fiber.become(_)))
 ```
 
 > A `Promise` is basically a `Fiber` with all the regular functionality plus the `complete` and `become` methods to manually fulfill the promise.
@@ -2753,12 +2753,12 @@ val d: Unit < Async =
 val e: Unit < Async =
     for
         barrier <- Barrier.init(3)
-        fiber1  <- Async.run(Async.sleep(1.second))
-        fiber2  <- Async.run(Async.sleep(2.seconds))
+        fiber1  <- Fiber.run(Async.sleep(1.second))
+        fiber2  <- Fiber.run(Async.sleep(2.seconds))
         _       <- Async.zip(
                      fiber1.get.map(_ => barrier.await),
                      fiber2.get.map(_ => barrier.await),
-                     Async.run(barrier.await).map(_.get)
+                     Fiber.run(barrier.await).map(_.get)
                    )
     yield ()
 ```
@@ -3349,7 +3349,7 @@ Kyo and ZIOs effects can be seamlessly mixed and matched within computations, al
 
 ```scala
 import kyo.*
-import zio.*
+import zio.{Fiber => _, *}
 
 // Note how ZIO includes the
 // Sync and Async effects
@@ -3357,14 +3357,14 @@ val a: Int < (Abort[Nothing] & Async) =
     for
         v1 <- ZIOs.get(ZIO.succeed(21))
         v2 <- Sync(21)
-        v3 <- Async.run(-42).map(_.get)
+        v3 <- Fiber.run(-42).map(_.get)
     yield v1 + v2 + v3
 
 // Using fibers from both libraries
 val b: Int < (Abort[Nothing] & Async) =
     for
         f1 <- ZIOs.get(ZIO.succeed(21).fork)
-        f2 <- Async.run(Sync(21))
+        f2 <- Fiber.run(Sync(21))
         v1 <- ZIOs.get(f1.join)
         v2 <- f2.get
     yield v1 + v2
@@ -3409,14 +3409,14 @@ val a: Int < (Abort[Nothing] & Async) =
     for
         v1 <- Cats.get(CatsIO.pure(21))
         v2 <- Sync(21)
-        v3 <- Async.run(-42).map(_.get)
+        v3 <- Fiber.run(-42).map(_.get)
     yield v1 + v2 + v3
 
 // Using fibers from both libraries:
 val b: Int < (Abort[Nothing] & Async) =
     for
         f1 <- Cats.get(CatsIO.pure(21).start)
-        f2 <- Async.run(Sync(21))
+        f2 <- Fiber.run(Sync(21))
         v1 <- Cats.get(f1.joinWith(CatsIO(99)))
         v2 <- f2.get
     yield v1 + v2
@@ -3566,7 +3566,7 @@ end effect
 // There are no combinators for handling Sync or blocking Async, since this should
 // be done at the edge of the program
 Sync.Unsafe.run {                        // Handles Sync
-    Async.runAndBlock(Duration.Inf) {  // Handles Async
+    Fiber.runAndBlock(Duration.Inf) {  // Handles Async
         Kyo.scoped {                   // Handles Resource
             Memo.run:                  // Handles Memo (introduced by .provide, below)
                 effect

--- a/kyo-actor/shared/src/main/scala/kyo/Actor.scala
+++ b/kyo-actor/shared/src/main/scala/kyo/Actor.scala
@@ -454,7 +454,7 @@ object Actor:
                     Sync.ensure(mailbox.close), // Ensure mailbox cleanup by closing it when the actor completes or fails
                     Env.run(_subject),          // Provide the actor's Subject to the environment so it can be accessed via Actor.self
                     Resource.run,               // Close used resources
-                    Async.run                   // Start the actor's processing loop in an async context
+                    Fiber.run                   // Start the actor's processing loop in an async context
                 )
             _ <- Resource.ensure(mailbox.close) // Registers a finalizer in the outer scope to provide the actor hierarchy behavior
         yield new Actor[E, A, B](_subject, _consumer):

--- a/kyo-aeron/jvm/src/test/scala/kyo/TopicTest.scala
+++ b/kyo-aeron/jvm/src/test/scala/kyo/TopicTest.scala
@@ -34,9 +34,9 @@ class TopicTest extends Test:
                         for
                             started <- Latch.init(1)
                             fiber <-
-                                Async.run(using Topic.isolate)(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
+                                Fiber.run(using Topic.isolate)(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
                             _        <- started.await
-                            _        <- Async.run(Topic.publish(uri)(Stream.init(messages)))
+                            _        <- Fiber.run(Topic.publish(uri)(Stream.init(messages)))
                             received <- fiber.get
                         yield assert(received == messages)
                     }
@@ -48,11 +48,11 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started       <- Latch.init(2)
-                            stringFiber   <- Async.run(started.release.andThen(Topic.stream[String](uri).take(strings.size).run))
-                            intFiber      <- Async.run(started.release.andThen(Topic.stream[Int](uri).take(ints.size).run))
+                            stringFiber   <- Fiber.run(started.release.andThen(Topic.stream[String](uri).take(strings.size).run))
+                            intFiber      <- Fiber.run(started.release.andThen(Topic.stream[Int](uri).take(ints.size).run))
                             _             <- started.await
-                            _             <- Async.run(Topic.publish(uri)(Stream.init(strings)))
-                            _             <- Async.run(Topic.publish(uri)(Stream.init(ints)))
+                            _             <- Fiber.run(Topic.publish(uri)(Stream.init(strings)))
+                            _             <- Fiber.run(Topic.publish(uri)(Stream.init(ints)))
                             stringResults <- stringFiber.get
                             intResults    <- intFiber.get
                         yield
@@ -69,12 +69,12 @@ class TopicTest extends Test:
                         for
                             started <- Latch.init(2)
                             strFiber <-
-                                Async.run(started.release.andThen(Topic.stream[GenericMessage[String]](uri).take(strMessages.size).run))
+                                Fiber.run(started.release.andThen(Topic.stream[GenericMessage[String]](uri).take(strMessages.size).run))
                             intFiber <-
-                                Async.run(started.release.andThen(Topic.stream[GenericMessage[Int]](uri).take(intMessages.size).run))
+                                Fiber.run(started.release.andThen(Topic.stream[GenericMessage[Int]](uri).take(intMessages.size).run))
                             _          <- started.await
-                            _          <- Async.run(Topic.publish(uri)(Stream.init(strMessages)))
-                            _          <- Async.run(Topic.publish(uri)(Stream.init(intMessages)))
+                            _          <- Fiber.run(Topic.publish(uri)(Stream.init(strMessages)))
+                            _          <- Fiber.run(Topic.publish(uri)(Stream.init(intMessages)))
                             strResults <- strFiber.get
                             intResults <- intFiber.get
                         yield
@@ -91,9 +91,9 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started  <- Latch.init(1)
-                            fiber    <- Async.run(started.release.andThen(Topic.stream[ComplexMessage](uri).take(messages.size).run))
+                            fiber    <- Fiber.run(started.release.andThen(Topic.stream[ComplexMessage](uri).take(messages.size).run))
                             _        <- started.await
-                            _        <- Async.run(Topic.publish(uri)(Stream.init(messages)))
+                            _        <- Fiber.run(Topic.publish(uri)(Stream.init(messages)))
                             received <- fiber.get
                         yield assert(received == messages)
                     }
@@ -107,10 +107,10 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started <- Latch.init(2)
-                            fiber1  <- Async.run(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
-                            fiber2  <- Async.run(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
+                            fiber1  <- Fiber.run(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
+                            fiber2  <- Fiber.run(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
                             _       <- started.await
-                            _       <- Async.run(Topic.publish(uri)(Stream.init(messages)))
+                            _       <- Fiber.run(Topic.publish(uri)(Stream.init(messages)))
                             result1 <- fiber1.get
                             result2 <- fiber2.get
                         yield
@@ -126,20 +126,20 @@ class TopicTest extends Test:
                         for
                             started <- Latch.init(2)
                             slowFiber <-
-                                Async.run(started.release.andThen(
+                                Fiber.run(started.release.andThen(
                                     Topic.stream[Message](uri)
                                         .map(r => Async.delay(1.millis)(r))
                                         .take(messages.size)
                                         .run
                                 ))
                             fastFiber <-
-                                Async.run(started.release.andThen(
+                                Fiber.run(started.release.andThen(
                                     Topic.stream[Message](uri)
                                         .take(messages.size)
                                         .run
                                 ))
                             _    <- started.await
-                            _    <- Async.run(Topic.publish(uri)(Stream.init(messages)))
+                            _    <- Fiber.run(Topic.publish(uri)(Stream.init(messages)))
                             slow <- slowFiber.get
                             fast <- fastFiber.get
                         yield
@@ -160,7 +160,7 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started <- Latch.init(1)
-                            fiber   <- Async.run(started.release.andThen(Topic.stream[Base](uri, failSchedule).run))
+                            fiber   <- Fiber.run(started.release.andThen(Topic.stream[Base](uri, failSchedule).run))
                             _       <- started.await
                             result1 <- Abort.run(Topic.publish(uri, failSchedule)(Stream.init(messages)))
                             result2 <- fiber.getResult
@@ -174,7 +174,7 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started <- Latch.init(1)
-                            fiber   <- Async.run(started.release.andThen(Topic.stream[Derived1](uri, failSchedule).run))
+                            fiber   <- Fiber.run(started.release.andThen(Topic.stream[Derived1](uri, failSchedule).run))
                             _       <- started.await
                             result1 <- Abort.run(Topic.publish(uri, failSchedule)(Stream.init(messages)))
                             result2 <- fiber.getResult
@@ -191,7 +191,7 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started <- Latch.init(1)
-                            fiber   <- Async.run(started.release.andThen(Topic.stream[GenericBase[String]](uri, failSchedule).run))
+                            fiber   <- Fiber.run(started.release.andThen(Topic.stream[GenericBase[String]](uri, failSchedule).run))
                             _       <- started.await
                             result1 <- Abort.run(Topic.publish(uri, failSchedule)(Stream.init(messages)))
                             result2 <- fiber.getResult
@@ -206,11 +206,11 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started  <- Latch.init(2)
-                            fiber1   <- Async.run(started.release.andThen(Topic.stream[Derived1](uri).take(messages1.size).run))
-                            fiber2   <- Async.run(started.release.andThen(Topic.stream[Derived2](uri).take(messages2.size).run))
+                            fiber1   <- Fiber.run(started.release.andThen(Topic.stream[Derived1](uri).take(messages1.size).run))
+                            fiber2   <- Fiber.run(started.release.andThen(Topic.stream[Derived2](uri).take(messages2.size).run))
                             _        <- started.await
-                            _        <- Async.run(Topic.publish(uri)(Stream.init(messages1)))
-                            _        <- Async.run(Topic.publish(uri)(Stream.init(messages2)))
+                            _        <- Fiber.run(Topic.publish(uri)(Stream.init(messages1)))
+                            _        <- Fiber.run(Topic.publish(uri)(Stream.init(messages2)))
                             results1 <- fiber1.get
                             results2 <- fiber2.get
                         yield
@@ -226,7 +226,7 @@ class TopicTest extends Test:
                 Topic.run {
                     for
                         started <- Latch.init(1)
-                        fiber   <- Async.run(started.release.andThen(Topic.stream[Message](uri).take(count).run))
+                        fiber   <- Fiber.run(started.release.andThen(Topic.stream[Message](uri).take(count).run))
                         _       <- started.await
                         result  <- Abort.run(Topic.publish[Message](uri)(Stream.init(messages)))
                     yield
@@ -241,7 +241,7 @@ class TopicTest extends Test:
                 Topic.run {
                     for
                         started <- Latch.init(1)
-                        fiber   <- Async.run(started.release.andThen(Topic.stream[Message](uri, failSchedule).take(1).run))
+                        fiber   <- Fiber.run(started.release.andThen(Topic.stream[Message](uri, failSchedule).take(1).run))
                         _       <- started.await
                         _       <- Topic.publish[Message](uri, failSchedule)(Stream.empty)
                         result  <- fiber.getResult
@@ -256,7 +256,7 @@ class TopicTest extends Test:
                 Topic.run {
                     for
                         started <- Latch.init(2)
-                        failingFiber <- Async.run(
+                        failingFiber <- Fiber.run(
                             started.release.andThen(
                                 Topic.stream[Message](uri)
                                     .map(_ => Abort.fail("Planned failure"): Message < Abort[String])
@@ -264,7 +264,7 @@ class TopicTest extends Test:
                                     .run
                             )
                         )
-                        normalFiber <- Async.run(
+                        normalFiber <- Fiber.run(
                             started.release.andThen(
                                 Topic.stream[Message](uri)
                                     .take(messageCount)
@@ -293,7 +293,7 @@ class TopicTest extends Test:
                 "subscriber without publisher" in run {
                     Topic.run {
                         for
-                            fiber  <- Async.run(Topic.stream[Message](uri, failSchedule).take(1).run)
+                            fiber  <- Fiber.run(Topic.stream[Message](uri, failSchedule).take(1).run)
                             result <- fiber.getResult
                         yield assert(result.isFailure)
                     }

--- a/kyo-bench/src/main/scala/kyo/bench/ChannelBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ChannelBench.scala
@@ -23,10 +23,10 @@ class ChannelBench extends BaseBench:
             for
                 channel <- Channel.init[Int](size)
                 _       <- channel.putBatch(Seq.fill(size)(intFillFn))
-                _       <- Async.run(channel.closeAwaitEmpty)
+                _       <- Fiber.run(channel.closeAwaitEmpty)
                 count   <- channel.streamUntilClosed(maxChunkSize).into(Sink.count)
             yield count
-        val count = Sync.Unsafe.evalOrThrow(Async.run(x).flatMap(_.block(Duration.Infinity))).getOrThrow
+        val count = Sync.Unsafe.evalOrThrow(Fiber.run(x).flatMap(_.block(Duration.Infinity))).getOrThrow
         assert(count == size, s"Expected $size, got $count")
     end streamChunks
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ArenaBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ArenaBench.scala
@@ -47,7 +47,7 @@ object ArenaBench:
         def forkKyo(warmup: KyoForkWarmup): A =
             import kyo.*
             import AllowUnsafe.embrace.danger
-            Sync.Unsafe.evalOrThrow(Async.run(kyoBenchFiber()).flatMap(_.block(Duration.Infinity))).getOrThrow
+            Sync.Unsafe.evalOrThrow(Fiber.run(kyoBenchFiber()).flatMap(_.block(Duration.Infinity))).getOrThrow
         end forkKyo
 
         @Benchmark

--- a/kyo-bench/src/main/scala/kyo/bench/arena/CountdownLatchBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/CountdownLatchBench.scala
@@ -29,7 +29,7 @@ class CountdownLatchBench extends ArenaBench.ForkOnly(0):
 
         for
             l <- Latch.init(depth)
-            _ <- Async.run(iterate(l, depth))
+            _ <- Fiber.run(iterate(l, depth))
             _ <- l.await
         yield 0
         end for

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkChainedBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkChainedBench.scala
@@ -24,11 +24,11 @@ class ForkChainedBench extends ArenaBench.ForkOnly(0):
 
         def iterate(p: Promise[Nothing, Unit], n: Int): Unit < Sync =
             if n <= 0 then p.complete(Result.unit).unit
-            else Kyo.unit.flatMap(_ => Async.run(iterate(p, n - 1)).unit)
+            else Kyo.unit.flatMap(_ => Fiber.run(iterate(p, n - 1)).unit)
 
         for
             p <- Promise.init[Nothing, Unit]
-            _ <- Async.run(iterate(p, depth))
+            _ <- Fiber.run(iterate(p, depth))
             _ <- p.get
         yield 0
         end for

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinBench.scala
@@ -18,7 +18,7 @@ class ForkJoinBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        val forkFiber     = Async.run(())
+        val forkFiber     = Fiber.run(())
         val forkAllFibers = Kyo.foreach(range)(_ => forkFiber)
 
         forkAllFibers.flatMap(fibers => Kyo.foreachDiscard(fibers)(_.get))

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinContentionBench.scala
@@ -21,7 +21,7 @@ class ForkJoinContentionBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        val forkFiber         = Async.run(())
+        val forkFiber         = Fiber.run(())
         val forkAllFibers     = Kyo.foreach(range)(_ => forkFiber)
         val forkJoinAllFibers = forkAllFibers.flatMap(fibers => Kyo.foreach(fibers)(_.get).unit)
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkManyBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkManyBench.scala
@@ -39,7 +39,7 @@ class ForkManyBench extends ArenaBench.ForkOnly(0):
                 case _ =>
                     false
             }
-            _ <- repeat(depth)(Async.run(effect))
+            _ <- repeat(depth)(Fiber.run(effect))
             _ <- promise.get
         yield 0
         end for

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkSpawnBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkSpawnBench.scala
@@ -39,7 +39,7 @@ class ForkSpawnBench extends ArenaBench.ForkOnly(()):
             if level == depth then
                 cdl.release
             else
-                repeat(width)(Async.run(loop(cdl, level + 1)).map(_ => ()))
+                repeat(width)(Fiber.run(loop(cdl, level + 1)).map(_ => ()))
 
         for
             cdl <- Latch.init(total)

--- a/kyo-bench/src/main/scala/kyo/bench/arena/PingPongBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/PingPongBench.scala
@@ -47,17 +47,17 @@ class PingPongBench extends ArenaBench.ForkOnly(()):
                 chan <- Channel.init[Unit](1)
                 effect =
                     for
-                        _ <- Async.run(chan.put(()))
+                        _ <- Fiber.run(chan.put(()))
                         _ <- chan.take
                         n <- ref.decrementAndGet
                         _ <- if n == 0 then promise.complete(Result.unit).unit else Kyo.unit
                     yield ()
-                _ <- repeat(depth)(Async.run[Closed, Unit, Any](effect))
+                _ <- repeat(depth)(Fiber.run[Closed, Unit, Any](effect))
             yield ()
 
         for
             promise <- Promise.init[Nothing, Unit]
-            _       <- Async.run(iterate(promise, depth))
+            _       <- Fiber.run(iterate(promise, depth))
             _       <- promise.get
         yield ()
         end for

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ProducerConsumerBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ProducerConsumerBench.scala
@@ -34,8 +34,8 @@ class ProducerConsumerBench extends ArenaBench.ForkOnly(()):
 
         Channel.init[Unit](depth / 2, Access.SingleProducerSingleConsumer).flatMap { q =>
             for
-                producer <- Async.run(repeat(depth)(q.put(())))
-                consumer <- Async.run(repeat(depth)(q.take))
+                producer <- Fiber.run(repeat(depth)(q.put(())))
+                consumer <- Fiber.run(repeat(depth)(q.take))
                 _        <- producer.get
                 _        <- consumer.get
             yield {}

--- a/kyo-bench/src/main/scala/kyo/bench/arena/RendezvousBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/RendezvousBench.scala
@@ -100,8 +100,8 @@ class RendezvousBench extends ArenaBench.ForkOnly(10000 * (10000 + 1) / 2):
 
         for
             waiting  <- AtomicRef.init[Any](null)
-            _        <- Async.run(produce(waiting))
-            consumer <- Async.run(consume(waiting))
+            _        <- Fiber.run(produce(waiting))
+            consumer <- Fiber.run(consume(waiting))
             res      <- consumer.get
         yield res
         end for

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SchedulingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SchedulingBench.scala
@@ -42,7 +42,7 @@ class SchedulingBench extends ArenaBench.ForkOnly(1001000):
             }
 
         Kyo.foreach(range) { i =>
-            Async.run(fiber(i))
+            Fiber.run(fiber(i))
         }.map { fibers =>
             Kyo.foreach(fibers)(_.get)
         }.map(_.sum)

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SemaphoreContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SemaphoreContentionBench.scala
@@ -47,7 +47,7 @@ class SemaphoreContentionBench extends ArenaBench.ForkOnly(()):
         for
             sem <- Meter.initSemaphore(permits)
             cdl <- Latch.init(parallism)
-            _   <- repeat(parallism)(Async.run(loop(sem, cdl)))
+            _   <- repeat(parallism)(Fiber.run(loop(sem, cdl)))
             _   <- cdl.await
         yield {}
         end for

--- a/kyo-cache/shared/src/test/scala/kyo/CacheTest.scala
+++ b/kyo-cache/shared/src/test/scala/kyo/CacheTest.scala
@@ -23,7 +23,7 @@ class CacheTest extends Test:
         for
             c <- Cache.init(_.maxSize(4))
             m = c.memo { (v: Int) =>
-                Async.run {
+                Fiber.run {
                     calls += 1
                     v + 1
                 }.map(_.get)
@@ -40,7 +40,7 @@ class CacheTest extends Test:
         for
             c <- Cache.init(_.maxSize(4))
             m = c.memo { (v: Int) =>
-                Async.run {
+                Fiber.run {
                     calls += 1
                     if calls == 1 then
                         throw ex

--- a/kyo-cats/shared/src/main/scala/kyo/Cats.scala
+++ b/kyo-cats/shared/src/main/scala/kyo/Cats.scala
@@ -40,7 +40,7 @@ object Cats:
     def run[A](v: => A < (Abort[Throwable] & Async))(using frame: Frame): CatsIO[A] =
         CatsIO.defer {
             import AllowUnsafe.embrace.danger
-            Async.run(v).map { fiber =>
+            Fiber.run(v).map { fiber =>
                 CatsIO.async[A] { cb =>
                     CatsIO {
                         fiber.unsafe.onComplete(r => cb(r.toEither))

--- a/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
+++ b/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
@@ -60,25 +60,25 @@ class CatsTest extends Test:
         "basic interop" in runKyo {
             for
                 v1 <- Cats.get(CatsIO.pure(1))
-                v2 <- Async.run(2).map(_.get)
+                v2 <- Fiber.run(2).map(_.get)
                 v3 <- Cats.get(CatsIO.pure(3))
             yield assert(v1 == 1 && v2 == 2 && v3 == 3)
         }
 
         "nested Kyo in Cats" in runKyo {
             Cats.get(CatsIO.defer {
-                val kyoComputation = Async.run(42).map(_.get)
+                val kyoComputation = Fiber.run(42).map(_.get)
                 Cats.run(kyoComputation)
             }).map(v => assert(v == 42))
         }
 
         "nested Cats in Kyo" in runKyo {
             val nestedCats = Cats.get(CatsIO.pure("nested"))
-            Async.run(nestedCats).map(_.get).map(s => assert(s == "nested"))
+            Fiber.run(nestedCats).map(_.get).map(s => assert(s == "nested"))
         }
 
         "complex nested pattern with parallel and race" in runKyo {
-            def kyoTask(i: Int): Int < (Abort[Nothing] & Async)  = Async.run(i * 2).map(_.get)
+            def kyoTask(i: Int): Int < (Abort[Nothing] & Async)  = Fiber.run(i * 2).map(_.get)
             def catsTask(i: Int): Int < (Abort[Nothing] & Async) = Cats.get(CatsIO.pure(i + 1))
 
             for
@@ -144,7 +144,7 @@ class CatsTest extends Test:
                     val v =
                         for
                             _ <- Cats.get(catsLoop(started, done))
-                            _ <- Async.run(kyoLoop(started, done))
+                            _ <- Fiber.run(kyoLoop(started, done))
                         yield ()
                     for
                         f <- Cats.run(v).start
@@ -201,7 +201,7 @@ class CatsTest extends Test:
                     val done    = new CountDownLatch(1)
                     val panic   = Result.Panic(new Exception)
                     for
-                        f <- Async.run(Cats.get(catsLoop(started, done)))
+                        f <- Fiber.run(Cats.get(catsLoop(started, done)))
                         _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt(panic)
                         r <- f.getResult
@@ -219,7 +219,7 @@ class CatsTest extends Test:
                             _ <- kyoLoop(started, done)
                         yield ()
                     for
-                        f <- Async.run(v)
+                        f <- Fiber.run(v)
                         _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
@@ -237,7 +237,7 @@ class CatsTest extends Test:
                         Async.zip[Throwable, Unit, Unit, Any](loop1, loop2)
                     end parallelEffect
                     for
-                        f <- Async.run(parallelEffect)
+                        f <- Fiber.run(parallelEffect)
                         _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
@@ -255,7 +255,7 @@ class CatsTest extends Test:
                         Async.race(loop1, loop2)
                     end raceEffect
                     for
-                        f <- Async.run(raceEffect)
+                        f <- Fiber.run(raceEffect)
                         _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult

--- a/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
@@ -16,7 +16,7 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
     inline def fork(
         using frame: Frame
     ): Fiber[E, A] < (Sync & Ctx) =
-        Async.run(effect)
+        Fiber.run(effect)
 
     /** Forks this computation using the Async effect and returns its result as a `Fiber[E, A]`, managed by the Resource effect. Unlike
       * `fork`, which creates an unmanaged fiber, `forkScoped` ensures that the fiber is properly cleaned up when the enclosing scope is
@@ -28,7 +28,7 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
     inline def forkScoped(
         using frame: Frame
     ): Fiber[E, A] < (Sync & Ctx & Resource) =
-        Kyo.acquireRelease(Async.run(effect))(_.interrupt.unit)
+        Kyo.acquireRelease(Fiber.run(effect))(_.interrupt.unit)
 
     /** Performs this computation and then the next one in parallel, discarding the result of this computation.
       *
@@ -49,8 +49,8 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
         fr: Frame
     ): A1 < (r.SReduced & r1.SReduced & Async & Ctx & Ctx1) =
         for
-            fiberA  <- Async.run(using s)(effect)
-            fiberA1 <- Async.run(using s2)(next)
+            fiberA  <- Fiber.run(using s)(effect)
+            fiberA1 <- Fiber.run(using s2)(next)
             _       <- fiberA.awaitCompletion
             a1      <- fiberA1.join
         yield a1
@@ -74,8 +74,8 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
         fr: Frame
     ): A < (r.SReduced & r1.SReduced & Async & Ctx & Ctx1) =
         for
-            fiberA  <- Async.run(using s)(effect)
-            fiberA1 <- Async.run(using s2)(next)
+            fiberA  <- Fiber.run(using s)(effect)
+            fiberA1 <- Fiber.run(using s2)(next)
             a       <- fiberA.join
             _       <- fiberA1.awaitCompletion
         yield a
@@ -99,8 +99,8 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
         fr: Frame
     ): (A, A1) < (r.SReduced & r1.SReduced & Async & Ctx & Ctx1) =
         for
-            fiberA  <- Async.run(using s)(effect)
-            fiberA1 <- Async.run(using s2)(next)
+            fiberA  <- Fiber.run(using s)(effect)
+            fiberA1 <- Fiber.run(using s2)(next)
             a       <- fiberA.join
             a1      <- fiberA1.join
         yield (a, a1)

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -41,10 +41,10 @@ extension (kyoObject: Kyo.type)
         for
             promise <- Promise.init[Nothing, A]
             registerFn = (eff: A < Async) =>
-                val effFiber = Async.run(eff)
+                val effFiber = Fiber.run(eff)
                 val updatePromise =
                     effFiber.map(_.onComplete(a => promise.completeDiscard(a)))
-                val updatePromiseIO = Async.run(updatePromise).unit
+                val updatePromiseIO = Fiber.run(updatePromise).unit
                 import AllowUnsafe.embrace.danger
                 Sync.Unsafe.evalOrThrow(updatePromiseIO)
             _ <- register(registerFn)

--- a/kyo-combinators/shared/src/test/scala/kyo/FiberCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/FiberCombinatorsTest.scala
@@ -10,7 +10,7 @@ class FiberCombinatorsTest extends Test:
                     state = state + 1
                     continuation(state)
                 )
-                Async.run(effect).map(_.toFuture).map { handledEffect =>
+                Fiber.run(effect).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v =>
                         assert(state == 1)
                         assert(v == 1)
@@ -21,7 +21,7 @@ class FiberCombinatorsTest extends Test:
             "should construct from Future" in run {
                 val future = scala.concurrent.Future(100)
                 val effect = Kyo.fromFuture(future)
-                Async.run(effect).map(_.toFuture).map { handledEffect =>
+                Fiber.run(effect).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v =>
                         assert(v == 100)
                     )
@@ -34,21 +34,21 @@ class FiberCombinatorsTest extends Test:
                 scala.concurrent.Future {
                     promise.complete(scala.util.Success(100))
                 }
-                Async.run(effect).map(_.toFuture).map { handledEffect =>
+                Fiber.run(effect).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v => assert(v == 100))
                 }
             }
 
             "should construct from foreachPar" in run {
                 val effect = Kyo.foreachPar(Seq(1, 2, 3))(v => v * 2)
-                Async.run(effect).map(_.toFuture).map { handledEffect =>
+                Fiber.run(effect).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v => assert(v == Seq(2, 4, 6)))
                 }
             }
 
             "should construct from traversePar" in run {
                 val effect = Kyo.traversePar(Seq(Sync(1), Sync(2), Sync(3)))
-                Async.run(effect).map(_.toFuture).map { handledEffect =>
+                Fiber.run(effect).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v => assert(v == Seq(1, 2, 3)))
                 }
             }
@@ -57,7 +57,7 @@ class FiberCombinatorsTest extends Test:
                 val effect = Kyo.never
                 runJVM {
                     Abort.run[Throwable] {
-                        val r = Async.runAndBlock(5.millis)(effect)
+                        val r = Fiber.runAndBlock(5.millis)(effect)
                         Abort.catching[Throwable](r)
                     }.map { handledEffect =>
                         assert(handledEffect match
@@ -73,16 +73,16 @@ class FiberCombinatorsTest extends Test:
                 val effect       = Async.sleep(100.millis) *> 10
                 val forkedEffect = effect.fork
                 val joinedEffect = forkedEffect.map(_.get)
-                Async.run(joinedEffect).map(_.toFuture).map { handled =>
+                Fiber.run(joinedEffect).map(_.toFuture).map { handled =>
                     handled.map(v => assert(v == 10))
                 }
             }
 
             "should join a forked effect" in run {
                 val effect       = Async.sleep(100.millis) *> 10
-                val forkedEffect = Async.run(effect)
+                val forkedEffect = Fiber.run(effect)
                 val joinedEffect = forkedEffect.join
-                Async.run(joinedEffect).map(_.toFuture).map { handled =>
+                Fiber.run(joinedEffect).map(_.toFuture).map { handled =>
                     handled.map(v => assert(v == 10))
                 }
             }
@@ -98,7 +98,7 @@ class FiberCombinatorsTest extends Test:
                 val e1     = Sync(1)
                 val e2     = Sync(2)
                 val effect = e1 &> e2
-                Async.run(effect).map(_.toFuture).map { handled =>
+                Fiber.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v =>
                         assert(v == 2)
                     )
@@ -109,7 +109,7 @@ class FiberCombinatorsTest extends Test:
                 val e1     = Sync(1)
                 val e2     = Sync(2)
                 val effect = e1 <& e2
-                Async.run(effect).map(_.toFuture).map { handled =>
+                Fiber.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v =>
                         assert(v == 1)
                     )
@@ -120,7 +120,7 @@ class FiberCombinatorsTest extends Test:
                 val e1     = Sync(1)
                 val e2     = Sync(2)
                 val effect = e1 <&> e2
-                Async.run(effect).map(_.toFuture).map { handled =>
+                Fiber.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v =>
                         assert(v == (1, 2))
                     )
@@ -141,7 +141,7 @@ class FiberCombinatorsTest extends Test:
                         result <- fiber.join
                     yield result
 
-                Async.run(Resource.run(program)).map(_.toFuture).map { handledEffect =>
+                Fiber.run(Resource.run(program)).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v =>
                         assert(state == 1)
                         assert(v == 1)
@@ -162,7 +162,7 @@ class FiberCombinatorsTest extends Test:
                         result <- fiber.join
                     yield result
 
-                Async.run(Resource.run(program)).map(_.toFuture).map { handledEffect =>
+                Fiber.run(Resource.run(program)).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v =>
                         assert(v == 42)
                         assert(cleanedUp)
@@ -186,7 +186,7 @@ class FiberCombinatorsTest extends Test:
                         _     <- fiber.awaitCompletion
                     yield completed
 
-                Async.run(program).map(_.toFuture).map { handledEffect =>
+                Fiber.run(program).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v =>
                         assert(v)
                     )
@@ -204,7 +204,7 @@ class FiberCombinatorsTest extends Test:
                         _     <- fiber.awaitCompletion
                     yield ()
 
-                Async.run(program).map(_.toFuture).map { handledEffect =>
+                Fiber.run(program).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v =>
                         assert(v == ())
                     )

--- a/kyo-combinators/shared/src/test/scala/kyo/KyoCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/KyoCombinatorsTest.scala
@@ -172,13 +172,13 @@ class KyoCombinatorsTest extends Test:
         "delay" - {
             "with short delay" in run {
                 val effect = Sync(42).delay(1.millis)
-                Async.run(effect).map(_.toFuture).map { handled =>
+                Fiber.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v => assert(v == 42))
                 }
             }
             "with zero delay" in run {
                 val effect = Sync("test").delay(0.millis)
-                Async.run(effect).map(_.toFuture).map { handled =>
+                Fiber.run(effect).map(_.toFuture).map { handled =>
                     handled.map(v => assert(v == "test"))
                 }
             }
@@ -209,7 +209,7 @@ class KyoCombinatorsTest extends Test:
                     var count    = 0
                     val schedule = Schedule.repeat(3)
                     val effect   = Sync { count += 1; count }.repeatAtInterval(schedule)
-                    Async.run(effect).map(_.toFuture).map { handled =>
+                    Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map { v =>
                             assert(v == 4)
                             assert(count == 4)
@@ -223,7 +223,7 @@ class KyoCombinatorsTest extends Test:
                     var count   = 0
                     val backoff = (i: Int) => Math.pow(2, i).toLong.millis
                     val effect  = Sync { count += 1; count }.repeatAtInterval(backoff, 3)
-                    Async.run(effect).map(_.toFuture).map { handled =>
+                    Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map { v =>
                             assert(v == 4)
                             assert(count == 4)
@@ -238,14 +238,14 @@ class KyoCombinatorsTest extends Test:
                 "condition becomes false" in run {
                     var count  = 0
                     val effect = Sync { count += 1; count }.repeatWhile(_ < 3)
-                    Async.run(effect).map(_.toFuture).map { handled =>
+                    Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }
                 "condition is initially false" in run {
                     var count  = 5
                     val effect = Sync { count += 1; count }.repeatWhile(_ < 3)
-                    Async.run(effect).map(_.toFuture).map { handled =>
+                    Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 6))
                     }
                 }
@@ -255,7 +255,7 @@ class KyoCombinatorsTest extends Test:
                 "condition becomes false with delay" in run {
                     var count  = 0
                     val effect = Sync { count += 1; count }.repeatWhile((v, i) => (v < 3, 10.millis))
-                    Async.run(effect).map(_.toFuture).map { handled =>
+                    Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }
@@ -267,14 +267,14 @@ class KyoCombinatorsTest extends Test:
                 "condition becomes true" in run {
                     var count  = 0
                     val effect = Sync { count += 1; count }.repeatUntil(_ == 3)
-                    Async.run(effect).map(_.toFuture).map { handled =>
+                    Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }
                 "condition is initially true" in run {
                     var count  = 0
                     val effect = Sync { count += 1; count }.repeatUntil(_ => true)
-                    Async.run(effect).map(_.toFuture).map { handled =>
+                    Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 1))
                     }
                 }
@@ -284,7 +284,7 @@ class KyoCombinatorsTest extends Test:
                 "condition becomes true with delay" in run {
                     var count  = 0
                     val effect = Sync { count += 1; count }.repeatUntil((v, i) => (v == 3, 10.millis))
-                    Async.run(effect).map(_.toFuture).map { handled =>
+                    Fiber.run(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }

--- a/kyo-combinators/shared/src/test/scala/kyo/ResourceCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ResourceCombinatorsTest.scala
@@ -19,7 +19,7 @@ class ResourceCombinatorsTest extends Test:
                 yield result
             assert(state == 0)
             val handledResources: Int < Async = Resource.run(effect)
-            Async.run(handledResources).map(_.toFuture).map { handled =>
+            Fiber.run(handledResources).map(_.toFuture).map { handled =>
                 for
                     assertion1 <- handled.map(_ == 50)
                     assertion2 <- Future(assert(state == 0))
@@ -31,7 +31,7 @@ class ResourceCombinatorsTest extends Test:
         "should construct a resource using addFinalizer" in run {
             var state  = 0
             val effect = Kyo.addFinalizer(Sync { state = 100 })
-            Async.run(Resource.run(effect)).map(_.toFuture).map { handled =>
+            Fiber.run(Resource.run(effect)).map(_.toFuture).map { handled =>
                 for
                     ass1 <- handled
                     ass2 <- Future(assert(state == 100))
@@ -46,7 +46,7 @@ class ResourceCombinatorsTest extends Test:
                 override def close(): Unit = state = 100
             val effect = Kyo.fromAutoCloseable(closeable)
             assert(state == 0)
-            Async.run(Resource.run(effect)).map(_.toFuture).map { handled =>
+            Fiber.run(Resource.run(effect)).map(_.toFuture).map { handled =>
                 for
                     ass2 <- handled.map(v => assert(v.equals(closeable)))
                     ass3 <- Future(assert(state == 100))

--- a/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -19,7 +19,7 @@ abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abo
                 val race = Async.race(fiber.get, previousAsync)
                 Async.timeout(timeout)(race)
             }
-            val _ = Sync.Unsafe.evalOrThrow(Async.run(racedAsyncIO))
+            val _ = Sync.Unsafe.evalOrThrow(Fiber.run(racedAsyncIO))
         }.toChunk
     end run
 

--- a/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -5,7 +5,7 @@ abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abo
     final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         initCode = initCode.appended(() =>
-            val result = Sync.Unsafe.evalOrThrow(Abort.run(Async.runAndBlock(timeout)(handle(v))))
+            val result = Sync.Unsafe.evalOrThrow(Abort.run(Fiber.runAndBlock(timeout)(handle(v))))
             onResult(result)
         )
     end run

--- a/kyo-core/jvm/src/main/scala/kyo/Process.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Process.scala
@@ -194,7 +194,7 @@ object Process:
                                 ()
                             }
                             for
-                                _ <- Async.run(Resource.run(resources))
+                                _ <- Fiber.run(Resource.run(resources))
                             yield ()
                         case _ => Kyo.unit
                 yield process

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -499,7 +499,7 @@ object Clock:
     )(
         f: A => A < (Async & Abort[E])
     )(using Frame): Fiber[E, A] < Sync =
-        Async.run {
+        Fiber.run {
             Clock.use { clock =>
                 Loop(state, delaySchedule) { (state, schedule) =>
                     clock.now.map { now =>
@@ -601,7 +601,7 @@ object Clock:
     )(
         f: A => A < (Async & Abort[E])
     )(using Frame): Fiber[E, A] < Sync =
-        Async.run {
+        Fiber.run {
             Clock.use { clock =>
                 clock.now.map { now =>
                     Loop(now, state, intervalSchedule) { (lastExecution, state, period) =>

--- a/kyo-core/shared/src/main/scala/kyo/Hub.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Hub.scala
@@ -226,7 +226,7 @@ object Hub:
             val channel          = Channel.Unsafe.init[A](capacity, Access.MultiProducerSingleConsumer).safe
             val listeners        = new CopyOnWriteArraySet[Listener[A]]
             def currentListeners = Chunk.fromNoCopy(listeners.toArray()).asInstanceOf[Chunk[Listener[A]]]
-            Async.run {
+            Fiber.run {
                 Loop.foreach {
                     channel.take.map { value =>
                         Abort.recover { error =>

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -92,7 +92,7 @@ object KyoApp:
         def runAndBlock[A](timeout: Duration)(
             v: A < (Async & Resource & Abort[Throwable])
         )(using Frame, AllowUnsafe): Result[Throwable, A] =
-            Abort.run(Sync.Unsafe.run(Async.runAndBlock(timeout)(Resource.run(v)))).eval
+            Abort.run(Sync.Unsafe.run(Fiber.runAndBlock(timeout)(Resource.run(v)))).eval
     end Unsafe
 
 end KyoApp

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -185,7 +185,7 @@ object Resource:
                                                 Abort.run[Throwable](task(ex))
                                                     .map(_.foldError(_ => (), ex => Log.error("Resource finalizer failed", ex.exception)))
                                             }
-                                                .handle(Async.run[Nothing, Unit, Any])
+                                                .handle(Fiber.run[Nothing, Unit, Any])
                                                 .map(promise.becomeDiscard)
                             }
 

--- a/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
+++ b/kyo-core/shared/src/main/scala/kyo/StreamCoreExtensions.scala
@@ -88,7 +88,7 @@ object StreamCoreExtensions:
             t2: Tag[Emit[Chunk[A]]],
             fr: Frame
         ): Unit < (Async & S & Resource) =
-            Resource.acquireRelease(Async.run {
+            Resource.acquireRelease(Fiber.run {
                 Abort.run[E](
                     Abort.run[Closed](
                         latch.await.andThen(stream.foreachChunk(chunk => hub.put(Result.Success(Present(chunk)))))
@@ -139,7 +139,7 @@ object StreamCoreExtensions:
                 Channel.init[Maybe[Chunk[V]]](bufferSize, Access.MultiProducerMultiConsumer).map: channel =>
                     Sync.ensure(channel.close):
                         for
-                            _ <- Async.run[E, Unit, S](Abort.run {
+                            _ <- Fiber.run[E, Unit, S](Abort.run {
                                 Async.foreachDiscard(streams)(
                                     _.foreachChunk(c => Abort.run[Closed](channel.put(Present(c))))
                                 )
@@ -257,7 +257,7 @@ object StreamCoreExtensions:
                 Channel.initWith[Maybe[Chunk[V]]](bufferSize, Access.MultiProducerMultiConsumer): channel =>
                     Sync.ensure(channel.close):
                         for
-                            _ <- Async.run(Abort.run(
+                            _ <- Fiber.run(Abort.run(
                                 Async
                                     .foreachDiscard(streams)(
                                         _.foreachChunk(c => Abort.run(channel.put(Present(c))))
@@ -338,7 +338,7 @@ object StreamCoreExtensions:
                 Channel.initWith[Maybe[Chunk[V]]](bufferSize, Access.MultiProducerMultiConsumer): channel =>
                     Sync.ensure(channel.close):
                         for
-                            _ <- Async.run(
+                            _ <- Fiber.run(
                                 Async.gather(
                                     stream.foreachChunk(c => channel.put(Present(c)))
                                         .andThen(channel.put(Absent)),
@@ -404,14 +404,14 @@ object StreamCoreExtensions:
                                     Kyo.foreach(input) { v =>
                                         // Fork transformation, pass result through stagingChannel merely as rate limiter,
                                         // (signal to continue)
-                                        Async.run(f(v)).map: transformationFiber =>
+                                        Fiber.run(f(v)).map: transformationFiber =>
                                             transformationFiber.map(_ => true).map: signalFiber =>
                                                 stagingChannel.put(signalFiber).andThen:
                                                     transformationFiber
                                     }.map: fiberChunk =>
                                         // Note that this means one of the concurrency is "slots" is used to assemble chunk
                                         // this is not an expensive operation, however, so should not be a problem
-                                        Async.run(Kyo.foreach(fiberChunk)(_.get)).map: chunkFiber =>
+                                        Fiber.run(Kyo.foreach(fiberChunk)(_.get)).map: chunkFiber =>
                                             stagingChannel.put(chunkFiber).andThen:
                                                 Loop.continue(cont(()))
                         ).andThen(stagingChannel.put(Fiber.success(false)))
@@ -426,7 +426,7 @@ object StreamCoreExtensions:
                                     case chunk: Chunk[V2] => channelOut.put(Present(chunk)).andThen(Loop.continue)
 
                         // Run stream and staging handlers in background, handling failures (end stream)
-                        val background = Async.run:
+                        val background = Fiber.run:
                             Abort.fold[E | Closed](
                                 onSuccess = _ => Abort.run(channelOut.put(Absent)).unit,
                                 onFail = {
@@ -488,7 +488,7 @@ object StreamCoreExtensions:
                     Channel.initWith[Fiber[E | Closed, Boolean]](parallel): parChannel =>
                         // Handle transformation effect, with signal to continue streaming
                         def throttledFork(effect: Any < (Async & Abort[Closed | E] & S2)) =
-                            Async.run(effect).map: effectFiber =>
+                            Fiber.run(effect).map: effectFiber =>
                                 effectFiber.map(_ => true).map: signalFiber =>
                                     parChannel.put(signalFiber).andThen:
                                         effectFiber
@@ -510,7 +510,7 @@ object StreamCoreExtensions:
                                     if continue then Loop.continue
                                     else Loop.done
 
-                        val background = Async.run:
+                        val background = Fiber.run:
                             Abort.fold[E | Closed](
                                 onSuccess = _ => Abort.run(channelOut.put(Absent)).unit,
                                 onFail = {
@@ -579,7 +579,7 @@ object StreamCoreExtensions:
                         val handledStream = ArrowEffect.handleLoop(t1, stream.emit)(
                             handle = [C] =>
                                 (input, cont) =>
-                                    Async.run(f(input).map(Present(_))).map: fiber =>
+                                    Fiber.run(f(input).map(Present(_))).map: fiber =>
                                         stagingChannel.put(fiber).andThen:
                                             Loop.continue(cont(()))
                         ).andThen(stagingChannel.put(Fiber.success(Absent)).unit)
@@ -593,7 +593,7 @@ object StreamCoreExtensions:
                                         else Loop.continue
 
                         // Run stream handler and staging handler in background, handling errors
-                        val background = Async.run:
+                        val background = Fiber.run:
                             Abort.fold[E | Closed](
                                 onSuccess = _ => Abort.run(outputChannel.put(Absent)).unit,
                                 onFail = {
@@ -658,7 +658,7 @@ object StreamCoreExtensions:
                     Channel.initWith[Fiber[E | Closed, Boolean]](parallel - 1): parChannel =>
                         // Handle transformation effect, with signal to continue streaming
                         def throttledFork[A](task: Any < (Async & Abort[Closed | E] & S2)) =
-                            Async.run(task).map: fiber =>
+                            Fiber.run(task).map: fiber =>
                                 fiber.map(_ => true).map: signalFiber =>
                                     parChannel.put(signalFiber).unit
 
@@ -678,7 +678,7 @@ object StreamCoreExtensions:
                                 else Loop.done
 
                         // Run stream handler and par handler in background, handling errors (ensure stream ends)
-                        val background = Async.run:
+                        val background = Fiber.run:
                             Abort.fold[E | Closed](
                                 onSuccess = _ => Abort.run(channelOut.put(Absent)).unit,
                                 onFail = {
@@ -984,8 +984,8 @@ object StreamCoreExtensions:
 
                     // Handle loop collecting emitted values and flushing them until completion
                     val push: Fiber[E | Closed, Unit] < (Sync & S) =
-                        Async.run[E | Closed, Unit, S]:
-                            Sync.ensure(Async.run[Closed, Unit, Any](channel.put(Flush))):
+                        Fiber.run[E | Closed, Unit, S]:
+                            Sync.ensure(Fiber.run[Closed, Unit, Any](channel.put(Flush))):
                                 ArrowEffect.handleLoop(t1, stream.emit)(
                                     handle = [C] =>
                                         (chunk, cont) =>

--- a/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
@@ -13,7 +13,7 @@ private[kyo] trait BaseKyoCoreTest extends BaseKyoKernelTest[Abort[Any] & Async 
                 case e             => throw new IllegalStateException(s"Test aborted with $e")
             },
             Async.timeout(timeout),
-            Async.run,
+            Fiber.run,
             _.map(_.toFuture).map(_.flatten),
             Sync.Unsafe.evalOrThrow
         )

--- a/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
@@ -32,7 +32,7 @@ class BarrierTest extends Test:
     "await + fibers" in run {
         for
             barrier <- Barrier.init(1)
-            _       <- Async.run(barrier.await)
+            _       <- Fiber.run(barrier.await)
             _       <- barrier.await
         yield succeed
     }

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -48,10 +48,10 @@ class ChannelTest extends Test:
         for
             c     <- Channel.init[Int](2)
             b     <- c.offer(1)
-            put   <- Async.run(c.put(2))
+            put   <- Fiber.run(c.put(2))
             _     <- untilTrue(c.full)
-            take1 <- Async.run(c.take)
-            take2 <- Async.run(c.take)
+            take1 <- Fiber.run(c.take)
+            take2 <- Fiber.run(c.take)
             v1    <- take1.get
             _     <- put.get
             v2    <- take1.get
@@ -63,7 +63,7 @@ class ChannelTest extends Test:
             c  <- Channel.init[Int](2)
             _  <- c.put(1)
             _  <- c.put(2)
-            f  <- Async.run(c.put(3))
+            f  <- Fiber.run(c.put(3))
             _  <- Async.sleep(10.millis)
             d1 <- f.done
             v1 <- c.poll
@@ -75,7 +75,7 @@ class ChannelTest extends Test:
     "blocking take" in run {
         for
             c  <- Channel.init[Int](2)
-            f  <- Async.run(c.take)
+            f  <- Fiber.run(c.take)
             _  <- Async.sleep(10.millis)
             d1 <- f.done
             _  <- c.put(1)
@@ -95,7 +95,7 @@ class ChannelTest extends Test:
             "should put batch incrementally if exceeds channel size" in run {
                 for
                     c   <- Channel.init[Int](2)
-                    f   <- Async.run(c.putBatch(Chunk(1, 2, 3, 4, 5, 6)))
+                    f   <- Fiber.run(c.putBatch(Chunk(1, 2, 3, 4, 5, 6)))
                     res <- c.takeExactly(6)
                     _   <- Fiber.get(f)
                 yield assert(res == Chunk(1, 2, 3, 4, 5, 6))
@@ -121,8 +121,8 @@ class ChannelTest extends Test:
             "should notify waiting takers immediately" in run {
                 for
                     c     <- Channel.init[Int](2)
-                    take1 <- Async.run(c.take)
-                    take2 <- Async.run(c.take)
+                    take1 <- Fiber.run(c.take)
+                    take2 <- Fiber.run(c.take)
                     _     <- c.putBatch(Seq(1, 2))
                     v1    <- take1.get
                     v2    <- take2.get
@@ -133,11 +133,11 @@ class ChannelTest extends Test:
                     c     <- Channel.init[Int](2)
                     _     <- c.put(1)
                     _     <- c.put(2)
-                    take1 <- Async.run(c.take)
-                    fiber <- Async.run(c.putBatch(Seq(3, 4)))
+                    take1 <- Fiber.run(c.take)
+                    fiber <- Fiber.run(c.putBatch(Seq(3, 4)))
                     v1    <- take1.get
                     done1 <- fiber.done
-                    take2 <- Async.run(c.take)
+                    take2 <- Fiber.run(c.take)
                     v2    <- take2.get
                     _     <- fiber.get
                 yield assert(v1 == 1 && v2 == 2 && !done1)
@@ -160,7 +160,7 @@ class ChannelTest extends Test:
             "should preserve elements put before closure during partial batch put" in run {
                 for
                     c     <- Channel.init[Int](2)
-                    fiber <- Async.run(c.putBatch(Chunk(1, 2, 3, 4, 5)))
+                    fiber <- Fiber.run(c.putBatch(Chunk(1, 2, 3, 4, 5)))
                     v1    <- c.take
                     v2    <- c.take
                     _     <- c.close
@@ -180,7 +180,7 @@ class ChannelTest extends Test:
             "should put batch incrementally if exceeds channel size" in run {
                 for
                     c   <- Channel.init[Any](2)
-                    f   <- Async.run(c.putBatch(Chunk(Chunk(1), Chunk(2), Chunk(3), Chunk(4), Chunk(5), Chunk(6))))
+                    f   <- Fiber.run(c.putBatch(Chunk(Chunk(1), Chunk(2), Chunk(3), Chunk(4), Chunk(5), Chunk(6))))
                     res <- c.takeExactly(6)
                     _   <- Fiber.get(f)
                 yield assert(res == Chunk(Chunk(1), Chunk(2), Chunk(3), Chunk(4), Chunk(5), Chunk(6)))
@@ -215,7 +215,7 @@ class ChannelTest extends Test:
             "should put batch incrementally if exceeds channel size" in run {
                 for
                     c <- Channel.init[Chunk.Indexed[Int]](2)
-                    f <- Async.run(c.putBatch(Chunk(
+                    f <- Fiber.run(c.putBatch(Chunk(
                         Chunk(1).toIndexed,
                         Chunk(2).toIndexed,
                         Chunk(3).toIndexed,
@@ -269,7 +269,7 @@ class ChannelTest extends Test:
             for
                 c  <- Channel.init[Int](3)
                 _  <- Kyo.foreach(1 to 3)(c.put(_))
-                f  <- Async.run(c.takeExactly(5))
+                f  <- Fiber.run(c.takeExactly(5))
                 _  <- untilTrue(c.size.map(_ == 0))
                 fd <- f.done
                 _  <- f.interrupt
@@ -287,7 +287,7 @@ class ChannelTest extends Test:
             for
                 c  <- Channel.init[Int](3)
                 _  <- Kyo.foreach(1 to 3)(c.put(_))
-                f  <- Async.run(c.takeExactly(6))
+                f  <- Fiber.run(c.takeExactly(6))
                 _  <- untilTrue(c.empty)
                 fd <- f.done
                 _  <- Kyo.foreach(4 to 6)(c.put(_))
@@ -314,9 +314,9 @@ class ChannelTest extends Test:
         "should consider pending puts" in run {
             for
                 c         <- Channel.init[Int](2)
-                _         <- Async.run(c.put(1))
-                _         <- Async.run(c.put(2))
-                _         <- Async.run(c.put(3))
+                _         <- Fiber.run(c.put(1))
+                _         <- Fiber.run(c.put(2))
+                _         <- Fiber.run(c.put(3))
                 _         <- untilTrue(c.pendingPuts.map(_ == 1))
                 result    <- c.drain
                 finalSize <- c.size
@@ -326,9 +326,9 @@ class ChannelTest extends Test:
         "should consider pending puts - zero capacity" in run {
             for
                 c         <- Channel.init[Int](0)
-                _         <- Async.run(c.put(1))
-                _         <- Async.run(c.put(2))
-                _         <- Async.run(c.put(3))
+                _         <- Fiber.run(c.put(1))
+                _         <- Fiber.run(c.put(2))
+                _         <- Fiber.run(c.put(3))
                 _         <- untilTrue(c.pendingPuts.map(_ == 3))
                 result    <- c.drain
                 finalSize <- c.size
@@ -390,10 +390,10 @@ class ChannelTest extends Test:
         "should consider pending puts" in run {
             for
                 c         <- Channel.init[Int](2)
-                _         <- Async.run(c.put(1))
-                _         <- Async.run(c.put(2))
-                _         <- Async.run(c.put(3))
-                _         <- Async.run(c.put(4))
+                _         <- Fiber.run(c.put(1))
+                _         <- Fiber.run(c.put(2))
+                _         <- Fiber.run(c.put(3))
+                _         <- Fiber.run(c.put(4))
                 _         <- untilTrue(c.pendingPuts.map(_ == 2))
                 result    <- c.drainUpTo(3)
                 finalSize <- c.size
@@ -402,10 +402,10 @@ class ChannelTest extends Test:
         "should consider pending puts - zero capacity" in run {
             for
                 c         <- Channel.init[Int](0)
-                _         <- Async.run(c.put(1))
-                _         <- Async.run(c.put(2))
-                _         <- Async.run(c.put(3))
-                _         <- Async.run(c.put(4))
+                _         <- Fiber.run(c.put(1))
+                _         <- Fiber.run(c.put(2))
+                _         <- Fiber.run(c.put(3))
+                _         <- Fiber.run(c.put(4))
                 _         <- untilTrue(c.pendingPuts.map(_ == 4))
                 result    <- c.drainUpTo(3)
                 finalSize <- c.size
@@ -441,7 +441,7 @@ class ChannelTest extends Test:
         "pending take" in run {
             for
                 c <- Channel.init[Int](2)
-                f <- Async.run(c.take)
+                f <- Fiber.run(c.take)
                 r <- c.close
                 d <- f.getResult
                 t <- Abort.run(c.full)
@@ -452,7 +452,7 @@ class ChannelTest extends Test:
                 c <- Channel.init[Int](2)
                 _ <- c.put(1)
                 _ <- c.put(2)
-                f <- Async.run(c.put(3))
+                f <- Fiber.run(c.put(3))
                 r <- c.close
                 d <- f.getResult
                 e <- Abort.run(c.offer(1))
@@ -461,7 +461,7 @@ class ChannelTest extends Test:
         "no buffer w/ pending put" in run {
             for
                 c <- Channel.init[Int](0)
-                f <- Async.run(c.put(1))
+                f <- Fiber.run(c.put(1))
                 r <- c.close
                 d <- f.getResult
                 t <- Abort.run(c.poll)
@@ -470,7 +470,7 @@ class ChannelTest extends Test:
         "no buffer w/ pending take" in run {
             for
                 c <- Channel.init[Int](0)
-                f <- Async.run(c.take)
+                f <- Fiber.run(c.take)
                 r <- c.close
                 d <- f.getResult
                 t <- Abort.run[Throwable](c.put(1))
@@ -480,7 +480,7 @@ class ChannelTest extends Test:
     "no buffer" in run {
         for
             c <- Channel.init[Int](0)
-            _ <- Async.run(c.put(1))
+            _ <- Fiber.run(c.put(1))
             v <- c.take
             f <- c.full
             e <- c.empty
@@ -490,8 +490,8 @@ class ChannelTest extends Test:
         "with buffer" in run {
             for
                 c  <- Channel.init[Int](10)
-                f1 <- Async.run(Async.fill(1000, 1000)(c.put(1)))
-                f2 <- Async.run(Async.fill(1000, 1000)(c.take))
+                f1 <- Fiber.run(Async.fill(1000, 1000)(c.put(1)))
+                f2 <- Fiber.run(Async.fill(1000, 1000)(c.take))
                 _  <- f1.get
                 _  <- f2.get
                 b  <- c.empty
@@ -501,8 +501,8 @@ class ChannelTest extends Test:
         "no buffer" in run {
             for
                 c  <- Channel.init[Int](0)
-                f1 <- Async.run(Async.fill(1000, 1000)(c.put(1)))
-                f2 <- Async.run(Async.fill(1000, 1000)(c.take))
+                f1 <- Fiber.run(Async.fill(1000, 1000)(c.put(1)))
+                f2 <- Fiber.run(Async.fill(1000, 1000)(c.take))
                 _  <- f1.get
                 _  <- f2.get
                 b  <- c.empty
@@ -546,10 +546,10 @@ class ChannelTest extends Test:
                 size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
-                offerFiber <- Async.run(
+                offerFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(channel.offer(i))))
                 )
-                closeFiber    <- Async.run(latch.await.andThen(channel.close))
+                closeFiber    <- Fiber.run(latch.await.andThen(channel.close))
                 _             <- latch.release
                 offered       <- offerFiber.get
                 backlog       <- closeFiber.get
@@ -576,10 +576,10 @@ class ChannelTest extends Test:
                 size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
-                offerFiber <- Async.run(
+                offerFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(channel.offer(i))))
                 )
-                pollFiber <- Async.run(
+                pollFiber <- Fiber.run(
                     latch.await.andThen(Async.fill(100, 100)(Abort.run(channel.poll)))
                 )
                 _           <- latch.release
@@ -596,10 +596,10 @@ class ChannelTest extends Test:
                 size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
-                putFiber <- Async.run(
+                putFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(channel.put(i))))
                 )
-                takeFiber <- Async.run(
+                takeFiber <- Fiber.run(
                     latch.await.andThen(Async.fill(100, 100)(Abort.run(channel.take)))
                 )
                 _     <- latch.release
@@ -616,10 +616,10 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 _       <- Kyo.foreach(1 to size)(i => channel.offer(i))
                 latch   <- Latch.init(1)
-                offerFiber <- Async.run(
+                offerFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(channel.offer(i))))
                 )
-                closeFiber <- Async.run(latch.await.andThen(channel.close))
+                closeFiber <- Fiber.run(latch.await.andThen(channel.close))
                 _          <- latch.release
                 offered    <- offerFiber.get
                 backlog    <- closeFiber.get
@@ -642,10 +642,10 @@ class ChannelTest extends Test:
                 size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
-                offerFiber <- Async.run(
+                offerFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(channel.offer(i))))
                 )
-                closeFiber <- Async.run(
+                closeFiber <- Fiber.run(
                     latch.await.andThen(Async.fill(100, 100)(channel.close))
                 )
                 _        <- latch.release
@@ -670,19 +670,19 @@ class ChannelTest extends Test:
                 size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
-                offerFiber <- Async.run(
+                offerFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 50, 50)(i => Abort.run(channel.offer(i))))
                 )
-                pollFiber <- Async.run(
+                pollFiber <- Fiber.run(
                     latch.await.andThen(Async.fill(50, 50)(Abort.run(channel.poll)))
                 )
-                putFiber <- Async.run(
+                putFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(51 to 100, 50)(i => Abort.run(channel.put(i))))
                 )
-                takeFiber <- Async.run(
+                takeFiber <- Fiber.run(
                     latch.await.andThen(Async.fill(50, 50)(Abort.run(channel.take)))
                 )
-                closeFiber <- Async.run(latch.await.andThen(channel.close))
+                closeFiber <- Fiber.run(latch.await.andThen(channel.close))
                 _          <- latch.release
                 offered    <- offerFiber.get
                 polled     <- pollFiber.get
@@ -711,12 +711,12 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
-                putFiber <- Async.run(
+                putFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach((1 to 60).grouped(3).toSeq, 60)(batch =>
                         channel.putBatch(batch).andThen(batch)
                     ))
                 )
-                takeFiber <- Async.run(
+                takeFiber <- Fiber.run(
                     latch.await.andThen(Async.fill(60, 60)(channel.take))
                 )
                 _         <- latch.release
@@ -734,12 +734,12 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
-                putFiber <- Async.run(
+                putFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach((1 to 60).grouped(3).toSeq, 60)(batch =>
                         channel.putBatch(batch).andThen(batch)
                     ))
                 )
-                takeFiber <- Async.run(
+                takeFiber <- Fiber.run(
                     latch.await.andThen(Async.fill(6, 6)(
                         channel.takeExactly(10)
                     ))
@@ -809,7 +809,7 @@ class ChannelTest extends Test:
         "should stream concurrently with ingest, without specified chunk size" in run {
             for
                 c  <- Channel.init[Int](4)
-                bg <- Async.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
+                bg <- Fiber.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
                 stream = c.stream().take(20).mapChunk(ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
@@ -819,7 +819,7 @@ class ChannelTest extends Test:
         "should stream concurrently with ingest, never exceeding specified chunk size" in run {
             for
                 c  <- Channel.init[Int](4)
-                bg <- Async.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
+                bg <- Fiber.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
                 stream = c.stream(2).take(20).mapChunk(ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
@@ -829,7 +829,7 @@ class ChannelTest extends Test:
         "should fail when channel is closed" in run {
             for
                 c  <- Channel.init[Int](3)
-                bg <- Async.run(Kyo.foreach(0 to 8)(c.put).andThen(c.close))
+                bg <- Fiber.run(Kyo.foreach(0 to 8)(c.put).andThen(c.close))
                 stream = c.stream().mapChunk(ch => Chunk(ch))
                 v <- Abort.run(stream.run)
             yield v match
@@ -841,7 +841,7 @@ class ChannelTest extends Test:
         "should stream concurrently with ingest via putBatch, yielding consistent chunk sizes" in run {
             for
                 c  <- Channel.init[Int](9)
-                bg <- Async.run(Loop(0)(i => c.putBatch(Chunk(i, i + 1, i + 2)).andThen(Loop.continue(i + 3))))
+                bg <- Fiber.run(Loop(0)(i => c.putBatch(Chunk(i, i + 1, i + 2)).andThen(Loop.continue(i + 3))))
                 stream = c.stream(3).take(15).mapChunk(ch => Chunk(ch))
                 res <- stream.run
                 _   <- bg.interrupt
@@ -906,7 +906,7 @@ class ChannelTest extends Test:
         "should stream concurrently with ingest, without specified chunk size" in run {
             for
                 c  <- Channel.init[Int](4)
-                bg <- Async.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
+                bg <- Fiber.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
                 stream = c.streamUntilClosed().take(20).mapChunk(ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
@@ -916,7 +916,7 @@ class ChannelTest extends Test:
         "should stream concurrently with ingest, with specified chunk size" in run {
             for
                 c  <- Channel.init[Int](4)
-                bg <- Async.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
+                bg <- Fiber.run(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
                 stream = c.streamUntilClosed(2).take(20).mapChunk(ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
@@ -928,7 +928,7 @@ class ChannelTest extends Test:
             for
                 c <- Channel.init[Int](3)
                 stream = c.streamUntilClosed()
-                f <- Async.run(stream.run)
+                f <- Fiber.run(stream.run)
                 _ <- Kyo.foreach(fullStream)(c.put).andThen(c.close)
                 r <- Fiber.get(f)
             yield assert(r.size <= fullStream.size && r == fullStream.take(r.size))
@@ -940,9 +940,9 @@ class ChannelTest extends Test:
             for
                 c <- Channel.init[Int](3)
                 stream = c.streamUntilClosed()
-                f <- Async.run(stream.run)
+                f <- Fiber.run(stream.run)
                 _ <- Kyo.foreach(fullStream)(c.put).andThen(c.close)
-                _ <- Async.run(c.closeAwaitEmpty)
+                _ <- Fiber.run(c.closeAwaitEmpty)
                 r <- Fiber.get(f)
             yield assert(r.size <= fullStream.size && r == fullStream.take(r.size))
             end for
@@ -962,7 +962,7 @@ class ChannelTest extends Test:
                 c       <- Channel.init[Int](10)
                 _       <- c.put(1)
                 _       <- c.put(2)
-                fiber   <- Async.run(c.closeAwaitEmpty)
+                fiber   <- Fiber.run(c.closeAwaitEmpty)
                 closed1 <- c.closed
                 _       <- c.take
                 closed2 <- c.closed
@@ -984,7 +984,7 @@ class ChannelTest extends Test:
             for
                 c      <- Channel.init[Int](10)
                 _      <- Kyo.foreach(1 to 5)(i => c.put(i))
-                fiber  <- Async.run(c.closeAwaitEmpty)
+                fiber  <- Fiber.run(c.closeAwaitEmpty)
                 _      <- Async.foreach(1 to 5)(_ => c.take)
                 result <- fiber.get
             yield assert(result)
@@ -1002,7 +1002,7 @@ class ChannelTest extends Test:
                 c      <- Channel.init[Int](2)
                 _      <- c.put(1)
                 _      <- c.put(2)
-                fiber  <- Async.run(c.closeAwaitEmpty)
+                fiber  <- Fiber.run(c.closeAwaitEmpty)
                 _      <- c.take
                 _      <- c.take
                 take   <- Abort.run(c.take)
@@ -1015,7 +1015,7 @@ class ChannelTest extends Test:
                 c      <- Channel.init[Int](10)
                 _      <- c.put(1)
                 _      <- c.put(2)
-                fiber  <- Async.run(Async.fill(10)(c.closeAwaitEmpty))
+                fiber  <- Fiber.run(Async.fill(10)(c.closeAwaitEmpty))
                 _      <- c.take
                 _      <- c.take
                 closes <- fiber.get
@@ -1028,10 +1028,10 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 _       <- Kyo.foreach(1 to (size min 5))(i => channel.put(i))
                 latch   <- Latch.init(1)
-                closeAwaitEmptyFiber <- Async.run(
+                closeAwaitEmptyFiber <- Fiber.run(
                     latch.await.andThen(channel.closeAwaitEmpty)
                 )
-                closeFiber <- Async.run(
+                closeFiber <- Fiber.run(
                     latch.await.andThen(channel.close)
                 )
                 _        <- latch.release
@@ -1053,20 +1053,20 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
-                producerFiber1 <- Async.run(
+                producerFiber1 <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(1 to 25, 10)(i => Abort.run(channel.put(i)))
                             .andThen(channel.closeAwaitEmpty)
                     )
                 )
-                producerFiber2 <- Async.run(
+                producerFiber2 <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(26 to 50, 10)(i => Abort.run(channel.put(i)))
                             .andThen(channel.closeAwaitEmpty)
                     )
                 )
 
-                consumerFiber <- Async.run(
+                consumerFiber <- Fiber.run(
                     latch.await.andThen(
                         Async.fill(100, 10)(Abort.run(channel.take))
                     )
@@ -1093,20 +1093,20 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
-                producerFiber1 <- Async.run(
+                producerFiber1 <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(1 to 25, 10)(i => Abort.run(channel.put(i)))
                             .andThen(channel.closeAwaitEmpty)
                     )
                 )
-                producerFiber2 <- Async.run(
+                producerFiber2 <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(26 to 50, 10)(i => Abort.run(channel.put(i)))
                             .andThen(channel.close)
                     )
                 )
 
-                consumerFiber <- Async.run(
+                consumerFiber <- Fiber.run(
                     latch.await.andThen(
                         Async.fill(100, 10)(Abort.run(channel.take))
                     )
@@ -1141,8 +1141,8 @@ class ChannelTest extends Test:
                 c     <- Channel.init[Int](2)
                 _     <- c.put(1)
                 _     <- c.put(2)
-                f1    <- Async.run(c.put(3))
-                f2    <- Async.run(c.put(4))
+                f1    <- Fiber.run(c.put(3))
+                f2    <- Fiber.run(c.put(4))
                 _     <- Async.sleep(10.millis)
                 puts  <- c.pendingPuts
                 takes <- c.pendingTakes
@@ -1156,8 +1156,8 @@ class ChannelTest extends Test:
         "should count pending takes when channel is empty" in run {
             for
                 c     <- Channel.init[Int](2)
-                f1    <- Async.run(c.take)
-                f2    <- Async.run(c.take)
+                f1    <- Fiber.run(c.take)
+                f2    <- Fiber.run(c.take)
                 _     <- Async.sleep(10.millis)
                 puts  <- c.pendingPuts
                 takes <- c.pendingTakes
@@ -1188,7 +1188,7 @@ class ChannelTest extends Test:
             ref <- AtomicRef.init(c0)
             // Create a fiber that repeatedly puts and item and then checks to see if the channel
             // has been drained. If it has then it closes the channel and creates a new one.
-            producer <- Async.run {
+            producer <- Fiber.run {
                 Loop.foreach:
                     for
                         c     <- ref.get

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -489,7 +489,7 @@ class FiberTest extends Test:
 
         "timeout" in runNotJS {
             for
-                fiber  <- Async.run(Async.sleep(1.second).andThen(42))
+                fiber  <- Fiber.run(Async.sleep(1.second).andThen(42))
                 result <- fiber.block(1.millis)
             yield assert(result.isFailure)
         }
@@ -502,7 +502,7 @@ class FiberTest extends Test:
             stop   <- Latch.init(1)
             result <- AtomicInt.init(0)
             fiber <-
-                Async.run {
+                Fiber.run {
                     for
                         _ <- start.release
                         _ <- run.await

--- a/kyo-core/shared/src/test/scala/kyo/HubTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/HubTest.scala
@@ -63,7 +63,7 @@ class HubTest extends Test:
                 _     <- h.listen(0)
                 _     <- h.put(1)
                 _     <- h.put(2)
-                fiber <- Async.run(h.put(3))
+                fiber <- Fiber.run(h.put(3))
                 _     <- Async.sleep(10.millis)
                 done  <- fiber.done
                 hFull <- h.full
@@ -161,7 +161,7 @@ class HubTest extends Test:
             for
                 h <- Hub.init[Int](4)
                 l <- h.listen
-                f <- Async.run(l.stream().take(4).run)
+                f <- Fiber.run(l.stream().take(4).run)
                 _ <- h.put(1)
                 _ <- h.put(2)
                 _ <- h.put(3)
@@ -174,7 +174,7 @@ class HubTest extends Test:
             for
                 h     <- Hub.init[Int](4)
                 l     <- h.listen
-                fiber <- Async.run(l.streamFailing().run)
+                fiber <- Fiber.run(l.streamFailing().run)
                 _     <- h.close
                 res   <- Abort.run[Closed](fiber.get)
             yield assert(res.isFailure)
@@ -184,7 +184,7 @@ class HubTest extends Test:
             for
                 h <- Hub.init[Int](4)
                 l <- h.listen
-                f <- Async.run(l.stream(2).mapChunk(Chunk(_)).take(2).run)
+                f <- Fiber.run(l.stream(2).mapChunk(Chunk(_)).take(2).run)
                 _ <- h.putBatch(1 to 4)
                 r <- f.get
             yield assert(r.forall(_.size <= 2))
@@ -194,7 +194,7 @@ class HubTest extends Test:
             for
                 h <- Hub.init[Int](4)
                 l <- h.listen
-                f <- Async.run(l.stream().take(1000).run)
+                f <- Fiber.run(l.stream().take(1000).run)
                 _ <- Kyo.foreachDiscard(1 to 1000)(h.put)
                 r <- f.get
             yield assert(r.size == 1000 && r == Chunk.from(1 to 1000))
@@ -209,22 +209,22 @@ class HubTest extends Test:
                 l2    <- hub.listen
                 l3    <- hub.listen
                 latch <- Latch.init(1)
-                pubFiber <- Async.run(
+                pubFiber <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(1 to 10, 10)(i => Abort.run(hub.put(i)))
                     )
                 )
-                sub1Fiber <- Async.run(
+                sub1Fiber <- Fiber.run(
                     latch.await.andThen(
                         Async.fill(10, 10)(Abort.run(l1.take))
                     )
                 )
-                sub2Fiber <- Async.run(
+                sub2Fiber <- Fiber.run(
                     latch.await.andThen(
                         Async.fill(10, 10)(Abort.run(l2.take))
                     )
                 )
-                sub3Fiber <- Async.run(
+                sub3Fiber <- Fiber.run(
                     latch.await.andThen(
                         Async.fill(10, 10)(Abort.run(l3.take))
                     )
@@ -250,12 +250,12 @@ class HubTest extends Test:
                 size  <- Choice.eval(1, 2, 10, 100)
                 hub   <- Hub.init[Int](size)
                 latch <- Latch.init(1)
-                listenerFiber <- Async.run(
+                listenerFiber <- Fiber.run(
                     latch.await.andThen(
                         Async.fill(20, 20)(Abort.run(hub.listen))
                     )
                 )
-                closeFiber <- Async.run(latch.await.andThen(hub.close))
+                closeFiber <- Fiber.run(latch.await.andThen(hub.close))
                 _          <- latch.release
                 listeners  <- listenerFiber.get
                 backlog    <- closeFiber.get
@@ -272,7 +272,7 @@ class HubTest extends Test:
                 latch <- Latch.init(1)
                 pubFibers <-
                     Async.foreach(0 until 4, 4) { n =>
-                        Async.run(
+                        Fiber.run(
                             latch.await.andThen(
                                 Kyo.foreachDiscard(
                                     (n * 250) until ((n + 1) * 250)
@@ -280,12 +280,12 @@ class HubTest extends Test:
                             )
                         )
                     }
-                collector1 <- Async.run(
+                collector1 <- Fiber.run(
                     latch.await.andThen(
                         l1.stream().take(1000).run
                     )
                 )
-                collector2 <- Async.run(
+                collector2 <- Fiber.run(
                     latch.await.andThen(
                         l2.stream().take(1000).run
                     )
@@ -308,14 +308,14 @@ class HubTest extends Test:
                 hub          <- Hub.init[Int](10)
                 latch        <- Latch.init(1)
                 slowListener <- hub.listen(0)
-                slowConsumer <- Async.run(
+                slowConsumer <- Fiber.run(
                     latch.await.andThen(
                         Kyo.foreach(1 to 10) { _ =>
                             Async.sleep(1.millis).andThen(slowListener.take)
                         }
                     )
                 )
-                producerFiber <- Async.run(
+                producerFiber <- Fiber.run(
                     latch.await.andThen(
                         Kyo.foreachDiscard(1 to 10)(hub.put)
                     )
@@ -335,14 +335,14 @@ class HubTest extends Test:
                 listeners <- Async.foreach(0 until 10, 10) { n =>
                     hub.listen(_ % 10 == n)
                 }
-                publisher <- Async.run(
+                publisher <- Fiber.run(
                     latch.await.andThen(
                         Kyo.foreachDiscard(1 to 1000)(hub.put)
                     )
                 )
                 collectors <- Async.collectAll(
                     listeners.map(l =>
-                        Async.run(
+                        Fiber.run(
                             latch.await.andThen(
                                 l.stream().take(100).run
                             )
@@ -406,7 +406,7 @@ class HubTest extends Test:
             for
                 h <- Hub.init[Int](0)
                 l <- h.listen
-                f <- Async.run(h.put(1))
+                f <- Fiber.run(h.put(1))
                 v <- l.take
                 d <- f.done
             yield assert(v == 1 && d)
@@ -451,7 +451,7 @@ class HubTest extends Test:
                     h     <- Hub.init[Int](2)
                     l     <- h.listen(2)
                     _     <- h.putBatch(1 to 2)
-                    fiber <- Async.run(h.putBatch(3 to 6))
+                    fiber <- Fiber.run(h.putBatch(3 to 6))
                     _     <- Async.sleep(10.millis)
                     done  <- fiber.done
                     size  <- l.size
@@ -472,7 +472,7 @@ class HubTest extends Test:
                 for
                     h     <- Hub.init[Int](4)
                     l     <- h.listen
-                    fiber <- Async.run(l.takeExactly(4))
+                    fiber <- Fiber.run(l.takeExactly(4))
                     _     <- Async.sleep(10.millis)
                     done1 <- fiber.done
                     _     <- h.putBatch(1 to 4)
@@ -494,7 +494,7 @@ class HubTest extends Test:
                 for
                     h     <- Hub.init[Int](4)
                     l     <- h.listen
-                    fiber <- Async.run(l.takeExactly(4))
+                    fiber <- Fiber.run(l.takeExactly(4))
                     _     <- h.putBatch(1 to 2)
                     _     <- h.close
                     res   <- Abort.run(fiber.get)

--- a/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
@@ -41,7 +41,7 @@ class LatchTest extends Test:
     "countDown + fibers + await" in run {
         for
             latch <- Latch.init(1)
-            _     <- Async.run(latch.release)
+            _     <- Fiber.run(latch.release)
             _     <- latch.await
         yield succeed
     }

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -15,12 +15,12 @@ class MeterTest extends Test:
                 t  <- Meter.initMutex
                 p  <- Promise.init[Nothing, Int]
                 b1 <- Promise.init[Nothing, Unit]
-                f1 <- Async.run(t.run(b1.complete(Result.unit).map(_ => p.getResult)))
+                f1 <- Fiber.run(t.run(b1.complete(Result.unit).map(_ => p.getResult)))
                 _  <- b1.get
                 a1 <- t.availablePermits
                 w1 <- t.pendingWaiters
                 b2 <- Promise.init[Nothing, Unit]
-                f2 <- Async.run(b2.complete(Result.unit).map(_ => t.run(2)))
+                f2 <- Fiber.run(b2.complete(Result.unit).map(_ => t.run(2)))
                 _  <- b2.get
                 a2 <- t.availablePermits
                 w2 <- t.pendingWaiters
@@ -39,7 +39,7 @@ class MeterTest extends Test:
                 sem <- Meter.initMutex
                 p   <- Promise.init[Nothing, Int]
                 b1  <- Promise.init[Nothing, Unit]
-                f1  <- Async.run(sem.tryRun(b1.complete(Result.unit).map(_ => p.getResult)))
+                f1  <- Fiber.run(sem.tryRun(b1.complete(Result.unit).map(_ => p.getResult)))
                 _   <- b1.get
                 a1  <- sem.availablePermits
                 w1  <- sem.pendingWaiters
@@ -65,15 +65,15 @@ class MeterTest extends Test:
                 t  <- Meter.initSemaphore(2)
                 p  <- Promise.init[Nothing, Int]
                 b1 <- Promise.init[Nothing, Unit]
-                f1 <- Async.run(t.run(b1.complete(Result.unit).map(_ => p.getResult)))
+                f1 <- Fiber.run(t.run(b1.complete(Result.unit).map(_ => p.getResult)))
                 _  <- b1.get
                 b2 <- Promise.init[Nothing, Unit]
-                f2 <- Async.run(t.run(b2.complete(Result.unit).map(_ => p.getResult)))
+                f2 <- Fiber.run(t.run(b2.complete(Result.unit).map(_ => p.getResult)))
                 _  <- b2.get
                 a1 <- t.availablePermits
                 w1 <- t.pendingWaiters
                 b3 <- Promise.init[Nothing, Unit]
-                f3 <- Async.run(b3.complete(Result.unit).map(_ => t.run(2)))
+                f3 <- Fiber.run(b3.complete(Result.unit).map(_ => t.run(2)))
                 _  <- b3.get
                 a2 <- t.availablePermits
                 w2 <- t.pendingWaiters
@@ -95,12 +95,12 @@ class MeterTest extends Test:
                 sem <- Meter.initSemaphore(2)
                 p   <- Promise.init[Nothing, Int]
                 b1  <- Promise.init[Nothing, Unit]
-                f1  <- Async.run(sem.tryRun(b1.complete(Result.unit).map(_ => p.getResult)))
+                f1  <- Fiber.run(sem.tryRun(b1.complete(Result.unit).map(_ => p.getResult)))
                 _   <- b1.get
                 a1  <- sem.availablePermits
                 w1  <- sem.pendingWaiters
                 b2  <- Promise.init[Nothing, Unit]
-                f2  <- Async.run(sem.tryRun(b2.complete(Result.unit).map(_ => p.getResult)))
+                f2  <- Fiber.run(sem.tryRun(b2.complete(Result.unit).map(_ => p.getResult)))
                 _   <- b2.get
                 a2  <- sem.availablePermits
                 w2  <- sem.pendingWaiters
@@ -143,12 +143,12 @@ class MeterTest extends Test:
                     meter   <- Meter.initSemaphore(size)
                     latch   <- Latch.init(1)
                     counter <- AtomicInt.init(0)
-                    runFiber <- Async.run(
+                    runFiber <- Fiber.run(
                         latch.await.andThen(Async.fill(100, 100)(
                             Abort.run(meter.run(counter.incrementAndGet))
                         ))
                     )
-                    closeFiber <- Async.run(latch.await.andThen(meter.close))
+                    closeFiber <- Fiber.run(latch.await.andThen(meter.close))
                     _          <- latch.release
                     closed     <- closeFiber.get
                     completed  <- runFiber.get
@@ -172,9 +172,9 @@ class MeterTest extends Test:
                     latch   <- Latch.init(1)
                     counter <- AtomicInt.init(0)
                     runFibers <- Kyo.foreach(1 to 100)(_ =>
-                        Async.run(started.release.andThen(latch.await.andThen(meter.run(counter.incrementAndGet))))
+                        Fiber.run(started.release.andThen(latch.await.andThen(meter.run(counter.incrementAndGet))))
                     )
-                    interruptFiber <- Async.run(latch.await.andThen(
+                    interruptFiber <- Fiber.run(latch.await.andThen(
                         Async.foreach(runFibers.take(50), 50)(_.interrupt(panic))
                     ))
                     _           <- started.await
@@ -206,7 +206,7 @@ class MeterTest extends Test:
             for
                 meter   <- Meter.initRateLimiter(10, 1.milli)
                 counter <- AtomicInt.init(0)
-                f1      <- Async.run(loop(meter, counter))
+                f1      <- Fiber.run(loop(meter, counter))
                 _       <- Async.sleep(5.millis)
                 _       <- f1.interrupt(panic)
                 v1      <- counter.get
@@ -216,8 +216,8 @@ class MeterTest extends Test:
             for
                 meter   <- Meter.initRateLimiter(10, 1.milli)
                 counter <- AtomicInt.init(0)
-                f1      <- Async.run(loop(meter, counter))
-                f2      <- Async.run(loop(meter, counter))
+                f1      <- Fiber.run(loop(meter, counter))
+                f2      <- Fiber.run(loop(meter, counter))
                 _       <- Async.sleep(5.millis)
                 _       <- f1.interrupt(panic)
                 _       <- f2.interrupt(panic)
@@ -239,8 +239,8 @@ class MeterTest extends Test:
             for
                 meter   <- Meter.pipeline(Meter.initRateLimiter(2, 1.milli), Meter.initMutex)
                 counter <- AtomicInt.init(0)
-                f1      <- Async.run(loop(meter, counter))
-                f2      <- Async.run(loop(meter, counter))
+                f1      <- Fiber.run(loop(meter, counter))
+                f2      <- Fiber.run(loop(meter, counter))
                 _       <- Async.sleep(5.millis)
                 _       <- f1.interrupt(panic)
                 _       <- f2.interrupt(panic)
@@ -251,7 +251,7 @@ class MeterTest extends Test:
         "tryRun" in run {
             for
                 meter <- Meter.pipeline(Meter.initRateLimiter(2, 10.millis), Meter.initMutex)
-                f1    <- Async.run(meter.run(Async.never))
+                f1    <- Fiber.run(meter.run(Async.never))
                 _     <- untilTrue(meter.tryRun(()).map(_.isEmpty))
                 _     <- f1.interrupt(panic)
             yield succeed
@@ -275,7 +275,7 @@ class MeterTest extends Test:
                 for
                     meter  <- Meter.initMutex(reentrant = false)
                     p      <- Promise.init[Nothing, Int]
-                    f      <- Async.run(meter.run(meter.run(42)))
+                    f      <- Fiber.run(meter.run(meter.run(42)))
                     _      <- Async.sleep(5.millis)
                     done   <- f.done
                     _      <- f.interrupt
@@ -289,7 +289,7 @@ class MeterTest extends Test:
                     (done, result) <- meter.run {
                         meter.run {
                             for
-                                f      <- Async.run(meter.run(42))
+                                f      <- Fiber.run(meter.run(42))
                                 _      <- Async.sleep(5.millis)
                                 done   <- f.done
                                 _      <- f.interrupt
@@ -317,7 +317,7 @@ class MeterTest extends Test:
                 for
                     meter  <- Meter.initSemaphore(1, reentrant = false)
                     p      <- Promise.init[Nothing, Int]
-                    f      <- Async.run(meter.run(meter.run(42)))
+                    f      <- Fiber.run(meter.run(meter.run(42)))
                     _      <- Async.sleep(5.millis)
                     done   <- f.done
                     _      <- f.interrupt
@@ -331,7 +331,7 @@ class MeterTest extends Test:
                     (done, result) <- meter.run {
                         meter.run {
                             for
-                                f      <- Async.run(meter.run(42))
+                                f      <- Fiber.run(meter.run(42))
                                 _      <- Async.sleep(5.millis)
                                 done   <- f.done
                                 _      <- f.interrupt
@@ -359,7 +359,7 @@ class MeterTest extends Test:
                 for
                     meter  <- Meter.initRateLimiter(1, 60.seconds, reentrant = false)
                     p      <- Promise.init[Nothing, Int]
-                    f      <- Async.run(meter.run(meter.run(42)))
+                    f      <- Fiber.run(meter.run(meter.run(42)))
                     _      <- Async.sleep(5.millis)
                     done   <- f.done
                     _      <- f.interrupt
@@ -373,7 +373,7 @@ class MeterTest extends Test:
                     (done, result) <- meter.run {
                         meter.run {
                             for
-                                f      <- Async.run(meter.run(42))
+                                f      <- Fiber.run(meter.run(42))
                                 _      <- Async.sleep(5.millis)
                                 done   <- f.done
                                 _      <- f.interrupt
@@ -407,7 +407,7 @@ class MeterTest extends Test:
                     rateLimiter <- Meter.initRateLimiter(1, 60.seconds)
                     pipeline    <- Meter.pipeline(mutex, sem, rateLimiter)
                     p           <- Promise.init[Nothing, Int]
-                    f <- Async.run(pipeline.run {
+                    f <- Fiber.run(pipeline.run {
                         pipeline.run(42)
                     })
                     _      <- Async.sleep(5.millis)
@@ -426,7 +426,7 @@ class MeterTest extends Test:
                     (done, result) <- meter.run {
                         meter.run {
                             for
-                                f      <- Async.run(meter.run(42))
+                                f      <- Fiber.run(meter.run(42))
                                 _      <- Async.sleep(5.millis)
                                 done   <- f.done
                                 _      <- f.interrupt

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -237,10 +237,10 @@ class QueueTest extends Test:
                 size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
-                offerFiber <- Async.run(
+                offerFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(queue.offer(i))))
                 )
-                closeFiber  <- Async.run(latch.await.andThen(queue.close))
+                closeFiber  <- Fiber.run(latch.await.andThen(queue.close))
                 _           <- latch.release
                 offered     <- offerFiber.get
                 backlog     <- closeFiber.get
@@ -263,10 +263,10 @@ class QueueTest extends Test:
                 size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
-                offerFiber <- Async.run(
+                offerFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(queue.offer(i))))
                 )
-                pollFiber <- Async.run(
+                pollFiber <- Fiber.run(
                     latch.await.andThen(Async.fill(100, 100)(Abort.run(queue.poll)))
                 )
                 _       <- latch.release
@@ -284,10 +284,10 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 _     <- Kyo.foreach(1 to size)(i => queue.offer(i))
                 latch <- Latch.init(1)
-                offerFiber <- Async.run(
+                offerFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 100)(i => Abort.run(queue.offer(i))))
                 )
-                closeFiber <- Async.run(latch.await.andThen(queue.close))
+                closeFiber <- Fiber.run(latch.await.andThen(queue.close))
                 _          <- latch.release
                 offered    <- offerFiber.get
                 backlog    <- closeFiber.get
@@ -306,10 +306,10 @@ class QueueTest extends Test:
                 size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
-                offerFiber <- Async.run(
+                offerFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(queue.offer(i))))
                 )
-                closeFiber <- Async.run(
+                closeFiber <- Fiber.run(
                     latch.await.andThen(Async.fill(100, 100)(queue.close))
                 )
                 _        <- latch.release
@@ -330,13 +330,13 @@ class QueueTest extends Test:
                 size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
-                offerFiber <- Async.run(
+                offerFiber <- Fiber.run(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(queue.offer(i))))
                 )
-                pollFiber <- Async.run(
+                pollFiber <- Fiber.run(
                     latch.await.andThen(Async.fill(100, 100)(Abort.run(queue.poll)))
                 )
-                closeFiber <- Async.run(latch.await.andThen(queue.close))
+                closeFiber <- Fiber.run(latch.await.andThen(queue.close))
                 _          <- latch.release
                 offered    <- offerFiber.get
                 polled     <- pollFiber.get
@@ -421,7 +421,7 @@ class QueueTest extends Test:
                 queue  <- Queue.init[Int](10)
                 _      <- queue.offer(1)
                 _      <- queue.offer(2)
-                fiber  <- Async.run(queue.closeAwaitEmpty)
+                fiber  <- Fiber.run(queue.closeAwaitEmpty)
                 _      <- queue.poll
                 _      <- queue.poll
                 result <- fiber.get
@@ -449,7 +449,7 @@ class QueueTest extends Test:
                     queue  <- Queue.Unbounded.init[Int]()
                     _      <- queue.add(1)
                     _      <- queue.add(2)
-                    fiber  <- Async.run(queue.closeAwaitEmpty)
+                    fiber  <- Fiber.run(queue.closeAwaitEmpty)
                     _      <- queue.poll
                     _      <- queue.poll
                     result <- fiber.get
@@ -461,7 +461,7 @@ class QueueTest extends Test:
             for
                 queue  <- Queue.init[Int](10)
                 _      <- Kyo.foreach(1 to 5)(i => queue.offer(i))
-                fiber  <- Async.run(queue.closeAwaitEmpty)
+                fiber  <- Fiber.run(queue.closeAwaitEmpty)
                 _      <- Async.foreach(1 to 5)(_ => queue.poll)
                 result <- fiber.get
             yield assert(result)
@@ -472,7 +472,7 @@ class QueueTest extends Test:
                 queue  <- Queue.Unbounded.initSliding[Int](2)
                 _      <- queue.add(1)
                 _      <- queue.add(2)
-                fiber  <- Async.run(queue.closeAwaitEmpty)
+                fiber  <- Fiber.run(queue.closeAwaitEmpty)
                 _      <- queue.poll
                 _      <- queue.poll
                 result <- fiber.get
@@ -484,7 +484,7 @@ class QueueTest extends Test:
                 queue  <- Queue.Unbounded.initDropping[Int](2)
                 _      <- queue.add(1)
                 _      <- queue.add(2)
-                fiber  <- Async.run(queue.closeAwaitEmpty)
+                fiber  <- Fiber.run(queue.closeAwaitEmpty)
                 _      <- queue.poll
                 _      <- queue.poll
                 result <- fiber.get
@@ -504,10 +504,10 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 _     <- Kyo.foreach(1 to (size min 5))(i => queue.offer(i))
                 latch <- Latch.init(1)
-                closeAwaitEmptyFiber <- Async.run(
+                closeAwaitEmptyFiber <- Fiber.run(
                     latch.await.andThen(queue.closeAwaitEmpty)
                 )
-                closeFiber <- Async.run(
+                closeFiber <- Fiber.run(
                     latch.await.andThen(queue.close)
                 )
                 _        <- latch.release
@@ -529,20 +529,20 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
 
-                producerFiber1 <- Async.run(
+                producerFiber1 <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(1 to 25, 10)(i => Abort.run(queue.offer(i)))
                             .andThen(queue.closeAwaitEmpty)
                     )
                 )
-                producerFiber2 <- Async.run(
+                producerFiber2 <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(26 to 50, 10)(i => Abort.run(queue.offer(i)))
                             .andThen(queue.closeAwaitEmpty)
                     )
                 )
 
-                consumerFiber <- Async.run(
+                consumerFiber <- Fiber.run(
                     latch.await.andThen(
                         Async.fill(100, 10)(untilTrue(queue.poll.map(_.isDefined)))
                     )
@@ -568,20 +568,20 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
 
-                producerFiber1 <- Async.run(
+                producerFiber1 <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(1 to 25, 10)(i => Abort.run(queue.offer(i)))
                             .andThen(queue.closeAwaitEmpty)
                     )
                 )
-                producerFiber2 <- Async.run(
+                producerFiber2 <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(26 to 50, 10)(i => Abort.run(queue.offer(i)))
                             .andThen(queue.close)
                     )
                 )
 
-                consumerFiber <- Async.run(
+                consumerFiber <- Fiber.run(
                     latch.await.andThen(
                         Async.fill(100, 10)(untilTrue(queue.poll.map(_.isDefined)))
                     )

--- a/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ResourceTest.scala
@@ -111,7 +111,7 @@ class ResourceTest extends Test:
 
         "ensure" in run {
             var closes = 0
-            Resource.ensure(Async.run(closes += 1).map(_.get).unit)
+            Resource.ensure(Fiber.run(closes += 1).map(_.get).unit)
                 .handle(
                     Resource.run,
                     Abort.run
@@ -126,7 +126,7 @@ class ResourceTest extends Test:
             val acquire = Abort.get(Some(42))
             // only Async in release
             def release(i: Int) =
-                Async.run {
+                Fiber.run {
                     assert(i == 42)
                     closes += 1
                 }.map(_.get)
@@ -142,7 +142,7 @@ class ResourceTest extends Test:
 
         "acquire" in run {
             val r = TestResource(1)
-            Resource.acquire(Async.run(r).map(_.get))
+            Resource.acquire(Fiber.run(r).map(_.get))
                 .handle(
                     Resource.run,
                     Abort.run
@@ -195,7 +195,7 @@ class ResourceTest extends Test:
             val io =
                 for
                     l <- Latch.init(1)
-                    f <- Async.run(l.await.andThen(Resource.ensure { called = true }))
+                    f <- Fiber.run(l.await.andThen(Resource.ensure { called = true }))
                 yield (l, f)
             for
                 (l, f) <- Resource.run(io)
@@ -216,7 +216,7 @@ class ResourceTest extends Test:
                 val resources = Kyo.foreach(1 to 3)(makeResource)
 
                 for
-                    close <- Async.run(resources.handle(Resource.run(3)))
+                    close <- Fiber.run(resources.handle(Resource.run(3)))
                     _     <- latch.await
                     ids   <- close.get
                 yield assert(ids == (1 to 3))
@@ -240,7 +240,7 @@ class ResourceTest extends Test:
                 val resources = Kyo.foreach(1 to 10)(makeResource)
 
                 for
-                    close <- Async.run(resources.handle(Resource.run(3)))
+                    close <- Fiber.run(resources.handle(Resource.run(3)))
                     ids   <- close.get
                 yield assert(ids == (1 to 10))
                 end for

--- a/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
@@ -191,7 +191,7 @@ class SignalTest extends Test:
                 ref     <- Signal.initRef(1)
                 v1      <- ref.current
                 started <- Latch.init(1)
-                f       <- Async.run(started.release.andThen(ref.next))
+                f       <- Fiber.run(started.release.andThen(ref.next))
                 _       <- started.await
                 _       <- ref.set(2)
                 v2      <- f.get
@@ -219,7 +219,7 @@ class SignalTest extends Test:
         "streamChanges" in run {
             for
                 ref    <- Signal.initRef(1)
-                f      <- Async.run(ref.streamChanges.take(3).run)
+                f      <- Fiber.run(ref.streamChanges.take(3).run)
                 _      <- Async.sleep(2.millis)
                 _      <- ref.set(2)
                 _      <- Async.sleep(2.millis)
@@ -249,11 +249,11 @@ class SignalTest extends Test:
             (for
                 ref <- Signal.initRef(0)
                 readers <-
-                    Async.run(Async.fill(10, 10)(
+                    Fiber.run(Async.fill(10, 10)(
                         Loop(0)(_ => ref.currentWith(v => if v < 10 then Loop.continue(v) else Loop.done(v)))
                     ))
                 writers <-
-                    Async.run(Async.fill(10, 10)(
+                    Fiber.run(Async.fill(10, 10)(
                         Loop.foreach {
                             ref.get.map { v =>
                                 if v < 10 then

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -533,9 +533,9 @@ class StreamCoreExtensionsTest extends Test:
                         val lazyStream = channel.streamUntilClosed(256).collectWhile(v => v)
                         lazyStream.broadcasted().map: reusableStream =>
                             Latch.initWith(10): latch =>
-                                Async.run(Async.foreach(1 to 10)(_ => latch.release.andThen(reusableStream.run))).map: runFiber =>
+                                Fiber.run(Async.foreach(1 to 10)(_ => latch.release.andThen(reusableStream.run))).map: runFiber =>
                                     latch.await.andThen:
-                                        Async.run(Kyo.foreach(0 to 10)(i => channel.put(Present(i))).andThen(channel.put(Absent))).andThen:
+                                        Fiber.run(Kyo.foreach(0 to 10)(i => channel.put(Present(i))).andThen(channel.put(Absent))).andThen:
                                             runFiber.get.map: resultChunks =>
                                                 assert(
                                                     resultChunks.size == 10 && resultChunks.toSet.size == 1 && resultChunks.head == (0 to 10)
@@ -562,11 +562,11 @@ class StreamCoreExtensionsTest extends Test:
                         val lazyStream = channel.streamUntilClosed(256).collectWhile(v => v)
                         lazyStream.broadcastDynamic().map: streamHub =>
                             Latch.initWith(10): latch =>
-                                Async.run(
+                                Fiber.run(
                                     Async.foreach(1 to 10)(_ => latch.release.andThen(streamHub.subscribe.map(_.run)))
                                 ).map: runFiber =>
                                     latch.await.andThen:
-                                        Async.run(Kyo.foreach(0 to 10)(i => channel.put(Present(i))).andThen(channel.put(Absent))).andThen:
+                                        Fiber.run(Kyo.foreach(0 to 10)(i => channel.put(Present(i))).andThen(channel.put(Absent))).andThen:
                                             runFiber.get.map: resultChunks =>
                                                 assert(
                                                     resultChunks.size == 10 && resultChunks.toSet.size == 1 && resultChunks.head == (0 to 10)

--- a/kyo-direct/shared/src/test/scala/kyo/CoreTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/CoreTest.scala
@@ -153,14 +153,14 @@ class CoreTest extends Test:
             assert(barrier.pending.now == 2)
 
             // Start two fibers that will wait at the barrier
-            val fiber1 = Async.run {
+            val fiber1 = Fiber.run {
                 direct {
                     barrier.await.now
                     true
                 }
             }.now
 
-            val fiber2 = Async.run {
+            val fiber2 = Fiber.run {
                 direct {
                     barrier.await.now
                     true
@@ -181,7 +181,7 @@ class CoreTest extends Test:
             latch.release.now
             assert(latch.pending.now == 1)
             latch.release.now
-            val awaited = Async.run {
+            val awaited = Fiber.run {
                 direct {
                     latch.await.now
                     true

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
@@ -23,7 +23,7 @@ object Log:
         val cfg = Env.get[DB.Config].now
         val q   = Queue.Unbounded.init[Entry](Access.MultiProducerSingleConsumer).now
         val log = Sync(Live(cfg.workingDir + "/log.dat", q)).now
-        val _   = Async.run(log.flushLoop(cfg.flushInterval)).now
+        val _   = Fiber.run(log.flushLoop(cfg.flushInterval)).now
         log
     }
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Isolate.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Isolate.scala
@@ -23,7 +23,7 @@ import scala.quoted.*
   *
   * ==Operations==
   *
-  * Operations determine which isolation capability they require. Some operations like Async.run require Contextual isolation to enable the
+  * Operations determine which isolation capability they require. Some operations like Fiber.run require Contextual isolation to enable the
   * forked computation to execute to completion, while others like Async.parallel allow Stateful isolation given that the return type allows
   * restoring forked effects after the parallel execution finishes. The choice between Contextual and Stateful isolation is made by the
   * operation, not the user.
@@ -142,15 +142,15 @@ object Isolate:
                             |
                             |  ${missing.map(_.show.red).mkString(" & ")}
                             |
-                            |Common mistake: Using operations like Async.run with effects that need complex state management.
+                            |Common mistake: Using operations like Fiber.run with effects that need complex state management.
                             |
                             |You have a couple of options, from simplest to most advanced:
                             |
                             |1. Handle these effects before the operation:
-                            |   Async.run(MyEffect.run(computation))
+                            |   Fiber.run(MyEffect.run(computation))
                             |
                             |2. Use an operation that supports complex state:
-                            |   Instead of Async.run, use Async.parallel 
+                            |   Instead of Fiber.run, use Async.parallel 
                             |""".stripMargin
                     )
                 end if

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
@@ -74,7 +74,7 @@ object StreamPublisher:
                             case _                    => discardSubscriber(subscriber)
             }
             supervisor <- Resource.acquireRelease(Fiber.Promise.init[Nothing, Unit])(_.interrupt)
-            _          <- Resource.acquireRelease(Async.run(consumeChannel(publisher, channel, supervisor)))(_.interrupt)
+            _          <- Resource.acquireRelease(Fiber.run(consumeChannel(publisher, channel, supervisor)))(_.interrupt)
         yield publisher
         end for
     end apply

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -65,7 +65,7 @@ final private[kyo] class StreamSubscription[V, S](
         Tag[Poll[Chunk[V]]],
         Frame
     ): Fiber[StreamCanceled, StreamComplete] < (Sync & S) =
-        Async.run[StreamCanceled, StreamComplete, S](Poll.runEmit(stream.emit)(poll).map(_._2))
+        Fiber.run[StreamCanceled, StreamComplete, S](Poll.runEmit(stream.emit)(poll).map(_._2))
             .map { fiber =>
                 fiber.onComplete {
                     case Result.Success(StreamComplete) => Sync(subscriber.onComplete())

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
@@ -137,10 +137,10 @@ abstract private class PublisherToSubscriberTest extends Test:
                 _ = publisher.subscribe(subscriber2)
                 _ = publisher.subscribe(subscriber3)
                 _ = publisher.subscribe(subscriber4)
-                fiber1 <- Async.run(modify(subStream1, shouldFail = false))
-                fiber2 <- Async.run(modify(subStream2, shouldFail = true))
-                fiber3 <- Async.run(modify(subStream3, shouldFail = false))
-                fiber4 <- Async.run(modify(subStream4, shouldFail = true))
+                fiber1 <- Fiber.run(modify(subStream1, shouldFail = false))
+                fiber2 <- Fiber.run(modify(subStream2, shouldFail = true))
+                fiber3 <- Fiber.run(modify(subStream3, shouldFail = false))
+                fiber4 <- Fiber.run(modify(subStream4, shouldFail = true))
                 value1 <- fiber1.get
                 value2 <- fiber2.getResult
                 value3 <- fiber3.get
@@ -179,12 +179,12 @@ abstract private class PublisherToSubscriberTest extends Test:
                 subscriber4 <- streamSubscriber
                 subStream4  <- subscriber4.stream
                 latch       <- Latch.init(4)
-                fiber1      <- Async.run(latch.release.andThen(subStream1.run.unit))
-                fiber2      <- Async.run(latch.release.andThen(subStream2.run.unit))
-                fiber3      <- Async.run(latch.release.andThen(subStream3.run.unit))
-                fiber4      <- Async.run(latch.release.andThen(subStream4.run.unit))
+                fiber1      <- Fiber.run(latch.release.andThen(subStream1.run.unit))
+                fiber2      <- Fiber.run(latch.release.andThen(subStream2.run.unit))
+                fiber3      <- Fiber.run(latch.release.andThen(subStream3.run.unit))
+                fiber4      <- Fiber.run(latch.release.andThen(subStream4.run.unit))
                 latchPub    <- Latch.init(1)
-                publisherFiber <- Async.run(latch.await.andThen(Resource.run(
+                publisherFiber <- Fiber.run(latch.await.andThen(Resource.run(
                     Stream(Emit.valueWith(Chunk.empty)(emit(counter)))
                         .toPublisher
                         .map { publisher =>

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamPublisherTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamPublisherTest.scala
@@ -27,7 +27,7 @@ final class StreamPublisherTest extends PublisherVerification[Int](new TestEnvir
                 StreamPublisher.Unsafe(
                     createStream(n.toInt),
                     subscribeCallback = fiber =>
-                        discard(Sync.Unsafe.evalOrThrow(Async.runAndBlock(Duration.Infinity)(fiber)))
+                        discard(Sync.Unsafe.evalOrThrow(Fiber.runAndBlock(Duration.Infinity)(fiber)))
                 )
             )
         end if
@@ -38,7 +38,7 @@ final class StreamPublisherTest extends PublisherVerification[Int](new TestEnvir
             StreamPublisher.Unsafe(
                 createStream(),
                 subscribeCallback = fiber =>
-                    val asynced = Async.runAndBlock(Duration.Infinity)(fiber)
+                    val asynced = Fiber.runAndBlock(Duration.Infinity)(fiber)
                     val result  = Sync.Unsafe.evalOrThrow(asynced)
                     discard(result.unsafe.interrupt())
             )

--- a/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
@@ -389,7 +389,7 @@ class TMapTest extends Test:
                 map   <- STM.run(TMap.init[Int, Int]())
                 latch <- Latch.init(1)
 
-                writeFiber <- Async.run(
+                writeFiber <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(1 to size, size)(i =>
                             STM.run(map.put(i, i * 2))
@@ -397,7 +397,7 @@ class TMapTest extends Test:
                     )
                 )
 
-                readFiber <- Async.run(
+                readFiber <- Fiber.run(
                     latch.await.andThen(
                         Async.foreach(1 to size, size)(i =>
                             STM.run(map.get(i))

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -31,7 +31,7 @@ class KyoSttpMonad extends MonadAsyncError[M]:
     def ensure[A](f: M[A], e: => M[Unit]) =
         Promise.initWith[Nothing, Unit] { p =>
             def run =
-                Async.run(e).map(p.become).unit
+                Fiber.run(e).map(p.become).unit
             Sync.ensure(run)(f).map(r => p.get.andThen(r))
         }
 

--- a/kyo-sttp/shared/src/test/scala/kyo/RequestsTest.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/RequestsTest.scala
@@ -37,7 +37,7 @@ class RequestsTest extends Test:
     "with fiber" in run {
         val backend = new TestBackend
         Requests.let(backend) {
-            Async.run {
+            Fiber.run {
                 for
                     r <- Requests(_.get(uri"https://httpbin.org/get"))
                 yield
@@ -60,7 +60,7 @@ class RequestsTest extends Test:
             def close(using Frame) = ???
         val backend = (new TestBackend).withMeter(meter)
         Requests.let(backend) {
-            Async.run {
+            Fiber.run {
                 for
                     r <- Requests(_.get(uri"https://httpbin.org/get"))
                 yield

--- a/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
@@ -90,7 +90,7 @@ class KyoSttpMonadTest extends Test:
             for
                 started   <- Latch.init(1)
                 cancelled <- Latch.init(1)
-                fiber <- Async.run {
+                fiber <- Fiber.run {
                     KyoSttpMonad.async[Int] { _ =>
                         import AllowUnsafe.embrace.danger
                         started.unsafe.release()

--- a/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServer.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServer.scala
@@ -80,7 +80,7 @@ case class NettyKyoServer(
         block: () => KyoSttpMonad.M[ServerResponse[NettyResponse]]
     ): (Future[ServerResponse[NettyResponse]], () => Future[Unit]) =
         import AllowUnsafe.embrace.danger
-        val fiber  = Sync.Unsafe.evalOrThrow(Async.run(block()))
+        val fiber  = Sync.Unsafe.evalOrThrow(Fiber.run(block()))
         val future = Sync.Unsafe.evalOrThrow(fiber.toFuture)
         val cancel = () =>
             val _ = Sync.Unsafe.evalOrThrow(fiber.interrupt)

--- a/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServerInterpreter.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServerInterpreter.scala
@@ -43,11 +43,11 @@ object NettyKyoServerInterpreter:
         override def apply(f: => KyoSttpMonad.M[Unit]): Unit =
             val exec =
                 if forkExecution then
-                    Async.run(f).map(_.get)
+                    Fiber.run(f).map(_.get)
                 else
                     f
             import AllowUnsafe.embrace.danger
-            val _ = Sync.Unsafe.evalOrThrow(Async.run(exec))
+            val _ = Sync.Unsafe.evalOrThrow(Fiber.run(exec))
         end apply
     end KyoRunAsync
 end NettyKyoServerInterpreter

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -61,7 +61,7 @@ object ZIOs:
     def run[A, E](v: => A < (Abort[E] & Async))(using frame: Frame, trace: zio.Trace): ZIO[Any, E, A] =
         ZIO.suspendSucceed {
             import AllowUnsafe.embrace.danger
-            Async.run(v).map { fiber =>
+            Fiber.run(v).map { fiber =>
                 ZIO.asyncInterrupt[Any, E, A] { cb =>
                     fiber.unsafe.onComplete {
                         case Result.Success(a) => cb(Exit.succeed(a))

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -94,25 +94,25 @@ class ZIOsTest extends Test:
         "basic interop" in runKyo {
             for
                 v1 <- ZIOs.get(ZIO.succeed(1))
-                v2 <- Async.run(2).map(_.get)
+                v2 <- Fiber.run(2).map(_.get)
                 v3 <- ZIOs.get(ZIO.succeed(3))
             yield assert(v1 == 1 && v2 == 2 && v3 == 3)
         }
 
         "nested Kyo in ZIO" in runKyo {
             ZIOs.get(ZIO.suspendSucceed {
-                val kyoComputation = Async.run(42).map(_.get)
+                val kyoComputation = Fiber.run(42).map(_.get)
                 ZIOs.run(kyoComputation)
             }).map(v => assert(v == 42))
         }
 
         "nested ZIO in Kyo" in runKyo {
-            Async.run(ZIOs.get(ZIOs.run(42))).map(_.get)
+            Fiber.run(ZIOs.get(ZIOs.run(42))).map(_.get)
                 .map(v => assert(v == 42))
         }
 
         "complex nested pattern with parallel and race" in runKyo {
-            def kyoTask(i: Int): Int < (Abort[Nothing] & Async)   = Async.run(i * 2).map(_.get)
+            def kyoTask(i: Int): Int < (Abort[Nothing] & Async)   = Fiber.run(i * 2).map(_.get)
             def zioTask(i: Int): Int < (Abort[Throwable] & Async) = ZIOs.get(ZIO.succeed(i + 1))
 
             for
@@ -178,7 +178,7 @@ class ZIOsTest extends Test:
                     val v =
                         for
                             _ <- ZIOs.get(zioLoop(started, done))
-                            _ <- Async.run(kyoLoop(started, done))
+                            _ <- Fiber.run(kyoLoop(started, done))
                         yield ()
                     for
                         f <- ZIOs.run(v).fork
@@ -235,7 +235,7 @@ class ZIOsTest extends Test:
                     val done    = new CountDownLatch(1)
                     val panic   = Result.Panic(new Exception)
                     for
-                        f <- Async.run(ZIOs.get(zioLoop(started, done)))
+                        f <- Fiber.run(ZIOs.get(zioLoop(started, done)))
                         _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt(panic)
                         r <- f.getResult
@@ -253,7 +253,7 @@ class ZIOsTest extends Test:
                             _ <- kyoLoop(started, done)
                         yield ()
                     for
-                        f <- Async.run(v)
+                        f <- Fiber.run(v)
                         _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
@@ -271,7 +271,7 @@ class ZIOsTest extends Test:
                         Async.zip[Throwable, Unit, Unit, Any](loop1, loop2)
                     end parallelEffect
                     for
-                        f <- Async.run(parallelEffect)
+                        f <- Fiber.run(parallelEffect)
                         _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
@@ -289,7 +289,7 @@ class ZIOsTest extends Test:
                         Async.race(loop1, loop2)
                     end raceEffect
                     for
-                        f <- Async.run(raceEffect)
+                        f <- Fiber.run(raceEffect)
                         _ <- Sync(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult


### PR DESCRIPTION
### Problem

`Fiber` is a low-level API and should be reserved for advanced usage. We've made changes over time to avoid it leaking in the main `Async` APIs but there's still the `Async.run*` methods that deal with fibers. This can be confusing to users since it can give the impression that it's necessary to use `Async.run` to fork computations, which isn't the case since the `Async` combinators already automatically fork as necessary.

### Solution

Move the `run` methods to `Fiber`. After this change, `Fiber` doesn't leak in any of the `Async` methods.
