### PR TITLE
[core] Signal: reactive combinator API

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Signal.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Signal.scala
@@ -220,13 +220,15 @@ object Signal:
         CanEqual[A, A],
         CanEqual[Chunk[A], Chunk[A]]
     ): Signal[Chunk[A]] =
-        if signals.isEmpty then initConst(Chunk.empty[A])
-        else
-            val sigs = Chunk.from(signals)
-            initRaw(
-                currentWith = [B, S] => f => Kyo.foreach(sigs)(_.current).map(f),
-                nextWith = [B, S] => f => Async.foreachDiscard(sigs, sigs.size)(_.next).andThen(Kyo.foreach(sigs)(_.current).map(f))
-            )
+        signals.size match
+            case 0 => initConst(Chunk.empty[A])
+            case 1 => signals.head.map(Chunk(_))
+            case n =>
+                val sigs = Chunk.from(signals, n)
+                initRaw(
+                    currentWith = [B, S] => f => Kyo.foreach(sigs)(_.current).map(f),
+                    nextWith = [B, S] => f => Async.foreachDiscard(sigs, sigs.size)(_.next).andThen(Kyo.foreach(sigs)(_.current).map(f))
+                )
 
     /** Zips a sequence of signals, emitting when any changes.
       *
@@ -242,8 +244,8 @@ object Signal:
         signals.size match
             case 0 => initConst(Chunk.empty[A])
             case 1 => signals.head.map(Chunk(_))
-            case _ =>
-                val sigs = Chunk.from(signals)
+            case n =>
+                val sigs = Chunk.from(signals, n)
                 initRaw(
                     currentWith = [C, S] => g => Kyo.foreach(sigs)(_.current).map(g),
                     nextWith = [C, S] => g => awaitAny(sigs).andThen(Kyo.foreach(sigs)(_.current).map(g))

--- a/kyo-core/shared/src/main/scala/kyo/Signal.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Signal.scala
@@ -89,10 +89,69 @@ sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
       *   A new signal containing transformed values
       */
     @nowarn("msg=anonymous")
-    inline def map[B](inline f: A => B)(using CanEqual[B, B]): Signal[B] =
+    inline def map[B](inline f: A => B)(using CanEqual[B, B], Frame): Signal[B] =
         Signal.initRaw(
             currentWith = [C, S] => g => self.currentWith(a => g(f(a))),
             nextWith = [C, S] => g => self.nextWith(a => g(f(a)))
+        )
+
+    /** Dynamically switches to an inner signal based on the current value.
+      *
+      * When the outer signal changes, switches to the new inner signal produced by `f`. When the current inner signal changes, propagates
+      * that change. This is switchMap semantics (no monad laws): the previous inner is implicitly dropped on outer change. The caller
+      * re-arms via `nextWith` in a loop matching the `streamChanges` driver pattern.
+      *
+      * Note: like `streamChanges`, may skip intermediate values if changes occur faster than they can be processed. The read/arm race
+      * window in `SignalRef` propagates here.
+      *
+      * @param f
+      *   The function that produces an inner signal from the current value
+      * @return
+      *   A new signal that tracks the current inner signal
+      */
+    @nowarn("msg=anonymous")
+    inline def switchMap[B](inline f: A => Signal[B])(using CanEqual[B, B], Frame): Signal[B] =
+        Signal.initRaw(
+            currentWith = [C, S] => g => self.currentWith(a => f(a).currentWith(g)),
+            nextWith = [C, S] =>
+                g =>
+                    self.currentWith { a =>
+                        val inner = f(a)
+                        Signal.awaitAny(Seq(self, inner))
+                            .andThen(self.currentWith { a2 =>
+                                (if a2 == a then inner else f(a2)).currentWith(g)
+                            })
+                }
+        )
+
+    /** Pairs this signal with another, waiting for both to change before emitting.
+      *
+      * @param other
+      *   The signal to pair with
+      * @return
+      *   A signal of pairs that updates only when both inputs have changed since the last emit
+      */
+    @nowarn("msg=anonymous")
+    inline def zip[B](other: Signal[B])(using CanEqual[(A, B), (A, B)], Frame): Signal[(A, B)] =
+        Signal.initRaw(
+            currentWith = [C, S] => g => self.currentWith(a => other.currentWith(b => g((a, b)))),
+            nextWith = [C, S] => g => Async.zip(self.next, other.next).andThen(self.currentWith(a => other.currentWith(b => g((a, b)))))
+        )
+
+    /** Pairs this signal with another, emitting when either changes (Rx combineLatest semantics).
+      *
+      * Note: like `streamChanges`, may skip intermediate values if changes occur faster than they can be processed.
+      *
+      * @param other
+      *   The signal to pair with
+      * @return
+      *   A signal of pairs that updates when either input changes
+      */
+    @nowarn("msg=anonymous")
+    inline def combineLatest[B](other: Signal[B])(using CanEqual[(A, B), (A, B)], Frame): Signal[(A, B)] =
+        Signal.initRaw(
+            currentWith = [C, S] => g => self.currentWith(a => other.currentWith(b => g((a, b)))),
+            nextWith = [C, S] => g => Signal.awaitAny(Seq(self, other)).andThen(self.currentWith(a => other.currentWith(b => g((a, b)))))
         )
 
     /** Creates a stream that continuously emits the current value of the signal.
@@ -137,6 +196,58 @@ end Signal
 export Signal.SignalRef
 
 object Signal:
+
+    /** Waits for any of the given signals to change.
+      *
+      * @param signals
+      *   The signals to watch
+      */
+    def awaitAny(signals: Seq[Signal[?]])(using Frame): Unit < Async =
+        if signals.isEmpty then ()
+        else Async.race(signals.map(_.next)).unit
+
+    /** Zips a sequence of signals, waiting for all to change before emitting.
+      *
+      * @param signals
+      *   The signals to zip
+      * @return
+      *   A signal of Chunk that updates when all inputs have changed
+      */
+    @nowarn("msg=anonymous")
+    inline def zipAll[A](signals: Seq[Signal[A]])(
+        using
+        Frame,
+        CanEqual[A, A],
+        CanEqual[Chunk[A], Chunk[A]]
+    ): Signal[Chunk[A]] =
+        if signals.isEmpty then initConst(Chunk.empty[A])
+        else
+            val sigs = Chunk.from(signals)
+            initRaw(
+                currentWith = [B, S] => f => Kyo.foreach(sigs)(_.current).map(f),
+                nextWith = [B, S] => f => Async.foreachDiscard(sigs, sigs.size)(_.next).andThen(Kyo.foreach(sigs)(_.current).map(f))
+            )
+
+    /** Zips a sequence of signals, emitting when any changes.
+      *
+      * Note: like `streamChanges`, may skip intermediate values if changes occur faster than they can be processed.
+      *
+      * @param signals
+      *   The signals to zip
+      * @return
+      *   A signal of Chunk that updates when any input changes
+      */
+    @nowarn("msg=anonymous")
+    inline def combineLatestAll[A](signals: Seq[Signal[A]])(using Frame, CanEqual[A, A]): Signal[Chunk[A]] =
+        signals.size match
+            case 0 => initConst(Chunk.empty[A])
+            case 1 => signals.head.map(Chunk(_))
+            case _ =>
+                val sigs = Chunk.from(signals)
+                initRaw(
+                    currentWith = [C, S] => g => Kyo.foreach(sigs)(_.current).map(g),
+                    nextWith = [C, S] => g => awaitAny(sigs).andThen(Kyo.foreach(sigs)(_.current).map(g))
+                )
 
     private inline val missingCanEqual =
         "Cannot create Signal because values of type '${A}' cannot be compared for equality to detect changes. Make sure there is a 'CanEqual[${A}, ${A}]' instance available."
@@ -497,7 +608,11 @@ object Signal:
             def init[A](initial: A)(using AllowUnsafe, CanEqual[A, A]): Unsafe[A] =
                 Unsafe(
                     AtomicRef.Unsafe.init(initial),
-                    AtomicRef.Unsafe.init(Promise.Unsafe.init())
+                    // Use initMasked so that interrupting one subscriber cannot propagate through the
+                    // signal's next-promise and accidentally interrupt other subscribers waiting on the
+                    // same signal. All subsequent promises (created in onUpdate) are already masked for
+                    // the same reason; the initial promise must be consistent.
+                    AtomicRef.Unsafe.init(Promise.Unsafe.initMasked())
                 )
         end Unsafe
 

--- a/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
@@ -281,4 +281,507 @@ class SignalTest extends Test:
 
     }
 
+    "switchMap" - {
+
+        "initial currentWith reflects inner.current" in run {
+            for
+                outer <- Signal.initRef(0)
+                inner <- Signal.initRef(42)
+                sm = outer.switchMap(_ => inner)
+                v <- sm.current
+            yield assert(v == 42)
+        }
+
+        "inner change is propagated" in run {
+            for
+                outer <- Signal.initRef(0)
+                inner <- Signal.initRef(10)
+                sm = outer.switchMap(_ => inner)
+                f <- Fiber.initUnscoped(sm.next)
+                _ <- untilTrue(outer.waiters.map(_ == 1))
+                _ <- inner.set(99)
+                v <- f.get
+            yield assert(v == 99)
+        }
+
+        "outer change switches to new inner" in run {
+            for
+                outer  <- Signal.initRef(0)
+                inner0 <- Signal.initRef(10)
+                inner1 <- Signal.initRef(20)
+                sm = outer.switchMap(v => if v == 0 then inner0 else inner1)
+                f <- Fiber.initUnscoped(sm.next)
+                _ <- untilTrue(outer.waiters.map(_ == 1))
+                _ <- outer.set(1)
+                v <- f.get
+            yield assert(v == 20)
+        }
+
+        "previous inner emissions after switch are ignored" in run {
+            for
+                outer  <- Signal.initRef(0)
+                inner0 <- Signal.initRef(10)
+                inner1 <- Signal.initRef(20)
+                sm = outer.switchMap(v => if v == 0 then inner0 else inner1)
+                f1 <- Fiber.initUnscoped(sm.next)
+                _  <- untilTrue(outer.waiters.map(_ == 1))
+                _  <- outer.set(1)
+                _  <- f1.get
+                f2 <- Fiber.initUnscoped(sm.next)
+                _  <- untilTrue(outer.waiters.map(_ == 1))
+                _  <- inner0.set(99)
+                _  <- inner1.set(30)
+                v  <- f2.get
+            yield assert(v == 30)
+        }
+
+        "race outer-vs-inner: both change simultaneously" in run {
+            for
+                outer <- Signal.initRef(0)
+                inner <- Signal.initRef(10)
+                sm = outer.switchMap(_ => inner)
+                f <- Fiber.initUnscoped(sm.next)
+                _ <- untilTrue(outer.waiters.map(_ == 1))
+                _ <- Fiber.initUnscoped(outer.set(1))
+                _ <- Fiber.initUnscoped(inner.set(99))
+                r <- Abort.run[Timeout](Async.timeout(2.seconds)(f.get))
+            yield assert(r.isSuccess)
+        }
+
+        "inside streamChanges produces expected sequence" in run {
+            for
+                outer <- Signal.initRef(0)
+                inner <- Signal.initRef(10)
+                sm = outer.switchMap(_ => inner)
+                f  <- Fiber.initUnscoped(sm.streamChanges.take(3).run)
+                _  <- Async.sleep(100.millis)
+                _  <- inner.set(11)
+                _  <- Async.sleep(100.millis)
+                _  <- inner.set(12)
+                vs <- f.get
+            yield assert(vs == Chunk(10, 11, 12))
+        }
+
+        "switchMap f called once when only inner changes" in run {
+            var callCount = 0
+            for
+                outerRef <- Signal.initRef(0)
+                innerRef <- Signal.initRef(0)
+                sm = outerRef.switchMap { _ =>
+                    callCount += 1; innerRef
+                }
+                f <- Fiber.initUnscoped(sm.next)
+                _ <- untilTrue(outerRef.waiters.map(_ == 1))
+                _ <- innerRef.set(1)
+                _ <- f.get
+            yield assert(callCount == 1, s"f called $callCount times, expected 1")
+            end for
+        }
+    }
+
+    "zip" - {
+
+        "initial currentWith returns paired currents" in run {
+            for
+                refA <- Signal.initRef(1)
+                refB <- Signal.initRef(2)
+                z = refA.zip(refB)
+                v <- z.current
+            yield assert(v == (1, 2))
+        }
+
+        "self change alone does not emit" in run {
+            val noEmitTimeout = if Platform.isNative then 1.second else 300.millis
+            for
+                refA <- Signal.initRef(0)
+                refB <- Signal.initRef(0)
+                z = refA.zip(refB)
+                f <- Fiber.initUnscoped(z.next)
+                _ <- untilTrue(refA.waiters.map(_ == 1))
+                _ <- refA.set(1)
+                r <- Abort.run[Timeout](Async.timeout(noEmitTimeout)(f.get))
+            yield assert(r.isFailure)
+            end for
+        }
+
+        "self-then-other emits the latest pair" in run {
+            for
+                refA <- Signal.initRef(0)
+                refB <- Signal.initRef(0)
+                z = refA.zip(refB)
+                f <- Fiber.initUnscoped(z.next)
+                _ <- untilTrue(refA.waiters.map(_ == 1))
+                _ <- refA.set(1)
+                _ <- untilTrue(refB.waiters.map(_ == 1))
+                _ <- refB.set(2)
+                v <- f.get
+            yield assert(v == (1, 2))
+        }
+
+        "zip other-then-self emits the latest pair" in run {
+            for
+                refA <- Signal.initRef(0)
+                refB <- Signal.initRef(0)
+                z = refA.zip(refB)
+                f      <- Fiber.initUnscoped(z.next)
+                _      <- untilTrue(refA.waiters.map(_ == 1))
+                _      <- refB.set(1)
+                _      <- refA.set(1)
+                result <- Abort.run[Timeout](Async.timeout(2.seconds)(f.get))
+            yield result match
+                case Result.Failure(_: Timeout) => fail("zip did not emit within 2s")
+                case Result.Success(pair)       => assert(pair == (1, 1))
+                case other                      => fail(s"unexpected: $other")
+        }
+    }
+
+    "combineLatest" - {
+
+        "initial currentWith returns paired currents" in run {
+            for
+                refA <- Signal.initRef(1)
+                refB <- Signal.initRef(2)
+                cl = refA.combineLatest(refB)
+                v <- cl.current
+            yield assert(v == (1, 2))
+        }
+
+        "self change alone emits" in run {
+            for
+                refA <- Signal.initRef(0)
+                refB <- Signal.initRef(0)
+                cl = refA.combineLatest(refB)
+                f <- Fiber.initUnscoped(cl.next)
+                _ <- untilTrue(refA.waiters.map(_ == 1))
+                _ <- refA.set(1)
+                v <- f.get
+            yield assert(v == (1, 0))
+        }
+
+        "other change alone emits" in run {
+            for
+                refA <- Signal.initRef(0)
+                refB <- Signal.initRef(0)
+                cl = refA.combineLatest(refB)
+                f <- Fiber.initUnscoped(cl.next)
+                _ <- untilTrue(refA.waiters.map(_ == 1))
+                _ <- refB.set(2)
+                v <- f.get
+            yield assert(v == (0, 2))
+        }
+
+        "successive other changes each emit" in run {
+            for
+                refA <- Signal.initRef(0)
+                refB <- Signal.initRef(0)
+                cl = refA.combineLatest(refB)
+                // First emit: refB fires; wait on refA as sync point (no ghosts yet)
+                f1 <- Fiber.initUnscoped(cl.next)
+                _  <- untilTrue(refA.waiters.map(_ == 1))
+                _  <- refB.set(1)
+                v1 <- f1.get
+                // Second emit: refB fires again.
+                // After f1 resolved via refB, refA has a ghost waiter (masked next
+                // from the race that was cancelled without removing the onComplete).
+                // refB has a fresh promise (0 waiters) because refB.set fired it.
+                // Wait on refB to confirm the second awaitAny is subscribed to refB.
+                f2 <- Fiber.initUnscoped(cl.next)
+                _  <- untilTrue(refB.waiters.map(_ >= 1))
+                _  <- refB.set(2)
+                v2 <- f2.get
+            yield assert(v1 == (0, 1) && v2 == (0, 2))
+        }
+
+        "interleaved self,other,self,other produces four emits" in run {
+            for
+                refA <- Signal.initRef(0)
+                refB <- Signal.initRef(0)
+                cl = refA.combineLatest(refB)
+                f  <- Fiber.initUnscoped(cl.streamChanges.take(5).run)
+                _  <- Async.sleep(50.millis)
+                _  <- refA.set(1)
+                _  <- Async.sleep(50.millis)
+                _  <- refB.set(1)
+                _  <- Async.sleep(50.millis)
+                _  <- refA.set(2)
+                _  <- Async.sleep(50.millis)
+                _  <- refB.set(2)
+                vs <- f.get
+            yield assert(vs.size >= 4 && vs.last == (2, 2))
+        }
+
+        "source remains usable after concurrent waiters complete" in run {
+            for
+                refA <- Signal.initRef(0)
+                refB <- Signal.initRef(0)
+                cl = refA.combineLatest(refB)
+                // Two independent waiters both see the broadcast when refA fires
+                f1 <- Fiber.initUnscoped(cl.next)
+                f2 <- Fiber.initUnscoped(cl.next)
+                _  <- untilTrue(refA.waiters.map(_ >= 2))
+                _  <- refA.set(1)
+                v1 <- f1.get
+                v2 <- f2.get
+                // After refA fired: refA has a fresh promise (0 waiters), refB has
+                // 2 ghost waiters (one from each race loser that cancelled without
+                // removing the onComplete from refB's promise).
+                // A third waiter adds 1 more to each; wait for refB >= 3 to confirm
+                // the new awaitAny is subscribed to refB before firing it.
+                f3 <- Fiber.initUnscoped(cl.next)
+                _  <- untilTrue(refB.waiters.map(_ >= 3))
+                _  <- refB.set(1)
+                v3 <- f3.get
+            yield assert(v1 == (1, 0) && v2 == (1, 0) && v3 == (1, 1))
+        }
+
+    }
+
+    "awaitAny" - {
+
+        "completes when any signal changes" in run {
+            for
+                r0 <- Signal.initRef(0)
+                r1 <- Signal.initRef(0)
+                r2 <- Signal.initRef(0)
+                f  <- Fiber.initUnscoped(Signal.awaitAny(Seq(r0, r1, r2)))
+                _  <- untilTrue(r0.waiters.map(_ == 1))
+                _  <- r1.set(1)
+                _  <- f.get
+            yield succeed
+        }
+
+        "single-element seq equivalent to signal.next" in run {
+            for
+                ref <- Signal.initRef(0)
+                f   <- Fiber.initUnscoped(Signal.awaitAny(Seq(ref)))
+                _   <- untilTrue(ref.waiters.map(_ == 1))
+                _   <- ref.set(1)
+                _   <- f.get
+            yield succeed
+        }
+
+        "source remains usable after concurrent waiters complete" in run {
+            for
+                r0 <- Signal.initRef(0)
+                r1 <- Signal.initRef(0)
+                // Two independent awaitAny waiters both see the broadcast when r0 fires
+                f1 <- Fiber.initUnscoped(Signal.awaitAny(Seq(r0, r1)))
+                f2 <- Fiber.initUnscoped(Signal.awaitAny(Seq(r0, r1)))
+                _  <- untilTrue(r0.waiters.map(_ >= 2))
+                _  <- r0.set(1)
+                _  <- f1.get
+                _  <- f2.get
+                // After r0 fired: r0 has a fresh promise (0 waiters), r1 has
+                // 2 ghost waiters (one from each race loser). A third waiter
+                // adds 1 more to r1; wait for r1 >= 3 to confirm subscription.
+                f3 <- Fiber.initUnscoped(Signal.awaitAny(Seq(r0, r1)))
+                _  <- untilTrue(r1.waiters.map(_ >= 3))
+                _  <- r1.set(1)
+                _  <- f3.get
+            yield succeed
+        }
+
+        "empty seq completes immediately" in run {
+            Signal.awaitAny(Seq.empty).andThen(succeed)
+        }
+    }
+
+    "zipAll" - {
+
+        "empty seq returns Chunk.empty const" in run {
+            val z = Signal.zipAll(Seq.empty[Signal[Int]])
+            for
+                v1 <- z.current
+                v2 <- z.next
+            yield assert(v1 == Chunk.empty && v2 == Chunk.empty)
+            end for
+        }
+
+        "single-element seq behaves like signal.map(Chunk(_))" in run {
+            for
+                ref <- Signal.initRef(5)
+                z = Signal.zipAll(Seq(ref))
+                v  <- z.current
+                f  <- Fiber.initUnscoped(z.next)
+                _  <- untilTrue(ref.waiters.map(_ == 1))
+                _  <- ref.set(6)
+                nv <- f.get
+            yield assert(v == Chunk(5) && nv == Chunk(6))
+        }
+
+        "N-element initial current returns Chunk of currents" in run {
+            for
+                r0 <- Signal.initRef(1)
+                r1 <- Signal.initRef(2)
+                r2 <- Signal.initRef(3)
+                z = Signal.zipAll(Seq(r0, r1, r2))
+                v <- z.current
+            yield assert(v == Chunk(1, 2, 3))
+        }
+
+        "all must change for next to fire" in run {
+            for
+                r0 <- Signal.initRef(0)
+                r1 <- Signal.initRef(0)
+                r2 <- Signal.initRef(0)
+                z = Signal.zipAll(Seq(r0, r1, r2))
+                // Arm the waiter
+                f <- Fiber.initUnscoped(z.next)
+                _ <- untilTrue(r0.waiters.map(_ == 1))
+                // Change r1 and r2 but NOT r0 — emit must not fire yet
+                _ <- r1.set(1)
+                _ <- r2.set(1)
+                // Check non-blocking: the fiber is still pending
+                done <- f.done
+                // Now change r0 — all 3 have changed, emit must fire
+                _ <- r0.set(1)
+                v <- f.get
+            yield assert(!done && v == Chunk(1, 1, 1))
+        }
+
+        "zipAll concurrent out-of-order changes emit" in run {
+            for
+                r0 <- Signal.initRef(0)
+                r1 <- Signal.initRef(0)
+                r2 <- Signal.initRef(0)
+                z = Signal.zipAll(Seq(r0, r1, r2))
+                f      <- Fiber.initUnscoped(z.next)
+                _      <- untilTrue(r0.waiters.map(_ == 1))
+                _      <- r2.set(1)
+                _      <- r1.set(1)
+                _      <- r0.set(1)
+                result <- Abort.run[Timeout](Async.timeout(2.seconds)(f.get))
+            yield result match
+                case Result.Failure(_: Timeout) => fail("zipAll did not emit within 2s")
+                case Result.Success(chunk)      => assert(chunk == Chunk(1, 1, 1))
+                case other                      => fail(s"unexpected: $other")
+        }
+    }
+
+    "combineLatestAll" - {
+
+        "empty seq returns Chunk.empty const" in run {
+            val z = Signal.combineLatestAll(Seq.empty[Signal[Int]])
+            for
+                v1 <- z.current
+                v2 <- z.next
+            yield assert(v1 == Chunk.empty && v2 == Chunk.empty)
+            end for
+        }
+
+        "single-element delegates to map" in run {
+            for
+                ref <- Signal.initRef(5)
+                z = Signal.combineLatestAll(Seq(ref))
+                v  <- z.current
+                f  <- Fiber.initUnscoped(z.next)
+                _  <- untilTrue(ref.waiters.map(_ == 1))
+                _  <- ref.set(6)
+                nv <- f.get
+            yield assert(v == Chunk(5) && nv == Chunk(6))
+        }
+
+        "any signal change emits" in run {
+            for
+                r0 <- Signal.initRef(0)
+                r1 <- Signal.initRef(0)
+                r2 <- Signal.initRef(0)
+                z = Signal.combineLatestAll(Seq(r0, r1, r2))
+                f <- Fiber.initUnscoped(z.next)
+                _ <- untilTrue(r0.waiters.map(_ == 1))
+                _ <- r1.set(99)
+                v <- f.get
+            yield assert(v == Chunk(0, 99, 0))
+        }
+
+        "every individual signal can wake the combinator" in run {
+            for
+                r0 <- Signal.initRef(0)
+                r1 <- Signal.initRef(0)
+                r2 <- Signal.initRef(0)
+                z = Signal.combineLatestAll(Seq(r0, r1, r2))
+                // First emit: r0 fires; r0 starts with 0 waiters so reliable sync point
+                f0 <- Fiber.initUnscoped(z.next)
+                _  <- untilTrue(r0.waiters.map(_ == 1))
+                _  <- r0.set(1)
+                v0 <- f0.get
+                // Second emit: r1 fires; after first emit, r1 has 1 ghost waiter.
+                // After second awaitAny subscribes, r1 has ghost+new=2.
+                // Use r1.waiters >= 2 as sync point to confirm subscription.
+                f1 <- Fiber.initUnscoped(z.next)
+                _  <- untilTrue(r1.waiters.map(_ >= 2))
+                _  <- r1.set(1)
+                v1 <- f1.get
+                // Third emit: r2 fires; after second emit, r1 is fresh (0 waiters),
+                // r2 has 2 ghost waiters. After third awaitAny subscribes, r1 has 1 new.
+                // Use r1.waiters >= 1 as sync point (r1 is fresh, so 0+1=1 is reliable).
+                f2 <- Fiber.initUnscoped(z.next)
+                _  <- untilTrue(r1.waiters.map(_ >= 1))
+                _  <- r2.set(1)
+                v2 <- f2.get
+            yield assert(v0 == Chunk(1, 0, 0) && v1 == Chunk(1, 1, 0) && v2 == Chunk(1, 1, 1))
+        }
+
+        "rapid bursts coalesce" in run {
+            for
+                ref <- Signal.initRef(0)
+                z = Signal.combineLatestAll(Seq(ref))
+                f  <- Fiber.initUnscoped(z.streamChanges.take(2).run)
+                _  <- Async.sleep(50.millis)
+                _  <- Kyo.foreachDiscard(Seq.range(1, 11))(ref.set)
+                vs <- f.get
+            yield assert(vs.size == 2 && vs.head == Chunk(0) && vs.last.head >= 1)
+        }
+
+    }
+
+    "composition" - {
+
+        "map -> switchMap -> zip composes at type level" in run {
+            for
+                ref <- Signal.initRef(0)
+                mapped = ref.map(_ + 1)
+                inner  = Signal.initConst(100)
+                sm     = mapped.switchMap(_ => inner)
+                inner2 = Signal.initConst(200)
+                zipped = sm.zip(inner2)
+                v <- zipped.current
+            yield assert(v == (100, 200))
+        }
+
+        "switchMap inside streamChanges with mutation" in run {
+            for
+                outer <- Signal.initRef(0)
+                inner <- Signal.initRef(10)
+                mapped = outer.map(_ * 2)
+                sm     = mapped.switchMap(_ => inner)
+                f  <- Fiber.initUnscoped(sm.streamChanges.take(3).run)
+                _  <- Async.sleep(100.millis)
+                _  <- inner.set(11)
+                _  <- Async.sleep(100.millis)
+                _  <- inner.set(12)
+                vs <- f.get
+            yield assert(vs == Chunk(10, 11, 12))
+        }
+
+        "combineLatest feeding streamChanges produces interleaved emit sequence" in run {
+            for
+                refA <- Signal.initRef(0)
+                refB <- Signal.initRef(0)
+                cl = refA.combineLatest(refB)
+                f  <- Fiber.initUnscoped(cl.streamChanges.take(5).run)
+                _  <- Async.sleep(50.millis)
+                _  <- refA.set(1)
+                _  <- Async.sleep(50.millis)
+                _  <- refB.set(1)
+                _  <- Async.sleep(50.millis)
+                _  <- refA.set(2)
+                _  <- Async.sleep(50.millis)
+                _  <- refB.set(2)
+                vs <- f.get
+            yield assert(vs.size >= 4 && vs.last == (2, 2))
+        }
+
+    }
+
 end SignalTest

--- a/kyo-data/shared/src/main/scala/kyo/Chunk.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Chunk.scala
@@ -611,7 +611,19 @@ object Chunk extends StrictOptimizedSeqFactory[Chunk]:
           * @return
           *   a new Chunk.Indexed containing the elements from the IterableOnce
           */
-        def from[A](source: IterableOnce[A]): Indexed[A] =
+        def from[A](source: IterableOnce[A]): Indexed[A] = from(source, -1)
+
+        /** Like [[from]] but, when the source must be copied (it is neither already an Indexed Chunk nor an `IndexedSeq`), pre-allocates the
+          * backing array to `exactSize` instead of growing a builder. Copying an unsized source such as a `List` otherwise pays the
+          * builder's resize-and-trim cost; passing its known size skips both allocations. The zero-copy `IndexedSeq` fast path is preserved.
+          *
+          * INTERNAL: `exactSize` must equal the source's element count; a negative value means "unknown" and falls back to size-agnostic
+          * copying (the single-argument [[from]] delegates here with `-1`).
+          *
+          * @param exactSize
+          *   the source's element count, or negative if unknown
+          */
+        private[kyo] def from[A](source: IterableOnce[A], exactSize: Int): Indexed[A] =
             source match
                 case chunk: Chunk.Indexed[A] @unchecked => chunk
                 case other =>
@@ -622,7 +634,12 @@ object Chunk extends StrictOptimizedSeqFactory[Chunk]:
                             other match
                                 case seq: IndexedSeq[A] @unchecked => FromSeq(seq)
                                 case _ =>
-                                    val array = other.iterator.toArray(using erasedTag[A])
+                                    val array =
+                                        if exactSize > 0 then
+                                            val buf = erasedTag[A].newArray(exactSize)
+                                            val _   = other.iterator.copyToArray(buf)
+                                            buf
+                                        else other.iterator.toArray(using erasedTag[A])
                                     array.length match
                                         case 0 => empty[A]
                                         case 1 => single(array(0))
@@ -704,6 +721,17 @@ object Chunk extends StrictOptimizedSeqFactory[Chunk]:
         source match
             case chunk: Chunk.Indexed[A] @unchecked => chunk
             case other                              => Indexed.from(other)
+        end match
+    end from
+
+    /** Like [[from]] but pre-allocates the backing array to `exactSize` when a copy is required, skipping the growable-builder resize a copy
+      * of an unsized source (e.g. a `List`) incurs while keeping the zero-copy `IndexedSeq` fast path. INTERNAL: `exactSize` must equal the
+      * source's element count; a negative value means "unknown".
+      */
+    private[kyo] def from[A](source: IterableOnce[A], exactSize: Int): Chunk[A] =
+        source match
+            case chunk: Chunk.Indexed[A] @unchecked => chunk
+            case other                              => Indexed.from(other, exactSize)
         end match
     end from
 

--- a/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ChunkTest.scala
@@ -73,6 +73,35 @@ class ChunkTest extends Test:
                 val chunk = Chunk.from(list)
                 assert(chunk.isInstanceOf[Chunk.internal.Compact[Int]])
             }
+
+            "with exact size hint" - {
+                "pre-sizes the copy of a non-IndexedSeq, same result as no hint" in {
+                    val list  = List(1, 2, 3, 4, 5)
+                    val hint  = Chunk.from(list, list.size)
+                    val plain = Chunk.from(list)
+                    assert(hint == Seq(1, 2, 3, 4, 5))
+                    assert(hint == plain)
+                    assert(hint.isInstanceOf[Chunk.internal.Compact[Int]])
+                }
+
+                "keeps the zero-copy FromSeq fast path for IndexedSeq input" in {
+                    val vector = Vector(1, 2, 3)
+                    val chunk  = Chunk.from(vector, vector.size)
+                    assert(chunk == Seq(1, 2, 3))
+                    assert(chunk.isInstanceOf[Chunk.internal.FromSeq[Int]])
+                }
+
+                "negative hint falls back to size-agnostic copying" in {
+                    val list  = List(1, 2, 3)
+                    val chunk = Chunk.from(list, -1)
+                    assert(chunk == Seq(1, 2, 3))
+                }
+
+                "empty source" in {
+                    val chunk = Chunk.from(List.empty[Int], 0)
+                    assert(chunk.isEmpty && (chunk eq Chunk.empty))
+                }
+            }
         }
 
         "Maybe" - {


### PR DESCRIPTION
## Problem

`Signal[A]` currently exposes `map` and the streaming helpers. Standard reactive combinators are missing: `switchMap`, `combineLatest`, the N-ary variants, `awaitAny`. They're the primitives any non-trivial reactive layer needs, and kyo-ui has been hitting the gap.

## Solution

Adds `switchMap`, `zip`, `combineLatest` to the instance, and `Signal.awaitAny`, `zipAll`, `combineLatestAll` to the companion. Named after Rx, not after the monadic operators. These don't satisfy monad laws and calling one `flatMap` would lie.

## Notes

Also fixes a pre-existing bug in `SignalRef.Unsafe.init`: the initial `nextPromise` was a plain `init()` while every rotation in `onUpdate` is `initMasked()`. The first subscriber to a fresh ref ended up with different interrupt semantics than every subsequent one. The initial promise now uses `initMasked()` to match.