### PR TITLE
[build] use setup-action for jdk+sbt setup

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -58,9 +58,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
-      - uses: olafurpg/setup-scala@v14
+      - uses: coursier/setup-action@v1
         with:
-          java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz
+          jvm: corretto:21
+          apps: sbt
 
       - name: install async-profiler
         run: |

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -19,9 +19,10 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libcurl4-openssl-dev libidn2-0-dev
-    - uses: olafurpg/setup-scala@v14
+    - uses: coursier/setup-action@v1
       with:
-        java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz
+        jvm: corretto:24
+        apps: sbt
 
     - name: Build JVM
       run: sbt '+kyoJVM/test'

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -29,9 +29,10 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libcurl4-openssl-dev libidn2-0-dev
-    - uses: olafurpg/setup-scala@v14
+    - uses: coursier/setup-action@v1
       with:
-        java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz
+        jvm: corretto:24
+        apps: sbt
 
     - name: Build ${{ matrix.target.name }}
       run: ${{ matrix.target.command }}

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -14,7 +14,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
-      - uses: olafurpg/setup-scala@v14
+      - uses: coursier/setup-action@v1
         with:
-          java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz
+          jvm: corretto:24
+          apps: sbt
       - run: sbt checkReadme

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
       - uses: coursier/cache-action@v6
-      - uses: olafurpg/setup-scala@v14
+      - uses: coursier/setup-action@v1
         with:
-          java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz
+          jvm: corretto:24
+          apps: sbt
       - run: sbt -Dplatform=JVM "ci-release"
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/scalafmt.yml
+++ b/.github/workflows/scalafmt.yml
@@ -14,7 +14,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
-      - uses: olafurpg/setup-scala@v14
+      - uses: coursier/setup-action@v1
         with:
-          java-version: openjdk@21.0.2=tgz+https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz
+          jvm: corretto:24
+          apps: sbt
       - run: sbt "scalafmtCheckAll"


### PR DESCRIPTION
### Problem
The CI was using an old, specific version of JDK21.

### Solution
Use coursier setup to manage JDK versioning.

### Notes
I kept bench on JDK21 as I suspect the current async-profiler setup is not correct for JDK24.
