### PR TITLE
[direct] fix macro hygiene + Validate edge cases

### DIFF
--- a/kyo-direct/shared/src/main/scala/kyo/Direct.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/Direct.scala
@@ -136,36 +136,48 @@ private def impl[A: Type](body: Expr[A])(using quotes: Quotes): Expr[Any] =
         genSym = genSym + 1
         s"${name}_N$genSym"
 
-    val preparedBody = Trees.transform(body.asTerm) {
-        case Apply(
-                Apply(
-                    TypeApply(
-                        Apply(
-                            ta: TypeApply,
-                            List(a @ Apply(TypeApply(Ident("now"), List(t, s)), List(_)))
-                        ),
-                        types0
-                    ),
-                    args0
-                ),
-                args1
-            ) if t.tpe.typeSymbol.flags.is(Flags.Opaque) =>
-
-            val newVal: Symbol = Symbol.newVal(
-                Symbol.spliceOwner,
-                freshName("opaqueAlias"),
-                t.tpe,
-                Flags.Private,
-                Symbol.noSymbol
-            )
-            Block(
-                List(ValDef(newVal, Some(a))),
-                Apply(
-                    Apply(TypeApply(Apply(ta, List(Ident(newVal.termRef))), types0), args0),
-                    args1
-                )
-            )
+    def containsAwait(term: Term): Boolean = Trees.exists(term) {
+        case Apply(TypeApply(Ident("now" | "later"), _), _) => true
     }
+
+    val hasOpaqueNow = Trees.exists(body.asTerm) {
+        case Apply(TypeApply(Ident("now"), List(t, _)), _) if t.tpe.typeSymbol.flags.is(Flags.Opaque) => true
+    }
+
+    val preparedBody =
+        if !hasOpaqueNow then body.asTerm
+        else
+            Trees.transform(body.asTerm) {
+                case Apply(
+                        Apply(
+                            TypeApply(
+                                Apply(
+                                    ta: TypeApply,
+                                    List(a @ Apply(TypeApply(Ident("now"), List(t, s)), List(_)))
+                                ),
+                                types0
+                            ),
+                            args0
+                        ),
+                        args1
+                    ) if t.tpe.typeSymbol.flags.is(Flags.Opaque) =>
+
+                    val newVal: Symbol = Symbol.newVal(
+                        Symbol.spliceOwner,
+                        freshName("opaqueAlias"),
+                        t.tpe,
+                        Flags.Private,
+                        Symbol.noSymbol
+                    )
+                    Block(
+                        List(ValDef(newVal, Some(a))),
+                        Apply(
+                            Apply(TypeApply(Apply(ta, List(Ident(newVal.termRef))), types0), args0),
+                            args1
+                        )
+                    )
+            }
+    end preparedBody
 
     pending.asType match
         case '[s] =>
@@ -174,7 +186,14 @@ private def impl[A: Type](body: Expr[A])(using quotes: Quotes): Expr[Any] =
                     term match
                         case Apply(TypeApply(Ident("now"), List(t, s2)), List(qual)) =>
                             (t.tpe.asType, s2.tpe.asType) match
-                                case ('[t], '[s2]) => '{
+                                case ('[t], '[s2]) =>
+                                    // The cps.await quote is built with `owner.asQuotes` so the synthetic
+                                    // `given KyoCpsMonad[s2]` val ends up owned by the enclosing definition
+                                    // (e.g. a `val b = expr.now` binds b as owner). Without this, the macro
+                                    // emits trees whose synthetic given vals are owned by `val macro`,
+                                    // failing dotty's owner-consistency check (see issue #1617).
+                                    given Quotes = owner.asQuotes
+                                    '{
                                         given KyoCpsMonad[s2] = KyoCpsMonad[s2]
                                         cps.await[[A] =>> A < s2, t, [A] =>> A < s2](${
                                             transformTerm(qual)(owner).asExprOf[t < s2]
@@ -184,7 +203,11 @@ private def impl[A: Type](body: Expr[A])(using quotes: Quotes): Expr[Any] =
                         case Apply(TypeApply(Ident("later"), List(t, s2)), List(qual)) =>
                             transformTerm(qual)(owner)
 
-                        case _ => super.transformTerm(term)(owner)
+                        // Skip recursion into subtrees with no `.now`/`.later` — nothing to rewrite,
+                        // and avoids re-copying Apply/Select nodes that the TreeMap would otherwise
+                        // route through xCheckMacro* assertions.
+                        case _ if !containsAwait(term) => term
+                        case _                         => super.transformTerm(term)(owner)
 
             val transformedBody: Tree = transformer.transformTree(preparedBody)(Symbol.spliceOwner)
 

--- a/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
+++ b/kyo-direct/shared/src/main/scala/kyo/internal/Validate.scala
@@ -70,19 +70,29 @@ private[kyo] object Validate:
             validType && validName
         end validAsyncShift
 
+        // Multi-statement lambdas like `xs.map { i => val v = ...; v + 1 }` are typed as
+        // `Block(Nil, Block(List(DefDef(...)), Closure(...)))` — an empty outer Block wraps
+        // the actual lambda Block. Peel any leading empty-stat Blocks to find the lambda's
+        // synthetic DefDef so we can route the traversal into the lambda body (and skip the
+        // DefDef-rejection that's meant for user-written method defs).
         @tailrec
-        def asyncShiftDive(qualifiers: List[Tree])(using Trees.Step): Unit =
-            qualifiers match
-                case Block(List(DefDef(_, _, _, Some(body))), _) :: xs =>
-                    body match
-                        case Match(_, cases) =>
-                            cases.foreach:
-                                case CaseDef(_, _, body) => Trees.Step.goto(body)
-                        case _ => Trees.Step.goto(body)
-                    end match
-                    asyncShiftDive(xs)
+        def unwrapLambda(t: Tree): Option[Tree] = t match
+            case Block(List(DefDef(_, _, _, Some(body))), _) => Some(body)
+            case Block(Nil, expr)                            => unwrapLambda(expr)
+            case _                                           => None
 
-                case _ => qualifiers.foreach(qual => Trees.Step.goto(qual))
+        def asyncShiftDive(qualifiers: List[Tree])(using Trees.Step): Unit =
+            qualifiers.foreach { qual =>
+                unwrapLambda(qual) match
+                    case Some(body) =>
+                        body match
+                            case Match(_, cases) =>
+                                cases.foreach:
+                                    case CaseDef(_, _, body) => Trees.Step.goto(body)
+                            case _ => Trees.Step.goto(body)
+                    case None =>
+                        Trees.Step.goto(qual)
+            }
 
         extension (term: Term)
             def children: List[Tree] =
@@ -104,6 +114,21 @@ private[kyo] object Validate:
                     case Inlined(Some(Apply(TypeApply(Ident("direct"), _), _)), _, _) => true
                     case _                                                            => false
         end DirectBlock
+
+        object ByNameArgWithNow:
+            def unapply(t: Term): Option[Term] = t match
+                case Apply(fun, args) =>
+                    fun.tpe.widen match
+                        case mt: MethodType =>
+                            mt.paramTypes.zip(args).collectFirst {
+                                case (_: ByNameType, arg) if Trees.exists(arg) {
+                                        case Apply(TypeApply(Ident("now"), _), _) => true
+                                    } =>
+                                    arg
+                            }
+                        case _ => None
+                case _ => None
+        end ByNameArgWithNow
 
         def statementsDive(tree: Tree)(using Trees.Step): Unit =
             @tailrec
@@ -203,6 +228,19 @@ private[kyo] object Validate:
 
             // direct: in direct:
             case DirectBlock() =>
+
+            // Match expressions: route into scrutinee + each case body, skipping the
+            // patterns themselves. Pattern internals (Bind, Wildcard) can carry effect
+            // types from generic destructuring (e.g. `case Some(inner) => ...` where
+            // `inner: Int < Sync` from `Option[Int < Sync]`); those bindings aren't
+            // "uses" of the effect — the actual use is in the case body where .now/.later
+            // will be checked normally.
+            case Match(scrutinee, cases) =>
+                Trees.Step.goto(scrutinee)
+                cases.foreach { c =>
+                    c.guard.foreach(Trees.Step.goto)
+                    Trees.Step.goto(c.rhs)
+                }
 
             case Apply(TypeApply(Ident("now"), _), List(qual)) =>
                 statementsDive(qual)
@@ -431,6 +469,33 @@ private[kyo] object Validate:
                     |• Most common: Atomic* classes (kyo-core)
                     |• With transactional behavior: TRef and derivatives (kyo-stm)
                     |• Advanced pure state management: Var (kyo-prelude)""".stripMargin
+                )
+
+            // By-name (lazy) arguments containing `.now` produce confusing
+            // "Can't determinate qual ... during search of AsyncShift" errors from
+            // dotty-cps-async. Catch them up-front with a clear message. CPS sequencing
+            // doesn't compose with by-name semantics: the effect would be captured in
+            // the by-name thunk rather than sequenced at the call site.
+            case ByNameArgWithNow(arg) =>
+                fail(
+                    arg,
+                    s"""${".now".cyan} cannot appear inside a ${"by-name".yellow} parameter.
+                       |
+                       |By-name parameters capture the expression lazily, which is incompatible with
+                       |effect sequencing. Extract the effect to a ${"`val`".yellow} first:
+                       |
+                       |${highlight("""
+                       |// Instead of:
+                       |def lazyArg(x: => Int): Int = x
+                       |direct {
+                       |  lazyArg(Sync.defer(10).now)   // NOT OK - .now in by-name arg
+                       |}
+                       |
+                       |// Extract first:
+                       |direct {
+                       |  val x = Sync.defer(10).now    // OK - sequence the effect
+                       |  lazyArg(x)
+                       |}""".stripMargin)}""".stripMargin
                 )
         }
     end apply

--- a/kyo-direct/shared/src/test/scala/kyo/CoreTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/CoreTest.scala
@@ -1,6 +1,39 @@
 package kyo
 
+import scala.util.Try
+
 class CoreTest extends Test:
+
+    "abort operations" - {
+        // Regression for issue #1617: a `val` binding whose RHS is an `Abort` effect's
+        // `.now` previously caused the macro to emit trees with mismatched owners
+        // (assertion only fires under -Xcheck-macros, but the wrong-owner trees are
+        // produced regardless).
+        "val binding with Abort[Throwable]" in run {
+            def divide(a: Int, b: Int)(using Frame): Int < Abort[Throwable] = Abort.get(Try(a / b))
+            def double(x: Int): Int                                         = x * 2
+
+            val computation: Int < Abort[Throwable] =
+                direct {
+                    val b = divide(10, 2).now
+                    double(b)
+                }
+
+            Abort.run(computation).map(r => assert(r.contains(10)))
+        }
+
+        "val binding with combined Sync & Abort" in run {
+            def divide(a: Int, b: Int)(using Frame): Int < Abort[Throwable] = Abort.get(Try(a / b))
+
+            Abort.run {
+                direct {
+                    val a = Sync.defer(20).now
+                    val b = divide(a, 4).now
+                    a + b
+                }
+            }.map(r => assert(r.contains(25)))
+        }
+    }
 
     "atomic operations" - {
         "AtomicInt" in run {

--- a/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/HygieneTest.scala
@@ -20,7 +20,7 @@ class HygieneTest extends Test:
             Sync.defer(1).now
           }
         """)(
-            "Exception occurred while executing macro expansion"
+            "return outside method definition"
         )
     }
 
@@ -151,7 +151,7 @@ class HygieneTest extends Test:
               new A(Sync.defer("blah").now)
           }
         """)(
-            "Can't find AsyncShift (Found:    cps.runtime.CpsMonadSelfAsyncShift[[A] =>> A < kyo.Sync"
+            ".now cannot appear inside a by-name parameter."
         )
     }
 
@@ -322,5 +322,37 @@ class HygieneTest extends Test:
             g.now
 
         assertResult(2)(res.eval)
+    }
+
+    // Tests below codify currently-broken behavior surfaced during coverage analysis.
+    // Each uses typeCheckFailure to capture the spurious error. When the bug is fixed,
+    // these tests will fail (the error message disappears), prompting cleanup —
+    // remove the typeCheckFailure assertion and move the snippet to a positive test
+    // in the appropriate file (BlockTest / IfTest / PatMatchTest / etc.).
+
+    // Scala 3 limitation: the .now extension's `A` type parameter is bound by both the
+    // receiver and the expected return type. When they conflict (e.g. expected Long but
+    // receiver returns Int < Sync), inference picks the expected type and fails.
+    // Workaround: type-ascribe the .now result, or extract to a separate val.
+    "implicit widening of .now result requires explicit type ascription" in {
+        typeCheckFailure(
+            """
+            direct {
+              val n: Long = Sync.defer(7).now
+              n
+            }
+            """
+        )("value now is not a member of Int < kyo.Sync")
+    }
+
+    ".now in by-name parameter is rejected with a clear error" in {
+        typeCheckFailure(
+            """
+            def lazyArg(x: => Int): Int = x + 1
+            direct {
+              lazyArg(Sync.defer(10).now)
+            }
+            """
+        )(".now cannot appear inside a by-name parameter.")
     }
 end HygieneTest

--- a/kyo-direct/shared/src/test/scala/kyo/IfTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/IfTest.scala
@@ -50,4 +50,26 @@ class IfTest extends AnyFreeSpec with Assertions:
             }
         }
     }
+    "val binding inside branch" - {
+        "then-branch" in {
+            runLiftTest(11) {
+                val cond = Sync.defer(true).now
+                if cond then
+                    val x = Sync.defer(10).now
+                    x + 1
+                else 0
+                end if
+            }
+        }
+        "else-branch" in {
+            runLiftTest(20) {
+                val cond = Sync.defer(false).now
+                if cond then 0
+                else
+                    val x = Sync.defer(20).now
+                    x
+                end if
+            }
+        }
+    }
 end IfTest

--- a/kyo-direct/shared/src/test/scala/kyo/PatMatchTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/PatMatchTest.scala
@@ -116,5 +116,24 @@ class PatMatchTest extends AnyFreeSpec with Assertions:
                 a
             }
         }
+        "val binding inside case body" in {
+            runLiftTest(10) {
+                val opt = Sync.defer(Option(5)).now
+                opt match
+                    case Some(v) =>
+                        val doubled = Sync.defer(v * 2).now
+                        doubled
+                    case None => 0
+                end match
+            }
+        }
+        "pattern-bound effect-typed identifier used via .now" in {
+            runLiftTest(14) {
+                val opt: Option[Int < Sync] = Option(Sync.defer(7).later)
+                opt match
+                    case Some(inner) => inner.now * 2
+                    case None        => 0
+            }
+        }
     }
 end PatMatchTest

--- a/kyo-direct/shared/src/test/scala/kyo/ShiftTest.scala
+++ b/kyo-direct/shared/src/test/scala/kyo/ShiftTest.scala
@@ -55,6 +55,17 @@ class ShiftTest extends AnyFreeSpec with Assertions:
 
     }
 
+    "val binding inside async-shifted lambda body" in {
+        val x: Seq[Int < Any] = Seq[Int < Any](1, 2, 3)
+        val x2: Seq[Int] < Any = direct:
+            x.map { e =>
+                val v = e.now
+                v + 1
+            }
+
+        assert(x2.eval == Seq(2, 3, 4))
+    }
+
 end ShiftTest
 
 class ShiftMethodSupportTest extends AnyFreeSpec with Assertions:


### PR DESCRIPTION
Fixes #1617

## Problem

A `val` binding whose RHS uses `.now` inside a `direct {...}` block caused the macro to emit trees with the wrong owner for the synthetic `given KyoCpsMonad` val. Under dotty's owner-consistency check the assertion failed and macro expansion errored.

While analyzing test coverage I also found three Validate bugs:

1. Multi-statement lambdas inside async-shifted methods (e.g. `xs.map { i => val v = ...now; v + 1 }`) got rejected. Validate's `asyncShiftDive` pattern only matched single-statement lambdas because multi-statement ones are typed as `Block(Nil, Block(DefDef, Closure))` (extra empty-stat Block wrapping); the synthetic DefDef fell through to the rejection meant for user-written methods with `.now`.

2. Pattern-bound effect-typed identifiers (e.g. `case Some(inner) => inner.now` where `opt: Option[Int < Sync]`) tripped the bare-effect-term check. The Wildcard inside the Bind has type `Int < Sync` and was visited as a Term even though its only use was through `.now` in the case body.

3. `.now` inside a by-name parameter (e.g. `lazyArg(Sync.defer(10).now)` for `def lazyArg(x: => Int)`) produced an unhelpful dotty-cps-async error: `Can't determinate qual for lazyArg during search of AsyncShift`.

## Solution

`Direct.scala`:
- `given Quotes = owner.asQuotes` when building the inner `cps.await` quote so the synthetic given val ends up owned by the enclosing definition. This is what dotty's tip in the original assertion message recommends.
- `containsAwait` short-circuit avoids recursing into subtrees with no `.now`/`.later`, since there is nothing to rewrite there.
- Skip the `preparedBody` walk entirely when the body has no opaque-typed `.now` (that pass only matters for the opaque rewrite).

`Validate.scala`:
- `unwrapLambda` peels `Block(Nil, ...)` wrappers before matching the lambda DefDef. `asyncShiftDive` then routes the traversal into the lambda body, bypassing the DefDef rejection that targets user-written methods.
- New `Match` case in the validation partial function: routes into scrutinee, guards, and case bodies, skipping pattern internals where Bind/Wildcard can carry effect types from generic destructuring.
- `ByNameArgWithNow` unapply detects by-name parameters via `MethodType.paramTypes` matching `ByNameType`. Emits a clear error with a workaround example, since CPS sequencing does not compose with by-name semantics.

## Notes

One related case is documented as a Scala 3 limitation rather than fixed:

```scala
val n: Long = Sync.defer(7).now
```

This fails because the `.now` extension's type parameter `A` gets driven by the expected return type (`Long`) rather than the receiver's effect parameter (`Int`). `transparent inline` was tried as a fix but broke 576 unrelated tests by changing return-type inference everywhere. `HygieneTest` has a marker test that records this with two workarounds: ascribe the `.now` result (`(expr.now: Int)`) or extract to a separate val.

Two existing test expectations were updated to match cleaner error messages produced by the new fixes:
- "use of return" inside `direct {...}` now surfaces dotty's `return outside method definition` instead of the previous internal macro panic, because `containsAwait` no longer recurses into the Return node.
- "new instance with by-name parameter" now hits the clear by-name error instead of the dotty-cps-async leak.

New regression tests live in `CoreTest` (abort + val binding), `IfTest` (val inside branch), `PatMatchTest` (val in case body, pattern-bound `.now`), and `ShiftTest` (val inside async-shifted lambda body). Total: 440 tests passing.
