### PR TITLE
Fix issue with a test caused by scala 3.8 type inferrence

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
@@ -53,9 +53,9 @@ private[kyo] object TagMacro:
                     case true => tpe
                     case false =>
                         seen.get(tpe.typeSymbol) match
-                            case None                          => tpe.typeSymbol
-                            case Some((t, _)) if t.equals(tpe) => tpe.typeSymbol
-                            case _                             => tpe
+                            case None                      => tpe.typeSymbol
+                            case Some((t, _)) if t =:= tpe => tpe.typeSymbol
+                            case _                         => tpe
             if seen.contains(key) then
                 seen(key)._2
             else


### PR DESCRIPTION
Hello! I'm part of the Scala 3 compiler team, and we've noticed an issue with running certain tests in Kyo with scala 3.8 in the [open community build](https://github.com/VirtusLab/community-build3). We usually use this information to pinpoint regressions in the compiler, but this time I've determined that an adjustment in the library would be more applicable.

### Problem
The issue stems from a difference between how certain types are inferred and represented when using the Quotes reflect API. More context/information here: https://github.com/scala/scala3/issues/24596

In the minimization there, one Tag macro had `TypeRef(ThisType(TypeRef(NoPrefix,module class lang)),class String)` passed to it and another had `TypeRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object java),object lang),class String)`, leading to the generation of different `Tag`s (while the expectation was that they would be the same).

### Solution
Using `=:=` instead of `equals` when tagging seen types. This makes sure that the same, but differently represented types produce the same `Tag`s (also helps users for cases outside of the test and in the previous scala versions, e.g. if they use an inferred type for one `Tag`, and explicit for another, they may still look be represented differently).
