### PR TITLE
[core] propagate interruption in Async.timeout when Duration is Zero

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -163,8 +163,7 @@ object Async extends AsyncPlatformSpecific:
     def timeout[E, A, S](
         using isolate: Isolate.Stateful[S, Abort[E] & Async]
     )(after: Duration)(v: => A < (Abort[E] & Async & S))(using frame: Frame): A < (Abort[E | Timeout] & Async & S) =
-        if after == Duration.Zero then Abort.fail(Timeout(Present(after)))
-        else if !after.isFinite then v
+        if !after.isFinite then v
         else
             isolate.capture { state =>
                 Fiber.init(isolate.isolate(state, v)).map { task =>

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -549,7 +549,7 @@ class AsyncTest extends Test:
                 flag   <- AtomicBoolean.init(false)
                 fiber  <- Promise.init[Nothing, Int]
                 _      <- fiber.onInterrupt(_ => flag.set(true))
-                result <- Fiber.init(Async.timeout(1.millis)(fiber.get))
+                result <- Fiber.init(Async.timeout(0.millis)(fiber.get))
                 result <- fiber.getResult
                 _      <- untilTrue(flag.get)
             yield assert(result.isPanic)


### PR DESCRIPTION
/fixes #1339
### Problem
The current `Async.timeout` avoids forking a fiber to interrupt the computation passed by directlying failing with abort. In the context of a joined Fiber, this means the underlying fiber will never be interrupted.

### Solution
Avoid the special casing for `Duration.Zero`. Always fork a fiber to interrupt.
