### PR TITLE
[kernel] lifted functions fixes

### DIFF
--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -72,7 +72,7 @@ object `<`:
                         val value = v.unsafeGet
                         Safepoint.handle(value)(
                             suspend = mapLoop(value),
-                            continue = f(value)
+                            continue = f(value): B < S2
                         )
             mapLoop(v)
         end map
@@ -101,7 +101,7 @@ object `<`:
                         val value = v.unsafeGet
                         Safepoint.handle(value)(
                             suspend = flatMapLoop(value),
-                            continue = f(value)
+                            continue = f(value): B < S2
                         )
             flatMapLoop(v)
         end flatMap
@@ -127,7 +127,7 @@ object `<`:
                         val value = v.unsafeGet
                         Safepoint.handle(value)(
                             suspend = andThenLoop(value),
-                            continue = f
+                            continue = f: B < S2
                         )
             andThenLoop(v)
         end andThen
@@ -437,37 +437,37 @@ object `<`:
     implicit inline def liftPureFunction1[A1, B](inline f: A1 => B)(
         using inline flat: CanLift[B]
     ): A1 => B < Any =
-        a1 => f(a1)
+        a1 => lift(f(a1))
 
     /** Converts a pure two-argument function to an effectful computation. */
     implicit inline def liftPureFunction2[A1, A2, B](inline f: (A1, A2) => B)(
         using inline flat: CanLift[B]
     ): (A1, A2) => B < Any =
-        (a1, a2) => f(a1, a2)
+        (a1, a2) => lift(f(a1, a2))
 
     /** Converts a pure three-argument function to an effectful computation. */
     implicit inline def liftPureFunction3[A1, A2, A3, B](inline f: (A1, A2, A3) => B)(
         using inline flat: CanLift[B]
     ): (A1, A2, A3) => B < Any =
-        (a1, a2, a3) => f(a1, a2, a3)
+        (a1, a2, a3) => lift(f(a1, a2, a3))
 
     /** Converts a pure four-argument function to an effectful computation. */
     implicit inline def liftPureFunction4[A1, A2, A3, A4, B](inline f: (A1, A2, A3, A4) => B)(
         using inline flat: CanLift[B]
     ): (A1, A2, A3, A4) => B < Any =
-        (a1, a2, a3, a4) => f(a1, a2, a3, a4)
+        (a1, a2, a3, a4) => lift(f(a1, a2, a3, a4))
 
     /** Converts a pure five-argument function to an effectful computation. */
     implicit inline def liftPureFunction5[A1, A2, A3, A4, A5, B](inline f: (A1, A2, A3, A4, A5) => B)(
         using inline flat: CanLift[B]
     ): (A1, A2, A3, A4, A5) => B < Any =
-        (a1, a2, a3, a4, a5) => f(a1, a2, a3, a4, a5)
+        (a1, a2, a3, a4, a5) => lift(f(a1, a2, a3, a4, a5))
 
     /** Converts a pure six-argument function to an effectful computation. */
     implicit inline def liftPureFunction6[A1, A2, A3, A4, A5, A6, B](inline f: (A1, A2, A3, A4, A5, A6) => B)(
         using inline flat: CanLift[B]
     ): (A1, A2, A3, A4, A5, A6) => B < Any =
-        (a1, a2, a3, a4, a5, a6) => f(a1, a2, a3, a4, a5, a6)
+        (a1, a2, a3, a4, a5, a6) => lift(f(a1, a2, a3, a4, a5, a6))
 
     given [A, S, APendingS <: A < S](using ra: Render[A]): Render[APendingS] with
         def asText(value: APendingS): Text = value match


### PR DESCRIPTION

### Problem

@ahoy-jon found a couple of issues with lifted functions. Due to the definition of the implicit conversions being in the same scope as the definition of `opaque type <`, the compiler doesn't introduce a `lift` conversion, which creates issues with nested computations in generic scopes. Additionally, the compiler is having issues with inlining of pure functions in generic contexts that requires an explicit type annotation.

### Solution

Introduce the missing `lift` calls in the function conversions and add explicit type annotations in methods that take functions.
