### PR TITLE
[data] add Dict.toChunk; include Throwable cause in KyoException.getMessage

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Dict.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Dict.scala
@@ -540,6 +540,28 @@ object Dict:
                     Span.fromUnsafe(arr)
             )
 
+        /** Build a `Chunk[(K, V)]` of all entries. Order is insertion order for small dicts; unspecified for hashmap-backed dicts. */
+        def toChunk: Chunk[(K, V)] =
+            reduce(
+                span =>
+                    val n = Span.size(span) / 2
+                    if n == 0 then Chunk.empty
+                    else
+                        val b = Chunk.newBuilder[(K, V)]
+                        @tailrec def loop(i: Int): Unit =
+                            if i < n then
+                                b += ((Span.apply(span)(i).asInstanceOf[K], Span.apply(span)(n + i).asInstanceOf[V]))
+                                loop(i + 1)
+                        loop(0)
+                        b.result()
+                    end if
+                ,
+                map =>
+                    val b = Chunk.newBuilder[(K, V)]
+                    map.foreachEntry((k, v) => b += ((k, v)))
+                    b.result()
+            )
+
         /** Converts this Dict to an immutable `Map`. */
         def toMap: Map[K, V] =
             reduce(

--- a/kyo-data/shared/src/main/scala/kyo/KyoException.scala
+++ b/kyo-data/shared/src/main/scala/kyo/KyoException.scala
@@ -50,7 +50,8 @@ class KyoException private[kyo] (
     override def getMessage(): String =
         val detail =
             cause match
-                case _: Throwable           => Absent
+                case t: Throwable =>
+                    Maybe(s"${t.getClass.getSimpleName}: ${Maybe(t.getMessage).getOrElse("")}".take(maxMessageLength))
                 case cause: Text @unchecked => Maybe(cause.take(maxMessageLength))
 
         if Environment.isDevelopment then

--- a/kyo-data/shared/src/test/scala/kyo/DictTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/DictTest.scala
@@ -1004,4 +1004,17 @@ class DictTest extends Test:
         }
     }
 
+    "toChunk" - {
+        "empty" in assert(Dict.empty[String, Int].toChunk == Chunk.empty)
+        "small" in {
+            val d = Dict("a" -> 1, "b" -> 2)
+            assert(d.toChunk.toSet == Set("a" -> 1, "b" -> 2))
+        }
+        "above threshold (9 entries)" in {
+            val entries = (1 to 9).map(i => s"k$i" -> i)
+            val d       = Dict.from(entries.toMap)
+            assert(d.toChunk.toSet == entries.toSet)
+        }
+    }
+
 end DictTest

--- a/kyo-data/shared/src/test/scala/kyo/KyoExceptionTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/KyoExceptionTest.scala
@@ -1,0 +1,31 @@
+package kyo
+
+class KyoExceptionTest extends Test:
+
+    "getMessage" - {
+        "includes Throwable cause class and message" in {
+            val ex  = new KyoException("outer", new java.io.IOException("inner"))
+            val msg = ex.getMessage
+            assert(msg.contains("outer"), s"expected 'outer' in '$msg'")
+            assert(msg.contains("IOException"), s"expected 'IOException' in '$msg'")
+            assert(msg.contains("inner"), s"expected 'inner' in '$msg'")
+        }
+        "handles Throwable with null message" in {
+            val ex  = new KyoException("outer", new RuntimeException())
+            val msg = ex.getMessage
+            assert(msg.contains("outer"), s"expected 'outer' in '$msg'")
+            assert(msg.contains("RuntimeException"), s"expected 'RuntimeException' in '$msg'")
+        }
+        "includes String cause" in {
+            val ex  = new KyoException("outer", "hint text")
+            val msg = ex.getMessage
+            assert(msg.contains("outer"), s"expected 'outer' in '$msg'")
+            assert(msg.contains("hint text"), s"expected 'hint text' in '$msg'")
+        }
+        "uses message only when no cause is provided" in {
+            val ex  = new KyoException("just the msg")
+            val msg = ex.getMessage
+            assert(msg.contains("just the msg"), s"expected 'just the msg' in '$msg'")
+        }
+    }
+end KyoExceptionTest


### PR DESCRIPTION
## Summary

Two small, unrelated improvements bundled because both touch kyo-data.

### 1. \`Dict.toChunk: Chunk[(K, V)]\`

Projects a Dict into a Chunk of key-value tuples. Fast path for the small Span-backed representation (tailrec walk with \`Chunk.newBuilder\`); HashMap path uses \`foreachEntry\`. Complements the existing \`foreach\` / \`foreachKey\` / \`foreachValue\` / \`toMap\` API when a \`Chunk\` is the natural target.

### 2. \`KyoException.getMessage\` now includes Throwable cause class + message

**Before**: when \`cause\` was a \`Throwable\`, production \`getMessage\` returned only the primary \`message\`, silently dropping the wrapped exception's class and text. Users saw e.g. \"Unexpected error for X\" with no signal of what actually went wrong.

**After**: production output includes \`\${classSimpleName}: \${causeMessage}\` appended to the primary message, preserving diagnostic information while keeping output bounded by \`maxMessageLength\`.

Development output is unchanged (already pretty-printed both).

## Test plan

- [x] \`DictTest\` — toChunk empty
- [x] \`DictTest\` — toChunk small (Span-backed, ≤ threshold)
- [x] \`DictTest\` — toChunk above threshold (HashMap-backed)
- [x] \`KyoExceptionTest\` — Throwable cause with message
- [x] \`KyoExceptionTest\` — Throwable cause with null message
- [x] \`KyoExceptionTest\` — Text (String) cause
- [x] \`KyoExceptionTest\` — no cause