### PR TITLE
Add acquireReleaseWith to Sync

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Sync.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Sync.scala
@@ -67,6 +67,27 @@ object Sync:
     inline def ensure[A, S](inline f: => Any < (Sync & Abort[Throwable]))(v: => A < S)(using inline frame: Frame): A < (Sync & S) =
         ensure(_ => f)(v)
 
+    /** Acquires a resource, uses it, and releases it after use.
+      *
+      * This is a lightweight bracket-style operator for Sync resources. The release action is registered only after acquisition succeeds
+      * and is guaranteed to run after the use computation completes or panics.
+      *
+      * @param acquire
+      *   The resource acquisition computation.
+      * @param release
+      *   The release action for a successfully acquired resource.
+      * @param use
+      *   The computation that uses the acquired resource.
+      * @return
+      *   The result of the use computation.
+      */
+    def acquireReleaseWith[A, S1](acquire: => A < (Sync & S1))(
+        release: A => Any < (Sync & Abort[Throwable])
+    )[B, S2](use: A => B < S2)(using Frame): B < (Sync & S1 & S2) =
+        Sync.defer(acquire).map { resource =>
+            Sync.ensure(release(resource))(use(resource))
+        }
+
     /** Ensures that a finalizer is run after the computation, regardless of success or failure.
       *
       * This version provides the finalizer with information about whether the computation completed successfully or failed with an

--- a/kyo-core/shared/src/test/scala/kyo/SyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SyncTest.scala
@@ -208,6 +208,70 @@ class SyncTest extends Test:
         }
     }
 
+    "acquireReleaseWith" - {
+        "success" in run {
+            var order = List.empty[String]
+
+            Sync.acquireReleaseWith(Sync.defer {
+                order = order :+ "acquire"
+                "resource"
+            }) { resource =>
+                Sync.defer {
+                    order = order :+ s"release:$resource"
+                }
+            } { resource =>
+                Sync.defer {
+                    order = order :+ s"use:$resource"
+                    resource.length
+                }
+            }.map { result =>
+                assert(result == 8)
+                assert(order == List("acquire", "use:resource", "release:resource"))
+            }
+        }
+
+        "release after panic in use" in run {
+            val ex        = new RuntimeException("boom")
+            var released  = false
+            var useCalled = false
+
+            Abort.run[Any] {
+                Sync.acquireReleaseWith(Sync.defer("resource")) { _ =>
+                    Sync.defer {
+                        released = true
+                    }
+                } { _ =>
+                    Sync.defer {
+                        useCalled = true
+                        throw ex
+                    }
+                }
+            }.map { result =>
+                assert(result == Result.panic(ex))
+                assert(useCalled)
+                assert(released)
+            }
+        }
+
+        "does not release when acquire panics" in run {
+            val ex       = new RuntimeException("boom")
+            var released = false
+
+            Abort.run[Any] {
+                Sync.acquireReleaseWith(Sync.defer[String, Any](throw ex)) { _ =>
+                    Sync.defer {
+                        released = true
+                    }
+                } { resource =>
+                    resource
+                }
+            }.map { result =>
+                assert(result == Result.panic(ex))
+                assert(!released)
+            }
+        }
+    }
+
     "evalOrThrow" - {
         import AllowUnsafe.embrace.danger
         "success" in run {


### PR DESCRIPTION
Closes #1220.

## Summary
- add Sync.acquireReleaseWith as a lightweight bracket-style operator
- release only after successful acquire, using existing Sync.ensure semantics
- cover success, use-side panic cleanup, and acquire-side panic behavior

IO is currently a deprecated alias for Sync, so this is also available as IO.acquireReleaseWith while following the current naming direction in the codebase.

## Verification
- kyo-core/testOnly kyo.SyncTest
- git diff --check