### PR TITLE
Support non-Throwable aborts in KyoApp

### DIFF
--- a/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -1,10 +1,10 @@
 package kyo
 
-abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Scope & Abort[Throwable]]:
+abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Scope & Abort[Any]]:
 
     private var last: Unit < (Async & Abort[Throwable]) = ()
 
-    final override protected def run[A](v: => A < (Async & Scope & Abort[Throwable]))(using Frame, Render[A]): Unit =
+    final override protected def run[A](v: => A < (Async & Scope & Abort[Any]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         val current: Unit < (Async & Abort[Throwable]) =
             Abort.runWith(Async.timeout(runTimeout)(handle(v)))(result => Sync.defer(onResult(result)).andThen(Abort.get(result)).unit)

--- a/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/KyoAppPlatformSpecific.scala
@@ -1,8 +1,8 @@
 package kyo
 
-abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Scope & Abort[Throwable]]:
+abstract class KyoAppPlatformSpecific extends KyoApp.Base[Async & Scope & Abort[Any]]:
 
-    final override protected def run[A](v: => A < (Async & Scope & Abort[Throwable]))(using Frame, Render[A]): Unit =
+    final override protected def run[A](v: => A < (Async & Scope & Abort[Any]))(using Frame, Render[A]): Unit =
         import AllowUnsafe.embrace.danger
         initCode = initCode.appended(() =>
             val result = Sync.Unsafe.evalOrThrow(Abort.run(KyoApp.runAndBlock(runTimeout)(handle(v))))

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -27,13 +27,16 @@ abstract class KyoApp extends KyoAppPlatformSpecific:
         promise.mask().safe
     end awaitInterrupt
 
-    override protected def handle[A](v: A < (Async & Scope & Abort[Throwable]))(using Frame): A < (Async & Abort[Throwable]) =
-        Async.raceFirst(Scope.run(v), awaitInterrupt.get)
+    override protected def handle[A](v: A < (Async & Scope & Abort[Any]))(using Frame): A < (Async & Abort[Throwable]) =
+        Async.raceFirst(KyoApp.abortAnyToThrowable(Scope.run(v)), awaitInterrupt.get)
     end handle
 end KyoApp
 
 object KyoApp:
-    def apply[A](v: => A < (Async & Scope & Abort[Throwable]))(using Frame, Render[A]): KyoApp =
+    final case class FailureException private[kyo] (error: Any)(using Frame)
+        extends KyoException("Uncaught error", String.valueOf(error))
+
+    def apply[A](v: => A < (Async & Scope & Abort[Any]))(using Frame, Render[A]): KyoApp =
         new KyoApp:
             run(v)
 
@@ -133,9 +136,18 @@ object KyoApp:
           *   A Result containing either the computed value or a failure.
           */
         def runAndBlock[A](timeout: Duration)(
-            v: A < (Async & Scope & Abort[Throwable])
+            v: A < (Async & Scope & Abort[Any])
         )(using Frame, AllowUnsafe): Result[Throwable, A] =
-            Abort.run(Sync.Unsafe.run(KyoApp.runAndBlock(timeout)(Scope.run(v)))).eval
+            Abort.run(Sync.Unsafe.run(KyoApp.runAndBlock(timeout)(KyoApp.abortAnyToThrowable(Scope.run(v))))).eval
     end Unsafe
+
+    private def abortAnyToThrowable[A, S](v: => A < (Abort[Any] & S))(using Frame): A < (Abort[Throwable] & S) =
+        Abort.run[Any](v).map {
+            case Result.Success(value)              => value
+            case Result.Failure(error: Throwable)   => Abort.fail(error)
+            case Result.Failure(error)              => Abort.fail(FailureException(error))
+            case panic @ Result.Panic(_: Throwable) => Abort.get(panic)
+        }
+    end abortAnyToThrowable
 
 end KyoApp

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -146,7 +146,7 @@ object KyoApp:
             case Result.Success(value)              => value
             case Result.Failure(error: Throwable)   => Abort.fail(error)
             case Result.Failure(error)              => Abort.fail(FailureException(error))
-            case panic @ Result.Panic(_: Throwable) => Abort.get(panic)
+            case panic: Result.Panic => Abort.get(panic)
         }
     end abortAnyToThrowable
 

--- a/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
+++ b/kyo-core/shared/src/main/scala/kyo/KyoApp.scala
@@ -143,10 +143,10 @@ object KyoApp:
 
     private def abortAnyToThrowable[A, S](v: => A < (Abort[Any] & S))(using Frame): A < (Abort[Throwable] & S) =
         Abort.run[Any](v).map {
-            case Result.Success(value)              => value
-            case Result.Failure(error: Throwable)   => Abort.fail(error)
-            case Result.Failure(error)              => Abort.fail(FailureException(error))
-            case panic: Result.Panic => Abort.get(panic)
+            case Result.Success(value)            => value
+            case Result.Failure(error: Throwable) => Abort.fail(error)
+            case Result.Failure(error)            => Abort.fail(FailureException(error))
+            case panic: Result.Panic              => Abort.get(panic)
         }
     end abortAnyToThrowable
 

--- a/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/KyoAppTest.scala
@@ -112,6 +112,27 @@ class KyoAppTest extends Test:
             case _                                           => fail("Unexpected Success...")
     }
 
+    "non-throwable aborts" in runNotJS {
+        val app = new KyoApp:
+            run(Abort.fail("Aborts!"))
+
+        assert(Result.catching[KyoApp.FailureException](app.main(Array.empty)).isFailure)
+    }
+
+    "unsafe non-throwable aborts" in runNotJS {
+        def run: Unit < (Async & Scope & Abort[String]) =
+            for
+                _ <- Clock.now
+                _ <- Random.nextInt
+                _ <- Abort.fail("Aborts!")
+            yield ()
+
+        import AllowUnsafe.embrace.danger
+        KyoApp.Unsafe.runAndBlock(Duration.Infinity)(run) match
+            case Result.Failure(exception: KyoApp.FailureException) => assert(exception.error.toString == "Aborts!")
+            case _                                                  => fail("Unexpected Success...")
+    }
+
     "effect mismatch" in {
         typeCheckFailure("""
             new KyoApp:


### PR DESCRIPTION
Closes #1186.

## Summary
- widen KyoApp's accepted effect boundary from Abort[Throwable] to Abort[Any]
- convert non-Throwable abort failures to a KyoApp.FailureException at the app boundary
- keep Throwable abort failures and panic handling on the existing Throwable path
- add KyoApp regression coverage for non-Throwable aborts through both main and Unsafe.runAndBlock

## Verification
- java "-Dsbt.server.forcestart=true" -Xms2G -Xmx4G -Xss10M -jar ..\tools\sbt-launch-1.10.11.jar "kyo-core/testOnly kyo.KyoAppTest"
- java "-Dsbt.server.forcestart=true" -Xms2G -Xmx4G -Xss10M -jar ..\tools\sbt-launch-1.10.11.jar "kyo-coreJS/Test/compile"
- git diff --check