### PR TITLE
Add protobuf HTTP body support

### DIFF
--- a/kyo-http/shared/src/main/scala/kyo/HttpException.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpException.scala
@@ -180,6 +180,8 @@ case class HttpHandlerException(error: Any)(using Frame)
   * @see
   *   [[kyo.HttpJsonDecodeException]] JSON body decode failed
   * @see
+  *   [[kyo.HttpProtobufDecodeException]] Protobuf body decode failed
+  * @see
   *   [[kyo.HttpFormDecodeException]] Form body decode failed
   * @see
   *   [[kyo.HttpUnsupportedMediaTypeException]] Unexpected Content-Type
@@ -250,6 +252,17 @@ case class HttpJsonDecodeException private (detail: String, method: String, url:
 object HttpJsonDecodeException:
     def apply(detail: String, method: String, url: String)(using Frame): HttpJsonDecodeException =
         new HttpJsonDecodeException(detail, method, HttpException.stripQuery(url))
+
+/** Protobuf body decode failed. */
+case class HttpProtobufDecodeException private (detail: String, method: String, url: String)(using Frame)
+    extends HttpDecodeException(
+        s"""Protobuf decode failed: $detail.
+           |
+           |  While processing: ${HttpException.showRequest(method, url)}""".stripMargin
+    )
+object HttpProtobufDecodeException:
+    def apply(detail: String, method: String, url: String)(using Frame): HttpProtobufDecodeException =
+        new HttpProtobufDecodeException(detail, method, HttpException.stripQuery(url))
 
 /** Form body decode failed. */
 case class HttpFormDecodeException private (detail: String, method: String, url: String, cause: Text | Throwable)(using Frame)

--- a/kyo-http/shared/src/main/scala/kyo/HttpRoute.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpRoute.scala
@@ -165,6 +165,25 @@ object HttpRoute:
     def deleteBinary(path: HttpPath[Any]): HttpRoute[Any, "body" ~ Span[Byte], Nothing] =
         deleteRaw(path).response(_.bodyBinary)
 
+    // ==================== Protobuf methods ====================
+
+    // Mirrors the JSON route helpers, but serializes typed bodies with kyo-schema's Protobuf codec.
+
+    def getProtobuf[A: Schema](path: HttpPath[Any]): HttpRoute[Any, "body" ~ A, Nothing] =
+        getRaw(path).response(_.bodyProtobuf[A])
+
+    def postProtobuf[A: Schema, B: Schema](path: HttpPath[Any]): HttpRoute["body" ~ B, "body" ~ A, Nothing] =
+        postRaw(path).request(_.bodyProtobuf[B]).response(_.bodyProtobuf[A])
+
+    def putProtobuf[A: Schema, B: Schema](path: HttpPath[Any]): HttpRoute["body" ~ B, "body" ~ A, Nothing] =
+        putRaw(path).request(_.bodyProtobuf[B]).response(_.bodyProtobuf[A])
+
+    def patchProtobuf[A: Schema, B: Schema](path: HttpPath[Any]): HttpRoute["body" ~ B, "body" ~ A, Nothing] =
+        patchRaw(path).request(_.bodyProtobuf[B]).response(_.bodyProtobuf[A])
+
+    def deleteProtobuf[A: Schema](path: HttpPath[Any]): HttpRoute[Any, "body" ~ A, Nothing] =
+        deleteRaw(path).response(_.bodyProtobuf[A])
+
     // ==================== ContentType ====================
 
     /** The content type and serialization strategy for a route's body field.
@@ -180,6 +199,8 @@ object HttpRoute:
         case Multipart                                                       extends ContentType[Seq[HttpRequest.Part]]
         case MultipartStream                                                 extends ContentType[Stream[HttpRequest.Part, Async]]
         case Json[A](schema: kyo.Schema[A], jsonSchema: kyo.Json.JsonSchema) extends ContentType[A]
+        // Schema-backed Protobuf payloads keep typed routes while using the binary wire format.
+        case Protobuf[A](schema: kyo.Schema[A]) extends ContentType[A]
         case Ndjson[V](schema: kyo.Schema[V], jsonSchema: kyo.Json.JsonSchema, emitTag: Tag[Emit[Chunk[V]]])
             extends ContentType[Stream[V, Async]]
         case Sse[V](schema: kyo.Schema[V], jsonSchema: kyo.Json.JsonSchema, emitTag: Tag[Emit[Chunk[HttpSseEvent[V]]]])
@@ -313,6 +334,15 @@ object HttpRoute:
         )[N <: String & Singleton](fieldName: N, description: String = "")(using Fields.Pin[N]): RequestDef[In & N ~ A] =
             add(Field.Body(fieldName, ContentType.Json(schema, kyo.Json.jsonSchema[A]), description))
 
+        // Declares a typed request body encoded as application/protobuf.
+        def bodyProtobuf[A](using schema: Schema[A]): RequestDef[In & "body" ~ A] =
+            add(Field.Body("body", ContentType.Protobuf(schema), ""))
+
+        def bodyProtobuf[A](using
+            schema: Schema[A]
+        )[N <: String & Singleton](fieldName: N, description: String = "")(using Fields.Pin[N]): RequestDef[In & N ~ A] =
+            add(Field.Body(fieldName, ContentType.Protobuf(schema), description))
+
         def bodyText: RequestDef[In & "body" ~ String] =
             add(Field.Body("body", ContentType.Text, ""))
 
@@ -438,6 +468,15 @@ object HttpRoute:
             schema: Schema[A]
         )[N <: String & Singleton](fieldName: N, description: String = "")(using Fields.Pin[N]): ResponseDef[Out & N ~ A] =
             addField(Field.Body(fieldName, ContentType.Json(schema, kyo.Json.jsonSchema[A]), description))
+
+        // Declares a typed response body encoded as application/protobuf.
+        def bodyProtobuf[A](using schema: Schema[A]): ResponseDef[Out & "body" ~ A] =
+            addField(Field.Body("body", ContentType.Protobuf(schema), ""))
+
+        def bodyProtobuf[A](using
+            schema: Schema[A]
+        )[N <: String & Singleton](fieldName: N, description: String = "")(using Fields.Pin[N]): ResponseDef[Out & N ~ A] =
+            addField(Field.Body(fieldName, ContentType.Protobuf(schema), description))
 
         def bodyText: ResponseDef[Out & "body" ~ String] =
             addField(Field.Body("body", ContentType.Text, ""))

--- a/kyo-http/shared/src/main/scala/kyo/internal/codec/OpenApiGenerator.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/codec/OpenApiGenerator.scala
@@ -193,7 +193,9 @@ private[kyo] object OpenApiGenerator:
 
     private def contentToMediaType(content: HttpRoute.ContentType[?]): Option[(String, HttpOpenApi.SchemaObject)] =
         content match
-            case j: HttpRoute.ContentType.Json[?]      => Some("application/json" -> jsonSchemaToHttpOpenApi(j.jsonSchema))
+            case j: HttpRoute.ContentType.Json[?] => Some("application/json" -> jsonSchemaToHttpOpenApi(j.jsonSchema))
+            // OpenAPI represents binary Protobuf bodies as string payloads under the protobuf media type.
+            case HttpRoute.ContentType.Protobuf(_)     => Some("application/protobuf" -> HttpOpenApi.SchemaObject.string)
             case HttpRoute.ContentType.Text            => Some("text/plain" -> HttpOpenApi.SchemaObject.string)
             case HttpRoute.ContentType.Binary          => Some("application/octet-stream" -> HttpOpenApi.SchemaObject.string)
             case HttpRoute.ContentType.ByteStream      => Some("application/octet-stream" -> HttpOpenApi.SchemaObject.string)

--- a/kyo-http/shared/src/main/scala/kyo/internal/server/RouteUtil.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/server/RouteUtil.scala
@@ -598,6 +598,10 @@ private[kyo] object RouteUtil:
             case json: HttpRoute.ContentType.Json[?] =>
                 val str = Json.encode(value)(using json.schema.asInstanceOf[Schema[Any]])
                 f("application/json", stringToSpan(str))
+            case protobuf: HttpRoute.ContentType.Protobuf[?] =>
+                // Route schemas carry enough information to encode typed values without generated message classes.
+                val bytes = Protobuf.encode(value)(using protobuf.schema.asInstanceOf[Schema[Any]])
+                f("application/protobuf", bytes)
             case form: HttpRoute.ContentType.Form[?] =>
                 val str = form.codec.asInstanceOf[HttpFormCodec[Any]].encode(value)
                 f("application/x-www-form-urlencoded", stringToSpan(str))
@@ -709,6 +713,18 @@ private[kyo] object RouteUtil:
                         Json.decode[Any](spanToString(bytes))(using summon[Json], schema, summon[Frame])
                             .mapFailure(e => HttpJsonDecodeException(e.getMessage, method, url.toString))
                     end if
+            case protobuf: HttpRoute.ContentType.Protobuf[?] =>
+                if !checkContentType(headers, "application/protobuf") then
+                    Result.fail(HttpUnsupportedMediaTypeException(
+                        "application/protobuf",
+                        headers.get("Content-Type"),
+                        method,
+                        url.toString
+                    ))
+                else
+                    // Convert schema decode failures into the HTTP decode error family used by clients and servers.
+                    Protobuf.decode[Any](bytes)(using summon[Protobuf], protobuf.schema.asInstanceOf[Schema[Any]], summon[Frame])
+                        .mapFailure(e => HttpProtobufDecodeException(e.getMessage, method, url.toString))
             case form: HttpRoute.ContentType.Form[?] =>
                 if !checkContentType(headers, "application/x-www-form-urlencoded") then
                     Result.fail(HttpUnsupportedMediaTypeException(

--- a/kyo-http/shared/src/test/scala/kyo/HttpRouteTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpRouteTest.scala
@@ -449,6 +449,25 @@ class HttpRouteTest extends Test:
             end match
         }
 
+        // Protobuf request bodies should behave like JSON bodies at the route-type level.
+        "protobuf stores field name and schema" in {
+            val r = HttpRoute.postRaw("users").request(_.bodyProtobuf[CreateUser])
+            assert(r.request.fields.size == 1)
+            r.request.fields(0) match
+                case Field.Body(fn, ContentType.Protobuf(_), _) =>
+                    assert(fn == "body")
+                case _ => fail("Expected Body with Protobuf")
+            end match
+        }
+
+        "protobuf with custom field name" in {
+            val r = HttpRoute.postRaw("users").request(_.bodyProtobuf[CreateUser]("payload"))
+            r.request.fields(0) match
+                case Field.Body(fn, ContentType.Protobuf(_), _) => assert(fn == "payload")
+                case _                                          => fail("Expected Protobuf body")
+            end match
+        }
+
         "text" in {
             val r = HttpRoute.postRaw("echo").request(_.bodyText)
             r.request.fields(0) match
@@ -558,6 +577,15 @@ class HttpRouteTest extends Test:
             r.response.fields(0) match
                 case Field.Body(fn, ContentType.Json(_, _), _) => assert(fn == "body")
                 case _                                         => fail("Expected Json body")
+            end match
+        }
+
+        // Response declarations carry the schema needed by RouteUtil to encode protobuf bytes.
+        "body protobuf" in {
+            val r = HttpRoute.getRaw("users").response(_.bodyProtobuf[User])
+            r.response.fields(0) match
+                case Field.Body(fn, ContentType.Protobuf(_), _) => assert(fn == "body")
+                case _                                          => fail("Expected Protobuf body")
             end match
         }
 

--- a/kyo-http/shared/src/test/scala/kyo/internal/RouteUtilTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/RouteUtilTest.scala
@@ -93,6 +93,23 @@ class RouteUtilTest extends kyo.Test:
             assert(bodyStr.contains("30"))
         }
 
+        // Encoding proves bodyProtobuf selects the Protobuf codec and media type, not raw binary passthrough.
+        "protobuf body" in {
+            val route = HttpRoute.postRaw("users").request(_.bodyProtobuf[User])
+            val user  = User("Alice", 30)
+            val request = HttpRequest.postRaw(HttpUrl.parse("http://localhost/users").getOrThrow)
+                .addField("body", user)
+
+            RouteUtil.encodeRequest(route, request)(
+                onEmpty = (_, _) => fail("expected buffered"),
+                onBuffered = (_, headers, bytes) =>
+                    assert(headers.get("Content-Type").contains("application/protobuf"))
+                    assert(Protobuf.decode[User](bytes).getOrThrow == user)
+                ,
+                onStreaming = (_, _, _) => fail("expected buffered")
+            )
+        }
+
         "text body" in {
             val route = HttpRoute.postRaw("echo").request(_.bodyText)
             val request = HttpRequest.postRaw(HttpUrl.parse("http://localhost/echo").getOrThrow)
@@ -242,6 +259,29 @@ class RouteUtilTest extends kyo.Test:
                     assert(response.status == HttpStatus.OK)
                     val user = response.fields.body
                     assert(user == User("Bob", 25))
+                case Result.Failure(err) => fail(s"decode failed: $err")
+                case p: Result.Panic     => throw p.exception
+            end match
+        }
+
+        // Client-side response decoding should reconstruct the typed body from application/protobuf bytes.
+        "protobuf body" in {
+            val route   = HttpRoute.getRaw("users").response(_.bodyProtobuf[User])
+            val user    = User("Bob", 25)
+            val bytes   = Protobuf.encode(user)
+            val headers = HttpHeaders.empty.add("Content-Type", "application/protobuf")
+
+            RouteUtil.decodeBufferedResponse(
+                route,
+                HttpStatus.OK,
+                headers,
+                bytes,
+                route.method.name,
+                HttpUrl.fromUri("/test")
+            ) match
+                case Result.Success(response) =>
+                    assert(response.status == HttpStatus.OK)
+                    assert(response.fields.body == user)
                 case Result.Failure(err) => fail(s"decode failed: $err")
                 case p: Result.Panic     => throw p.exception
             end match
@@ -410,6 +450,23 @@ class RouteUtilTest extends kyo.Test:
             )
             assert(headers.get("Content-Type").contains("application/json"))
             assert(bodyStr.contains("Bob"))
+        }
+
+        // Server-side response encoding should produce protobuf bytes that round-trip through kyo-schema.
+        "protobuf body" in {
+            val route = HttpRoute.getRaw("users").response(_.bodyProtobuf[User])
+            val user  = User("Bob", 25)
+            val response = HttpResponse.ok
+                .addField("body", user)
+
+            RouteUtil.encodeResponse(route, response)(
+                onEmpty = (_, _) => fail("expected buffered"),
+                onBuffered = (_, headers, bytes) =>
+                    assert(headers.get("Content-Type").contains("application/protobuf"))
+                    assert(Protobuf.decode[User](bytes).getOrThrow == user)
+                ,
+                onStreaming = (_, _, _) => fail("expected buffered")
+            )
         }
 
         "empty body" in {
@@ -749,6 +806,34 @@ class RouteUtilTest extends kyo.Test:
             RouteUtil.decodeBufferedRequest(route, Dict.empty[String, String], Absent, HttpHeaders.empty, bytes) match
                 case Result.Success(_)   => fail("expected failure")
                 case Result.Failure(err) => assert(err.getMessage.contains("JSON decode failed"))
+                case p: Result.Panic     => throw p.exception
+            end match
+        }
+
+        // Server-side request decoding should turn protobuf bytes into the typed route body.
+        "protobuf body" in {
+            val route   = HttpRoute.postRaw("users").request(_.bodyProtobuf[User])
+            val user    = User("Alice", 30)
+            val bytes   = Protobuf.encode(user)
+            val headers = HttpHeaders.empty.add("Content-Type", "application/protobuf")
+
+            RouteUtil.decodeBufferedRequest(route, Dict.empty[String, String], Absent, headers, bytes) match
+                case Result.Success(req) =>
+                    assert(req.fields.dict("body") == user)
+                case Result.Failure(err) => fail(s"decode failed: $err")
+                case p: Result.Panic     => throw p.exception
+            end match
+        }
+
+        // Malformed protobuf payloads should surface as HTTP decode failures, matching JSON/form behavior.
+        "invalid protobuf body fails" in {
+            val route   = HttpRoute.postRaw("users").request(_.bodyProtobuf[User])
+            val bytes   = Span.fromUnsafe(Array[Byte](8))
+            val headers = HttpHeaders.empty.add("Content-Type", "application/protobuf")
+
+            RouteUtil.decodeBufferedRequest(route, Dict.empty[String, String], Absent, headers, bytes) match
+                case Result.Success(_)   => fail("expected failure")
+                case Result.Failure(err) => assert(err.getMessage.contains("Protobuf decode failed"))
                 case p: Result.Panic     => throw p.exception
             end match
         }


### PR DESCRIPTION
## Summary

Adds schema-backed Protobuf request and response body support to kyo-http as a foundation for gRPC support in #390.

## Changes

- Add bodyProtobuf request/response route declarations and Protobuf route helpers.
- Encode/decode application/protobuf bodies through kyo-schema's Protobuf codec.
- Surface malformed Protobuf payloads as HttpProtobufDecodeException.
- Report application/protobuf bodies in generated OpenAPI metadata.
- Cover route construction plus request/response encode/decode behavior in tests.

## Validation

- sbt 'kyo-http/testOnly kyo.HttpRouteTest kyo.internal.RouteUtilTest'

## Notes

This is intended as a focused first step toward gRPC support rather than a complete gRPC implementation.