### PR TITLE
dev: Rework Kyo Parse

### DIFF
--- a/kyo-parse/shared/src/main/scala/kyo/Parse.scala
+++ b/kyo-parse/shared/src/main/scala/kyo/Parse.scala
@@ -1,14 +1,11 @@
-package kyo
+package kyo.parse
 
-import kyo.Ansi.*
-import kyo.kernel.*
-import scala.util.matching.Regex
+import kyo.*
+import kyo.kernel.ArrowEffect
+import scala.annotation.tailrec
+import scala.annotation.targetName
 
 /** Parser combinator effect for compositional text parsing.
-  *
-  * The Parse effect combines three fundamental capabilities needed for powerful parsing: state management through `Var[Parse.State]` to
-  * track input position, alternative exploration via `Choice` for backtracking and ambiguity handling, and structured error reporting with
-  * `Abort[ParseFailed]` for failures.
   *
   * This design enables building sophisticated parsers that can handle complex grammars while maintaining readability and composition of
   * parsing logic. The core parsing model is based on consuming text incrementally and producing typed values with precise control over
@@ -34,131 +31,36 @@ import scala.util.matching.Regex
   *   [[kyo.Parse.attempt]], [[kyo.Parse.peek]] for parsers with look-ahead and backtracking
   * @see
   *   [[kyo.Parse.run]] for executing parsers against input text
-  * @see
-  *   [[kyo.Var]], [[kyo.Choice]], [[kyo.Abort]] for the underlying effects that Parse composes
   */
-opaque type Parse[A] <: (Var[Parse.State[A]] & Choice & Abort[ParseFailed]) =
-    Var[Parse.State[A]] & Choice & Abort[ParseFailed]
+sealed trait Parse[In] extends ArrowEffect[[in] =>> Parse.Op[In, in], Id]
 
 object Parse:
 
-    type StateTag[A] = Tag[Var[State[A]]]
+    enum Op[In, +Out]:
+        case ModifyState(modify: ParseState[In] => (ParseState[In], Maybe[Out]))
+        case Or[In, A, S](branches: Chunk[() => A < (Parse[In] & S)])                                    extends Op[In, A < S]
+        case RecoverWith[In, A, S](parser: A < (Parse[In] & S), recoverStrategy: RecoverStrategy[In, A]) extends Op[In, A < S]
+    end Op
 
-    /** Aspect that modifies how text is read and parsed. This is the core parsing aspect that other parsing operations build upon. It takes
-      * the current text input and a parsing function, allowing for preprocessing of input or postprocessing of results.
+    inline def modifyState[Out](using
+        inline frame: Frame
+    )[In](modify: ParseState[In] => (ParseState[In], Maybe[Out]))(using inline tag: Tag[Parse[In]]): Out < Parse[In] =
+        ArrowEffect.suspend(tag, Op.ModifyState(modify))
+
+    /** Tries parsers in sequence until the first success, backtracking between attempts.
+      *
+      * Unlike anyOf, this stops at the first successful parse and won't detect ambiguities. This makes it suitable for ordered alternatives
+      * where earlier parsers take precedence over later ones. The parser backtracks (restores input position) after each failed attempt. If
+      * no parsers succeed, the parse branch is dropped.
       *
       * @return
-      *   An Aspect that transforms from Const[Text] to Maybe[(Text, C)]
+      *   Result from first successful parser, drops the parse branch if none succeed
       */
-    def readAspect[A: Tag]: Aspect[Const[Chunk[A]], [C] =>> Maybe[(Chunk[A], C)], Parse[A]] =
-        given Frame = Frame.internal
-        Aspect.init
-
-    /** Attempts to parse input using the provided parsing function
-      *
-      * @param f
-      *   Function that takes remaining text and returns:
-      *   - Present((remaining, value)) when parsing succeeds, containing the unconsumed text and parsed value
-      *   - Absent when the parser doesn't match at the current position, allowing for backtracking
-      * @return
-      *   Parsed value if successful, drops the current parse branch if unsuccessful
-      */
-    def read[A, In](f: Chunk[In] => Maybe[(Chunk[In], A)])(using
-        Frame,
-        Tag[In],
-        StateTag[In]
-    ): A < Parse[In] =
-        Var.use[State[In]] { state =>
-            readAspect[In](state.remaining)(f).map {
-                case Present((remaining, result)) =>
-                    val consumed = state.remaining.length - remaining.length
-                    Var.set(state.advance(consumed)).andThen(result)
-                case Absent =>
-                    Choice.drop
-            }
-        }
-
-    /** Drops the current parse branch
-      *
-      * @return
-      *   Nothing, as this always fails the current branch
-      */
-    def drop[In](using Frame): Nothing < Parse[In] =
-        Choice.drop
-
-    /** Drops the current parse branch if condition is true
-      *
-      * @param condition
-      *   When true, drops the current parse branch
-      */
-    def dropIf[In](condition: Boolean)(using Frame): Unit < Parse[In] =
-        Choice.dropIf(condition)
-
-    /** Terminally fail parsing with a message
-      *
-      * @param message
-      *   Error message for the failure
-      */
-    def fail[In](message: String)(using frame: Frame, tag: StateTag[In]): Nothing < Parse[In] =
-        Var.use[State[In]](s => fail(Seq(s), message))
-
-    private def fail[In](states: Seq[State[In]], message: String)(using frame: Frame): Nothing < Abort[ParseFailed] =
-        Abort.fail(ParseFailed(states, message))
-
-    /** Reads and consumes characters from the input as long as they satisfy the given predicate.
-      *
-      * @param f
-      *   Predicate function that tests each character
-      * @return
-      *   The matched text containing all consecutive characters that satisfied the predicate
-      */
-    def readWhile[A](f: A => Boolean)(using Frame, Tag[A], StateTag[A]): Chunk[A] < Parse[A] =
-        Parse.read { s =>
-            val (matched, rest) = s.span(f(_))
-            Maybe((rest, matched))
-        }
-
-    /** Modifies a computation to automatically handle whitespace in all its parsing operations. Any parser used within the computation will
-      * consume and discard leading and trailing whitespace around its expected input.
-      *
-      * Since this operates through the Aspect effect, it affects all parsing operations within the computation, not just the immediate
-      * parser. This makes it particularly useful for complex parsers like those for mathematical expressions or programming languages where
-      * whitespace should be uniformly handled.
-      *
-      * @param v
-      *   Computation containing parsing operations
-      * @return
-      *   A computation where all parsing operations handle surrounding whitespace
-      */
-    def spaced[A, S](v: A < (Parse[Char] & S), isWhitespace: Char => Boolean = _.isWhitespace)(using Frame): A < (Parse[Char] & S) =
-        readAspect[Char].let([C] =>
-            (input, cont) =>
-                cont(input.dropWhile(isWhitespace(_))).map {
-                    case Present((remaining, value)) =>
-                        Present((remaining.dropWhile(isWhitespace(_)), value))
-                    case Absent => Absent
-            })(v)
-
-    /** Tries each parser in sequence and ensures exactly one succeeds. Unlike firstOf, this will evaluate all parsers, but will fail if
-      * zero or multiple parsers succeed. This is useful for grammars where ambiguous parses should be considered an error.
-      *
-      * @param seq
-      *   Sequence of parsers to try
-      * @return
-      *   Result from the single successful parser, fails if zero or multiple parsers succeed
-      */
-    def anyOf[A](using Frame)[In, S](seq: (A < (Parse[In] & S))*): A < (Parse[In] & S) =
-        Choice.evalWith(seq)(identity)
-
-    private def firstOf[A, In, S](seq: Seq[() => A < (Parse[In] & S)])(using Frame, StateTag[In]): A < (Parse[In] & S) =
-        Loop(seq) {
-            case Seq() => Choice.drop
-            case head +: tail =>
-                attempt(head()).map {
-                    case Present(value) => Loop.done(value)
-                    case Absent         => Loop.continue(tail)
-                }
-        }
+    inline def firstOf[In, Out, S](parsers: Seq[() => Out < (Parse[In] & S)])(using
+        inline tag: Tag[Parse[In]],
+        inline frame: Frame
+    ): Out < (Parse[In] & S) =
+        ArrowEffect.suspendWith(tag, Op.Or(Chunk.from(parsers)))(x => x)
 
     /** Tries parsers in sequence until the first success, backtracking between attempts.
       *
@@ -172,7 +74,7 @@ object Parse:
     def firstOf[A, In, S](
         parser1: => A < (Parse[In] & S),
         parser2: => A < (Parse[In] & S)
-    )(using Frame, StateTag[In]): A < (Parse[In] & S) =
+    )(using Tag[Parse[In]], Frame): A < (Parse[In] & S) =
         firstOf(Seq(() => parser1, () => parser2))
 
     /** Tries parsers in sequence until the first success, backtracking between attempts.
@@ -190,8 +92,8 @@ object Parse:
         parser3: => A < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): A < (Parse[In] & S) =
         firstOf(Seq(() => parser1, () => parser2, () => parser3))
 
@@ -211,8 +113,8 @@ object Parse:
         parser4: => A < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): A < (Parse[In] & S) =
         firstOf(Seq(() => parser1, () => parser2, () => parser3, () => parser4))
 
@@ -233,8 +135,8 @@ object Parse:
         parser5: => A < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): A < (Parse[In] & S) =
         firstOf(Seq(() => parser1, () => parser2, () => parser3, () => parser4, () => parser5))
 
@@ -256,8 +158,8 @@ object Parse:
         parser6: => A < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): A < (Parse[In] & S) =
         firstOf(Seq(() => parser1, () => parser2, () => parser3, () => parser4, () => parser5, () => parser6))
 
@@ -280,8 +182,8 @@ object Parse:
         parser7: => A < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): A < (Parse[In] & S) =
         firstOf(Seq(() => parser1, () => parser2, () => parser3, () => parser4, () => parser5, () => parser6, () => parser7))
 
@@ -305,23 +207,121 @@ object Parse:
         parser8: => A < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): A < (Parse[In] & S) =
         firstOf(Seq(() => parser1, () => parser2, () => parser3, () => parser4, () => parser5, () => parser6, () => parser7, () => parser8))
 
-    private def inOrder[A, In, S](parsers: Seq[() => A < (Parse[In] & S)])(using Frame, StateTag[In]): Chunk[A] < (Parse[In] & S) =
-        parsers.size match
-            case 0 => Chunk.empty
-            case 1 => parsers(0)().map(Chunk(_))
-            case _ =>
-                Kyo.foldLeft(parsers)(Chunk.empty[A]) {
-                    case (acc, parser) =>
-                        attempt(parser()).map {
-                            case Present(result) => acc.append(result)
-                            case Absent          => Parse.drop
-                        }
-                }
+    inline def recoverWith[In, Out, S](
+        parser: Out < (Parse[In] & S),
+        recoverStrategy: RecoverStrategy[In, Out]
+    )(using inline tag: Tag[Parse[In]], inline frame: Frame): Out < (Parse[In] & S) =
+        ArrowEffect.suspendWith(tag, Op.RecoverWith(parser, recoverStrategy))(x => x)
+
+    def readOne[In, Out](f: In => Result[Chunk[String], Out])(using Tag[Parse[In]], Frame): Out < Parse[In] =
+        read(input =>
+            if input.done then Result.fail(Chunk(ParseError("EOF", input.position)))
+            else
+                f(input.remaining.head) match
+                    case Result.Failure(messages) => Result.fail(messages.map(ParseError(_, input.position)))
+                    case Result.Success(out)      => Result.succeed((input.advance(1), out))
+        )
+
+    /** Attempts to parse input using the provided parsing function
+      *
+      * @param f
+      *   Function that takes remaining text and returns:
+      *   - Present((remaining, value)) when parsing succeeds, containing the unconsumed text and parsed value
+      *   - Absent when the parser doesn't match at the current position, allowing for backtracking
+      * @return
+      *   Parsed value if successful, drops the current parse branch if unsuccessful
+      */
+    def read[In, Out](f: ParseInput[In] => Result[Chunk[ParseError], (ParseInput[In], Out)])(using Tag[Parse[In]], Frame): Out < Parse[In] =
+        modifyState(state =>
+            f(state.input) match
+                case Result.Panic(error) => throw error
+                case Result.Failure(errors) =>
+                    (state.copy(errors = state.errors ++ errors), Absent)
+                case Result.Success((newInput, out)) =>
+                    (state.copy(input = newInput), Present(out))
+        )
+
+    /** Fail the current parse branch with the given error.
+      *
+      * @return
+      *   Nothing, as this always fails the current branch
+      */
+    def fail[In](message: String)(using Tag[Parse[In]], Frame): Nothing < Parse[In] =
+        modifyState(state =>
+            (state.copy(errors = state.errors :+ ParseError(message, state.input.position)), Absent)
+        )
+
+    /** Get the position of the next token to parse.
+      *
+      * @return
+      *   the index of the next token
+      */
+    def position[In](using Tag[Parse[In]], Frame): Int < Parse[In] =
+        modifyState(state => (state, Present(state.input.position)))
+
+    /** Rewind the parser to a specific parsing position.
+      */
+    def rewind[In](position: Int)(using Tag[Parse[In]], Frame): Unit < Parse[In] =
+        modifyState(state => (state.copy(input = state.input.copy(position = position)), Present(())))
+
+    /** Consumes any single input element
+      *
+      * @return
+      *   The consumed input element
+      */
+    def any[A](using Tag[Parse[A]], Frame): A < Parse[A] =
+        readOne(Result.succeed)
+
+    /** Consumes a character matching predicate
+      *
+      * @param f
+      *   Predicate function for character
+      * @param errorMessage
+      *   The error message if the predicate fails
+      * @return
+      *   Matching character
+      */
+    def anyIf[A](f: A => Boolean)(errorMessage: A => String)(using Tag[Parse[A]], Frame): A < Parse[A] =
+        readOne(in =>
+            if f(in) then Result.succeed(in)
+            else Result.fail(Chunk(errorMessage(in)))
+        )
+
+    def anyMatch[A](using Frame)[In](pf: PartialFunction[In, A])(using Tag[Parse[In]]): A < Parse[In] =
+        Parse.read(in =>
+            if in.done then Result.fail(Chunk(ParseError("Unexpected token, got EOF", in.position)))
+            else if pf.isDefinedAt(in.remaining.head) then Result.succeed((in.advance(1), pf(in.remaining.head)))
+            else Result.fail(Chunk(ParseError("Unexpected token", in.position)))
+        )
+
+    @targetName("anyOfSeq")
+    def anyOf[A](values: Seq[A])(using Tag[Parse[A]], Frame): A < Parse[A] =
+        anyIf(values.contains)(in => s"Expected: ${values.mkString(", ")}, Got: $in")
+
+    @targetName("anyOfString")
+    def anyOf(values: String)(using Frame): Char < Parse[Char] =
+        anyIf[Char](values.contains(_))(in => s"Expected: ${values.mkString(", ")}, Got: $in")
+
+    def anyOf[A](values: A*)(using Tag[Parse[A]], Frame): A < Parse[A] =
+        anyOf(values)
+
+    /** Matches exact input
+      *
+      * @param value
+      *   Input to match
+      * @return
+      *   Unit if text matches
+      */
+    def literal[A](value: A)(using CanEqual[A, A], Tag[Parse[A]], Frame): A < Parse[A] =
+        anyIf[A](_ == value)(in => s"Expected: $value, Got: $in")
+
+    private def inOrder[A, In, S](parsers: Seq[() => A < (Parse[In] & S)])(using Tag[Parse[In]], Frame): Chunk[A] < (Parse[In] & S) =
+        Kyo.foldLeft(parsers)(Chunk.empty[A])((acc, parser) => parser().map(acc :+ _))
 
     /** Parses two parsers in sequence and combines their results. This operation is commonly known as "sequence" in other parsing
       * libraries.
@@ -332,7 +332,7 @@ object Parse:
     def inOrder[A, B, In, S](
         parser1: => A < (Parse[In] & S),
         parser2: => B < (Parse[In] & S)
-    )(using Frame, StateTag[In]): (A, B) < (Parse[In] & S) =
+    )(using Tag[Parse[In]], Frame): (A, B) < (Parse[In] & S) =
         inOrder(Chunk(
             () => parser1,
             () => parser2
@@ -351,8 +351,8 @@ object Parse:
         parser2: => B < (Parse[In] & S),
         parser3: => C < (Parse[In] & S)
     )(using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): (A, B, C) < (Parse[In] & S) =
         inOrder(Chunk(
             () => parser1,
@@ -375,8 +375,8 @@ object Parse:
         parser4: => D < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): (A, B, C, D) < (Parse[In] & S) =
         inOrder(Chunk(
             () => parser1,
@@ -401,8 +401,8 @@ object Parse:
         parser5: => E < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): (A, B, C, D, E) < (Parse[In] & S) =
         inOrder(Chunk(
             () => parser1,
@@ -429,8 +429,8 @@ object Parse:
         parser6: => F < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): (A, B, C, D, E, F) < (Parse[In] & S) =
         inOrder(Chunk(
             () => parser1,
@@ -467,8 +467,8 @@ object Parse:
         parser7: => G < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): (A, B, C, D, E, F, G) < (Parse[In] & S) =
         inOrder(Chunk(
             () => parser1,
@@ -508,8 +508,8 @@ object Parse:
         parser8: => H < (Parse[In] & S)
     )(
         using
-        Frame,
-        StateTag[In]
+        Tag[Parse[In]],
+        Frame
     ): (A, B, C, D, E, F, G, H) < (Parse[In] & S) =
         inOrder(Chunk(
             () => parser1,
@@ -534,110 +534,44 @@ object Parse:
                 )
         }
 
-    /** Skips input until parser succeeds
-      *
-      * @param v
-      *   Parser to try at each position
-      * @return
-      *   Result when parser succeeds
-      */
-    def skipUntil[A](using Frame)[In, S](v: A < (Parse[In] & S))(using StateTag[In]): A < (Parse[In] & S) =
-        attempt(v).map {
-            case Absent =>
-                Var.use[State[In]] { state =>
-                    if state.done then Parse.drop
-                    else Var.set(state.advance(1)).andThen(skipUntil(v))
-                }
-            case Present(v) => v
-        }
-
-    /** Tries a parser but backtracks on failure. If the parser succeeds, the input is consumed normally. If it fails, the input position is
-      * restored to where it was before the attempt. This is essential for implementing look-ahead and alternative parsing strategies where
-      * failed attempts shouldn't consume input.
-      *
-      * @param v
-      *   Parser to attempt
-      * @return
-      *   Maybe containing the result if successful, Absent if parser failed
-      */
-    def attempt[A](using Frame)[In, S](v: A < (Parse[In] & S))(using StateTag[In]): Maybe[A] < (Parse[In] & S) =
-        Var.use[State[In]] { start =>
-            Choice.run(v).map { r =>
-                result(r).map {
-                    case Absent =>
-                        Var.set(start).andThen(Maybe.empty)
-                    case result =>
-                        result
-                }
-            }
-        }
-
-    /** Like attempt but requires the parse to succeed, failing instead of returning Maybe.empty. Use this when a parser must succeed at
-      * this point - if it fails, the entire parse fails with no possibility of backtracking.
-      *
-      * This operation is sometimes known as a "cut" in other parsing libraries, as it cuts off the possibility of backtracking.
-      *
-      * @param v
-      *   Parser to run
-      * @return
-      *   Parser result, fails if parser fails with no possibility of backtracking
-      */
-    def require[A](using Frame)[In, S](v: A < (Parse[In] & S))(using StateTag[In]): A < (Parse[In] & S) =
-        attempt(v).map {
-            case Present(a) => a
-            case Absent => Parse.fail(
-                    "Parse.require failed - parser did not match at this position. A required parser " +
-                        "fails the entire parse instead of allowing backtracking."
-                )
-        }
-
-    /** Tries a parser without consuming input
-      *
-      * @param v
-      *   Parser to peek with
-      * @return
-      *   Maybe containing the result if successful
-      */
-    def peek[A](using Frame)[In, S](v: A < (Parse[In] & S))(using StateTag[In]): Maybe[A] < (Parse[In] & S) =
-        Var.use[State[In]] { start =>
-            Choice.run(v).map { r =>
-                Var.set(start).andThen(result(r))
-            }
-        }
-
     /** Repeats a parser until it fails
       *
-      * @param p
+      * @param element
       *   Parser to repeat
       * @return
       *   Chunk of all successful results
       */
-    def repeat[A](using Frame)[In, S](p: A < (Parse[In] & S))(using StateTag[In]): Chunk[A] < (Parse[In] & S) =
-        Loop(Chunk.empty[A]) { acc =>
-            attempt(p).map {
-                case Present(a) => Loop.continue(acc.append(a))
-                case Absent     => Loop.done(acc)
-            }
-        }
+    def repeat[Out](using Frame)[In, S](element: => Out < (Parse[In] & S))(using Tag[Parse[In]]): Chunk[Out] < (Parse[In] & S) =
+        firstOf(
+            for
+                head <- element
+                tail <- repeat(element)
+            yield head +: tail,
+            Chunk.empty[Out]
+        )
 
-    /** Repeats a parser exactly n times
-      *
-      * @param n
-      *   Number of repetitions required
-      * @param p
-      *   Parser to repeat
-      * @return
-      *   Chunk of n results, fails if can't get n results
-      */
-    def repeat[A](using Frame)[In, S](n: Int)(p: A < (Parse[In] & S))(using StateTag[In]): Chunk[A] < (Parse[In] & S) =
-        Loop.indexed(Chunk.empty[A]) { (idx, acc) =>
-            if idx == n then Loop.done(acc)
-            else
-                attempt(p).map {
-                    case Present(a) => Loop.continue(acc.append(a))
-                    case Absent     => Parse.drop
-                }
-        }
+    def repeatUntil[Out](using
+        Frame
+    )[In, S](
+        element: => Out < (Parse[In] & S),
+        until: => Any < (Parse[In] & S)
+    )(using Tag[Parse[In]]): Chunk[Out] < (Parse[In] & S) =
+        firstOf(
+            until.andThen(Chunk.empty[Out]),
+            for
+                head <- element
+                tail <- repeatUntil(element, until)
+            yield head +: tail
+        )
+
+    def skipUntil[In](
+        skip: => Any < Parse[In],
+        until: => Any < Parse[In]
+    )(using Tag[Parse[In]], Frame): Unit < Parse[In] =
+        firstOf(
+            until.andThen(()),
+            skip.andThen(skipUntil(skip, until))
+        )
 
     /** Parses a sequence of elements separated by a delimiter. For example, parsing comma-separated values or space-separated words.
       *
@@ -648,33 +582,29 @@ object Parse:
       *   Parser for individual elements
       * @param separator
       *   Parser for the delimiter between elements
+      * @param allowTrailing
+      *   If true, allow trailing separator
       * @return
       *   Chunk of successfully parsed elements
       */
-    def separatedBy[A, B](using
+    def separatedBy[Out](using
         Frame
     )[In, S](
-        element: => A < (Parse[In] & S),
-        separator: => B < (Parse[In] & S),
+        element: => Out < (Parse[In] & S),
+        separator: => Any < (Parse[In] & S),
         allowTrailing: Boolean = false
-    )(using StateTag[In]): Chunk[A] < (Parse[In] & S) =
-        attempt(element).map {
-            case Absent => Chunk.empty
-            case Present(first) =>
-                Loop(Chunk(first)) { acc =>
-                    attempt(separator).map {
-                        case Absent => Loop.done(acc)
-                        case Present(_) =>
-                            attempt(element).map {
-                                case Present(next) =>
-                                    Loop.continue(acc.append(next))
-                                case Absent =>
-                                    if allowTrailing then Loop.done(acc)
-                                    else Parse.drop
-                            }
-                    }
-                }
-        }
+    )(using Tag[Parse[In]]): Chunk[Out] < (Parse[In] & S) =
+        firstOf(
+            for
+                head <- element
+                tail <- separator.andThen(separatedBy(element, separator, allowTrailing))
+                _ <-
+                    if tail.isEmpty && !allowTrailing then fail("Trailing separator")
+                    else Kyo.lift(())
+            yield head +: tail,
+            element.map(Chunk(_)),
+            Chunk.empty[Out]
+        )
 
     /** Parses content between a left and right delimiter.
       *
@@ -687,159 +617,81 @@ object Parse:
       * @return
       *   The parsed content
       */
-    def between[A](using
+    def between[Out](using
         Frame
     )[In, S](
         left: => Any < (Parse[In] & S),
-        content: => A < (Parse[In] & S),
+        content: => Out < (Parse[In] & S),
         right: => Any < (Parse[In] & S)
-    ): A < (Parse[In] & S) =
+    ): Out < (Parse[In] & S) =
         for
             _      <- left
             result <- content
             _      <- right
         yield result
 
-    // **************
-    // ** Handlers **
-    // **************
-
-    /** Runs a parser on input text
-      *
-      * @param input
-      *   Text to parse
-      * @param v
-      *   Parser to run
-      * @return
-      *   Parsed result if successful
-      */
-    def run[A, In, S](input: Chunk[In])(v: A < (Parse[In] & S))(using Frame, StateTag[In]): A < (S & Abort[ParseFailed]) =
-        Choice.run(Var.runTuple(State(input, 0))(v)).map {
-            case Seq() =>
-                Parse.fail(Seq(State(input, 0)), "No valid parse results found")
-            case Seq((state, value)) =>
-                if state.done then value
-                else Parse.fail(Seq(state), "Incomplete parse - remaining input not consumed")
-            case seq =>
-                Parse.fail(seq.map(_._1), "Ambiguous parse - multiple results found")
-        }
-
-    /** Runs a parser on input text
-      *
-      * @param input
-      *   Text to parse
-      * @param v
-      *   Parser to run
-      * @return
-      *   Parsed result if successful
-      */
-    def run[A, S](input: Text)(v: A < (Parse[Char] & S))(using Frame): A < (S & Abort[ParseFailed]) =
-        run(input.toChunk)(v)
-
-    /** Runs a parser on a stream of text input, emitting parsed results as they become available. This streaming parser accumulates text
-      * chunks and continuously attempts to parse complete results, handling partial inputs and backtracking as needed.
-      *
-      * @param input
-      *   Stream of text chunks to parse
-      * @param v
-      *   Parser to run on the accumulated text
-      * @tparam A
-      *   Type of parsed result
-      * @tparam S
-      *   Effects required by input stream
-      * @tparam S2
-      *   Effects required by parser
-      * @return
-      *   Stream of successfully parsed results, which can abort with ParseFailed
-      */
-    def run[A, S, S2](input: Stream[Text, S])(v: A < (Parse[Char] & S2))(
-        using
-        Frame,
-        Tag[Emit[Chunk[Text]]],
-        Tag[Emit[Chunk[A]]]
-    ): Stream[A, S & S2 & Abort[ParseFailed]] =
-        Stream {
-            input.emit.handle {
-                // Maintains a running buffer of text and repeatedly attempts parsing
-                Emit.runFold[Chunk[Text]](Text.empty) {
-                    (acc: Text, curr: Chunk[Text]) =>
-                        // Concatenate new chunks with existing accumulated text
-                        val text = acc + curr.foldLeft(Text.empty)(_ + _)
-                        if text.isEmpty then
-                            // If no text to parse, request more input
-                            text
-                        else
-                            Choice.run(Var.runTuple(State(text.toChunk, 0))(v)).map {
-                                case Seq() =>
-                                    // No valid parse found yet - keep current text and continue
-                                    // collecting more input as the parse might succeed with additional text
-                                    text
-                                case Seq((state, value)) =>
-                                    if state.done then
-                                        // Parser consumed all input - might need more text to complete
-                                        // the next parse, so continue
-                                        text
-                                    else
-                                        // Successfully parsed a value with remaining text.
-                                        // Emit the parsed value and continue with unconsumed text
-                                        Emit.valueWith(Chunk(value))(Text(state.remaining.mkString))
-                                case seq =>
-                                    Parse.fail(seq.map(_._1), "Ambiguous parse - multiple results found")
-                            }
-                        end if
-                }
-            }.map { (text, _) => run(text)(repeat(v)).map(Emit.value(_)) }
-        }
-
-    private def result[A, In](seq: Seq[A])(using Frame, StateTag[In]): Maybe[A] < Parse[In] =
-        seq match
-            case Seq()      => Maybe.empty
-            case Seq(value) => Maybe(value)
-            case _          => Parse.fail("Ambiguous parse result - multiple values found")
-
-    /** Represents the current state of parsing
-      *
-      * @param input
-      *   The complete input text being parsed
-      * @param position
-      *   Current position in the input text
-      */
-    case class State[In](input: Chunk[In], position: Int):
-
-        /** Returns the remaining unparsed input text */
-        def remaining: Chunk[In] =
-            input.drop(position)
-
-        /** Advances the position by n characters, not exceeding input length
-          *
-          * @param n
-          *   Number of characters to advance
-          * @return
-          *   New state with updated position
-          */
-        def advance(n: Int): State[In] =
-            copy(position = Math.min(input.length, position + n))
-
-        /** Checks if all input has been consumed
-          *
-          * @return
-          *   true if position has reached the end of input
-          */
-        def done: Boolean =
-            position == input.length
-    end State
-
-    // **********************
-    // ** Standard parsers **
-    // **********************
-
-    /** Consumes whitespace characters
+    /** Succeeds only at end of input
       *
       * @return
-      *   Unit after consuming whitespace
+      *   Unit if at end of input
       */
-    def whitespaces(using Frame): Text < Parse[Char] =
-        Parse.readWhile[Char](_.isWhitespace).map(c => Text(c.mkString))
+    def end[In](using Tag[Parse[In]], Frame): Unit < Parse[In] =
+        read(input =>
+            if input.done then Result.succeed(input, ())
+            else Result.fail(Chunk(ParseError(s"Expected: EOF, Got: ${input.remaining.head}", input.position)))
+        )
+
+    /** Tries a parser without consuming input
+      *
+      * @param parser
+      *   Parser to peek with
+      * @return
+      *   Maybe containing the result if successful
+      */
+    def peek[Out](using Frame)[In, S](parser: Out < (Parse[In] & S))(using Tag[Parse[In]]): Maybe[Out] < (Parse[In] & S) =
+        attempt(
+            for
+                pos    <- position
+                result <- parser
+                _      <- rewind(pos)
+            yield result
+        )
+
+    def not[In, S](parser: Any < (Parse[In] & S))(using Tag[Parse[In]], Frame): Unit < (Parse[In] & S) =
+        attempt(parser).map(result =>
+            if result.isDefined then fail("Not supposed to parse")
+            else ()
+        )
+
+    /** Tries a parser but backtracks on failure. If the parser succeeds, the input is consumed normally. If it fails, the input position is
+      * restored to where it was before the attempt. This is essential for implementing look-ahead and alternative parsing strategies where
+      * failed attempts shouldn't consume input.
+      *
+      * @param parser
+      *   Parser to attempt
+      * @return
+      *   Maybe containing the result if successful, Absent if parser failed
+      */
+    def attempt[Out](using Frame)[In, S](parser: Out < (Parse[In] & S))(using Tag[Parse[In]]): Maybe[Out] < (Parse[In] & S) =
+        firstOf(
+            parser.map(Present.apply),
+            Absent
+        )
+
+    def andIs[Out](using
+        Frame
+    )[In, S](
+        parser: Out < (Parse[In] & S),
+        and: Any < (Parse[In] & S)
+    )(using Tag[Parse[In]]): Out < (Parse[In] & S) =
+        for
+            pos    <- position
+            result <- parser
+            resPos <- position
+            _      <- rewind(pos)
+            _      <- and
+            _      <- rewind(resPos)
+        yield result
 
     /** Parses an integer
       *
@@ -847,10 +699,12 @@ object Parse:
       *   Parsed integer value
       */
     def int(using Frame): Int < Parse[Char] =
-        Parse.read { s =>
-            val (num, rest) = s.span(c => c.isDigit || c == '-')
-            Maybe.fromOption(num.mkString.toIntOption).map((rest, _))
-        }
+        read: in =>
+            val num = in.remaining.takeWhile(c => c.isDigit || c == '-')
+            Maybe
+                .fromOption(num.mkString.toIntOption)
+                .toResult(Result.fail(Chunk(ParseError("Invalid int", in.position))))
+                .map(res => (in.advance(num.length), res))
 
     /** Parses a decimal number
       *
@@ -858,10 +712,12 @@ object Parse:
       *   Parsed double value
       */
     def decimal(using Frame): Double < Parse[Char] =
-        Parse.read { s =>
-            val (num, rest) = s.span(c => c.isDigit || c == '.' || c == '-')
-            Maybe.fromOption(num.mkString.toDoubleOption).map((rest, _))
-        }
+        read: in =>
+            val num = in.remaining.takeWhile(c => c.isDigit || c == '.' || c == '-')
+            Maybe
+                .fromOption(num.mkString.toDoubleOption)
+                .toResult(Result.fail(Chunk(ParseError("Invalid decimal", in.position))))
+                .map(res => (in.advance(num.length), res))
 
     /** Parses a boolean ("true" or "false")
       *
@@ -869,151 +725,88 @@ object Parse:
       *   Parsed boolean value
       */
     def boolean(using Frame): Boolean < Parse[Char] =
-        Parse.read { s =>
-            if s.startsWith("true") then Maybe((s.drop(4), true))
-            else if s.startsWith("false") then Maybe((s.drop(5), false))
-            else Maybe.empty
-        }
+        read: in =>
+            if in.remaining.startsWith("true") then Result.succeed((in.advance(4), true))
+            else if in.remaining.startsWith("false") then Result.succeed((in.advance(5), false))
+            else Result.fail(Chunk(ParseError("Invalid boolean", in.position)))
 
-    /** Matches a specific character
-      *
-      * @param c
-      *   Character to match
-      * @return
-      *   Unit if character matches
-      */
-    def char(c: Char)(using Frame): Char < Parse[Char] =
-        literal(c)
+    private[kyo] def runWith[In, Out, S, Out2, S2](state: ParseState[In])(parser: Out < (Parse[In] & S))(f: Out => Out2 < S2)(using
+        tag: Tag[Parse[In]],
+        frame: Frame
+    ): (ParseState[In], ParseResult[Out2]) < (S & S2) =
+        extension [X, S1](v: X < (S1 & Parse[In]))
+            def castS: X < Parse[In] = v.asInstanceOf
 
-    /** Matches exact input
-      *
-      * @param str
-      *   Input to match
-      * @return
-      *   Unit if text matches
-      */
-    def literal[In](expected: In)(using Frame, CanEqual[In, In], Tag[In], StateTag[In]): In < Parse[In] =
-        Parse.read { s =>
-            Maybe.fromOption(s.headOption.filter(_ == expected).map(_ => (s.drop(1), expected)))
-        }
+        ArrowEffect.handleLoop(tag, state, parser)(
+            [C] =>
+                (input, state, cont) =>
+                    input match
+                        case Op.ModifyState(modify) =>
+                            val (newState, optOut) = modify(state)
+                            optOut match
+                                case Absent       => Loop.done((newState, ParseResult.failure(newState.errors)))
+                                case Present(out) => Loop.continue(newState, cont(out))
 
-    /** Matches exact text
-      *
-      * @param str
-      *   Text to match
-      * @return
-      *   Unit if text matches
-      */
-    def literal(str: Text)(using Frame): Text < Parse[Char] =
-        Parse.read { s =>
-            if s.startsWith(str.toString) then
-                Maybe((s.drop(str.length), str))
-            else
-                Maybe.empty
-        }
+                        case Op.Or(branches: Chunk[() => C < (Parse[In] & S)] @unchecked) =>
 
-    /** Consumes any single character
-      *
-      * @return
-      *   The character consumed
-      */
-    def char(using Frame): Char < Parse[Char] =
-        Parse.read(s => s.headMaybe.map(c => (s.drop(1), c)))
+                            def rec(branches: Chunk[() => C < (Parse[In] & S)])
+                                : Loop.Outcome2[ParseState[In], Out < (Parse[In] & S), (ParseState[In], ParseResult[Out2])] < (S & S2) =
+                                branches match
+                                    case head +: tail =>
+                                        runState(state)(head())
+                                            .map((state, result) =>
+                                                result.out match
+                                                    case None      => rec(tail)
+                                                    case Some(out) => Loop.continue(state, cont(out))
+                                            )
+                                    case _ => Loop.done((state, ParseResult.failure(state.errors)))
 
-    /** Consumes any single input element
-      *
-      * @return
-      *   The consumed input element
-      */
-    def any[In](using Frame, Tag[In], StateTag[In]): In < Parse[In] =
-        Parse.read(s => s.headMaybe.map(c => (s.drop(1), c)))
+                            rec(branches)
 
-    /** Consumes a character matching predicate
-      *
-      * @param p
-      *   Predicate function for character
-      * @return
-      *   Matching character
-      */
-    def charIf(p: Char => Boolean)(using Frame): Char < Parse[Char] =
-        Parse.read(s => s.headMaybe.filter(p).map(c => (s.drop(1), c)))
+                        case Op.RecoverWith(parser: (Out < Parse[In]) @unchecked, recoverStrategy) =>
+                            runState(state)(parser)
+                                .map((parseState, result) =>
+                                    result.out match
+                                        case None =>
+                                            runState(state.copy(errors = Chunk.empty))(recoverStrategy(parser))
+                                                .map((recoverState, recoverResult) =>
+                                                    recoverResult.out match
+                                                        case None => Loop.done((parseState, ParseResult.failure(parseState.errors)))
+                                                        case Some(recouverOut) => Loop.continue(
+                                                                recoverState.copy(errors = recoverState.errors ++ parseState.errors),
+                                                                cont(Kyo.lift(recouverOut))
+                                                            )
+                                                )
+                                        case Some(out) => Loop.continue(parseState, cont(Kyo.lift(out)))
+                                ),
+            done = (s, r) => f(r).map(out => (s, ParseResult.success(s.errors, out)))
+        )
+    end runWith
 
-    /** Consumes a character matching predicate
-      *
-      * @param p
-      *   Predicate function for character
-      * @return
-      *   Matching character
-      */
-    def anyIf[In](p: In => Boolean)(using Frame, Tag[In], StateTag[In]): In < Parse[In] =
-        Parse.read(s => s.headMaybe.filter(p).map(c => (s.drop(1), c)))
+    def runState[In, Out, S](state: ParseState[In])(parser: Out < (Parse[In] & S))(using
+        Tag[Parse[In]],
+        Frame
+    ): (ParseState[In], ParseResult[Out]) < S =
+        runWith(state)(parser)(identity)
 
-    def anyMatch[A](using Frame)[In](pf: PartialFunction[In, A])(using Tag[In], StateTag[In]): A < Parse[In] =
-        Parse.read(s => Maybe.fromOption(s.headOption.flatMap(pf.lift)).map(c => (s.drop(1), c)))
+    def run[In, Out, S](state: ParseState[In])(parser: Out < (Parse[In] & S))(using Tag[Parse[In]], Frame): ParseResult[Out] < S =
+        runState(state)(parser).map(_._2)
 
-    /** Matches text using regex pattern
-      *
-      * @param pattern
-      *   Regex pattern
-      * @return
-      *   Matched text
-      */
-    def regex(pattern: Regex)(using Frame): Text < Parse[Char] =
-        Parse.read { s =>
-            Maybe.fromOption(pattern.findPrefixOf(s.mkString).map(m => (s.drop(m.length), Text(m))))
-        }
+    def run[In, Out, S](input: ParseInput[In])(parser: Out < (Parse[In] & S))(using Tag[Parse[In]], Frame): ParseResult[Out] < S =
+        run(ParseState(input, Chunk.empty))(parser)
 
-    /** Matches text using regex pattern
-      *
-      * @param pattern
-      *   Regex pattern string
-      * @return
-      *   Matched text
-      */
-    def regex(pattern: String)(using Frame): Text < Parse[Char] =
-        regex(pattern.r)
+    def run[In, Out, S](input: Chunk[In])(parser: Out < (Parse[In] & S))(using Tag[Parse[In]], Frame): ParseResult[Out] < S =
+        run(ParseInput(input, 0))(parser)
 
-    /** Parses an identifier (letter/underscore followed by letters/digits/underscores)
-      *
-      * @return
-      *   Parsed identifier text
-      */
-    def identifier(using Frame): Text < Parse[Char] =
-        Parse.read { s =>
-            s.headMaybe.filter(c => c.isLetter || c == '_').map { _ =>
-                val (id, rest) = s.span(c => c.isLetterOrDigit || c == '_')
-                (rest, Text(id.mkString))
-            }
-        }
+    def run[Out, S](input: String)(parser: Out < (Parse[Char] & S))(using Tag[Parse[Char]], Frame): ParseResult[Out] < S =
+        run(Chunk.from(input))(parser)
 
-    /** Matches any character in string
-      *
-      * @param chars
-      *   String of valid characters
-      * @return
-      *   Matched character
-      */
-    def charIn(chars: String)(using Frame): Char < Parse[Char] =
-        charIf(c => chars.contains(c))
-
-    /** Matches any character not in string
-      *
-      * @param chars
-      *   String of invalid characters
-      * @return
-      *   Matched character
-      */
-    def charNotIn(chars: String)(using Frame): Char < Parse[Char] =
-        charIf(c => !chars.contains(c))
-
-    /** Succeeds only at end of input
-      *
-      * @return
-      *   Unit if at end of input
-      */
-    def end[In](using Frame, Tag[In], StateTag[In]): Unit < Parse[In] =
-        Parse.read(s => if s.isEmpty then Maybe((s, ())) else Maybe.empty)
-
+    // TODO Rework
+    def debug[In, Out](name: String, parser: Out < Parse[In])(using Tag[Parse[In]], Frame): Out < Parse[In] =
+        for
+            start <- position
+            _ = println(s"$name <= $start")
+            res <- parser
+            _ = println(s"$name => $res")
+        yield res
 end Parse
-
-case class ParseFailed(states: Seq[Parse.State[?]], message: String)(using Frame) extends KyoException(message, Render.asText(states))

--- a/kyo-parse/shared/src/main/scala/kyo/ParseError.scala
+++ b/kyo-parse/shared/src/main/scala/kyo/ParseError.scala
@@ -1,0 +1,3 @@
+package kyo.parse
+
+case class ParseError(message: String, position: Int)

--- a/kyo-parse/shared/src/main/scala/kyo/ParseInput.scala
+++ b/kyo-parse/shared/src/main/scala/kyo/ParseInput.scala
@@ -1,0 +1,25 @@
+package kyo.parse
+
+import kyo.Chunk
+
+case class ParseInput[In](tokens: Chunk[In], position: Int):
+
+    def remaining: Chunk[In] = tokens.drop(position)
+
+    /** Advances the position by n characters, not exceeding input length
+      *
+      * @param n
+      *   Number of characters to advance
+      * @return
+      *   New State with updated position
+      */
+    def advance(n: Int): ParseInput[In] =
+        copy(position = Math.min(tokens.length, position + n))
+
+    /** Checks if all input has been consumed
+      *
+      * @return
+      *   true if position has reached the end of input
+      */
+    def done: Boolean = position == tokens.length
+end ParseInput

--- a/kyo-parse/shared/src/main/scala/kyo/ParseResult.scala
+++ b/kyo-parse/shared/src/main/scala/kyo/ParseResult.scala
@@ -1,0 +1,13 @@
+package kyo.parse
+
+import kyo.Chunk
+
+case class ParseResult[+Out](errors: Chunk[ParseError], out: Option[Out])
+
+object ParseResult:
+    def success[Out](errors: Chunk[ParseError], out: Out): ParseResult[Out] =
+        ParseResult(errors, Some(out))
+
+    def failure(errors: Chunk[ParseError]): ParseResult[Nothing] =
+        ParseResult(errors, None)
+end ParseResult

--- a/kyo-parse/shared/src/main/scala/kyo/ParseState.scala
+++ b/kyo-parse/shared/src/main/scala/kyo/ParseState.scala
@@ -1,0 +1,5 @@
+package kyo.parse
+
+import kyo.Chunk
+
+case class ParseState[In](input: ParseInput[In], errors: Chunk[ParseError])

--- a/kyo-parse/shared/src/main/scala/kyo/RecoverStrategy.scala
+++ b/kyo-parse/shared/src/main/scala/kyo/RecoverStrategy.scala
@@ -1,0 +1,62 @@
+package kyo.parse
+
+import kyo.*
+
+@FunctionalInterface
+trait RecoverStrategy[In, Out]:
+    def apply(failedParser: Out < Parse[In]): Out < Parse[In]
+
+object RecoverStrategy:
+
+    def viaParser[In, Out](parser: Out < Parse[In]): RecoverStrategy[In, Out] =
+        _ => parser
+
+    def skipThenRetryUntil[In, Out](skip: Any < Parse[In], until: Any < Parse[In])(using Tag[Parse[In]], Frame): RecoverStrategy[In, Out] =
+        failedParser =>
+            Parse.firstOf(
+                until.andThen(Parse.fail("Until reached")),
+                skip.andThen(Parse.firstOf(failedParser, skipThenRetryUntil(skip, until)(failedParser)))
+            )
+
+    def nestedDelimiters[In, Out](
+        left: In,
+        right: In,
+        others: Seq[(In, In)],
+        fallback: Out
+    )(using CanEqual[In, In], Tag[Parse[In]], Frame): RecoverStrategy[In, Out] =
+        viaParser:
+            val allDelimiters = (left, right) +: others
+
+            def manyBlocks: Unit < Parse[In] =
+                val anyBlock =
+                    Parse.firstOf(
+                        others.map((l, r) =>
+                            () =>
+                                Parse.between(
+                                    Parse.literal(l),
+                                    manyBlocks,
+                                    Parse.literal(r)
+                                )
+                        )
+                    )
+
+                val skip =
+                    Parse.andIs(
+                        Parse.any.andThen(()),
+                        Parse.not(Parse.firstOf(
+                            allDelimiters.flatMap((l, r) => Seq(() => Parse.literal(l), () => Parse.literal(r)))
+                        ))
+                    )
+
+                Parse.repeat(Parse.firstOf(
+                    anyBlock,
+                    skip
+                )).andThen(())
+            end manyBlocks
+
+            Parse.between(
+                Parse.literal(left),
+                manyBlocks,
+                Parse.literal(right)
+            ).andThen(fallback)
+end RecoverStrategy

--- a/kyo-parse/shared/src/test/scala/kyo/ParseTest.scala
+++ b/kyo-parse/shared/src/test/scala/kyo/ParseTest.scala
@@ -1,4 +1,6 @@
-package kyo
+package kyo.parse
+
+import kyo.*
 
 class ParseTest extends Test:
 


### PR DESCRIPTION
Following #1400 and #1305

### Problem

In its current state, `Parse` does pretty much what other parser combinator libraries do. However it is not powerful enough for many real-world use cases such as production-ready programming languages, LSPs etc. Such projects require features like error accumulation and AST recovery.

### Solution

This PR reworks the entire `Parse` effect, providing the mentioned features as well as the already existing ones in the `main` branch.

As suggested by @ahoy-jon, I encoded `Parse` as its own `ArrowEffect`. I found it much easier to implement the new `Parse` this way, especially error accumulation.

### Notes

- I still need adapt the tests
- I did not implement `spaced` at the moment. Not sure which way is the best to implement it.
- I did not add `char` and String-specific friends that overlapped with the generic methods e.g `any`, `literal`... Should I add them?
- I did not add `anyOf` (well, another method has the same name but I can still rename it). I'm not sure if it was really used. Should I add it?
- I struggled to support additional effects in `runWith` and resorted to `@unchecked` two times. Is there a way to avoid that?