### PR TITLE
Fix code block formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3655,7 +3655,7 @@ Being more modular than ZIO, Kyo separates effect constructors in the companion 
 
 ### Simple example
 
-```scala
+```scala mdoc:skip
 import kyo.*
 import scala.concurrent.duration.*
 import java.io.IOException


### PR DESCRIPTION
### Problem


The ZIO-like Combinators simple example has no code highlighting (see https://getkyo.io/#/?id=simple-example), because of the ```scala 3 instruction