### PR TITLE
[core] respect Thread interruption on blocking boundaries

### DIFF
--- a/kyo-cats/shared/src/main/scala/kyo/Cats.scala
+++ b/kyo-cats/shared/src/main/scala/kyo/Cats.scala
@@ -44,7 +44,7 @@ object Cats:
                 CatsIO.async[A] { cb =>
                     CatsIO {
                         fiber.unsafe.onComplete(r => cb(r.toEither))
-                        Some(CatsIO(fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))).void)
+                        Some(CatsIO(fiber.unsafe.interrupt(Result.Panic(Interrupted(frame)))).void)
                     }
                 }
             }.handle(Sync.Unsafe.evalOrThrow)

--- a/kyo-cats/shared/src/main/scala/kyo/Cats.scala
+++ b/kyo-cats/shared/src/main/scala/kyo/Cats.scala
@@ -44,7 +44,7 @@ object Cats:
                 CatsIO.async[A] { cb =>
                     CatsIO {
                         fiber.unsafe.onComplete(r => cb(r.toEither))
-                        Some(CatsIO(fiber.unsafe.interrupt(Result.Panic(Interrupted(frame)))).void)
+                        Some(CatsIO(fiber.unsafe.interrupt()).void)
                     }
                 }
             }.handle(Sync.Unsafe.evalOrThrow)

--- a/kyo-core/jvm-native/src/test/scala/kyo/scheduler/IOPromiseBlockingTest.scala
+++ b/kyo-core/jvm-native/src/test/scala/kyo/scheduler/IOPromiseBlockingTest.scala
@@ -1,0 +1,69 @@
+package kyo.scheduler
+
+import kyo.*
+import org.scalatest.compatible.Assertion
+import scala.annotation.tailrec
+
+class IOPromiseBlockingTest extends Test:
+
+    def deadline(after: Duration = timeout) =
+        import AllowUnsafe.embrace.danger
+        Clock.live.unsafe.deadline(after)
+
+    "block" - {
+        "immediate completion" in {
+            val p = new IOPromise[Nothing, Int]()
+            p.complete(Result.succeed(42))
+            val result = p.block(deadline())
+            assert(result == Result.succeed(42))
+        }
+
+        "timeout" in runNotJS {
+            val p      = new IOPromise[Nothing, Int]()
+            val result = p.block(deadline(10.millis))
+            assert(result.isFailure)
+        }
+
+        "block with very short timeout" in runNotJS {
+            val p      = new IOPromise[Nothing, Int]()
+            val result = p.block(deadline(10.millis))
+            assert(result.isFailure)
+        }
+
+        def threadInterruption[E, A](promise: IOPromise[E, A])(assertion: Result[E | Timeout, A] => Assertion) =
+            @volatile var threadStarted = false
+            val thread = new Thread:
+                override def run(): Unit =
+                    threadStarted = true
+                    discard(promise.block(deadline(Duration.Infinity)))
+                end run
+            thread.start()
+
+            // wait for parking
+            while !threadStarted do Thread.sleep(10)
+            Thread.sleep(10)
+
+            thread.interrupt()
+            thread.join(200)
+
+            val result = promise.block(deadline())
+            assertion(result)
+        end threadInterruption
+
+        "thread interruption" - {
+            "uncompleted" in {
+                threadInterruption(new IOPromise[Nothing, Int]()) { result =>
+                    assert(result.isPanic)
+                }
+            }
+            "linked" in runNotJS {
+                val p = new IOPromise[Nothing, Int]()
+                p.becomeDiscard(new IOPromise[Nothing, Int]())
+                threadInterruption(p) { result =>
+                    assert(result.isPanic)
+                }
+            }
+        }
+    }
+
+end IOPromiseBlockingTest

--- a/kyo-core/shared/src/main/scala/kyo/Interrupt.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Interrupt.scala
@@ -1,3 +1,0 @@
-package kyo
-
-class Interrupt()(using Frame) extends KyoException("Fiber has been interrupted.")

--- a/kyo-core/shared/src/main/scala/kyo/Interrupted.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Interrupted.scala
@@ -1,0 +1,6 @@
+package kyo
+
+final case class Interrupted(at: Frame, by: Maybe[Text] = Absent)
+    extends KyoException("Fiber interrupted at " + at.position.show + by.fold("")(" by " + _))(using at)
+object Interrupted:
+    def apply(at: Frame, by: Text): Interrupted = Interrupted(at, Present(by))

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -18,7 +18,7 @@ abstract class KyoApp extends KyoAppPlatformSpecific:
         val interrupt = (signal: String) =>
             () =>
                 promise
-                    .completeDiscard(Result.panic(Fiber.Interrupted(Frame.internal, s"Interrupt Signal Reached: $signal")))
+                    .completeDiscard(Result.panic(Interrupted(Frame.internal, s"Interrupt Signal: $signal")))
 
         if System.live.unsafe.operatingSystem() != System.OS.Windows then
             OsSignal.handle("INT", interrupt("INT"))

--- a/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/scheduler/IOPromiseTest.scala
@@ -4,7 +4,7 @@ import kyo.*
 import org.scalatest.compatible.Assertion
 import scala.annotation.tailrec
 
-class SyncPromiseTest extends Test:
+class IOPromiseTest extends Test:
 
     def deadline(after: Duration = timeout) =
         import AllowUnsafe.embrace.danger
@@ -198,49 +198,6 @@ class SyncPromiseTest extends Test:
             p.onComplete(_ => called = true)
             p.complete(Result.succeed(42))
             assert(called)
-        }
-    }
-
-    "block" - {
-        "immediate completion" in {
-            val p = new IOPromise[Nothing, Int]()
-            p.complete(Result.succeed(42))
-            val result = p.block(deadline())
-            assert(result == Result.succeed(42))
-        }
-
-        "timeout" in runNotJS {
-            val p      = new IOPromise[Nothing, Int]()
-            val result = p.block(deadline(10.millis))
-            assert(result.isFailure)
-        }
-
-        "block with very short timeout" in runNotJS {
-            val p      = new IOPromise[Nothing, Int]()
-            val result = p.block(deadline(10.millis))
-            assert(result.isFailure)
-        }
-
-        "thread interruption" in runNotJS {
-            val p                       = new IOPromise[Nothing, Int]()
-            @volatile var threadStarted = false
-            val thread = new Thread:
-                override def run(): Unit =
-                    threadStarted = true
-                    discard(p.block(deadline(Duration.Infinity)))
-                end run
-            thread.start()
-
-            // wait for parking
-            while !threadStarted do Thread.sleep(10)
-            Thread.sleep(10)
-
-            thread.interrupt()
-            thread.join(1000)
-
-            val result = p.block(deadline())
-            println(result.show)
-            assert(result.isPanic)
         }
     }
 
@@ -1037,4 +994,4 @@ class SyncPromiseTest extends Test:
         }
     }
 
-end SyncPromiseTest
+end IOPromiseTest

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
@@ -55,7 +55,7 @@ object StreamPublisher:
                     for
                         subscription <- publisher.getSubscription(subscriber)
                         fiber        <- subscription.subscribe.andThen(subscription.consume)
-                        _            <- supervisor.onInterrupt(_ => fiber.interrupt(Result.Panic(Interrupt())))
+                        _            <- supervisor.onInterrupt(_ => fiber.interrupt(Result.Panic(Interrupted(summon[Frame]))))
                     yield ()
             )
 

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -69,7 +69,7 @@ object ZIOs:
                         case Result.Panic(e)   => cb(Exit.die(e))
                     }
                     Left(ZIO.succeed {
-                        fiber.unsafe.interrupt(Result.Panic(Fiber.Interrupted(frame)))
+                        fiber.unsafe.interrupt(Result.Panic(Interrupted(frame)))
                     })
                 }
             }.handle(Sync.Unsafe.evalOrThrow)
@@ -102,7 +102,7 @@ object ZIOs:
                 cause match
                     case Fail(e, trace)            => Maybe(Result.Failure(e))
                     case Die(e, trace)             => Maybe(Result.Panic(e))
-                    case Interrupt(fiberId, trace) => Maybe(Result.Panic(Fiber.Interrupted(frame)))
+                    case Interrupt(fiberId, trace) => Maybe(Result.Panic(Interrupted(frame, fiberId.threadName)))
                     case Then(left, right)         => loop(left).orElse(loop(right))
                     case Both(left, right)         => loop(left).orElse(loop(right))
                     case Stackless(e, trace)       => loop(e)

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -68,9 +68,7 @@ object ZIOs:
                         case Result.Failure(e) => cb(Exit.fail(e))
                         case Result.Panic(e)   => cb(Exit.die(e))
                     }
-                    Left(ZIO.succeed {
-                        fiber.unsafe.interrupt(Result.Panic(Interrupted(frame)))
-                    })
+                    Left(ZIO.succeed(fiber.unsafe.interrupt()))
                 }
             }.handle(Sync.Unsafe.evalOrThrow)
         }

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -394,8 +394,8 @@ class ZIOsTest extends Test:
 
         "Interrupt" in runKyo {
             Cause.interrupt(zio.FiberId.None).toError match
-                case Result.Panic(e: Fiber.Interrupted) => succeed
-                case _                                  => fail("Expected Result.Panic with Fiber.Interrupted")
+                case Result.Panic(e: Interrupted) => succeed
+                case _                            => fail("Expected Result.Panic with Interrupted")
             end match
         }
 


### PR DESCRIPTION
Merge Interrupt and Interrupted exceptions

### Problem
Imperative code using Thread interruption will not propagate interruption to the Fiber/Promise being awaited.

### Solution
Check the Thread interrupt status + restore it.
