### PR TITLE
[data] Frame: add calleeName, rename methodName to callerName, kyo.internal placeholder

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Frame.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Frame.scala
@@ -8,7 +8,12 @@ opaque type Frame <: AnyRef = String
 
 object Frame:
 
-    private val version = '0'
+    // version bytes:
+    //   '0' (legacy): $0$file:line:col|$cls|$method|$snippet
+    //   '1' adds the syntactic name of the function whose implicit Frame parameter is being filled at the
+    //         macro-expansion call site: $1$file:line:col|$cls|$method|$callee|$snippet
+    // Accessors detect the version and parse accordingly; `calleeName` returns "" for a '0' Frame.
+    private val version = '1'
 
     private val snippetShortMaxChars = 50
 
@@ -53,26 +58,45 @@ object Frame:
             val start = findNextSeparator(1) + 1
             parseSection(start, findNextSeparator(start))
 
-        def methodName: String =
+        def callerName: String =
             val firstSep = findNextSeparator(1)
             val start    = findNextSeparator(firstSep + 1) + 1
             parseSection(start, findNextSeparator(start))
-        end methodName
+        end callerName
+
+        /** Syntactic name of the function whose implicit `Frame` parameter is being filled at the macro-expansion call site (e.g. `"map"`
+          * for `comp.map(f)`, `"assertEmpty"` for `Browser.assertEmpty(sel)`). Returns `""` for legacy (version `'0'`) frames that did not
+          * encode this segment.
+          */
+        def calleeName: String =
+            if self.charAt(0) == '0' then ""
+            else
+                val firstSep  = findNextSeparator(1)
+                val secondSep = findNextSeparator(firstSep + 1)
+                val thirdSep  = findNextSeparator(secondSep + 1)
+                val start     = thirdSep + 1
+                parseSection(start, findNextSeparator(start))
+            end if
+        end calleeName
 
         def snippet: String =
             val firstSep  = findNextSeparator(1)
             val secondSep = findNextSeparator(firstSep + 1)
-            val start     = findNextSeparator(secondSep + 1) + 1
+            val thirdSep  = findNextSeparator(secondSep + 1)
+            // Version '0' has 3 separators ($file|$cls|$method|$snippet); '1' has 4 ($file|$cls|$method|$callee|$snippet).
+            val start =
+                if self.charAt(0) == '0' then thirdSep + 1
+                else findNextSeparator(thirdSep + 1) + 1
             self.substring(start)
         end snippet
 
         def snippetShort: String = snippet.split("📍")(0).reverse.take(snippetShortMaxChars).takeWhile(_ != '\n').trim.reverse
 
-        def show: String = s"Frame(${Position.show(position)}, $className, $methodName, $snippetShort)"
+        def show: String = s"Frame(${Position.show(position)}, $className, $callerName, $snippetShort)"
 
         def render: String =
             Ansi.highlight(
-                s"// ${Position.show(position)} $className $methodName",
+                s"// ${Position.show(position)} $className $callerName",
                 snippet.toString(),
                 s"",
                 Math.max(0, Position.lineNumber(self) - 2)
@@ -89,7 +113,7 @@ object Frame:
                             case v         => pprint(v).render
                         }.mkString("\n\n")
             Ansi.highlight(
-                s"// ${Position.show(position)} $className $methodName",
+                s"// ${Position.show(position)} $className $callerName",
                 snippet.toString(),
                 detailsString,
                 Math.max(0, Position.lineNumber(self) - 2)
@@ -123,21 +147,103 @@ object Frame:
         end if
 
         val cls    = FindEnclosing(_.isClassDef).map(_.fullName).getOrElse("?")
-        val method = if internal then "?" else FindEnclosing(_.isDefDef).map(_.name).getOrElse("?")
+        val caller = if internal then "?" else FindEnclosing(_.isDefDef).map(_.name).getOrElse("?")
+
+        val rawContent =
+            if internal then ""
+            else pos.sourceFile.content.getOrElse(report.errorAndAbort("Can't locate source code")).replace("\r\n", "\n")
+
+        // Callee = syntactic name of the function whose `(using Frame)` parameter the macro is filling.
+        // The macro splice always lands at the end of a call expression: either right after the function
+        // identifier (no explicit args) or right after the closing `)`/`]` of the trailing explicit
+        // arg/type-arg list. Reading the source text backwards from `pos.end`, peeling any trailing
+        // matched `(...)` / `[...]` groups, and taking the identifier that immediately precedes them
+        // recovers the called function's name across all of these shapes.
+        //
+        // Caveats: returns "?" in the rare case the call is split across lines by comments or
+        // unusual whitespace. Operator-named methods (return the operator string like "+", "==",
+        // "::") and backticked identifiers (return the content without backticks) are both
+        // handled.
+        val callee = if internal then "?" else extractCalleeName(rawContent, pos.end)
 
         val snippet =
             if internal then "<internal>"
             else
-                val content = pos.sourceFile.content.getOrElse(
-                    report.errorAndAbort("Can't locate source code")
-                ).replace("\r\n", "\n")
-                val marked = content.take(pos.end) + "📍" + content.drop(pos.end)
+                val marked = rawContent.take(pos.end) + "📍" + rawContent.drop(pos.end)
                 val lines  = marked.linesIterator.slice(pos.startLine - 1, pos.endLine + 2).filter(_.exists(_ != ' ')).toSeq
                 val toDrop = lines.map(_.takeWhile(_ == ' ').length).min
                 lines.map(_.drop(toDrop)).mkString("\n")
 
-        Expr(s"$version$fileName:${pos.startLine + 1}:${pos.startColumn + 1}|$cls|$method|$snippet")
+        Expr(s"$version$fileName:${pos.startLine + 1}:${pos.startColumn + 1}|$cls|$caller|$callee|$snippet")
     end frameImpl
+
+    /** Source-text extraction of the callee identifier from `source` walking backwards starting at `end`. Pulled out to a pure helper so
+      * the algorithm can be exercised directly from unit tests with hand-built inputs.
+      */
+    private[kyo] def extractCalleeName(source: String, end: Int): String =
+        def isIdChar(c: Char): Boolean = c.isLetterOrDigit || c == '_' || c == '$'
+        def isOpChar(c: Char): Boolean =
+            c match
+                case '+' | '-' | '*' | '/' | '<' | '>' | '=' | '!' | '&' | '|' | '^' | '%' | ':' | '~' | '?' | '@' | '#' => true
+                case _                                                                                                   => false
+
+        @tailrec def skipWhitespace(idx: Int): Int =
+            if idx >= 0 && source(idx).isWhitespace then skipWhitespace(idx - 1) else idx
+
+        @tailrec def skipMatchedBracket(idx: Int, closeChar: Char, openChar: Char, depth: Int): Int =
+            if idx < 0 || depth == 0 then idx
+            else
+                val nextDepth = source(idx) match
+                    case c if c == closeChar => depth + 1
+                    case c if c == openChar  => depth - 1
+                    case _                   => depth
+                skipMatchedBracket(idx - 1, closeChar, openChar, nextDepth)
+            end if
+        end skipMatchedBracket
+
+        @tailrec def peelBrackets(idx: Int): Int =
+            if idx >= 0 && (source(idx) == ')' || source(idx) == ']') then
+                val closeChar = source(idx)
+                val openChar  = if closeChar == ')' then '(' else '['
+                val afterBkt  = skipMatchedBracket(idx - 1, closeChar, openChar, 1)
+                peelBrackets(skipWhitespace(afterBkt))
+            else idx
+
+        @tailrec def collectIdStart(idx: Int): Int =
+            if idx >= 0 && isIdChar(source(idx)) then collectIdStart(idx - 1) else idx
+
+        @tailrec def collectOpStart(idx: Int): Int =
+            if idx >= 0 && isOpChar(source(idx)) then collectOpStart(idx - 1) else idx
+
+        @tailrec def findOpeningBacktick(idx: Int): Int =
+            if idx < 0 then -1
+            else if source(idx) == '`' then idx
+            else findOpeningBacktick(idx - 1)
+
+        val afterWs   = skipWhitespace(end - 1)
+        val afterBkts = peelBrackets(afterWs)
+        val tokenEnd  = afterBkts + 1
+
+        // Backticked identifier (e.g. ``foo.`my method`(x)``): peel landed on the closing backtick.
+        if afterBkts >= 0 && source(afterBkts) == '`' then
+            val openIdx = findOpeningBacktick(afterBkts - 1)
+            if openIdx < 0 then "?"
+            else source.substring(openIdx + 1, afterBkts)
+        else if afterBkts >= 0 && isOpChar(source(afterBkts)) then
+            // Operator-named method: trailing token is a contiguous run of operator chars.
+            val opStart = collectOpStart(afterBkts) + 1
+            source.substring(opStart, tokenEnd)
+        else
+            // Plain identifier: must start with a letter, `_`, or `$`. Numeric literals and other
+            // non-identifier trailing tokens surface as "?".
+            val idStart = collectIdStart(afterBkts) + 1
+            if idStart >= tokenEnd then "?"
+            else
+                val first = source(idStart)
+                if first.isLetter || first == '_' || first == '$' then source.substring(idStart, tokenEnd) else "?"
+            end if
+        end if
+    end extractCalleeName
 
     private def render(using Quotes)(symbol: quotes.reflect.Symbol): String =
         if symbol.isClassDef then symbol.fullName

--- a/kyo-data/shared/src/main/scala/kyo/internal/package.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/package.scala
@@ -1,0 +1,13 @@
+package kyo
+
+/** Package object for `kyo.internal`.
+  *
+  * `kyo.internal` is a split package contributed to by kyo-data, kyo-core, kyo-schema, and kyo-sql. Without an explicit package object, the
+  * Scala 3 compiler can be driven (via an `inline def` that references a `private[kyo]` member through a `kyo.internal.X` path) to "mock
+  * up" a synthetic module class for `kyo.internal` and emit `getstatic kyo/internal.MODULE$` at call sites, a class that never exists on
+  * the runtime classpath, causing `NoClassDefFoundError: kyo/internal`.
+  *
+  * Declaring the package object here, in the lowest module of the dependency graph, gives every downstream compile a real `kyo.internal`
+  * module so the compiler resolves it instead of mocking one up.
+  */
+package object internal

--- a/kyo-data/shared/src/test/scala/kyo/FrameTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/FrameTest.scala
@@ -74,7 +74,7 @@ class FrameTest extends Test:
 
     "parse" in {
         assert(test1.className == "kyo.FrameTest")
-        assert(test1.methodName == "test1")
+        assert(test1.callerName == "test1")
         assert(test1.position.fileName == "FrameTest.scala")
         assert(test1.position.lineNumber == 7)
         assert(test1.position.columnNumber == 28)
@@ -84,12 +84,185 @@ class FrameTest extends Test:
 
     "internal" in {
         assert(internal.className == "kyo.FrameTest")
-        assert(internal.methodName == "?")
+        assert(internal.callerName == "?")
         assert(internal.position.fileName == "FrameTest.scala")
         assert(internal.position.lineNumber == 14)
         assert(internal.position.columnNumber == 20)
         assert(internal.snippet == "<internal>")
         assert(internal.snippetShort == "<internal>")
+    }
+
+    "calleeName" - {
+
+        // ── End-to-end via the macro ────────────────────────────────────────
+
+        def captureFrame(using f: Frame): Frame                           = f
+        def takeArg(arg: String)(using f: Frame): Frame                   = f
+        def takeTwo(a: Int, b: Int)(using f: Frame): Frame                = f
+        def takeNamed(arg: String, count: Int = 1)(using f: Frame): Frame = f
+        def takeTypeArg[A](arg: A)(using f: Frame): Frame                 = f
+        def takeCurried(a: Int)(b: Int)(using f: Frame): Frame            = f
+        def under_score(using f: Frame): Frame                            = f
+        def with$Dollar(using f: Frame): Frame                            = f
+
+        "bare call (no explicit args, only implicit Frame)" in {
+            assert(captureFrame.calleeName == "captureFrame")
+        }
+
+        "call with one explicit arg" in {
+            assert(takeArg("hello").calleeName == "takeArg")
+        }
+
+        "call with multiple explicit args" in {
+            assert(takeTwo(1, 2).calleeName == "takeTwo")
+        }
+
+        "call with expression argument" in {
+            assert(takeArg("hello " + "world").calleeName == "takeArg")
+        }
+
+        "call with a named argument" in {
+            assert(takeNamed("x", count = 3).calleeName == "takeNamed")
+        }
+
+        "call with an explicit type argument" in {
+            assert(takeTypeArg[Int](7).calleeName == "takeTypeArg")
+        }
+
+        "call with curried argument lists" in {
+            assert(takeCurried(1)(2).calleeName == "takeCurried")
+        }
+
+        "underscore in the identifier" in {
+            assert(under_score.calleeName == "under_score")
+        }
+
+        "dollar sign in the identifier" in {
+            assert(with$Dollar.calleeName == "with$Dollar")
+        }
+
+        "called from inside a lambda" in {
+            val callFromLambda: () => Frame = () => captureFrame
+            assert(callFromLambda().calleeName == "captureFrame")
+        }
+
+        "called from inside a for-comprehension" in {
+            val frames =
+                for i <- List(1)
+                yield captureFrame
+            assert(frames.head.calleeName == "captureFrame")
+        }
+
+        // ── Pure helper exercises (hand-built source strings) ───────────────
+
+        "extractCalleeName on a bare identifier" in {
+            assert(Frame.extractCalleeName("val a = foo", 11) == "foo")
+        }
+
+        "extractCalleeName on a one-arg call" in {
+            assert(Frame.extractCalleeName("val a = foo(1)", 14) == "foo")
+        }
+
+        "extractCalleeName on a chained method call" in {
+            assert(Frame.extractCalleeName("val a = obj.method(x)", 21) == "method")
+        }
+
+        "extractCalleeName on curried application" in {
+            assert(Frame.extractCalleeName("val a = foo(1)(2)", 17) == "foo")
+        }
+
+        "extractCalleeName peels type args" in {
+            assert(Frame.extractCalleeName("val a = foo[Int](1)", 19) == "foo")
+        }
+
+        "extractCalleeName peels multiple type args + explicit args mixed" in {
+            assert(Frame.extractCalleeName("val a = foo[A][B](x)(y)", 23) == "foo")
+        }
+
+        "extractCalleeName handles nested parens" in {
+            assert(Frame.extractCalleeName("val a = foo(bar(baz(1)))", 24) == "foo")
+        }
+
+        "extractCalleeName handles whitespace between identifier and args" in {
+            assert(Frame.extractCalleeName("val a = foo  (1)", 16) == "foo")
+        }
+
+        "extractCalleeName handles trailing whitespace" in {
+            assert(Frame.extractCalleeName("foo  ", 5) == "foo")
+        }
+
+        "extractCalleeName preserves underscores in identifier" in {
+            assert(Frame.extractCalleeName("snake_case_name", 15) == "snake_case_name")
+        }
+
+        "extractCalleeName preserves dollar signs in identifier" in {
+            assert(Frame.extractCalleeName("withDollar$Suffix", 17) == "withDollar$Suffix")
+        }
+
+        "extractCalleeName returns the operator string for operator-named methods" in {
+            assert(Frame.extractCalleeName("val a = 1 +", 11) == "+")
+            assert(Frame.extractCalleeName("val a = 1 ==", 12) == "==")
+            assert(Frame.extractCalleeName("val a = 1 <=", 12) == "<=")
+            assert(Frame.extractCalleeName("val a = 1 ::", 12) == "::")
+            assert(Frame.extractCalleeName("val a = xs ++", 13) == "++")
+        }
+
+        "extractCalleeName handles backticked identifiers" in {
+            assert(Frame.extractCalleeName("val a = `name`", 14) == "name")
+            assert(Frame.extractCalleeName("val a = `my method`", 19) == "my method")
+            assert(Frame.extractCalleeName("val a = `a.b.c`", 15) == "a.b.c")
+        }
+
+        "extractCalleeName returns '?' for an empty prefix" in {
+            assert(Frame.extractCalleeName("", 0) == "?")
+        }
+
+        "extractCalleeName returns '?' when the trailing token starts with a digit" in {
+            assert(Frame.extractCalleeName("val a = 123abc", 14) == "?")
+        }
+
+        "extractCalleeName returns '?' on unbalanced parens (still safe, no exception)" in {
+            // A bare `)` with no matching `(`: peel walks the whole prefix, leaving no identifier.
+            assert(Frame.extractCalleeName(")", 1) == "?")
+        }
+
+        "extractCalleeName returns the identifier at end-of-string" in {
+            assert(Frame.extractCalleeName("identifier", 10) == "identifier")
+        }
+
+        "calleeName via macro reports the called method, not the enclosing one" in {
+            assert(test1.callerName == "test1")
+            assert(test1.calleeName == "test")
+        }
+
+        // Backward compatibility with legacy v'0' frames.
+
+        "calleeName returns \"\" for a legacy version-'0' Frame" in {
+            // Legacy format: '0' + position + |cls|method|snippet (no callee segment).
+            // Frame is an opaque alias for String; cast is the test-only construction path.
+            val legacy = "0FrameTest.scala:7:28|kyo.FrameTest|test1|def test1 = test(1 + 2)📍".asInstanceOf[Frame]
+            assert(legacy.calleeName == "")
+        }
+
+        "snippet on a legacy version-'0' Frame skips three separators (not four)" in {
+            val legacy = "0FrameTest.scala:7:28|kyo.FrameTest|test1|def test1 = test(1 + 2)📍".asInstanceOf[Frame]
+            assert(legacy.snippet == "def test1 = test(1 + 2)📍")
+        }
+
+        "snippet on a current version-'1' Frame skips four separators" in {
+            val current = "1FrameTest.scala:7:28|kyo.FrameTest|test1|test|def test1 = test(1 + 2)📍".asInstanceOf[Frame]
+            assert(current.snippet == "def test1 = test(1 + 2)📍")
+            assert(current.calleeName == "test")
+        }
+
+        "legacy v'0' parses className/callerName/position the same as v'1'" in {
+            val legacy = "0FrameTest.scala:7:28|kyo.FrameTest|test1|def test1 = test(1 + 2)📍".asInstanceOf[Frame]
+            assert(legacy.className == "kyo.FrameTest")
+            assert(legacy.callerName == "test1")
+            assert(legacy.position.fileName == "FrameTest.scala")
+            assert(legacy.position.lineNumber == 7)
+            assert(legacy.position.columnNumber == 28)
+        }
     }
 
 end FrameTest

--- a/kyo-kernel/jvm/src/test/scala/kyo/kernel/internal/SafepointTest.scala
+++ b/kyo-kernel/jvm/src/test/scala/kyo/kernel/internal/SafepointTest.scala
@@ -304,7 +304,7 @@ class SafepointTest extends Test:
                 val logs = ArrayBuffer.empty[String]
 
                 def enter(frame: Frame, value: Any): Boolean =
-                    logs += s"Entering ${frame.methodName} with value: $value"
+                    logs += s"Entering ${frame.callerName} with value: $value"
                     true
                 end enter
 

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Trace.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Trace.scala
@@ -124,7 +124,7 @@ private[kyo] object Trace:
                     }.map { frame =>
                         StackTraceElement(
                             frame.snippetShort.reverse.padTo(toPad, ' ').reverse + " @ " + frame.className,
-                            frame.methodName,
+                            frame.callerName,
                             frame.position.fileName,
                             frame.position.lineNumber
                         )

--- a/kyo-schema/shared/src/test/scala/kyo/SchemaTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/SchemaTest.scala
@@ -4427,7 +4427,7 @@ class SchemaTest extends Test:
                 val back   = auditJsonRoundTrip(frame)(using schema)
                 assert(frame.toString == back.toString)
                 assert(back.className.nonEmpty)
-                assert(back.methodName.nonEmpty)
+                assert(back.callerName.nonEmpty)
             }
 
             "Tag[Int] round-trip — static tag" in {


### PR DESCRIPTION
## Problem

Three independent items.

`Frame.methodName` returns the enclosing method's name (where the Frame was captured). For library code that wants to report "the user called `Browser.click`" rather than "the user is inside `withBrowser` while it called us", there is no accessor for the syntactic name of the function whose implicit Frame parameter the macro is filling. The name `methodName` is also ambiguous about which method ("caller" vs "callee") it refers to.

Separately: kyo-schema, kyo-core, kyo-browser, and kyo-sql all contribute to the split package `kyo.internal`. Without an explicit `package object kyo.internal` declared somewhere in the dependency graph, Scala 3 can be driven (via an `inline def` that references a `private[kyo]` member through a `kyo.internal.X` path) to mock up a synthetic module class for `kyo.internal` and emit `getstatic kyo/internal.MODULE$` at the call site, which produces `NoClassDefFoundError: kyo/internal` on JS and Native targets.

## Solution

Rename `methodName` to `callerName` (no alias) and add a sibling `calleeName`. The new pair makes the asymmetry obvious. Rename cascades through kyo-kernel (`Trace.scala`, `SafepointTest.scala`) and kyo-schema (`SchemaTest.scala`).

`calleeName` reads the source text backwards from the macro splice position, peels matched `(...)` and `[...]` groups, and returns the identifier that precedes them. Operator-named methods return the operator string (`"+"`, `"=="`, `"::"`); backticked identifiers return the content without backticks. The walk is implemented with `@tailrec` helpers. The pure helper `extractCalleeName(source, end)` is exposed as `private[kyo]` so it can be exercised directly from FrameTest.

Add an explicit `package object internal` in kyo-data (the lowest module in the dependency graph). Every downstream compile now resolves a real `kyo.internal` module instead of mocking one up.

## Notes

Frame is `opaque type Frame <: AnyRef = String`. Backward-compat tests that need to construct a legacy version-'0' Frame from a raw string use a plain `.asInstanceOf[Frame]` rather than introducing a named test helper, to avoid surfacing a `Frame.fromString`-style entry point that AI agents would be tempted to grep for and misuse.