### PR TITLE
[http] WebSocket: raise default maxFrameSize and surface reader failures

### DIFF
--- a/kyo-http/shared/src/main/scala/kyo/HttpWebSocket.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpWebSocket.scala
@@ -79,7 +79,10 @@ object HttpWebSocket:
       * @param bufferSize
       *   Channel capacity for inbound and outbound message queues. Controls backpressure — when a channel is full, the sender suspends.
       * @param maxFrameSize
-      *   Maximum size in bytes of a single HttpWebSocket frame. Frames exceeding this limit cause the connection to close.
+      *   Maximum size in bytes of a single HttpWebSocket frame. Frames exceeding this limit cause the connection to close. Default is 16 MiB,
+      *   which comfortably handles realistic single-frame payloads (Chrome CDP screenshots up to ~4K, large RPC responses, base64-encoded
+      *   binary uploads) while still capping pathological remotes. Lower it for memory-sensitive deployments; raise it for clients that need
+      *   to receive larger frames in one go.
       * @param autoPingInterval
       *   If set, the backend sends ping frames at this interval to keep the connection alive through proxies.
       * @param closeTimeout
@@ -89,7 +92,7 @@ object HttpWebSocket:
       */
     case class Config(
         bufferSize: Int = 32,
-        maxFrameSize: Int = 65536,
+        maxFrameSize: Int = 16 * 1024 * 1024,
         autoPingInterval: Maybe[Duration] = Absent,
         closeTimeout: Duration = 5.seconds,
         subprotocols: Seq[String] = Seq.empty

--- a/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
@@ -750,9 +750,13 @@ final private[kyo] class HttpClientBackend[Handle] private (
                         }
                     }.map { readFiber =>
                         Fiber.initUnscoped {
-                            readFiber.getResult.map { _ =>
+                            readFiber.getResult.map { result =>
+                                val log = result match
+                                    case Result.Failure(e) => Log.warn(s"HttpWebSocket client reader failed: $e")
+                                    case Result.Panic(t)   => Log.warn("HttpWebSocket client reader panicked", t)
+                                    case Result.Success(_) => Kyo.unit
                                 // Close both channels so the write fiber observes EOF on outbound.take and exits promptly.
-                                inbound.close.unit.andThen(outbound.close.unit)
+                                log.andThen(inbound.close.unit).andThen(outbound.close.unit)
                             }
                         }.map { monitorFiber =>
                             Fiber.initUnscoped {

--- a/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
@@ -323,8 +323,17 @@ private[kyo] object UnsafeServerDispatch:
                         }
                     }.map { readFiber =>
                         Fiber.initUnscoped {
-                            readFiber.getResult.map { _ =>
-                                inbound.close.unit.andThen(outbound.close.unit)
+                            readFiber.getResult.map {
+                                case Result.Failure(e) =>
+                                    Log.warn(s"HttpWebSocket server reader failed: $e")
+                                        .andThen(inbound.close.unit)
+                                        .andThen(outbound.close.unit)
+                                case Result.Panic(t) =>
+                                    Log.warn("HttpWebSocket server reader panicked", t)
+                                        .andThen(inbound.close.unit)
+                                        .andThen(outbound.close.unit)
+                                case Result.Success(_) =>
+                                    inbound.close.unit.andThen(outbound.close.unit)
                             }
                         }.map { monitorFiber =>
                             Fiber.initUnscoped {

--- a/kyo-http/shared/src/test/scala/kyo/internal/WebSocketCodecTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/WebSocketCodecTest.scala
@@ -30,6 +30,44 @@ class WebSocketCodecTest extends kyo.Test:
         def writtenString: String = new String(output.toByteArray, Utf8)
     end MockConn
 
+    /** Build an unmasked WebSocket frame (server-to-client direction).
+      *
+      * Layout:
+      *   - byte 0: FIN bit + opcode
+      *   - byte 1: payload-length encoding (7-bit, 16-bit, or 64-bit)
+      *   - bytes after length: payload (no masking key for server frames)
+      */
+    private def makeFrame(opcode: Int, fin: Boolean, payload: Array[Byte]): Array[Byte] =
+        val finBit = if fin then 0x80 else 0
+        val b0     = ((finBit | opcode) & 0xff).toByte
+        val len    = payload.length
+        val header =
+            if len < 126 then
+                Array[Byte](b0, len.toByte)
+            else if len < 65536 then
+                Array[Byte](
+                    b0,
+                    126.toByte,
+                    ((len >> 8) & 0xff).toByte,
+                    (len & 0xff).toByte
+                )
+            else
+                val ll = len.toLong
+                Array[Byte](
+                    b0,
+                    127.toByte,
+                    ((ll >> 56) & 0xff).toByte,
+                    ((ll >> 48) & 0xff).toByte,
+                    ((ll >> 40) & 0xff).toByte,
+                    ((ll >> 32) & 0xff).toByte,
+                    ((ll >> 24) & 0xff).toByte,
+                    ((ll >> 16) & 0xff).toByte,
+                    ((ll >> 8) & 0xff).toByte,
+                    (ll & 0xff).toByte
+                )
+        header ++ payload
+    end makeFrame
+
     // ── Accept key ──────────────────────────────────────────────
 
     "computeAcceptKey" - {
@@ -163,6 +201,36 @@ class WebSocketCodecTest extends kyo.Test:
             val longReason = "x" * 200
             val payload    = WebSocketCodec.encodeClosePayload(1000, longReason)
             assert(payload.size == 2 + 123) // 125 max total, minus 2 for code
+        }
+    }
+
+    // ── Fragmented messages (continuation frames) ──────────────
+
+    "fragmented messages (continuation frames) reassemble into a single message" - {
+        "three-frame text message: text/FIN=0 + continuation/FIN=0 + continuation/FIN=1" in run {
+            pending
+            // Spec: a WebSocket message MAY be split across multiple frames per RFC 6455.
+            // The first frame carries the opcode (text or binary) with FIN=0; subsequent
+            // frames use opcode 0x0 (continuation) with FIN=0; the final frame uses
+            // opcode 0x0 with FIN=1. WebSocketCodec.readFrameWith should reassemble
+            // the concatenated payload and yield a single Payload value with the
+            // original text opcode.
+            //
+            // Current behavior: readFrameWith delivers each frame raw (opcode 0x1 for
+            // the first, 0x0 for the continuations), and maxFrameSize is checked per
+            // individual frame. The kyo-http 16 MiB default is a per-frame pragmatic
+            // ceiling; proper reassembly is the follow-up.
+            val frame1 = makeFrame(opcode = 0x1, fin = false, payload = "AAA".getBytes(Utf8))
+            val frame2 = makeFrame(opcode = 0x0, fin = false, payload = "BBB".getBytes(Utf8))
+            val frame3 = makeFrame(opcode = 0x0, fin = true, payload = "CCC".getBytes(Utf8))
+            val mock   = new MockConn(frame1 ++ frame2 ++ frame3)
+            WebSocketCodec.readFrameWith(mock.read, mock, Int.MaxValue) { (payload, _) =>
+                payload match
+                    case HttpWebSocket.Payload.Text(s) =>
+                        assert(s == "AAABBBCCC")
+                    case other =>
+                        fail(s"expected Text payload with reassembled content, got $other")
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

Two issues on the WebSocket layer surfaced during kyo-browser work.

`HttpWebSocket.Config.maxFrameSize` defaulted to 64 KiB. Chrome CDP routinely sends single-frame payloads larger than that (screenshot envelopes, large Runtime.evaluate results, PDFs, DOM dumps). kyo-http does not reassemble continuation frames, so the cap applies per individual frame; any oversize frame aborted the read.

Worse, when the reader aborted, the monitor fiber in both client and server pipelines ran `readFiber.getResult.map { _ => inbound.close.unit }`, silently discarding the typed `HttpException`. Downstream consumers saw only an opaque "channel closed" with no protocol context, making diagnosis painful several layers downstream.

## Solution

Raise the default to 16 MiB. Covers realistic single-frame payloads (Chrome CDP at 4K, large RPC, base64 binary uploads) while still capping pathological remotes. Scaladoc documents the rationale and tuning guidance.

Pattern-match on the reader's `Result` in both `HttpClientBackend` and `UnsafeServerDispatch` monitor fibers. `Failure` emits `Log.warn(s"HttpWebSocket {client,server} reader failed: \$e")` with the typed exception; `Panic` emits `Log.warn(msg, t)` so the throwable stack trace is preserved. Channels still close on every outcome.

## Notes

kyo-http does not currently reassemble continuation frames; `WebSocketCodec.readRawFrameWith` applies `maxFrameSize` per individual frame. The 16 MiB default is a pragmatic ceiling for the no-reassembly status quo. A pending test in `WebSocketCodecTest` ("fragmented messages (continuation frames) reassemble into a single message") documents the contract that reassembly should fulfill once implemented; activating it is the follow-up.