### PR TITLE
[compat] Resolve plugin-generated paths against the build root

### DIFF
--- a/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatLibrary.scala
+++ b/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatLibrary.scala
@@ -171,12 +171,28 @@ private[compat] object CompatLibrary {
             val process: Project => Project = (proj: Project) => {
                 val withPlugin = enablePlatformPlugin(proj)
                 val withDeps = withPlugin.settings(
-                    moduleName    := name.value + backend.directorySuffix,
-                    baseDirectory := backendBase,
-                    Compile / unmanagedSourceDirectories ++= Seq(sharedMain, perBackendMain, backendMain),
-                    Test / unmanagedSourceDirectories ++= Seq(sharedTest, perBackendTest, backendTest),
-                    Compile / unmanagedResourceDirectories ++= Seq(sharedMainR, perBackendMainR, backendMainR),
-                    Test / unmanagedResourceDirectories ++= Seq(sharedTestR, perBackendTestR, backendTestR),
+                    moduleName := name.value + backend.directorySuffix,
+                    baseDirectory := {
+                        val dir = IO.resolve((LocalRootProject / baseDirectory).value, backendBase)
+                        IO.createDirectory(dir)
+                        dir
+                    },
+                    Compile / unmanagedSourceDirectories ++= {
+                        val root = (LocalRootProject / baseDirectory).value
+                        Seq(sharedMain, perBackendMain, backendMain).map(IO.resolve(root, _))
+                    },
+                    Test / unmanagedSourceDirectories ++= {
+                        val root = (LocalRootProject / baseDirectory).value
+                        Seq(sharedTest, perBackendTest, backendTest).map(IO.resolve(root, _))
+                    },
+                    Compile / unmanagedResourceDirectories ++= {
+                        val root = (LocalRootProject / baseDirectory).value
+                        Seq(sharedMainR, perBackendMainR, backendMainR).map(IO.resolve(root, _))
+                    },
+                    Test / unmanagedResourceDirectories ++= {
+                        val root = (LocalRootProject / baseDirectory).value
+                        Seq(sharedTestR, perBackendTestR, backendTestR).map(IO.resolve(root, _))
+                    },
                     libraryDependencies ++= {
                         val isBound = metaOf(matrixId).exists(_.bindings.contains(backend.name))
                         if (isBound) Seq.empty

--- a/project/TestKyo.scala
+++ b/project/TestKyo.scala
@@ -198,6 +198,8 @@ object TestKyo {
     private def fileToProjects(file: String, allProjectNames: Set[String]): Set[String] = {
         val parts = file.split("/").toList
         parts match {
+            case module :: "plugin" :: _ if allProjectNames.contains(s"$module-plugin") =>
+                Set(s"$module-plugin")
             case module :: sub :: _ =>
                 val affectedPlatforms = sub match {
                     case "shared" => Seq("JVM", "JS", "Native")


### PR DESCRIPTION
`compatLibrary` captures `m.base` — relative when the matrix is declared as `(projectMatrix in file("my-lib"))` — and assigns the derived `File`s directly into `baseDirectory` and the unmanaged source/resource directories of every generated row. sbt derives globs from those settings, and sbt-io prints `Warning: Tried to extract the base path for relative glob ...` for each one on every build load (~34 lines for a 4-backend JVM matrix) unless the consumer sets `-Dsbt.io.implicit.relative.glob.conversion=allow`.

This resolves each captured path against `LocalRootProject / baseDirectory` at setting-evaluation time. `IO.resolve` is a no-op for already-absolute paths, so builds passing absolute base dirs are unaffected.

It also creates the per-row `baseDirectory` eagerly: it is the forked JVM's working directory under `Test / fork := true`, and tests fail with `Cannot run program "java" (in directory ...)` when only `shared/` exists on disk — previously consumers had to pre-create the `<lib>/<backend>/<platform>/` dirs.

Found while building a new lib on kyo-compat.