### PR TITLE
Clarify Memo docs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,16 +1206,13 @@ val fibonacci: Int => Int < Memo =
             yield a + b
     }
 
-val result: (Int, Int) < Memo = 
+val result: (Int, Int) < Any =
     Memo.run {
         for
             fib10 <- fibonacci(10)
             fib11 <- fibonacci(11)
         yield (fib10, fib11)
     }
-
-val result2: (Int, Int) < Any =
-    Memo.run(result)
 ```
 
 Key points about `Memo`:


### PR DESCRIPTION
Closes #1546.

## Summary
- clarify the Memo README example by annotating `Memo.run` as returning `(Int, Int) < Any`
- remove the extra `Memo.run(result)` block that made the example look like it still required `Memo`

## Verification
- `git diff --check`