### PR TITLE
[zio-test] force TestResult arrows inside the test body's scope

### DIFF
--- a/kyo-zio-test/shared/src/main/scala/kyo/test/KyoSpecAbstract.scala
+++ b/kyo-zio-test/shared/src/main/scala/kyo/test/KyoSpecAbstract.scala
@@ -46,7 +46,16 @@ abstract class KyoSpecAbstract[S] extends ZIOSpecAbstract:
                 Spec.labeled(
                     label,
                     Spec
-                        .test(ZTest(label, run[A](assertion)), TestAnnotationMap.empty)
+                        .test(
+                            ZTest(
+                                label,
+                                run[A](assertion.map { result =>
+                                    val _ = result.result
+                                    result
+                                })
+                            ),
+                            TestAnnotationMap.empty
+                        )
                         .annotate(trace, sl :: Nil)
                 )
 
@@ -54,6 +63,10 @@ abstract class KyoSpecAbstract[S] extends ZIOSpecAbstract:
         new CheckConstructor[Any, A < S1]:
             type OutEnvironment = Any
             type OutError       = Throwable
-            def apply(input: => A < S1)(using Trace): ZIO[OutEnvironment, OutError, TestResult] = run(input)
+            def apply(input: => A < S1)(using Trace): ZIO[OutEnvironment, OutError, TestResult] =
+                run(input.map { result =>
+                    val _ = result.result
+                    result
+                })
 
 end KyoSpecAbstract

--- a/kyo-zio-test/shared/src/test/scala/kyo/test/ScopeAssertEvalSpec.scala
+++ b/kyo-zio-test/shared/src/test/scala/kyo/test/ScopeAssertEvalSpec.scala
@@ -1,54 +1,32 @@
 package kyo.test
 
-import java.nio.file.Files
-import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicBoolean
 import kyo.*
 import zio.test.*
 
 object ScopeAssertEvalSpec extends KyoSpecDefault:
 
-    private def tempDir(using Frame): Path < (Scope & Sync) =
+    private def aliveFlag(using Frame): AtomicBoolean < (Scope & Sync) =
         Scope.acquireRelease(
-            Sync.defer(Files.createTempDirectory("scope-assert-eval-").nn)
-        )(p => Sync.defer(deleteRecursive(p)))
-
-    private def deleteRecursive(path: Path): Unit =
-        if Files.isDirectory(path) then
-            val entries = Files.list(path).nn
-            try entries.forEach(p => deleteRecursive(p.nn))
-            finally entries.close()
-        end if
-        Files.deleteIfExists(path)
-        ()
-    end deleteRecursive
-
-    private def writeMarker(dir: Path): Path =
-        val file = dir.resolve("marker.txt").nn
-        Files.writeString(file, "hi")
-        file
-    end writeMarker
-
-    private def fileExists(p: Path): Boolean = Files.exists(p)
+            Sync.defer(new AtomicBoolean(true))
+        )(flag => Sync.defer(flag.set(false)))
 
     def spec = suite("ScopeAssertEvalSpec")(
         test("assertTrue captures inside Scope see live resources"):
             for
-                dir <- tempDir
-                file = writeMarker(dir)
-            yield assertTrue(fileExists(file))
+                alive <- aliveFlag
+            yield assertTrue(alive.get)
         ,
         test("eagerly captured Boolean works"):
             for
-                dir <- tempDir
-                file   = writeMarker(dir)
-                exists = fileExists(file)
-            yield assertTrue(exists)
+                alive <- aliveFlag
+                isAlive = alive.get
+            yield assertTrue(isAlive)
         ,
-        test("Sync.defer right before yield sees the file"):
+        test("Sync.defer right before yield sees the flag set"):
             for
-                dir <- tempDir
-                file = writeMarker(dir)
-                seen <- Sync.defer(fileExists(file))
-            yield assertTrue(seen)
+                alive   <- aliveFlag
+                isAlive <- Sync.defer(alive.get)
+            yield assertTrue(isAlive)
     )
 end ScopeAssertEvalSpec

--- a/kyo-zio-test/shared/src/test/scala/kyo/test/ScopeAssertEvalSpec.scala
+++ b/kyo-zio-test/shared/src/test/scala/kyo/test/ScopeAssertEvalSpec.scala
@@ -1,0 +1,54 @@
+package kyo.test
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kyo.*
+import zio.test.*
+
+object ScopeAssertEvalSpec extends KyoSpecDefault:
+
+    private def tempDir(using Frame): Path < (Scope & Sync) =
+        Scope.acquireRelease(
+            Sync.defer(Files.createTempDirectory("scope-assert-eval-").nn)
+        )(p => Sync.defer(deleteRecursive(p)))
+
+    private def deleteRecursive(path: Path): Unit =
+        if Files.isDirectory(path) then
+            val entries = Files.list(path).nn
+            try entries.forEach(p => deleteRecursive(p.nn))
+            finally entries.close()
+        end if
+        Files.deleteIfExists(path)
+        ()
+    end deleteRecursive
+
+    private def writeMarker(dir: Path): Path =
+        val file = dir.resolve("marker.txt").nn
+        Files.writeString(file, "hi")
+        file
+    end writeMarker
+
+    private def fileExists(p: Path): Boolean = Files.exists(p)
+
+    def spec = suite("ScopeAssertEvalSpec")(
+        test("assertTrue captures inside Scope see live resources"):
+            for
+                dir <- tempDir
+                file = writeMarker(dir)
+            yield assertTrue(fileExists(file))
+        ,
+        test("eagerly captured Boolean works"):
+            for
+                dir <- tempDir
+                file   = writeMarker(dir)
+                exists = fileExists(file)
+            yield assertTrue(exists)
+        ,
+        test("Sync.defer right before yield sees the file"):
+            for
+                dir <- tempDir
+                file = writeMarker(dir)
+                seen <- Sync.defer(fileExists(file))
+            yield assertTrue(seen)
+    )
+end ScopeAssertEvalSpec


### PR DESCRIPTION
### Problem
zio-test's `assertTrue` returns a `TestResult` whose `result: TestTrace` is a lazy val that re-evaluates the captured `TestArrow` chain on first access. With `KyoSpecDefault.run = ZIOs.run(Scope.run(v))`, `Scope.run` closes finalizers before zio-test inspects the result, so any captured expression that references a `Scope.acquireRelease`-managed resource observes torn-down state — e.g. `assertTrue(fileExists(file))` reports "Result was false" against a temp directory just deleted by the scope's finalizer.

### Solution
Splice a `.map { tr.result; tr }` step into both `KyoTestConstructor` and `KyoCheckConstructor` so the arrow chain is forced inside the test body's effect scope, ahead of finalizer close.

Adds `ScopeAssertEvalSpec` with one regression case (assertion against a file inside a `Scope.acquireRelease` temp dir) plus two controls (eagerly-bound boolean, `Sync.defer` immediately before the yield) that isolate the property to TestResult eval ordering.

### Notes
'Problem' and 'Solution' sections where written by Claude. The problem showed up as failing tests in another project I am working on, and Claude suggested this solution.
The solution seems legit, even if I am not sure the are best ways to fix it.