### PR TITLE
Add tests for ops allowed after closeAwaitEmpty

### DIFF
--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -526,6 +526,59 @@ class QueueTest extends Test:
     }
 
     "closeAwaitEmpty" - {
+        "allowed following ops when empty" in runNotNative {
+            for
+                q  <- Queue.init[Int](2)
+                c1 <- q.closeAwaitEmpty
+                v1 <- Abort.run(q.size)
+                v2 <- Abort.run(q.empty)
+                v3 <- Abort.run(q.full)
+                v4 <- Abort.run(q.offer(2))
+                v5 <- Abort.run(q.poll)
+                v6 <- Abort.run(q.peek)
+                v7 <- Abort.run(q.drain)
+                c2 <- Abort.run(q.closeAwaitEmpty)
+            yield assert(
+                c1 &&
+                    v1.isFailure &&
+                    v2.isFailure &&
+                    v3.isFailure &&
+                    v4.isFailure &&
+                    v5.isFailure &&
+                    v6.isFailure &&
+                    v7.isFailure &&
+                    c2.isSuccess
+            )
+        }
+
+        "allowed following ops when not empty" in runNotNative {
+            for
+                q  <- Queue.init[Int](2)
+                _  <- q.offer(1)
+                _  <- q.offer(1)
+                f1 <- Fiber.init(q.closeAwaitEmpty)
+                v1 <- Abort.run(q.size)
+                v2 <- Abort.run(q.empty)
+                v3 <- Abort.run(q.full)
+                v4 <- Abort.run(q.offer(2))
+                v5 <- Abort.run(q.poll)
+                v6 <- Abort.run(q.peek)
+                v7 <- Abort.run(q.drain)
+                c2 <- Abort.run(q.closeAwaitEmpty)
+                c1 <- f1.get
+            yield assert(
+                c1 &&
+                    v1.isSuccess &&
+                    v2.isSuccess &&
+                    v3.isSuccess &&
+                    v4.isFailure &&
+                    v5.isSuccess &&
+                    v6.isSuccess &&
+                    v7.isSuccess &&
+                    c2.isSuccess
+            )
+        }
+
         "returns true when queue is already empty" in runNotNative {
             for
                 queue  <- Queue.init[Int](10)


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

I ran into some trouble writing tests for #1334 whereby the effects from `Queue.closeAwaitEmpty` were not happening in a deterministic way. The test initially failed in #1261. After updating to the latest changes in main this problem has gone so the fix in there was not needed.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

This adds tests to ensure that the behaviour does not regress back again.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
