### PR TITLE
[build] disable Native tests again

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -34,4 +34,4 @@ jobs:
       run: sbt '+kyoJS/test'
 
     - name: Build Native
-      run: sbt '+kyoNative/testQuick'
+      run: sbt '+kyoNative/Test/compile'

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,7 +18,7 @@ jobs:
         target:
           - { name: "JVM", command: "sbt '+kyoJVM/testQuick'" }
           - { name: "JS", command: "sbt '+kyoJS/testQuick'" }
-          - { name: "Native", command: "sbt '+kyoNative/testQuick'" }
+          - { name: "Native", command: "sbt '+kyoNative/Test/compile'" }
     env:
       JAVA_OPTS: -Xms15G -Xmx15G -Xss10M -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS:  -Xms15G -Xmx15G -Xss10M -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8


### PR DESCRIPTION
The issue with the Native test runner remains. Tests are passing both locally and in CI but the execution hangs at the end and then times out. It seems some concurrency issue. Let's disable the tests again for now so we have a green main.