### PR TITLE
Added Stream#zip

### DIFF
--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -1,6 +1,7 @@
 package kyo
 
 import kyo.Tag
+import kyo.debug.Debug
 import kyo.kernel.ArrowEffect
 import scala.annotation.nowarn
 import scala.annotation.publicInBinary
@@ -670,6 +671,76 @@ abstract class Stream[+V, -S] @publicInBinary private[kyo] () extends Serializab
                     end if
                 case (_, _) => Loop.done(curChunk -> Stream(Emit.value(Chunk.empty[VV])))
     end splitAt
+
+    /** Combine with another stream, emitting tuples of the two streams' values. Faster streams will be slowed down to emit with slower
+      * streams. A stream with more values to emit will be halted when the other stream stops emitting values.
+      *
+      * @param other
+      *   Second stream to combine with
+      * @return
+      *   A new stream that produces a tuple of the outputs of the source streams.
+      */
+    final def zip[VV >: V, V2, S2](other: Stream[V2, S2])(using
+        t1: Tag[Emit[Chunk[VV]]],
+        t2: Tag[Emit[Chunk[V2]]],
+        t3: Tag[Emit[Chunk[(VV, V2)]]],
+        f: Frame
+    ): Stream[(VV, V2), S & S2] =
+        Stream:
+            Loop(emit: Unit < (Emit[Chunk[VV]] & S), Chunk.empty[VV], other.emit, Chunk.empty[V2]):
+                (emit1, leftovers1, emit2, leftovers2) =>
+                    ArrowEffect.handleFirst(t1, emit1)(
+                        handle = [C] =>
+                            (vals1: Chunk[VV], cont1) =>
+                                val allVals1 = leftovers1 ++ vals1
+                                ArrowEffect.handleFirst(t2, emit2)(
+                                    handle = [C] =>
+                                        (vals2: Chunk[V2], cont2) =>
+                                            val allVals2      = leftovers2 ++ vals2
+                                            val zippedVals    = allVals1.zip(allVals2)
+                                            val newLeftovers1 = allVals1.drop(zippedVals.length)
+                                            val newLeftovers2 = allVals2.drop(zippedVals.length)
+                                            if zippedVals.nonEmpty then
+                                                Emit.valueWith(zippedVals):
+                                                    Loop.continue(cont1(()), newLeftovers1, cont2(()), newLeftovers2)
+                                            else Loop.continue(cont1(()), newLeftovers1, cont2(()), newLeftovers2)
+                                            end if
+                                    ,
+                                    done = _ =>
+                                        if leftovers2.isEmpty then Loop.done(())
+                                        else
+                                            val zippedVals    = allVals1.zip(leftovers2)
+                                            val newLeftovers1 = allVals1.drop(zippedVals.length)
+                                            val newLeftovers2 = leftovers2.drop(zippedVals.length)
+                                            if zippedVals.nonEmpty then
+                                                Emit.valueWith(zippedVals):
+                                                    Loop.continue(cont1(()), newLeftovers1, emit2, newLeftovers2)
+                                            else Loop.continue(cont1(()), newLeftovers1, emit2, newLeftovers2)
+                                            end if
+                            )
+                        ,
+                        done = _ =>
+                            if leftovers1.isEmpty then Loop.done(())
+                            else
+                                ArrowEffect.handleFirst(t2, emit2)(
+                                    handle = [C] =>
+                                        (vals2: Chunk[V2], cont2) =>
+                                            val allVals2      = leftovers2 ++ vals2
+                                            val zippedVals    = leftovers1.zip(allVals2)
+                                            val newLeftovers1 = leftovers1.drop(zippedVals.length)
+                                            val newLeftovers2 = allVals2.drop(zippedVals.length)
+                                            if zippedVals.nonEmpty then
+                                                Emit.valueWith(zippedVals):
+                                                    Loop.continue(emit1, newLeftovers1, cont2(()), newLeftovers2)
+                                            else Loop.continue(emit1, newLeftovers1, cont2(()), newLeftovers2)
+                                            end if
+                                    ,
+                                    done = _ =>
+                                        Loop.done(())
+                                )
+                    )
+
+    end zip
 
     /** Transform with a [[Pipe]] of corresponding input streaming element type.
       *

--- a/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/StreamTest.scala
@@ -1412,6 +1412,50 @@ class StreamTest extends Test:
         )
     }
 
+    "zip" - {
+        "should zip all elements of streams of the same length" in {
+            val s1: Stream[Int, Any]  = Stream.init(Chunk(1, 2, 3, 4, 5))
+            val s2: Stream[Char, Any] = Stream.init(Chunk('a', 'b', 'c', 'd', 'e'))
+            val sz                    = s1.zip(s2)
+            val result                = sz.run.eval
+            assert(result == Chunk((1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')))
+        }
+
+        "should drop elements of second stream if it's longer" in {
+            val s1: Stream[Int, Any]  = Stream.init(Chunk(1, 2, 3))
+            val s2: Stream[Char, Any] = Stream.init(Chunk('a', 'b', 'c', 'd', 'e'))
+            val sz                    = s1.zip(s2)
+            val result                = sz.run.eval
+            assert(result == Chunk((1, 'a'), (2, 'b'), (3, 'c')))
+        }
+
+        "should drop elements of first stream if it's longer" in {
+            val s1: Stream[Int, Any]  = Stream.init(Chunk(1, 2, 3, 4, 5))
+            val s2: Stream[Char, Any] = Stream.init(Chunk('a', 'b', 'c'))
+            val sz                    = s1.zip(s2)
+            val result                = sz.run.eval
+            assert(result == Chunk((1, 'a'), (2, 'b'), (3, 'c')))
+        }
+
+        "should combine effects" in {
+            val s1: Stream[Int, Var[Int]] =
+                val emit = Loop.forever:
+                    Var.use[Int](i => Var.update[Int](_ + 1).andThen(Emit.value(Chunk(i))))
+                Stream(emit)
+            end s1
+
+            val s2: Stream[Char, Env[String]] = Stream.unwrap(Env.use[String](_ => Stream.init(Chunk('a', 'b', 'c', 'd', 'e'))))
+
+            val s2v = Env.run("test")(s2.run).eval
+            assert(s2v == Chunk('a', 'b', 'c', 'd', 'e'))
+
+            val sz = s1.zip(s2)
+
+            val result = sz.run.handle(Env.run("test"), Var.run(1)).eval
+            assert(result == Chunk((1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')))
+        }
+    }
+
     "unwrap" - {
         "should fuse effect contexts" in {
             val stream: Stream[Int, Choice] =


### PR DESCRIPTION
<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->

Fixes #1538 

### Problem
<!--
Explain here the context, and why you're making this change. What is the problem you're trying to solve?
-->

The Stream method does have a zip method, which is standard and expected 

### Solution
<!--
Describe your solution. Focus on helping reviewers understand your technical approach and implementation decisions.
-->

Pretty straightforward: use `handleFirst` to take values chunk at a time, emit zipped chunks, loop with leftovers, and complete when one stream is done *and* there are no leftovers left

### Notes
<!--
Add any important additional information as bullet points, such as:
- Implementation details reviewers should know about
- Open questions and concerns
- Limitations
-->

I did not add a `Stream.zip` method to zip more than two streams. The reason is that we end up needing `Tag[Emit[X]]` for every emitted type `X` along with `Tag[Emit[(X, Y)]]` for every combination of zipped types used. We end up needing to derive a huge number of Tags, in other words, which is not ideal.
