### PR TITLE
[data] fix package check for internal Frames

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/internal/FindEnclosing.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/FindEnclosing.scala
@@ -15,7 +15,7 @@ private[kyo] object FindEnclosing:
         else
             val path     = pos.sourceFile.path
             val excluded = (path.contains("src/test/") && testFileSuffixes.exists(fileName.endsWith)) || fileName.endsWith("Bench.scala")
-            apply(sym => sym.fullName.startsWith("kyo") && !excluded).nonEmpty
+            apply(sym => sym.fullName.startsWith("kyo.") && !excluded).nonEmpty
         end if
     end isInternal
 


### PR DESCRIPTION

### Problem

The `Frame` macro fails for any package or root object that starts with `kyo`. This issue was [reported in discord](https://discord.com/channels/632150470000902164/632150470000902166/1387834223540572182):

I have a question regarding Kyo. I copy-pasted one of the first code example fromm https://getkyo.io/ in a Scala CLI script:

//> using scala "3.7.1"
//> using dep "io.getkyo::kyo-core::0.19.0"
//> using dep "io.getkyo::kyo-prelude::0.19.0"

//> using scalacOptions -Wvalue-discard -Wnonunit-statement -Wconf:msg=(unused.*value|discarded.*value|pure.*statement):error -language:strictEquality

import kyo.*

// An 'Int' is also an 'Int < Any'
val a: Int < Any = 1

// Since there are no pending effects,
// the computation can produce a pure value
val b: Int = a.eval


But unfortunately it does not compile:

[error] ./kyoparse.scala:17:22
[error] Frame cannot be derived within the kyo package.
[error] 
[error] To resolve this issue:
[error] 1. Propagate the Frame from user code via a `using` parameter.
[error] 2. If absolutely necessary, you can use Frame.internal, but this is not recommended for general use.
[error] 
[error] Example of propagating Frame:
[error] def myMethod[A](a: A)(using Frame): Unit = ...
[error]   val b: Int = a.eval
[error]


### Solution

Fix the macro to check for the prefix `kyo.` instead of just `kyo`.

### Notes

A test would require a source file outside of the `kyo` package, I don't think it's worth it.