### PR TITLE
Add kyo-grpc module: gRPC runtime support

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,2 @@
+-J-Xmx4G
+-J-XX:+UseG1GC

--- a/build.sbt
+++ b/build.sbt
@@ -151,6 +151,7 @@ lazy val kyoJVM = project
         `kyo-http`.jvm,
         `kyo-flow`.jvm,
         `kyo-caliban`.jvm,
+        `kyo-grpc`.jvm,
         `kyo-bench`.jvm,
         `kyo-zio-test`.jvm,
         `kyo-zio`.jvm,
@@ -608,6 +609,25 @@ lazy val `kyo-flow` =
             `js-settings`,
             scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
         )
+
+lazy val `kyo-grpc` =
+    crossProject(JVMPlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Pure)
+        .in(file("kyo-grpc"))
+        .dependsOn(`kyo-core`)
+        .settings(
+            `kyo-settings`,
+            libraryDependencies ++= Seq(
+                "io.grpc"              % "grpc-stub"              % "1.72.0",
+                "io.grpc"              % "grpc-protobuf"          % "1.72.0",
+                "io.grpc"              % "grpc-netty"             % "1.72.0",
+                "com.thesamet.scalapb" %% "scalapb-runtime"       % "0.11.17",
+                "com.thesamet.scalapb" %% "scalapb-runtime-grpc"  % "0.11.17"
+            ),
+            libraryDependencies += "org.scalatest" %% "scalatest" % scalaTestVersion % Test
+        )
+        .jvmSettings(mimaCheck(false))
 
 lazy val `kyo-caliban` =
     crossProject(JVMPlatform)

--- a/kyo-grpc/src/main/scala/kyo/grpc/Grpc.scala
+++ b/kyo-grpc/src/main/scala/kyo/grpc/Grpc.scala
@@ -1,0 +1,227 @@
+package kyo.grpc
+
+import io.grpc.*
+import io.grpc.netty.NettyChannelBuilder
+import io.grpc.netty.NettyServerBuilder
+import io.grpc.stub.ServerCalls
+import io.grpc.stub.StreamObserver
+import kyo.*
+import kyo.Emit
+import scala.concurrent.Future
+
+/** Core gRPC support for Kyo. Provides server/channel lifecycle management and bridges between Kyo effects and gRPC's callback-based API.
+  */
+object Grpcs:
+
+    // ===== Error Handling =====
+
+    private def completeObserver[Resp](observer: StreamObserver[Resp], result: Result[StatusException, Unit]): Unit =
+        result match
+            case Result.Success(_) =>
+                observer.onCompleted()
+            case Result.Failure(statusEx) =>
+                observer.onError(statusEx.asInstanceOf[StatusException])
+            case Result.Panic(ex) =>
+                observer.onError(
+                    Status.INTERNAL
+                        .withDescription(ex.getMessage)
+                        .withCause(ex)
+                        .asException()
+                )
+
+    private def runEffect(effect: Unit < Async)(using Frame): Unit =
+        import AllowUnsafe.embrace.danger
+        discard(Sync.Unsafe.evalOrThrow(
+            KyoApp.runAndBlock(Duration.Infinity)(effect)
+        ))
+    end runEffect
+
+    // ===== Server Lifecycle =====
+
+    def server(
+        port: Int,
+        services: Seq[ServerServiceDefinition]
+    )(using Frame): Server < (Async & Scope) =
+        Scope.acquireRelease {
+            Sync.defer {
+                val builder = NettyServerBuilder.forPort(port)
+                services.foreach(ssd => discard(builder.addService(ssd)))
+                builder.build().start()
+            }
+        } { server =>
+            Sync.defer {
+                discard(server.shutdown())
+            }
+        }
+
+    // ===== Channel Lifecycle =====
+
+    def channel(target: String)(using Frame): ManagedChannel < (Async & Scope) =
+        Scope.acquireRelease {
+            Sync.defer(NettyChannelBuilder.forTarget(target).usePlaintext().build())
+        } { channel =>
+            Sync.defer {
+                discard(channel.shutdown())
+            }
+        }
+
+    // ===== Server Call Handlers =====
+
+    def unaryHandler[Req, Resp](
+        method: MethodDescriptor[Req, Resp],
+        handler: Req => Resp < (Abort[StatusException] & Async)
+    )(using Frame): ServerMethodDefinition[Req, Resp] =
+        ServerMethodDefinition.create(
+            method,
+            ServerCalls.asyncUnaryCall(
+                new ServerCalls.UnaryMethod[Req, Resp]:
+                    override def invoke(request: Req, observer: StreamObserver[Resp]): Unit =
+                        runEffect {
+                            Abort.run[StatusException](handler(request)).map {
+                                case Result.Success(resp) =>
+                                    observer.onNext(resp)
+                                    observer.onCompleted()
+                                case Result.Failure(statusEx) =>
+                                    observer.onError(statusEx.asInstanceOf[StatusException])
+                                case Result.Panic(ex) =>
+                                    observer.onError(
+                                        Status.INTERNAL
+                                            .withDescription(ex.getMessage)
+                                            .withCause(ex)
+                                            .asException()
+                                    )
+                            }
+                        }
+                    end invoke
+            )
+        )
+
+    def serverStreamingHandler[Req, Resp](
+        method: MethodDescriptor[Req, Resp],
+        handler: Req => Stream[Resp, Abort[StatusException] & Async]
+    )(using Frame, Tag[Emit[Chunk[Resp]]]): ServerMethodDefinition[Req, Resp] =
+        ServerMethodDefinition.create(
+            method,
+            ServerCalls.asyncServerStreamingCall(
+                new ServerCalls.ServerStreamingMethod[Req, Resp]:
+                    override def invoke(request: Req, observer: StreamObserver[Resp]): Unit =
+                        runEffect {
+                            Abort.run[StatusException] {
+                                handler(request).foreach { resp =>
+                                    observer.onNext(resp)
+                                }
+                            }.map(r => completeObserver(observer, r))
+                        }
+                    end invoke
+            )
+        )
+
+    def clientStreamingHandler[Req, Resp](
+        method: MethodDescriptor[Req, Resp],
+        handler: Stream[Req, Async] => Resp < (Abort[StatusException] & Async)
+    )(using Frame, Tag[Emit[Chunk[Req]]]): ServerMethodDefinition[Req, Resp] =
+        ServerMethodDefinition.create(
+            method,
+            ServerCalls.asyncClientStreamingCall(
+                new ServerCalls.ClientStreamingMethod[Req, Resp]:
+                    override def invoke(observer: StreamObserver[Resp]): StreamObserver[Req] =
+                        import AllowUnsafe.embrace.danger
+                        val ch     = kyo.Channel.Unsafe.init[Req](1024)
+                        val stream = ch.safe.streamUntilClosed()
+
+                        discard(Sync.Unsafe.evalOrThrow(
+                            Fiber.initUnscoped {
+                                Abort.run[StatusException](handler(stream)).map {
+                                    case Result.Success(resp) =>
+                                        observer.onNext(resp)
+                                        observer.onCompleted()
+                                    case Result.Failure(statusEx) =>
+                                        observer.onError(statusEx.asInstanceOf[StatusException])
+                                    case Result.Panic(ex) =>
+                                        observer.onError(
+                                            Status.INTERNAL
+                                                .withDescription(ex.getMessage)
+                                                .withCause(ex)
+                                                .asException()
+                                        )
+                                }
+                            }
+                        ))
+
+                        new StreamObserver[Req]:
+                            override def onNext(value: Req): Unit =
+                                import AllowUnsafe.embrace.danger
+                                discard(ch.offer(value))
+                            override def onError(t: Throwable): Unit =
+                                import AllowUnsafe.embrace.danger
+                                discard(ch.close())
+                            override def onCompleted(): Unit =
+                                import AllowUnsafe.embrace.danger
+                                discard(ch.close())
+                        end new
+                    end invoke
+            )
+        )
+
+    def bidiStreamingHandler[Req, Resp](
+        method: MethodDescriptor[Req, Resp],
+        handler: Stream[Req, Async] => Stream[Resp, Abort[StatusException] & Async]
+    )(using Frame, Tag[Emit[Chunk[Req]]], Tag[Emit[Chunk[Resp]]]): ServerMethodDefinition[Req, Resp] =
+        ServerMethodDefinition.create(
+            method,
+            ServerCalls.asyncBidiStreamingCall(
+                new ServerCalls.BidiStreamingMethod[Req, Resp]:
+                    override def invoke(observer: StreamObserver[Resp]): StreamObserver[Req] =
+                        import AllowUnsafe.embrace.danger
+                        val ch         = kyo.Channel.Unsafe.init[Req](1024)
+                        val reqStream  = ch.safe.streamUntilClosed()
+                        val respStream = handler(reqStream)
+
+                        discard(Sync.Unsafe.evalOrThrow(
+                            Fiber.initUnscoped {
+                                Abort.run[StatusException] {
+                                    respStream.foreach { resp =>
+                                        observer.onNext(resp)
+                                    }
+                                }.map(r => completeObserver(observer, r))
+                            }
+                        ))
+
+                        new StreamObserver[Req]:
+                            override def onNext(value: Req): Unit =
+                                import AllowUnsafe.embrace.danger
+                                discard(ch.offer(value))
+                            override def onError(t: Throwable): Unit =
+                                import AllowUnsafe.embrace.danger
+                                discard(ch.close())
+                            override def onCompleted(): Unit =
+                                import AllowUnsafe.embrace.danger
+                                discard(ch.close())
+                        end new
+                    end invoke
+            )
+        )
+
+    // ===== Client Call Helpers =====
+
+    def unaryCall[Req, Resp](
+        grpcChannel: io.grpc.Channel,
+        method: MethodDescriptor[Req, Resp],
+        request: Req
+    )(using Frame): Resp < (Abort[StatusException] & Async) =
+        Async.defer {
+            val promise = scala.concurrent.Promise[Resp]()
+            io.grpc.stub.ClientCalls.asyncUnaryCall(
+                grpcChannel.newCall(method, CallOptions.DEFAULT),
+                request,
+                new StreamObserver[Resp]:
+                    override def onNext(value: Resp): Unit =
+                        discard(promise.success(value))
+                    override def onError(t: Throwable): Unit =
+                        discard(promise.failure(t))
+                    override def onCompleted(): Unit = ()
+            )
+            Async.fromFuture(promise.future)
+        }.map(resp => resp)
+
+end Grpcs

--- a/kyo-grpc/src/test/scala/kyo/grpc/GrpcTest.scala
+++ b/kyo-grpc/src/test/scala/kyo/grpc/GrpcTest.scala
@@ -1,0 +1,54 @@
+package kyo.grpc
+
+import io.grpc.MethodDescriptor
+import io.grpc.MethodDescriptor.Marshaller
+import io.grpc.MethodDescriptor.MethodType
+import io.grpc.ServerServiceDefinition
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import kyo.*
+import org.scalatest.freespec.AnyFreeSpec
+
+class GrpcTest extends AnyFreeSpec:
+
+    private val stringMarshaller: Marshaller[String] = new Marshaller[String]:
+        override def stream(value: String): InputStream =
+            new ByteArrayInputStream(value.getBytes("UTF-8"))
+        override def parse(stream: InputStream): String =
+            new String(stream.readAllBytes(), "UTF-8")
+
+    private val echoMethod: MethodDescriptor[String, String] =
+        MethodDescriptor.newBuilder(stringMarshaller, stringMarshaller)
+            .setType(MethodType.UNARY)
+            .setFullMethodName("test.TestService/Echo")
+            .build()
+
+    "unary echo round-trip" in {
+        import AllowUnsafe.embrace.danger
+
+        val handler = Grpcs.unaryHandler[String, String](
+            echoMethod,
+            request => Async.defer(s"echo: $request")
+        )
+
+        val ssd = ServerServiceDefinition.builder("test.TestService")
+            .addMethod(echoMethod, handler.getServerCallHandler)
+            .build()
+
+        val result = Sync.Unsafe.evalOrThrow {
+            KyoApp.runAndBlock(Duration.Infinity) {
+                Scope.run {
+                    for
+                        server <- Grpcs.server(0, Seq(ssd))
+                        port = server.getPort
+                        channel <- Grpcs.channel(s"localhost:$port")
+                        result  <- Grpcs.unaryCall(channel, echoMethod, "hello")
+                    yield result
+                }
+            }
+        }
+
+        assert(result == "echo: hello")
+    }
+
+end GrpcTest


### PR DESCRIPTION
## Summary

Initial gRPC runtime support for Kyo, adding a `kyo-grpc` module that bridges Kyo's effect system with grpc-java.

Resolves #390

## What's included

- **`Grpcs` object** with Kyo-native APIs for all 4 gRPC RPC types:
  - `unaryHandler` — bridges `Req => Resp < (Abort[StatusException] & Async)` to gRPC
  - `serverStreamingHandler` — bridges `Req => Stream[Resp, ...]` to gRPC
  - `clientStreamingHandler` — bridges `Stream[Req, ...] => Resp < ...` using `Channel.Unsafe` for callback bridging
  - `bidiStreamingHandler` — full bidirectional streaming support
  - `unaryCall` — client-side unary calls returning Kyo effects via `Async.fromFuture`
- **Server/Channel lifecycle** managed via `Scope.acquireRelease`
- **Passing end-to-end test** demonstrating a unary echo round-trip

## Design decisions

- Uses `Scope` (not deprecated `Resource`) for lifecycle management
- Uses `KyoApp.runAndBlock` + `Sync.Unsafe.evalOrThrow` to bridge from gRPC's callback thread into Kyo's effect world
- Uses `Channel.Unsafe` + `streamUntilClosed()` to bridge incoming `StreamObserver` callbacks into Kyo `Stream`
- No code generator yet — this PR provides the runtime foundation; ScalaPB code generator will follow

## Next steps

- [ ] ScalaPB code generator for generating Kyo service traits from .proto files
- [ ] Additional tests (error handling, streaming, cancellation)
- [ ] Benchmarks comparing with zio-grpc and fs2-grpc
- [ ] SBT plugin for easy setup