### PR TITLE
Make Semaphore test less flaky

### DIFF
--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -93,16 +93,16 @@ class MeterTest extends Test:
                 t  <- Meter.initSemaphore(2)
                 p  <- Promise.init[Int, Any]
                 b1 <- Promise.init[Unit, Any]
-                f1 <- Fiber.initUnscoped(t.run(b1.completeUnit.map(_ => p.getResult)))
+                f1 <- Fiber.initUnscoped(t.run(b1.completeUnit.andThen(p.getResult)))
                 _  <- b1.get
                 b2 <- Promise.init[Unit, Any]
-                f2 <- Fiber.initUnscoped(t.run(b2.completeUnit.map(_ => p.getResult)))
+                f2 <- Fiber.initUnscoped(t.run(b2.completeUnit.andThen(p.getResult)))
                 _  <- b2.get
                 a1 <- t.availablePermits
                 w1 <- t.pendingWaiters
                 b3 <- Promise.init[Unit, Any]
-                f3 <- Fiber.initUnscoped(b3.completeUnit.map(_ => t.run(2)))
-                _  <- b3.get
+                f3 <- Fiber.initUnscoped(b3.completeUnit.andThen(t.run(2)))
+                _  <- b3.get.andThen(untilTrue(t.pendingWaiters.map(_ > 0)))
                 a2 <- t.availablePermits
                 w2 <- t.pendingWaiters
                 d1 <- f1.done


### PR DESCRIPTION
See: https://github.com/getkyo/kyo/actions/runs/18804182670/job/53655827126

### Problem
There's a race condition in the semaphore test where the waiter has not yet gone async:
```
Time ─────────────────────────────────────────────────────────────────────────>

Main     | init t(2)
         | spawn f1 -----------------------------| complete b1
         | spawn f2 -----------------------------| complete b2
         | read a1,w1  ==> state=0, pending=0  (OK)
         | spawn f3 -----------------------------| complete b3
         | read a2,w2 ──┐
                        ├─ Case A (pass): f3 ran before read
                        │
f1       | t.run -> CAS 2→1 -> holds permit -> wait p.getResult
f2       | t.run -> CAS 1→0 -> holds permit -> wait p.getResult
f3       |                           t.run -> CAS 0→-1 -> enqueue waiter
State    | 2 ──(f1)→ 1 ──(f2)→ 0 ───────────────(f3)→ -1
pending  |                        0 ------------------→ 1
         | a2=0, w2=1  (as test expects)

                        └─ Case B (flake): read happened first
f3       |                                     t.run -> CAS 0→-1 -> enqueue waiter
State    | 2 → 1 → 0 → (read a2=0,w2=0) → -1
pending  |                0 → (read 0) → 1

         => In Case B, main reads while state is still 0 (no CAS yet), so w2=0.
```

### Solution
Avoid proceeding until the pending waiter is registered.

