### PR TITLE
Revert "[core] remove scala-native Adder Stubs (#1371)"

### DIFF
--- a/kyo-core/native/src/main/scala/kyo/addersStubs.scala
+++ b/kyo-core/native/src/main/scala/kyo/addersStubs.scala
@@ -1,0 +1,29 @@
+package java.util.concurrent.atomic
+
+class DoubleAdder():
+    private var curr: Double = 0
+    def add(v: Double)       = synchronized { curr += v }
+    def sum(): Double        = synchronized { curr }
+    def reset()              = synchronized { curr = 0 }
+    def sumThenReset(): Double =
+        synchronized {
+            val res = curr
+            curr = 0
+            res
+        }
+end DoubleAdder
+
+class LongAdder():
+    private var curr: Long = 0
+    def add(v: Long)       = synchronized { curr += v }
+    def decrement()        = synchronized { curr -= 1 }
+    def increment()        = synchronized { curr += 1 }
+    def sum(): Long        = synchronized { curr }
+    def reset()            = synchronized { curr = 0 }
+    def sumThenReset(): Long =
+        synchronized {
+            val res = curr
+            curr = 0
+            res
+        }
+end LongAdder


### PR DESCRIPTION
This reverts commit c467fbdc0d9f85ea92b4d1ceded10bd744a27cd8.

I opened https://github.com/scala-native/scala-native/issues/4442