### PR TITLE
[data] rename KArray => Span

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Stat.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Stat.scala
@@ -184,7 +184,7 @@ final class Stat(private val registryScope: StatsRegistry.Scope) extends Seriali
         name: String,
         attributes: Attributes = Attributes.empty
     )(v: => A < S)(using Frame): A < (Sync & S) =
-        Stat.traceReceiver.use(internal.Span.trace(_, registryScope.path, name, attributes)(v))
+        Stat.traceReceiver.use(internal.TraceSpan.trace(_, registryScope.path, name, attributes)(v))
 end Stat
 
 object Stat:

--- a/kyo-core/shared/src/main/scala/kyo/stats/internal/TraceReceiver.scala
+++ b/kyo-core/shared/src/main/scala/kyo/stats/internal/TraceReceiver.scala
@@ -11,9 +11,9 @@ trait TraceReceiver extends Serializable:
     def startSpan(
         scope: List[String],
         name: String,
-        parent: Maybe[Span] = Maybe.empty,
+        parent: Maybe[TraceSpan] = Maybe.empty,
         attributes: Attributes = Attributes.empty
-    )(using Frame): Span < Sync
+    )(using Frame): TraceSpan < Sync
 end TraceReceiver
 
 object TraceReceiver:
@@ -23,10 +23,10 @@ object TraceReceiver:
             def startSpan(
                 scope: List[String],
                 name: String,
-                parent: Maybe[Span] = Maybe.empty,
+                parent: Maybe[TraceSpan] = Maybe.empty,
                 attributes: Attributes = Attributes.empty
             )(using Frame) =
-                Span.noop
+                TraceSpan.noop
 
     val get: TraceReceiver =
         ServiceLoader.load(classOf[TraceReceiver]).iterator().asScala.toList match
@@ -42,9 +42,9 @@ object TraceReceiver:
             def startSpan(
                 scope: List[String],
                 name: String,
-                parent: Maybe[Span] = Maybe.empty,
+                parent: Maybe[TraceSpan] = Maybe.empty,
                 a: Attributes = Attributes.empty
             )(using Frame) =
                 Kyo.foreach(receivers)(_.startSpan(scope, name, Maybe.empty, a))
-                    .map(Span.all)
+                    .map(TraceSpan.all)
 end TraceReceiver

--- a/kyo-core/shared/src/main/scala/kyo/stats/internal/TraceSpan.scala
+++ b/kyo-core/shared/src/main/scala/kyo/stats/internal/TraceSpan.scala
@@ -5,24 +5,24 @@ import kyo.stats.*
 import kyo.stats.Attributes
 import scala.annotation.tailrec
 
-final case class Span(unsafe: Span.Unsafe):
+final case class TraceSpan(unsafe: TraceSpan.Unsafe):
 
     def end(using Frame): Unit < Sync =
         Sync.defer(unsafe.end())
 
     def event(name: String, a: Attributes)(using Frame): Unit < Sync =
         Sync.defer(unsafe.event(name, a))
-end Span
+end TraceSpan
 
-object Span:
+object TraceSpan:
 
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe:
         def end(): Unit
         def event(name: String, a: Attributes): Unit
 
-    val noop: Span =
-        Span(
+    val noop: TraceSpan =
+        TraceSpan(
             new Unsafe:
                 def end() =
                     ()
@@ -30,24 +30,24 @@ object Span:
                     ()
         )
 
-    def all(l: Seq[Span]): Span =
+    def all(l: Seq[TraceSpan]): TraceSpan =
         l match
             case Seq() =>
-                Span.noop
+                TraceSpan.noop
             case h +: Nil =>
                 h
             case l =>
-                Span(
-                    new Span.Unsafe:
+                TraceSpan(
+                    new TraceSpan.Unsafe:
                         def end() =
-                            @tailrec def loop(c: Seq[Span]): Unit =
+                            @tailrec def loop(c: Seq[TraceSpan]): Unit =
                                 if c ne Nil then
                                     c.head.unsafe.end()
                                     loop(c.tail)
                             loop(l)
                         end end
                         def event(name: String, a: Attributes) =
-                            @tailrec def loop(c: Seq[Span]): Unit =
+                            @tailrec def loop(c: Seq[TraceSpan]): Unit =
                                 if c ne Nil then
                                     c.head.unsafe.event(name, a)
                                     loop(c.tail)
@@ -55,7 +55,7 @@ object Span:
                         end event
                 )
 
-    private val currentSpan = Local.init(Maybe.empty[Span])
+    private val currentSpan = Local.init(Maybe.empty[TraceSpan])
 
     def trace[A, S](
         receiver: TraceReceiver,
@@ -72,4 +72,4 @@ object Span:
                     }
                 }
         }
-end Span
+end TraceSpan

--- a/kyo-core/shared/src/test/scala/kyo/stats/internal/TraceReceiverTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/stats/internal/TraceReceiverTest.scala
@@ -9,7 +9,7 @@ class TraceReceiverTest extends Test:
         val noopReceiver = TraceReceiver.noop
         val span         = noopReceiver.startSpan(Nil, "noopSpan", Maybe.empty, Attributes.empty)
         span.map { span =>
-            assert(span.unsafe eq Span.noop.unsafe)
+            assert(span.unsafe eq TraceSpan.noop.unsafe)
         }
     }
 
@@ -28,11 +28,11 @@ class TraceReceiverTest extends Test:
         def startSpan(
             scope: List[String],
             name: String,
-            parent: Maybe[Span],
+            parent: Maybe[TraceSpan],
             attributes: Attributes
-        )(using Frame): Span < Sync =
+        )(using Frame): TraceSpan < Sync =
             spanStarted = true
-            Span.noop
+            TraceSpan.noop
         end startSpan
     end TestTraceReceiver
 end TraceReceiverTest

--- a/kyo-core/shared/src/test/scala/kyo/stats/internal/TraceSpanTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/stats/internal/TraceSpanTest.scala
@@ -7,7 +7,7 @@ class SpanTest extends Test:
 
     "end" in run {
         val unsafe = new TestSpan
-        val span   = Span(unsafe)
+        val span   = TraceSpan(unsafe)
         for
             _ <- span.end
         yield assert(unsafe.isEnded)
@@ -15,14 +15,14 @@ class SpanTest extends Test:
 
     "event" in run {
         val unsafe = new TestSpan
-        val span   = Span(unsafe)
+        val span   = TraceSpan(unsafe)
         for
             _ <- span.event("testEvent", Attributes.empty)
         yield assert(unsafe.lastEvent == "testEvent")
     }
 
     "noop" in run {
-        val noopSpan = Span.noop
+        val noopSpan = TraceSpan.noop
         noopSpan.end
         noopSpan.event("noopEvent", Attributes.empty)
         succeed
@@ -30,23 +30,23 @@ class SpanTest extends Test:
 
     "all" - {
         "empty" in run {
-            assert(Span.all(Nil).unsafe eq Span.noop.unsafe)
+            assert(TraceSpan.all(Nil).unsafe eq TraceSpan.noop.unsafe)
         }
         "one" in run {
-            val span = Span(new TestSpan)
-            assert(Span.all(List(span)).unsafe eq span.unsafe)
+            val span = TraceSpan(new TestSpan)
+            assert(TraceSpan.all(List(span)).unsafe eq span.unsafe)
         }
         "multiple" in run {
             val unsafe1       = new TestSpan
             val unsafe2       = new TestSpan
-            val compositeSpan = Span.all(List(Span(unsafe1), Span(unsafe2)))
+            val compositeSpan = TraceSpan.all(List(TraceSpan(unsafe1), TraceSpan(unsafe2)))
             for
                 _ <- compositeSpan.end
             yield assert(unsafe1.isEnded && unsafe2.isEnded)
         }
     }
 
-    class TestSpan extends Span.Unsafe:
+    class TestSpan extends TraceSpan.Unsafe:
         var isEnded           = false
         var lastEvent: String = ""
 

--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -17,9 +17,9 @@ import scala.util.control.NoStackTrace
   * Chunk uses structural sharing to optimize operations that would normally require copying data. This makes it particularly valuable when
   * performing slicing operations or working with large collections.
   *
-  * Note that Chunk boxes primitive types, unlike KArray which doesn't. This means KArray is more memory-efficient when working with
-  * primitive values like Int, Long, Double, etc. Consider using KArray instead when you need simpler, more predictable performance
-  * characteristics or when memory efficiency with primitive types is your primary concern.
+  * Note that Chunk boxes primitive types, unlike Span which doesn't. This means Span is more memory-efficient when working with primitive
+  * values like Int, Long, Double, etc. Consider using Span instead when you need simpler, more predictable performance characteristics or
+  * when memory efficiency with primitive types is your primary concern.
   *
   * @tparam A
   *   the type of elements in this Chunk

--- a/kyo-data/shared/src/main/scala/kyo/Span.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Span.scala
@@ -7,124 +7,124 @@ import scala.reflect.ClassTag
 
 /** An efficient, immutable array-backed sequence of elements.
   *
-  * KArray is similar to Scala's built-in IArray (immutable array), but provides optimized methods for common operations and additional
+  * Span is similar to Scala's built-in IArray (immutable array), but provides optimized methods for common operations and additional
   * utility functions. It offers better performance characteristics than standard Scala collections for many use cases while maintaining
-  * immutability semantics. In practice, using KArray is akin to using Array directly but with a richer and safer immutable API.
+  * immutability semantics. In practice, using Span is akin to using Array directly but with a richer and safer immutable API.
   *
-  * KArray is essentially a thin wrapper around arrays, making it ideal for scenarios where you need predictable, array-like performance
-  * with O(1) indexing and iteration. It excels in memory-sensitive contexts due to its minimal overhead.
+  * Span is essentially a thin wrapper around arrays, making it ideal for scenarios where you need predictable, array-like performance with
+  * O(1) indexing and iteration. It excels in memory-sensitive contexts due to its minimal overhead.
   *
-  * A key advantage of KArray over Chunk is that KArray doesn't box primitive types, while Chunk does. This makes KArray more
-  * memory-efficient when working with primitive values like Int, Long, Double, etc.
+  * A key advantage of Span over Chunk is that Span doesn't box primitive types, while Chunk does. This makes Span more memory-efficient
+  * when working with primitive values like Int, Long, Double, etc.
   *
-  * Important: Unlike Chunk, KArray is NOT part of Scala's collection hierarchy. It doesn't extend Seq or any other collection trait, which
+  * Important: Unlike Chunk, Span is NOT part of Scala's collection hierarchy. It doesn't extend Seq or any other collection trait, which
   * means it won't work with methods expecting standard Scala collections. Consider using Chunk instead when you need compatibility with
   * Scala's collection library or when you require efficient structural operations like slicing without copying data.
   *
   * @tparam A
-  *   the type of elements in this KArray
+  *   the type of elements in this Span
   */
-opaque type KArray[A] = Array[A]
+opaque type Span[A] = Array[A]
 
-object KArray:
+object Span:
 
     import internal.*
 
-    /** Creates a new KArray containing the given elements.
+    /** Creates a new Span containing the given elements.
       *
       * @param values
-      *   the elements to include in the KArray
+      *   the elements to include in the Span
       * @return
-      *   a new KArray containing the specified elements
+      *   a new Span containing the specified elements
       */
-    def apply[A: ClassTag](values: A*): KArray[A] =
+    def apply[A: ClassTag](values: A*): Span[A] =
         values match
             case values: ArraySeq[A] => values.unsafeArray.asInstanceOf[Array[A]]
             case values              => values.toArray
 
-    /** Returns an empty KArray.
+    /** Returns an empty Span.
       *
       * @return
-      *   an empty KArray of type A
+      *   an empty Span of type A
       */
-    def empty[A: ClassTag as ct]: KArray[A] =
+    def empty[A: ClassTag as ct]: Span[A] =
         if cachedEmpty.contains(ct) then
             cachedEmpty(ct).asInstanceOf[Array[A]]
         else
             Array.empty
 
-    /** Creates a KArray from an Array without copying the array.
+    /** Creates a Span from an Array without copying the array.
       *
-      * Note: This method does not create a defensive copy of the array, so changes to the original array will be reflected in the KArray.
-      * Use with caution.
+      * Note: This method does not create a defensive copy of the array, so changes to the original array will be reflected in the Span. Use
+      * with caution.
       *
       * @param array
-      *   the Array to create the KArray from
+      *   the Array to create the Span from
       * @return
-      *   a new KArray sharing the same underlying array
+      *   a new Span sharing the same underlying array
       */
-    def fromUnsafe[A](array: Array[A]): KArray[A] = array
+    def fromUnsafe[A](array: Array[A]): Span[A] = array
 
-    /** Creates a KArray from an IArray.
+    /** Creates a Span from an IArray.
       *
       * Since IArray is already immutable, this operation is safe.
       *
       * @param array
-      *   the IArray to create the KArray from
+      *   the IArray to create the Span from
       * @return
-      *   a new KArray containing the elements from the IArray
+      *   a new Span containing the elements from the IArray
       */
-    def from[A](array: IArray[A])(using Discriminator): KArray[A] =
+    def from[A](array: IArray[A])(using Discriminator): Span[A] =
         array.unsafeArray.asInstanceOf[Array[A]]
 
-    /** Creates a KArray from an IterableOnce.
+    /** Creates a Span from an IterableOnce.
       *
       * @param seq
-      *   the IterableOnce to create the KArray from
+      *   the IterableOnce to create the Span from
       * @return
-      *   a new KArray containing the elements from the IterableOnce
+      *   a new Span containing the elements from the IterableOnce
       */
-    def fromUnsafe[A: ClassTag](seq: IterableOnce[A]): KArray[A] =
+    def fromUnsafe[A: ClassTag](seq: IterableOnce[A]): Span[A] =
         seq.iterator.toArray
 
-    /** Creates a KArray from an Array by copying the array.
+    /** Creates a Span from an Array by copying the array.
       *
       * @param array
-      *   the Array to create the KArray from
+      *   the Array to create the Span from
       * @return
-      *   a new KArray containing a copy of the elements from the Array
+      *   a new Span containing a copy of the elements from the Array
       */
-    def from[A: ClassTag](array: Array[A]): KArray[A] =
+    def from[A: ClassTag](array: Array[A]): Span[A] =
         val copy = new Array[A](array.length)
         System.arraycopy(array, 0, copy, 0, array.length)
         copy
     end from
 
-    /** Creates a KArray from an IterableOnce. This method is identical to fromUnsafe for IterableOnce since it always creates a new array.
+    /** Creates a Span from an IterableOnce. This method is identical to fromUnsafe for IterableOnce since it always creates a new array.
       *
       * @param seq
-      *   the IterableOnce to create the KArray from
+      *   the IterableOnce to create the Span from
       * @return
-      *   a new KArray containing the elements from the IterableOnce
+      *   a new Span containing the elements from the IterableOnce
       */
-    def from[A: ClassTag](seq: IterableOnce[A]): KArray[A] =
+    def from[A: ClassTag](seq: IterableOnce[A]): Span[A] =
         seq.iterator.toArray
 
-    extension [A](self: KArray[A])
+    extension [A](self: Span[A])
 
-        /** Returns the number of elements in this KArray.
+        /** Returns the number of elements in this Span.
           *
           * @return
-          *   the number of elements in this KArray
+          *   the number of elements in this Span
           */
         def size: Int = self.length
 
         inline def length: Int = size
 
-        /** Checks if this KArray is empty.
+        /** Checks if this Span is empty.
           *
           * @return
-          *   true if the KArray contains no elements, false otherwise
+          *   true if the Span contains no elements, false otherwise
           */
         def isEmpty: Boolean = size == 0
 
@@ -137,21 +137,21 @@ object KArray:
           */
         inline def apply(idx: Int): A = self(idx)
 
-        /** Checks if this KArray is equal to another KArray.
+        /** Checks if this Span is equal to another Span.
           *
           * @param other
-          *   the KArray to compare with
+          *   the Span to compare with
           * @return
           *   true if the KArrays contain the same elements in the same order, false otherwise
           */
-        inline def is(other: KArray[A])(using CanEqual[A, A]): Boolean =
+        inline def is(other: Span[A])(using CanEqual[A, A]): Boolean =
             val size = self.length
             @tailrec def loop(idx: Int): Boolean =
                 idx == size || (self(idx) == other(idx) && loop(idx + 1))
             loop(0)
         end is
 
-        /** Checks if all elements in this KArray satisfy the given predicate.
+        /** Checks if all elements in this Span satisfy the given predicate.
           *
           * @param f
           *   the predicate to test each element with
@@ -165,7 +165,7 @@ object KArray:
             loop(0)
         end forall
 
-        /** Checks if at least one element in this KArray satisfies the given predicate.
+        /** Checks if at least one element in this Span satisfies the given predicate.
           *
           * @param f
           *   the predicate to test each element with
@@ -179,14 +179,14 @@ object KArray:
             loop(0)
         end exists
 
-        /** Applies a function to each element of this KArray and returns a new KArray with the results.
+        /** Applies a function to each element of this Span and returns a new Span with the results.
           *
           * @param f
           *   the function to apply to each element
           * @return
-          *   a new KArray containing the results of applying the function to each element
+          *   a new Span containing the results of applying the function to each element
           */
-        inline def map[B: ClassTag](inline f: A => B): KArray[B] =
+        inline def map[B: ClassTag](inline f: A => B): Span[B] =
             val size = self.length
             val r    = new Array[B](self.length)
             @tailrec def loop(idx: Int): Unit =
@@ -197,12 +197,12 @@ object KArray:
             r
         end map
 
-        /** Converts this KArray to a String with the given separator between elements.
+        /** Converts this Span to a String with the given separator between elements.
           *
           * @param separator
           *   the string to insert between each element
           * @return
-          *   a string representation of this KArray
+          *   a string representation of this Span
           */
         def mkString(separator: String): String =
             val r = new java.lang.StringBuilder
@@ -219,7 +219,7 @@ object KArray:
         /** Returns a copy of the underlying array.
           *
           * @return
-          *   a new array containing all elements of this KArray
+          *   a new array containing all elements of this Span
           */
         def toArray(using ClassTag[A]): Array[A] =
             val copy = new Array[A](self.length)
@@ -229,11 +229,11 @@ object KArray:
 
         /** Returns the underlying array without copying.
           *
-          * Note: This method does not create a defensive copy of the array, so changes to the returned array will be reflected in the
-          * KArray. Use with caution.
+          * Note: This method does not create a defensive copy of the array, so changes to the returned array will be reflected in the Span.
+          * Use with caution.
           *
           * @return
-          *   the underlying array of this KArray
+          *   the underlying array of this Span
           */
         def toArrayUnsafe: Array[A] = self
 
@@ -244,9 +244,9 @@ object KArray:
       * Both KArrays must have the same size. This method will throw an exception if the KArrays have different lengths.
       *
       * @param a
-      *   the first KArray
+      *   the first Span
       * @param b
-      *   the second KArray
+      *   the second Span
       * @param f
       *   the predicate to test each pair of elements with
       * @return
@@ -254,7 +254,7 @@ object KArray:
       * @throws IllegalArgumentException
       *   if the KArrays have different lengths
       */
-    inline def existsZip[A, B](a: KArray[A], b: KArray[B])(inline f: (A, B) => Boolean) =
+    inline def existsZip[A, B](a: Span[A], b: Span[B])(inline f: (A, B) => Boolean) =
         val size = a.length
         require(size == b.length)
         @tailrec def loop(idx: Int): Boolean =
@@ -267,11 +267,11 @@ object KArray:
       * All KArrays must have the same size. This method will throw an exception if the KArrays have different lengths.
       *
       * @param a
-      *   the first KArray
+      *   the first Span
       * @param b
-      *   the second KArray
+      *   the second Span
       * @param c
-      *   the third KArray
+      *   the third Span
       * @param f
       *   the predicate to test each triplet of elements with
       * @return
@@ -279,7 +279,7 @@ object KArray:
       * @throws IllegalArgumentException
       *   if the KArrays have different lengths
       */
-    inline def existsZip[A, B, C](a: KArray[A], b: KArray[B], c: KArray[C])(inline f: (A, B, C) => Boolean) =
+    inline def existsZip[A, B, C](a: Span[A], b: Span[B], c: Span[C])(inline f: (A, B, C) => Boolean) =
         val size = a.length
         require(size == b.length)
         @tailrec def loop(idx: Int): Boolean =
@@ -292,9 +292,9 @@ object KArray:
       * Both KArrays must have the same size. This method will throw an exception if the KArrays have different lengths.
       *
       * @param a
-      *   the first KArray
+      *   the first Span
       * @param b
-      *   the second KArray
+      *   the second Span
       * @param f
       *   the predicate to test each pair of elements with
       * @return
@@ -302,7 +302,7 @@ object KArray:
       * @throws IllegalArgumentException
       *   if the KArrays have different lengths
       */
-    inline def forallZip[A, B](a: KArray[A], b: KArray[B])(inline f: (A, B) => Boolean) =
+    inline def forallZip[A, B](a: Span[A], b: Span[B])(inline f: (A, B) => Boolean) =
         val size = a.length
         require(size == b.length)
         @tailrec def loop(idx: Int): Boolean =
@@ -315,11 +315,11 @@ object KArray:
       * All KArrays must have the same size. This method will throw an exception if the KArrays have different lengths.
       *
       * @param a
-      *   the first KArray
+      *   the first Span
       * @param b
-      *   the second KArray
+      *   the second Span
       * @param c
-      *   the third KArray
+      *   the third Span
       * @param f
       *   the predicate to test each triplet of elements with
       * @return
@@ -327,7 +327,7 @@ object KArray:
       * @throws IllegalArgumentException
       *   if the KArrays have different lengths
       */
-    inline def forallZip[A, B, C](a: KArray[A], b: KArray[B], c: KArray[C])(inline f: (A, B, C) => Boolean) =
+    inline def forallZip[A, B, C](a: Span[A], b: Span[B], c: Span[C])(inline f: (A, B, C) => Boolean) =
         val size = a.length
         require(size == b.length)
         @tailrec def loop(idx: Int): Boolean =
@@ -349,4 +349,4 @@ object KArray:
             )
     end internal
 
-end KArray
+end Span

--- a/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
@@ -73,10 +73,10 @@ private[kyo] object TagMacro:
                         case tpe if tpe =:= TypeRepr.of[Null]    => NullEntry
 
                         case tpe @ AndType(_, _) =>
-                            IntersectionEntry(KArray.from(flattenAnd(tpe).map(visit)))
+                            IntersectionEntry(Span.from(flattenAnd(tpe).map(visit)))
 
                         case tpe @ OrType(_, _) =>
-                            UnionEntry(KArray.from(flattenOr(tpe).map(visit)))
+                            UnionEntry(Span.from(flattenOr(tpe).map(visit)))
 
                         case tpe @ ConstantType(const) =>
                             LiteralEntry(visit(tpe.widen), const.value.toString())
@@ -93,9 +93,9 @@ private[kyo] object TagMacro:
                                 case TypeBounds(low, high) => visit(high)
                             }
                             LambdaEntry(
-                                KArray.from(params),
-                                KArray.from(lowerBounds),
-                                KArray.from(higherBounds),
+                                Span.from(params),
+                                Span.from(lowerBounds),
+                                Span.from(higherBounds),
                                 visit(body)
                             )
 
@@ -114,9 +114,9 @@ private[kyo] object TagMacro:
                             require(params.size == variances.size)
                             ClassEntry(
                                 name,
-                                KArray.from(variances),
-                                KArray.from(params),
-                                KArray.from(immediateParents(tpe).map(visit))
+                                Span.from(variances),
+                                Span.from(params),
+                                Span.from(immediateParents(tpe).map(visit))
                             )
 
                         case tpe if tpe.typeSymbol.flags.is(Flags.Opaque) && tpe.typeSymbol.isTypeDef =>
@@ -134,7 +134,7 @@ private[kyo] object TagMacro:
                                             end if
                                         }
                                     require(params.size == variances.size)
-                                    OpaqueEntry(name, visit(lower), visit(upper), KArray.from(variances), KArray.from(params))
+                                    OpaqueEntry(name, visit(lower), visit(upper), Span.from(variances), Span.from(params))
                             end match
 
                         case tpe =>

--- a/kyo-data/shared/src/test/scala/kyo/SpanTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/SpanTest.scala
@@ -4,36 +4,36 @@ import scala.util.Try
 
 class KArrayTest extends Test:
 
-    "KArray.apply" - {
-        "creates a KArray from varargs" in {
-            val arr = KArray(1, 2, 3)
+    "Span.apply" - {
+        "creates a Span from varargs" in {
+            val arr = Span(1, 2, 3)
             assert(arr.size == 3)
             assert(arr(0) == 1)
             assert(arr(1) == 2)
             assert(arr(2) == 3)
         }
 
-        "creates an empty KArray when no arguments are provided" in {
-            val arr = KArray[Int]()
+        "creates an empty Span when no arguments are provided" in {
+            val arr = Span[Int]()
             assert(arr.isEmpty)
         }
     }
 
-    "KArray.empty" - {
-        "creates an empty KArray" in {
-            val arr = KArray.empty[Int]
+    "Span.empty" - {
+        "creates an empty Span" in {
+            val arr = Span.empty[Int]
             assert(arr.isEmpty)
         }
 
         "returns cached empty arrays for primitive types" in {
-            val booleanChain = KArray.empty[Boolean]
-            val byteChain    = KArray.empty[Byte]
-            val charChain    = KArray.empty[Char]
-            val doubleChain  = KArray.empty[Double]
-            val floatChain   = KArray.empty[Float]
-            val intChain     = KArray.empty[Int]
-            val longChain    = KArray.empty[Long]
-            val shortChain   = KArray.empty[Short]
+            val booleanChain = Span.empty[Boolean]
+            val byteChain    = Span.empty[Byte]
+            val charChain    = Span.empty[Char]
+            val doubleChain  = Span.empty[Double]
+            val floatChain   = Span.empty[Float]
+            val intChain     = Span.empty[Int]
+            val longChain    = Span.empty[Long]
+            val shortChain   = Span.empty[Short]
 
             assert(booleanChain.isEmpty)
             assert(byteChain.isEmpty)
@@ -46,51 +46,51 @@ class KArrayTest extends Test:
         }
     }
 
-    "KArray.from" - {
+    "Span.from" - {
         "Array" - {
-            "creates a KArray from a non-empty Array" in {
+            "creates a Span from a non-empty Array" in {
                 val array = Array("a", "b", "c")
-                val arr   = KArray.from(array)
+                val arr   = Span.from(array)
                 assert(arr.size == 3)
                 assert(arr(0) == "a")
                 assert(arr(1) == "b")
                 assert(arr(2) == "c")
             }
 
-            "creates an empty KArray from an empty Array" in {
+            "creates an empty Span from an empty Array" in {
                 val array = Array.empty[String]
-                val arr   = KArray.from(array)
+                val arr   = Span.from(array)
                 assert(arr.isEmpty)
             }
 
             "creates a copy of the underlying array" in {
                 val array = Array("a", "b", "c")
-                val arr   = KArray.from(array)
+                val arr   = Span.from(array)
                 array(0) = "x"
                 assert(arr(0) == "a")
             }
         }
 
         "Seq" - {
-            "creates a KArray from a non-empty Seq" in {
+            "creates a Span from a non-empty Seq" in {
                 val seq = Seq("a", "b", "c")
-                val arr = KArray.from(seq)
+                val arr = Span.from(seq)
                 assert(arr.size == 3)
                 assert(arr(0) == "a")
                 assert(arr(1) == "b")
                 assert(arr(2) == "c")
             }
 
-            "creates an empty KArray from an empty Seq" in {
+            "creates an empty Span from an empty Seq" in {
                 val seq = Seq.empty[String]
-                val arr = KArray.from(seq)
+                val arr = Span.from(seq)
                 assert(arr.isEmpty)
             }
 
             "handles different Seq types" - {
                 "List" in {
                     val list = List(1, 2, 3)
-                    val arr  = KArray.from(list)
+                    val arr  = Span.from(list)
                     assert(arr.size == 3)
                     assert(arr(0) == 1)
                     assert(arr(1) == 2)
@@ -99,7 +99,7 @@ class KArrayTest extends Test:
 
                 "Vector" in {
                     val vector = Vector(1, 2, 3)
-                    val arr    = KArray.from(vector)
+                    val arr    = Span.from(vector)
                     assert(arr.size == 3)
                     assert(arr(0) == 1)
                     assert(arr(1) == 2)
@@ -109,51 +109,51 @@ class KArrayTest extends Test:
         }
     }
 
-    "KArray.fromUnsafe" - {
+    "Span.fromUnsafe" - {
         "Array" - {
-            "creates a KArray from a non-empty Array" in {
+            "creates a Span from a non-empty Array" in {
                 val array = Array("a", "b", "c")
-                val arr   = KArray.fromUnsafe(array)
+                val arr   = Span.fromUnsafe(array)
                 assert(arr.size == 3)
                 assert(arr(0) == "a")
                 assert(arr(1) == "b")
                 assert(arr(2) == "c")
             }
 
-            "creates an empty KArray from an empty Array" in {
+            "creates an empty Span from an empty Array" in {
                 val array = Array.empty[String]
-                val arr   = KArray.fromUnsafe(array)
+                val arr   = Span.fromUnsafe(array)
                 assert(arr.isEmpty)
             }
 
             "shares the same underlying array" in {
                 val array = Array("a", "b", "c")
-                val arr   = KArray.fromUnsafe(array)
+                val arr   = Span.fromUnsafe(array)
                 array(0) = "x"
                 assert(arr(0) == "x")
             }
         }
 
         "Seq" - {
-            "creates a KArray from a non-empty Seq" in {
+            "creates a Span from a non-empty Seq" in {
                 val seq = Seq("a", "b", "c")
-                val arr = KArray.fromUnsafe(seq)
+                val arr = Span.fromUnsafe(seq)
                 assert(arr.size == 3)
                 assert(arr(0) == "a")
                 assert(arr(1) == "b")
                 assert(arr(2) == "c")
             }
 
-            "creates an empty KArray from an empty Seq" in {
+            "creates an empty Span from an empty Seq" in {
                 val seq = Seq.empty[String]
-                val arr = KArray.fromUnsafe(seq)
+                val arr = Span.fromUnsafe(seq)
                 assert(arr.isEmpty)
             }
 
             "handles different Seq types" - {
                 "List" in {
                     val list = List(1, 2, 3)
-                    val arr  = KArray.fromUnsafe(list)
+                    val arr  = Span.fromUnsafe(list)
                     assert(arr.size == 3)
                     assert(arr(0) == 1)
                     assert(arr(1) == 2)
@@ -162,7 +162,7 @@ class KArrayTest extends Test:
 
                 "Vector" in {
                     val vector = Vector(1, 2, 3)
-                    val arr    = KArray.fromUnsafe(vector)
+                    val arr    = Span.fromUnsafe(vector)
                     assert(arr.size == 3)
                     assert(arr(0) == 1)
                     assert(arr(1) == 2)
@@ -173,46 +173,46 @@ class KArrayTest extends Test:
     }
 
     "size" - {
-        "returns the number of elements in a non-empty KArray" in {
-            val arr = KArray(1, 2, 3, 4, 5)
+        "returns the number of elements in a non-empty Span" in {
+            val arr = Span(1, 2, 3, 4, 5)
             assert(arr.size == 5)
         }
 
-        "returns 0 for an empty KArray" in {
-            val arr = KArray.empty[Int]
+        "returns 0 for an empty Span" in {
+            val arr = Span.empty[Int]
             assert(arr.size == 0)
         }
     }
 
     "isEmpty" - {
-        "returns false for a non-empty KArray" in {
-            val arr = KArray(1, 2, 3)
+        "returns false for a non-empty Span" in {
+            val arr = Span(1, 2, 3)
             assert(!arr.isEmpty)
         }
 
-        "returns true for an empty KArray" in {
-            val arr = KArray.empty[Int]
+        "returns true for an empty Span" in {
+            val arr = Span.empty[Int]
             assert(arr.isEmpty)
         }
     }
 
     "apply" - {
-        "returns correct elements from a KArray" in {
-            val arr = KArray(1, 2, 3, 4, 5)
+        "returns correct elements from a Span" in {
+            val arr = Span(1, 2, 3, 4, 5)
             assert(arr(0) == 1)
             assert(arr(2) == 3)
             assert(arr(4) == 5)
         }
 
         "throws for negative index" in {
-            val arr = KArray(1, 2, 3)
+            val arr = Span(1, 2, 3)
             assertThrows[Throwable] {
                 arr(-1)
             }
         }
 
         "throws for index >= size" in {
-            val arr = KArray(1, 2, 3)
+            val arr = Span(1, 2, 3)
             assertThrows[Throwable] {
                 arr(3)
             }
@@ -221,26 +221,26 @@ class KArrayTest extends Test:
 
     "is" - {
         "returns true for equal Chains" in {
-            val chain1 = KArray(1, 2, 3)
-            val chain2 = KArray(1, 2, 3)
+            val chain1 = Span(1, 2, 3)
+            val chain2 = Span(1, 2, 3)
             assert(chain1.is(chain2))
         }
 
         "returns false for different Chains" in {
-            val chain1 = KArray(1, 2, 3)
-            val chain2 = KArray(3, 2, 1)
+            val chain1 = Span(1, 2, 3)
+            val chain2 = Span(3, 2, 1)
             assert(!chain1.is(chain2))
         }
 
         "returns true for empty Chains" in {
-            val chain1 = KArray.empty[Int]
-            val chain2 = KArray.empty[Int]
+            val chain1 = Span.empty[Int]
+            val chain2 = Span.empty[Int]
             assert(chain1.is(chain2))
         }
 
         "returns false for Chains of different sizes" in {
-            val chain1 = KArray(1, 2, 3)
-            val chain2 = KArray(1, 2)
+            val chain1 = Span(1, 2, 3)
+            val chain2 = Span(1, 2)
             assertThrows[Throwable] {
                 chain1.is(chain2)
             }
@@ -249,41 +249,41 @@ class KArrayTest extends Test:
 
     "forall" - {
         "returns true when all elements satisfy the predicate" in {
-            val arr = KArray(2, 4, 6, 8, 10)
+            val arr = Span(2, 4, 6, 8, 10)
             assert(arr.forall(_ % 2 == 0))
         }
 
         "returns false when at least one element does not satisfy the predicate" in {
-            val arr = KArray(2, 4, 5, 8, 10)
+            val arr = Span(2, 4, 5, 8, 10)
             assert(!arr.forall(_ % 2 == 0))
         }
 
-        "returns true for an empty KArray" in {
-            val arr = KArray.empty[Int]
+        "returns true for an empty Span" in {
+            val arr = Span.empty[Int]
             assert(arr.forall(_ => false))
         }
     }
 
     "exists" - {
         "returns true when at least one element satisfies the predicate" in {
-            val arr = KArray(1, 3, 5, 6, 9)
+            val arr = Span(1, 3, 5, 6, 9)
             assert(arr.exists(_ % 2 == 0))
         }
 
         "returns false when no element satisfies the predicate" in {
-            val arr = KArray(1, 3, 5, 7, 9)
+            val arr = Span(1, 3, 5, 7, 9)
             assert(!arr.exists(_ % 2 == 0))
         }
 
-        "returns false for an empty KArray" in {
-            val arr = KArray.empty[Int]
+        "returns false for an empty Span" in {
+            val arr = Span.empty[Int]
             assert(!arr.exists(_ => true))
         }
     }
 
     "map" - {
         "transforms all elements using the provided function" in {
-            val arr    = KArray(1, 2, 3, 4, 5)
+            val arr    = Span(1, 2, 3, 4, 5)
             val result = arr.map(_ * 2)
             assert(result.size == 5)
             assert(result(0) == 2)
@@ -293,14 +293,14 @@ class KArrayTest extends Test:
             assert(result(4) == 10)
         }
 
-        "returns an empty KArray when mapping an empty KArray" in {
-            val arr    = KArray.empty[Int]
+        "returns an empty Span when mapping an empty Span" in {
+            val arr    = Span.empty[Int]
             val result = arr.map(_ * 2)
             assert(result.isEmpty)
         }
 
         "handles type transformations" in {
-            val arr    = KArray(1, 2, 3)
+            val arr    = Span(1, 2, 3)
             val result = arr.map(_.toString)
             assert(result.size == 3)
             assert(result(0) == "1")
@@ -311,90 +311,90 @@ class KArrayTest extends Test:
 
     "mkString" - {
         "joins elements with the specified separator" in {
-            val arr = KArray(1, 2, 3, 4, 5)
+            val arr = Span(1, 2, 3, 4, 5)
             assert(arr.mkString(", ") == "1, 2, 3, 4, 5")
         }
 
-        "returns an empty string for an empty KArray" in {
-            val arr = KArray.empty[Int]
+        "returns an empty string for an empty Span" in {
+            val arr = Span.empty[Int]
             assert(arr.mkString(", ") == "")
         }
 
         "works with a single element" in {
-            val arr = KArray("single")
+            val arr = Span("single")
             assert(arr.mkString(", ") == "single")
         }
 
         "uses toString on complex objects" in {
             case class Person(name: String)
-            val arr = KArray(Person("Alice"), Person("Bob"))
+            val arr = Span(Person("Alice"), Person("Bob"))
             assert(arr.mkString("; ") == "Person(Alice); Person(Bob)")
         }
     }
 
-    "KArray.exists (binary)" - {
+    "Span.exists (binary)" - {
         "returns true when at least one pair satisfies the predicate" in {
-            val chain1 = KArray(1, 4, 3)
-            val chain2 = KArray(3, 4, 5)
-            assert(KArray.existsZip(chain1, chain2)(_ == _))
+            val chain1 = Span(1, 4, 3)
+            val chain2 = Span(3, 4, 5)
+            assert(Span.existsZip(chain1, chain2)(_ == _))
         }
 
         "returns false when no pair satisfies the predicate" in {
-            val chain1 = KArray(1, 2, 3)
-            val chain2 = KArray(4, 5, 6)
-            assert(!KArray.existsZip(chain1, chain2)(_ == _))
+            val chain1 = Span(1, 2, 3)
+            val chain2 = Span(4, 5, 6)
+            assert(!Span.existsZip(chain1, chain2)(_ == _))
         }
 
         "throws an exception for Chains of different sizes" in {
-            val chain1 = KArray(1, 2, 3)
-            val chain2 = KArray(4, 5)
+            val chain1 = Span(1, 2, 3)
+            val chain2 = Span(4, 5)
             assertThrows[IllegalArgumentException] {
-                KArray.existsZip(chain1, chain2)(_ == _)
+                Span.existsZip(chain1, chain2)(_ == _)
             }
         }
     }
 
-    "KArray.forall (binary)" - {
+    "Span.forall (binary)" - {
         "returns true when all pairs satisfy the predicate" in {
-            val chain1 = KArray(1, 2, 3)
-            val chain2 = KArray(1, 2, 3)
-            assert(KArray.forallZip(chain1, chain2)(_ == _))
+            val chain1 = Span(1, 2, 3)
+            val chain2 = Span(1, 2, 3)
+            assert(Span.forallZip(chain1, chain2)(_ == _))
         }
 
         "returns false when at least one pair does not satisfy the predicate" in {
-            val chain1 = KArray(1, 2, 3)
-            val chain2 = KArray(1, 4, 3)
-            assert(!KArray.forallZip(chain1, chain2)(_ == _))
+            val chain1 = Span(1, 2, 3)
+            val chain2 = Span(1, 4, 3)
+            assert(!Span.forallZip(chain1, chain2)(_ == _))
         }
 
         "throws an exception for Chains of different sizes" in {
-            val chain1 = KArray(1, 2, 3)
-            val chain2 = KArray(1, 2)
+            val chain1 = Span(1, 2, 3)
+            val chain2 = Span(1, 2)
             assertThrows[IllegalArgumentException] {
-                KArray.forallZip(chain1, chain2)(_ == _)
+                Span.forallZip(chain1, chain2)(_ == _)
             }
         }
     }
 
     "mixed" - {
         "chained operations" in {
-            val arr    = KArray(1, 2, 3, 4, 5)
+            val arr    = Span(1, 2, 3, 4, 5)
             val result = arr.map(_ * 2)
             assert(result.forall(_ % 2 == 0))
             assert(result.exists(_ > 8))
             assert(result.mkString("-") == "2-4-6-8-10")
         }
 
-        "empty KArray operations" in {
-            val arr = KArray.empty[Int]
+        "empty Span operations" in {
+            val arr = Span.empty[Int]
             assert(arr.map(_ * 2).isEmpty)
             assert(arr.forall(_ => false))
             assert(!arr.exists(_ => true))
             assert(arr.mkString(",") == "")
         }
 
-        "single element KArray operations" in {
-            val arr = KArray(42)
+        "single element Span operations" in {
+            val arr = Span(42)
             assert(arr.size == 1)
             assert(!arr.isEmpty)
             assert(arr(0) == 42)
@@ -408,14 +408,14 @@ class KArrayTest extends Test:
     "toArray and toArrayUnsafe" - {
         "toArray" - {
             "returns a copy of the underlying array" in {
-                val arr   = KArray(1, 2, 3)
+                val arr   = Span(1, 2, 3)
                 val array = arr.toArray
                 array(0) = 99
                 assert(arr(0) == 1)
             }
 
-            "returns an empty array for an empty KArray" in {
-                val arr   = KArray.empty[Int]
+            "returns an empty array for an empty Span" in {
+                val arr   = Span.empty[Int]
                 val array = arr.toArray
                 assert(array.isEmpty)
             }
@@ -423,14 +423,14 @@ class KArrayTest extends Test:
 
         "toArrayUnsafe" - {
             "returns the underlying array without copying" in {
-                val arr   = KArray(1, 2, 3)
+                val arr   = Span(1, 2, 3)
                 val array = arr.toArrayUnsafe
                 array(0) = 99
                 assert(arr(0) == 99)
             }
 
-            "returns an empty array for an empty KArray" in {
-                val arr   = KArray.empty[Int]
+            "returns an empty array for an empty Span" in {
+                val arr   = Span.empty[Int]
                 val array = arr.toArrayUnsafe
                 assert(array.isEmpty)
             }


### PR DESCRIPTION

### Problem

`KArray` doesn't follow Kyo's naming patterns.

### Solution

Rename `KArray` to `Span` (@hearnadam's suggestion). I've also rename the existing tracing `Span` to `TraceSpan` to avoid confusion.

