### PR TITLE
fix indentation of retry section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2485,7 +2485,7 @@ val c: Boolean < Sync =
 
 > A `Promise` is basically a `Fiber` with all the regular functionality plus the `complete` and `become` methods to manually fulfill the promise.
 
-## Retry: Automatic Retries
+### Retry: Automatic Retries
 
 `Retry` provides a mechanism for retrying computations that may fail, with configurable policies for backoff and retry limits. This is particularly useful for operations that might fail due to transient issues, such as network requests or database operations.
 


### PR DESCRIPTION
I believe this section belongs under the Async effects section

<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

<img width="261" height="236" alt="image" src="https://github.com/user-attachments/assets/0e2f2288-a3b7-4455-933c-0c3437ee2aa8" />

On the Kyo static page, there's only one concurrent effect, Async, and everything else is under Retry. I believe this is a small heading error.

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->
I increased the heading to H3 for Retry

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->
