### PR TITLE
Enforce WebSocket max frame size

### DIFF
--- a/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
@@ -739,7 +739,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
 
                     Fiber.initUnscoped {
                         Loop(wsStream) { stream =>
-                            WebSocketCodec.readFrameWith(stream, transportStream) { (frame, remaining) =>
+                            WebSocketCodec.readFrameWith(stream, transportStream, config.maxFrameSize) { (frame, remaining) =>
                                 inbound.put(frame).andThen(Loop.continue(remaining))
                             }
                         }

--- a/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
@@ -312,7 +312,7 @@ private[kyo] object UnsafeServerDispatch:
 
                     Fiber.initUnscoped {
                         Loop(conn.read) { stream =>
-                            WebSocketCodec.readFrameWith(stream, conn) { (frame, remaining) =>
+                            WebSocketCodec.readFrameWith(stream, conn, wsHandler.wsConfig.maxFrameSize) { (frame, remaining) =>
                                 inbound.put(frame).andThen(Loop.continue(remaining))
                             }
                         }

--- a/kyo-http/shared/src/main/scala/kyo/internal/websocket/WebSocketCodec.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/websocket/WebSocketCodec.scala
@@ -38,19 +38,19 @@ private[kyo] object WebSocketCodec:
     // ── Public API ──────────────────────────────────────────────
 
     /** Read one complete frame, passing (frame, remainingStream) to f. Handles Ping by auto-sending Pong. On Close frame: Abort[Closed]. */
-    def readFrameWith[A, S](src: Stream[Span[Byte], Async], dst: TransportStream)(
+    def readFrameWith[A, S](src: Stream[Span[Byte], Async], dst: TransportStream, maxFrameSize: Int = Int.MaxValue)(
         f: (HttpWebSocket.Payload, Stream[Span[Byte], Async]) => A < S
     )(using Frame): A < (S & Async & Abort[Closed]) =
         Abort.recover[HttpException](_ => Abort.fail(new Closed("HttpWebSocket", summon[Frame]))) {
-            readRawFrameWith(src) { (opcode, payload, remaining) =>
+            readRawFrameWith(src, maxFrameSize) { (opcode, payload, remaining) =>
                 opcode match
                     case OpText   => f(HttpWebSocket.Payload.Text(new String(payload.toArrayUnsafe, Utf8)), remaining)
                     case OpBinary => f(HttpWebSocket.Payload.Binary(payload), remaining)
                     case OpClose  => Abort.fail(new Closed("HttpWebSocket", summon[Frame], "Close frame received"))
                     case OpPing =>
-                        writeRawFrame(dst, OpPong, payload, mask = false).andThen(readFrameWith(remaining, dst)(f))
+                        writeRawFrame(dst, OpPong, payload, mask = false).andThen(readFrameWith(remaining, dst, maxFrameSize)(f))
                     case OpPong =>
-                        readFrameWith(remaining, dst)(f)
+                        readFrameWith(remaining, dst, maxFrameSize)(f)
                     case other =>
                         Abort.fail(new Closed("HttpWebSocket", summon[Frame], s"Unknown opcode: $other"))
                 end match
@@ -216,7 +216,7 @@ private[kyo] object WebSocketCodec:
     // ── Internal I/O ────────────────────────────────────────────
 
     /** Read a single raw frame (handles extended length + masking). */
-    private inline def readRawFrameWith[A, S2](src: Stream[Span[Byte], Async])(
+    private inline def readRawFrameWith[A, S2](src: Stream[Span[Byte], Async], maxFrameSize: Int)(
         inline f: (Int, Span[Byte], Stream[Span[Byte], Async]) => A < S2
     )(using inline frame: Frame): A < (S2 & Async & Abort[HttpException]) =
         ByteStream.readExactWith(src, 2) { (header, rem1) =>
@@ -226,7 +226,9 @@ private[kyo] object WebSocketCodec:
 
             if extLenBytes == 0 then
                 val actualLen = payloadLen.toLong
-                if fh.masked then
+                if actualLen > maxFrameSize.toLong then
+                    Abort.fail(HttpProtocolException("HttpWebSocket frame exceeds max frame size"))
+                else if fh.masked then
                     ByteStream.readExactWith(rem1, 4) { (maskKey, rem2) =>
                         ByteStream.readExactWith(rem2, actualLen.toInt) { (payload, rem3) =>
                             f(fh.opcode, unmask(payload, maskKey), rem3)
@@ -245,7 +247,9 @@ private[kyo] object WebSocketCodec:
                             @tailrec def readLong(i: Int, acc: Long): Long =
                                 if i >= 8 then acc else readLong(i + 1, (acc << 8) | (ext(i) & 0xff))
                             readLong(0, 0L)
-                    if fh.masked then
+                    if actualLen < 0 || actualLen > maxFrameSize.toLong || actualLen > Int.MaxValue.toLong then
+                        Abort.fail(HttpProtocolException("HttpWebSocket frame exceeds max frame size"))
+                    else if fh.masked then
                         ByteStream.readExactWith(rem2, 4) { (maskKey, rem3) =>
                             ByteStream.readExactWith(rem3, actualLen.toInt) { (payload, rem4) =>
                                 f(fh.opcode, unmask(payload, maskKey), rem4)

--- a/kyo-http/shared/src/test/scala/kyo/internal/UnsafeServerDispatchTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/UnsafeServerDispatchTest.scala
@@ -1,6 +1,7 @@
 package kyo.internal
 
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicBoolean
 import kyo.*
 import kyo.internal.codec.*
 import kyo.internal.http1.*
@@ -1093,6 +1094,35 @@ class UnsafeServerDispatchTest extends kyo.Test:
                 // Clean up: close inbound to terminate WS fibers
                 discard(inbound.close())
                 succeed
+            }
+        }
+
+        "HttpWebSocket rejects frames exceeding configured maxFrameSize" in run {
+            val received = new AtomicBoolean(false)
+            val config   = HttpWebSocket.Config(maxFrameSize = 4)
+            val handler = HttpHandler.webSocket("ws", config) { (_, ws) =>
+                Abort.run[Closed](ws.take()).map {
+                    case Result.Success(_) =>
+                        discard(received.set(true))
+                    case _ => ()
+                }
+            }
+            val router = HttpRouter(Seq(handler), Absent)
+
+            val inbound  = Channel.Unsafe.init[Span[Byte]](64)
+            val outbound = Channel.Unsafe.init[Span[Byte]](64)
+
+            discard(inbound.offer(Span.fromUnsafe(wsUpgradeRequest("ws").getBytes(StandardCharsets.US_ASCII))))
+
+            UnsafeServerDispatch.serve(router, inbound, outbound, defaultConfig)
+
+            collectWsUpgradeResponse(outbound).map { response =>
+                assert(response.contains("HTTP/1.1 101 Switching Protocols"), s"Expected 101, got: $response")
+                discard(inbound.offer(Span.fromUnsafe(encodeClientTextFrame("hello"))))
+                Async.sleep(100.millis).map { _ =>
+                    assert(!received.get(), "Oversized frame should close before reaching the handler")
+                    discard(inbound.close())
+                }.andThen(succeed)
             }
         }
 

--- a/kyo-http/shared/src/test/scala/kyo/internal/WebSocketCodecTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/WebSocketCodecTest.scala
@@ -207,6 +207,37 @@ class WebSocketCodecTest extends kyo.Test:
                 }
             }
         }
+
+        "rejects frame larger than maxFrameSize" in run {
+            val payload = "hello".getBytes(Utf8)
+            val frame = Array[Byte](
+                (0x80 | 0x01).toByte,
+                payload.length.toByte
+            ) ++ payload
+            val conn = new MockConn(frame)
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn, maxFrameSize = 4)((frame, _) => frame)).map { result =>
+                assert(result.isFailure)
+            }
+        }
+
+        "rejects 64-bit frame lengths before integer overflow" in run {
+            val frame = Array[Byte](
+                (0x80 | 0x01).toByte,
+                127.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x80.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x00.toByte
+            )
+            val conn = new MockConn(frame)
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn)((frame, _) => frame)).map { result =>
+                assert(result.isFailure)
+            }
+        }
     }
 
     // ── Upgrade handshake ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- enforce `HttpWebSocket.Config.maxFrameSize` while decoding inbound WebSocket frames
- apply the configured limit on both server and client WebSocket read loops
- reject oversized 64-bit frame lengths before converting to `Int`
- add codec and server-dispatch regression coverage

## Test
```powershell
kyo-http/testOnly kyo.internal.WebSocketCodecTest
kyo-http/testOnly kyo.internal.WebSocketCodecTest kyo.internal.UnsafeServerDispatchTest -- -z maxFrameSize
kyo-http/testOnly kyo.internal.WebSocketCodecTest kyo.internal.UnsafeServerDispatchTest -- -z HttpWebSocket
```