### PR TITLE
[core] add System.architecture

### DIFF
--- a/kyo-core/js/src/main/scala/kyo/internal/SystemPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/internal/SystemPlatformSpecific.scala
@@ -1,0 +1,50 @@
+package kyo.internal
+
+import kyo.AllowUnsafe
+import scala.scalajs.js
+
+/** JS-specific `os.name` detection.
+  *
+  * Scala.js's `java.lang.System.getProperty("os.name")` returns `null`. Fall back to Node's `process.platform`, which gives one of
+  * `"darwin" | "linux" | "win32" | "freebsd" | ...`. We translate these into the same tokens that Java's `os.name` would produce (e.g.
+  * `"Mac OS X"`, `"Linux"`) so downstream `String.contains("mac")` checks just work.
+  */
+private[kyo] object SystemPlatformSpecific:
+    def osName()(using AllowUnsafe): String =
+        val javaProp = java.lang.System.getProperty("os.name", "")
+        if javaProp.nonEmpty then javaProp
+        else if js.typeOf(js.Dynamic.global.process) != "undefined"
+            && js.typeOf(js.Dynamic.global.process.platform) != "undefined"
+        then
+            js.Dynamic.global.process.platform.asInstanceOf[String] match
+                case "darwin"  => "Mac OS X"
+                case "linux"   => "Linux"
+                case "win32"   => "Windows"
+                case "freebsd" => "FreeBSD"
+                case "openbsd" => "OpenBSD"
+                case "sunos"   => "SunOS"
+                case "aix"     => "AIX"
+                case other     => other
+        else ""
+        end if
+    end osName
+
+    /** Returns the CPU architecture. Falls back to Node's `process.arch` when Java's `os.arch` is unavailable (Scala.js returns null),
+      * normalised to Java-style tokens so callers can match on `"aarch64"`, `"x86_64"`, etc.
+      */
+    def osArch()(using AllowUnsafe): String =
+        val javaProp = java.lang.System.getProperty("os.arch", "")
+        if javaProp.nonEmpty then javaProp
+        else if js.typeOf(js.Dynamic.global.process) != "undefined"
+            && js.typeOf(js.Dynamic.global.process.arch) != "undefined"
+        then
+            js.Dynamic.global.process.arch.asInstanceOf[String] match
+                case "x64"   => "x86_64"
+                case "arm64" => "aarch64"
+                case "ia32"  => "x86"
+                case "arm"   => "arm"
+                case other   => other
+        else ""
+        end if
+    end osArch
+end SystemPlatformSpecific

--- a/kyo-core/jvm-native/src/main/scala/kyo/internal/SystemPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/internal/SystemPlatformSpecific.scala
@@ -1,0 +1,11 @@
+package kyo.internal
+
+import kyo.AllowUnsafe
+
+/** Platform-specific accessors for the default `System.live` implementation. On JVM and Scala Native the standard Java stdlib populates
+  * `os.name`, `user.name`, and `line.separator` via `java.lang.System` — simply delegate.
+  */
+private[kyo] object SystemPlatformSpecific:
+    def osName()(using AllowUnsafe): String = java.lang.System.getProperty("os.name", "")
+    def osArch()(using AllowUnsafe): String = java.lang.System.getProperty("os.arch", "")
+end SystemPlatformSpecific

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -5,6 +5,7 @@ import java.lang.System as JSystem
 import java.net.MalformedURLException
 import java.net.URISyntaxException
 import java.time.format.DateTimeParseException
+import kyo.internal.SystemPlatformSpecific
 
 /** A platform-independent accessor for system environment and properties.
   *
@@ -42,6 +43,7 @@ abstract class System extends Serializable:
     def lineSeparator(using Frame): String < Sync
     def userName(using Frame): String < Sync
     def operatingSystem(using Frame): System.OS < Sync
+    def architecture(using Frame): System.Arch < Sync
     def availableProcessors(using Frame): Int < Sync
 end System
 
@@ -52,6 +54,10 @@ object System:
     enum OS derives CanEqual:
         case Linux, MacOS, Windows, BSD, Solaris, IBMI, AIX, Unknown
 
+    /** Enumeration of supported CPU architectures. */
+    enum Arch derives CanEqual:
+        case X86, X86_64, Arm, Aarch64, Unknown
+
     /** WARNING: Low-level API meant for integrations, libraries, and performance-sensitive code. See AllowUnsafe for more details. */
     abstract class Unsafe extends Serializable:
         def env(name: String)(using AllowUnsafe): Maybe[String]
@@ -59,6 +65,7 @@ object System:
         def lineSeparator()(using AllowUnsafe): String
         def userName()(using AllowUnsafe): String
         def operatingSystem()(using AllowUnsafe): OS
+        def architecture()(using AllowUnsafe): Arch
         def availableProcessors()(using AllowUnsafe): Int
         def safe: System = System(this)
     end Unsafe
@@ -80,6 +87,7 @@ object System:
             def lineSeparator(using Frame): String < Sync    = Sync.Unsafe.defer(u.lineSeparator())
             def userName(using Frame): String < Sync         = Sync.Unsafe.defer(u.userName())
             def operatingSystem(using Frame): OS < Sync      = Sync.Unsafe.defer(u.operatingSystem())
+            def architecture(using Frame): Arch < Sync       = Sync.Unsafe.defer(u.architecture())
             def availableProcessors(using Frame): Int < Sync = Sync.Unsafe.defer(u.availableProcessors())
             def unsafe: Unsafe                               = u
 
@@ -96,18 +104,33 @@ object System:
                 def lineSeparator()(using AllowUnsafe): String = JSystem.lineSeparator()
                 def userName()(using AllowUnsafe): String      = JSystem.getProperty("user.name")
                 def operatingSystem()(using AllowUnsafe): OS =
-                    Maybe(JSystem.getProperty("os.name")).map { prop =>
-                        val osName = prop.toLowerCase
-                        if osName.contains("linux") then OS.Linux
-                        else if osName.contains("mac") then OS.MacOS
-                        else if osName.contains("windows") then OS.Windows
-                        else if osName.contains("bsd") then OS.BSD
-                        else if osName.contains("sunos") then OS.Solaris
-                        else if osName.contains("os/400") || osName.contains("os400") then OS.IBMI
-                        else if osName.contains("aix") then OS.AIX
-                        else OS.Unknown
-                        end if
-                    }.getOrElse(OS.Unknown)
+                    // Delegate raw `os.name` lookup to the platform-specific shim: on JVM/Native this goes through
+                    // `java.lang.System`; on Scala.js (which returns null for that property) it falls back to Node's
+                    // `process.platform`. The classification below stays shared.
+                    val osName = SystemPlatformSpecific.osName().toLowerCase
+                    if osName.isEmpty then OS.Unknown
+                    else if osName.contains("linux") then OS.Linux
+                    else if osName.contains("mac") then OS.MacOS
+                    else if osName.contains("windows") then OS.Windows
+                    else if osName.contains("bsd") then OS.BSD
+                    else if osName.contains("sunos") then OS.Solaris
+                    else if osName.contains("os/400") || osName.contains("os400") then OS.IBMI
+                    else if osName.contains("aix") then OS.AIX
+                    else OS.Unknown
+                    end if
+                end operatingSystem
+
+                def architecture()(using AllowUnsafe): Arch =
+                    val arch = SystemPlatformSpecific.osArch().toLowerCase
+                    if arch.isEmpty then Arch.Unknown
+                    else if arch == "aarch64" || arch == "arm64" then Arch.Aarch64
+                    else if arch == "x86_64" || arch == "amd64" || arch == "x64" then Arch.X86_64
+                    else if arch == "x86" || arch == "i386" || arch == "i686" then Arch.X86
+                    else if arch.startsWith("arm") then Arch.Arm
+                    else Arch.Unknown
+                    end if
+                end architecture
+
                 def availableProcessors()(using AllowUnsafe): Int = Runtime.getRuntime.availableProcessors()
         )
 
@@ -205,6 +228,9 @@ object System:
 
     /** Retrieves the current operating system. */
     def operatingSystem(using Frame): OS < Sync = local.use(_.operatingSystem)
+
+    /** Retrieves the current CPU architecture. */
+    def architecture(using Frame): Arch < Sync = local.use(_.architecture)
 
     /** Retrieves the number of processors available to the JVM. */
     def availableProcessors(using Frame): Int < Sync = local.use(_.availableProcessors)

--- a/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SystemTest.scala
@@ -2,6 +2,7 @@ package kyo
 
 import System.Parser
 import java.lang as j
+import kyo.System.Arch
 import kyo.System.OS
 import kyo.System.Unsafe
 
@@ -119,6 +120,7 @@ class SystemTest extends Test:
             def userName(using Frame): String < Sync         = Sync.defer("custom_user")
             def userHome(using Frame): String < Sync         = Sync.defer("custom_home")
             def operatingSystem(using Frame): OS < Sync      = Sync.defer(OS.AIX)
+            def architecture(using Frame): Arch < Sync       = Sync.defer(Arch.X86_64)
             def availableProcessors(using Frame): Int < Sync = Sync.defer(4)
 
         for
@@ -379,6 +381,7 @@ class SystemTest extends Test:
         lineSeparator: String = "\n",
         userName: String = "test_user",
         os: OS = OS.Unknown,
+        arch: Arch = Arch.Unknown,
         processors: Int = 1
     ) extends System.Unsafe:
         def env(name: String)(using AllowUnsafe): Maybe[String] =
@@ -392,6 +395,8 @@ class SystemTest extends Test:
         def userName()(using AllowUnsafe): String = userName
 
         def operatingSystem()(using AllowUnsafe): OS = os
+
+        def architecture()(using AllowUnsafe): Arch = arch
 
         def availableProcessors()(using AllowUnsafe): Int = processors
     end TestUnsafeSystem


### PR DESCRIPTION
Adds an Arch enum (X86, X86_64, Arm, Aarch64, Unknown) and System.architecture accessor, classifying os.arch tokens consistently across JVM, JS, and Native.

A new SystemPlatformSpecific shim provides osName/osArch lookup. JVM and Native share a trivial java.lang.System.getProperty implementation; JS falls back to Node's process.platform / process.arch (since Scala.js's java.lang.System.getProperty returns null) and normalises Node tokens (x64 → x86_64, arm64 → aarch64, ia32 → x86) so the shared classification logic applies on every platform.
