### PR TITLE
Reuse active TimeControl in nested scopes

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Clock.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Clock.scala
@@ -311,61 +311,67 @@ object Clock:
       *   The result of running the effect with controlled time
       */
     def withTimeControl[A, S](f: TimeControl => A < S)(using Frame): A < (Sync & S) =
-        Sync.Unsafe.defer {
-            val controlled =
-                new Unsafe with TimeControl:
-                    @volatile var current = Instant.Epoch
+        Sync.Unsafe.withLocal(local) { clock =>
+            clock.unsafe match
+                case control: TimeControl =>
+                    f(control)
+                case _ =>
+                    Sync.Unsafe.defer {
+                        val controlled =
+                            new Unsafe with TimeControl:
+                                @volatile var current = Instant.Epoch
 
-                    case class Task(deadline: Instant) extends IOPromise[Nothing, Unit < Any]
-                    val queue = new PriorityQueue[Task](using Ordering.fromLessThan((a, b) => b.deadline < a.deadline))
+                                case class Task(deadline: Instant) extends IOPromise[Nothing, Unit < Any]
+                                val queue = new PriorityQueue[Task](using Ordering.fromLessThan((a, b) => b.deadline < a.deadline))
 
-                    def now()(using AllowUnsafe) = current
+                                def now()(using AllowUnsafe) = current
 
-                    def nowMonotonic()(using AllowUnsafe) = current.toDuration
+                                def nowMonotonic()(using AllowUnsafe) = current.toDuration
 
-                    def sleep(duration: Duration): Fiber.Unsafe[Unit, Any] =
-                        val task = new Task(current + duration)
-                        queue.synchronized {
-                            queue.enqueue(task)
-                        }
-                        Promise.Unsafe.fromIOPromise(task)
-                    end sleep
+                                def sleep(duration: Duration): Fiber.Unsafe[Unit, Any] =
+                                    val task = new Task(current + duration)
+                                    queue.synchronized {
+                                        queue.enqueue(task)
+                                    }
+                                    Promise.Unsafe.fromIOPromise(task)
+                                end sleep
 
-                    def set(now: Instant) = set(now, 100.millis)
+                                def set(now: Instant) = set(now, 100.millis)
 
-                    def set(now: Instant, wallClockDelay: Duration) =
-                        Sync.defer {
-                            current = now
-                            tick()
-                            Clock.live.unsafe.sleep(wallClockDelay).safe.get
-                        }
+                                def set(now: Instant, wallClockDelay: Duration) =
+                                    Sync.defer {
+                                        current = now
+                                        tick()
+                                        Clock.live.unsafe.sleep(wallClockDelay).safe.get
+                                    }
 
-                    def advance(duration: Duration) = advance(duration, duration.min(100.millis))
+                                def advance(duration: Duration) = advance(duration, duration.min(100.millis))
 
-                    def advance(duration: Duration, wallClockDelay: Duration) =
-                        Sync.defer {
-                            current = current + duration
-                            tick()
-                            Clock.live.unsafe.sleep(wallClockDelay).safe.get
-                        }
+                                def advance(duration: Duration, wallClockDelay: Duration) =
+                                    Sync.defer {
+                                        current = current + duration
+                                        tick()
+                                        Clock.live.unsafe.sleep(wallClockDelay).safe.get
+                                    }
 
-                    def tick(): Unit =
-                        queue.synchronized {
-                            queue.headOption match
-                                case Some(task) if task.deadline <= current =>
-                                    Maybe(queue.dequeue())
-                                case Some(task) if task.done() =>
-                                    discard(queue.dequeue())
-                                    Maybe.empty
-                                case _ =>
-                                    Maybe.empty
-                        } match
-                            case Present(task) =>
-                                task.completeDiscard(Result.succeed(()))
-                                tick()
-                            case Absent =>
-                                ()
-            let(Clock(controlled))(f(controlled))
+                                def tick(): Unit =
+                                    queue.synchronized {
+                                        queue.headOption match
+                                            case Some(task) if task.deadline <= current =>
+                                                Maybe(queue.dequeue())
+                                            case Some(task) if task.done() =>
+                                                discard(queue.dequeue())
+                                                Maybe.empty
+                                            case _ =>
+                                                Maybe.empty
+                                    } match
+                                        case Present(task) =>
+                                            task.completeDiscard(Result.succeed(()))
+                                            tick()
+                                        case Absent =>
+                                            ()
+                        let(Clock(controlled))(f(controlled))
+                    }
         }
     end withTimeControl
 

--- a/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ClockTest.scala
@@ -43,6 +43,23 @@ class ClockTest extends Test:
                 yield assert(now == Instant.Max)
             }
         }
+
+        "nested time control reuses current control" in run {
+            Clock.withTimeControl { outer =>
+                for
+                    _ <- outer.set(Instant.Epoch)
+                    result <- Clock.withTimeControl { inner =>
+                        for
+                            _   <- inner.advance(1.second)
+                            now <- Clock.now
+                        yield (outer.asInstanceOf[AnyRef] eq inner.asInstanceOf[AnyRef], now)
+                    }
+                    now <- Clock.now
+                yield
+                    assert(result == (true, Instant.Epoch + 1.second))
+                    assert(now == Instant.Epoch + 1.second)
+            }
+        }
     }
 
     "Stopwatch" - {


### PR DESCRIPTION
Addresses #1600.\n\n## Summary\n- make Clock.withTimeControl reuse the current local TimeControl when one is already active\n- keep the existing controlled-clock creation path for non-controlled clocks\n- add a regression test that proves nested withTimeControl scopes share the same control and the same clock timeline\n\n## Verification\n- java -Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8 -jar ..\\tools\\sbt-launch-1.12.5.jar ';kyo-core/clean;kyo-core/testOnly kyo.ClockTest' passes: 44 tests succeeded, 0 failed\n- git diff --check fix/1600-nested-time-control^ fix/1600-nested-time-control passes