### PR TITLE
Fix TMap initWith and contains

### DIFF
--- a/kyo-stm/shared/src/main/scala/kyo/TMap.scala
+++ b/kyo-stm/shared/src/main/scala/kyo/TMap.scala
@@ -61,14 +61,14 @@ object TMap:
       */
     inline def initWith[K, V](inline entries: (K, V)*)[A, S](inline f: TMap[K, V] => A < S)(
         using inline frame: Frame
-    ): TMap[K, V] < (Sync & S) =
+    ): A < (Sync & S) =
         STM.withCurrentTransactionOrNew { tick =>
             val trefs =
                 entries.foldLeft(Map.empty[K, TRef[V]]) {
                     case (acc, (k, v)) =>
                         acc.updated(k, TRef.Unsafe.init(tick, v))
                 }
-            TRef.Unsafe.init(tick, trefs)
+            f(TRef.Unsafe.init(tick, trefs))
         }
 
     extension [K, V](self: TMap[K, V])
@@ -165,7 +165,7 @@ object TMap:
           *   true if the key exists, false otherwise
           */
         def contains(key: K)(using Frame): Boolean < STM =
-            self.use(!_.isEmpty)
+            self.use(_.contains(key))
 
         /** Updates the value associated with a key based on its current value.
           *

--- a/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
+++ b/kyo-stm/shared/src/test/scala/kyo/TMapTest.scala
@@ -26,6 +26,19 @@ class TMapTest extends Test:
             }
         }
 
+        "initWith applies function" in run {
+            STM.run {
+                TMap.initWith("a" -> 1, "b" -> 2) { map =>
+                    for
+                        _        <- map.put("c", 3)
+                        snapshot <- map.snapshot
+                    yield snapshot
+                }
+            }.map { snapshot =>
+                assert(snapshot == Map("a" -> 1, "b" -> 2, "c" -> 3))
+            }
+        }
+
         "add and contains" in run {
             STM.run {
                 for
@@ -36,7 +49,7 @@ class TMapTest extends Test:
                     value   <- map.get("key")
                 yield (exists, missing, value)
             }.map { case (exists, missing, value) =>
-                assert(exists && missing && value == Maybe(42))
+                assert(exists && !missing && value == Maybe(42))
             }
         }
 


### PR DESCRIPTION
## Summary
- fix `TMap.initWith` so it applies and returns the provided function result
- fix `TMap.contains(key)` so it checks the requested key instead of only map non-emptiness
- add regression coverage for both behaviors

Fixes #1621
Fixes #1622

## Test
- `kyo-stm/testOnly kyo.TMapTest` -> 29 passed

Note: `kyo-stm/test` currently fails in unrelated `STMTest` concurrency cases on this machine (`concurrent modifications` / `concurrent updates`).