### PR TITLE
Queue resource safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -2414,46 +2414,46 @@ import kyo.*
 
 // A bounded queue that rejects new
 // elements once full
-val a: Queue[Int] < Sync =
+val a: Queue[Int] < (Sync & Resource) =
     Queue.init(capacity = 42)
 
 // Obtain the number of items in the queue
 // via the method 'size' in 'Queue'
-val b: Int < (Sync & Abort[Closed]) =
+val b: Int < (Sync & Abort[Closed] & Resource) =
     a.map(_.size)
 
 // Get the queue capacity
-val c: Int < Sync =
+val c: Int < (Sync & Resource) =
     a.map(_.capacity)
 
 // Try to offer a new item
-val d: Boolean < (Sync & Abort[Closed]) =
+val d: Boolean < (Sync & Abort[Closed] & Resource) =
     a.map(_.offer(42))
 
 // Try to poll an item
-val e: Maybe[Int] < (Sync & Abort[Closed]) =
+val e: Maybe[Int] < (Sync & Abort[Closed] & Resource) =
     a.map(_.poll)
 
 // Try to 'peek' an item without removing it
-val f: Maybe[Int] < (Sync & Abort[Closed]) =
+val f: Maybe[Int] < (Sync & Abort[Closed] & Resource) =
     a.map(_.peek)
 
 // Check if the queue is empty
-val g: Boolean < (Sync & Abort[Closed]) =
+val g: Boolean < (Sync & Abort[Closed] & Resource) =
     a.map(_.empty)
 
 // Check if the queue is full
-val h: Boolean < (Sync & Abort[Closed]) =
+val h: Boolean < (Sync & Abort[Closed] & Resource) =
     a.map(_.full)
 
 // Drain the queue items
-val i: Seq[Int] < (Sync & Abort[Closed]) =
+val i: Seq[Int] < (Sync & Abort[Closed] & Resource) =
     a.map(_.drain)
 
 // Close the queue. If successful,
 // returns a Some with the drained
 // elements
-val j: Maybe[Seq[Int]] < Sync =
+val j: Maybe[Seq[Int]] < (Sync & Resource) =
     a.map(_.close)
 ```
 
@@ -2464,25 +2464,25 @@ import kyo.*
 // Avoid `Queue.unbounded` since if queues can
 // grow without limits, the GC overhead can make
 // the system fail
-val a: Queue.Unbounded[Int] < Sync =
+val a: Queue.Unbounded[Int] < (Sync & Resource) =
     Queue.Unbounded.init()
 
 // A 'dropping' queue discards new entries
 // when full
-val b: Queue.Unbounded[Int] < Sync =
+val b: Queue.Unbounded[Int] < (Sync & Resource) =
     Queue.Unbounded.initDropping(capacity = 42)
 
 // A 'sliding' queue discards the oldest
 // entries if necessary to make space for new
 // entries
-val c: Queue.Unbounded[Int] < Sync =
+val c: Queue.Unbounded[Int] < (Sync & Resource) =
     Queue.Unbounded.initSliding(capacity = 42)
 
 // Note how 'dropping' and 'sliding' queues
 // return 'Queue.Unbounded`. It provides
 // an additional method to 'add' new items
 // unconditionally
-val d: Unit < Sync =
+val d: Unit < (Sync & Resource) =
     c.map(_.add(42))
 ```
 
@@ -2507,7 +2507,7 @@ import kyo.*
 // Initialize a bounded queue with a
 // Multiple Producers, Multiple
 // Consumers policy
-val a: Queue[Int] < Sync =
+val a: Queue[Int] < (Sync & Resource) =
     Queue.init(
         capacity = 42,
         access = Access.MultiProducerMultiConsumer

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -345,12 +345,40 @@ object Queue:
             initDroppingUnscoped[A](capacity, access).map: queue =>
                 Resource.ensure(Queue.close(queue)).andThen(queue)
 
+        /** Uses a new dropping queue with the specified capacity and access pattern, closing queue after usage.
+          *
+          * @param capacity
+          *   the capacity of the queue. Note that this will be rounded up to the next power of two.
+          * @param access
+          *   the access pattern (default is MPMC)
+          * @return
+          *   a new Unbounded Queue instance that drops elements when full
+          *
+          * @note
+          *   The actual capacity will be rounded up to the next power of two.
+          * @warning
+          *   The actual capacity may be larger than the specified capacity due to rounding.
+          */
         def useDropping[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](f: Unbounded[A] => B < S)(
             using Frame
         ): B < (Sync & S) =
             initDroppingUnscoped[A](capacity, access).map: queue =>
                 Sync.ensure(Queue.close(queue))(f(queue))
 
+        /** Initializes a new dropping queue with the specified capacity and access pattern without guaranteeing cleanup.
+          *
+          * @param capacity
+          *   the capacity of the queue. Note that this will be rounded up to the next power of two.
+          * @param access
+          *   the access pattern (default is MPMC)
+          * @return
+          *   a new Unbounded Queue instance that drops elements when full
+          *
+          * @note
+          *   The actual capacity will be rounded up to the next power of two.
+          * @warning
+          *   The actual capacity may be larger than the specified capacity due to rounding.
+          */
         def initDroppingUnscoped[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(
             using Frame
         ): Unbounded[A] < Sync =

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
@@ -21,7 +21,7 @@ object Log:
 
     val init: Log < (Env[DB.Config] & Sync) = direct {
         val cfg = Env.get[DB.Config].now
-        val q   = Queue.Unbounded.init[Entry](Access.MultiProducerSingleConsumer).now
+        val q   = Queue.Unbounded.initUnscoped[Entry](Access.MultiProducerSingleConsumer).now
         val log = Sync.defer(Live(cfg.workingDir + "/log.dat", q)).now
         val _   = Fiber.init(log.flushLoop(cfg.flushInterval)).now
         log


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

Concludes resource safety API updates (see #1313 for discussion)

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

`Queue`'s init methods do not guarantee cleanup

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Updated init/initWith, added use/initUnscoped/initUnscopedWith both for Queue and Queue.Unbounded variants (left out -With methods for unbounded variants, as these were not included originally)

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
