### PR TITLE
Add Ansi support for Text

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Ansi.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Ansi.scala
@@ -6,6 +6,33 @@ import scala.util.control.NonFatal
   */
 object Ansi:
 
+    private def applyText(text: Text, code: String): Text =
+        Text("\u001b[") + code + "m" + text + "\u001b[0m"
+
+    private def stripAnsiText(text: Text): Text =
+        val len     = text.length
+        val builder = new StringBuilder(len)
+        var i       = 0
+        while i < len do
+            if text.charAt(i) == '\u001b' && i + 1 < len && text.charAt(i + 1) == '[' then
+                val start = i
+                i += 2
+                while i < len && (text.charAt(i).isDigit || text.charAt(i) == ';') do
+                    i += 1
+                if i < len && text.charAt(i).isLetter then
+                    i += 1
+                else
+                    i = start
+                    builder.append(text.charAt(i))
+                    i += 1
+                end if
+            else
+                builder.append(text.charAt(i))
+                i += 1
+        end while
+        Text(builder.toString)
+    end stripAnsiText
+
     extension (str: String)
         /** Applies black color to the string. */
         def black: String = s"\u001b[30m$str\u001b[0m"
@@ -48,6 +75,50 @@ object Ansi:
 
         /** Removes all ANSI escape sequences from the string. */
         def stripAnsi: String = str.replaceAll("\u001b\\[[0-9;]*[a-zA-Z]", "")
+    end extension
+
+    extension (text: Text)
+        /** Applies black color to the text. */
+        def black: Text = applyText(text, "30")
+
+        /** Applies red color to the text. */
+        def red: Text = applyText(text, "31")
+
+        /** Applies green color to the text. */
+        def green: Text = applyText(text, "32")
+
+        /** Applies yellow color to the text. */
+        def yellow: Text = applyText(text, "33")
+
+        /** Applies blue color to the text. */
+        def blue: Text = applyText(text, "34")
+
+        /** Applies magenta color to the text. */
+        def magenta: Text = applyText(text, "35")
+
+        /** Applies cyan color to the text. */
+        def cyan: Text = applyText(text, "36")
+
+        /** Applies white color to the text. */
+        def white: Text = applyText(text, "37")
+
+        /** Applies grey color to the text. */
+        def grey: Text = applyText(text, "90")
+
+        /** Applies bold formatting to the text. */
+        def bold: Text = applyText(text, "1")
+
+        /** Applies dim formatting to the text. */
+        def dim: Text = applyText(text, "2")
+
+        /** Applies italic formatting to the text. */
+        def italic: Text = applyText(text, "3")
+
+        /** Applies underline formatting to the text. */
+        def underline: Text = applyText(text, "4")
+
+        /** Removes all ANSI escape sequences from the text. */
+        def stripAnsi: Text = stripAnsiText(text)
     end extension
 
     object highlight:

--- a/kyo-data/shared/src/test/scala/kyo/AnsiTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/AnsiTest.scala
@@ -65,4 +65,20 @@ class AnsiTest extends Test:
         assert(coloredString.stripAnsi == "test")
     }
 
+    "text red" in {
+        val text: Text = Text("test")
+        assert(text.red.is(Text("\u001b[31mtest\u001b[0m")))
+    }
+
+    "text formatting composes without forcing the input text" in {
+        val text: Text    = Text("te") + Text("st")
+        val colored: Text = text.red.bold.underline
+        assert(colored.is(Text("\u001b[4m\u001b[1m\u001b[31mtest\u001b[0m\u001b[0m\u001b[0m")))
+    }
+
+    "text stripAnsi" in {
+        val coloredText: Text = (Text("te") + Text("st")).red.bold.underline
+        assert(coloredText.stripAnsi.is(Text("test")))
+    }
+
 end AnsiTest


### PR DESCRIPTION
Closes #1188.

## Summary
- add Text-based Ansi styling extensions alongside the existing String API
- build styled Text through Text concatenation so composed Text values are not flattened before styling
- add Text stripAnsi support with focused coverage for styling, composition, and stripping

## Verification
- kyo-data/testOnly kyo.AnsiTest
- git diff --check upstream/main...HEAD