### PR TITLE
Rename: Resource -> Scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,12 +142,12 @@ If you want to contribute a new method like `S.newMethod` or `s.newMethod`, feel
 
 ### Where to add Your `newMethod`
 
-| Subproject        | Use For                                                 |
-| ----------------- | ------------------------------------------------------- |
-| `kyo-data`        | Data structures (`Chunk`, `Maybe`, `Result`, etc.)      |
+| Subproject        | Use For                                                   |
+| ----------------- | --------------------------------------------------------- |
+| `kyo-data`        | Data structures (`Chunk`, `Maybe`, `Result`, etc.)        |
 | `kyo-prelude`     | Effect types without `Sync` (`Abort`, `Env`, `Var`, etc.) |
-| `kyo-core`        | Methods requiring `Sync`, `Async`, or `Resource`          |
-| `kyo-combinators` | Extensions or composition helpers                       |
+| `kyo-core`        | Methods requiring `Sync`, `Async`, or `Scope`             |
+| `kyo-combinators` | Extensions or composition helpers                         |
 
 Add corresponding tests in the same subproject.
 

--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ Kyo is structured as a monorepo, published to Maven Central:
 
 #### Core Libraries
 
-| Module          | JVM | JS  | Native | Description                                                    |
-| --------------- | --- | --- | ------ | -------------------------------------------------------------- |
-| kyo-data        | ✅   | ✅   | ✅      | Efficient `Maybe`, `Result`, `Duration`, and other data types  |
-| kyo-kernel      | ✅   | ✅   | ✅      | Core algebraic effects engine and type-level effect tracking   |
-| kyo-prelude     | ✅   | ✅   | ✅      | Pure effects: `Abort`, `Env`, `Var`, `Emit`, `Choice`, etc.    |
-| kyo-core        | ✅   | ✅   | ✅      | Side-effectful computations: `Sync`, `Async`, `Resource`, etc. |
-| kyo-direct      | ✅   | ✅   | ✅      | Direct-style syntax using `.await` and control flow            |
-| kyo-combinators | ✅   | ✅   | ✅      | ZIO-like effect combinators and utility methods                |
-| kyo-actor       | ✅   | ✅   | ✅      | Type-safe actor system with supervision and messaging          |
-| kyo-stm         | ✅   | ✅   | ✅      | Software transactional memory for managing state               |
-| kyo-offheap     | ✅   | ❌   | ✅      | Direct memory allocation and off-heap data structures          |
+| Module          | JVM | JS  | Native | Description                                                   |
+| --------------- | --- | --- | ------ | ------------------------------------------------------------- |
+| kyo-data        | ✅   | ✅   | ✅      | Efficient `Maybe`, `Result`, `Duration`, and other data types |
+| kyo-kernel      | ✅   | ✅   | ✅      | Core algebraic effects engine and type-level effect tracking  |
+| kyo-prelude     | ✅   | ✅   | ✅      | Pure effects: `Abort`, `Env`, `Var`, `Emit`, `Choice`, etc.   |
+| kyo-core        | ✅   | ✅   | ✅      | Side-effectful computations: `Sync`, `Async`, `Scope`, etc.   |
+| kyo-direct      | ✅   | ✅   | ✅      | Direct-style syntax using `.await` and control flow           |
+| kyo-combinators | ✅   | ✅   | ✅      | ZIO-like effect combinators and utility methods               |
+| kyo-actor       | ✅   | ✅   | ✅      | Type-safe actor system with supervision and messaging         |
+| kyo-stm         | ✅   | ✅   | ✅      | Software transactional memory for managing state              |
+| kyo-offheap     | ✅   | ❌   | ✅      | Direct memory allocation and off-heap data structures         |
 
 #### Integrations
 
@@ -87,7 +87,7 @@ Use `%%` for JVM/Scala Native, or `%%%` for ScalaJS cross-compilation. See the m
 > These talks are listed in reverse chronological order, as Kyo has grown and transformed significantly in preparation for 1.0.
 
 | Title                                                                                                          | Speaker(s)                 | Host                   | Date           | Resources                                                                                             |
-|----------------------------------------------------------------------------------------------------------------|----------------------------|------------------------|----------------|-------------------------------------------------------------------------------------------------------|
+| -------------------------------------------------------------------------------------------------------------- | -------------------------- | ---------------------- | -------------- | ----------------------------------------------------------------------------------------------------- |
 | [Suspension: the magic behind composability (or "The Kyo Monad")](https://www.youtube.com/watch?v=y3KiuFczOFE) | Flavio Brasil              | Lambda Days            | June, 2025     | [slides](https://speakerdeck.com/fwbrasil/suspension-the-magic-behind-composability-or-the-kyo-monad) |
 | [An Algebra of Thoughts: When Kyo effects meet LLMs](https://www.youtube.com/watch?v=KIjtXM5dlgY)              | Flavio Brasil              | Func Prog Sweden       | May, 2025      |                                                                                                       |
 | [Redefining Stream Composition with Algebraic Effects](https://www.youtube.com/watch?v=WcYKTyQwEA0)            | Adam Hearn                 | LambdaConf             | May, 2025      |                                                                                                       |
@@ -531,7 +531,7 @@ The `kyo-direct` module is constructed as a wrapper around [dotty-cps-async](htt
 
 ### Defining an App
 
-`KyoApp` offers a structured approach similar to Scala's `App` for defining application entry points. However, it comes with added capabilities, handling a suite of default effects. As a result, the `run` method within `KyoApp` can accommodate various effects, such as Sync, Async, Resource, Clock, Console, Random, Timer, and Aspect.
+`KyoApp` offers a structured approach similar to Scala's `App` for defining application entry points. However, it comes with added capabilities, handling a suite of default effects. As a result, the `run` method within `KyoApp` can accommodate various effects, such as Sync, Async, Scope, Clock, Console, Random, Timer, and Aspect.
 
 ```scala
 import kyo.*
@@ -910,9 +910,9 @@ val b: Int < Sync =
 
 > Note: Kyo's effects are designed so locals are properly propagated. For example, they're automatically inherited by forked computations in `Async`.
 
-### Resource: Resource Safety
+### Scope: Resource Safety
 
-The `Resource` effect handles the safe use of external resources like network connections, files, and any other resource that needs to be freed once the computation finalizes. It serves as a mechanism similar to ZIO's `Scope`.
+The `Scope` effect handles the safe use of external resources like network connections, files, and any other resource that needs to be freed once the computation finalizes. It serves as a mechanism similar to ZIO's `Scope`.
 
 ```scala
 import java.io.Closeable
@@ -924,36 +924,36 @@ class Database extends Closeable:
 
 // The `acquire` method accepts any object that
 // implements Java's `Closeable` interface
-val db: Database < (Resource & Async) =
-    Resource.acquire(new Database)
+val db: Database < (Scope & Async) =
+    Scope.acquire(new Database)
 
 // Use `run` to handle the effect, while also
 // closing the resources utilized by the
 // computation
 val b: Int < Async =
-    Resource.run(db.map(_.count))
+    Scope.run(db.map(_.count))
 
 // The `ensure` method provides a low-level API to handle the finalization of
 // resources directly. The `acquire` method is implemented in terms of `ensure`.
 
 // Example method to execute a function on a database
-def withDb[T](f: Database => T < Async): T < (Resource & Async) =
+def withDb[T](f: Database => T < Async): T < (Scope & Async) =
     // Initializes the database ('new Database' is a placeholder)
     Sync.defer(new Database).map { db =>
         // Registers `db.close` to be finalized
-        Resource.ensure(db.close).andThen {
+        Scope.ensure(db.close).andThen {
             // Invokes the function
             f(db)
         }
     }
 
 // Execute a function
-val c: Int < (Resource & Async) =
+val c: Int < (Scope & Async) =
     withDb(_.count)
 
 // Close resources
 val d: Int < Async =
-    Resource.run(c)
+    Scope.run(c)
 ```
 
 ### Batch: Efficient Data Processing
@@ -1427,10 +1427,10 @@ import kyo.*
 
 case class Config(someConfig: String)
 
-val original: Stream[Int, Resource & Env[Config] & Abort[String] & Async] = Stream.init(Seq(1))
+val original: Stream[Int, Scope & Env[Config] & Abort[String] & Async] = Stream.init(Seq(1))
 
 val handled: Stream[Int, Async] = original.handle(
-    Resource.run(_),
+    Scope.run(_),
     Env.run(Config("some config"))(_),
     Abort.run[String](_)
 )
@@ -2118,7 +2118,7 @@ val createDir: Unit < Sync =
 - File metadata: `exists`, `isDir`, `isFile`, `isLink`
 - File manipulation: `mkDir`, `mkFile`, `move`, `copy`, `remove`, `removeAll`
 
-All methods that perform side effects are suspended using the `Sync` effect, ensuring referential transparency. Methods that work with streams of data, such as `readStream` and `walk`, return a `Stream` of the appropriate type, suspended using the `Resource` effect to ensure proper resource handling.
+All methods that perform side effects are suspended using the `Sync` effect, ensuring referential transparency. Methods that work with streams of data, such as `readStream` and `walk`, return a `Stream` of the appropriate type, suspended using the `Scope` effect to ensure proper resource handling.
 
 ```scala
 import kyo.*
@@ -2127,11 +2127,11 @@ import java.io.IOException
 val path: Path = Path("tmp", "file.txt")
 
 // Read a file as a stream of lines
-val lines: Stream[String, Resource & Sync] =
+val lines: Stream[String, Scope & Sync] =
     path.readLinesStream()
 
 // Process the stream
-val result: Unit < (Resource & Console & Async & Abort[IOException]) =
+val result: Unit < (Scope & Console & Async & Abort[IOException]) =
     lines.map(line => Console.printLine(line)).discard
 
 // Walk a directory tree
@@ -2152,7 +2152,7 @@ import kyo.*
 val bytes: Stream[Byte, Sync] = Stream.init(Seq[Byte](1, 2, 3))
 
 // Write the stream to a file
-val sinkResult: Unit < (Resource & Sync) =
+val sinkResult: Unit < (Scope & Sync) =
     bytes.sink(Path("path", "to", "file.bin"))
 ```
 
@@ -2455,46 +2455,46 @@ import kyo.*
 
 // A bounded queue that rejects new
 // elements once full
-val a: Queue[Int] < (Sync & Resource) =
+val a: Queue[Int] < (Sync & Scope) =
     Queue.init(capacity = 42)
 
 // Obtain the number of items in the queue
 // via the method 'size' in 'Queue'
-val b: Int < (Sync & Abort[Closed] & Resource) =
+val b: Int < (Sync & Abort[Closed] & Scope) =
     a.map(_.size)
 
 // Get the queue capacity
-val c: Int < (Sync & Resource) =
+val c: Int < (Sync & Scope) =
     a.map(_.capacity)
 
 // Try to offer a new item
-val d: Boolean < (Sync & Abort[Closed] & Resource) =
+val d: Boolean < (Sync & Abort[Closed] & Scope) =
     a.map(_.offer(42))
 
 // Try to poll an item
-val e: Maybe[Int] < (Sync & Abort[Closed] & Resource) =
+val e: Maybe[Int] < (Sync & Abort[Closed] & Scope) =
     a.map(_.poll)
 
 // Try to 'peek' an item without removing it
-val f: Maybe[Int] < (Sync & Abort[Closed] & Resource) =
+val f: Maybe[Int] < (Sync & Abort[Closed] & Scope) =
     a.map(_.peek)
 
 // Check if the queue is empty
-val g: Boolean < (Sync & Abort[Closed] & Resource) =
+val g: Boolean < (Sync & Abort[Closed] & Scope) =
     a.map(_.empty)
 
 // Check if the queue is full
-val h: Boolean < (Sync & Abort[Closed] & Resource) =
+val h: Boolean < (Sync & Abort[Closed] & Scope) =
     a.map(_.full)
 
 // Drain the queue items
-val i: Seq[Int] < (Sync & Abort[Closed] & Resource) =
+val i: Seq[Int] < (Sync & Abort[Closed] & Scope) =
     a.map(_.drain)
 
 // Close the queue. If successful,
 // returns a Some with the drained
 // elements
-val j: Maybe[Seq[Int]] < (Sync & Resource) =
+val j: Maybe[Seq[Int]] < (Sync & Scope) =
     a.map(_.close)
 ```
 
@@ -2505,25 +2505,25 @@ import kyo.*
 // Avoid `Queue.unbounded` since if queues can
 // grow without limits, the GC overhead can make
 // the system fail
-val a: Queue.Unbounded[Int] < (Sync & Resource) =
+val a: Queue.Unbounded[Int] < (Sync & Scope) =
     Queue.Unbounded.init()
 
 // A 'dropping' queue discards new entries
 // when full
-val b: Queue.Unbounded[Int] < (Sync & Resource) =
+val b: Queue.Unbounded[Int] < (Sync & Scope) =
     Queue.Unbounded.initDropping(capacity = 42)
 
 // A 'sliding' queue discards the oldest
 // entries if necessary to make space for new
 // entries
-val c: Queue.Unbounded[Int] < (Sync & Resource) =
+val c: Queue.Unbounded[Int] < (Sync & Scope) =
     Queue.Unbounded.initSliding(capacity = 42)
 
 // Note how 'dropping' and 'sliding' queues
 // return 'Queue.Unbounded`. It provides
 // an additional method to 'add' new items
 // unconditionally
-val d: Unit < (Sync & Resource) =
+val d: Unit < (Sync & Scope) =
     c.map(_.add(42))
 ```
 
@@ -2548,7 +2548,7 @@ import kyo.*
 // Initialize a bounded queue with a
 // Multiple Producers, Multiple
 // Consumers policy
-val a: Queue[Int] < (Sync & Resource) =
+val a: Queue[Int] < (Sync & Scope) =
     Queue.init(
         capacity = 42,
         access = Access.MultiProducerMultiConsumer
@@ -2567,12 +2567,12 @@ import kyo.*
 // A 'Channel' is initialized with a fixed capacity
 // Note the `Resource` effect, which ensures the channel
 // will eventually be closed
-val a: Channel[Int] < (Sync & Resource) =
+val a: Channel[Int] < (Sync & Scope) =
     Channel.init(capacity = 42)
 
 // It's also possible to specify
 // an 'Access' policy
-val b: Channel[Int] < (Sync & Resource) =
+val b: Channel[Int] < (Sync & Scope) =
     Channel.init(
         capacity = 42,
         access = Access.MultiProducerMultiConsumer
@@ -2585,28 +2585,28 @@ While `Channel` share similarities with `Queue`—such as methods for querying s
 import kyo.*
 
 // An example channel
-val a: Channel[Int] < (Sync & Resource) =
+val a: Channel[Int] < (Sync & Scope) =
     Channel.init(capacity = 42)
 
 // Adds a new item to the channel.
 // If there's no capacity, the fiber
 // is automatically suspended until
 // space is made available
-val b: Unit < (Async & Abort[Closed] & Resource) =
+val b: Unit < (Async & Abort[Closed] & Scope) =
     a.map(_.put(42))
 
 // Takes an item from the channel.
 // If the channel is empty, the fiber
 // is suspended until a new item is
 // made available
-val c: Int < (Async & Abort[Closed] & Resource) =
+val c: Int < (Async & Abort[Closed] & Scope) =
     a.map(_.take)
 
 // Closes the channel. If successful,
 // returns a Some with the drained
 // elements. All pending puts and takes
 // are automatically interrupted
-val f: Maybe[Seq[Int]] < (Sync & Resource) =
+val f: Maybe[Seq[Int]] < (Sync & Scope) =
     a.map(_.close)
 ```
 
@@ -2623,13 +2623,13 @@ import kyo.*
 import kyo.Hub.Listener
 
 // Initialize a Hub with a buffer
-val a: Hub[Int] < (Sync & Resource) =
+val a: Hub[Int] < (Sync & Scope) =
     Hub.init[Int](3)
 
 // Hub provide APIs similar to
 // channels: size, offer, isEmpty,
 // isFull, put
-val b: Boolean < (Sync & Abort[Closed] & Resource) =
+val b: Boolean < (Sync & Abort[Closed] & Scope) =
     a.map(_.offer(1))
 
 // But reading from hubs can only
@@ -2637,26 +2637,26 @@ val b: Boolean < (Sync & Abort[Closed] & Resource) =
 // only receive messages sent after
 // their creation. To create call
 // `listen`:
-val c: Listener[Int] < (Sync & Abort[Closed] & Resource) =
+val c: Listener[Int] < (Sync & Abort[Closed] & Scope) =
     a.map(_.listen)
 
 // Each listener can have an
 // additional message buffer
-val d: Listener[Int] < (Sync & Abort[Closed] & Resource) =
+val d: Listener[Int] < (Sync & Abort[Closed] & Scope) =
     a.map(_.listen(bufferSize = 3))
 
 // Listeners provide methods for
 // receiving messages similar to
 // channels: size, isEmpty, isFull,
 // poll, take
-val e: Int < (Async & Abort[Closed] & Resource) =
+val e: Int < (Async & Abort[Closed] & Scope) =
     d.map(_.take)
 
 // A listener can be closed
 // individually. If successful,
 // a Some with the backlog of
 // pending messages is returned
-val f: Maybe[Seq[Int]] < (Sync & Abort[Closed] & Resource) =
+val f: Maybe[Seq[Int]] < (Sync & Abort[Closed] & Scope) =
     d.map(_.close)
 
 // Listeners are also managed
@@ -2664,7 +2664,7 @@ val f: Maybe[Seq[Int]] < (Sync & Abort[Closed] & Resource) =
 // when their `Resource` effect
 // is handled
 val g: Int < (Async & Abort[Closed]) =
-    Resource.run(e)
+    Scope.run(e)
 
 // If the Hub is closed, all
 // listeners are automatically
@@ -2672,7 +2672,7 @@ val g: Int < (Async & Abort[Closed]) =
 // only include items pending in
 // the hub's buffer. The listener
 // buffers are discarded
-val h: Maybe[Seq[Int]] < (Sync & Resource) =
+val h: Maybe[Seq[Int]] < (Sync & Scope) =
     a.map(_.close)
 ```
 
@@ -2690,22 +2690,22 @@ The `Meter` effect offers utilities to regulate computational execution, be it l
 import kyo.*
 
 // 'mutex': One computation at a time
-val a: Meter < (Sync & Resource) =
+val a: Meter < (Sync & Scope) =
     Meter.initMutex
 
 // 'semaphore': Limit concurrent tasks
-val b: Meter < (Sync & Resource) =
+val b: Meter < (Sync & Scope) =
     Meter.initSemaphore(concurrency = 42)
 
 // 'rateLimiter': Tasks per time window
-val c: Meter < (Sync & Resource) =
+val c: Meter < (Sync & Scope) =
     Meter.initRateLimiter(
         rate = 10,
         period = 1.second
     )
 
 // 'pipeline': Combine multiple 'Meter's
-val d: Meter < (Sync & Resource) =
+val d: Meter < (Sync & Scope) =
     Meter.pipeline(a, b, c)
 ```
 
@@ -2715,25 +2715,25 @@ The `Meter` class comes with a handful of methods designed to provide insights i
 import kyo.*
 
 // An example 'Meter'
-val a: Meter < (Sync & Resource) =
+val a: Meter < (Sync & Scope) =
     Meter.initMutex
 
 // Get the number available permits
-val b: Int < (Async & Abort[Closed] & Resource) =
+val b: Int < (Async & Abort[Closed] & Scope) =
     a.map(_.availablePermits)
 
 // Get the number of waiting fibers
-val c: Int < (Async & Abort[Closed] & Resource) =
+val c: Int < (Async & Abort[Closed] & Scope) =
     a.map(_.pendingWaiters)
 
 // Use 'run' to execute tasks
 // respecting meter limits
-val d: Int < (Async & Abort[Closed] & Resource) =
+val d: Int < (Async & Abort[Closed] & Scope) =
     a.map(_.run(Math.cos(42).toInt))
 
 // 'tryRun' executes if a permit is
 // available; returns 'None' otherwise
-val e: Maybe[Int] < (Async & Abort[Closed] & Resource) =
+val e: Maybe[Int] < (Async & Abort[Closed] & Scope) =
     a.map(_.tryRun(Math.cos(42).toInt))
 ```
 
@@ -3590,12 +3590,12 @@ end HelloService
 val keepTicking: Nothing < (Async & Emit[String]) =
     (Kyo.emit(".") *> Kyo.sleep(1.second)).forever
 
-val effect: Unit < (Async & Resource & Abort[Throwable] & Env[HelloService]) =
+val effect: Unit < (Async & Scope & Abort[Throwable] & Env[HelloService]) =
     for
         nameService <- Kyo.service[HelloService]      // Introduces Env[NameService]
         _           <- keepTicking                    // Introduces Async and Emit[String]
             .foreachEmit(Console.print)               // Handles Emit[String] and introduces Abort[IOException]
-            .forkScoped                               // Introduces Resource
+            .forkScoped                               // Introduces Scope
         saluee      <- Console.readln
         _           <- Kyo.sleep(2.seconds)
         _           <- nameService.sayHelloTo(saluee) // Lifts Abort[IOException] to Abort[Throwable]
@@ -3607,7 +3607,7 @@ end effect
 // be done at the edge of the program
 Sync.Unsafe.run {                        // Handles Sync
     KyoApp.runAndBlock(Duration.Inf) {  // Handles Async
-        Kyo.scoped {                   // Handles Resource
+        Kyo.scoped {                   // Handles Scope
             Memo.run:                  // Handles Memo (introduced by .provide, below)
                 effect
                     .catching((thr: Throwable) =>             // Handles Abort[Throwable]
@@ -3707,7 +3707,7 @@ val retriedAUntilSucceed: Int < (Abort[B | C]) = effect.forAbort[A].retryForever
 
 Kyo's development was originally inspired by the paper ["Do Be Do Be Do"](https://arxiv.org/pdf/1611.09259.pdf) and its implementation in the [Unison](https://www.unison-lang.org/learn/language-reference/abilities-and-ability-handlers/) programming language. Kyo's design evolved from using interface-based effects to suspending concrete values associated with specific effects, making it more efficient when executed on the JVM.
 
-Additionally, Kyo draws inspiration from [ZIO](https://zio.dev/) in various aspects. The core mechanism for algebraic effects can be seen as a generalization of ZIO's effect rotation, and many of Kyo's effects are directly influenced by ZIO's mature set of primitives. For instance, `Env` and `Abort` correspond to ZIO's effect channels, `Resource` function similarly to `Scope`, and `Hub` was introduced based on ZIO.
+Additionally, Kyo draws inspiration from [ZIO](https://zio.dev/) in various aspects. The core mechanism for algebraic effects can be seen as a generalization of ZIO's effect rotation, and many of Kyo's effects are directly influenced by ZIO's mature set of primitives. For instance, `Env` and `Abort` correspond to ZIO's effect channels, `Scope` function similarly to `Scope`, and `Hub` was introduced based on ZIO.
 
 Kyo's asynchronous primitives take several aspects from [Twitter's util](https://github.com/twitter/util) and [Finagle](https://github.com/twitter/finagle), including features like async root compression, to provide stack safety, and support for cancellations (interruptions in Kyo).
 

--- a/kyo-actor/shared/src/main/scala/kyo/Actor.scala
+++ b/kyo-actor/shared/src/main/scala/kyo/Actor.scala
@@ -115,16 +115,15 @@ object Actor:
       *     `self` and `selfWith` methods.
       *   - [[Abort[Closed]]]: Supports handling of mailbox closure situations with the specialized Closed error type. Triggered when
       *     `close` is called on the actor.
-      *   - [[Resource]]: Enables proper management and cleanup of acquired resources. Used within the actor implementation for mailbox
-      *     cleanup and for maintaining actor hierarchies where child actors are automatically cleaned up when their parent completes or
-      *     fails.
+      *   - [[Scope]]: Enables proper management and cleanup of acquired resources. Used within the actor implementation for mailbox cleanup
+      *     and for maintaining actor hierarchies where child actors are automatically cleaned up when their parent completes or fails.
       *   - [[Async]]: Provides asynchronous execution capabilities. Used to run the actor's processing loop concurrently.
       *
       * @tparam A
       *   The type of messages this actor context can process
       */
-    opaque type Context[A] <: Poll[A] & Env[Subject[A]] & Abort[Closed] & Resource & Async =
-        Poll[A] & Env[Subject[A]] & Abort[Closed] & Resource & Async
+    opaque type Context[A] <: Poll[A] & Env[Subject[A]] & Abort[Closed] & Scope & Async =
+        Poll[A] & Env[Subject[A]] & Abort[Closed] & Scope & Async
 
     /** Retrieves the current actor's Subject from the environment.
       *
@@ -392,7 +391,7 @@ object Actor:
         Tag[Emit[A]],
         Tag[Subject[A]],
         Frame
-    ): Actor[E, A, B] < (Resource & Async & S) =
+    ): Actor[E, A, B] < (Scope & Async & S) =
         run(defaultCapacity)(behavior)
 
     /** Creates and starts new actor from a message processing behavior.
@@ -433,7 +432,7 @@ object Actor:
         Tag[Emit[A]],
         Tag[Subject[A]],
         Frame
-    ): Actor[E, A, B] < (Resource & Async & S) =
+    ): Actor[E, A, B] < (Scope & Async & S) =
         for
             mailbox <-
                 // Create a bounded channel to serve as the actor's mailbox
@@ -453,10 +452,10 @@ object Actor:
                 }.handle(
                     Sync.ensure(mailbox.close), // Ensure mailbox cleanup by closing it when the actor completes or fails
                     Env.run(_subject),          // Provide the actor's Subject to the environment so it can be accessed via Actor.self
-                    Resource.run,               // Close used resources
+                    Scope.run,                  // Close used resources
                     Fiber.init                  // Start the actor's processing loop in an async context
                 )
-            _ <- Resource.ensure(mailbox.close) // Registers a finalizer in the outer scope to provide the actor hierarchy behavior
+            _ <- Scope.ensure(mailbox.close) // Registers a finalizer in the outer scope to provide the actor hierarchy behavior
         yield new Actor[E, A, B](_subject, _consumer):
             def close(using Frame) = mailbox.close
 end Actor

--- a/kyo-actor/shared/src/test/scala/kyo/ActorTest.scala
+++ b/kyo-actor/shared/src/test/scala/kyo/ActorTest.scala
@@ -124,7 +124,7 @@ class ActorTest extends Test:
                     for
                         childActor1 <- Actor.run {
                             for
-                                _ <- Resource.ensure(childActorStates.add("child1 cleaned up"))
+                                _ <- Scope.ensure(childActorStates.add("child1 cleaned up"))
                                 _ <- childActorStates.add("child1 started")
                             yield Actor.receiveAll[Int] { _ =>
                                 childActorStates.add("child1 received message").andThen(consumed.release)
@@ -132,7 +132,7 @@ class ActorTest extends Test:
                         }
                         childActor2 <- Actor.run {
                             for
-                                _ <- Resource.ensure(childActorStates.add("child2 cleaned up"))
+                                _ <- Scope.ensure(childActorStates.add("child2 cleaned up"))
                                 _ <- childActorStates.add("child2 started")
                             yield Actor.receiveAll[Int] { _ =>
                                 childActorStates.add("child2 received message").andThen(consumed.release)
@@ -167,7 +167,7 @@ class ActorTest extends Test:
                         for
                             childActor <- Actor.run {
                                 for
-                                    _ <- Resource.ensure(childCleaned.set(true))
+                                    _ <- Scope.ensure(childCleaned.set(true))
                                 yield Actor.receiveAll[Int] { _ =>
                                     messageReceived.release
                                 }
@@ -195,7 +195,7 @@ class ActorTest extends Test:
                         childActors <- Async.fill(actorCount) {
                             Actor.run {
                                 for
-                                    _ <- Resource.ensure(cleanupCounter.incrementAndGet)
+                                    _ <- Scope.ensure(cleanupCounter.incrementAndGet)
                                     _ <- startCounter.incrementAndGet
                                 yield Actor.receiveAll[Int] { _ =>
                                     allReceived.release
@@ -305,7 +305,7 @@ class ActorTest extends Test:
             for
                 resourceCleaned <- AtomicBoolean.init(false)
                 actor <- Actor.run {
-                    Resource.ensure(resourceCleaned.set(true)).andThen {
+                    Scope.ensure(resourceCleaned.set(true)).andThen {
                         Actor.receiveMax[Int](3) { _ => () }
                     }
                 }
@@ -322,7 +322,7 @@ class ActorTest extends Test:
             for
                 resourceCleaned <- AtomicBoolean.init(false)
                 actor <- Actor.run {
-                    Resource.ensure(resourceCleaned.set(true)).andThen {
+                    Scope.ensure(resourceCleaned.set(true)).andThen {
                         Actor.receiveMax[Int](1) { _ =>
                             Abort.fail(TestError)
                         }

--- a/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
@@ -34,7 +34,7 @@ extension [A, E, S](effect: A < (Abort[E] & Async & S))
         isolate: Isolate[S, Sync, S2],
         reduce: Reducible[Abort[E]],
         frame: Frame
-    ): Fiber[A, reduce.SReduced & S2] < (Sync & S & Resource) =
+    ): Fiber[A, reduce.SReduced & S2] < (Sync & S & Scope) =
         Kyo.acquireRelease(Fiber.init(effect))(_.interrupt)
 
     /** Performs this computation and then the next one in parallel, discarding the result of this computation.

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -17,8 +17,8 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that manages the resource lifecycle using Resource and Sync effects
       */
-    def acquireRelease[A, S](acquire: => A < S)(release: A => Any < Async)(using Frame): A < (S & Resource & Sync) =
-        Resource.acquireRelease(acquire)(release)
+    def acquireRelease[A, S](acquire: => A < S)(release: A => Any < (Async & Abort[Throwable]))(using Frame): A < (S & Scope & Sync) =
+        Scope.acquireRelease(acquire)(release)
 
     /** Adds a finalizer to the current effect using Resource.
       *
@@ -27,8 +27,8 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that ensures the finalizer is executed when the effect is completed
       */
-    def addFinalizer(finalizer: => Any < (Async & Abort[Throwable]))(using Frame): Unit < (Resource & Sync) =
-        Resource.ensure(finalizer)
+    def addFinalizer(finalizer: => Any < (Async & Abort[Throwable]))(using Frame): Unit < (Scope & Sync) =
+        Scope.ensure(finalizer)
 
     /** Creates an asynchronous effect that can be completed by the given register function.
       *
@@ -131,10 +131,10 @@ extension (kyoObject: Kyo.type)
       * @param resource
       *   The AutoCloseable resource to create an effect from
       * @return
-      *   An effect that manages the resource lifecycle using Resource and Sync effects
+      *   An effect that manages the resource lifecycle using Scope and Sync effects
       */
-    def fromAutoCloseable[A <: AutoCloseable, S](resource: => A < S)(using Frame): A < (S & Resource & Sync) =
-        Resource.acquire(resource)
+    def fromAutoCloseable[A <: AutoCloseable, S](resource: => A < S)(using Frame): A < (S & Scope & Sync) =
+        Scope.acquire(resource)
 
     /** Creates an effect from an Either[E, A] and handles Left[E] to Abort[E].
       *
@@ -357,8 +357,8 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that manages the resource lifecycle using Resource and Sync effects
       */
-    def scoped[A, S](resource: => A < (S & Resource))(using Frame): A < (Async & S) =
-        Resource.run(resource)
+    def scoped[A, S](resource: => A < (S & Scope))(using Frame): A < (Async & S) =
+        Scope.run(resource)
 
     /** Retrieves a dependency from Env.
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/KyoCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/KyoCombinators.scala
@@ -236,8 +236,8 @@ extension [A, S](effect: A < S)
       * @return
       *   An effect that executes the finalizer after this effect
       */
-    def ensuring(finalizer: => Any < (Async & Abort[Throwable]))(using Frame): A < (S & Resource & Sync) =
-        Resource.ensure(finalizer).andThen(effect)
+    def ensuring(finalizer: => Any < (Async & Abort[Throwable]))(using Frame): A < (S & Scope & Sync) =
+        Scope.ensure(finalizer).andThen(effect)
 
     /** Ensures that the specified finalizer is executed after this effect, whether it succeeds or fails. The finalizer will execute when
       * the Resource effect is handled.
@@ -249,7 +249,7 @@ extension [A, S](effect: A < S)
       * @return
       *   An effect that executes the finalizer after this effect
       */
-    def ensuringError(finalizer: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using Frame): A < (S & Resource & Sync) =
-        Resource.ensure(finalizer).andThen(effect)
+    def ensuringError(finalizer: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using Frame): A < (S & Scope & Sync) =
+        Scope.ensure(finalizer).andThen(effect)
 
 end extension

--- a/kyo-combinators/shared/src/test/scala/kyo/AsyncCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AsyncCombinatorsTest.scala
@@ -154,7 +154,7 @@ class FiberCombinatorsTest extends Test:
                         result <- fiber.join
                     yield result
 
-                Fiber.init(Resource.run(program)).map(_.toFuture).map { handledEffect =>
+                Fiber.init(Scope.run(program)).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v =>
                         assert(state == 1)
                         assert(v == 1)
@@ -171,11 +171,11 @@ class FiberCombinatorsTest extends Test:
                 val program =
                     for
                         fiber  <- effect.forkScoped
-                        _      <- Resource.acquireRelease(())(_ => cleanedUp = true)
+                        _      <- Scope.acquireRelease(())(_ => cleanedUp = true)
                         result <- fiber.join
                     yield result
 
-                Fiber.init(Resource.run(program)).map(_.toFuture).map { handledEffect =>
+                Fiber.init(Scope.run(program)).map(_.toFuture).map { handledEffect =>
                     handledEffect.map(v =>
                         assert(v == 42)
                         assert(cleanedUp)

--- a/kyo-combinators/shared/src/test/scala/kyo/ScopeCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ScopeCombinatorsTest.scala
@@ -3,7 +3,7 @@ package kyo
 import kyo.Result.Error
 import scala.concurrent.Future
 
-class ResourceCombinatorsTest extends Test:
+class ScopeCombinatorsTest extends Test:
 
     "construct" - {
         "should construct a resource with acquireRelease" in run {
@@ -12,14 +12,14 @@ class ResourceCombinatorsTest extends Test:
                 (i: Int) => Sync.defer { state = i }
             }
             val resource = Kyo.acquireRelease(acquire)(_(0))
-            val effect: Int < (Resource & Sync) =
+            val effect: Int < (Scope & Sync) =
                 for
                     setter <- resource
                     _      <- setter(50)
                     result <- Sync.defer(state)
                 yield result
             assert(state == 0)
-            val handledResources: Int < Async = Resource.run(effect)
+            val handledResources: Int < Async = Scope.run(effect)
             Fiber.init(handledResources).map(_.toFuture).map { handled =>
                 for
                     assertion1 <- handled.map(_ == 50)
@@ -32,7 +32,7 @@ class ResourceCombinatorsTest extends Test:
         "should construct a resource using addFinalizer" in run {
             var state  = 0
             val effect = Kyo.addFinalizer(Sync.defer { state = 100 })
-            Fiber.init(Resource.run(effect)).map(_.toFuture).map { handled =>
+            Fiber.init(Scope.run(effect)).map(_.toFuture).map { handled =>
                 for
                     ass1 <- handled
                     ass2 <- Future(assert(state == 100))
@@ -47,7 +47,7 @@ class ResourceCombinatorsTest extends Test:
                 override def close(): Unit = state = 100
             val effect = Kyo.fromAutoCloseable(closeable)
             assert(state == 0)
-            Fiber.init(Resource.run(effect)).map(_.toFuture).map { handled =>
+            Fiber.init(Scope.run(effect)).map(_.toFuture).map { handled =>
                 for
                     ass2 <- handled.map(v => assert(v.equals(closeable)))
                     ass3 <- Future(assert(state == 100))
@@ -61,7 +61,7 @@ class ResourceCombinatorsTest extends Test:
         "ensuring" in run {
             var finalizerCalled                          = false
             def ensure: Unit < (Sync & Abort[Throwable]) = Sync.defer { finalizerCalled = true }
-            Resource.run(Sync.defer(()).ensuring(ensure))
+            Scope.run(Sync.defer(()).ensuring(ensure))
                 .andThen(assert(finalizerCalled))
         }
 
@@ -70,9 +70,9 @@ class ResourceCombinatorsTest extends Test:
             given [A]: CanEqual[A, A]    = CanEqual.derived
 
             val ensure: Maybe[Error[Any]] => Unit < (Sync & Abort[Throwable]) = ex => Sync.defer { error = ex }
-            Abort.fail("failure").ensuringError(ensure).handle(Resource.run, Abort.run(_)).andThen {
+            Abort.fail("failure").ensuringError(ensure).handle(Scope.run, Abort.run(_)).andThen {
                 assert(error == Result.fail("failure"))
             }
         }
     }
-end ResourceCombinatorsTest
+end ScopeCombinatorsTest

--- a/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -1,10 +1,10 @@
 package kyo
 
-abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abort[Throwable]]:
+abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Scope & Abort[Throwable]]:
 
     private var last: Unit < (Async & Abort[Throwable]) = ()
 
-    final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): Unit =
+    final override protected def run[A](v: => A < (Async & Scope & Abort[Throwable]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         val current: Unit < (Async & Abort[Throwable]) =
             Abort.runWith(Async.timeout(runTimeout)(handle(v)))(result => Sync.defer(onResult(result)).andThen(Abort.get(result)).unit)

--- a/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -1,8 +1,8 @@
 package kyo
 
-abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Resource & Abort[Throwable]]:
+abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Scope & Abort[Throwable]]:
 
-    final override protected def run[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): Unit =
+    final override protected def run[A](v: => A < (Async & Scope & Abort[Throwable]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         initCode = initCode.appended(() =>
             val result = Sync.Unsafe.evalOrThrow(Abort.run(KyoApp.runAndBlock(runTimeout)(handle(v))))

--- a/kyo-core/jvm/src/main/scala/kyo/Process.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Process.scala
@@ -186,7 +186,7 @@ object Process:
                     }
                     _ <- stdin match
                         case Input.Stream(stream) =>
-                            val resources = Resource.acquireRelease((stream, process.stdin)) { streams =>
+                            val resources = Scope.acquireRelease((stream, process.stdin)) { streams =>
                                 streams._1.close()
                                 streams._2.close()
                             }.map { streams =>
@@ -194,7 +194,7 @@ object Process:
                                 ()
                             }
                             for
-                                _ <- Fiber.init(Resource.run(resources))
+                                _ <- Fiber.init(Scope.run(resources))
                             yield ()
                         case _ => Kyo.unit
                 yield process

--- a/kyo-core/jvm/src/test/scala/kyo/KyoAppSignalTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/KyoAppSignalTest.scala
@@ -7,7 +7,7 @@ class KyoAppSignalTest extends Test:
         run {
             for
                 _ <- Console.printLine("TestSignalApp started - waiting for signal")
-                _ <- Resource.ensure(ex => Console.printLine(s"TestSignalApp finished: $ex"))
+                _ <- Scope.ensure(ex => Console.printLine(s"TestSignalApp finished: $ex"))
                 _ <- Async.never
             yield ()
         }

--- a/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/PathTest.scala
@@ -17,7 +17,7 @@ class PathTest extends Test:
         JFiles.delete(Paths.get(name))
 
     def useFile(name: String, text: String) =
-        Resource.acquireRelease(Sync.defer(createFile(name, text)))(_ => Sync.defer(destroyFile(name)))
+        Scope.acquireRelease(Sync.defer(createFile(name, text)))(_ => Sync.defer(destroyFile(name)))
 
     "read and write files" - {
         "read file as string" in run {

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -318,7 +318,7 @@ object Channel:
       * @warning
       *   The actual capacity may be larger than the specified capacity due to rounding.
       */
-    def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Channel[A] < (Sync & Resource) =
+    def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Channel[A] < (Sync & Scope) =
         initWith[A](capacity, access)(identity)
 
     /** Uses a new Channel with the provided configuration.
@@ -329,10 +329,10 @@ object Channel:
       */
     inline def initWith[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](
         inline f: Channel[A] => B < S
-    )(using inline frame: Frame): B < (S & Sync & Resource) =
+    )(using inline frame: Frame): B < (S & Sync & Scope) =
         Sync.Unsafe:
             val channel = Unsafe.init[A](capacity, access)
-            Resource.ensure(Channel.close(channel)).andThen:
+            Scope.ensure(Channel.close(channel)).andThen:
                 f(channel)
 
     /** Uses a new Channel with the provided configuration, closing the channel after usage.

--- a/kyo-core/shared/src/main/scala/kyo/Hub.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Hub.scala
@@ -111,7 +111,7 @@ final class Hub[A] private[kyo] (
       * @see
       *   [[Hub.DefaultBufferSize]] for the default buffer size used by this method
       */
-    def listen(using Frame): Listener[A] < (Sync & Abort[Closed] & Resource) =
+    def listen(using Frame): Listener[A] < (Sync & Abort[Closed] & Scope) =
         listen(DefaultBufferSize)
 
     /** Creates a new listener for this Hub with the specified buffer size.
@@ -121,7 +121,7 @@ final class Hub[A] private[kyo] (
       * @return
       *   a new Listener with the specified buffer size
       */
-    def listen(bufferSize: Int)(using frame: Frame): Listener[A] < (Sync & Abort[Closed] & Resource) =
+    def listen(bufferSize: Int)(using frame: Frame): Listener[A] < (Sync & Abort[Closed] & Scope) =
         listen(bufferSize, _ => true)
 
     /** Creates a new listener for this Hub with a custom filter predicate.
@@ -133,7 +133,7 @@ final class Hub[A] private[kyo] (
       * @see
       *   [[Hub.DefaultBufferSize]] for the default buffer size used by this method
       */
-    def listen(filter: A => Boolean)(using frame: Frame): Listener[A] < (Sync & Abort[Closed] & Resource) =
+    def listen(filter: A => Boolean)(using frame: Frame): Listener[A] < (Sync & Abort[Closed] & Scope) =
         listen(DefaultBufferSize, filter)
 
     /** Creates a new listener for this Hub with specified buffer size and filter.
@@ -152,7 +152,7 @@ final class Hub[A] private[kyo] (
       * @return
       *   a new Listener that will receive filtered messages from the Hub
       */
-    def listen(bufferSize: Int, filter: A => Boolean)(using frame: Frame): Listener[A] < (Sync & Abort[Closed] & Resource) =
+    def listen(bufferSize: Int, filter: A => Boolean)(using frame: Frame): Listener[A] < (Sync & Abort[Closed] & Scope) =
         def fail = Abort.fail(Closed("Hub", initFrame))
         closed.map {
             case true => fail
@@ -169,7 +169,7 @@ final class Hub[A] private[kyo] (
                                 fail
                             }
                         case false =>
-                            Resource.acquireRelease(listener)(_.close.unit)
+                            Scope.acquireRelease(listener)(_.close.unit)
                     }
                 }
         }
@@ -195,7 +195,7 @@ object Hub:
       * @see
       *   [[Hub.DefaultBufferSize]] for the default capacity value used by this method
       */
-    def init[A](using Frame): Hub[A] < (Sync & Resource) =
+    def init[A](using Frame): Hub[A] < (Sync & Scope) =
         init(DefaultBufferSize)
 
     /** Initializes a new Hub with the specified capacity.
@@ -207,7 +207,7 @@ object Hub:
       * @return
       *   a new Hub instance
       */
-    def init[A](capacity: Int)(using Frame): Hub[A] < (Sync & Resource) =
+    def init[A](capacity: Int)(using Frame): Hub[A] < (Sync & Scope) =
         initWith[A](capacity)(identity)
 
     /** Uses a new Hub with the given type and capacity.
@@ -221,9 +221,9 @@ object Hub:
       * @return
       *   The result of applying the function
       */
-    def initWith[A](capacity: Int)[B, S](f: Hub[A] => B < S)(using Frame): B < (S & Sync & Resource) =
+    def initWith[A](capacity: Int)[B, S](f: Hub[A] => B < S)(using Frame): B < (S & Sync & Scope) =
         initUnscopedWith[A](capacity): hub =>
-            Resource.ensure(hub.close).andThen:
+            Scope.ensure(hub.close).andThen:
                 f(hub)
 
     def use[A](capacity: Int)[B, S](f: Hub[A] => B < S)(using Frame): B < (S & Sync) =

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -27,13 +27,13 @@ abstract class KyoApp extends KyoAppPlatformSpecific:
         promise.mask().safe
     end awaitInterrupt
 
-    override protected def handle[A](v: A < (Async & Resource & Abort[Throwable]))(using Frame): A < (Async & Abort[Throwable]) =
-        Async.raceFirst(Resource.run(v), awaitInterrupt.get)
+    override protected def handle[A](v: A < (Async & Scope & Abort[Throwable]))(using Frame): A < (Async & Abort[Throwable]) =
+        Async.raceFirst(Scope.run(v), awaitInterrupt.get)
     end handle
 end KyoApp
 
 object KyoApp:
-    def apply[A](v: => A < (Async & Resource & Abort[Throwable]))(using Frame, Render[A]): KyoApp =
+    def apply[A](v: => A < (Async & Scope & Abort[Throwable]))(using Frame, Render[A]): KyoApp =
         new KyoApp:
             run(v)
 
@@ -133,9 +133,9 @@ object KyoApp:
           *   A Result containing either the computed value or a failure.
           */
         def runAndBlock[A](timeout: Duration)(
-            v: A < (Async & Resource & Abort[Throwable])
+            v: A < (Async & Scope & Abort[Throwable])
         )(using Frame, AllowUnsafe): Result[Throwable, A] =
-            Abort.run(Sync.Unsafe.run(KyoApp.runAndBlock(timeout)(Resource.run(v)))).eval
+            Abort.run(Sync.Unsafe.run(KyoApp.runAndBlock(timeout)(Scope.run(v)))).eval
     end Unsafe
 
 end KyoApp

--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -106,7 +106,7 @@ object Meter:
       * @return
       *   A Meter effect that represents a mutex.
       */
-    def initMutex(using Frame): Meter < (Sync & Resource) =
+    def initMutex(using Frame): Meter < (Sync & Scope) =
         initMutex(true)
 
     /** Creates a Meter that acts as a mutex (binary semaphore).
@@ -116,7 +116,7 @@ object Meter:
       * @return
       *   A Meter effect that represents a mutex.
       */
-    def initMutex(reentrant: Boolean)(using Frame): Meter < (Sync & Resource) =
+    def initMutex(reentrant: Boolean)(using Frame): Meter < (Sync & Scope) =
         initSemaphore(1, reentrant)
 
     /** Use a **reentrant** Meter that acts as a mutex (binary semaphore). Meter is closed automatically after usage.
@@ -164,8 +164,8 @@ object Meter:
       * @return
       *   A Meter effect that represents a semaphore.
       */
-    def initSemaphore(concurrency: Int, reentrant: Boolean = true)(using Frame): Meter < (Sync & Resource) =
-        Resource.acquireRelease(initSemaphoreUnscoped(concurrency, reentrant))(_.close)
+    def initSemaphore(concurrency: Int, reentrant: Boolean = true)(using Frame): Meter < (Sync & Scope) =
+        Scope.acquireRelease(initSemaphoreUnscoped(concurrency, reentrant))(_.close)
 
     /** Use a Meter that acts as a semaphore with the specified concurrency. Meter is closed automatically after usage.
       *
@@ -209,8 +209,8 @@ object Meter:
       * @return
       *   A Meter effect that represents a rate limiter.
       */
-    def initRateLimiter(rate: Int, period: Duration, reentrant: Boolean = true)(using initFrame: Frame): Meter < (Sync & Resource) =
-        Resource.acquireRelease(initRateLimiterUnscoped(rate, period, reentrant))(_.close)
+    def initRateLimiter(rate: Int, period: Duration, reentrant: Boolean = true)(using initFrame: Frame): Meter < (Sync & Scope) =
+        Scope.acquireRelease(initRateLimiterUnscoped(rate, period, reentrant))(_.close)
 
     /** Use a Meter that acts as a rate limiter. Meter is closed automatically after usage
       *

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -163,7 +163,7 @@ object Queue:
       * @warning
       *   The actual capacity may be larger than the specified capacity due to rounding.
       */
-    def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Queue[A] < (Sync & Resource) =
+    def init[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using Frame): Queue[A] < (Sync & Scope) =
         initWith[A](capacity, access)(identity)
 
     /** Uses a new Queue with the provided count.
@@ -178,9 +178,9 @@ object Queue:
       */
     inline def initWith[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)[B, S](inline f: Queue[A] => B < S)(
         using inline frame: Frame
-    ): B < (Sync & S & Resource) =
+    ): B < (Sync & S & Scope) =
         initUnscopedWith[A](capacity, access): queue =>
-            Resource.ensure(Queue.close(queue)).andThen(f(queue))
+            Scope.ensure(Queue.close(queue)).andThen(f(queue))
 
     /** Uses a new Queue with the provided count, closing the queue after usage.
       *
@@ -260,7 +260,7 @@ object Queue:
           * @return
           *   a new Unbounded Queue instance
           */
-        def init[A](access: Access = Access.MultiProducerMultiConsumer, chunkSize: Int = 8)(using Frame): Unbounded[A] < (Sync & Resource) =
+        def init[A](access: Access = Access.MultiProducerMultiConsumer, chunkSize: Int = 8)(using Frame): Unbounded[A] < (Sync & Scope) =
             initWith[A](access, chunkSize)(identity)
 
         /** Uses a new unbounded Queue with the provided count.
@@ -276,9 +276,9 @@ object Queue:
             chunkSize: Int = 8
         )[B, S](inline f: Unbounded[A] => B < S)(
             using inline frame: Frame
-        ): B < (Sync & S & Resource) =
+        ): B < (Sync & S & Scope) =
             initUnscopedWith[A](access, chunkSize): queue =>
-                Resource.ensure(Queue.close(queue)).andThen(f(queue))
+                Scope.ensure(Queue.close(queue)).andThen(f(queue))
 
         /** Uses a new unbounded Queue with the provided count, closing the queue after usage.
           * @param count
@@ -341,9 +341,9 @@ object Queue:
           */
         def initDropping[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using
             Frame
-        ): Unbounded[A] < (Resource & Sync) =
+        ): Unbounded[A] < (Scope & Sync) =
             initDroppingUnscoped[A](capacity, access).map: queue =>
-                Resource.ensure(Queue.close(queue)).andThen(queue)
+                Scope.ensure(Queue.close(queue)).andThen(queue)
 
         /** Uses a new dropping queue with the specified capacity and access pattern, closing queue after usage.
           *
@@ -400,8 +400,8 @@ object Queue:
           */
         def initSliding[A](capacity: Int, access: Access = Access.MultiProducerMultiConsumer)(using
             Frame
-        ): Unbounded[A] < (Resource & Sync) =
-            Resource.acquireRelease(initSlidingUnscoped[A](capacity, access))(Queue.close(_))
+        ): Unbounded[A] < (Scope & Sync) =
+            Scope.acquireRelease(initSlidingUnscoped[A](capacity, access))(Queue.close(_))
 
         /** Uses a new sliding queue with the specified capacity and access pattern, closing queue after usage.
           *

--- a/kyo-core/shared/src/main/scala/kyo/Scope.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Scope.scala
@@ -7,36 +7,36 @@ import kyo.kernel.ContextEffect
 
 /** A structured effect for safe acquisition and finalization of resources.
   *
-  * Resource provides a principled mechanism for working with entities that require proper cleanup, ensuring resources are released in a
+  * Scope provides a principled mechanism for working with entities that require proper cleanup, ensuring resources are released in a
   * deterministic manner even in the presence of errors or interruptions. This effect is particularly valuable for managing external
   * dependencies with lifecycle requirements such as file handles, network connections, database sessions, or any action that needs a
   * corresponding cleanup step.
   *
   * Key features:
-  *   - Automatic resource finalization through `Resource.run` when computations complete or fail
+  *   - Automatic resource finalization through `Scope.run` when computations complete or fail
   *   - Compositional API allowing resource dependencies to be built up safely with `acquireRelease` and `acquire`
   *   - Support for parallel cleanup through configurable concurrency levels with `run(closeParallelism)(...)`
-  *   - Declarative cleanup registration using `Resource.ensure` for custom finalizers
+  *   - Declarative cleanup registration using `Scope.ensure` for custom finalizers
   *
-  * The Resource effect follows the bracket pattern (acquire-use-release) but with improved interruption handling and parallel cleanup
-  * capabilities. Resource finalizers registered with `ensure` are guaranteed to run exactly once when the associated scope completes, with
+  * The Scope effect follows the bracket pattern (acquire-use-release) but with improved interruption handling and parallel cleanup
+  * capabilities. Scope finalizers registered with `ensure` are guaranteed to run exactly once when the associated scope completes, with
   * failures in finalizers logged rather than thrown to avoid masking the primary computation result.
   *
   * Typically, you would use `acquireRelease` to pair resource acquisition with its cleanup function, then compose multiple resources
-  * together before running the combined effect with `Resource.run`.
+  * together before running the combined effect with `Scope.run`.
   *
   * @see
-  *   [[kyo.Resource.acquireRelease]] For creating resources with custom acquire and release functions
+  *   [[kyo.Scope.acquireRelease]] For creating resources with custom acquire and release functions
   * @see
-  *   [[kyo.Resource.acquire]] For creating resources from Java Closeables
+  *   [[kyo.Scope.acquire]] For creating resources from Java Closeables
   * @see
-  *   [[kyo.Resource.ensure]] For registering cleanup actions
+  *   [[kyo.Scope.ensure]] For registering cleanup actions
   * @see
-  *   [[kyo.Resource.run]] For executing resource-managed computations
+  *   [[kyo.Scope.run]] For executing resource-managed computations
   */
-sealed trait Resource extends ContextEffect[Resource.Finalizer]
+sealed trait Scope extends ContextEffect[Scope.Finalizer]
 
-object Resource:
+object Scope:
 
     /** Ensures that the given effect is executed when the resource is released.
       *
@@ -47,8 +47,8 @@ object Resource:
       * @return
       *   A unit value wrapped in Resource and Sync effects.
       */
-    inline def ensure(inline v: => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & Sync) =
-        ContextEffect.suspendWith(Tag[Resource])(_.ensure(_ => v))
+    inline def ensure(inline v: => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Scope & Sync) =
+        ContextEffect.suspendWith(Tag[Scope])(_.ensure(_ => v))
 
     /** Ensures that the given effect is executed when the resource is released, with information about the computation's outcome.
       *
@@ -63,8 +63,8 @@ object Resource:
       * @return
       *   A unit value wrapped in Resource and Sync effects.
       */
-    inline def ensure(inline f: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Resource & Sync) =
-        ContextEffect.suspendWith(Tag[Resource])(_.ensure(f))
+    inline def ensure(inline f: Maybe[Error[Any]] => Any < (Async & Abort[Throwable]))(using frame: Frame): Unit < (Scope & Sync) =
+        ContextEffect.suspendWith(Tag[Scope])(_.ensure(f))
 
     /** Acquires a resource and provides a release function.
       *
@@ -77,7 +77,7 @@ object Resource:
       * @return
       *   The acquired resource wrapped in Resource, Sync, and S effects.
       */
-    def acquireRelease[A, S](acquire: => A < S)(release: A => Any < (Async & Abort[Throwable]))(using Frame): A < (Resource & Sync & S) =
+    def acquireRelease[A, S](acquire: => A < S)(release: A => Any < (Async & Abort[Throwable]))(using Frame): A < (Scope & Sync & S) =
         Sync.defer {
             acquire.map { resource =>
                 ensure(release(resource)).andThen(resource)
@@ -93,7 +93,7 @@ object Resource:
       * @return
       *   The acquired Closeable resource wrapped in Resource, Sync, and S effects.
       */
-    def acquire[A <: java.lang.AutoCloseable, S](resource: => A < S)(using Frame): A < (Resource & Sync & S) =
+    def acquire[A <: java.lang.AutoCloseable, S](resource: => A < S)(using Frame): A < (Scope & Sync & S) =
         acquireRelease(resource)(_.close())
 
     /** Runs a resource-managed effect with default parallelism of 1.
@@ -108,7 +108,7 @@ object Resource:
       * @return
       *   The result of the effect wrapped in Async and S effects.
       */
-    def run[A, S](v: A < (Resource & S))(using frame: Frame): A < (Async & S) =
+    def run[A, S](v: A < (Scope & S))(using frame: Frame): A < (Async & S) =
         run(1)(v)
 
     /** Runs a resource-managed effect with specified parallelism for cleanup.
@@ -126,10 +126,10 @@ object Resource:
       * @return
       *   The result of the effect wrapped in Async and S effects.
       */
-    def run[A, S](closeParallelism: Int)(v: A < (Resource & S))(using frame: Frame): A < (Async & S) =
+    def run[A, S](closeParallelism: Int)(v: A < (Scope & S))(using frame: Frame): A < (Async & S) =
         Sync.Unsafe {
             val finalizer = Finalizer.Awaitable.Unsafe.init(closeParallelism)
-            ContextEffect.handle(Tag[Resource], finalizer, _ => finalizer)(v)
+            ContextEffect.handle(Tag[Scope], finalizer, _ => finalizer)(v)
                 .handle(
                     Sync.ensure(finalizer.close),
                     Abort.run[Any]
@@ -165,7 +165,7 @@ object Resource:
                                     Abort.panic(new Closed(
                                         "Finalizer",
                                         frame,
-                                        "This finalizer is already closed. This may happen if a background fiber escapes the scope of a 'Resource.run' call."
+                                        "This finalizer is already closed. This may happen if a background fiber escapes the scope of a 'Scope.run' call."
                                     ))
                                 else ()
                             }
@@ -181,7 +181,7 @@ object Resource:
                                         else
                                             Async.foreachDiscard(tasks, parallelism) { task =>
                                                 Abort.run[Throwable](task(ex))
-                                                    .map(_.foldError(_ => (), ex => Log.error("Resource finalizer failed", ex.exception)))
+                                                    .map(_.foldError(_ => (), ex => Log.error("Scope finalizer failed", ex.exception)))
                                             }
                                                 .handle(Fiber.init[Nothing, Unit, Any, Any])
                                                 .map(promise.becomeDiscard)
@@ -193,4 +193,4 @@ object Resource:
         end Awaitable
     end Finalizer
 
-end Resource
+end Scope

--- a/kyo-core/shared/src/main/scala/kyo/Sync.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Sync.scala
@@ -64,7 +64,7 @@ object Sync:
       * @tparam A
       *   The result type of the main computation.
       */
-    inline def ensure[A, S](inline f: => Any < Sync)(v: => A < S)(using inline frame: Frame): A < (Sync & S) =
+    inline def ensure[A, S](inline f: => Any < (Sync & Abort[Throwable]))(v: => A < S)(using inline frame: Frame): A < (Sync & S) =
         ensure(_ => f)(v)
 
     /** Ensures that a finalizer is run after the computation, regardless of success or failure.
@@ -86,7 +86,9 @@ object Sync:
       * @return
       *   The result of the computation, with the finalizer guaranteed to run.
       */
-    inline def ensure[A, S](inline f: Maybe[Error[Any]] => Any < Sync)(v: => A < S)(using inline frame: Frame): A < (Sync & S) =
+    inline def ensure[A, S](inline f: Maybe[Error[Any]] => Any < (Sync & Abort[Throwable]))(v: => A < S)(using
+        inline frame: Frame
+    ): A < (Sync & S) =
         Unsafe(Safepoint.ensure(ex => Sync.Unsafe.evalOrThrow(f(ex)))(v))
 
     /** Retrieves a local value and applies a function that can perform side effects.

--- a/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
@@ -3,11 +3,11 @@ package kyo.internal
 import kyo.*
 import scala.concurrent.Future
 
-private[kyo] trait BaseKyoCoreTest extends BaseKyoKernelTest[Abort[Any] & Async & Resource]:
-    def run(v: Future[Assertion] < (Abort[Any] & Async & Resource))(using Frame): Future[Assertion] =
+private[kyo] trait BaseKyoCoreTest extends BaseKyoKernelTest[Abort[Any] & Async & Scope]:
+    def run(v: Future[Assertion] < (Abort[Any] & Async & Scope))(using Frame): Future[Assertion] =
         import AllowUnsafe.embrace.danger
         v.handle(
-            Resource.run,
+            Scope.run,
             Abort.recover[Any] {
                 case ex: Throwable => throw ex
                 case e             => throw new IllegalStateException(s"Test aborted with $e")

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -13,7 +13,7 @@ class ChannelTest extends Test:
         }
 
         "resource safety" in run {
-            Resource.run(Channel.initWith[Int](10) { c =>
+            Scope.run(Channel.initWith[Int](10) { c =>
                 for
                     b <- c.put(1)
                     v <- c.take

--- a/kyo-core/shared/src/test/scala/kyo/HubTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/HubTest.scala
@@ -14,8 +14,8 @@ class HubTest extends Test:
             }
         }
 
-        "resource" in run {
-            val effect: (Int, Hub[Int]) < (Abort[Closed] & Async) = Resource.run:
+        "scope" in run {
+            val effect: (Int, Hub[Int]) < (Abort[Closed] & Async) = Scope.run:
                 Hub.initWith[Int](10) { h =>
                     for
                         l <- h.listen
@@ -40,7 +40,7 @@ class HubTest extends Test:
             }
         }
 
-        "resource" in run {
+        "scope" in run {
             Hub.use[Int](10) { h =>
                 for
                     l <- h.listen
@@ -386,7 +386,7 @@ class HubTest extends Test:
         }
     }
 
-    "resource management" - {
+    "scope management" - {
         "listeners are cleaned up when hub closes" in run {
             for
                 h  <- Hub.init[Int](4)
@@ -411,10 +411,10 @@ class HubTest extends Test:
             yield assert(c1 && !c2 && v == 1)
         }
 
-        "resource safety" in run {
+        "scope safety" in run {
             for
                 h <- Hub.init[Int](4)
-                r <- Resource.run {
+                r <- Scope.run {
                     for
                         l <- h.listen
                         _ <- h.put(1)

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
@@ -45,13 +45,13 @@ class KyoAppTest extends Test:
     }
 
     "effects in JVM" taggedAs jvmOnly in {
-        def run: Int < (Async & Resource & Abort[Throwable]) =
+        def run: Int < (Async & Scope & Abort[Throwable]) =
             for
                 _ <- Clock.repeatAtInterval(1.second, 1.second)(())
                 i <- Random.nextInt
                 _ <- Console.printLine(s"$i")
                 _ <- Clock.now
-                _ <- Resource.ensure(())
+                _ <- Scope.ensure(())
                 _ <- Async.sleep(1.second)
             yield 1
 
@@ -68,7 +68,7 @@ class KyoAppTest extends Test:
                     i <- Random.nextInt
                     _ <- Console.printLine(s"$i")
                     _ <- Clock.now
-                    _ <- Resource.ensure(())
+                    _ <- Scope.ensure(())
                     _ <- Async.sleep(1.second)
                 yield promise.complete(Try(succeed))
             }
@@ -90,7 +90,7 @@ class KyoAppTest extends Test:
     }
 
     "failing effects" taggedAs jvmOnly in {
-        def run: Unit < (Async & Resource & Abort[Throwable]) =
+        def run: Unit < (Async & Scope & Abort[Throwable]) =
             for
                 _ <- Clock.now
                 _ <- Random.nextInt

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -4,7 +4,7 @@ class MeterTest extends Test:
 
     "mutex" - {
         "init" in run {
-            Resource.run(Meter.initMutex).map: meter =>
+            Scope.run(Meter.initMutex).map: meter =>
                 meter.closed.map: isClosed =>
                     assert(isClosed)
         }
@@ -68,7 +68,7 @@ class MeterTest extends Test:
 
     "semaphore" - {
         "init" in run {
-            Resource.run(Meter.initSemaphore(3)).map: meter =>
+            Scope.run(Meter.initSemaphore(3)).map: meter =>
                 meter.closed.map: isClosed =>
                     assert(isClosed)
         }
@@ -225,7 +225,7 @@ class MeterTest extends Test:
 
     "rate limiter" - {
         "init" in run {
-            Resource.run(Meter.initRateLimiter(2, 1.milli)).map: meter =>
+            Scope.run(Meter.initRateLimiter(2, 1.milli)).map: meter =>
                 meter.closed.map: isClosed =>
                     assert(isClosed)
         }

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -19,7 +19,7 @@ class QueueTest extends Test:
                     }
                     end effect
 
-                    Resource.run(effect).map:
+                    Scope.run(effect).map:
                         case (q, b, v) =>
                             q.closed.map: isClosed =>
                                 assert(isClosed && b && v == Maybe(1))
@@ -144,7 +144,7 @@ class QueueTest extends Test:
                     }
                     end effect
 
-                    Resource.run(effect).map:
+                    Scope.run(effect).map:
                         case (q, b, v) =>
                             q.closed.map: isClosed =>
                                 assert(isClosed && b && v == Maybe(1))
@@ -208,7 +208,7 @@ class QueueTest extends Test:
                     }
                     end effect
 
-                    Resource.run(effect).map:
+                    Scope.run(effect).map:
                         case (q, b, v) =>
                             q.closed.map: isClosed =>
                                 assert(isClosed && b && v == Maybe(1))
@@ -257,7 +257,7 @@ class QueueTest extends Test:
                     }
                     end effect
 
-                    Resource.run(effect).map:
+                    Scope.run(effect).map:
                         case (q, b, v) =>
                             q.closed.map: isClosed =>
                                 assert(isClosed && b && v == Maybe(1))

--- a/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/StreamCoreExtensionsTest.scala
@@ -679,12 +679,12 @@ class StreamCoreExtensionsTest extends Test:
                 }.andThen(succeed)
             }
 
-            "resource" in run {
+            "scope" in run {
                 pending
                 class TestResource(var closes: Int = 0) extends java.io.Closeable:
                     def close() = closes += 1
 
-                val stream        = Stream(Resource.acquire(TestResource()).map(r => Emit.value(Chunk(r))))
+                val stream        = Stream(Scope.acquire(TestResource()).map(r => Emit.value(Chunk(r))))
                 val groupedWithin = stream.groupedWithin(3, Duration.Infinity)
                 groupedWithin.run.map: grouped =>
                     stream.run.map: streamResult =>

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -708,8 +708,8 @@ abstract class Stream[+V, -S] @publicInBinary private[kyo] () extends Serializab
       *
       * For example, to ensure all resources close when the stream is evaluated:
       * ```
-      * val original: Stream[Int, Resource & Async] = ???
-      * val withCleanup = original.handle(Resource.run)
+      * val original: Stream[Int, Scope & Async] = ???
+      * val withCleanup = original.handle(Scope.run)
       * ```
       *
       * While `handle` can be used with any function that processes the underlying effect, its main purpose is to facilitate effect handling
@@ -717,9 +717,9 @@ abstract class Stream[+V, -S] @publicInBinary private[kyo] () extends Serializab
       * sequential style.
       *
       * ```
-      * val original: Stream[Int, Resource & Abort[String] & Var[Int]] = ???
+      * val original: Stream[Int, Scope & Abort[String] & Var[Int]] = ???
       * val handled: Stream[Int, Any] = original.handle(
-      *   Resource.run,
+      *   Scope.run,
       *   Abort.run[String](_),
       *   Var.run(20),
       * )

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscriber.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscriber.scala
@@ -260,8 +260,8 @@ final private[kyo] class StreamSubscriber[V](
             }
         }
 
-    def stream(using Frame, Tag[Emit[Chunk[V]]]): Stream[V, Async] < (Resource & Sync) =
-        Resource.ensure(interupt).andThen:
+    def stream(using Frame, Tag[Emit[Chunk[V]]]): Stream[V, Async] < (Scope & Sync) =
+        Scope.ensure(interupt).andThen:
             Stream(emit)
 
 end StreamSubscriber

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -97,11 +97,11 @@ object StreamSubscription:
         Frame,
         Tag[Emit[Chunk[V]]],
         Tag[Poll[Chunk[V]]]
-    ): StreamSubscription[V, S] < (Sync & S & Resource) =
+    ): StreamSubscription[V, S] < (Sync & S & Scope) =
         for
             subscription <- Sync.Unsafe(new StreamSubscription[V, S](stream, subscriber))
             _            <- subscription.subscribe
-            _            <- Resource.acquireRelease(subscription.consume)(_.interrupt.unit)
+            _            <- Scope.acquireRelease(subscription.consume)(_.interrupt.unit)
         yield subscription
 
     object Unsafe:

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/package.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/package.scala
@@ -15,7 +15,7 @@ package object flow:
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Stream[T, Async] < (Resource & Sync) =
+    ): Stream[T, Async] < (Scope & Sync) =
         for
             subscriber <- StreamSubscriber[T](bufferSize, emitStrategy)
             _          <- Sync.defer(publisher.subscribe(subscriber))
@@ -33,7 +33,7 @@ package object flow:
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Subscription < (Resource & Sync & S) =
+    ): Subscription < (Scope & Sync & S) =
         StreamSubscription.subscribe(stream, subscriber)
 
     def streamToPublisher[T, S](
@@ -45,6 +45,6 @@ package object flow:
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Publisher[T] < (Resource & Sync & S) = StreamPublisher[T, S](stream)
+    ): Publisher[T] < (Scope & Sync & S) = StreamPublisher[T, S](stream)
 
 end flow

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/reactive-streams/package.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/reactive-streams/package.scala
@@ -16,7 +16,7 @@ package object reactivestreams:
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Stream[T, Async] < (Resource & Sync) =
+    ): Stream[T, Async] < (Scope & Sync) =
         flow.fromPublisher(FlowAdapters.toFlowPublisher(publisher), bufferSize, emitStrategy)
 
     @nowarn("msg=anonymous")
@@ -30,7 +30,7 @@ package object reactivestreams:
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Subscription < (Resource & Sync & S) =
+    ): Subscription < (Scope & Sync & S) =
         flow.subscribeToStream(stream, FlowAdapters.toFlowSubscriber(subscriber)).map { subscription =>
             new Subscription:
                 override def request(n: Long): Unit = subscription.request(n)
@@ -46,7 +46,7 @@ package object reactivestreams:
         Frame,
         Tag[Emit[Chunk[T]]],
         Tag[Poll[Chunk[T]]]
-    ): Publisher[T] < (Resource & Sync & S) = flow.streamToPublisher(stream).map { publisher =>
+    ): Publisher[T] < (Scope & Sync & S) = flow.streamToPublisher(stream).map { publisher =>
         FlowAdapters.toPublisher(publisher)
     }
 end reactivestreams

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/package.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/package.scala
@@ -13,7 +13,7 @@ object StreamReactiveStreamsExtensions:
             Frame,
             Tag[Emit[Chunk[T]]],
             Tag[Poll[Chunk[T]]]
-        ): Subscription < (Resource & Sync & S) =
+        ): Subscription < (Scope & Sync & S) =
             subscribeToStream(stream, subscriber)
 
         def toPublisher(
@@ -21,7 +21,7 @@ object StreamReactiveStreamsExtensions:
             Frame,
             Tag[Emit[Chunk[T]]],
             Tag[Poll[Chunk[T]]]
-        ): Publisher[T] < (Resource & Sync & S) =
+        ): Publisher[T] < (Scope & Sync & S) =
             streamToPublisher(stream)
     end extension
 end StreamReactiveStreamsExtensions

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/CancellationTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/CancellationTest.scala
@@ -16,7 +16,7 @@ final class CancellationTest extends Test:
 
     val attempts = 100
 
-    def testStreamSubscription(clue: String)(program: Subscription => Unit): Unit < (Sync & Resource) =
+    def testStreamSubscription(clue: String)(program: Subscription => Unit): Unit < (Sync & Scope) =
         Loop(attempts) { index =>
             if index <= 0 then
                 Loop.done

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
@@ -184,7 +184,7 @@ abstract private class PublisherToSubscriberTest extends Test:
                 fiber3      <- Fiber.init(latch.release.andThen(subStream3.run.unit))
                 fiber4      <- Fiber.init(latch.release.andThen(subStream4.run.unit))
                 latchPub    <- Latch.init(1)
-                publisherFiber <- Fiber.init(latch.await.andThen(Resource.run(
+                publisherFiber <- Fiber.init(latch.await.andThen(Scope.run(
                     Stream(Emit.valueWith(Chunk.empty)(emit(counter)))
                         .toPublisher
                         .map { publisher =>
@@ -224,7 +224,7 @@ abstract private class PublisherToSubscriberTest extends Test:
                                 case _                       => promise.completeDiscard(Failure(TestError))
                         })))
                 }
-                _      <- Resource.run(subscriber.stream.map(_.take(10).discard))
+                _      <- Scope.run(subscriber.stream.map(_.take(10).discard))
                 result <- promise.getResult
             yield assert(result == Success(()))
             end for

--- a/kyo-sttp/jvm/src/test/scala/kyo/RequestsLiveTest.scala
+++ b/kyo-sttp/jvm/src/test/scala/kyo/RequestsLiveTest.scala
@@ -34,7 +34,7 @@ class RequestsLiveTest extends Test:
         endpointPath: String,
         response: Try[String],
         port: Int = 8000
-    ): Int < (Sync & Resource) =
+    ): Int < (Sync & Scope) =
         Sync.defer {
 
             import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
@@ -63,7 +63,7 @@ class RequestsLiveTest extends Test:
             )
             server.setExecutor(null)
             server.start()
-            Resource.ensure(server.stop(0))
+            Scope.ensure(server.stop(0))
                 .andThen(Sync.defer(server.getAddress.getPort()))
         }
 end RequestsLiveTest

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -31,7 +31,7 @@ class KyoSttpMonad extends MonadAsyncError[M]:
     def ensure[A](f: M[A], e: => M[Unit]) =
         Promise.initWith[Unit, Any] { p =>
             def run =
-                Fiber.init(e).map(p.become).unit
+                Fiber.init(e).map(p.becomeDiscard)
             Sync.ensure(run)(f).map(r => p.get.andThen(r))
         }
 

--- a/kyo-zio-test/shared/src/main/scala/kyo/test/KyoSpecDefault.scala
+++ b/kyo-zio-test/shared/src/main/scala/kyo/test/KyoSpecDefault.scala
@@ -4,9 +4,9 @@ import kyo.*
 import zio.ZIO
 import zio.test.Spec
 
-abstract class KyoSpecDefault extends KyoSpecAbstract[Async & Resource & Abort[Throwable]]:
-    final override def run[In](v: => In < (Async & Resource & Abort[Throwable]))(using Frame): ZIO[Environment, Throwable, In] =
-        ZIOs.run(Resource.run(v))
+abstract class KyoSpecDefault extends KyoSpecAbstract[Async & Scope & Abort[Throwable]]:
+    final override def run[In](v: => In < (Async & Scope & Abort[Throwable]))(using Frame): ZIO[Environment, Throwable, In] =
+        ZIOs.run(Scope.run(v))
 
     def timeout: Duration = Duration.Infinity
 

--- a/kyo-zio/shared/src/main/scala/kyo/ZStreams.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZStreams.scala
@@ -7,7 +7,7 @@ import zio.Cause
 import zio.Exit
 import zio.FiberId
 import zio.Runtime
-import zio.Scope
+import zio.Scope as ZScope
 import zio.StackTrace
 import zio.Trace
 import zio.Unsafe
@@ -29,9 +29,9 @@ object ZStreams:
     ): Stream[A, Abort[E] & Async] =
         Stream:
             Sync.defer {
-                val scope = Unsafe.unsafely(Scope.unsafe.make)
-                Resource.run {
-                    Resource.ensure(ex => ZIOs.get(scope.close(ex.fold(Exit.unit)(_.toExit)))).andThen {
+                val scope = Unsafe.unsafely(ZScope.unsafe.make)
+                Scope.run {
+                    Scope.ensure(ex => ZIOs.get(scope.close(ex.fold(Exit.unit)(_.toExit)))).andThen {
                         ZIOs.get(stream.channel.toPullIn(scope)).map: pullIn =>
                             Loop.foreach:
                                 ZIOs.get(pullIn).map {


### PR DESCRIPTION
### Problem
- We plan to add support for heirarchical Resource scopes (see: #1131), but the naming of `Resource` makes the behavior less clear. It seems much more intuitive to 'nest' scopes.

### Solution
- Rename Resource to Scope. In #1315 Flavio will add a followup for local scoping.
