### PR TITLE
[core] fix Async.foreach and derived methods

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -408,7 +408,7 @@ object Async extends AsyncPlatformSpecific:
                 case 1 => f(0, iterable.head).map(Chunk(_))
                 case size =>
                     isolate.capture { state =>
-                        val items = Chunk.from(iterable).toIndexed
+                        val items = Chunk.Indexed.from(iterable)
                         Fiber.internal.foreachIndexed(items, concurrency) { (idx, v) =>
                             isolate.isolate(state, f(idx, v))
                         }.map(_.use(r => Kyo.foreach(r)(isolate.restore)))

--- a/kyo-core/shared/src/main/scala/kyo/Async.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Async.scala
@@ -406,17 +406,12 @@ object Async extends AsyncPlatformSpecific:
             iterable.size match
                 case 0 => Chunk.empty
                 case 1 => f(0, iterable.head).map(Chunk(_))
-                case size if size <= concurrency =>
-                    isolate.capture { state =>
-                        Fiber.internal.foreachIndexed(iterable)((idx, v) => isolate.isolate(state, f(idx, v)))
-                            .map(_.use(r => Kyo.foreach(r)(isolate.restore)))
-                    }
                 case size =>
                     isolate.capture { state =>
-                        val groupSize = Math.ceil(size.toDouble / Math.max(1, concurrency)).toInt
-                        Fiber.internal.foreachIndexed(Chunk.from(iterable.grouped(groupSize)))((idx, group) =>
-                            Kyo.foreachIndexed(Chunk.from(group))((idx2, v) => isolate.isolate(state, f(idx + idx2, v)))
-                        ).map(_.use(r => Kyo.foreach(r.flattenChunk)(isolate.restore)))
+                        val items = Chunk.from(iterable).toIndexed
+                        Fiber.internal.foreachIndexed(items, concurrency) { (idx, v) =>
+                            isolate.isolate(state, f(idx, v))
+                        }.map(_.use(r => Kyo.foreach(r)(isolate.restore)))
                     }
 
     /** Executes a sequence of computations using bounded concurrency.

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -690,43 +690,47 @@ object Fiber:
             if size == 0 then Fiber.succeed(Chunk.empty)
             else
                 val numWorkers = Math.min(size, concurrency)
-                Sync.Unsafe.defer {
-                    class State extends IOPromise[Any, Chunk[B] < Abort[E]]
-                        with (Result[E, Unit] => Unit):
-                        val results = (new Array[Any](size)).asInstanceOf[Array[B]]
-                        val pending = AtomicInt.Unsafe.init(size)
-                        val counter = AtomicInt.Unsafe.init(0)
-                        def complete(idx: Int, value: B): Unit =
-                            results(idx) = value
-                            if pending.decrementAndGet() == 0 then
-                                this.completeDiscard(Result.succeed(Chunk.fromNoCopy(results)))
-                        end complete
-                        def apply(result: Result[E, Unit]): Unit =
-                            result.foldError(_ => (), this.interruptDiscard)
-                    end State
-                    val state = new State
-                    Isolate.internal.runDetached { (trace, context) =>
-                        val safepoint = Safepoint.get
-                        @tailrec def loop(i: Int): Unit =
-                            if i < numWorkers then
-                                def workerLoop(): Unit < (Abort[E] & Async) =
-                                    val idx = state.counter.getAndIncrement()
-                                    if idx >= size then ()
-                                    else
-                                        f(idx, items(idx)).map { value =>
-                                            state.complete(idx, value)
-                                            workerLoop()
-                                        }
-                                    end if
-                                end workerLoop
-                                val fiber = IOTask(workerLoop(), safepoint.copyTrace(trace), context)
-                                state.interrupts(fiber)
-                                fiber.onComplete(state)
-                                loop(i + 1)
-                        loop(0)
-                        state
+                if numWorkers == 1 then
+                    Fiber.initUnscoped[E, Chunk[B], Any, Any](Kyo.foreachIndexed(items)(f))
+                else
+                    Sync.Unsafe.defer {
+                        class State extends IOPromise[Any, Chunk[B] < Abort[E]]
+                            with (Result[E, Unit] => Unit):
+                            val results = (new Array[Any](size)).asInstanceOf[Array[B]]
+                            val pending = AtomicInt.Unsafe.init(size)
+                            val counter = AtomicInt.Unsafe.init(0)
+                            def complete(idx: Int, value: B): Unit =
+                                results(idx) = value
+                                if pending.decrementAndGet() == 0 then
+                                    this.completeDiscard(Result.succeed(Chunk.fromNoCopy(results)))
+                            end complete
+                            def apply(result: Result[E, Unit]): Unit =
+                                result.foldError(_ => (), this.interruptDiscard)
+                        end State
+                        val state = new State
+                        Isolate.internal.runDetached { (trace, context) =>
+                            val safepoint = Safepoint.get
+                            @tailrec def loop(i: Int): Unit =
+                                if i < numWorkers then
+                                    def workerLoop(): Unit < (Abort[E] & Async) =
+                                        val idx = state.counter.getAndIncrement()
+                                        if idx >= size then ()
+                                        else
+                                            f(idx, items(idx)).map { value =>
+                                                state.complete(idx, value)
+                                                workerLoop()
+                                            }
+                                        end if
+                                    end workerLoop
+                                    val fiber = IOTask(workerLoop(), safepoint.copyTrace(trace), context)
+                                    state.interrupts(fiber)
+                                    fiber.onComplete(state)
+                                    loop(i + 1)
+                            loop(0)
+                            state
+                        }
                     }
-                }
+                end if
             end if
         end foreachIndexed
 

--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -681,45 +681,54 @@ object Fiber:
     ): Fiber[Chunk[A], Abort[E]] < Sync =
         internal.gather(max)(iterable)
 
-    private[kyo] def foreachIndexed[E, A, B](iterable: Iterable[A])(f: (Int, A) => B < (Abort[E] & Async))(
-        using frame: Frame
-    ): Fiber[Chunk[B], Abort[E]] < Sync =
-        internal.foreachIndexed(iterable)(f)
-
     private[kyo] object internal:
 
-        def foreachIndexed[E, A, B](iterable: Iterable[A])(f: (Int, A) => B < (Abort[E] & Async))(
-            using frame: Frame
-        ): Fiber[Chunk[B], Abort[E]] < Sync =
-            iterable.size match
-                case 0 => Fiber.succeed(Chunk.empty)
-                case size =>
-                    Sync.Unsafe.defer {
-                        class State extends IOPromise[Any, Chunk[B] < Abort[E]]
-                            with ((Int, Result[E, B]) => Unit):
-                            val results = (new Array[Any](size)).asInstanceOf[Array[B]]
-                            val pending = AtomicInt.Unsafe.init(size)
-                            def apply(idx: Int, result: Result[E, B]): Unit =
-                                result.foldError(
-                                    { value =>
-                                        results(idx) = value
-                                        if pending.decrementAndGet() == 0 then
-                                            this.completeDiscard(Result.succeed(Chunk.fromNoCopy(results)))
-                                    },
-                                    this.interruptDiscard
-                                )
-                        end State
-                        val state = new State
-                        Isolate.internal.runDetached { (trace, context) =>
-                            val safepoint = Safepoint.get
-                            foreach(iterable) { (idx, v) =>
-                                val fiber = IOTask(f(idx, v), safepoint.copyTrace(trace), context)
+        def foreachIndexed[E, A, B](items: Chunk.Indexed[A], concurrency: Int)(
+            f: (Int, A) => B < (Abort[E] & Async)
+        )(using frame: Frame): Fiber[Chunk[B], Abort[E]] < Sync =
+            val size = items.size
+            if size == 0 then Fiber.succeed(Chunk.empty)
+            else
+                val numWorkers = Math.min(size, concurrency)
+                Sync.Unsafe.defer {
+                    class State extends IOPromise[Any, Chunk[B] < Abort[E]]
+                        with (Result[E, Unit] => Unit):
+                        val results = (new Array[Any](size)).asInstanceOf[Array[B]]
+                        val pending = AtomicInt.Unsafe.init(size)
+                        val counter = AtomicInt.Unsafe.init(0)
+                        def complete(idx: Int, value: B): Unit =
+                            results(idx) = value
+                            if pending.decrementAndGet() == 0 then
+                                this.completeDiscard(Result.succeed(Chunk.fromNoCopy(results)))
+                        end complete
+                        def apply(result: Result[E, Unit]): Unit =
+                            result.foldError(_ => (), this.interruptDiscard)
+                    end State
+                    val state = new State
+                    Isolate.internal.runDetached { (trace, context) =>
+                        val safepoint = Safepoint.get
+                        @tailrec def loop(i: Int): Unit =
+                            if i < numWorkers then
+                                def workerLoop(): Unit < (Abort[E] & Async) =
+                                    val idx = state.counter.getAndIncrement()
+                                    if idx >= size then ()
+                                    else
+                                        f(idx, items(idx)).map { value =>
+                                            state.complete(idx, value)
+                                            workerLoop()
+                                        }
+                                    end if
+                                end workerLoop
+                                val fiber = IOTask(workerLoop(), safepoint.copyTrace(trace), context)
                                 state.interrupts(fiber)
-                                fiber.onComplete(state(idx, _))
-                            }
-                            state
-                        }
+                                fiber.onComplete(state)
+                                loop(i + 1)
+                        loop(0)
+                        state
                     }
+                }
+            end if
+        end foreachIndexed
 
         def race[E, A](iterable: Iterable[A < (Abort[E] & Async)])(using Frame): Fiber[A, Abort[E]] < Sync =
             Race.success(iterable)

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -1505,6 +1505,96 @@ class AsyncTest extends Test:
         }
     }
 
+    "foreachIndexed" - {
+        "indices are correct when size > concurrency (batching path)" in run {
+            // When size > concurrency, items are batched. The index passed to f
+            // should be the global item index, not group_index + within_group_index.
+            val items = (0 until 20).toList
+            Async.foreachIndexed(items, concurrency = 3) { (idx, value) =>
+                (idx, value)
+            }.map { results =>
+                val pairs = results.toSeq
+                // Each item's index should equal its value since items = 0..19
+                pairs.zipWithIndex.foreach { case ((reportedIdx, value), position) =>
+                    assert(reportedIdx == position, s"Item at position $position: expected index $position but got $reportedIdx")
+                    assert(value == position, s"Item at position $position: expected value $position but got $value")
+                }
+                succeed
+            }
+        }
+
+        "indices are correct with uneven batches" in run {
+            // 10 items with concurrency=3 → groups of 4,4,2
+            // Bug: idx + idx2 gives 0,1,2,3 / 1,2,3,4 / 2,3 instead of 0,1,2,3 / 4,5,6,7 / 8,9
+            val items = (0 until 10).toList
+            Async.foreachIndexed(items, concurrency = 3) { (idx, _) =>
+                idx
+            }.map { results =>
+                assert(results == Chunk.from(0 until 10), s"Expected indices 0..9 but got $results")
+            }
+        }
+
+        "indices are correct via foreach (delegates to foreachIndexed)" in run {
+            // foreach wraps foreachIndexed, discarding the index.
+            // Verify by capturing indices through the values themselves.
+            val items = (0 until 12).toList
+            Async.foreach(items, concurrency = 2) { value =>
+                value
+            }.map { results =>
+                assert(results == Chunk.from(0 until 12))
+            }
+        }
+
+        "indices correct with many items and low concurrency" in run {
+            // 100 items, concurrency 4 → 4 groups of 25
+            // With the bug: group 0 gets 0..24, group 1 gets 1..25, group 2 gets 2..26, group 3 gets 3..27
+            val items = (0 until 100).toList
+            Async.foreachIndexed(items, concurrency = 4) { (idx, _) =>
+                idx
+            }.map { results =>
+                assert(results == Chunk.from(0 until 100), s"Expected indices 0..99 but got ${results.take(30)}...")
+            }
+        }
+    }
+
+    "batching concurrency" - {
+        "tasks are picked up by idle workers instead of waiting in static batch" in run {
+            // With static batching: items split into equal groups, each processed sequentially.
+            // If one batch has all slow tasks, other workers idle after finishing their fast batch.
+            //
+            // Create a scenario where the first batch finishes fast but the last batch is slow.
+            // With proper work-stealing, idle workers would pick up remaining slow tasks.
+            //
+            // 8 items, concurrency=2 → 2 batches of 4
+            // Batch 0 (items 0-3): instant
+            // Batch 1 (items 4-7): each sleeps 50ms → 200ms sequential
+            // With static batching: ~200ms (batch 1 runs all 4 sequentially)
+            // With work-stealing: ~100ms (2 workers each run 2 slow tasks)
+            for
+                maxConcurrent <- AtomicInt.init(0)
+                active        <- AtomicInt.init(0)
+                results <- Async.foreach(0 until 8, concurrency = 2) { i =>
+                    for
+                        current <- active.incrementAndGet
+                        _       <- maxConcurrent.updateAndGet(max => if current > max then current else max)
+                        _       <- Kyo.when(i >= 4)(Async.sleep(50.millis))
+                        _       <- active.decrementAndGet
+                    yield i
+                }
+                peak <- maxConcurrent.get
+            yield
+                // Results should preserve order regardless
+                assert(results.toSeq == (0 until 8).toSeq)
+                // With effective concurrency, both workers should be utilized during
+                // the slow tasks. If batching is static, only 1 worker handles all slow tasks.
+                // We check that at some point 2 workers were active simultaneously during
+                // the slow phase. This assertion will pass with work-stealing but may
+                // fail with static batching since batch 0 (fast) finishes before batch 1 starts slow tasks.
+                assert(peak == 2, s"Expected both workers active concurrently during slow phase, but peak was $peak")
+            end for
+        }
+    }
+
     "zip" - {
         "executes nine computations in parallel" in run {
             for

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -241,14 +241,14 @@ class FiberTest extends Test:
     "foreachIndexed" - {
         "empty sequence" in run {
             for
-                fiber  <- Fiber.internal.foreachIndexed(Seq())((idx, v) => (idx, v))
+                fiber  <- Fiber.internal.foreachIndexed(Chunk.from(Seq()).toIndexed, Int.MaxValue)((idx, v) => (idx, v))
                 result <- fiber.get
             yield assert(result == Seq())
         }
 
         "small collection + Sync" in run {
             for
-                fiber  <- Fiber.internal.foreachIndexed(Seq(1, 2, 3))((idx, v) => Sync.defer((idx, v)))
+                fiber  <- Fiber.internal.foreachIndexed(Chunk.from(Seq(1, 2, 3)).toIndexed, Int.MaxValue)((idx, v) => Sync.defer((idx, v)))
                 result <- fiber.get
             yield assert(result == Seq((0, 1), (1, 2), (2, 3)))
         }
@@ -261,7 +261,7 @@ class FiberTest extends Test:
                         if v == 3 then Abort.fail(error)
                         else v
 
-                    Fiber.internal.foreachIndexed(1 to 5)(task)
+                    Fiber.internal.foreachIndexed(Chunk.from(1 to 5).toIndexed, Int.MaxValue)(task)
                 }
                 result <- fiber.getResult
             yield assert(result.failure.contains(error))
@@ -681,15 +681,17 @@ class FiberTest extends Test:
 
     "boundary inference with Abort" - {
         "same failures" in {
-            val v: Int < Abort[Int]                   = 1
-            val _: Fiber[Int, Abort[Int]] < Sync      = Fiber.internal.race(Seq(v))
-            val _: Fiber[Seq[Int], Abort[Int]] < Sync = Fiber.internal.foreachIndexed(Seq(v))((_, v) => v)
+            val v: Int < Abort[Int]              = 1
+            val _: Fiber[Int, Abort[Int]] < Sync = Fiber.internal.race(Seq(v))
+            val _: Fiber[Seq[Int], Abort[Int]] < Sync =
+                Fiber.internal.foreachIndexed(Chunk.from(Seq(v)).toIndexed, Int.MaxValue)((_, v) => v)
             succeed
         }
         "additional failure" in {
-            val v: Int < Abort[Int]                            = 1
-            val _: Fiber[Int, Abort[Int | String]] < Sync      = Fiber.internal.race(Seq(v))
-            val _: Fiber[Seq[Int], Abort[Int | String]] < Sync = Fiber.internal.foreachIndexed(Seq(v))((_, v) => v)
+            val v: Int < Abort[Int]                       = 1
+            val _: Fiber[Int, Abort[Int | String]] < Sync = Fiber.internal.race(Seq(v))
+            val _: Fiber[Seq[Int], Abort[Int | String]] < Sync =
+                Fiber.internal.foreachIndexed(Chunk.from(Seq(v)).toIndexed, Int.MaxValue)((_, v) => v)
             succeed
         }
     }


### PR DESCRIPTION
### Problem

The bounded concurrency in `Async.foreach*` and derived methods had two issues:

1. Index bug: `f(idx + idx2, v)` used the group index instead of the item offset, producing wrong indices for all groups after the first (e.g. 0,1,2,3,1,2,3,4,2,3 instead of 0..9). See tests.

2. Static batching: items were split into equal-sized groups with sequential execution within each group. Workers that finished fast batches sat idle while slow batches continued, wasting concurrency.

### Solution

Replace implementation with a new `Fiber.internal.foreachIndexedBounded`: spawns `min(size, concurrency)` worker fibers that pull items dynamically using a shared `AtomicInt` counter. 