### PR TITLE
[data][prelude] allow bypassing dynamic tag check + support dynamic tags in Aspect.init

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Tag.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Tag.scala
@@ -61,7 +61,9 @@ object Tag:
       * @return
       *   A Tag for type A
       */
-    inline given derive[A]: Tag[A] = ${ TagMacro.deriveImpl[A] }
+    inline given derive[A]: Tag[A] = ${ TagMacro.deriveImpl[A](allowDynamic = false) }
+
+    private[kyo] inline def dynamic[A]: Tag[A] = ${ TagMacro.deriveImpl[A](allowDynamic = true) }
 
     extension [A](self: Tag[A])
 

--- a/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
@@ -11,13 +11,13 @@ import scala.collection.immutable.HashMap
 import scala.quoted.{Type as SType, *}
 
 private[kyo] object TagMacro:
-    def deriveImpl[A: SType](using Quotes): Expr[String | Tag.internal.Dynamic] =
+    def deriveImpl[A: SType](allowDynamic: Boolean)(using Quotes): Expr[String | Tag.internal.Dynamic] =
         import quotes.reflect.*
         val (staticDB, dynamicDB) = deriveDB[A]
         val encoded               = Expr(Tag.internal.encode(staticDB))
         if dynamicDB.isEmpty then
             encoded
-        else if FindEnclosing.isInternal then
+        else if !allowDynamic && FindEnclosing.isInternal then
             val missing =
                 dynamicDB.map {
                     case (_, (tpe, _)) =>

--- a/kyo-prelude/shared/src/main/scala/kyo/Aspect.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Aspect.scala
@@ -32,7 +32,7 @@ import Aspect.*
   * @tparam S
   *   The effect type - what effects the aspect can perform
   */
-final class Aspect[Input[_], Output[_], S] private[kyo] (
+final class Aspect[Input[_], Output[_], S](
     using
     tag: Tag[(Input[Any], Output[Any])],
     frame: Frame
@@ -165,7 +165,7 @@ object Aspect:
       * @tparam S
       *   The effect type
       */
-    def init[I[_], O[_], S](using Frame, Tag[(I[Any], O[Any])]): Aspect[I, O, S] =
-        new Aspect[I, O, S]
+    inline def init[I[_], O[_], S](using Frame): Aspect[I, O, S] =
+        new Aspect[I, O, S](using Tag.dynamic[(I[Any], O[Any])])
 
 end Aspect


### PR DESCRIPTION

### Problem

For performance reasons, we don't allow dynamic tags to be inferred within the `kyo` package. This is a good optimization in general but it isn't a strict requirement. For example, in https://github.com/getkyo/kyo/pull/1305 we had to inline methods that don't make sense to inline to work it around, which isn't ideal.

### Solution

Introduce `Tag.dynamic` to allow bypassing the check within the `kyo` package and use it in `Aspect.init` to avoid the unnecessary inlining in https://github.com/getkyo/kyo/pull/1305. It seems reasonable as an exceptional case.
