### PR TITLE
[core][prelude] Path.confinedTo + Process.Input.Pipe + Stream.find

### DIFF
--- a/kyo-core/js/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -14,6 +14,7 @@ import scala.scalajs.js.typedarray.Uint8Array
 @JSImport("node:fs", JSImport.Namespace)
 private[kyo] object NodeFs extends js.Object:
     def existsSync(path: String): Boolean                                                       = js.native
+    def realpathSync(path: String): String                                                      = js.native
     def statSync(path: String): NodeStats                                                       = js.native
     def lstatSync(path: String): NodeStats                                                      = js.native
     def readFileSync(path: String, encoding: String): String                                    = js.native
@@ -165,6 +166,12 @@ final private[kyo] class NodePathUnsafe(raw: String) extends Path.Unsafe:
     def isSymbolicLink()(using AllowUnsafe): Boolean =
         try NodeFs.lstatSync(pathStr).isSymbolicLink()
         catch case _: js.JavaScriptException => false
+
+    def realPath()(using AllowUnsafe, Frame): Result[FileException, Path] =
+        try Result.succeed(Path(NodeFs.realpathSync(pathStr)))
+        catch
+            case e: js.JavaScriptException => Result.fail(NodeError.translateFs(safe, e))
+            case e: Throwable              => Result.panic(e)
 
     // --- Read ---
 
@@ -654,6 +661,9 @@ abstract private[kyo] class PathPlatformSpecific extends PathDirectories:
 
     private[kyo] def homePath: Path =
         make(Chunk(NodeOs.homedir()))
+
+    private[kyo] def cwdPath: Path =
+        make(Chunk(js.Dynamic.global.process.applyDynamic("cwd")().asInstanceOf[String]))
 
     private[kyo] def osPlatform: String =
         NodeOs.platform() match

--- a/kyo-core/js/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
+++ b/kyo-core/js/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
@@ -558,6 +558,7 @@ final private[kyo] class NodeCommandUnsafe(
                                             stdinSource match
                                                 case Process.Input.FromStream(is) => feedInputStream(is, child.stdin)
                                                 case Process.Input.Inherit        => ()
+                                                case Process.Input.Pipe           => ()
                                             end match
                                     end match
 
@@ -623,6 +624,7 @@ final private[kyo] class NodeCommandUnsafe(
                                             firstCmd.stdinSource match
                                                 case Process.Input.FromStream(is) => feedInputStream(is, children.head.stdin)
                                                 case Process.Input.Inherit        => ()
+                                                case Process.Input.Pipe           => ()
                                             end match
                                     end match
 

--- a/kyo-core/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -59,6 +59,14 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
     def isRegularFile()(using AllowUnsafe): Boolean  = Files.isRegularFile(jpath)
     def isSymbolicLink()(using AllowUnsafe): Boolean = Files.isSymbolicLink(jpath)
 
+    def realPath()(using AllowUnsafe, Frame): Result[FileException, Path] =
+        try Result.succeed(Path.of(jpath.toRealPath()))
+        catch
+            case e: IOException if isFileNotFound(e) => Result.fail(FileNotFoundException(safe))
+            case e: AccessDeniedException            => Result.fail(FileAccessDeniedException(safe))
+            case e: IOException                      => Result.fail(FileIOException(safe, e))
+            case e: Throwable                        => Result.panic(e)
+
     // --- Read ---
 
     def read()(using AllowUnsafe, Frame): Result[FileReadException, String] =
@@ -525,6 +533,12 @@ abstract private[kyo] class PathPlatformSpecific extends PathDirectories:
         if h == null || h.isEmpty then make(Chunk(""))
         else make(Chunk(h))
     end homePath
+
+    private[kyo] def cwdPath: Path =
+        val d = java.lang.System.getProperty("user.dir")
+        if d == null || d.isEmpty then make(Chunk(""))
+        else make(Chunk(d))
+    end cwdPath
 
     private[kyo] def osPlatform: String =
         val os = java.lang.System.getProperty("os.name", "").toLowerCase

--- a/kyo-core/jvm-native/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
@@ -192,6 +192,7 @@ final private[kyo] class JvmCommandUnsafe(
                             stdinSource match
                                 case Process.Input.Inherit       => discard(pb.redirectInput(JProcessBuilder.Redirect.INHERIT))
                                 case Process.Input.FromStream(_) => discard(pb.redirectInput(JProcessBuilder.Redirect.PIPE))
+                                case Process.Input.Pipe          => discard(pb.redirectInput(JProcessBuilder.Redirect.PIPE))
                             end match
                     end match
                 end if
@@ -350,6 +351,7 @@ final private[kyo] class JvmCommandUnsafe(
                                         stdinSource match
                                             case Process.Input.FromStream(is) => feedInputStream(is, jp.getOutputStream)
                                             case Process.Input.Inherit        => ()
+                                            case Process.Input.Pipe           => ()
                                 end match
                                 Result.succeed(proc)
                             catch
@@ -389,6 +391,7 @@ final private[kyo] class JvmCommandUnsafe(
                                 firstCmd.stdinSource match
                                     case Process.Input.FromStream(is) => feedInputStream(is, jp.getOutputStream)
                                     case Process.Input.Inherit        => ()
+                                    case Process.Input.Pipe           => ()
                                 end match
                         end match
                         Result.succeed(proc)

--- a/kyo-core/jvm/src/test/scala/kyo/PathJvmTest.scala
+++ b/kyo-core/jvm/src/test/scala/kyo/PathJvmTest.scala
@@ -52,6 +52,42 @@ class PathJvmTest extends Test:
         end for
     }
 
+    "realPath follows a symbolic link to its underlying target" in run {
+        val tmp    = JFiles.createTempDirectory("kyo-test")
+        val target = tmp.resolve("target.txt")
+        val link   = tmp.resolve("link.txt")
+        JFiles.createFile(target)
+        JFiles.createSymbolicLink(link, target)
+        val linkPath = Path(link.toString)
+        for
+            real <- linkPath.realPath
+            _    <- Path(tmp.toString).removeAll
+        yield assert(real.parts.lastOption.contains("target.txt"))
+        end for
+    }
+
+    "confinedTo rejects a symlink inside root that escapes to outside root" in run {
+        // tmp/root contains a symlink `escape` -> tmp/outside.txt. Without realPath the
+        // syntactic check would accept it (no `..`, not absolute, no `.`), but
+        // confinedTo resolves the link and rejects.
+        val tmp     = JFiles.createTempDirectory("kyo-test")
+        val root    = tmp.resolve("root")
+        val outside = tmp.resolve("outside.txt")
+        JFiles.createDirectory(root)
+        JFiles.createFile(outside)
+        val escape = root.resolve("escape")
+        JFiles.createSymbolicLink(escape, outside)
+        val rootP   = Path(root.toString)
+        val escapeP = Path(escape.toString)
+        for
+            res <- Abort.run[FileException](escapeP.confinedTo(rootP))
+            _   <- Path(tmp.toString).removeAll
+        yield
+            assert(res.isFailure)
+            assert(res.failure.exists(_.isInstanceOf[FileAccessDeniedException]))
+        end for
+    }
+
     "exists(followLinks=false) on symlink returns true; exists(true) returns false for dangling link" in run {
         val tmp    = JFiles.createTempDirectory("kyo-test")
         val target = tmp.resolve("ghost-target.txt")

--- a/kyo-core/shared/src/main/scala/kyo/Command.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Command.scala
@@ -172,6 +172,12 @@ object Command:
         /** Inherits stdin from the parent process. */
         def inheritStdin: Command = self.unsafe.withStdin(Process.Input.Inherit).safe
 
+        /** Opens an unmanaged pipe on the child's stdin. The caller drives writes directly via
+          * `proc.unsafe.stdinJava` (no auto-pump fiber). Use when wiring the child into a custom
+          * protocol layer that owns when bytes flow in (e.g. JSON-RPC over stdio).
+          */
+        def pipeStdin: Command = self.unsafe.withStdin(Process.Input.Pipe).safe
+
         /** Inherits stdout from the parent process (not captured). */
         def inheritStdout: Command = self.unsafe.withInheritStdout(true).safe
 

--- a/kyo-core/shared/src/main/scala/kyo/Path.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Path.scala
@@ -84,6 +84,22 @@ object Path extends PathPlatformSpecific:
             else Present(Path(ps.init*))
         end parent
 
+        /** Lazily yields self, its parent, its grandparent, ..., up to and including the filesystem root.
+          *
+          * Use with `Stream.find` for "first ancestor where X" lookups (e.g., finding a project root
+          * marker like `.git` or `build.sbt`). The stream is pure: it does not stat anything on disk.
+          */
+        def ancestors(using tag: Tag[Emit[Chunk[Path]]], frame: Frame): Stream[Path, Any] =
+            @scala.annotation.tailrec
+            def loop(cur: Path, acc: Chunk[Path]): Chunk[Path] =
+                val next = acc.append(cur)
+                cur.parent match
+                    case Maybe.Present(parent) => loop(parent, next)
+                    case Maybe.Absent          => next
+            end loop
+            Stream.init(loop(self, Chunk.empty))
+        end ancestors
+
         /** Returns `true` if this path is absolute (begins at a filesystem root).
           *
           * Absolute paths are normalised to start with a leading `""` segment.
@@ -126,6 +142,41 @@ object Path extends PathPlatformSpecific:
         /** Returns `true` if this path is a symbolic link. */
         def isSymbolicLink(using Frame): Boolean < Sync =
             Sync.Unsafe.defer(self.unsafe.isSymbolicLink())
+
+        /** Returns the canonical absolute path with every symbolic link in the chain resolved.
+          *
+          * Fails with `FileNotFoundException` if any element of the path does not exist, or
+          * `FileAccessDeniedException` if the filesystem denies access. Useful for safe
+          * path-under-root validation: compare `path.realPath` against `root.realPath` instead
+          * of relying on syntactic checks (which miss symlinks that point outside the root).
+          */
+        def realPath(using Frame): Path < (Sync & Abort[FileException]) =
+            Sync.Unsafe.defer(Abort.get(self.unsafe.realPath()))
+
+        /** Returns this path resolved to its canonical real path, but only if that real path is contained
+          * within `root` (after resolving `root`'s own symlinks).
+          *
+          * The check follows every symbolic link in both `self` and `root`, so a symlink inside `root`
+          * pointing outside is rejected. The pure path-prefix comparison runs against the canonical parts
+          * of both paths; a path equal to `root` is considered contained.
+          *
+          * Both `self` and `root` must exist; if either does not, fails with `FileNotFoundException`.
+          * If `self`'s real path is outside `root`'s real path, fails with `FileAccessDeniedException`
+          * carrying the offending real path.
+          *
+          * Useful for any tool that exposes a configured root and accepts user-supplied relative paths:
+          * call `(root / userInput).confinedTo(root)` to obtain a path that is statically known to live
+          * under the root, defending against symlink escapes.
+          */
+        def confinedTo(root: Path)(using Frame): Path < (Sync & Abort[FileException]) =
+            Sync.Unsafe.defer {
+                Abort.get(root.unsafe.realPath()).map { rootReal =>
+                    Abort.get(self.unsafe.realPath()).map { selfReal =>
+                        if selfReal.parts.take(rootReal.parts.size) == rootReal.parts then (selfReal: Path < Abort[FileException])
+                        else Abort.fail[FileException](FileAccessDeniedException(selfReal))
+                    }
+                }
+            }
 
         // --- Read ---
 
@@ -431,6 +482,14 @@ object Path extends PathPlatformSpecific:
 
     // --- System directories ---
 
+    /** The current working directory of the JVM (JVM/Native) or Node process (JS).
+      *
+      * Reads at call time, so subsequent `process.chdir` (or test fixtures that fork with a
+      * different working dir) take effect on the next access. Use with `path.ancestors` for
+      * "find the project root containing X" style lookups.
+      */
+    def cwd(using Frame): Path < Sync = Sync.Unsafe.defer(cwdPath)
+
     /** Well-known base directories for the current OS (cache, config, data, etc.). */
     lazy val basePaths: BasePaths = platformBasePaths
 
@@ -533,6 +592,7 @@ object Path extends PathPlatformSpecific:
         def isDirectory()(using AllowUnsafe): Boolean
         def isRegularFile()(using AllowUnsafe): Boolean
         def isSymbolicLink()(using AllowUnsafe): Boolean
+        def realPath()(using AllowUnsafe, Frame): Result[FileException, Path]
 
         // --- Read ---
 

--- a/kyo-core/shared/src/main/scala/kyo/Process.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Process.scala
@@ -198,12 +198,15 @@ object Process:
     /** The source for a process's standard input.
       *
       * `Inherit` pipes the parent process's stdin through. `FromStream` reads from the given `InputStream` (feeding it into the child
-      * process's stdin via a background fiber when the process is spawned).
+      * process's stdin via a background fiber when the process is spawned). `Pipe` opens an unmanaged pipe on the child's stdin so the
+      * caller can drive it directly via `proc.unsafe.stdinJava` (no auto-pump fiber). Use `Pipe` when wiring the child into a custom
+      * protocol layer where the caller owns when bytes flow in.
       */
     sealed trait Input derives CanEqual
     object Input:
         case object Inherit                        extends Input
         case class FromStream(stream: InputStream) extends Input
+        case object Pipe                           extends Input
     end Input
 
     // --- Unsafe ---

--- a/kyo-core/shared/src/main/scala/kyo/internal/PathDirectories.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/PathDirectories.scala
@@ -18,6 +18,14 @@ private[kyo] trait PathDirectories:
     /** The current user's home directory. */
     private[kyo] def homePath: Path
 
+    /** The current working directory at the time of the call.
+      *
+      * On JVM/Native this reads the `user.dir` system property; on Node it calls `process.cwd()`.
+      * The value is captured eagerly — if the application changes its working directory at
+      * runtime (e.g., via `process.chdir`), call this method again to get the new path.
+      */
+    private[kyo] def cwdPath: Path
+
     /** Normalised OS tag: `"mac"`, `"linux"`, or `"win"`. */
     private[kyo] def osPlatform: String
 

--- a/kyo-core/shared/src/test/scala/kyo/PathTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/PathTest.scala
@@ -141,6 +141,104 @@ class PathTest extends Test:
         end for
     }
 
+    "Path.cwd returns a non-empty path" in run {
+        Path.cwd.map { cwd =>
+            assert(cwd.parts.nonEmpty, s"expected non-empty cwd, got parts=${cwd.parts.mkString(",")}")
+        }
+    }
+
+    "Path.parent terminates after finite steps" in run {
+        Path.cwd.map { cwd =>
+            @scala.annotation.tailrec
+            def loop(cur: Path, depth: Int): Int =
+                if depth > 64 then depth
+                else
+                    cur.parent match
+                        case Maybe.Present(p) => loop(p, depth + 1)
+                        case Maybe.Absent     => depth
+            val depth = loop(cwd, 0)
+            assert(depth < 64, s"parent walk should terminate quickly, but reached depth $depth (cwd=${cwd.toString})")
+        }
+    }
+
+    "ancestors yields self -> parent -> ... -> root and terminates" in run {
+        for
+            cwd <- Path.cwd
+            all <- cwd.ancestors.run
+        yield
+            assert(all.size >= 1)
+            assert(all.headOption.exists(_.parts == cwd.parts))
+            assert(all.size <= 50, s"ancestors should be small + finite, got ${all.size}")
+            assert(all.lastOption.exists(_.parts.size <= 1))
+        end for
+    }
+
+    "Stream.find on ancestors finds a matching ancestor and short-circuits" in run {
+        for
+            cwd <- Path.cwd
+            // Find the cwd itself (trivial predicate, must match first).
+            hit <- cwd.ancestors.find(p => (p.parts == cwd.parts))
+        yield assert(hit.isDefined)
+        end for
+    }
+
+    "realPath canonicalizes an existing file path" in run {
+        for
+            dir <- Path.tempDir("kyo-test")
+            file = dir / "file.txt"
+            _    <- file.write("hi")
+            real <- file.realPath
+            _    <- dir.removeAll
+        yield
+            assert(real.isAbsolute)
+            assert(real.parts.lastOption.contains("file.txt"))
+        end for
+    }
+
+    "realPath fails with FileNotFoundException for non-existent path" in run {
+        val ghost = Path / "kyo-test-realpath-does-not-exist-xyzzy-99"
+        Abort.run[FileException](ghost.realPath).map { r =>
+            assert(r.isFailure)
+            assert(r.failure.exists(_.isInstanceOf[FileNotFoundException]))
+        }
+    }
+
+    "confinedTo accepts a path inside root" in run {
+        for
+            dir <- Path.tempDir("kyo-test")
+            file = dir / "inside.txt"
+            _        <- file.write("ok")
+            confined <- file.confinedTo(dir)
+            _        <- dir.removeAll
+        yield assert(confined.parts.takeRight(1).headOption.contains("inside.txt"))
+        end for
+    }
+
+    "confinedTo rejects a path equal to root with success (root is contained in itself)" in run {
+        for
+            dir      <- Path.tempDir("kyo-test")
+            confined <- dir.confinedTo(dir)
+            _        <- dir.removeAll
+        yield assert(confined.parts.lastOption == dir.parts.lastOption)
+        end for
+    }
+
+    "confinedTo rejects a sibling-of-root path with FileAccessDeniedException" in run {
+        for
+            base <- Path.tempDir("kyo-test")
+            // Two siblings: `base/inside` is root; `base/outside.txt` is outside it.
+            root = base / "inside"
+            _ <- root.mkDir
+            outside = base / "outside.txt"
+            _   <- outside.write("escape")
+            res <- Abort.run[FileException](outside.confinedTo(root))
+            _   <- base.removeAll
+        yield
+            assert(res.isFailure)
+            assert(res.failure.exists(_.isInstanceOf[FileAccessDeniedException]))
+        end for
+    }
+
     // =========================================================================
     // Read
     // =========================================================================

--- a/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Stream.scala
@@ -398,6 +398,19 @@ abstract class Stream[+V, -S] @publicInBinary private[kyo] () extends Serializab
             )
         )
 
+    /** Returns the first element that satisfies the predicate, short-circuiting the upstream
+      * as soon as a match is found. Returns `Absent` if the stream completes with no match.
+      *
+      * Terminal operation: equivalent to `filter(f).take(1).run.map(_.headMaybe)` but without
+      * the intermediate chunk allocation.
+      */
+    def find[VV >: V, S2](f: VV => Boolean < S2)(using tag: Tag[Emit[Chunk[VV]]], frame: Frame): Maybe[VV] < (S & S2) =
+        filter(f).take(1).run.map(_.headMaybe)
+
+    /** Pure variant of [[find]] for predicates that do not require an effect. */
+    def findPure[VV >: V](f: VV => Boolean)(using tag: Tag[Emit[Chunk[VV]]], frame: Frame): Maybe[VV] < S =
+        filterPure(f).take(1).run.map(_.headMaybe)
+
     /** Transform the stream with a partial function, filtering out values for which the partial function is undefined. Combines the
       * functionality of map and filter.
       *


### PR DESCRIPTION
## Problem

Three independent gaps surfaced while building filesystem-server-style features on top of kyo-core, plus one missing high-level Stream op:

  1. **Path lacks symlink resolution and confinement.** Anything that takes a user-supplied path and must keep operations under a fixed root (file servers, filesystem-exposing endpoints, sandboxed subprocess working directories) has to drop to `java.nio.file.Files.toRealPath` plus an ad-hoc prefix comparison. That's leaky: the prefix check is easy to get wrong against `..` segments and symlinks, and it bypasses kyo's effect-typed API surface.

  2. **`Process.Input` cannot pipe content into a subprocess' stdin.** The existing variants (`Inherit`, `Redirect[File]`, `Bytes`) cover terminal forwarding, file redirection, and one-shot byte buffers, but there is no way to stream content programmatically into the child's stdin once it has started. Tools that wrap a subprocess and feed it work-items over its lifetime need this.

  3. **`Stream` lacks a short-circuiting `find`.** Callers spell it as `filter(p).take(1).run.map(_.headMaybe)`, which is correct but allocates an intermediate Chunk and reads as incidental composition rather than the operation. The new `Path.cwd.ancestors.find(p => (p / "build.sbt").exists)` project-root pattern in particular wants this.

## Solution

All purely additive ; no signature changes to existing API.

**kyo-core/Path.scala**

  - `Path.cwd: Path < Sync` ; the current working directory as a Path.
  - `Path.ancestors: Stream[Path, Any]` ; lazy stream of self, parent, grandparent, ..., up to the filesystem root.
  - `Path.realPath: Path < (Sync & Abort[FileException])` ; resolves symbolic links via `Files.toRealPath`. Mirrored in `Unsafe.realPath`.
  - `Path.confinedTo(root): Path < (Sync & Abort[FileException])` ; `realPath`-resolves both `self` and `root`, then aborts if the resolved path is not under the resolved root. The realPath round- trip is what makes this symlink-safe: a path that lives inside `root` but is itself a symlink to outside `root` is rejected after resolution, not before.

  Platform shims for the above land in `jvm-native/PathPlatformSpecific.scala`,
  `js/PathPlatformSpecific.scala`, and `internal/PathDirectories.scala`,
  following the existing Path platform-shim pattern.

**kyo-core/Process.scala + Command.scala**

  - New `Process.Input.Pipe` variant.
  - `Command.pipeStdin: Command` ; convenience returning a Command whose stdin is set to `Pipe`. Callers then stream into the resulting handle through the existing process-stdin plumbing.

**kyo-prelude/Stream.scala**

  - `Stream.find(f)` and `Stream.findPure(f)` ; first element satisfying the predicate, `Absent` if the stream completes with no match. `findPure` is the no-effect variant for hot paths, mirroring the existing `filterPure` / `mapPure` split.

## Notes

  - **`Path.confinedTo` is the recommended way** to validate any untrusted path before further filesystem operations. The pattern is `userPath.confinedTo(serverRoot).map(safe => ...)`. Pre- resolution checks (`startsWith`, `normalize`) are not enough on platforms that follow symlinks transparently.

  - `Stream.find` short-circuits upstream emission as soon as a match is found, so expensive predicates over long streams stay cheap. No new tests for Stream itself in this PR ; it is exercised end-to-end by the PathTest ancestor-search scenarios.
