### PR TITLE
[scheduler] deliver fiber interrupts reliably

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -31,12 +31,16 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
     final override def removeFinalizer(f: Maybe[Error[Any]] => Unit) =
         finalizers = finalizers.remove(f)
 
-    // Bridges fiber-level interruption to thread-level interruption. When the promise is
-    // successfully interrupted (CAS from Pending to Error), sets the needsInterrupt flag
-    // and wakes the BlockingMonitor for immediate scan. If the worker thread is blocked
-    // (flat CPU time), Thread.interrupt() is dispatched within ~100μs.
+    // Fiber interruption is recorded by IOPromise.interrupt's CAS of the promise state to
+    // Error — the single source of truth. needsInterrupt and eval's stop check both read
+    // it, so an interrupt can never be lost to a racing scheduler-level state update.
+    final override def needsInterrupt(): Boolean =
+        !isPending()
+
+    // Wakes the BlockingMonitor for an immediate scan. If the worker thread is blocked
+    // (flat CPU time), Thread.interrupt() is dispatched once the monitor observes the
+    // interrupted promise.
     final override def preInterrupt(): Boolean =
-        requestInterrupt()
         Scheduler.get.notifyInterrupt()
         true
     end preInterrupt
@@ -51,7 +55,11 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
                 Isolate.internal.restoring(trace, this) {
                     ArrowEffect.handlePartial(erasedAbortTag, Tag[Async.Join], curr, context)(
                         stop =
-                            shouldPreempt() || (deadline != Long.MaxValue && clock.currentMillis() > deadline),
+                            // !isPending() is the authoritative interrupt signal — IOPromise.interrupt
+                            // CAS-completes the promise, so checking it here stops an interrupted fiber even if
+                            // the racing scheduler preemption flag was lost. Ordered after shouldPreempt() and
+                            // the deadline check so a step that stops for either of those skips the read.
+                            shouldPreempt() || (deadline != Long.MaxValue && clock.currentMillis() > deadline) || !isPending(),
                         [C] =>
                             (input, cont) =>
                                 locally {

--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -59,7 +59,7 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
                             // CAS-completes the promise, so checking it here stops an interrupted fiber even if
                             // the racing scheduler preemption flag was lost. Ordered after shouldPreempt() and
                             // the deadline check so a step that stops for either of those skips the read.
-                            shouldPreempt() || (deadline != Long.MaxValue && clock.currentMillis() > deadline) || !isPending(),
+                            shouldPreempt() || (deadline != Long.MaxValue && clock.currentMillis() > deadline) || needsInterrupt(),
                         [C] =>
                             (input, cont) =>
                                 locally {

--- a/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/AsyncTest.scala
@@ -142,6 +142,25 @@ class AsyncTest extends Test:
                 _            <- done.await
             yield assert(interrupted1 && interrupted2 && interrupted3)
         }
+        "repeated — interrupt of a running fiber is never lost" in runNotJS {
+            // Regression: interrupting a fiber that is actively running (not suspended)
+            // must not be lost to a scheduler state update racing on another thread. The
+            // race is intermittent, so the single-fiber scenario is repeated; a lost
+            // interrupt leaves the Scope finalizer unrun and hangs on done.await.
+            def once =
+                for
+                    started     <- Latch.init(1)
+                    done        <- Latch.init(1)
+                    fiber       <- Fiber.initUnscoped(runLoop(started, done))
+                    _           <- started.await
+                    interrupted <- fiber.interrupt(panic)
+                    _           <- done.await
+                yield interrupted
+            def repeat(n: Int): Assertion < (Abort[Any] & Async & Scope) =
+                if n <= 0 then succeed
+                else once.map(i => if i then repeat(n - 1) else fail("interrupt returned false"))
+            repeat(50)
+        }
     }
 
     "race" - {

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/BlockingMonitor.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/BlockingMonitor.scala
@@ -25,7 +25,7 @@ import scala.util.control.NonFatal
   *
   * ==Interrupt dispatch==
   *
-  * When a fiber is interrupted, the task's needsInterrupt flag is set and the monitor is woken for an immediate scan via wake(). If the
+  * When a fiber is interrupted, the task reports it via needsInterrupt() and the monitor is woken for an immediate scan via wake(). If the
   * worker's thread is blocked, Thread.interrupt() is dispatched to wake it from the blocking operation. The monitor re-interrupts on
   * subsequent cycles if the thread re-blocks (e.g., code that catches InterruptedException and retries).
   *
@@ -51,7 +51,7 @@ import scala.util.control.NonFatal
   * @see
   *   Worker for the blocked flag and checkAvailability
   * @see
-  *   Task for needsInterrupt/requestInterrupt
+  *   Task for needsInterrupt
   */
 private[scheduler] class BlockingMonitor(
     workers: Array[Worker],

--- a/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/BlockingMonitorTest.scala
+++ b/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/BlockingMonitorTest.scala
@@ -532,8 +532,8 @@ class BlockingMonitorTest extends AnyFreeSpec with NonImplicitAssertions {
             assert(started.await(5, TimeUnit.SECONDS))
             Thread.sleep(10)
 
-            task.requestInterrupt()
-            assert(task.needsInterrupt(), "needsInterrupt should be set after requestInterrupt")
+            task.interrupted = true
+            assert(task.needsInterrupt(), "needsInterrupt should reflect the interrupt flag")
 
             eventually(timeout(scaled(org.scalatest.time.Span(2, org.scalatest.time.Seconds)))) {
                 assert(interrupted.get(), "blocked thread should receive Thread.interrupt()")
@@ -591,7 +591,7 @@ class BlockingMonitorTest extends AnyFreeSpec with NonImplicitAssertions {
             assert(started.await(5, TimeUnit.SECONDS))
             Thread.sleep(10)
 
-            task.requestInterrupt()
+            task.interrupted = true
 
             eventually(timeout(scaled(org.scalatest.time.Span(5, org.scalatest.time.Seconds)))) {
                 assert(interruptCount.get() >= 3, s"expected at least 3 interrupts, got ${interruptCount.get()}")
@@ -666,7 +666,7 @@ class BlockingMonitorTest extends AnyFreeSpec with NonImplicitAssertions {
             assert(started.await(10, TimeUnit.SECONDS))
             Thread.sleep(10)
 
-            tasks.foreach(_.requestInterrupt())
+            tasks.foreach(t => t.interrupted = true)
 
             eventually(timeout(scaled(Span(5, Seconds)))) {
                 (0 until count).foreach { i =>
@@ -707,7 +707,7 @@ class BlockingMonitorTest extends AnyFreeSpec with NonImplicitAssertions {
             Thread.sleep(20)
 
             // Request interrupt on all tasks simultaneously
-            tasks.foreach(_.requestInterrupt())
+            tasks.foreach(t => t.interrupted = true)
             scheduler.notifyInterrupt()
 
             // All tasks should eventually get interrupted. With blockThreshold=2 and
@@ -744,7 +744,7 @@ class BlockingMonitorTest extends AnyFreeSpec with NonImplicitAssertions {
             assert(started.await(5, TimeUnit.SECONDS))
             Thread.sleep(10)
 
-            task.requestInterrupt()
+            task.interrupted = true
 
             // Monitor should re-interrupt on each cycle when thread re-blocks
             eventually(timeout(scaled(Span(10, Seconds)))) {
@@ -803,8 +803,8 @@ class BlockingMonitorTest extends AnyFreeSpec with NonImplicitAssertions {
             Thread.sleep(30)
 
             // Request interrupt on ALL 4 tasks
-            blockingTasks.foreach(_.requestInterrupt())
-            activeTasks.foreach(_.requestInterrupt())
+            blockingTasks.foreach(t => t.interrupted = true)
+            activeTasks.foreach(t => t.interrupted = true)
             scheduler.notifyInterrupt()
 
             // Blocking tasks should get interrupted
@@ -857,7 +857,7 @@ class BlockingMonitorTest extends AnyFreeSpec with NonImplicitAssertions {
             assert(firstStarted.await(60, TimeUnit.SECONDS))
 
             // Request interrupt while first task is blocking
-            firstTask.requestInterrupt()
+            firstTask.interrupted = true
             scheduler.notifyInterrupt()
 
             // Wait for first task to complete
@@ -1024,66 +1024,43 @@ class BlockingMonitorTest extends AnyFreeSpec with NonImplicitAssertions {
 
     "task bit-packing" - {
 
-        "requestInterrupt preserves runtime across preemption" in {
+        "runtime preserved across preemption" in {
             val task = new TaskTestHelper(10)
             assert(task.checkRuntime() == 11) // initial 1 + added 10
 
             task.doPreempt()
             assert(task.checkShouldPreempt())
             assert(task.checkRuntime() == 11, "doPreempt should not change runtime")
-
-            task.requestInterrupt()
-            assert(task.needsInterrupt())
-            assert(task.checkShouldPreempt(), "requestInterrupt should keep preemption")
-            assert(task.checkRuntime() == 11, "requestInterrupt should not change runtime")
         }
 
-        "addRuntime preserves interrupt bit" in {
+        "addRuntime accumulates runtime and clears preemption" in {
             val task = new TaskTestHelper(0)
-            task.requestInterrupt()
-            assert(task.needsInterrupt())
+            task.doPreempt()
+            assert(task.checkShouldPreempt())
 
             task.addRuntime(5)
-            assert(task.needsInterrupt(), "addRuntime should not clear interrupt bit")
             assert(task.checkRuntime() == 6, "runtime should be initial 1 + added 5")
             assert(!task.checkShouldPreempt(), "addRuntime should clear preemption (flip to positive)")
         }
 
-        "multiple requestInterrupt calls are idempotent" in {
+        "addRuntime accumulates runtime across preemption" in {
             val task = new TaskTestHelper(10)
-            task.requestInterrupt()
-            val r1 = task.checkRuntime()
-            val p1 = task.checkShouldPreempt()
-            task.requestInterrupt()
-            assert(task.checkRuntime() == r1, "repeated requestInterrupt should not change runtime")
-            assert(task.checkShouldPreempt() == p1, "repeated requestInterrupt should not change preemption")
-            assert(task.needsInterrupt())
+            task.doPreempt()
+            task.addRuntime(5)
+            assert(task.checkRuntime() == 16, "runtime accumulates regardless of the preemption flag")
         }
 
-        "ordering preserved with interrupt bit set" in {
+        "ordering preserved with preemption set" in {
             import scala.collection.mutable.PriorityQueue
             val t1 = Task((), 1)
             val t2 = Task((), 2)
             val t3 = Task((), 3)
-            t2.requestInterrupt()
+            t2.doPreempt()
             val q      = PriorityQueue(t2, t3, t1)
             val result = q.dequeueAll
             assert(result(0) eq t1, "lowest runtime first")
-            assert(result(1) eq t2, "middle runtime second (interrupt bit shouldn't affect order)")
+            assert(result(1) eq t2, "middle runtime second (preemption shouldn't affect order)")
             assert(result(2) eq t3, "highest runtime last")
-        }
-
-        "needsInterrupt works on both positive and negative state" in {
-            val task = new TaskTestHelper(5)
-            assert(!task.needsInterrupt(), "initially false")
-
-            task.requestInterrupt() // negates state
-            assert(task.needsInterrupt(), "true after requestInterrupt (negative state)")
-            assert(task.checkShouldPreempt(), "should be preempted")
-
-            task.addRuntime(1) // flips to positive
-            assert(task.needsInterrupt(), "true after addRuntime (positive state)")
-            assert(!task.checkShouldPreempt(), "should not be preempted after addRuntime")
         }
     }
 

--- a/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/TestTask.scala
+++ b/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/TestTask.scala
@@ -6,8 +6,13 @@ case class TestTask(
 ) extends Task {
     @volatile var executions  = 0
     @volatile var preemptions = 0
+    @volatile var interrupted = false
     override def doPreempt(): Unit =
         _preempt()
+    // Real IOTasks derive needsInterrupt from their promise; this test hook lets a
+    // BlockingMonitor test drive the monitor's interrupt-dispatch path directly.
+    override def needsInterrupt(): Boolean =
+        interrupted
     def run(startMillis: Long, clock: InternalClock, deadline: Long) =
         try {
             val r = _run()

--- a/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/WorkerTest.scala
+++ b/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/WorkerTest.scala
@@ -605,7 +605,7 @@ class WorkerTest extends AnyFreeSpec with NonImplicitAssertions with Eventually 
         val task = TestTask()
         assert(!task.needsInterrupt())
 
-        task.requestInterrupt()
+        task.interrupted = true
         assert(task.needsInterrupt())
     }
 }

--- a/kyo-scheduler/shared/src/main/scala/kyo/scheduler/Task.scala
+++ b/kyo-scheduler/shared/src/main/scala/kyo/scheduler/Task.scala
@@ -16,18 +16,12 @@ trait Task {
 
     def run(startMillis: Long, clock: InternalClock, deadline: Long): Task.Result
 
-    /** Marks this task for thread interrupt dispatch by the BlockingMonitor.
+    /** Whether the BlockingMonitor should dispatch Thread.interrupt() for this task.
       *
-      * Called by IOTask.interrupt when a fiber is interrupted. Sets the needsInterrupt flag and also forces preemption so the task yields
-      * at the next effect boundary. The BlockingMonitor periodically checks this flag and, if the worker thread's CPU time is flat (thread
-      * is blocked), dispatches Thread.interrupt() to wake it.
+      * Defaults to false — plain tasks are never interrupted. IOTask overrides this to derive interruption from its own promise state, the
+      * single source of truth for fiber interruption.
       */
-    def requestInterrupt(): Unit =
-        this.state = state.interrupt
-
-    /** Whether this task has been marked for thread interrupt dispatch. */
-    def needsInterrupt(): Boolean =
-        state.needsInterrupt
+    def needsInterrupt(): Boolean = false
 
     protected def runtime(): Int =
         state.runtime
@@ -38,46 +32,36 @@ trait Task {
 
 object Task {
 
-    /** Bit-packed task state encoding preemption, interrupt request, and runtime priority in a single Int.
+    /** Bit-packed task state encoding preemption and runtime priority in a single Int.
       *
-      * The encoding avoids additional volatile fields on the hot path by packing three concerns into one value:
-      *   - '''bit 0''': needsInterrupt — whether the BlockingMonitor should dispatch Thread.interrupt() for this task
-      *   - '''bits 1-30''': runtime — accumulated execution time, used for priority ordering (lower = higher priority)
-      *   - '''bit 31 (sign)''': preempting — when negative, the task should yield at the next effect boundary
+      *   - '''bits 0-30''': runtime — accumulated execution time, used for priority ordering (lower = higher priority)
+      *   - '''bit 31 (sign)''': preempting — when negative, the task should yield at the next effect boundary so the worker can serve other
+      *     queued tasks (time-slice fairness)
       *
-      * Key invariants:
-      *   - Negation preserves bit 0 in two's complement (odd numbers stay odd when negated), so preemption doesn't clear the interrupt flag
-      *   - addRuntime shifts by 1 (`v << 1`) to write into bits 1-30 without affecting the interrupt bit
-      *   - addRuntime always produces a positive (non-preempting) state, since runtime is added after task execution when preemption is no
-      *     longer relevant
+      * `state` is mutated by non-atomic read-modify-writes from two threads — the worker (addRuntime) and the coordinator (doPreempt, via
+      * Worker.checkStalling). A lost update can only drop a best-effort time-slice preemption (retried on the next checkStalling pass) or a
+      * runtime increment (a priority heuristic), so plain @volatile is sufficient. Fiber interruption is intentionally NOT tracked here: it
+      * is observed from IOPromise's CAS-updated state, so no cross-thread interrupt write exists to be lost.
       */
     private[scheduler] type State = Int
 
     private[scheduler] object State {
-        private val InterruptMask: Int = 1
 
-        /** Initial state: runtime = 1, no interrupt, not preempting. */
-        def init: State = 2
+        /** Initial state: runtime = 1, not preempting. */
+        def init: State = 1
 
         implicit class StateOps(private val s: State) extends AnyVal {
-            def preempting: Boolean     = s < 0
-            def needsInterrupt: Boolean = (s & InterruptMask) != 0
-            def runtime: Int            = (if (s < 0) -s else s) >>> 1
+            def preempting: Boolean = s < 0
+            def runtime: Int        = if (s < 0) -s else s
 
             /** Sets the preemption flag (negates). No-op if already preempting. */
             def preempt: State = -s
 
-            /** Sets both interrupt flag and preemption. */
-            def interrupt: State = {
-                val abs = if (s < 0) -s else s
-                -(abs | InterruptMask)
-            }
-
-            /** Adds execution time. Clears preemption (flips to positive) since runtime is added after task execution when preemption is no
-              * longer relevant.
+            /** Adds execution time, clearing the preemption flag (flips to positive): a time-slice preemption has been consumed by the time
+              * runtime is recorded.
               */
             def addRuntime(v: Int): State =
-                (if (s < 0) -s else s) + (v << 1)
+                (if (s < 0) -s else s) + v
         }
     }
 

--- a/kyo-scheduler/shared/src/test/scala/kyoTest/scheduler/TaskTest.scala
+++ b/kyo-scheduler/shared/src/test/scala/kyoTest/scheduler/TaskTest.scala
@@ -15,40 +15,58 @@ class TaskTest extends AnyFreeSpec with NonImplicitAssertions {
         def checkRuntime(): Int                                          = runtime()
     }
 
-    "needsInterrupt" - {
-        "returns false initially" in {
-            val t = new TestTask(5)
-            assert(!t.needsInterrupt())
-        }
-        "returns true after requestInterrupt" in {
-            val t = new TestTask(5)
-            t.requestInterrupt()
-            assert(t.needsInterrupt())
-        }
-        "requestInterrupt also preempts" in {
+    "preemption" - {
+        "not preempting initially" in {
             val t = new TestTask(5)
             assert(!t.checkShouldPreempt())
-            t.requestInterrupt()
+        }
+        "doPreempt sets preemption" in {
+            val t = new TestTask(5)
+            t.doPreempt()
             assert(t.checkShouldPreempt())
         }
-        "requestInterrupt on already-preempted task preserves runtime" in {
+        "addRuntime clears preemption" in {
             val t = new TestTask(10)
             t.doPreempt()
-            t.requestInterrupt()
-            assert(t.needsInterrupt())
             assert(t.checkShouldPreempt())
+            t.addRuntime(5)
+            assert(!t.checkShouldPreempt())
+        }
+    }
+
+    "runtime" - {
+        "starts at the initial value" in {
+            val t = new TestTask(10)
             assert(t.checkRuntime() == 11) // initial 1 + added 10
         }
-        "doPreempt preserves needsInterrupt flag" in {
-            val t = new TestTask(5)
-            t.requestInterrupt()
-            assert(t.needsInterrupt())
-            // addRuntime on negative state un-preempts but preserves bit 0
-            t.addRuntime(1)
-            assert(t.needsInterrupt())
+        "addRuntime accumulates" in {
+            val t = new TestTask(10)
+            t.addRuntime(5)
+            assert(t.checkRuntime() == 16)
+        }
+        "addRuntime accumulates while preempted" in {
+            val t = new TestTask(10)
             t.doPreempt()
-            assert(t.needsInterrupt())
-            assert(t.checkShouldPreempt())
+            t.addRuntime(5)
+            assert(t.checkRuntime() == 16)
+        }
+        "doPreempt does not change runtime" in {
+            val t = new TestTask(10)
+            t.doPreempt()
+            assert(t.checkRuntime() == 11)
+        }
+    }
+
+    "needsInterrupt" - {
+        // Interruption is no longer tracked on Task — IOTask derives it from its
+        // promise. A plain Task is never interrupted, so needsInterrupt stays false.
+        "false for a plain task, regardless of preemption or runtime" in {
+            val t = new TestTask(5)
+            assert(!t.needsInterrupt())
+            t.doPreempt()
+            assert(!t.needsInterrupt())
+            t.addRuntime(1)
+            assert(!t.needsInterrupt())
         }
     }
 


### PR DESCRIPTION
## Problem

`AsyncTest`'s `interrupt` tests ("one fiber", "multiple fibers") intermittently hung to the 60s test timeout — an intermittent CI failure on JVM and Native.

Root cause: a lost-update race on `Task.state`. That single `@volatile Int` packs the interrupt flag, the preemption flag, and accumulated runtime. `requestInterrupt` (called from the interrupting thread) and `addRuntime` (called from the worker thread in `Worker.runTask`'s finally block) both perform non-atomic read-modify-writes of it. `@volatile` provides visibility, not read-modify-write atomicity: a worker that read `state` *before* an interrupt landed and then wrote back `addRuntime(staleSnapshot)` silently clobbered the just-set interrupt and preemption bits. The interrupt was lost, `shouldPreempt()` stayed `false`, `IOTask.eval`'s evaluation loop never returned, the `Scope` finalizer never ran, and the fiber awaiting completion hung.

## Solution

Interruption is now sourced from `IOPromise`, whose state is CAS-completed to `Error` on interrupt and therefore cannot be lost. `IOTask.eval`'s stop check and `IOTask.needsInterrupt()` read it directly (`!isPending()`). `Task.requestInterrupt` is removed and `Task.state` packs only runtime and preemption — there is no longer a cross-thread interrupt write that can be raced. A looped regression test is added to `AsyncTest`.

## Notes

- A stress harness reproduced the hang at iteration 3 on unmodified code; with the fix it runs 1000+ consecutive iterations cleanly.
- Verified on JVM (`kyo-core` 1875, `kyo-scheduler` 170, `AsyncTest` 130), JS, and Native (`kyo-coreNative AsyncTest` 130 — the fix and regression test pass on Native).
- Scheduler-level interrupt unit tests are updated to the new model (interruption derived from the promise rather than a `Task` flag) — no coverage removed.
- `Task.state`'s remaining `doPreempt`/`addRuntime` race (runtime + preemption bits only) is benign: at worst a dropped best-effort time-slice preemption, retried on the next `checkStalling` pass.
