### PR TITLE
Fix Text#dropUntilNext dropping one too many characters

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Text.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Text.scala
@@ -549,7 +549,7 @@ object Text:
           */
         def dropUntilNext(p: Predicate): Text =
             val idx = self.indexWhere(!p(_))
-            if idx == -1 then Text.empty else self.drop(idx + 1)
+            if idx == -1 then Text.empty else self.drop(idx)
 
     end extension
 

--- a/kyo-data/shared/src/test/scala/kyo/TextTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/TextTest.scala
@@ -661,7 +661,7 @@ class TextTest extends Test:
         }
 
         "dropUntilNext" in {
-            assert(Text("hello123world").dropUntilNext(_.isLetter).toString == "23world")
+            assert(Text("hello123world").dropUntilNext(_.isLetter).toString == "123world")
             assert(Text("hello").dropUntilNext(_.isLetter).isEmpty)
             assert(Text("").dropUntilNext(_.isLetter).isEmpty)
         }


### PR DESCRIPTION
Addresses #1382.

`Text#dropUntilNext` was dropping one too many characters.