### PR TITLE
KyoApp: add ScalaDocs & simplified implementations

### DIFF
--- a/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -1,26 +1,20 @@
 package kyo
 
-import kyo.Maybe.Absent
-import kyo.Maybe.Present
-
 abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abort[Throwable]]:
 
-    private var maybePreviousAsync: Maybe[Unit < (Async & Abort[Throwable])] = Absent
+    private var last: Unit < (Async & Abort[Throwable]) = ()
 
     final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
-        val currentAsync: Unit < (Async & Abort[Throwable]) =
-            Abort.run(handle(v)).map(result => Sync.defer(onResult(result)).andThen(Abort.get(result)).unit)
-        maybePreviousAsync = maybePreviousAsync match
-            case Absent                 => Present(currentAsync)
-            case Present(previousAsync) => Present(previousAsync.map(_ => currentAsync))
-        initCode = maybePreviousAsync.map { previousAsync => () =>
-            val racedAsyncIO = Clock.repeatWithDelay(1.hour)(()).map { fiber =>
-                val race = Async.race(fiber.get, previousAsync)
-                Async.timeout(timeout)(race)
-            }
-            val _ = Sync.Unsafe.evalOrThrow(Fiber.init(racedAsyncIO))
-        }.toChunk
+        val current: Unit < (Async & Abort[Throwable]) =
+            Abort.runWith(Async.timeout(runTimeout)(handle(v)))(result => Sync.defer(onResult(result)).andThen(Abort.get(result)).unit)
+
+        last = last.andThen(current)
+
+        initCode = Chunk(() =>
+            val raced = Async.raceFirst(Clock.repeatWithDelay(1.hour)(()).map(_.get), last)
+            val _     = Sync.Unsafe.evalOrThrow(Fiber.init(raced))
+        )
     end run
 
 end KyoAppPlatformSpecific

--- a/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -5,7 +5,7 @@ abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abo
     final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         initCode = initCode.appended(() =>
-            val result = Sync.Unsafe.evalOrThrow(Abort.run(Async.runAndBlock(timeout)(handle(v))))
+            val result = Sync.Unsafe.evalOrThrow(Abort.run(Async.runAndBlock(runTimeout)(handle(v))))
             onResult(result)
         )
     end run

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -11,8 +11,6 @@ import kyo.internal.OsSignal
   * Note: This class and its methods are unsafe and should only be used as the entrypoint of an application.
   */
 abstract class KyoApp extends KyoAppPlatformSpecific:
-    override def timeout: Duration = Duration.Infinity
-
     private val awaitInterrupt =
         given AllowUnsafe = AllowUnsafe.embrace.danger
         val promise       = Promise.Unsafe.init[Nothing, Nothing]()
@@ -35,6 +33,9 @@ abstract class KyoApp extends KyoAppPlatformSpecific:
 end KyoApp
 
 object KyoApp:
+    def apply[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): KyoApp =
+        new KyoApp:
+            run(v)
 
     /** An abstract base class for Kyo applications.
       *
@@ -44,25 +45,49 @@ object KyoApp:
       *   The effect type used by the application.
       */
     abstract class Base[S]:
-        protected def timeout: Duration
-
-        protected def handle[A](v: A < S)(using Frame): A < (Async & Abort[Throwable])
-
-        final protected def args: Array[String] = _args
-
-        private var _args: Array[String] = null
-
+        private var _args: Array[String]          = null
         protected var initCode: Chunk[() => Unit] = Chunk.empty
 
         final def main(args: Array[String]) =
             this._args = args
-            for proc <- initCode do proc()
+            if initCode.isEmpty then
+                import AllowUnsafe.embrace.danger
+                onResult(Result.fail(Ansi.highlight(
+                    header = "KyoApp: nothing to execute. Did you forget to use a run block?",
+                    code = """|
+                              | object Example extends KyoApp:
+                              |   run {
+                              |     Console.printLine("Hello, world!")
+                              |   }
+                              |""".stripMargin,
+                    trailer = ""
+                )))
+            else for proc <- initCode do proc()
+            end if
         end main
 
+        /** The argument(s) this application was started with. */
+        final protected def args: Chunk[String] =
+            if _args eq null then Chunk.empty
+            else Chunk.fromNoCopy(_args)
+
+        /** Unsafely exits the application. */
+        protected def exit(code: Int)(using AllowUnsafe): Unit =
+            kernel.Platform.exit(code)
+
+        /** Unified handling logic for supporting arbitrary effects. */
+        protected def handle[A](v: A < S)(using Frame): A < (Async & Abort[Throwable])
+
+        /** The timeout for each [[run]] block. */
+        protected def runTimeout: Duration = Duration.Infinity
+
+        /** The main entrypoint to this application. */
         protected def run[A](v: => A < S)(using Frame, Render[A]): Unit
 
-        protected def exit(code: Int)(using AllowUnsafe): Unit = kernel.Platform.exit(code)
-
+        /** Handles the result of the [[run]] block computation.
+          *
+          * Override this method to control how the result is handled.
+          */
         protected def onResult[E, A](result: Result[E, A])(using Render[Result[E, A]], AllowUnsafe): Unit =
             if !result.exists(().equals(_)) then println(result.show)
             result match


### PR DESCRIPTION
### Problem
KyoApp is the 'frontend' of users experience Kyo. Let's make it nice!

### Solution
- Add scaladocs
- rename `timeout` -> `runTimeout` - this is more accurate and prevents imported `timeout` methods from causing compiler errors (like `import Async.timeout`, then `timeout(effect)`
- Introduce `KyoApp.apply` for even simpler running of effects.