### PR TITLE
[build] prevent failures from canceling other platforms

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: build
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         target:
           - { name: "JVM", command: "sbt '+kyoJVM/testQuick'" }


### PR DESCRIPTION
### Problem
When a single test fails in a platform like JVM, then JS and Native will be canceled.

### Solution
Avoid fail fast since a flaky test requires more re-runs.