### PR TITLE
[combinators] clean up Async Combinators + Constructors

### DIFF
--- a/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
@@ -14,9 +14,7 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
       * @return
       *   A computation that produces the result of this computation with Async effect
       */
-    inline def fork(
-        using frame: Frame
-    ): Fiber[E, A] < (Sync & Ctx) =
+    inline def fork(using Frame, Isolate.Contextual[Ctx, Sync]): Fiber[E, A] < (Sync & Ctx) =
         Fiber.init(effect)
 
     /** Forks this computation using the Async effect and returns its result as a `Fiber[E, A]`, managed by the Resource effect. Unlike
@@ -26,10 +24,8 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
       * @return
       *   A computation that produces the result of this computation with Async and Resource effects
       */
-    inline def forkScoped(
-        using frame: Frame
-    ): Fiber[E, A] < (Sync & Ctx & Resource) =
-        Kyo.acquireRelease(Fiber.init(effect))(_.interrupt.unit)
+    inline def forkScoped(using Frame, Isolate.Contextual[Ctx, Sync]): Fiber[E, A] < (Sync & Ctx & Resource) =
+        Kyo.acquireRelease(Fiber.init(effect))(_.interrupt)
 
     /** Performs this computation and then the next one in parallel, discarding the result of this computation.
       *
@@ -41,15 +37,15 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
     @targetName("zipRightPar")
     def &>[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
         using
+        fr: Frame,
         i1: Isolate.Contextual[Ctx, Sync],
-        i2: Isolate.Contextual[Ctx1, Sync],
-        f: Frame
+        i2: Isolate.Contextual[Ctx1, Sync]
     ): A1 < (Abort[E | E1] & Async & Ctx & Ctx1) =
         for
-            fiberA  <- Fiber.init(using i1)(effect)
-            fiberA1 <- Fiber.init(using i2)(next)
-            _       <- fiberA.awaitCompletion
-            a1      <- fiberA1.join
+            left  <- Fiber.init(using i1)(effect)
+            right <- Fiber.init(using i2)(next)
+            _     <- left.await
+            a1    <- right.join
         yield a1
 
     /** Performs this computation and then the next one in parallel, discarding the result of the next computation.
@@ -62,15 +58,15 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
     @targetName("zipLeftPar")
     def <&[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
         using
+        f: Frame,
         i1: Isolate.Contextual[Ctx, Sync],
-        i2: Isolate.Contextual[Ctx1, Sync],
-        f: Frame
+        i2: Isolate.Contextual[Ctx1, Sync]
     ): A < (Abort[E | E1] & Async & Ctx & Ctx1) =
         for
-            fiberA  <- Fiber.init(using i1)(effect)
-            fiberA1 <- Fiber.init(using i2)(next)
-            a       <- fiberA.join
-            _       <- fiberA1.awaitCompletion
+            left  <- Fiber.init(using i1)(effect)
+            right <- Fiber.init(using i2)(next)
+            a     <- left.join
+            _     <- right.await
         yield a
 
     /** Performs this computation and then the next one in parallel, returning both results as a tuple.
@@ -83,16 +79,16 @@ extension [A, E, Ctx](effect: A < (Abort[E] & Async & Ctx))
     @targetName("zipPar")
     def <&>[A1, E1, Ctx1](next: A1 < (Abort[E1] & Async & Ctx1))(
         using
+        fr: Frame,
         i1: Isolate.Contextual[Ctx, Sync],
         i2: Isolate.Contextual[Ctx1, Sync],
-        f: Frame,
         zippable: Zippable[A, A1]
     ): zippable.Out < (Abort[E | E1] & Async & Ctx & Ctx1) =
         for
-            fiberA  <- Fiber.init(using i1)(effect)
-            fiberA1 <- Fiber.init(using i2)(next)
-            a       <- fiberA.join
-            a1      <- fiberA1.join
+            left  <- Fiber.init(using i1)(effect)
+            right <- Fiber.init(using i2)(next)
+            a     <- left.join
+            a1    <- right.join
         yield zippable.zip(a, a1)
 
 end extension
@@ -104,7 +100,7 @@ extension [A, E, S](fiber: Fiber[E, A] < S)
       * @return
       *   A computation that produces the result of this computation with Async effect
       */
-    def join(using Frame): A < (S & Abort[E] & Async) =
+    def join(using frame: Frame, reduce: Reducible[Abort[E]]): A < (S & reduce.SReduced & Async) =
         fiber.map(_.get)
 
     /** Awaits the completion of the fiber and returns its result as a `Unit`.
@@ -112,6 +108,6 @@ extension [A, E, S](fiber: Fiber[E, A] < S)
       * @return
       *   A computation that produces the result of this computation with Async effect
       */
-    def awaitCompletion(using Frame): Unit < (S & Async) =
-        fiber.map(_.getResult.unit)
+    def await(using Frame): Result[E, A] < (S & Async) =
+        fiber.map(_.getResult)
 end extension

--- a/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
@@ -13,8 +13,8 @@ extension [A, S](effect: A < (S & Choice))
       * @return
       *   A computation that produces the result of this computation with Choice effect
       */
-    def filterChoice[S1](fn: A => Boolean < S1)(using Frame): A < (S & S1 & Choice) =
-        effect.map(a => fn(a).map(b => Choice.dropIf(!b)).andThen(a))
+    def filterChoice[S1](predicate: A => Boolean < S1)(using Frame): A < (S & S1 & Choice) =
+        effect.map(a => predicate(a).map(b => Choice.dropIf(!b)).andThen(a))
 
     /** Handles the Choice effect and returns its result as a `Seq[A]`.
       *

--- a/kyo-combinators/shared/src/test/scala/kyo/AsyncCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AsyncCombinatorsTest.scala
@@ -184,9 +184,9 @@ class FiberCombinatorsTest extends Test:
             }
         }
 
-        "awaitCompletion" - {
+        "await" - {
 
-            "should wait for fiber completion without returning result" in run {
+            "should wait for fiber completion" in run {
                 var completed = false
                 val effect = Kyo.async[Int, Nothing](continuation =>
                     completed = true
@@ -195,31 +195,13 @@ class FiberCombinatorsTest extends Test:
 
                 val program =
                     for
-                        fiber <- effect.fork
-                        _     <- fiber.awaitCompletion
-                    yield completed
+                        fiber  <- effect.fork
+                        result <- fiber.await
+                    yield result
 
                 Fiber.init(program).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v =>
-                        assert(v)
-                    )
-                }
-            }
-
-            "should not propagate fiber result" in run {
-                val effect = Kyo.async[Int, Nothing]((continuation) =>
-                    continuation(42)
-                )
-
-                val program =
-                    for
-                        fiber <- effect.fork
-                        _     <- fiber.awaitCompletion
-                    yield ()
-
-                Fiber.init(program).map(_.toFuture).map { handledEffect =>
-                    handledEffect.map(v =>
-                        assert(v == ())
+                        assert(v == Result.succeed(42) && completed)
                     )
                 }
             }

--- a/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ConstructorsTest.scala
@@ -165,20 +165,6 @@ class ConstructorsTest extends Test:
             }
         }
 
-        "suspendAttempt" - {
-            "should suspend an effect and handle exceptions" in {
-                import AllowUnsafe.embrace.danger
-                val successEffect = Kyo.deferAttempt(42)
-                val failureEffect = Kyo.deferAttempt(throw new Exception("Error"))
-
-                val successResult = Sync.Unsafe.evalOrThrow(Abort.run[Throwable](successEffect))
-                val failureResult = Sync.Unsafe.evalOrThrow(Abort.run[Throwable](failureEffect))
-
-                assert(successResult == Result.succeed(42))
-                assert(failureResult.isInstanceOf[Result.Failure[?]])
-            }
-        }
-
         "foreachPar" - {
             "should apply a function to each element in parallel" in run {
                 val input  = Seq(1, 2, 3, 4, 5)
@@ -235,30 +221,6 @@ class ConstructorsTest extends Test:
             import AllowUnsafe.embrace.danger
             Sync.Unsafe.evalOrThrow(effect)
             assert(state == 1)
-        }
-
-        "deferAttempt" - {
-            "success" in {
-                var state = 0
-                val effect = Kyo.deferAttempt:
-                    state += 1
-                assert(state == 0)
-                import AllowUnsafe.embrace.danger
-                Sync.Unsafe.evalOrThrow(effect)
-                assert(state == 1)
-            }
-
-            "fail" in {
-                var state     = 0
-                val exception = Exception("failure")
-                val effect = Kyo.deferAttempt:
-                    state += 1
-                    throw exception
-                assert(state == 0)
-                import AllowUnsafe.embrace.danger
-                val result = Sync.Unsafe.evalOrThrow(Abort.run(effect))
-                assert(state == 1 && result == Result.Failure(exception))
-            }
         }
     }
 

--- a/kyo-core/shared/src/main/scala/kyo/Resource.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Resource.scala
@@ -93,7 +93,7 @@ object Resource:
       * @return
       *   The acquired Closeable resource wrapped in Resource, Sync, and S effects.
       */
-    def acquire[A <: java.io.Closeable, S](resource: => A < S)(using Frame): A < (Resource & Sync & S) =
+    def acquire[A <: java.lang.AutoCloseable, S](resource: => A < S)(using Frame): A < (Resource & Sync & S) =
         acquireRelease(resource)(_.close())
 
     /** Runs a resource-managed effect with default parallelism of 1.


### PR DESCRIPTION
### Problem
This PR refines some of the signatures in Async combinators and Constructors to more closely align with ZIO + what I expect as a user.

### Changes
- Add `Reducible` to `Fiber.join`
- Refactor `awaitCompletion` to `await` - let users discard the `Result`
- Fix `Kyo.addFinalizer` to support all effects supported by `Resource`.
- remove `deferAttempt
- Enable `Resource.acquire` to support `AutoClosable` (parent type of `Closable`
