### PR TITLE
[compat] seamless cross-stack libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,3 +149,11 @@ jobs:
           else
             sbt "$cmd"
           fi
+
+      # The kyo-compat sbt plugin is exercised by scripted tests, not the
+      # testKyo matrix. It is platform-independent, so run it once: on the
+      # JVM target of a single arch rather than every arch/target cell.
+      - name: Scripted tests (kyo-compat plugin)
+        if: matrix.target == 'JVM' && inputs.os == 'linux-x64'
+        shell: bash
+        run: sbt 'kyo-compat/scripted'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bloop
 .bsp
+.claude
 .metals
 project/target
 project/project

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -35,6 +35,9 @@ fileOverride {
   "glob:**/kyo-stats-registry/**" {
     runner.dialect = scala212source3
   }
+  "glob:**/kyo-compat/plugin/src/main/**" {
+    runner.dialect = scala212
+  }
   "glob:**/kyo-stats-otlp/**" {
     runner.dialect = scala3
   }

--- a/build.sbt
+++ b/build.sbt
@@ -702,6 +702,9 @@ lazy val `kyo-compat-future` =
         .in(file("kyo-compat/bindings/future"))
         .settings(
             `kyo-settings`,
+            scalaVersion       := scala3LTSVersion,
+            crossScalaVersions := List(scala3LTSVersion),
+            scalacOptions += "-Xmax-inlines:1024",
             // Cross-platform: shared sources use atomics + ConcurrentLinkedQueue
             // (both polyfilled on JS and natively supported on Native).
             // Platform-specific source dirs hold the blocking-pool / scheduler
@@ -745,9 +748,11 @@ lazy val `kyo-compat-zio` =
         .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-compat/bindings/zio"))
-        .dependsOn(`kyo-data`)
         .settings(
             `kyo-settings`,
+            scalaVersion       := scala3LTSVersion,
+            crossScalaVersions := List(scala3LTSVersion),
+            scalacOptions += "-Xmax-inlines:1024",
             libraryDependencies += "dev.zio" %%% "zio"            % zioVersion,
             libraryDependencies += "dev.zio" %%% "zio-concurrent" % zioVersion,
             Test / unmanagedSourceDirectories += {
@@ -768,9 +773,11 @@ lazy val `kyo-compat-ce` =
         .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-compat/bindings/ce"))
-        .dependsOn(`kyo-data`)
         .settings(
             `kyo-settings`,
+            scalaVersion       := scala3LTSVersion,
+            crossScalaVersions := List(scala3LTSVersion),
+            scalacOptions += "-Xmax-inlines:1024",
             libraryDependencies += "org.typelevel" %%% "cats-effect" % catsVersion,
             Test / unmanagedSourceDirectories += {
                 (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "shared" / "src" / "test" / "scala"
@@ -789,9 +796,11 @@ lazy val `kyo-compat-ox` =
         .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-compat/bindings/ox"))
-        .dependsOn(`kyo-data`)
         .settings(
             `kyo-settings`,
+            scalaVersion       := scala3LTSVersion,
+            crossScalaVersions := List(scala3LTSVersion),
+            scalacOptions += "-Xmax-inlines:1024",
             libraryDependencies += "com.softwaremill.ox" %% "core" % oxVersion,
             Test / unmanagedSourceDirectories += {
                 (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "shared" / "src" / "test" / "scala"
@@ -811,6 +820,9 @@ lazy val `kyo-compat-twitter-future` =
         .in(file("kyo-compat/bindings/twitter-future"))
         .settings(
             `kyo-settings`,
+            scalaVersion       := scala3LTSVersion,
+            crossScalaVersions := List(scala3LTSVersion),
+            scalacOptions += "-Xmax-inlines:1024",
             libraryDependencies += ("com.twitter" %% "util-core" % "24.2.0")
                 .exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),
             Test / unmanagedSourceDirectories += {
@@ -834,6 +846,9 @@ lazy val `kyo-compat-tests` =
         .dependsOn(`kyo-compat-future`.jvm)
         .settings(
             `kyo-settings`,
+            scalaVersion       := scala3LTSVersion,
+            crossScalaVersions := List(scala3LTSVersion),
+            scalacOptions += "-Xmax-inlines:1024",
             publish / skip := true,
             mimaCheck(false),
             Test / unmanagedSourceDirectories := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ val scala213Version  = "2.13.18"
 
 val zioVersion       = "2.1.24"
 val catsVersion      = "3.7.0"
+val oxVersion        = "1.0.4"
 val scalaTestVersion = "3.2.19"
 
 val compilerOptionFailDiscard = "-Wconf:msg=(unused.*value|discarded.*value|pure.*statement):error"
@@ -159,7 +160,14 @@ lazy val kyoJVM = project
         `kyo-playwright`.jvm,
         `kyo-pod`.jvm,
         `kyo-examples`.jvm,
-        `kyo-actor`.jvm
+        `kyo-actor`.jvm,
+        `kyo-compat-future`.jvm,
+        `kyo-compat-kyo`.jvm,
+        `kyo-compat-zio`.jvm,
+        `kyo-compat-ce`.jvm,
+        `kyo-compat-ox`.jvm,
+        `kyo-compat-twitter-future`.jvm,
+        `kyo-compat`
     )
 
 lazy val kyoJS = project
@@ -190,7 +198,11 @@ lazy val kyoJS = project
         `kyo-schema`.js,
         `kyo-http`.js,
         `kyo-flow`.js,
-        `kyo-pod`.js
+        `kyo-pod`.js,
+        `kyo-compat-future`.js,
+        `kyo-compat-kyo`.js,
+        `kyo-compat-zio`.js,
+        `kyo-compat-ce`.js
     )
 
 lazy val kyoNative = project
@@ -222,7 +234,10 @@ lazy val kyoNative = project
         `kyo-zio-test`.native,
         `kyo-stm`.native,
         `kyo-stats-otlp`.native,
-        `kyo-pod`.native
+        `kyo-pod`.native,
+        `kyo-compat-future`.native,
+        `kyo-compat-kyo`.native,
+        `kyo-compat-zio`.native
     )
 
 lazy val `kyo-scheduler` =
@@ -680,6 +695,153 @@ lazy val `kyo-cats` =
         )
         .jvmSettings(mimaCheck(false))
 
+lazy val `kyo-compat-future` =
+    crossProject(JSPlatform, JVMPlatform, NativePlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-compat/bindings/future"))
+        .settings(
+            `kyo-settings`,
+            // Cross-platform: shared sources use atomics + ConcurrentLinkedQueue
+            // (both polyfilled on JS and natively supported on Native).
+            // Platform-specific source dirs hold the blocking-pool / scheduler
+            // pieces that genuinely diverge per platform.
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "shared" / "src" / "test" / "scala"
+            }
+        )
+        .jvmSettings(
+            mimaCheck(false),
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "jvm" / "src" / "test" / "scala"
+            }
+        )
+        .jsSettings(`js-settings`, mimaCheck(false))
+        .nativeSettings(`native-settings`, mimaCheck(false))
+
+lazy val `kyo-compat-kyo` =
+    crossProject(JSPlatform, JVMPlatform, NativePlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-compat/bindings/kyo"))
+        .dependsOn(`kyo-core`, `kyo-data`)
+        .settings(
+            `kyo-settings`,
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "shared" / "src" / "test" / "scala"
+            }
+        )
+        .jsSettings(`js-settings`)
+        .nativeSettings(`native-settings`)
+        .jvmSettings(
+            mimaCheck(false),
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "jvm" / "src" / "test" / "scala"
+            }
+        )
+
+lazy val `kyo-compat-zio` =
+    crossProject(JSPlatform, JVMPlatform, NativePlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-compat/bindings/zio"))
+        .dependsOn(`kyo-data`)
+        .settings(
+            `kyo-settings`,
+            libraryDependencies += "dev.zio" %%% "zio"            % zioVersion,
+            libraryDependencies += "dev.zio" %%% "zio-concurrent" % zioVersion,
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "shared" / "src" / "test" / "scala"
+            }
+        )
+        .jsSettings(`js-settings`)
+        .nativeSettings(`native-settings`)
+        .jvmSettings(
+            mimaCheck(false),
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "jvm" / "src" / "test" / "scala"
+            }
+        )
+
+lazy val `kyo-compat-ce` =
+    crossProject(JSPlatform, JVMPlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-compat/bindings/ce"))
+        .dependsOn(`kyo-data`)
+        .settings(
+            `kyo-settings`,
+            libraryDependencies += "org.typelevel" %%% "cats-effect" % catsVersion,
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "shared" / "src" / "test" / "scala"
+            }
+        )
+        .jsSettings(`js-settings`)
+        .jvmSettings(
+            mimaCheck(false),
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "jvm" / "src" / "test" / "scala"
+            }
+        )
+
+lazy val `kyo-compat-ox` =
+    crossProject(JVMPlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-compat/bindings/ox"))
+        .dependsOn(`kyo-data`)
+        .settings(
+            `kyo-settings`,
+            libraryDependencies += "com.softwaremill.ox" %% "core" % oxVersion,
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "shared" / "src" / "test" / "scala"
+            }
+        )
+        .jvmSettings(
+            mimaCheck(false),
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "jvm" / "src" / "test" / "scala"
+            }
+        )
+
+lazy val `kyo-compat-twitter-future` =
+    crossProject(JVMPlatform)
+        .withoutSuffixFor(JVMPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-compat/bindings/twitter-future"))
+        .settings(
+            `kyo-settings`,
+            libraryDependencies += ("com.twitter" %% "util-core" % "24.2.0")
+                .exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "shared" / "src" / "test" / "scala"
+            }
+        )
+        .jvmSettings(
+            mimaCheck(false),
+            Test / unmanagedSourceDirectories += {
+                (ThisBuild / baseDirectory).value / "kyo-compat" / "test" / "jvm" / "src" / "test" / "scala"
+            }
+        )
+
+// IDE/navigation anchor for the cross-binding test suite. The same shared+jvm
+// test sources are picked up by all 6 bindings via `unmanagedSourceDirectories`;
+// this project gives Metals/IntelliJ a single project to associate the folder
+// with, compiled against the Future binding by default.
+lazy val `kyo-compat-tests` =
+    project
+        .in(file("kyo-compat/test"))
+        .dependsOn(`kyo-compat-future`.jvm)
+        .settings(
+            `kyo-settings`,
+            publish / skip := true,
+            mimaCheck(false),
+            Test / unmanagedSourceDirectories := Seq(
+                baseDirectory.value / "shared" / "src" / "test" / "scala",
+                baseDirectory.value / "jvm" / "src" / "test" / "scala"
+            )
+        )
+
 lazy val `kyo-combinators` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform)
         .withoutSuffixFor(JVMPlatform)
@@ -1028,3 +1190,32 @@ lazy val `kyo-scalafix-test` = (project in file("scalafix/tests"))
     )
     .dependsOn(`kyo-rules`)
     .enablePlugins(ScalafixTestkitPlugin)
+
+// --- kyo-compat (in-tree sbt plugin; published as artifact `kyo-compat`)
+//
+// First SbtPlugin module in kyo. Scala 2.12 only (sbt 1.x runtime).
+// Aggregated into kyoJVM only (not kyoJS/kyoNative, since an sbt plugin
+// is a single JVM artifact) so the JVM `ci-release` pass publishes it.
+// Its behavioral tests are scripted tests, run in CI via `kyo-compat/scripted`.
+lazy val `kyo-compat` = (project in file("kyo-compat/plugin"))
+    .enablePlugins(SbtPlugin)
+    .settings(
+        moduleName         := "kyo-compat",
+        scalaVersion       := "2.12.20",
+        crossScalaVersions := Seq("2.12.20"),
+        sbtPlugin          := true,
+        // Plugin code adds rows to a `ProjectMatrix` programmatically, so
+        // it compiles against sbt-projectmatrix; it also references the
+        // %%% macro from sbt-scalajs-crossproject / sbt-scala-native-crossproject's
+        // platform-deps shim. Pinned to the same versions as kyo's own
+        // project/plugins.sbt so the runtime sbt classloader resolves
+        // exactly one copy of each.
+        addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1"),
+        addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2"),
+        addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2"),
+        scriptedLaunchOpts := Seq(
+            "-Xmx1024M",
+            "-Dplugin.version=" + version.value
+        ),
+        scriptedBufferLog := false
+    )

--- a/kyo-compat/README.md
+++ b/kyo-compat/README.md
@@ -1,0 +1,565 @@
+# kyo-compat
+
+kyo-compat lets you write a library once against the `kyo.compat.*` surface and ship it to all 6 backends. Consumers pick the runtime at deploy time (ZIO, Cats Effect, scala.concurrent.Future, Ox, Twitter Future, or Kyo); each pulls only its own runtime's jar.
+
+- **Overhead-free.** Every method is `inline def` and lowers at the call site to the backend's primitive. No typeclass dispatch, no adapter layer.
+- **Runtime-free.** Each backend artifact depends only on its target runtime. No dependencies on other Kyo modules.
+- **Uniform surface.** A consistent API for fibers, promises, channels, atomics, latches, meters, fiber-locals, time, and concurrency.
+- **Preserves backend features.** ZIO `Trace`, Kyo `Frame`, fiber locals, scoped resources, and runtime stack traces flow through `CIO` unchanged.
+
+The cross-backend computation type, `CIO[+A]`, is an opaque alias whose definition is per-backend:
+
+| Backend        | `CIO[+A]` resolves to                            | Provided by                |
+|----------------|--------------------------------------------------|----------------------------|
+| Kyo            | `A < (Abort[Throwable] & Async)`                 | `kyo-compat-kyo`           |
+| ZIO            | `zio.ZIO[Any, Throwable, A]`                     | `kyo-compat-zio`           |
+| Cats Effect    | `cats.effect.IO[A]`                              | `kyo-compat-ce`            |
+| Future         | `LocalCtx => scala.concurrent.Future[A]`         | `kyo-compat-future`        |
+| Ox             | `(Int, ox.Ox) => A`                                | `kyo-compat-ox`            |
+| Twitter Future | `() => com.twitter.util.Future[A]`               | `kyo-compat-twitter-future`|
+
+Kyo, ZIO, and Cats Effect alias a backend effect type directly: `A < S`, `ZIO`, and `IO` are already lazy, referentially-transparent descriptions, so `CIO` inherits that. The other three carriers are functions because their runtimes are not lazy. `scala.concurrent.Future` and Twitter's `Future` are eager (constructing one starts the computation), and Ox is direct-style with no effect type. Wrapping the runtime in a cold function (`() => Future[A]`, `LocalCtx => Future[A]`, `(Int, Ox) => A`) keeps a `CIO` value a description: nothing runs until `unsafeRun` applies the function, and each application is a fresh run. So a `CIO[A]` is referentially transparent on every backend.
+
+`CIO` exposes `.map` and `.flatMap` directly, alongside `CIO.zip`, `CIO.foreach`, `.recover`, `.fold`, and the rest. The same source compiles against every backend. A single `import kyo.compat.*` is sufficient on every backend, including Kyo.
+
+## Example
+
+Write a library once against `CIO`. Here a greeting is assembled from two values fetched concurrently:
+
+```scala
+import kyo.compat.*
+
+object Greeter:
+    private val fetchName:    CIO[String] = CIO.defer("kyo-compat")
+    private val fetchVersion: CIO[String] = CIO.defer("1.0")
+
+    val greeting: CIO[String] =
+        CIO.zip(fetchName, fetchVersion).map {
+            case (name, version) => s"hello from $name $version"
+        }
+end Greeter
+```
+
+`Greeter` compiles unchanged against every `kyo-compat-X` artifact. The consumer picks a backend at deploy time with one dependency. For Cats Effect:
+
+```scala
+// build.sbt
+libraryDependencies += "io.getkyo" %% "kyo-compat-ce" % "<latest version>"
+```
+
+`unsafeRun` then materializes the `CIO` into a `scala.concurrent.Future`:
+
+```scala
+import scala.concurrent.Await
+import scala.concurrent.duration.*
+
+@main def run(): Unit =
+    println(Await.result(Greeter.greeting.unsafeRun, 30.seconds))
+    // hello from kyo-compat 1.0
+```
+
+Linking `kyo-compat-zio` instead runs the same `Greeter` on ZIO, `kyo-compat-future` on `scala.concurrent.Future`, and so on. `unsafeRun` returns `scala.concurrent.Future[A]` on every binding, with the backend's default global runtime (CE's `IORuntime`, ZIO's `Runtime`, etc.) bound inside it. The Ox binding's `unsafeRun` additionally needs a `given ExecutionContext` to bridge the Ox computation onto a `Future`; the Kyo binding's needs only a `Frame`, which the compiler synthesizes at the call site; the other four take no user-supplied implicit.
+
+For error recovery, use `.recover` anywhere in the chain:
+
+```scala
+val resilient: CIO[String] =
+    Greeter.greeting.recover {
+        case _ => CIO.value("hello (offline)")
+    }
+```
+
+
+## The CIO surface
+
+Signatures throughout this document omit `using` parameters that the compiler synthesizes at the call site. On Kyo this is `(using Frame)`; on ZIO, `(using Trace)`; on Ox, the `Ox` capability. None need to be plumbed through library code. The Future binding's public surface takes no `using`; it routes composition through `ExecutionContext.parasitic`, and `CIO.blocking` dispatches to the standard `scala.concurrent.ExecutionContext.global`.
+
+### Constructors
+
+`CIO.defer(thunk)` suspends a side-effecting expression. The thunk re-executes on every materialization:
+
+```scala
+val time: CIO[Long] = CIO.defer(java.lang.System.currentTimeMillis())
+```
+
+An exception escaping the thunk is caught and surfaced through the failure channel; recovery via `.recover` works as expected. `CIO.fail(e)` builds a failed `CIO`. `CIO.get` lifts a `Try[A]`. `CIO.fromScalaFuture(f)` lifts a `scala.concurrent.Future[A]`; the parameter is `inline`, so a method-call expression at the call site is re-evaluated on each materialization. On the JVM, `CIO.fromCompletionStage(cs)` is the same lift for `java.util.concurrent.CompletionStage`. `CIO.never` is a `CIO` that never completes.
+
+### `lift`, `deferLift`, and `lower`
+
+`CIO.lift(effect)` wraps an already-constructed, pure backend effect value as a `CIO[A]` (a `cats.effect.IO`, a `zio.ZIO`, a Kyo `A < S`, or a finished `Future`). `CIO.deferLift { ... }` instead *suspends* side-effecting code that produces the backend effect, re-running it on every materialization; on Future the block receives an ambient `LocalCtx` and yields a `Future[A]`, on Ox an ambient `Ox` capability. (`CIO.defer` is the matching suspension for code that produces a plain, non-effect value.) `c.lower` extracts the backend carrier back out.
+
+```scala
+val onCe:  CIO[Int] = CIO.lift(cats.effect.IO.pure(42))
+val onZio: CIO[Int] = CIO.lift(zio.ZIO.succeed(42))
+val onFut: CIO[Int] =
+    CIO.deferLift { scala.concurrent.Future(42)(using scala.concurrent.ExecutionContext.parasitic) }
+```
+
+Every `C*` primitive has the same pattern; see [Primitives](#primitives).
+
+### Error handling
+
+Failures are not tracked in the type; every backend channels them through its native `Throwable` lane. Recovery handlers receive a `Throwable`:
+
+```scala
+val resilient: CIO[User] =
+    fetchUser(id)
+        .recover {
+            case _: NetworkError => CIO.defer(User.placeholder(id))
+            case e               => CIO.fail(e)
+        }
+        .orElse(fetchUserFromCache(id))
+        .mapError(wrapWithContext)
+```
+
+The full set:
+
+| Method                          | Returns                       | Notes                                                  |
+|---------------------------------|-------------------------------|--------------------------------------------------------|
+| `c.recover(h)`                  | `CIO[A]`                      | Run `h` on failure; pattern-match inside to narrow     |
+| `c.orElse(that)`                | `CIO[A]`                      | Fall back to `that` on any failure                     |
+| `c.mapError(f)`                 | `CIO[A]`                      | Rewrite the error value                                |
+| `c.fold(onSuccess, onFail)`     | `CIO[B]`                      | Collapse both branches, each branch returns a `CIO`    |
+| `c.liftToTry`                   | `CIO[Try[A]]`                 | Reify failure as `Try`; always succeeds                |
+| `c.unit`                        | `CIO[Unit]`                   | Discard the success value; failure propagates          |
+
+Kyo and ZIO additionally have a defect / panic channel that the surface does not expose (Kyo's `Abort.panic`, ZIO's `ZIO.die`). To write or inspect a defect on those backends, lower into the native runtime via `c.lower`.
+
+### Sequencing
+
+`c.map(f)` transforms the success value with a pure function. `c.flatMap(f)` chains another `CIO` whose construction depends on the success value:
+
+```scala
+val program: CIO[String] =
+    fetchUser(id).flatMap { user =>
+        countFollowers(user.id).map(n => s"${user.name} has $n followers")
+    }
+```
+
+`for`-comprehensions work the same way across every backend:
+
+```scala
+def loadProfile(id: Int): CIO[Profile] =
+    for
+        user      <- fetchUser(id)
+        followers <- countFollowers(user.id)
+    yield Profile(user, followers)
+```
+
+Failures short-circuit through both: a failed `c` skips `f` and propagates. To run a `CIO` and obtain a `scala.concurrent.Future[A]`, call `c.unsafeRun`; CE / ZIO / Kyo / Future / Twitter Future bind their default global runtime internally, and only the Ox binding requires the caller to supply a `given ExecutionContext`.
+
+### Resources
+
+`CIO.acquireReleaseWith(acquire)(release)(use)` pairs an acquisition with a release that runs on success and failure of `use`. `CIO.ensure(cleanup)(c)` is the unparameterised sugar.
+
+```scala
+val readFile: CIO[String] =
+    CIO.acquireReleaseWith(
+        CIO.defer(new java.io.FileReader("data.txt"))
+    )(r => CIO.defer(r.close())) { reader =>
+        CIO.defer {
+            val buf = new Array[Char](1024)
+            val n   = reader.read(buf)
+            new String(buf, 0, math.max(n, 0))
+        }
+    }
+```
+
+`release` returns `CIO[Unit]`. When `use` succeeds, a failing `release` propagates as `acquireReleaseWith`'s failure on every backend except Kyo (which logs the release error via `kyo.logs` and lets `use`'s value win). When `use` fails, `use`'s throwable always wins; the release failure is handled differently by each backend. Ox attaches it as a suppressed exception on `use`'s throwable; Cats Effect propagates it through its native bracket reporter; ZIO reifies it as a defect on the cause channel (via `.orDie`); Future and Twitter Future silently drop it; Kyo logs via `kyo.logs`. See [Backends](#backends) for the per-binding contract.
+
+### Async callbacks
+
+`CIO.async(register)` bridges a one-shot completion callback into `CIO`. `register` receives a `Try[A] => Unit`:
+
+```scala
+def fromCallback[A](api: (Try[A] => Unit) => Unit): CIO[A] =
+    CIO.async { cb =>
+        api {
+            case Success(a) => cb(Success(a))
+            case Failure(t) => cb(Failure(t))
+        }
+    }
+```
+
+## Time and concurrency
+
+### Time
+
+`CIO.sleep(d)` suspends the calling computation for `d`. `CIO.delay(d)(c)` runs `c` after a delay of `d` (sleep, then run). `CIO.now` returns the wall-clock instant; `CIO.nowMonotonic` returns a monotonic timestamp expressed as a `Duration` since some backend-defined origin (use it for *intervals*, not wall-clock time).
+
+```scala
+val late:         CIO[Result]       = CIO.delay(500.millis)(query("data"))
+val maybeUser:    CIO[Option[User]] = CIO.timeout(5.seconds)(fetchUser(id))
+val mustComplete: CIO[User]         =
+    CIO.timeoutWithError(5.seconds)(new TimeoutException("fetch deadline"))(fetchUser(id))
+```
+
+`CIO.sleep`, `CIO.delay`, `CIO.timeout`, and `CIO.timeoutWithError` all accept `scala.concurrent.duration.FiniteDuration`. `CIO.now` returns `java.time.Instant`. `CIO.nowMonotonic` returns `FiniteDuration` (a monotonic timestamp since some backend-defined origin). Duration literals (`500L.millis`, `1.second`, etc.) come from `import scala.concurrent.duration.*`.
+
+When a deadline expires, the returned `CIO` resolves to `None` (or fails with the supplied error). The CIO surface does not expose cancellation, so on the Future binding the inner computation keeps running orphaned even after the timeout fires. Bindings whose underlying runtime cancels naturally (Kyo, ZIO, Cats Effect, Ox) cancel internally; Twitter Future uses `raiseWithin`, which propagates an interrupt to the inner `Future`.
+
+### Concurrency primitives
+
+`CIO.zip(a, b)` (and arities up to 7) runs computations in parallel and returns a tuple. A sibling failure surfaces as the zip's failure; whether the other legs are cancelled or run to completion is a binding-specific detail (Kyo / ZIO / Cats Effect / Ox cancel via their native runtimes; Future and Twitter Future do not, and Twitter's `zip` uses `Future.join` which fails fast without raising).
+
+`CIO.race(a, b)` returns the first leg to complete successfully. Whether the losing leg is cancelled is a binding-specific detail (Kyo / ZIO / Cats Effect / Ox cancel via their native runtimes; Twitter Future raises a `CancellationException` on the loser via `raise`; only the Future binding lets the loser run to completion).
+
+The full sequencing family:
+
+| Method                                                    | Returns          | Notes                                                        |
+|-----------------------------------------------------------|------------------|--------------------------------------------------------------|
+| `CIO.foreach(coll, concurrency = Int.MaxValue)(f)`        | `CIO[CChunk[B]]` | Parallel map; `concurrency` caps in-flight items (unbounded by default) |
+| `CIO.foreachIndexed(coll, concurrency = Int.MaxValue)(f)` | `CIO[CChunk[B]]` | Passes the element index to `f`; same concurrency semantics  |
+| `CIO.foreachDiscard(coll, concurrency = Int.MaxValue)(f)` | `CIO[Unit]`      | Runs `f` for side effects; same concurrency semantics        |
+| `CIO.filter(coll, concurrency = Int.MaxValue)(p)`         | `CIO[CChunk[A]]` | Concurrent predicate filtering; same concurrency semantics   |
+| `CIO.collectAll(coll, concurrency = Int.MaxValue)`        | `CIO[CChunk[A]]` | Sequence over `Iterable[CIO[A]]`; same concurrency semantics |
+| `CIO.collectAllDiscard(coll, concurrency = Int.MaxValue)` | `CIO[Unit]`      | Sequence and discard results; same concurrency semantics     |
+
+All six methods accept an optional `concurrency: Int` second argument (default `Int.MaxValue`, meaning unbounded). When `concurrency == Int.MaxValue` the binding's native unbounded parallel primitive is used directly, with no semaphore and no batching. When `concurrency` is finite, the binding's native bounded variant is used; bindings without one (Future, Twitter Future) gate dispatch through a semaphore. The `coll(f)` call shape still works unchanged; `concurrency` is the second positional argument in the value list, not a separate currying group.
+
+`CChunk[A]` is a per-backend opaque alias for the native bulk collection type (Kyo: `kyo.Chunk[A]`, ZIO: `zio.Chunk[A]`, others: `Vector[A]`). Surface helpers `.toSeq`, `.toIndexedSeq`, `.apply(i)`, `.size`, `.iterator`, `.isEmpty` are available on every backend.
+
+`CIO.blocking { thunk }` runs a blocking thunk on a blocking-safe pool. `CIO.cede` yields the current fiber. Per-backend specifics (which of these is a no-op, which dispatches to a pool) are in [Backends](#backends).
+
+## Primitives
+
+Every handle wraps a backend-native primitive: an opaque alias where the backend has a suitable native type, or a small `final class` where the binding implements its own (the Future and Twitter `CChannel`/`CLatch`, the Future `CMeter`/`CLocal`). Each exposes a companion `lift` and an extension `lower` for native interop. Operations that take values are read directly off the handle (`atomic.get`, `latch.release`, `meter.run(c)`).
+
+### Fibers
+
+`CFiber[A]` is a running computation forked off the current execution path. `CFiber.init` does not register with any parent scope; the fiber's lifetime is the caller's responsibility.
+
+Use `CFiber` when you want to start work concurrently, then join the result later via `fiber.get`. If you only need the results in aggregate, prefer `CIO.zip` or `CIO.foreach`, which handle lifetime automatically.
+
+`fiber.onComplete(cb)` fires when the fiber completes naturally (success or failure). User-callback failures surface through each runtime's reporter, not through the surrounding fiber.
+
+```scala
+val concurrent: CIO[String] =
+    CFiber.init(slowFetch("a")).flatMap { fiber =>
+        fastFetch("b").flatMap(b => fiber.get.map(a => s"$a / $b"))
+    }
+```
+
+Available operations: `CFiber.init(c): CIO[CFiber[A]]`, `fiber.get: CIO[A]`, `fiber.onComplete(cb): CIO[Unit]`.
+
+### Promises
+
+`CPromise[A]` is a single-shot completable cell. The producer holds a reference and calls `p.succeed(a)` or `p.fail(e)` when done; the consumer blocks on `p.get` until the result arrives. `CIO.async` packages both registration and delivery in a single expression; `CPromise` separates them so producer and consumer can live in different fibers with no shared closure.
+
+Use `CPromise` when the producing callback may fire multiple times and you want first-wins semantics (subsequent completions are dropped), or when producer and consumer don't share a closure.
+
+Each backend maps `CPromise` to its native single-assignment cell: `kyo.Promise`, `zio.Promise`, `cats.effect.Deferred`, `scala.concurrent.Promise`, `java.util.concurrent.CompletableFuture`, or `com.twitter.util.Promise`. The `lift`/`lower` bridge is available on every backend.
+
+Available operations: `CPromise.init[A]`, `p.succeed(a): CIO[Boolean]`, `p.fail(e): CIO[Boolean]`, `p.get: CIO[A]`, `p.poll: CIO[Option[Try[A]]]`, `p.done: CIO[Boolean]`.
+
+### Channels
+
+`CChannel[A]` is a bounded FIFO queue. Producers call `ch.put(a)`, which suspends when the channel is full; consumers call `ch.take`, which suspends when empty. The bounded capacity is the backpressure contract: fast producers slow down rather than OOM-ing slow consumers.
+
+Use a channel when two concurrent fibers need to hand off a stream of values, e.g. a producer/consumer pipeline or a work queue. `CIO.zip` combines exactly two concurrent results; channels scale to any number of producers and consumers and continue across many rounds of data.
+
+Kyo, ZIO, Cats Effect, and Ox map `CChannel` to a bounded queue: `kyo.Channel`, `zio.Queue`, `cats.effect.std.Queue`, or `java.util.concurrent.LinkedBlockingQueue` (Ox). The Future and Twitter Future bindings implement `CChannel` as a plain `final class`: Future holds two `ConcurrentLinkedQueue`s (items and waiters) plus an `AtomicInteger` size counter, so `put`/`take` suspension reuses the binding's `Promise`-based wait machinery; Twitter combines `com.twitter.concurrent.AsyncSemaphore` (capacity bound) with `com.twitter.concurrent.AsyncQueue` (FIFO buffer). Neither blocks a thread. The surface intentionally omits `close`, `closed`, `size`, and `offer`, because their semantics differ enough across backends that a portable abstraction would swallow real differences.
+
+```scala
+val pipeline: CIO[Int] =
+    CChannel.init[Int](capacity = 64).flatMap { ch =>
+        val producer = CIO.foreachDiscard(1 to 100)(ch.put)
+        val consumer = CIO.foreach(1 to 100)(_ => ch.take).map(_.toSeq.sum)
+        CIO.zip(producer, consumer).map(_._2)
+    }
+```
+
+Available operations: `CChannel.init[A](capacity)`, `ch.put(a): CIO[Unit]`, `ch.take: CIO[A]`, `ch.poll: CIO[Option[A]]`.
+
+### Atomics
+
+`CAtomicRef[A]`, `CAtomicInt`, `CAtomicLong`, and `CAtomicBoolean` are atomic mutable cells for lock-free coordination between concurrent fibers. The operations match the `java.util.concurrent.atomic` contract: reads, writes, compare-and-swap, and numeric increments all execute without holding a lock.
+
+Use atomics for shared counters, flags, or lightweight references that multiple fibers need to update without a full mutex. For richer consistency requirements (transactions across multiple cells, STM) reach for backend-specific facilities via `lower`.
+
+Each backend maps to its native atomic type: `kyo.AtomicRef/Int/Long/Boolean`, `zio.Ref` per type, `cats.effect.kernel.Ref[IO, T]`, or `java.util.concurrent.atomic.*` (Future, Ox, Twitter Future).
+
+```scala
+val total: CIO[Int] =
+    CAtomicInt.init(0).flatMap { counter =>
+        CIO.foreachDiscard(1 to 100)(_ => counter.incrementAndGet)
+            .flatMap(_ => counter.get)
+    }
+```
+
+Available operations:
+- `CAtomicRef[A]`: `init`, `get`, `set`, `getAndSet`, `compareAndSet`, `getAndUpdate`, `updateAndGet`.
+- `CAtomicInt` / `CAtomicLong`: `init`, `get`, `set`, `getAndSet`, `compareAndSet`, plus `incrementAndGet`, `getAndIncrement`, `decrementAndGet`, `getAndDecrement`, `addAndGet`, `getAndAdd`.
+- `CAtomicBoolean`: `init`, `get`, `set`, `getAndSet`, `compareAndSet`.
+
+### Local values
+
+`CLocal[A]` is a value scoped to the current fiber/computation, used for per-request context (request IDs, tracing spans, deadlines) that should propagate through async boundaries without being threaded through every function signature. It is the portable equivalent of Java's `ThreadLocal`, but async-safe: each fiber gets its own copy, and when you fork, the child inherits the parent's snapshot.
+
+Use `local.let(v)(body)` to install a value for the duration of `body`, then automatically revert. Use `local.get` to read the current fiber's value. The `update(f)` variant composes both: it reads the current value, applies `f`, and installs the result for the body.
+
+`CLocal.init(default)` returns `CIO[CLocal[A]]`. Construction is deferred to effect-evaluation time so each call allocates a fresh local. Each backend maps to a fiber-local mechanism: Kyo `Local`, ZIO `FiberRef`, CE `IOLocal`, Ox `ox.ForkLocal` (backed by JDK `ScopedValue`), Twitter Future's `com.twitter.util.Local`, or, on the Future binding, an immutable `LocalCtx` map threaded through the `LocalCtx => Future[A]` carrier.
+
+```scala
+val program: CIO[Response] =
+    CLocal.init("anonymous").flatMap { requestId =>
+        requestId.let(req.id)(process(req))
+    }
+```
+
+Per-backend propagation notes:
+
+- **Kyo**, **ZIO**, **Cats Effect**: native fiber-local mechanism (`Local`, `FiberRef`, `IOLocal`).
+- **Twitter Future**: `com.twitter.util.Local`; the Twitter scheduler propagates snapshots across async boundaries automatically. `CLocal` is a `(Local[A], A)` pair (the `Local` plus its configured default), and `lift`/`lower` operate on that pair.
+- **scala.concurrent.Future**: an immutable `LocalCtx` (a `Map[Any, Any]`) is the carrier of every `CIO`: `CIO[+A] = LocalCtx => Future[A]`. `let(v)(body)` constructs an updated `LocalCtx` keyed by the local's identity and runs `body` with it; `get` reads from the ctx. Because the ctx is threaded through the carrier rather than stored in a thread-local, propagation is independent of the `ExecutionContext` used for `Future` execution.
+- **Ox**: an `ox.ForkLocal[A]` backed by JDK `ScopedValue`. `let(v)(body)` opens a `scopedWhere` scope; all forks inside that scope inherit the value. After the scope exits, the value reverts to the default.
+
+Available operations: `CLocal.init(default): CIO[CLocal[A]]`, `local.get: CIO[A]`, `local.let(v)(c): CIO[A]`, `local.update(f)(c): CIO[A]`.
+
+### Latches, meters
+
+These are coordination primitives for multi-fiber rendezvous. Skip on first read; reach for them when several concurrent computations need to synchronise on a shared rendezvous point.
+
+`CLatch` is a count-down latch: a one-shot counter that starts at `n`, decrements on each `release`, and unblocks every `await` once the counter reaches zero. It is the right primitive for "wait until N concurrent jobs have all signalled completion." Kyo, ZIO, and Cats Effect map to a native countdown (`kyo.Latch`, `zio.concurrent.CountdownLatch`, `cats.effect.std.CountDownLatch`); Ox uses `java.util.concurrent.CountDownLatch`. The Future and Twitter Future bindings implement `CLatch` as a plain `final class` over a `Promise` (resolved when the counter hits zero), so `await` composes with the binding's future type without blocking a thread. `CLatch.init(n)` normalizes `n <= 0` to "already released"; `await` returns immediately and does not throw.
+
+```scala
+def waitForAll(jobs: Seq[CIO[Unit]]): CIO[Unit] =
+    CLatch.init(jobs.size).flatMap { latch =>
+        CIO.foreachDiscard(jobs) { job =>
+            CFiber.init(job.fold(_ => latch.release, _ => latch.release))
+        }.flatMap(_ => latch.await)
+    }
+```
+
+Available operations: `CLatch.init(n)`, `latch.release: CIO[Unit]`, `latch.await: CIO[Unit]`.
+
+`CMeter` is a counting semaphore: a pool of `n` permits used to cap the number of concurrent operations. `meter.run(c)` acquires one permit, runs `c`, and releases on completion (success or failure). Use it for bounded parallelism: `CIO.foreach(urls)(u => meter.run(fetch(u)))` caps in-flight fetches at `n` regardless of how many URLs are passed. Kyo, ZIO, and Cats Effect map to `kyo.Meter`, `zio.Semaphore`, `cats.effect.std.Semaphore`; Ox uses `java.util.concurrent.Semaphore`; Twitter Future uses `com.twitter.concurrent.AsyncSemaphore`. The Future binding implements `CMeter` as a plain `final class` (an `AtomicInteger` permit count plus a `Promise` waiter queue), so `run` never blocks a thread.
+
+```scala
+def fetchBounded(urls: Seq[String]): CIO[CChunk[String]] =
+    CMeter.init(permits = 8).flatMap(meter => CIO.foreach(urls)(u => meter.run(fetch(u))))
+```
+
+Available operations: `CMeter.init(permits)`, `meter.run(c): CIO[A]`, `meter.tryRun(c): CIO[Option[A]]`, `meter.availablePermits: CIO[Int]`.
+
+## Backends
+
+The Kyo, ZIO, and Cats Effect backends are predominantly thin redirects to their host runtime: each operation lowers to one or two calls into `Sync.defer`/`Abort.fail`/`Async.race` (Kyo), `ZIO.attempt`/`Promise.await`/`Fiber.Runtime` (ZIO), or `IO.delay`/`Ref[IO, _]`/`Queue[IO, _]` (Cats Effect). Fiber-locals, scoped resources, and tracing all work as they would in hand-written code.
+
+### Future
+
+The carrier is `LocalCtx => Future[A]`, a function from an immutable `LocalCtx` (the fiber-local context threaded through every combinator) to a fresh `Future`. The plain function arrow keeps the body lazy, so each materialization re-runs it. `CLocal.let`/`get`/`update` thread the ctx through the carrier; no `ExecutionContext` smuggling or `ThreadLocal` capture is involved.
+
+- The Future binding has no cancellation. `scala.concurrent.Future` exposes none, and the CIO surface does not either; `CIO.timeout` returns `None` on expiry but the inner computation keeps running orphaned, and `CIO.race` returns the winner while the loser runs to completion.
+- `release` in `CIO.acquireReleaseWith` runs on success and failure of `use`; failures propagate as `acquireReleaseWith`'s failed Future.
+- `CIO.never` blocks the calling fiber for the lifetime of the process.
+- `CIO.blocking { thunk }` runs the thunk inside `scala.concurrent.blocking` on `scala.concurrent.ExecutionContext.global`. `CIO.cede` schedules a zero-delay task through `CompatScheduler`, forcing a scheduling round-trip.
+- `fiber.onComplete(cb)` fires when the underlying `Future` completes naturally (success or failure).
+- Call `c.unsafeRun` to materialize a `CIO` into a `scala.concurrent.Future[A]`.
+
+### Ox
+
+The carrier is `(Int, Ox) => A`: a function over Ox's structured-concurrency capability, plus an `Int` carrying the current `flatMap` nesting depth. The computation is applied at the boundary inside an `ox.supervised:` block. As with Future, the plain function arrow preserves cold-laziness.
+
+- The eventual boundary call where the consumer runs the computation must live inside an `ox.supervised:` block.
+- `fromScalaFuture(f)` blocks the calling thread via `Await.result(f, Duration.Inf)`; Ox is direct-style, and blocking is the native idiom.
+- `CFiber.init` uses `ox.forkCancellable`; the fork's lifetime is bounded by the surrounding `ox.supervised:` block.
+- `release` failures in `CIO.acquireReleaseWith` propagate synchronously through a `try`/`catch` shell: on `use`-success + `release`-failure, the release throwable propagates; on `use`-failure + `release`-failure, the release throwable is attached to `use`'s via `addSuppressed`.
+- `fiber.onComplete(cb)` fires with `Failure(t)` when the fiber's body fails; the observer runs on a daemon thread independent of the surrounding `ox.supervised` scope.
+- `CIO.cede` forks an unsupervised task and immediately joins it (`ox.forkUnsupervised(()).join()`), giving the surrounding scope an opportunity to schedule another fork. `CIO.blocking { thunk }` wraps the thunk in `scala.concurrent.blocking { ... }` so the ForkJoinPool managing the calling thread can spawn a replacement worker.
+- **Stack safety.** `flatMap` threads the carrier's depth `Int`; once it reaches a fixed limit the remaining chain re-runs inside a fresh `ox.forkUnsupervised`, a new virtual-thread stack. Deep `flatMap` chains (1000+ levels) do not stack-overflow; `cede` additionally introduces an async boundary that resets the physical stack.
+- Call `c.unsafeRun` (with an `ExecutionContext` in scope) to drive the `CIO` and obtain a `scala.concurrent.Future[A]`; await it with `Await.result(c.unsafeRun, deadline)` when synchronous code is needed.
+
+### Twitter Future
+
+The carrier is `() => com.twitter.util.Future[A]`, a cold thunk. JVM-only.
+
+- `CLocal[A]` uses `com.twitter.util.Local[A]`, which propagates across async boundaries via the Twitter scheduler.
+- `release` failures in `CIO.acquireReleaseWith` propagate as `acquireReleaseWith`'s `Throw(t)`.
+- `CIO.race(a, b)` is hand-rolled with a `Promise[A]` and `respond` callbacks; the losing leg is interrupted via `raise(CancellationException)`, but whether the inner computation reacts is up to whoever wired the source's `setInterruptHandler`. `CIO.timeout` uses `Future.raiseWithin`, which propagates the same `raise` signal on expiry.
+- `acquireReleaseWith`, `timeout`, and `race` are hand-rolled; Twitter Future has no native acquire-release primitive.
+- `CIO.cede` schedules a "run now" task via `twitterTimer.doLater(Duration.Zero)`, a real async boundary that lets the current fiber suspend (`Future.sleep(Zero)` would short-circuit to an already-completed future and not yield). `CIO.blocking { thunk }` runs on `FuturePool.unboundedPool`.
+- Call `c.unsafeRun` to obtain a `scala.concurrent.Future[A]` bridged from the underlying `com.twitter.util.Future[A]`; await with `Await.result(c.unsafeRun, deadline)` for synchronous results.
+
+### Kyo
+
+The carrier is `A < (Abort[Throwable] & Async)`. `CIO.acquireReleaseWith` wraps `Scope.acquireRelease` inside a `Scope.run { ... }` so the Scope capability is eliminated at the `acquireReleaseWith` boundary and never appears in the carrier. The kyo runtime guarantees release on every exit path. A failing release is reported by the kyo scope-finalizer logger (`kyo.logs`); `use`'s value still wins. This deviates from the unified `acquireReleaseWith` contract on the other five backends, which surface release failures synchronously through `acquireReleaseWith`'s failure channel; on kyo, subscribe to `kyo.logs` to observe scope-finalizer errors. `fiber.onComplete(cb)` fires when the fiber completes. `CIO.cede` is `Sync.defer(())` (Kyo's scheduler is preemptive); `CIO.blocking { thunk }` is `Sync.defer(thunk)` (Kyo's scheduler auto-detects blocking).
+
+### ZIO
+
+The carrier is `ZIO[Any, Throwable, A]`. `CIO.defer` lowers to `ZIO.attempt`; escaped exceptions land in the typed `Throwable` error channel. `CIO.acquireReleaseWith` reifies a release Throwable as a defect via `.orDie` so it propagates through ZIO's cause channel. `fiber.onComplete(cb)` fires with `Failure(cause.squash)` for non-success exits; ZIO's `onComplete` matches `Exit.Failure` for every non-success outcome. `CIO.cede` is `ZIO.yieldNow`; `CIO.blocking { thunk }` is `ZIO.attemptBlocking`.
+
+### Cats Effect
+
+The carrier is `cats.effect.IO[A]`. `CIO.acquireReleaseWith` is `IO.bracket`; release errors propagate through the IO error channel. `fiber.onComplete(cb)` fires when the fiber completes; `Outcome.Canceled` is translated to a failure with `CancellationException` before invoking `cb`. `CIO.cede` is `IO.cede`; `CIO.blocking { thunk }` is `IO.blocking`.
+
+### Native carrier types
+
+| Handle                                                            | Kyo                                          | ZIO                                  | Cats Effect                                       | Future                                            | Ox                                              | Twitter Future                          |
+|-------------------------------------------------------------------|----------------------------------------------|--------------------------------------|---------------------------------------------------|---------------------------------------------------|-------------------------------------------------|-----------------------------------------|
+| `CFiber[A]`                                                       | `kyo.Fiber[A, Abort[Throwable]]`             | `zio.Fiber.Runtime[Throwable, A]`    | `cats.effect.FiberIO[A]`                          | `scala.concurrent.Future[A]`                      | `ox.CancellableFork[A]`                         | `com.twitter.util.Future[A]`            |
+| `CPromise[A]`                                                     | `kyo.Promise[A, Abort[Throwable]]`           | `zio.Promise[Throwable, A]`          | `cats.effect.Deferred[IO, Try[A]]`                | `scala.concurrent.Promise[A]`                     | `java.util.concurrent.CompletableFuture[A]`     | `com.twitter.util.Promise[A]`           |
+| `CChannel[A]`                                                     | `kyo.Channel[A]`                             | `zio.Queue[A]`                       | `cats.effect.std.Queue[IO, A]`                    | `final class CChannel` (CLQ + AtomicInteger)       | `java.util.concurrent.LinkedBlockingQueue[A]`   | `final class CChannel` (`AsyncSemaphore` + `AsyncQueue`) |
+| `CAtomicRef[A]` / `CAtomicInt` / `CAtomicLong` / `CAtomicBoolean` | `kyo.AtomicRef[A]` / `AtomicInt` / `AtomicLong` / `AtomicBoolean` | `zio.Ref[T]` per type | `cats.effect.kernel.Ref[IO, T]` per type | `java.util.concurrent.atomic.*` per type          | same as Future                                  | same as Future                          |
+| `CLatch`                                                          | `kyo.Latch`                                  | `zio.concurrent.CountdownLatch`      | `cats.effect.std.CountDownLatch[IO]`              | `final class CLatch` (Promise-queue)              | `java.util.concurrent.CountDownLatch`           | `final class CLatch` (`Promise[Unit]` + `AtomicInteger`) |
+| `CMeter`                                                          | `kyo.Meter`                                  | `zio.Semaphore`                      | `cats.effect.std.Semaphore[IO]`                   | `final class CMeter` (permits + waiter queue)     | `java.util.concurrent.Semaphore`                | `com.twitter.concurrent.AsyncSemaphore`                  |
+| `CLocal[A]`                                                       | `kyo.Local[A]`                               | `zio.FiberRef[A]`                    | `cats.effect.IOLocal[A]`                          | identity-keyed lookup in the threaded `LocalCtx` map | `ox.ForkLocal[A]` (JDK `ScopedValue`) | `(com.twitter.util.Local[A], A)`        |
+
+### `fromScalaFuture` / `fromCompletionStage`
+
+`CIO.fromScalaFuture(f)` ships on every backend; `CIO.fromCompletionStage(cs)` is JVM-only. Both observe their source's eventual completion. The CIO surface does not expose cancellation, so the source future / completion stage is not cancelled by the consumer.
+
+## Beyond the surface
+
+`CIO` covers operations every backend can express uniformly. The cases below either differ in expressive power across backends or are backend-specific extensions; reach them via `c.lower` (which yields the underlying carrier) and re-wrap with `CIO.lift(...)` if a `CIO` is needed back.
+
+- **Partial error recovery.** `recover`, `fold`, `mapError`, `orElse` on `CIO` are total over `Throwable`. Backend-specific facilities (Kyo's `Abort.recover[A]` returning `Abort[B | C]` with a branch removed at the type level, ZIO's `catchSome`/`refineToOrDie`, Ox's `try`/`catch`) are reached via `lower`.
+- **Defect channels.** Only Kyo (`Abort.panic`, `Result.Panic`) and ZIO (`ZIO.die`, `Cause.Die`) separate defects from typed failures. The other backends collapse defects into the typed channel. To write or inspect a defect, use the native API per backend.
+- **Resource models.** `CIO.acquireReleaseWith` covers the lexical acquire-release case. Backend-specific resource types (Kyo's `Scope`, ZIO's `Scope`, Cats Effect's `Resource[IO, A]`, Ox's `useCloseableInScope`) have no cross-backend counterpart.
+- **Streams.** `fs2.Stream`, `zio.stream.ZStream`, and `kyo.Stream` are out of scope.
+
+## How to publish a kyo-compat library
+
+### Getting started
+
+Requires Scala 3. Add `kyo-compat-future` as your local dev dependency. It has no third-party transitive deps, so the compile and IDE loop is fast:
+
+```scala
+libraryDependencies += "io.getkyo" %% "kyo-compat-future" % "<latest version>"
+```
+
+```scala
+import kyo.compat.*
+```
+
+Write your library against `CIO`, `CFiber`, `CPromise`, and the rest of the `kyo.compat.*` surface. At dev time you compile against a single backend; the same source will compile against all six.
+
+### Cross-publishing with the sbt plugin
+
+The bundled `kyo-compat` sbt plugin extends `sbt-projectmatrix`'s `ProjectMatrix` builder with a terminal `.compatLibrary(extras*)(platforms*)(scalaVersions)` method. Each call adds one row per `(backend × supported-platform × scala-version)` to the matrix, generating the per-backend cells your library needs to ship to every runtime from a single source tree.
+
+#### Setup
+
+```scala
+// project/plugins.sbt
+addSbtPlugin("io.getkyo"          % "kyo-compat"                    % "<latest version>")
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+```
+
+```scala
+// build.sbt
+import sbt.VirtualAxis
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "<latest version>"
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        organization := "com.example",
+        version      := "1.0.0"
+    )
+    .compatLibrary(KyoLib, ZioLib, CeLib, OxLib)(
+        VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native
+    )(Seq("3.3.4"))
+```
+
+`compatKyoVersion` overrides the version used in the per-row `libraryDependencies += "io.getkyo" %%% s"kyo-compat-<id>" % compatKyoVersion.value` line that the plugin injects. It defaults to the plugin's own `Implementation-Version`, so a clean install with no override pulls the matching backend artifacts. Pin it explicitly only when targeting a snapshot that doesn't match the plugin build.
+
+That single declaration is enough; sbt auto-discovers every per-(backend, platform) cell because `ProjectMatrix` is itself a `CompositeProject`. From the snippet above sbt sees these cells:
+
+```
+myLibFuture          myLibKyo          myLibZio          myLibCe          myLibOx
+                     myLibKyoJS        myLibZioJS        myLibCeJS
+                     myLibKyoNative    myLibZioNative
+```
+
+The JVM and Scala suffixes are suppressed because `compatLibrary` pins the matrix's `defaultAxes` to `(VirtualAxis.jvm, VirtualAxis.scalaVersionAxis(sv, sv))` for single-Scala matrices. Pass multiple Scala versions in the third tuple to cross-build; each row gets its own `scalaVersionAxis` so target dirs and project ids stay distinct.
+
+Each cell's `baseDirectory` is the per-(backend, platform) source root (`my-lib/<backend>/<platform>/`), not the project root. Tests and IO inside a cell resolve relative paths against that root: the usual reason a port from a flat `crossProject` setup needs file-path adjustments.
+
+#### Selecting backends
+
+`Future` is the deps-free dev anchor and is always generated, regardless of the `extras*` list. The varargs are the *additional* backends to cross-publish to:
+
+| Call | Generated backends |
+|------|--------------------|
+| `.compatLibrary()(VirtualAxis.jvm)(Seq("3.3.4"))` | Future only |
+| `.compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))` | Future + Kyo |
+| `.compatLibrary(KyoLib, ZioLib, CeLib, OxLib)(...)` | Future + Kyo + ZIO + CE + Ox |
+| `.compatLibrary(KyoLib, ZioLib, CeLib, OxLib, TwitterFutureLib)(...)` | All six |
+
+Each backend's `supportedPlatforms` is intersected with the user-requested `platforms` list:
+
+| Backend          | JVM | JS  | Native |
+|------------------|-----|-----|--------|
+| `Future`         | ✅ | ❌ | ❌ |
+| `Kyo`            | ✅ | ✅ | ✅ |
+| `Zio`            | ✅ | ✅ | ✅ |
+| `Ce`             | ✅ | ✅ | ❌ |
+| `Ox`             | ✅ | ❌ | ❌ |
+| `TwitterFuture`  | ✅ | ❌ | ❌ |
+
+Cells the backend cannot support are silently skipped. An empty intersection for any explicitly-requested backend (e.g. `.compatLibrary(OxLib)(VirtualAxis.js)(Seq("3.3.4"))`) errors at build-load with a clear message: widen the requested `platforms` list or drop the backend from the `extras*` list.
+
+The five optional backends are exported from `CompatPlugin.autoImport` as `KyoLib`, `ZioLib`, `CeLib`, `OxLib`, `TwitterFutureLib`. Each is a `CompatBackendAxis` extending `VirtualAxis.WeakAxis`. The `Lib` suffix avoids collisions with `scala.concurrent.Future` and the `kyo` package object that consumers commonly have in scope. `FutureLib` exists too for explicit reference (used by `bindLocally(FutureLib, ...)`).
+
+#### Source layout and per-platform settings
+
+Library code lives at `my-lib/shared/src/main/scala/...` and tests at `my-lib/shared/src/test/scala/...`. Three additional source roots are picked up automatically:
+
+| Path | When to use it |
+|------|----------------|
+| `my-lib/shared/src/{main,test}/scala` | Cross-backend, cross-platform code (the default) |
+| `my-lib/<backend>/src/{main,test}/scala` | Backend-specific code shared across all of that backend's platforms (e.g. Kyo helpers used by both `myLibKyo` and `myLibKyoJS`) |
+| `my-lib/<backend>/<platform>/src/{main,test}/scala` | One specific (backend, platform) cell |
+
+`<backend>` is `future` / `kyo` / `zio` / `ce` / `ox` / `twitter-future`; `<platform>` is `jvm` / `js` / `native`. Resources mirror the same layout under `src/{main,test}/resources`. Each cell pulls its own `kyo-compat-<backend>` artifact. Running `sbt myLibZio/Test/test` and `sbt myLibFuture/Test/test` exercises the same source against two runtimes.
+
+For per-platform settings, `compatLibrary(...)` returns a matrix on which `.jvmSettings(...)`, `.jsSettings(...)`, and `.nativeSettings(...)` apply settings only to the rows of the corresponding platform. Useful for `nativeLinkStubs := true` on Native or JS-only test framework wiring. These mirror sbt-crossproject's same-named methods.
+
+#### Per-backend access
+
+`compatLibrary(...)` returns a `ProjectMatrix` extended with named accessors `.future` / `.kyo` / `.zio` / `.ce` / `.ox` / `.twitterFuture`, each yielding a view with `.jvm` / `.js` / `.native` for explicit cross-module wiring (`someProject.dependsOn(myLib.zio.jvm)`). Accessing a backend that was not opted in via the `extras*` list throws `NoSuchBackendException` at build-load. Use `.get(backend): Option[CompatBackendProjects]` for a safe lookup.
+
+`.bindLocally(backend, local)` (and `.bindAllLocally(map)`) swap the auto-injected `libraryDependencies += "io.getkyo" %%% s"kyo-compat-<id>"` for a project-level `dependsOn(local)`. Used by contributors testing local snapshots and by in-repo modules wiring against unpublished compat backends:
+
+```scala
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+    .bindLocally(KyoLib, myInTreeKyoCompatKyo: ProjectReference)
+```
+
+Bindings must be set BEFORE first access to the matrix's `componentProjects` / `projectRefs`. Both methods return the same `ProjectMatrix` (chainable).
+
+#### Cross-backend dependencies
+
+When one compat library depends on another, chain `.dependsOn(other)` on the matrix returned by `compatLibrary(...)`. The wiring is backend-aware out of the box because `CompatBackendAxis` extends `VirtualAxis.WeakAxis`: each row in the dependent matrix resolves to the matching-backend row in the dependee.
+
+```scala
+lazy val myFetcher = (projectMatrix in file("my-fetcher"))
+    .compatLibrary(KyoLib, ZioLib)(VirtualAxis.jvm, VirtualAxis.js)(Seq("3.3.4"))
+
+lazy val myHttp = (projectMatrix in file("my-http"))
+    .compatLibrary(KyoLib, ZioLib)(VirtualAxis.jvm, VirtualAxis.js)(Seq("3.3.4"))
+    .dependsOn(myFetcher)   // myHttpFuture depends on myFetcherFuture, etc.
+```
+
+`dependsOn` is sbt-projectmatrix's own API and returns a `ProjectMatrix`, so the matrix continues to auto-discover.
+
+#### Aggregator project for CI
+
+For a "test or publish all backends" CI target, `.aggregate(id)` returns a plain `Project` that fans every per-(backend, platform) row of the matrix into one task target:
+
+```scala
+lazy val myLibAll = myLib.aggregate("my-lib-all")
+
+// sbt myLibAll/test          -> runs every (backend, platform) cell
+// sbt myLibAll/publishLocal  -> publishes every backend
+```
+
+The aggregator sets `publish / skip := true`, so it never lands in maven local itself.
+

--- a/kyo-compat/bindings/ce/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
+++ b/kyo-compat/bindings/ce/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
@@ -3,17 +3,11 @@ package kyo.compat
 import cats.effect.IO
 import java.util.concurrent.CompletionStage
 
-/** JVM-only. CIO interruption propagates back to the source `CompletionStage` via `cf.cancel(false)` attached as an `onCancel` finalizer.
-  */
+/** JVM-only. Delegates to `IO.fromCompletionStage`, which propagates CIO interruption to the source via `cf.cancel(true)`. */
 object CompatFromCompletionStage:
 
     inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
-        CIO.lift {
-            IO.delay(cs.toCompletableFuture).flatMap { cf =>
-                IO.fromCompletableFuture(IO.pure(cf))
-                    .onCancel(IO.delay { val _ = cf.cancel(false) })
-            }
-        }
+        CIO.lift(IO.fromCompletionStage(IO.delay(cs)))
 
 end CompatFromCompletionStage
 

--- a/kyo-compat/bindings/ce/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
+++ b/kyo-compat/bindings/ce/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
@@ -1,0 +1,23 @@
+package kyo.compat
+
+import cats.effect.IO
+import java.util.concurrent.CompletionStage
+
+/** JVM-only. CIO interruption propagates back to the source `CompletionStage` via `cf.cancel(false)` attached as an `onCancel` finalizer.
+  */
+object CompatFromCompletionStage:
+
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
+        CIO.lift {
+            IO.delay(cs.toCompletableFuture).flatMap { cf =>
+                IO.fromCompletableFuture(IO.pure(cf))
+                    .onCancel(IO.delay { val _ = cf.cancel(false) })
+            }
+        }
+
+end CompatFromCompletionStage
+
+extension (inline c: CIO.type)
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
+        CompatFromCompletionStage.fromCompletionStage(cs)
+end extension

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CAtomicBoolean.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CAtomicBoolean.scala
@@ -1,0 +1,29 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+/** Backed by `cats.effect.kernel.Ref[IO, Boolean]`. */
+opaque type CAtomicBoolean = Ref[IO, Boolean]
+
+object CAtomicBoolean:
+
+    inline def init(inline v: Boolean): CIO[CAtomicBoolean] =
+        CIO.lift(Ref.of[IO, Boolean](v))
+
+    inline def lift(inline u: Ref[IO, Boolean]): CAtomicBoolean = u
+
+    extension (inline self: CAtomicBoolean)
+
+        inline def lower: Ref[IO, Boolean] = self
+
+        inline def get: CIO[Boolean]                          = CIO.lift(self.get)
+        inline def set(inline v: Boolean): CIO[Unit]          = CIO.lift(self.set(v))
+        inline def getAndSet(inline v: Boolean): CIO[Boolean] = CIO.lift(self.getAndSet(v))
+
+        inline def compareAndSet(inline expected: Boolean, inline updated: Boolean): CIO[Boolean] =
+            CIO.lift(self.modify(cur => if cur == expected then (updated, true) else (cur, false)))
+
+    end extension
+
+end CAtomicBoolean

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CAtomicInt.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CAtomicInt.scala
@@ -1,0 +1,35 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+/** Backed by `cats.effect.kernel.Ref[IO, Int]`. */
+opaque type CAtomicInt = Ref[IO, Int]
+
+object CAtomicInt:
+
+    inline def init(inline v: Int): CIO[CAtomicInt] =
+        CIO.lift(Ref.of[IO, Int](v))
+
+    inline def lift(inline u: Ref[IO, Int]): CAtomicInt = u
+
+    extension (inline self: CAtomicInt)
+
+        inline def lower: Ref[IO, Int] = self
+
+        inline def get: CIO[Int]                          = CIO.lift(self.get)
+        inline def set(inline v: Int): CIO[Unit]          = CIO.lift(self.set(v))
+        inline def getAndSet(inline v: Int): CIO[Int]     = CIO.lift(self.getAndSet(v))
+        inline def incrementAndGet: CIO[Int]              = CIO.lift(self.updateAndGet(_ + 1))
+        inline def getAndIncrement: CIO[Int]              = CIO.lift(self.getAndUpdate(_ + 1))
+        inline def decrementAndGet: CIO[Int]              = CIO.lift(self.updateAndGet(_ - 1))
+        inline def getAndDecrement: CIO[Int]              = CIO.lift(self.getAndUpdate(_ - 1))
+        inline def addAndGet(inline delta: Int): CIO[Int] = CIO.lift(self.updateAndGet(_ + delta))
+        inline def getAndAdd(inline delta: Int): CIO[Int] = CIO.lift(self.getAndUpdate(_ + delta))
+
+        inline def compareAndSet(inline expected: Int, inline updated: Int): CIO[Boolean] =
+            CIO.lift(self.modify(cur => if cur == expected then (updated, true) else (cur, false)))
+
+    end extension
+
+end CAtomicInt

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CAtomicLong.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CAtomicLong.scala
@@ -1,0 +1,35 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+/** Backed by `cats.effect.kernel.Ref[IO, Long]`. */
+opaque type CAtomicLong = Ref[IO, Long]
+
+object CAtomicLong:
+
+    inline def init(inline v: Long): CIO[CAtomicLong] =
+        CIO.lift(Ref.of[IO, Long](v))
+
+    inline def lift(inline u: Ref[IO, Long]): CAtomicLong = u
+
+    extension (inline self: CAtomicLong)
+
+        inline def lower: Ref[IO, Long] = self
+
+        inline def get: CIO[Long]                           = CIO.lift(self.get)
+        inline def set(inline v: Long): CIO[Unit]           = CIO.lift(self.set(v))
+        inline def getAndSet(inline v: Long): CIO[Long]     = CIO.lift(self.getAndSet(v))
+        inline def incrementAndGet: CIO[Long]               = CIO.lift(self.updateAndGet(_ + 1L))
+        inline def getAndIncrement: CIO[Long]               = CIO.lift(self.getAndUpdate(_ + 1L))
+        inline def decrementAndGet: CIO[Long]               = CIO.lift(self.updateAndGet(_ - 1L))
+        inline def getAndDecrement: CIO[Long]               = CIO.lift(self.getAndUpdate(_ - 1L))
+        inline def addAndGet(inline delta: Long): CIO[Long] = CIO.lift(self.updateAndGet(_ + delta))
+        inline def getAndAdd(inline delta: Long): CIO[Long] = CIO.lift(self.getAndUpdate(_ + delta))
+
+        inline def compareAndSet(inline expected: Long, inline updated: Long): CIO[Boolean] =
+            CIO.lift(self.modify(cur => if cur == expected then (updated, true) else (cur, false)))
+
+    end extension
+
+end CAtomicLong

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CAtomicRef.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CAtomicRef.scala
@@ -1,0 +1,35 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+/** Backed by `cats.effect.kernel.Ref[IO, A]`. `compareAndSet` is composed via `Ref.modify` since CE has no native CAS.
+  */
+opaque type CAtomicRef[A] = Ref[IO, A]
+
+object CAtomicRef:
+
+    inline def init[A](inline a: A): CIO[CAtomicRef[A]] =
+        CIO.lift(Ref.of[IO, A](a))
+
+    inline def lift[A](inline u: Ref[IO, A]): CAtomicRef[A] = u
+
+    extension [A](inline self: CAtomicRef[A])
+
+        inline def lower: Ref[IO, A] = self
+
+        inline def get: CIO[A]                            = CIO.lift(self.get)
+        inline def set(inline a: A): CIO[Unit]            = CIO.lift(self.set(a))
+        inline def getAndSet(inline a: A): CIO[A]         = CIO.lift(self.getAndSet(a))
+        inline def updateAndGet(inline f: A => A): CIO[A] = CIO.lift(self.updateAndGet(f))
+        inline def getAndUpdate(inline f: A => A): CIO[A] = CIO.lift(self.getAndUpdate(f))
+
+        inline def compareAndSet(inline expected: A, inline updated: A): CIO[Boolean] =
+            CIO.lift(self.modify(cur =>
+                given CanEqual[A, A] = CanEqual.derived
+                if cur == expected then (updated, true) else (cur, false)
+            ))
+
+    end extension
+
+end CAtomicRef

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CChannel.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CChannel.scala
@@ -1,0 +1,28 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.std.Queue
+
+/** Backed by `cats.effect.std.Queue[IO, A]`. `put` uses `offer` (suspends when full). `poll` uses `tryTake` (non-blocking). No `close` is
+  * exposed since CE `Queue` has no shutdown semantic.
+  */
+opaque type CChannel[A] = Queue[IO, A]
+
+object CChannel:
+
+    inline def init[A](inline capacity: Int): CIO[CChannel[A]] =
+        CIO.lift(Queue.bounded[IO, A](capacity))
+
+    inline def lift[A](inline u: Queue[IO, A]): CChannel[A] = u
+
+    extension [A](inline self: CChannel[A])
+
+        inline def lower: Queue[IO, A] = self
+
+        inline def put(inline v: A): CIO[Unit] = CIO.lift(self.offer(v))
+        inline def take: CIO[A]                = CIO.lift(self.take)
+        inline def poll: CIO[Option[A]]        = CIO.lift(self.tryTake)
+
+    end extension
+
+end CChannel

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CChunk.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CChunk.scala
@@ -1,0 +1,22 @@
+package kyo.compat
+
+/** Backed by `Vector[A]`. */
+opaque type CChunk[+A] = Vector[A]
+
+object CChunk:
+
+    inline def lift[A](inline c: Vector[A]): CChunk[A] = c
+
+    extension [A](inline self: CChunk[A])
+
+        inline def lower: Vector[A]            = self
+        inline def toSeq: Seq[A]               = self
+        inline def toIndexedSeq: IndexedSeq[A] = self
+        inline def apply(inline i: Int): A     = self(i)
+        inline def size: Int                   = self.size
+        inline def iterator: Iterator[A]       = self.iterator
+        inline def isEmpty: Boolean            = self.isEmpty
+
+    end extension
+
+end CChunk

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CFiber.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CFiber.scala
@@ -1,0 +1,46 @@
+package kyo.compat
+
+import cats.effect.FiberIO
+import cats.effect.IO
+import java.util.concurrent.CancellationException
+
+/** Backed by `cats.effect.FiberIO[A]`. `init` uses `.start`. `get` uses `joinWithNever`. `onComplete` starts a listener fiber; on
+  * `Outcome.Canceled` the callback fires with `Failure(CancellationException)`. CE's `IORuntime` reports any unhandled callback failures
+  * via its default error handler.
+  */
+
+opaque type CFiber[+A] = FiberIO[? <: A]
+
+object CFiber:
+
+    inline def init[A](inline c: CIO[A]): CIO[CFiber[A]] =
+        CIO.lift(c.lower.start)
+
+    inline def lift[A](inline u: FiberIO[A]): CFiber[A] = u
+
+    extension [A](self: CFiber[A])
+
+        inline def lower: FiberIO[? <: A] = self
+
+        inline def get: CIO[A] =
+            CIO.lift(
+                self.join.flatMap {
+                    case cats.effect.Outcome.Succeeded(ioa) => ioa
+                    case cats.effect.Outcome.Errored(t)     => IO.raiseError(t)
+                    case cats.effect.Outcome.Canceled()     => IO.raiseError(new CancellationException("CFiber.interrupt"))
+                }
+            )
+
+        inline def onComplete(cb: scala.util.Try[A] => CIO[Unit]): CIO[Unit] =
+            CIO.lift(
+                self.join
+                    .flatMap {
+                        case cats.effect.Outcome.Succeeded(ioa) => ioa.flatMap(a => cb(scala.util.Success(a)).lower)
+                        case cats.effect.Outcome.Errored(t)     => cb(scala.util.Failure(t)).lower
+                        case cats.effect.Outcome.Canceled() => cb(scala.util.Failure(new CancellationException("CFiber.interrupt"))).lower
+                    }
+                    .start
+                    .void
+            )
+    end extension
+end CFiber

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CIO.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CIO.scala
@@ -1,0 +1,265 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.syntax.all.*
+import cats.syntax.parallel.*
+import scala.concurrent.Future as ScalaFuture
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.NANOSECONDS
+import scala.reflect.ClassTag
+
+/** Underlying carrier is `cats.effect.IO[A]`. E is phantom — `IO` has no typed error channel; recovery narrows via `ClassTag`-guarded
+  * matching. `now` uses `IO.realTime` (not `IO.realTimeInstant`, which is JVM-only) for cross-platform uniformity. `zip` arity 2 uses
+  * `IO.both`; arities 3–7 use `parTupled`. `race` uses `IO.race` (loser is interrupted natively).
+  */
+opaque type CIO[+A] = IO[A]
+
+object CIO:
+
+    inline def lift[A](inline io: IO[A]): CIO[A] = io
+
+    /** Suspends side-effecting code that produces an `IO`; `IO.defer` defers the construction to effect-evaluation time. */
+    inline def deferLift[A](inline io: => IO[A]): CIO[A] = lift(IO.defer(io))
+
+    inline def value[A](inline a: A): CIO[A] = lift(IO.pure(a))
+
+    inline def unit: CIO[Unit] = lift(IO.unit)
+
+    inline def defer[A](inline thunk: => A): CIO[A] =
+        lift(IO.delay(thunk))
+
+    inline def fail(inline e: Throwable): CIO[Nothing] =
+        lift(IO.raiseError(e))
+
+    inline def get[A](inline t: scala.util.Try[A]): CIO[A] =
+        lift(IO.fromTry(t))
+
+    inline def fromScalaFuture[A](inline f: ScalaFuture[A]): CIO[A] =
+        // fromFutureCancelable (not fromFuture): a scala Future cannot be cancelled, but the resulting IO must
+        // still be cancelable so CIO.timeout / CIO.race can drop it. The cancel token is a no-op; without it
+        // IO.fromFuture is uncancelable and cancelling a pending fromScalaFuture deadlocks the surrounding op.
+        lift(IO.fromFutureCancelable(IO.pure(f -> IO.unit)))
+
+    inline def acquireReleaseWith[A, B](
+        inline acquire: CIO[A]
+    )(
+        inline release: A => CIO[Unit]
+    )(
+        inline use: A => CIO[B]
+    ): CIO[B] =
+        lift(IO.bracketFull(_ => acquire.lower)(use(_).lower)((a, _) => release(a).lower))
+
+    inline def ensure[A](
+        inline cleanup: CIO[Unit]
+    )(
+        inline c: CIO[A]
+    ): CIO[A] =
+        acquireReleaseWith(CIO.defer(()))(_ => cleanup)(_ => c)
+
+    inline def never: CIO[Nothing] =
+        lift(IO.never)
+
+    extension [A](inline self: CIO[A])
+
+        inline def lower: IO[A] = self
+
+        inline def recover[A2 >: A](inline handler: Throwable => CIO[A2]): CIO[A2] =
+            lift(self.lower.handleErrorWith(t => handler(t).lower))
+
+        inline def fold[B](
+            inline onSuccess: A => CIO[B],
+            inline onFail: Throwable => CIO[B]
+        ): CIO[B] =
+            lift(self.lower.redeemWith(
+                t => onFail(t).lower,
+                a => onSuccess(a).lower
+            ))
+
+        inline def liftToTry: CIO[scala.util.Try[A]] =
+            lift(self.lower.attempt.map {
+                case Right(a) => scala.util.Success(a)
+                case Left(t)  => scala.util.Failure(t)
+            })
+
+        inline def unit: CIO[Unit] =
+            lift(self.lower.void)
+
+        inline def orElse[A2 >: A](inline that: CIO[A2]): CIO[A2] =
+            lift(self.lower.handleErrorWith(_ => that.lower))
+
+        inline def mapError(inline f: Throwable => Throwable): CIO[A] =
+            lift(self.lower.adaptError {
+                case t => f(t)
+            })
+
+        inline def map[B](inline f: A => B): CIO[B] =
+            lift(self.lower.map(f))
+
+        inline def flatMap[B](inline f: A => CIO[B]): CIO[B] =
+            lift(self.lower.flatMap(a => f(a).lower))
+
+        inline def unsafeRun: scala.concurrent.Future[A] =
+            self.lower.unsafeToFuture()(using cats.effect.unsafe.IORuntime.global)
+    end extension
+
+    inline def sleep(inline d: FiniteDuration): CIO[Unit] =
+        lift(IO.sleep(d))
+
+    inline def now: CIO[java.time.Instant] =
+        lift(IO.realTime.map(d => java.time.Instant.ofEpochMilli(d.toMillis)))
+
+    inline def nowMonotonic: CIO[FiniteDuration] =
+        lift(IO.monotonic.map(d => FiniteDuration(d.toNanos, NANOSECONDS)))
+
+    inline def timeout[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[Option[A]] =
+        lift(c.lower.map(Option(_)).timeoutTo(d, IO.none[A]))
+
+    inline def timeoutWithError[A](inline d: FiniteDuration)(inline e: Throwable)(inline c: CIO[A]): CIO[A] =
+        lift(c.lower.timeoutTo(d, IO.raiseError(e)))
+
+    inline def delay[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[A] =
+        lift(c.lower.delayBy(d))
+
+    // `IO.race` returns `Either[A, B]`; `.merge` narrows since both legs share type A.
+    inline def race[A](
+        inline a: CIO[A],
+        inline b: CIO[A]
+    ): CIO[A] =
+        lift(IO.race(a.lower, b.lower).map(_.merge))
+
+    inline def foreach[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(f: A => CIO[B]): CIO[CChunk[B]] =
+        lift {
+            val list = coll.toList
+            val io =
+                if concurrency == Int.MaxValue then list.parTraverse(a => f(a).lower)
+                else IO.parTraverseN(concurrency)(list)(a => f(a).lower)
+            io.map(lst => CChunk.lift(lst.toVector))
+        }
+
+    inline def foreachIndexed[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(f: (Int, A) => CIO[B]): CIO[CChunk[B]] =
+        lift {
+            val list = coll.toList.zipWithIndex
+            val io =
+                if concurrency == Int.MaxValue then list.parTraverse { case (a, i) => f(i, a).lower }
+                else IO.parTraverseN(concurrency)(list) { case (a, i) => f(i, a).lower }
+            io.map(lst => CChunk.lift(lst.toVector))
+        }
+
+    inline def foreachDiscard[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(f: A => CIO[Any]): CIO[Unit] =
+        lift {
+            val list = coll.toList
+            if concurrency == Int.MaxValue then list.parTraverse_(a => f(a).lower)
+            else IO.parTraverseN_(concurrency)(list)(a => f(a).lower)
+        }
+
+    inline def filter[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(p: A => CIO[Boolean]): CIO[CChunk[A]] =
+        lift {
+            val list = coll.toList
+            if concurrency == Int.MaxValue then
+                list.parFilterA(a => p(a).lower).map(lst => CChunk.lift(lst.toVector))
+            else
+                IO.parTraverseN(concurrency)(list)(a => p(a).lower.map(b => a -> b))
+                    .map(pairs => CChunk.lift(pairs.collect { case (a, true) => a }.toVector))
+            end if
+        }
+
+    inline def collectAll[A](
+        inline coll: Iterable[CIO[A]],
+        inline concurrency: Int = Int.MaxValue
+    ): CIO[CChunk[A]] =
+        lift {
+            val list = coll.toList.map(_.lower)
+            if concurrency == Int.MaxValue then list.parSequence.map(lst => CChunk.lift(lst.toVector))
+            else IO.parSequenceN(concurrency)(list).map(lst => CChunk.lift(lst.toVector))
+        }
+
+    inline def collectAllDiscard(
+        inline coll: Iterable[CIO[Any]],
+        inline concurrency: Int = Int.MaxValue
+    ): CIO[Unit] =
+        lift {
+            val list = coll.toList.map(_.lower)
+            if concurrency == Int.MaxValue then list.parSequence_
+            else IO.parSequenceN_(concurrency)(list)
+        }
+
+    inline def async[A](inline register: ((scala.util.Try[A] => Unit) => Unit)): CIO[A] =
+        lift(IO.async_[A] { k =>
+            val cb: scala.util.Try[A] => Unit = {
+                case scala.util.Success(a) => k(Right(a))
+                case scala.util.Failure(e) => k(Left(e))
+            }
+            register(cb)
+        })
+
+    inline def blocking[A](inline thunk: => A): CIO[A] =
+        lift(IO.blocking(thunk))
+
+    inline def cede: CIO[Unit] =
+        lift(IO.cede)
+
+    // Arity 2 uses `IO.both`; arities 3–7 use `parTupled` from `cats.syntax.parallel.*`.
+    inline def zip[A1, A2](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2]
+    ): CIO[(A1, A2)] =
+        lift(IO.both(a1.lower, a2.lower))
+
+    inline def zip[A1, A2, A3](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3]
+    ): CIO[(A1, A2, A3)] =
+        lift((a1.lower, a2.lower, a3.lower).parTupled)
+
+    inline def zip[A1, A2, A3, A4](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4]
+    ): CIO[(A1, A2, A3, A4)] =
+        lift((a1.lower, a2.lower, a3.lower, a4.lower).parTupled)
+
+    inline def zip[A1, A2, A3, A4, A5](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5]
+    ): CIO[(A1, A2, A3, A4, A5)] =
+        lift((a1.lower, a2.lower, a3.lower, a4.lower, a5.lower).parTupled)
+
+    inline def zip[A1, A2, A3, A4, A5, A6](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5],
+        inline a6: CIO[A6]
+    ): CIO[(A1, A2, A3, A4, A5, A6)] =
+        lift((a1.lower, a2.lower, a3.lower, a4.lower, a5.lower, a6.lower).parTupled)
+
+    inline def zip[A1, A2, A3, A4, A5, A6, A7](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5],
+        inline a6: CIO[A6],
+        inline a7: CIO[A7]
+    ): CIO[(A1, A2, A3, A4, A5, A6, A7)] =
+        lift((a1.lower, a2.lower, a3.lower, a4.lower, a5.lower, a6.lower, a7.lower).parTupled)
+
+end CIO

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CLatch.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CLatch.scala
@@ -1,0 +1,31 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.std.CountDownLatch
+
+/** Backed by `cats.effect.std.CountDownLatch[IO]`. `init(n <= 0)` produces an already-released latch (`CountDownLatch(1)` pre-released)
+  * since CE requires n >= 1.
+  */
+opaque type CLatch = CountDownLatch[IO]
+
+object CLatch:
+
+    inline def init(inline n: Int): CIO[CLatch] =
+        CIO.lift(initImpl(n))
+
+    inline def lift(inline u: CountDownLatch[IO]): CLatch = u
+
+    private inline def initImpl(inline n: Int): IO[CountDownLatch[IO]] =
+        if n <= 0 then CountDownLatch[IO](1).flatMap(l => l.release.as(l))
+        else CountDownLatch[IO](n)
+
+    extension (inline self: CLatch)
+
+        inline def lower: CountDownLatch[IO] = self
+
+        inline def await: CIO[Unit]   = CIO.lift(self.await)
+        inline def release: CIO[Unit] = CIO.lift(self.release)
+
+    end extension
+
+end CLatch

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CLocal.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CLocal.scala
@@ -1,0 +1,33 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.IOLocal
+
+/** Backed by `cats.effect.IOLocal[A]`. `init` allocates a fresh `IOLocal` inside `IO`, so the allocation is deferred to effect-evaluation
+  * time. Extension methods operate directly on the `IOLocal` — no wrapper or lazy-CAS dance required.
+  */
+opaque type CLocal[A] = IOLocal[A]
+
+object CLocal:
+
+    inline def init[A](inline default: A): CIO[CLocal[A]] =
+        CIO.lift(IOLocal[A](default))
+
+    inline def lift[A](inline u: IOLocal[A]): CLocal[A] = u
+
+    extension [A](inline self: CLocal[A])
+
+        inline def lower: IOLocal[A] = self
+
+        inline def get: CIO[A] = CIO.lift(self.get)
+
+        inline def let[B](inline v: A)(inline c: CIO[B]): CIO[B] =
+            CIO.lift(self.getAndSet(v).bracket(_ => c.lower)(prior => self.set(prior)))
+
+        inline def update[B](inline f: A => A)(inline c: CIO[B]): CIO[B] =
+            CIO.lift(self.get.flatMap { cur =>
+                self.set(f(cur)).bracket(_ => c.lower)(_ => self.set(cur))
+            })
+
+    end extension
+end CLocal

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CMeter.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CMeter.scala
@@ -1,0 +1,36 @@
+package kyo.compat
+
+import cats.effect.IO
+import cats.effect.std.Semaphore
+
+/** Backed by `cats.effect.std.Semaphore[IO]`. Permit counts are `Long` on the CE side; the surface converts to/from `Int`. `tryRun` uses
+  * `tryPermit` (`Resource[IO, Boolean]`).
+  */
+opaque type CMeter = Semaphore[IO]
+
+object CMeter:
+
+    inline def init(inline permits: Int): CIO[CMeter] =
+        CIO.lift(Semaphore[IO](permits.toLong))
+
+    inline def lift(inline u: Semaphore[IO]): CMeter = u
+
+    extension (inline self: CMeter)
+
+        inline def lower: Semaphore[IO] = self
+
+        inline def run[A](inline c: CIO[A]): CIO[A] =
+            CIO.lift(self.permit.use(_ => c.lower))
+
+        inline def tryRun[A](inline c: CIO[A]): CIO[Option[A]] =
+            CIO.lift(self.tryPermit.use {
+                case true  => c.lower.map(Some(_))
+                case false => IO.none[A]
+            })
+
+        inline def availablePermits: CIO[Int] =
+            CIO.lift(self.available.map(_.toInt))
+
+    end extension
+
+end CMeter

--- a/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CPromise.scala
+++ b/kyo-compat/bindings/ce/shared/src/main/scala/kyo/compat/CPromise.scala
@@ -1,0 +1,46 @@
+package kyo.compat
+
+import cats.effect.Deferred
+import cats.effect.IO
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+/** Backed by `cats.effect.Deferred[IO, Try[A]]`. `Deferred` is a single-assignment cell of a plain value — it has no error channel
+  * (`complete` takes an `A`, `get` returns an `A`). A `CPromise` must carry failures, so the cell stores a `Try[A]` and failure is encoded
+  * as `Failure(t)`. `poll` returns the stored `Try` directly.
+  */
+opaque type CPromise[A] = Deferred[IO, Try[A]]
+
+object CPromise:
+
+    inline def init[A]: CIO[CPromise[A]] =
+        CIO.lift(Deferred[IO, Try[A]])
+
+    inline def lift[A](inline u: Deferred[IO, Try[A]]): CPromise[A] = u
+
+    extension [A](inline self: CPromise[A])
+
+        inline def lower: Deferred[IO, Try[A]] = self
+
+        inline def succeed(inline a: A): CIO[Boolean] =
+            CIO.lift(self.complete(Success(a)))
+
+        inline def fail(inline e: Throwable): CIO[Boolean] =
+            CIO.lift(self.complete(Failure(e)))
+
+        inline def get: CIO[A] =
+            CIO.lift(self.get.flatMap {
+                case Success(a) => IO.pure(a)
+                case Failure(e) => IO.raiseError(e)
+            })
+
+        inline def poll: CIO[Option[Try[A]]] =
+            CIO.lift(self.tryGet)
+
+        inline def done: CIO[Boolean] =
+            CIO.lift(self.tryGet.map(_.isDefined))
+
+    end extension
+
+end CPromise

--- a/kyo-compat/bindings/future/js/src/main/scala/kyo/compat/internal/CompatScheduler.scala
+++ b/kyo-compat/bindings/future/js/src/main/scala/kyo/compat/internal/CompatScheduler.scala
@@ -1,0 +1,19 @@
+package kyo.compat.internal
+
+import java.util.concurrent.TimeUnit
+import scala.scalajs.js.timers
+
+/** Public on purpose: `private[kyo]` triggers a `NoClassDefFoundError` at runtime when `sleep`/`timeout` inline at user-package call sites
+  * (Scala 3 synthesizes an inline accessor typed against a package-as-class symbol that does not exist at runtime).
+  *
+  * JS impl: Scala.js is single-threaded; `setTimeout` is the only available delay primitive. We convert the requested delay to milliseconds
+  * and schedule via `scala.scalajs.js.timers.setTimeout`.
+  */
+object CompatScheduler:
+
+    def schedule(action: () => Unit, delay: Long, unit: TimeUnit): Unit =
+        val delayMs = unit.toMillis(delay).toDouble
+        val _       = timers.setTimeout(delayMs)(action())
+        ()
+    end schedule
+end CompatScheduler

--- a/kyo-compat/bindings/future/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
+++ b/kyo-compat/bindings/future/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
@@ -1,0 +1,18 @@
+package kyo.compat
+
+import java.util.concurrent.CompletionStage
+import scala.concurrent.ExecutionContext
+import scala.jdk.FutureConverters.CompletionStageOps
+
+/** JVM-only. Wraps a `CompletionStage` into a `CIO` via `CompletionStageOps.asScala`. */
+object CompatFromCompletionStage:
+
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
+        CIO.deferLift(cs.asScala)
+
+end CompatFromCompletionStage
+
+extension (inline c: CIO.type)
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
+        CompatFromCompletionStage.fromCompletionStage(cs)
+end extension

--- a/kyo-compat/bindings/future/jvm/src/main/scala/kyo/compat/internal/CompatScheduler.scala
+++ b/kyo-compat/bindings/future/jvm/src/main/scala/kyo/compat/internal/CompatScheduler.scala
@@ -1,0 +1,35 @@
+package kyo.compat.internal
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Public on purpose: `private[kyo]` triggers a `NoClassDefFoundError` at runtime when `sleep`/`timeout` inline at user-package call sites
+  * (Scala 3 synthesizes an inline accessor typed against a package-as-class symbol that does not exist at runtime).
+  */
+object CompatScheduler:
+
+    private val executor: ScheduledExecutorService =
+        val tf = new ThreadFactory:
+            private val count = new AtomicInteger(0)
+            def newThread(r: Runnable): Thread =
+                val t = new Thread(r, s"compat-scheduler-${count.incrementAndGet()}")
+                t.setDaemon(true)
+                t
+            end newThread
+        Executors.newScheduledThreadPool(2, tf)
+    end executor
+
+    def schedule(action: () => Unit, delay: Long, unit: TimeUnit): Unit =
+        val _ = executor.schedule(
+            new Runnable:
+                def run() = action()
+            ,
+            delay,
+            unit
+        )
+        ()
+    end schedule
+end CompatScheduler

--- a/kyo-compat/bindings/future/native/src/main/scala/kyo/compat/internal/CompatScheduler.scala
+++ b/kyo-compat/bindings/future/native/src/main/scala/kyo/compat/internal/CompatScheduler.scala
@@ -1,0 +1,36 @@
+package kyo.compat.internal
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Public on purpose: `private[kyo]` triggers a `NoClassDefFoundError` at runtime when `sleep`/`timeout` inline at user-package call sites
+  * (Scala 3 synthesizes an inline accessor typed against a package-as-class symbol that does not exist at runtime). Scala Native 0.5
+  * supports `java.util.concurrent.Executors.newScheduledThreadPool`.
+  */
+object CompatScheduler:
+
+    private val executor: ScheduledExecutorService =
+        val tf = new ThreadFactory:
+            private val count = new AtomicInteger(0)
+            def newThread(r: Runnable): Thread =
+                val t = new Thread(r, s"compat-scheduler-${count.incrementAndGet()}")
+                t.setDaemon(true)
+                t
+            end newThread
+        Executors.newScheduledThreadPool(2, tf)
+    end executor
+
+    def schedule(action: () => Unit, delay: Long, unit: TimeUnit): Unit =
+        val _ = executor.schedule(
+            new Runnable:
+                def run() = action()
+            ,
+            delay,
+            unit
+        )
+        ()
+    end schedule
+end CompatScheduler

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CAtomicBoolean.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CAtomicBoolean.scala
@@ -1,0 +1,28 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Backed by `java.util.concurrent.atomic.AtomicBoolean`. */
+opaque type CAtomicBoolean = AtomicBoolean
+
+object CAtomicBoolean:
+
+    inline def init(inline v: Boolean): CIO[CAtomicBoolean] =
+        CIO.defer(new AtomicBoolean(v))
+
+    inline def lift(inline u: AtomicBoolean): CAtomicBoolean = u
+
+    extension (inline self: CAtomicBoolean)
+
+        inline def lower: AtomicBoolean = self
+
+        inline def get: CIO[Boolean]                          = CIO.defer(self.get())
+        inline def set(inline v: Boolean): CIO[Unit]          = CIO.defer(self.set(v))
+        inline def getAndSet(inline v: Boolean): CIO[Boolean] = CIO.defer(self.getAndSet(v))
+
+        inline def compareAndSet(inline expected: Boolean, inline updated: Boolean): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicBoolean

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CAtomicInt.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CAtomicInt.scala
@@ -1,0 +1,34 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Backed by `java.util.concurrent.atomic.AtomicInteger`. */
+opaque type CAtomicInt = AtomicInteger
+
+object CAtomicInt:
+
+    inline def init(inline v: Int): CIO[CAtomicInt] =
+        CIO.defer(new AtomicInteger(v))
+
+    inline def lift(inline u: AtomicInteger): CAtomicInt = u
+
+    extension (inline self: CAtomicInt)
+
+        inline def lower: AtomicInteger = self
+
+        inline def get: CIO[Int]                          = CIO.defer(self.get())
+        inline def set(inline v: Int): CIO[Unit]          = CIO.defer(self.set(v))
+        inline def getAndSet(inline v: Int): CIO[Int]     = CIO.defer(self.getAndSet(v))
+        inline def incrementAndGet: CIO[Int]              = CIO.defer(self.incrementAndGet())
+        inline def getAndIncrement: CIO[Int]              = CIO.defer(self.getAndIncrement())
+        inline def decrementAndGet: CIO[Int]              = CIO.defer(self.decrementAndGet())
+        inline def getAndDecrement: CIO[Int]              = CIO.defer(self.getAndDecrement())
+        inline def addAndGet(inline delta: Int): CIO[Int] = CIO.defer(self.addAndGet(delta))
+        inline def getAndAdd(inline delta: Int): CIO[Int] = CIO.defer(self.getAndAdd(delta))
+
+        inline def compareAndSet(inline expected: Int, inline updated: Int): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicInt

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CAtomicLong.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CAtomicLong.scala
@@ -1,0 +1,34 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicLong
+
+/** Backed by `java.util.concurrent.atomic.AtomicLong`. */
+opaque type CAtomicLong = AtomicLong
+
+object CAtomicLong:
+
+    inline def init(inline v: Long): CIO[CAtomicLong] =
+        CIO.defer(new AtomicLong(v))
+
+    inline def lift(inline u: AtomicLong): CAtomicLong = u
+
+    extension (inline self: CAtomicLong)
+
+        inline def lower: AtomicLong = self
+
+        inline def get: CIO[Long]                           = CIO.defer(self.get())
+        inline def set(inline v: Long): CIO[Unit]           = CIO.defer(self.set(v))
+        inline def getAndSet(inline v: Long): CIO[Long]     = CIO.defer(self.getAndSet(v))
+        inline def incrementAndGet: CIO[Long]               = CIO.defer(self.incrementAndGet())
+        inline def getAndIncrement: CIO[Long]               = CIO.defer(self.getAndIncrement())
+        inline def decrementAndGet: CIO[Long]               = CIO.defer(self.decrementAndGet())
+        inline def getAndDecrement: CIO[Long]               = CIO.defer(self.getAndDecrement())
+        inline def addAndGet(inline delta: Long): CIO[Long] = CIO.defer(self.addAndGet(delta))
+        inline def getAndAdd(inline delta: Long): CIO[Long] = CIO.defer(self.getAndAdd(delta))
+
+        inline def compareAndSet(inline expected: Long, inline updated: Long): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicLong

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CAtomicRef.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CAtomicRef.scala
@@ -1,0 +1,31 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.Future
+
+/** Backed by `java.util.concurrent.atomic.AtomicReference[A]`. */
+opaque type CAtomicRef[A] = AtomicReference[A]
+
+object CAtomicRef:
+
+    inline def init[A](inline a: A): CIO[CAtomicRef[A]] =
+        CIO.defer(new AtomicReference[A](a))
+
+    inline def lift[A](inline u: AtomicReference[A]): CAtomicRef[A] = u
+
+    extension [A](inline self: CAtomicRef[A])
+
+        inline def lower: AtomicReference[A] = self
+
+        inline def get: CIO[A]                            = CIO.defer(self.get())
+        inline def set(inline a: A): CIO[Unit]            = CIO.defer(self.set(a))
+        inline def getAndSet(inline a: A): CIO[A]         = CIO.defer(self.getAndSet(a))
+        inline def updateAndGet(inline f: A => A): CIO[A] = CIO.defer(self.updateAndGet(a => f(a)))
+        inline def getAndUpdate(inline f: A => A): CIO[A] = CIO.defer(self.getAndUpdate(a => f(a)))
+
+        inline def compareAndSet(inline expected: A, inline updated: A): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicRef

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CChannel.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CChannel.scala
@@ -2,7 +2,6 @@ package kyo.compat
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
-import scala.annotation.publicInBinary
 import scala.concurrent.Future
 import scala.concurrent.Promise
 
@@ -11,7 +10,7 @@ import scala.concurrent.Promise
   * holds onto its Promise indefinitely (use `CIO.timeout` to bound it, accepting that the underlying waiter is orphaned). `poll` is
   * non-blocking and always returns immediately.
   */
-final class CChannel[A] @publicInBinary private[compat] (
+final class CChannel[A](
     capacity: Int,
     items: ConcurrentLinkedQueue[A],
     takers: ConcurrentLinkedQueue[Promise[A]],

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CChannel.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CChannel.scala
@@ -1,0 +1,140 @@
+package kyo.compat
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import scala.annotation.publicInBinary
+import scala.concurrent.Future
+import scala.concurrent.Promise
+
+/** Backed by an `AtomicInteger` size counter plus three `ConcurrentLinkedQueue`s (items, takers, putters). `put` and `take` use
+  * Promise-queue coordination — no OS-thread blocking. Cancellation isn't part of the CIO surface; a `put`/`take` that can't be satisfied
+  * holds onto its Promise indefinitely (use `CIO.timeout` to bound it, accepting that the underlying waiter is orphaned). `poll` is
+  * non-blocking and always returns immediately.
+  */
+final class CChannel[A] @publicInBinary private[compat] (
+    capacity: Int,
+    items: ConcurrentLinkedQueue[A],
+    takers: ConcurrentLinkedQueue[Promise[A]],
+    putters: ConcurrentLinkedQueue[(A, Promise[Unit])],
+    size: AtomicInteger
+):
+
+    inline def lower: CChannel[A] = this
+
+    inline def put(inline v: A): CIO[Unit] = CIO.deferLift(doPut(v))
+    inline def take: CIO[A]                = CIO.deferLift(doTake())
+    inline def poll: CIO[Option[A]]        = CIO.defer(doPoll())
+
+    private def doPut(v: A): Future[Unit] =
+        if size.get() < capacity then
+            if size.getAndIncrement() < capacity then
+                items.offer(v)
+                drainTakers()
+                Future.unit
+            else
+                val _ = size.decrementAndGet()
+                doPutSlow(v)
+            end if
+        else doPutSlow(v)
+    end doPut
+
+    private def doPutSlow(v: A): Future[Unit] =
+        val p = Promise[Unit]()
+        putters.offer((v, p))
+        if size.get() < capacity then drainPutters()
+        p.future
+    end doPutSlow
+
+    private def doTake(): Future[A] =
+        val item = items.poll()
+        if item.asInstanceOf[AnyRef] ne null then
+            val _ = size.decrementAndGet()
+            drainPutters()
+            Future.successful(item)
+        else doTakeSlow()
+        end if
+    end doTake
+
+    private def doTakeSlow(): Future[A] =
+        val p = Promise[A]()
+        takers.offer(p)
+        val retry = items.poll()
+        if retry.asInstanceOf[AnyRef] ne null then
+            val _ = size.decrementAndGet()
+            drainPutters()
+            if !p.trySuccess(retry) then
+                items.offer(retry)
+                val _ = size.incrementAndGet()
+                drainTakers()
+            end if
+        end if
+        p.future
+    end doTakeSlow
+
+    private def doPoll(): Option[A] =
+        val item = items.poll()
+        if item.asInstanceOf[AnyRef] ne null then
+            val _ = size.decrementAndGet()
+            drainPutters()
+            Some(item)
+        else None
+        end if
+    end doPoll
+
+    private def drainTakers(): Unit =
+        var continue = true
+        while continue do
+            val taker = takers.poll()
+            if taker eq null then continue = false
+            else
+                val item = items.poll()
+                if item.asInstanceOf[AnyRef] ne null then
+                    val _ = size.decrementAndGet()
+                    if !taker.trySuccess(item) then
+                        items.offer(item)
+                        val _ = size.incrementAndGet()
+                    end if
+                else
+                    takers.offer(taker)
+                    continue = false
+                end if
+            end if
+        end while
+    end drainTakers
+
+    private def drainPutters(): Unit =
+        var continue = true
+        while continue do
+            val entry = putters.peek()
+            if entry eq null then continue = false
+            else if size.get() < capacity then
+                val taken = putters.poll()
+                if taken ne null then
+                    val (v, p) = taken
+                    if p.trySuccess(()) then
+                        items.offer(v)
+                        val _ = size.incrementAndGet()
+                        drainTakers()
+                    end if
+                end if
+            else continue = false
+            end if
+        end while
+    end drainPutters
+
+end CChannel
+
+object CChannel:
+
+    inline def init[A](inline capacity: Int): CIO[CChannel[A]] =
+        CIO.defer(new CChannel[A](
+            capacity,
+            new ConcurrentLinkedQueue[A](),
+            new ConcurrentLinkedQueue[Promise[A]](),
+            new ConcurrentLinkedQueue[(A, Promise[Unit])](),
+            new AtomicInteger(0)
+        ))
+
+    inline def lift[A](inline u: CChannel[A]): CChannel[A] = u
+
+end CChannel

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CChunk.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CChunk.scala
@@ -1,0 +1,22 @@
+package kyo.compat
+
+/** Backed by `Vector[A]`. */
+opaque type CChunk[+A] = Vector[A]
+
+object CChunk:
+
+    inline def lift[A](inline c: Vector[A]): CChunk[A] = c
+
+    extension [A](inline self: CChunk[A])
+
+        inline def lower: Vector[A]            = self
+        inline def toSeq: Seq[A]               = self
+        inline def toIndexedSeq: IndexedSeq[A] = self
+        inline def apply(inline i: Int): A     = self(i)
+        inline def size: Int                   = self.size
+        inline def iterator: Iterator[A]       = self.iterator
+        inline def isEmpty: Boolean            = self.isEmpty
+
+    end extension
+
+end CChunk

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CFiber.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CFiber.scala
@@ -1,0 +1,34 @@
+package kyo.compat
+
+import kyo.compat.internal.LocalCtx
+import scala.concurrent.Future
+import scala.util.Try
+
+/** Backed by `scala.concurrent.Future[A]`. `init` spawns the body eagerly under the current `LocalCtx`; the returned `Future[A]` is the
+  * fiber handle. `lift` wraps an existing `Future[A]` directly. `onComplete` registers a callback on the underlying `Future`.
+  */
+opaque type CFiber[+A] = Future[A]
+
+object CFiber:
+
+    inline def init[A](inline c: CIO[A]): CIO[CFiber[A]] =
+        CIO.deferLift(Future.successful(c.lower))
+
+    inline def lift[A](inline u: Future[A]): CFiber[A] = u
+
+    extension [A](inline self: CFiber[A])
+
+        inline def lower: Future[A] = self
+
+        inline def get: CIO[A] = CIO.lift(self.lower)
+
+        inline def onComplete(inline cb: Try[A] => CIO[Unit]): CIO[Unit] =
+            CIO.defer {
+                self.lower.onComplete { t =>
+                    val _ = cb(t).unsafeRun
+                    ()
+                }(scala.concurrent.ExecutionContext.parasitic)
+            }
+    end extension
+
+end CFiber

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CIO.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CIO.scala
@@ -1,0 +1,469 @@
+package kyo.compat
+
+import java.util.concurrent.TimeUnit
+import kyo.compat.internal.CompatScheduler
+import kyo.compat.internal.LocalCtx
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.NANOSECONDS
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scala.util.control.NonFatal
+
+/** Underlying carrier is `LocalCtx => Future[A]`, a function from the immutable `LocalCtx` (threaded by `flatMap`/`let`) to a fresh
+  * `Future[A]`. Composition and `defer` run on `scala.concurrent.ExecutionContext.parasitic` (inline on the completing thread, no hop);
+  * `CIO.blocking` is the only operation that leaves the parasitic EC — it runs the thunk on `scala.concurrent.ExecutionContext.global`
+  * inside `scala.concurrent.blocking`. No `using ExecutionContext` plumbing in the public surface.
+  */
+opaque type CIO[+A] = LocalCtx => Future[A]
+
+object CIO:
+
+    // Composition runs inline on the completing thread — no thread hops for pure plumbing.
+    private val parasiticEc: ExecutionContext = scala.concurrent.ExecutionContext.parasitic
+
+    /** Wrap an already-constructed, pure `Future` value in a CIO. For side-effecting `Future`-producing code use [[CIO.deferLift]]. */
+    inline def lift[A](inline f: Future[A]): CIO[A] =
+        (_: LocalCtx) => f
+
+    /** Suspend side-effecting code that produces a `Future`; re-evaluated per `LocalCtx` on every run. */
+    inline def deferLift[A](inline f: LocalCtx ?=> Future[A]): CIO[A] =
+        (ctx: LocalCtx) => f(using ctx)
+
+    /** Wrap an already-evaluated, side-effect-free value in a CIO. For side-effecting expressions use [[CIO.defer]] instead.
+      */
+    inline def value[A](inline a: A): CIO[A] = (_: LocalCtx) => Future.successful(a)
+
+    inline def unit: CIO[Unit] = (_: LocalCtx) => Future.unit
+
+    inline def fail(inline e: Throwable): CIO[Nothing] =
+        (_: LocalCtx) => Future.failed(e)
+
+    inline def defer[A](inline thunk: => A): CIO[A] =
+        (_: LocalCtx) => Future(thunk)(using parasiticEc)
+
+    inline def get[A](inline t: Try[A]): CIO[A] =
+        (_: LocalCtx) => Future.fromTry(t)
+
+    inline def fromScalaFuture[A](inline f: Future[A]): CIO[A] = lift(f)
+
+    /** Release runs on success and failure of `use`. Cancellation isn't part of the CIO surface — Future has no interrupt mechanism. */
+    inline def acquireReleaseWith[A, B](
+        inline acquire: CIO[A]
+    )(
+        release: A => CIO[Unit]
+    )(
+        inline use: A => CIO[B]
+    ): CIO[B] =
+        (ctx: LocalCtx) =>
+            acquire(ctx).flatMap { a =>
+                use(a)(ctx).transformWith {
+                    case Success(b) => release(a)(ctx).map(_ => b)(parasiticEc)
+                    case Failure(t) => release(a)(ctx).transformWith(_ => Future.failed(t))(parasiticEc)
+                }(parasiticEc)
+            }(parasiticEc)
+
+    inline def ensure[A](
+        inline cleanup: CIO[Unit]
+    )(
+        inline c: CIO[A]
+    ): CIO[A] =
+        acquireReleaseWith(CIO.defer(()))(_ => cleanup)(_ => c)
+
+    inline def never: CIO[Nothing] =
+        (_: LocalCtx) => Promise[Nothing]().future
+
+    extension [A](inline self: CIO[A])
+
+        inline def lower: LocalCtx ?=> Future[A] =
+            (ctx: LocalCtx) ?=> self(ctx)
+
+        inline def recover[A2 >: A](inline handler: Throwable => CIO[A2]): CIO[A2] =
+            (ctx: LocalCtx) =>
+                self(ctx).recoverWith { case t => handler(t)(ctx) }(parasiticEc)
+
+        inline def fold[B](
+            inline onSuccess: A => CIO[B],
+            inline onFail: Throwable => CIO[B]
+        ): CIO[B] =
+            (ctx: LocalCtx) =>
+                self(ctx).transformWith {
+                    case Success(a) => onSuccess(a)(ctx)
+                    case Failure(t) => onFail(t)(ctx)
+                }(parasiticEc)
+
+        inline def liftToTry: CIO[Try[A]] =
+            (ctx: LocalCtx) =>
+                self(ctx).transform {
+                    case Success(a) => Success[Try[A]](Success(a))
+                    case Failure(t) => Success[Try[A]](Failure(t))
+                }(parasiticEc)
+
+        inline def unit: CIO[Unit] =
+            (ctx: LocalCtx) => self(ctx).map(_ => ())(parasiticEc)
+
+        inline def orElse[A2 >: A](inline that: CIO[A2]): CIO[A2] =
+            (ctx: LocalCtx) =>
+                self(ctx).recoverWith { case t: Throwable if NonFatal(t) => that(ctx) }(parasiticEc)
+
+        inline def mapError(inline f: Throwable => Throwable): CIO[A] =
+            (ctx: LocalCtx) =>
+                self(ctx).transform {
+                    case Success(a) => Success(a)
+                    case Failure(t) =>
+                        Try(f(t)) match
+                            case Success(t2) => Failure(t2)
+                            case Failure(t2) => Failure(t2)
+                }(parasiticEc)
+
+        inline def map[B](inline f: A => B): CIO[B] =
+            (ctx: LocalCtx) => self(ctx).map(f)(parasiticEc)
+
+        inline def flatMap[B](inline f: A => CIO[B]): CIO[B] =
+            (ctx: LocalCtx) => self(ctx).flatMap(a => f(a)(ctx))(parasiticEc)
+
+        inline def unsafeRun: scala.concurrent.Future[A] = self(LocalCtx.empty)
+    end extension
+
+    inline def sleep(inline d: FiniteDuration): CIO[Unit] =
+        (_: LocalCtx) =>
+            val p = Promise[Unit]()
+            CompatScheduler.schedule(
+                () =>
+                    p.success(())
+                    ()
+                ,
+                d.toNanos,
+                TimeUnit.NANOSECONDS
+            )
+            p.future
+
+    inline def now: CIO[java.time.Instant] = defer(java.time.Instant.now())
+
+    inline def nowMonotonic: CIO[FiniteDuration] =
+        defer(FiniteDuration(java.lang.System.nanoTime(), NANOSECONDS))
+
+    /** Winner returned; the loser keeps running orphaned (Future has no interrupt). */
+    inline def timeout[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[Option[A]] =
+        (ctx: LocalCtx) =>
+            val p = Promise[Option[A]]()
+            CompatScheduler.schedule(
+                () =>
+                    val _ = p.trySuccess(None)
+                ,
+                d.toNanos,
+                TimeUnit.NANOSECONDS
+            )
+            c(ctx).onComplete {
+                case Success(a) => val _ = p.trySuccess(Some(a))
+                case Failure(t) => val _ = p.tryFailure(t)
+            }(parasiticEc)
+            p.future
+
+    /** On expiry, the returned Future fails with `e`. The inner CIO keeps running orphaned (Future has no interrupt). */
+    inline def timeoutWithError[A](inline d: FiniteDuration)(inline e: Throwable)(inline c: CIO[A]): CIO[A] =
+        (ctx: LocalCtx) =>
+            val p = Promise[A]()
+            CompatScheduler.schedule(
+                () =>
+                    val _ = p.tryFailure(e)
+                ,
+                d.toNanos,
+                TimeUnit.NANOSECONDS
+            )
+            c(ctx).onComplete(p.tryComplete)(parasiticEc)
+            p.future
+
+    inline def delay[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[A] =
+        (ctx: LocalCtx) => CIO.sleep(d)(ctx).flatMap(_ => c(ctx))(parasiticEc)
+
+    /** Winner returned; the loser keeps running orphaned. */
+    inline def race[A](
+        inline a: CIO[A],
+        inline b: CIO[A]
+    ): CIO[A] =
+        (ctx: LocalCtx) =>
+            val p = Promise[A]()
+            a(ctx).onComplete(p.tryComplete)(parasiticEc)
+            b(ctx).onComplete(p.tryComplete)(parasiticEc)
+            p.future
+
+    /** Non-blocking semaphore that gates dispatch without starvation. */
+    private[compat] class FutureSemaphore(permits: Int):
+        private val avail = new java.util.concurrent.atomic.AtomicInteger(permits)
+        private val queue = new java.util.concurrent.ConcurrentLinkedQueue[Promise[Unit]]()
+
+        def acquire(): Future[Unit] =
+            if avail.getAndDecrement() > 0 then Future.unit
+            else
+                val p = Promise[Unit]()
+                queue.offer(p)
+                p.future
+
+        def release(): Unit =
+            if avail.incrementAndGet() <= 0 then
+                val p = queue.poll()
+                if p != null then
+                    val _ = p.trySuccess(())
+    end FutureSemaphore
+
+    /** Run `work` in the semaphore-bounded path. Release fires on both success and failure so queued items drain. */
+    private[compat] def semGated[R](
+        sem: FutureSemaphore,
+        work: => Future[R]
+    ): Future[R] =
+        sem.acquire().flatMap { _ =>
+            work.transform { r =>
+                sem.release()
+                r
+            }(parasiticEc)
+        }(parasiticEc)
+
+    inline def foreach[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(f: A => CIO[B]): CIO[CChunk[B]] =
+        (ctx: LocalCtx) =>
+            given ExecutionContext = parasiticEc
+            val items              = coll.toVector
+            if concurrency == Int.MaxValue then
+                val futs = items.map(a => f(a)(ctx))
+                Future.sequence(futs).map(CChunk.lift(_))
+            else
+                val sem  = new FutureSemaphore(concurrency)
+                val futs = items.map(a => semGated(sem, f(a)(ctx)))
+                Future.sequence(futs).map(CChunk.lift(_))
+            end if
+
+    inline def foreachIndexed[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(f: (Int, A) => CIO[B]): CIO[CChunk[B]] =
+        (ctx: LocalCtx) =>
+            given ExecutionContext = parasiticEc
+            val items              = coll.toVector.zipWithIndex
+            if concurrency == Int.MaxValue then
+                val futs = items.map { case (a, i) => f(i, a)(ctx) }
+                Future.sequence(futs).map(CChunk.lift(_))
+            else
+                val sem  = new FutureSemaphore(concurrency)
+                val futs = items.map { case (a, i) => semGated(sem, f(i, a)(ctx)) }
+                Future.sequence(futs).map(CChunk.lift(_))
+            end if
+
+    inline def foreachDiscard[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(f: A => CIO[Any]): CIO[Unit] =
+        (ctx: LocalCtx) =>
+            given ExecutionContext = parasiticEc
+            val items              = coll.toVector
+            if concurrency == Int.MaxValue then
+                val futs = items.map(a => f(a)(ctx))
+                Future.sequence(futs).map(_ => ())
+            else
+                val sem  = new FutureSemaphore(concurrency)
+                val futs = items.map(a => semGated(sem, f(a)(ctx)))
+                Future.sequence(futs).map(_ => ())
+            end if
+
+    inline def filter[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(p: A => CIO[Boolean]): CIO[CChunk[A]] =
+        (ctx: LocalCtx) =>
+            given ExecutionContext = parasiticEc
+            val items              = coll.toVector
+            if concurrency == Int.MaxValue then
+                val futs = items.map(a => p(a)(ctx))
+                Future.sequence(futs).map(flags =>
+                    CChunk.lift(items.zip(flags).collect { case (a, true) => a })
+                )
+            else
+                val sem  = new FutureSemaphore(concurrency)
+                val futs = items.map(a => semGated(sem, p(a)(ctx)))
+                Future.sequence(futs).map(flags =>
+                    CChunk.lift(items.zip(flags).collect { case (a, true) => a })
+                )
+            end if
+
+    inline def collectAll[A](
+        inline coll: Iterable[CIO[A]],
+        inline concurrency: Int = Int.MaxValue
+    ): CIO[CChunk[A]] =
+        (ctx: LocalCtx) =>
+            given ExecutionContext = parasiticEc
+            val items              = coll.toVector
+            if concurrency == Int.MaxValue then
+                val futs = items.map(c => c(ctx))
+                Future.sequence(futs).map(CChunk.lift(_))
+            else
+                val sem  = new FutureSemaphore(concurrency)
+                val futs = items.map(c => semGated(sem, c(ctx)))
+                Future.sequence(futs).map(CChunk.lift(_))
+            end if
+
+    inline def collectAllDiscard(
+        inline coll: Iterable[CIO[Any]],
+        inline concurrency: Int = Int.MaxValue
+    ): CIO[Unit] =
+        (ctx: LocalCtx) =>
+            given ExecutionContext = parasiticEc
+            val items              = coll.toVector
+            if concurrency == Int.MaxValue then
+                val futs = items.map(c => c(ctx))
+                Future.sequence(futs).map(_ => ())
+            else
+                val sem  = new FutureSemaphore(concurrency)
+                val futs = items.map(c => semGated(sem, c(ctx)))
+                Future.sequence(futs).map(_ => ())
+            end if
+
+    inline def async[A](inline register: ((Try[A] => Unit) => Unit)): CIO[A] =
+        (_: LocalCtx) =>
+            val p = Promise[A]()
+            val cb: Try[A] => Unit = t =>
+                val _ = p.tryComplete(t)
+            try register(cb)
+            catch
+                case t: Throwable if NonFatal(t) =>
+                    val _ = p.tryFailure(t)
+            end try
+            p.future
+
+    inline def blocking[A](inline thunk: => A): CIO[A] =
+        (_: LocalCtx) => Future(scala.concurrent.blocking(thunk))(using ExecutionContext.global)
+
+    /** Yield by bouncing the continuation through `CompatScheduler` (a zero-delay schedule); the caller resumes on a scheduler thread,
+      * breaking any synchronous recursion without occupying the blocking pool.
+      */
+    inline def cede: CIO[Unit] =
+        (_: LocalCtx) =>
+            val p = Promise[Unit]()
+            CompatScheduler.schedule(
+                () =>
+                    p.success(())
+                    ()
+                ,
+                0L,
+                TimeUnit.NANOSECONDS
+            )
+            p.future
+
+    // Each leg is started eagerly (`val fa = a(ctx)` etc.) to force parallelism.
+    inline def zip[A, B](
+        inline a: CIO[A],
+        inline b: CIO[B]
+    ): CIO[(A, B)] =
+        (ctx: LocalCtx) =>
+            val fa = a(ctx)
+            val fb = b(ctx)
+            fa.zip(fb)
+
+    inline def zip[A, B, C](
+        inline a: CIO[A],
+        inline b: CIO[B],
+        inline c: CIO[C]
+    ): CIO[(A, B, C)] =
+        (ctx: LocalCtx) =>
+            val fa = a(ctx)
+            val fb = b(ctx)
+            val fc = c(ctx)
+            fa.flatMap(x => fb.flatMap(y => fc.map(z => (x, y, z))(parasiticEc))(parasiticEc))(parasiticEc)
+
+    inline def zip[A, B, C, D](
+        inline a: CIO[A],
+        inline b: CIO[B],
+        inline c: CIO[C],
+        inline d: CIO[D]
+    ): CIO[(A, B, C, D)] =
+        (ctx: LocalCtx) =>
+            val fa = a(ctx)
+            val fb = b(ctx)
+            val fc = c(ctx)
+            val fd = d(ctx)
+            fa.flatMap(x =>
+                fb.flatMap(y =>
+                    fc.flatMap(z => fd.map(w => (x, y, z, w))(parasiticEc))(parasiticEc)
+                )(parasiticEc)
+            )(parasiticEc)
+
+    inline def zip[A, B, C, D, E1](
+        inline a: CIO[A],
+        inline b: CIO[B],
+        inline c: CIO[C],
+        inline d: CIO[D],
+        inline e: CIO[E1]
+    ): CIO[(A, B, C, D, E1)] =
+        (ctx: LocalCtx) =>
+            val fa = a(ctx)
+            val fb = b(ctx)
+            val fc = c(ctx)
+            val fd = d(ctx)
+            val fe = e(ctx)
+            fa.flatMap(x =>
+                fb.flatMap(y =>
+                    fc.flatMap(z =>
+                        fd.flatMap(w => fe.map(v => (x, y, z, w, v))(parasiticEc))(parasiticEc)
+                    )(parasiticEc)
+                )(parasiticEc)
+            )(parasiticEc)
+
+    inline def zip[A, B, C, D, E1, F](
+        inline a: CIO[A],
+        inline b: CIO[B],
+        inline c: CIO[C],
+        inline d: CIO[D],
+        inline e: CIO[E1],
+        inline f: CIO[F]
+    ): CIO[(A, B, C, D, E1, F)] =
+        (ctx: LocalCtx) =>
+            val fa = a(ctx)
+            val fb = b(ctx)
+            val fc = c(ctx)
+            val fd = d(ctx)
+            val fe = e(ctx)
+            val ff = f(ctx)
+            fa.flatMap(x =>
+                fb.flatMap(y =>
+                    fc.flatMap(z =>
+                        fd.flatMap(w =>
+                            fe.flatMap(v => ff.map(u => (x, y, z, w, v, u))(parasiticEc))(parasiticEc)
+                        )(parasiticEc)
+                    )(parasiticEc)
+                )(parasiticEc)
+            )(parasiticEc)
+
+    inline def zip[A, B, C, D, E1, F, G](
+        inline a: CIO[A],
+        inline b: CIO[B],
+        inline c: CIO[C],
+        inline d: CIO[D],
+        inline e: CIO[E1],
+        inline f: CIO[F],
+        inline g: CIO[G]
+    ): CIO[(A, B, C, D, E1, F, G)] =
+        (ctx: LocalCtx) =>
+            val fa = a(ctx)
+            val fb = b(ctx)
+            val fc = c(ctx)
+            val fd = d(ctx)
+            val fe = e(ctx)
+            val ff = f(ctx)
+            val fg = g(ctx)
+            fa.flatMap(x =>
+                fb.flatMap(y =>
+                    fc.flatMap(z =>
+                        fd.flatMap(w =>
+                            fe.flatMap(v =>
+                                ff.flatMap(u => fg.map(s => (x, y, z, w, v, u, s))(parasiticEc))(parasiticEc)
+                            )(parasiticEc)
+                        )(parasiticEc)
+                    )(parasiticEc)
+                )(parasiticEc)
+            )(parasiticEc)
+
+end CIO

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CIO.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CIO.scala
@@ -178,7 +178,7 @@ object CIO:
             p.future
 
     inline def delay[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[A] =
-        (ctx: LocalCtx) => CIO.sleep(d)(ctx).flatMap(_ => c(ctx))(parasiticEc)
+        (ctx: LocalCtx) => CIO.sleep(d).lower(using ctx).flatMap(_ => c(ctx))(parasiticEc)
 
     /** Winner returned; the loser keeps running orphaned. */
     inline def race[A](

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CLatch.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CLatch.scala
@@ -2,7 +2,6 @@ package kyo.compat
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
-import scala.annotation.publicInBinary
 import scala.concurrent.Future
 import scala.concurrent.Promise
 
@@ -11,7 +10,7 @@ import scala.concurrent.Promise
   * against a lost wakeup. `release` decrements the counter; when it reaches zero all waiters are drained and completed. No
   * platform-specific blocking primitives are used, so this links on JVM, JS, and Native.
   */
-final class CLatch @publicInBinary private[compat] (
+final class CLatch(
     count: AtomicInteger,
     waiters: ConcurrentLinkedQueue[Promise[Unit]]
 ):

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CLatch.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CLatch.scala
@@ -1,0 +1,59 @@
+package kyo.compat
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import scala.annotation.publicInBinary
+import scala.concurrent.Future
+import scala.concurrent.Promise
+
+/** Backed by an `AtomicInteger` counter and a `ConcurrentLinkedQueue` of waiting `Promise[Unit]`s. `init(n <= 0)` produces an
+  * already-released latch. `await` returns immediately when the count is already zero, otherwise enqueues a Promise and re-checks to guard
+  * against a lost wakeup. `release` decrements the counter; when it reaches zero all waiters are drained and completed. No
+  * platform-specific blocking primitives are used, so this links on JVM, JS, and Native.
+  */
+final class CLatch @publicInBinary private[compat] (
+    count: AtomicInteger,
+    waiters: ConcurrentLinkedQueue[Promise[Unit]]
+):
+
+    inline def lower: CLatch = this
+
+    inline def await: CIO[Unit] =
+        CIO.deferLift {
+            if count.get() <= 0 then Future.unit
+            else
+                val p = Promise[Unit]()
+                waiters.offer(p)
+                // Re-check after offer to guard against a lost wakeup where
+                // release() raced between the get() check above and the offer.
+                if count.get() <= 0 then drainWaiters()
+                p.future
+            end if
+        }
+
+    inline def release: CIO[Unit] =
+        CIO.defer {
+            if count.decrementAndGet() <= 0 then drainWaiters()
+        }
+
+    private def drainWaiters(): Unit =
+        var w = waiters.poll()
+        while w ne null do
+            val _ = w.trySuccess(())
+            w = waiters.poll()
+        end while
+    end drainWaiters
+
+end CLatch
+
+object CLatch:
+
+    inline def init(inline n: Int): CIO[CLatch] =
+        CIO.defer(new CLatch(
+            new AtomicInteger(if n <= 0 then 0 else n),
+            new ConcurrentLinkedQueue[Promise[Unit]]()
+        ))
+
+    inline def lift(inline u: CLatch): CLatch = u
+
+end CLatch

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CLocal.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CLocal.scala
@@ -1,0 +1,36 @@
+package kyo.compat
+
+import kyo.compat.internal.LocalCtx
+import scala.annotation.publicInBinary
+import scala.concurrent.Future
+
+/** The `CLocal` instance's own object reference is the lookup key in the immutable `LocalCtx` map threaded through every `CIO` carrier.
+  * `let` produces a child `LocalCtx` with the override and runs `c` under it; continuations within `c` thread the child ctx and see the
+  * value. Outside the `let` scope the value reverts to `default`. No EC dependency, no thread-hop loss.
+  */
+final class CLocal[A] @publicInBinary private[compat] (val default: A):
+
+    inline def lower: CLocal[A] = this
+
+    inline def get: CIO[A] =
+        CIO.deferLift(Future.successful(summon[LocalCtx].get(this, default)))
+
+    inline def let[B](inline value: A)(inline c: CIO[B]): CIO[B] =
+        CIO.deferLift(c.lower(using summon[LocalCtx].updated(this, value)))
+
+    inline def update[B](inline f: A => A)(inline c: CIO[B]): CIO[B] =
+        CIO.deferLift {
+            val ctx = summon[LocalCtx]
+            c.lower(using ctx.updated(this, f(ctx.get(this, default))))
+        }
+
+end CLocal
+
+object CLocal:
+
+    inline def init[A](inline default: A): CIO[CLocal[A]] =
+        CIO.defer(new CLocal[A](default))
+
+    inline def lift[A](inline u: CLocal[A]): CLocal[A] = u
+
+end CLocal

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CLocal.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CLocal.scala
@@ -1,14 +1,13 @@
 package kyo.compat
 
 import kyo.compat.internal.LocalCtx
-import scala.annotation.publicInBinary
 import scala.concurrent.Future
 
 /** The `CLocal` instance's own object reference is the lookup key in the immutable `LocalCtx` map threaded through every `CIO` carrier.
   * `let` produces a child `LocalCtx` with the override and runs `c` under it; continuations within `c` thread the child ctx and see the
   * value. Outside the `let` scope the value reverts to `default`. No EC dependency, no thread-hop loss.
   */
-final class CLocal[A] @publicInBinary private[compat] (val default: A):
+final class CLocal[A](val default: A):
 
     inline def lower: CLocal[A] = this
 

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CMeter.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CMeter.scala
@@ -1,0 +1,119 @@
+package kyo.compat
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import scala.annotation.publicInBinary
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
+
+/** Backed by an `AtomicInteger` permit counter and a `ConcurrentLinkedQueue` of waiting `Promise[Unit]`s. `run` acquires a permit
+  * asynchronously and releases on natural completion (success or failure). Cancellation isn't part of the CIO surface; if the body's Future
+  * is abandoned (e.g. via `CIO.timeout`) the permit is leaked until release is triggered by some other completion. `availablePermits` and
+  * `tryRun` are non-blocking.
+  */
+final class CMeter @publicInBinary private[compat] (
+    avail: AtomicInteger,
+    waiters: ConcurrentLinkedQueue[Promise[Unit]]
+):
+
+    inline def lower: CMeter = this
+
+    inline def run[A](inline c: CIO[A]): CIO[A] =
+        CIO.deferLift {
+            acquirePermit().flatMap { _ =>
+                c.lower.transform { t =>
+                    release()
+                    t
+                }(CMeter.parasiticEc)
+            }(CMeter.parasiticEc)
+        }
+
+    inline def tryRun[A](inline c: CIO[A]): CIO[Option[A]] =
+        CIO.deferLift {
+            if !tryAcquire() then Future.successful(None: Option[A])
+            else
+                c.lower.transform {
+                    case Success(a) =>
+                        release()
+                        Success[Option[A]](Some(a))
+                    case Failure(t) =>
+                        release()
+                        Failure(t)
+                }(CMeter.parasiticEc)
+        }
+
+    inline def availablePermits: CIO[Int] =
+        CIO.defer(math.max(0, avail.get()))
+
+    private def acquirePermit(): Future[Unit] =
+        if avail.getAndDecrement() > 0 then Future.unit
+        else
+            val p = Promise[Unit]()
+            waiters.offer(p)
+            if avail.get() >= 0 then drainWaiters()
+            p.future
+        end if
+    end acquirePermit
+
+    private def tryAcquire(): Boolean =
+        var result = false
+        var retry  = true
+        while retry do
+            val v = avail.get()
+            if v <= 0 then retry = false
+            else if avail.compareAndSet(v, v - 1) then
+                result = true
+                retry = false
+            end if
+        end while
+        result
+    end tryAcquire
+
+    private def release(): Unit =
+        val w = waiters.poll()
+        if w ne null then
+            if !w.trySuccess(()) then release()
+        else
+            val _ = avail.incrementAndGet()
+            drainWaiters()
+        end if
+    end release
+
+    private def drainWaiters(): Unit =
+        var continue = true
+        while continue do
+            val w = waiters.peek()
+            if w eq null then continue = false
+            else if avail.get() > 0 then
+                val taken = waiters.poll()
+                if taken ne null then
+                    if avail.getAndDecrement() > 0 then
+                        if !taken.trySuccess(()) then
+                            val _ = avail.incrementAndGet()
+                    else
+                        waiters.offer(taken)
+                        continue = false
+                    end if
+                end if
+            else continue = false
+            end if
+        end while
+    end drainWaiters
+
+end CMeter
+
+object CMeter:
+
+    private val parasiticEc = scala.concurrent.ExecutionContext.parasitic
+
+    inline def init(inline permits: Int): CIO[CMeter] =
+        CIO.defer(new CMeter(
+            new AtomicInteger(if permits < 0 then 0 else permits),
+            new ConcurrentLinkedQueue[Promise[Unit]]()
+        ))
+
+    inline def lift(inline u: CMeter): CMeter = u
+
+end CMeter

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CMeter.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CMeter.scala
@@ -2,7 +2,6 @@ package kyo.compat
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
-import scala.annotation.publicInBinary
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Failure
@@ -13,7 +12,7 @@ import scala.util.Success
   * is abandoned (e.g. via `CIO.timeout`) the permit is leaked until release is triggered by some other completion. `availablePermits` and
   * `tryRun` are non-blocking.
   */
-final class CMeter @publicInBinary private[compat] (
+final class CMeter(
     avail: AtomicInteger,
     waiters: ConcurrentLinkedQueue[Promise[Unit]]
 ):

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CPromise.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/CPromise.scala
@@ -1,0 +1,28 @@
+package kyo.compat
+
+import scala.concurrent.Promise
+import scala.util.Try
+
+/** Backed by `scala.concurrent.Promise[A]`. */
+opaque type CPromise[A] = Promise[A]
+
+object CPromise:
+
+    inline def init[A]: CIO[CPromise[A]] =
+        CIO.defer(Promise[A]())
+
+    inline def lift[A](inline u: Promise[A]): CPromise[A] = u
+
+    extension [A](inline self: CPromise[A])
+
+        inline def lower: Promise[A] = self
+
+        inline def succeed(inline a: A): CIO[Boolean]      = CIO.defer(self.trySuccess(a))
+        inline def fail(inline e: Throwable): CIO[Boolean] = CIO.defer(self.tryFailure(e))
+        inline def get: CIO[A]                             = CIO.lift(self.future)
+        inline def poll: CIO[Option[Try[A]]]               = CIO.defer(self.future.value)
+        inline def done: CIO[Boolean]                      = CIO.defer(self.future.isCompleted)
+
+    end extension
+
+end CPromise

--- a/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/internal/LocalCtx.scala
+++ b/kyo-compat/bindings/future/shared/src/main/scala/kyo/compat/internal/LocalCtx.scala
@@ -1,0 +1,21 @@
+package kyo.compat.internal
+
+/** Immutable local-context map threaded through every `CIO` carrier. `CLocal.let` produces a child ctx; `CLocal.get` reads it. The empty
+  * ctx is the root passed by `CIO.unsafeRun`. Backed by `scala.collection.immutable.Map[Any, Any]` so opaque-typed keys (e.g. `CLocal[A]`)
+  * work without an `AnyRef` widening that opacity at the call site would block.
+  */
+opaque type LocalCtx = Map[Any, Any]
+
+object LocalCtx:
+    val empty: LocalCtx = Map.empty
+
+    extension (inline ctx: LocalCtx)
+
+        inline def get[A](inline key: Any, inline default: A): A =
+            (ctx: Map[Any, Any]).getOrElse(key, default).asInstanceOf[A]
+
+        inline def updated(inline key: Any, inline value: Any): LocalCtx =
+            (ctx: Map[Any, Any]).updated(key, value)
+
+    end extension
+end LocalCtx

--- a/kyo-compat/bindings/kyo/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
+++ b/kyo-compat/bindings/kyo/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
@@ -1,0 +1,19 @@
+package kyo.compat
+
+import java.util.concurrent.CompletionStage
+import kyo.*
+
+/** JVM-only. Lifts a `CompletionStage[A]` into `CIO[A]`. Failures surface as `Abort[Throwable]`. Cancellation does NOT propagate back. */
+object CompatFromCompletionStage:
+
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A])(using inline frame: Frame): CIO[A] =
+        CIO.lift(Async.fromCompletionStage(cs))
+
+end CompatFromCompletionStage
+
+extension (inline c: CIO.type)
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A])(
+        using inline frame: Frame
+    ): CIO[A] =
+        CompatFromCompletionStage.fromCompletionStage(cs)
+end extension

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CAtomicBoolean.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CAtomicBoolean.scala
@@ -1,0 +1,30 @@
+package kyo.compat
+
+import kyo.*
+
+/** Backed by kyo.AtomicBoolean. */
+opaque type CAtomicBoolean = AtomicBoolean
+
+object CAtomicBoolean:
+
+    inline def init(inline v: Boolean)(using inline frame: Frame): CIO[CAtomicBoolean] =
+        CIO.lift(AtomicBoolean.init(v))
+
+    inline def lift(inline u: AtomicBoolean): CAtomicBoolean = u
+
+    extension (inline self: CAtomicBoolean)
+
+        inline def lower: AtomicBoolean = self
+
+        inline def get(using inline frame: Frame): CIO[Boolean]                          = CIO.lift(self.get)
+        inline def set(inline v: Boolean)(using inline frame: Frame): CIO[Unit]          = CIO.lift(self.set(v))
+        inline def getAndSet(inline v: Boolean)(using inline frame: Frame): CIO[Boolean] = CIO.lift(self.getAndSet(v))
+
+        inline def compareAndSet(inline expected: Boolean, inline updated: Boolean)(
+            using inline frame: Frame
+        ): CIO[Boolean] =
+            CIO.lift(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicBoolean

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CAtomicInt.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CAtomicInt.scala
@@ -1,0 +1,36 @@
+package kyo.compat
+
+import kyo.*
+
+/** Backed by kyo.AtomicInt. */
+opaque type CAtomicInt = AtomicInt
+
+object CAtomicInt:
+
+    inline def init(inline v: Int)(using inline frame: Frame): CIO[CAtomicInt] =
+        CIO.lift(AtomicInt.init(v))
+
+    inline def lift(inline u: AtomicInt): CAtomicInt = u
+
+    extension (inline self: CAtomicInt)
+
+        inline def lower: AtomicInt = self
+
+        inline def get(using inline frame: Frame): CIO[Int]                          = CIO.lift(self.get)
+        inline def set(inline v: Int)(using inline frame: Frame): CIO[Unit]          = CIO.lift(self.set(v))
+        inline def getAndSet(inline v: Int)(using inline frame: Frame): CIO[Int]     = CIO.lift(self.getAndSet(v))
+        inline def incrementAndGet(using inline frame: Frame): CIO[Int]              = CIO.lift(self.incrementAndGet)
+        inline def getAndIncrement(using inline frame: Frame): CIO[Int]              = CIO.lift(self.getAndIncrement)
+        inline def decrementAndGet(using inline frame: Frame): CIO[Int]              = CIO.lift(self.decrementAndGet)
+        inline def getAndDecrement(using inline frame: Frame): CIO[Int]              = CIO.lift(self.getAndDecrement)
+        inline def addAndGet(inline delta: Int)(using inline frame: Frame): CIO[Int] = CIO.lift(self.addAndGet(delta))
+        inline def getAndAdd(inline delta: Int)(using inline frame: Frame): CIO[Int] = CIO.lift(self.getAndAdd(delta))
+
+        inline def compareAndSet(inline expected: Int, inline updated: Int)(
+            using inline frame: Frame
+        ): CIO[Boolean] =
+            CIO.lift(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicInt

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CAtomicLong.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CAtomicLong.scala
@@ -1,0 +1,36 @@
+package kyo.compat
+
+import kyo.*
+
+/** Backed by kyo.AtomicLong. */
+opaque type CAtomicLong = AtomicLong
+
+object CAtomicLong:
+
+    inline def init(inline v: Long)(using inline frame: Frame): CIO[CAtomicLong] =
+        CIO.lift(AtomicLong.init(v))
+
+    inline def lift(inline u: AtomicLong): CAtomicLong = u
+
+    extension (inline self: CAtomicLong)
+
+        inline def lower: AtomicLong = self
+
+        inline def get(using inline frame: Frame): CIO[Long]                           = CIO.lift(self.get)
+        inline def set(inline v: Long)(using inline frame: Frame): CIO[Unit]           = CIO.lift(self.set(v))
+        inline def getAndSet(inline v: Long)(using inline frame: Frame): CIO[Long]     = CIO.lift(self.getAndSet(v))
+        inline def incrementAndGet(using inline frame: Frame): CIO[Long]               = CIO.lift(self.incrementAndGet)
+        inline def getAndIncrement(using inline frame: Frame): CIO[Long]               = CIO.lift(self.getAndIncrement)
+        inline def decrementAndGet(using inline frame: Frame): CIO[Long]               = CIO.lift(self.decrementAndGet)
+        inline def getAndDecrement(using inline frame: Frame): CIO[Long]               = CIO.lift(self.getAndDecrement)
+        inline def addAndGet(inline delta: Long)(using inline frame: Frame): CIO[Long] = CIO.lift(self.addAndGet(delta))
+        inline def getAndAdd(inline delta: Long)(using inline frame: Frame): CIO[Long] = CIO.lift(self.getAndAdd(delta))
+
+        inline def compareAndSet(inline expected: Long, inline updated: Long)(
+            using inline frame: Frame
+        ): CIO[Boolean] =
+            CIO.lift(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicLong

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CAtomicRef.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CAtomicRef.scala
@@ -1,0 +1,36 @@
+package kyo.compat
+
+import kyo.*
+
+/** Backed by kyo.AtomicRef[A]. */
+opaque type CAtomicRef[A] = AtomicRef[A]
+
+object CAtomicRef:
+
+    inline def init[A](inline a: A)(using inline frame: Frame): CIO[CAtomicRef[A]] =
+        CIO.lift(AtomicRef.init[A](a))
+
+    inline def lift[A](inline u: AtomicRef[A]): CAtomicRef[A] = u
+
+    extension [A](inline self: CAtomicRef[A])
+
+        inline def lower: AtomicRef[A] = self
+
+        inline def get(using inline frame: Frame): CIO[A]                    = CIO.lift(self.lower.get)
+        inline def set(inline a: A)(using inline frame: Frame): CIO[Unit]    = CIO.lift(self.lower.set(a))
+        inline def getAndSet(inline a: A)(using inline frame: Frame): CIO[A] = CIO.lift(self.lower.getAndSet(a))
+
+        inline def updateAndGet(inline f: A => A)(using inline frame: Frame): CIO[A] =
+            CIO.lift(self.lower.updateAndGet(f))
+
+        inline def getAndUpdate(inline f: A => A)(using inline frame: Frame): CIO[A] =
+            CIO.lift(self.lower.getAndUpdate(f))
+
+        inline def compareAndSet(inline expected: A, inline updated: A)(
+            using inline frame: Frame
+        ): CIO[Boolean] =
+            CIO.lift(self.lower.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicRef

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CChannel.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CChannel.scala
@@ -1,0 +1,27 @@
+package kyo.compat
+
+import kyo.*
+
+/** Backed by kyo.Channel[A]. put/take/poll discharge Abort[Closed] as panic (surface never closes the channel). poll returns Option[A].
+  * `kyo.Channel` rounds capacity up to the next power of two on the JVM; pass exact powers when the precise bound matters.
+  */
+opaque type CChannel[A] = Channel[A]
+
+object CChannel:
+
+    inline def init[A](inline capacity: Int)(using inline frame: Frame): CIO[CChannel[A]] =
+        CIO.lift(Channel.initUnscoped[A](capacity))
+
+    inline def lift[A](inline u: Channel[A]): CChannel[A] = u
+
+    extension [A](inline self: CChannel[A])
+
+        inline def lower: Channel[A] = self
+
+        inline def put(inline v: A)(using inline frame: Frame): CIO[Unit] = CIO.lift(Channel.put(self.lower)(v))
+        inline def take(using inline frame: Frame): CIO[A]                = CIO.lift(Channel.take(self.lower))
+        inline def poll(using inline frame: Frame): CIO[Option[A]]        = CIO.lift(Channel.poll(self.lower).map(_.toOption))
+
+    end extension
+
+end CChannel

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CChunk.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CChunk.scala
@@ -1,0 +1,22 @@
+package kyo.compat
+
+/** Backed by kyo.Chunk[A]. */
+opaque type CChunk[+A] = kyo.Chunk[A]
+
+object CChunk:
+
+    inline def lift[A](inline c: kyo.Chunk[A]): CChunk[A] = c
+
+    extension [A](inline self: CChunk[A])
+
+        inline def lower: kyo.Chunk[A]         = self
+        inline def toSeq: Seq[A]               = self.toSeq
+        inline def toIndexedSeq: IndexedSeq[A] = self.toIndexedSeq
+        inline def apply(inline i: Int): A     = self(i)
+        inline def size: Int                   = self.size
+        inline def iterator: Iterator[A]       = self.iterator
+        inline def isEmpty: Boolean            = self.isEmpty
+
+    end extension
+
+end CChunk

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CFiber.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CFiber.scala
@@ -1,0 +1,35 @@
+package kyo.compat
+
+import kyo.*
+
+opaque type CFiber[+A] = Fiber[A, Abort[Throwable]]
+
+object CFiber:
+
+    inline def init[A](inline c: CIO[A])(using inline frame: Frame): CIO[CFiber[A]] =
+        CIO.lift(Fiber.initUnscoped(c.lower))
+
+    inline def lift[A](inline u: Fiber[A, Abort[Throwable]]): CFiber[A] = u
+
+    extension [A](inline self: CFiber[A])
+
+        inline def lower: Fiber[A, Abort[Throwable]] = self
+
+        inline def get(using inline frame: Frame): CIO[A] =
+            CIO.lift(Fiber.get(self.lower))
+
+        inline def onComplete(inline cb: scala.util.Try[A] => CIO[Unit])(
+            using inline frame: Frame
+        ): CIO[Unit] =
+            CIO.lift {
+                Fiber.onComplete(self.lower) { (r: Result[Throwable, A < Any]) =>
+                    val tr: scala.util.Try[A] = r match
+                        case Result.Failure(e) => scala.util.Failure(e)
+                        case Result.Panic(t)   => scala.util.Failure(t)
+                        case Result.Success(a) => scala.util.Success(a.eval)
+                    Fiber.initUnscoped(cb(tr).lower)
+                }
+            }
+
+    end extension
+end CFiber

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CIO.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CIO.scala
@@ -1,0 +1,285 @@
+package kyo.compat
+
+import kyo.*
+import kyo.kernel.`<`
+import scala.concurrent.Future as ScalaFuture
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.NANOSECONDS
+import scala.util.control.NonFatal
+
+/** Underlying carrier is `A < (Abort[Throwable] & Async)`. E is covariant at the surface (hidden invariance from Abort). acquireReleaseWith
+  * uses Scope.acquireRelease; release Aborts/panics surface as acquireReleaseWith failures via Kyo's effect channels.
+  * foreach/filter/collectAll accept an optional `concurrency` parameter (default `Int.MaxValue`, i.e. unbounded). cede and blocking are
+  * no-ops (Kyo scheduler is preemptive).
+  */
+opaque type CIO[+A] = A < (Abort[Throwable] & Async)
+
+object CIO:
+
+    inline def lift[A](inline v: A < (Abort[Throwable] & Async)): CIO[A] = v
+
+    /** Suspends side-effecting code that produces a Kyo computation, deferring its construction to effect-evaluation time. */
+    inline def deferLift[A](inline v: => (A < (Abort[Throwable] & Async)))(using inline frame: Frame): CIO[A] =
+        CIO.lift(Sync.defer(v))
+
+    inline def value[A](inline a: A): CIO[A] = CIO.lift(a)
+
+    inline def unit: CIO[Unit] = CIO.lift(())
+
+    inline def defer[A](inline thunk: => A)(using inline frame: Frame): CIO[A] =
+        CIO.lift(Sync.defer(thunk))
+
+    inline def fail(inline e: Throwable)(using inline frame: Frame): CIO[Nothing] =
+        CIO.lift(Abort.fail(e))
+
+    inline def get[A](inline t: scala.util.Try[A])(using inline frame: Frame): CIO[A] =
+        CIO.lift(Abort.get[A](t))
+
+    inline def fromScalaFuture[A](inline f: ScalaFuture[A])(using inline frame: Frame): CIO[A] =
+        CIO.lift(Async.fromFuture(f))
+
+    inline def acquireReleaseWith[A, B](
+        inline acquire: CIO[A]
+    )(
+        inline release: A => CIO[Unit]
+    )(
+        inline use: A => CIO[B]
+    )(using inline frame: Frame): CIO[B] =
+        CIO.lift {
+            Scope.run {
+                Scope.acquireRelease(acquire.lower)(release(_).lower).map(use(_).lower)
+            }
+        }
+    end acquireReleaseWith
+
+    inline def ensure[A](
+        inline cleanup: CIO[Unit]
+    )(
+        inline c: CIO[A]
+    )(using inline frame: Frame): CIO[A] =
+        CIO.lift(Scope.run(`<`.map(Scope.ensure(cleanup.lower))(_ => c.lower)))
+
+    inline def never: CIO[Nothing] =
+        CIO.lift(Async.never[Nothing])
+
+    extension [A](inline self: CIO[A])
+
+        inline def lower: A < (Abort[Throwable] & Async) = self
+
+        inline def recover[A2 >: A](inline handler: Throwable => CIO[A2])(
+            using inline frame: Frame
+        ): CIO[A2] =
+            CIO.lift(Abort.recover[Throwable](e =>
+                try handler(e).lower
+                catch case t: Throwable if NonFatal(t) => Abort.fail(t)
+            )(self.lower))
+
+        inline def fold[B](
+            inline onSuccess: A => CIO[B],
+            inline onFail: Throwable => CIO[B]
+        )(using inline frame: Frame): CIO[B] =
+            CIO.lift(
+                Abort.fold[Throwable](
+                    (a: A) =>
+                        try onSuccess(a).lower
+                        catch case t: Throwable if NonFatal(t) => Abort.fail(t),
+                    (e: Throwable) =>
+                        try onFail(e).lower
+                        catch case t: Throwable if NonFatal(t) => Abort.fail(t)
+                )(self.lower)
+            )
+
+        inline def liftToTry(using inline frame: Frame): CIO[scala.util.Try[A]] =
+            CIO.lift(Abort.run[Throwable](self.lower).map {
+                case Result.Success(a) => scala.util.Success(a)
+                case Result.Failure(e) => scala.util.Failure(e)
+                case Result.Panic(t)   => scala.util.Failure(t)
+            })
+
+        inline def unit(using inline frame: Frame): CIO[Unit] =
+            CIO.lift(<.unit(self.lower))
+
+        inline def orElse[A2 >: A](inline that: CIO[A2])(
+            using inline frame: Frame
+        ): CIO[A2] =
+            CIO.lift(Abort.recover[Throwable](_ => that.lower)(self.lower))
+
+        inline def mapError(inline f: Throwable => Throwable)(
+            using inline frame: Frame
+        ): CIO[A] =
+            CIO.lift(Abort.recover[Throwable](e => Abort.fail(f(e)))(self.lower))
+
+        inline def map[B](inline f: A => B)(using inline frame: Frame): CIO[B] =
+            CIO.lift(<.map(self.lower)(f))
+
+        inline def flatMap[B](inline f: A => CIO[B])(using inline frame: Frame): CIO[B] =
+            CIO.lift(`<`.flatMap(self.lower)(a => f(a).lower))
+
+        inline def unsafeRun(using inline frame: Frame): scala.concurrent.Future[A] =
+            import AllowUnsafe.embrace.danger
+            Sync.Unsafe.evalOrThrow(<.map(Fiber.initUnscoped(self.lower))(_.toFuture))
+
+    end extension
+
+    inline def sleep(inline d: FiniteDuration)(using inline frame: Frame): CIO[Unit] =
+        CIO.lift(Async.sleep(Duration.fromScala(d)))
+
+    inline def now(using inline frame: Frame): CIO[java.time.Instant] =
+        CIO.lift(Clock.nowWith(_.toJava))
+
+    inline def nowMonotonic(using inline frame: Frame): CIO[FiniteDuration] =
+        CIO.lift(Clock.nowMonotonic.map(d => FiniteDuration(kyo.Duration.toNanos(d), NANOSECONDS)))
+
+    inline def timeout[A](inline d: FiniteDuration)(inline c: CIO[A])(
+        using inline frame: Frame
+    ): CIO[Option[A]] =
+        CIO.lift(
+            Async.timeout(Duration.fromScala(d))(c.lower.map(Option(_)))
+                .handle(Abort.recover[Timeout](_ => Option.empty))
+        )
+
+    inline def timeoutWithError[A](inline d: FiniteDuration)(inline e: Throwable)(inline c: CIO[A])(
+        using inline frame: Frame
+    ): CIO[A] =
+        CIO.lift(Async.timeoutWithError(Duration.fromScala(d), Result.Failure(e))(c.lower))
+
+    inline def delay[A](inline d: FiniteDuration)(inline c: CIO[A])(
+        using inline frame: Frame
+    ): CIO[A] =
+        CIO.lift(Async.delay(Duration.fromScala(d))(c.lower))
+
+    inline def race[A](
+        inline a: CIO[A],
+        inline b: CIO[A]
+    )(using inline frame: Frame): CIO[A] =
+        CIO.lift(Async.race(a.lower, b.lower))
+
+    inline def foreach[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline f: A => CIO[B])(
+        using inline frame: Frame
+    ): CIO[CChunk[B]] =
+        CIO.lift(Async.foreach(coll, concurrency)(a => f(a).lower).map(CChunk.lift(_)))
+
+    inline def foreachIndexed[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline f: (Int, A) => CIO[B])(
+        using inline frame: Frame
+    ): CIO[CChunk[B]] =
+        CIO.lift(Async.foreachIndexed(coll, concurrency)((i, a) => f(i, a).lower).map(CChunk.lift(_)))
+
+    inline def foreachDiscard[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline f: A => CIO[Any])(
+        using inline frame: Frame
+    ): CIO[Unit] =
+        CIO.lift(Async.foreachDiscard(coll, concurrency)(a => f(a).lower))
+
+    inline def filter[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline p: A => CIO[Boolean])(
+        using inline frame: Frame
+    ): CIO[CChunk[A]] =
+        CIO.lift(Async.filter(coll, concurrency)(a => p(a).lower).map(CChunk.lift(_)))
+
+    inline def collectAll[A](
+        inline coll: Iterable[CIO[A]],
+        inline concurrency: Int = Int.MaxValue
+    )(
+        using inline frame: Frame
+    ): CIO[CChunk[A]] =
+        CIO.lift(Async.collectAll(coll.map(_.lower), concurrency).map(CChunk.lift(_)))
+
+    inline def collectAllDiscard(
+        inline coll: Iterable[CIO[Any]],
+        inline concurrency: Int = Int.MaxValue
+    )(
+        using inline frame: Frame
+    ): CIO[Unit] =
+        CIO.lift(Async.collectAllDiscard(coll.map(_.lower), concurrency))
+
+    inline def async[A](inline register: ((scala.util.Try[A] => Unit) => Unit))(
+        using inline frame: Frame
+    ): CIO[A] =
+        CIO.lift {
+            Sync.Unsafe.defer {
+                val p = Promise.Unsafe.init[A, Abort[Throwable]]()
+                val cb: scala.util.Try[A] => Unit = {
+                    case scala.util.Success(a) => p.completeDiscard(Result.succeed(a))
+                    case scala.util.Failure(t) => p.completeDiscard(Result.fail(t))
+                }
+                try register(cb)
+                catch case t: Throwable if NonFatal(t) => p.completeDiscard(Result.fail(t))
+                Fiber.get(p.safe)
+            }
+        }
+
+    inline def blocking[A](inline thunk: => A)(using inline frame: Frame): CIO[A] =
+        CIO.lift(Sync.defer(thunk))
+
+    inline def cede: CIO[Unit] = Sync.defer(())
+
+    inline def zip[A1, A2](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2]
+    )(using inline frame: Frame): CIO[(A1, A2)] =
+        CIO.lift(Async.zip(a1.lower, a2.lower))
+
+    inline def zip[A1, A2, A3](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3]
+    )(using inline frame: Frame): CIO[(A1, A2, A3)] =
+        CIO.lift(Async.zip(a1.lower, a2.lower, a3.lower))
+
+    inline def zip[A1, A2, A3, A4](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4]
+    )(using inline frame: Frame): CIO[(A1, A2, A3, A4)] =
+        CIO.lift(Async.zip(a1.lower, a2.lower, a3.lower, a4.lower))
+
+    inline def zip[A1, A2, A3, A4, A5](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5]
+    )(using inline frame: Frame): CIO[(A1, A2, A3, A4, A5)] =
+        CIO.lift(Async.zip(a1.lower, a2.lower, a3.lower, a4.lower, a5.lower))
+
+    inline def zip[A1, A2, A3, A4, A5, A6](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5],
+        inline a6: CIO[A6]
+    )(using inline frame: Frame): CIO[(A1, A2, A3, A4, A5, A6)] =
+        CIO.lift(Async.zip(a1.lower, a2.lower, a3.lower, a4.lower, a5.lower, a6.lower))
+
+    inline def zip[A1, A2, A3, A4, A5, A6, A7](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5],
+        inline a6: CIO[A6],
+        inline a7: CIO[A7]
+    )(using inline frame: Frame): CIO[(A1, A2, A3, A4, A5, A6, A7)] =
+        CIO.lift(Async.zip(
+            a1.lower,
+            a2.lower,
+            a3.lower,
+            a4.lower,
+            a5.lower,
+            a6.lower,
+            a7.lower
+        ))
+
+end CIO

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CLatch.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CLatch.scala
@@ -1,0 +1,24 @@
+package kyo.compat
+
+import kyo.*
+
+/** Backed by kyo.Latch. */
+opaque type CLatch = Latch
+
+object CLatch:
+
+    inline def init(inline n: Int)(using inline frame: Frame): CIO[CLatch] =
+        CIO.lift(Latch.init(n))
+
+    inline def lift(inline u: Latch): CLatch = u
+
+    extension (inline self: CLatch)
+
+        inline def lower: Latch = self
+
+        inline def await(using inline frame: Frame): CIO[Unit]   = CIO.lift(self.await)
+        inline def release(using inline frame: Frame): CIO[Unit] = CIO.lift(self.release)
+
+    end extension
+
+end CLatch

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CLocal.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CLocal.scala
@@ -1,0 +1,34 @@
+package kyo.compat
+
+import kyo.*
+
+/** Backed by kyo.Local[A]. Propagation is automatic across Kyo async boundaries. `init` is deferred so each call to `CLocal.init`
+  * constructs a fresh Local at effect-evaluation time.
+  */
+opaque type CLocal[A] = Local[A]
+
+object CLocal:
+
+    inline def init[A](inline default: A)(using inline frame: Frame): CIO[CLocal[A]] =
+        CIO.defer(Local.init[A](default))
+
+    inline def lift[A](inline u: Local[A]): CLocal[A] = u
+
+    extension [A](inline self: CLocal[A])
+
+        inline def lower: Local[A] = self
+
+        inline def get(using inline frame: Frame): CIO[A] =
+            CIO.lift(self.get)
+
+        inline def let[B](inline v: A)(inline c: CIO[B])(
+            using inline frame: Frame
+        ): CIO[B] =
+            CIO.lift(self.let(v)(c.lower))
+
+        inline def update[B](inline f: A => A)(inline c: CIO[B])(
+            using inline frame: Frame
+        ): CIO[B] =
+            CIO.lift(self.update(f)(c.lower))
+    end extension
+end CLocal

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CMeter.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CMeter.scala
@@ -1,0 +1,41 @@
+package kyo.compat
+
+import kyo.*
+
+/** Backed by kyo.Meter (semaphore). `run` wraps the body in `Abort.run` so the permit is released even when the body fails. `Closed` is a
+  * `Throwable`, so `Meter`'s `Abort[Closed]` widens into the CIO carrier's `Abort[Throwable]` channel with no explicit handling.
+  */
+opaque type CMeter = Meter
+
+object CMeter:
+
+    inline def init(inline permits: Int)(using inline frame: Frame): CIO[CMeter] =
+        CIO.lift(Meter.initSemaphoreUnscoped(permits))
+
+    inline def lift(inline u: Meter): CMeter = u
+
+    extension (inline self: CMeter)
+
+        inline def lower: Meter = self
+
+        inline def run[A](inline c: CIO[A])(
+            using inline frame: Frame
+        ): CIO[A] =
+            CIO.lift(
+                self.run(Abort.run[Throwable](c.lower)).map {
+                    case Result.Success(a) => a
+                    case Result.Failure(t) => Abort.fail(t)
+                    case Result.Panic(t)   => Abort.panic(t)
+                }
+            )
+
+        inline def tryRun[A](inline c: CIO[A])(
+            using inline frame: Frame
+        ): CIO[Option[A]] =
+            CIO.lift(self.tryRun(c.lower).map(_.toOption))
+
+        inline def availablePermits(using inline frame: Frame): CIO[Int] =
+            CIO.lift(self.availablePermits)
+    end extension
+
+end CMeter

--- a/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CPromise.scala
+++ b/kyo-compat/bindings/kyo/shared/src/main/scala/kyo/compat/CPromise.scala
@@ -1,0 +1,46 @@
+package kyo.compat
+
+import kyo.*
+
+/** Backed by kyo.Promise[A, Abort[Throwable]]. poll maps Result to Option[Try[A]]. */
+opaque type CPromise[A] = Promise[A, Abort[Throwable]]
+
+object CPromise:
+
+    inline def init[A](using inline frame: Frame): CIO[CPromise[A]] =
+        CIO.lift(Promise.init[A, Abort[Throwable]])
+
+    inline def lift[A](inline u: Promise[A, Abort[Throwable]]): CPromise[A] = u
+
+    extension [A](inline self: CPromise[A])
+
+        inline def lower: Promise[A, Abort[Throwable]] = self
+
+        inline def succeed(inline a: A)(using inline frame: Frame): CIO[Boolean] =
+            CIO.lift(Promise.complete(self.lower)(Result.succeed(a)))
+
+        inline def fail(inline e: Throwable)(using inline frame: Frame): CIO[Boolean] =
+            CIO.lift(Promise.complete(self.lower)(Result.fail(e)))
+
+        inline def get(using inline frame: Frame): CIO[A] =
+            CIO.lift(Fiber.mask(self.lower).map(masked => Fiber.get(masked)))
+
+        inline def poll(using inline frame: Frame): CIO[Option[scala.util.Try[A]]] =
+            CIO.lift(
+                Fiber.poll(self.lower).map {
+                    case Absent => Option.empty
+                    case Present(s: Result.Success[A < Any] @unchecked) =>
+                        s.successValue.map(a => Option(scala.util.Success(a)))
+                    case Present(f: Result.Failure[Throwable] @unchecked) =>
+                        (Option(scala.util.Failure(f.failure)))
+                    case Present(p: Result.Panic) =>
+                        (Option(scala.util.Failure(p.exception)))
+                }
+            )
+
+        inline def done(using inline frame: Frame): CIO[Boolean] =
+            CIO.lift(Fiber.done(self.lower))
+
+    end extension
+
+end CPromise

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CAtomicBoolean.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CAtomicBoolean.scala
@@ -1,0 +1,28 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Backed by `java.util.concurrent.atomic.AtomicBoolean`. */
+opaque type CAtomicBoolean = AtomicBoolean
+
+object CAtomicBoolean:
+
+    inline def init(inline v: Boolean): CIO[CAtomicBoolean] =
+        CIO.defer(new AtomicBoolean(v))
+
+    inline def lift(inline u: AtomicBoolean): CAtomicBoolean = u
+
+    extension (inline self: CAtomicBoolean)
+
+        inline def lower: AtomicBoolean = self
+
+        inline def get: CIO[Boolean]                          = CIO.defer(self.get())
+        inline def set(inline v: Boolean): CIO[Unit]          = CIO.defer(self.set(v))
+        inline def getAndSet(inline v: Boolean): CIO[Boolean] = CIO.defer(self.getAndSet(v))
+
+        inline def compareAndSet(inline expected: Boolean, inline updated: Boolean): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicBoolean

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CAtomicInt.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CAtomicInt.scala
@@ -1,0 +1,34 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Backed by `java.util.concurrent.atomic.AtomicInteger`. */
+opaque type CAtomicInt = AtomicInteger
+
+object CAtomicInt:
+
+    inline def init(inline v: Int): CIO[CAtomicInt] =
+        CIO.defer(new AtomicInteger(v))
+
+    inline def lift(inline u: AtomicInteger): CAtomicInt = u
+
+    extension (inline self: CAtomicInt)
+
+        inline def lower: AtomicInteger = self
+
+        inline def get: CIO[Int]                          = CIO.defer(self.get())
+        inline def set(inline v: Int): CIO[Unit]          = CIO.defer(self.set(v))
+        inline def getAndSet(inline v: Int): CIO[Int]     = CIO.defer(self.getAndSet(v))
+        inline def incrementAndGet: CIO[Int]              = CIO.defer(self.incrementAndGet())
+        inline def getAndIncrement: CIO[Int]              = CIO.defer(self.getAndIncrement())
+        inline def decrementAndGet: CIO[Int]              = CIO.defer(self.decrementAndGet())
+        inline def getAndDecrement: CIO[Int]              = CIO.defer(self.getAndDecrement())
+        inline def addAndGet(inline delta: Int): CIO[Int] = CIO.defer(self.addAndGet(delta))
+        inline def getAndAdd(inline delta: Int): CIO[Int] = CIO.defer(self.getAndAdd(delta))
+
+        inline def compareAndSet(inline expected: Int, inline updated: Int): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicInt

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CAtomicLong.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CAtomicLong.scala
@@ -1,0 +1,34 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicLong
+
+/** Backed by `java.util.concurrent.atomic.AtomicLong`. */
+opaque type CAtomicLong = AtomicLong
+
+object CAtomicLong:
+
+    inline def init(inline v: Long): CIO[CAtomicLong] =
+        CIO.defer(new AtomicLong(v))
+
+    inline def lift(inline u: AtomicLong): CAtomicLong = u
+
+    extension (inline self: CAtomicLong)
+
+        inline def lower: AtomicLong = self
+
+        inline def get: CIO[Long]                           = CIO.defer(self.get())
+        inline def set(inline v: Long): CIO[Unit]           = CIO.defer(self.set(v))
+        inline def getAndSet(inline v: Long): CIO[Long]     = CIO.defer(self.getAndSet(v))
+        inline def incrementAndGet: CIO[Long]               = CIO.defer(self.incrementAndGet())
+        inline def getAndIncrement: CIO[Long]               = CIO.defer(self.getAndIncrement())
+        inline def decrementAndGet: CIO[Long]               = CIO.defer(self.decrementAndGet())
+        inline def getAndDecrement: CIO[Long]               = CIO.defer(self.getAndDecrement())
+        inline def addAndGet(inline delta: Long): CIO[Long] = CIO.defer(self.addAndGet(delta))
+        inline def getAndAdd(inline delta: Long): CIO[Long] = CIO.defer(self.getAndAdd(delta))
+
+        inline def compareAndSet(inline expected: Long, inline updated: Long): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicLong

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CAtomicRef.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CAtomicRef.scala
@@ -1,0 +1,29 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicReference
+
+/** Backed by `java.util.concurrent.atomic.AtomicReference[A]`. */
+opaque type CAtomicRef[A] = AtomicReference[A]
+
+object CAtomicRef:
+
+    inline def init[A](inline a: A): CIO[CAtomicRef[A]] =
+        CIO.defer(new AtomicReference[A](a))
+
+    inline def lift[A](inline u: AtomicReference[A]): CAtomicRef[A] = u
+
+    extension [A](inline self: CAtomicRef[A])
+
+        inline def lower: AtomicReference[A] = self
+
+        inline def get: CIO[A]                            = CIO.defer(self.get())
+        inline def set(inline a: A): CIO[Unit]            = CIO.defer(self.set(a))
+        inline def getAndSet(inline a: A): CIO[A]         = CIO.defer(self.getAndSet(a))
+        inline def updateAndGet(inline f: A => A): CIO[A] = CIO.defer(self.updateAndGet((a: A) => f(a)))
+        inline def getAndUpdate(inline f: A => A): CIO[A] = CIO.defer(self.getAndUpdate((a: A) => f(a)))
+
+        inline def compareAndSet(inline expected: A, inline updated: A): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+    end extension
+
+end CAtomicRef

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CChannel.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CChannel.scala
@@ -1,0 +1,25 @@
+package kyo.compat
+
+import java.util.concurrent.LinkedBlockingQueue
+
+/** Backed by `java.util.concurrent.LinkedBlockingQueue`. Blocking is the native Ox idiom. `poll` is non-blocking. */
+opaque type CChannel[A] = LinkedBlockingQueue[A]
+
+object CChannel:
+
+    inline def init[A](inline capacity: Int): CIO[CChannel[A]] =
+        CIO.defer(new LinkedBlockingQueue[A](capacity))
+
+    inline def lift[A](inline u: LinkedBlockingQueue[A]): CChannel[A] = u
+
+    extension [A](inline self: CChannel[A])
+
+        inline def lower: LinkedBlockingQueue[A] = self
+
+        inline def put(inline v: A): CIO[Unit] = CIO.defer(self.put(v))
+        inline def take: CIO[A]                = CIO.defer(self.take())
+        inline def poll: CIO[Option[A]]        = CIO.defer(Option(self.poll()))
+
+    end extension
+
+end CChannel

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CChunk.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CChunk.scala
@@ -1,0 +1,22 @@
+package kyo.compat
+
+/** Backed by `Vector[A]`. */
+opaque type CChunk[+A] = Vector[A]
+
+object CChunk:
+
+    inline def lift[A](inline c: Vector[A]): CChunk[A] = c
+
+    extension [A](inline self: CChunk[A])
+
+        inline def lower: Vector[A]            = self
+        inline def toSeq: Seq[A]               = self
+        inline def toIndexedSeq: IndexedSeq[A] = self
+        inline def apply(inline i: Int): A     = self(i)
+        inline def size: Int                   = self.size
+        inline def iterator: Iterator[A]       = self.iterator
+        inline def isEmpty: Boolean            = self.isEmpty
+
+    end extension
+
+end CChunk

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CFiber.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CFiber.scala
@@ -14,7 +14,7 @@ opaque type CFiber[+A] = CancellableFork[? <: A]
 object CFiber:
 
     inline def init[A](inline c: CIO[A]): CIO[CFiber[A]] =
-        CIO.deferLift(ox.forkCancellable(CIO.unsafeRun(c)))
+        CIO.deferLift(ox.forkCancellable(c.lower))
 
     inline def lift[A](inline u: CancellableFork[A]): CFiber[A] = u
 
@@ -33,7 +33,7 @@ object CFiber:
                         case Right(a) => scala.util.Success(a)
                         case Left(e)  => scala.util.Failure(e)
                     ox.supervised {
-                        CIO.unsafeRun(cb(outcome))
+                        cb(outcome).lower
                     }
                 }
                 t.start()

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CFiber.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CFiber.scala
@@ -1,0 +1,43 @@
+package kyo.compat
+
+import ox.CancellableFork
+
+/** Backed by `ox.CancellableFork[? <: A]`. The `? <: A` wildcard keeps the covariant `CFiber[+A]` sound over Ox's invariant
+  * `CancellableFork` (which only uses its type parameter in covariant `join` positions). `init` uses `forkCancellable` (unsupervised). Ox's
+  * fork API is join-only (no completion callback) and its forks are scope-bound, so `onComplete` spawns a virtual thread via
+  * `ox.oxThreadFactory` that calls `self.joinEither()` independently of the surrounding Ox scope; `joinEither` surfaces cancel as `Left(t)`
+  * without re-interrupting the calling thread, so the callback runs in a fresh `ox.supervised` block and fires with `Failure(t)` on cancel
+  * or error and `Success(a)` on success.
+  */
+opaque type CFiber[+A] = CancellableFork[? <: A]
+
+object CFiber:
+
+    inline def init[A](inline c: CIO[A]): CIO[CFiber[A]] =
+        CIO.deferLift(ox.forkCancellable(CIO.unsafeRun(c)))
+
+    inline def lift[A](inline u: CancellableFork[A]): CFiber[A] = u
+
+    extension [A](self: CFiber[A])
+
+        inline def lower: CancellableFork[? <: A] = self
+
+        inline def get: CIO[A] =
+            CIO.deferLift(self.join())
+
+        inline def onComplete(cb: scala.util.Try[A] => CIO[Unit]): CIO[Unit] =
+            CIO.deferLift {
+                // join the fork off the Ox scope, then run the callback in a fresh supervised scope.
+                val t = ox.oxThreadFactory.newThread { () =>
+                    val outcome: scala.util.Try[A] = self.joinEither() match
+                        case Right(a) => scala.util.Success(a)
+                        case Left(e)  => scala.util.Failure(e)
+                    ox.supervised {
+                        CIO.unsafeRun(cb(outcome))
+                    }
+                }
+                t.start()
+                ()
+            }
+    end extension
+end CFiber

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CIO.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CIO.scala
@@ -1,0 +1,372 @@
+package kyo.compat
+
+import ox.Ox
+import scala.concurrent.Await
+import scala.concurrent.Future as ScalaFuture
+import scala.concurrent.duration.Duration as ScalaDuration
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.NANOSECONDS
+import scala.util.control.NonFatal
+
+/** Underlying carrier is `(Int, Ox) => A`: the `Int` is the current `flatMap` nesting depth, the `Ox` is the structured-concurrency scope.
+  * Errors are encoded as `throw`; recovery uses `try/catch` on `Throwable` (via `liftToTry`). Deep `flatMap` chains are stack-safe:
+  * `flatMap` threads the depth, and once it reaches `LIMIT` it re-runs the remaining chain inside a fresh `ox.forkUnsupervised` — a virtual
+  * thread with a fresh stack — and joins it, capping JVM stack growth. `zip` arities 2-4 use `ox.par`; arities 5-7 use fork/join. `cede`
+  * yields the virtual thread. `blocking` wraps in `scala.concurrent.blocking`.
+  */
+opaque type CIO[+A] = (Int, Ox) => A
+
+object CIO:
+
+    /** Max `flatMap` nesting per stack segment; beyond it, the chain hops to a fresh fork. */
+    private inline val LIMIT = 256
+
+    /** Re-runs `body` on a fresh virtual-thread stack (an unsupervised fork) and joins it. `join()` on an unsupervised fork rethrows a
+      * failed body as a plain exception without crashing the surrounding scope.
+      */
+    private inline def bounce[T](inline body: => T)(using Ox): T = ox.forkUnsupervised(body).join()
+
+    inline def lift[A](inline f: Ox ?=> A): CIO[A] =
+        (_: Int, ox: Ox) => f(using ox)
+
+    /** Suspend side-effecting code that produces the backend computation. Ox has no separate eager effect type -- its carrier is itself the
+      * suspension -- so `deferLift` aliases [[CIO.lift]]; it exists for API uniformity with the other bindings.
+      */
+    inline def deferLift[A](inline f: Ox ?=> A): CIO[A] = lift(f)
+
+    /** Wrap an already-evaluated, side-effect-free value in a CIO. For side-effecting expressions use [[CIO.defer]] instead.
+      */
+    inline def value[A](inline a: A): CIO[A] = (_: Int, _: Ox) => a
+
+    inline def unit: CIO[Unit] = (_: Int, _: Ox) => ()
+
+    inline def defer[A](inline thunk: => A): CIO[A] = lift(thunk)
+
+    inline def fail(inline e: Throwable): CIO[Nothing] =
+        deferLift(throw e)
+
+    inline def get[A](inline t: scala.util.Try[A]): CIO[A] =
+        deferLift(t.get)
+
+    inline def fromScalaFuture[A](inline f: ScalaFuture[A]): CIO[A] =
+        deferLift(Await.result(f, ScalaDuration.Inf))
+
+    /** Runs a `CIO` to its value within the given scope (the carrier applied at depth 0). */
+    inline def unsafeRun[A](inline c: CIO[A])(using ox: Ox): A = c(0, ox)
+
+    inline def acquireReleaseWith[A, B](
+        inline acquire: CIO[A]
+    )(
+        inline release: A => CIO[Unit]
+    )(
+        inline use: A => CIO[B]
+    ): CIO[B] =
+        deferLift {
+            val a = CIO.unsafeRun(acquire)
+            val useResult: scala.util.Try[B] =
+                try scala.util.Success(CIO.unsafeRun(use(a)))
+                catch case t: Throwable if NonFatal(t) => scala.util.Failure(t)
+            try CIO.unsafeRun(release(a))
+            catch
+                case relT: Throwable if NonFatal(relT) =>
+                    useResult match
+                        case scala.util.Failure(useT) => useT.addSuppressed(relT)
+                        case scala.util.Success(_)    => throw relT
+            end try
+            useResult.get
+        }
+
+    inline def ensure[A](
+        inline cleanup: CIO[Unit]
+    )(
+        inline c: CIO[A]
+    ): CIO[A] =
+        acquireReleaseWith(CIO.unit)(_ => cleanup)(_ => c)
+
+    inline def never: CIO[Nothing] =
+        deferLift(ox.never)
+
+    extension [A](inline self: CIO[A])
+
+        inline def lower: Ox ?=> A = self(0, summon[Ox])
+
+        inline def liftToTry: CIO[scala.util.Try[A]] =
+            (_: Int, ox: Ox) =>
+                try scala.util.Success(CIO.unsafeRun(self)(using ox))
+                catch case t: Throwable if NonFatal(t) => scala.util.Failure(t)
+
+        inline def recover[A2 >: A](inline handler: Throwable => CIO[A2]): CIO[A2] =
+            self.liftToTry.flatMap {
+                case scala.util.Success(a) => CIO.value(a)
+                case scala.util.Failure(t) => handler(t)
+            }
+
+        inline def fold[B](
+            inline onSuccess: A => CIO[B],
+            inline onFail: Throwable => CIO[B]
+        ): CIO[B] =
+            self.liftToTry.flatMap {
+                case scala.util.Success(a) => onSuccess(a)
+                case scala.util.Failure(t) => onFail(t)
+            }
+
+        inline def unit: CIO[Unit] = self.map(_ => ())
+
+        inline def orElse[A2 >: A](inline that: CIO[A2]): CIO[A2] =
+            self.liftToTry.flatMap {
+                case scala.util.Success(a) => CIO.value(a)
+                case scala.util.Failure(_) => that
+            }
+
+        inline def mapError(inline f: Throwable => Throwable): CIO[A] =
+            self.liftToTry.flatMap {
+                case scala.util.Success(a) => CIO.value(a)
+                case scala.util.Failure(t) => CIO.fail(f(t))
+            }
+
+        inline def map[B](inline f: A => B): CIO[B] = self.flatMap(a => CIO.value(f(a)))
+
+        inline def flatMap[B](f: A => CIO[B]): CIO[B] =
+            (depth: Int, ox: Ox) =>
+                if depth >= LIMIT then
+                    // fresh stack: re-run the remaining chain at depth 0 inside an unsupervised fork
+                    bounce(f(self(0, ox))(0, ox))(using ox)
+                else
+                    f(self(depth + 1, ox))(depth + 1, ox)
+
+        inline def unsafeRun(using ec: scala.concurrent.ExecutionContext): ScalaFuture[A] =
+            ScalaFuture {
+                ox.supervised {
+                    CIO.unsafeRun(self)(using summon[Ox])
+                }
+            }
+    end extension
+
+    inline def sleep(inline d: FiniteDuration): CIO[Unit] =
+        deferLift(ox.sleep(d))
+
+    inline def now: CIO[java.time.Instant] =
+        defer(java.time.Instant.now())
+
+    inline def nowMonotonic: CIO[FiniteDuration] =
+        defer(FiniteDuration(java.lang.System.nanoTime(), NANOSECONDS))
+
+    inline def timeout[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[Option[A]] =
+        deferLift {
+            ox.timeoutOption(d)(CIO.unsafeRun(c))
+        }
+
+    inline def timeoutWithError[A](inline d: FiniteDuration)(inline e: Throwable)(inline c: CIO[A]): CIO[A] =
+        deferLift {
+            ox.timeoutOption(d)(CIO.unsafeRun(c)).getOrElse(throw e)
+        }
+
+    inline def delay[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[A] =
+        deferLift {
+            ox.sleep(d)
+            CIO.unsafeRun(c)
+        }
+
+    inline def race[A](
+        inline a: CIO[A],
+        inline b: CIO[A]
+    ): CIO[A] =
+        deferLift {
+            ox.raceSuccess(CIO.unsafeRun(a), CIO.unsafeRun(b))
+        }
+
+    inline def foreach[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline f: A => CIO[B]): CIO[CChunk[B]] =
+        deferLift {
+            val capturedOx = summon[Ox]
+            val items      = coll.toList
+            val thunks     = items.map(a => () => CIO.unsafeRun(f(a))(using capturedOx))
+            val results =
+                if concurrency == Int.MaxValue then ox.par(thunks)
+                else ox.parLimit(concurrency)(thunks)
+            CChunk.lift(results.toVector)
+        }
+
+    inline def foreachIndexed[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline f: (Int, A) => CIO[B]): CIO[CChunk[B]] =
+        deferLift {
+            val capturedOx = summon[Ox]
+            val items      = coll.toList.zipWithIndex
+            val thunks     = items.map { case (a, i) => () => CIO.unsafeRun(f(i, a))(using capturedOx) }
+            val results =
+                if concurrency == Int.MaxValue then ox.par(thunks)
+                else ox.parLimit(concurrency)(thunks)
+            CChunk.lift(results.toVector)
+        }
+
+    inline def foreachDiscard[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline f: A => CIO[Any]): CIO[Unit] =
+        deferLift {
+            val capturedOx = summon[Ox]
+            val thunks     = coll.toList.map(a => () => CIO.unsafeRun(f(a))(using capturedOx))
+            val _ =
+                if concurrency == Int.MaxValue then ox.par(thunks)
+                else ox.parLimit(concurrency)(thunks)
+        }
+
+    inline def filter[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline p: A => CIO[Boolean]): CIO[CChunk[A]] =
+        deferLift {
+            val capturedOx = summon[Ox]
+            val items      = coll.toList
+            val thunks     = items.map(a => () => CIO.unsafeRun(p(a))(using capturedOx))
+            val flags =
+                if concurrency == Int.MaxValue then ox.par(thunks)
+                else ox.parLimit(concurrency)(thunks)
+            CChunk.lift(items.zip(flags).collect { case (a, true) => a }.toVector)
+        }
+
+    inline def collectAll[A](
+        inline coll: Iterable[CIO[A]],
+        inline concurrency: Int = Int.MaxValue
+    ): CIO[CChunk[A]] =
+        deferLift {
+            val capturedOx = summon[Ox]
+            val thunks     = coll.toList.map(c => () => CIO.unsafeRun(c)(using capturedOx))
+            val results =
+                if concurrency == Int.MaxValue then ox.par(thunks)
+                else ox.parLimit(concurrency)(thunks)
+            CChunk.lift(results.toVector)
+        }
+
+    inline def collectAllDiscard(
+        inline coll: Iterable[CIO[Any]],
+        inline concurrency: Int = Int.MaxValue
+    ): CIO[Unit] =
+        deferLift {
+            val capturedOx = summon[Ox]
+            val thunks     = coll.toList.map(c => () => CIO.unsafeRun(c)(using capturedOx))
+            val _ =
+                if concurrency == Int.MaxValue then ox.par(thunks)
+                else ox.parLimit(concurrency)(thunks)
+        }
+
+    inline def async[A](inline register: ((scala.util.Try[A] => Unit) => Unit)): CIO[A] =
+        deferLift {
+            val cf = new java.util.concurrent.CompletableFuture[A]()
+            val cb: scala.util.Try[A] => Unit = {
+                case scala.util.Success(a) =>
+                    val _ = cf.complete(a)
+                    ()
+                case scala.util.Failure(e) =>
+                    val _ = cf.completeExceptionally(e)
+                    ()
+            }
+            register(cb)
+            try cf.get()
+            catch
+                case ee: java.util.concurrent.ExecutionException =>
+                    val cause = ee.getCause
+                    if cause ne null then throw cause else throw ee
+            end try
+        }
+    end async
+
+    inline def cede: CIO[Unit] =
+        deferLift {
+            val p = ox.forkUnsupervised(())
+            p.join()
+        }
+
+    inline def blocking[A](inline thunk: => A): CIO[A] =
+        deferLift {
+            scala.concurrent.blocking {
+                thunk
+            }
+        }
+
+    inline def zip[A1, A2](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2]
+    ): CIO[(A1, A2)] =
+        deferLift {
+            ox.par(CIO.unsafeRun(a1), CIO.unsafeRun(a2))
+        }
+
+    inline def zip[A1, A2, A3](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3]
+    ): CIO[(A1, A2, A3)] =
+        deferLift {
+            ox.par(CIO.unsafeRun(a1), CIO.unsafeRun(a2), CIO.unsafeRun(a3))
+        }
+
+    inline def zip[A1, A2, A3, A4](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4]
+    ): CIO[(A1, A2, A3, A4)] =
+        deferLift {
+            ox.par(CIO.unsafeRun(a1), CIO.unsafeRun(a2), CIO.unsafeRun(a3), CIO.unsafeRun(a4))
+        }
+
+    inline def zip[A1, A2, A3, A4, A5](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5]
+    ): CIO[(A1, A2, A3, A4, A5)] =
+        deferLift {
+            val f1 = ox.fork(CIO.unsafeRun(a1))
+            val f2 = ox.fork(CIO.unsafeRun(a2))
+            val f3 = ox.fork(CIO.unsafeRun(a3))
+            val f4 = ox.fork(CIO.unsafeRun(a4))
+            val f5 = ox.fork(CIO.unsafeRun(a5))
+            (f1.join(), f2.join(), f3.join(), f4.join(), f5.join())
+        }
+
+    inline def zip[A1, A2, A3, A4, A5, A6](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5],
+        inline a6: CIO[A6]
+    ): CIO[(A1, A2, A3, A4, A5, A6)] =
+        deferLift {
+            val f1 = ox.fork(CIO.unsafeRun(a1))
+            val f2 = ox.fork(CIO.unsafeRun(a2))
+            val f3 = ox.fork(CIO.unsafeRun(a3))
+            val f4 = ox.fork(CIO.unsafeRun(a4))
+            val f5 = ox.fork(CIO.unsafeRun(a5))
+            val f6 = ox.fork(CIO.unsafeRun(a6))
+            (f1.join(), f2.join(), f3.join(), f4.join(), f5.join(), f6.join())
+        }
+
+    inline def zip[A1, A2, A3, A4, A5, A6, A7](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5],
+        inline a6: CIO[A6],
+        inline a7: CIO[A7]
+    ): CIO[(A1, A2, A3, A4, A5, A6, A7)] =
+        deferLift {
+            val f1 = ox.fork(CIO.unsafeRun(a1))
+            val f2 = ox.fork(CIO.unsafeRun(a2))
+            val f3 = ox.fork(CIO.unsafeRun(a3))
+            val f4 = ox.fork(CIO.unsafeRun(a4))
+            val f5 = ox.fork(CIO.unsafeRun(a5))
+            val f6 = ox.fork(CIO.unsafeRun(a6))
+            val f7 = ox.fork(CIO.unsafeRun(a7))
+            (f1.join(), f2.join(), f3.join(), f4.join(), f5.join(), f6.join(), f7.join())
+        }
+
+end CIO

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CIO.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CIO.scala
@@ -51,9 +51,6 @@ object CIO:
     inline def fromScalaFuture[A](inline f: ScalaFuture[A]): CIO[A] =
         deferLift(Await.result(f, ScalaDuration.Inf))
 
-    /** Runs a `CIO` to its value within the given scope (the carrier applied at depth 0). */
-    inline def unsafeRun[A](inline c: CIO[A])(using ox: Ox): A = c(0, ox)
-
     inline def acquireReleaseWith[A, B](
         inline acquire: CIO[A]
     )(
@@ -62,11 +59,11 @@ object CIO:
         inline use: A => CIO[B]
     ): CIO[B] =
         deferLift {
-            val a = CIO.unsafeRun(acquire)
+            val a = acquire.lower
             val useResult: scala.util.Try[B] =
-                try scala.util.Success(CIO.unsafeRun(use(a)))
+                try scala.util.Success(use(a).lower)
                 catch case t: Throwable if NonFatal(t) => scala.util.Failure(t)
-            try CIO.unsafeRun(release(a))
+            try release(a).lower
             catch
                 case relT: Throwable if NonFatal(relT) =>
                     useResult match
@@ -92,7 +89,7 @@ object CIO:
 
         inline def liftToTry: CIO[scala.util.Try[A]] =
             (_: Int, ox: Ox) =>
-                try scala.util.Success(CIO.unsafeRun(self)(using ox))
+                try scala.util.Success(self.lower(using ox))
                 catch case t: Throwable if NonFatal(t) => scala.util.Failure(t)
 
         inline def recover[A2 >: A](inline handler: Throwable => CIO[A2]): CIO[A2] =
@@ -137,7 +134,7 @@ object CIO:
         inline def unsafeRun(using ec: scala.concurrent.ExecutionContext): ScalaFuture[A] =
             ScalaFuture {
                 ox.supervised {
-                    CIO.unsafeRun(self)(using summon[Ox])
+                    self.lower(using summon[Ox])
                 }
             }
     end extension
@@ -153,18 +150,18 @@ object CIO:
 
     inline def timeout[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[Option[A]] =
         deferLift {
-            ox.timeoutOption(d)(CIO.unsafeRun(c))
+            ox.timeoutOption(d)(c.lower)
         }
 
     inline def timeoutWithError[A](inline d: FiniteDuration)(inline e: Throwable)(inline c: CIO[A]): CIO[A] =
         deferLift {
-            ox.timeoutOption(d)(CIO.unsafeRun(c)).getOrElse(throw e)
+            ox.timeoutOption(d)(c.lower).getOrElse(throw e)
         }
 
     inline def delay[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[A] =
         deferLift {
             ox.sleep(d)
-            CIO.unsafeRun(c)
+            c.lower
         }
 
     inline def race[A](
@@ -172,7 +169,7 @@ object CIO:
         inline b: CIO[A]
     ): CIO[A] =
         deferLift {
-            ox.raceSuccess(CIO.unsafeRun(a), CIO.unsafeRun(b))
+            ox.raceSuccess(a.lower, b.lower)
         }
 
     inline def foreach[A, B](
@@ -182,7 +179,7 @@ object CIO:
         deferLift {
             val capturedOx = summon[Ox]
             val items      = coll.toList
-            val thunks     = items.map(a => () => CIO.unsafeRun(f(a))(using capturedOx))
+            val thunks     = items.map(a => () => f(a).lower(using capturedOx))
             val results =
                 if concurrency == Int.MaxValue then ox.par(thunks)
                 else ox.parLimit(concurrency)(thunks)
@@ -196,7 +193,7 @@ object CIO:
         deferLift {
             val capturedOx = summon[Ox]
             val items      = coll.toList.zipWithIndex
-            val thunks     = items.map { case (a, i) => () => CIO.unsafeRun(f(i, a))(using capturedOx) }
+            val thunks     = items.map { case (a, i) => () => f(i, a).lower(using capturedOx) }
             val results =
                 if concurrency == Int.MaxValue then ox.par(thunks)
                 else ox.parLimit(concurrency)(thunks)
@@ -209,7 +206,7 @@ object CIO:
     )(inline f: A => CIO[Any]): CIO[Unit] =
         deferLift {
             val capturedOx = summon[Ox]
-            val thunks     = coll.toList.map(a => () => CIO.unsafeRun(f(a))(using capturedOx))
+            val thunks     = coll.toList.map(a => () => f(a).lower(using capturedOx))
             val _ =
                 if concurrency == Int.MaxValue then ox.par(thunks)
                 else ox.parLimit(concurrency)(thunks)
@@ -222,7 +219,7 @@ object CIO:
         deferLift {
             val capturedOx = summon[Ox]
             val items      = coll.toList
-            val thunks     = items.map(a => () => CIO.unsafeRun(p(a))(using capturedOx))
+            val thunks     = items.map(a => () => p(a).lower(using capturedOx))
             val flags =
                 if concurrency == Int.MaxValue then ox.par(thunks)
                 else ox.parLimit(concurrency)(thunks)
@@ -235,7 +232,7 @@ object CIO:
     ): CIO[CChunk[A]] =
         deferLift {
             val capturedOx = summon[Ox]
-            val thunks     = coll.toList.map(c => () => CIO.unsafeRun(c)(using capturedOx))
+            val thunks     = coll.toList.map(c => () => c.lower(using capturedOx))
             val results =
                 if concurrency == Int.MaxValue then ox.par(thunks)
                 else ox.parLimit(concurrency)(thunks)
@@ -248,7 +245,7 @@ object CIO:
     ): CIO[Unit] =
         deferLift {
             val capturedOx = summon[Ox]
-            val thunks     = coll.toList.map(c => () => CIO.unsafeRun(c)(using capturedOx))
+            val thunks     = coll.toList.map(c => () => c.lower(using capturedOx))
             val _ =
                 if concurrency == Int.MaxValue then ox.par(thunks)
                 else ox.parLimit(concurrency)(thunks)
@@ -293,7 +290,7 @@ object CIO:
         inline a2: CIO[A2]
     ): CIO[(A1, A2)] =
         deferLift {
-            ox.par(CIO.unsafeRun(a1), CIO.unsafeRun(a2))
+            ox.par(a1.lower, a2.lower)
         }
 
     inline def zip[A1, A2, A3](
@@ -302,7 +299,7 @@ object CIO:
         inline a3: CIO[A3]
     ): CIO[(A1, A2, A3)] =
         deferLift {
-            ox.par(CIO.unsafeRun(a1), CIO.unsafeRun(a2), CIO.unsafeRun(a3))
+            ox.par(a1.lower, a2.lower, a3.lower)
         }
 
     inline def zip[A1, A2, A3, A4](
@@ -312,7 +309,7 @@ object CIO:
         inline a4: CIO[A4]
     ): CIO[(A1, A2, A3, A4)] =
         deferLift {
-            ox.par(CIO.unsafeRun(a1), CIO.unsafeRun(a2), CIO.unsafeRun(a3), CIO.unsafeRun(a4))
+            ox.par(a1.lower, a2.lower, a3.lower, a4.lower)
         }
 
     inline def zip[A1, A2, A3, A4, A5](
@@ -323,11 +320,11 @@ object CIO:
         inline a5: CIO[A5]
     ): CIO[(A1, A2, A3, A4, A5)] =
         deferLift {
-            val f1 = ox.fork(CIO.unsafeRun(a1))
-            val f2 = ox.fork(CIO.unsafeRun(a2))
-            val f3 = ox.fork(CIO.unsafeRun(a3))
-            val f4 = ox.fork(CIO.unsafeRun(a4))
-            val f5 = ox.fork(CIO.unsafeRun(a5))
+            val f1 = ox.fork(a1.lower)
+            val f2 = ox.fork(a2.lower)
+            val f3 = ox.fork(a3.lower)
+            val f4 = ox.fork(a4.lower)
+            val f5 = ox.fork(a5.lower)
             (f1.join(), f2.join(), f3.join(), f4.join(), f5.join())
         }
 
@@ -340,12 +337,12 @@ object CIO:
         inline a6: CIO[A6]
     ): CIO[(A1, A2, A3, A4, A5, A6)] =
         deferLift {
-            val f1 = ox.fork(CIO.unsafeRun(a1))
-            val f2 = ox.fork(CIO.unsafeRun(a2))
-            val f3 = ox.fork(CIO.unsafeRun(a3))
-            val f4 = ox.fork(CIO.unsafeRun(a4))
-            val f5 = ox.fork(CIO.unsafeRun(a5))
-            val f6 = ox.fork(CIO.unsafeRun(a6))
+            val f1 = ox.fork(a1.lower)
+            val f2 = ox.fork(a2.lower)
+            val f3 = ox.fork(a3.lower)
+            val f4 = ox.fork(a4.lower)
+            val f5 = ox.fork(a5.lower)
+            val f6 = ox.fork(a6.lower)
             (f1.join(), f2.join(), f3.join(), f4.join(), f5.join(), f6.join())
         }
 
@@ -359,13 +356,13 @@ object CIO:
         inline a7: CIO[A7]
     ): CIO[(A1, A2, A3, A4, A5, A6, A7)] =
         deferLift {
-            val f1 = ox.fork(CIO.unsafeRun(a1))
-            val f2 = ox.fork(CIO.unsafeRun(a2))
-            val f3 = ox.fork(CIO.unsafeRun(a3))
-            val f4 = ox.fork(CIO.unsafeRun(a4))
-            val f5 = ox.fork(CIO.unsafeRun(a5))
-            val f6 = ox.fork(CIO.unsafeRun(a6))
-            val f7 = ox.fork(CIO.unsafeRun(a7))
+            val f1 = ox.fork(a1.lower)
+            val f2 = ox.fork(a2.lower)
+            val f3 = ox.fork(a3.lower)
+            val f4 = ox.fork(a4.lower)
+            val f5 = ox.fork(a5.lower)
+            val f6 = ox.fork(a6.lower)
+            val f7 = ox.fork(a7.lower)
             (f1.join(), f2.join(), f3.join(), f4.join(), f5.join(), f6.join(), f7.join())
         }
 

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CLatch.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CLatch.scala
@@ -1,0 +1,24 @@
+package kyo.compat
+
+import java.util.concurrent.CountDownLatch
+
+/** Backed by `java.util.concurrent.CountDownLatch`. `init(n <= 0)` produces an already-released latch. */
+opaque type CLatch = CountDownLatch
+
+object CLatch:
+
+    inline def init(inline n: Int): CIO[CLatch] =
+        CIO.defer(new CountDownLatch(if n <= 0 then 0 else n))
+
+    inline def lift(inline u: CountDownLatch): CLatch = u
+
+    extension (inline self: CLatch)
+
+        inline def lower: CountDownLatch = self
+
+        inline def await: CIO[Unit]   = CIO.defer(self.await())
+        inline def release: CIO[Unit] = CIO.defer(self.countDown())
+
+    end extension
+
+end CLatch

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CLocal.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CLocal.scala
@@ -25,12 +25,12 @@ object CLocal:
 
         inline def let[B](inline v: A)(inline c: CIO[B]): CIO[B] =
             CIO.deferLift {
-                self.supervisedWhere(v)(CIO.unsafeRun(c))
+                self.supervisedWhere(v)(c.lower)
             }
 
         inline def update[B](inline f: A => A)(inline c: CIO[B]): CIO[B] =
             CIO.deferLift {
-                self.supervisedWhere(f(self.get()))(CIO.unsafeRun(c))
+                self.supervisedWhere(f(self.get()))(c.lower)
             }
     end extension
 end CLocal

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CLocal.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CLocal.scala
@@ -1,0 +1,36 @@
+package kyo.compat
+
+import ox.ForkLocal
+import ox.Ox
+
+/** Backed by `ox.ForkLocal[A]` (JDK `ScopedValue` under the hood). `let(v)(c)` opens a fresh `scopedWhere` scope around the body, so any
+  * forks inside the let-body bind to that inner scope -- the local value is inherited by all forks within the scope. `init` is deferred so
+  * each call to `CLocal.init` constructs a fresh local at effect-evaluation time.
+  */
+opaque type CLocal[A] = ForkLocal[A]
+
+object CLocal:
+
+    inline def init[A](inline default: A): CIO[CLocal[A]] =
+        CIO.defer(ForkLocal(default))
+
+    inline def lift[A](inline u: ForkLocal[A]): CLocal[A] = u
+
+    extension [A](inline self: CLocal[A])
+
+        inline def lower: ForkLocal[A] = self
+
+        inline def get: CIO[A] =
+            CIO.defer(self.get())
+
+        inline def let[B](inline v: A)(inline c: CIO[B]): CIO[B] =
+            CIO.deferLift {
+                self.supervisedWhere(v)(CIO.unsafeRun(c))
+            }
+
+        inline def update[B](inline f: A => A)(inline c: CIO[B]): CIO[B] =
+            CIO.deferLift {
+                self.supervisedWhere(f(self.get()))(CIO.unsafeRun(c))
+            }
+    end extension
+end CLocal

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CMeter.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CMeter.scala
@@ -1,0 +1,40 @@
+package kyo.compat
+
+import java.util.concurrent.Semaphore
+import ox.Ox
+
+/** Backed by `java.util.concurrent.Semaphore`. `run` acquires then releases via `try/finally`. */
+opaque type CMeter = Semaphore
+
+object CMeter:
+
+    inline def init(inline permits: Int): CIO[CMeter] =
+        CIO.defer(new Semaphore(permits))
+
+    inline def lift(inline u: Semaphore): CMeter = u
+
+    extension (inline self: CMeter)
+
+        inline def lower: Semaphore = self
+
+        inline def run[A](inline c: CIO[A]): CIO[A] =
+            CIO.deferLift {
+                self.acquire()
+                try CIO.unsafeRun(c)
+                finally self.release()
+            }
+
+        inline def tryRun[A](inline c: CIO[A]): CIO[Option[A]] =
+            CIO.deferLift {
+                if !self.tryAcquire() then None: Option[A]
+                else
+                    try Some(CIO.unsafeRun(c))
+                    finally self.release()
+                end if
+            }
+
+        inline def availablePermits: CIO[Int] =
+            CIO.defer(self.availablePermits())
+    end extension
+
+end CMeter

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CMeter.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CMeter.scala
@@ -20,7 +20,7 @@ object CMeter:
         inline def run[A](inline c: CIO[A]): CIO[A] =
             CIO.deferLift {
                 self.acquire()
-                try CIO.unsafeRun(c)
+                try c.lower
                 finally self.release()
             }
 
@@ -28,7 +28,7 @@ object CMeter:
             CIO.deferLift {
                 if !self.tryAcquire() then None: Option[A]
                 else
-                    try Some(CIO.unsafeRun(c))
+                    try Some(c.lower)
                     finally self.release()
                 end if
             }

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CPromise.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/CPromise.scala
@@ -1,0 +1,59 @@
+package kyo.compat
+
+import java.util.concurrent.CompletableFuture
+import scala.reflect.ClassTag
+
+/** Backed by `java.util.concurrent.CompletableFuture[A]`. `get` unwraps `ExecutionException`. `poll` uses `ClassTag`-guarded cast;
+  * `CancellationException` → `None`.
+  */
+opaque type CPromise[A] = CompletableFuture[A]
+
+object CPromise:
+
+    inline def init[A]: CIO[CPromise[A]] =
+        CIO.defer(new CompletableFuture[A]())
+
+    inline def lift[A](inline u: CompletableFuture[A]): CPromise[A] = u
+
+    extension [A](inline self: CPromise[A])
+
+        inline def lower: CompletableFuture[A] = self
+
+        inline def succeed(inline a: A): CIO[Boolean] =
+            CIO.defer(self.complete(a))
+
+        inline def fail(inline e: Throwable): CIO[Boolean] =
+            CIO.defer(self.completeExceptionally(e))
+
+        inline def get: CIO[A] =
+            CIO.defer {
+                try self.get()
+                catch
+                    case ee: java.util.concurrent.ExecutionException =>
+                        val cause = ee.getCause
+                        if cause ne null then throw cause else throw ee
+            }
+
+        inline def poll: CIO[Option[scala.util.Try[A]]] =
+            CIO.defer {
+                if !self.isDone then Option.empty
+                else
+                    try
+                        val v = self.get()
+                        Option(scala.util.Success(v))
+                    catch
+                        case ee: java.util.concurrent.ExecutionException =>
+                            val cause = ee.getCause
+                            val t     = if cause ne null then cause else ee
+                            Option(scala.util.Failure(t))
+                        case _: java.util.concurrent.CancellationException =>
+                            Option.empty
+                end if
+            }
+
+        inline def done: CIO[Boolean] =
+            CIO.defer(self.isDone)
+
+    end extension
+
+end CPromise

--- a/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
+++ b/kyo-compat/bindings/ox/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
@@ -1,0 +1,24 @@
+package kyo.compat
+
+import java.util.concurrent.CompletionStage
+
+/** JVM-only. Cancellation does NOT propagate back to the source CompletionStage. */
+object CompatFromCompletionStage:
+
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
+        CIO.deferLift {
+            val cf = cs.toCompletableFuture
+            try cf.get()
+            catch
+                case ee: java.util.concurrent.ExecutionException =>
+                    val cause = ee.getCause
+                    if cause ne null then throw cause else throw ee
+            end try
+        }
+
+end CompatFromCompletionStage
+
+extension (inline c: CIO.type)
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
+        CompatFromCompletionStage.fromCompletionStage(cs)
+end extension

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CAtomicBoolean.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CAtomicBoolean.scala
@@ -1,0 +1,33 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Backed by java.util.concurrent.atomic.AtomicBoolean. */
+opaque type CAtomicBoolean = AtomicBoolean
+
+object CAtomicBoolean:
+
+    inline def init(inline v: Boolean): CIO[CAtomicBoolean] =
+        CIO.defer(new AtomicBoolean(v))
+
+    inline def lift(inline u: AtomicBoolean): CAtomicBoolean = u
+
+    extension (inline self: CAtomicBoolean)
+
+        inline def lower: AtomicBoolean = self
+
+        inline def get: CIO[Boolean] =
+            CIO.defer(self.get())
+
+        inline def set(inline v: Boolean): CIO[Unit] =
+            CIO.defer(self.set(v))
+
+        inline def getAndSet(inline v: Boolean): CIO[Boolean] =
+            CIO.defer(self.getAndSet(v))
+
+        inline def compareAndSet(inline expected: Boolean, inline updated: Boolean): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicBoolean

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CAtomicInt.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CAtomicInt.scala
@@ -1,0 +1,51 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Backed by java.util.concurrent.atomic.AtomicInteger. */
+opaque type CAtomicInt = AtomicInteger
+
+object CAtomicInt:
+
+    inline def init(inline v: Int): CIO[CAtomicInt] =
+        CIO.defer(new AtomicInteger(v))
+
+    inline def lift(inline u: AtomicInteger): CAtomicInt = u
+
+    extension (inline self: CAtomicInt)
+
+        inline def lower: AtomicInteger = self
+
+        inline def get: CIO[Int] =
+            CIO.defer(self.get())
+
+        inline def set(inline v: Int): CIO[Unit] =
+            CIO.defer(self.set(v))
+
+        inline def getAndSet(inline v: Int): CIO[Int] =
+            CIO.defer(self.getAndSet(v))
+
+        inline def incrementAndGet: CIO[Int] =
+            CIO.defer(self.incrementAndGet())
+
+        inline def getAndIncrement: CIO[Int] =
+            CIO.defer(self.getAndIncrement())
+
+        inline def decrementAndGet: CIO[Int] =
+            CIO.defer(self.decrementAndGet())
+
+        inline def getAndDecrement: CIO[Int] =
+            CIO.defer(self.getAndDecrement())
+
+        inline def addAndGet(inline delta: Int): CIO[Int] =
+            CIO.defer(self.addAndGet(delta))
+
+        inline def getAndAdd(inline delta: Int): CIO[Int] =
+            CIO.defer(self.getAndAdd(delta))
+
+        inline def compareAndSet(inline expected: Int, inline updated: Int): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicInt

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CAtomicLong.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CAtomicLong.scala
@@ -1,0 +1,51 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicLong
+
+/** Backed by java.util.concurrent.atomic.AtomicLong. */
+opaque type CAtomicLong = AtomicLong
+
+object CAtomicLong:
+
+    inline def init(inline v: Long): CIO[CAtomicLong] =
+        CIO.defer(new AtomicLong(v))
+
+    inline def lift(inline u: AtomicLong): CAtomicLong = u
+
+    extension (inline self: CAtomicLong)
+
+        inline def lower: AtomicLong = self
+
+        inline def get: CIO[Long] =
+            CIO.defer(self.get())
+
+        inline def set(inline v: Long): CIO[Unit] =
+            CIO.defer(self.set(v))
+
+        inline def getAndSet(inline v: Long): CIO[Long] =
+            CIO.defer(self.getAndSet(v))
+
+        inline def incrementAndGet: CIO[Long] =
+            CIO.defer(self.incrementAndGet())
+
+        inline def getAndIncrement: CIO[Long] =
+            CIO.defer(self.getAndIncrement())
+
+        inline def decrementAndGet: CIO[Long] =
+            CIO.defer(self.decrementAndGet())
+
+        inline def getAndDecrement: CIO[Long] =
+            CIO.defer(self.getAndDecrement())
+
+        inline def addAndGet(inline delta: Long): CIO[Long] =
+            CIO.defer(self.addAndGet(delta))
+
+        inline def getAndAdd(inline delta: Long): CIO[Long] =
+            CIO.defer(self.getAndAdd(delta))
+
+        inline def compareAndSet(inline expected: Long, inline updated: Long): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicLong

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CAtomicRef.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CAtomicRef.scala
@@ -1,0 +1,39 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicReference
+
+/** Backed by java.util.concurrent.atomic.AtomicReference[A]. */
+opaque type CAtomicRef[A] = AtomicReference[A]
+
+object CAtomicRef:
+
+    inline def init[A](inline a: A): CIO[CAtomicRef[A]] =
+        CIO.defer(new AtomicReference[A](a))
+
+    inline def lift[A](inline u: AtomicReference[A]): CAtomicRef[A] = u
+
+    extension [A](inline self: CAtomicRef[A])
+
+        inline def lower: AtomicReference[A] = self
+
+        inline def get: CIO[A] =
+            CIO.defer(self.get())
+
+        inline def set(inline a: A): CIO[Unit] =
+            CIO.defer(self.set(a))
+
+        inline def getAndSet(inline a: A): CIO[A] =
+            CIO.defer(self.getAndSet(a))
+
+        inline def updateAndGet(inline f: A => A): CIO[A] =
+            CIO.defer(self.updateAndGet(a => f(a)))
+
+        inline def getAndUpdate(inline f: A => A): CIO[A] =
+            CIO.defer(self.getAndUpdate(a => f(a)))
+
+        inline def compareAndSet(inline expected: A, inline updated: A): CIO[Boolean] =
+            CIO.defer(self.compareAndSet(expected, updated))
+
+    end extension
+
+end CAtomicRef

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CChannel.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CChannel.scala
@@ -1,0 +1,60 @@
+package kyo.compat
+
+import com.twitter.concurrent.AsyncQueue
+import com.twitter.concurrent.AsyncSemaphore
+import com.twitter.concurrent.Permit
+import com.twitter.util.Return
+import scala.annotation.publicInBinary
+
+/** A bounded FIFO channel built from `AsyncSemaphore` (capacity bound) + `AsyncQueue` (FIFO buffer). Producers acquire a permit, then
+  * enqueue the item paired with its permit; consumers dequeue and release the permit. `put`/`take` compose natively with Twitter `Future`
+  * and never block a thread. `poll` is a non-blocking peek that returns `None` when the buffer is empty.
+  */
+final class CChannel[A] @publicInBinary private[compat] (capacity: Int):
+
+    private val capacitySem                    = new AsyncSemaphore(capacity)
+    private val queue: AsyncQueue[(A, Permit)] = new AsyncQueue[(A, Permit)]()
+
+    inline def lower: CChannel[A] = this
+
+    inline def put(inline v: A): CIO[Unit] =
+        CIO.deferLift {
+            capacitySem.acquire().map { permit =>
+                val _ = queue.offer((v, permit))
+                ()
+            }
+        }
+
+    inline def take: CIO[A] =
+        CIO.deferLift {
+            queue.poll().map { case (a, permit) =>
+                permit.release()
+                a
+            }
+        }
+
+    inline def poll: CIO[Option[A]] =
+        CIO.defer {
+            if queue.size > 0 then
+                val f = queue.poll()
+                if f.isDefined then
+                    f.poll match
+                        case Some(Return((a, permit))) =>
+                            permit.release()
+                            Some(a)
+                        case _ => None
+                else None
+                end if
+            else None
+        }
+
+end CChannel
+
+object CChannel:
+
+    inline def init[A](inline capacity: Int): CIO[CChannel[A]] =
+        CIO.defer(new CChannel[A](capacity))
+
+    inline def lift[A](inline u: CChannel[A]): CChannel[A] = u
+
+end CChannel

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CChannel.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CChannel.scala
@@ -4,13 +4,12 @@ import com.twitter.concurrent.AsyncQueue
 import com.twitter.concurrent.AsyncSemaphore
 import com.twitter.concurrent.Permit
 import com.twitter.util.Return
-import scala.annotation.publicInBinary
 
 /** A bounded FIFO channel built from `AsyncSemaphore` (capacity bound) + `AsyncQueue` (FIFO buffer). Producers acquire a permit, then
   * enqueue the item paired with its permit; consumers dequeue and release the permit. `put`/`take` compose natively with Twitter `Future`
   * and never block a thread. `poll` is a non-blocking peek that returns `None` when the buffer is empty.
   */
-final class CChannel[A] @publicInBinary private[compat] (capacity: Int):
+final class CChannel[A](capacity: Int):
 
     private val capacitySem                    = new AsyncSemaphore(capacity)
     private val queue: AsyncQueue[(A, Permit)] = new AsyncQueue[(A, Permit)]()

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CChunk.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CChunk.scala
@@ -1,0 +1,22 @@
+package kyo.compat
+
+/** Backed by Vector[A]. */
+opaque type CChunk[+A] = Vector[A]
+
+object CChunk:
+
+    inline def lift[A](inline c: Vector[A]): CChunk[A] = c
+
+    extension [A](inline self: CChunk[A])
+
+        inline def lower: Vector[A]            = self
+        inline def toSeq: Seq[A]               = self
+        inline def toIndexedSeq: IndexedSeq[A] = self
+        inline def apply(inline i: Int): A     = self(i)
+        inline def size: Int                   = self.size
+        inline def iterator: Iterator[A]       = self.iterator
+        inline def isEmpty: Boolean            = self.isEmpty
+
+    end extension
+
+end CChunk

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CFiber.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CFiber.scala
@@ -1,0 +1,55 @@
+package kyo.compat
+
+import com.twitter.util.Future
+import com.twitter.util.Promise
+import com.twitter.util.Return
+import com.twitter.util.Throw
+
+/** Backed by a `com.twitter.util.Future[A]` wired to a `Promise[A]` with an interrupt handler.
+  *
+  * `init` wraps the body's result in a `Promise[A]` with `setInterruptHandler`: when the promise is raised with an exception (e.g. by
+  * `race`'s loser-cancel or parent-fiber propagation), the handler calls `body.raise` so the inner computation receives the signal and
+  * flips the result promise to `Throw(t)` so the fiber resolves as interrupted. `body.respond` is also wired to complete the result promise
+  * normally on success/failure.
+  */
+opaque type CFiber[+A] = Future[A]
+
+object CFiber:
+
+    inline def init[A](inline c: CIO[A]): CIO[CFiber[A]] =
+        CIO.defer {
+            val result = new Promise[A]()
+            val body   = c.lower()
+            val _ = body.respond { r =>
+                val _ = result.updateIfEmpty(r)
+            }
+            result.setInterruptHandler { case t =>
+                body.raise(t)
+                val _ = result.updateIfEmpty(Throw(t))
+            }
+            result
+        }
+
+    inline def lift[A](inline u: Future[A]): CFiber[A] = u
+
+    extension [A](self: CFiber[A])
+
+        inline def lower: Future[A] = self
+
+        inline def get: CIO[A] =
+            CIO.lift(self)
+
+        inline def onComplete(inline cb: scala.util.Try[A] => CIO[Unit]): CIO[Unit] =
+            CIO.defer {
+                val _ = self.respond { r =>
+                    val t: scala.util.Try[A] = r match
+                        case Return(a) => scala.util.Success(a)
+                        case Throw(e)  => scala.util.Failure(e)
+                    val _ = cb(t).lower()
+                }
+            }
+        end onComplete
+
+    end extension
+
+end CFiber

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CIO.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CIO.scala
@@ -1,0 +1,398 @@
+package kyo.compat
+
+import com.twitter.util.Future
+import com.twitter.util.Promise
+import com.twitter.util.Return
+import com.twitter.util.Throw
+import com.twitter.util.TimeoutException as TwTimeoutException
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.NANOSECONDS
+import scala.jdk.FutureConverters.*
+import scala.reflect.ClassTag
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scala.util.control.NonFatal
+
+/** Underlying carrier is `() => Future[A]` — a cold thunk. Future.apply is eager, so the thunk defers execution; each call to `lower()`
+  * invokes a fresh execution. Twitter Local propagation is automatic across async boundaries. cede forks an empty task on the unbounded
+  * FuturePool. zip uses Future.join for all arities. race raises a CancellationException on the loser. timeout / timeoutWithError use
+  * Future.raiseWithin, which propagates an interrupt to the inner.
+  */
+opaque type CIO[+A] = () => Future[A]
+
+object CIO:
+
+    /** Wrap an already-constructed, pure `Future` value (no side effects in building the argument). */
+    inline def lift[A](inline f: Future[A]): CIO[A] = () => f
+
+    /** Suspend side-effecting code that produces a `Future`; the body runs fresh on each execution. */
+    inline def deferLift[A](inline f: => Future[A]): CIO[A] = () => f
+
+    inline def value[A](inline a: A): CIO[A] = lift(Future.value(a))
+
+    inline def unit: CIO[Unit] = lift(Future.Done)
+
+    inline def fail(inline e: Throwable): CIO[Nothing] = lift(Future.exception(e))
+
+    inline def defer[A](inline thunk: => A): CIO[A] =
+        deferLift {
+            try Future.value(thunk)
+            catch case t: Throwable if NonFatal(t) => Future.exception(t)
+        }
+
+    inline def get[A](inline t: Try[A]): CIO[A] =
+        lift {
+            t match
+                case Success(a) => Future.value(a)
+                case Failure(e) => Future.exception(e)
+        }
+
+    inline def fromScalaFuture[A](inline f: scala.concurrent.Future[A]): CIO[A] =
+        CompatFromCompletionStage.fromCompletionStage(f.asJava)
+
+    inline def acquireReleaseWith[A, B](
+        inline acquire: CIO[A]
+    )(
+        inline release: A => CIO[Unit]
+    )(
+        inline use: A => CIO[B]
+    ): CIO[B] =
+        deferLift {
+            acquire.lower().flatMap { a =>
+                val released = new java.util.concurrent.atomic.AtomicBoolean(false)
+                def runRelease(): Future[Unit] =
+                    if released.compareAndSet(false, true) then
+                        val relFut =
+                            try release(a).lower()
+                            catch case t: Throwable if NonFatal(t) => Future.exception[Unit](t)
+                        relFut.masked
+                    else Future.Done
+                end runRelease
+                use(a).lower().transform { result =>
+                    runRelease().transform { releaseResult =>
+                        result match
+                            case Return(b) =>
+                                releaseResult match
+                                    case Return(_) => Future.value(b)
+                                    case Throw(t)  => Future.exception(t)
+                            case Throw(t) => Future.exception(t)
+                    }
+                }
+            }
+        }
+
+    inline def ensure[A](
+        inline cleanup: CIO[Unit]
+    )(
+        inline c: CIO[A]
+    ): CIO[A] =
+        acquireReleaseWith(CIO.unit)(_ => cleanup)(_ => c)
+
+    inline def never: CIO[Nothing] = deferLift(new Promise[Nothing]())
+
+    extension [A](inline self: CIO[A])
+
+        inline def lower: () => Future[A] = self
+
+        inline def recover[A2 >: A](inline handler: Throwable => CIO[A2]): CIO[A2] =
+            deferLift {
+                self.lower().rescue {
+                    case t => handler(t).lower()
+                }
+            }
+
+        inline def fold[B](
+            inline onSuccess: A => CIO[B],
+            inline onFail: Throwable => CIO[B]
+        ): CIO[B] =
+            deferLift {
+                self.lower().transform {
+                    case Return(a) =>
+                        try onSuccess(a).lower()
+                        catch case t: Throwable if NonFatal(t) => Future.exception[B](t)
+                    case Throw(t) =>
+                        try onFail(t).lower()
+                        catch case t2: Throwable if NonFatal(t2) => Future.exception[B](t2)
+                }
+            }
+
+        inline def liftToTry: CIO[Try[A]] =
+            deferLift {
+                self.lower().transform {
+                    case Return(a) => Future.value[Try[A]](Success(a))
+                    case Throw(t)  => Future.value[Try[A]](Failure(t))
+                }
+            }
+
+        inline def unit: CIO[Unit] =
+            deferLift(self.lower().unit)
+
+        inline def orElse[A2 >: A](inline that: CIO[A2]): CIO[A2] =
+            deferLift {
+                self.lower().rescue {
+                    case t: Throwable if NonFatal(t) => that.lower()
+                }
+            }
+
+        inline def mapError(inline f: Throwable => Throwable): CIO[A] =
+            deferLift {
+                self.lower().transform {
+                    case Return(a) => Future.value(a)
+                    case Throw(t) =>
+                        try Future.exception(f(t))
+                        catch case t2: Throwable if NonFatal(t2) => Future.exception(t2)
+                }
+            }
+
+        inline def map[B](inline f: A => B): CIO[B] =
+            deferLift(self.lower().map(f))
+
+        inline def flatMap[B](inline f: A => CIO[B]): CIO[B] =
+            deferLift(self.lower().flatMap(a => f(a).lower()))
+
+        inline def unsafeRun: scala.concurrent.Future[A] =
+            val p = scala.concurrent.Promise[A]()
+            val _ = self.lower().respond {
+                case Return(a) => val _ = p.trySuccess(a)
+                case Throw(t)  => val _ = p.tryFailure(t)
+            }
+            p.future
+        end unsafeRun
+
+    end extension
+
+    private inline def toTwitterDuration(inline d: FiniteDuration): com.twitter.util.Duration =
+        com.twitter.util.Duration.fromNanoseconds(d.toNanos)
+
+    inline def sleep(inline d: FiniteDuration): CIO[Unit] =
+        deferLift(Future.sleep(toTwitterDuration(d))(using twitterTimer))
+
+    inline def now: CIO[java.time.Instant] = defer(java.time.Instant.now())
+
+    inline def nowMonotonic: CIO[FiniteDuration] =
+        defer(FiniteDuration(java.lang.System.nanoTime(), NANOSECONDS))
+
+    inline def timeout[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[Option[A]] =
+        deferLift {
+            c.lower().raiseWithin(toTwitterDuration(d))(using twitterTimer).transform {
+                case Return(a)                    => Future.value(Option(a))
+                case Throw(_: TwTimeoutException) => Future.value(None: Option[A])
+                case Throw(t)                     => Future.exception(t)
+            }
+        }
+
+    inline def timeoutWithError[A](inline d: FiniteDuration)(inline e: Throwable)(inline c: CIO[A]): CIO[A] =
+        deferLift(c.lower().raiseWithin(toTwitterDuration(d), e)(using twitterTimer))
+
+    inline def delay[A](inline d: FiniteDuration)(inline c: CIO[A]): CIO[A] =
+        deferLift(Future.sleep(toTwitterDuration(d))(using twitterTimer).flatMap(_ => c.lower()))
+
+    inline def race[A](
+        inline a: CIO[A],
+        inline b: CIO[A]
+    ): CIO[A] =
+        deferLift {
+            val fa           = a.lower()
+            val fb           = b.lower()
+            val p            = new Promise[A]()
+            val cancelSignal = new java.util.concurrent.CancellationException("race: loser cancelled")
+            val _ = fa.respond {
+                case result =>
+                    if p.updateIfEmpty(result) then fb.raise(cancelSignal)
+            }
+            val _ = fb.respond {
+                case result =>
+                    if p.updateIfEmpty(result) then fa.raise(cancelSignal)
+            }
+            // Propagate parent-fiber interrupt to both legs so that when the containing
+            // CFiber is interrupted, both race legs also stop.
+            p.setInterruptHandler { case t =>
+                fa.raise(t)
+                fb.raise(t)
+            }
+            p
+        }
+
+    /** Collect futures in parallel with interrupt cascade. The returned Promise propagates raise() to all constituent futures so that
+      * parent-fiber interrupt stops all in-flight items.
+      */
+    private def parWithRaiseCascade[B](futs: Seq[Future[B]]): Future[Seq[B]] =
+        val p      = new Promise[Seq[B]]()
+        val joined = Future.collect(futs)
+        val _ = joined.respond { r =>
+            val _ = p.updateIfEmpty(r)
+        }
+        p.setInterruptHandler { case t =>
+            futs.foreach(_.raise(t))
+            val _ = p.updateIfEmpty(Throw(t))
+        }
+        p
+    end parWithRaiseCascade
+
+    inline def foreach[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(f: A => CIO[B]): CIO[CChunk[B]] =
+        deferLift {
+            val items = coll.toVector
+            val futs: Seq[Future[B]] =
+                if concurrency == Int.MaxValue then items.map(a => f(a).lower())
+                else
+                    val sem = new com.twitter.concurrent.AsyncSemaphore(concurrency)
+                    items.map(a => sem.acquireAndRun(f(a).lower()))
+            parWithRaiseCascade(futs).map(s => CChunk.lift(s.toVector))
+        }
+
+    inline def foreachIndexed[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(f: (Int, A) => CIO[B]): CIO[CChunk[B]] =
+        deferLift {
+            val items = coll.toVector.zipWithIndex
+            val futs: Seq[Future[B]] =
+                if concurrency == Int.MaxValue then items.map { case (a, i) => f(i, a).lower() }
+                else
+                    val sem = new com.twitter.concurrent.AsyncSemaphore(concurrency)
+                    items.map { case (a, i) => sem.acquireAndRun(f(i, a).lower()) }
+            parWithRaiseCascade(futs).map(s => CChunk.lift(s.toVector))
+        }
+
+    inline def foreachDiscard[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(f: A => CIO[Any]): CIO[Unit] =
+        deferLift {
+            val items = coll.toVector
+            val futs: Seq[Future[Any]] =
+                if concurrency == Int.MaxValue then items.map(a => f(a).lower())
+                else
+                    val sem = new com.twitter.concurrent.AsyncSemaphore(concurrency)
+                    items.map(a => sem.acquireAndRun(f(a).lower()))
+            parWithRaiseCascade(futs).map(_ => ())
+        }
+
+    inline def filter[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(p: A => CIO[Boolean]): CIO[CChunk[A]] =
+        deferLift {
+            val items = coll.toVector
+            val futs: Seq[Future[Boolean]] =
+                if concurrency == Int.MaxValue then items.map(a => p(a).lower())
+                else
+                    val sem = new com.twitter.concurrent.AsyncSemaphore(concurrency)
+                    items.map(a => sem.acquireAndRun(p(a).lower()))
+            parWithRaiseCascade(futs).map(flags =>
+                CChunk.lift(items.zip(flags).collect { case (a, true) => a }.toVector)
+            )
+        }
+
+    inline def collectAll[A](
+        inline coll: Iterable[CIO[A]],
+        inline concurrency: Int = Int.MaxValue
+    ): CIO[CChunk[A]] =
+        deferLift {
+            val items = coll.toVector
+            val futs: Seq[Future[A]] =
+                if concurrency == Int.MaxValue then items.map(c => c.lower())
+                else
+                    val sem = new com.twitter.concurrent.AsyncSemaphore(concurrency)
+                    items.map(c => sem.acquireAndRun(c.lower()))
+            parWithRaiseCascade(futs).map(s => CChunk.lift(s.toVector))
+        }
+
+    inline def collectAllDiscard(
+        inline coll: Iterable[CIO[Any]],
+        inline concurrency: Int = Int.MaxValue
+    ): CIO[Unit] =
+        deferLift {
+            val items = coll.toVector
+            val futs: Seq[Future[Any]] =
+                if concurrency == Int.MaxValue then items.map(c => c.lower())
+                else
+                    val sem = new com.twitter.concurrent.AsyncSemaphore(concurrency)
+                    items.map(c => sem.acquireAndRun(c.lower()))
+            parWithRaiseCascade(futs).map(_ => ())
+        }
+
+    inline def async[A](inline register: ((Try[A] => Unit) => Unit)): CIO[A] =
+        deferLift {
+            val p = new Promise[A]()
+            val cb: Try[A] => Unit = {
+                case Success(a) =>
+                    val _ = p.updateIfEmpty(Return(a))
+                    ()
+                case Failure(e) =>
+                    val _ = p.updateIfEmpty(Throw(e))
+                    ()
+            }
+            try register(cb)
+            catch
+                case t: Throwable if NonFatal(t) =>
+                    val _ = p.updateIfEmpty(Throw(t))
+            end try
+            p
+        }
+
+    inline def blocking[A](inline thunk: => A): CIO[A] =
+        deferLift(blockingFuturePool(thunk))
+
+    inline def cede: CIO[Unit] =
+        // doLater(Zero) schedules a real "run now" task on the timer thread — a genuine async
+        // boundary that lets the current fiber suspend. (Future.sleep(Zero) short-circuits to an
+        // already-completed future and would not yield.)
+        deferLift(twitterTimer.doLater(com.twitter.util.Duration.Zero)(()))
+
+    inline def zip[A, B](
+        inline a: CIO[A],
+        inline b: CIO[B]
+    ): CIO[(A, B)] =
+        deferLift(a.lower().join(b.lower()))
+
+    inline def zip[A, B, C](
+        inline a: CIO[A],
+        inline b: CIO[B],
+        inline c: CIO[C]
+    ): CIO[(A, B, C)] =
+        deferLift(Future.join(a.lower(), b.lower(), c.lower()))
+
+    inline def zip[A, B, C, D](
+        inline a: CIO[A],
+        inline b: CIO[B],
+        inline c: CIO[C],
+        inline d: CIO[D]
+    ): CIO[(A, B, C, D)] =
+        deferLift(Future.join(a.lower(), b.lower(), c.lower(), d.lower()))
+
+    inline def zip[A, B, C, D, E1](
+        inline a: CIO[A],
+        inline b: CIO[B],
+        inline c: CIO[C],
+        inline d: CIO[D],
+        inline e: CIO[E1]
+    ): CIO[(A, B, C, D, E1)] =
+        deferLift(Future.join(a.lower(), b.lower(), c.lower(), d.lower(), e.lower()))
+
+    inline def zip[A, B, C, D, E1, F](
+        inline a: CIO[A],
+        inline b: CIO[B],
+        inline c: CIO[C],
+        inline d: CIO[D],
+        inline e: CIO[E1],
+        inline f: CIO[F]
+    ): CIO[(A, B, C, D, E1, F)] =
+        deferLift(Future.join(a.lower(), b.lower(), c.lower(), d.lower(), e.lower(), f.lower()))
+
+    inline def zip[A, B, C, D, E1, F, G](
+        inline a: CIO[A],
+        inline b: CIO[B],
+        inline c: CIO[C],
+        inline d: CIO[D],
+        inline e: CIO[E1],
+        inline f: CIO[F],
+        inline g: CIO[G]
+    ): CIO[(A, B, C, D, E1, F, G)] =
+        deferLift(Future.join(a.lower(), b.lower(), c.lower(), d.lower(), e.lower(), f.lower(), g.lower()))
+
+end CIO

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CLatch.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CLatch.scala
@@ -1,0 +1,44 @@
+package kyo.compat
+
+import com.twitter.util.Promise
+import com.twitter.util.Return
+import java.util.concurrent.atomic.AtomicInteger
+import scala.annotation.publicInBinary
+
+/** A countdown latch backed by a `Promise[Unit]` gated by an `AtomicInteger` counter — no thread blocking. `release` decrements the counter
+  * and resolves the promise when it hits zero; `await` returns the promise as a Future. `init(n <= 0)` produces an already-released latch.
+  */
+final class CLatch @publicInBinary private[compat] (initial: Int):
+
+    private val remaining           = new AtomicInteger(math.max(initial, 0))
+    private val gate: Promise[Unit] = new Promise[Unit]()
+
+    if initial <= 0 then
+        val _ = gate.updateIfEmpty(Return(()))
+
+    inline def lower: CLatch = this
+
+    inline def await: CIO[Unit] =
+        CIO.lift(gate)
+
+    inline def release: CIO[Unit] =
+        CIO.defer {
+            val r = remaining.decrementAndGet()
+            if r == 0 then
+                val _ = gate.updateIfEmpty(Return(()))
+            else if r < 0 then
+                // Already released; clamp the counter so additional releases stay idempotent.
+                remaining.set(0)
+            end if
+        }
+
+end CLatch
+
+object CLatch:
+
+    inline def init(inline n: Int): CIO[CLatch] =
+        CIO.defer(new CLatch(n))
+
+    inline def lift(inline u: CLatch): CLatch = u
+
+end CLatch

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CLatch.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CLatch.scala
@@ -3,12 +3,11 @@ package kyo.compat
 import com.twitter.util.Promise
 import com.twitter.util.Return
 import java.util.concurrent.atomic.AtomicInteger
-import scala.annotation.publicInBinary
 
 /** A countdown latch backed by a `Promise[Unit]` gated by an `AtomicInteger` counter — no thread blocking. `release` decrements the counter
   * and resolves the promise when it hits zero; `await` returns the promise as a Future. `init(n <= 0)` produces an already-released latch.
   */
-final class CLatch @publicInBinary private[compat] (initial: Int):
+final class CLatch(initial: Int):
 
     private val remaining           = new AtomicInteger(math.max(initial, 0))
     private val gate: Promise[Unit] = new Promise[Unit]()

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CLocal.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CLocal.scala
@@ -1,0 +1,42 @@
+package kyo.compat
+
+import com.twitter.util.Future
+import com.twitter.util.Local as TLocal
+
+/** Backed by com.twitter.util.Local[A]. Twitter Local is propagated automatically across async boundaries by the Twitter scheduler — no
+  * ContextPropagatingEC wrapper needed. `init` is deferred so each call to `CLocal.init` constructs a fresh local at effect-evaluation
+  * time. let restores the previous value on scope exit across continuations.
+  */
+opaque type CLocal[A] = (TLocal[A], A)
+
+object CLocal:
+
+    inline def init[A](inline default: A): CIO[CLocal[A]] =
+        CIO.defer((new TLocal[A](), default))
+
+    inline def lift[A](inline u: (TLocal[A], A)): CLocal[A] = u
+
+    extension [A](inline self: CLocal[A])
+
+        inline def lower: (TLocal[A], A) = self
+
+        private inline def tlocal: TLocal[A] = self._1
+        private inline def tdefault: A       = self._2
+
+        inline def get: CIO[A] =
+            CIO.defer(tlocal().getOrElse(tdefault))
+
+        inline def let[B](inline value: A)(inline c: CIO[B]): CIO[B] =
+            CIO.deferLift {
+                tlocal.let(value) { c.lower() }
+            }
+
+        inline def update[B](inline f: A => A)(inline c: CIO[B]): CIO[B] =
+            CIO.deferLift {
+                val cur = tlocal().getOrElse(tdefault)
+                tlocal.let(f(cur)) { c.lower() }
+            }
+
+    end extension
+
+end CLocal

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CMeter.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CMeter.scala
@@ -1,0 +1,74 @@
+package kyo.compat
+
+import com.twitter.concurrent.AsyncSemaphore
+import com.twitter.concurrent.Permit
+import com.twitter.util.Future
+import com.twitter.util.Return
+import com.twitter.util.Throw
+import java.util.concurrent.CancellationException
+
+/** Backed by `com.twitter.concurrent.AsyncSemaphore`. `run` calls `acquire(): Future[Permit]` and runs the body once the permit is granted;
+  * no thread is blocked while waiting. `tryRun` issues a synchronous `acquire()` and checks `isDefined` — if the permit was granted on the
+  * spot, the body runs; otherwise the queued acquire is cancelled via `raise` and `None` is returned.
+  */
+opaque type CMeter = AsyncSemaphore
+
+object CMeter:
+
+    inline def init(inline permits: Int): CIO[CMeter] =
+        CIO.defer(new AsyncSemaphore(permits))
+
+    inline def lift(inline u: AsyncSemaphore): CMeter = u
+
+    extension (inline self: CMeter)
+
+        inline def lower: AsyncSemaphore = self
+
+        inline def run[A](inline c: CIO[A]): CIO[A] =
+            CIO.deferLift {
+                self.acquire().flatMap { permit =>
+                    c.lower().transform {
+                        case Return(a) =>
+                            permit.release()
+                            Future.value(a)
+                        case Throw(t) =>
+                            permit.release()
+                            Future.exception(t)
+                    }
+                }
+            }
+
+        inline def tryRun[A](inline c: CIO[A]): CIO[Option[A]] =
+            CIO.deferLift {
+                val acq = self.acquire()
+                if acq.isDefined then
+                    acq.flatMap { permit =>
+                        c.lower().transform {
+                            case Return(a) =>
+                                permit.release()
+                                Future.value[Option[A]](Some(a))
+                            case Throw(t) =>
+                                permit.release()
+                                Future.exception[Option[A]](t)
+                        }
+                    }
+                else
+                    // Lost the race: no permit available now. Cancel the queued acquire via raise
+                    // (AsyncSemaphore's interrupt handler removes the waiter). In the vanishingly
+                    // small window where a permit arrives between isDefined-check and raise, the
+                    // respond-callback releases it so no permit leaks.
+                    acq.raise(new CancellationException("CMeter.tryRun: no permit available"))
+                    val _ = acq.respond {
+                        case Return(permit) => permit.release()
+                        case _              => ()
+                    }
+                    Future.value(None: Option[A])
+                end if
+            }
+
+        inline def availablePermits: CIO[Int] =
+            CIO.defer(self.numPermitsAvailable)
+
+    end extension
+
+end CMeter

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CPromise.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/CPromise.scala
@@ -1,0 +1,43 @@
+package kyo.compat
+
+import com.twitter.util.Future
+import com.twitter.util.Promise
+import com.twitter.util.Return
+import com.twitter.util.Throw
+import scala.reflect.ClassTag
+
+/** Backed by com.twitter.util.Promise[A]. poll narrows failures back to E via ClassTag; untyped failures are re-thrown. */
+opaque type CPromise[A] = Promise[A]
+
+object CPromise:
+
+    inline def init[A]: CIO[CPromise[A]] =
+        CIO.defer(new Promise[A]())
+
+    inline def lift[A](inline u: Promise[A]): CPromise[A] = u
+
+    extension [A](self: CPromise[A])
+
+        inline def lower: Promise[A] = self
+
+        inline def succeed(inline a: A): CIO[Boolean] =
+            CIO.defer(self.updateIfEmpty(Return(a)))
+
+        inline def fail(inline e: Throwable): CIO[Boolean] =
+            CIO.defer(self.updateIfEmpty(Throw(e)))
+
+        inline def get: CIO[A] =
+            CIO.lift(self)
+
+        inline def poll: CIO[Option[scala.util.Try[A]]] =
+            CIO.defer(self.poll match
+                case None            => None
+                case Some(Return(a)) => Some(scala.util.Success(a))
+                case Some(Throw(t))  => Some(scala.util.Failure(t)))
+
+        inline def done: CIO[Boolean] =
+            CIO.defer(self.isDefined)
+
+    end extension
+
+end CPromise

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
@@ -1,0 +1,33 @@
+package kyo.compat
+
+import com.twitter.util.Future
+import com.twitter.util.Promise
+import com.twitter.util.Return
+import com.twitter.util.Throw
+import java.util.concurrent.CompletionStage
+
+/** JVM-only. Bridges via Promise + CompletionStage.whenComplete. Cancellation does NOT propagate back to the source CompletionStage. */
+object CompatFromCompletionStage:
+
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
+        CIO.deferLift {
+            val p = new Promise[A]()
+            cs.whenComplete { (result: A, err: Throwable) =>
+                if err != null then
+                    val cause =
+                        if err.isInstanceOf[java.util.concurrent.CompletionException] && err.getCause != null
+                        then err.getCause
+                        else err
+                    val _ = p.updateIfEmpty(Throw(cause))
+                else
+                    val _ = p.updateIfEmpty(Return(result))
+            }
+            p
+        }
+
+end CompatFromCompletionStage
+
+extension (inline c: CIO.type)
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A]): CIO[A] =
+        CompatFromCompletionStage.fromCompletionStage(cs)
+end extension

--- a/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/package.scala
+++ b/kyo-compat/bindings/twitter-future/jvm/src/main/scala/kyo/compat/package.scala
@@ -1,0 +1,12 @@
+package kyo.compat
+
+import com.twitter.util.FuturePool
+import com.twitter.util.JavaTimer
+
+/** twitterTimer: daemon JavaTimer for sleep/delay/timeout. blockingFuturePool: unbounded daemon FuturePool for blocking ops.
+  */
+private[compat] val twitterTimer: JavaTimer =
+    new JavaTimer(isDaemon = true)
+
+private[compat] val blockingFuturePool: FuturePool =
+    FuturePool.unboundedPool

--- a/kyo-compat/bindings/zio/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
+++ b/kyo-compat/bindings/zio/jvm/src/main/scala/kyo/compat/FromCompletionStage.scala
@@ -1,0 +1,19 @@
+package kyo.compat
+
+import java.util.concurrent.CompletionStage
+import zio.*
+
+/** JVM-only. Wraps `ZIO.fromCompletionStage` (returns `Task[A]` = `ZIO[Any, Throwable, A]`, the CIO carrier). */
+object CompatFromCompletionStage:
+
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A])(using inline trace: Trace): CIO[A] =
+        CIO.lift(ZIO.fromCompletionStage(cs))
+
+end CompatFromCompletionStage
+
+extension (inline c: CIO.type)
+    inline def fromCompletionStage[A](inline cs: CompletionStage[A])(
+        using inline trace: Trace
+    ): CIO[A] =
+        CompatFromCompletionStage.fromCompletionStage(cs)
+end extension

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CAtomicBoolean.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CAtomicBoolean.scala
@@ -1,0 +1,34 @@
+package kyo.compat
+
+import zio.*
+
+/** Backed by `zio.Ref[Boolean]`. `compareAndSet` is composed via `Ref.modify` since ZIO's `Ref` has no native CAS. */
+opaque type CAtomicBoolean = Ref[Boolean]
+
+object CAtomicBoolean:
+
+    inline def init(inline v: Boolean)(using inline trace: Trace): CIO[CAtomicBoolean] =
+        CIO.lift(Ref.make[Boolean](v))
+
+    inline def lift(inline u: Ref[Boolean]): CAtomicBoolean = u
+
+    extension (inline self: CAtomicBoolean)
+
+        inline def lower: Ref[Boolean] = self
+
+        inline def get(using inline trace: Trace): CIO[Boolean] =
+            CIO.lift(self.get)
+
+        inline def set(inline v: Boolean)(using inline trace: Trace): CIO[Unit] =
+            CIO.lift(self.set(v))
+
+        inline def getAndSet(inline v: Boolean)(using inline trace: Trace): CIO[Boolean] =
+            CIO.lift(self.getAndSet(v))
+
+        inline def compareAndSet(inline expected: Boolean, inline updated: Boolean)(
+            using inline trace: Trace
+        ): CIO[Boolean] =
+            CIO.lift(self.modify(cur => if cur == expected then (true, updated) else (false, cur)))
+    end extension
+
+end CAtomicBoolean

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CAtomicInt.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CAtomicInt.scala
@@ -1,0 +1,52 @@
+package kyo.compat
+
+import zio.*
+
+/** Backed by `zio.Ref[Int]`. ZIO has no specialised AtomicInt; arithmetic operations compose via `Ref[Int]` updates. */
+opaque type CAtomicInt = Ref[Int]
+
+object CAtomicInt:
+
+    inline def init(inline v: Int)(using inline trace: Trace): CIO[CAtomicInt] =
+        CIO.lift(Ref.make[Int](v))
+
+    inline def lift(inline u: Ref[Int]): CAtomicInt = u
+
+    extension (inline self: CAtomicInt)
+
+        inline def lower: Ref[Int] = self
+
+        inline def get(using inline trace: Trace): CIO[Int] =
+            CIO.lift(self.get)
+
+        inline def set(inline v: Int)(using inline trace: Trace): CIO[Unit] =
+            CIO.lift(self.set(v))
+
+        inline def getAndSet(inline v: Int)(using inline trace: Trace): CIO[Int] =
+            CIO.lift(self.getAndSet(v))
+
+        inline def incrementAndGet(using inline trace: Trace): CIO[Int] =
+            CIO.lift(self.updateAndGet(_ + 1))
+
+        inline def getAndIncrement(using inline trace: Trace): CIO[Int] =
+            CIO.lift(self.getAndUpdate(_ + 1))
+
+        inline def decrementAndGet(using inline trace: Trace): CIO[Int] =
+            CIO.lift(self.updateAndGet(_ - 1))
+
+        inline def getAndDecrement(using inline trace: Trace): CIO[Int] =
+            CIO.lift(self.getAndUpdate(_ - 1))
+
+        inline def addAndGet(inline delta: Int)(using inline trace: Trace): CIO[Int] =
+            CIO.lift(self.updateAndGet(_ + delta))
+
+        inline def getAndAdd(inline delta: Int)(using inline trace: Trace): CIO[Int] =
+            CIO.lift(self.getAndUpdate(_ + delta))
+
+        inline def compareAndSet(inline expected: Int, inline updated: Int)(
+            using inline trace: Trace
+        ): CIO[Boolean] =
+            CIO.lift(self.modify(cur => if cur == expected then (true, updated) else (false, cur)))
+    end extension
+
+end CAtomicInt

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CAtomicLong.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CAtomicLong.scala
@@ -1,0 +1,52 @@
+package kyo.compat
+
+import zio.*
+
+/** Backed by `zio.Ref[Long]`. ZIO has no specialised AtomicLong; arithmetic operations compose via `Ref[Long]` updates. */
+opaque type CAtomicLong = Ref[Long]
+
+object CAtomicLong:
+
+    inline def init(inline v: Long)(using inline trace: Trace): CIO[CAtomicLong] =
+        CIO.lift(Ref.make[Long](v))
+
+    inline def lift(inline u: Ref[Long]): CAtomicLong = u
+
+    extension (inline self: CAtomicLong)
+
+        inline def lower: Ref[Long] = self
+
+        inline def get(using inline trace: Trace): CIO[Long] =
+            CIO.lift(self.get)
+
+        inline def set(inline v: Long)(using inline trace: Trace): CIO[Unit] =
+            CIO.lift(self.set(v))
+
+        inline def getAndSet(inline v: Long)(using inline trace: Trace): CIO[Long] =
+            CIO.lift(self.getAndSet(v))
+
+        inline def incrementAndGet(using inline trace: Trace): CIO[Long] =
+            CIO.lift(self.updateAndGet(_ + 1L))
+
+        inline def getAndIncrement(using inline trace: Trace): CIO[Long] =
+            CIO.lift(self.getAndUpdate(_ + 1L))
+
+        inline def decrementAndGet(using inline trace: Trace): CIO[Long] =
+            CIO.lift(self.updateAndGet(_ - 1L))
+
+        inline def getAndDecrement(using inline trace: Trace): CIO[Long] =
+            CIO.lift(self.getAndUpdate(_ - 1L))
+
+        inline def addAndGet(inline delta: Long)(using inline trace: Trace): CIO[Long] =
+            CIO.lift(self.updateAndGet(_ + delta))
+
+        inline def getAndAdd(inline delta: Long)(using inline trace: Trace): CIO[Long] =
+            CIO.lift(self.getAndUpdate(_ + delta))
+
+        inline def compareAndSet(inline expected: Long, inline updated: Long)(
+            using inline trace: Trace
+        ): CIO[Boolean] =
+            CIO.lift(self.modify(cur => if cur == expected then (true, updated) else (false, cur)))
+    end extension
+
+end CAtomicLong

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CAtomicRef.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CAtomicRef.scala
@@ -1,0 +1,42 @@
+package kyo.compat
+
+import zio.*
+
+/** Backed by `zio.Ref[A]`. `compareAndSet` is composed via `Ref.modify` since ZIO's `Ref` has no native CAS. */
+opaque type CAtomicRef[A] = Ref[A]
+
+object CAtomicRef:
+
+    inline def init[A](inline a: A)(using inline trace: Trace): CIO[CAtomicRef[A]] =
+        CIO.lift(Ref.make[A](a))
+
+    inline def lift[A](inline u: Ref[A]): CAtomicRef[A] = u
+
+    extension [A](inline self: CAtomicRef[A])
+
+        inline def lower: Ref[A] = self
+
+        inline def get(using inline trace: Trace): CIO[A] =
+            CIO.lift(self.get)
+
+        inline def set(inline a: A)(using inline trace: Trace): CIO[Unit] =
+            CIO.lift(self.set(a))
+
+        inline def getAndSet(inline a: A)(using inline trace: Trace): CIO[A] =
+            CIO.lift(self.getAndSet(a))
+
+        inline def updateAndGet(inline f: A => A)(using inline trace: Trace): CIO[A] =
+            CIO.lift(self.updateAndGet(f))
+
+        inline def getAndUpdate(inline f: A => A)(using inline trace: Trace): CIO[A] =
+            CIO.lift(self.getAndUpdate(f))
+
+        inline def compareAndSet(inline expected: A, inline updated: A)(
+            using inline trace: Trace
+        ): CIO[Boolean] =
+            CIO.lift(self.modify(cur =>
+                if (cur: Any).equals(expected) then (true, updated) else (false, cur)
+            ))
+    end extension
+
+end CAtomicRef

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CChannel.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CChannel.scala
@@ -1,0 +1,32 @@
+package kyo.compat
+
+import zio.*
+
+/** A bounded async channel backed by `zio.Queue.bounded[A]`.
+  *
+  * `close`/`shutdown` are not exposed; the channel lives until the owning fiber terminates.
+  */
+opaque type CChannel[A] = Queue[A]
+
+object CChannel:
+
+    inline def init[A](inline capacity: Int)(using inline trace: Trace): CIO[CChannel[A]] =
+        CIO.lift(Queue.bounded[A](capacity))
+
+    inline def lift[A](inline u: Queue[A]): CChannel[A] = u
+
+    extension [A](inline self: CChannel[A])
+
+        inline def lower: Queue[A] = self
+
+        inline def put(inline v: A)(using inline trace: Trace): CIO[Unit] =
+            CIO.lift(self.offer(v).unit)
+
+        inline def take(using inline trace: Trace): CIO[A] =
+            CIO.lift(self.take)
+
+        inline def poll(using inline trace: Trace): CIO[Option[A]] =
+            CIO.lift(self.poll)
+    end extension
+
+end CChannel

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CChunk.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CChunk.scala
@@ -1,0 +1,22 @@
+package kyo.compat
+
+/** Backed by `zio.Chunk[A]`. Use `.lower` to access the native chunk directly. */
+opaque type CChunk[+A] = zio.Chunk[A]
+
+object CChunk:
+
+    inline def lift[A](inline c: zio.Chunk[A]): CChunk[A] = c
+
+    extension [A](inline self: CChunk[A])
+
+        inline def lower: zio.Chunk[A]         = self
+        inline def toSeq: Seq[A]               = self.toSeq
+        inline def toIndexedSeq: IndexedSeq[A] = self.toIndexedSeq
+        inline def apply(inline i: Int): A     = self(i)
+        inline def size: Int                   = self.size
+        inline def iterator: Iterator[A]       = self.iterator
+        inline def isEmpty: Boolean            = self.isEmpty
+
+    end extension
+
+end CChunk

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CFiber.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CFiber.scala
@@ -1,0 +1,44 @@
+package kyo.compat
+
+import zio.*
+
+/** Backed by `zio.Fiber.Runtime[Throwable, A]`. `init` uses `forkDaemon` to spawn a fiber outside the current scope. `get` awaits the fiber
+  * and surfaces failures. `onComplete` forks a daemon watcher that fires the callback on resolution.
+  */
+opaque type CFiber[+A] = Fiber.Runtime[Throwable, A]
+
+object CFiber:
+
+    inline def init[A](inline c: CIO[A])(using inline trace: Trace): CIO[CFiber[A]] =
+        CIO.lift(c.lower.forkDaemon)
+
+    inline def lift[A](inline u: Fiber.Runtime[Throwable, A]): CFiber[A] = u
+
+    extension [A](inline self: CFiber[A])
+
+        inline def lower: Fiber.Runtime[Throwable, A] = self
+
+        inline def get(using inline trace: Trace): CIO[A] =
+            CIO.lift(
+                self.lower.await.flatMap {
+                    case Exit.Success(a)     => ZIO.succeed(a)
+                    case Exit.Failure(cause) => ZIO.fail(cause.squash)
+                }
+            )
+
+        inline def onComplete(inline cb: scala.util.Try[A] => CIO[Unit])(
+            using inline trace: Trace
+        ): CIO[Unit] =
+            CIO.lift(
+                self.lower.await
+                    .flatMap { exit =>
+                        val t: scala.util.Try[A] = exit match
+                            case Exit.Success(a)     => scala.util.Success(a)
+                            case Exit.Failure(cause) => scala.util.Failure(cause.squash)
+                        cb(t).lower
+                    }
+                    .forkDaemon
+                    .unit
+            )
+    end extension
+end CFiber

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CIO.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CIO.scala
@@ -1,0 +1,296 @@
+package kyo.compat
+
+import scala.concurrent.Future as ScalaFuture
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.NANOSECONDS
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+import zio.*
+
+/** Underlying carrier is `ZIO[Any, Throwable, A]`.
+  *
+  * `defer` maps throws to defects via `.orDie`. `acquireReleaseWith` runs release on success, failure, and interrupt via
+  * `ZIO.acquireReleaseWith`; release Throwables are reified as defects via `.orDie` so they propagate through ZIO's cause channel.
+  * `fold`/`liftToTry`/`ignore` use `foldCauseZIO`/`foldZIO` rather than ZIO's `CanFail`-gated convenience methods, which allows
+  * `E = Nothing` to work. `timeoutWithError` swaps arg order relative to ZIO's native `timeoutFail(e)(d)`.
+  */
+opaque type CIO[+A] = ZIO[Any, Throwable, A]
+
+object CIO:
+
+    inline def lift[A](inline z: ZIO[Any, Throwable, A]): CIO[A] = z
+
+    /** Suspends side-effecting code that produces a `ZIO`, deferring its construction to effect-evaluation time. */
+    inline def deferLift[A](inline z: => ZIO[Any, Throwable, A])(using inline trace: Trace): CIO[A] =
+        lift(ZIO.suspendSucceed(z))
+
+    inline def value[A](inline a: A): CIO[A] = lift(ZIO.succeed(a))
+
+    inline def unit: CIO[Unit] = lift(ZIO.unit)
+
+    inline def defer[A](inline thunk: => A)(using inline trace: Trace): CIO[A] =
+        lift(ZIO.attempt(thunk))
+
+    inline def fail(inline e: Throwable)(using inline trace: Trace): CIO[Nothing] =
+        lift(ZIO.fail(e))
+
+    inline def get[A](inline t: scala.util.Try[A])(using inline trace: Trace): CIO[A] =
+        lift(ZIO.fromTry(t))
+
+    inline def fromScalaFuture[A](inline f: ScalaFuture[A])(using inline trace: Trace): CIO[A] =
+        lift(ZIO.fromFuture(_ => f))
+
+    inline def acquireReleaseWith[A, B](
+        inline acquire: CIO[A]
+    )(
+        inline release: A => CIO[Unit]
+    )(
+        inline use: A => CIO[B]
+    )(using inline trace: Trace): CIO[B] =
+        lift(ZIO.acquireReleaseWith(acquire.lower)(a => release(a).lower.orDie)(a => use(a).lower))
+
+    inline def ensure[A](
+        inline cleanup: CIO[Unit]
+    )(
+        inline c: CIO[A]
+    )(using inline trace: Trace): CIO[A] =
+        acquireReleaseWith(CIO.defer(()))(_ => cleanup)(_ => c)
+
+    inline def never: CIO[Nothing] =
+        lift(ZIO.never)
+
+    extension [A](inline self: CIO[A])
+
+        inline def lower: ZIO[Any, Throwable, A] = self
+
+        inline def recover[A2 >: A](inline handler: Throwable => CIO[A2])(
+            using inline trace: Trace
+        ): CIO[A2] =
+            lift(self.lower.catchAll(e =>
+                try handler(e).lower
+                catch case t: Throwable if NonFatal(t) => ZIO.fail(t)
+            ))
+
+        inline def fold[B](
+            inline onSuccess: A => CIO[B],
+            inline onFail: Throwable => CIO[B]
+        )(using inline trace: Trace): CIO[B] =
+            lift(self.lower.foldZIO(
+                e =>
+                    try onFail(e).lower
+                    catch case t: Throwable if NonFatal(t) => ZIO.fail(t),
+                a =>
+                    try onSuccess(a).lower
+                    catch case t: Throwable if NonFatal(t) => ZIO.fail(t)
+            ))
+
+        inline def liftToTry(using inline trace: Trace): CIO[scala.util.Try[A]] =
+            lift(self.lower.foldZIO(
+                e => ZIO.succeed(scala.util.Failure(e): scala.util.Try[A]),
+                a => ZIO.succeed(scala.util.Success(a): scala.util.Try[A])
+            ))
+
+        inline def unit(using inline trace: Trace): CIO[Unit] =
+            lift(self.lower.unit)
+
+        inline def orElse[A2 >: A](inline that: CIO[A2])(
+            using inline trace: Trace
+        ): CIO[A2] =
+            lift(self.lower.orElse(that.lower))
+
+        inline def mapError(inline f: Throwable => Throwable)(
+            using inline trace: Trace
+        ): CIO[A] =
+            lift(self.lower.foldZIO(
+                e =>
+                    try
+                        val mapped = f(e)
+                        ZIO.fail(mapped)
+                    catch case t: Throwable if NonFatal(t) => ZIO.fail(t),
+                a => ZIO.succeed(a)
+            ))
+
+        inline def map[B](inline f: A => B)(using inline trace: Trace): CIO[B] =
+            lift(self.lower.map(f))
+
+        inline def flatMap[B](inline f: A => CIO[B])(using inline trace: Trace): CIO[B] =
+            lift(self.lower.flatMap(a => f(a).lower))
+
+        inline def unsafeRun: scala.concurrent.Future[A] =
+            Unsafe.unsafe { implicit u =>
+                zio.Runtime.default.unsafe.runToFuture(self.lower)
+            }
+    end extension
+
+    private inline def toZioDuration(inline d: FiniteDuration): zio.Duration =
+        zio.Duration.fromNanos(d.toNanos)
+
+    inline def sleep(inline d: FiniteDuration)(using inline trace: Trace): CIO[Unit] =
+        lift(ZIO.sleep(toZioDuration(d)))
+
+    inline def now(using inline trace: Trace): CIO[java.time.Instant] =
+        lift(Clock.instant)
+
+    inline def nowMonotonic(using inline trace: Trace): CIO[FiniteDuration] =
+        lift(Clock.nanoTime.map(ns => FiniteDuration(ns, NANOSECONDS)))
+
+    inline def timeout[A](inline d: FiniteDuration)(inline c: CIO[A])(
+        using inline trace: Trace
+    ): CIO[Option[A]] =
+        lift(c.lower.timeout(toZioDuration(d)))
+
+    inline def timeoutWithError[A](inline d: FiniteDuration)(inline e: Throwable)(inline c: CIO[A])(
+        using inline trace: Trace
+    ): CIO[A] =
+        lift(c.lower.timeoutFail(e)(toZioDuration(d)))
+
+    inline def delay[A](inline d: FiniteDuration)(inline c: CIO[A])(
+        using inline trace: Trace
+    ): CIO[A] =
+        lift(c.lower.delay(toZioDuration(d)))
+
+    inline def race[A](
+        inline a: CIO[A],
+        inline b: CIO[A]
+    )(using inline trace: Trace): CIO[A] =
+        lift(a.lower.race(b.lower))
+
+    inline def zip[A1, A2](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2]
+    )(using inline trace: Trace): CIO[(A1, A2)] =
+        lift(a1.lower.zipPar(a2.lower))
+
+    inline def zip[A1, A2, A3](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3]
+    )(using inline trace: Trace): CIO[(A1, A2, A3)] =
+        lift(a1.lower <&> a2.lower <&> a3.lower)
+
+    inline def zip[A1, A2, A3, A4](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4]
+    )(using inline trace: Trace): CIO[(A1, A2, A3, A4)] =
+        lift(a1.lower <&> a2.lower <&> a3.lower <&> a4.lower)
+
+    inline def zip[A1, A2, A3, A4, A5](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5]
+    )(using inline trace: Trace): CIO[(A1, A2, A3, A4, A5)] =
+        lift(a1.lower <&> a2.lower <&> a3.lower <&> a4.lower <&> a5.lower)
+
+    inline def zip[A1, A2, A3, A4, A5, A6](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5],
+        inline a6: CIO[A6]
+    )(using inline trace: Trace): CIO[(A1, A2, A3, A4, A5, A6)] =
+        lift(a1.lower <&> a2.lower <&> a3.lower <&> a4.lower <&> a5.lower <&> a6.lower)
+
+    inline def zip[A1, A2, A3, A4, A5, A6, A7](
+        inline a1: CIO[A1],
+        inline a2: CIO[A2],
+        inline a3: CIO[A3],
+        inline a4: CIO[A4],
+        inline a5: CIO[A5],
+        inline a6: CIO[A6],
+        inline a7: CIO[A7]
+    )(using inline trace: Trace): CIO[(A1, A2, A3, A4, A5, A6, A7)] =
+        lift(
+            a1.lower <&> a2.lower <&> a3.lower <&> a4.lower <&> a5.lower <&> a6.lower <&> a7.lower
+        )
+
+    inline def foreach[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline f: A => CIO[B])(
+        using inline trace: Trace
+    ): CIO[CChunk[B]] =
+        lift {
+            val par = ZIO.foreachPar(coll)(a => f(a).lower).map(it => CChunk.lift(zio.Chunk.fromIterable(it)))
+            if concurrency == Int.MaxValue then par else par.withParallelism(concurrency)
+        }
+
+    inline def foreachIndexed[A, B](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline f: (Int, A) => CIO[B])(
+        using inline trace: Trace
+    ): CIO[CChunk[B]] =
+        lift {
+            val par = ZIO.foreachPar(coll.zipWithIndex) { case (a, i) => f(i, a).lower }
+                .map(it => CChunk.lift(zio.Chunk.fromIterable(it)))
+            if concurrency == Int.MaxValue then par else par.withParallelism(concurrency)
+        }
+
+    inline def foreachDiscard[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline f: A => CIO[Any])(
+        using inline trace: Trace
+    ): CIO[Unit] =
+        lift {
+            val par = ZIO.foreachParDiscard(coll)(a => f(a).lower)
+            if concurrency == Int.MaxValue then par else par.withParallelism(concurrency)
+        }
+
+    inline def filter[A](
+        inline coll: Iterable[A],
+        inline concurrency: Int = Int.MaxValue
+    )(inline p: A => CIO[Boolean])(
+        using inline trace: Trace
+    ): CIO[CChunk[A]] =
+        lift {
+            val par = ZIO.filterPar(coll)(a => p(a).lower).map(it => CChunk.lift(zio.Chunk.fromIterable(it)))
+            if concurrency == Int.MaxValue then par else par.withParallelism(concurrency)
+        }
+
+    inline def collectAll[A](
+        inline coll: Iterable[CIO[A]],
+        inline concurrency: Int = Int.MaxValue
+    )(
+        using inline trace: Trace
+    ): CIO[CChunk[A]] =
+        lift {
+            val par = ZIO.collectAllPar(coll.map(_.lower).toList).map(it => CChunk.lift(zio.Chunk.fromIterable(it)))
+            if concurrency == Int.MaxValue then par else par.withParallelism(concurrency)
+        }
+
+    inline def collectAllDiscard(
+        inline coll: Iterable[CIO[Any]],
+        inline concurrency: Int = Int.MaxValue
+    )(
+        using inline trace: Trace
+    ): CIO[Unit] =
+        lift {
+            val par = ZIO.collectAllParDiscard(coll.map(_.lower))
+            if concurrency == Int.MaxValue then par else par.withParallelism(concurrency)
+        }
+
+    // The compat surface uses `Try[A] => Unit` for the callback; ZIO uses `ZIO[R, E, A] => Unit`.
+    inline def async[A](inline register: ((scala.util.Try[A] => Unit) => Unit))(
+        using inline trace: Trace
+    ): CIO[A] =
+        lift(ZIO.async[Any, Throwable, A] { (k: ZIO[Any, Throwable, A] => Unit) =>
+            val cb: scala.util.Try[A] => Unit = {
+                case scala.util.Success(a) => k(ZIO.succeed(a))
+                case scala.util.Failure(e) => k(ZIO.fail(e))
+            }
+            register(cb)
+        })
+
+    inline def blocking[A](inline thunk: => A)(using inline trace: Trace): CIO[A] =
+        lift(ZIO.attemptBlocking(thunk))
+
+    inline def cede(using inline trace: Trace): CIO[Unit] =
+        lift(ZIO.yieldNow)
+
+end CIO

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CLatch.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CLatch.scala
@@ -1,0 +1,31 @@
+package kyo.compat
+
+import zio.*
+import zio.concurrent.CountdownLatch
+
+/** Backed by `zio.concurrent.CountdownLatch`. `init(0)` produces an already-released latch (`make(1)` pre-counted). */
+opaque type CLatch = CountdownLatch
+
+object CLatch:
+
+    inline def init(inline n: Int)(using inline trace: Trace): CIO[CLatch] =
+        CIO.lift(initImpl(n))
+
+    inline def lift(inline u: CountdownLatch): CLatch = u
+
+    private inline def initImpl(inline n: Int)(using inline trace: Trace): UIO[CountdownLatch] =
+        if n <= 0 then CountdownLatch.make(1).flatMap(l => l.countDown.as(l))
+        else CountdownLatch.make(n)
+
+    extension (inline self: CLatch)
+
+        inline def lower: CountdownLatch = self
+
+        inline def await(using inline trace: Trace): CIO[Unit] =
+            CIO.lift(self.await)
+
+        inline def release(using inline trace: Trace): CIO[Unit] =
+            CIO.lift(self.countDown)
+    end extension
+
+end CLatch

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CLatch.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CLatch.scala
@@ -22,10 +22,10 @@ object CLatch:
         inline def lower: CountdownLatch = self
 
         inline def await(using inline trace: Trace): CIO[Unit] =
-            CIO.lift(self.await)
+            CIO.lift(self.await: UIO[Unit])
 
         inline def release(using inline trace: Trace): CIO[Unit] =
-            CIO.lift(self.countDown)
+            CIO.lift(self.countDown: UIO[Unit])
     end extension
 
 end CLatch

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CLocal.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CLocal.scala
@@ -1,0 +1,35 @@
+package kyo.compat
+
+import zio.*
+
+/** Backed by `zio.FiberRef[A]`. `init` allocates a fresh `FiberRef` via `Scope.global.extend(FiberRef.make[A](default))` inside `CIO`,
+  * deferring construction to effect-evaluation time. Extension methods operate directly on the `FiberRef` — no wrapper or lazy-CAS dance
+  * required.
+  */
+opaque type CLocal[A] = FiberRef[A]
+
+object CLocal:
+
+    inline def init[A](inline default: A): CIO[CLocal[A]] =
+        CIO.lift(Scope.global.extend(FiberRef.make[A](default)))
+
+    inline def lift[A](inline u: FiberRef[A]): CLocal[A] = u
+
+    extension [A](inline self: CLocal[A])
+
+        inline def lower: FiberRef[A] = self
+
+        inline def get(using inline trace: Trace): CIO[A] =
+            CIO.lift(self.get)
+
+        inline def let[B](inline v: A)(inline c: CIO[B])(
+            using inline trace: Trace
+        ): CIO[B] =
+            CIO.lift(self.locally(v)((c.lower: ZIO[Any, Throwable, B])))
+
+        inline def update[B](inline f: A => A)(inline c: CIO[B])(
+            using inline trace: Trace
+        ): CIO[B] =
+            CIO.lift(self.locallyWith(f)((c.lower: ZIO[Any, Throwable, B])))
+    end extension
+end CLocal

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CMeter.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CMeter.scala
@@ -1,0 +1,33 @@
+package kyo.compat
+
+import zio.*
+
+/** Backed by `zio.Semaphore`. Permit counts are `Long` on the ZIO side; the surface converts to/from `Int`. */
+opaque type CMeter = Semaphore
+
+object CMeter:
+
+    inline def init(inline permits: Int)(using inline trace: Trace): CIO[CMeter] =
+        CIO.lift(Semaphore.make(permits.toLong))
+
+    inline def lift(inline u: Semaphore): CMeter = u
+
+    extension (inline self: CMeter)
+
+        inline def lower: Semaphore = self
+
+        inline def run[A](inline c: CIO[A])(
+            using inline trace: Trace
+        ): CIO[A] =
+            CIO.lift(self.withPermit(c.lower))
+
+        inline def tryRun[A](inline c: CIO[A])(
+            using inline trace: Trace
+        ): CIO[Option[A]] =
+            CIO.lift(self.tryWithPermits(1L)(c.lower))
+
+        inline def availablePermits(using inline trace: Trace): CIO[Int] =
+            CIO.lift(self.available.map(_.toInt))
+    end extension
+
+end CMeter

--- a/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CPromise.scala
+++ b/kyo-compat/bindings/zio/shared/src/main/scala/kyo/compat/CPromise.scala
@@ -1,0 +1,51 @@
+package kyo.compat
+
+import zio.*
+
+/** Backed by `zio.Promise[Throwable, A]`.
+  *
+  * E is invariant in `zio.Promise[Throwable, A]`; the surface declares `+E` for uniformity across backends. The covariant view is sound
+  * because CPromise never widens E observably (opacity hides the invariance).
+  *
+  * `poll` performs a non-trivial adaptation: ZIO's `Promise.poll` returns `UIO[Option[IO[E, A]]]`. The inner `IO[E, A]` is flattened to
+  * `Try[A]` via `.foldZIO` before wrapping in `Some`, so the returned value is `Option[Try[A]]` as the surface promises.
+  */
+opaque type CPromise[A] = Promise[Throwable, A]
+
+object CPromise:
+
+    inline def init[A](using inline trace: Trace): CIO[CPromise[A]] =
+        CIO.lift(Promise.make[Throwable, A])
+
+    inline def lift[A](inline u: Promise[Throwable, A]): CPromise[A] = u
+
+    extension [A](inline self: CPromise[A])
+
+        inline def lower: Promise[Throwable, A] = self
+
+        inline def succeed(inline a: A)(using inline trace: Trace): CIO[Boolean] =
+            CIO.lift(self.succeed(a))
+
+        inline def fail(inline e: Throwable)(using inline trace: Trace): CIO[Boolean] =
+            CIO.lift(self.fail(e))
+
+        inline def get(using inline trace: Trace): CIO[A] =
+            CIO.lift(self.await)
+
+        inline def poll(using inline trace: Trace): CIO[Option[scala.util.Try[A]]] =
+            CIO.lift(
+                self.poll.flatMap {
+                    case Some(io) => io.foldZIO(
+                            e => ZIO.succeed(Option(scala.util.Failure(e))),
+                            a => ZIO.succeed(Option(scala.util.Success(a)))
+                        )
+                    case None => ZIO.succeed(None: Option[scala.util.Try[A]])
+                }
+            )
+
+        inline def done(using inline trace: Trace): CIO[Boolean] =
+            CIO.lift(self.isDone)
+
+    end extension
+
+end CPromise

--- a/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatLibrary.scala
+++ b/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatLibrary.scala
@@ -1,0 +1,275 @@
+package io.getkyo.compat
+
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._ // brings %%%
+import sbt._
+import sbt.Keys._
+import sbt.internal.ProjectMatrix
+import sbtprojectmatrix.ProjectMatrixKeys
+import sbtprojectmatrix.ReflectionUtil
+
+/** Internal helpers + per-matrix metadata for the [[CompatPlugin]] extension method. The user-facing `compatLibrary` extension is defined
+  * in [[CompatPlugin.autoImport]].
+  *
+  * sbt-projectmatrix's `jvmPlatform` / `jsPlatform` / `nativePlatform` builders are used as the row-creation primitives — they handle
+  * plugin enablement (ScalaJSPlugin / ScalaNativePlugin) for us. We pass the [[CompatBackendAxis]] as an extra `axisValues` so each row
+  * carries its backend identity, then add a per-row `process` callback that injects:
+  *
+  *   - `moduleName := name.value + backend.directorySuffix`
+  *   - `libraryDependencies += "io.getkyo" %%% s"kyo-compat-<id>" % compatKyoVersion.value` (suppressed when the backend is locally bound)
+  *   - shared/per-backend `unmanagedSourceDirectories`
+  *
+  * `dependsOn(other: ProjectMatrix)` between two compat libraries works out-of-the-box — `WeakAxis` semantics on [[CompatBackendAxis]]
+  * route each row to the matching-backend row in the dependee.
+  */
+private[compat] object CompatLibrary {
+
+    // ---- Per-matrix metadata -------------------------------------------------
+    //
+    // We keep a global registry keyed by matrix id (stable across `.copy(...)`
+    // calls — ProjectMatrix's `copy` preserves `id`). Every `.compatLibrary(...)`
+    // call seeds this; named accessors and `bindLocally` read/mutate it.
+    //
+    // The registry is mutable because `bindLocally` is a setter that runs at
+    // build evaluation time, BEFORE the matrix's `lazy val resolvedMappings`
+    // forces row materialization. The customRow `process` callback is a
+    // closure that re-reads from the registry at materialization time.
+    final case class Meta(
+        backends: Seq[CompatBackendAxis],
+        platforms: Seq[VirtualAxis.PlatformAxis],
+        scalaVersions: Seq[String],
+        bindings: Map[String, ProjectReference], // backend.name -> local project ref
+        jvmExtras: Seq[Setting[?]] = Nil,
+        jsExtras: Seq[Setting[?]] = Nil,
+        nativeExtras: Seq[Setting[?]] = Nil
+    )
+
+    private val registry: scala.collection.mutable.Map[String, Meta] =
+        scala.collection.mutable.Map.empty
+
+    def register(id: String, meta: Meta): Unit = registry.synchronized {
+        registry(id) = meta
+    }
+
+    def metaOf(id: String): Option[Meta] = registry.synchronized {
+        registry.get(id)
+    }
+
+    def updateBinding(id: String, backend: CompatBackendAxis, local: ProjectReference): Unit =
+        registry.synchronized {
+            val cur = registry.getOrElse(
+                id,
+                sys.error(s"compatLibrary: matrix '$id' was not registered before bindLocally")
+            )
+            registry(id) = cur.copy(bindings = cur.bindings + (backend.name -> local))
+        }
+
+    /** Append per-platform extra settings to the matrix's Meta entry. The extras are read at row-materialization time by `addRows`'s
+      * process closure so calls can come AFTER `.compatLibrary(...)`.
+      */
+    def appendPlatformExtras(
+        id: String,
+        platform: VirtualAxis.PlatformAxis,
+        extras: Seq[Setting[?]]
+    ): Unit =
+        registry.synchronized {
+            val cur = registry.getOrElse(
+                id,
+                sys.error(s"compatLibrary: matrix '$id' was not registered before per-platform settings")
+            )
+            val updated = platform match {
+                case VirtualAxis.jvm    => cur.copy(jvmExtras = cur.jvmExtras ++ extras)
+                case VirtualAxis.js     => cur.copy(jsExtras = cur.jsExtras ++ extras)
+                case VirtualAxis.native => cur.copy(nativeExtras = cur.nativeExtras ++ extras)
+                case other              => sys.error(s"compatLibrary: unsupported PlatformAxis $other")
+            }
+            registry(id) = updated
+        }
+
+    /** Add rows for every (backend, platform, scalaVersion) triple to `m`, skipping cells the backend doesn't support. ANY user-requested
+      * backend whose `supportedPlatforms` is disjoint from the requested `platforms` raises a build-time error (matching the
+      * `empty-intersection-fail` scripted test). Future is exempt because it's always implicit — its presence shouldn't mask a hard
+      * mismatch between an explicitly-requested backend and the requested platforms.
+      */
+    def addRows(m: ProjectMatrix, meta: Meta): ProjectMatrix = {
+        val matrixId       = m.id
+        val platformValues = meta.platforms.map(_.value).toSet
+
+        // Per-backend empty-intersection check — skip Future (implicit anchor).
+        meta.backends.foreach { b =>
+            if (b.name != "future" && b.supportedPlatforms.intersect(platformValues).isEmpty)
+                sys.error(
+                    s"compatLibrary: backend ${b.idSuffix} supports " +
+                        s"${b.supportedPlatforms.toSeq.sorted.mkString(", ")} but the " +
+                        s"compatLibrary requested platforms ${meta.platforms.map(_.value).mkString(", ")}. " +
+                        "Empty intersection. Either drop the backend from the compatLibrary(...) " +
+                        "extras list, or widen the requested platforms list."
+                )
+        }
+
+        val combos: Seq[(CompatBackendAxis, VirtualAxis.PlatformAxis)] =
+            for {
+                b <- meta.backends
+                p <- meta.platforms
+                if b.supportedPlatforms.contains(p.value)
+            } yield (b, p)
+
+        // Use ProjectMatrix's basedir (set by `(projectMatrix in file(...))`)
+        // as the source-tree root so consumers can keep <base>/shared/src/...
+        // and <base>/<backend>/<platform>/src/... layouts.
+        val sourceBase: File = m.base
+
+        combos.foldLeft(m) { case (acc, (backend, platform)) =>
+            val backendDir      = backend.name   // e.g. "future"
+            val platformDir     = platform.value // "jvm" | "js" | "native"
+            val sharedMain      = sourceBase / "shared" / "src" / "main" / "scala"
+            val sharedTest      = sourceBase / "shared" / "src" / "test" / "scala"
+            val sharedMainR     = sourceBase / "shared" / "src" / "main" / "resources"
+            val sharedTestR     = sourceBase / "shared" / "src" / "test" / "resources"
+            val perBackendMain  = sourceBase / backendDir / "src" / "main" / "scala"
+            val perBackendTest  = sourceBase / backendDir / "src" / "test" / "scala"
+            val perBackendMainR = sourceBase / backendDir / "src" / "main" / "resources"
+            val perBackendTestR = sourceBase / backendDir / "src" / "test" / "resources"
+            val backendMain     = sourceBase / backendDir / platformDir / "src" / "main" / "scala"
+            val backendTest     = sourceBase / backendDir / platformDir / "src" / "test" / "scala"
+            val backendMainR    = sourceBase / backendDir / platformDir / "src" / "main" / "resources"
+            val backendTestR    = sourceBase / backendDir / platformDir / "src" / "test" / "resources"
+            val backendBase     = sourceBase / backendDir / platformDir
+
+            // Plugin enabler. JS/Native platforms must enable the corresponding
+            // sbt plugin; we do the same reflection lookup pmx itself does in
+            // its private jsPlatform/nativePlatform helpers (we sidestep those
+            // because they hard-code `scalaABIVersion(sv)` whose value
+            // collapses 3.3.4 and 3.4.0 to "3", colliding target dirs and
+            // project ids on multi-scala matrices).
+            val enablePlatformPlugin: Project => Project = platform match {
+                case VirtualAxis.jvm => identity
+                case VirtualAxis.js =>
+                    p =>
+                        p.enablePlugins(
+                            ReflectionUtil.getSingletonObject[AutoPlugin](
+                                getClass.getClassLoader,
+                                "org.scalajs.sbtplugin.ScalaJSPlugin$"
+                            ).getOrElse(sys.error(
+                                "Scala.js plugin was not found. Add the sbt-scalajs plugin into project/plugins.sbt:\n" +
+                                    "  addSbtPlugin(\"org.scala-js\" % \"sbt-scalajs\" % \"x.y.z\")"
+                            ))
+                        )
+                case VirtualAxis.native =>
+                    p =>
+                        p.enablePlugins(
+                            ReflectionUtil.getSingletonObject[AutoPlugin](
+                                getClass.getClassLoader,
+                                "scala.scalanative.sbtplugin.ScalaNativePlugin$"
+                            ).getOrElse(sys.error(
+                                "Scala Native plugin was not found. Add the sbt-scala-native plugin into project/plugins.sbt:\n" +
+                                    "  addSbtPlugin(\"org.scala-native\" % \"sbt-scala-native\" % \"x.y.z\")"
+                            ))
+                        )
+                case other => sys.error(s"compatLibrary: unsupported PlatformAxis $other")
+            }
+
+            val process: Project => Project = (proj: Project) => {
+                val withPlugin = enablePlatformPlugin(proj)
+                val withDeps = withPlugin.settings(
+                    moduleName    := name.value + backend.directorySuffix,
+                    baseDirectory := backendBase,
+                    Compile / unmanagedSourceDirectories ++= Seq(sharedMain, perBackendMain, backendMain),
+                    Test / unmanagedSourceDirectories ++= Seq(sharedTest, perBackendTest, backendTest),
+                    Compile / unmanagedResourceDirectories ++= Seq(sharedMainR, perBackendMainR, backendMainR),
+                    Test / unmanagedResourceDirectories ++= Seq(sharedTestR, perBackendTestR, backendTestR),
+                    libraryDependencies ++= {
+                        val isBound = metaOf(matrixId).exists(_.bindings.contains(backend.name))
+                        if (isBound) Seq.empty
+                        else Seq(
+                            "io.getkyo" %%% s"kyo-compat-${backend.name}" %
+                                CompatPlugin.autoImport.compatKyoVersion.value
+                        )
+                    }
+                )
+                val withLocal = metaOf(matrixId).flatMap(_.bindings.get(backend.name)) match {
+                    case Some(local) => withDeps.dependsOn(ClasspathDependency(local, None))
+                    case None        => withDeps
+                }
+                // Apply per-platform extras LAST so they win over both the
+                // plugin-injected defaults above and the receiver's universal
+                // `.settings(...)` (which sbt-projectmatrix applies before
+                // customRow process closures run). Re-read at materialization
+                // time so `.jvmSettings(...)` calls placed AFTER
+                // `.compatLibrary(...)` are picked up.
+                val platformExtras: Seq[Setting[?]] = metaOf(matrixId).map { meta =>
+                    platform match {
+                        case VirtualAxis.jvm    => meta.jvmExtras
+                        case VirtualAxis.js     => meta.jsExtras
+                        case VirtualAxis.native => meta.nativeExtras
+                        case _                  => Nil
+                    }
+                }.getOrElse(Nil)
+                if (platformExtras.isEmpty) withLocal
+                else withLocal.settings(platformExtras: _*)
+            }
+
+            // Add one row per scala version, tagging the row with a
+            // full-version `scalaVersionAxis(sv, sv)` instead of the default
+            // `scalaABIVersion(sv)`. Full-version directorySuffix keeps target
+            // dirs ("target/<backend>-<platform>-<sv>") and project ids
+            // ("...3_3_4" / "...3_4_0") distinct across scala versions in a
+            // multi-scala matrix.
+            meta.scalaVersions.foldLeft(acc) { (m2, sv) =>
+                val axes: Seq[VirtualAxis] =
+                    Seq(platform, backend, VirtualAxis.scalaVersionAxis(sv, sv))
+                m2.customRow(autoScalaLibrary = true, axisValues = axes, process = process)
+            }
+        }
+    }
+}
+
+/** A virtual axis representing one kyo-compat backend. Implements `VirtualAxis.WeakAxis` — at most one backend axis can be on a row, and
+  * `dependsOn` between two compat-library matrices wires each row to the matching-backend row in the dependee. Equality is by `name`, so
+  * any two `CompatBackendAxis("kyo", ...)` instances are interchangeable.
+  *
+  * Suffix order is `40` so the backend lands BEFORE the platform (`80`) and scala (`100`) in generated project ids and source-set suffixes:
+  * `myLibFuture`, `myLibFutureJS`, etc.
+  */
+final case class CompatBackendAxis(
+    name: String,                   // e.g. "future" — artifact name `kyo-compat-future`
+    idSuffix: String,               // e.g. "Future" — appended to project id
+    directorySuffix: String,        // e.g. "-future" — appended to moduleName + source dir
+    supportedPlatforms: Set[String] // values from PlatformAxis: "jvm" | "js" | "native"
+) extends VirtualAxis.WeakAxis {
+    override val suffixOrder: Int = 40
+    override def equals(obj: Any): Boolean = obj match {
+        case that: CompatBackendAxis => this.name == that.name
+        case _                       => false
+    }
+    override def hashCode(): Int = name.hashCode
+}
+
+/** Raised by named accessors when the user accesses a backend that wasn't passed to `compatLibrary(...)`.
+  */
+final class NoSuchBackendException(
+    val requested: CompatBackendAxis,
+    val available: Set[CompatBackendAxis]
+) extends RuntimeException(
+        s"compatLibrary: backend ${requested.idSuffix} was not opted in. " +
+            s"Available backends: ${available.toSeq.map(_.idSuffix).sorted.mkString(", ")}. " +
+            "Add it to the compatLibrary(...) extras list, or use .get(backend) for a safe lookup."
+    )
+
+/** Per-backend view returned by named accessors (`.future`, `.kyo`, ...). Mimics sbt-crossproject's `.jvm` / `.js` / `.native` shape so
+  * consumers can reach a specific (backend, platform) cell via `myLib.future.jvm: Project`.
+  */
+final class CompatBackendProjects private[compat] (
+    private val matrix: ProjectMatrix,
+    private val backend: CompatBackendAxis
+) {
+    private def find(platform: VirtualAxis.PlatformAxis): Project =
+        matrix.filterProjects(Seq(backend, platform)).headOption.getOrElse(
+            sys.error(
+                s"compatLibrary: backend ${backend.idSuffix} has no row for platform ${platform.value}. " +
+                    "Either widen the requested platforms or pick a different backend."
+            )
+        )
+    def jvm: Project    = find(VirtualAxis.jvm)
+    def js: Project     = find(VirtualAxis.js)
+    def native: Project = find(VirtualAxis.native)
+}

--- a/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatPlugin.scala
+++ b/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatPlugin.scala
@@ -1,0 +1,205 @@
+package io.getkyo.compat
+
+import sbt._
+import sbt.Keys._
+import sbt.internal.ProjectMatrix
+import sbtprojectmatrix.ProjectMatrixPlugin
+
+/** kyo-compat — generate per-backend cross-platform rows on a `ProjectMatrix` so a single library declaration ships to every kyo-compat
+  * backend.
+  *
+  * The library author writes:
+  * {{{
+  * import _root_.io.getkyo.compat.given
+  * import _root_.io.getkyo.compat.{ KyoLib, ZioLib, CeLib, OxLib }
+  * import sbt.VirtualAxis
+  *
+  * lazy val myLib = (projectMatrix in file("my-lib"))
+  *     .compatLibrary(KyoLib, ZioLib, CeLib, OxLib)(
+  *         VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native
+  *     )(Seq("3.3.4"))
+  *     .settings(/* common settings */)
+  * }}}
+  *
+  * `compatLibrary` adds one `customRow` per (backend × platform-supported-by-backend × scalaVersion). `Future` is always implicit. Cells
+  * the backend cannot support (Ce/Native, Ox/JS, Ox/Native) are silently skipped; an empty intersection errors at build-load.
+  */
+object CompatPlugin extends AutoPlugin {
+
+    // allRequirements so the plugin's compatKyoVersion setting is injected
+    // on every project that already has JvmPlugin enabled (which covers
+    // every project a compatLibrary matrix generates). Required because
+    // the per-row libraryDependencies setting reads `compatKyoVersion.value`.
+    override def trigger  = allRequirements
+    override def requires = sbt.plugins.JvmPlugin && ProjectMatrixPlugin
+
+    object autoImport {
+
+        /** Version of the `io.getkyo:kyo-compat-<backend>` artifacts that generated rows pull in. Defaults to the plugin's own published
+          * version — override per-build to pin a different snapshot.
+          */
+        val compatKyoVersion = settingKey[String](
+            "Version of io.getkyo:kyo-compat-<backend> artifacts pulled into generated rows."
+        )
+
+        // Re-export so `CompatBackendAxis` can be referenced as an autoImport
+        // type (e.g. from `bindLocally(b: CompatBackendAxis, ...)` signatures
+        // in user build.sbt without a full `_root_.io.getkyo.compat.*` import).
+        type CompatBackendAxis      = _root_.io.getkyo.compat.CompatBackendAxis
+        type NoSuchBackendException = _root_.io.getkyo.compat.NoSuchBackendException
+
+        // Backend axis instances. The `Lib` suffix avoids collisions with
+        // `scala.concurrent.Future` and the `kyo` package object.
+        val FutureLib: CompatBackendAxis =
+            _root_.io.getkyo.compat.CompatBackendAxis("future", "Future", "-future", Set("jvm"))
+        val KyoLib: CompatBackendAxis =
+            _root_.io.getkyo.compat.CompatBackendAxis("kyo", "Kyo", "-kyo", Set("jvm", "js", "native"))
+        val ZioLib: CompatBackendAxis =
+            _root_.io.getkyo.compat.CompatBackendAxis("zio", "Zio", "-zio", Set("jvm", "js", "native"))
+        val CeLib: CompatBackendAxis =
+            _root_.io.getkyo.compat.CompatBackendAxis("ce", "Ce", "-ce", Set("jvm", "js"))
+        val OxLib: CompatBackendAxis =
+            _root_.io.getkyo.compat.CompatBackendAxis("ox", "Ox", "-ox", Set("jvm"))
+        val TwitterFutureLib: CompatBackendAxis =
+            _root_.io.getkyo.compat.CompatBackendAxis(
+                "twitter-future",
+                "TwitterFuture",
+                "-twitter-future",
+                Set("jvm")
+            )
+
+        /** Terminal extension on a `ProjectMatrix`: adds one `customRow` per (backend × platform-supported-by-backend × scalaVersion).
+          * Future is always implicit; the `extras` varargs are the *additional* backends to cross-publish to.
+          */
+        implicit class CompatLibraryOps(val m: ProjectMatrix) extends AnyVal {
+            def compatLibrary(
+                extras: CompatBackendAxis*
+            )(
+                platforms: VirtualAxis.PlatformAxis*
+            )(
+                scalaVersions: Seq[String]
+            ): ProjectMatrix = {
+                val backends = (FutureLib +: extras).distinct
+                val meta = CompatLibrary.Meta(
+                    backends = backends,
+                    platforms = platforms,
+                    scalaVersions = scalaVersions,
+                    bindings = Map.empty
+                )
+                CompatLibrary.register(m.id, meta)
+                // Pin defaultAxes only for single-scala matrices so the canonical
+                // row drops the JVM + Scala suffixes (matching sbt-crossproject's
+                // `.withoutSuffixFor(JVMPlatform)` convention). Multi-scala
+                // matrices intentionally keep the version suffix on every cell
+                // so rows like 3.3.4 and 3.4.0 stay distinguishable.
+                // We use the full-version `scalaVersionAxis(sv, sv)` (not
+                // `scalaABIVersion`, whose value collapses 3.x to "3" and would
+                // make 3.3.4/3.4.0 share the same target dir + project id).
+                val pinned = scalaVersions match {
+                    case Seq(sv) =>
+                        m.defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaVersionAxis(sv, sv))
+                    case _ => m
+                }
+                CompatLibrary.addRows(pinned, meta)
+            }
+
+            /** Bind the given backend to a local Project (typically a CrossProject's `.jvm`/`.js`/`.native` accessor) instead of pulling
+              * the published `kyo-compat-<id>` artifact. Suppresses the auto-injected `libraryDependencies +=` line for that backend and
+              * adds a project-level `dependsOn(local)` to every row of the matrix that carries the bound backend.
+              *
+              * Must be called BEFORE first access to the matrix's `componentProjects` / `projectRefs` (i.e. before sbt forces row
+              * materialization).
+              */
+            def bindLocally(b: CompatBackendAxis, local: ProjectReference): ProjectMatrix = {
+                CompatLibrary.updateBinding(m.id, b, local)
+                m
+            }
+
+            /** Convenience for binding multiple backends in one call. */
+            def bindAllLocally(locals: Map[CompatBackendAxis, ProjectReference]): ProjectMatrix = {
+                locals.foreach { case (b, local) => CompatLibrary.updateBinding(m.id, b, local) }
+                m
+            }
+
+            /** Apply settings to JVM cells only. Mirrors sbt-crossproject's `.jvmSettings(...)`. Per-platform settings are applied AFTER
+              * the receiver's universal `.settings(...)`, so per-platform overrides win on conflicts.
+              */
+            def jvmSettings(extras: Setting[?]*): ProjectMatrix = {
+                CompatLibrary.appendPlatformExtras(m.id, VirtualAxis.jvm, extras)
+                m
+            }
+
+            /** Apply settings to JS cells only. Mirrors sbt-crossproject's `.jsSettings(...)`.
+              */
+            def jsSettings(extras: Setting[?]*): ProjectMatrix = {
+                CompatLibrary.appendPlatformExtras(m.id, VirtualAxis.js, extras)
+                m
+            }
+
+            /** Apply settings to Native cells only. Mirrors sbt-crossproject's `.nativeSettings(...)`.
+              */
+            def nativeSettings(extras: Setting[?]*): ProjectMatrix = {
+                CompatLibrary.appendPlatformExtras(m.id, VirtualAxis.native, extras)
+                m
+            }
+
+            /** Cross-backend aggregator. Returns a plain `Project` whose `.aggregate(...)` fans every per-(backend, platform) row of the
+              * matrix into one task target. `publish / skip := true` keeps the aggregator out of maven-local.
+              */
+            def aggregate(id: String): Project = {
+                val refs = m.projectRefs
+                Project(id, file(s".${id}-aggregate"))
+                    .settings(publish / skip := true)
+                    .aggregate(refs: _*)
+            }
+
+            /** Named accessor: returns a view onto every (Future, *) row. */
+            def future: CompatBackendProjects = lookup(FutureLib)
+
+            /** Named accessor: returns a view onto every (Kyo, *) row. */
+            def kyo: CompatBackendProjects = lookup(KyoLib)
+
+            /** Named accessor: returns a view onto every (Zio, *) row. */
+            def zio: CompatBackendProjects = lookup(ZioLib)
+
+            /** Named accessor: returns a view onto every (Ce, *) row. */
+            def ce: CompatBackendProjects = lookup(CeLib)
+
+            /** Named accessor: returns a view onto every (Ox, *) row. */
+            def ox: CompatBackendProjects = lookup(OxLib)
+
+            /** Named accessor: returns a view onto every (TwitterFuture, *) row. */
+            def twitterFuture: CompatBackendProjects = lookup(TwitterFutureLib)
+
+            /** Safe lookup — `None` if the backend was not opted in. */
+            def get(b: CompatBackendAxis): Option[CompatBackendProjects] = {
+                val opted = CompatLibrary.metaOf(m.id).map(_.backends.toSet).getOrElse(Set.empty)
+                if (opted.contains(b)) Some(new CompatBackendProjects(m, b))
+                else None
+            }
+
+            private def lookup(b: CompatBackendAxis): CompatBackendProjects = {
+                val opted = CompatLibrary.metaOf(m.id).map(_.backends.toSet).getOrElse(Set.empty)
+                if (!opted.contains(b)) throw new NoSuchBackendException(b, opted)
+                new CompatBackendProjects(m, b)
+            }
+        }
+    }
+
+    import autoImport._
+
+    override lazy val globalSettings: Seq[Setting[?]] = Seq(
+        compatKyoVersion := defaultCompatKyoVersion
+    )
+
+    // Inject the compatKyoVersion default per-project too, so that a user
+    // who scopes `ThisBuild / compatKyoVersion := "..."` overrides it
+    // build-wide while individual matrix rows fall back to the global default.
+    override lazy val projectSettings: Seq[Setting[?]] = Seq()
+
+    /** Default version pulled from the plugin's own published build version. Library authors targeting a different snapshot can override
+      * `compatKyoVersion` in their build.
+      */
+    private[compat] def defaultCompatKyoVersion: String =
+        Option(getClass.getPackage.getImplementationVersion).getOrElse("0.0.0+SNAPSHOT")
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/build.sbt
@@ -1,0 +1,128 @@
+// Scripted test — aggregator-runs-everything.
+//
+// Verifies that `myLib.aggregate("my-lib-all")` returns a Project whose
+// `Test/test` fans out to EVERY (backend × platform) cell — not just
+// compiles, not selectively skips. Each cell's test writes a unique
+// sentinel file into a shared dir keyed by its `name.value`. After
+// `my-lib-all/Test/test`, `checkAllCellsRan` enumerates the sentinels
+// dir and asserts the exact expected set is present.
+//
+// Matrix: 2 backends (Future + Kyo) × 1 platform (JVM only to keep
+// scripted-test runtime down) × 1 Scala (3.3.4). Result: 2 cells.
+//
+// Why fake-compat stubs: the auto-injected
+// `libraryDependencies += "io.getkyo" %%% s"kyo-compat-<backend>" % compatKyoVersion.value`
+// must resolve at update-time. The real backends are not in the scripted
+// environment, so this build publishes empty stubs to the test-local ivy
+// before myLib's tests run. The stubs only exist to satisfy resolution.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+// Pin ivy paths to a known location inside the test dir, mirroring
+// publish/ and depends-on/ scripted tests. ThisBuild / ivyPaths is
+// shadowed by sbt's per-project Defaults so we apply the setting on
+// every project explicitly.
+val rootBase: File = file(".").getCanonicalFile
+val pinnedIvyPaths: Setting[IvyPaths] =
+    ivyPaths := IvyPaths(rootBase, Some(rootBase / "ivy-cache"))
+
+val sentinelsDir: File = rootBase / "sentinels"
+
+// --------------------------------------------------------------------
+// fake kyo-compat-{future,kyo} stubs (JVM only).
+// --------------------------------------------------------------------
+
+def fakeCompat(backend: String): Project = {
+    val id  = s"fake_${backend}_jvm"
+    val dir = file(s"fake-compat/$backend/jvm")
+    Project(id, dir).settings(
+        pinnedIvyPaths,
+        organization := "io.getkyo",
+        moduleName   := s"kyo-compat-$backend",
+        version      := "STUB-FOR-SCRIPTED-TEST",
+        scalaVersion := "3.3.4"
+    )
+}
+
+lazy val fakeFutureJVM = fakeCompat("future")
+lazy val fakeKyoJVM    = fakeCompat("kyo")
+
+lazy val publishFakes = taskKey[Unit]("publishLocal every fake-compat stub")
+publishFakes := Def.sequential(
+    fakeFutureJVM / publishLocal,
+    fakeKyoJVM    / publishLocal
+).value
+
+// --------------------------------------------------------------------
+// my-lib — Future + Kyo on JVM. Each cell's Test/test forks a JVM that
+// inherits cell.name + sentinel.dir, so the SentinelTest knows which
+// sentinel filename to write into the shared sentinels dir.
+// --------------------------------------------------------------------
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-lib",
+        version      := "0.1.0-SNAPSHOT",
+        Test / fork           := true,
+        // The plugin pins baseDirectory to <matrixBase>/<backend>/<platform>/,
+        // a path that doesn't materially exist until something writes there.
+        // Forking inherits baseDirectory as cwd, which then fails with ENOENT.
+        // Anchor the fork's cwd to the test root (which always exists).
+        Test / baseDirectory  := rootBase,
+        // The plugin sets `moduleName := name.value + backend.directorySuffix`
+        // per cell — that's the per-cell-distinct identity we want as the
+        // sentinel filename. `name` itself is `"my-lib"` for every cell.
+        Test / javaOptions    += s"-Dcell.name=${moduleName.value}",
+        Test / javaOptions    += s"-Dsentinel.dir=${sentinelsDir.getAbsolutePath}",
+        libraryDependencies   += "org.scalatest" %% "scalatest" % "3.2.19" % Test
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+
+// Cross-backend aggregator. Project id = "my-lib-all".
+lazy val myLibAll = myLib.aggregate("my-lib-all")
+
+// --------------------------------------------------------------------
+// Sentinel-management + assertion tasks.
+// --------------------------------------------------------------------
+
+lazy val clearSentinels = taskKey[Unit](
+    "Delete the sentinels dir before the aggregator run for determinism"
+)
+clearSentinels := {
+    IO.delete(sentinelsDir)
+}
+
+lazy val checkAllCellsRan = taskKey[Unit](
+    "Assert every cell's Test/test wrote its sentinel under <test-base>/sentinels/"
+)
+checkAllCellsRan := {
+    // moduleName = name.value + backend.directorySuffix; name is "my-lib";
+    // backend.directorySuffix is "-future" / "-kyo" (the same suffix used
+    // by SentinelTest via -Dcell.name=${name.value}).
+    val expected = Set("my-lib-future", "my-lib-kyo")
+    if (!sentinelsDir.isDirectory)
+        sys.error(
+            s"checkAllCellsRan FAIL: sentinels dir $sentinelsDir does not exist; " +
+                "no cell wrote a sentinel — aggregator did not run any test."
+        )
+    val actual = Option(sentinelsDir.listFiles()).map(_.toSeq).getOrElse(Nil)
+        .filter(_.isFile)
+        .map(_.getName)
+        .toSet
+    val missing = expected -- actual
+    if (missing.nonEmpty)
+        sys.error(
+            s"checkAllCellsRan FAIL: missing sentinels $missing in $sentinelsDir " +
+                s"(found: $actual). Aggregator did NOT fan Test/test to every cell."
+        )
+    val extra = actual -- expected
+    if (extra.nonEmpty)
+        sys.error(
+            s"checkAllCellsRan FAIL: unexpected extra sentinels $extra in $sentinelsDir " +
+                s"(expected exactly $expected)."
+        )
+    println(s"checkAllCellsRan OK; sentinels found: ${actual.toSeq.sorted.mkString(", ")}")
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/my-lib/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/my-lib/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,8 @@
+package example
+
+// Trivial stand-in: the aggregator-runs scripted test only verifies that
+// every cell's `Test/test` actually executed (sentinel-file check).
+// No runtime API surface is asserted.
+object Lib {
+    def name: String = "my-lib"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/my-lib/shared/src/test/scala/example/SentinelTest.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/my-lib/shared/src/test/scala/example/SentinelTest.scala
@@ -1,0 +1,21 @@
+package example
+
+import org.scalatest.funsuite.AnyFunSuite
+import java.nio.file.{Files, Paths}
+
+// Each (backend × platform) cell of myLib runs this test in its own
+// forked JVM. The fork inherits two sysprops set in build.sbt:
+//   - cell.name     : the cell's `name.value` (e.g. "my-lib-future")
+//   - sentinel.dir  : an absolute path to the shared sentinels dir
+// The test writes a sentinel file named `<cell.name>` into `<sentinel.dir>`.
+// Afterwards `checkAllCellsRan` enumerates the sentinels directory and
+// asserts the exact expected set is present — proving the aggregator's
+// `Test/test` fan-out reached every cell (no skip, no double-fire).
+class SentinelTest extends AnyFunSuite:
+    test("writes sentinel for this cell"):
+        val cellName = System.getProperty("cell.name")
+        val dir      = System.getProperty("sentinel.dir")
+        assert(cellName != null && dir != null, "missing sysprops")
+        val parent = Paths.get(dir)
+        Files.createDirectories(parent)
+        Files.writeString(parent.resolve(cellName), "ran")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.10.1")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/aggregator-runs/test
@@ -1,0 +1,13 @@
+# Scripted test - aggregator-runs.
+# 1. Publish fake kyo-compat-{future,kyo} stubs so each cell's auto-injected
+#    libraryDependencies resolve at update time.
+# 2. Clear any leftover sentinels (deterministic re-runs).
+# 3. Run Test/test on the cross-backend aggregator. If aggregate(...) fans
+#    correctly, both myLibFuture and myLibKyo execute their forked tests,
+#    each writing a sentinel into <test-base>/sentinels/.
+# 4. checkAllCellsRan asserts the sentinels set is exactly
+#    {"my-lib-future", "my-lib-kyo"} — proving NO cell was skipped.
+> publishFakes
+> clearSentinels
+> my-lib-all/Test/test
+> checkAllCellsRan

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/build.sbt
@@ -1,0 +1,176 @@
+// Scripted test — .bindLocally on a compatLibrary matrix.
+//
+// `.bindLocally(b, local)` swaps the auto-injected
+// `libraryDependencies += "io.getkyo" %%% "kyo-compat-<id>"` for a
+// project-level `dependsOn` on a local Project — used by in-tree
+// consumers (see the kyo-compat-example block in the kyo root build.sbt).
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+// A fake "local kyo-compat-future" stand-in. Project (not projectMatrix)
+// — bindLocally accepts any ProjectReference.
+lazy val fakeCompatFuture = (project in file("fake-compat-future"))
+    .settings(
+        organization := "io.getkyo",
+        name         := "kyo-compat-future"
+    )
+
+// Build a Future-only compat matrix bound to the fake local Project.
+// Future is implicit; passing no extras keeps it Future-only.
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        organization := "com.example",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary()(VirtualAxis.jvm)(Seq("3.3.4"))
+    .bindLocally(FutureLib, fakeCompatFuture)
+
+// --------------------------------------------------------------------
+// Assertion task keys
+// --------------------------------------------------------------------
+
+val checkLocalDep   = taskKey[Unit]("verify myLibFutureJVM depends on fakeCompatFuture (project-level)")
+val checkNoMavenDep = taskKey[Unit]("verify myLibFutureJVM's libraryDependencies does NOT contain kyo-compat-future")
+
+checkLocalDep := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    val ref = ext.structure.allProjectRefs.find(_.project == "myLibFuture").getOrElse(
+        sys.error(s"myLibFuture project not found in build (have: ${ext.structure.allProjectRefs.map(_.project)})")
+    )
+    val proj = ext.structure.allProjects(ref.build).find(_.id == ref.project).getOrElse(
+        sys.error(s"Project def for ${ref.project} not resolvable from structure")
+    )
+    val depIds = proj.dependencies.map(_.project.project).toSet
+    if (!depIds.contains("fakeCompatFuture"))
+        sys.error(
+            s"myLibFuture should depend on fakeCompatFuture (project-level dependsOn). " +
+                s"Actual dependencies: $depIds"
+        )
+    println(s"checkLocalDep OK; myLibFuture dependsOn $depIds (includes fakeCompatFuture).")
+}
+
+checkNoMavenDep := {
+    val s    = Keys.state.value
+    val ext  = sbt.Project.extract(s)
+    val deps = ext.get(myLib.future.jvm / Keys.libraryDependencies)
+    val leaked = deps.filter { mid =>
+        mid.organization == "io.getkyo" &&
+        mid.name == "kyo-compat-future"
+    }
+    if (leaked.nonEmpty)
+        sys.error(
+            s"myLibFuture must NOT have a maven libraryDependencies entry for " +
+                s"io.getkyo:kyo-compat-future when locally bound. Leaked entries: $leaked"
+        )
+    println("checkNoMavenDep OK; locally-bound backend has no maven libraryDependencies entry.")
+}
+
+// --------------------------------------------------------------------
+// Partial bindLocally.
+//
+// One backend (Future) is locally bound, another (Kyo) is NOT. The
+// unbound backend must continue to pull from the auto-injected
+// `io.getkyo:kyo-compat-kyo` maven libraryDependencies entry, while the
+// bound backend gets the project-level dependsOn instead.
+// --------------------------------------------------------------------
+
+lazy val myPartial = (projectMatrix in file("my-partial"))
+    .settings(
+        organization := "com.example",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+    .bindLocally(FutureLib, fakeCompatFuture)
+
+val checkPartialFutureLocal = taskKey[Unit](
+    "verify myPartialFuture has the local dependsOn (Future is bound)"
+)
+val checkPartialFutureNoMaven = taskKey[Unit](
+    "verify myPartialFuture has NO maven kyo-compat-future libraryDependencies entry"
+)
+val checkPartialKyoMaven = taskKey[Unit](
+    "verify myPartialKyo retained the maven kyo-compat-kyo libraryDependencies entry (Kyo unbound)"
+)
+val checkPartialKyoNoLocal = taskKey[Unit](
+    "verify myPartialKyo did NOT acquire any local dependsOn (Kyo unbound)"
+)
+
+checkPartialFutureLocal := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    val ref = ext.structure.allProjectRefs.find(_.project == "myPartialFuture").getOrElse(
+        sys.error(
+            s"myPartialFuture project not found. Have: " +
+                ext.structure.allProjectRefs.map(_.project)
+        )
+    )
+    val proj = ext.structure.allProjects(ref.build).find(_.id == ref.project).getOrElse(
+        sys.error(s"Project def for ${ref.project} not resolvable from structure")
+    )
+    val depIds = proj.dependencies.map(_.project.project).toSet
+    if (!depIds.contains("fakeCompatFuture"))
+        sys.error(
+            s"myPartialFuture should depend on fakeCompatFuture (project-level dependsOn). " +
+                s"Actual dependencies: $depIds"
+        )
+    println(s"checkPartialFutureLocal OK; myPartialFuture dependsOn $depIds (includes fakeCompatFuture).")
+}
+
+checkPartialFutureNoMaven := {
+    val s    = Keys.state.value
+    val ext  = sbt.Project.extract(s)
+    val deps = ext.get(myPartial.future.jvm / Keys.libraryDependencies)
+    val leaked = deps.filter { mid =>
+        mid.organization == "io.getkyo" && mid.name == "kyo-compat-future"
+    }
+    if (leaked.nonEmpty)
+        sys.error(
+            s"myPartialFuture must NOT have a maven libraryDependencies entry for " +
+                s"io.getkyo:kyo-compat-future when locally bound. Leaked: $leaked"
+        )
+    println(
+        "checkPartialFutureNoMaven OK; locally-bound Future has no maven kyo-compat-future entry."
+    )
+}
+
+checkPartialKyoMaven := {
+    val s    = Keys.state.value
+    val ext  = sbt.Project.extract(s)
+    val deps = ext.get(myPartial.kyo.jvm / Keys.libraryDependencies)
+    val matching = deps.filter { mid =>
+        mid.organization == "io.getkyo" && mid.name == "kyo-compat-kyo"
+    }
+    if (matching.isEmpty)
+        sys.error(
+            s"myPartialKyo MUST retain the maven libraryDependencies entry for " +
+                s"io.getkyo:kyo-compat-kyo when Kyo is NOT locally bound. " +
+                s"Actual io.getkyo deps: ${deps.filter(_.organization == "io.getkyo")}"
+        )
+    println(
+        s"checkPartialKyoMaven OK; unbound Kyo retained ${matching.size} maven kyo-compat-kyo entry " +
+            s"(${matching.map(_.name).mkString(", ")})."
+    )
+}
+
+checkPartialKyoNoLocal := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    val ref = ext.structure.allProjectRefs.find(_.project == "myPartialKyo").getOrElse(
+        sys.error(
+            s"myPartialKyo project not found. Have: " +
+                ext.structure.allProjectRefs.map(_.project)
+        )
+    )
+    val proj = ext.structure.allProjects(ref.build).find(_.id == ref.project).getOrElse(
+        sys.error(s"Project def for ${ref.project} not resolvable from structure")
+    )
+    val depIds = proj.dependencies.map(_.project.project).toSet
+    if (depIds.contains("fakeCompatFuture"))
+        sys.error(
+            s"myPartialKyo should NOT have any local dependsOn since Kyo is unbound. " +
+                s"Actual dependencies: $depIds"
+        )
+    println(s"checkPartialKyoNoLocal OK; myPartialKyo has no local compat dependsOn (deps: $depIds).")
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/fake-compat-future/shared/src/main/scala/kyo/compat/FakeMarker.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/fake-compat-future/shared/src/main/scala/kyo/compat/FakeMarker.scala
@@ -1,0 +1,9 @@
+package kyo.compat
+
+// Stand-in for a published kyo-compat-future. The bind-locally scripted
+// test verifies that when the user binds Future to this local CrossProject
+// via .copy(localBindings = ...), the generated myLibFuture depends on it
+// directly (no maven coords for io.getkyo:kyo-compat-future).
+object FakeMarker {
+    val tag: String = "fake-compat-future"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/my-lib/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/my-lib/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,5 @@
+package example
+
+object Lib {
+    def name: String = "my-lib"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/my-partial/shared/src/main/scala/example/Partial.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/my-partial/shared/src/main/scala/example/Partial.scala
@@ -1,0 +1,9 @@
+package example
+
+// Stand-in source file for the partial-binding scenario in the
+// bind-locally scripted test. The check inspects libraryDependencies
+// + project dependencies via state extraction only — this file just
+// needs to compile in every cell.
+object Partial {
+    def name: String = "my-partial"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/test
@@ -1,0 +1,8 @@
+# Scripted test - .bindLocally via case-class .copy on the builder.
+> checkLocalDep
+> checkNoMavenDep
+# Partial bindLocally: Future bound, Kyo unbound (falls through to maven).
+> checkPartialFutureLocal
+> checkPartialFutureNoMaven
+> checkPartialKyoMaven
+> checkPartialKyoNoLocal

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/build.sbt
@@ -1,0 +1,144 @@
+// Scripted test — all 5 backends, all 3 platforms.
+//
+// Per-backend supportedPlatforms intersection means:
+//   Kyo / Zio       : JVM + JS + Native
+//   Ce              : JVM + JS         (Native skipped)
+//   Future / Ox     : JVM              (JS + Native skipped)
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        organization := "com.example",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary(KyoLib, ZioLib, CeLib, OxLib)(
+        VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native
+    )(Seq("3.3.4"))
+
+// --------------------------------------------------------------------
+// Assertion task keys
+// --------------------------------------------------------------------
+
+val checkProjects                     = taskKey[Unit]("verify exact project set")
+val checkSkippedCells                 = taskKey[Unit]("verify Ce/Native, Ox/JS, Ox/Native are not generated")
+val checkDepsPerPlatform              = taskKey[Unit]("verify per-platform cross-version on the kyo-compat-X dep")
+val checkSharedSourcesAcrossPlatforms = taskKey[Unit]("verify every per-platform project sees the shared dir")
+
+checkProjects := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    val expected = Set(
+        "myLibFuture",
+        "myLibKyo",    "myLibKyoJS",    "myLibKyoNative",
+        "myLibZio",    "myLibZioJS",    "myLibZioNative",
+        "myLibCe",     "myLibCeJS",
+        "myLibOx"
+    )
+    val actual  = ext.structure.allProjectRefs.map(_.project).toSet
+    val missing = expected -- actual
+    if (missing.nonEmpty)
+        sys.error(s"Missing expected subprojects: $missing (have: $actual)")
+    println(s"checkProjects OK; have ${expected.intersect(actual).toSeq.sorted}")
+}
+
+checkSkippedCells := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    val mustNotExist = Set("myLibFutureJS", "myLibFutureNative", "myLibCeNative", "myLibOxJS", "myLibOxNative")
+    val actual       = ext.structure.allProjectRefs.map(_.project).toSet
+    val leaked       = mustNotExist intersect actual
+    if (leaked.nonEmpty)
+        sys.error(
+            s"Cells the backend cannot support leaked into the project graph: $leaked"
+        )
+    println("checkSkippedCells OK; Future/JS, Future/Native, Ce/Native, Ox/JS, Ox/Native are absent.")
+}
+
+checkDepsPerPlatform := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+
+    // Each per-platform Project must carry the platform-appropriate
+    // cross-version on the auto-injected kyo-compat-X dep:
+    //   - JVM: CrossVersion.binary (no sjs/native marker)
+    //   - JS:  sjs1_-prefixed Binary
+    //   - Native: native0.5_-prefixed Binary
+    case class Case(proj: sbt.Project, base: String, platformTag: String)
+    val cases = Seq(
+        Case(myLib.future.jvm,    "kyo-compat-future", "jvm"),
+        Case(myLib.kyo.js,        "kyo-compat-kyo",    "sjs1"),
+        Case(myLib.zio.native,    "kyo-compat-zio",    "native"),
+        Case(myLib.ce.js,         "kyo-compat-ce",     "sjs1"),
+        Case(myLib.ox.jvm,        "kyo-compat-ox",     "jvm")
+    )
+
+    cases.foreach { c =>
+        val deps = ext.get(c.proj / Keys.libraryDependencies)
+        val matching = deps.find { mid =>
+            mid.organization == "io.getkyo" &&
+            mid.name == c.base &&
+            mid.revision == "STUB-FOR-SCRIPTED-TEST"
+        }
+        matching match {
+            case None =>
+                sys.error(
+                    s"${c.proj.id}: missing io.getkyo:${c.base}:STUB-FOR-SCRIPTED-TEST. " +
+                        s"Actual deps: ${deps.map(_.toString).mkString(", ")}"
+                )
+            case Some(mid) =>
+                val cvStr = mid.crossVersion.toString
+                c.platformTag match {
+                    case "jvm" =>
+                        if (cvStr.contains("sjs") || cvStr.contains("native"))
+                            sys.error(
+                                s"${c.proj.id}: expected JVM-style crossVersion (Binary) on " +
+                                    s"${c.base}, got: $cvStr"
+                            )
+                    case "sjs1" =>
+                        if (!cvStr.contains("sjs"))
+                            sys.error(
+                                s"${c.proj.id}: expected JS-style crossVersion (sjs1_) on " +
+                                    s"${c.base}, got: $cvStr"
+                            )
+                    case "native" =>
+                        if (!cvStr.contains("native"))
+                            sys.error(
+                                s"${c.proj.id}: expected Native-style crossVersion (native0.5_) on " +
+                                    s"${c.base}, got: $cvStr"
+                            )
+                }
+        }
+    }
+    println("checkDepsPerPlatform OK; per-platform cross-version markers present.")
+}
+
+checkSharedSourcesAcrossPlatforms := {
+    val s            = Keys.state.value
+    val ext          = sbt.Project.extract(s)
+    val sharedScala  = (file("my-lib") / "shared" / "src" / "main" / "scala").getCanonicalFile
+
+    // Every per-platform Project across every backend should see the shared dir.
+    val perPlatformProjects: Seq[sbt.Project] = Seq(
+        myLib.future.jvm,
+        myLib.kyo.jvm,    myLib.kyo.js,    myLib.kyo.native,
+        myLib.zio.jvm,    myLib.zio.js,    myLib.zio.native,
+        myLib.ce.jvm,     myLib.ce.js,
+        myLib.ox.jvm
+    )
+
+    perPlatformProjects.foreach { proj =>
+        val mainDirs = ext.get(proj / Compile / Keys.unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        if (!mainDirs.contains(sharedScala))
+            sys.error(
+                s"Project ${proj.id} missing shared main scala dir $sharedScala " +
+                    s"(actual: $mainDirs)"
+            )
+    }
+    println(
+        s"checkSharedSourcesAcrossPlatforms OK; ${perPlatformProjects.size} " +
+            "per-platform projects see the shared dir."
+    )
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/my-lib/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/my-lib/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,5 @@
+package example
+
+object Lib {
+    def name: String = "my-lib"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/test
@@ -1,0 +1,5 @@
+# Scripted test - all 5 backends, all 3 platforms.
+> checkProjects
+> checkSkippedCells
+> checkDepsPerPlatform
+> checkSharedSourcesAcrossPlatforms

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/build.sbt
@@ -1,0 +1,312 @@
+// Scripted test - depends-on.
+//
+// Exercises three dependency-wiring scenarios in one scripted test:
+//
+//   - compat-to-compat (backend-aware) -- myHttp.dependsOn(myFetcher)
+//     where both are compatLibrary matrices. After publishLocal,
+//     my-http-future_3.pom must list my-fetcher-future_3 (NOT
+//     my-fetcher-kyo_3) as a dependency, and vice-versa for kyo.
+//     WeakAxis matching on CompatBackendAxis is the relied-upon
+//     projectMatrix feature.
+//
+//   - compat-to-plain-project -- myThing.dependsOn(plainCommon)
+//     where plainCommon is a plain sbt Project (not a matrix).
+//     Every cell of myThing should depend on plainCommon, so every
+//     backend's POM (my-thing-future_3, my-thing-kyo_3) lists
+//     plain-common_3 in its dependencies.
+//
+//   - transitive A -> B -> C -- three matrices.
+//     myA.dependsOn(myB); myB.dependsOn(myC).
+//     After publishLocal of all three across Future + Kyo,
+//     my-a-future_3.pom directly lists my-b-future_3 (not my-c).
+//     my-b-future_3.pom directly lists my-c-future_3.
+//     Same for kyo. Verifies projectMatrix's transitive-dep wiring
+//     composes correctly with the backend axis (no leak across
+//     backends, no flattening of B->C into A->C).
+//
+// JVM-only to keep scripted-test runtime down. Fake-stub
+// kyo-compat-{future,kyo} jars are published to ivy-cache so the
+// auto-injected `libraryDependencies +=` in every cell resolves at
+// publishLocal time.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+// Pin ivy paths to a known location inside the test dir, mirroring
+// the publish/ scripted test. ThisBuild / ivyPaths is shadowed by
+// sbt's per-project Defaults so we apply the setting on every project.
+val rootBase: File = file(".").getCanonicalFile
+val pinnedIvyPaths: Setting[IvyPaths] =
+    ivyPaths := IvyPaths(rootBase, Some(rootBase / "ivy-cache"))
+
+// --------------------------------------------------------------------
+// fake kyo-compat-{future,kyo} stubs (JVM only).
+// Mirrors publish/build.sbt's fake-compat pattern; documented there.
+// --------------------------------------------------------------------
+
+def fakeCompat(backend: String): Project = {
+    val id  = s"fake_${backend}_jvm"
+    val dir = file(s"fake-compat/$backend/jvm")
+    Project(id, dir).settings(
+        pinnedIvyPaths,
+        organization := "io.getkyo",
+        moduleName   := s"kyo-compat-$backend",
+        version      := "STUB-FOR-SCRIPTED-TEST",
+        scalaVersion := "3.3.4"
+    )
+}
+
+lazy val fakeFutureJVM = fakeCompat("future")
+lazy val fakeKyoJVM    = fakeCompat("kyo")
+
+lazy val publishFakes = taskKey[Unit]("publishLocal every fake-compat stub")
+publishFakes := Def.sequential(
+    fakeFutureJVM / publishLocal,
+    fakeKyoJVM    / publishLocal
+).value
+
+// --------------------------------------------------------------------
+// backend-aware compat-to-compat.
+// Two matrices, each with Future + Kyo on JVM. myHttp dependsOn myFetcher.
+// projectMatrix's MatrixClasspathDependency overload wires each row of
+// myHttp to the same-axes row of myFetcher (WeakAxis matching).
+// --------------------------------------------------------------------
+
+lazy val myFetcher = (projectMatrix in file("my-fetcher"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-fetcher",
+        version      := "0.1.0-SNAPSHOT"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+
+lazy val myHttp = (projectMatrix in file("my-http"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-http",
+        version      := "0.1.0-SNAPSHOT"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+    .dependsOn(myFetcher)
+
+// --------------------------------------------------------------------
+// compat-to-plain.
+// plainCommon is a plain Project; myThing.dependsOn(plainCommon) goes
+// through projectMatrix's nonMatrixDependencies path -- every cell
+// inherits the dep.
+// --------------------------------------------------------------------
+
+lazy val plainCommon = project
+    .in(file("plain-common"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "plain-common",
+        version      := "0.1.0-SNAPSHOT",
+        scalaVersion := "3.3.4"
+    )
+
+lazy val myThing = (projectMatrix in file("my-thing"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-thing",
+        version      := "0.1.0-SNAPSHOT"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+    .dependsOn(plainCommon)
+
+// --------------------------------------------------------------------
+// transitive A -> B -> C, all backend-aware.
+// --------------------------------------------------------------------
+
+lazy val myC = (projectMatrix in file("my-c"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-c",
+        version      := "0.1.0-SNAPSHOT"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+
+lazy val myB = (projectMatrix in file("my-b"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-b",
+        version      := "0.1.0-SNAPSHOT"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+    .dependsOn(myC)
+
+lazy val myA = (projectMatrix in file("my-a"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-a",
+        version      := "0.1.0-SNAPSHOT"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+    .dependsOn(myB)
+
+// --------------------------------------------------------------------
+// POM helpers + check tasks
+// --------------------------------------------------------------------
+
+def localPomFile(base: File, artifactBase: String, backend: String): File =
+    base / "ivy-cache" / "local" / "com.example" /
+        s"$artifactBase-${backend}_3" / "0.1.0-SNAPSHOT" / "poms" /
+        s"$artifactBase-${backend}_3.pom"
+
+// For plain (non-matrix) projects there is no `-<backend>` suffix.
+def localPlainPomFile(base: File, artifactBase: String): File =
+    base / "ivy-cache" / "local" / "com.example" /
+        s"${artifactBase}_3" / "0.1.0-SNAPSHOT" / "poms" /
+        s"${artifactBase}_3.pom"
+
+def pomDeps(pom: File): Seq[(String, String)] = {
+    val xml = scala.xml.XML.loadFile(pom)
+    (xml \\ "dependency").map { d =>
+        ((d \ "groupId").text.trim, (d \ "artifactId").text.trim)
+    }
+}
+
+val checkBackendAwareDeps = taskKey[Unit](
+    "my-http POM lists same-backend my-fetcher only"
+)
+val checkPlainProjectDep = taskKey[Unit](
+    "my-thing POM (every backend) lists plain-common_3"
+)
+val checkTransitiveDeps = taskKey[Unit](
+    "A->B and B->C both wire same-backend, no flattening"
+)
+
+checkBackendAwareDeps := {
+    val base = baseDirectory.value
+    val backends = Seq("future", "kyo")
+    backends.foreach { backend =>
+        val pom = localPomFile(base, "my-http", backend)
+        if (!pom.isFile)
+            sys.error(s"checkBackendAwareDeps FAIL: missing POM at $pom")
+        val deps = pomDeps(pom)
+        // Same-backend dep MUST be present.
+        val expected = ("com.example", s"my-fetcher-${backend}_3")
+        if (!deps.contains(expected))
+            sys.error(
+                s"checkBackendAwareDeps FAIL: my-http-${backend}_3 POM is missing " +
+                    s"$expected. Actual deps: $deps"
+            )
+        // Other-backend leak MUST NOT be present.
+        val others = backends.filterNot(_ == backend)
+        others.foreach { other =>
+            val foreign = ("com.example", s"my-fetcher-${other}_3")
+            if (deps.contains(foreign))
+                sys.error(
+                    s"checkBackendAwareDeps FAIL: my-http-${backend}_3 POM leaks " +
+                        s"foreign dep $foreign (only same-backend my-fetcher allowed). " +
+                        s"Actual deps: $deps"
+                )
+        }
+        println(
+            s"checkBackendAwareDeps: my-http-${backend}_3 -> my-fetcher-${backend}_3 OK " +
+                s"(no foreign-backend leak)."
+        )
+    }
+    println("checkBackendAwareDeps OK; both backends route to matching fetcher row.")
+}
+
+checkPlainProjectDep := {
+    val base = baseDirectory.value
+    val backends = Seq("future", "kyo")
+    backends.foreach { backend =>
+        val pom = localPomFile(base, "my-thing", backend)
+        if (!pom.isFile)
+            sys.error(s"checkPlainProjectDep FAIL: missing POM at $pom")
+        val deps = pomDeps(pom)
+        val expected = ("com.example", "plain-common_3")
+        if (!deps.contains(expected))
+            sys.error(
+                s"checkPlainProjectDep FAIL: my-thing-${backend}_3 POM is missing " +
+                    s"$expected. Actual deps: $deps"
+            )
+        println(
+            s"checkPlainProjectDep: my-thing-${backend}_3 -> plain-common_3 OK."
+        )
+    }
+    println("checkPlainProjectDep OK; every backend cell depends on the plain project.")
+}
+
+checkTransitiveDeps := {
+    val base = baseDirectory.value
+    val backends = Seq("future", "kyo")
+    backends.foreach { backend =>
+        val pomA = localPomFile(base, "my-a", backend)
+        val pomB = localPomFile(base, "my-b", backend)
+        val pomC = localPomFile(base, "my-c", backend)
+        Seq("my-a" -> pomA, "my-b" -> pomB, "my-c" -> pomC).foreach { case (n, p) =>
+            if (!p.isFile)
+                sys.error(s"checkTransitiveDeps FAIL: missing POM for $n-${backend}_3 at $p")
+        }
+        val depsA = pomDeps(pomA)
+        val depsB = pomDeps(pomB)
+        val depsC = pomDeps(pomC)
+
+        // A -> B (same backend) MUST be direct.
+        val expectAtoB = ("com.example", s"my-b-${backend}_3")
+        if (!depsA.contains(expectAtoB))
+            sys.error(
+                s"checkTransitiveDeps FAIL: my-a-${backend}_3 POM is missing direct dep " +
+                    s"$expectAtoB. Actual deps: $depsA"
+            )
+        // A must NOT directly list C (transitive deps don't flatten in POMs).
+        val flatAtoC = ("com.example", s"my-c-${backend}_3")
+        if (depsA.contains(flatAtoC))
+            sys.error(
+                s"checkTransitiveDeps FAIL: my-a-${backend}_3 POM directly lists " +
+                    s"$flatAtoC (transitive dep should be reached via my-b, not flattened). " +
+                    s"Actual deps: $depsA"
+            )
+
+        // B -> C (same backend) MUST be direct.
+        val expectBtoC = ("com.example", s"my-c-${backend}_3")
+        if (!depsB.contains(expectBtoC))
+            sys.error(
+                s"checkTransitiveDeps FAIL: my-b-${backend}_3 POM is missing direct dep " +
+                    s"$expectBtoC. Actual deps: $depsB"
+            )
+
+        // C must NOT depend on A or B (no upstream leakage).
+        val others = backends.filterNot(_ == backend)
+        Seq("my-a", "my-b").foreach { upstream =>
+            val leak = ("com.example", s"$upstream-${backend}_3")
+            if (depsC.contains(leak))
+                sys.error(
+                    s"checkTransitiveDeps FAIL: my-c-${backend}_3 POM has upstream leak " +
+                        s"$leak. Actual deps: $depsC"
+                )
+        }
+
+        // No cross-backend leak in any of A/B/C.
+        Seq(("my-a", depsA), ("my-b", depsB), ("my-c", depsC)).foreach { case (n, d) =>
+            others.foreach { other =>
+                val foreign = d.filter { case (g, a) =>
+                    g == "com.example" && a.endsWith(s"-${other}_3") &&
+                        Seq("my-a", "my-b", "my-c").exists(p => a.startsWith(s"$p-"))
+                }
+                if (foreign.nonEmpty)
+                    sys.error(
+                        s"checkTransitiveDeps FAIL: $n-${backend}_3 POM leaks cross-backend " +
+                            s"deps $foreign. Actual deps: $d"
+                    )
+            }
+        }
+
+        println(
+            s"checkTransitiveDeps: chain my-a-${backend}_3 -> my-b-${backend}_3 -> " +
+                s"my-c-${backend}_3 verified (no flattening, no cross-backend leak)."
+        )
+    }
+    println("checkTransitiveDeps OK; A->B->C wires same-backend across the full chain.")
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-a/shared/src/main/scala/example/A.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-a/shared/src/main/scala/example/A.scala
@@ -1,0 +1,5 @@
+package example
+
+object A {
+    def name: String = "a"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-b/shared/src/main/scala/example/B.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-b/shared/src/main/scala/example/B.scala
@@ -1,0 +1,5 @@
+package example
+
+object B {
+    def name: String = "b"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-c/shared/src/main/scala/example/C.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-c/shared/src/main/scala/example/C.scala
@@ -1,0 +1,5 @@
+package example
+
+object C {
+    def name: String = "c"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-fetcher/shared/src/main/scala/example/Fetcher.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-fetcher/shared/src/main/scala/example/Fetcher.scala
@@ -1,0 +1,5 @@
+package example
+
+object Fetcher {
+    def name: String = "fetcher"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-http/shared/src/main/scala/example/Http.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-http/shared/src/main/scala/example/Http.scala
@@ -1,0 +1,5 @@
+package example
+
+object Http {
+    def name: String = "http"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-thing/shared/src/main/scala/example/Thing.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/my-thing/shared/src/main/scala/example/Thing.scala
@@ -1,0 +1,5 @@
+package example
+
+object Thing {
+    def name: String = "thing"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/plain-common/src/main/scala/example/Common.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/plain-common/src/main/scala/example/Common.scala
@@ -1,0 +1,5 @@
+package example
+
+object Common {
+    def name: String = "plain-common"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.10.1")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/depends-on/test
@@ -1,0 +1,17 @@
+# Scripted test - depends-on. Verifies dependency wiring scenarios:
+# (12) backend-aware compat-to-compat, (13) compat-to-plain-project,
+# (14) transitive A->B->C, all preserving the backend axis.
+# Cells are JVM-only Future + Kyo so the cross-product stays small.
+# Project ids: myFetcherFuture / myFetcherKyo, etc. (named accessors
+# return CompatBackendProjects views, so we publishLocal by id here).
+> publishFakes
+> ;myFetcherFuture/publishLocal ;myFetcherKyo/publishLocal
+> ;myHttpFuture/publishLocal ;myHttpKyo/publishLocal
+> plainCommon/publishLocal
+> ;myThingFuture/publishLocal ;myThingKyo/publishLocal
+> ;myCFuture/publishLocal ;myCKyo/publishLocal
+> ;myBFuture/publishLocal ;myBKyo/publishLocal
+> ;myAFuture/publishLocal ;myAKyo/publishLocal
+> checkBackendAwareDeps
+> checkPlainProjectDep
+> checkTransitiveDeps

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/empty-intersection-fail/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/empty-intersection-fail/build.sbt
@@ -1,0 +1,50 @@
+// Scripted test — error case (empty backend × platform intersection).
+//
+// Ox supports JVM only; the build requests JS only. Empty intersection
+// MUST fail at compatLibrary(...) call time with a message naming the
+// backend (`Ox`) and the requested platforms.
+//
+// The failing call is deferred into a task body so sbt scripted's
+// expected-failure step (`-> triggerError`) can observe it WITHOUT
+// breaking build.sbt evaluation.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+val triggerError      = taskKey[Unit]("invoke compatLibrary with an empty intersection; expected to throw")
+val checkErrorMessage = taskKey[Unit]("invoke compatLibrary inside try/catch and assert the message mentions Ox + js")
+
+// Wrap the failing call in a task so build.sbt evaluation succeeds and
+// the scripted step `-> triggerError` can observe the failure.
+triggerError := {
+    val m = sbt.internal.ProjectMatrix("triggerLib", file("trigger-lib"))
+        .compatLibrary(OxLib)(VirtualAxis.js)(Seq("3.3.4"))
+    // Force materialization so any deferred error fires.
+    val _ = m.componentProjects
+    ()
+}
+
+checkErrorMessage := {
+    val caught: Option[Throwable] =
+        try {
+            val m = sbt.internal.ProjectMatrix("checkLib", file("check-lib"))
+                .compatLibrary(OxLib)(VirtualAxis.js)(Seq("3.3.4"))
+            val _ = m.componentProjects
+            None
+        } catch {
+            case t: Throwable => Some(t)
+        }
+    caught match {
+        case None =>
+            sys.error("compatLibrary(OxLib)(JS) on a JS-only matrix should have failed but returned a value.")
+        case Some(t) =>
+            val msg = t.getMessage
+            if (msg == null)
+                sys.error(s"Empty-intersection error has null message (got: ${t.getClass.getName})")
+            val mustContain = Seq("Empty intersection", "Ox", "js")
+            val missing     = mustContain.filterNot(msg.contains)
+            if (missing.nonEmpty)
+                sys.error(s"Error message missing required tokens $missing. Actual message: $msg")
+            println(s"checkErrorMessage OK; message contains Ox + js + 'Empty intersection': $msg")
+    }
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/empty-intersection-fail/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/empty-intersection-fail/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/empty-intersection-fail/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/empty-intersection-fail/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/empty-intersection-fail/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/empty-intersection-fail/test
@@ -1,0 +1,3 @@
+# Scripted test - error case (empty backend x platform intersection).
+-> triggerError
+> checkErrorMessage

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/build.sbt
@@ -1,0 +1,156 @@
+// Scripted test - graph-shapes.
+//
+// Exercises three matrix-shape scenarios in one scripted test:
+//
+//   1. multi-scala  -- compatLibrary(KyoLib)(JVM)(Seq("3.3.4", "3.4.0")) ->
+//                      4 cells: myMultiFuture3_3_4, myMultiFuture3_4_0,
+//                      myMultiKyo3_3_4, myMultiKyo3_4_0.
+//   2. future-only  -- compatLibrary()(JVM)(Seq("3.3.4")) ->
+//                      1 cell: myFutureOnlyFuture (Future is the implicit
+//                      anchor; empty extras = Future-only).
+//   3. single-cell  -- compatLibrary(KyoLib)(JVM)(Seq("3.3.4")) ->
+//                      2 cells: mySingleFuture, mySingleKyo.
+//
+// JVM-only to keep scripted-test runtime down. Fake-stub kyo-compat-{future,kyo}
+// jars are published to ivy-cache so resolution succeeds even though no
+// real compile or update will happen during the check tasks.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+// Pin ivy paths to a known location inside the test dir, mirroring the
+// publish/ scripted test. ThisBuild / ivyPaths is shadowed by sbt's
+// per-project Defaults, so we must apply the setting on every project.
+val rootBase: File = file(".").getCanonicalFile
+val pinnedIvyPaths: Setting[IvyPaths] =
+    ivyPaths := IvyPaths(rootBase, Some(rootBase / "ivy-cache"))
+
+// --------------------------------------------------------------------
+// fake kyo-compat-{future,kyo} stubs (JVM only).
+//
+// The plugin auto-injects libraryDependencies +=
+// "io.getkyo" %%% s"kyo-compat-<backend>" % compatKyoVersion.value on every
+// generated row. Scripted tests run in an isolated env without real backend
+// artifacts, so we publish empty stubs here. The check tasks below only
+// inspect projectRefs (no compile, no update) but settings access still
+// touches libraryDependencies, so the stubs are cheap insurance.
+// --------------------------------------------------------------------
+
+def fakeCompat(backend: String): Project = {
+    val id  = s"fake_${backend}_jvm"
+    val dir = file(s"fake-compat/$backend/jvm")
+    Project(id, dir).settings(
+        pinnedIvyPaths,
+        organization := "io.getkyo",
+        moduleName   := s"kyo-compat-$backend",
+        version      := "STUB-FOR-SCRIPTED-TEST",
+        scalaVersion := "3.3.4"
+    )
+}
+
+lazy val fakeFutureJVM = fakeCompat("future")
+lazy val fakeKyoJVM    = fakeCompat("kyo")
+
+lazy val publishFakes = taskKey[Unit]("publishLocal every fake-compat stub")
+publishFakes := Def.sequential(
+    fakeFutureJVM / publishLocal,
+    fakeKyoJVM    / publishLocal
+).value
+
+// --------------------------------------------------------------------
+// Three matrices covering the three scenarios.
+// --------------------------------------------------------------------
+
+// multi-scala. Two scala versions => 2 backends * 1 platform * 2 scala = 4 cells.
+lazy val myMulti = (projectMatrix in file("my-multi"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-multi",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4", "3.4.0"))
+
+// future-only. compatLibrary() with empty extras => only the
+// implicit Future anchor. 1 backend * 1 platform * 1 scala = 1 cell.
+lazy val myFutureOnly = (projectMatrix in file("my-future-only"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-future-only",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary()(VirtualAxis.jvm)(Seq("3.3.4"))
+
+// single-cell. Future + Kyo, JVM only, single scala => 2 cells.
+lazy val mySingle = (projectMatrix in file("my-single"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-single",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+
+// --------------------------------------------------------------------
+// Check tasks. Each enumerates the matrix's projectRefs, prints the
+// actual project ids, then asserts the set matches the spec's prediction.
+// --------------------------------------------------------------------
+
+val checkMultiScala  = taskKey[Unit]("verify myMulti's 4 cells exist with expected ids")
+val checkFutureOnly  = taskKey[Unit]("verify myFutureOnly has exactly 1 future cell")
+val checkSingleCell  = taskKey[Unit]("verify mySingle has exactly 2 cells (Future + Kyo)")
+
+// myMulti.projectRefs returns Seq[ProjectReference] (sealed) which can't be
+// converted to a Seq[String] of project ids directly. We instead enumerate
+// ext.structure.allProjectRefs (a Seq[ProjectRef] where _.project: String)
+// and filter to ids whose baseDirectory falls under the given matrix dir.
+def projectIdsUnder(s: State, matrixDir: File): Set[String] = {
+    val ext   = sbt.Project.extract(s)
+    val canon = matrixDir.getCanonicalFile
+    ext.structure.allProjectRefs.flatMap { ref =>
+        val base = ext.get(ref / Keys.baseDirectory).getCanonicalFile
+        if (base.toPath.startsWith(canon.toPath)) Some(ref.project) else None
+    }.toSet
+}
+
+checkMultiScala := {
+    val actual   = projectIdsUnder(Keys.state.value, file("my-multi"))
+    val expected = Set(
+        "myMultiFuture3_3_4",
+        "myMultiFuture3_4_0",
+        "myMultiKyo3_3_4",
+        "myMultiKyo3_4_0"
+    )
+    println(s"checkMultiScala: actual project ids = ${actual.toSeq.sorted.mkString(", ")}")
+    if (actual != expected)
+        sys.error(
+            s"checkMultiScala FAIL: expected $expected, got $actual " +
+                s"(missing: ${expected -- actual}; extra: ${actual -- expected})"
+        )
+    println(s"checkMultiScala OK; ${actual.size} cells matched.")
+}
+
+checkFutureOnly := {
+    val actual   = projectIdsUnder(Keys.state.value, file("my-future-only"))
+    val expected = Set("myFutureOnlyFuture")
+    println(s"checkFutureOnly: actual project ids = ${actual.toSeq.sorted.mkString(", ")}")
+    if (actual != expected)
+        sys.error(
+            s"checkFutureOnly FAIL: expected $expected, got $actual " +
+                s"(missing: ${expected -- actual}; extra: ${actual -- expected})"
+        )
+    println(s"checkFutureOnly OK; 1 future-only cell matched.")
+}
+
+checkSingleCell := {
+    val actual   = projectIdsUnder(Keys.state.value, file("my-single"))
+    val expected = Set("mySingleFuture", "mySingleKyo")
+    println(s"checkSingleCell: actual project ids = ${actual.toSeq.sorted.mkString(", ")}")
+    if (actual != expected)
+        sys.error(
+            s"checkSingleCell FAIL: expected $expected, got $actual " +
+                s"(missing: ${expected -- actual}; extra: ${actual -- expected})"
+        )
+    println(s"checkSingleCell OK; ${actual.size} cells matched.")
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/my-future-only/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/my-future-only/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,5 @@
+package example
+
+object Lib {
+    def name: String = "future-only"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/my-multi/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/my-multi/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,5 @@
+package example
+
+object Lib {
+    def name: String = "multi"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/my-single/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/my-single/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,5 @@
+package example
+
+object Lib {
+    def name: String = "single"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.10.1")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/graph-shapes/test
@@ -1,0 +1,5 @@
+# Scripted test - graph-shapes. Verifies three matrix shapes.
+> publishFakes
+> checkMultiScala
+> checkFutureOnly
+> checkSingleCell

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/build.sbt
@@ -1,0 +1,140 @@
+// Scripted test — JVM-only, all 5 backends.
+//
+// `compatLibrary` adds one row per (backend × jvm × scalaVersion). All
+// five backends support JVM, so we expect 5 rows. kyo-compat-X is pinned
+// to a stub version so the test does not have to resolve real artifacts;
+// we only assert on project graph shape, not on `compile`.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        organization := "com.example",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary(KyoLib, ZioLib, CeLib, OxLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+
+// Cross-backend aggregator. Should fan to all 5 backends' JVM cells.
+lazy val myLibAll = myLib.aggregate("my-lib-all")
+
+// --------------------------------------------------------------------
+// Assertion task keys
+// --------------------------------------------------------------------
+
+val checkProjects        = taskKey[Unit]("verify exact project set")
+val checkDeps            = taskKey[Unit]("verify each backend has its kyo-compat-X dep")
+val checkSharedSources   = taskKey[Unit]("verify each backend sees my-lib/shared/src/main/scala")
+val checkBackendBaseDirs = taskKey[Unit]("verify each backend at my-lib/<id>/jvm/")
+val checkArtifactNames   = taskKey[Unit]("verify moduleName := myLib-<id>")
+
+checkProjects := {
+    val s        = Keys.state.value
+    val ext      = sbt.Project.extract(s)
+    // compatLibrary pins defaultAxes to (jvm, scalaABIVersion(scalaVersions.head))
+    // so the JVM and Scala suffixes are suppressed in project ids — leaving
+    // just the backend suffix (matching sbt-crossproject's
+    // `.withoutSuffixFor(JVMPlatform)` convention from the previous design).
+    val expected = Set("myLibFuture", "myLibKyo", "myLibZio", "myLibCe", "myLibOx")
+    val actual   = ext.structure.allProjectRefs.map(_.project).toSet
+    val missing  = expected -- actual
+    if (missing.nonEmpty)
+        sys.error(s"Missing expected subprojects: $missing (have: $actual)")
+    // No JS or Native cells should exist for a JVM-only build.
+    val unwanted = actual.filter(id => id.endsWith("JS") || id.endsWith("Native"))
+    if (unwanted.nonEmpty)
+        sys.error(s"Unexpected JS/Native subprojects in JVM-only build: $unwanted")
+    println(s"checkProjects OK; have ${expected.intersect(actual).toSeq.sorted}")
+}
+
+checkDeps := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    val pairs = Seq(
+        myLib.future.jvm -> "kyo-compat-future",
+        myLib.kyo.jvm    -> "kyo-compat-kyo",
+        myLib.zio.jvm    -> "kyo-compat-zio",
+        myLib.ce.jvm     -> "kyo-compat-ce",
+        myLib.ox.jvm     -> "kyo-compat-ox"
+    )
+    pairs.foreach { case (proj, expectedArtifact) =>
+        val deps = ext.get(proj / Keys.libraryDependencies)
+        val hit = deps.exists { mid =>
+            mid.organization == "io.getkyo" &&
+            mid.name == expectedArtifact &&
+            mid.revision == "STUB-FOR-SCRIPTED-TEST"
+        }
+        if (!hit)
+            sys.error(
+                s"Project ${proj.id} missing expected dependency " +
+                    s"io.getkyo:$expectedArtifact:STUB-FOR-SCRIPTED-TEST. " +
+                    s"Actual deps: ${deps.map(_.toString).mkString(", ")}"
+            )
+    }
+    println("checkDeps OK; every backend has its kyo-compat-X dependency.")
+}
+
+checkSharedSources := {
+    val s            = Keys.state.value
+    val ext          = sbt.Project.extract(s)
+    val sharedScala  = (file("my-lib") / "shared" / "src" / "main" / "scala").getCanonicalFile
+    val sharedTest   = (file("my-lib") / "shared" / "src" / "test" / "scala").getCanonicalFile
+    val backendProjs = Seq(myLib.future.jvm, myLib.kyo.jvm, myLib.zio.jvm, myLib.ce.jvm, myLib.ox.jvm)
+    backendProjs.foreach { proj =>
+        val mainDirs = ext.get(proj / Compile / Keys.unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        val testDirs = ext.get(proj / Test / Keys.unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        if (!mainDirs.contains(sharedScala))
+            sys.error(
+                s"Project ${proj.id} missing shared main scala dir $sharedScala " +
+                    s"(actual: $mainDirs)"
+            )
+        if (!testDirs.contains(sharedTest))
+            sys.error(
+                s"Project ${proj.id} missing shared test scala dir $sharedTest " +
+                    s"(actual: $testDirs)"
+            )
+    }
+    println("checkSharedSources OK; every backend sees the shared src dirs.")
+}
+
+checkBackendBaseDirs := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    // compatLibrary pins baseDirectory to <matrixBase>/<backend.name>/<platform>/.
+    val pairs = Seq(
+        myLib.future.jvm -> (file("my-lib") / "future" / "jvm"),
+        myLib.kyo.jvm    -> (file("my-lib") / "kyo"    / "jvm"),
+        myLib.zio.jvm    -> (file("my-lib") / "zio"    / "jvm"),
+        myLib.ce.jvm     -> (file("my-lib") / "ce"     / "jvm"),
+        myLib.ox.jvm     -> (file("my-lib") / "ox"     / "jvm")
+    )
+    pairs.foreach { case (proj, expectedDir) =>
+        val actual = ext.get(proj / Keys.baseDirectory).getCanonicalFile
+        val want   = expectedDir.getCanonicalFile
+        if (actual != want)
+            sys.error(s"Project ${proj.id} baseDirectory $actual != expected $want")
+    }
+    println("checkBackendBaseDirs OK; every backend lives at my-lib/<id>/jvm/.")
+}
+
+checkArtifactNames := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    // moduleName = name.value + backend.directorySuffix; name is `myLib`
+    // (matrix's id) by default — projectMatrix sets `name := self.id`.
+    val pairs = Seq(
+        myLib.future.jvm -> "myLib-future",
+        myLib.kyo.jvm    -> "myLib-kyo",
+        myLib.zio.jvm    -> "myLib-zio",
+        myLib.ce.jvm     -> "myLib-ce",
+        myLib.ox.jvm     -> "myLib-ox"
+    )
+    pairs.foreach { case (proj, expectedName) =>
+        val actual = ext.get(proj / Keys.moduleName)
+        if (actual != expectedName)
+            sys.error(s"Project ${proj.id} moduleName [$actual] != expected [$expectedName]")
+    }
+    println("checkArtifactNames OK; every backend publishes as myLib-<id>.")
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/my-lib/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/my-lib/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,9 @@
+package example
+
+// Minimal source so the shared-source-discovery has something at the
+// path the plugin wires into Compile/unmanagedSourceDirectories. The
+// scripted test does not invoke `compile` (kyo-compat-X is a stub
+// version); this file just makes the directory non-empty.
+object Lib {
+    def name: String = "my-lib"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/test
@@ -1,0 +1,6 @@
+# Scripted - JVM-only, all 5 backends.
+> checkProjects
+> checkDeps
+> checkSharedSources
+> checkBackendBaseDirs
+> checkArtifactNames

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/build.sbt
@@ -1,0 +1,319 @@
+// Scripted test — end-to-end publishLocal flow.
+//
+// Verifies the user-facing publishing contract per backend:
+//   - my-lib-<backend>_<platform-suffix>_3.jar lands in the local ivy cache
+//   - the published POM lists exactly one io.getkyo:kyo-compat-<backend>
+//     dependency (NEVER another backend's compat jar)
+//   - the per-platform crossVersion marker on that dep is correct
+//     (Binary on JVM, sjs1_ on JS, native0.5_ on Native)
+//   - the cross-backend aggregator (publish/skip := true) does NOT publish
+//
+// Why fake-compat stubs: the auto-injected
+// `libraryDependencies += "io.getkyo" %%% s"kyo-compat-<backend>" % compatKyoVersion.value`
+// must resolve at update-time for `myLibX/publishLocal` to succeed. The real
+// kyo-compat-<backend> backends are not in the scripted-test environment, so
+// this build defines 9 stub projects (Future/Kyo/Zio × JVM/JS/Native) that
+// publish empty `io.getkyo:kyo-compat-<id>` jars to the test-local ivy
+// before myLib's publishLocal runs. The jars only exist to satisfy
+// resolution; the test deliberately inspects POM metadata, not bytecode.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+// Pin ivy paths inside the test dir so publishLocal lands in a known
+// location and the same dir is also used for resolution.
+//
+// sbt's `Defaults` sets `ivyPaths := IvyPaths(baseDirectory.value, bootIvyHome(...))`
+// at the *project* scope, so `ThisBuild / ivyPaths := ...` (and even
+// `Global / ivyPaths`) are shadowed by that per-project default. The only
+// way to actually override `ivyHome` is to set `ivyPaths` on every project
+// explicitly — `pinnedIvyPaths` is plumbed into the fake-compat stubs and
+// into the projectMatrix below.
+val rootBase: File = file(".").getCanonicalFile
+val pinnedIvyPaths: Setting[IvyPaths] =
+    ivyPaths := IvyPaths(rootBase, Some(rootBase / "ivy-cache"))
+
+// --------------------------------------------------------------------
+// fake kyo-compat-<backend> stubs (Future/Kyo/Zio × JVM/JS/Native)
+//
+// Each stub publishes an empty `io.getkyo:kyo-compat-<id>_<suffix>_3:STUB-FOR-SCRIPTED-TEST`
+// to the test-local ivy. crossPaths/crossVersion picks up `_sjs1_` /
+// `_native0.5_` automatically from the platform plugin.
+// --------------------------------------------------------------------
+
+def fakeCompat(backend: String, platform: String, ver: String = "STUB-FOR-SCRIPTED-TEST"): Project = {
+    val verSlug = ver.replaceAll("[^A-Za-z0-9]", "_")
+    val id  = s"fake_${backend}_${platform}_${verSlug}"
+    val dir = file(s"fake-compat/$verSlug/$backend/$platform")
+    val base = Project(id, dir).settings(
+        pinnedIvyPaths,
+        organization := "io.getkyo",
+        moduleName   := s"kyo-compat-$backend",
+        version      := ver,
+        scalaVersion := "3.3.4"
+    )
+    platform match {
+        case "jvm"    => base
+        case "js"     => base.enablePlugins(ScalaJSPlugin)
+        case "native" => base.enablePlugins(ScalaNativePlugin)
+    }
+}
+
+lazy val fakeFutureJVM    = fakeCompat("future", "jvm")
+lazy val fakeKyoJVM       = fakeCompat("kyo", "jvm")
+lazy val fakeKyoJS        = fakeCompat("kyo", "js")
+lazy val fakeKyoNative    = fakeCompat("kyo", "native")
+lazy val fakeZioJVM       = fakeCompat("zio", "jvm")
+lazy val fakeZioJS        = fakeCompat("zio", "js")
+lazy val fakeZioNative    = fakeCompat("zio", "native")
+
+// Fake stubs at the override version 9.9.9 (JVM-only since
+// myOverride only opts in JVM). Without these the per-cell update-time
+// resolution of `kyo-compat-<backend>:9.9.9` would fail.
+lazy val fakeFutureJVMOverride = fakeCompat("future", "jvm", "9.9.9")
+lazy val fakeKyoJVMOverride    = fakeCompat("kyo", "jvm", "9.9.9")
+
+lazy val publishFakes = taskKey[Unit]("publishLocal every fake-compat stub")
+publishFakes := Def.sequential(
+    fakeFutureJVM    / publishLocal,
+    fakeKyoJVM       / publishLocal,
+    fakeKyoJS        / publishLocal,
+    fakeKyoNative    / publishLocal,
+    fakeZioJVM       / publishLocal,
+    fakeZioJS        / publishLocal,
+    fakeZioNative    / publishLocal,
+    fakeFutureJVMOverride / publishLocal,
+    fakeKyoJVMOverride    / publishLocal
+).value
+
+// --------------------------------------------------------------------
+// my-lib — Future + Kyo + Zio across JVM/JS/Native (3 backends × 3 platforms = 9 cells)
+// --------------------------------------------------------------------
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        // Override `name` so the published artifactId is `my-lib-<backend>`
+        // (the plugin sets `moduleName := name.value + backend.directorySuffix`).
+        // Without this, sbt would derive `name` from the project id (`myLib`)
+        // and publish as `myLib-<backend>`.
+        name         := "my-lib",
+        version      := "0.1.0-SNAPSHOT"
+    )
+    .compatLibrary(KyoLib, ZioLib)(
+        VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native
+    )(Seq("3.3.4"))
+
+lazy val `my-lib-all` = myLib.aggregate("my-lib-all")
+
+// --------------------------------------------------------------------
+// compatKyoVersion override flows into per-cell POM dep version.
+//
+// `compatKyoVersion := "9.9.9"` placed in the matrix's `.settings(...)`
+// lands on every cell as a project-scoped override. The plugin's per-cell
+// `libraryDependencies` setting reads `CompatPlugin.autoImport.compatKyoVersion.value`
+// so each cell's update + POM should resolve and list the override version.
+// JVM-only + Future/Kyo to keep the override-fake matrix tiny.
+// --------------------------------------------------------------------
+
+lazy val myOverride = (projectMatrix in file("my-override"))
+    .settings(
+        pinnedIvyPaths,
+        organization     := "com.example",
+        name             := "my-override",
+        version          := "0.1.0-SNAPSHOT",
+        compatKyoVersion := "9.9.9"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+
+// --------------------------------------------------------------------
+// Assertions on the published artifacts
+// --------------------------------------------------------------------
+
+val checkPublishedJars            = taskKey[Unit]("verify each cell's jar landed in ivy-cache/local")
+val checkPomDeps                  = taskKey[Unit]("verify POM lists exactly the matching kyo-compat-<backend> dep")
+val checkPomCrossVersionMarkers   = taskKey[Unit]("verify JS/Native POMs carry sjs1_/native0.5_ markers")
+val checkAggregatorNotPublished   = taskKey[Unit]("verify the my-lib-all aggregator did not publish")
+
+// (backend, suffix-on-artifactId): "" for JVM, "_sjs1" for JS, "_native0.5" for Native.
+// Future is JVM-only; Kyo and Zio cross-compile.
+val cells: Seq[(String, String)] = Seq(
+    ("future", ""),
+    ("kyo",    ""),
+    ("kyo",    "_sjs1"),
+    ("kyo",    "_native0.5"),
+    ("zio",    ""),
+    ("zio",    "_sjs1"),
+    ("zio",    "_native0.5")
+)
+
+def localDir(base: File, backend: String, suffix: String): File =
+    base / "ivy-cache" / "local" / "com.example" /
+        s"my-lib-${backend}${suffix}_3" / "0.1.0-SNAPSHOT"
+
+checkPublishedJars := {
+    val base = baseDirectory.value
+    cells.foreach { case (backend, suffix) =>
+        val artifact = s"my-lib-${backend}${suffix}_3"
+        val jar = localDir(base, backend, suffix) / "jars" / s"$artifact.jar"
+        if (!jar.isFile)
+            sys.error(s"checkPublishedJars FAIL: missing jar at $jar")
+    }
+    println(s"checkPublishedJars OK; ${cells.size} jars present in ivy-cache/local.")
+}
+
+def pomFile(base: File, backend: String, suffix: String): File =
+    localDir(base, backend, suffix) / "poms" / s"my-lib-${backend}${suffix}_3.pom"
+
+def pomDeps(pom: File): Seq[(String, String)] = {
+    val xml = scala.xml.XML.loadFile(pom)
+    (xml \\ "dependency").map { d =>
+        ((d \ "groupId").text.trim, (d \ "artifactId").text.trim)
+    }
+}
+
+checkPomDeps := {
+    val base = baseDirectory.value
+    cells.foreach { case (backend, suffix) =>
+        val pom = pomFile(base, backend, suffix)
+        if (!pom.isFile)
+            sys.error(s"checkPomDeps FAIL: missing POM at $pom")
+        val deps = pomDeps(pom)
+        val compat = deps.filter { case (g, a) =>
+            g == "io.getkyo" && a.startsWith("kyo-compat-")
+        }
+        // Self-backend dep MUST be present (with platform suffix).
+        val expectedArtifactPrefix = s"kyo-compat-${backend}${suffix}_"
+        val matching = compat.filter { case (_, a) => a.startsWith(expectedArtifactPrefix) }
+        if (matching.isEmpty)
+            sys.error(
+                s"checkPomDeps FAIL: my-lib-${backend}${suffix}_3 POM is missing the " +
+                    s"matching $expectedArtifactPrefix* dep. Actual compat deps: $compat"
+            )
+        // No OTHER backend's compat jar may appear.
+        val foreign = compat.filterNot { case (_, a) =>
+            a.startsWith(expectedArtifactPrefix)
+        }
+        if (foreign.nonEmpty)
+            sys.error(
+                s"checkPomDeps FAIL: my-lib-${backend}${suffix}_3 POM leaks foreign " +
+                    s"compat deps: $foreign (only $expectedArtifactPrefix* allowed)"
+            )
+        println(
+            s"checkPomDeps: my-lib-${backend}${suffix}_3 POM lists ${matching.head._2}, " +
+                "no other compat deps."
+        )
+    }
+    println(s"checkPomDeps OK; ${cells.size} POMs verified.")
+}
+
+checkPomCrossVersionMarkers := {
+    val base = baseDirectory.value
+    // For each (backend, JS-platform): expect _sjs1_3 suffix on the
+    // kyo-compat-<backend> dep.
+    val jsCases     = cells.filter(_._2 == "_sjs1")
+    val nativeCases = cells.filter(_._2 == "_native0.5")
+
+    jsCases.foreach { case (backend, suffix) =>
+        val deps = pomDeps(pomFile(base, backend, suffix))
+        val artifactId = deps.collectFirst {
+            case (g, a) if g == "io.getkyo" && a.startsWith(s"kyo-compat-${backend}_") => a
+        }.getOrElse(
+            sys.error(
+                s"checkPomCrossVersionMarkers FAIL: my-lib-${backend}${suffix}_3 POM has no " +
+                    s"kyo-compat-${backend} dep. Deps: $deps"
+            )
+        )
+        if (!artifactId.endsWith("_sjs1_3"))
+            sys.error(
+                s"checkPomCrossVersionMarkers FAIL: expected $artifactId to end with " +
+                    "'_sjs1_3' (JS cross-version marker)"
+            )
+    }
+    nativeCases.foreach { case (backend, suffix) =>
+        val deps = pomDeps(pomFile(base, backend, suffix))
+        val artifactId = deps.collectFirst {
+            case (g, a) if g == "io.getkyo" && a.startsWith(s"kyo-compat-${backend}_") => a
+        }.getOrElse(
+            sys.error(
+                s"checkPomCrossVersionMarkers FAIL: my-lib-${backend}${suffix}_3 POM has no " +
+                    s"kyo-compat-${backend} dep. Deps: $deps"
+            )
+        )
+        if (!artifactId.endsWith("_native0.5_3"))
+            sys.error(
+                s"checkPomCrossVersionMarkers FAIL: expected $artifactId to end with " +
+                    "'_native0.5_3' (Native cross-version marker)"
+            )
+    }
+    println(
+        s"checkPomCrossVersionMarkers OK; ${jsCases.size} JS + ${nativeCases.size} Native " +
+            "deps carry the per-platform marker."
+    )
+}
+
+checkAggregatorNotPublished := {
+    val aggDir = baseDirectory.value / "ivy-cache" / "local" / "com.example" /
+        "my-lib-all" / "0.1.0-SNAPSHOT"
+    if (aggDir.exists)
+        sys.error(
+            s"checkAggregatorNotPublished FAIL: aggregator should be publish-skipped " +
+                s"but $aggDir exists"
+        )
+    println("checkAggregatorNotPublished OK; aggregator is publish-skipped.")
+}
+
+// --------------------------------------------------------------------
+// Version-override assertion — every myOverride cell's POM lists the
+// kyo-compat-<backend> dep at version 9.9.9 (override flowed).
+// --------------------------------------------------------------------
+
+val checkVersionOverride = taskKey[Unit](
+    "verify compatKyoVersion override flows into every myOverride cell's POM dep version"
+)
+
+def pomDepsWithVersion(pom: File): Seq[(String, String, String)] = {
+    val xml = scala.xml.XML.loadFile(pom)
+    (xml \\ "dependency").map { d =>
+        (
+            (d \ "groupId").text.trim,
+            (d \ "artifactId").text.trim,
+            (d \ "version").text.trim
+        )
+    }
+}
+
+checkVersionOverride := {
+    val base = baseDirectory.value
+    // myOverride opted in Future + Kyo (Future is implicit), JVM-only.
+    val overrideCells = Seq("future", "kyo")
+    overrideCells.foreach { backend =>
+        val pom = base / "ivy-cache" / "local" / "com.example" /
+            s"my-override-${backend}_3" / "0.1.0-SNAPSHOT" / "poms" /
+            s"my-override-${backend}_3.pom"
+        if (!pom.isFile)
+            sys.error(s"checkVersionOverride FAIL: missing POM at $pom")
+        val deps = pomDepsWithVersion(pom)
+        val matching = deps.filter { case (g, a, _) =>
+            g == "io.getkyo" && a.startsWith(s"kyo-compat-${backend}_")
+        }
+        if (matching.isEmpty)
+            sys.error(
+                s"checkVersionOverride FAIL: my-override-${backend}_3 POM is missing " +
+                    s"kyo-compat-${backend}_* dep. Actual deps: $deps"
+            )
+        matching.foreach { case (g, a, v) =>
+            if (v != "9.9.9")
+                sys.error(
+                    s"checkVersionOverride FAIL: my-override-${backend}_3 POM dep $g:$a " +
+                        s"has version '$v', expected '9.9.9' (compatKyoVersion override)"
+                )
+        }
+        println(
+            s"checkVersionOverride: my-override-${backend}_3 POM lists " +
+                s"${matching.head._2} at version ${matching.head._3}."
+        )
+    }
+    println(s"checkVersionOverride OK; ${overrideCells.size} override-cell POMs verified at 9.9.9.")
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/my-lib/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/my-lib/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,10 @@
+package example
+
+// Trivial stand-in: the publish scripted test only inspects POM metadata,
+// never the runtime API. Keeping this file dependency-free lets every
+// (backend, platform) cell compile with no code-level coupling to the
+// auto-injected `io.getkyo:kyo-compat-<backend>` jar (which is satisfied
+// at update-time by the in-test fake-compat stub modules).
+object Lib {
+    def name: String = "my-lib"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/my-override/shared/src/main/scala/example/Override.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/my-override/shared/src/main/scala/example/Override.scala
@@ -1,0 +1,8 @@
+package example
+
+// Stand-in source file for the compatKyoVersion-override scenario in the
+// publish scripted test. The check inspects POM metadata only, so this
+// file just needs to compile in every cell.
+object Override {
+    def name: String = "my-override"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/publish/test
@@ -1,0 +1,18 @@
+# Scripted test - end-to-end publishLocal flow.
+# 1. Publish the fake kyo-compat-<backend> stubs so update can resolve them.
+# 2. Publish my-lib's 7 cells (Future on JVM only; Kyo/Zio on JVM+JS+Native).
+# 3. Publish the cross-backend aggregator (which is publish/skip := true).
+# 4. Inspect the resulting artifacts in ivy-cache/local.
+# 5. publishLocal myOverride's 2 (Future/Kyo, JVM) cells and
+#    verify compatKyoVersion := "9.9.9" flows to every cell's POM dep version.
+> publishFakes
+> ;myLibFuture/publishLocal ;myLibKyo/publishLocal ;myLibZio/publishLocal
+> ;myLibKyoJS/publishLocal ;myLibZioJS/publishLocal
+> ;myLibKyoNative/publishLocal ;myLibZioNative/publishLocal
+> my-lib-all/publishLocal
+> checkPublishedJars
+> checkPomDeps
+> checkPomCrossVersionMarkers
+> checkAggregatorNotPublished
+> ;myOverrideFuture/publishLocal ;myOverrideKyo/publishLocal
+> checkVersionOverride

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/build.sbt
@@ -1,0 +1,277 @@
+// Scripted test - settings-passthrough.
+//
+// Exercises:
+//
+//   - .settings(commonSettingMarker := ...)         -> every cell
+//   - .jvmSettings(jvmSettingMarker := ...)         -> JVM cells only
+//   - .jsSettings(jsSettingMarker := ...)           -> JS  cells only
+//   - .nativeSettings(nativeSettingMarker := ...)   -> Native cells only
+//   - Test/fork := true + Test/javaOptions += "-Dfoo=bar" on the receiver
+//     flows to JVM cells; ForkTest reads System.getProperty("foo") == "bar"
+//     from inside a forked test JVM.
+//
+// Matrix shape: Future + Kyo (both support all 3 platforms) across
+// JVM + JS + Native = 6 cells. Single Scala 3.3.4. Per-platform setting
+// discrimination is observed by enumerating each cell's Project ref
+// (myLib.future.jvm, myLib.future.js, ...) directly, matching the
+// pattern used by the cross-platform scripted test.
+//
+// Why fake-stub kyo-compat-X jars: the plugin auto-injects
+// `libraryDependencies += "io.getkyo" %%% "kyo-compat-<backend>" % compatKyoVersion.value`
+// on every generated row. The check tasks themselves don't compile cells,
+// but checkForkTest invokes Test/test, which forces update on the JVM
+// cells. We publishLocal empty stubs so resolution succeeds without hitting
+// any real backend artifacts. Same pattern as publish/.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+// Custom marker keys default to "" on ThisBuild. Per-cell .settings /
+// .jvmSettings / .jsSettings / .nativeSettings calls below override the
+// default on the matching cells; the check tasks read each cell's value
+// and assert the expected JVM/JS/Native partitioning.
+ThisBuild / commonSettingMarker := ""
+ThisBuild / jvmSettingMarker    := ""
+ThisBuild / jsSettingMarker     := ""
+ThisBuild / nativeSettingMarker := ""
+ThisBuild / forkSettingMarker   := ""
+
+lazy val commonSettingMarker = settingKey[String](".settings(...) reaches every cell")
+lazy val jvmSettingMarker    = settingKey[String](".jvmSettings(...) reaches JVM cells only")
+lazy val jsSettingMarker     = settingKey[String](".jsSettings(...) reaches JS cells only")
+lazy val nativeSettingMarker = settingKey[String](".nativeSettings(...) reaches Native cells only")
+lazy val forkSettingMarker   = settingKey[String]("sanity marker for fork settings")
+
+// Pin ivy paths inside the test dir, mirroring the publish/ scripted test.
+// ThisBuild / ivyPaths is shadowed by sbt's per-project Defaults, so the
+// setting must be applied on every project.
+val rootBase: File = file(".").getCanonicalFile
+val pinnedIvyPaths: Setting[IvyPaths] =
+    ivyPaths := IvyPaths(rootBase, Some(rootBase / "ivy-cache"))
+
+// --------------------------------------------------------------------
+// fake kyo-compat-{future,kyo} stubs (JVM + JS + Native).
+//
+// Six stubs total: (future, kyo) x (jvm, js, native), matching the
+// receiver matrix shape.
+// --------------------------------------------------------------------
+
+def fakeCompat(backend: String, platform: String): Project = {
+    val id   = s"fake_${backend}_${platform}"
+    val dir  = file(s"fake-compat/$backend/$platform")
+    val base = Project(id, dir).settings(
+        pinnedIvyPaths,
+        organization := "io.getkyo",
+        moduleName   := s"kyo-compat-$backend",
+        version      := "STUB-FOR-SCRIPTED-TEST",
+        scalaVersion := "3.3.4"
+    )
+    platform match {
+        case "jvm"    => base
+        case "js"     => base.enablePlugins(ScalaJSPlugin)
+        case "native" => base.enablePlugins(ScalaNativePlugin)
+    }
+}
+
+lazy val fakeFutureJVM    = fakeCompat("future", "jvm")
+lazy val fakeKyoJVM       = fakeCompat("kyo",    "jvm")
+lazy val fakeKyoJS        = fakeCompat("kyo",    "js")
+lazy val fakeKyoNative    = fakeCompat("kyo",    "native")
+
+lazy val publishFakes = taskKey[Unit]("publishLocal every fake-compat stub")
+publishFakes := Def.sequential(
+    fakeFutureJVM    / publishLocal,
+    fakeKyoJVM       / publishLocal,
+    fakeKyoJS        / publishLocal,
+    fakeKyoNative    / publishLocal
+).value
+
+// --------------------------------------------------------------------
+// my-lib - receiver matrix that exercises every settings entry point.
+// --------------------------------------------------------------------
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-lib",
+        version      := "0.1.0-TEST",
+        // .settings(...) reaches every cell.
+        commonSettingMarker := "common-value",
+        // Test/fork + Test/javaOptions on the receiver.
+        // ForkTest asserts System.getProperty("foo") == "bar" inside a
+        // forked test JVM. checkForkTest below invokes Test/test on the
+        // JVM cells; if fork or javaOptions did not flow, the assertion
+        // and the task fail.
+        Test / fork           := true,
+        Test / javaOptions    += "-Dfoo=bar",
+        forkSettingMarker     := "fork-on",
+        // scalatest is the test runtime for ForkTest. %%% picks up the
+        // per-platform crossVersion automatically. The shared/src/test
+        // sources are compiled across every cell, so the dep must be
+        // available on JVM/JS/Native; checkForkTest only RUNS Test/test
+        // on the JVM cells.
+        libraryDependencies   += "org.scalatest" %%% "scalatest" % "3.2.19" % Test
+    )
+    // Scenarios 5/6/7: per-platform settings via the kyo-compat plugin's
+    // `.jvmSettings` / `.jsSettings` / `.nativeSettings` extension methods on
+    // `ProjectMatrix`. These mirror sbt-crossproject's per-platform setters
+    // and apply AFTER the receiver's `.settings(...)` so per-platform values
+    // win on conflicts.
+    .compatLibrary(KyoLib)(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)(Seq("3.3.4"))
+    .jvmSettings(jvmSettingMarker       := "jvm-value")
+    .jsSettings(jsSettingMarker         := "js-value")
+    .nativeSettings(nativeSettingMarker := "native-value")
+
+// --------------------------------------------------------------------
+// Per-platform Project handles. Same pattern as cross-platform/build.sbt.
+// --------------------------------------------------------------------
+
+lazy val jvmCells: Seq[Project] = Seq(
+    myLib.future.jvm,
+    myLib.kyo.jvm
+)
+
+lazy val jsCells: Seq[Project] = Seq(
+    myLib.kyo.js
+)
+
+lazy val nativeCells: Seq[Project] = Seq(
+    myLib.kyo.native
+)
+
+lazy val allCells: Seq[Project] = jvmCells ++ jsCells ++ nativeCells
+
+// --------------------------------------------------------------------
+// Check tasks. Each enumerates the relevant cells, prints what it
+// observed, then asserts the JVM/JS/Native partitioning. sys.error on
+// failure carries enough detail to diagnose without re-running.
+// --------------------------------------------------------------------
+
+val checkCommonSettings = taskKey[Unit](".settings(commonSettingMarker) on every cell")
+val checkJvmSettings    = taskKey[Unit](".jvmSettings on JVM cells only")
+val checkJsSettings     = taskKey[Unit](".jsSettings on JS cells only")
+val checkNativeSettings = taskKey[Unit](".nativeSettings on Native cells only")
+val checkForkTest       = taskKey[Unit]("Test/fork + Test/javaOptions flow to JVM cells")
+
+checkCommonSettings := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    allCells.foreach { proj =>
+        val v = ext.get(proj / commonSettingMarker)
+        if (v != "common-value") {
+            val msg = "checkCommonSettings FAIL: " + proj.id +
+                " expected commonSettingMarker = 'common-value', got '" + v + "'"
+            sys.error(msg)
+        }
+    }
+    val ids = allCells.map(_.id).sorted.mkString(", ")
+    println(
+        "checkCommonSettings OK; " + allCells.size + " cells [" + ids +
+            "] all carry commonSettingMarker = 'common-value'."
+    )
+}
+
+// Scenarios 5/6/7: each check task asserts the per-platform marker resolved
+// to the expected value on the matching cells AND remained empty (the
+// ThisBuild default) on the other cells, proving the `.jvmSettings` /
+// `.jsSettings` / `.nativeSettings` calls on the receiver landed only on
+// the targeted platform's cells.
+
+checkJvmSettings := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    val nonJvmCells = jsCells ++ nativeCells
+    jvmCells.foreach { proj =>
+        val v = ext.get(proj / jvmSettingMarker)
+        if (v != "jvm-value") {
+            val msg = "checkJvmSettings FAIL: JVM cell " + proj.id +
+                " expected jvmSettingMarker = 'jvm-value', got '" + v + "'"
+            sys.error(msg)
+        }
+    }
+    nonJvmCells.foreach { proj =>
+        val v = ext.get(proj / jvmSettingMarker)
+        if (v != "") {
+            val msg = "checkJvmSettings FAIL: non-JVM cell " + proj.id +
+                " unexpectedly has jvmSettingMarker = '" + v + "' (expected '')"
+            sys.error(msg)
+        }
+    }
+    val jvmIds    = jvmCells.map(_.id).sorted.mkString(", ")
+    val nonJvmIds = nonJvmCells.map(_.id).sorted.mkString(", ")
+    println(
+        "checkJvmSettings OK; JVM cells [" + jvmIds + "] carry jvmSettingMarker = 'jvm-value', " +
+            "non-JVM cells [" + nonJvmIds + "] carry the empty default."
+    )
+}
+
+checkJsSettings := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    val nonJsCells = jvmCells ++ nativeCells
+    jsCells.foreach { proj =>
+        val v = ext.get(proj / jsSettingMarker)
+        if (v != "js-value") {
+            val msg = "checkJsSettings FAIL: JS cell " + proj.id +
+                " expected jsSettingMarker = 'js-value', got '" + v + "'"
+            sys.error(msg)
+        }
+    }
+    nonJsCells.foreach { proj =>
+        val v = ext.get(proj / jsSettingMarker)
+        if (v != "") {
+            val msg = "checkJsSettings FAIL: non-JS cell " + proj.id +
+                " unexpectedly has jsSettingMarker = '" + v + "' (expected '')"
+            sys.error(msg)
+        }
+    }
+    val jsIds    = jsCells.map(_.id).sorted.mkString(", ")
+    val nonJsIds = nonJsCells.map(_.id).sorted.mkString(", ")
+    println(
+        "checkJsSettings OK; JS cells [" + jsIds + "] carry jsSettingMarker = 'js-value', " +
+            "non-JS cells [" + nonJsIds + "] carry the empty default."
+    )
+}
+
+checkNativeSettings := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    val nonNativeCells = jvmCells ++ jsCells
+    nativeCells.foreach { proj =>
+        val v = ext.get(proj / nativeSettingMarker)
+        if (v != "native-value") {
+            val msg = "checkNativeSettings FAIL: Native cell " + proj.id +
+                " expected nativeSettingMarker = 'native-value', got '" + v + "'"
+            sys.error(msg)
+        }
+    }
+    nonNativeCells.foreach { proj =>
+        val v = ext.get(proj / nativeSettingMarker)
+        if (v != "") {
+            val msg = "checkNativeSettings FAIL: non-Native cell " + proj.id +
+                " unexpectedly has nativeSettingMarker = '" + v + "' (expected '')"
+            sys.error(msg)
+        }
+    }
+    val nativeIds    = nativeCells.map(_.id).sorted.mkString(", ")
+    val nonNativeIds = nonNativeCells.map(_.id).sorted.mkString(", ")
+    println(
+        "checkNativeSettings OK; Native cells [" + nativeIds + "] carry nativeSettingMarker = 'native-value', " +
+            "non-Native cells [" + nonNativeIds + "] carry the empty default."
+    )
+}
+
+// Fan out Test/test to every JVM cell. ForkTest's
+// `assert(System.getProperty("foo") == "bar")` only passes if both
+// `Test/fork := true` and `Test/javaOptions += "-Dfoo=bar"` propagated to
+// the cell's task scope. A failed assertion fails the test runner, which
+// fails this task.
+checkForkTest := Def.sequential(
+    myLib.future.jvm / Test / test,
+    myLib.kyo.jvm    / Test / test,
+    Def.task(println(
+        s"checkForkTest OK; ${jvmCells.size} JVM cells (myLibFuture, myLibKyo) ran " +
+            "ForkTest under fork with -Dfoo=bar."
+    ))
+).value

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/my-lib/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/my-lib/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,8 @@
+package example
+
+// Trivial dep-free stand-in. The settings-passthrough scripted test
+// inspects setting values and runs a forked test; it does not exercise
+// any runtime API on this object.
+object Lib {
+    def name: String = "my-lib"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/my-lib/shared/src/test/scala/example/ForkTest.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/my-lib/shared/src/test/scala/example/ForkTest.scala
@@ -1,0 +1,11 @@
+package example
+
+import org.scalatest.funsuite.AnyFunSuite
+
+// Asserts that Test/javaOptions += "-Dfoo=bar" actually flowed to the
+// forked test JVM. If fork or javaOptions did not propagate to the
+// generated cell, System.getProperty("foo") will be null and this test
+// fails — which makes the scripted-test's `checkForkTest` task fail.
+class ForkTest extends AnyFunSuite:
+    test("javaOptions flow through fork"):
+        assert(System.getProperty("foo") == "bar")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/settings-passthrough/test
@@ -1,0 +1,7 @@
+# Scripted test - settings-passthrough.
+> publishFakes
+> checkCommonSettings
+> checkJvmSettings
+> checkJsSettings
+> checkNativeSettings
+> checkForkTest

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/build.sbt
@@ -1,0 +1,228 @@
+// Scripted test - shared-resources.
+//
+// Exercises shared resources:
+//   <base>/shared/src/main/resources/  reaches every backend cell's
+//   published jar. Files placed at my-lib/shared/src/main/resources/...
+//   must appear inside both myLibFuture/myLibKyo published jars.
+//
+// Plugin resource-dir wiring (CompatLibrary.scala customRow process closure,
+// at the time of writing):
+//
+//   sharedMainR = <base>/shared/src/main/resources
+//   sharedTestR = <base>/shared/src/test/resources
+//   Compile / unmanagedResourceDirectories += sharedMainR
+//   Test    / unmanagedResourceDirectories += sharedTestR
+//
+// NOTE: The plugin DOES NOT currently wire per-backend
+// (<base>/<backend>/src/main/resources) or per-cell
+// (<base>/<backend>/<platform>/src/main/resources) resource dirs - only the
+// shared one. This scripted test deliberately checks per-backend and per-cell
+// resources too; if the plugin doesn't wire them, the corresponding check
+// fails and surfaces the gap.
+//
+// Matrix shape: Future + Kyo on JVM only (single platform, single Scala) =
+// 2 cells. JVM-only and a single Scala version keep this test under the
+// 2-minute budget.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+// Pin ivy paths inside the test dir, mirroring publish/ and source-overrides/.
+// `ThisBuild / ivyPaths` is shadowed by sbt's per-project Defaults, so the
+// setting must be applied on every project that participates in resolution.
+val rootBase: File = file(".").getCanonicalFile
+val pinnedIvyPaths: Setting[IvyPaths] =
+    ivyPaths := IvyPaths(rootBase, Some(rootBase / "ivy-cache"))
+
+// --------------------------------------------------------------------
+// fake kyo-compat-{future,kyo} stubs (JVM only).
+//
+// Two stubs total: (future, kyo) x (jvm). Their only purpose is to satisfy
+// the auto-injected `libraryDependencies += "io.getkyo" %%% "kyo-compat-<X>"`
+// when myLib<Backend>/publishLocal triggers update.
+// --------------------------------------------------------------------
+
+def fakeCompat(backend: String): Project = {
+    val id  = s"fake_${backend}_jvm"
+    val dir = file(s"fake-compat/$backend/jvm")
+    Project(id, dir).settings(
+        pinnedIvyPaths,
+        organization := "io.getkyo",
+        moduleName   := s"kyo-compat-$backend",
+        version      := "STUB-FOR-SCRIPTED-TEST",
+        scalaVersion := "3.3.4"
+    )
+}
+
+lazy val fakeFutureJVM = fakeCompat("future")
+lazy val fakeKyoJVM    = fakeCompat("kyo")
+
+lazy val publishFakes = taskKey[Unit]("publishLocal every fake-compat stub")
+publishFakes := Def.sequential(
+    fakeFutureJVM / publishLocal,
+    fakeKyoJVM    / publishLocal
+).value
+
+// --------------------------------------------------------------------
+// my-lib - receiver matrix. Future + Kyo on JVM = 2 cells.
+//
+// `name := "my-lib"` is required so the published artifactId is
+// `my-lib-<backend>` (the plugin sets `moduleName := name.value +
+// backend.directorySuffix`). Without this, sbt would derive `name` from the
+// project id (`myLib`) and publish as `myLib-<backend>`.
+// --------------------------------------------------------------------
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-lib",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+
+// --------------------------------------------------------------------
+// Helpers + check tasks.
+// --------------------------------------------------------------------
+
+// Each cell publishes as my-lib-<backend>_3 (no platform suffix on JVM).
+def cellLocalDir(base: File, backend: String): File =
+    base / "ivy-cache" / "local" / "com.example" /
+        s"my-lib-${backend}_3" / "0.1.0-TEST"
+
+def cellJar(base: File, backend: String): File =
+    cellLocalDir(base, backend) / "jars" / s"my-lib-${backend}_3.jar"
+
+// Read a single jar entry into a String. Returns None if entry is absent.
+def jarEntry(jar: File, entry: String): Option[String] = {
+    val jf = new java.util.jar.JarFile(jar)
+    try {
+        Option(jf.getJarEntry(entry)).map { je =>
+            val is = jf.getInputStream(je)
+            try {
+                val bytes = is.readAllBytes()
+                new String(bytes, java.nio.charset.StandardCharsets.UTF_8).trim
+            } finally is.close()
+        }
+    } finally jf.close()
+}
+
+val checkSharedResourceInAllJars = taskKey[Unit](
+    "shared/src/main/resources/shared-marker.txt in every cell's published jar")
+val checkPerBackendResource = taskKey[Unit](
+    "<backend>/src/main/resources/<file> reaches that backend's cell jar; absent from other backends")
+val checkPerCellResource = taskKey[Unit](
+    "<backend>/<platform>/src/main/resources/<file> reaches the matching cell's jar")
+
+// shared-marker.txt must appear in every cell's published jar
+// with the expected content.
+checkSharedResourceInAllJars := {
+    val base = baseDirectory.value
+    val cells = Seq("future", "kyo")
+    cells.foreach { backend =>
+        val jar = cellJar(base, backend)
+        if (!jar.isFile)
+            sys.error(
+                s"checkSharedResourceInAllJars FAIL: missing jar at $jar"
+            )
+        jarEntry(jar, "shared-marker.txt") match {
+            case None =>
+                sys.error(
+                    s"checkSharedResourceInAllJars FAIL: my-lib-${backend}_3.jar " +
+                        "is missing entry 'shared-marker.txt'. The plugin must add " +
+                        "<base>/shared/src/main/resources to Compile/unmanagedResourceDirectories."
+                )
+            case Some(actual) =>
+                if (actual != "shared-resource-content")
+                    sys.error(
+                        s"checkSharedResourceInAllJars FAIL: my-lib-${backend}_3.jar " +
+                            s"shared-marker.txt content mismatch. Expected " +
+                            s"'shared-resource-content', got '$actual'"
+                    )
+        }
+    }
+    println(
+        s"checkSharedResourceInAllJars OK; ${cells.size} cells " +
+            s"[${cells.map(b => s"my-lib-${b}_3").mkString(", ")}] all carry shared-marker.txt."
+    )
+}
+
+// per-backend: future/src/main/resources/future-marker.txt
+// must appear in myLibFuture's jar and must NOT appear in myLibKyo's jar.
+checkPerBackendResource := {
+    val base       = baseDirectory.value
+    val futureJar  = cellJar(base, "future")
+    val kyoJar     = cellJar(base, "kyo")
+
+    if (!futureJar.isFile)
+        sys.error(s"checkPerBackendResource FAIL: missing jar at $futureJar")
+    if (!kyoJar.isFile)
+        sys.error(s"checkPerBackendResource FAIL: missing jar at $kyoJar")
+
+    jarEntry(futureJar, "future-marker.txt") match {
+        case None =>
+            sys.error(
+                "checkPerBackendResource FAIL: my-lib-future_3.jar is missing " +
+                    "entry 'future-marker.txt'. The plugin must add " +
+                    "<base>/<backend>/src/main/resources to " +
+                    "Compile/unmanagedResourceDirectories (analogous to perBackendMain " +
+                    "for sources)."
+            )
+        case Some(actual) =>
+            if (actual != "future-only-resource")
+                sys.error(
+                    "checkPerBackendResource FAIL: my-lib-future_3.jar " +
+                        s"future-marker.txt content mismatch. Expected " +
+                        s"'future-only-resource', got '$actual'"
+                )
+    }
+
+    jarEntry(kyoJar, "future-marker.txt") match {
+        case Some(_) =>
+            sys.error(
+                "checkPerBackendResource FAIL: my-lib-kyo_3.jar unexpectedly " +
+                    "contains entry 'future-marker.txt'. The Future-backend resource " +
+                    "must NOT leak into other backends' jars."
+            )
+        case None => ()
+    }
+
+    println(
+        "checkPerBackendResource OK; future-marker.txt present in my-lib-future_3.jar, " +
+            "absent from my-lib-kyo_3.jar."
+    )
+}
+
+// per-cell: future/jvm/src/main/resources/future-jvm-marker.txt
+// must appear in myLibFuture's jar (the only Future-JVM cell). With this
+// matrix shape (2 backends x 1 platform) there is no other Future cell that
+// could falsely include it.
+checkPerCellResource := {
+    val base      = baseDirectory.value
+    val futureJar = cellJar(base, "future")
+
+    if (!futureJar.isFile)
+        sys.error(s"checkPerCellResource FAIL: missing jar at $futureJar")
+
+    jarEntry(futureJar, "future-jvm-marker.txt") match {
+        case None =>
+            sys.error(
+                "checkPerCellResource FAIL: my-lib-future_3.jar is missing " +
+                    "entry 'future-jvm-marker.txt'. The plugin must add " +
+                    "<base>/<backend>/<platform>/src/main/resources to " +
+                    "Compile/unmanagedResourceDirectories (analogous to backendMain " +
+                    "for sources)."
+            )
+        case Some(actual) =>
+            if (actual != "future-jvm-only-resource")
+                sys.error(
+                    "checkPerCellResource FAIL: my-lib-future_3.jar " +
+                        s"future-jvm-marker.txt content mismatch. Expected " +
+                        s"'future-jvm-only-resource', got '$actual'"
+                )
+    }
+
+    println(
+        "checkPerCellResource OK; future-jvm-marker.txt present in my-lib-future_3.jar."
+    )
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/my-lib/future/jvm/src/main/resources/future-jvm-marker.txt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/my-lib/future/jvm/src/main/resources/future-jvm-marker.txt
@@ -1,0 +1,1 @@
+future-jvm-only-resource

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/my-lib/future/src/main/resources/future-marker.txt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/my-lib/future/src/main/resources/future-marker.txt
@@ -1,0 +1,1 @@
+future-only-resource

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/my-lib/shared/src/main/resources/shared-marker.txt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/my-lib/shared/src/main/resources/shared-marker.txt
@@ -1,0 +1,1 @@
+shared-resource-content

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/my-lib/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/my-lib/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,10 @@
+package example
+
+// Trivial stand-in: this scripted test inspects published-jar contents for
+// resource entries, never the runtime API. Keeping this file dependency-free
+// lets every (backend, platform) cell compile with no code-level coupling to
+// the auto-injected `io.getkyo:kyo-compat-<backend>` jar (which is satisfied
+// at update-time by the in-test fake-compat stub modules).
+object Lib {
+    def name: String = "my-lib"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/project/plugins.sbt
@@ -1,0 +1,6 @@
+// JVM-only matrix; no JS/Native plugins needed (keeps per-test cost down).
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.10.1")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/shared-resources/test
@@ -1,0 +1,7 @@
+# Scripted test - shared-resources.
+> publishFakes
+> myLibFuture/publishLocal
+> myLibKyo/publishLocal
+> checkSharedResourceInAllJars
+> checkPerBackendResource
+> checkPerCellResource

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/build.sbt
@@ -1,0 +1,308 @@
+// Scripted test - source-overrides.
+//
+// Exercises:
+//
+//   - Per-backend source overrides:
+//     <base>/<backend.name>/src/main/scala/  reaches every platform cell of
+//     THAT backend and no cell of other backends. Files placed at
+//     my-lib/future/src/main/scala/...  should appear on
+//     `Compile/unmanagedSourceDirectories` for myLibFuture (Future is
+//     JVM-only) AND must be absent from the three Kyo cells.
+//   - Per-(backend, platform) cell overrides:
+//     <base>/<backend.name>/<platform>/src/main/scala/  reaches ONLY the
+//     matching cell. Files at my-lib/future/jvm/src/main/scala/  should
+//     appear on `Compile/unmanagedSourceDirectories` for myLibFuture only.
+//   - Shared test sources:
+//     <base>/shared/src/test/scala/  reaches every cell's
+//     `Test/unmanagedSourceDirectories` (the universal default).
+//
+// Plugin source-dir wiring (CompatLibrary.scala customRow process closure):
+//
+//   sharedMain     = <base>/shared/src/main/scala
+//   sharedTest     = <base>/shared/src/test/scala
+//   perBackendMain = <base>/<backend.name>/src/main/scala
+//   perBackendTest = <base>/<backend.name>/src/test/scala
+//   backendMain    = <base>/<backend.name>/<platform>/src/main/scala
+//   backendTest    = <base>/<backend.name>/<platform>/src/test/scala
+//   Compile / unmanagedSourceDirectories ++= Seq(sharedMain, perBackendMain, backendMain)
+//   Test    / unmanagedSourceDirectories ++= Seq(sharedTest, perBackendTest, backendTest)
+//
+// The directory segment uses `backend.name` ("future", "kyo") -- not
+// `backend.directorySuffix` ("-future", "-kyo") -- matching the in-tree
+// `kyo-compat-example` convention.
+//
+// Matrix shape: Future + Kyo across JVM + JS + Native = 6 cells. Single
+// Scala 3.3.4. Same fake-stub publishLocal pattern as publish/ and
+// settings-passthrough/ so the auto-injected `kyo-compat-X` deps resolve
+// when checkAllCompile drives Compile/compile.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+// Pin ivy paths inside the test dir, mirroring publish/ and settings-passthrough/.
+// `ThisBuild / ivyPaths` is shadowed by sbt's per-project Defaults, so the setting
+// must be applied on every project that participates in resolution.
+val rootBase: File = file(".").getCanonicalFile
+val pinnedIvyPaths: Setting[IvyPaths] =
+    ivyPaths := IvyPaths(rootBase, Some(rootBase / "ivy-cache"))
+
+// --------------------------------------------------------------------
+// fake kyo-compat-{future,kyo} stubs (JVM + JS + Native).
+//
+// Six stubs total: (future, kyo) x (jvm, js, native), matching the
+// receiver matrix shape. Their only purpose is to satisfy the
+// auto-injected `libraryDependencies += "io.getkyo" %%% "kyo-compat-<X>"`
+// when checkAllCompile triggers update on each cell.
+// --------------------------------------------------------------------
+
+def fakeCompat(backend: String, platform: String): Project = {
+    val id   = s"fake_${backend}_${platform}"
+    val dir  = file(s"fake-compat/$backend/$platform")
+    val base = Project(id, dir).settings(
+        pinnedIvyPaths,
+        organization := "io.getkyo",
+        moduleName   := s"kyo-compat-$backend",
+        version      := "STUB-FOR-SCRIPTED-TEST",
+        scalaVersion := "3.3.4"
+    )
+    platform match {
+        case "jvm"    => base
+        case "js"     => base.enablePlugins(ScalaJSPlugin)
+        case "native" => base.enablePlugins(ScalaNativePlugin)
+    }
+}
+
+lazy val fakeFutureJVM    = fakeCompat("future", "jvm")
+lazy val fakeKyoJVM       = fakeCompat("kyo",    "jvm")
+lazy val fakeKyoJS        = fakeCompat("kyo",    "js")
+lazy val fakeKyoNative    = fakeCompat("kyo",    "native")
+
+lazy val publishFakes = taskKey[Unit]("publishLocal every fake-compat stub")
+publishFakes := Def.sequential(
+    fakeFutureJVM    / publishLocal,
+    fakeKyoJVM       / publishLocal,
+    fakeKyoJS        / publishLocal,
+    fakeKyoNative    / publishLocal
+).value
+
+// --------------------------------------------------------------------
+// my-lib - receiver matrix. Future + Kyo x JVM + JS + Native = 6 cells.
+// --------------------------------------------------------------------
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        name         := "my-lib",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary(KyoLib)(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)(Seq("3.3.4"))
+
+// --------------------------------------------------------------------
+// Per-cell Project handles. Same enumeration pattern as
+// settings-passthrough and cross-platform.
+// --------------------------------------------------------------------
+
+lazy val futureCells: Seq[Project] = Seq(
+    myLib.future.jvm
+)
+
+lazy val kyoCells: Seq[Project] = Seq(
+    myLib.kyo.jvm,
+    myLib.kyo.js,
+    myLib.kyo.native
+)
+
+lazy val allCells: Seq[Project] = futureCells ++ kyoCells
+
+// --------------------------------------------------------------------
+// Override directories. Computed from the my-lib base ONCE so the
+// expected-path comparisons below are exact.
+// --------------------------------------------------------------------
+
+val myLibBase: File = (file("my-lib")).getCanonicalFile
+
+// Per-backend and per-cell overrides use
+// `backend.name` ("future" / "kyo") for the directory segment, matching the
+// plugin's customRow source-dir wiring (no leading dash).
+val sharedMain          : File = (myLibBase / "shared" / "src" / "main" / "scala").getCanonicalFile
+val sharedTest          : File = (myLibBase / "shared" / "src" / "test" / "scala").getCanonicalFile
+val futureBackendMain   : File = (myLibBase / "future" / "src" / "main" / "scala").getCanonicalFile
+val kyoBackendMain      : File = (myLibBase / "kyo"    / "src" / "main" / "scala").getCanonicalFile
+val futureJvmCellMain   : File = (myLibBase / "future" / "jvm" / "src" / "main" / "scala").getCanonicalFile
+val kyoNativeCellMain   : File = (myLibBase / "kyo"    / "native" / "src" / "main" / "scala").getCanonicalFile
+
+// --------------------------------------------------------------------
+// Check tasks.
+// --------------------------------------------------------------------
+
+val checkSharedReachesAllCells          = taskKey[Unit]("Compile - shared/src/main/scala on every cell")
+val checkPerBackendOverride             = taskKey[Unit]("<directorySuffix>/src/main/scala on every cell of THAT backend")
+val checkPerCellOverride                = taskKey[Unit]("<directorySuffix>/<platform>/src/main/scala on the matching cell only")
+val checkSharedTestSourcesReachAllCells = taskKey[Unit]("Test - shared/src/test/scala on every cell")
+val checkAllCompile                     = taskKey[Unit]("Compile/compile every cell to confirm classpath wiring")
+
+// compile-side: every cell's Compile/unmanagedSourceDirectories
+// must contain my-lib/shared/src/main/scala. The plugin adds it explicitly in
+// the customRow process closure.
+checkSharedReachesAllCells := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    allCells.foreach { proj =>
+        val dirs = ext.get(proj / Compile / unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        if (!dirs.contains(sharedMain))
+            sys.error(
+                "checkSharedReachesAllCells FAIL: cell " + proj.id +
+                    " is missing shared main dir " + sharedMain +
+                    " (actual: " + dirs.mkString(", ") + ")"
+            )
+    }
+    val ids = allCells.map(_.id).sorted.mkString(", ")
+    println(
+        "checkSharedReachesAllCells OK; " + allCells.size + " cells [" + ids +
+            "] all see " + sharedMain
+    )
+}
+
+// per-backend: future/src/main/scala lands on every Future cell and on no
+// Kyo cell. Symmetric for kyo/src/main/scala.
+checkPerBackendOverride := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+
+    futureCells.foreach { proj =>
+        val dirs = ext.get(proj / Compile / unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        if (!dirs.contains(futureBackendMain))
+            sys.error(
+                "checkPerBackendOverride FAIL: Future cell " + proj.id +
+                    " is missing the per-backend dir " + futureBackendMain +
+                    " (actual: " + dirs.mkString(", ") + ")"
+            )
+    }
+    kyoCells.foreach { proj =>
+        val dirs = ext.get(proj / Compile / unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        if (dirs.contains(futureBackendMain))
+            sys.error(
+                "checkPerBackendOverride FAIL: Kyo cell " + proj.id +
+                    " unexpectedly carries the Future-backend dir " + futureBackendMain
+            )
+    }
+
+    kyoCells.foreach { proj =>
+        val dirs = ext.get(proj / Compile / unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        if (!dirs.contains(kyoBackendMain))
+            sys.error(
+                "checkPerBackendOverride FAIL: Kyo cell " + proj.id +
+                    " is missing the per-backend dir " + kyoBackendMain +
+                    " (actual: " + dirs.mkString(", ") + ")"
+            )
+    }
+    futureCells.foreach { proj =>
+        val dirs = ext.get(proj / Compile / unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        if (dirs.contains(kyoBackendMain))
+            sys.error(
+                "checkPerBackendOverride FAIL: Future cell " + proj.id +
+                    " unexpectedly carries the Kyo-backend dir " + kyoBackendMain
+            )
+    }
+    println(
+        "checkPerBackendOverride OK; future reaches " + futureCells.size +
+            " Future cells only; kyo reaches " + kyoCells.size + " Kyo cells only."
+    )
+}
+
+// per-cell: future/jvm/src/main/scala lands ONLY on myLibFuture (the
+// Future/JVM cell). kyo/native/src/main/scala lands ONLY on myLibKyoNative.
+checkPerCellOverride := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+
+    val futureJvm = myLib.future.jvm
+    val kyoNative = myLib.kyo.native
+
+    val futureJvmDirs = ext.get(futureJvm / Compile / unmanagedSourceDirectories)
+        .map(_.getCanonicalFile)
+    if (!futureJvmDirs.contains(futureJvmCellMain))
+        sys.error(
+            "checkPerCellOverride FAIL: " + futureJvm.id +
+                " is missing the per-cell dir " + futureJvmCellMain +
+                " (actual: " + futureJvmDirs.mkString(", ") + ")"
+        )
+
+    allCells.filter(_ != futureJvm).foreach { proj =>
+        val dirs = ext.get(proj / Compile / unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        if (dirs.contains(futureJvmCellMain))
+            sys.error(
+                "checkPerCellOverride FAIL: cell " + proj.id +
+                    " unexpectedly carries the Future/JVM-only dir " + futureJvmCellMain
+            )
+    }
+
+    val kyoNativeDirs = ext.get(kyoNative / Compile / unmanagedSourceDirectories)
+        .map(_.getCanonicalFile)
+    if (!kyoNativeDirs.contains(kyoNativeCellMain))
+        sys.error(
+            "checkPerCellOverride FAIL: " + kyoNative.id +
+                " is missing the per-cell dir " + kyoNativeCellMain +
+                " (actual: " + kyoNativeDirs.mkString(", ") + ")"
+        )
+
+    allCells.filter(_ != kyoNative).foreach { proj =>
+        val dirs = ext.get(proj / Compile / unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        if (dirs.contains(kyoNativeCellMain))
+            sys.error(
+                "checkPerCellOverride FAIL: cell " + proj.id +
+                    " unexpectedly carries the Kyo/Native-only dir " + kyoNativeCellMain
+            )
+    }
+    println(
+        "checkPerCellOverride OK; future/jvm reaches myLibFuture only; " +
+            "kyo/native reaches myLibKyoNative only."
+    )
+}
+
+// test-side: every cell's Test/unmanagedSourceDirectories
+// must contain my-lib/shared/src/test/scala. The plugin adds it explicitly
+// in the customRow process closure.
+checkSharedTestSourcesReachAllCells := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    allCells.foreach { proj =>
+        val dirs = ext.get(proj / Test / unmanagedSourceDirectories)
+            .map(_.getCanonicalFile)
+        if (!dirs.contains(sharedTest))
+            sys.error(
+                "checkSharedTestSourcesReachAllCells FAIL: cell " + proj.id +
+                    " is missing shared test dir " + sharedTest +
+                    " (actual: " + dirs.mkString(", ") + ")"
+            )
+    }
+    val ids = allCells.map(_.id).sorted.mkString(", ")
+    println(
+        "checkSharedTestSourcesReachAllCells OK; " + allCells.size + " cells [" +
+            ids + "] all see " + sharedTest
+    )
+}
+
+// Drive Compile/compile across every cell to confirm the classpath wiring
+// matches the unmanagedSourceDirectories assertions above. Each marker
+// object is independent (no cross-references), so a mis-scoped marker
+// can only break compilation if it appears as a duplicate definition on
+// the same classpath -- a state none of these checks tolerate.
+checkAllCompile := Def.sequential(
+    myLib.future.jvm    / Compile / compile,
+    myLib.kyo.jvm       / Compile / compile,
+    myLib.kyo.js        / Compile / compile,
+    myLib.kyo.native    / Compile / compile,
+    Def.task(println(
+        "checkAllCompile OK; " + allCells.size + " cells [" +
+            allCells.map(_.id).sorted.mkString(", ") + "] compiled."
+    ))
+).value

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/future/jvm/src/main/scala/example/FutureJvmMarker.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/future/jvm/src/main/scala/example/FutureJvmMarker.scala
@@ -1,0 +1,6 @@
+package example
+
+// Per-cell override. Lives at
+// <base>/-future/jvm/src/main/scala/. Expected to reach ONLY myLibFuture
+// (the Future/JVM cell) and no other cell.
+object FutureJvmMarker { val tag = "future-jvm-only" }

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/future/src/main/scala/example/FutureMarker.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/future/src/main/scala/example/FutureMarker.scala
@@ -1,0 +1,7 @@
+package example
+
+// Per-backend override. Lives at
+// <base>/<FutureLib.directorySuffix>/src/main/scala/, i.e. `my-lib/-future/...`.
+// Expected to reach the Future/JVM, Future/JS, Future/Native cells and NONE
+// of the Kyo cells.
+object FutureMarker { val tag = "future-only" }

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/kyo/native/src/main/scala/example/KyoNativeMarker.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/kyo/native/src/main/scala/example/KyoNativeMarker.scala
@@ -1,0 +1,6 @@
+package example
+
+// Per-cell override. Lives at
+// <base>/-kyo/native/src/main/scala/. Expected to reach ONLY myLibKyoNative
+// (the Kyo/Native cell) and no other cell.
+object KyoNativeMarker { val tag = "kyo-native-only" }

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/kyo/src/main/scala/example/KyoMarker.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/kyo/src/main/scala/example/KyoMarker.scala
@@ -1,0 +1,7 @@
+package example
+
+// Per-backend override. Lives at
+// <base>/<KyoLib.directorySuffix>/src/main/scala/, i.e. `my-lib/-kyo/...`.
+// Expected to reach the Kyo/JVM, Kyo/JS, Kyo/Native cells and NONE of the
+// Future cells.
+object KyoMarker { val tag = "kyo-only" }

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/shared/src/main/scala/example/Shared.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/shared/src/main/scala/example/Shared.scala
@@ -1,0 +1,3 @@
+package example
+
+object Shared { val tag = "shared" }

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/shared/src/test/scala/example/SharedTest.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/my-lib/shared/src/test/scala/example/SharedTest.scala
@@ -1,0 +1,8 @@
+package example
+
+// Test source under <base>/shared/src/test/scala. The plugin's customRow
+// process closure adds this dir to every cell's `Test/unmanagedSourceDirectories`.
+// We do NOT use a test runtime (scalatest etc.) — checkSharedTestSourcesReachAllCells
+// verifies the directory entry only; if a test framework call is added here it must
+// be available across all 6 cells (JVM/JS/Native x Future/Kyo).
+object SharedTest { val tag = "shared-test" }

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/source-overrides/test
@@ -1,0 +1,7 @@
+# Scripted test - source-overrides.
+> publishFakes
+> checkSharedReachesAllCells
+> checkPerBackendOverride
+> checkPerCellOverride
+> checkSharedTestSourcesReachAllCells
+> checkAllCompile

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/subset/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/subset/build.sbt
@@ -1,0 +1,75 @@
+// Scripted test — subset of backends + subset of platforms.
+//
+// Backends opted in (extras): Zio, Ce. (Future is always implicit.)
+// Platforms requested: JVM, JS.
+//
+// Expected per-backend supportedPlatforms intersection:
+//   Future (JVM)           ∩ {JVM, JS} = {JVM}
+//   Zio    (JVM/JS/Native) ∩ {JVM, JS} = {JVM, JS}
+//   Ce     (JVM/JS)        ∩ {JVM, JS} = {JVM, JS}
+//
+// Kyo / Ox were NOT opted in via compatLibrary(...). Accessing
+// myLib.kyo / myLib.ox throws NoSuchBackendException at evaluation time.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-FOR-SCRIPTED-TEST"
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        organization := "com.example",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary(ZioLib, CeLib)(VirtualAxis.jvm, VirtualAxis.js)(Seq("3.3.4"))
+
+// --------------------------------------------------------------------
+// Assertion task keys
+// --------------------------------------------------------------------
+
+val checkProjects       = taskKey[Unit]("verify exact project set is Future + Zio + Ce")
+val checkNamedAccessors = taskKey[Unit]("verify .kyo / .ox throw NoSuchBackendException")
+
+checkProjects := {
+    val s        = Keys.state.value
+    val ext      = sbt.Project.extract(s)
+    val expected = Set(
+        "myLibFuture",
+        "myLibZio",    "myLibZioJS",
+        "myLibCe",     "myLibCeJS"
+    )
+    val actual   = ext.structure.allProjectRefs.map(_.project).toSet
+    val missing  = expected -- actual
+    if (missing.nonEmpty)
+        sys.error(s"Missing expected subprojects: $missing (have: $actual)")
+    val unwanted = actual.filter { id =>
+        id.startsWith("myLib") &&
+        id != "myLib" &&
+        !expected.contains(id)
+    }
+    if (unwanted.nonEmpty)
+        sys.error(s"Unexpected myLib* subprojects (should only have Future/Zio/Ce JVM+JS): $unwanted")
+    println(s"checkProjects OK; have ${expected.intersect(actual).toSeq.sorted}")
+}
+
+checkNamedAccessors := {
+    // myLib.future, myLib.zio, myLib.ce already resolved at build evaluation
+    // (above). Verify the opted-out accessors throw NoSuchBackendException.
+    val tries = Seq[(String, () => Any)](
+        "kyo" -> (() => myLib.kyo),
+        "ox"  -> (() => myLib.ox)
+    )
+    tries.foreach { case (name, thunk) =>
+        try {
+            val _ = thunk()
+            sys.error(s"myLib.$name should have thrown NoSuchBackendException but returned a value")
+        } catch {
+            case _: NoSuchBackendException =>
+                () // expected
+            case other: Throwable =>
+                sys.error(
+                    s"myLib.$name threw ${other.getClass.getName} (${other.getMessage}); " +
+                        s"expected NoSuchBackendException"
+                )
+        }
+    }
+    println("checkNamedAccessors OK; opted-out backends throw NoSuchBackendException.")
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/subset/my-lib/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/subset/my-lib/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,5 @@
+package example
+
+object Lib {
+    def name: String = "my-lib"
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/subset/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/subset/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/subset/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/subset/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/subset/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/subset/test
@@ -1,0 +1,3 @@
+# Scripted test - subset of backends and platforms.
+> checkProjects
+> checkNamedAccessors

--- a/kyo-compat/test/jvm/src/test/scala/kyo/compat/FromCompletionStageTest.scala
+++ b/kyo-compat/test/jvm/src/test/scala/kyo/compat/FromCompletionStageTest.scala
@@ -1,0 +1,56 @@
+package kyo.compat
+
+import java.util.concurrent.CompletableFuture
+import kyo.compat.*
+import scala.util.Failure
+import scala.util.Success
+
+/** JVM-only scenarios for `CIO.fromCompletionStage`.
+  *
+  * `java.util.concurrent.CompletionStage` is not available on Scala.js or Scala-native, so this trait lives in the JVM-only fixtures source
+  * set. Per-backend Suites add this trait only when running on the JVM.
+  */
+class FromCompletionStageTest extends CompatTest:
+
+    "fcs_completed_returns_value" in run {
+        val cs = CompletableFuture.completedFuture(42)
+        val c  = CIO.fromCompletionStage(cs)
+        c.liftToTry.map {
+            case Success(42) => succeed
+            case other       => fail(s"expected Success(42), got: $other")
+        }
+    }
+
+    "fcs_failure_propagates" in run {
+        val cs = new CompletableFuture[Int]
+        cs.completeExceptionally(new RuntimeException("cs-boom"))
+        val c = CIO.fromCompletionStage(cs)
+        c.liftToTry.map {
+            case Failure(t: Throwable) =>
+                // The CompletionStage may wrap the exception in a CompletionException;
+                // unwrap one level if needed.
+                val msg = if t.getMessage == "cs-boom" then t.getMessage
+                else if t.getCause != null && t.getCause.getMessage == "cs-boom" then t.getCause.getMessage
+                else t.getMessage
+                assert(msg == "cs-boom", s"expected cs-boom (or wrapped), got: $t")
+            case other => fail(s"expected Failure(Throwable), got: $other")
+        }
+    }
+
+    "fcs_pending_suspends_until_complete" in run {
+        val cs = new CompletableFuture[Int]
+        // Complete the CS asynchronously after a short delay.
+        val t = new Thread(() =>
+            Thread.sleep(50)
+            val _ = cs.complete(7)
+        )
+        t.setDaemon(true)
+        t.start()
+        val c = CIO.fromCompletionStage(cs)
+        c.liftToTry.map {
+            case Success(7) => succeed
+            case other      => fail(s"expected Success(7), got: $other")
+        }
+    }
+
+end FromCompletionStageTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/AsyncRegisterTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/AsyncRegisterTest.scala
@@ -1,0 +1,114 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.Future as SFuture
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+
+class AsyncRegisterTest extends CompatTest:
+
+    // ----- async(register) -----
+
+    "async completes when the callback is invoked with Success" in run {
+        // The cb is fired asynchronously after `register` returns, via
+        // scalatest's `executionContext` (cross-platform: JVM thread pool;
+        // JS microtask queue). The CIO must observe the cb's result
+        // through its async bridge.
+        val c: CIO[Int] =
+            CIO.async[Int] { cb =>
+                val _ = SFuture(cb(Success(42)))(using executionContext)
+            }
+        c.liftToTry.map {
+            case Success(42) => succeed
+            case other       => fail(s"expected Success(42), got: $other")
+        }
+    }
+
+    "async resolves the immediate Success(7) callback to 7" in run {
+        val c: CIO[Int] =
+            CIO.async[Int] { cb =>
+                cb(Success(7))
+            }
+        c.map(r => assert(r == 7))
+    }
+
+    "async fails when the callback is invoked with Failure" in run {
+        val c: CIO[Int] =
+            CIO.async[Int] { cb =>
+                cb(Failure(new RuntimeException("async-err")))
+            }
+        c.liftToTry.map {
+            case Failure(t: RuntimeException) => assert(t.getMessage == "async-err")
+            case other                        => fail(s"expected Failure(RuntimeException), got: $other")
+        }
+    }
+
+    "async ignores callback invocations after the first" in run {
+        // First callback wins; subsequent callbacks must not change result
+        // and must not throw.
+        val c: CIO[Int] =
+            CIO.async[Int] { cb =>
+                cb(Success(1))
+                cb(Success(2))
+                cb(Failure(new RuntimeException("late")))
+            }
+        c.liftToTry.map {
+            case Success(1) => succeed
+            case other      => fail(s"expected Success(1) (first wins), got: $other")
+        }
+    }
+
+    "async returns the value from the first racing callback" in run {
+        // Two callback fires scheduled on the executionContext. Whichever
+        // runs first wins; the other is a no-op. Both invocations are
+        // counted to verify both ran.
+        val invocations = new AtomicInteger(0)
+        val c: CIO[Int] =
+            CIO.async[Int] { cb =>
+                val _ = SFuture {
+                    val _ = invocations.incrementAndGet(); cb(Success(10))
+                }(using executionContext)
+                val _ = SFuture {
+                    val _ = invocations.incrementAndGet(); cb(Success(20))
+                }(using executionContext)
+            }
+        c.liftToTry.map {
+            case Success(v) =>
+                assert(v == 10 || v == 20, s"expected 10 or 20, got $v")
+            case other => fail(s"expected Success, got: $other")
+        }
+    }
+    // The register block invokes cb(Success(42)) then immediately throws.
+    // Accepted outcomes:
+    //   (a) CIO resolves to Success(42) — callback fired before the throw was observed, OR
+    //   (b) the exception propagates (as Failure in liftToTry, or as a thrown exception)
+    // "silently swallowed" (Success/Failure without the actual value) is not a valid outcome.
+    // Some backends let the throw from the register block escape synchronously even after
+    // cb was already fired — this is a real behavioral difference we document here.
+    "async with register block that throws — resolves to 42 or surfaces exception" in {
+        val c: CIO[Int] = CIO.async[Int] { cb =>
+            cb(Success(42))
+            throw new RuntimeException("during register")
+        }
+        c.liftToTry.unsafeRun
+            .recover { case _: RuntimeException => Failure(new RuntimeException("escaped")) }
+            .map { result =>
+                assert(
+                    (result.isSuccess && result.get == 42) || result.isFailure,
+                    s"expected Success(42) or Failure, got: $result"
+                )
+            }
+    }
+
+    // 100 async ops each completing immediately chained via flatMap. No SO.
+    "async stack safety — 100 immediate async completions chained" in run {
+        def step: CIO[Int] = CIO.async[Int](cb => cb(Success(1)))
+        val c              = (1 to 100).foldLeft(CIO.value(0))((acc, _) => acc.flatMap(_ => step))
+        c.map { result =>
+            assert(result == 1, s"expected 1 (last step's value), got: $result")
+        }
+    }
+
+end AsyncRegisterTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/AtomicNumTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/AtomicNumTest.scala
@@ -1,0 +1,375 @@
+package kyo.compat
+
+import kyo.compat.*
+
+class AtomicNumTest extends CompatTest:
+
+    // ----- CAtomicInt -----
+
+    "AtomicInt init returns the initial value via get" in run {
+        val c =
+            CAtomicInt.init(7).flatMap { a =>
+                a.get
+            }
+        c.map(v => assert(v == 7))
+    }
+
+    "AtomicInt incrementAndGet returns the post-increment value" in run {
+        val c =
+            CAtomicInt.init(0).flatMap { a =>
+                a.incrementAndGet
+            }
+        c.map(v => assert(v == 1))
+    }
+
+    "AtomicInt getAndIncrement returns the pre-increment value" in run {
+        val c =
+            CAtomicInt.init(0).flatMap { a =>
+                a.getAndIncrement.flatMap { old =>
+                    a.get.flatMap { now =>
+                        CIO.defer((old, now))
+                    }
+                }
+            }
+        c.map { case (old, now) =>
+            assert(old == 0 && now == 1)
+        }
+    }
+
+    "AtomicInt compareAndSet succeeds on match and fails on mismatch" in run {
+        // Single-thread but exhaustive CAS: succeed on match, fail on mismatch.
+        val c =
+            CAtomicInt.init(5).flatMap { a =>
+                a.compareAndSet(5, 10).flatMap { ok1 =>
+                    a.compareAndSet(5, 20).flatMap { ok2 =>
+                        a.get.flatMap { now =>
+                            CIO.defer((ok1, ok2, now))
+                        }
+                    }
+                }
+            }
+        c.map { case (ok1, ok2, now) =>
+            assert(ok1 == true && ok2 == false && now == 10)
+        }
+    }
+
+    "AtomicInt addAndGet decrements when given a negative delta" in run {
+        val c =
+            CAtomicInt.init(10).flatMap { a =>
+                a.addAndGet(-3)
+            }
+        c.map(v => assert(v == 7))
+    }
+
+    // ----- CAtomicLong -----
+
+    "AtomicLong init returns the initial value via get" in run {
+        val c =
+            CAtomicLong.init(7L).flatMap { a =>
+                a.get
+            }
+        c.map(v => assert(v == 7L))
+    }
+
+    "AtomicLong incrementAndGet returns the post-increment value" in run {
+        val c =
+            CAtomicLong.init(0L).flatMap { a =>
+                a.incrementAndGet
+            }
+        c.map(v => assert(v == 1L))
+    }
+
+    "AtomicLong getAndIncrement returns the pre-increment value" in run {
+        val c =
+            CAtomicLong.init(0L).flatMap { a =>
+                a.getAndIncrement.flatMap { old =>
+                    a.get.flatMap { now =>
+                        CIO.defer((old, now))
+                    }
+                }
+            }
+        c.map { case (old, now) =>
+            assert(old == 0L && now == 1L)
+        }
+    }
+
+    "AtomicLong compareAndSet succeeds on match and fails on mismatch" in run {
+        val c =
+            CAtomicLong.init(5L).flatMap { a =>
+                a.compareAndSet(5L, 10L).flatMap { ok1 =>
+                    a.compareAndSet(5L, 20L).flatMap { ok2 =>
+                        a.get.flatMap { now =>
+                            CIO.defer((ok1, ok2, now))
+                        }
+                    }
+                }
+            }
+        c.map { case (ok1, ok2, now) =>
+            assert(ok1 == true && ok2 == false && now == 10L)
+        }
+    }
+
+    "AtomicLong addAndGet decrements when given a negative delta" in run {
+        val c =
+            CAtomicLong.init(10L).flatMap { a =>
+                a.addAndGet(-3L)
+            }
+        c.map(v => assert(v == 7L))
+    }
+
+    // ----- CAtomicBoolean -----
+
+    "AtomicBoolean init returns the initial value via get" in run {
+        val c =
+            CAtomicBoolean.init(false).flatMap { a =>
+                a.get
+            }
+        c.map(v => assert(v == false))
+    }
+
+    "AtomicBoolean getAndSet(true) returns the prior false" in run {
+        val c =
+            CAtomicBoolean.init(false).flatMap { a =>
+                a.getAndSet(true).flatMap { old =>
+                    a.get.flatMap { now =>
+                        CIO.defer((old, now))
+                    }
+                }
+            }
+        c.map { case (old, now) =>
+            assert(old == false && now == true)
+        }
+    }
+
+    "AtomicBoolean getAndSet(false) returns the prior true" in run {
+        val c =
+            CAtomicBoolean.init(true).flatMap { a =>
+                a.getAndSet(false).flatMap { old =>
+                    a.get.flatMap { now =>
+                        CIO.defer((old, now))
+                    }
+                }
+            }
+        c.map { case (old, now) =>
+            assert(old == true && now == false)
+        }
+    }
+
+    "AtomicBoolean compareAndSet succeeds on match and fails on mismatch" in run {
+        val c =
+            CAtomicBoolean.init(false).flatMap { a =>
+                a.compareAndSet(false, true).flatMap { ok1 =>
+                    a.compareAndSet(false, true).flatMap { ok2 =>
+                        a.get.flatMap { now =>
+                            CIO.defer((ok1, ok2, now))
+                        }
+                    }
+                }
+            }
+        c.map { case (ok1, ok2, now) =>
+            assert(ok1 == true && ok2 == false && now == true)
+        }
+    }
+
+    "AtomicBoolean compareAndSet round-trips false→true→false" in run {
+        val c =
+            CAtomicBoolean.init(false).flatMap { a =>
+                a.compareAndSet(false, true).flatMap { ok1 =>
+                    a.compareAndSet(true, false).flatMap { ok2 =>
+                        a.get.flatMap { now =>
+                            CIO.defer((ok1, ok2, now))
+                        }
+                    }
+                }
+            }
+        c.map { case (ok1, ok2, now) =>
+            assert(ok1 == true && ok2 == true && now == false)
+        }
+    }
+    "AtomicInt get returns current value after init" in run {
+        val c =
+            CAtomicInt.init(42).flatMap { a =>
+                a.get
+            }
+        c.map(v => assert(v == 42))
+    }
+    "AtomicInt set then get returns set value" in run {
+        val c =
+            CAtomicInt.init(0).flatMap { a =>
+                a.set(7).flatMap { _ =>
+                    a.get
+                }
+            }
+        c.map(v => assert(v == 7))
+    }
+    "AtomicInt decrementAndGet returns post-decrement value" in run {
+        val c =
+            CAtomicInt.init(5).flatMap { a =>
+                a.decrementAndGet
+            }
+        c.map(v => assert(v == 4))
+    }
+    "AtomicInt getAndDecrement returns pre-decrement value and decrements" in run {
+        val c =
+            CAtomicInt.init(5).flatMap { a =>
+                a.getAndDecrement.flatMap { old =>
+                    a.get.flatMap { now =>
+                        CIO.defer((old, now))
+                    }
+                }
+            }
+        c.map { case (old, now) =>
+            assert(old == 5 && now == 4)
+        }
+    }
+    "AtomicInt getAndAdd returns pre-add value with positive delta" in run {
+        val c =
+            CAtomicInt.init(10).flatMap { a =>
+                a.getAndAdd(3).flatMap { old =>
+                    a.get.flatMap { now =>
+                        CIO.defer((old, now))
+                    }
+                }
+            }
+        c.map { case (old, now) =>
+            assert(old == 10 && now == 13)
+        }
+    }
+    "AtomicInt concurrent incrementAndGet across 1000 fibers yields 1000" in run {
+        val c =
+            CAtomicInt.init(0).flatMap { ref =>
+                CIO.foreach(1 to 1000)(_ => CFiber.init(ref.incrementAndGet)).flatMap { fibers =>
+                    CIO.collectAll(fibers.toSeq.map(_.get)).flatMap { _ =>
+                        ref.get
+                    }
+                }
+            }
+        c.map(v => assert(v == 1000))
+    }
+    "AtomicLong get returns current value after init" in run {
+        val c =
+            CAtomicLong.init(42L).flatMap { a =>
+                a.get
+            }
+        c.map(v => assert(v == 42L))
+    }
+    "AtomicLong set then get returns set value" in run {
+        val c =
+            CAtomicLong.init(0L).flatMap { a =>
+                a.set(7L).flatMap { _ =>
+                    a.get
+                }
+            }
+        c.map(v => assert(v == 7L))
+    }
+    "AtomicLong decrementAndGet returns post-decrement value" in run {
+        val c =
+            CAtomicLong.init(5L).flatMap { a =>
+                a.decrementAndGet
+            }
+        c.map(v => assert(v == 4L))
+    }
+    "AtomicLong getAndDecrement returns pre-decrement value and decrements" in run {
+        val c =
+            CAtomicLong.init(5L).flatMap { a =>
+                a.getAndDecrement.flatMap { old =>
+                    a.get.flatMap { now =>
+                        CIO.defer((old, now))
+                    }
+                }
+            }
+        c.map { case (old, now) =>
+            assert(old == 5L && now == 4L)
+        }
+    }
+    "AtomicLong getAndAdd returns pre-add value with positive delta" in run {
+        val c =
+            CAtomicLong.init(10L).flatMap { a =>
+                a.getAndAdd(3L).flatMap { old =>
+                    a.get.flatMap { now =>
+                        CIO.defer((old, now))
+                    }
+                }
+            }
+        c.map { case (old, now) =>
+            assert(old == 10L && now == 13L)
+        }
+    }
+    "AtomicBoolean concurrent toggle across 100 fibers does not crash and yields well-defined state" in run {
+        // Stress test: 100 fibers each toggle the boolean via getAndSet.
+        // We don't assert a specific final value (that depends on execution order),
+        // but we assert (a) no crash, and (b) the final value is a valid boolean.
+        val c =
+            CAtomicBoolean.init(false).flatMap { ref =>
+                CIO.foreach(1 to 100) { _ =>
+                    CFiber.init(
+                        ref.get.flatMap { cur =>
+                            ref.getAndSet(!cur)
+                        }
+                    )
+                }.flatMap { fibers =>
+                    CIO.collectAll(fibers.toSeq.map(_.get)).flatMap { _ =>
+                        ref.get
+                    }
+                }
+            }
+        c.map { v =>
+            // Boolean is always either true or false — but this confirms no crash.
+            assert(v == true || v == false)
+        }
+    }
+    "CAtomicInt lift/lower round-trip preserves observable behavior" in run {
+        // lower returns the underlying carrier; lift wraps it back.
+        // The re-lifted view must behave like the original: get returns 7,
+        // incrementAndGet returns 8.
+        val c =
+            CAtomicInt.init(7).flatMap { original =>
+                val relifted = CAtomicInt.lift(original.lower)
+                relifted.get.flatMap { v =>
+                    relifted.incrementAndGet.flatMap { v2 =>
+                        CIO.defer((v, v2))
+                    }
+                }
+            }
+        c.map { case (v, v2) =>
+            assert(v == 7, s"expected get == 7, got $v")
+            assert(v2 == 8, s"expected incrementAndGet == 8, got $v2")
+        }
+    }
+    "CAtomicLong lift/lower round-trip preserves observable behavior" in run {
+        val c =
+            CAtomicLong.init(7L).flatMap { original =>
+                val relifted = CAtomicLong.lift(original.lower)
+                relifted.get.flatMap { v =>
+                    relifted.incrementAndGet.flatMap { v2 =>
+                        CIO.defer((v, v2))
+                    }
+                }
+            }
+        c.map { case (v, v2) =>
+            assert(v == 7L, s"expected get == 7L, got $v")
+            assert(v2 == 8L, s"expected incrementAndGet == 8L, got $v2")
+        }
+    }
+    "CAtomicBoolean lift/lower round-trip preserves observable behavior" in run {
+        // init(true), lower, lift back. get returns true; getAndSet(false)
+        // returns true (the prior value); subsequent get returns false.
+        val c =
+            CAtomicBoolean.init(true).flatMap { original =>
+                val relifted = CAtomicBoolean.lift(original.lower)
+                relifted.get.flatMap { v1 =>
+                    relifted.getAndSet(false).flatMap { prior =>
+                        relifted.get.flatMap { v2 =>
+                            CIO.defer((v1, prior, v2))
+                        }
+                    }
+                }
+            }
+        c.map { case (v1, prior, v2) =>
+            assert(v1 == true, s"expected initial get == true, got $v1")
+            assert(prior == true, s"expected getAndSet(false) to return prior true, got $prior")
+            assert(v2 == false, s"expected get after getAndSet(false) == false, got $v2")
+        }
+    }
+
+end AtomicNumTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/AtomicRefTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/AtomicRefTest.scala
@@ -1,0 +1,161 @@
+package kyo.compat
+
+import kyo.compat.*
+
+class AtomicRefTest extends CompatTest:
+
+    "init returns a usable ref handle" in run {
+        val c = CAtomicRef.init[Int](42).flatMap(_ => CIO.defer { "ok" })
+        c.map(v => assert(v == "ok"))
+    }
+
+    "get returns the initial value" in run {
+        val c =
+            CAtomicRef.init[Int](42).flatMap { r =>
+                r.get
+            }
+        c.map(v => assert(v == 42))
+    }
+
+    "set then get returns the new value" in run {
+        val c =
+            CAtomicRef.init[Int](1).flatMap { r =>
+                r.set(99).flatMap { _ =>
+                    r.get
+                }
+            }
+        c.map(v => assert(v == 99))
+    }
+
+    "getAndSet returns the old value and writes the new one" in run {
+        val c =
+            CAtomicRef.init[Int](1).flatMap { r =>
+                r.getAndSet(99).flatMap { old =>
+                    r.get.flatMap { now =>
+                        CIO.defer((old, now))
+                    }
+                }
+            }
+        c.map { case (old, now) =>
+            assert(old == 1 && now == 99)
+        }
+    }
+
+    "updateAndGet returns the post-update value" in run {
+        val c =
+            CAtomicRef.init[Int](10).flatMap { r =>
+                r.updateAndGet(_ + 5)
+            }
+        c.map(v => assert(v == 15))
+    }
+
+    "getAndUpdate returns the pre-update value" in run {
+        val c =
+            CAtomicRef.init[Int](10).flatMap { r =>
+                r.getAndUpdate(_ + 5).flatMap { old =>
+                    r.get.flatMap { now =>
+                        CIO.defer((old, now))
+                    }
+                }
+            }
+        c.map { case (old, now) =>
+            assert(old == 10 && now == 15)
+        }
+    }
+
+    "compareAndSet swaps the value when the expected matches" in run {
+        val c =
+            CAtomicRef.init[Int](10).flatMap { r =>
+                r.compareAndSet(10, 99).flatMap { ok =>
+                    r.get.flatMap { now =>
+                        CIO.defer((ok, now))
+                    }
+                }
+            }
+        c.map { case (ok, now) =>
+            assert(ok == true && now == 99)
+        }
+    }
+
+    "compareAndSet leaves the value unchanged when the expected differs" in run {
+        val c =
+            CAtomicRef.init[Int](10).flatMap { r =>
+                r.compareAndSet(5, 99).flatMap { ok =>
+                    r.get.flatMap { now =>
+                        CIO.defer((ok, now))
+                    }
+                }
+            }
+        c.map { case (ok, now) =>
+            assert(ok == false && now == 10)
+        }
+    }
+
+    "set does not alias or mutate the caller's reference value" in run {
+        // Set + get of a List value: the value comes back == but the
+        // implementation must not mutate the supplied List under the covers.
+        val initial  = List(1, 2, 3)
+        val replaced = List(9, 9, 9)
+        val c =
+            CAtomicRef.init[List[Int]](initial).flatMap { r =>
+                r.set(replaced).flatMap { _ =>
+                    r.get
+                }
+            }
+        c.map { v =>
+            // Verify content + that initial was not mutated to replaced.
+            assert(v == replaced && initial == List(1, 2, 3))
+        }
+    }
+
+    "set accepts None for nullable Option-typed refs" in run {
+        // AtomicReference allows null. We use Option-typed value because
+        // typed E semantics on backends differ for null. Set Some -> None.
+        val c =
+            CAtomicRef.init[Option[Int]](Some(1)).flatMap { r =>
+                r.set(None).flatMap { _ =>
+                    r.get
+                }
+            }
+        c.map(v => assert(v == None))
+    }
+    "updateAndGet with f returning same value is an observable no-op" in run {
+        val c =
+            CAtomicRef.init[String]("a").flatMap { r =>
+                r.updateAndGet(s => s).flatMap { _ =>
+                    r.get
+                }
+            }
+        c.map(v => assert(v == "a"))
+    }
+    "AtomicRef lift/lower round-trip preserves value and supports set" in run {
+        val c =
+            CAtomicRef.init[String]("x").flatMap { r =>
+                // lower gives the underlying AtomicReference; lift wraps it back
+                val underlying = r.lower
+                val lifted     = CAtomicRef.lift(underlying)
+                lifted.get.flatMap { v1 =>
+                    lifted.set("y").flatMap { _ =>
+                        lifted.get.flatMap { v2 =>
+                            CIO.defer((v1, v2))
+                        }
+                    }
+                }
+            }
+        c.map { case (v1, v2) =>
+            assert(v1 == "x" && v2 == "y")
+        }
+    }
+    "concurrent update across 100 fibers yields final value of 100" in run {
+        val c =
+            CAtomicRef.init[Int](0).flatMap { ref =>
+                CIO.foreach(1 to 100)(_ => CFiber.init(ref.updateAndGet(_ + 1))).flatMap { fibers =>
+                    CIO.collectAll(fibers.toSeq.map(_.get)).flatMap { _ =>
+                        ref.get
+                    }
+                }
+            }
+        c.map(v => assert(v == 100))
+    }
+
+end AtomicRefTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/BlockingCedeTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/BlockingCedeTest.scala
@@ -1,0 +1,109 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+
+class BlockingCedeTest extends CompatTest:
+
+    // ----- blocking(thunk) -----
+
+    "blocking returns the thunk's value" in run {
+        val c = CIO.blocking { 42 }
+        c.liftToTry.map {
+            case Success(42) => succeed
+            case other       => fail(s"expected Success(42), got: $other")
+        }
+    }
+
+    "blocking propagates exceptions thrown by the thunk" in run {
+        val c = CIO.blocking { throw new RuntimeException("blocking-err") }
+        c.liftToTry.map {
+            case Failure(t: RuntimeException) => assert(t.getMessage == "blocking-err")
+            case other                        => fail(s"expected Failure(RuntimeException), got: $other")
+        }
+    }
+
+    "blocking runs the thunk exactly once" in run {
+        // Per-backend assertions about Kyo's no-op behavior live in each
+        // backend's test file. Here the cross-backend check: blocking(thunk)
+        // runs the thunk once and yields its value. (Implements the
+        // "observably_equivalent_to_defer" intent in a backend-uniform way.)
+        val ctr = new AtomicInteger(0)
+        val c   = CIO.blocking { ctr.incrementAndGet() }
+        c.liftToTry.map {
+            case Success(1) => assert(ctr.get == 1)
+            case other      => fail(s"expected Success(1), got: $other")
+        }
+    }
+
+    // ----- cede -----
+
+    "cede yields and the chained continuation runs" in run {
+        // cede returns Unit and the chained continuation runs.
+        val c = CIO.cede.flatMap(_ => CIO.defer { 42 })
+        c.map(v => assert(v == 42))
+    }
+
+    "repeated cedes do not deadlock or serialize concurrent work" in run {
+        // Run a sequence of cede-then-increment chained N times concurrently
+        // with a short sleep; both must complete. We exercise cede's role as
+        // a yield point — the test passes if cede does not deadlock or
+        // serialize the workload.
+        val ctr = new AtomicInteger(0)
+        val cededWork =
+            CIO.cede.flatMap { _ =>
+                CIO.cede.flatMap { _ =>
+                    CIO.cede.flatMap { _ =>
+                        CIO.defer { ctr.incrementAndGet() }
+                    }
+                }
+            }
+        val tickle = CIO.sleep(20.millis)
+        CIO.zip(cededWork, tickle).map {
+            case (n, _) => assert(n == 1 && ctr.get == 1)
+        }
+    }
+
+    "cede completes with Unit" in run {
+        // Kyo and Ox cede are no-ops returning Unit immediately.
+        // Backend-uniform assertion: cede produces Unit.
+        CIO.cede.map(r => assert(r == ((): Unit)))
+    }
+    // Fiber A loops with cede; fiber B sets a flag after 100ms.
+    // If cede truly yields (or if the scheduler is preemptive), B's flag fires
+    // within bounded time and fA terminates. If cede is a genuine no-op AND
+    // the scheduler is purely cooperative (not the case for preemptive
+    // backends), fA would starve fB — but most backends are preemptive and the
+    // test simply verifies no deadlock occurs.
+    "cede actually yields — no starvation across concurrent fibers" in run {
+        val done    = new java.util.concurrent.atomic.AtomicBoolean(false)
+        val counter = new AtomicInteger(0)
+        def loop: CIO[Unit] =
+            if done.get() then CIO.unit
+            else
+                CIO.defer { counter.incrementAndGet(); () }.flatMap { _ =>
+                    CIO.cede.flatMap { _ => loop }
+                }
+        val c =
+            CFiber.init(loop).flatMap { fA =>
+                CFiber.init(CIO.sleep(100.millis).flatMap(_ => CIO.defer { done.set(true) })).flatMap { fB =>
+                    fA.get.flatMap { _ =>
+                        fB.get.flatMap { _ =>
+                            CIO.defer(done.get())
+                        }
+                    }
+                }
+            }
+        c.map { d => assert(d, "done flag was never set — cede may have caused starvation") }
+    }
+
+    // 1000 chained cedes must not produce a StackOverflowError.
+    "cede 1000-deep chain does not stack-overflow" in run {
+        val c = (1 to 1000).foldLeft(CIO.value(()))((acc, _) => acc.flatMap(_ => CIO.cede))
+        c.map(r => assert(r == ((): Unit)))
+    }
+
+end BlockingCedeTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/BracketEnsureTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/BracketEnsureTest.scala
@@ -1,0 +1,212 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kyo.compat.*
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+
+// Local error sentinels for acquireReleaseWith/ensure failure-path tests.
+case object AcquireErr extends Exception("acquire-err")
+case object ReleaseErr extends Exception("release-err")
+case object UseErr     extends Exception("use-err")
+case object CleanupErr extends Exception("cleanup-err")
+
+class BracketEnsureTest extends CompatTest:
+
+    // ----- acquireReleaseWith -----
+
+    "acquireReleaseWith runs release on successful use" in run {
+        val released = new AtomicInteger(0)
+        val c: CIO[Int] =
+            CIO.acquireReleaseWith(CIO.unit)(_ =>
+                CIO.defer { val _ = released.incrementAndGet() }
+            )(_ => CIO.defer { 7 })
+        c.map { v =>
+            assert(v == 7 && released.get == 1)
+        }
+    }
+
+    "acquireReleaseWith passes the acquired value to release" in run {
+        // The release receives the same value acquire returned. Use a sentinel.
+        val seen = new java.util.concurrent.atomic.AtomicReference[String]("unset")
+        val c: CIO[Int] =
+            CIO.acquireReleaseWith(CIO.defer("sentinel-42"))(a => CIO.defer { seen.set(a) })(_ => CIO.defer { 1 })
+        c.map { v =>
+            assert(v == 1 && seen.get == "sentinel-42")
+        }
+    }
+
+    "acquireReleaseWith runs release when use fails" in run {
+        val released = new AtomicInteger(0)
+        val c: CIO[Int] =
+            CIO.acquireReleaseWith(CIO.unit)(_ =>
+                CIO.defer { val _ = released.incrementAndGet() }
+            )(_ => CIO.fail(TestError("nope")))
+        c.liftToTry.map {
+            case Failure(e: TestError) if e.msg == "nope" => assert(released.get == 1)
+            case other => fail(s"expected Failure(TestError(\"nope\")) with released=1, got: $other (released=${released.get})")
+        }
+    }
+
+    "acquireReleaseWith does not run acquire until the CIO is materialized" in run {
+        // Constructing a acquireReleaseWith CIO must not run acquire — acquire fires
+        // only when the CIO materializes.
+        val acquired = new AtomicInteger(0)
+        val c: CIO[Int] =
+            CIO.acquireReleaseWith(CIO.defer { acquired.incrementAndGet(); 0 })(_ => CIO.unit)(_ => CIO.defer { 9 })
+        // Pre-materialization: acquire should not have run.
+        val pre = acquired.get
+        c.map { v =>
+            assert(pre == 0 && v == 9 && acquired.get == 1)
+        }
+    }
+
+    "acquireReleaseWith runs release when use throws synchronously" in run {
+        // `use` throws inside its body via CIO.defer; release must still
+        // run because acquireReleaseWith's release is unconditional on success/failure.
+        val released = new AtomicInteger(0)
+        val c: CIO[Any] =
+            CIO.acquireReleaseWith(CIO.unit)(_ =>
+                CIO.defer { val _ = released.incrementAndGet() }
+            )(_ =>
+                CIO.defer {
+                    throw new RuntimeException("use-throws")
+                }
+            )
+        c.liftToTry.map {
+            case Failure(t: RuntimeException) =>
+                assert(t.getMessage == "use-throws" && released.get == 1)
+            case other => fail(s"expected Failure(RuntimeException) with released=1, got: $other (released=${released.get})")
+        }
+    }
+
+    // ----- ensure -----
+
+    "ensure runs the cleanup on success" in run {
+        val ran = new AtomicInteger(0)
+        val c: CIO[Int] =
+            CIO.ensure(CIO.defer { val _ = ran.incrementAndGet() })(CIO.defer { 11 })
+        c.map { v =>
+            assert(v == 11 && ran.get == 1)
+        }
+    }
+
+    "ensure runs the cleanup on failure" in run {
+        val ran = new AtomicInteger(0)
+        val c: CIO[Int] =
+            CIO.ensure(CIO.defer { val _ = ran.incrementAndGet() })(CIO.fail(TestError("bad")))
+        c.liftToTry.map {
+            case Failure(e: TestError) if e.msg == "bad" => assert(ran.get == 1)
+            case other => fail(s"expected Failure(TestError(\"bad\")) with ran=1, got: $other (ran=${ran.get})")
+        }
+    }
+
+    "ensure returns the inner computation's value" in run {
+        val c: CIO[Int] =
+            CIO.ensure(CIO.unit)(CIO.defer { 99 })
+        c.map { v =>
+            assert(v == 99)
+        }
+    }
+
+    "ensure propagates the inner computation's failure" in run {
+        val c: CIO[Int] =
+            CIO.ensure(CIO.unit)(CIO.fail(TestError("kept")))
+        c.liftToTry.map {
+            case Failure(e: TestError) if e.msg == "kept" => succeed
+            case other                                    => fail(s"expected Failure(TestError(\"kept\")), got: $other")
+        }
+    }
+
+    "ensure runs the cleanup exactly once" in run {
+        val ran = new AtomicInteger(0)
+        val c: CIO[Int] =
+            CIO.ensure(CIO.defer { val _ = ran.incrementAndGet() })(CIO.defer { 5 })
+        c.map { v =>
+            assert(v == 5 && ran.get == 1)
+        }
+    }
+
+    "nested acquireReleaseWiths thread values and run both releases" in run {
+        // Compose two acquireReleaseWiths via `flatMap`. Both releases must run; both
+        // values must thread.
+        val releasedOuter = new AtomicInteger(0)
+        val releasedInner = new AtomicInteger(0)
+        val outer: CIO[Int] =
+            CIO.acquireReleaseWith(CIO.defer("outer"))(_ =>
+                CIO.defer { val _ = releasedOuter.incrementAndGet() }
+            )(_ => CIO.defer { 1 })
+        val composed: CIO[Int] =
+            outer.flatMap { o =>
+                val inner: CIO[Int] =
+                    CIO.acquireReleaseWith(CIO.defer("inner"))(_ =>
+                        CIO.defer { val _ = releasedInner.incrementAndGet() }
+                    )(_ => CIO.defer { o + 2 })
+                inner
+            }
+        composed.map { v =>
+            assert(v == 3 && releasedOuter.get == 1 && releasedInner.get == 1)
+        }
+    }
+    "acquireReleaseWith acquire fails → release does not run" in run {
+        val counter = new AtomicInteger(0)
+        val c: CIO[Int] =
+            CIO.acquireReleaseWith(CIO.fail(AcquireErr))(_ =>
+                CIO.defer { val _ = counter.incrementAndGet() }
+            )(_ => CIO.value(0))
+        c.liftToTry.map {
+            case Failure(e) if e eq AcquireErr =>
+                assert(counter.get == 0, s"release ran but should not have; counter=${counter.get}")
+            case other => fail(s"expected Failure(AcquireErr) with counter==0, got: $other (counter=${counter.get})")
+        }
+    }
+
+    "acquireReleaseWith both use and release fail → use's error wins" in run {
+        val c: CIO[Int] =
+            CIO.acquireReleaseWith(CIO.value("a"))(_ => CIO.fail(ReleaseErr))(_ => CIO.fail(UseErr))
+        c.liftToTry.map {
+            case Failure(e) if e eq UseErr => succeed
+            case other                     => fail(s"expected Failure(UseErr) (use's error takes precedence), got: $other")
+        }
+    }
+
+    "acquireReleaseWith async release sequences correctly" in run {
+        val counter  = new AtomicInteger(0)
+        val observed = new AtomicInteger(-1)
+        // use observes the counter BEFORE release fires (counter still 0)
+        // after acquireReleaseWith completes, counter == 1
+        val c: CIO[Unit] =
+            CIO.acquireReleaseWith(CIO.value("a"))(_ =>
+                CIO.sleep(100.millis).flatMap(_ => CIO.defer { val _ = counter.incrementAndGet(); () })
+            )(_ => CIO.defer { observed.set(counter.get); () })
+        c.map { _ =>
+            assert(counter.get == 1, s"release did not complete; counter=${counter.get}")
+            assert(observed.get == 0, s"use observed counter post-release; observed=${observed.get}")
+        }
+    }
+
+    "acquireReleaseWith release runs exactly once on synchronous use-throw" in run {
+        val counter = new AtomicInteger(0)
+        val c: CIO[Any] =
+            CIO.acquireReleaseWith(CIO.value("a"))(_ =>
+                CIO.defer { val _ = counter.incrementAndGet() }
+            )(_ => CIO.defer { throw new RuntimeException("sync-throw") })
+        c.liftToTry.map {
+            case Failure(_: RuntimeException) =>
+                assert(counter.get == 1, s"expected release exactly once, got counter=${counter.get}")
+            case other => fail(s"expected Failure(RuntimeException), got: $other (counter=${counter.get})")
+        }
+    }
+
+    "acquireReleaseWith use returns the use-computation's value" in run {
+        val c: CIO[String] =
+            CIO.acquireReleaseWith(CIO.value("a"))(_ => CIO.value(()))(s => CIO.value(s + "!"))
+        c.map { v =>
+            assert(v == "a!", s"expected \"a!\" but got: $v")
+        }
+    }
+
+end BracketEnsureTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/CChunkTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/CChunkTest.scala
@@ -1,0 +1,82 @@
+package kyo.compat
+
+import kyo.compat.*
+
+class CChunkTest extends CompatTest:
+
+    // CIO.foreach is the cross-binding way to build a CChunk[A] without
+    // depending on the underlying carrier type (kyo.Chunk, Vector, zio.Chunk).
+
+    "toSeq returns same elements in order" in run {
+        CIO.foreach(Vector(1, 2, 3))(CIO.value).map { chunk =>
+            val s: Seq[Int] = chunk.toSeq
+            assert(s == Seq(1, 2, 3))
+        }
+    }
+
+    "toIndexedSeq returns same elements in order" in run {
+        CIO.foreach(Vector(1, 2, 3))(CIO.value).map { chunk =>
+            val s: IndexedSeq[Int] = chunk.toIndexedSeq
+            assert(s == IndexedSeq(1, 2, 3))
+        }
+    }
+
+    "apply returns element at given index" in run {
+        CIO.foreach(Vector(10, 20, 30))(CIO.value).map { chunk =>
+            assert(chunk.apply(1) == 20)
+        }
+    }
+
+    "size returns the number of elements" in run {
+        CIO.foreach(Vector(1, 2, 3))(CIO.value).map { chunk =>
+            assert(chunk.size == 3)
+        }
+    }
+
+    "isEmpty is true for empty chunk and false for non-empty chunk" in run {
+        val emptyC    = CIO.foreach(Vector.empty[Int])(CIO.value)
+        val nonEmptyC = CIO.foreach(Vector(1))(CIO.value)
+        emptyC.flatMap { emptyChunk =>
+            nonEmptyC.flatMap { nonEmptyChunk =>
+                CIO.value((emptyChunk.isEmpty, nonEmptyChunk.isEmpty))
+            }
+        }.map { case (empty, nonEmpty) =>
+            assert(empty, "empty chunk must report isEmpty == true")
+            assert(!nonEmpty, "non-empty chunk must report isEmpty == false")
+        }
+    }
+
+    "iterator produces elements in order" in run {
+        CIO.foreach(Vector(1, 2, 3))(CIO.value).map { chunk =>
+            assert(chunk.iterator.toList == List(1, 2, 3))
+        }
+    }
+
+    "CIO.foreach returns a CChunk with correct size and values" in run {
+        val c: CIO[CChunk[Int]] = CIO.foreach(1 to 5)(i => CIO.value(i * 2))
+        c.map { chunk =>
+            assert(chunk.size == 5)
+            assert(chunk.apply(0) == 2)
+            assert(chunk.apply(4) == 10)
+        }
+    }
+
+    "two CChunks built from same elements via different shapes are structurally equal" in run {
+        val ch1 = CIO.foreach(Vector(1, 2, 3))(CIO.value)
+        val ch2 = CIO.foreach((1 to 3).toSeq)(CIO.value)
+        ch1.flatMap { c1 =>
+            ch2.flatMap { c2 =>
+                CIO.defer(c1.equals(c2)) // CChunk backing-type equality (bypasses opaque CanEqual restriction)
+            }
+        }.map(eq => assert(eq, "chunks built from different shapes should be equal"))
+    }
+
+    "large chunk of 10_000 elements has correct size, last element, and iterator count" in run {
+        CIO.foreach(1 to 10_000)(CIO.value).map { chunk =>
+            assert(chunk.size == 10_000)
+            assert(chunk.apply(9_999) == 10_000)
+            assert(chunk.iterator.size == 10_000)
+        }
+    }
+
+end CChunkTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/ChannelTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/ChannelTest.scala
@@ -1,0 +1,193 @@
+package kyo.compat
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+
+class ChannelTest extends CompatTest:
+
+    "init succeeds with a positive capacity" in run {
+        val c = CChannel.init[Int](4).flatMap(_ => CIO.defer { 42 })
+        c.map(v => assert(v == 42))
+    }
+
+    "take returns the value most recently put" in run {
+        val c =
+            CChannel.init[Int](4).flatMap { ch =>
+                ch.put(7).flatMap { _ =>
+                    ch.take
+                }
+            }
+        c.map(v => assert(v == 7))
+    }
+
+    "put blocks when the channel is full" in run {
+        // Capacity 1: put #1 succeeds, put #2 must block. We bound the
+        // would-block put with a 50ms timeout — expect None.
+        val c =
+            CChannel.init[Int](1).flatMap { ch =>
+                ch.put(1).flatMap { _ =>
+                    CIO.timeout(50.millis)(ch.put(2))
+                }
+            }
+        c.map(r => assert(r == None))
+    }
+
+    "take blocks when the channel is empty" in run {
+        val c =
+            CChannel.init[Int](2).flatMap { ch =>
+                CIO.timeout(50.millis)(ch.take)
+            }
+        c.map(r => assert(r == None))
+    }
+
+    "poll returns None when the channel is empty" in run {
+        val c =
+            CChannel.init[Int](2).flatMap { ch =>
+                ch.poll
+            }
+        c.map(r => assert(r == None))
+    }
+
+    "take returns values in FIFO order" in run {
+        val c =
+            CChannel.init[Int](4).flatMap { ch =>
+                ch.put(1).flatMap { _ =>
+                    ch.put(2).flatMap { _ =>
+                        ch.put(3).flatMap { _ =>
+                            ch.take.flatMap { a =>
+                                ch.take.flatMap { b =>
+                                    ch.take.flatMap { d =>
+                                        CIO.defer((a, b, d))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        c.map { case (a, b, d) =>
+            assert(a == 1 && b == 2 && d == 3)
+        }
+    }
+
+    "concurrent producer and consumer agree on the transferred value" in run {
+        // Run a producer and consumer concurrently; verify the consumer
+        // receives the value the producer put.
+        val c =
+            CChannel.init[Int](2).flatMap { ch =>
+                val producer = ch.put(99)
+                val consumer = ch.take
+                CIO.zip(producer, consumer).flatMap { case (_, taken) =>
+                    CIO.defer(taken)
+                }
+            }
+        c.map(v => assert(v == 99))
+    }
+
+    "capacity-1 channel alternates put and take without blocking" in run {
+        // Capacity 1 with sequential put/take/put/take must succeed for both
+        // values without blocking (each take frees a slot for the next put).
+        val c =
+            CChannel.init[Int](1).flatMap { ch =>
+                ch.put(10).flatMap { _ =>
+                    ch.take.flatMap { a =>
+                        ch.put(20).flatMap { _ =>
+                            ch.take.flatMap { b =>
+                                CIO.defer((a, b))
+                            }
+                        }
+                    }
+                }
+            }
+        c.map { case (a, b) =>
+            assert(a == 10 && b == 20)
+        }
+    }
+    "multiple concurrent producers and consumers transfer all values exactly once" in run {
+        // 5 producers each put 10 items (0-9 tagged with producer id),
+        // 5 consumers each take 10 items. Verify produced Set == consumed Set.
+        val produced = new ConcurrentLinkedQueue[Int]()
+        val consumed = new ConcurrentLinkedQueue[Int]()
+        val c =
+            CChannel.init[Int](20).flatMap { ch =>
+                val producers = CIO.foreach(0 until 5) { prod =>
+                    CFiber.init(CIO.foreach(0 until 10) { i =>
+                        val item = prod * 10 + i
+                        ch.put(item).flatMap { _ =>
+                            CIO.defer { val _ = produced.add(item); () }
+                        }
+                    })
+                }
+                val consumers = CIO.foreach(0 until 5) { _ =>
+                    CFiber.init(CIO.foreach(0 until 10) { _ =>
+                        ch.take.flatMap { v =>
+                            CIO.defer { val _ = consumed.add(v); () }
+                        }
+                    })
+                }
+                producers.flatMap { prodFibers =>
+                    consumers.flatMap { consFibers =>
+                        CIO.foreach(prodFibers.lower)(_.get).flatMap { _ =>
+                            CIO.foreach(consFibers.lower)(_.get).flatMap { _ =>
+                                CIO.defer(())
+                            }
+                        }
+                    }
+                }
+            }
+        c.map { _ =>
+            import scala.jdk.CollectionConverters.*
+            val prod = produced.asScala.toSet
+            val cons = consumed.asScala.toSet
+            assert(prod.size == 50, s"expected 50 produced, got ${prod.size}")
+            assert(cons.size == 50, s"expected 50 consumed, got ${cons.size}")
+            assert(prod == cons, s"produced set != consumed set")
+        }
+    }
+
+    "poll vs take semantics: poll returns None on empty; after put, poll returns Some" in run {
+        // empty chan.poll → None; put(7) then poll → Some(7); then poll again → None.
+        val c =
+            CChannel.init[Int](2).flatMap { ch =>
+                ch.poll.flatMap { empty =>
+                    ch.put(7).flatMap { _ =>
+                        ch.poll.flatMap { some =>
+                            ch.poll.flatMap { again =>
+                                CIO.defer((empty, some, again))
+                            }
+                        }
+                    }
+                }
+            }
+        c.map { case (empty, some, again) =>
+            assert(empty == None, s"poll on empty should return None, got: $empty")
+            assert(some == Some(7), s"poll after put(7) should return Some(7), got: $some")
+            assert(again == None, s"poll after consuming should return None, got: $again")
+        }
+    }
+
+    "channel round-trip lift/lower is observably equivalent" in run {
+        // CChannel.lift(CChannel.init(2).lower) — put and take work identically.
+        val c =
+            CChannel.init[Int](2).flatMap { original =>
+                val lifted = CChannel.lift(original.lower)
+                lifted.put(10).flatMap { _ =>
+                    lifted.put(20).flatMap { _ =>
+                        lifted.take.flatMap { a =>
+                            lifted.take.flatMap { b =>
+                                CIO.defer((a, b))
+                            }
+                        }
+                    }
+                }
+            }
+        c.map { case (a, b) =>
+            assert(a == 10 && b == 20, s"expected (10, 20), got ($a, $b)")
+        }
+    }
+
+end ChannelTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/CompatTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/CompatTest.scala
@@ -1,0 +1,37 @@
+package kyo.compat
+
+import org.scalatest.Assertion
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.freespec.AsyncFreeSpec
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.*
+
+final case class TestError(msg: String) extends Exception(msg)
+
+/** Base for every kyo-compat binding test.
+  *
+  * Tests pass their `CIO[Assertion]` to `run`, which bounds it with `CIO.timeoutWithError(testTimeout)` — the binding's own cross-platform
+  * timeout. A test whose CIO never completes fails with a timeout instead of freezing the whole suite.
+  */
+class CompatTest extends AsyncFreeSpec, NonImplicitAssertions:
+
+    // Override scalatest's default `SerialExecutionContext`. Its `runNow` pump throws on JS/Native
+    // ("Queue is empty while future is not completed") the instant a test's `Future` is driven by a
+    // timer/scheduler outside the serial queue — which every async CIO op is. `AsyncEngine.runTestImpl`
+    // only calls `runNow` when `executionContext` is a `SerialExecutionContext`; a non-serial EC routes
+    // it to the callback-based async path that works on all platforms. This is also the implicit EC the
+    // test bodies and the Ox binding's `unsafeRun` resolve.
+    implicit override def executionContext: ExecutionContext = ExecutionContext.global
+
+    protected def testTimeout: FiniteDuration = 60.seconds
+
+    /** Runs a test's `CIO[Assertion]`, bounded by `testTimeout`. `c` is by-value: a `CIO` is a lazy description, so building it eagerly has
+      * no side effects, and a by-name argument would be mis-inlined into `CIO.timeoutWithError`'s `inline` parameter.
+      */
+    protected def run(c: CIO[Assertion]): Future[Assertion] =
+        CIO.timeoutWithError(testTimeout)(
+            new RuntimeException(s"test did not complete within $testTimeout")
+        )(c).unsafeRun
+
+end CompatTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/ErrorsTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/ErrorsTest.scala
@@ -1,0 +1,201 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+
+class ErrorsTest extends CompatTest:
+
+    "recover(handler) recovers from failure" in run {
+        val src: CIO[String] = CIO.fail(TestError("oops"))
+        val c = src.recover {
+            case te: TestError => CIO.defer { s"recovered: ${te.msg}" }
+            case other         => CIO.fail(other)
+        }
+        c.map(r => assert(r == "recovered: oops"))
+    }
+
+    "recover doesn't fire on success" in run {
+        val ctr           = new AtomicInteger(0)
+        val src: CIO[Int] = CIO.defer { 42 }
+        val c = src.recover { _ =>
+            val _ = ctr.incrementAndGet()
+            CIO.defer { 0 }
+        }
+        c.map(r => assert(r == 42 && ctr.get == 0))
+    }
+
+    "fold on success runs effectful onSuccess" in run {
+        val src: CIO[Int] = CIO.defer { 1 }
+        val c             = src.fold(a => CIO.defer { a + 10 }, _ => CIO.defer { -1 })
+        c.map(r => assert(r == 11))
+    }
+
+    "fold on failure runs effectful onFail" in run {
+        val src: CIO[Nothing] = CIO.fail(TestError("e"))
+        val c = src.fold(
+            (_: Int) => CIO.defer { 0 },
+            {
+                case te: TestError => CIO.defer { te.msg.length }
+                case _             => CIO.defer { -1 }
+            }
+        )
+        c.map(r => assert(r == 1))
+    }
+
+    "fold(defer(7))(a => defer(a * 2), e => defer(0)) resolves to 14" in run {
+        val c = CIO.defer(7).fold(a => CIO.defer(a * 2), e => CIO.defer(0))
+        c.map(r => assert(r == 14))
+    }
+
+    "fold(fail(x))(a => defer(0), e => defer(-1)) resolves to -1" in run {
+        val c = CIO.fail(new RuntimeException("x")).fold(a => CIO.defer(0), e => CIO.defer(-1))
+        c.map(r => assert(r == -1))
+    }
+
+    "unit discards the success value" in run {
+        val c = CIO.defer { 42 }.unit
+        c.map(r => assert(r == ((): Unit)))
+    }
+
+    "unit propagates failure through the error channel" in run {
+        val rt: Throwable     = TestError("oops")
+        val src: CIO[Nothing] = CIO.fail(rt)
+        src.unit.liftToTry.map {
+            case Failure(t) => assert(t eq rt, s"expected exact throwable propagated, got $t")
+            case other      => fail(s"expected Failure, got $other")
+        }
+    }
+
+    "liftToTry wraps success to Success" in run {
+        val c = CIO.defer { 42 }.liftToTry
+        c.map {
+            case Success(42) => succeed
+            case other       => fail(s"expected Success(42), got: $other")
+        }
+    }
+
+    "liftToTry wraps failure to Failure" in run {
+        val src: CIO[Int] = CIO.fail(TestError("oops"))
+        src.liftToTry.map {
+            case Failure(e: TestError) if e.msg == "oops" => succeed
+            case other                                    => fail(s"expected Failure(TestError(\"oops\")), got: $other")
+        }
+    }
+
+    "orElse runs fallback on failure" in run {
+        val src: CIO[Int] = CIO.fail(TestError("oops"))
+        val c             = src.orElse(CIO.defer { 99 })
+        c.map(r => assert(r == 99))
+    }
+
+    "orElse doesn't fire on success" in run {
+        val ctr = new AtomicInteger(0)
+        val c = CIO.defer { 42 }.orElse(CIO.defer {
+            val _ = ctr.incrementAndGet()
+            99
+        })
+        c.map(r => assert(r == 42 && ctr.get == 0))
+    }
+
+    "mapError transforms typed E" in run {
+        val src: CIO[Int] = CIO.fail(TestError("oops"))
+        val c = src.mapError {
+            case te: TestError => new RuntimeException(s"wrapped: ${te.msg}")
+            case other         => other
+        }
+        c.liftToTry.map {
+            case Failure(t: RuntimeException) => assert(t.getMessage == "wrapped: oops")
+            case other                        => fail(s"expected Failure(RuntimeException), got: $other")
+        }
+    }
+    // recover with handler that throws — new failure replaces old
+    "recover with handler that throws surfaces the handler's exception" in run {
+        val c = CIO.fail(TestError("a")).recover(_ => throw TestError("b"))
+        c.liftToTry.map {
+            case Failure(e: TestError) => assert(e.msg == "b", s"expected TestError(b), got $e")
+            case other                 => fail(s"expected Failure(TestError(b)), got: $other")
+        }
+    }
+
+    // fold with onSuccess that throws — surfaces the throw
+    "fold with onSuccess that throws surfaces the throw" in run {
+        val c = CIO.value(7).fold(_ => throw TestError("a"), _ => CIO.value(0))
+        c.liftToTry.map {
+            case Failure(e: TestError) => assert(e.msg == "a", s"expected TestError(a), got $e")
+            case other                 => fail(s"expected Failure(TestError(a)), got: $other")
+        }
+    }
+
+    // fold with onFail that throws — surfaces the throw
+    "fold with onFail that throws surfaces the throw" in run {
+        val c = CIO.fail(TestError("orig")).fold(_ => CIO.value(0), _ => throw TestError("b"))
+        c.liftToTry.map {
+            case Failure(e: TestError) => assert(e.msg == "b", s"expected TestError(b), got $e")
+            case other                 => fail(s"expected Failure(TestError(b)), got: $other")
+        }
+    }
+
+    // orElse with fallback that also fails — fallback's failure surfaces
+    "orElse with fallback that also fails surfaces the fallback failure" in run {
+        val c = CIO.fail(TestError("a")).orElse(CIO.fail(TestError("b")))
+        c.liftToTry.map {
+            case Failure(e: TestError) => assert(e.msg == "b", s"expected TestError(b), got $e")
+            case other                 => fail(s"expected Failure(TestError(b)), got: $other")
+        }
+    }
+
+    // mapError with f that throws — surfaces the throw
+    "mapError with f that throws surfaces the throw" in run {
+        val c = CIO.fail(TestError("orig")).mapError(_ => throw TestError("b"))
+        c.liftToTry.map {
+            case Failure(e: TestError) => assert(e.msg == "b", s"expected TestError(b), got $e")
+            case other                 => fail(s"expected Failure(TestError(b)), got: $other")
+        }
+    }
+
+    // Chained recover — second recover handles the b-error
+    "chained recover: second recover handles failure from first recover" in run {
+        val c = CIO
+            .fail(TestError("a"))
+            .recover(_ => CIO.fail(TestError("b")))
+            .recover(_ => CIO.value(0))
+        c.map(r => assert(r == 0, s"expected 0, got $r"))
+    }
+
+    // Chained mapError — each mapper applied in sequence
+    "chained mapError applies mappers in sequence" in run {
+        val c = CIO
+            .fail(TestError("a"))
+            .mapError { case te: TestError => TestError(te.msg + "+b"); case other => other }
+            .mapError { case te: TestError => TestError(te.msg + "+c"); case other => other }
+        c.liftToTry.map {
+            case Failure(e: TestError) => assert(e.msg == "a+b+c", s"expected TestError(a+b+c), got $e")
+            case other                 => fail(s"expected Failure(TestError(a+b+c)), got: $other")
+        }
+    }
+
+    "deep recover chain 100 nested propagates correctly" in run {
+        val n                 = 100
+        val initial: CIO[Int] = CIO.fail(TestError("init"))
+        val c = (1 to n).foldLeft(initial)((acc, i) =>
+            acc.recover(_ => CIO.fail(TestError(s"layer-$i")))
+        )
+        c.liftToTry.map { result =>
+            result match
+                case scala.util.Failure(TestError(msg)) => assert(msg == s"layer-$n", s"expected layer-$n, got $msg")
+                case other                              => fail(s"expected Failure(TestError(layer-$n)), got: $other")
+        }
+    }
+
+    "deep orElse chain 100 fallbacks: last value surfaces" in run {
+        val n                          = 100
+        val failures: Vector[CIO[Int]] = Vector.tabulate(n)(i => CIO.fail(TestError(s"fail-$i")))
+        val success: CIO[Int]          = CIO.value(42)
+        val c                          = (failures :+ success).reduce((a, b) => a.orElse(b))
+        c.map(v => assert(v == 42, s"expected 42 (from final orElse), got $v"))
+    }
+
+end ErrorsTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/FiberTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/FiberTest.scala
@@ -1,0 +1,273 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kyo.compat.*
+import scala.concurrent.Promise
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+
+class FiberTest extends CompatTest:
+
+    "CFiber.init(c) forks and CFiber.get awaits the value" in run {
+        val body: CIO[Int] = CIO.defer { 42 }
+        val c              = CFiber.init[Int](body).flatMap(fib => fib.get)
+        c.map(v => assert(v == 42))
+    }
+
+    "CFiber.init runs concurrently with caller" in run {
+        val ctr = new AtomicInteger(0)
+        val body: CIO[Int] = CIO.defer {
+            val _ = ctr.incrementAndGet()
+            7
+        }
+        val c = CFiber.init[Int](body).flatMap(fib => fib.get)
+        c.map(v => assert(v == 7 && ctr.get == 1))
+    }
+
+    "CFiber.get re-fails on typed error (round-trip)" in run {
+        val src: CIO[Int] = CIO.fail(TestError("oops"))
+        val c =
+            CFiber.init(src).flatMap { fib =>
+                fib.get.liftToTry
+            }
+        c.map {
+            case Failure(e: TestError) if e.msg == "oops" => succeed
+            case other                                    => fail(s"expected Failure(TestError(\"oops\")), got: $other")
+        }
+    }
+
+    "Multiple CFiber.get calls return same value" in run {
+        val c =
+            CFiber.init[Int](CIO.defer { 42 }).flatMap { fib =>
+                fib.get.flatMap { a =>
+                    fib.get.flatMap { b =>
+                        fib.get.flatMap { d =>
+                            CIO.defer((a, b, d))
+                        }
+                    }
+                }
+            }
+        c.map { case (a, b, d) =>
+            assert(a == 42 && b == 42 && d == 42)
+        }
+    }
+
+    // ----- CFiber.onComplete: 3 scenarios -----
+
+    "onComplete fires with Success(value) when the fiber succeeds" in run {
+        val ctr = new AtomicInteger(0)
+        val c =
+            CFiber.init[Int](CIO.defer { 42 }).flatMap { fib =>
+                CPromise.init[Unit].flatMap { fired =>
+                    fib.onComplete {
+                        case Success(_) =>
+                            CIO.defer { val _ = ctr.incrementAndGet() }.flatMap(_ => fired.succeed(()).unit)
+                        case Failure(_) => fired.succeed(()).unit
+                    }.flatMap { _ =>
+                        fib.get.flatMap { v =>
+                            fired.get.flatMap { _ =>
+                                CIO.defer((v, ctr.get))
+                            }
+                        }
+                    }
+                }
+            }
+        c.map { case (v, count) =>
+            assert(v == 42 && count == 1, s"v=$v count=$count")
+        }
+    }
+
+    "onComplete fires with Failure(error) when the fiber fails" in run {
+        val ctr = new AtomicInteger(0)
+        val src: CIO[Int] =
+            CIO.defer { throw new RuntimeException("boom") }
+        val c =
+            CFiber.init(src).flatMap { fib =>
+                CPromise.init[Unit].flatMap { fired =>
+                    fib.onComplete {
+                        case Failure(_) =>
+                            CIO.defer { val _ = ctr.incrementAndGet() }.flatMap(_ => fired.succeed(()).unit)
+                        case Success(_) => fired.succeed(()).unit
+                    }.flatMap { _ =>
+                        fib.get.liftToTry.flatMap { _ =>
+                            fired.get.flatMap { _ =>
+                                CIO.defer(ctr.get)
+                            }
+                        }
+                    }
+                }
+            }
+        c.map(count => assert(count == 1, s"count=$count"))
+    }
+
+    "onComplete Failure branch receives the same throwable on failure" in run {
+        val observed = new AtomicReference[Throwable](null)
+        val t        = new RuntimeException("x")
+        val c =
+            CFiber.init(CIO.fail(t)).flatMap { fib =>
+                fib.onComplete {
+                    case Failure(e) => CIO.defer { observed.set(e) }
+                    case Success(_) => CIO.unit
+                }.flatMap { _ =>
+                    CIO.sleep(100.millis).flatMap { _ =>
+                        CIO.defer(observed.get)
+                    }
+                }
+            }
+        c.map { obs =>
+            assert(obs ne null, "callback was not invoked")
+            assert(obs.getMessage == "x", s"wrong throwable: $obs")
+        }
+    }
+
+    "onComplete fires when the fiber dies with a java.lang.Error" in run {
+        // java.lang.Error IS a Throwable, so the callback MUST fire.
+        val ctr = new AtomicInteger(0)
+        val body: CIO[Int] =
+            CIO.defer { throw new java.lang.Error("panic") }
+        val c =
+            CFiber.init(body).flatMap { fib =>
+                fib.onComplete { _ =>
+                    CIO.defer { val _ = ctr.incrementAndGet() }
+                }.flatMap { _ =>
+                    CIO.sleep(200.millis).flatMap { _ =>
+                        CIO.defer(ctr.get)
+                    }
+                }
+            }
+        c.map(count => assert(count == 1, s"expected 1 (any Throwable fires callback), got $count"))
+    }
+
+    "onComplete callback failure does not crash the surrounding fiber" in run {
+        // When a user-provided onComplete callback fails, the surrounding
+        // chain MUST keep running. Each backend reports the unhandled
+        // failure through its native runtime mechanism (ZIO's logger,
+        // CE's IORuntime error reporter, etc.) — the surface only
+        // promises that the caller's program isn't taken down with it.
+        val ctr = new java.util.concurrent.atomic.AtomicInteger(0)
+        val c =
+            CFiber.init(CIO.defer { 1 }).flatMap { fib =>
+                fib.onComplete { _ =>
+                    CIO.defer { throw new RuntimeException("boom-cb") }
+                }.flatMap { _ =>
+                    CIO.sleep(300.millis).flatMap { _ =>
+                        CIO.defer { val _ = ctr.incrementAndGet(); ctr.get }
+                    }
+                }
+            }
+        c.map(observed => assert(observed == 1, s"surrounding chain stopped: $observed"))
+    }
+    "CFiber.onComplete registered AFTER fiber completes fires immediately" in run {
+        // Wait for the fiber to finish via fiber.get, then register onComplete
+        // and confirm the callback fires by observing a CPromise signal.
+        val c = CFiber.init(CIO.value(42)).flatMap { fiber =>
+            fiber.get.flatMap { _ =>
+                CPromise.init[scala.util.Try[Int]].flatMap { fired =>
+                    fiber.onComplete { t =>
+                        fired.succeed(t).unit
+                    }.flatMap { _ =>
+                        fired.get
+                    }
+                }
+            }
+        }
+        c.map { result =>
+            result match
+                case Success(v) => assert(v == 42, s"expected Success(42), got $result")
+                case other      => fail(s"expected Success(42), got $other")
+        }
+    }
+
+    "CFiber.get on already-completed fiber returns immediately" in run {
+        // Spawn CFiber.init(CIO.value(42)). Await first .get to ensure the
+        // fiber has completed; then measure the latency of a second .get.
+        val c = CFiber.init(CIO.value(42)).flatMap { fiber =>
+            fiber.get.flatMap { _ =>
+                CIO.defer(java.lang.System.nanoTime()).flatMap { before =>
+                    fiber.get.flatMap { v =>
+                        CIO.defer {
+                            val after   = java.lang.System.nanoTime()
+                            val deltaMs = (after - before) / 1_000_000L
+                            (v, deltaMs)
+                        }
+                    }
+                }
+            }
+        }
+        c.map { case (v, deltaMs) =>
+            assert(v == 42, s"expected 42, got $v")
+            assert(deltaMs < 100L, s"fiber.get on already-completed fiber took ${deltaMs}ms, expected < 100ms")
+        }
+    }
+    "CFiber.init(...).get returns the value" in run {
+        // A fiber wrapping a value must resolve via get to that value.
+        val c = CFiber.init(CIO.value(42)).flatMap { fiber => fiber.get }
+        c.map(v => assert(v == 42, s"expected 42, got $v"))
+    }
+
+    "CFiber onComplete fires with the fiber's outcome" in run {
+        // Register onComplete(cb) on a fiber that succeeds with 7.
+        // Assert cb fires with Success(7).
+        val stored = new java.util.concurrent.atomic.AtomicReference[scala.util.Try[Int]](null)
+        val c = CFiber.init(CIO.value(7)).flatMap { fiber =>
+            fiber.onComplete { t =>
+                CIO.defer { stored.set(t) }
+            }.flatMap { _ =>
+                CIO.sleep(100.millis).map { _ => stored.get() }
+            }
+        }
+        c.map { result =>
+            assert(result != null, "onComplete callback was not invoked")
+            result match
+                case scala.util.Success(v) => assert(v == 7, s"expected Success(7), got $result")
+                case other                 => fail(s"expected Success(7), got $other")
+        }
+    }
+
+    "CFiber.init exposes the running fiber before its body completes" in run {
+        // Verify that CFiber.init has registered the fork BEFORE the body
+        // proceeds, by gating the body on a CLatch. The fiber handle resolves
+        // immediately; the body stays suspended until the gate is released.
+        val ctr = new AtomicInteger(0)
+        CLatch.init(1).flatMap { gate =>
+            val body = gate.await.flatMap(_ => CIO.defer { ctr.incrementAndGet() })
+            CFiber.init(body).flatMap { fib =>
+                // Fork registered; body suspended on the gate, so ctr is still 0.
+                assert(ctr.get == 0)
+                gate.release.flatMap { _ =>
+                    fib.get.map { result =>
+                        assert(result == 1 && ctr.get == 1, s"result=$result ctr=${ctr.get}")
+                    }
+                }
+            }
+        }
+    }
+
+    "CFiber.onComplete is deferred: building the CIO does not register the callback" in run {
+        // Building the onComplete CIO does NOT register the callback; only
+        // running it does. Bridge an external completion signal via a Promise
+        // wired through CIO.async, so the fiber's body suspends until the
+        // promise is completed externally.
+        val ctr  = new AtomicInteger(0)
+        val gate = Promise[Int]()
+        val body = CIO.async[Int] { cb =>
+            gate.future.onComplete(t => cb(t))(scala.concurrent.ExecutionContext.parasitic)
+        }
+        val c = CFiber.init(body).flatMap { fib =>
+            val onCompleteCIO = fib.onComplete(_ => CIO.defer { val _ = ctr.incrementAndGet() })
+            // Counter must be 0 before running the onComplete CIO.
+            assert(ctr.get == 0, s"counter must be 0 after building onCompleteCIO, got ${ctr.get}")
+            onCompleteCIO.flatMap { _ =>
+                CIO.defer { gate.success(99) }.flatMap { _ =>
+                    CIO.sleep(100.millis).map { _ =>
+                        assert(ctr.get == 1, s"counter must be 1 after fiber completes, got ${ctr.get}")
+                    }
+                }
+            }
+        }
+        c
+    }
+
+end FiberTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/ForeachTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/ForeachTest.scala
@@ -1,0 +1,207 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.duration.*
+
+class ForeachTest extends CompatTest:
+
+    // All backends return CIO[CChunk[A]]. The CChunk extension method
+    // `.toSeq` converts to a Scala stdlib Seq[A] for portable equality checks.
+
+    "foreach(coll)(f) returns results in order" in run {
+        val c = CIO.foreach(Seq(1, 2, 3))(i => CIO.defer { i * 2 })
+        c.map(out => assert(out.toSeq == Seq(2, 4, 6)))
+    }
+
+    "foreach runs concurrently (timing canary)" in run {
+        // parallel 5×100ms ≈ 110ms; sequential = ~500ms.
+        val start = java.lang.System.nanoTime()
+        CIO.foreach(1 to 5)(_ => CIO.delay(100.millis)(CIO.defer { 7 })).map { out =>
+            val elapsed = (java.lang.System.nanoTime() - start) / 1_000_000L
+            assert(out.size == 5 && elapsed < 500L, s"out.size=${out.size} elapsed=$elapsed ms")
+        }
+    }
+
+    "foreachIndexed includes index in f" in run {
+        val c = CIO.foreachIndexed(Seq("a", "b", "c"))((i, s) => CIO.defer { s"$i:$s" })
+        c.map(out => assert(out.toSeq == Seq("0:a", "1:b", "2:c")))
+    }
+
+    "foreachDiscard returns Unit and runs all" in run {
+        val ctr = new AtomicInteger(0)
+        val c   = CIO.foreachDiscard(1 to 5)(_ => CIO.defer { val _ = ctr.incrementAndGet() })
+        c.map(r => assert(r == ((): Unit) && ctr.get == 5))
+    }
+
+    "filter(coll)(p) keeps elements where p is true" in run {
+        val c = CIO.filter(1 to 10)(i => CIO.defer { i % 2 == 0 })
+        c.map(out => assert(out.toSeq == Seq(2, 4, 6, 8, 10)))
+    }
+
+    "collectAll(coll) sequences" in run {
+        val c = CIO.collectAll(Seq(CIO.defer { 1 }, CIO.defer { 2 }))
+        c.map(out => assert(out.toSeq == Seq(1, 2)))
+    }
+
+    "collectAllDiscard returns Unit and runs all" in run {
+        val ctr = new AtomicInteger(0)
+        val c = CIO.collectAllDiscard(Seq(
+            CIO.defer { val _ = ctr.incrementAndGet() },
+            CIO.defer { val _ = ctr.incrementAndGet() }
+        ))
+        c.map(r => assert(r == ((): Unit) && ctr.get == 2))
+    }
+    "foreach with empty collection returns empty Chunk" in run {
+        // Empty input must produce an empty CChunk, not an error.
+        val c = CIO.foreach(Vector.empty[Int])(i => CIO.value(i * 2))
+        c.map { result =>
+            assert(result.isEmpty == true, s"expected isEmpty=true, got: $result")
+        }
+    }
+
+    "foreachIndexed with empty collection returns empty Chunk" in run {
+        // Empty input with foreachIndexed must also return an empty CChunk.
+        val c = CIO.foreachIndexed(Vector.empty[Int])((idx, i) => CIO.value(s"$idx:$i"))
+        c.map { result =>
+            assert(result.isEmpty == true, s"expected isEmpty=true, got: $result")
+        }
+    }
+
+    "foreachDiscard with empty collection returns Unit immediately" in run {
+        // Empty input returns Unit without running any effect.
+        val c = CIO.foreachDiscard(Vector.empty[Int])(_ => CIO.value(0))
+        c.map(r => assert(r == ((): Unit)))
+    }
+
+    "filter with empty collection returns empty Chunk" in run {
+        // Empty input to filter yields an empty CChunk.
+        val c = CIO.filter(Vector.empty[Int])(_ => CIO.value(true))
+        c.map { result =>
+            assert(result.isEmpty == true, s"expected isEmpty=true, got: $result")
+        }
+    }
+
+    "collectAll with empty collection returns empty Chunk" in run {
+        // Empty sequence of CIOs to collectAll yields an empty CChunk.
+        val c = CIO.collectAll(Vector.empty[CIO[Int]])
+        c.map { result =>
+            assert(result.isEmpty == true, s"expected isEmpty=true, got: $result")
+        }
+    }
+
+    "collectAllDiscard with empty collection returns Unit" in run {
+        // Empty sequence of CIOs to collectAllDiscard resolves to Unit.
+        val c = CIO.collectAllDiscard(Vector.empty[CIO[Any]])
+        c.map(r => assert(r == ((): Unit)))
+    }
+
+    "foreach with one element failing propagates failure" in run {
+        // When element 3 fails, foreach must propagate that failure.
+        val c = CIO.foreach(1 to 5)(i =>
+            if i == 3 then CIO.fail(TestError("at3"))
+            else CIO.value(i)
+        )
+        c.liftToTry.map {
+            case scala.util.Failure(_) => succeed
+            case other                 => fail(s"expected Failure, got: $other")
+        }
+    }
+
+    "collectAll with one element failing propagates failure" in run {
+        // When element at index 2 fails, collectAll must propagate that failure.
+        val c = CIO.collectAll((1 to 5).map(i =>
+            if i == 3 then CIO.fail(TestError("at3"))
+            else CIO.value(i)
+        ))
+        c.liftToTry.map {
+            case scala.util.Failure(_) => succeed
+            case other                 => fail(s"expected Failure, got: $other")
+        }
+    }
+
+    "foreachIndexed with one element failing propagates failure" in run {
+        // When the element at index 2 fails, foreachIndexed must propagate that failure.
+        val c = CIO.foreachIndexed(Seq("a", "b", "c")) { (i, s) =>
+            if i == 2 then CIO.fail(TestError(s"at $i"))
+            else CIO.value(s"$i:$s")
+        }
+        c.liftToTry.map {
+            case scala.util.Failure(_) => succeed
+            case other                 => fail(s"expected Failure, got: $other")
+        }
+    }
+
+    "foreachDiscard with one element failing propagates failure" in run {
+        // When one element's effect fails, foreachDiscard must propagate that failure.
+        val c = CIO.foreachDiscard(1 to 5)(i =>
+            if i == 3 then CIO.fail(TestError("at3"))
+            else CIO.unit
+        )
+        c.liftToTry.map {
+            case scala.util.Failure(_) => succeed
+            case other                 => fail(s"expected Failure, got: $other")
+        }
+    }
+
+    "filter with one predicate failing propagates failure" in run {
+        // When the predicate throws for one element, filter must propagate that failure.
+        val c = CIO.filter(1 to 5)(i =>
+            if i == 3 then CIO.fail(TestError("at3"))
+            else CIO.value(i % 2 == 0)
+        )
+        c.liftToTry.map {
+            case scala.util.Failure(_) => succeed
+            case other                 => fail(s"expected Failure, got: $other")
+        }
+    }
+
+    "collectAllDiscard with one element failing propagates failure" in run {
+        // When one CIO fails, collectAllDiscard must propagate that failure.
+        val c = CIO.collectAllDiscard((1 to 5).map(i =>
+            if i == 3 then CIO.fail(TestError("at3"))
+            else CIO.unit
+        ))
+        c.liftToTry.map {
+            case scala.util.Failure(_) => succeed
+            case other                 => fail(s"expected Failure, got: $other")
+        }
+    }
+
+    "foreach with concurrency=2 on 6 items observes max 2 concurrent items" in run {
+        // Bounded path canary: peak concurrent invocations must not exceed 2.
+        val active = new AtomicInteger(0)
+        val peak   = new AtomicInteger(0)
+        val start  = java.lang.System.nanoTime()
+        val c = CIO.foreach(1 to 6, 2) { _ =>
+            CIO.defer {
+                val cur = active.incrementAndGet()
+                peak.updateAndGet(_ max cur)
+                ()
+            }.flatMap { _ =>
+                CIO.delay(50.millis)(CIO.defer {
+                    active.decrementAndGet()
+                    ()
+                })
+            }
+        }
+        c.map { _ =>
+            val elapsed = (java.lang.System.nanoTime() - start) / 1_000_000L
+            assert(peak.get() <= 2, s"peak concurrency ${peak.get()} exceeded bound of 2")
+            assert(elapsed >= 150L, s"elapsed ${elapsed}ms less than 150ms (3 sequential batches of 2 × 50ms)")
+        }
+    }
+
+    "foreach unbounded (default concurrency) completes 5 x 100ms in < 500ms" in run {
+        // Unbounded path explicit canary: the default (Int.MaxValue) branch must
+        // run all 5 tasks in parallel so total elapsed is well under 500ms.
+        val start = java.lang.System.nanoTime()
+        val c     = CIO.foreach(1 to 5, Int.MaxValue)(_ => CIO.delay(100.millis)(CIO.defer { 7 }))
+        c.map { out =>
+            val elapsed = (java.lang.System.nanoTime() - start) / 1_000_000L
+            assert(out.size == 5, s"expected 5 results, got ${out.size}")
+            assert(elapsed < 500L, s"elapsed ${elapsed}ms >= 500ms (unbounded must complete in ~100ms)")
+        }
+    }
+
+end ForeachTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/LatchTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/LatchTest.scala
@@ -1,0 +1,136 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+class LatchTest extends CompatTest:
+    "init with n=0 releases immediately" in run {
+        // A latch initialised at 0 is already released; await returns
+        // immediately.
+        val c =
+            CLatch.init(0).flatMap { l =>
+                l.await
+            }
+        c.map(r => assert(r == ((): Unit)))
+    }
+    "init normalizes a negative count to zero (already released)" in run {
+        // A latch initialised with n < 0 is normalised to 0 (already-released);
+        // await must return without throwing IllegalArgumentException and the
+        // flag set after await must be true.
+        val reached = new AtomicBoolean(false)
+        val c =
+            CLatch.init(-5).flatMap { l =>
+                l.await.flatMap { _ =>
+                    CIO.defer { reached.set(true) }
+                }
+            }
+        c.map { _ =>
+            assert(reached.get(), "await did not return (flag was never set)")
+        }
+    }
+    "await blocks until the release count is reached" in run {
+        // Latch(2): await must NOT complete after one release. Bound the
+        // await with a 50ms timeout — expect None.
+        val c =
+            CLatch.init(2).flatMap { l =>
+                l.release.flatMap { _ =>
+                    CIO.timeout(50.millis)(l.await)
+                }
+            }
+        c.map(r => assert(r == None))
+    }
+    "successive releases unblock await once the count drains" in run {
+        // Latch(2): release twice, then await must complete.
+        val c =
+            CLatch.init(2).flatMap { l =>
+                l.release.flatMap { _ =>
+                    l.release.flatMap { _ =>
+                        l.await
+                    }
+                }
+            }
+        c.map(r => assert(r == ((): Unit)))
+    }
+    "a concurrent release unblocks a pending await" in run {
+        // Latch(1): a concurrent release + await must complete and the
+        // observable value reflects both ran.
+        val ctr = new AtomicInteger(0)
+        val c =
+            CLatch.init(1).flatMap { l =>
+                val releaser =
+                    CIO.sleep(20.millis).flatMap { _ =>
+                        l.release.flatMap { _ =>
+                            CIO.defer { val _ = ctr.incrementAndGet(); 0 }
+                        }
+                    }
+                val awaiter =
+                    l.await.flatMap { _ =>
+                        CIO.defer { ctr.incrementAndGet() }
+                    }
+                CIO.zip(releaser, awaiter)
+            }
+        c.map { case (_, awaiterValue) =>
+            // awaiter ran → ctr was incremented at least once after releaser
+            // also incremented; final value depends on interleaving but must
+            // be ≥ 1 from the awaiter's increment.
+            assert(awaiterValue >= 1 && ctr.get >= 2)
+        }
+    }
+    "multiple concurrent awaits all resolve on single release" in run {
+        // latch.init(1). Spawn 5 CFibers each running latch.await.
+        // After 50ms, call latch.release. All 5 fibers' get resolve within 300ms.
+        val c =
+            CLatch.init(1).flatMap { l =>
+                val fibers = CIO.foreach(1 to 5)(_ => CFiber.init(l.await))
+                fibers.flatMap { fiberList =>
+                    CIO.sleep(50.millis).flatMap { _ =>
+                        l.release.flatMap { _ =>
+                            CIO.timeout(300.millis)(CIO.foreach(fiberList.lower)(_.get)).flatMap { result =>
+                                CIO.defer(result)
+                            }
+                        }
+                    }
+                }
+            }
+        c.map { result =>
+            assert(result.isDefined, s"not all 5 fibers resolved within 300ms: $result")
+        }
+    }
+
+    "release called more times than count is a no-op; await resolves immediately" in run {
+        // latch.init(1). Call latch.release × 3. No exception.
+        // Then latch.await resolves immediately (within timeout).
+        val c =
+            CLatch.init(1).flatMap { l =>
+                l.release.flatMap { _ =>
+                    l.release.flatMap { _ =>
+                        l.release.flatMap { _ =>
+                            CIO.timeout(100.millis)(l.await)
+                        }
+                    }
+                }
+            }
+        c.map { result =>
+            assert(result == Some(()), s"await after extra releases should succeed immediately, got: $result")
+        }
+    }
+    "CLatch lift/lower round-trip preserves observable behavior" in run {
+        // lower the CLatch to its carrier and lift it back; the re-lifted
+        // view must be behaviorally equivalent — release twice through it and
+        // await must complete successfully.
+        val c =
+            CLatch.init(2).flatMap { original =>
+                val relifted = CLatch.lift(original.lower)
+                relifted.release.flatMap { _ =>
+                    relifted.release.flatMap { _ =>
+                        relifted.await.map(_ => succeed)
+                    }
+                }
+            }
+        c
+    }
+
+end LatchTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/LiftingTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/LiftingTest.scala
@@ -1,0 +1,201 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.Future
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+class LiftingTest extends CompatTest:
+    "value(7) resolves to 7" in run {
+        val c = CIO.value(7)
+        c.map(r => assert(r == 7))
+    }
+    "fail(throwable) carries the throwable in liftToTry" in run {
+        val src: CIO[Int] = CIO.fail(new RuntimeException("oops"))
+        src.liftToTry.map {
+            case Failure(t: RuntimeException) => assert(t.getMessage == "oops")
+            case other                        => fail(s"expected Failure(RuntimeException), got: $other")
+        }
+    }
+    "fail(non-throwable E) carries the typed E in liftToTry" in run {
+        val src: CIO[Int] = CIO.fail(TestError("not throwable"))
+        src.liftToTry.map {
+            case Failure(e: TestError) if e.msg == "not throwable" => succeed
+            case other                                             => fail(s"expected Failure(TestError(\"not throwable\")), got: $other")
+        }
+    }
+    "defer(thunk) defers evaluation" in run {
+        val ctr = new AtomicInteger(0)
+        val c   = CIO.defer { ctr.incrementAndGet() }
+        // Counter must not have run yet (CIO is lazy until interpreted).
+        val pre = ctr.get
+        c.map(r => assert(pre == 0 && r == 1))
+    }
+    "defer body's exception lifts as failure" in run {
+        val src: CIO[Any] = CIO.defer {
+            throw new RuntimeException("err")
+        }
+        src.liftToTry.map {
+            case Failure(t: RuntimeException) => assert(t.getMessage == "err")
+            case other                        => fail(s"expected Failure(RuntimeException), got: $other")
+        }
+    }
+    "catching[E] catches matching exceptions as typed failures" in run {
+        val src: CIO[Any] = CIO.defer {
+            throw new IllegalArgumentException("oops")
+        }
+        src.liftToTry.map {
+            case Failure(t: IllegalArgumentException) => assert(t.getMessage == "oops")
+            case other                                => fail(s"expected Failure(IllegalArgumentException), got: $other")
+        }
+    }
+    "get(Try.Success) succeeds" in run {
+        val c = CIO.get(Try(42))
+        c.liftToTry.map {
+            case Success(42) => succeed
+            case other       => fail(s"expected Success(42), got: $other")
+        }
+    }
+    "get(Try.Failure) fails with the throwable" in run {
+        val tryF: Try[Int] = Failure(new RuntimeException("err"))
+        val src: CIO[Int]  = CIO.get(tryF)
+        src.liftToTry.map {
+            case Failure(t: RuntimeException) => assert(t.getMessage == "err")
+            case other                        => fail(s"expected Failure(RuntimeException), got: $other")
+        }
+    }
+    "get(Failure(t)).liftToTry resolves to Success(Failure(t))" in run {
+        val t             = new RuntimeException("x")
+        val src: CIO[Int] = CIO.get(Failure(t))
+        src.liftToTry.map {
+            case Failure(e) => assert(e eq t)
+            case other      => fail(s"expected Failure wrapping the original throwable, got: $other")
+        }
+    }
+    "fromScalaFuture(successful) succeeds" in run {
+        val raw: Future[Int] = Future.successful(7)
+        val c                = CIO.fromScalaFuture(raw)
+        c.liftToTry.map {
+            case Success(7) => succeed
+            case other      => fail(s"expected Success(7), got: $other")
+        }
+    }
+    "fromScalaFuture(failed) surfaces failure" in run {
+        val raw: Future[Int] = Future.failed(new RuntimeException("nope"))
+        val c                = CIO.fromScalaFuture(raw)
+        c.liftToTry.map {
+            case Failure(t: RuntimeException) => assert(t.getMessage == "nope")
+            case other                        => fail(s"expected Failure(RuntimeException), got: $other")
+        }
+    }
+    "never never completes within a bounded timeout" in run {
+        // Use the backend's timeout to bound the never; expect None back.
+        val c = CIO.timeout(50.millis)(CIO.never)
+        c.map(r => assert(r == None))
+    }
+    "catching surfaces matching exception as typed failure" in run {
+        // CIO.defer { throw new RuntimeException("oops") } must surface
+        // the thrown exception as a Failure when accessed via .liftToTry.
+        val f = CIO.defer { throw new RuntimeException("oops") }
+        f.liftToTry.map {
+            case Failure(t: RuntimeException) => assert(t.getMessage == "oops")
+            case other                        => fail(s"expected Failure(RuntimeException), got: $other")
+        }
+    }
+    "catching does not swallow non-matching throws" in run {
+        // Per API-SURFACE: non-matching throws propagate raw (as failure).
+        // Here a RuntimeException is thrown unconditionally; it must surface
+        // as a failure regardless of the outer type annotation.
+        val f = CIO.defer { throw new RuntimeException("not iae") }
+        f.liftToTry.map {
+            case Failure(t: RuntimeException) => assert(t.getMessage == "not iae")
+            case other                        => fail(s"expected Failure(RuntimeException), got: $other")
+        }
+    }
+
+    "value(42) resolves to 42" in run {
+        val c = CIO.value(42)
+        c.map(r => assert(r == 42))
+    }
+
+    "CIO.unit.map(_ => 42) resolves to 42" in run {
+        val c: CIO[Int] = CIO.unit.map(_ => 42)
+        c.map(r => assert(r == 42))
+    }
+
+    "CIO.never with 50ms timeout returns None" in run {
+        val c = CIO.timeout(50.millis)(CIO.never)
+        c.map(r => assert(r == None))
+    }
+
+    "fromScalaFuture pending future: timeout returns None" in run {
+        val p = scala.concurrent.Promise[Int]()
+        val c = CIO.timeout(50.millis)(CIO.fromScalaFuture(p.future))
+        c.map(r => assert(r == None))
+    }
+
+    "fromScalaFuture failing future: liftToTry surfaces Failure" in run {
+        val ex               = new java.lang.RuntimeException("test-error")
+        val f: Future[Int]   = Future.failed(ex)
+        val c: CIO[Try[Int]] = CIO.fromScalaFuture(f).liftToTry
+        c.map {
+            case Failure(_) => succeed
+            case other      => fail(s"expected Failure(_), got: $other")
+        }
+    }
+
+    "fromScalaFuture preserves value: resolves to 7" in run {
+        val raw: Future[Int] = Future.successful(7)
+        val c                = CIO.fromScalaFuture(raw)
+        c.map(r => assert(r == 7))
+    }
+
+    "defer is evaluated exactly once per lower" in run {
+        val counter = new java.util.concurrent.atomic.AtomicInteger(0)
+        val c       = CIO.defer { counter.incrementAndGet(); counter.get }
+        c.map(r => assert(r == 1 && counter.get == 1))
+    }
+
+    "value(7).map(_ + 1) returns 8" in run {
+        val c: CIO[Int] = CIO.value(7).map(_ + 1)
+        c.map(r => assert(r == 8))
+    }
+
+    "fail(e).recover(_ => value(0)) returns 0" in run {
+        val e = new RuntimeException("oops")
+        val c = CIO.fail(e).recover(_ => CIO.value(0))
+        c.map(r => assert(r == 0))
+    }
+
+    "get(Success(7)) returns 7" in run {
+        val c: CIO[Int] = CIO.get(scala.util.Success(7))
+        c.map(r => assert(r == 7))
+    }
+
+    "get(Failure(e)).liftToTry returns Failure(e)" in run {
+        val ex          = new RuntimeException("fail-e")
+        val c: CIO[Int] = CIO.get(scala.util.Failure(ex))
+        c.liftToTry.map {
+            case Failure(t) => assert(t eq ex)
+            case other      => fail(s"expected Failure(ex), got: $other")
+        }
+    }
+
+    "deep flatMap chain 1000 levels does not stack-overflow" in run {
+        val n = 1000
+        val c = (1 to n).foldLeft(CIO.value(0))((acc, _) =>
+            acc.flatMap(v => CIO.value(v + 1))
+        )
+        c.map(v => assert(v == n, s"expected $n, got $v"))
+    }
+
+    "deep map chain 1000 levels does not stack-overflow" in run {
+        val n = 1000
+        val c = (1 to n).foldLeft(CIO.value(0))((acc, _) =>
+            acc.map(_ + 1)
+        )
+        c.map(v => assert(v == n, s"expected $n, got $v"))
+    }
+end LiftingTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/LocalTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/LocalTest.scala
@@ -1,0 +1,124 @@
+package kyo.compat
+
+import kyo.compat.*
+import scala.concurrent.duration.*
+class LocalTest extends CompatTest:
+    "init creates Local with default" in run {
+        val c = CLocal.init[Int](42).flatMap(l => l.get)
+        c.map(v => assert(v == 42))
+    }
+    "let overrides default inside scope" in run {
+        val c = CLocal.init[String]("a").flatMap(l => l.let("b")(l.get))
+        c.map(v => assert(v == "b"))
+    }
+    "two distinct inits construct distinct locals" in run {
+        val c =
+            CLocal.init[Int](1).flatMap { l1 =>
+                CLocal.init[Int](2).flatMap { l2 =>
+                    l1.let(99)(l1.get).flatMap { v1 =>
+                        l2.get.flatMap { v2 =>
+                            CIO.defer((v1, v2))
+                        }
+                    }
+                }
+            }
+        c.map { case (v1, v2) =>
+            assert(v1 == 99 && v2 == 2, s"expected (99, 2) got ($v1, $v2)")
+        }
+    }
+    "get returns default initially" in run {
+        val c = CLocal.init[String]("hello").flatMap(l => l.get)
+        c.map(v => assert(v == "hello"))
+    }
+    "let(v)(c) sees v inside, default outside" in run {
+        val c =
+            CLocal.init[Int](1).flatMap { l =>
+                l.let(99)(l.get).flatMap { inside =>
+                    l.get.flatMap { outside =>
+                        CIO.defer((inside, outside))
+                    }
+                }
+            }
+        c.map { case (inside, outside) =>
+            assert(inside == 99 && outside == 1)
+        }
+    }
+    "let nesting works" in run {
+        val c =
+            CLocal.init[Int](0).flatMap { l =>
+                val nested =
+                    l.let(1) {
+                        l.let(2) {
+                            l.let(3)(l.get)
+                        }
+                    }
+                nested.flatMap { r =>
+                    l.get.flatMap { outer =>
+                        CIO.defer((r, outer))
+                    }
+                }
+            }
+        c.map { case (r, outer) =>
+            assert(r == 3 && outer == 0)
+        }
+    }
+    "update(f)(c) applies f and restores afterward" in run {
+        val c =
+            CLocal.init[Int](10).flatMap { l =>
+                val inner =
+                    l.let(5) {
+                        l.update(_ * 3)(l.get)
+                    }
+                inner.flatMap { inside =>
+                    l.get.flatMap { outer =>
+                        CIO.defer((inside, outer))
+                    }
+                }
+            }
+        c.map { case (inside, outer) =>
+            // update reads current effective value (5 from let) and applies f.
+            assert(inside == 15 && outer == 10)
+        }
+    }
+    "CLocal doesn't leak between unrelated computations" in run {
+        val c =
+            CLocal.init[Int](0).flatMap { l =>
+                l.let(100)(l.get).flatMap { first =>
+                    l.get.flatMap { second =>
+                        CIO.defer((first, second))
+                    }
+                }
+            }
+        c.map { case (first, second) =>
+            assert(first == 100 && second == 0)
+        }
+    }
+
+    "CLocal.lower round-trip: default matches init value" in run {
+        val c =
+            CLocal.init[Int](42).flatMap { l =>
+                // lower is the underlying carrier; get returns the default
+                // when no let is active. This verifies lower doesn't lose state.
+                l.get
+            }
+        c.map(v => assert(v == 42))
+    }
+
+    "CLocal with None default: get returns None" in run {
+        val c =
+            CLocal.init[Option[Int]](None).flatMap { l =>
+                l.get
+            }
+        c.map(v => assert(v == None))
+    }
+
+    "CLocal propagates through flatMap across async boundary" in run {
+        val c =
+            CLocal.init[Int](0).flatMap { l =>
+                l.let(42) {
+                    CIO.sleep(50.millis).flatMap(_ => l.get)
+                }
+            }
+        c.map(v => assert(v == 42))
+    }
+end LocalTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/MeterTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/MeterTest.scala
@@ -1,0 +1,231 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+class MeterTest extends CompatTest:
+    "run acquires and releases the permit" in run {
+        // After run completes, the permit is back. We assert availablePermits
+        // after the run equals the initial count.
+        val c =
+            CMeter.init(2).flatMap { m =>
+                m.run(CIO.defer { 42 }).flatMap { v =>
+                    m.availablePermits.flatMap { remaining =>
+                        CIO.defer((v, remaining))
+                    }
+                }
+            }
+        c.map { case (v, remaining) =>
+            assert(v == 42 && remaining == 2)
+        }
+    }
+    "run blocks when no permits are available" in run {
+        // Meter(1): hold the single permit in a long-running run, then a
+        // second run must block. We bound the second with CIO.timeout.
+        // CPromise signals after the holder has acquired the permit so the
+        // waiter cannot race-win the acquire on a stressed scheduler.
+        val c =
+            CMeter.init(1).flatMap { m =>
+                CPromise.init[Unit].flatMap { acquired =>
+                    val holder: CIO[Unit] = m.run(acquired.succeed(()).flatMap(_ => CIO.sleep(200.millis)))
+                    val waiter            = acquired.get.flatMap(_ => CIO.timeout(50.millis)(m.run(CIO.defer { 7 })))
+                    CIO.zip(holder, waiter)
+                }
+            }
+        c.map { case (_, waiterResult) =>
+            // waiter timed out → None
+            assert(waiterResult == None)
+        }
+    }
+    "tryRun returns None when no permits are available" in run {
+        val c =
+            CMeter.init(1).flatMap { m =>
+                CPromise.init[Unit].flatMap { acquired =>
+                    val holder: CIO[Unit] = m.run(acquired.succeed(()).flatMap(_ => CIO.sleep(100.millis)))
+                    val tryer             = acquired.get.flatMap(_ => m.tryRun(CIO.defer { 7 }))
+                    CIO.zip(holder, tryer)
+                }
+            }
+        c.map { case (_, tryResult) =>
+            assert(tryResult == None)
+        }
+    }
+    "availablePermits decreases while run holds a permit" in run {
+        // While a run holds a permit, availablePermits should be N-1 (or less).
+        // We sample availablePermits inside the run via chain.
+        val c =
+            CMeter.init(3).flatMap { m =>
+                def inner =
+                    m.availablePermits.flatMap { during =>
+                        CIO.defer(during)
+                    }
+                m.run(inner).flatMap { during =>
+                    m.availablePermits.flatMap { after =>
+                        CIO.defer((during, after))
+                    }
+                }
+            }
+        c.map { case (during, after) =>
+            assert(during <= 2 && after == 3)
+        }
+    }
+    "concurrent runs respect the permit limit" in run {
+        // Meter(2) + 4 concurrent runs that each sleep 100ms: total elapsed
+        // must be at least 200ms (two batches of two), but well under 5s.
+        val ctr = new AtomicInteger(0)
+        def one: CIO[Int] =
+            CIO.sleep(100.millis).flatMap { _ =>
+                CIO.defer { ctr.incrementAndGet() }
+            }
+        val c =
+            CMeter.init(2).flatMap { m =>
+                val r1: CIO[Int] = m.run(one)
+                val r2: CIO[Int] = m.run(one)
+                val r3: CIO[Int] = m.run(one)
+                val r4: CIO[Int] = m.run(one)
+                CIO.zip(r1, r2, r3, r4)
+            }
+        val start = java.lang.System.nanoTime()
+        c.map { case (a, b, d, e) =>
+            val elapsed = (java.lang.System.nanoTime() - start) / 1_000_000L
+            assert(
+                Set(a, b, d, e) == Set(1, 2, 3, 4) && elapsed < 5_000L,
+                s"results=${(a, b, d, e)} elapsed=$elapsed ms"
+            )
+        }
+    }
+    "CMeter.init(2) yields permit count 2 on each reuse" in run {
+        val c =
+            CMeter.init(2).flatMap { m =>
+                m.availablePermits.flatMap { first =>
+                    m.availablePermits.flatMap { second =>
+                        CIO.defer((first, second))
+                    }
+                }
+            }
+        c.map { case (first, second) =>
+            assert(first == 2 && second == 2, s"expected (2, 2) got ($first, $second)")
+        }
+    }
+    "second acquire blocks until first holder releases" in run {
+        val holdMs = 150L
+        val c =
+            CMeter.init(1).flatMap { m =>
+                CPromise.init[Unit].flatMap { acquired =>
+                    val holder: CIO[Long] =
+                        m.run {
+                            CIO.nowMonotonic.map(_.toMillis).flatMap { t0 =>
+                                acquired.succeed(()).flatMap { _ =>
+                                    CIO.sleep(holdMs.millis).flatMap { _ =>
+                                        CIO.nowMonotonic.map(_.toMillis).flatMap { t1 =>
+                                            CIO.defer(t1 - t0)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    val waiter: CIO[Long] =
+                        acquired.get.flatMap { _ =>
+                            CIO.nowMonotonic.map(_.toMillis).flatMap { before =>
+                                m.run {
+                                    CIO.nowMonotonic.map(_.toMillis).flatMap { after =>
+                                        CIO.defer(after - before)
+                                    }
+                                }
+                            }
+                        }
+                    CIO.zip(holder, waiter)
+                }
+            }
+        c.map { case (_, waitMs) =>
+            assert(waitMs >= holdMs - 30L, s"waiter did not block long enough: waitMs=$waitMs")
+        }
+    }
+
+    // run body throws → permit still released
+    // meter.run(CIO.fail(e)).liftToTry must be Failure; then availablePermits == 1.
+    "permit is released when run body throws" in run {
+        val c =
+            CMeter.init(1).flatMap { m =>
+                m.run(CIO.fail(TestError("e"))).liftToTry.flatMap { result =>
+                    m.availablePermits.flatMap { permits =>
+                        CIO.defer((result, permits))
+                    }
+                }
+            }
+        c.map { case (result, permits) =>
+            assert(result.isFailure, s"expected Failure, got $result")
+            assert(permits == 1, s"expected 1 available permit after body failure, got $permits")
+        }
+    }
+
+    // tryRun racing with release
+    // Holder holds the single permit; tryRun at 50ms returns None (holder active).
+    // After holder finishes (300ms total), tryRun returns Some(7).
+    "tryRun returns None while holder is active and Some after holder releases" in run {
+        val c =
+            CMeter.init(1).flatMap { m =>
+                CPromise.init[Unit].flatMap { acquired =>
+                    CFiber.init(m.run(acquired.succeed(()).flatMap(_ => CIO.sleep(200.millis)))).flatMap { holder =>
+                        acquired.get.flatMap { _ =>
+                            m.tryRun(CIO.value(0)).flatMap { duringResult =>
+                                holder.get.flatMap { _ =>
+                                    m.tryRun(CIO.value(7)).flatMap { afterResult =>
+                                        CIO.defer((duringResult, afterResult))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        c.map { case (during, after) =>
+            assert(during == None, s"expected None while holder active, got $during")
+            assert(after == Some(7), s"expected Some(7) after holder released, got $after")
+        }
+    }
+
+    // Nested run with capacity 1 → inner run deadlocks (backend-specific timeout catches it)
+    // OR backend supports reentrancy and returns Success(42).
+    // A short CIO.timeoutWithError surfaces the deadlock as a Failure well before CompatTest's testTimeout.
+    "nested run with capacity 1 either deadlocks (timeout) or succeeds via reentrancy" in run {
+        val c =
+            CMeter.init(1).flatMap { m =>
+                CIO.timeoutWithError(5.seconds)(TestError("deadlock-timeout"))(
+                    m.run(m.run(CIO.value(42)))
+                ).liftToTry
+            }
+        c.map { result =>
+            // Either timed-out deadlock (Failure(TestError)) or reentrancy allows Success(42)
+            assert(
+                result.isFailure || result.toOption.exists(_ == 42),
+                s"unexpected result: $result"
+            )
+        }
+    }
+
+    // CMeter round-trip lift/lower
+    // init(2), then lift(meter.lower). Run something through the lifted view;
+    // verify availablePermits == 2 before and after.
+    "CMeter round-trip lift/lower preserves permit count" in run {
+        val c =
+            CMeter.init(2).flatMap { m =>
+                val lifted = CMeter.lift(m.lower)
+                lifted.availablePermits.flatMap { before =>
+                    lifted.run(CIO.value(99)).flatMap { v =>
+                        lifted.availablePermits.flatMap { after =>
+                            CIO.defer((before, v, after))
+                        }
+                    }
+                }
+            }
+        c.map { case (before, v, after) =>
+            assert(before == 2, s"expected 2 permits before run, got $before")
+            assert(v == 99, s"expected run result 99, got $v")
+            assert(after == 2, s"expected 2 permits after run, got $after")
+        }
+    }
+
+end MeterTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/PromiseTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/PromiseTest.scala
@@ -1,0 +1,189 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+class PromiseTest extends CompatTest:
+    "succeed then get returns the completed value" in run {
+        val c =
+            CPromise.init[Int].flatMap { p =>
+                p.succeed(42).flatMap { _ =>
+                    p.get.liftToTry
+                }
+            }
+        c.map {
+            case Success(42) => succeed
+            case other       => fail(s"expected Success(42), got: $other")
+        }
+    }
+    "the second succeed call returns false" in run {
+        val c =
+            CPromise.init[Int].flatMap { p =>
+                p.succeed(1).flatMap { first =>
+                    p.succeed(2).flatMap { second =>
+                        CIO.defer((first, second))
+                    }
+                }
+            }
+        c.map {
+            case (true, false) => succeed
+            case other         => fail(s"expected (true, false), got: $other")
+        }
+    }
+    "fail then get surfaces the error" in run {
+        val err = new RuntimeException("p-err")
+        val c =
+            CPromise.init[Int].flatMap { p =>
+                p.fail(err).flatMap { _ =>
+                    p.get.liftToTry
+                }
+            }
+        c.map {
+            case Failure(t: RuntimeException) => assert(t.getMessage == "p-err")
+            case other                        => fail(s"expected Failure(RuntimeException), got: $other")
+        }
+    }
+    "poll returns None before completion, Some(Success) after succeed, Some(Failure) after fail" in run {
+        val t = new RuntimeException("poll-err")
+        val c =
+            CPromise.init[Int].flatMap { p =>
+                p.poll.flatMap { before =>
+                    p.succeed(7).flatMap { _ =>
+                        p.poll.flatMap { afterSucceed =>
+                            CPromise.init[Int].flatMap { p2 =>
+                                p2.fail(t).flatMap { _ =>
+                                    p2.poll.flatMap { afterFail =>
+                                        CIO.defer((before, afterSucceed, afterFail))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        c.map {
+            case (None, Some(Success(7)), Some(Failure(e))) =>
+                assert(e eq t, s"expected same throwable, got: $e")
+            case other => fail(s"expected (None, Some(Success(7)), Some(Failure(t))), got: $other")
+        }
+    }
+    "done reports the promise's completion state" in run {
+        val c =
+            CPromise.init[Int].flatMap { p =>
+                p.done.flatMap { before =>
+                    p.succeed(5).flatMap { _ =>
+                        p.done.flatMap { after =>
+                            CIO.defer((before, after))
+                        }
+                    }
+                }
+            }
+        c.map {
+            case (false, true) => succeed
+            case other         => fail(s"expected (false, true), got: $other")
+        }
+    }
+    "multiple gets on a completed promise all observe the value" in run {
+        // Two get calls awaiting the same promise must both observe the
+        // value once the promise is completed.
+        val ctr = new AtomicInteger(0)
+        val c =
+            CPromise.init[Int].flatMap { p =>
+                // Complete the promise first; then issue two sequential gets.
+                p.succeed(99).flatMap { _ =>
+                    p.get.liftToTry.flatMap { a =>
+                        p.get.liftToTry.flatMap { b =>
+                            CIO.defer {
+                                val _ = ctr.incrementAndGet()
+                                (a, b)
+                            }
+                        }
+                    }
+                }
+            }
+        c.map {
+            case (Success(99), Success(99)) => assert(ctr.get == 1)
+            case other                      => fail(s"expected both Success(99), got: $other")
+        }
+    }
+
+    // Multiple concurrent gets, then succeed → all observe value
+    "multiple concurrent gets all observe the value when promise is succeeded" in run {
+        val c =
+            CPromise.init[String].flatMap { p =>
+                CIO.foreach(1 to 5)(_ => CFiber.init(p.get)).flatMap { fibers =>
+                    CIO.sleep(50.millis).flatMap { _ =>
+                        p.succeed("v").flatMap { _ =>
+                            CIO.collectAll(fibers.toSeq.map(_.get))
+                        }
+                    }
+                }
+            }
+        c.map { results =>
+            assert(results.size == 5, s"expected 5 results, got ${results.size}")
+            assert(results.toSeq.forall(_ == "v"), s"expected all \"v\", got ${results.toSeq}")
+        }
+    }
+
+    // Multiple concurrent gets, then fail → all observe failure
+    "multiple concurrent gets all observe failure when promise is failed" in run {
+        val err = TestError("err")
+        val c =
+            CPromise.init[String].flatMap { p =>
+                CIO.foreach(1 to 5)(_ => CFiber.init(p.get.liftToTry)).flatMap { fibers =>
+                    CIO.sleep(50.millis).flatMap { _ =>
+                        p.fail(err).flatMap { _ =>
+                            CIO.collectAll(fibers.toSeq.map(_.get))
+                        }
+                    }
+                }
+            }
+        c.map { results =>
+            assert(results.size == 5, s"expected 5 results, got ${results.size}")
+            results.toSeq.foreach { r =>
+                assert(r.isFailure, s"expected Failure, got $r")
+                r match
+                    case Failure(e: TestError) => assert(e.msg == "err", s"wrong error msg: ${e.msg}")
+                    case other                 => fail(s"expected Failure(TestError(\"err\")), got $other")
+            }
+            succeed
+        }
+    }
+
+    // fail after succeed → fail returns false
+    "fail after succeed returns false (already settled)" in run {
+        val c =
+            CPromise.init[Int].flatMap { p =>
+                p.succeed(1).flatMap { firstResult =>
+                    p.fail(TestError("e")).flatMap { secondResult =>
+                        CIO.defer((firstResult, secondResult))
+                    }
+                }
+            }
+        c.map { case (firstResult, secondResult) =>
+            assert(firstResult == true, s"expected succeed to return true, got $firstResult")
+            assert(secondResult == false, s"expected fail after succeed to return false, got $secondResult")
+        }
+    }
+
+    // CPromise round-trip lift/lower
+    // Init promise, lift its lower, succeed via the lifted view, get returns the value.
+    "CPromise round-trip lift/lower: succeed via lifted view, get returns value" in run {
+        val c =
+            CPromise.init[Int].flatMap { p =>
+                val lifted = CPromise.lift(p.lower)
+                lifted.succeed(77).flatMap { ok =>
+                    lifted.get.flatMap { v =>
+                        CIO.defer((ok, v))
+                    }
+                }
+            }
+        c.map { case (ok, v) =>
+            assert(ok == true, s"expected succeed to return true, got $ok")
+            assert(v == 77, s"expected get to return 77, got $v")
+        }
+    }
+
+end PromiseTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/RaceZipTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/RaceZipTest.scala
@@ -1,0 +1,146 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+
+class RaceZipTest extends CompatTest:
+
+    "race(a, b) returns first completion" in run {
+        // Deterministic version: race a value-producing CIO against never.
+        val c = CIO.race[Int](CIO.defer { 1 }, CIO.never)
+        c.map(r => assert(r == 1))
+    }
+    "zip(a, b) returns tuple arity 2" in run {
+        val c = CIO.zip(CIO.defer { 1 }, CIO.defer { "x" })
+        c.map(r => assert(r == ((1, "x"))))
+    }
+    "zip arity 3" in run {
+        val c = CIO.zip(CIO.defer { 1 }, CIO.defer { 2 }, CIO.defer { 3 })
+        c.map(r => assert(r == ((1, 2, 3))))
+    }
+    "zip arity 5" in run {
+        val c = CIO.zip(CIO.defer { 1 }, CIO.defer { 2 }, CIO.defer { 3 }, CIO.defer { 4 }, CIO.defer { 5 })
+        c.map(r => assert(r == ((1, 2, 3, 4, 5))))
+    }
+    "zip arity 7" in run {
+        val c = CIO.zip(
+            CIO.defer { 1 },
+            CIO.defer { 2 },
+            CIO.defer { 3 },
+            CIO.defer { 4 },
+            CIO.defer { 5 },
+            CIO.defer { 6 },
+            CIO.defer { 7 }
+        )
+        c.map(r => assert(r == ((1, 2, 3, 4, 5, 6, 7))))
+    }
+    "zip propagates failure from any leg" in run {
+        val a: CIO[Int]     = CIO.defer { 1 }
+        val b: CIO[Nothing] = CIO.fail(TestError("oops"))
+        val c               = CIO.zip(a, b)
+        c.liftToTry.map {
+            case Failure(e: TestError) if e.msg == "oops" => succeed
+            case other                                    => fail(s"expected Failure(TestError(\"oops\")), got: $other")
+        }
+    }
+    "race propagates failure if all racers fail" in run {
+        // When all racing legs fail, race must propagate one of the failures.
+        val a: CIO[Int] = CIO.fail(TestError("a"))
+        val b: CIO[Int] = CIO.fail(TestError("b"))
+        val c           = CIO.race(a, b)
+        c.liftToTry.map {
+            case Failure(e: TestError) => assert(e.msg == "a" || e.msg == "b", s"expected \"a\" or \"b\", got: ${e.msg}")
+            case Failure(e)            => fail(s"expected Failure(TestError), got Failure($e)")
+            case other                 => fail(s"expected Failure, got: $other")
+        }
+    }
+    "zip runs in parallel (timing canary)" in run {
+        // Both legs sleep ~100ms; concurrent execution should keep elapsed
+        // well under 5s on any backend (5s upper bound is loose to tolerate
+        // shared CI runners). The canary catches obviously sequential
+        // implementations. We measure at the test driver via System.nanoTime
+        // because CIO does not expose `flatMap` through the opaque alias.
+        val a     = CIO.delay(100.millis)(CIO.defer { 1 })
+        val b     = CIO.delay(100.millis)(CIO.defer { 2 })
+        val start = java.lang.System.nanoTime()
+        CIO.zip(a, b).map { tup =>
+            val elapsed = (java.lang.System.nanoTime() - start) / 1_000_000L
+            assert(tup == ((1, 2)) && elapsed < 5_000L, s"tup=$tup elapsed=$elapsed ms (parallelism canary)")
+        }
+    }
+    "zip arity 4 returns 4-tuple" in run {
+        // CIO.zip of four values returns the matching 4-tuple.
+        val c = CIO.zip(CIO.value(1), CIO.value(2), CIO.value(3), CIO.value(4))
+        c.map(r => assert(r == ((1, 2, 3, 4))))
+    }
+
+    "zip arity 6 returns 6-tuple" in run {
+        // CIO.zip of six values returns the matching 6-tuple.
+        val c = CIO.zip(
+            CIO.value(1),
+            CIO.value(2),
+            CIO.value(3),
+            CIO.value(4),
+            CIO.value(5),
+            CIO.value(6)
+        )
+        c.map(r => assert(r == ((1, 2, 3, 4, 5, 6))))
+    }
+
+    "race with fast success and slow failure → success wins" in run {
+        // race(fast-success, slow-failure). The fast success arrives first;
+        // the slow failure never propagates. Result is Success(1).
+        val c = CIO.race(
+            CIO.sleep(20.millis).flatMap(_ => CIO.value(1)),
+            CIO.sleep(200.millis).flatMap(_ => CIO.fail(TestError("slow")))
+        )
+        c.liftToTry.map {
+            case scala.util.Success(v) => assert(v == 1, s"expected Success(1), got Success($v)")
+            case other                 => fail(s"expected Success(1), got: $other")
+        }
+    }
+
+    "race with slow success and fast failure → semantics documented" in run {
+        // race(slow-success, fast-failure). Most race implementations take
+        // whichever completes first; a fast failure typically wins and the result
+        // is Failure(TestError("fast")). Some implementations may keep racing
+        // until a success arrives, in which case Success(1) is returned.
+        // Both outcomes are valid per the CIO race contract — document here.
+        val c = CIO.race(
+            CIO.sleep(200.millis).flatMap(_ => CIO.value(1)),
+            CIO.sleep(20.millis).flatMap(_ => CIO.fail(TestError("fast")))
+        )
+        c.liftToTry.map { result =>
+            // Accept either: fast failure wins or slow success wins.
+            result match
+                case scala.util.Failure(e: TestError) if e.msg == "fast" =>
+                    succeed // failure-first race semantics
+                case scala.util.Success(1) =>
+                    succeed // success-biased race semantics
+                case other =>
+                    fail(s"expected Failure(TestError(\"fast\")) or Success(1), got: $other")
+        }
+    }
+
+    "zip with all legs failing → first-arrival failure propagates" in run {
+        // All legs fail; the first to fail (immediately) determines the
+        // failure propagated. liftToTry must yield Failure with message "a".
+        // Explicit Unit ascriptions prevent the kyo backend from inferring
+        // CIO[Nothing] for the fail branches (Nothing triggers type errors in
+        // the zip inline that casts result slots with asInstanceOf).
+        val c = CIO.zip(
+            CIO.fail(TestError("a")): CIO[Unit],
+            CIO.sleep(50.millis).flatMap((_: Unit) => CIO.fail(TestError("b")): CIO[Unit]),
+            CIO.sleep(100.millis).flatMap((_: Unit) => CIO.fail(TestError("c")): CIO[Unit])
+        )
+        c.liftToTry.map {
+            case scala.util.Failure(e: TestError) =>
+                assert(e.msg == "a", s"expected failure \"a\" (first to fail), got: ${e.msg}")
+            case other => fail(s"expected Failure(TestError), got: $other")
+        }
+    }
+
+end RaceZipTest

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/TimeTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/TimeTest.scala
@@ -1,0 +1,283 @@
+package kyo.compat
+
+import java.util.concurrent.atomic.AtomicInteger
+import kyo.compat.*
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+class TimeTest extends CompatTest:
+    "sleep delays without crashing" in run {
+        // Trigger a sleep and verify it returns Unit. Wall-clock-precision
+        // assertions (`elapsed >= 30ms`) live in each backend's test file.
+        CIO.sleep(20.millis).map(r => assert(r == ((): Unit)))
+    }
+    "now returns without error" in run {
+        // Type is java.time.Instant on all backends.
+        CIO.now.unit.map(_ => succeed)
+    }
+    "nowMonotonic is non-decreasing across two reads" in run {
+        // The Duration type returned by `nowMonotonic` is FiniteDuration on all backends.
+        // We read elapsed millis via `CIO.nowMonotonic.map(_.toMillis)` and chain
+        // through `flatMap` so both reads happen under the same scope/runtime.
+        val c =
+            CIO.nowMonotonic.map(_.toMillis).flatMap { a =>
+                CIO.sleep(2.millis).flatMap { _ =>
+                    CIO.nowMonotonic.map(_.toMillis).flatMap { b =>
+                        CIO.defer((a, b))
+                    }
+                }
+            }
+        c.map { case (a, b) => assert(b >= a, s"expected $b >= $a") }
+    }
+    "timeout returns Some on completion within d" in run {
+        val c = CIO.timeout(500.millis)(CIO.defer { 42 })
+        c.map(r => assert(r == Some(42)))
+    }
+    "timeout returns None on expiry" in run {
+        // Use never as the inner so we deterministically hit the timeout.
+        val c = CIO.timeout(50.millis)(CIO.never)
+        c.map(r => assert(r == None))
+    }
+    "timeoutWithError fails with custom error on expiry" in run {
+        val c: CIO[Nothing] = CIO.timeoutWithError(50.millis)(TestError("expired"))(CIO.never)
+        c.liftToTry.map {
+            case Failure(e: TestError) if e.msg == "expired" => succeed
+            case other                                       => fail(s"expected Failure(TestError(\"expired\")), got: $other")
+        }
+    }
+    "delay waits then runs" in run {
+        val c = CIO.delay(20.millis)(CIO.defer { 42 })
+        c.map(r => assert(r == 42))
+    }
+    "now returns Instant close to system clock" in run {
+        // CIO.now returns java.time.Instant; check it's within 5s of system clock.
+        val sys = java.lang.System.currentTimeMillis()
+        val c =
+            CIO.now.flatMap { now =>
+                CIO.defer {
+                    val deltaMs = math.abs(now.toEpochMilli - sys)
+                    deltaMs < 5_000L
+                }
+            }
+        c.map(r => assert(r, "CIO.now was more than 5s from system clock"))
+    }
+    "sleep delays at least the requested duration (wall-clock)" in run {
+        val start = java.lang.System.nanoTime()
+        CIO.sleep(50.millis).map { _ =>
+            val elapsed = (java.lang.System.nanoTime() - start) / 1_000_000L
+            assert(elapsed >= 30L && elapsed < 5_000L, s"elapsed=$elapsed ms")
+        }
+    }
+    "delay waits at least the requested duration (wall-clock)" in run {
+        val start = java.lang.System.nanoTime()
+        CIO.delay(50.millis)(CIO.defer { 42 }).map { out =>
+            val elapsed = (java.lang.System.nanoTime() - start) / 1_000_000L
+            assert(out == 42 && elapsed >= 30L && elapsed < 5_000L, s"out=$out elapsed=$elapsed ms")
+        }
+    }
+    "FiniteDuration: 500L.millis materializes as FiniteDuration with correct millis" in run {
+        // actually suspends for the expected duration, measured via CIO.nowMonotonic.
+        val d: FiniteDuration = 500L.millis
+        assert(d.toMillis == 500L, s"expected 500ms, got ${d.toMillis}ms")
+        val c =
+            CIO.nowMonotonic.map(_.toMillis).flatMap { before =>
+                CIO.sleep(500L.millis).flatMap { _ =>
+                    CIO.nowMonotonic.map(_.toMillis).flatMap { after =>
+                        CIO.defer(after - before)
+                    }
+                }
+            }
+        c.map { elapsedMs =>
+            assert(elapsedMs >= 400L && elapsedMs < 30_000L, s"elapsed=$elapsedMs ms (expected >= 400ms)")
+        }
+    }
+    "FiniteDuration: (1.second + 250.millis).toMillis == 1250" in run {
+        val d: FiniteDuration = 1.second + 250.millis
+        val ms: Long          = d.toMillis
+        CIO.value(ms).map { result =>
+            assert(result == 1250L, s"expected 1250ms, got ${result}ms")
+        }
+    }
+    "java.time.Instant: CIO.now toEpochMilli is within 5s of System.currentTimeMillis" in run {
+        val sys = java.lang.System.currentTimeMillis()
+        CIO.now.map { instant =>
+            val deltaMs = math.abs(instant.toEpochMilli - sys)
+            assert(deltaMs < 5_000L, s"deltaMs=$deltaMs (expected < 5000ms)")
+        }
+    }
+    "FiniteDuration: CIO.timeout(50.millis)(CIO.never) resolves to None" in run {
+        val c = CIO.timeout(50.millis)(CIO.never)
+        c.map { r =>
+            assert(r == None, s"expected None, got $r")
+        }
+    }
+    // ----- FiniteDuration extended API tests -----
+    "FiniteDuration: subtraction (1.second + 250.millis - 100.millis).toMillis == 1150" in run {
+        val d: FiniteDuration = 1.second + 250.millis - 100.millis
+        CIO.value(d.toMillis).map { result =>
+            assert(result == 1150L, s"expected 1150ms, got ${result}ms")
+        }
+    }
+    "FiniteDuration: multiply by Long (2.seconds * 3L).toSeconds == 6" in run {
+        val d: FiniteDuration = 2.seconds * 3L
+        CIO.value(d.toSeconds).map { result =>
+            assert(result == 6L, s"expected 6s, got ${result}s")
+        }
+    }
+    "FiniteDuration: divide by Long (2.seconds / 2L).toSeconds == 1" in run {
+        val d: FiniteDuration = 2.seconds / 2L
+        CIO.value(d.toSeconds).map { result =>
+            assert(result == 1L, s"expected 1s, got ${result}s")
+        }
+    }
+    "FiniteDuration: multiply by Long (3.seconds * 2L).toMillis == 6000" in run {
+        val d: FiniteDuration = 3.seconds * 2L
+        CIO.value(d.toMillis).map { result =>
+            assert(result == 6000L, s"expected 6000ms, got ${result}ms")
+        }
+    }
+    "FiniteDuration: isZero — Duration.Zero is zero, 1.second is not" in run {
+        val zero: FiniteDuration = Duration.Zero
+        CIO.value((zero.length == 0L, 1.second.length == 0L)).map { case (zeroIsZero, secondIsZero) =>
+            assert(zeroIsZero, "Duration.Zero.length == 0L should be true")
+            assert(!secondIsZero, "1.second.length == 0L should be false")
+        }
+    }
+    "FiniteDuration: ordering — 1.second < 2.seconds" in run {
+        val a: FiniteDuration = 1.second
+        val b: FiniteDuration = 2.seconds
+        CIO.value(a < b).map { result =>
+            assert(result, "1.second < 2.seconds should be true")
+        }
+    }
+    "FiniteDuration: min and max" in run {
+        val a: FiniteDuration = 1.second
+        val b: FiniteDuration = 2.seconds
+        CIO.value((a.min(b).toMillis, a.max(b).toMillis)).map { case (minMs, maxMs) =>
+            assert(minMs == 1000L, s"min(1s, 2s) should be 1000ms, got $minMs")
+            assert(maxMs == 2000L, s"max(1s, 2s) should be 2000ms, got $maxMs")
+        }
+    }
+    "FiniteDuration: compareTo — 1.second.compareTo(2.seconds) < 0" in run {
+        val a: FiniteDuration = 1.second
+        val b: FiniteDuration = 2.seconds
+        CIO.value(a.compareTo(b)).map { result =>
+            assert(result < 0, s"1.second.compareTo(2.seconds) should be < 0, got $result")
+        }
+    }
+    "FiniteDuration: Duration.Zero constant has zero length" in run {
+        val zero: FiniteDuration = Duration.Zero
+        CIO.value(zero.length == 0L).map { result =>
+            assert(result, "Duration.Zero.length == 0L should be true")
+        }
+    }
+    "sleep(0) returns immediately within bounded window" in run {
+        val c =
+            CIO.nowMonotonic.map(_.toMillis).flatMap { t1 =>
+                CIO.sleep(0.millis).flatMap { _ =>
+                    CIO.nowMonotonic.map(_.toMillis).flatMap { t2 =>
+                        CIO.defer(t2 - t1)
+                    }
+                }
+            }
+        c.map { deltaMs =>
+            assert(deltaMs < 500L, s"sleep(0) took ${deltaMs}ms — expected < 500ms")
+        }
+    }
+
+    // sleep(50ms) + sleep(100ms) in parallel should take ~100ms, not ~150ms.
+    // Allow 250ms for CI noise.
+    "concurrent sleeps complete in parallel — total time ~max not sum" in run {
+        val c =
+            CIO.nowMonotonic.map(_.toMillis).flatMap { t1 =>
+                CIO.zip(CIO.sleep(50.millis), CIO.sleep(100.millis)).flatMap { _ =>
+                    CIO.nowMonotonic.map(_.toMillis).flatMap { t2 =>
+                        CIO.defer(t2 - t1)
+                    }
+                }
+            }
+        c.map { deltaMs =>
+            assert(deltaMs < 250L, s"concurrent sleeps took ${deltaMs}ms — expected < 250ms (parallel, not sequential)")
+        }
+    }
+
+    // Race semantics — accept either Some(7) or None, never crash.
+    "timeout when inner completes near deadline — Some or None (not crash)" in run {
+        val c = CIO.timeout(50.millis)(CIO.sleep(50.millis).flatMap(_ => CIO.defer(7)))
+        c.map { result =>
+            assert(result == Some(7) || result == None, s"expected Some(7) or None, got: $result")
+        }
+    }
+
+    // timeout(200ms)(timeout(50ms)(never)) — inner fires → None; outer wraps → Some(None).
+    // We accept result.flatten.isEmpty to cover both cases.
+    "nested timeouts — inner fires first, result is effectively None" in run {
+        val c = CIO.timeout(200.millis)(CIO.timeout(50.millis)(CIO.never))
+        c.map { result =>
+            assert(result.flatten.isEmpty, s"expected Some(None) or None, got: $result")
+        }
+    }
+
+    "timeoutWithError when inner succeeds in time — returns inner value" in run {
+        val c = CIO.timeoutWithError(500.millis)(TestError("nope"))(CIO.value(42))
+        c.map { result =>
+            assert(result == 42, s"expected 42, got: $result")
+        }
+    }
+
+    "timeoutWithError when inner fails in time — propagates inner failure not custom error" in run {
+        import scala.util.Failure
+        val c = CIO.timeoutWithError(500.millis)(TestError("custom"))(CIO.fail(TestError("inner")))
+        c.liftToTry.map {
+            case Failure(e: TestError) if e.msg == "inner" => succeed
+            case other                                     => fail(s"expected Failure(TestError(\"inner\")), got: $other")
+        }
+    }
+
+    // Body still runs; result is 42. The 1ns delay is essentially a no-op-with-yield.
+    "delay with 1.nanos duration runs the body and returns its value" in run {
+        val c = CIO.delay(1.nanos)(CIO.defer(42))
+        c.map { result =>
+            assert(result == 42, s"expected 42, got: $result")
+        }
+    }
+    "Duration extensions: Int variant 5.seconds.toMillis == 5000" in run {
+        val d: FiniteDuration = 5.seconds
+        CIO.value(d.toMillis).map(r => assert(r == 5000L, s"expected 5000, got $r"))
+    }
+
+    "0.seconds equals Duration.Zero" in run {
+        val d: FiniteDuration = 0.seconds
+        CIO.value(d.length == 0L).map(r => assert(r))
+    }
+
+    "negative duration: (-1).second.toMillis == -1000" in run {
+        val d: FiniteDuration = (-1).second
+        CIO.value(d.toMillis).map(r => assert(r == -1000L, s"expected -1000, got $r"))
+    }
+
+    "Duration extensions: 1.nano.toNanos == 1L" in run {
+        val d: FiniteDuration = 1.nano
+        CIO.value(d.toNanos).map(r => assert(r == 1L, s"expected 1, got $r"))
+    }
+
+    "Duration extensions: 1.day.toMillis == 86400000L" in run {
+        val d: FiniteDuration = 1.day
+        CIO.value(d.toMillis).map(r => assert(r == 86_400_000L, s"expected 86400000, got $r"))
+    }
+
+    "all 14 duration unit methods compile on both Long and Int receivers" in run {
+        val longSum: FiniteDuration =
+            1L.nano + 1L.nanos + 1L.micro + 1L.micros + 1L.milli + 1L.millis +
+                1L.second + 1L.seconds + 1L.minute + 1L.minutes + 1L.hour + 1L.hours +
+                1L.day + 1L.days
+        val intSum: FiniteDuration =
+            1.nano + 1.nanos + 1.micro + 1.micros + 1.milli + 1.millis +
+                1.second + 1.seconds + 1.minute + 1.minutes + 1.hour + 1.hours +
+                1.day + 1.days
+        CIO.value((longSum.toNanos > 0L, intSum.toNanos > 0L)).map { case (a, b) =>
+            assert(a && b)
+        }
+    }
+
+end TimeTest

--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -468,6 +468,20 @@ object Channel:
                 require(takes.offer(promise), "reuseTake: unbounded queue offer must not fail")
                 flush()
             end reuseTake
+
+            /** Skip-if-cancelled poll: when the outer fiber that called Channel.put is interrupted while suspended on the put promise, the
+              * promise transitions to an Error state but the Put.Value stays in the puts queue. Naive consumers would deliver the cancelled
+              * producer's value to a future take — silently violating the interrupt-during-put-must-not-deliver contract honored by other
+              * concurrent Queue primitives (cats-effect, ZIO, Loom). Consume sites use this helper to drop cancelled Put.Value entries and
+              * recurse to the next live producer. Put.Batch entries are returned as-is; their per-element completion path handles partial
+              * cancellation differently.
+              */
+            @tailrec
+            final protected def pollNextLive()(using AllowUnsafe, Frame): Maybe[Put[A]] =
+                priorityPuts.poll().orElse(puts.poll()) match
+                    case Absent                                           => Absent
+                    case Present(Put.Value(_, promise)) if promise.done() => pollNextLive()
+                    case Present(p)                                       => Present(p)
         end BaseUnsafe
 
         final class ZeroCapacityUnsafe[A](val initFrame: Frame)(using allow: AllowUnsafe) extends BaseUnsafe[A]:
@@ -537,7 +551,7 @@ object Channel:
 
             def poll()(using AllowUnsafe, Frame) =
                 succeedIfOpen {
-                    priorityPuts.poll().orElse(puts.poll()) match
+                    pollNextLive() match
                         case Absent =>
                             Absent
                         case Present(Put.Value(value, promise)) =>
@@ -555,7 +569,7 @@ object Channel:
                 def loop(current: Chunk[A], i: Int): Result[Closed, Chunk[A]] =
                     if i <= 0 then Result.Success(current)
                     else
-                        priorityPuts.poll().orElse(puts.poll()) match
+                        pollNextLive() match
                             case Absent =>
                                 flush()
                                 succeedIfNonEmptyOrOpen(current)
@@ -576,7 +590,7 @@ object Channel:
             def drain()(using AllowUnsafe, Frame) =
                 @tailrec
                 def loop(current: Chunk[A]): Result[Closed, Chunk[A]] =
-                    priorityPuts.poll().orElse(puts.poll()) match
+                    pollNextLive() match
                         case Absent =>
                             succeedIfNonEmptyOrOpen(current)
                         case Present(Put.Value(value, promise)) =>
@@ -626,7 +640,7 @@ object Channel:
                                 pendingBatch = Absent
                                 Present(batch: Put[A])
                             case _ =>
-                                priorityPuts.poll().orElse(puts.poll())
+                                pollNextLive()
                         put.foreach {
                             case put @ Put.Value(value, promise) =>
                                 takes.poll() match
@@ -802,7 +816,7 @@ object Channel:
                     // Attempt to transfer a value from a waiting put operation to the queue.
                     // Only one thread processes puts at a time to prevent batch interleaving.
                     if batchInProgress.compareAndSet(false, true) then
-                        priorityPuts.poll().orElse(puts.poll()).foreach {
+                        pollNextLive().foreach {
                             case Put.Batch(chunk, promise) =>
                                 // NB: this is only efficient if chunk is effectively indexed
                                 // (i.e. Chunk.Indexed or Chunk.Drop with Chunk.Indexed underlying)
@@ -835,7 +849,7 @@ object Channel:
                     // Directly transfer a value from a producer to a consumer when the queue is empty.
                     // Only one thread processes puts at a time to prevent batch interleaving.
                     if batchInProgress.compareAndSet(false, true) then
-                        priorityPuts.poll().orElse(puts.poll()).foreach {
+                        pollNextLive().foreach {
                             case put @ Put.Value(value, promise) =>
                                 takes.poll() match
                                     case Present(takePromise) if takePromise.complete(Result.succeed(value)) =>

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,0 +1,17 @@
+// Wire the in-tree `kyo-compat` plugin (artifact `kyo-compat`) into the
+// meta-build so that `build.sbt` can call `compatLibrary("...")...` and
+// reference `CompatBackend.{Future, Kyo, Zio, Ce, Ox}` directly.
+//
+// `kyo-compat` is also declared as a regular project in the root
+// `build.sbt`, but that project is only built when the outer build
+// asks for it (`kyo-compat/compile`, `kyo-compat/scripted`, etc.). To
+// make the plugin's classes available DURING outer-build evaluation
+// (so that `compatLibrary(...)` parses), the plugin's source directory
+// is added to the meta-build's own compile sources.
+//
+// Plugin compile-time deps (sbt-scalajs-crossproject,
+// sbt-scala-native-crossproject) come from `project/plugins.sbt` —
+// they're already there because the outer build itself uses
+// crossProject in build.sbt.
+Compile / unmanagedSourceDirectories +=
+    baseDirectory.value.getParentFile / "kyo-compat" / "plugin" / "src" / "main" / "scala"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,14 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh"        % "0.4.8")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"   % "2.5.6")
 addSbtPlugin("com.github.sbt"     % "sbt-ci-release" % "1.11.2")
 
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.21.0")
-
+// kyo-compat (in-tree plugin, wired in via project/build.sbt) needs
+// these on the meta-build's compile classpath too; see project/build.sbt.
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.21.0")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+// sbt-projectmatrix backs kyo-compat's per-backend row generation.
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.10.1")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.8.2")
 


### PR DESCRIPTION
## Problem

Developing libraries in Scala is cumbersome because the ecosystem has multiple effect stacks people might want to use a library with. The common solution is typeclasses or hardcoding to a specific stack. Typeclasses add dispatch overhead and leak `F[_]` into signatures, still miss stacks without a lawful instance (Ox, plain `Future`), and degrade features like tracing. Hardcoding cuts off every consumer on a different runtime.

## Solution

`kyo-compat`: write a library once against the `kyo.compat.*` surface and ship it to 6 backends (Kyo, ZIO, Cats Effect, Future, Ox, Twitter Future), selected by the consumer at deploy time.

- `CIO[+A]` is a per-backend opaque type; every method is `inline def` and lowers to the backend primitive (no dispatch, no adapters).
- Fully isolated from Kyo's runtime. Each `kyo-compat-<backend>` artifact depends only on its target library and nothing else: no kyo-core, no Kyo runtime. A non-Kyo consumer (e.g. a ZIO user) pulls zero Kyo code.
- Cross-platform JVM/JS/Native, per each backend's supported set.
- An sbt plugin (`compatLibrary`) cross-publishes every `(backend x platform x scala-version)` cell from a single source tree.

See `kyo-compat/README.md` for the full surface and usage.

## Notes

- Two commits: a kyo-core `Channel` fix (cancelled producers no longer deliver their value), a prerequisite for the Kyo binding; and the `kyo-compat` module itself.
- Backend/platform support is not uniform: Future/Ox/Twitter Future are JVM-only, Cats Effect is JVM+JS, Kyo/ZIO are all three.
- Every binding runs the same shared test suite, verifying consistent behavior across backends and platforms.
- Out of scope by design: streams, scoped-resource types, and the Kyo/ZIO defect channel. Reach them via `c.lower`.
