### PR TITLE
Abort: remove usage of erased Tags

### DIFF
--- a/kyo-actor/shared/src/main/scala/kyo/Actor.scala
+++ b/kyo-actor/shared/src/main/scala/kyo/Actor.scala
@@ -44,7 +44,7 @@ import scala.annotation.*
   * @tparam B
   *   The type of result this actor produces upon completion
   */
-sealed abstract class Actor[+E, A, B](_subject: Subject[A], _fiber: Fiber[B, Abort[Closed | E]]):
+sealed abstract class Actor[E, A, B](_subject: Subject[A], _fiber: Fiber[B, Abort[Closed | E]]):
 
     /** Returns the message subject interface for sending messages to this actor.
       *
@@ -75,7 +75,7 @@ sealed abstract class Actor[+E, A, B](_subject: Subject[A], _fiber: Fiber[B, Abo
       * @return
       *   The actor's final result of type B
       */
-    def await(using Frame): B < (Async & Abort[Closed | E]) = fiber.get
+    def await(using Frame, Tag[Abort[Closed | E]]): B < (Async & Abort[Closed | E]) = fiber.get
 
     /** Closes the actor's mailbox, preventing it from receiving any new messages.
       *

--- a/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/AsyncCombinators.scala
@@ -61,6 +61,8 @@ extension [A, E, S](effect: A < (Abort[E] & Async & S))
     def &>[A1, E1, S2, S3](next: A1 < (Abort[E1] & Async & S2))(
         using
         fr: Frame,
+        tag1: Tag[Abort[E]],
+        tag2: Tag[Abort[E1]],
         i1: Isolate[S, Sync, S3],
         i2: Isolate[S2, Sync, S3]
     ): A1 < (Abort[E | E1] & Async & S & S2 & S3) =
@@ -82,6 +84,8 @@ extension [A, E, S](effect: A < (Abort[E] & Async & S))
     def <&[A1, E1, S2, S3](next: A1 < (Abort[E1] & Async & S2))(
         using
         f: Frame,
+        tag1: Tag[Abort[E]],
+        tag2: Tag[Abort[E1]],
         i1: Isolate[S, Sync, S3],
         i2: Isolate[S2, Sync, S3]
     ): A < (Abort[E | E1] & Async & S & S2 & S3) =
@@ -103,6 +107,8 @@ extension [A, E, S](effect: A < (Abort[E] & Async & S))
     def <&>[A1, E1, S2, S3](next: A1 < (Abort[E1] & Async & S2))(
         using
         fr: Frame,
+        tag1: Tag[Abort[E]],
+        tag2: Tag[Abort[E1]],
         i1: Isolate[S, Sync, S3],
         i2: Isolate[S2, Sync, S3],
         zippable: Zippable[A, A1]
@@ -123,7 +129,7 @@ extension [A, E, S, S2](fiber: Fiber[A, Abort[E] & S2] < S)
       * @return
       *   A computation that produces the result of this computation with Async effect
       */
-    def join(using Frame): A < (S & S2 & Abort[E] & Async) =
+    def join(using Frame, Tag[Abort[E]]): A < (S & S2 & Abort[E] & Async) =
         fiber.map(_.get)
 
     /** Awaits the completion of the fiber and returns its result as a `Unit`.

--- a/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/ChoiceCombinators.scala
@@ -50,7 +50,7 @@ extension [A, S](effect: A < (S & Choice))
       * @return
       *   A computation that produces the result of this computation with dropped Choice translated to Abort[E]
       */
-    def choiceDropToFailure[E](error: => E)(using Frame): A < (Choice & Abort[E] & S) =
+    def choiceDropToFailure[E](error: => E)(using Frame, Tag[Abort[E]]): A < (Choice & Abort[E] & S) =
         Choice.run(effect).map:
             case seq if seq.isEmpty => Abort.fail(error)
             case other              => Choice.evalSeq(other)

--- a/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/Constructors.scala
@@ -37,7 +37,10 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that can be completed by the given register function
       */
-    def async[A, E](register: (A < (Abort[E] & Async) => Unit) => Any < (Abort[E] & Async))(using Frame): A < (Abort[E] & Async) =
+    def async[A, E](register: (A < (Abort[E] & Async) => Unit) => Any < (Abort[E] & Async))(using
+        Frame,
+        Tag[Abort[E]]
+    ): A < (Abort[E] & Async) =
         for
             promise <- Promise.init[A, Abort[E]]
             registerFn = (eff: A < (Abort[E] & Async)) =>
@@ -88,7 +91,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that fails with the given error
       */
-    def fail[E](error: => E)(using Frame): Nothing < Abort[E] =
+    def fail[E](error: => E)(using Frame, Tag[Abort[E]]): Nothing < Abort[E] =
         Abort.fail(error)
 
     /** Applies a function to each element in parallel and returns a new sequence with the results.
@@ -143,7 +146,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that attempts to run the given effect and handles Left[E] to Abort[E].
       */
-    def fromEither[E, A](either: Either[E, A])(using Frame): A < Abort[E] =
+    def fromEither[E, A](either: Either[E, A])(using Frame, Tag[Abort[E]]): A < Abort[E] =
         Abort.get(either)
 
     /** Creates an effect from an Option[A] and handles None to Abort[Absent].
@@ -173,7 +176,7 @@ extension (kyoObject: Kyo.type)
       * @return
       *   An effect that attempts to run the given effect and handles Result.Failure[E] to Abort[E].
       */
-    def fromResult[E, A](result: Result[E, A])(using Frame): A < Abort[E] =
+    def fromResult[E, A](result: Result[E, A])(using Frame, Tag[Abort[E]]): A < Abort[E] =
         Abort.get(result)
 
     /** Creates an effect from a Future[A] and handles the Future to Async.

--- a/kyo-combinators/shared/src/main/scala/kyo/MaybeCombinators.scala
+++ b/kyo-combinators/shared/src/main/scala/kyo/MaybeCombinators.scala
@@ -46,7 +46,7 @@ extension [A, S, E](effect: A < (Abort[Absent] & S))
       * @return
       *   A computation that produces the result of this computation with the Abort[Absent] effect translated to Abort[E]
       */
-    def absentToFailure(failure: => E)(using Frame): A < (S & Abort[E]) =
+    def absentToFailure(failure: => E)(using Frame, Tag[Abort[E]]): A < (S & Abort[E]) =
         for
             res <- effect.forAbort[Absent].result
         yield res match

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -239,7 +239,7 @@ object Fiber:
           * @return
           *   The result of the Fiber
           */
-        def get(using Frame): A < (Abort[E] & Async & S) =
+        def get(using Frame, Tag[Abort[E]]): A < (Abort[E] & Async & S) =
             Async.use(self.lower)(identity)
 
         /** Uses the result of the Fiber to compute a new value.
@@ -249,7 +249,7 @@ object Fiber:
           * @return
           *   The result of applying the function to the Fiber's result
           */
-        def use[B, S2](f: A => B < S2)(using Frame): B < (Abort[E] & Async & S & S2) =
+        def use[B, S2](f: A => B < S2)(using Frame, Tag[Abort[E]]): B < (Abort[E] & Async & S & S2) =
             Async.use(self.lower)(_.map(f))
 
         /** Gets the result of the Fiber as a Result.

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -49,7 +49,9 @@ object KyoApp:
     def runAndBlock[E, A, S](
         using isolate: Isolate[S, Sync, Any]
     )(timeout: Duration)(v: => A < (Abort[E] & Async & S))(
-        using frame: Frame
+        using
+        frame: Frame,
+        t: Tag[Abort[E | Timeout]]
     ): A < (Abort[E | Timeout] & Sync & S) =
         Fiber.initUnscoped(v).map { fiber =>
             fiber.block(timeout).map(Abort.get(_))

--- a/kyo-core/shared/src/main/scala/kyo/Retry.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Retry.scala
@@ -37,7 +37,7 @@ object Retry:
       * @return
       *   The result of the operation, or an abort if all retries fail
       */
-    def apply[E: ConcreteTag](using Frame)[A, S](v: => A < (Abort[E] & S)): A < (Async & Abort[E] & S) =
+    def apply[E: ConcreteTag](using Frame, Tag[Abort[E]])[A, S](v: => A < (Abort[E] & S)): A < (Async & Abort[E] & S) =
         apply(defaultSchedule)(v)
 
     /** Retries an operation using a custom policy builder.
@@ -49,7 +49,7 @@ object Retry:
       * @return
       *   The result of the operation, or an abort if all retries fail.
       */
-    def apply[E: ConcreteTag](using Frame)[A, S](schedule: Schedule)(v: => A < (Abort[E] & S)): A < (Async & Abort[E] & S) =
+    def apply[E: ConcreteTag](using Frame, Tag[Abort[E]])[A, S](schedule: Schedule)(v: => A < (Abort[E] & S)): A < (Async & Abort[E] & S) =
         Abort.run[E](v).map {
             case Result.Success(value) => value
             case result: Result.Failure[E] @unchecked =>

--- a/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/BaseKyoCoreTest.scala
@@ -10,7 +10,7 @@ private[kyo] trait BaseKyoCoreTest extends BaseKyoKernelTest[Abort[Any] & Async 
             Scope.run,
             Abort.recover[Any] {
                 case ex: Throwable => throw ex
-                case e             => throw new IllegalStateException(s"Test aborted with $e")
+                case e             => throw new IllegalStateException(s"Test aborted with [$e]")
             },
             Async.timeout(timeout),
             Fiber.initUnscoped,

--- a/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
@@ -85,9 +85,9 @@ class SystemTest extends Test:
     "custom System implementation" in run {
         val customSystem = new System:
             def unsafe: Unsafe = ???
-            def env[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync) =
+            def env[E, A](name: String)(using Parser[E, A], Frame, Tag[Abort[E]]): Maybe[A] < (Abort[E] & Sync) =
                 Sync.defer(Maybe("custom_env").asInstanceOf[Maybe[A]])
-            def property[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync) =
+            def property[E, A](name: String)(using Parser[E, A], Frame, Tag[Abort[E]]): Maybe[A] < (Abort[E] & Sync) =
                 Sync.defer(Maybe("custom_property").asInstanceOf[Maybe[A]])
             def lineSeparator(using Frame): String < Sync = Sync.defer("custom_separator")
             def userName(using Frame): String < Sync      = Sync.defer("custom_user")

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -1282,7 +1282,7 @@ class AbortTest extends Test:
         }
 
         "generic" in {
-            def test[A](a: A): Nothing < Abort[A] =
+            def test[A](a: A)(using Tag[Abort[a.type]]): Nothing < Abort[A] =
                 Abort.literal.fail(a)
 
             val result                  = test(1)

--- a/kyo-sttp/shared/src/main/scala/kyo/Requests.scala
+++ b/kyo-sttp/shared/src/main/scala/kyo/Requests.scala
@@ -78,7 +78,10 @@ object Requests:
       * @return
       *   The response body wrapped in an effect
       */
-    def apply[E, A](f: BasicRequest => Request[Either[E, A], Any])(using Frame): A < (Async & Abort[FailedRequest | E]) =
+    def apply[E, A](f: BasicRequest => Request[Either[E, A], Any])(using
+        Frame,
+        Tag[Abort[FailedRequest | E]]
+    ): A < (Async & Abort[FailedRequest | E]) =
         request(f(basicRequest))
 
     /** Sends an HTTP request
@@ -92,7 +95,7 @@ object Requests:
       * @return
       *   The response body wrapped in an effect
       */
-    def request[E, A](req: Request[Either[E, A], Any])(using Frame): A < (Async & Abort[FailedRequest | E]) =
+    def request[E, A](req: Request[Either[E, A], Any])(using Frame, Tag[Abort[FailedRequest | E]]): A < (Async & Abort[FailedRequest | E]) =
         local.use(_.send(req)).map { r =>
             Abort.get(r.body)
         }

--- a/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
+++ b/kyo-tapir/shared/src/main/scala/kyo/Routes.scala
@@ -51,7 +51,7 @@ object Routes:
       */
     def add[A: Tag, I, E: ConcreteTag, O](e: Endpoint[A, I, E, O, Any])(
         f: I => O < (Async & Env[A] & Abort[E])
-    )(using Frame): Unit < Routes =
+    )(using Frame, Tag[Abort[E]]): Unit < Routes =
         Emit.value(
             Route(
                 e.serverSecurityLogic[A, KyoSttpMonad.M](a => Right(a)).serverLogic((a: A) =>
@@ -78,7 +78,7 @@ object Routes:
         e: PublicEndpoint[Unit, Unit, Unit, Any] => Endpoint[A, I, E, O, Any]
     )(
         f: I => O < (Async & Env[A] & Abort[E])
-    )(using Frame): Unit < Routes =
+    )(using Frame, Tag[Abort[E]]): Unit < Routes =
         add(e(endpoint))(f)
 
     /** Collects multiple route initializations into a single Routes effect.

--- a/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZIOs.scala
@@ -21,7 +21,7 @@ object ZIOs:
       * @return
       *   A Kyo effect that, when run, will execute the zio.ZIO
       */
-    def get[E, A](v: => ZIO[Any, E, A])(using f: Frame, t: Trace): A < (Abort[E] & Async) =
+    def get[E, A](v: => ZIO[Any, E, A])(using f: Frame, t: Trace, tag: Tag[Abort[E]]): A < (Abort[E] & Async) =
         Sync.Unsafe {
             Unsafe.unsafely {
                 given ce: CanEqual[E, E] = CanEqual.derived

--- a/kyo-zio/shared/src/main/scala/kyo/ZLayers.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZLayers.scala
@@ -22,7 +22,7 @@ object ZLayers:
       * @return
       *   A Kyo Layer that, when run, will instantiate the resource from the ZLayer
       */
-    def get[E, A: ZTag: Tag](layer: => ZLayer[Any, E, A])(using Frame, Trace): Layer[A, Abort[E] & Async & Scope] =
+    def get[E, A: ZTag: Tag](layer: => ZLayer[Any, E, A])(using Frame, Trace, Tag[Abort[E]]): Layer[A, Abort[E] & Async & Scope] =
         Layer {
             Sync.Unsafe {
                 val scope = Unsafe.unsafely(ZScope.unsafe.make)

--- a/kyo-zio/shared/src/main/scala/kyo/ZStreams.scala
+++ b/kyo-zio/shared/src/main/scala/kyo/ZStreams.scala
@@ -25,7 +25,8 @@ object ZStreams:
     def get[E, A](stream: => ZStream[Any, E, A])(using
         Frame,
         Trace,
-        Tag[Emit[Chunk[A]]]
+        Tag[Emit[Chunk[A]]],
+        Tag[Abort[E]]
     ): Stream[A, Abort[E] & Async] =
         Stream:
             Sync.defer {


### PR DESCRIPTION
Related to #1247 and #1443

### Problem
Erased tags are leftover from earlier limitations with splicing and subtype checking of tags.

### Solution
Require tag evidences in all Abort methods.