### PR TITLE
[data] fix Chunk.toArray for primitive types

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -1,6 +1,7 @@
 package kyo
 
 import Chunk.Indexed
+import java.util.Arrays
 import scala.annotation.tailrec
 import scala.annotation.targetName
 import scala.collection.IterableFactoryDefaults
@@ -474,7 +475,7 @@ sealed abstract class Chunk[+A]
                     case c: Compact[A] @unchecked =>
                         val l = c.array.length
                         if l > 0 then
-                            System.arraycopy(c.array, dropLeft, array, start, l - dropRight - dropLeft)
+                            Array.copy(c.array, dropLeft, array, start, l - dropRight - dropLeft)
                     case c: FromSeq[A] @unchecked =>
                         val seq    = c.value
                         val length = Math.min(end, c.value.length - dropLeft - dropRight)

--- a/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
@@ -707,6 +707,11 @@ class ChunkTest extends Test:
             val array2 = chunk.toArray
             assert(array1 ne array2)
         }
+
+        "handles primitive types properly" in {
+            val chunk = Chunk.from(Array(1, 2))
+            assert(chunk.toArray.toList == List(1, 2))
+        }
     }
 
     "copyTo" - {


### PR DESCRIPTION


### Problem

`Chunk.toArray` isn't properly handling the case when the `Chunk` is holding a boxed primitive and a primitive `Array` needs to be produced.

### Solution

Use Scala's `Array.copy` instead of `System.arraycopy`, which handles the boxing to primitive conversion if necessary.
