### PR TITLE
[prelude] parametrized generic aspects

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Aspect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Aspect.scala
@@ -34,7 +34,7 @@ import Aspect.*
   */
 final class Aspect[Input[_], Output[_], S] private[kyo] (
     using
-    tag: Tag[(Input[Any], Output[Any], S)],
+    tag: Tag[(Input[Any], Output[Any])],
     frame: Frame
 ) extends Serializable:
 
@@ -165,7 +165,7 @@ object Aspect:
       * @tparam S
       *   The effect type
       */
-    def init[I[_], O[_], S](using Frame, Tag[(I[Any], O[Any], S)]): Aspect[I, O, S] =
+    def init[I[_], O[_], S](using Frame, Tag[(I[Any], O[Any])]): Aspect[I, O, S] =
         new Aspect[I, O, S]
 
 end Aspect

--- a/kyo-prelude/shared/src/test/scala/kyo/AspectTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AspectTest.scala
@@ -204,7 +204,6 @@ class AspectTest extends Test:
         case class Wrapped[+A, B](value: A, meta: B) derives CanEqual
         case class Container[+A](value: A, meta: String) derives CanEqual
 
-        // TODO SIGSEGV in Scala Native
         "with same input/output wrapper" in run {
             val aspect = Aspect.init[Wrapped[*, String], Wrapped[*, String], Any]
 


### PR DESCRIPTION

### Problem

`Aspect`s can't be used in generic contexts when their inputs or outputs depend on a parametrized type. This issue was raised as part of the work to generalize `Parse` in https://github.com/getkyo/kyo/pull/1305.

### Solution

Instead of relying on the object identity of the `Aspect` instance, manage `Cut` activations based on a pair of the type signature of the `Aspect` via `Tag` and its allocation site via `Frame`. 

### Notes

- This approach doesn't keep a strict identity as before since the `Frame` can be shared in case it's available a scope with multiple `Aspect` instantiations but that's something that should happen only in Kyo's codebase since users shouldn't manage `Frame`s.
- I've removed the `default` cut to simplify the implementation since it's unused.