### PR TITLE
Cleanup usages of `Frame.internal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3292,7 +3292,7 @@ val c: String < (Async & Abort[FailedRequest]) =
 // Implementing a custom mock backend
 val backend: Backend =
     new Backend:
-        def send[T](r: Request[T, Any]) =
+        def send[T](r: Request[T, Any])(using Frame) =
             Response.ok(Right("mocked")).asInstanceOf[Response[T]]
 
 // Use the custom backend

--- a/kyo-prelude/shared/src/main/scala/kyo/Layer.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Layer.scala
@@ -292,9 +292,8 @@ object Layer:
         case class To[Out1, Out2, S1, S2](lhs: Layer[?, ?], rhs: Layer[?, ?])                            extends Layer[Out1 & Out2, S1 & S2]
         case class FromKyo[In, Out, S](kyo: () => TypeMap[Out] < (Env[In] & S))(using val tag: Tag[Out]) extends Layer[Out, S]
 
-        private given Frame = Frame.internal
-
         class DoRun[Out, S] extends Serializable:
+            private given Frame = Frame.internal
             private val memo = Memo[Layer[Out, S], TypeMap[Out], S & Memo] { self =>
                 type Expected = TypeMap[Out] < (S & Memo)
                 self match

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -23,7 +23,6 @@ final private[kyo] class StreamSubscription[V, S](
     end request
 
     override def cancel(): Unit =
-        given Frame = Frame.internal
         discard(requestChannel.close())
     end cancel
 

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamPublisherTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/reactive-streams/StreamPublisherTest.scala
@@ -10,7 +10,6 @@ import org.scalatestplus.testng.*
 
 final class StreamPublisherTest extends PublisherVerification[Int](new TestEnvironment(50L)), TestNGSuiteLike:
     import AllowUnsafe.embrace.danger
-    given Frame = Frame.internal
 
     private def createStream(n: Int = 1) =
         if n <= 0 then

--- a/kyo-sttp/js/src/main/scala/kyo/PlatformBackend.scala
+++ b/kyo-sttp/js/src/main/scala/kyo/PlatformBackend.scala
@@ -7,8 +7,7 @@ object PlatformBackend:
     val default =
         new Backend:
             val b = FetchBackend()
-            def send[A](r: Request[A, Any]) =
-                given Frame = Frame.internal
+            def send[A](r: Request[A, Any])(using Frame) =
                 Abort.run(Async.fromFuture(r.send(b)))
                     .map(_.foldError(identity, ex => Abort.fail(FailedRequest(ex.failureOrPanic))))
             end send

--- a/kyo-sttp/jvm/src/main/scala/kyo/PlatformBackend.scala
+++ b/kyo-sttp/jvm/src/main/scala/kyo/PlatformBackend.scala
@@ -10,7 +10,7 @@ object PlatformBackend:
 
     def apply(backend: SttpBackend[KyoSttpMonad.M, WebSockets])(using Frame): Backend =
         new Backend:
-            def send[A](r: Request[A, Any]) =
+            def send[A](r: Request[A, Any])(using Frame) =
                 r.send(backend)
 
     def apply(client: HttpClient)(using Frame): Backend =
@@ -19,6 +19,6 @@ object PlatformBackend:
     val default =
         new Backend:
             val b = HttpClientKyoBackend()
-            def send[A](r: Request[A, Any]) =
+            def send[A](r: Request[A, Any])(using Frame) =
                 r.send(b)
 end PlatformBackend

--- a/kyo-sttp/native/src/main/scala/kyo/PlatformBackend.scala
+++ b/kyo-sttp/native/src/main/scala/kyo/PlatformBackend.scala
@@ -7,8 +7,7 @@ object PlatformBackend:
     val default =
         new Backend:
             val b = CurlBackend()
-            def send[A](r: Request[A, Any]) =
-                given Frame = Frame.internal
+            def send[A](r: Request[A, Any])(using Frame) =
                 def call    = r.send(b)
                 Abort.run[Throwable](Sync.defer(call))
                     .map(_.foldError(identity, ex => Abort.fail(FailedRequest(ex.failureOrPanic))))

--- a/kyo-sttp/shared/src/test/scala/kyo/RequestsTest.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/RequestsTest.scala
@@ -7,7 +7,7 @@ class RequestsTest extends Test:
 
     class TestBackend extends Requests.Backend:
         var calls = 0
-        def send[A](r: Request[A, Any]) =
+        def send[A](r: Request[A, Any])(using Frame) =
             calls += 1
             Response.ok(Right("mocked")).asInstanceOf[Response[A]]
     end TestBackend


### PR DESCRIPTION
### Problem
Using Frame.internal reduces the clarity of stack traces.

### Solution
Remove or limit the scope of Frame.internal where possible.
