### PR TITLE
Queue: make subsequent closeAwaitEmpty calls wait for drain

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -563,7 +563,13 @@ object Queue:
                     handleHalfOpen()
                     p
                 else
-                    Fiber.Unsafe.init(Result.succeed(false))
+                    state.get() match
+                        case State.HalfOpen(other, _) =>
+                            p.becomeDiscard(other.safe)
+                        case _ => // Closed
+                            p.completeDiscard(Result.succeed(false))
+                    end match
+                    p.map(_ => false) // avoid returning `true` from other promise
                 end if
             end closeAwaitEmpty
 

--- a/kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala
@@ -26,7 +26,7 @@ private[kyo] trait BaseKyoKernelTest[S] extends BaseKyoDataTest:
     def runNative(v: => Assertion < S)(using Frame): Future[Assertion] = runNative(v.map(Future.successful(_)))
 
     @targetName("runNotNativeAssertion")
-    def runNotNative(v: => Assertion < S)(using Frame): Future[Assertion] = runNative(v.map(Future.successful(_)))
+    def runNotNative(v: => Assertion < S)(using Frame): Future[Assertion] = runNotNative(v.map(Future.successful(_)))
 
     def runJVM(v: => Future[Assertion] < S)(using Frame): Future[Assertion] =
         if Platform.isJVM then


### PR DESCRIPTION
Problem
- Only the first closeAwaitEmpty awaited drain; later calls returned immediately (false).

Change
- If HalfOpen, subsequent calls adopt the existing promise (join the same wait) and map the result to false.
- If Closed, they still complete immediately with false.
- First caller still observes true; later callers observe false but now wait for the drain.

Before
```
  Open ├─ closeAwaitEmpty #1 ──> HalfOpen(P) ── waits for drain ──> Closed → true
       └─ closeAwaitEmpty #2..N ── immediate → false
```

After
```
  Open ├─ closeAwaitEmpty #1 ──> HalfOpen(P) ── waits for drain ──> Closed → true
       └─ closeAwaitEmpty #2..N ── join P ───── waits with #1 ───────┘     → false
```