### PR TITLE
[data] fix subtype check for null vs literal types

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Tag.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Tag.scala
@@ -385,7 +385,7 @@ object Tag:
                 aEntry match
                     case NothingEntry => true
                     case AnyEntry     => bEntry eq AnyEntry
-                    case NullEntry    => true
+                    case NullEntry    => !bEntry.isInstanceOf[LiteralEntry]
 
                     case IntersectionEntry(aSet) =>
                         bEntry match

--- a/kyo-data/shared/src/test/scala/kyo/TagTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/TagTest.scala
@@ -1042,6 +1042,12 @@ class TagTest extends Test:
             class Box[A]
             test[Box[1], Box[1.0]]
         }
+
+        "Null vs literals" - {
+            test[Null, 1]
+            test[Null, "A"]
+            test[List[Null], List["A"]]
+        }
     }
 
     "subtype and supertype with different type argument (bug #551)" - {


### PR DESCRIPTION
Fixes #1176 

### Problem

The `Tag` impl isn't properly checking the subtype relationship between `Null` and literal types.

### Solution

Fix the logic to not consider `Null` a subtype of a literal type.
