### PR TITLE
[schema] derivation fix: generic case-class defaults and nested transform routing

### DIFF
--- a/kyo-schema/shared/src/main/scala/kyo/internal/BuilderMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/BuilderMacro.scala
@@ -79,7 +79,7 @@ object BuilderMacro:
 
             fieldType.asType match
                 case '[ft] =>
-                    MacroUtils.getDefault(sym, idx) match
+                    MacroUtils.getDefault(tpe, idx) match
                         case Some(defaultExpr) =>
                             val typedDefault = defaultExpr.asExprOf[ft]
                             '{ $values.getOrElse(${ Expr(fieldName) }, $typedDefault).asInstanceOf[ft] }.asTerm

--- a/kyo-schema/shared/src/main/scala/kyo/internal/CodecMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/CodecMacro.scala
@@ -41,7 +41,7 @@ object CodecMacro:
         val caseFields = sym.caseFields
 
         caseFields.zipWithIndex.flatMap { (field, idx) =>
-            MacroUtils.getDefault(sym, idx).map(field.name -> _)
+            MacroUtils.getDefault(tpe, idx).map(field.name -> _)
         }.toMap
     end caseClassDefaultsPublic
 

--- a/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
@@ -1465,7 +1465,7 @@ import scala.quoted.*
 
             // Collect fields with defaults
             val fieldsWithDefaults = sym.caseFields.zipWithIndex.flatMap: (field, idx) =>
-                MacroUtils.getDefault(sym, idx).map: defaultExpr =>
+                MacroUtils.getDefault(nominalType, idx).map: defaultExpr =>
                     val fieldName  = field.name
                     val fieldType  = nominalType.memberType(field)
                     val nameType   = ConstantType(StringConstant(fieldName))

--- a/kyo-schema/shared/src/main/scala/kyo/internal/MacroUtils.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/MacroUtils.scala
@@ -154,12 +154,21 @@ private[internal] object MacroUtils:
         sym.companionModule.methodMember(defaultMethodName).nonEmpty
     end hasDefault
 
-    /** Gets the default value expression for a case class field at the given index, if any. */
-    private[internal] def getDefault(using Quotes)(sym: quotes.reflect.Symbol, idx: Int): Option[Expr[Any]] =
+    /** Gets the default value expression for a case class field at the given index, if any.
+      *
+      * For generic case classes, the generated default-value method is itself type-parameterized (`<init>$default$N[A, ...]`); we must
+      * apply the case class's type arguments to the method reference before treating it as an expression, otherwise `asExprOf` raises
+      * "Expected an expression. This is a partially applied Term" at macro expansion time.
+      */
+    private[internal] def getDefault(using Quotes)(tpe: quotes.reflect.TypeRepr, idx: Int): Option[Expr[Any]] =
         import quotes.reflect.*
+        val sym               = tpe.typeSymbol
         val defaultMethodName = s"$$lessinit$$greater$$default$$${idx + 1}"
         sym.companionModule.methodMember(defaultMethodName).headOption.map { method =>
-            Ref(sym.companionModule).select(method).asExprOf[Any]
+            val typeArgs = tpe.typeArgs
+            val ref      = Ref(sym.companionModule).select(method)
+            val applied  = if typeArgs.nonEmpty then ref.appliedToTypes(typeArgs) else ref
+            applied.asExprOf[Any]
         }
     end getDefault
 

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaConvertMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaConvertMacro.scala
@@ -75,7 +75,7 @@ import scala.quoted.*
                             case Some(_) =>
                                 Select.unique(srcExpr, fieldName)
                             case None =>
-                                MacroUtils.getDefault(targetType.typeSymbol, idx).get.asExprOf[ft].asTerm
+                                MacroUtils.getDefault(targetType, idx).get.asExprOf[ft].asTerm
                 end match
         end generateArgs
 

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
@@ -321,15 +321,22 @@ private[kyo] object SchemaSerializer:
             else
                 phase match
                     case 0 =>
-                        // Read entire flat object, extract discriminator, buffer other fields
+                        // Read entire flat object, extract discriminator, buffer other fields.
+                        // Use fieldParse + matchField to identify the discriminator in a wire-format-agnostic
+                        // way: JSON's matchField compares parsed UTF-8 bytes, Protobuf's compares the parsed
+                        // field tag's numeric ID against CodecMacro.fieldId(name). Without this routing the
+                        // Protobuf path would compare numeric tag-strings (e.g. "12345") against the literal
+                        // discriminator name ("type") and never find it.
                         val _                           = inner.objectStart()
                         val fields                      = scala.collection.mutable.ListBuffer[(String, Reader)]()
                         var foundVariant: Maybe[String] = Maybe.empty
+                        val discFieldBytes              = discField.getBytes(java.nio.charset.StandardCharsets.UTF_8)
                         while inner.hasNextField() do
-                            val fname = inner.field()
-                            if fname == discField then
+                            inner.fieldParse()
+                            if inner.matchField(discFieldBytes) then
                                 foundVariant = Maybe(inner.string())
                             else
+                                val fname    = inner.lastFieldName()
                                 val captured = inner.captureValue()
                                 fields += ((fname, captured))
                             end if
@@ -438,7 +445,16 @@ private[kyo] object SchemaSerializer:
             else if _parsedFieldName.isEmpty then false
             else
                 val expected = new String(nameBytes, java.nio.charset.StandardCharsets.UTF_8)
-                _parsedFieldName.get == expected
+                val parsed   = _parsedFieldName.get
+                if parsed == expected then true
+                else
+                    // Wire-format-agnostic fallback: when the underlying inner reader is wire-format-tagged
+                    // (e.g. Protobuf, which reports fields by their numeric tag id), the buffered "name" is a
+                    // numeric string. Match it against CodecMacro.fieldId(expected) to align with the way
+                    // the macro-generated case-class read body matches fields downstream.
+                    try parsed.toInt == CodecMacro.fieldId(expected)
+                    catch case _: NumberFormatException => false
+                end if
         end matchField
 
         override def lastFieldName(): String =

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SerializationMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SerializationMacro.scala
@@ -72,7 +72,7 @@ private[internal] object SerializationMacro:
                     $maybeAccess match
                         case kyo.Present(innerVal) =>
                             $writer.fieldBytes($fieldBytes($idxExpr), $fidExpr)
-                            $schemaExpr.serializeWrite(innerVal, $writer)
+                            kyo.internal.SchemaSerializer.writeTo($schemaExpr, innerVal, $writer)(using kyo.Frame.internal)
                         case _ => ()
                 })
             else if optionFields.contains(idx) then
@@ -80,7 +80,7 @@ private[internal] object SerializationMacro:
                 List('{
                     if $optAccess.isDefined then
                         $writer.fieldBytes($fieldBytes($idxExpr), $fidExpr)
-                        $schemaExpr.serializeWrite($optAccess, $writer)
+                        kyo.internal.SchemaSerializer.writeTo($schemaExpr, $optAccess, $writer)(using kyo.Frame.internal)
                 })
             else if isPrimitiveType(ft) then
                 // Primitive field: emit a direct typed Writer call. No Function2.apply, no autoboxing.
@@ -114,7 +114,7 @@ private[internal] object SerializationMacro:
                             case None =>
                                 List(
                                     '{ $writer.fieldBytes($fieldBytes($idxExpr), $fidExpr) },
-                                    '{ $schemaExpr.serializeWrite($fieldAccess, $writer) }
+                                    '{ kyo.internal.SchemaSerializer.writeTo($schemaExpr, $fieldAccess, $writer)(using kyo.Frame.internal) }
                                 )
                         end match
                 end match
@@ -837,11 +837,12 @@ private[internal] object SerializationMacro:
             if isMaybe then
                 // Maybe[T]: wrap the inner serializeRead result in kyo.Present.
                 ft.asType match
-                    case '[t] => '{ kyo.Present($schemaExpr.serializeRead($reader)).asInstanceOf[t] }
+                    case '[t] =>
+                        '{ kyo.Present(kyo.internal.SchemaSerializer.readFrom($schemaExpr, $reader)(using $reader.frame)).asInstanceOf[t] }
             else if isOption then
                 // Option[T]: the Option schema's serializeRead already yields Option[T].
                 ft.asType match
-                    case '[t] => '{ $schemaExpr.serializeRead($reader).asInstanceOf[t] }
+                    case '[t] => '{ kyo.internal.SchemaSerializer.readFrom($schemaExpr, $reader)(using $reader.frame).asInstanceOf[t] }
             else if fieldIsPrimitive(idx) then
                 // Direct primitive reader call — no boxing.
                 primitiveReadExpr(ft, reader)
@@ -859,7 +860,13 @@ private[internal] object SerializationMacro:
                                     case '[t] => '{ $readExpr.asInstanceOf[t] }
                             case None =>
                                 ft.asType match
-                                    case '[t] => '{ $schemaExpr.serializeRead($reader).asInstanceOf[t] }
+                                    case '[t] =>
+                                        '{
+                                            kyo.internal.SchemaSerializer.readFrom(
+                                                $schemaExpr,
+                                                $reader
+                                            )(using $reader.frame).asInstanceOf[t]
+                                        }
                         end match
                 end match
             end if

--- a/kyo-schema/shared/src/main/scala/kyo/internal/StructureMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/StructureMacro.scala
@@ -137,7 +137,7 @@ object StructureMacro:
                 val fieldRef  = deriveType(fieldType, newSeen)
 
                 // Check for default value — convert to Structure.Value
-                val defaultExpr: Expr[Maybe[Structure.Value]] = MacroUtils.getDefault(sym, idx) match
+                val defaultExpr: Expr[Maybe[Structure.Value]] = MacroUtils.getDefault(dealiased, idx) match
                     case Some(defVal) =>
                         fieldType.asType match
                             case '[t] =>

--- a/kyo-schema/shared/src/test/scala/kyo/JsonTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/JsonTest.scala
@@ -2081,6 +2081,79 @@ class JsonTest extends Test:
     }
 
     // ===================================================================
+    // Generic case class default-value derivation (regression: MacroUtils.getDefault
+    // must apply type arguments to the generated default-method ref). The bug
+    // surfaced as "Expected an expression. This is a partially applied Term"
+    // at Schema-derivation time for any generic case class with at least one
+    // default-valued field. The fix lives in `MacroUtils.getDefault` and the
+    // tests below pin both the "Schema derives at all" property and the
+    // "decode honors the default" / "round-trip preserves omitted-vs-present"
+    // properties.
+    // ===================================================================
+
+    "generic case class with defaults" - {
+
+        "MTGenericDefault[Int]: Schema derives without macro error (compile-time pin)" in {
+            // The mere presence of `derives Schema` on a generic case class with a default
+            // previously crashed at macro-expansion. Summoning the Schema here forces the
+            // macro to run; a regression would fail the compile, not the assertion.
+            val _ = summon[Schema[MTGenericDefault[Int]]]
+            succeed
+        }
+
+        "MTGenericDefault[Int]: omitted default decodes to the declared default" in {
+            // Input lacks `tag`; the macro-driven decoder must source the default from the
+            // generic companion's `<init>$default$2[A]: String` method, applying the type
+            // arg `Int`. Pre-fix: macro never compiled; post-fix: default is honored.
+            val json    = """{"value":42}"""
+            val decoded = Json.decode[MTGenericDefault[Int]](json).getOrThrow
+            assert(decoded == MTGenericDefault[Int](42, "default"))
+        }
+
+        "MTGenericDefault[String]: explicit value overrides the default and round-trips" in {
+            val original = MTGenericDefault[String]("hi", tag = "custom")
+            val encoded  = Json.encode(original)
+            val decoded  = Json.decode[MTGenericDefault[String]](encoded).getOrThrow
+            assert(decoded == original)
+        }
+
+        "MTGenericMaybe[Int]: both Maybe-defaulted fields decode from empty object" in {
+            // Two Maybe[?]-typed fields with Absent defaults. The macro fix must apply the
+            // [Int] type arg to BOTH default methods independently.
+            val json    = """{}"""
+            val decoded = Json.decode[MTGenericMaybe[Int]](json).getOrThrow
+            assert(decoded == MTGenericMaybe[Int]())
+        }
+
+        "MTGenericMaybe[Int]: Present(value) round-trips through encode/decode" in {
+            val original = MTGenericMaybe[Int](result = Present(7))
+            val encoded  = Json.encode(original)
+            val decoded  = Json.decode[MTGenericMaybe[Int]](encoded).getOrThrow
+            assert(decoded == original)
+        }
+
+        "MTGenericMaybe[String]: error-only payload preserves both fields" in {
+            val original = MTGenericMaybe[String](error = Present("bad"))
+            val encoded  = Json.encode(original)
+            val decoded  = Json.decode[MTGenericMaybe[String]](encoded).getOrThrow
+            assert(decoded == original)
+        }
+
+        "MTGenericTwoParam[Int, String]: two type params with one default field" in {
+            val original = MTGenericTwoParam[Int, String](1, "a")
+            val encoded  = Json.encode(original)
+            val decoded  = Json.decode[MTGenericTwoParam[Int, String]](encoded).getOrThrow
+            assert(decoded == original)
+        }
+
+        "MTGenericTwoParam[Int, String]: omitted default decodes to 'pair'" in {
+            val json    = """{"first":3,"second":"x"}"""
+            val decoded = Json.decode[MTGenericTwoParam[Int, String]](json).getOrThrow
+            assert(decoded == MTGenericTwoParam[Int, String](3, "x", "pair"))
+        }
+    }
+
+    // ===================================================================
     // Local test type definitions
     // ===================================================================
 

--- a/kyo-schema/shared/src/test/scala/kyo/NestedTransformTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/NestedTransformTest.scala
@@ -1,0 +1,82 @@
+package kyo
+
+// --- Reporter's repro: discriminator on a nested sealed-trait field ---
+sealed trait NestedRO derives CanEqual
+object NestedRO:
+    final case class `string`(value: String) extends NestedRO derives CanEqual, Schema
+    final case class `number`(value: Int)    extends NestedRO derives CanEqual, Schema
+end NestedRO
+
+given Schema[NestedRO] = Schema.derived[NestedRO].discriminator("type")
+final case class NestedEnvelope(result: NestedRO) derives CanEqual, Schema
+
+// --- Two-deep nesting of the same discriminator ---
+final case class NestedTwoDeepMiddle(payload: NestedRO) derives CanEqual, Schema
+final case class NestedTwoDeepOuter(middle: NestedTwoDeepMiddle) derives CanEqual, Schema
+
+// --- .drop on nested schema ---
+final case class NestedDropInner(visible: String, secret: String) derives CanEqual
+given Schema[NestedDropInner] = Schema[NestedDropInner].drop("secret")
+final case class NestedDropOuter(inner: NestedDropInner) derives CanEqual, Schema
+
+// --- .rename on nested schema ---
+final case class NestedRenameInner(x: Int) derives CanEqual
+given Schema[NestedRenameInner] = Schema[NestedRenameInner].rename("x", "y")
+final case class NestedRenameOuter(inner: NestedRenameInner) derives CanEqual, Schema
+
+// --- .add on nested schema ---
+final case class NestedAddInner(x: Int) derives CanEqual
+given Schema[NestedAddInner] = Schema[NestedAddInner].add("derived")(_.x * 2)
+final case class NestedAddOuter(inner: NestedAddInner) derives CanEqual, Schema
+
+class NestedTransformTest extends Test:
+
+    "discriminator survives one level of nesting (reporter's repro)" in {
+        val v  = NestedEnvelope(NestedRO.`string`("hi"))
+        val js = Json.encode(v)
+        assert(js == """{"result":{"type":"string","value":"hi"}}""", js)
+        val dec = Json.decode[NestedEnvelope](js)
+        assert(dec == Result.succeed(v))
+    }
+
+    "discriminator survives two levels deep" in {
+        val v  = NestedTwoDeepOuter(NestedTwoDeepMiddle(NestedRO.`number`(42)))
+        val js = Json.encode(v)
+        assert(js.contains("""{"type":"number","value":42}"""), js)
+        assert(Json.decode[NestedTwoDeepOuter](js) == Result.succeed(v))
+    }
+
+    "drop on nested schema omits the dropped field at the inner level" in {
+        val js = Json.encode(NestedDropOuter(NestedDropInner("v", "s")))
+        assert(!js.contains("secret"), js)
+        assert(js.contains("\"visible\":\"v\""), js)
+    }
+
+    "rename on nested schema renames at the inner level" in {
+        val js = Json.encode(NestedRenameOuter(NestedRenameInner(5)))
+        assert(js.contains("\"y\":5"), js)
+    }
+
+    "add (computed field) on nested schema emits the computed field at the inner level" in {
+        val js = Json.encode(NestedAddOuter(NestedAddInner(3)))
+        assert(js.contains("\"derived\":6"), js)
+    }
+
+    "discriminator + drop combine on a nested schema" in {
+        pending
+        // Design follow-up: chaining `.discriminator(...)` and `.drop(...)` on
+        // the same sum-type schema is not expressible today — the API rejects
+        // `.drop` on sealed traits at compile time ("Schema.drop is not
+        // supported for sealed traits") because transforms operate on case
+        // class fields. Supporting this combination would require either a
+        // sum-level field-removal primitive or per-variant `.drop` that
+        // survives discriminator dispatch at nested positions.
+    }
+
+    "discriminator survives Protobuf round-trip" in {
+        val v   = NestedEnvelope(NestedRO.`string`("hi"))
+        val b   = Protobuf.encode(v)
+        val dec = Protobuf.decode[NestedEnvelope](b)
+        assert(dec == Result.succeed(v))
+    }
+end NestedTransformTest

--- a/kyo-schema/shared/src/test/scala/kyo/SchemaTestData.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/SchemaTestData.scala
@@ -7,6 +7,14 @@ case class MTTeam(name: String, lead: MTPersonAddr, members: List[MTPersonAddr])
 case class MTCompany(name: String, hq: MTTeam) derives CanEqual
 case class MTConfig(host: String, port: Int = 8080, ssl: Boolean = false) derives CanEqual
 case class MTPair[A, B](first: A, second: B) derives CanEqual
+
+// Generic case classes WITH default values. Regression coverage for the macro bug where
+// `MacroUtils.getDefault` failed to apply the case class's type arguments to the generated
+// `$lessinit$greater$default$N` method, raising "Expected an expression. This is a partially
+// applied Term" at Schema-derivation time.
+case class MTGenericDefault[A](value: A, tag: String = "default") derives CanEqual
+case class MTGenericMaybe[A](result: Maybe[A] = Absent, error: Maybe[String] = Absent) derives CanEqual
+case class MTGenericTwoParam[A, B](first: A, second: B, label: String = "pair") derives CanEqual
 case class MTOrder(id: Int, items: List[MTItem]) derives CanEqual
 case class MTItem(name: String, price: Double) derives CanEqual
 case class MTWrapper(value: String) derives CanEqual


### PR DESCRIPTION
## Problem

Two macro-level bugs in `Schema.derived`:

1. `Schema.derived[F[A]]` crashed at macro expansion ("Expected an expression. This is a partially applied Term") for any generic case class with at least one default-valued field, because `MacroUtils.getDefault` emitted the companion's default-method reference without applying the case class's type arguments.

2. Discriminator-tagged sum types nested inside another case class lost their discriminator on both JSON and Protobuf round-trips, because `SerializationMacro` emitted direct `$schema.serializeWrite/Read` calls for nested fields, bypassing the transform-aware dispatch layer.

## Solution

`MacroUtils.getDefault` now takes a `TypeRepr` and applies `tpe.typeArgs` to the method reference before lifting to an `Expr`. Five call sites (`BuilderMacro`, `CodecMacro`, `FocusMacro`, `SchemaConvertMacro`, `StructureMacro`) pass the local `TypeRepr` already in scope.

`SerializationMacro`'s four nested-field call sites now route through `kyo.internal.SchemaSerializer.writeTo/readFrom` instead of calling `$schema.serializeWrite/Read` directly. The dispatch helper resolves the field's transform-aware Schema. For the Protobuf path specifically, the discriminator reader phase 0 now matches field tags via `inner.fieldParse() + matchField(nameBytes)` (a wire-format-agnostic match that compares parsed field tags rather than UTF-8 names), and `matchField` falls back to `CodecMacro.fieldId(expected)` for wire formats that report fields by numeric tag.

## Notes

`NestedTransformTest` (new) pins six scenarios: one-level discriminator nesting, two-level deep, `.drop`, `.rename`, `.add` (computed field), and discriminator survival through Protobuf round-trip. A seventh scenario (`discriminator + drop` combined) is `pending` as a documented design follow-up.

Eight new `JsonTest` scenarios + three fixtures in `SchemaTestData` (`MTGenericDefault[A]`, `MTGenericMaybe[A]`, `MTGenericTwoParam[A, B]`) cover the generic-default fix.

<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->