### PR TITLE
[core] add System.availableProcessors

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -42,6 +42,7 @@ abstract class System extends Serializable:
     def lineSeparator(using Frame): String < Sync
     def userName(using Frame): String < Sync
     def operatingSystem(using Frame): System.OS < Sync
+    def availableProcessors(using Frame): Int < Sync
 end System
 
 /** Companion object for System, containing utility methods and type classes. */
@@ -58,6 +59,7 @@ object System:
         def lineSeparator()(using AllowUnsafe): String
         def userName()(using AllowUnsafe): String
         def operatingSystem()(using AllowUnsafe): OS
+        def availableProcessors()(using AllowUnsafe): Int
         def safe: System = System(this)
     end Unsafe
 
@@ -75,10 +77,11 @@ object System:
                         case Absent     => Absent
                         case Present(v) => Abort.get(p(v).map(Maybe(_)))
                 }
-            def lineSeparator(using Frame): String < Sync = Sync.Unsafe.defer(u.lineSeparator())
-            def userName(using Frame): String < Sync      = Sync.Unsafe.defer(u.userName())
-            def operatingSystem(using Frame): OS < Sync   = Sync.Unsafe.defer(u.operatingSystem())
-            def unsafe: Unsafe                            = u
+            def lineSeparator(using Frame): String < Sync    = Sync.Unsafe.defer(u.lineSeparator())
+            def userName(using Frame): String < Sync         = Sync.Unsafe.defer(u.userName())
+            def operatingSystem(using Frame): OS < Sync      = Sync.Unsafe.defer(u.operatingSystem())
+            def availableProcessors(using Frame): Int < Sync = Sync.Unsafe.defer(u.availableProcessors())
+            def unsafe: Unsafe                               = u
 
     private val local = Local.init(live)
 
@@ -105,6 +108,7 @@ object System:
                         else OS.Unknown
                         end if
                     }.getOrElse(OS.Unknown)
+                def availableProcessors()(using AllowUnsafe): Int = Runtime.getRuntime.availableProcessors()
         )
 
     /** Executes a computation with a custom System implementation.
@@ -201,6 +205,9 @@ object System:
 
     /** Retrieves the current operating system. */
     def operatingSystem(using Frame): OS < Sync = local.use(_.operatingSystem)
+
+    /** Retrieves the number of processors available to the JVM. */
+    def availableProcessors(using Frame): Int < Sync = local.use(_.availableProcessors)
 
     /** Abstract class for parsing string values into specific types. */
     sealed abstract class Parser[E, A] extends Serializable:

--- a/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
@@ -82,6 +82,32 @@ class SystemTest extends Test:
         yield assert(OS.values.contains(os))
     }
 
+    "availableProcessors returns positive" in run {
+        System.availableProcessors.map(n => assert(n >= 1))
+    }
+
+    "availableProcessors is stable across calls" in run {
+        for
+            a <- System.availableProcessors
+            b <- System.availableProcessors
+        yield assert(a == b)
+    }
+
+    "let overrides availableProcessors" in run {
+        import AllowUnsafe.embrace.danger
+        val custom = System(new TestUnsafeSystem(processors = 42))
+        System.let(custom)(System.availableProcessors).map(n => assert(n == 42))
+    }
+
+    "Unsafe.availableProcessors matches safe" in run {
+        import AllowUnsafe.embrace.danger
+        for
+            safe <- System.availableProcessors
+            unsafe = System.live.unsafe.availableProcessors()
+        yield assert(safe == unsafe)
+        end for
+    }
+
     "custom System implementation" in run {
         val customSystem = new System:
             def unsafe: Unsafe = ???
@@ -89,10 +115,11 @@ class SystemTest extends Test:
                 Sync.defer(Maybe("custom_env").asInstanceOf[Maybe[A]])
             def property[E, A](name: String)(using Parser[E, A], Frame): Maybe[A] < (Abort[E] & Sync) =
                 Sync.defer(Maybe("custom_property").asInstanceOf[Maybe[A]])
-            def lineSeparator(using Frame): String < Sync = Sync.defer("custom_separator")
-            def userName(using Frame): String < Sync      = Sync.defer("custom_user")
-            def userHome(using Frame): String < Sync      = Sync.defer("custom_home")
-            def operatingSystem(using Frame): OS < Sync   = Sync.defer(OS.AIX)
+            def lineSeparator(using Frame): String < Sync    = Sync.defer("custom_separator")
+            def userName(using Frame): String < Sync         = Sync.defer("custom_user")
+            def userHome(using Frame): String < Sync         = Sync.defer("custom_home")
+            def operatingSystem(using Frame): OS < Sync      = Sync.defer(OS.AIX)
+            def availableProcessors(using Frame): Int < Sync = Sync.defer(4)
 
         for
             env       <- System.let(customSystem)(System.env[String]("ANY"))
@@ -351,7 +378,8 @@ class SystemTest extends Test:
         properties: Map[String, String] = Map.empty,
         lineSeparator: String = "\n",
         userName: String = "test_user",
-        os: OS = OS.Unknown
+        os: OS = OS.Unknown,
+        processors: Int = 1
     ) extends System.Unsafe:
         def env(name: String)(using AllowUnsafe): Maybe[String] =
             Maybe.fromOption(envVars.get(name))
@@ -364,6 +392,8 @@ class SystemTest extends Test:
         def userName()(using AllowUnsafe): String = userName
 
         def operatingSystem()(using AllowUnsafe): OS = os
+
+        def availableProcessors()(using AllowUnsafe): Int = processors
     end TestUnsafeSystem
 
 end SystemTest


### PR DESCRIPTION
## Summary

Adds a new public accessor to the \`kyo.System\` service that returns the number of processors available to the JVM.

## Surface

- Abstract method on \`System\` trait: \`availableProcessors(using Frame): Int < Sync\`
- Abstract method on \`System.Unsafe\`: \`availableProcessors()(using AllowUnsafe): Int\`
- Live wiring via \`Sync.Unsafe.defer(u.availableProcessors())\`
- Live Unsafe impl returns \`Runtime.getRuntime.availableProcessors()\`
- Companion forwarder \`System.availableProcessors\`

Mirrors the shape of existing \`lineSeparator\` / \`userName\` accessors.

## Test plan

- [x] \`SystemTest\` — returns positive value
- [x] \`SystemTest\` — stable across calls
- [x] \`SystemTest\` — \`System.let\` can override via custom Unsafe
- [x] \`SystemTest\` — live Unsafe matches the safe-path value