### PR TITLE
[js] optimizations

### DIFF
--- a/kyo-actor/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-actor/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-aeron/jvm/src/test/scala/kyo/Test.scala
+++ b/kyo-aeron/jvm/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-cache/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-cache/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext

--- a/kyo-caliban/src/test/scala/kyo/Test.scala
+++ b/kyo-caliban/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoKernelTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext

--- a/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
+++ b/kyo-cats/shared/src/test/scala/kyo/CatsTest.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kyo.*
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.Eventually.*
 import scala.concurrent.Future

--- a/kyo-cats/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-cats/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext

--- a/kyo-combinators/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-combinators/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -91,7 +91,7 @@ object KyoApp:
 
         /** Unsafely exits the application. */
         protected def exit(code: Int)(using AllowUnsafe): Unit =
-            kernel.Platform.exit(code)
+            internal.Platform.exit(code)
 
         /** Unified handling logic for supporting arbitrary effects. */
         protected def handle[A](v: A < S)(using Frame): A < (Async & Abort[Throwable])

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -1,6 +1,6 @@
 package kyo
 
-import kyo.kernel.Platform
+import kyo.internal.Platform
 
 class QueueTest extends Test:
 

--- a/kyo-core/shared/src/test/scala/kyo/Tagged.scala
+++ b/kyo-core/shared/src/test/scala/kyo/Tagged.scala
@@ -4,6 +4,6 @@ import org.scalatest.Tag
 
 object Tagged:
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 end Tagged

--- a/kyo-core/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-core/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-data/js/src/main/scala/kyo/internal/Platform.scala
+++ b/kyo-data/js/src/main/scala/kyo/internal/Platform.scala
@@ -1,4 +1,4 @@
-package kyo.kernel
+package kyo.internal
 
 import scala.concurrent.ExecutionContext
 

--- a/kyo-data/jvm/src/main/scala/kyo/internal/Platform.scala
+++ b/kyo-data/jvm/src/main/scala/kyo/internal/Platform.scala
@@ -1,4 +1,4 @@
-package kyo.kernel
+package kyo.internal
 
 import scala.concurrent.ExecutionContext
 

--- a/kyo-data/native/src/main/scala/kyo/internal/Platform.scala
+++ b/kyo-data/native/src/main/scala/kyo/internal/Platform.scala
@@ -1,4 +1,4 @@
-package kyo.kernel
+package kyo.internal
 
 import scala.concurrent.ExecutionContext
 

--- a/kyo-data/shared/src/main/scala/kyo/Tag.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Tag.scala
@@ -2,6 +2,7 @@ package kyo
 
 import java.util.concurrent.ConcurrentHashMap
 import kyo.Tag.internal.Type.Entry.*
+import kyo.internal.Platform
 import kyo.internal.TagMacro
 import scala.annotation.tailrec
 import scala.collection.immutable.HashMap
@@ -293,7 +294,10 @@ object Tag:
             end Entry
         end Type
 
-        private val threadSlots  = Runtime.getRuntime().availableProcessors() * 8
+        private val threadSlots =
+            if Platform.isJS then 1
+            else Runtime.getRuntime().availableProcessors() * 8
+
         private val cacheEntries = 128
         private val cacheSlots   = Array.ofDim[Long](threadSlots, cacheEntries)
 

--- a/kyo-direct/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala
@@ -2,7 +2,7 @@ package kyo.internal
 
 import java.util.concurrent.TimeoutException
 import kyo.*
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import scala.annotation.targetName
 import scala.concurrent.Future
 
@@ -62,5 +62,5 @@ private[kyo] trait BaseKyoKernelTest[S] extends BaseKyoDataTest:
         if Platform.isDebugEnabled then
             Duration.Infinity
         else
-            8.seconds
+            15.seconds
 end BaseKyoKernelTest

--- a/kyo-kernel/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoKernelTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.compiletime.testing.typeCheckErrors

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/Tagged.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/Tagged.scala
@@ -4,7 +4,7 @@ import org.scalatest.Tag
 
 object Tagged:
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly   extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object notNative extends Tag(runWhen(!kyo.kernel.Platform.isNative))
-    object jsOnly    extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly   extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object notNative extends Tag(runWhen(!kyo.internal.Platform.isNative))
+    object jsOnly    extends Tag(runWhen(kyo.internal.Platform.isJS))
 end Tagged

--- a/kyo-offheap/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-offheap/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-playwright/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-playwright/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext

--- a/kyo-prelude/shared/src/test/scala/kyo/Tagged.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/Tagged.scala
@@ -4,7 +4,7 @@ import org.scalatest.Tag
 
 object Tagged:
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly   extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object notNative extends Tag(runWhen(!kyo.kernel.Platform.isNative))
-    object jsOnly    extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly   extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object notNative extends Tag(runWhen(!kyo.internal.Platform.isNative))
+    object jsOnly    extends Tag(runWhen(kyo.internal.Platform.isJS))
 end Tagged

--- a/kyo-prelude/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoKernelTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.compiletime.testing.typeCheckErrors

--- a/kyo-reactive-streams/shared/src/test/scala/kyo/interop/Test.scala
+++ b/kyo-reactive-streams/shared/src/test/scala/kyo/interop/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-scheduler/js/src/main/scala/kyo/scheduler/InternalClock.scala
+++ b/kyo-scheduler/js/src/main/scala/kyo/scheduler/InternalClock.scala
@@ -6,7 +6,15 @@ import scala.annotation.nowarn
 @nowarn
 final class InternalClock(executor: Executor = null) {
 
-    def currentMillis(): Long = System.currentTimeMillis()
+    var steps = 0
+    var curr  = System.currentTimeMillis()
+
+    def currentMillis(): Long = {
+        steps += 1
+        if ((steps & 128) == 0)
+            curr = System.currentTimeMillis()
+        curr
+    }
 
     def stop(): Unit = {}
 

--- a/kyo-stats-otel/shared/src/test/scala/kyo/stats/otel/Test.scala
+++ b/kyo-stats-otel/shared/src/test/scala/kyo/stats/otel/Test.scala
@@ -1,7 +1,7 @@
 package kyo.stats.otel
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest {
 
     private def runWhen(cond: => Boolean) = if (cond) "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/STMTest.scala
@@ -553,7 +553,7 @@ class STMTest extends Test:
         val repeats = 10
         val sizes   = Choice.eval(1, 10, 100, 1000)
 
-        "concurrent updates" in runNotJS {
+        "concurrent updates" in run {
             (for
                 size  <- sizes
                 ref   <- TRef.init(0)
@@ -564,7 +564,7 @@ class STMTest extends Test:
                 .andThen(succeed)
         }
 
-        "concurrent reads and writes" in runNotJS {
+        "concurrent reads and writes" in run {
             (for
                 size  <- sizes
                 ref   <- TRef.init(0)
@@ -584,7 +584,7 @@ class STMTest extends Test:
                 .andThen(succeed)
         }
 
-        "concurrent nested transactions" in runNotJS {
+        "concurrent nested transactions" in run {
             (for
                 size <- sizes
                 ref  <- TRef.init(0)
@@ -607,7 +607,7 @@ class STMTest extends Test:
                 .andThen(succeed)
         }
 
-        "dining philosophers" in runNotJS {
+        "dining philosophers" in run {
             val philosophers = 5
             (for
                 forks <- Kyo.fill(philosophers)(TRef.init(true))
@@ -637,7 +637,7 @@ class STMTest extends Test:
                 .andThen(succeed)
         }
 
-        "bank account transfers" in runNotJS {
+        "bank account transfers" in run {
             (for
                 account1 <- TRef.init(500)
                 account2 <- TRef.init(300)
@@ -687,7 +687,7 @@ class STMTest extends Test:
                 .andThen(succeed)
         }
 
-        "circular account transfers" in runNotJS {
+        "circular account transfers" in run {
             (for
                 account1 <- TRef.init(300)
                 account2 <- TRef.init(200)

--- a/kyo-stm/shared/src/test/scala/kyo/TChunkTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TChunkTest.scala
@@ -187,7 +187,7 @@ class TChunkTest extends Test:
     "concurrency" - {
         val repeats = 100
 
-        "concurrent modifications" in runNotJS {
+        "concurrent modifications" in run {
             (for
                 size     <- Choice.eval(1, 10, 100)
                 chunk    <- TChunk.init[Int]()
@@ -201,7 +201,7 @@ class TChunkTest extends Test:
                 .andThen(succeed)
         }
 
-        "concurrent filtering" in runNotJS {
+        "concurrent filtering" in run {
             (for
                 size  <- Choice.eval(1, 10, 100)
                 chunk <- TChunk.init[Int]()
@@ -220,7 +220,7 @@ class TChunkTest extends Test:
                 .andThen(succeed)
         }
 
-        "concurrent slice operations" in runNotJS {
+        "concurrent slice operations" in run {
             (for
                 size  <- Choice.eval(1, 10, 100)
                 chunk <- TChunk.init[Int]()
@@ -244,7 +244,7 @@ class TChunkTest extends Test:
                 .andThen(succeed)
         }
 
-        "concurrent compaction" in runNotJS {
+        "concurrent compaction" in run {
             (for
                 size  <- Choice.eval(1, 10, 100)
                 chunk <- TChunk.init[Int]()

--- a/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
@@ -369,7 +369,7 @@ class TMapTest extends Test:
     "Concurrency" - {
         val repeats = 100
 
-        "concurrent modifications" in runNotJS {
+        "concurrent modifications" in run {
             (for
                 size     <- Choice.eval(1, 10, 100)
                 map      <- STM.run(TMap.init[Int, Int]())
@@ -383,7 +383,7 @@ class TMapTest extends Test:
                 .andThen(succeed)
         }
 
-        "concurrent reads and writes" in runNotJS {
+        "concurrent reads and writes" in run {
             (for
                 size  <- Choice.eval(1, 10, 100)
                 map   <- STM.run(TMap.init[Int, Int]())
@@ -418,7 +418,7 @@ class TMapTest extends Test:
                 .andThen(succeed)
         }
 
-        "concurrent updates" in runNotJS {
+        "concurrent updates" in run {
             (for
                 size <- Choice.eval(1, 10, 100)
                 map  <- STM.run(TMap.init[Int, Int]())
@@ -441,7 +441,7 @@ class TMapTest extends Test:
                 .andThen(succeed)
         }
 
-        "concurrent removals" in runNotJS {
+        "concurrent removals" in run {
             (for
                 size <- Choice.eval(1, 10, 100)
                 map  <- STM.run(TMap.init[Int, Int]())
@@ -457,7 +457,7 @@ class TMapTest extends Test:
                 .andThen(succeed)
         }
 
-        "concurrent bulk operations" in runNotJS {
+        "concurrent bulk operations" in run {
             (for
                 size <- Choice.eval(1, 10, 100)
                 map  <- STM.run(TMap.init[Int, Int]())

--- a/kyo-stm/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-sttp/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-sttp/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-tapir/shared/src/test/scala/kyo/server/Test.scala
+++ b/kyo-tapir/shared/src/test/scala/kyo/server/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.Tag
 import org.scalatest.freespec.AsyncFreeSpec
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 abstract class Test extends AsyncFreeSpec with NonImplicitAssertions with BaseKyoCoreTest:
 
     private def runWhen(cond: => Boolean) = if cond then "" else "org.scalatest.Ignore"
-    object jvmOnly extends Tag(runWhen(kyo.kernel.Platform.isJVM))
-    object jsOnly  extends Tag(runWhen(kyo.kernel.Platform.isJS))
+    object jvmOnly extends Tag(runWhen(kyo.internal.Platform.isJVM))
+    object jsOnly  extends Tag(runWhen(kyo.internal.Platform.isJS))
 
     type Assertion = org.scalatest.Assertion
     def assertionSuccess              = succeed

--- a/kyo-zio/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/Test.scala
@@ -1,7 +1,7 @@
 package kyo
 
 import kyo.internal.BaseKyoCoreTest
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.freespec.AsyncFreeSpec
 import scala.concurrent.ExecutionContext

--- a/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
+++ b/kyo-zio/shared/src/test/scala/kyo/ZIOsTest.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kyo.*
 import kyo.ZIOs.*
-import kyo.kernel.Platform
+import kyo.internal.Platform
 import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.Eventually.*
 import scala.concurrent.Future


### PR DESCRIPTION

### Problem

We've been having many CI failures due to the performance in JS. If I remember correctly, two main changes led to the current degraded performance:

- New `Tag` implementation
- Introduction of times slices in the JS scheduler

### Solution

- Tune the number of thread slots of the `Tag` cache to 1 in JS
- Change the time slice preemption to check time only after 128 steps

### Notes

- I moved `Platform` from `kyo-kernel` to `kyo-data` for the tag cache tuning.
- I re-enabled some tests that were disable due to the performance issues. They're passing locally but let's see in CI.
- Test timeout increased from 8 seconds to 15
