### PR TITLE
Scoped Fiber init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All breaking API changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- [kyo-core] `Fiber.use`: use a forked fiber within a function and clean it up
+- [kyo-core] `Fiber.initUnscoped`: fork a fiber without guaranteeing cleanup (formerly `Fiber.init`)
+- [kyo-combinators] `.forkUsing`: apply `Fiber.use`
+
+### Removed
+
+- [kyo-combinators] `.forkScoped`: changed to `.fork`
+
+### Changed
+
+- [kyo-core] `Fiber.init`: use `Scope` effect to guarantee termination of forked fiber
+- [kyo-combinators] `.fork`: apply `Fiber.init` (formerly `.forkScoped`)

--- a/README.md
+++ b/README.md
@@ -2244,7 +2244,7 @@ import kyo.*
 // taken by reference and automatically
 // suspended with 'Sync'
 val a: Fiber[Int, Any] < Sync =
-    Fiber.init(Math.cos(42).toInt)
+    Fiber.initUnscoped(Math.cos(42).toInt)
 
 // It's possible to "extract" the value of a
 // 'Fiber' via the 'get' method. This is also
@@ -2384,11 +2384,11 @@ import kyo.*
 
 // An example computation with fibers
 val a: Int < Async =
-    Fiber.init(Math.cos(42).toInt).map(_.get)
+    Fiber.initUnscoped(Math.cos(42).toInt).map(_.get)
 
 // Avoid handling 'Async' directly
 val b: Fiber[Int, Any] < Sync =
-    Fiber.init(a)
+    Fiber.initUnscoped(a)
 
 // The 'runAndBlock' method accepts
 // arbitrary pending effects but relies
@@ -2415,7 +2415,7 @@ val b: Boolean < Sync =
 // Fullfil the promise with
 // another fiber
 val c: Boolean < Sync =
-    a.map(fiber => Fiber.init(1).map(fiber.become(_)))
+    a.map(fiber => Fiber.initUnscoped(1).map(fiber.become(_)))
 ```
 
 > A `Promise` is basically a `Fiber` with all the regular functionality plus the `complete` and `become` methods to manually fulfill the promise.
@@ -2796,12 +2796,12 @@ val d: Unit < Async =
 val e: Unit < Async =
     for
         barrier <- Barrier.init(3)
-        fiber1  <- Fiber.init(Async.sleep(1.second))
-        fiber2  <- Fiber.init(Async.sleep(2.seconds))
+        fiber1  <- Fiber.initUnscoped(Async.sleep(1.second))
+        fiber2  <- Fiber.initUnscoped(Async.sleep(2.seconds))
         _       <- Async.zip(
                      fiber1.get.map(_ => barrier.await),
                      fiber2.get.map(_ => barrier.await),
-                     Fiber.init(barrier.await).map(_.get)
+                     Fiber.initUnscoped(barrier.await).map(_.get)
                    )
     yield ()
 ```
@@ -3400,14 +3400,14 @@ val a: Int < (Abort[Nothing] & Async) =
     for
         v1 <- ZIOs.get(ZIO.succeed(21))
         v2 <- Sync.defer(21)
-        v3 <- Fiber.init(-42).map(_.get)
+        v3 <- Fiber.initUnscoped(-42).map(_.get)
     yield v1 + v2 + v3
 
 // Using fibers from both libraries
 val b: Int < (Abort[Nothing] & Async) =
     for
         f1 <- ZIOs.get(ZIO.succeed(21).fork)
-        f2 <- Fiber.init(Sync.defer(21))
+        f2 <- Fiber.initUnscoped(Sync.defer(21))
         v1 <- ZIOs.get(f1.join)
         v2 <- f2.get
     yield v1 + v2
@@ -3452,14 +3452,14 @@ val a: Int < (Abort[Nothing] & Async) =
     for
         v1 <- Cats.get(CatsIO.pure(21))
         v2 <- Sync.defer(21)
-        v3 <- Fiber.init(-42).map(_.get)
+        v3 <- Fiber.initUnscoped(-42).map(_.get)
     yield v1 + v2 + v3
 
 // Using fibers from both libraries:
 val b: Int < (Abort[Nothing] & Async) =
     for
         f1 <- Cats.get(CatsIO.pure(21).start)
-        f2 <- Fiber.init(Sync.defer(21))
+        f2 <- Fiber.initUnscoped(Sync.defer(21))
         v1 <- Cats.get(f1.joinWith(CatsIO(99)))
         v2 <- f2.get
     yield v1 + v2

--- a/build.sbt
+++ b/build.sbt
@@ -749,8 +749,8 @@ lazy val `kyo-scalafix-input` = (project in file("scalafix/input"))
         scalaVersion                       := scala3Version,
         semanticdbEnabled                  := true,
         semanticdbVersion                  := scalafixSemanticdb.revision,
-        libraryDependencies += "io.getkyo" %% "kyo-direct" % "0.19.0",
-        libraryDependencies += "io.getkyo" %% "kyo-combinators" % "0.19.0",
+        libraryDependencies += "io.getkyo" %% "kyo-direct"      % "0.19.0",
+        libraryDependencies += "io.getkyo" %% "kyo-combinators" % "0.19.0"
     )
 
 lazy val `kyo-scalafix-output` = (project in file("scalafix/output"))

--- a/build.sbt
+++ b/build.sbt
@@ -749,7 +749,8 @@ lazy val `kyo-scalafix-input` = (project in file("scalafix/input"))
         scalaVersion                       := scala3Version,
         semanticdbEnabled                  := true,
         semanticdbVersion                  := scalafixSemanticdb.revision,
-        libraryDependencies += "io.getkyo" %% "kyo-direct" % "0.19.0"
+        libraryDependencies += "io.getkyo" %% "kyo-direct" % "0.19.0",
+        libraryDependencies += "io.getkyo" %% "kyo-combinators" % "0.19.0",
     )
 
 lazy val `kyo-scalafix-output` = (project in file("scalafix/output"))
@@ -758,7 +759,10 @@ lazy val `kyo-scalafix-output` = (project in file("scalafix/output"))
         scalaVersion      := scala3Version,
         semanticdbEnabled := true,
         semanticdbVersion := scalafixSemanticdb.revision
-    ).dependsOn(`kyo-direct`.projects(JVMPlatform))
+    ).dependsOn(
+        `kyo-direct`.projects(JVMPlatform),
+        `kyo-combinators`.projects(JVMPlatform)
+    )
 
 lazy val `kyo-scalafix-test` = (project in file("scalafix/tests"))
     .settings(

--- a/kyo-aeron/jvm/src/test/scala/kyo/TopicTest.scala
+++ b/kyo-aeron/jvm/src/test/scala/kyo/TopicTest.scala
@@ -34,9 +34,11 @@ class TopicTest extends Test:
                         for
                             started <- Latch.init(1)
                             fiber <-
-                                Fiber.init(using Topic.isolate)(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
+                                Fiber.initUnscoped(using Topic.isolate)(
+                                    started.release.andThen(Topic.stream[Message](uri).take(messages.size).run)
+                                )
                             _        <- started.await
-                            _        <- Fiber.init(Topic.publish(uri)(Stream.init(messages)))
+                            _        <- Fiber.initUnscoped(Topic.publish(uri)(Stream.init(messages)))
                             received <- fiber.get
                         yield assert(received == messages)
                     }
@@ -48,11 +50,11 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started       <- Latch.init(2)
-                            stringFiber   <- Fiber.init(started.release.andThen(Topic.stream[String](uri).take(strings.size).run))
-                            intFiber      <- Fiber.init(started.release.andThen(Topic.stream[Int](uri).take(ints.size).run))
+                            stringFiber   <- Fiber.initUnscoped(started.release.andThen(Topic.stream[String](uri).take(strings.size).run))
+                            intFiber      <- Fiber.initUnscoped(started.release.andThen(Topic.stream[Int](uri).take(ints.size).run))
                             _             <- started.await
-                            _             <- Fiber.init(Topic.publish(uri)(Stream.init(strings)))
-                            _             <- Fiber.init(Topic.publish(uri)(Stream.init(ints)))
+                            _             <- Fiber.initUnscoped(Topic.publish(uri)(Stream.init(strings)))
+                            _             <- Fiber.initUnscoped(Topic.publish(uri)(Stream.init(ints)))
                             stringResults <- stringFiber.get
                             intResults    <- intFiber.get
                         yield
@@ -69,12 +71,16 @@ class TopicTest extends Test:
                         for
                             started <- Latch.init(2)
                             strFiber <-
-                                Fiber.init(started.release.andThen(Topic.stream[GenericMessage[String]](uri).take(strMessages.size).run))
+                                Fiber.initUnscoped(
+                                    started.release.andThen(Topic.stream[GenericMessage[String]](uri).take(strMessages.size).run)
+                                )
                             intFiber <-
-                                Fiber.init(started.release.andThen(Topic.stream[GenericMessage[Int]](uri).take(intMessages.size).run))
+                                Fiber.initUnscoped(
+                                    started.release.andThen(Topic.stream[GenericMessage[Int]](uri).take(intMessages.size).run)
+                                )
                             _          <- started.await
-                            _          <- Fiber.init(Topic.publish(uri)(Stream.init(strMessages)))
-                            _          <- Fiber.init(Topic.publish(uri)(Stream.init(intMessages)))
+                            _          <- Fiber.initUnscoped(Topic.publish(uri)(Stream.init(strMessages)))
+                            _          <- Fiber.initUnscoped(Topic.publish(uri)(Stream.init(intMessages)))
                             strResults <- strFiber.get
                             intResults <- intFiber.get
                         yield
@@ -90,10 +96,10 @@ class TopicTest extends Test:
                     )
                     Topic.run {
                         for
-                            started  <- Latch.init(1)
-                            fiber    <- Fiber.init(started.release.andThen(Topic.stream[ComplexMessage](uri).take(messages.size).run))
-                            _        <- started.await
-                            _        <- Fiber.init(Topic.publish(uri)(Stream.init(messages)))
+                            started <- Latch.init(1)
+                            fiber <- Fiber.initUnscoped(started.release.andThen(Topic.stream[ComplexMessage](uri).take(messages.size).run))
+                            _     <- started.await
+                            _     <- Fiber.initUnscoped(Topic.publish(uri)(Stream.init(messages)))
                             received <- fiber.get
                         yield assert(received == messages)
                     }
@@ -107,10 +113,10 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started <- Latch.init(2)
-                            fiber1  <- Fiber.init(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
-                            fiber2  <- Fiber.init(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
+                            fiber1  <- Fiber.initUnscoped(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
+                            fiber2  <- Fiber.initUnscoped(started.release.andThen(Topic.stream[Message](uri).take(messages.size).run))
                             _       <- started.await
-                            _       <- Fiber.init(Topic.publish(uri)(Stream.init(messages)))
+                            _       <- Fiber.initUnscoped(Topic.publish(uri)(Stream.init(messages)))
                             result1 <- fiber1.get
                             result2 <- fiber2.get
                         yield
@@ -126,20 +132,20 @@ class TopicTest extends Test:
                         for
                             started <- Latch.init(2)
                             slowFiber <-
-                                Fiber.init(started.release.andThen(
+                                Fiber.initUnscoped(started.release.andThen(
                                     Topic.stream[Message](uri)
                                         .map(r => Async.delay(1.millis)(r))
                                         .take(messages.size)
                                         .run
                                 ))
                             fastFiber <-
-                                Fiber.init(started.release.andThen(
+                                Fiber.initUnscoped(started.release.andThen(
                                     Topic.stream[Message](uri)
                                         .take(messages.size)
                                         .run
                                 ))
                             _    <- started.await
-                            _    <- Fiber.init(Topic.publish(uri)(Stream.init(messages)))
+                            _    <- Fiber.initUnscoped(Topic.publish(uri)(Stream.init(messages)))
                             slow <- slowFiber.get
                             fast <- fastFiber.get
                         yield
@@ -160,7 +166,7 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started <- Latch.init(1)
-                            fiber   <- Fiber.init(started.release.andThen(Topic.stream[Base](uri, failSchedule).run))
+                            fiber   <- Fiber.initUnscoped(started.release.andThen(Topic.stream[Base](uri, failSchedule).run))
                             _       <- started.await
                             result1 <- Abort.run(Topic.publish(uri, failSchedule)(Stream.init(messages)))
                             result2 <- fiber.getResult
@@ -174,7 +180,7 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started <- Latch.init(1)
-                            fiber   <- Fiber.init(started.release.andThen(Topic.stream[Derived1](uri, failSchedule).run))
+                            fiber   <- Fiber.initUnscoped(started.release.andThen(Topic.stream[Derived1](uri, failSchedule).run))
                             _       <- started.await
                             result1 <- Abort.run(Topic.publish(uri, failSchedule)(Stream.init(messages)))
                             result2 <- fiber.getResult
@@ -191,7 +197,7 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started <- Latch.init(1)
-                            fiber   <- Fiber.init(started.release.andThen(Topic.stream[GenericBase[String]](uri, failSchedule).run))
+                            fiber   <- Fiber.initUnscoped(started.release.andThen(Topic.stream[GenericBase[String]](uri, failSchedule).run))
                             _       <- started.await
                             result1 <- Abort.run(Topic.publish(uri, failSchedule)(Stream.init(messages)))
                             result2 <- fiber.getResult
@@ -206,11 +212,11 @@ class TopicTest extends Test:
                     Topic.run {
                         for
                             started  <- Latch.init(2)
-                            fiber1   <- Fiber.init(started.release.andThen(Topic.stream[Derived1](uri).take(messages1.size).run))
-                            fiber2   <- Fiber.init(started.release.andThen(Topic.stream[Derived2](uri).take(messages2.size).run))
+                            fiber1   <- Fiber.initUnscoped(started.release.andThen(Topic.stream[Derived1](uri).take(messages1.size).run))
+                            fiber2   <- Fiber.initUnscoped(started.release.andThen(Topic.stream[Derived2](uri).take(messages2.size).run))
                             _        <- started.await
-                            _        <- Fiber.init(Topic.publish(uri)(Stream.init(messages1)))
-                            _        <- Fiber.init(Topic.publish(uri)(Stream.init(messages2)))
+                            _        <- Fiber.initUnscoped(Topic.publish(uri)(Stream.init(messages1)))
+                            _        <- Fiber.initUnscoped(Topic.publish(uri)(Stream.init(messages2)))
                             results1 <- fiber1.get
                             results2 <- fiber2.get
                         yield
@@ -226,7 +232,7 @@ class TopicTest extends Test:
                 Topic.run {
                     for
                         started <- Latch.init(1)
-                        fiber   <- Fiber.init(started.release.andThen(Topic.stream[Message](uri).take(count).run))
+                        fiber   <- Fiber.initUnscoped(started.release.andThen(Topic.stream[Message](uri).take(count).run))
                         _       <- started.await
                         result  <- Abort.run(Topic.publish[Message](uri)(Stream.init(messages)))
                     yield
@@ -241,7 +247,7 @@ class TopicTest extends Test:
                 Topic.run {
                     for
                         started <- Latch.init(1)
-                        fiber   <- Fiber.init(started.release.andThen(Topic.stream[Message](uri, failSchedule).take(1).run))
+                        fiber   <- Fiber.initUnscoped(started.release.andThen(Topic.stream[Message](uri, failSchedule).take(1).run))
                         _       <- started.await
                         _       <- Topic.publish[Message](uri, failSchedule)(Stream.empty)
                         result  <- fiber.getResult
@@ -256,7 +262,7 @@ class TopicTest extends Test:
                 Topic.run {
                     for
                         started <- Latch.init(2)
-                        failingFiber <- Fiber.init(
+                        failingFiber <- Fiber.initUnscoped(
                             started.release.andThen(
                                 Topic.stream[Message](uri)
                                     .map(_ => Abort.fail("Planned failure"): Message < Abort[String])
@@ -264,7 +270,7 @@ class TopicTest extends Test:
                                     .run
                             )
                         )
-                        normalFiber <- Fiber.init(
+                        normalFiber <- Fiber.initUnscoped(
                             started.release.andThen(
                                 Topic.stream[Message](uri)
                                     .take(messageCount)
@@ -293,7 +299,7 @@ class TopicTest extends Test:
                 "subscriber without publisher" in run {
                     Topic.run {
                         for
-                            fiber  <- Fiber.init(Topic.stream[Message](uri, failSchedule).take(1).run)
+                            fiber  <- Fiber.initUnscoped(Topic.stream[Message](uri, failSchedule).take(1).run)
                             result <- fiber.getResult
                         yield assert(result.isFailure)
                     }

--- a/kyo-bench/src/main/scala/kyo/bench/ChannelBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/ChannelBench.scala
@@ -23,10 +23,10 @@ class ChannelBench extends BaseBench:
             for
                 channel <- Channel.initUnscoped[Int](size)
                 _       <- channel.putBatch(Seq.fill(size)(intFillFn))
-                _       <- Fiber.init(channel.closeAwaitEmpty)
+                _       <- Fiber.initUnscoped(channel.closeAwaitEmpty)
                 count   <- channel.streamUntilClosed(maxChunkSize).into(Sink.count)
             yield count
-        val count = Sync.Unsafe.evalOrThrow(Fiber.init(x).flatMap(_.block(Duration.Infinity))).getOrThrow
+        val count = Sync.Unsafe.evalOrThrow(Fiber.initUnscoped(x).flatMap(_.block(Duration.Infinity))).getOrThrow
         assert(count == size, s"Expected $size, got $count")
     end streamChunks
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ArenaBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ArenaBench.scala
@@ -47,7 +47,7 @@ object ArenaBench:
         def forkKyo(warmup: KyoForkWarmup): A =
             import kyo.*
             import AllowUnsafe.embrace.danger
-            Sync.Unsafe.evalOrThrow(Fiber.init(kyoBenchFiber()).flatMap(_.block(Duration.Infinity))).getOrThrow
+            Sync.Unsafe.evalOrThrow(Fiber.initUnscoped(kyoBenchFiber()).flatMap(_.block(Duration.Infinity))).getOrThrow
         end forkKyo
 
         @Benchmark

--- a/kyo-bench/src/main/scala/kyo/bench/arena/CountdownLatchBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/CountdownLatchBench.scala
@@ -29,7 +29,7 @@ class CountdownLatchBench extends ArenaBench.ForkOnly(0):
 
         for
             l <- Latch.init(depth)
-            _ <- Fiber.init(iterate(l, depth))
+            _ <- Fiber.initUnscoped(iterate(l, depth))
             _ <- l.await
         yield 0
         end for

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkChainedBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkChainedBench.scala
@@ -24,11 +24,11 @@ class ForkChainedBench extends ArenaBench.ForkOnly(0):
 
         def iterate(p: Promise[Unit, Any], n: Int): Unit < Sync =
             if n <= 0 then p.completeUnitDiscard
-            else Kyo.unit.flatMap(_ => Fiber.init(iterate(p, n - 1)).unit)
+            else Kyo.unit.flatMap(_ => Fiber.initUnscoped(iterate(p, n - 1)).unit)
 
         for
             p <- Promise.init[Unit, Any]
-            _ <- Fiber.init(iterate(p, depth))
+            _ <- Fiber.initUnscoped(iterate(p, depth))
             _ <- p.get
         yield 0
         end for

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinBench.scala
@@ -18,7 +18,7 @@ class ForkJoinBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        val forkFiber     = Fiber.init(())
+        val forkFiber     = Fiber.initUnscoped(())
         val forkAllFibers = Kyo.foreach(range)(_ => forkFiber)
 
         forkAllFibers.flatMap(fibers => Kyo.foreachDiscard(fibers)(_.get))

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkJoinContentionBench.scala
@@ -21,7 +21,7 @@ class ForkJoinContentionBench extends ArenaBench.ForkOnly(()):
     override def kyoBenchFiber() =
         import kyo.*
 
-        val forkFiber         = Fiber.init(())
+        val forkFiber         = Fiber.initUnscoped(())
         val forkAllFibers     = Kyo.foreach(range)(_ => forkFiber)
         val forkJoinAllFibers = forkAllFibers.flatMap(fibers => Kyo.foreach(fibers)(_.get).unit)
 

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkManyBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkManyBench.scala
@@ -39,7 +39,7 @@ class ForkManyBench extends ArenaBench.ForkOnly(0):
                 case _ =>
                     false
             }
-            _ <- repeat(depth)(Fiber.init(effect))
+            _ <- repeat(depth)(Fiber.initUnscoped(effect))
             _ <- promise.get
         yield 0
         end for

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ForkSpawnBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ForkSpawnBench.scala
@@ -39,7 +39,7 @@ class ForkSpawnBench extends ArenaBench.ForkOnly(()):
             if level == depth then
                 cdl.release
             else
-                repeat(width)(Fiber.init(loop(cdl, level + 1)).map(_ => ()))
+                repeat(width)(Fiber.initUnscoped(loop(cdl, level + 1)).map(_ => ()))
 
         for
             cdl <- Latch.init(total)

--- a/kyo-bench/src/main/scala/kyo/bench/arena/PingPongBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/PingPongBench.scala
@@ -47,17 +47,17 @@ class PingPongBench extends ArenaBench.ForkOnly(()):
                 chan <- Channel.initUnscoped[Unit](1)
                 effect =
                     for
-                        _ <- Fiber.init(chan.put(()))
+                        _ <- Fiber.initUnscoped(chan.put(()))
                         _ <- chan.take
                         n <- ref.decrementAndGet
                         _ <- if n == 0 then promise.completeUnit else Kyo.unit
                     yield ()
-                _ <- repeat(depth)(Fiber.init(effect))
+                _ <- repeat(depth)(Fiber.initUnscoped(effect))
             yield ()
 
         for
             promise <- Promise.init[Unit, Any]
-            _       <- Fiber.init(iterate(promise, depth))
+            _       <- Fiber.initUnscoped(iterate(promise, depth))
             _       <- promise.get
         yield ()
         end for

--- a/kyo-bench/src/main/scala/kyo/bench/arena/ProducerConsumerBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/ProducerConsumerBench.scala
@@ -34,8 +34,8 @@ class ProducerConsumerBench extends ArenaBench.ForkOnly(()):
 
         Channel.initUnscoped[Unit](depth / 2, Access.SingleProducerSingleConsumer).flatMap { q =>
             for
-                producer <- Fiber.init(repeat(depth)(q.put(())))
-                consumer <- Fiber.init(repeat(depth)(q.take))
+                producer <- Fiber.initUnscoped(repeat(depth)(q.put(())))
+                consumer <- Fiber.initUnscoped(repeat(depth)(q.take))
                 _        <- producer.get
                 _        <- consumer.get
             yield {}

--- a/kyo-bench/src/main/scala/kyo/bench/arena/RendezvousBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/RendezvousBench.scala
@@ -100,8 +100,8 @@ class RendezvousBench extends ArenaBench.ForkOnly(10000 * (10000 + 1) / 2):
 
         for
             waiting  <- AtomicRef.init[Any](null)
-            _        <- Fiber.init(produce(waiting))
-            consumer <- Fiber.init(consume(waiting))
+            _        <- Fiber.initUnscoped(produce(waiting))
+            consumer <- Fiber.initUnscoped(consume(waiting))
             res      <- consumer.get
         yield res
         end for

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SchedulingBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SchedulingBench.scala
@@ -42,7 +42,7 @@ class SchedulingBench extends ArenaBench.ForkOnly(1001000):
             }
 
         Kyo.foreach(range) { i =>
-            Fiber.init(fiber(i))
+            Fiber.initUnscoped(fiber(i))
         }.map { fibers =>
             Kyo.foreach(fibers)(_.get)
         }.map(_.sum)

--- a/kyo-bench/src/main/scala/kyo/bench/arena/SemaphoreContentionBench.scala
+++ b/kyo-bench/src/main/scala/kyo/bench/arena/SemaphoreContentionBench.scala
@@ -47,7 +47,7 @@ class SemaphoreContentionBench extends ArenaBench.ForkOnly(()):
         for
             sem <- Meter.initSemaphoreUnscoped(permits)
             cdl <- Latch.init(parallism)
-            _   <- repeat(parallism)(Fiber.init(loop(sem, cdl)))
+            _   <- repeat(parallism)(Fiber.initUnscoped(loop(sem, cdl)))
             _   <- cdl.await
         yield {}
         end for

--- a/kyo-cache/shared/src/test/scala/kyo/CacheTest.scala
+++ b/kyo-cache/shared/src/test/scala/kyo/CacheTest.scala
@@ -23,7 +23,7 @@ class CacheTest extends Test:
         for
             c <- Cache.init(_.maxSize(4))
             m = c.memo { (v: Int) =>
-                Fiber.init {
+                Fiber.initUnscoped {
                     calls += 1
                     v + 1
                 }.map(_.get)
@@ -40,7 +40,7 @@ class CacheTest extends Test:
         for
             c <- Cache.init(_.maxSize(4))
             m = c.memo { (v: Int) =>
-                Fiber.init {
+                Fiber.initUnscoped {
                     calls += 1
                     if calls == 1 then
                         throw ex

--- a/kyo-cats/shared/src/main/scala/kyo/Cats.scala
+++ b/kyo-cats/shared/src/main/scala/kyo/Cats.scala
@@ -40,7 +40,7 @@ object Cats:
     def run[A](v: => A < (Abort[Throwable] & Async))(using frame: Frame): CatsIO[A] =
         CatsIO.defer {
             import AllowUnsafe.embrace.danger
-            Fiber.init(v).map { fiber =>
+            Fiber.initUnscoped(v).map { fiber =>
                 CatsIO.async[A] { cb =>
                     CatsIO {
                         fiber.unsafe.onComplete(r => cb(r.map(_.eval).toEither))

--- a/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
@@ -20,7 +20,7 @@ extension [A, E, S](effect: A < (Abort[E] & Async & S))
         reduce: Reducible[Abort[E]],
         frame: Frame
     ): Fiber[A, reduce.SReduced & S2] < (Sync & S) =
-        Fiber.init(effect)
+        Fiber.initUnscoped(effect)
 
     /** Forks this computation using the Async effect and returns its result as a `Fiber[A, Abort[E]]`, managed by the Resource effect.
       * Unlike `fork`, which creates an unmanaged fiber, `forkScoped` ensures that the fiber is properly cleaned up when the enclosing scope
@@ -35,7 +35,7 @@ extension [A, E, S](effect: A < (Abort[E] & Async & S))
         reduce: Reducible[Abort[E]],
         frame: Frame
     ): Fiber[A, reduce.SReduced & S2] < (Sync & S & Scope) =
-        Kyo.acquireRelease(Fiber.init(effect))(_.interrupt)
+        Kyo.acquireRelease(Fiber.initUnscoped(effect))(_.interrupt)
 
     /** Performs this computation and then the next one in parallel, discarding the result of this computation.
       *
@@ -52,8 +52,8 @@ extension [A, E, S](effect: A < (Abort[E] & Async & S))
         i2: Isolate[S2, Sync, S3]
     ): A1 < (Abort[E | E1] & Async & S & S2 & S3) =
         for
-            left  <- Fiber.init(using i1)(effect)
-            right <- Fiber.init(using i2)(next)
+            left  <- Fiber.initUnscoped(using i1)(effect)
+            right <- Fiber.initUnscoped(using i2)(next)
             _     <- left.await
             a1    <- right.join
         yield a1
@@ -73,8 +73,8 @@ extension [A, E, S](effect: A < (Abort[E] & Async & S))
         i2: Isolate[S2, Sync, S3]
     ): A < (Abort[E | E1] & Async & S & S2 & S3) =
         for
-            left  <- Fiber.init(using i1)(effect)
-            right <- Fiber.init(using i2)(next)
+            left  <- Fiber.initUnscoped(using i1)(effect)
+            right <- Fiber.initUnscoped(using i2)(next)
             a     <- left.join
             _     <- right.await
         yield a
@@ -95,8 +95,8 @@ extension [A, E, S](effect: A < (Abort[E] & Async & S))
         zippable: Zippable[A, A1]
     ): zippable.Out < (Abort[E | E1] & Async & S & S2 & S3) =
         for
-            left  <- Fiber.init(using i1)(effect)
-            right <- Fiber.init(using i2)(next)
+            left  <- Fiber.initUnscoped(using i1)(effect)
+            right <- Fiber.initUnscoped(using i2)(next)
             a     <- left.join
             a1    <- right.join
         yield zippable.zip(a, a1)

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -41,10 +41,10 @@ extension (kyoObject: Kyo.type)
         for
             promise <- Promise.init[A, Abort[E]]
             registerFn = (eff: A < (Abort[E] & Async)) =>
-                val effFiber = Fiber.init(eff)
+                val effFiber = Fiber.initUnscoped(eff)
                 val updatePromise =
                     effFiber.map(_.onComplete(a => promise.completeDiscard(a)))
-                val updatePromiseIO = Fiber.init(updatePromise).unit
+                val updatePromiseIO = Fiber.initUnscoped(updatePromise).unit
                 import AllowUnsafe.embrace.danger
                 Sync.Unsafe.evalOrThrow(updatePromiseIO)
             _ <- register(registerFn)

--- a/kyo-combinators/shared/src/test/scala/kyo/AsyncCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/AsyncCombinatorsTest.scala
@@ -1,6 +1,6 @@
 package kyo
 
-class FiberCombinatorsTest extends Test:
+class AsyncCombinatorsTest extends Test:
 
     "async" - {
         "construct" - {
@@ -10,11 +10,8 @@ class FiberCombinatorsTest extends Test:
                     val cont = Sync.defer { state = state + 1; state }
                     continuation(cont)
                 )
-                Fiber.initUnscoped(effect).map(_.toFuture).map { handledEffect =>
-                    handledEffect.map(v =>
-                        assert(state == 1)
-                        assert(v == 1)
-                    )
+                effect.map { v =>
+                    assert(state == 1 && v == 1)
                 }
             }
 
@@ -23,22 +20,18 @@ class FiberCombinatorsTest extends Test:
                 val effect = Kyo.async[Int, String]((continuation) =>
                     continuation(Abort.fail("failed"))
                 )
-                Fiber.initUnscoped(Abort.run(effect)).map(_.toFuture).map { handledEffect =>
-                    handledEffect.map:
-                        case Result.Success(value) => fail(s"Unexpectedly succeeded with value $value")
-                        case Result.Failure(err)   => assert(err == "failed")
-                        case Result.Panic(thr)     => fail(s"Unexpectedly panic with exception $thr")
-                }
+                Abort.run(effect).map:
+                    case Result.Success(value) => fail(s"Unexpectedly succeeded with value $value")
+                    case Result.Failure(err)   => assert(err == "failed")
+                    case Result.Panic(thr)     => fail(s"Unexpectedly panic with exception $thr")
             }
 
             "should construct from Future" in run {
                 val future = scala.concurrent.Future(100)
                 val effect = Kyo.fromFuture(future)
-                Fiber.initUnscoped(effect).map(_.toFuture).map { handledEffect =>
-                    handledEffect.map(v =>
-                        assert(v == 100)
-                    )
-                }
+                effect.map(v =>
+                    assert(v == 100)
+                )
             }
 
             "should construct from Promise" in run {
@@ -47,62 +40,45 @@ class FiberCombinatorsTest extends Test:
                 scala.concurrent.Future {
                     promise.complete(scala.util.Success(100))
                 }
-                Fiber.initUnscoped(effect).map(_.toFuture).map { handledEffect =>
-                    handledEffect.map(v => assert(v == 100))
-                }
+                effect.map(v => assert(v == 100))
             }
 
             "should construct from foreachPar" in run {
                 val effect = Kyo.foreachPar(Seq(1, 2, 3))(v => v * 2)
-                Fiber.initUnscoped(effect).map(_.toFuture).map { handledEffect =>
-                    handledEffect.map(v => assert(v == Seq(2, 4, 6)))
-                }
+                effect.map(v => assert(v == Seq(2, 4, 6)))
             }
 
             "should construct from collectAllPar" in run {
                 val effect = Kyo.collectAllPar(Seq(Sync.defer(1), Sync.defer(2), Sync.defer(3)))
-                Fiber.initUnscoped(effect).map(_.toFuture).map { handledEffect =>
-                    handledEffect.map(v => assert(v == Seq(1, 2, 3)))
-                }
+                effect.map(v => assert(v == Seq(1, 2, 3)))
             }
 
-            "should generate a fiber that doesn't complete using never" in run {
+            "should generate a fiber that doesn't complete using never" in runJVM {
                 val effect = Kyo.never
-                runJVM {
-                    Abort.run[Throwable] {
-                        val r = KyoApp.runAndBlock(5.millis)(effect)
-                        Abort.catching[Throwable](r)
-                    }.map { handledEffect =>
-                        assert(handledEffect match
-                            case Result.Failure(_: Timeout) => true
-                            case _                          => false)
-                    }
+                Abort.run[Throwable] {
+                    val r = KyoApp.runAndBlock(5.millis)(effect)
+                    Abort.catching[Throwable](r)
+                }.map { handledEffect =>
+                    assert(handledEffect match
+                        case Result.Failure(_: Timeout) => true
+                        case _                          => false)
                 }
             }
         }
 
-        "fork" - {
+        "forkUnscoped" - {
             "should fork a fibers effect" in run {
                 val effect       = Async.sleep(100.millis) *> 10
-                val forkedEffect = effect.fork
+                val forkedEffect = effect.forkUnscoped
                 val joinedEffect = forkedEffect.map(_.get)
-                Fiber.initUnscoped(joinedEffect).map(_.toFuture).map { handled =>
-                    handled.map(v => assert(v == 10))
-                }
+                joinedEffect.map(v => assert(v == 10))
             }
 
             "should join a forked effect" in run {
                 val effect       = Async.sleep(100.millis) *> 10
                 val forkedEffect = Fiber.initUnscoped(effect)
                 val joinedEffect = forkedEffect.join
-                Fiber.initUnscoped(joinedEffect).map(_.toFuture).map { handled =>
-                    handled.map(v => assert(v == 10))
-                }
-            }
-
-            "should construct from type and use" in {
-                val effect = Kyo.serviceWith[String](_.length)
-                assert(Env.run("value")(effect).eval == 5)
+                joinedEffect.map(v => assert(v == 10))
             }
         }
 
@@ -111,36 +87,30 @@ class FiberCombinatorsTest extends Test:
                 val e1     = Sync.defer(1)
                 val e2     = Sync.defer(2)
                 val effect = e1 &> e2
-                Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
-                    handled.map(v =>
-                        assert(v == 2)
-                    )
-                }
+                effect.map(v =>
+                    assert(v == 2)
+                )
             }
 
             "should zip left par" in run {
                 val e1     = Sync.defer(1)
                 val e2     = Sync.defer(2)
                 val effect = e1 <& e2
-                Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
-                    handled.map(v =>
-                        assert(v == 1)
-                    )
-                }
+                effect.map(v =>
+                    assert(v == 1)
+                )
             }
 
             "should zip par" in run {
                 val e1     = Sync.defer(1)
                 val e2     = Sync.defer(2)
                 val effect = e1 <&> e2
-                Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
-                    handled.map(v =>
-                        assert(v == (1, 2))
-                    )
-                }
+                effect.map(v =>
+                    assert(v == (1, 2))
+                )
             }
         }
-        "forkScoped" - {
+        "fork" - {
             "should fork a fiber and manage its lifecycle" in run {
                 var state = 0
                 val effect = Kyo.async[Int, Nothing]((continuation) =>
@@ -150,16 +120,13 @@ class FiberCombinatorsTest extends Test:
 
                 val program =
                     for
-                        fiber  <- effect.forkScoped
+                        fiber  <- effect.fork
                         result <- fiber.join
                     yield result
 
-                Fiber.initUnscoped(Scope.run(program)).map(_.toFuture).map { handledEffect =>
-                    handledEffect.map(v =>
-                        assert(state == 1)
-                        assert(v == 1)
-                    )
-                }
+                Scope.run(program).map(v =>
+                    assert(state == 1 && v == 1)
+                )
             }
 
             "should clean up resources when scope is closed" in run {
@@ -170,16 +137,13 @@ class FiberCombinatorsTest extends Test:
 
                 val program =
                     for
-                        fiber  <- effect.forkScoped
+                        fiber  <- effect.fork
                         _      <- Scope.acquireRelease(())(_ => cleanedUp = true)
                         result <- fiber.join
                     yield result
 
-                Fiber.initUnscoped(Scope.run(program)).map(_.toFuture).map { handledEffect =>
-                    handledEffect.map(v =>
-                        assert(v == 42)
-                        assert(cleanedUp)
-                    )
+                Scope.run(program).map { v =>
+                    assert(v == 42 && cleanedUp)
                 }
             }
         }
@@ -195,16 +159,14 @@ class FiberCombinatorsTest extends Test:
 
                 val program =
                     for
-                        fiber  <- effect.fork
+                        fiber  <- effect.forkUnscoped
                         result <- fiber.await
                     yield result
 
-                Fiber.initUnscoped(program).map(_.toFuture).map { handledEffect =>
-                    handledEffect.map(v =>
-                        assert(v == Result.succeed(42) && completed)
-                    )
+                program.map { v =>
+                    assert(v == Result.succeed(42) && completed)
                 }
             }
         }
     }
-end FiberCombinatorsTest
+end AsyncCombinatorsTest

--- a/kyo-combinators/shared/src/test/scala/kyo/KyoCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/KyoCombinatorsTest.scala
@@ -170,13 +170,13 @@ class KyoCombinatorsTest extends Test:
         "delay" - {
             "with short delay" in run {
                 val effect = Sync.defer(42).delay(1.millis)
-                Fiber.init(effect).map(_.toFuture).map { handled =>
+                Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
                     handled.map(v => assert(v == 42))
                 }
             }
             "with zero delay" in run {
                 val effect = Sync.defer("test").delay(0.millis)
-                Fiber.init(effect).map(_.toFuture).map { handled =>
+                Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
                     handled.map(v => assert(v == "test"))
                 }
             }
@@ -207,7 +207,7 @@ class KyoCombinatorsTest extends Test:
                     var count    = 0
                     val schedule = Schedule.repeat(3)
                     val effect   = Sync.defer { count += 1; count }.repeat(schedule)
-                    Fiber.init(effect).map(_.toFuture).map { handled =>
+                    Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
                         handled.map { v =>
                             assert(v == 4)
                             assert(count == 4)
@@ -221,7 +221,7 @@ class KyoCombinatorsTest extends Test:
                     var count   = 0
                     val backoff = (i: Int) => Math.pow(2, i).toLong.millis
                     val effect  = Sync.defer { count += 1; count }.repeatAtInterval(backoff, 3)
-                    Fiber.init(effect).map(_.toFuture).map { handled =>
+                    Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
                         handled.map { v =>
                             assert(v == 4)
                             assert(count == 4)
@@ -236,14 +236,14 @@ class KyoCombinatorsTest extends Test:
                 "condition becomes false" in run {
                     var count  = 0
                     val effect = Sync.defer { count += 1; count }.repeatWhile(_ < 3)
-                    Fiber.init(effect).map(_.toFuture).map { handled =>
+                    Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }
                 "condition is initially false" in run {
                     var count  = 5
                     val effect = Sync.defer { count += 1; count }.repeatWhile(_ < 3)
-                    Fiber.init(effect).map(_.toFuture).map { handled =>
+                    Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 6))
                     }
                 }
@@ -253,7 +253,7 @@ class KyoCombinatorsTest extends Test:
                 "condition becomes false with delay" in run {
                     var count  = 0
                     val effect = Sync.defer { count += 1; count }.repeatWhile((v, i) => (v < 3, 10.millis))
-                    Fiber.init(effect).map(_.toFuture).map { handled =>
+                    Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }
@@ -265,14 +265,14 @@ class KyoCombinatorsTest extends Test:
                 "condition becomes true" in run {
                     var count  = 0
                     val effect = Sync.defer { count += 1; count }.repeatUntil(_ == 3)
-                    Fiber.init(effect).map(_.toFuture).map { handled =>
+                    Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }
                 "condition is initially true" in run {
                     var count  = 0
                     val effect = Sync.defer { count += 1; count }.repeatUntil(_ => true)
-                    Fiber.init(effect).map(_.toFuture).map { handled =>
+                    Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 1))
                     }
                 }
@@ -282,7 +282,7 @@ class KyoCombinatorsTest extends Test:
                 "condition becomes true with delay" in run {
                     var count  = 0
                     val effect = Sync.defer { count += 1; count }.repeatUntil((v, i) => (v == 3, 10.millis))
-                    Fiber.init(effect).map(_.toFuture).map { handled =>
+                    Fiber.initUnscoped(effect).map(_.toFuture).map { handled =>
                         handled.map(v => assert(v == 3))
                     }
                 }

--- a/kyo-combinators/shared/src/test/scala/kyo/ScopeCombinatorsTest.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/ScopeCombinatorsTest.scala
@@ -20,7 +20,7 @@ class ScopeCombinatorsTest extends Test:
                 yield result
             assert(state == 0)
             val handledResources: Int < Async = Scope.run(effect)
-            Fiber.init(handledResources).map(_.toFuture).map { handled =>
+            Fiber.initUnscoped(handledResources).map(_.toFuture).map { handled =>
                 for
                     assertion1 <- handled.map(_ == 50)
                     assertion2 <- Future(assert(state == 0))
@@ -32,7 +32,7 @@ class ScopeCombinatorsTest extends Test:
         "should construct a resource using addFinalizer" in run {
             var state  = 0
             val effect = Kyo.addFinalizer(Sync.defer { state = 100 })
-            Fiber.init(Scope.run(effect)).map(_.toFuture).map { handled =>
+            Fiber.initUnscoped(Scope.run(effect)).map(_.toFuture).map { handled =>
                 for
                     ass1 <- handled
                     ass2 <- Future(assert(state == 100))
@@ -47,7 +47,7 @@ class ScopeCombinatorsTest extends Test:
                 override def close(): Unit = state = 100
             val effect = Kyo.fromAutoCloseable(closeable)
             assert(state == 0)
-            Fiber.init(Scope.run(effect)).map(_.toFuture).map { handled =>
+            Fiber.initUnscoped(Scope.run(effect)).map(_.toFuture).map { handled =>
                 for
                     ass2 <- handled.map(v => assert(v.equals(closeable)))
                     ass3 <- Future(assert(state == 100))

--- a/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -13,7 +13,7 @@ abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Scope & Abort[
 
         initCode = Chunk(() =>
             val raced = Async.raceFirst(Clock.repeatWithDelay(1.hour)(()).map(_.get), last)
-            val _     = Sync.Unsafe.evalOrThrow(Fiber.init(raced))
+            val _     = Sync.Unsafe.evalOrThrow(Fiber.initUnscoped(raced))
         )
     end run
 

--- a/kyo-core/jvm/src/main/scala/kyo/Process.scala
+++ b/kyo-core/jvm/src/main/scala/kyo/Process.scala
@@ -194,7 +194,7 @@ object Process:
                                 ()
                             }
                             for
-                                _ <- Fiber.init(Scope.run(resources))
+                                _ <- Fiber.initUnscoped(Scope.run(resources))
                             yield ()
                         case _ => Kyo.unit
                 yield process

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -120,7 +120,7 @@ object Async extends AsyncPlatformSpecific:
         using frame: Frame
     ): A < (Abort[E] & Async & S) =
         isolate.capture { state =>
-            Fiber.init(isolate.isolate(state, v)).map(_.mask.map(fiber => isolate.restore(fiber.get)))
+            Fiber.initUnscoped(isolate.isolate(state, v)).map(_.mask.map(fiber => isolate.restore(fiber.get)))
         }
 
     /** Creates a computation that never completes.
@@ -166,7 +166,7 @@ object Async extends AsyncPlatformSpecific:
         if !after.isFinite then v
         else
             isolate.capture { state =>
-                Fiber.init(isolate.isolate(state, v)).map { task =>
+                Fiber.initUnscoped(isolate.isolate(state, v)).map { task =>
                     Clock.use { clock =>
                         Sync.Unsafe {
                             val sleepFiber = clock.unsafe.sleep(after)

--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -537,7 +537,7 @@ object Clock:
         frame: Frame,
         reduce: Reducible[Abort[E]]
     ): Fiber[A, reduce.SReduced] < (Sync & S) =
-        Fiber.init {
+        Fiber.initUnscoped {
             Clock.use { clock =>
                 Loop(state, delaySchedule) { (state, schedule) =>
                     clock.now.map { now =>
@@ -677,7 +677,7 @@ object Clock:
         frame: Frame,
         reduce: Reducible[Abort[E]]
     ): Fiber[A, reduce.SReduced] < (Sync & S) =
-        Fiber.init {
+        Fiber.initUnscoped {
             Clock.use { clock =>
                 clock.now.map { now =>
                     Loop(now, state, intervalSchedule) { (lastExecution, state, period) =>

--- a/kyo-core/shared/src/main/scala/kyo/Hub.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Hub.scala
@@ -238,7 +238,7 @@ object Hub:
             val channel          = Channel.Unsafe.init[A](capacity, Access.MultiProducerSingleConsumer).safe
             val listeners        = new CopyOnWriteArraySet[Listener[A]]
             def currentListeners = Chunk.fromNoCopy(listeners.toArray()).asInstanceOf[Chunk[Listener[A]]]
-            Fiber.init {
+            Fiber.initUnscoped {
                 Loop.foreach {
                     channel.take.map { value =>
                         Abort.recover { error =>

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -51,7 +51,7 @@ object KyoApp:
     )(timeout: Duration)(v: => A < (Abort[E] & Async & S))(
         using frame: Frame
     ): A < (Abort[E | Timeout] & Sync & S) =
-        Fiber.init(v).map { fiber =>
+        Fiber.initUnscoped(v).map { fiber =>
             fiber.block(timeout).map(Abort.get(_))
         }
 

--- a/kyo-core/shared/src/main/scala/kyo/Scope.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Scope.scala
@@ -189,7 +189,7 @@ object Scope:
                                                 Abort.run[Throwable](task(ex))
                                                     .map(_.foldError(_ => (), ex => Log.error("Scope finalizer failed", ex.exception)))
                                             }
-                                                .handle(Fiber.init[Nothing, Unit, Any, Any])
+                                                .handle(Fiber.initUnscoped[Nothing, Unit, Any, Any])
                                                 .map(promise.becomeDiscard)
                             }
 

--- a/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
@@ -13,7 +13,7 @@ private[kyo] trait BaseKyoCoreTest extends BaseKyoKernelTest[Abort[Any] & Async 
                 case e             => throw new IllegalStateException(s"Test aborted with $e")
             },
             Async.timeout(timeout),
-            Fiber.init,
+            Fiber.initUnscoped,
             _.map(_.toFuture).map(_.flatten),
             Sync.Unsafe.evalOrThrow
         )

--- a/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/BarrierTest.scala
@@ -32,7 +32,7 @@ class BarrierTest extends Test:
     "await + fibers" in run {
         for
             barrier <- Barrier.init(1)
-            _       <- Fiber.init(barrier.await)
+            _       <- Fiber.initUnscoped(barrier.await)
             _       <- barrier.await
         yield succeed
     }

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -87,10 +87,10 @@ class ChannelTest extends Test:
         for
             c     <- Channel.init[Int](2)
             b     <- c.offer(1)
-            put   <- Fiber.init(c.put(2))
+            put   <- Fiber.initUnscoped(c.put(2))
             _     <- untilTrue(c.full)
-            take1 <- Fiber.init(c.take)
-            take2 <- Fiber.init(c.take)
+            take1 <- Fiber.initUnscoped(c.take)
+            take2 <- Fiber.initUnscoped(c.take)
             v1    <- take1.get
             _     <- put.get
             v2    <- take1.get
@@ -102,7 +102,7 @@ class ChannelTest extends Test:
             c  <- Channel.init[Int](2)
             _  <- c.put(1)
             _  <- c.put(2)
-            f  <- Fiber.init(c.put(3))
+            f  <- Fiber.initUnscoped(c.put(3))
             _  <- Async.sleep(10.millis)
             d1 <- f.done
             v1 <- c.poll
@@ -114,7 +114,7 @@ class ChannelTest extends Test:
     "blocking take" in run {
         for
             c  <- Channel.init[Int](2)
-            f  <- Fiber.init(c.take)
+            f  <- Fiber.initUnscoped(c.take)
             _  <- Async.sleep(10.millis)
             d1 <- f.done
             _  <- c.put(1)
@@ -134,7 +134,7 @@ class ChannelTest extends Test:
             "should put batch incrementally if exceeds channel size" in run {
                 for
                     c   <- Channel.init[Int](2)
-                    f   <- Fiber.init(c.putBatch(Chunk(1, 2, 3, 4, 5, 6)))
+                    f   <- Fiber.initUnscoped(c.putBatch(Chunk(1, 2, 3, 4, 5, 6)))
                     res <- c.takeExactly(6)
                     _   <- Fiber.get(f)
                 yield assert(res == Chunk(1, 2, 3, 4, 5, 6))
@@ -160,8 +160,8 @@ class ChannelTest extends Test:
             "should notify waiting takers immediately" in run {
                 for
                     c     <- Channel.init[Int](2)
-                    take1 <- Fiber.init(c.take)
-                    take2 <- Fiber.init(c.take)
+                    take1 <- Fiber.initUnscoped(c.take)
+                    take2 <- Fiber.initUnscoped(c.take)
                     _     <- c.putBatch(Seq(1, 2))
                     v1    <- take1.get
                     v2    <- take2.get
@@ -172,11 +172,11 @@ class ChannelTest extends Test:
                     c     <- Channel.init[Int](2)
                     _     <- c.put(1)
                     _     <- c.put(2)
-                    take1 <- Fiber.init(c.take)
-                    fiber <- Fiber.init(c.putBatch(Seq(3, 4)))
+                    take1 <- Fiber.initUnscoped(c.take)
+                    fiber <- Fiber.initUnscoped(c.putBatch(Seq(3, 4)))
                     v1    <- take1.get
                     done1 <- fiber.done
-                    take2 <- Fiber.init(c.take)
+                    take2 <- Fiber.initUnscoped(c.take)
                     v2    <- take2.get
                     _     <- fiber.get
                 yield assert(v1 == 1 && v2 == 2 && !done1)
@@ -199,7 +199,7 @@ class ChannelTest extends Test:
             "should preserve elements put before closure during partial batch put" in run {
                 for
                     c     <- Channel.init[Int](2)
-                    fiber <- Fiber.init(c.putBatch(Chunk(1, 2, 3, 4, 5)))
+                    fiber <- Fiber.initUnscoped(c.putBatch(Chunk(1, 2, 3, 4, 5)))
                     v1    <- c.take
                     v2    <- c.take
                     _     <- c.close
@@ -219,7 +219,7 @@ class ChannelTest extends Test:
             "should put batch incrementally if exceeds channel size" in run {
                 for
                     c   <- Channel.init[Any](2)
-                    f   <- Fiber.init(c.putBatch(Chunk(Chunk(1), Chunk(2), Chunk(3), Chunk(4), Chunk(5), Chunk(6))))
+                    f   <- Fiber.initUnscoped(c.putBatch(Chunk(Chunk(1), Chunk(2), Chunk(3), Chunk(4), Chunk(5), Chunk(6))))
                     res <- c.takeExactly(6)
                     _   <- Fiber.get(f)
                 yield assert(res == Chunk(Chunk(1), Chunk(2), Chunk(3), Chunk(4), Chunk(5), Chunk(6)))
@@ -254,7 +254,7 @@ class ChannelTest extends Test:
             "should put batch incrementally if exceeds channel size" in run {
                 for
                     c <- Channel.init[Chunk.Indexed[Int]](2)
-                    f <- Fiber.init(c.putBatch(Chunk(
+                    f <- Fiber.initUnscoped(c.putBatch(Chunk(
                         Chunk(1).toIndexed,
                         Chunk(2).toIndexed,
                         Chunk(3).toIndexed,
@@ -308,7 +308,7 @@ class ChannelTest extends Test:
             for
                 c  <- Channel.init[Int](3)
                 _  <- Kyo.foreach(1 to 3)(c.put(_))
-                f  <- Fiber.init(c.takeExactly(5))
+                f  <- Fiber.initUnscoped(c.takeExactly(5))
                 _  <- untilTrue(c.size.map(_ == 0))
                 fd <- f.done
                 _  <- f.interrupt
@@ -326,7 +326,7 @@ class ChannelTest extends Test:
             for
                 c  <- Channel.init[Int](3)
                 _  <- Kyo.foreach(1 to 3)(c.put(_))
-                f  <- Fiber.init(c.takeExactly(6))
+                f  <- Fiber.initUnscoped(c.takeExactly(6))
                 _  <- untilTrue(c.empty)
                 fd <- f.done
                 _  <- Kyo.foreach(4 to 6)(c.put(_))
@@ -353,9 +353,9 @@ class ChannelTest extends Test:
         "should consider pending puts" in run {
             for
                 c         <- Channel.init[Int](2)
-                _         <- Fiber.init(c.put(1))
-                _         <- Fiber.init(c.put(2))
-                _         <- Fiber.init(c.put(3))
+                _         <- Fiber.initUnscoped(c.put(1))
+                _         <- Fiber.initUnscoped(c.put(2))
+                _         <- Fiber.initUnscoped(c.put(3))
                 _         <- untilTrue(c.pendingPuts.map(_ == 1))
                 result    <- c.drain
                 finalSize <- c.size
@@ -365,9 +365,9 @@ class ChannelTest extends Test:
         "should consider pending puts - zero capacity" in run {
             for
                 c         <- Channel.init[Int](0)
-                _         <- Fiber.init(c.put(1))
-                _         <- Fiber.init(c.put(2))
-                _         <- Fiber.init(c.put(3))
+                _         <- Fiber.initUnscoped(c.put(1))
+                _         <- Fiber.initUnscoped(c.put(2))
+                _         <- Fiber.initUnscoped(c.put(3))
                 _         <- untilTrue(c.pendingPuts.map(_ == 3))
                 result    <- c.drain
                 finalSize <- c.size
@@ -429,10 +429,10 @@ class ChannelTest extends Test:
         "should consider pending puts" in run {
             for
                 c         <- Channel.init[Int](2)
-                _         <- Fiber.init(c.put(1))
-                _         <- Fiber.init(c.put(2))
-                _         <- Fiber.init(c.put(3))
-                _         <- Fiber.init(c.put(4))
+                _         <- Fiber.initUnscoped(c.put(1))
+                _         <- Fiber.initUnscoped(c.put(2))
+                _         <- Fiber.initUnscoped(c.put(3))
+                _         <- Fiber.initUnscoped(c.put(4))
                 _         <- untilTrue(c.pendingPuts.map(_ == 2))
                 result    <- c.drainUpTo(3)
                 finalSize <- c.size
@@ -441,10 +441,10 @@ class ChannelTest extends Test:
         "should consider pending puts - zero capacity" in run {
             for
                 c         <- Channel.init[Int](0)
-                _         <- Fiber.init(c.put(1))
-                _         <- Fiber.init(c.put(2))
-                _         <- Fiber.init(c.put(3))
-                _         <- Fiber.init(c.put(4))
+                _         <- Fiber.initUnscoped(c.put(1))
+                _         <- Fiber.initUnscoped(c.put(2))
+                _         <- Fiber.initUnscoped(c.put(3))
+                _         <- Fiber.initUnscoped(c.put(4))
                 _         <- untilTrue(c.pendingPuts.map(_ == 4))
                 result    <- c.drainUpTo(3)
                 finalSize <- c.size
@@ -480,7 +480,7 @@ class ChannelTest extends Test:
         "pending take" in run {
             for
                 c <- Channel.init[Int](2)
-                f <- Fiber.init(c.take)
+                f <- Fiber.initUnscoped(c.take)
                 r <- c.close
                 d <- f.getResult
                 t <- Abort.run(c.full)
@@ -491,7 +491,7 @@ class ChannelTest extends Test:
                 c <- Channel.init[Int](2)
                 _ <- c.put(1)
                 _ <- c.put(2)
-                f <- Fiber.init(c.put(3))
+                f <- Fiber.initUnscoped(c.put(3))
                 r <- c.close
                 d <- f.getResult
                 e <- Abort.run(c.offer(1))
@@ -500,7 +500,7 @@ class ChannelTest extends Test:
         "no buffer w/ pending put" in run {
             for
                 c <- Channel.init[Int](0)
-                f <- Fiber.init(c.put(1))
+                f <- Fiber.initUnscoped(c.put(1))
                 r <- c.close
                 d <- f.getResult
                 t <- Abort.run(c.poll)
@@ -509,7 +509,7 @@ class ChannelTest extends Test:
         "no buffer w/ pending take" in run {
             for
                 c <- Channel.init[Int](0)
-                f <- Fiber.init(c.take)
+                f <- Fiber.initUnscoped(c.take)
                 r <- c.close
                 d <- f.getResult
                 t <- Abort.run[Throwable](c.put(1))
@@ -519,7 +519,7 @@ class ChannelTest extends Test:
     "no buffer" in run {
         for
             c <- Channel.init[Int](0)
-            _ <- Fiber.init(c.put(1))
+            _ <- Fiber.initUnscoped(c.put(1))
             v <- c.take
             f <- c.full
             e <- c.empty
@@ -529,8 +529,8 @@ class ChannelTest extends Test:
         "with buffer" in run {
             for
                 c  <- Channel.init[Int](10)
-                f1 <- Fiber.init(Async.fill(1000, 1000)(c.put(1)))
-                f2 <- Fiber.init(Async.fill(1000, 1000)(c.take))
+                f1 <- Fiber.initUnscoped(Async.fill(1000, 1000)(c.put(1)))
+                f2 <- Fiber.initUnscoped(Async.fill(1000, 1000)(c.take))
                 _  <- f1.get
                 _  <- f2.get
                 b  <- c.empty
@@ -540,8 +540,8 @@ class ChannelTest extends Test:
         "no buffer" in run {
             for
                 c  <- Channel.init[Int](0)
-                f1 <- Fiber.init(Async.fill(1000, 1000)(c.put(1)))
-                f2 <- Fiber.init(Async.fill(1000, 1000)(c.take))
+                f1 <- Fiber.initUnscoped(Async.fill(1000, 1000)(c.put(1)))
+                f2 <- Fiber.initUnscoped(Async.fill(1000, 1000)(c.take))
                 _  <- f1.get
                 _  <- f2.get
                 b  <- c.empty
@@ -585,10 +585,10 @@ class ChannelTest extends Test:
                 size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
-                offerFiber <- Fiber.init(
+                offerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(channel.offer(i))))
                 )
-                closeFiber    <- Fiber.init(latch.await.andThen(channel.close))
+                closeFiber    <- Fiber.initUnscoped(latch.await.andThen(channel.close))
                 _             <- latch.release
                 offered       <- offerFiber.get
                 backlog       <- closeFiber.get
@@ -615,10 +615,10 @@ class ChannelTest extends Test:
                 size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
-                offerFiber <- Fiber.init(
+                offerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(channel.offer(i))))
                 )
-                pollFiber <- Fiber.init(
+                pollFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(100, 100)(Abort.run(channel.poll)))
                 )
                 _           <- latch.release
@@ -635,10 +635,10 @@ class ChannelTest extends Test:
                 size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
-                putFiber <- Fiber.init(
+                putFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(channel.put(i))))
                 )
-                takeFiber <- Fiber.init(
+                takeFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(100, 100)(Abort.run(channel.take)))
                 )
                 _     <- latch.release
@@ -655,10 +655,10 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 _       <- Kyo.foreach(1 to size)(i => channel.offer(i))
                 latch   <- Latch.init(1)
-                offerFiber <- Fiber.init(
+                offerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(channel.offer(i))))
                 )
-                closeFiber <- Fiber.init(latch.await.andThen(channel.close))
+                closeFiber <- Fiber.initUnscoped(latch.await.andThen(channel.close))
                 _          <- latch.release
                 offered    <- offerFiber.get
                 backlog    <- closeFiber.get
@@ -681,10 +681,10 @@ class ChannelTest extends Test:
                 size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
-                offerFiber <- Fiber.init(
+                offerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(channel.offer(i))))
                 )
-                closeFiber <- Fiber.init(
+                closeFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(100, 100)(channel.close))
                 )
                 _        <- latch.release
@@ -709,19 +709,19 @@ class ChannelTest extends Test:
                 size    <- Choice.eval(0, 1, 2, 10, 100)
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
-                offerFiber <- Fiber.init(
+                offerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 50, 50)(i => Abort.run(channel.offer(i))))
                 )
-                pollFiber <- Fiber.init(
+                pollFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(50, 50)(Abort.run(channel.poll)))
                 )
-                putFiber <- Fiber.init(
+                putFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(51 to 100, 50)(i => Abort.run(channel.put(i))))
                 )
-                takeFiber <- Fiber.init(
+                takeFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(50, 50)(Abort.run(channel.take)))
                 )
-                closeFiber <- Fiber.init(latch.await.andThen(channel.close))
+                closeFiber <- Fiber.initUnscoped(latch.await.andThen(channel.close))
                 _          <- latch.release
                 offered    <- offerFiber.get
                 polled     <- pollFiber.get
@@ -750,12 +750,12 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
-                putFiber <- Fiber.init(
+                putFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach((1 to 60).grouped(3).toSeq, 60)(batch =>
                         channel.putBatch(batch).andThen(batch)
                     ))
                 )
-                takeFiber <- Fiber.init(
+                takeFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(60, 60)(channel.take))
                 )
                 _         <- latch.release
@@ -773,12 +773,12 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
-                putFiber <- Fiber.init(
+                putFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach((1 to 60).grouped(3).toSeq, 60)(batch =>
                         channel.putBatch(batch).andThen(batch)
                     ))
                 )
-                takeFiber <- Fiber.init(
+                takeFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(6, 6)(
                         channel.takeExactly(10)
                     ))
@@ -848,7 +848,7 @@ class ChannelTest extends Test:
         "should stream concurrently with ingest, without specified chunk size" in run {
             for
                 c  <- Channel.init[Int](4)
-                bg <- Fiber.init(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
+                bg <- Fiber.initUnscoped(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
                 stream = c.stream().take(20).mapChunk(ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
@@ -858,7 +858,7 @@ class ChannelTest extends Test:
         "should stream concurrently with ingest, never exceeding specified chunk size" in run {
             for
                 c  <- Channel.init[Int](4)
-                bg <- Fiber.init(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
+                bg <- Fiber.initUnscoped(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
                 stream = c.stream(2).take(20).mapChunk(ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
@@ -868,7 +868,7 @@ class ChannelTest extends Test:
         "should fail when channel is closed" in run {
             for
                 c  <- Channel.init[Int](3)
-                bg <- Fiber.init(Kyo.foreach(0 to 8)(c.put).andThen(c.close))
+                bg <- Fiber.initUnscoped(Kyo.foreach(0 to 8)(c.put).andThen(c.close))
                 stream = c.stream().mapChunk(ch => Chunk(ch))
                 v <- Abort.run(stream.run)
             yield v match
@@ -880,7 +880,7 @@ class ChannelTest extends Test:
         "should stream concurrently with ingest via putBatch, yielding consistent chunk sizes" in run {
             for
                 c  <- Channel.init[Int](9)
-                bg <- Fiber.init(Loop(0)(i => c.putBatch(Chunk(i, i + 1, i + 2)).andThen(Loop.continue(i + 3))))
+                bg <- Fiber.initUnscoped(Loop(0)(i => c.putBatch(Chunk(i, i + 1, i + 2)).andThen(Loop.continue(i + 3))))
                 stream = c.stream(3).take(15).mapChunk(ch => Chunk(ch))
                 res <- stream.run
                 _   <- bg.interrupt
@@ -945,7 +945,7 @@ class ChannelTest extends Test:
         "should stream concurrently with ingest, without specified chunk size" in run {
             for
                 c  <- Channel.init[Int](4)
-                bg <- Fiber.init(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
+                bg <- Fiber.initUnscoped(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
                 stream = c.streamUntilClosed().take(20).mapChunk(ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
@@ -955,7 +955,7 @@ class ChannelTest extends Test:
         "should stream concurrently with ingest, with specified chunk size" in run {
             for
                 c  <- Channel.init[Int](4)
-                bg <- Fiber.init(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
+                bg <- Fiber.initUnscoped(Loop(0)(i => c.put(i).andThen(Loop.continue(i + 1))))
                 stream = c.streamUntilClosed(2).take(20).mapChunk(ch => Chunk(ch))
                 v <- stream.run
                 _ <- bg.interrupt
@@ -967,7 +967,7 @@ class ChannelTest extends Test:
             for
                 c <- Channel.init[Int](3)
                 stream = c.streamUntilClosed()
-                f <- Fiber.init(stream.run)
+                f <- Fiber.initUnscoped(stream.run)
                 _ <- Kyo.foreach(fullStream)(c.put).andThen(c.close)
                 r <- Fiber.get(f)
             yield assert(r.size <= fullStream.size && r == fullStream.take(r.size))
@@ -979,9 +979,9 @@ class ChannelTest extends Test:
             for
                 c <- Channel.init[Int](3)
                 stream = c.streamUntilClosed()
-                f <- Fiber.init(stream.run)
+                f <- Fiber.initUnscoped(stream.run)
                 _ <- Kyo.foreach(fullStream)(c.put).andThen(c.close)
-                _ <- Fiber.init(c.closeAwaitEmpty)
+                _ <- Fiber.initUnscoped(c.closeAwaitEmpty)
                 r <- Fiber.get(f)
             yield assert(r.size <= fullStream.size && r == fullStream.take(r.size))
             end for
@@ -1001,7 +1001,7 @@ class ChannelTest extends Test:
                 c       <- Channel.init[Int](10)
                 _       <- c.put(1)
                 _       <- c.put(2)
-                fiber   <- Fiber.init(c.closeAwaitEmpty)
+                fiber   <- Fiber.initUnscoped(c.closeAwaitEmpty)
                 closed1 <- c.closed
                 _       <- c.take
                 closed2 <- c.closed
@@ -1023,7 +1023,7 @@ class ChannelTest extends Test:
             for
                 c      <- Channel.init[Int](10)
                 _      <- Kyo.foreach(1 to 5)(i => c.put(i))
-                fiber  <- Fiber.init(c.closeAwaitEmpty)
+                fiber  <- Fiber.initUnscoped(c.closeAwaitEmpty)
                 _      <- Async.foreach(1 to 5)(_ => c.take)
                 result <- fiber.get
             yield assert(result)
@@ -1041,7 +1041,7 @@ class ChannelTest extends Test:
                 c      <- Channel.init[Int](2)
                 _      <- c.put(1)
                 _      <- c.put(2)
-                fiber  <- Fiber.init(c.closeAwaitEmpty)
+                fiber  <- Fiber.initUnscoped(c.closeAwaitEmpty)
                 _      <- c.take
                 _      <- c.take
                 take   <- Abort.run(c.take)
@@ -1054,7 +1054,7 @@ class ChannelTest extends Test:
                 c      <- Channel.init[Int](10)
                 _      <- c.put(1)
                 _      <- c.put(2)
-                fiber  <- Fiber.init(Async.fill(10)(c.closeAwaitEmpty))
+                fiber  <- Fiber.initUnscoped(Async.fill(10)(c.closeAwaitEmpty))
                 _      <- c.take
                 _      <- c.take
                 closes <- fiber.get
@@ -1067,10 +1067,10 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 _       <- Kyo.foreach(1 to (size min 5))(i => channel.put(i))
                 latch   <- Latch.init(1)
-                closeAwaitEmptyFiber <- Fiber.init(
+                closeAwaitEmptyFiber <- Fiber.initUnscoped(
                     latch.await.andThen(channel.closeAwaitEmpty)
                 )
-                closeFiber <- Fiber.init(
+                closeFiber <- Fiber.initUnscoped(
                     latch.await.andThen(channel.close)
                 )
                 _        <- latch.release
@@ -1092,20 +1092,20 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
-                producerFiber1 <- Fiber.init(
+                producerFiber1 <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.foreach(1 to 25, 10)(i => Abort.run(channel.put(i)))
                             .andThen(channel.closeAwaitEmpty)
                     )
                 )
-                producerFiber2 <- Fiber.init(
+                producerFiber2 <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.foreach(26 to 50, 10)(i => Abort.run(channel.put(i)))
                             .andThen(channel.closeAwaitEmpty)
                     )
                 )
 
-                consumerFiber <- Fiber.init(
+                consumerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.fill(100, 10)(Abort.run(channel.take))
                     )
@@ -1132,20 +1132,20 @@ class ChannelTest extends Test:
                 channel <- Channel.init[Int](size)
                 latch   <- Latch.init(1)
 
-                producerFiber1 <- Fiber.init(
+                producerFiber1 <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.foreach(1 to 25, 10)(i => Abort.run(channel.put(i)))
                             .andThen(channel.closeAwaitEmpty)
                     )
                 )
-                producerFiber2 <- Fiber.init(
+                producerFiber2 <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.foreach(26 to 50, 10)(i => Abort.run(channel.put(i)))
                             .andThen(channel.close)
                     )
                 )
 
-                consumerFiber <- Fiber.init(
+                consumerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.fill(100, 10)(Abort.run(channel.take))
                     )
@@ -1180,8 +1180,8 @@ class ChannelTest extends Test:
                 c     <- Channel.init[Int](2)
                 _     <- c.put(1)
                 _     <- c.put(2)
-                f1    <- Fiber.init(c.put(3))
-                f2    <- Fiber.init(c.put(4))
+                f1    <- Fiber.initUnscoped(c.put(3))
+                f2    <- Fiber.initUnscoped(c.put(4))
                 _     <- Async.sleep(10.millis)
                 puts  <- c.pendingPuts
                 takes <- c.pendingTakes
@@ -1195,8 +1195,8 @@ class ChannelTest extends Test:
         "should count pending takes when channel is empty" in run {
             for
                 c     <- Channel.init[Int](2)
-                f1    <- Fiber.init(c.take)
-                f2    <- Fiber.init(c.take)
+                f1    <- Fiber.initUnscoped(c.take)
+                f2    <- Fiber.initUnscoped(c.take)
                 _     <- Async.sleep(10.millis)
                 puts  <- c.pendingPuts
                 takes <- c.pendingTakes
@@ -1227,7 +1227,7 @@ class ChannelTest extends Test:
             ref <- AtomicRef.init(c0)
             // Create a fiber that repeatedly puts and item and then checks to see if the channel
             // has been drained. If it has then it closes the channel and creates a new one.
-            producer <- Fiber.init {
+            producer <- Fiber.initUnscoped {
                 Loop.foreach:
                     for
                         c     <- ref.get

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -490,7 +490,7 @@ class FiberTest extends Test:
 
         "timeout" in runNotJS {
             for
-                fiber  <- Fiber.init(Async.sleep(1.second).andThen(42))
+                fiber  <- Fiber.initUnscoped(Async.sleep(1.second).andThen(42))
                 result <- fiber.block(1.millis)
             yield assert(result.isFailure)
         }
@@ -503,7 +503,7 @@ class FiberTest extends Test:
             stop   <- Latch.init(1)
             result <- AtomicInt.init(0)
             fiber <-
-                Fiber.init {
+                Fiber.initUnscoped {
                     for
                         _ <- start.release
                         _ <- run.await

--- a/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/LatchTest.scala
@@ -41,7 +41,7 @@ class LatchTest extends Test:
     "countDown + fibers + await" in run {
         for
             latch <- Latch.init(1)
-            _     <- Fiber.init(latch.release)
+            _     <- Fiber.initUnscoped(latch.release)
             _     <- latch.await
         yield succeed
     }

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -354,10 +354,10 @@ class QueueTest extends Test:
                 size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
-                offerFiber <- Fiber.init(
+                offerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(queue.offer(i))))
                 )
-                closeFiber  <- Fiber.init(latch.await.andThen(queue.close))
+                closeFiber  <- Fiber.initUnscoped(latch.await.andThen(queue.close))
                 _           <- latch.release
                 offered     <- offerFiber.get
                 backlog     <- closeFiber.get
@@ -380,10 +380,10 @@ class QueueTest extends Test:
                 size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
-                offerFiber <- Fiber.init(
+                offerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(queue.offer(i))))
                 )
-                pollFiber <- Fiber.init(
+                pollFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(100, 100)(Abort.run(queue.poll)))
                 )
                 _       <- latch.release
@@ -401,10 +401,10 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 _     <- Kyo.foreach(1 to size)(i => queue.offer(i))
                 latch <- Latch.init(1)
-                offerFiber <- Fiber.init(
+                offerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 100)(i => Abort.run(queue.offer(i))))
                 )
-                closeFiber <- Fiber.init(latch.await.andThen(queue.close))
+                closeFiber <- Fiber.initUnscoped(latch.await.andThen(queue.close))
                 _          <- latch.release
                 offered    <- offerFiber.get
                 backlog    <- closeFiber.get
@@ -423,10 +423,10 @@ class QueueTest extends Test:
                 size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
-                offerFiber <- Fiber.init(
+                offerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(queue.offer(i))))
                 )
-                closeFiber <- Fiber.init(
+                closeFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(100, 100)(queue.close))
                 )
                 _        <- latch.release
@@ -447,13 +447,13 @@ class QueueTest extends Test:
                 size  <- Choice.eval(0, 1, 2, 10, 100)
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
-                offerFiber <- Fiber.init(
+                offerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.foreach(1 to 100, 100)(i => Abort.run(queue.offer(i))))
                 )
-                pollFiber <- Fiber.init(
+                pollFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(100, 100)(Abort.run(queue.poll)))
                 )
-                closeFiber <- Fiber.init(latch.await.andThen(queue.close))
+                closeFiber <- Fiber.initUnscoped(latch.await.andThen(queue.close))
                 _          <- latch.release
                 offered    <- offerFiber.get
                 polled     <- pollFiber.get
@@ -556,7 +556,7 @@ class QueueTest extends Test:
                 q  <- Queue.init[Int](2)
                 _  <- q.offer(1)
                 _  <- q.offer(1)
-                f1 <- Fiber.init(q.closeAwaitEmpty)
+                f1 <- Fiber.initUnscoped(q.closeAwaitEmpty)
                 v1 <- Abort.run(q.size)
                 v2 <- Abort.run(q.empty)
                 v3 <- Abort.run(q.full)
@@ -591,7 +591,7 @@ class QueueTest extends Test:
                 queue  <- Queue.init[Int](10)
                 _      <- queue.offer(1)
                 _      <- queue.offer(2)
-                fiber  <- Fiber.init(queue.closeAwaitEmpty)
+                fiber  <- Fiber.initUnscoped(queue.closeAwaitEmpty)
                 _      <- queue.poll
                 _      <- queue.poll
                 result <- fiber.get
@@ -619,7 +619,7 @@ class QueueTest extends Test:
                     queue  <- Queue.Unbounded.init[Int]()
                     _      <- queue.add(1)
                     _      <- queue.add(2)
-                    fiber  <- Fiber.init(queue.closeAwaitEmpty)
+                    fiber  <- Fiber.initUnscoped(queue.closeAwaitEmpty)
                     _      <- queue.poll
                     _      <- queue.poll
                     result <- fiber.get
@@ -631,7 +631,7 @@ class QueueTest extends Test:
             for
                 queue  <- Queue.init[Int](10)
                 _      <- Kyo.foreach(1 to 5)(i => queue.offer(i))
-                fiber  <- Fiber.init(queue.closeAwaitEmpty)
+                fiber  <- Fiber.initUnscoped(queue.closeAwaitEmpty)
                 _      <- Async.foreach(1 to 5)(_ => queue.poll)
                 result <- fiber.get
             yield assert(result)
@@ -642,7 +642,7 @@ class QueueTest extends Test:
                 queue  <- Queue.Unbounded.initSliding[Int](2)
                 _      <- queue.add(1)
                 _      <- queue.add(2)
-                fiber  <- Fiber.init(queue.closeAwaitEmpty)
+                fiber  <- Fiber.initUnscoped(queue.closeAwaitEmpty)
                 _      <- queue.poll
                 _      <- queue.poll
                 result <- fiber.get
@@ -654,7 +654,7 @@ class QueueTest extends Test:
                 queue  <- Queue.Unbounded.initDropping[Int](2)
                 _      <- queue.add(1)
                 _      <- queue.add(2)
-                fiber  <- Fiber.init(queue.closeAwaitEmpty)
+                fiber  <- Fiber.initUnscoped(queue.closeAwaitEmpty)
                 _      <- queue.poll
                 _      <- queue.poll
                 result <- fiber.get
@@ -674,10 +674,10 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 _     <- Kyo.foreach(1 to (size min 5))(i => queue.offer(i))
                 latch <- Latch.init(1)
-                closeAwaitEmptyFiber <- Fiber.init(
+                closeAwaitEmptyFiber <- Fiber.initUnscoped(
                     latch.await.andThen(queue.closeAwaitEmpty)
                 )
-                closeFiber <- Fiber.init(
+                closeFiber <- Fiber.initUnscoped(
                     latch.await.andThen(queue.close)
                 )
                 _        <- latch.release
@@ -699,20 +699,20 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
 
-                producerFiber1 <- Fiber.init(
+                producerFiber1 <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.foreach(1 to 25, 10)(i => Abort.run(queue.offer(i)))
                             .andThen(queue.closeAwaitEmpty)
                     )
                 )
-                producerFiber2 <- Fiber.init(
+                producerFiber2 <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.foreach(26 to 50, 10)(i => Abort.run(queue.offer(i)))
                             .andThen(queue.closeAwaitEmpty)
                     )
                 )
 
-                consumerFiber <- Fiber.init(
+                consumerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.fill(100, 10)(untilTrue(queue.poll.map(_.isDefined)))
                     )
@@ -738,20 +738,20 @@ class QueueTest extends Test:
                 queue <- Queue.init[Int](size)
                 latch <- Latch.init(1)
 
-                producerFiber1 <- Fiber.init(
+                producerFiber1 <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.foreach(1 to 25, 10)(i => Abort.run(queue.offer(i)))
                             .andThen(queue.closeAwaitEmpty)
                     )
                 )
-                producerFiber2 <- Fiber.init(
+                producerFiber2 <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.foreach(26 to 50, 10)(i => Abort.run(queue.offer(i)))
                             .andThen(queue.close)
                     )
                 )
 
-                consumerFiber <- Fiber.init(
+                consumerFiber <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.fill(100, 10)(untilTrue(queue.poll.map(_.isDefined)))
                     )

--- a/kyo-core/shared/src/test/scala/kyo/ScopeTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ScopeTest.scala
@@ -111,7 +111,7 @@ class ScopeTest extends Test:
 
         "ensure" in run {
             var closes = 0
-            Scope.ensure(Fiber.init(closes += 1).map(_.get).unit)
+            Scope.ensure(Fiber.initUnscoped(closes += 1).map(_.get).unit)
                 .handle(
                     Scope.run,
                     Abort.run
@@ -126,7 +126,7 @@ class ScopeTest extends Test:
             val acquire = Abort.get(Some(42))
             // only Async in release
             def release(i: Int) =
-                Fiber.init {
+                Fiber.initUnscoped {
                     assert(i == 42)
                     closes += 1
                 }.map(_.get)
@@ -142,7 +142,7 @@ class ScopeTest extends Test:
 
         "acquire" in run {
             val r = TestResource(1)
-            Scope.acquire(Fiber.init(r).map(_.get))
+            Scope.acquire(Fiber.initUnscoped(r).map(_.get))
                 .handle(
                     Scope.run,
                     Abort.run
@@ -195,7 +195,7 @@ class ScopeTest extends Test:
             val io =
                 for
                     l <- Latch.init(1)
-                    f <- Fiber.init(l.await.andThen(Scope.ensure { called = true }))
+                    f <- Fiber.initUnscoped(l.await.andThen(Scope.ensure { called = true }))
                 yield (l, f)
             for
                 (l, f) <- Scope.run(io)
@@ -216,7 +216,7 @@ class ScopeTest extends Test:
                 val resources = Kyo.foreach(1 to 3)(makeResource)
 
                 for
-                    close <- Fiber.init(resources.handle(Scope.run(3)))
+                    close <- Fiber.initUnscoped(resources.handle(Scope.run(3)))
                     _     <- latch.await
                     ids   <- close.get
                 yield assert(ids == (1 to 3))
@@ -240,7 +240,7 @@ class ScopeTest extends Test:
                 val resources = Kyo.foreach(1 to 10)(makeResource)
 
                 for
-                    close <- Fiber.init(resources.handle(Scope.run(3)))
+                    close <- Fiber.initUnscoped(resources.handle(Scope.run(3)))
                     ids   <- close.get
                 yield assert(ids == (1 to 10))
                 end for

--- a/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
@@ -191,7 +191,7 @@ class SignalTest extends Test:
                 ref     <- Signal.initRef(1)
                 v1      <- ref.current
                 started <- Latch.init(1)
-                f       <- Fiber.init(started.release.andThen(ref.next))
+                f       <- Fiber.initUnscoped(started.release.andThen(ref.next))
                 _       <- started.await
                 _       <- ref.set(2)
                 v2      <- f.get
@@ -219,7 +219,7 @@ class SignalTest extends Test:
         "streamChanges" in run {
             for
                 ref    <- Signal.initRef(1)
-                f      <- Fiber.init(ref.streamChanges.take(3).run)
+                f      <- Fiber.initUnscoped(ref.streamChanges.take(3).run)
                 _      <- Async.sleep(2.millis)
                 _      <- ref.set(2)
                 _      <- Async.sleep(2.millis)
@@ -249,11 +249,11 @@ class SignalTest extends Test:
             (for
                 ref <- Signal.initRef(0)
                 readers <-
-                    Fiber.init(Async.fill(10, 10)(
+                    Fiber.initUnscoped(Async.fill(10, 10)(
                         Loop(0)(_ => ref.currentWith(v => if v < 10 then Loop.continue(v) else Loop.done(v)))
                     ))
                 writers <-
-                    Fiber.init(Async.fill(10, 10)(
+                    Fiber.initUnscoped(Async.fill(10, 10)(
                         Loop.foreach {
                             ref.get.map { v =>
                                 if v < 10 then

--- a/kyo-direct/shared/src/test/scala/kyo/CoreTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/CoreTest.scala
@@ -153,14 +153,14 @@ class CoreTest extends Test:
             assert(barrier.pending.now == 2)
 
             // Start two fibers that will wait at the barrier
-            val fiber1 = Fiber.init {
+            val fiber1 = Fiber.initUnscoped {
                 direct {
                     barrier.await.now
                     true
                 }
             }.now
 
-            val fiber2 = Fiber.init {
+            val fiber2 = Fiber.initUnscoped {
                 direct {
                     barrier.await.now
                     true
@@ -181,7 +181,7 @@ class CoreTest extends Test:
             latch.release.now
             assert(latch.pending.now == 1)
             latch.release.now
-            val awaited = Fiber.init {
+            val awaited = Fiber.initUnscoped {
                 direct {
                     latch.await.now
                     true

--- a/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
+++ b/kyo-examples/jvm/src/main/scala/examples/ledger/db/Log.scala
@@ -23,7 +23,7 @@ object Log:
         val cfg = Env.get[DB.Config].now
         val q   = Queue.Unbounded.initUnscoped[Entry](Access.MultiProducerSingleConsumer).now
         val log = Sync.defer(Live(cfg.workingDir + "/log.dat", q)).now
-        val _   = Fiber.init(log.flushLoop(cfg.flushInterval)).now
+        val _   = Fiber.initUnscoped(log.flushLoop(cfg.flushInterval)).now
         log
     }
 

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamPublisher.scala
@@ -74,7 +74,7 @@ object StreamPublisher:
                             case _                    => discardSubscriber(subscriber)
             }
             supervisor <- Scope.acquireRelease(Fiber.Promise.init[Nothing, Unit])(_.interrupt)
-            _          <- Scope.acquireRelease(Fiber.init(consumeChannel(publisher, channel, supervisor)))(_.interrupt)
+            _          <- Scope.acquireRelease(Fiber.initUnscoped(consumeChannel(publisher, channel, supervisor)))(_.interrupt)
         yield publisher
         end for
     end apply

--- a/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
+++ b/kyo-reactive-streams/shared/src/main/scala/kyo/interop/flow/StreamSubscription.scala
@@ -64,7 +64,7 @@ final private[kyo] class StreamSubscription[V, S](
         Tag[Poll[Chunk[V]]],
         Frame
     ): Fiber[StreamComplete, Abort[StreamCanceled]] < (Sync & S) =
-        Fiber.init[StreamCanceled, StreamComplete, S, Any](Poll.runEmit(stream.emit)(poll).map(_._2))
+        Fiber.initUnscoped[StreamCanceled, StreamComplete, S, Any](Poll.runEmit(stream.emit)(poll).map(_._2))
             .map { fiber =>
                 fiber.onComplete { r =>
                     val x = r.map(_.eval)

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/flow/PublisherToSubscriberTest.scala
@@ -137,10 +137,10 @@ abstract private class PublisherToSubscriberTest extends Test:
                 _ = publisher.subscribe(subscriber2)
                 _ = publisher.subscribe(subscriber3)
                 _ = publisher.subscribe(subscriber4)
-                fiber1 <- Fiber.init(modify(subStream1, shouldFail = false))
-                fiber2 <- Fiber.init(modify(subStream2, shouldFail = true))
-                fiber3 <- Fiber.init(modify(subStream3, shouldFail = false))
-                fiber4 <- Fiber.init(modify(subStream4, shouldFail = true))
+                fiber1 <- Fiber.initUnscoped(modify(subStream1, shouldFail = false))
+                fiber2 <- Fiber.initUnscoped(modify(subStream2, shouldFail = true))
+                fiber3 <- Fiber.initUnscoped(modify(subStream3, shouldFail = false))
+                fiber4 <- Fiber.initUnscoped(modify(subStream4, shouldFail = true))
                 value1 <- fiber1.get
                 value2 <- fiber2.getResult
                 value3 <- fiber3.get
@@ -179,12 +179,12 @@ abstract private class PublisherToSubscriberTest extends Test:
                 subscriber4 <- streamSubscriber
                 subStream4  <- subscriber4.stream
                 latch       <- Latch.init(4)
-                fiber1      <- Fiber.init(latch.release.andThen(subStream1.run.unit))
-                fiber2      <- Fiber.init(latch.release.andThen(subStream2.run.unit))
-                fiber3      <- Fiber.init(latch.release.andThen(subStream3.run.unit))
-                fiber4      <- Fiber.init(latch.release.andThen(subStream4.run.unit))
+                fiber1      <- Fiber.initUnscoped(latch.release.andThen(subStream1.run.unit))
+                fiber2      <- Fiber.initUnscoped(latch.release.andThen(subStream2.run.unit))
+                fiber3      <- Fiber.initUnscoped(latch.release.andThen(subStream3.run.unit))
+                fiber4      <- Fiber.initUnscoped(latch.release.andThen(subStream4.run.unit))
                 latchPub    <- Latch.init(1)
-                publisherFiber <- Fiber.init(latch.await.andThen(Scope.run(
+                publisherFiber <- Fiber.initUnscoped(latch.await.andThen(Scope.run(
                     Stream(Emit.valueWith(Chunk.empty)(emit(counter)))
                         .toPublisher
                         .map { publisher =>

--- a/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
@@ -18,7 +18,7 @@ class STMTest extends Test:
                 ref      <- TRef.init(0)
                 start    <- Latch.init(1)
                 continue <- Latch.init(1)
-                fiber <- Fiber.init {
+                fiber <- Fiber.initUnscoped {
                     STM.run {
                         for
                             _ <- ref.set(42)
@@ -94,7 +94,7 @@ class STMTest extends Test:
                     latch2   <- Latch.init(1)
                     attempts <- AtomicInt.init
                     _ <-
-                        Fiber.init {
+                        Fiber.initUnscoped {
                             STM.run(latch1.release.andThen(ref.set(42)))
                                 .andThen(latch2.release)
                         }
@@ -121,7 +121,7 @@ class STMTest extends Test:
                 latch2   <- Latch.init(1)
                 attempts <- AtomicInt.init
                 _ <-
-                    Fiber.init {
+                    Fiber.initUnscoped {
                         STM.run(latch1.release.andThen(ref.set(42)))
                             .andThen(latch2.release)
                     }
@@ -569,10 +569,10 @@ class STMTest extends Test:
                 size  <- sizes
                 ref   <- TRef.init(0)
                 latch <- Latch.init(1)
-                writeFiber <- Fiber.init(
+                writeFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(size, size)(STM.run(ref.update(_ + 1))))
                 )
-                readFiber <- Fiber.init(
+                readFiber <- Fiber.initUnscoped(
                     latch.await.andThen(Async.fill(size, size)(STM.run(ref.get)))
                 )
                 _     <- latch.release
@@ -748,7 +748,7 @@ class STMTest extends Test:
                     STM.run {
                         for
                             _ <- ref.set(1)
-                            fiber <- Fiber.init {
+                            fiber <- Fiber.initUnscoped {
                                 STM.run {
                                     for
                                         _ <- ref.set(2)
@@ -776,7 +776,7 @@ class STMTest extends Test:
                 (parentTid, childTid) <-
                     STM.run {
                         TID.useIO { parentTid =>
-                            Fiber.init {
+                            Fiber.initUnscoped {
                                 STM.run(TID.useIO(identity))
                             }.map(_.get).map { childTid =>
                                 (parentTid, childTid)
@@ -791,7 +791,7 @@ class STMTest extends Test:
         def unsafeToFuture[A](a: => A < (Async & Abort[Throwable])): Future[A] =
             import kyo.AllowUnsafe.embrace.danger
             Sync.Unsafe.evalOrThrow(
-                Fiber.init(a).map(_.toFuture)
+                Fiber.initUnscoped(a).map(_.toFuture)
             )
         end unsafeToFuture
 

--- a/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
@@ -389,7 +389,7 @@ class TMapTest extends Test:
                 map   <- STM.run(TMap.init[Int, Int]())
                 latch <- Latch.init(1)
 
-                writeFiber <- Fiber.init(
+                writeFiber <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.foreach(1 to size, size)(i =>
                             STM.run(map.put(i, i * 2))
@@ -397,7 +397,7 @@ class TMapTest extends Test:
                     )
                 )
 
-                readFiber <- Fiber.init(
+                readFiber <- Fiber.initUnscoped(
                     latch.await.andThen(
                         Async.foreach(1 to size, size)(i =>
                             STM.run(map.get(i))

--- a/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/internal/KyoSttpMonad.scala
@@ -26,7 +26,7 @@ sealed class KyoSttpMonad(using Frame) extends MonadAsyncError[M]:
     def ensure[A](f: M[A], e: => M[Unit]) =
         Promise.initWith[Unit, Any] { p =>
             def run =
-                Fiber.init(e).map(p.becomeDiscard)
+                Fiber.initUnscoped(e).map(p.becomeDiscard)
             Sync.ensure(run)(f).map(r => p.get.andThen(r))
         }
 

--- a/kyo-sttp/shared/src/test/scala/kyo/RequestsTest.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/RequestsTest.scala
@@ -37,7 +37,7 @@ class RequestsTest extends Test:
     "with fiber" in run {
         val backend = new TestBackend
         Requests.let(backend) {
-            Fiber.init {
+            Fiber.initUnscoped {
                 for
                     r <- Requests(_.get(uri"https://httpbin.org/get"))
                 yield
@@ -60,7 +60,7 @@ class RequestsTest extends Test:
             def close(using Frame) = ???
         val backend = (new TestBackend).withMeter(meter)
         Requests.let(backend) {
-            Fiber.init {
+            Fiber.initUnscoped {
                 for
                     r <- Requests(_.get(uri"https://httpbin.org/get"))
                 yield

--- a/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/internal/KyoSttpMonadTest.scala
@@ -90,7 +90,7 @@ class KyoSttpMonadTest extends Test:
             for
                 started   <- Latch.init(1)
                 cancelled <- Latch.init(1)
-                fiber <- Fiber.init {
+                fiber <- Fiber.initUnscoped {
                     KyoSttpMonad.async[Int] { _ =>
                         import AllowUnsafe.embrace.danger
                         started.unsafe.release()

--- a/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServer.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServer.scala
@@ -80,7 +80,7 @@ case class NettyKyoServer(
         block: () => KyoSttpMonad.M[ServerResponse[NettyResponse]]
     ): (Future[ServerResponse[NettyResponse]], () => Future[Unit]) =
         import AllowUnsafe.embrace.danger
-        val fiber  = Sync.Unsafe.evalOrThrow(Fiber.init(block()))
+        val fiber  = Sync.Unsafe.evalOrThrow(Fiber.initUnscoped(block()))
         val future = Sync.Unsafe.evalOrThrow(fiber.toFuture)
         val cancel = () =>
             val _ = Sync.Unsafe.evalOrThrow(fiber.interrupt)

--- a/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServerInterpreter.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/server/NettyKyoServerInterpreter.scala
@@ -43,11 +43,11 @@ object NettyKyoServerInterpreter:
         override def apply(f: => KyoSttpMonad.M[Unit]): Unit =
             val exec =
                 if forkExecution then
-                    Fiber.init(f).map(_.get)
+                    Fiber.initUnscoped(f).map(_.get)
                 else
                     f
             import AllowUnsafe.embrace.danger
-            val _ = Sync.Unsafe.evalOrThrow(Fiber.init(exec))
+            val _ = Sync.Unsafe.evalOrThrow(Fiber.initUnscoped(exec))
         end apply
     end KyoRunAsync
 end NettyKyoServerInterpreter

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -61,7 +61,7 @@ object ZIOs:
     def run[A, E](v: => A < (Abort[E] & Async))(using frame: Frame, trace: zio.Trace): ZIO[Any, E, A] =
         ZIO.suspendSucceed {
             import AllowUnsafe.embrace.danger
-            Fiber.init(v).map { fiber =>
+            Fiber.initUnscoped(v).map { fiber =>
                 ZIO.asyncInterrupt[Any, E, A] { cb =>
                     fiber.unsafe.onComplete {
                         case Result.Success(a) => cb(Exit.succeed(a.eval))

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -94,25 +94,25 @@ class ZIOsTest extends Test:
         "basic interop" in runKyo {
             for
                 v1 <- ZIOs.get(ZIO.succeed(1))
-                v2 <- Fiber.init(2).map(_.get)
+                v2 <- Fiber.initUnscoped(2).map(_.get)
                 v3 <- ZIOs.get(ZIO.succeed(3))
             yield assert(v1 == 1 && v2 == 2 && v3 == 3)
         }
 
         "nested Kyo in ZIO" in runKyo {
             ZIOs.get(ZIO.suspendSucceed {
-                val kyoComputation = Fiber.init(42).map(_.get)
+                val kyoComputation = Fiber.initUnscoped(42).map(_.get)
                 ZIOs.run(kyoComputation)
             }).map(v => assert(v == 42))
         }
 
         "nested ZIO in Kyo" in runKyo {
-            Fiber.init(ZIOs.get(ZIOs.run(42))).map(_.get)
+            Fiber.initUnscoped(ZIOs.get(ZIOs.run(42))).map(_.get)
                 .map(v => assert(v == 42))
         }
 
         "complex nested pattern with parallel and race" in runKyo {
-            def kyoTask(i: Int): Int < (Abort[Nothing] & Async)   = Fiber.init(i * 2).map(_.get)
+            def kyoTask(i: Int): Int < (Abort[Nothing] & Async)   = Fiber.initUnscoped(i * 2).map(_.get)
             def zioTask(i: Int): Int < (Abort[Throwable] & Async) = ZIOs.get(ZIO.succeed(i + 1))
 
             for
@@ -178,7 +178,7 @@ class ZIOsTest extends Test:
                     val v =
                         for
                             _ <- ZIOs.get(zioLoop(started, done))
-                            _ <- Fiber.init(kyoLoop(started, done))
+                            _ <- Fiber.initUnscoped(kyoLoop(started, done))
                         yield ()
                     for
                         f <- ZIOs.run(v).fork
@@ -235,7 +235,7 @@ class ZIOsTest extends Test:
                     val done    = new CountDownLatch(1)
                     val panic   = Result.Panic(new Exception)
                     for
-                        f <- Fiber.init(ZIOs.get(zioLoop(started, done)))
+                        f <- Fiber.initUnscoped(ZIOs.get(zioLoop(started, done)))
                         _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt(panic)
                         r <- f.getResult
@@ -253,7 +253,7 @@ class ZIOsTest extends Test:
                             _ <- kyoLoop(started, done)
                         yield ()
                     for
-                        f <- Fiber.init(v)
+                        f <- Fiber.initUnscoped(v)
                         _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
@@ -271,7 +271,7 @@ class ZIOsTest extends Test:
                         Async.zip[Throwable, Unit, Unit, Any](loop1, loop2)
                     end parallelEffect
                     for
-                        f <- Fiber.init(parallelEffect)
+                        f <- Fiber.initUnscoped(parallelEffect)
                         _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult
@@ -289,7 +289,7 @@ class ZIOsTest extends Test:
                         Async.race(loop1, loop2)
                     end raceEffect
                     for
-                        f <- Fiber.init(raceEffect)
+                        f <- Fiber.initUnscoped(raceEffect)
                         _ <- Sync.defer(started.await(100, TimeUnit.MILLISECONDS))
                         _ <- f.interrupt
                         r <- f.getResult

--- a/scalafix/input/src/main/scala/fix/TestKyoUpdateToV1_0.scala
+++ b/scalafix/input/src/main/scala/fix/TestKyoUpdateToV1_0.scala
@@ -14,5 +14,9 @@ object TestKyoUpdateToV1_0:
 
     val async: Fiber[Nothing, Unit] < Async = Async.run(Async.apply(Async(Kyo.unit)))
 
+    val forked: Fiber[Nothing, Unit] < Async = Kyo.unit.fork
+
     val resource: Any < (Resource & IO) = Resource.acquireRelease(prg)(Unit => Kyo.unit)
+
+    val forkedResource: Fiber[Nothing, Unit] < (Async & Resource) = Kyo.unit.forkScoped
 end TestKyoUpdateToV1_0

--- a/scalafix/output/src/main/scala/fix/TestKyoUpdateToV1_0.scala
+++ b/scalafix/output/src/main/scala/fix/TestKyoUpdateToV1_0.scala
@@ -11,5 +11,9 @@ object TestKyoUpdateToV1_0:
 
     val async: Fiber[Nothing, Unit] < Async = /* Consider using Fiber.init or Fiber.use to guarantee termination */ Fiber.initUnscoped(Async.defer(Async.defer(Kyo.unit)))
 
+    val forked: Fiber[Nothing, Unit] < Async = Kyo.unit.forkUnscoped
+
     val resource: Any < (Scope & Sync) = Scope.acquireRelease(prg)(Unit => Kyo.unit)
+
+    val forkedResource: Fiber[Nothing, Unit] < (Async & Scope) = Kyo.unit.fork
 end TestKyoUpdateToV1_0

--- a/scalafix/output/src/main/scala/fix/TestKyoUpdateToV1_0.scala
+++ b/scalafix/output/src/main/scala/fix/TestKyoUpdateToV1_0.scala
@@ -9,7 +9,7 @@ object TestKyoUpdateToV1_0:
         init.now
         Console.printLine("hello").now
 
-    val async: Fiber[Nothing, Unit] < Async = Fiber.initUnscoped(Async.defer(Async.defer(Kyo.unit)))
+    val async: Fiber[Nothing, Unit] < Async = /* Consider using Fiber.init or Fiber.use to guarantee termination */ Fiber.initUnscoped(Async.defer(Async.defer(Kyo.unit)))
 
     val resource: Any < (Scope & Sync) = Scope.acquireRelease(prg)(Unit => Kyo.unit)
 end TestKyoUpdateToV1_0

--- a/scalafix/output/src/main/scala/fix/TestKyoUpdateToV1_0.scala
+++ b/scalafix/output/src/main/scala/fix/TestKyoUpdateToV1_0.scala
@@ -9,7 +9,7 @@ object TestKyoUpdateToV1_0:
         init.now
         Console.printLine("hello").now
 
-    val async: Fiber[Nothing, Unit] < Async = Fiber.init(Async.defer(Async.defer(Kyo.unit)))
+    val async: Fiber[Nothing, Unit] < Async = Fiber.initUnscoped(Async.defer(Async.defer(Kyo.unit)))
 
     val resource: Any < (Scope & Sync) = Scope.acquireRelease(prg)(Unit => Kyo.unit)
 end TestKyoUpdateToV1_0

--- a/scalafix/rules/src/main/scala/kyo/rules/KyoUpdateToV1_0.scala
+++ b/scalafix/rules/src/main/scala/kyo/rules/KyoUpdateToV1_0.scala
@@ -44,6 +44,13 @@ class KyoUpdateToV1_0 extends SemanticRule("KyoUpdateToV1_0") {
 
             case resource @ q"Resource" if resource matches "kyo.Resource" =>
                 Patch.replaceTree(resource, "Scope")
+
+            // Async combinator
+            case fork @ q"$eff.fork" =>
+                Patch.replaceTree(fork, s"$eff.forkUnscoped")
+
+            case forkScoped @ q"$eff.forkScoped" =>
+                Patch.replaceTree(forkScoped, s"$eff.fork")
         }).asPatch
 
     }

--- a/scalafix/rules/src/main/scala/kyo/rules/KyoUpdateToV1_0.scala
+++ b/scalafix/rules/src/main/scala/kyo/rules/KyoUpdateToV1_0.scala
@@ -30,7 +30,7 @@ class KyoUpdateToV1_0 extends SemanticRule("KyoUpdateToV1_0") {
 
             // Async
             case asyncRun @ q"Async.run" if asyncRun.matches("kyo.Async.run") =>
-                Patch.replaceTree(asyncRun, "Fiber.init")
+                Patch.replaceTree(asyncRun, "/* Consider using Fiber.init or Fiber.use to guarantee termination */ Fiber.initUnscoped")
 
             case apply @ q"Async.apply" if apply.matches("kyo.Async.apply") =>
                 Patch.replaceTree(apply, "Async.defer")


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

Fixes #1167 

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

By default, `Fiber.init` forks a fiber without ever guaranteeing it will be interrupted. The result is that fibers can easily end up lost in an application in a permanently suspended or long-running state. It would be good to have a behavior somewhat like ZIO, that guarantees cleanup of fibers

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Following the pattern established by #1168 , we change `Fiber.init` to introduce the `Scope` effect, interrupting the forked fiber in the registered finalizer; we add a `Fiber.use` method to use a forked fiber within a function and clean it up afterwards; and finally, we add `Fiber.initUnscoped` to produce the previous behavior, which forks a fiber and never guarantees interruptions.

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->

While this change was inspired by ZIO's behavior, it departs from ZIO in that by default ZIO binds each forked fiber to the parent fiber and interrupts child fiber whenever its parent fiber completes. I chose not to try to reproduce this for two reasons:
1. It would require some deeper changes to the runtime
2. I don't actually like ZIO's behavior so much, because it means the behavior of async effects depends on how they are composed. See for instance:

```scala
import zio.stream._
import zio._

Unsafe.unsafe { implicit unsafe =>
  val eff1 = for
    fiberA <- (ZIO.sleep(1.second) *> Console.printLine("A")).fork
    fiberB <- (ZIO.sleep(1.second) *> Console.printLine("B")).fork
    _ <- Console.printLine("1")
  yield ()

  val eff2 = eff1 *> (ZIO.sleep(5.seconds) *> Console.printLine("2"))

  val eff3 = eff1.fork *> (ZIO.sleep(5.seconds) *> Console.printLine("3"))

  val eff4 = eff1.fork.flatMap(f => (ZIO.sleep(5.seconds) *> f.join *> Console.printLine("4")))

  Runtime.default.unsafe.run(eff1).getOrThrowFiberFailure()
  Runtime.default.unsafe.run(eff2).getOrThrowFiberFailure()
  Runtime.default.unsafe.run(eff3).getOrThrowFiberFailure()
  Runtime.default.unsafe.run(eff4).getOrThrowFiberFailure()
}
```

`eff1` on its own will just print `1`
`eff2` will print `1`, `A`, `B`, `2`
`eff3` will print `1`, `2`
`eff4` will print `1`, `4`

If you construct an effect that depends on ephemeral forked tasks, it will behave properly in a test or when used in an application in a forked handler, but when you sequence it other effects it may behave differently.

In conclusion, I think introducing the notion of parent fiber and child fiber makes it harder to reason about the fiber lifecycle than if fibers are just treated the same way as other resources.

