### PR TITLE
[http-client] Add client filter scopes

### DIFF
--- a/kyo-caliban/README.md
+++ b/kyo-caliban/README.md
@@ -366,10 +366,10 @@ case class Query(
 ) derives caliban.schema.Schema.SemiAuto
 
 val filter = new HttpFilter.Passthrough[Nothing]:
-    def apply[In, Out, E](
+    def apply[In, Out, E, S](
         request: HttpRequest[In],
-        next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E | HttpResponse.Halt])
-    )(using Frame): HttpResponse[Out] < (Async & Abort[E | HttpResponse.Halt]) =
+        next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E | HttpResponse.Halt])
+    )(using Frame): HttpResponse[Out] < (S & Async & Abort[E | HttpResponse.Halt]) =
         next(request).map(_.setHeader("X-Custom", "test-value"))
 
 val server: HttpServer < (Async & Scope & Abort[caliban.CalibanError]) =

--- a/kyo-caliban/src/test/scala/kyo/ResolversTest.scala
+++ b/kyo-caliban/src/test/scala/kyo/ResolversTest.scala
@@ -307,10 +307,10 @@ class ResolverTest extends BaseCalibanTest:
 
     "Config - filter adds response header" in {
         val filter = new HttpFilter.Passthrough[Nothing]:
-            def apply[In, Out, E2](
+            def apply[In, Out, E2, S](
                 request: HttpRequest[In],
-                next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-            )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+            )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                 next(request).map(_.setHeader("X-Custom", "test-value"))
 
         val api = graphQL(RootResolver(defaultQuery))

--- a/kyo-compat/README.md
+++ b/kyo-compat/README.md
@@ -526,7 +526,7 @@ The bundled `kyo-compat-plugin` sbt plugin extends `sbt-projectmatrix`'s `Projec
 
 ```scala doctest:expect=skipped
 // project/plugins.sbt
-addSbtPlugin("io.getkyo"          % "kyo-compat-plugin"              % "<latest version>")
+addSbtPlugin("io.getkyo"          % "kyo-compat-plugin"             % "<latest version>")
 addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")

--- a/kyo-config/README.md
+++ b/kyo-config/README.md
@@ -37,10 +37,9 @@ Flags are declared as Scala objects. The fully-qualified object name becomes the
 Note: Flags must be Scala `object`s declared at top level or nested in other objects. The flag name is derived from the JVM class name, so a flag declared inside a class, trait, method, or as an anonymous value gets a mangled name and is rejected at construction with `FlagNameException`.
 
 ```scala doctest:expect=skipped
-package myapp.db
-
 import kyo.*
 
+// In package myapp.db
 object poolSize   extends StaticFlag[Int](10)
 object maxRetries extends StaticFlag[Int](3)
 object jdbcUrl    extends StaticFlag[String]("jdbc:h2:mem:test")
@@ -74,18 +73,19 @@ Note: When a flag resolves to its default, kyo-config scans system properties an
 An optional validation function transforms or constrains the resolved value:
 
 ```scala doctest:expect=skipped
-package myapp.db
-
 import kyo.*
 
+// In package myapp.db
 // Clamp pool size to at least 1 and at most 100
 object poolSize extends StaticFlag[Int](10, n => Right(math.max(1, math.min(n, 100))))
 
 // Ensure the URL is non-empty
-object jdbcUrl extends StaticFlag[String]("jdbc:h2:mem:test", url =>
-  if url.nonEmpty then Right(url)
-  else Left(new IllegalArgumentException("URL must not be empty"))
-)
+object jdbcUrl extends StaticFlag[String](
+        "jdbc:h2:mem:test",
+        url =>
+            if url.nonEmpty then Right(url)
+            else Left(new IllegalArgumentException("URL must not be empty"))
+    )
 ```
 
 The validate parameter has signature `A => Either[Throwable, A]`.
@@ -130,10 +130,9 @@ Parse errors at class load time throw a `FlagValueParseException`, failing fast 
 Dynamic flags follow the same declaration pattern:
 
 ```scala doctest:expect=skipped
-package myapp.features
-
 import kyo.*
 
+// In package myapp.features
 object newCheckout extends DynamicFlag[Boolean](false)
 object rateLimit   extends DynamicFlag[Int](100)
 ```
@@ -353,10 +352,9 @@ However, **decreasing** a percentage can remove entities: going from 75% back to
 StaticFlag evaluates the rollout expression once at class load time. The path comes from `kyo.rollout.path` (or auto-detected cloud metadata), and the bucket is derived from hashing that path:
 
 ```scala doctest:expect=skipped
-package myapp.db
-
 import kyo.*
 
+// In package myapp.db
 // -Dkyo.rollout.path=prod/us-east-1/az1
 // -Dmyapp.db.poolSize="50@prod/us-east-1;30@prod;10"
 object poolSize extends StaticFlag[Int](10)
@@ -416,10 +414,9 @@ Missing segments are skipped. For example, if only `AWS_REGION=us-east-1` is set
 DynamicFlag evaluates the rollout expression on every call. The path comes from the caller's attributes, and the bucket is derived from hashing the caller's key:
 
 ```scala doctest:expect=skipped
-package myapp.features
-
 import kyo.*
 
+// In package myapp.features
 // -Dmyapp.features.newCheckout="true@premium/50%;false"
 object newCheckout extends DynamicFlag[Boolean](false)
 

--- a/kyo-flow/README.md
+++ b/kyo-flow/README.md
@@ -475,9 +475,10 @@ The in-memory store (`FlowStore.initMemory`) is for development and testing. For
 
 ```scala doctest:expect=skipped
 class PostgresFlowStore(pool: ConnectionPool) extends FlowStore:
-    def claimReady(...) = // SELECT ... FOR UPDATE SKIP LOCKED
-    def updateStatus(...) = // UPDATE + INSERT in one transaction
+    def claimReady(): Unit   = ??? // SELECT ... FOR UPDATE SKIP LOCKED
+    def updateStatus(): Unit = ??? // UPDATE + INSERT in one transaction
     // ... 15 abstract methods total
+end PostgresFlowStore
 ```
 
 Key invariants:

--- a/kyo-http/README.md
+++ b/kyo-http/README.md
@@ -676,7 +676,7 @@ HttpClient.withConfig(
 ```
 
 ```scala
-// Temporary policy scoped to one computation
+// Temporary policy scoped to one computation, composed into the active HttpClientConfig
 HttpClient.withFilter(HttpFilter.client.addHeader("X-Request-Id", "request-123")) {
     HttpClient.postJson[User]("/users", CreateUser("Alice", "alice@example.com"))
 }
@@ -689,7 +689,10 @@ val route = HttpRoute
     .filter(HttpFilter.client.bearerAuth("secret-token"))
 ```
 
-The client-side composition order is ServiceLoader filters, config filters, scoped filters, then route filters. Built-in client filters:
+Scoped filters are stored in the active `HttpClientConfig`, so they can be inspected with `HttpClient.useConfig` or
+`HttpClient.useFilter`. Use `HttpClient.withoutFilters { ... }` to clear config and scoped client filters in a nested computation.
+
+The client-side composition order is ServiceLoader filters, config filters, then route filters. Built-in client filters:
 `bearerAuth(token)`, `basicAuth(username, password)`, `addHeader(name, value)`, and `logging`.
 
 Client filters also apply to WebSocket HTTP upgrade handshakes, so auth and tracing headers can be configured in the same place for HTTP

--- a/kyo-http/README.md
+++ b/kyo-http/README.md
@@ -669,7 +669,7 @@ They can be attached at several levels:
 HttpClient.withConfig(
     HttpClientConfig()
         .baseUrl("https://api.example.com")
-        .filter(HttpFilter.client.bearerAuth(token))
+        .filter(HttpFilter.client.bearerAuth("secret-token"))
 ) {
     HttpClient.getText("/users")
 }
@@ -677,8 +677,8 @@ HttpClient.withConfig(
 
 ```scala
 // Temporary policy scoped to one computation
-HttpClient.withFilter(HttpFilter.client.addHeader("X-Request-Id", requestId)) {
-    HttpClient.postJson[CreateUser]("/users", body)
+HttpClient.withFilter(HttpFilter.client.addHeader("X-Request-Id", "request-123")) {
+    HttpClient.postJson[User]("/users", CreateUser("Alice", "alice@example.com"))
 }
 ```
 
@@ -686,7 +686,7 @@ HttpClient.withFilter(HttpFilter.client.addHeader("X-Request-Id", requestId)) {
 // Endpoint-specific policy attached to a typed route
 val route = HttpRoute
     .getText("/users")
-    .filter(HttpFilter.client.bearerAuth(token))
+    .filter(HttpFilter.client.bearerAuth("secret-token"))
 ```
 
 The client-side composition order is ServiceLoader filters, config filters, scoped filters, then route filters. Built-in client filters:

--- a/kyo-http/README.md
+++ b/kyo-http/README.md
@@ -689,20 +689,35 @@ val route = HttpRoute
     .filter(HttpFilter.client.bearerAuth("secret-token"))
 ```
 
-Scoped filters are stored in the active `HttpClientConfig`, so they can be inspected with `HttpClient.useConfig` or
-`HttpClient.useFilter`. Use `HttpClient.withoutFilters { ... }` to clear config and scoped client filters in a nested computation.
+Configured filters are stored in the active `HttpClientConfig`, so they can be inspected with `HttpClient.useConfig` or
+`HttpClient.useFilter`. Use `HttpClient.withoutFilters { ... }` to clear configured client filters in a nested computation.
 
-The client-side composition order is ServiceLoader filters, config filters, then route filters. Built-in client filters:
+The client-side composition order is auto filters, configured filters, then route filters. Auto filters come from
+`HttpFilter.Factory` implementations discovered through `ServiceLoader`. Configured filters come from `HttpClientConfig.filter`,
+`HttpClient.withFilter`, and `HttpClient.withFilters`. Route filters come from `HttpRoute.filter`. Built-in client filters:
 `bearerAuth(token)`, `basicAuth(username, password)`, `addHeader(name, value)`, and `logging`.
 
 Client filters also apply to WebSocket HTTP upgrade handshakes, so auth and tracing headers can be configured in the same place for HTTP
 requests and WebSocket connections. They do not intercept WebSocket messages after the connection has upgraded.
 
+Use `HttpClient.withoutAutoFilters { ... }` or `HttpClientConfig.withoutAutoFilters` to disable auto filters while keeping configured and
+route filters. `HttpClient.useAutoFilter` exposes the currently active auto filter, returning `HttpFilter.noop` when no auto filter is
+active.
+
 #### Global Filters via `HttpFilter.Factory`
 
-For cross-cutting concerns that should apply to every request without touching each route (distributed tracing, metrics, structured logging), implement the `HttpFilter.Factory` ServiceLoader SPI. Register your implementation in `META-INF/services/kyo.HttpFilter$Factory`, then override `serverFilter` to install a filter on every incoming request and `clientFilter` to install one on every outgoing request. Either method may return `Absent` to skip installation, which lets a factory be enabled or disabled at runtime via system properties or environment variables. All discovered factories are composed in discovery order.
+For cross-cutting concerns that should apply without touching each route, such as distributed tracing, metrics, structured logging, and
+shared authentication policy, implement the `HttpFilter.Factory` ServiceLoader SPI. Register your implementation in
+`META-INF/services/kyo.HttpFilter$Factory`, then override `serverFilter` to install an auto filter on incoming HTTP requests and
+`clientFilter` to install an auto filter on outgoing HTTP requests and WebSocket upgrade handshakes. Either method may return `Absent` to
+skip installation, which lets a factory be enabled or disabled at runtime via system properties or environment variables. All discovered
+factories are composed in discovery order.
 
-Caution: Factory instances load eagerly at first server or client use, so any side effect in the Factory constructor runs at an unexpected time. Put initialization logic inside the `serverFilter` / `clientFilter` body, not the constructor.
+Server auto filters are applied during `HttpServer` initialization and can be disabled per server with
+`HttpServerConfig.withoutAutoFilters`. This switch affects only auto filters. Route filters still apply.
+
+Caution: Factory instances load eagerly at first server or client use, so any side effect in the Factory constructor runs at an unexpected
+time. Put initialization logic inside the `serverFilter` / `clientFilter` body, not the constructor.
 
 ### Custom Codecs
 

--- a/kyo-http/README.md
+++ b/kyo-http/README.md
@@ -661,9 +661,39 @@ HttpServer.init(
 
 #### Client Filters
 
-Filters also work on the client side, attaching to typed routes to add authentication or custom headers to outgoing requests.
+Filters also work on the client side, adding authentication, request IDs, logging, tracing, metrics, or custom headers to outgoing requests.
+They can be attached at several levels:
 
-Built-in client filters: `bearerAuth(token)`, `basicAuth(username, password)`, `addHeader(name, value)`, and `logging`.
+```scala
+// Reusable policy carried by HttpClientConfig
+HttpClient.withConfig(
+    HttpClientConfig()
+        .baseUrl("https://api.example.com")
+        .filter(HttpFilter.client.bearerAuth(token))
+) {
+    HttpClient.getText("/users")
+}
+```
+
+```scala
+// Temporary policy scoped to one computation
+HttpClient.withFilter(HttpFilter.client.addHeader("X-Request-Id", requestId)) {
+    HttpClient.postJson[CreateUser]("/users", body)
+}
+```
+
+```scala
+// Endpoint-specific policy attached to a typed route
+val route = HttpRoute
+    .getText("/users")
+    .filter(HttpFilter.client.bearerAuth(token))
+```
+
+The client-side composition order is ServiceLoader filters, config filters, scoped filters, then route filters. Built-in client filters:
+`bearerAuth(token)`, `basicAuth(username, password)`, `addHeader(name, value)`, and `logging`.
+
+Client filters also apply to WebSocket HTTP upgrade handshakes, so auth and tracing headers can be configured in the same place for HTTP
+requests and WebSocket connections. They do not intercept WebSocket messages after the connection has upgraded.
 
 #### Global Filters via `HttpFilter.Factory`
 

--- a/kyo-http/js-wasm/src/test/scala/kyo/HttpFilterTestRegistration.scala
+++ b/kyo-http/js-wasm/src/test/scala/kyo/HttpFilterTestRegistration.scala
@@ -1,0 +1,14 @@
+package kyo
+
+import kyo.stats.internal.JSServiceLoaderRegistry
+import scala.scalajs.js.annotation.JSExportTopLevel
+
+object HttpFilterTestRegistration:
+
+    @JSExportTopLevel("__kyo_http_filter_test_init")
+    val init: Boolean =
+        JSServiceLoaderRegistry.register(classOf[HttpFilter.Factory], new HttpFilterTestFactory())
+        true
+    end init
+
+end HttpFilterTestRegistration

--- a/kyo-http/shared/src/main/scala/kyo/HttpClient.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpClient.scala
@@ -143,7 +143,7 @@ object HttpClient:
 
     /** Clears client filters for the given computation. ServiceLoader and route filters still apply. */
     def withoutFilters[A, S](v: A < S)(using Frame): A < S =
-        withConfig(_.withoutFilters)(v)
+        withConfig(_.clearFilters)(v)
 
     // --- Factory methods ---
 

--- a/kyo-http/shared/src/main/scala/kyo/HttpClient.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpClient.scala
@@ -16,6 +16,7 @@ import kyo.internal.client.HttpClientBackend
   *   - `HttpClient.withConfig(_.timeout(10.seconds)) { ... }` — transform the config (stacks with the current config)
   *   - `HttpClient.withConfig(config) { ... }` — replace the config entirely (discards current config)
   *   - `HttpClient.withFilter(filter) { ... }`: add a scoped client filter for outgoing requests
+  *   - `HttpClient.withoutFilters { ... }`: clear client filters for a nested scope
   *
   * The request lifecycle chains through `retryWith → redirectsWith → timeoutWith → poolWith`, each layer wrapping the next. Retries only
   * activate when a `Schedule` is set in the config. Redirects follow up to `maxRedirects` hops and switch to GET on 303 See Other per RFC
@@ -50,8 +51,8 @@ object HttpClient:
         initUnsafe(HttpPlatformTransport.transport, 100, 60.seconds)
     end defaultClient
 
-    private val local: Local[(HttpClient, HttpClientConfig, HttpFilter.Passthrough[Nothing])] =
-        Local.init((defaultClient, HttpClientConfig(), HttpFilter.noop))
+    private val local: Local[(HttpClient, HttpClientConfig)] =
+        Local.init((defaultClient, HttpClientConfig()))
 
     // Cached non-generic routes — avoids per-request allocation for convenience methods.
     private val routeGetText      = HttpRoute.getText("")
@@ -80,8 +81,8 @@ object HttpClient:
         )(
             f: HttpResponse[Out] => A < (Async & Abort[HttpException])
         )(using Frame): A < (Async & Abort[HttpException]) =
-            local.use { (_, config, filter) =>
-                self.sendWithConfig(route, request, config, filter)(f)
+            local.use { (_, config) =>
+                self.sendWithConfig(route, request, config)(f)
             }
 
         /** Closes the client with a grace period for in-flight requests. */
@@ -102,35 +103,47 @@ object HttpClient:
 
     /** Sets the client instance for all `HttpClient` calls within the given computation. The current config is preserved. */
     def let[A, S](client: HttpClient)(v: A < S)(using Frame): A < S =
-        local.use { (_, config, filter) => local.let((client, config, filter))(v) }
+        local.use { (_, config) => local.let((client, config))(v) }
 
     /** Accesses the current client. */
     def use[A, S](f: HttpClient => A < S)(using Frame): A < S =
-        local.use { (client, _, _) => f(client) }
+        local.use { (client, _) => f(client) }
+
+    /** Accesses the current client configuration. */
+    def useConfig[A, S](f: HttpClientConfig => A < S)(using Frame): A < S =
+        local.use { (_, config) => f(config) }
+
+    /** Accesses the current composed client filter. */
+    def useFilter[A, S](f: HttpFilter.Passthrough[Nothing] => A < S)(using Frame): A < S =
+        useConfig(config => f(config.clientFilter))
 
     /** Transforms the current client for the given computation. */
     def update[A, S](f: HttpClient => HttpClient)(v: A < S)(using Frame): A < S =
-        local.use { (client, config, filter) => local.let((f(client), config, filter))(v) }
+        local.use { (client, config) => local.let((f(client), config))(v) }
 
     /** Applies a config transformation for all `HttpClient` calls within the given computation. Stacks with the current config —
       * `withConfig(_.timeout(5.seconds)) { withConfig(_.retry(schedule)) { ... } }` results in a config with both timeout and retry set.
       */
     def withConfig[A, S](f: HttpClientConfig => HttpClientConfig)(v: A < S)(using Frame): A < S =
-        local.use { (client, config, filter) => local.let((client, f(config), filter))(v) }
+        local.use { (client, config) => local.let((client, f(config)))(v) }
 
     /** Replaces the config entirely for all `HttpClient` calls within the given computation. Unlike the function overload, this does not
       * stack — it discards the current config.
       */
     def withConfig[A, S](config: HttpClientConfig)(v: A < S)(using Frame): A < S =
-        local.use { (client, _, filter) => local.let((client, config, filter))(v) }
+        local.use { (client, _) => local.let((client, config))(v) }
 
     /** Applies a client filter for all `HttpClient` calls within the given computation. Stacks with the current scoped filter. */
     def withFilter[A, S](filter: HttpFilter.Passthrough[Nothing])(v: A < S)(using Frame): A < S =
-        local.use { (client, config, current) => local.let((client, config, current.andThen(filter)))(v) }
+        withConfig(_.filter(filter))(v)
 
     /** Applies multiple client filters for all `HttpClient` calls within the given computation. */
     def withFilters[A, S](filters: Seq[HttpFilter.Passthrough[Nothing]])(v: A < S)(using Frame): A < S =
-        withFilter(filters.foldLeft(HttpFilter.noop: HttpFilter.Passthrough[Nothing])(_.andThen(_)))(v)
+        withConfig(_.filters(filters))(v)
+
+    /** Clears client filters for the given computation. ServiceLoader and route filters still apply. */
+    def withoutFilters[A, S](v: A < S)(using Frame): A < S =
+        withConfig(_.withoutFilters)(v)
 
     // --- Factory methods ---
 
@@ -751,7 +764,7 @@ object HttpClient:
     )(
         f: HttpWebSocket => A < S
     )(using Frame): A < (S & Async & Abort[HttpException]) =
-        local.use { (client, clientConfig, filter) =>
+        local.use { (client, clientConfig) =>
             val resolved = clientConfig.baseUrl match
                 case Present(base) if !url.contains("://") =>
                     base.toString.stripSuffix("/") + url
@@ -762,7 +775,7 @@ object HttpClient:
                     resolveHeaders(headers),
                     config,
                     clientConfig.connectTimeout,
-                    clientConfig.clientFilter.andThen(filter)
+                    clientConfig.clientFilter
                 )(f)
             )
         }
@@ -777,8 +790,8 @@ object HttpClient:
     def webSocket[A, S](url: HttpUrl, headers: HttpHeaders, config: HttpWebSocket.Config)(
         f: HttpWebSocket => A < S
     )(using Frame): A < (S & Async & Abort[HttpException]) =
-        local.use { (client, clientConfig, filter) =>
-            client.connectWebSocket(url, headers, config, clientConfig.connectTimeout, clientConfig.clientFilter.andThen(filter))(f)
+        local.use { (client, clientConfig) =>
+            client.connectWebSocket(url, headers, config, clientConfig.connectTimeout, clientConfig.clientFilter)(f)
         }
 
     // ==================== Raw connection methods ====================
@@ -793,7 +806,7 @@ object HttpClient:
         body: Span[Byte] = Span.empty,
         headers: HttpHeaders | Seq[(String, String)] = HttpHeaders.empty
     )(using Frame): HttpRawConnection < (Async & Abort[HttpException] & Scope) =
-        local.use { (client, clientConfig, _) =>
+        local.use { (client, clientConfig) =>
             resolveUrl(url).map(parsed =>
                 client.connectRaw(parsed, method, body, resolveHeaders(headers), clientConfig.connectTimeout)
             )
@@ -836,9 +849,9 @@ object HttpClient:
     )(
         extract: HttpResponse[Out] => A
     )(using Frame): A < (Async & Abort[HttpException]) =
-        local.use { (client, config, filter) =>
+        local.use { (client, config) =>
             val req = HttpRequest(route.method, applyQuery(url, query), headers, Record.empty)
-            client.sendWithConfig(route, req, config, filter) { resp =>
+            client.sendWithConfig(route, req, config) { resp =>
                 if !resp.status.isSuccess then
                     resp.rawBody match
                         case Present(b) => Abort.fail(HttpStatusException(resp.status, route.method.name, url.baseUrl, b))
@@ -856,9 +869,9 @@ object HttpClient:
     )(
         extract: HttpResponse[Out] => A
     )(using Frame): A < (Async & Abort[HttpException]) =
-        local.use { (client, config, filter) =>
+        local.use { (client, config) =>
             val req = HttpRequest(route.method, applyQuery(url, query), headers, Record.empty).addField("body", body)
-            client.sendWithConfig(route, req, config, filter) { resp =>
+            client.sendWithConfig(route, req, config) { resp =>
                 if !resp.status.isSuccess then
                     resp.rawBody match
                         case Present(b) => Abort.fail(HttpStatusException(resp.status, route.method.name, url.baseUrl, b))
@@ -875,9 +888,9 @@ object HttpClient:
     )(
         extract: HttpResponse[Out] => A
     )(using Frame): A < (Async & Abort[HttpException]) =
-        local.use { (client, config, filter) =>
+        local.use { (client, config) =>
             val req = HttpRequest(route.method, applyQuery(url, query), headers, Record.empty)
-            client.sendWithConfig(route, req, config, filter)(extract)
+            client.sendWithConfig(route, req, config)(extract)
         }
 
     private def sendUrl[B, Out, A](
@@ -889,9 +902,9 @@ object HttpClient:
     )(
         extract: HttpResponse[Out] => A
     )(using Frame): A < (Async & Abort[HttpException]) =
-        local.use { (client, config, filter) =>
+        local.use { (client, config) =>
             val req = HttpRequest(route.method, applyQuery(url, query), headers, Record.empty).addField("body", body)
-            client.sendWithConfig(route, req, config, filter)(extract)
+            client.sendWithConfig(route, req, config)(extract)
         }
 
     // --- Private implementation ---

--- a/kyo-http/shared/src/main/scala/kyo/HttpClient.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpClient.scala
@@ -16,7 +16,8 @@ import kyo.internal.client.HttpClientBackend
   *   - `HttpClient.withConfig(_.timeout(10.seconds)) { ... }` — transform the config (stacks with the current config)
   *   - `HttpClient.withConfig(config) { ... }` — replace the config entirely (discards current config)
   *   - `HttpClient.withFilter(filter) { ... }`: add a scoped client filter for outgoing requests
-  *   - `HttpClient.withoutFilters { ... }`: clear client filters for a nested scope
+  *   - `HttpClient.withoutFilters { ... }`: clear configured client filters for a nested scope
+  *   - `HttpClient.withoutAutoFilters { ... }`: disable ServiceLoader-discovered filters for a nested scope
   *
   * The request lifecycle chains through `retryWith → redirectsWith → timeoutWith → poolWith`, each layer wrapping the next. Retries only
   * activate when a `Schedule` is set in the config. Redirects follow up to `maxRedirects` hops and switch to GET on 303 See Other per RFC
@@ -117,6 +118,10 @@ object HttpClient:
     def useFilter[A, S](f: HttpFilter.Passthrough[Nothing] => A < S)(using Frame): A < S =
         useConfig(config => f(config.clientFilter))
 
+    /** Accesses the current auto-discovered client filter, or `noop` when no auto filter is active. */
+    def useAutoFilter[A, S](f: HttpFilter.Passthrough[Nothing] => A < S)(using Frame): A < S =
+        useConfig(config => f(if config.autoFilters then HttpFilter.Factory.composedClient else HttpFilter.noop))
+
     /** Transforms the current client for the given computation. */
     def update[A, S](f: HttpClient => HttpClient)(v: A < S)(using Frame): A < S =
         local.use { (client, config) => local.let((f(client), config))(v) }
@@ -141,9 +146,13 @@ object HttpClient:
     def withFilters[A, S](filters: Seq[HttpFilter.Passthrough[Nothing]])(v: A < S)(using Frame): A < S =
         withConfig(_.filters(filters))(v)
 
-    /** Clears client filters for the given computation. ServiceLoader and route filters still apply. */
+    /** Clears configured client filters for the given computation. Auto-discovered and route filters still apply. */
     def withoutFilters[A, S](v: A < S)(using Frame): A < S =
         withConfig(_.clearFilters)(v)
+
+    /** Disables auto-discovered client filters for the given computation. Configured and route filters still apply. */
+    def withoutAutoFilters[A, S](v: A < S)(using Frame): A < S =
+        withConfig(_.withoutAutoFilters)(v)
 
     // --- Factory methods ---
 
@@ -775,7 +784,8 @@ object HttpClient:
                     resolveHeaders(headers),
                     config,
                     clientConfig.connectTimeout,
-                    clientConfig.clientFilter
+                    clientConfig.clientFilter,
+                    clientConfig.autoFilters
                 )(f)
             )
         }
@@ -791,7 +801,14 @@ object HttpClient:
         f: HttpWebSocket => A < S
     )(using Frame): A < (S & Async & Abort[HttpException]) =
         local.use { (client, clientConfig) =>
-            client.connectWebSocket(url, headers, config, clientConfig.connectTimeout, clientConfig.clientFilter)(f)
+            client.connectWebSocket(
+                url,
+                headers,
+                config,
+                clientConfig.connectTimeout,
+                clientConfig.clientFilter,
+                clientConfig.autoFilters
+            )(f)
         }
 
     // ==================== Raw connection methods ====================

--- a/kyo-http/shared/src/main/scala/kyo/HttpClient.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpClient.scala
@@ -15,6 +15,7 @@ import kyo.internal.client.HttpClientBackend
   *   - `HttpClient.let(client) { ... }` — install a specific client instance for the duration
   *   - `HttpClient.withConfig(_.timeout(10.seconds)) { ... }` — transform the config (stacks with the current config)
   *   - `HttpClient.withConfig(config) { ... }` — replace the config entirely (discards current config)
+  *   - `HttpClient.withFilter(filter) { ... }`: add a scoped client filter for outgoing requests
   *
   * The request lifecycle chains through `retryWith → redirectsWith → timeoutWith → poolWith`, each layer wrapping the next. Retries only
   * activate when a `Schedule` is set in the config. Redirects follow up to `maxRedirects` hops and switch to GET on 303 See Other per RFC
@@ -49,7 +50,8 @@ object HttpClient:
         initUnsafe(HttpPlatformTransport.transport, 100, 60.seconds)
     end defaultClient
 
-    private val local: Local[(HttpClient, HttpClientConfig)] = Local.init((defaultClient, HttpClientConfig()))
+    private val local: Local[(HttpClient, HttpClientConfig, HttpFilter.Passthrough[Nothing])] =
+        Local.init((defaultClient, HttpClientConfig(), HttpFilter.noop))
 
     // Cached non-generic routes — avoids per-request allocation for convenience methods.
     private val routeGetText      = HttpRoute.getText("")
@@ -78,8 +80,8 @@ object HttpClient:
         )(
             f: HttpResponse[Out] => A < (Async & Abort[HttpException])
         )(using Frame): A < (Async & Abort[HttpException]) =
-            local.use { (_, config) =>
-                self.sendWithConfig(route, request, config)(f)
+            local.use { (_, config, filter) =>
+                self.sendWithConfig(route, request, config, filter)(f)
             }
 
         /** Closes the client with a grace period for in-flight requests. */
@@ -100,27 +102,35 @@ object HttpClient:
 
     /** Sets the client instance for all `HttpClient` calls within the given computation. The current config is preserved. */
     def let[A, S](client: HttpClient)(v: A < S)(using Frame): A < S =
-        local.use { (_, config) => local.let((client, config))(v) }
+        local.use { (_, config, filter) => local.let((client, config, filter))(v) }
 
     /** Accesses the current client. */
     def use[A, S](f: HttpClient => A < S)(using Frame): A < S =
-        local.use { (client, _) => f(client) }
+        local.use { (client, _, _) => f(client) }
 
     /** Transforms the current client for the given computation. */
     def update[A, S](f: HttpClient => HttpClient)(v: A < S)(using Frame): A < S =
-        local.use { (client, config) => local.let((f(client), config))(v) }
+        local.use { (client, config, filter) => local.let((f(client), config, filter))(v) }
 
     /** Applies a config transformation for all `HttpClient` calls within the given computation. Stacks with the current config —
       * `withConfig(_.timeout(5.seconds)) { withConfig(_.retry(schedule)) { ... } }` results in a config with both timeout and retry set.
       */
     def withConfig[A, S](f: HttpClientConfig => HttpClientConfig)(v: A < S)(using Frame): A < S =
-        local.use { (client, config) => local.let((client, f(config)))(v) }
+        local.use { (client, config, filter) => local.let((client, f(config), filter))(v) }
 
     /** Replaces the config entirely for all `HttpClient` calls within the given computation. Unlike the function overload, this does not
       * stack — it discards the current config.
       */
     def withConfig[A, S](config: HttpClientConfig)(v: A < S)(using Frame): A < S =
-        local.use { (client, _) => local.let((client, config))(v) }
+        local.use { (client, _, filter) => local.let((client, config, filter))(v) }
+
+    /** Applies a client filter for all `HttpClient` calls within the given computation. Stacks with the current scoped filter. */
+    def withFilter[A, S](filter: HttpFilter.Passthrough[Nothing])(v: A < S)(using Frame): A < S =
+        local.use { (client, config, current) => local.let((client, config, current.andThen(filter)))(v) }
+
+    /** Applies multiple client filters for all `HttpClient` calls within the given computation. */
+    def withFilters[A, S](filters: Seq[HttpFilter.Passthrough[Nothing]])(v: A < S)(using Frame): A < S =
+        withFilter(filters.foldLeft(HttpFilter.noop: HttpFilter.Passthrough[Nothing])(_.andThen(_)))(v)
 
     // --- Factory methods ---
 
@@ -741,13 +751,19 @@ object HttpClient:
     )(
         f: HttpWebSocket => A < S
     )(using Frame): A < (S & Async & Abort[HttpException]) =
-        local.use { (client, clientConfig) =>
+        local.use { (client, clientConfig, filter) =>
             val resolved = clientConfig.baseUrl match
                 case Present(base) if !url.contains("://") =>
                     base.toString.stripSuffix("/") + url
                 case _ => url
             Abort.get(HttpUrl.parse(resolved)).map(parsed =>
-                client.connectWebSocket(parsed, resolveHeaders(headers), config, clientConfig.connectTimeout)(f)
+                client.connectWebSocket(
+                    parsed,
+                    resolveHeaders(headers),
+                    config,
+                    clientConfig.connectTimeout,
+                    clientConfig.clientFilter.andThen(filter)
+                )(f)
             )
         }
 
@@ -761,8 +777,8 @@ object HttpClient:
     def webSocket[A, S](url: HttpUrl, headers: HttpHeaders, config: HttpWebSocket.Config)(
         f: HttpWebSocket => A < S
     )(using Frame): A < (S & Async & Abort[HttpException]) =
-        local.use { (client, clientConfig) =>
-            client.connectWebSocket(url, headers, config, clientConfig.connectTimeout)(f)
+        local.use { (client, clientConfig, filter) =>
+            client.connectWebSocket(url, headers, config, clientConfig.connectTimeout, clientConfig.clientFilter.andThen(filter))(f)
         }
 
     // ==================== Raw connection methods ====================
@@ -777,7 +793,7 @@ object HttpClient:
         body: Span[Byte] = Span.empty,
         headers: HttpHeaders | Seq[(String, String)] = HttpHeaders.empty
     )(using Frame): HttpRawConnection < (Async & Abort[HttpException] & Scope) =
-        local.use { (client, clientConfig) =>
+        local.use { (client, clientConfig, _) =>
             resolveUrl(url).map(parsed =>
                 client.connectRaw(parsed, method, body, resolveHeaders(headers), clientConfig.connectTimeout)
             )
@@ -820,9 +836,9 @@ object HttpClient:
     )(
         extract: HttpResponse[Out] => A
     )(using Frame): A < (Async & Abort[HttpException]) =
-        local.use { (client, config) =>
+        local.use { (client, config, filter) =>
             val req = HttpRequest(route.method, applyQuery(url, query), headers, Record.empty)
-            client.sendWithConfig(route, req, config) { resp =>
+            client.sendWithConfig(route, req, config, filter) { resp =>
                 if !resp.status.isSuccess then
                     resp.rawBody match
                         case Present(b) => Abort.fail(HttpStatusException(resp.status, route.method.name, url.baseUrl, b))
@@ -840,9 +856,9 @@ object HttpClient:
     )(
         extract: HttpResponse[Out] => A
     )(using Frame): A < (Async & Abort[HttpException]) =
-        local.use { (client, config) =>
+        local.use { (client, config, filter) =>
             val req = HttpRequest(route.method, applyQuery(url, query), headers, Record.empty).addField("body", body)
-            client.sendWithConfig(route, req, config) { resp =>
+            client.sendWithConfig(route, req, config, filter) { resp =>
                 if !resp.status.isSuccess then
                     resp.rawBody match
                         case Present(b) => Abort.fail(HttpStatusException(resp.status, route.method.name, url.baseUrl, b))
@@ -859,9 +875,9 @@ object HttpClient:
     )(
         extract: HttpResponse[Out] => A
     )(using Frame): A < (Async & Abort[HttpException]) =
-        local.use { (client, config) =>
+        local.use { (client, config, filter) =>
             val req = HttpRequest(route.method, applyQuery(url, query), headers, Record.empty)
-            client.sendWithConfig(route, req, config)(extract)
+            client.sendWithConfig(route, req, config, filter)(extract)
         }
 
     private def sendUrl[B, Out, A](
@@ -873,9 +889,9 @@ object HttpClient:
     )(
         extract: HttpResponse[Out] => A
     )(using Frame): A < (Async & Abort[HttpException]) =
-        local.use { (client, config) =>
+        local.use { (client, config, filter) =>
             val req = HttpRequest(route.method, applyQuery(url, query), headers, Record.empty).addField("body", body)
-            client.sendWithConfig(route, req, config)(extract)
+            client.sendWithConfig(route, req, config, filter)(extract)
         }
 
     // --- Private implementation ---

--- a/kyo-http/shared/src/main/scala/kyo/HttpClientConfig.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpClientConfig.scala
@@ -43,7 +43,7 @@ import kyo.*
   *   `HttpClientConfig` on [[HttpClient.init]].
   * @param clientFilter
   *   Programmatic client filter applied to outgoing HTTP requests and WebSocket upgrade handshakes after ServiceLoader filters and before
-  *   scoped or route filters.
+  *   route filters.
   *
   * @see
   *   [[kyo.HttpClient.withConfig]] Applies this config to a block of code
@@ -87,4 +87,6 @@ case class HttpClientConfig(
         copy(clientFilter = clientFilter.andThen(f))
     def filters(fs: Seq[HttpFilter.Passthrough[Nothing]]): HttpClientConfig =
         copy(clientFilter = fs.foldLeft(clientFilter)(_.andThen(_)))
+    def withoutFilters: HttpClientConfig =
+        copy(clientFilter = HttpFilter.noop)
 end HttpClientConfig

--- a/kyo-http/shared/src/main/scala/kyo/HttpClientConfig.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpClientConfig.scala
@@ -87,6 +87,6 @@ case class HttpClientConfig(
         copy(clientFilter = clientFilter.andThen(f))
     def filters(fs: Seq[HttpFilter.Passthrough[Nothing]]): HttpClientConfig =
         copy(clientFilter = fs.foldLeft(clientFilter)(_.andThen(_)))
-    def withoutFilters: HttpClientConfig =
+    def clearFilters: HttpClientConfig =
         copy(clientFilter = HttpFilter.noop)
 end HttpClientConfig

--- a/kyo-http/shared/src/main/scala/kyo/HttpClientConfig.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpClientConfig.scala
@@ -41,9 +41,11 @@ import kyo.*
   * @param tls
   *   TLS settings applied to HTTPS connections made by this client. See [[HttpTlsConfig]]. Per-request TLS overrides can be set via
   *   `HttpClientConfig` on [[HttpClient.init]].
+  * @param autoFilters
+  *   Whether ServiceLoader-discovered client filters are applied. Defaults to true.
   * @param clientFilter
-  *   Programmatic client filter applied to outgoing HTTP requests and WebSocket upgrade handshakes after ServiceLoader filters and before
-  *   route filters.
+  *   Programmatic client filter applied to outgoing HTTP requests and WebSocket upgrade handshakes after auto filters and before route
+  *   filters.
   *
   * @see
   *   [[kyo.HttpClient.withConfig]] Applies this config to a block of code
@@ -64,6 +66,7 @@ case class HttpClientConfig(
     retryOn: HttpStatus => Boolean = _.isServerError,
     transportConfig: HttpTransportConfig = HttpTransportConfig.default,
     tls: HttpTlsConfig = HttpTlsConfig.default,
+    autoFilters: Boolean = true,
     clientFilter: HttpFilter.Passthrough[Nothing] = HttpFilter.noop
 ):
     require(maxRedirects >= 0, s"maxRedirects must be non-negative: $maxRedirects")
@@ -83,6 +86,8 @@ case class HttpClientConfig(
     def retryOn(f: HttpStatus => Boolean): HttpClientConfig       = copy(retryOn = f)
     def transportConfig(v: HttpTransportConfig): HttpClientConfig = copy(transportConfig = v)
     def tls(config: HttpTlsConfig): HttpClientConfig              = copy(tls = config)
+    def autoFilters(v: Boolean): HttpClientConfig                 = copy(autoFilters = v)
+    def withoutAutoFilters: HttpClientConfig                      = autoFilters(false)
     def filter(f: HttpFilter.Passthrough[Nothing]): HttpClientConfig =
         copy(clientFilter = clientFilter.andThen(f))
     def filters(fs: Seq[HttpFilter.Passthrough[Nothing]]): HttpClientConfig =

--- a/kyo-http/shared/src/main/scala/kyo/HttpClientConfig.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpClientConfig.scala
@@ -2,7 +2,7 @@ package kyo
 
 import kyo.*
 
-/** Configuration for an [[kyo.HttpClient]], controlling timeouts, retries, redirects, and base URL resolution.
+/** Configuration for an [[kyo.HttpClient]], controlling timeouts, retries, redirects, client filters, and base URL resolution.
   *
   * Applied via `HttpClient.withConfig(_.timeout(10.seconds)) { ... }`. The function overload composes with the current config — nested
   * `withConfig` calls stack rather than replace each other, so each layer only overrides the fields it changes. To discard the current
@@ -41,6 +41,9 @@ import kyo.*
   * @param tls
   *   TLS settings applied to HTTPS connections made by this client. See [[HttpTlsConfig]]. Per-request TLS overrides can be set via
   *   `HttpClientConfig` on [[HttpClient.init]].
+  * @param clientFilter
+  *   Programmatic client filter applied to outgoing HTTP requests and WebSocket upgrade handshakes after ServiceLoader filters and before
+  *   scoped or route filters.
   *
   * @see
   *   [[kyo.HttpClient.withConfig]] Applies this config to a block of code
@@ -60,7 +63,8 @@ case class HttpClientConfig(
     retrySchedule: Maybe[Schedule] = Absent,
     retryOn: HttpStatus => Boolean = _.isServerError,
     transportConfig: HttpTransportConfig = HttpTransportConfig.default,
-    tls: HttpTlsConfig = HttpTlsConfig.default
+    tls: HttpTlsConfig = HttpTlsConfig.default,
+    clientFilter: HttpFilter.Passthrough[Nothing] = HttpFilter.noop
 ):
     require(maxRedirects >= 0, s"maxRedirects must be non-negative: $maxRedirects")
     require(timeout > Duration.Zero || timeout == Duration.Infinity, s"timeout must be positive or Infinity: $timeout")
@@ -79,4 +83,8 @@ case class HttpClientConfig(
     def retryOn(f: HttpStatus => Boolean): HttpClientConfig       = copy(retryOn = f)
     def transportConfig(v: HttpTransportConfig): HttpClientConfig = copy(transportConfig = v)
     def tls(config: HttpTlsConfig): HttpClientConfig              = copy(tls = config)
+    def filter(f: HttpFilter.Passthrough[Nothing]): HttpClientConfig =
+        copy(clientFilter = clientFilter.andThen(f))
+    def filters(fs: Seq[HttpFilter.Passthrough[Nothing]]): HttpClientConfig =
+        copy(clientFilter = fs.foldLeft(clientFilter)(_.andThen(_)))
 end HttpClientConfig

--- a/kyo-http/shared/src/main/scala/kyo/HttpFilter.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpFilter.scala
@@ -42,10 +42,10 @@ import kyo.*
   */
 sealed abstract class HttpFilter[ReqUse, ReqAdd, ResUse, ResAdd, +E]:
 
-    def apply[In, Out, E2](
+    def apply[In, Out, E2, S](
         request: HttpRequest[In & ReqUse],
-        next: HttpRequest[In & ReqUse & ReqAdd] => HttpResponse[Out & ResUse] < (Async & Abort[E2 | HttpResponse.Halt])
-    )(using Frame): HttpResponse[Out & ResUse & ResAdd] < (Async & Abort[E | E2 | HttpResponse.Halt])
+        next: HttpRequest[In & ReqUse & ReqAdd] => HttpResponse[Out & ResUse] < (S & Async & Abort[E2 | HttpResponse.Halt])
+    )(using Frame): HttpResponse[Out & ResUse & ResAdd] < (S & Async & Abort[E | E2 | HttpResponse.Halt])
 
     /** Composes this filter with another, running this filter first, then `that`. Type parameters are intersected: the composed filter
       * requires the union of both filters' required fields and adds the union of both filters' added fields. If either filter is `noop`,
@@ -59,12 +59,12 @@ sealed abstract class HttpFilter[ReqUse, ReqAdd, ResUse, ResAdd, +E]:
         else
             val self = this
             new HttpFilter[ReqUse & RI2, ReqAdd & RO2, ResUse & SI2, ResAdd & SO2, E | E2]:
-                def apply[In, Out, E3](
+                def apply[In, Out, E3, S](
                     request: HttpRequest[In & ReqUse & RI2],
                     next: HttpRequest[In & ReqUse & RI2 & ReqAdd & RO2] => HttpResponse[
                         Out & ResUse & SI2
-                    ] < (Async & Abort[E3 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out & ResUse & SI2 & ResAdd & SO2] < (Async & Abort[E | E2 | E3 | HttpResponse.Halt]) =
+                    ] < (S & Async & Abort[E3 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out & ResUse & SI2 & ResAdd & SO2] < (S & Async & Abort[E | E2 | E3 | HttpResponse.Halt]) =
                     self(request, req => that(req, next))
             end new
     end andThen
@@ -87,20 +87,20 @@ object HttpFilter:
             else
                 val self = this
                 new Passthrough[E | E2]:
-                    def apply[In, Out, E3](
+                    def apply[In, Out, E3, S](
                         request: HttpRequest[In],
-                        next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E3 | HttpResponse.Halt])
-                    )(using Frame): HttpResponse[Out] < (Async & Abort[E | E2 | E3 | HttpResponse.Halt]) =
+                        next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E3 | HttpResponse.Halt])
+                    )(using Frame): HttpResponse[Out] < (S & Async & Abort[E | E2 | E3 | HttpResponse.Halt]) =
                         self(request, req => that(req, next))
                 end new
     end Passthrough
 
     val noop: Passthrough[Nothing] =
         new Passthrough[Nothing]:
-            def apply[In, Out, E2](
+            def apply[In, Out, E2, S](
                 request: HttpRequest[In],
-                next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-            )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+            )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                 next(request)
 
     // --- Server-side filters ---
@@ -123,12 +123,12 @@ object HttpFilter:
           */
         def basicAuth(validate: (String, String) => Boolean < Async): Request["authorization" ~ Maybe[String], "user" ~ String, Nothing] =
             new Request["authorization" ~ Maybe[String], "user" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In & "authorization" ~ Maybe[String]],
                     next: HttpRequest[In & "authorization" ~ Maybe[String] & "user" ~ String] => HttpResponse[
                         Out
-                    ] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    ] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     request.fields.authorization match
                         case Present(auth)
                             if auth.length > 6 && auth.regionMatches(true, 0, "Basic ", 0, 6) =>
@@ -157,10 +157,12 @@ object HttpFilter:
           */
         def bearerAuth(validate: String => Boolean < Async): Request["authorization" ~ Maybe[String], Any, Nothing] =
             new Request["authorization" ~ Maybe[String], Any, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In & "authorization" ~ Maybe[String]],
-                    next: HttpRequest[In & "authorization" ~ Maybe[String]] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "authorization" ~ Maybe[String]] => HttpResponse[
+                        Out
+                    ] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     request.fields.authorization match
                         case Present(auth)
                             if auth.length > 7 && auth.regionMatches(true, 0, "Bearer ", 0, 7) =>
@@ -181,10 +183,10 @@ object HttpFilter:
                     .setHeader("Retry-After", retryAfter.toString)
             )
             new Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     // Meter.tryRun introduces Abort[Closed] which must be handled here to avoid
                     // leaking it into the filter's return type. A closed meter is treated as exhausted.
                     meter.tryRun(next(request)).handle(Abort.run[Closed]).map {
@@ -234,10 +236,10 @@ object HttpFilter:
                 HttpResponse.Halt(r4)
             end preflight
             new Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     def addCorsHeaders[F](res: HttpResponse[F]): HttpResponse[F] =
                         val r0 = res.setHeader("Access-Control-Allow-Origin", allowOrigin)
                         val r1 =
@@ -265,10 +267,10 @@ object HttpFilter:
             csp: Maybe[String] = Absent
         ): Passthrough[Nothing] =
             new Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request).map { res =>
                         val r0 = res
                             .setHeader("X-Content-Type-Options", "nosniff")
@@ -286,10 +288,10 @@ object HttpFilter:
         /** Logs requests: "METHOD /path -> STATUS (Xms)" */
         def logging: Passthrough[Nothing] =
             new Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     Clock.stopwatch.map { sw =>
                         next(request).map { res =>
                             sw.elapsed.map { dur =>
@@ -305,10 +307,10 @@ object HttpFilter:
 
         def requestId(headerName: String): Passthrough[Nothing] =
             new Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     val getId = request.headers.get(headerName) match
                         case Present(id) => id: String < Any
                         case Absent      => Random.nextStringAlphanumeric(32)
@@ -326,10 +328,10 @@ object HttpFilter:
         /** Adds Bearer token header to outgoing requests. */
         def bearerAuth(token: String): Passthrough[Nothing] =
             new Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.setHeader("Authorization", s"Bearer $token"))
 
         /** Adds Basic auth header to outgoing requests. */
@@ -338,10 +340,10 @@ object HttpFilter:
                 s"$username:$password".getBytes("UTF-8")
             )
             new Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.setHeader("Authorization", s"Basic $encoded"))
             end new
         end basicAuth
@@ -349,19 +351,19 @@ object HttpFilter:
         /** Adds a custom header to outgoing requests. */
         def addHeader(name: String, value: String): Passthrough[Nothing] =
             new Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.setHeader(name, value))
 
         /** Logs requests: "METHOD /path -> STATUS (Xms)" */
         def logging: Passthrough[Nothing] =
             new Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     Clock.stopwatch.map { sw =>
                         next(request).map { res =>
                             sw.elapsed.map { dur =>
@@ -379,11 +381,11 @@ object HttpFilter:
         composed: HttpFilter[In, ReqAdd, Out, ResAdd, E]
     ): HttpFilter[In & ReqAdd, Any, Out & ResAdd, Any, E] =
         new HttpFilter[In & ReqAdd, Any, Out & ResAdd, Any, E]:
-            def apply[In2, Out2, E2](
+            def apply[In2, Out2, E2, S](
                 request: HttpRequest[In2 & (In & ReqAdd)],
-                next: HttpRequest[In2 & (In & ReqAdd)] => HttpResponse[Out2 & (Out & ResAdd)] < (Async & Abort[E2 | HttpResponse.Halt])
-            )(using Frame): HttpResponse[Out2 & (Out & ResAdd)] < (Async & Abort[E | E2 | HttpResponse.Halt]) =
-                composed[In2 & ReqAdd, Out2 & ResAdd, E2](request, next)
+                next: HttpRequest[In2 & (In & ReqAdd)] => HttpResponse[Out2 & (Out & ResAdd)] < (S & Async & Abort[E2 | HttpResponse.Halt])
+            )(using Frame): HttpResponse[Out2 & (Out & ResAdd)] < (S & Async & Abort[E | E2 | HttpResponse.Halt]) =
+                composed[In2 & ReqAdd, Out2 & ResAdd, E2, S](request, next)
 
     /** SPI for contributing HTTP filters that apply globally to all requests or responses, discovered via `java.util.ServiceLoader`.
       *

--- a/kyo-http/shared/src/main/scala/kyo/HttpHandler.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpHandler.scala
@@ -5,8 +5,9 @@ import kyo.*
 /** An executable endpoint that pairs an [[kyo.HttpRoute]] with a request handler function.
   *
   * `HttpHandler` is what the server dispatches to when an incoming request matches the route's method and path. It wraps the route's filter
-  * chain so that server-side filters (contributed via [[kyo.HttpFilter.Factory]]) and route-level filters are applied automatically on every
-  * request. The handler function receives a typed `HttpRequest[In]` with all declared fields accessible via `req.fields`.
+  * chain so route-level filters are applied automatically on every request. Server-wide auto filters contributed via
+  * [[kyo.HttpFilter.Factory]] are applied by [[kyo.HttpServer]] according to [[kyo.HttpServerConfig]]. The handler function receives a typed
+  * `HttpRequest[In]` with all declared fields accessible via `req.fields`.
   *
   * For common use cases, use the convenience methods on the companion object (`getJson`, `postText`, `getSseJson`, etc.). These create both
   * a route and a handler in one call and automatically wrap the return value in `HttpResponse.ok`. For full control over response status,
@@ -29,7 +30,7 @@ import kyo.*
   * @see
   *   [[kyo.HttpResponse.Halt]] Short-circuit mechanism for early response exits
   * @see
-  *   [[kyo.HttpFilter.Factory]] SPI for contributing server-wide filters
+  *   [[kyo.HttpFilter.Factory]] SPI for contributing server-wide auto filters
   */
 sealed abstract class HttpHandler[In, Out, +E](val route: HttpRoute[In, Out, E]):
 
@@ -107,12 +108,27 @@ object HttpHandler:
     )(
         handler: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E | HttpResponse.Halt])
     ): HttpHandler[In, Out, E] =
-        val f = HttpFilter.Factory.composedServer.andThen(route.filter)
+        val f = route.filter
             .asInstanceOf[HttpFilter[Any, Any, Any, Any, E]]
         new HttpHandler[In, Out, E](route):
             def apply(request: HttpRequest[In])(using Frame) =
                 f(request, handler)
     end init
+
+    private[kyo] def withFilter[In, Out, E](
+        handler: HttpHandler[In, Out, E],
+        filter: HttpFilter.Passthrough[Nothing]
+    ): HttpHandler[In, Out, E] =
+        if filter eq HttpFilter.noop then handler
+        else
+            handler match
+                case _: WebSocketHttpHandler => handler
+                case h =>
+                    new HttpHandler[In, Out, E](h.route):
+                        def apply(request: HttpRequest[In])(using Frame) =
+                            filter(request, h.apply)
+                    end new
+    end withFilter
 
     private[kyo] def wrapHeaders[In, Out, E](
         handler: HttpHandler[In, Out, E],

--- a/kyo-http/shared/src/main/scala/kyo/HttpServer.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpServer.scala
@@ -112,8 +112,14 @@ object HttpServer:
                 }
             case Absent =>
                 handlers
+        val serverFilter =
+            if config.autoFilters then HttpFilter.Factory.composedServer
+            else HttpFilter.noop
+        val filteredHandlers =
+            if serverFilter eq HttpFilter.noop then allHandlers
+            else allHandlers.map(h => HttpHandler.withFilter(h, serverFilter))
         Sync.Unsafe.defer {
-            val listenFiber = Unsafe.init(HttpPlatformTransport.transport, config, allHandlers)
+            val listenFiber = Unsafe.init(HttpPlatformTransport.transport, config, filteredHandlers)
             Abort.run[Closed](listenFiber.safe.get).map {
                 case Result.Success(server) => server.safe
                 case Result.Failure(closed) =>

--- a/kyo-http/shared/src/main/scala/kyo/HttpServerConfig.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpServerConfig.scala
@@ -41,6 +41,8 @@ import kyo.*
   *   Low-level I/O tuning: read buffer size, channel capacity, I/O pool size. See [[HttpTransportConfig]].
   * @param idleTimeout
   *   Duration after which idle keep-alive connections are closed. Defaults to 60 seconds. Set to `Duration.Infinity` to disable.
+  * @param autoFilters
+  *   Whether ServiceLoader-discovered server filters are applied. Defaults to true.
   *
   * @see
   *   [[kyo.HttpServer.init]] Uses this config to bind a server
@@ -63,7 +65,8 @@ case class HttpServerConfig(
     tls: Maybe[HttpTlsConfig],
     unixSocket: Maybe[String] = Absent,
     transportConfig: HttpTransportConfig = HttpTransportConfig.default,
-    idleTimeout: Duration = 60.seconds
+    idleTimeout: Duration = 60.seconds,
+    autoFilters: Boolean = true
 ) derives CanEqual:
     def port(p: Int): HttpServerConfig                            = copy(port = p)
     def host(h: String): HttpServerConfig                         = copy(host = h)
@@ -78,6 +81,8 @@ case class HttpServerConfig(
     def unixSocket(path: String): HttpServerConfig                = copy(unixSocket = Present(path))
     def transportConfig(v: HttpTransportConfig): HttpServerConfig = copy(transportConfig = v)
     def idleTimeout(v: Duration): HttpServerConfig                = copy(idleTimeout = v)
+    def autoFilters(v: Boolean): HttpServerConfig                 = copy(autoFilters = v)
+    def withoutAutoFilters: HttpServerConfig                      = autoFilters(false)
     def openApi(
         path: String = "/openapi.json",
         title: String = "API",
@@ -104,7 +109,8 @@ object HttpServerConfig:
             tls = Absent,
             unixSocket = Absent,
             transportConfig = HttpTransportConfig.default,
-            idleTimeout = 60.seconds
+            idleTimeout = 60.seconds,
+            autoFilters = true
         )
 
     case class OpenApiEndpoint(

--- a/kyo-http/shared/src/main/scala/kyo/HttpUrl.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpUrl.scala
@@ -44,9 +44,7 @@ final case class HttpUrl(
     def full: String =
         scheme match
             case Absent =>
-                rawQuery match
-                    case Present(q) => s"$path?$q"
-                    case Absent     => path
+                pathWithQuery
             case Present(s) =>
                 unixSocket match
                     case Present(socketPath) =>
@@ -71,6 +69,12 @@ final case class HttpUrl(
                             case Present(q) => discard(sb.append('?').append(q))
                             case Absent     =>
                         sb.toString
+
+    /** Path plus query string, suitable as an HTTP/1.1 request target. */
+    def pathWithQuery: String =
+        rawQuery match
+            case Present(q) => s"$path?$q"
+            case Absent     => path
 
     def ssl: Boolean = scheme match
         case Present(s) => s.equalsIgnoreCase("https")

--- a/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
@@ -530,7 +530,8 @@ final private[kyo] class HttpClientBackend[Handle] private (
         url: HttpUrl,
         headers: HttpHeaders,
         config: HttpWebSocket.Config,
-        connectTimeout: Duration = Duration.Infinity
+        connectTimeout: Duration = Duration.Infinity,
+        clientFilter: HttpFilter.Passthrough[Nothing] = HttpFilter.noop
     )(
         f: HttpWebSocket => A < S
     )(using Frame): A < (S & Async & Abort[HttpException]) =
@@ -551,7 +552,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
             else Async.timeout(connectTimeout)(connect)
         Abort.runWith[Closed | Timeout](timed) {
             case Result.Success(connection) =>
-                runWsSessionWith(connection, url, headers, config)(f)
+                runWsSessionWith(connection, url, headers, config, clientFilter)(f)
             case Result.Failure(_: Timeout) =>
                 Abort.fail(HttpConnectTimeoutException(eh, ep, connectTimeout))
             case Result.Failure(closed: Closed) =>
@@ -700,19 +701,46 @@ final private[kyo] class HttpClientBackend[Handle] private (
         connection: Connection[Handle],
         url: HttpUrl,
         headers: HttpHeaders,
-        config: HttpWebSocket.Config
+        config: HttpWebSocket.Config,
+        clientFilter: HttpFilter.Passthrough[Nothing]
     )(
         f: HttpWebSocket => A < S
     )(using Frame): A < (S & Async & Abort[HttpException]) =
         val transportStream = new ConnectionBackedStream(connection)
+        val path = url.rawQuery match
+            case Present(q) => s"${url.path}?$q"
+            case Absent     => url.path
         Sync.ensure {
             Sync.Unsafe.defer {
                 connection.close()
             }
         } {
-            WebSocketCodec.requestUpgradeWith(transportStream, url.host, url.path, headers, config) { wsStream =>
-                serveWebSocketWith(transportStream, wsStream, config)(f)
-            }
+            val filter = HttpFilter.Factory.composedClient.andThen(clientFilter)
+            if filter.eq(HttpFilter.noop) then
+                WebSocketCodec.requestUpgradeWith(transportStream, url.host, path, headers, config) { wsStream =>
+                    serveWebSocketWith(transportStream, wsStream, config)(f)
+                }
+            else
+                val request = HttpRequest(HttpMethod.GET, url, headers, Record.empty)
+                filter[Any, "body" ~ A, HttpException](
+                    request,
+                    (filteredReq: HttpRequest[Any]) =>
+                        val filteredPath = filteredReq.url.rawQuery match
+                            case Present(q) => s"${filteredReq.url.path}?$q"
+                            case Absent     => filteredReq.url.path
+                        WebSocketCodec.requestUpgradeWith(
+                            transportStream,
+                            filteredReq.url.host,
+                            filteredPath,
+                            filteredReq.headers,
+                            config
+                        ) { wsStream =>
+                            serveWebSocketWith(transportStream, wsStream, config)(f).map { result =>
+                                HttpResponse(HttpStatus.SwitchingProtocols).addField("body", result)
+                            }
+                        }.asInstanceOf[HttpResponse["body" ~ A] < (Async & Abort[HttpException | HttpResponse.Halt])]
+                ).map(_.fields.body).asInstanceOf[A < (S & Async & Abort[HttpException])]
+            end if
         }
     end runWsSessionWith
 
@@ -828,7 +856,8 @@ final private[kyo] class HttpClientBackend[Handle] private (
     def sendWithConfig[In, Out, A](
         route: HttpRoute[In, Out, Any],
         request: HttpRequest[In],
-        config: HttpClientConfig
+        config: HttpClientConfig,
+        scopedFilter: HttpFilter.Passthrough[Nothing] = HttpFilter.noop
     )(
         f: HttpResponse[Out] => A < (Async & Abort[HttpException])
     )(using Frame): A < (Async & Abort[HttpException]) =
@@ -836,20 +865,21 @@ final private[kyo] class HttpClientBackend[Handle] private (
             case Present(base) if request.url.scheme.isEmpty =>
                 request.copy(url = HttpUrl(base.scheme, base.host, base.port, request.url.path, request.url.rawQuery))
             case _ => request
-        retryWith(route, resolved, config)(f)
+        retryWith(route, resolved, config, scopedFilter)(f)
     end sendWithConfig
 
     private def retryWith[In, Out, A](
         route: HttpRoute[In, Out, Any],
         request: HttpRequest[In],
-        config: HttpClientConfig
+        config: HttpClientConfig,
+        scopedFilter: HttpFilter.Passthrough[Nothing]
     )(
         f: HttpResponse[Out] => A < (Async & Abort[HttpException])
     )(using Frame): A < (Async & Abort[HttpException]) =
         config.retrySchedule match
             case Present(schedule) =>
                 def loop(remaining: Schedule): A < (Async & Abort[HttpException]) =
-                    timeoutWith(route, request, config) { res =>
+                    timeoutWith(route, request, config, scopedFilter) { res =>
                         if !config.retryOn(res.status) then f(res)
                         else
                             Clock.nowWith { now =>
@@ -861,20 +891,21 @@ final private[kyo] class HttpClientBackend[Handle] private (
                     }
                 loop(schedule)
             case Absent =>
-                timeoutWith(route, request, config)(f)
+                timeoutWith(route, request, config, scopedFilter)(f)
     end retryWith
 
     private def timeoutWith[In, Out, A](
         route: HttpRoute[In, Out, Any],
         request: HttpRequest[In],
-        config: HttpClientConfig
+        config: HttpClientConfig,
+        scopedFilter: HttpFilter.Passthrough[Nothing]
     )(
         f: HttpResponse[Out] => A < (Async & Abort[HttpException])
     )(using Frame): A < (Async & Abort[HttpException]) =
         // Apply redirect-aware callback wrapping
         if config.followRedirects then
             def loop(req: HttpRequest[In], count: Int, chain: Chunk[String]): A < (Async & Abort[HttpException]) =
-                val inner = poolWith(route, req, config) { res =>
+                val inner = poolWith(route, req, config, scopedFilter) { res =>
                     if !res.status.isRedirect then f(res)
                     else if count >= config.maxRedirects then
                         Abort.fail(HttpRedirectLoopException(count, req.method.name, req.url.baseUrl, chain))
@@ -906,7 +937,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
             end loop
             loop(request, 0, Chunk.empty)
         else
-            val inner = poolWith(route, request, config)(f)
+            val inner = poolWith(route, request, config, scopedFilter)(f)
             if config.timeout == Duration.Infinity then inner
             else
                 Async.timeoutWithError(
@@ -969,14 +1000,15 @@ final private[kyo] class HttpClientBackend[Handle] private (
     private def poolWith[In, Out, A](
         route: HttpRoute[In, Out, Any],
         request: HttpRequest[In],
-        config: HttpClientConfig
+        config: HttpClientConfig,
+        scopedFilter: HttpFilter.Passthrough[Nothing]
     )(
         f: HttpResponse[Out] => A < (Async & Abort[HttpException])
     )(using Frame): A < (Async & Abort[HttpException]) =
         // Client-side filters (e.g. basicAuth, bearerAuth) are Passthrough — they transform the request
         // and forward next's result unchanged.
         // Auto-discovered filters (e.g. W3C trace context from kyo-stats-otlp) are composed first.
-        val clientFilter = HttpFilter.Factory.composedClient
+        val clientFilter = HttpFilter.Factory.composedClient.andThen(config.clientFilter).andThen(scopedFilter)
         val routeFilter  = route.filter
         if (clientFilter eq HttpFilter.noop) && (routeFilter eq HttpFilter.noop) then
             // Fast path: no filters configured — call impl directly without filter closure

--- a/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
@@ -633,14 +633,10 @@ final private[kyo] class HttpClientBackend[Handle] private (
             // Compute host header
             val isDefaultPort   = if url.ssl then url.port == 443 else url.port == 80
             val hostHeaderValue = if isDefaultPort || url.host.isEmpty then url.host else s"${url.host}:${url.port}"
-            // Build path with query string
-            val path = url.rawQuery match
-                case Present(q) => s"${url.path}?$q"
-                case Absent     => url.path
             // Send the HTTP request
             val responsePromise = http1.sendDirect(
                 method,
-                path,
+                url.pathWithQuery,
                 headers,
                 body,
                 hostHeaderValue,
@@ -707,9 +703,6 @@ final private[kyo] class HttpClientBackend[Handle] private (
         f: HttpWebSocket => A < S
     )(using Frame): A < (S & Async & Abort[HttpException]) =
         val transportStream = new ConnectionBackedStream(connection)
-        val path = url.rawQuery match
-            case Present(q) => s"${url.path}?$q"
-            case Absent     => url.path
         Sync.ensure {
             Sync.Unsafe.defer {
                 connection.close()
@@ -717,32 +710,55 @@ final private[kyo] class HttpClientBackend[Handle] private (
         } {
             val filter = HttpFilter.Factory.composedClient.andThen(clientFilter)
             if filter.eq(HttpFilter.noop) then
-                WebSocketCodec.requestUpgradeWith(transportStream, url.host, path, headers, config) { wsStream =>
+                WebSocketCodec.requestUpgradeWith(transportStream, url.host, url.pathWithQuery, headers, config) { wsStream =>
                     serveWebSocketWith(transportStream, wsStream, config)(f)
                 }
             else
                 val request = HttpRequest(HttpMethod.GET, url, headers, Record.empty)
-                filter[Any, "body" ~ A, HttpException](
-                    request,
-                    (filteredReq: HttpRequest[Any]) =>
-                        val filteredPath = filteredReq.url.rawQuery match
-                            case Present(q) => s"${filteredReq.url.path}?$q"
-                            case Absent     => filteredReq.url.path
-                        WebSocketCodec.requestUpgradeWith(
-                            transportStream,
-                            filteredReq.url.host,
-                            filteredPath,
-                            filteredReq.headers,
-                            config
-                        ) { wsStream =>
-                            serveWebSocketWith(transportStream, wsStream, config)(f).map { result =>
-                                HttpResponse(HttpStatus.SwitchingProtocols).addField("body", result)
-                            }
-                        }.asInstanceOf[HttpResponse["body" ~ A] < (Async & Abort[HttpException | HttpResponse.Halt])]
-                ).map(_.fields.body).asInstanceOf[A < (S & Async & Abort[HttpException])]
+                handleWebSocketFilterResult(
+                    url,
+                    filter[Any, "body" ~ A, HttpException](
+                        request,
+                        (filteredReq: HttpRequest[Any]) =>
+                            eraseWebSocketUserEffects(WebSocketCodec.requestUpgradeWith(
+                                transportStream,
+                                filteredReq.url.host,
+                                filteredReq.url.pathWithQuery,
+                                filteredReq.headers,
+                                config
+                            ) { wsStream =>
+                                serveWebSocketWith(transportStream, wsStream, config)(f).map { result =>
+                                    HttpResponse(HttpStatus.SwitchingProtocols).addField("body", result)
+                                }
+                            })
+                    ).map(_.fields.body)
+                )
             end if
         }
     end runWsSessionWith
+
+    private def eraseWebSocketUserEffects[A, S](
+        v: HttpResponse["body" ~ A] < (S & Async & Abort[HttpException | HttpResponse.Halt])
+    ): HttpResponse["body" ~ A] < (Async & Abort[HttpException | HttpResponse.Halt]) =
+        // HttpFilter continuations model Async and Abort only. WebSocket user code may carry an extra effect row S, but filters only
+        // forward the continuation result, they never inspect or handle S. The enclosing result restores S after the filtered response is
+        // unwrapped.
+        v.asInstanceOf[HttpResponse["body" ~ A] < (Async & Abort[HttpException | HttpResponse.Halt])]
+
+    private def handleWebSocketFilterResult[A, S](
+        url: HttpUrl,
+        v: A < (Async & Abort[HttpException | HttpResponse.Halt])
+    )(using Frame): A < (S & Async & Abort[HttpException]) =
+        val handled = Abort.run[HttpResponse.Halt](v).map {
+            case Result.Success(value) => value
+            case Result.Failure(halt) =>
+                Abort.fail(HttpStatusException(halt.response.status, HttpMethod.GET.name, url.baseUrl, halt.response.rawBody.getOrElse("")))
+            case Result.Panic(t) => throw t
+        }
+        // The filtered result has already handled filter-level Halt. The cast restores the user session effect row S, which was erased
+        // only because HttpFilter continuations cannot express extra effects on the downstream WebSocket session.
+        handled.asInstanceOf[A < (S & Async & Abort[HttpException])]
+    end handleWebSocketFilterResult
 
     /** Three concurrent fibers: read loop, write loop, user handler.
       *
@@ -856,8 +872,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
     def sendWithConfig[In, Out, A](
         route: HttpRoute[In, Out, Any],
         request: HttpRequest[In],
-        config: HttpClientConfig,
-        scopedFilter: HttpFilter.Passthrough[Nothing] = HttpFilter.noop
+        config: HttpClientConfig
     )(
         f: HttpResponse[Out] => A < (Async & Abort[HttpException])
     )(using Frame): A < (Async & Abort[HttpException]) =
@@ -865,21 +880,20 @@ final private[kyo] class HttpClientBackend[Handle] private (
             case Present(base) if request.url.scheme.isEmpty =>
                 request.copy(url = HttpUrl(base.scheme, base.host, base.port, request.url.path, request.url.rawQuery))
             case _ => request
-        retryWith(route, resolved, config, scopedFilter)(f)
+        retryWith(route, resolved, config)(f)
     end sendWithConfig
 
     private def retryWith[In, Out, A](
         route: HttpRoute[In, Out, Any],
         request: HttpRequest[In],
-        config: HttpClientConfig,
-        scopedFilter: HttpFilter.Passthrough[Nothing]
+        config: HttpClientConfig
     )(
         f: HttpResponse[Out] => A < (Async & Abort[HttpException])
     )(using Frame): A < (Async & Abort[HttpException]) =
         config.retrySchedule match
             case Present(schedule) =>
                 def loop(remaining: Schedule): A < (Async & Abort[HttpException]) =
-                    timeoutWith(route, request, config, scopedFilter) { res =>
+                    timeoutWith(route, request, config) { res =>
                         if !config.retryOn(res.status) then f(res)
                         else
                             Clock.nowWith { now =>
@@ -891,21 +905,20 @@ final private[kyo] class HttpClientBackend[Handle] private (
                     }
                 loop(schedule)
             case Absent =>
-                timeoutWith(route, request, config, scopedFilter)(f)
+                timeoutWith(route, request, config)(f)
     end retryWith
 
     private def timeoutWith[In, Out, A](
         route: HttpRoute[In, Out, Any],
         request: HttpRequest[In],
-        config: HttpClientConfig,
-        scopedFilter: HttpFilter.Passthrough[Nothing]
+        config: HttpClientConfig
     )(
         f: HttpResponse[Out] => A < (Async & Abort[HttpException])
     )(using Frame): A < (Async & Abort[HttpException]) =
         // Apply redirect-aware callback wrapping
         if config.followRedirects then
             def loop(req: HttpRequest[In], count: Int, chain: Chunk[String]): A < (Async & Abort[HttpException]) =
-                val inner = poolWith(route, req, config, scopedFilter) { res =>
+                val inner = poolWith(route, req, config) { res =>
                     if !res.status.isRedirect then f(res)
                     else if count >= config.maxRedirects then
                         Abort.fail(HttpRedirectLoopException(count, req.method.name, req.url.baseUrl, chain))
@@ -937,7 +950,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
             end loop
             loop(request, 0, Chunk.empty)
         else
-            val inner = poolWith(route, request, config, scopedFilter)(f)
+            val inner = poolWith(route, request, config)(f)
             if config.timeout == Duration.Infinity then inner
             else
                 Async.timeoutWithError(
@@ -1000,15 +1013,14 @@ final private[kyo] class HttpClientBackend[Handle] private (
     private def poolWith[In, Out, A](
         route: HttpRoute[In, Out, Any],
         request: HttpRequest[In],
-        config: HttpClientConfig,
-        scopedFilter: HttpFilter.Passthrough[Nothing]
+        config: HttpClientConfig
     )(
         f: HttpResponse[Out] => A < (Async & Abort[HttpException])
     )(using Frame): A < (Async & Abort[HttpException]) =
         // Client-side filters (e.g. basicAuth, bearerAuth) are Passthrough — they transform the request
         // and forward next's result unchanged.
         // Auto-discovered filters (e.g. W3C trace context from kyo-stats-otlp) are composed first.
-        val clientFilter = HttpFilter.Factory.composedClient.andThen(config.clientFilter).andThen(scopedFilter)
+        val clientFilter = HttpFilter.Factory.composedClient.andThen(config.clientFilter)
         val routeFilter  = route.filter
         if (clientFilter eq HttpFilter.noop) && (routeFilter eq HttpFilter.noop) then
             // Fast path: no filters configured — call impl directly without filter closure

--- a/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
@@ -531,7 +531,8 @@ final private[kyo] class HttpClientBackend[Handle] private (
         headers: HttpHeaders,
         config: HttpWebSocket.Config,
         connectTimeout: Duration = Duration.Infinity,
-        clientFilter: HttpFilter.Passthrough[Nothing] = HttpFilter.noop
+        clientFilter: HttpFilter.Passthrough[Nothing] = HttpFilter.noop,
+        autoFilters: Boolean = true
     )(
         f: HttpWebSocket => A < S
     )(using Frame): A < (S & Async & Abort[HttpException]) =
@@ -552,7 +553,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
             else Async.timeout(connectTimeout)(connect)
         Abort.runWith[Closed | Timeout](timed) {
             case Result.Success(connection) =>
-                runWsSessionWith(connection, url, headers, config, clientFilter)(f)
+                runWsSessionWith(connection, url, headers, config, clientFilter, autoFilters)(f)
             case Result.Failure(_: Timeout) =>
                 Abort.fail(HttpConnectTimeoutException(eh, ep, connectTimeout))
             case Result.Failure(closed: Closed) =>
@@ -698,7 +699,8 @@ final private[kyo] class HttpClientBackend[Handle] private (
         url: HttpUrl,
         headers: HttpHeaders,
         config: HttpWebSocket.Config,
-        clientFilter: HttpFilter.Passthrough[Nothing]
+        clientFilter: HttpFilter.Passthrough[Nothing],
+        autoFilters: Boolean
     )(
         f: HttpWebSocket => A < S
     )(using Frame): A < (S & Async & Abort[HttpException]) =
@@ -708,7 +710,10 @@ final private[kyo] class HttpClientBackend[Handle] private (
                 connection.close()
             }
         } {
-            val filter = HttpFilter.Factory.composedClient.andThen(clientFilter)
+            val autoFilter =
+                if autoFilters then HttpFilter.Factory.composedClient
+                else HttpFilter.noop
+            val filter = autoFilter.andThen(clientFilter)
             if filter.eq(HttpFilter.noop) then
                 WebSocketCodec.requestUpgradeWith(transportStream, url.host, url.pathWithQuery, headers, config) { wsStream =>
                     serveWebSocketWith(transportStream, wsStream, config)(f)
@@ -717,10 +722,10 @@ final private[kyo] class HttpClientBackend[Handle] private (
                 val request = HttpRequest(HttpMethod.GET, url, headers, Record.empty)
                 handleWebSocketFilterResult(
                     url,
-                    filter[Any, "body" ~ A, HttpException](
+                    filter[Any, "body" ~ A, HttpException, S](
                         request,
                         (filteredReq: HttpRequest[Any]) =>
-                            eraseWebSocketUserEffects(WebSocketCodec.requestUpgradeWith(
+                            WebSocketCodec.requestUpgradeWith(
                                 transportStream,
                                 filteredReq.url.host,
                                 filteredReq.url.pathWithQuery,
@@ -730,34 +735,23 @@ final private[kyo] class HttpClientBackend[Handle] private (
                                 serveWebSocketWith(transportStream, wsStream, config)(f).map { result =>
                                     HttpResponse(HttpStatus.SwitchingProtocols).addField("body", result)
                                 }
-                            })
+                            }
                     ).map(_.fields.body)
                 )
             end if
         }
     end runWsSessionWith
 
-    private def eraseWebSocketUserEffects[A, S](
-        v: HttpResponse["body" ~ A] < (S & Async & Abort[HttpException | HttpResponse.Halt])
-    ): HttpResponse["body" ~ A] < (Async & Abort[HttpException | HttpResponse.Halt]) =
-        // HttpFilter continuations model Async and Abort only. WebSocket user code may carry an extra effect row S, but filters only
-        // forward the continuation result, they never inspect or handle S. The enclosing result restores S after the filtered response is
-        // unwrapped.
-        v.asInstanceOf[HttpResponse["body" ~ A] < (Async & Abort[HttpException | HttpResponse.Halt])]
-
     private def handleWebSocketFilterResult[A, S](
         url: HttpUrl,
-        v: A < (Async & Abort[HttpException | HttpResponse.Halt])
+        v: A < (S & Async & Abort[HttpException | HttpResponse.Halt])
     )(using Frame): A < (S & Async & Abort[HttpException]) =
-        val handled = Abort.run[HttpResponse.Halt](v).map {
+        Abort.run[HttpResponse.Halt](v).map {
             case Result.Success(value) => value
             case Result.Failure(halt) =>
                 Abort.fail(HttpStatusException(halt.response.status, HttpMethod.GET.name, url.baseUrl, halt.response.rawBody.getOrElse("")))
             case Result.Panic(t) => throw t
         }
-        // The filtered result has already handled filter-level Halt. The cast restores the user session effect row S, which was erased
-        // only because HttpFilter continuations cannot express extra effects on the downstream WebSocket session.
-        handled.asInstanceOf[A < (S & Async & Abort[HttpException])]
     end handleWebSocketFilterResult
 
     /** Three concurrent fibers: read loop, write loop, user handler.
@@ -1020,7 +1014,10 @@ final private[kyo] class HttpClientBackend[Handle] private (
         // Client-side filters (e.g. basicAuth, bearerAuth) are Passthrough — they transform the request
         // and forward next's result unchanged.
         // Auto-discovered filters (e.g. W3C trace context from kyo-stats-otlp) are composed first.
-        val clientFilter = HttpFilter.Factory.composedClient.andThen(config.clientFilter)
+        val autoFilter =
+            if config.autoFilters then HttpFilter.Factory.composedClient
+            else HttpFilter.noop
+        val clientFilter = autoFilter.andThen(config.clientFilter)
         val routeFilter  = route.filter
         if (clientFilter eq HttpFilter.noop) && (routeFilter eq HttpFilter.noop) then
             // Fast path: no filters configured — call impl directly without filter closure
@@ -1028,7 +1025,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
         else
             val filter = clientFilter.andThen(routeFilter)
                 .asInstanceOf[HttpFilter[Any, In, Out, Out, Nothing]]
-            filter[In, Out, HttpException](
+            filter[In, Out, HttpException, Any](
                 request,
                 (filteredReq: HttpRequest[In]) =>
                     poolWithImpl(route, filteredReq, config)(f)

--- a/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
@@ -266,8 +266,10 @@ private[kyo] object UnsafeServerDispatch:
         parser: Http1Parser
     )(using AllowUnsafe, Frame): Unit =
         val headers = HttpHeaders.fromPacked(request.headersAsPacked)
-        val path    = request.pathAsString
-        val conn    = new ChannelBackedStream(streamCtx.inbound, streamCtx.outbound)
+        val path = request.queryRawString match
+            case Present(query) => s"${request.pathAsString}?$query"
+            case Absent         => request.pathAsString
+        val conn = new ChannelBackedStream(streamCtx.inbound, streamCtx.outbound)
         discard(IOTask(
             Abort.run[Any](
                 WebSocketCodec.acceptUpgrade(conn, headers, wsHandler.wsConfig).andThen {

--- a/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
@@ -266,14 +266,12 @@ private[kyo] object UnsafeServerDispatch:
         parser: Http1Parser
     )(using AllowUnsafe, Frame): Unit =
         val headers = HttpHeaders.fromPacked(request.headersAsPacked)
-        val path = request.queryRawString match
-            case Present(query) => s"${request.pathAsString}?$query"
-            case Absent         => request.pathAsString
-        val conn = new ChannelBackedStream(streamCtx.inbound, streamCtx.outbound)
+        val url     = HttpUrl(Absent, "", 0, request.pathAsString, request.queryRawString)
+        val conn    = new ChannelBackedStream(streamCtx.inbound, streamCtx.outbound)
         discard(IOTask(
             Abort.run[Any](
                 WebSocketCodec.acceptUpgrade(conn, headers, wsHandler.wsConfig).andThen {
-                    serveWebSocket(conn, streamCtx.inbound, streamCtx.outbound, wsHandler, headers, path)
+                    serveWebSocket(conn, streamCtx.inbound, streamCtx.outbound, wsHandler, headers, url)
                 }
             ).map {
                 case Result.Failure(error) =>
@@ -297,7 +295,7 @@ private[kyo] object UnsafeServerDispatch:
         outboundRaw: Channel.Unsafe[Span[Byte]],
         wsHandler: WebSocketHttpHandler,
         headers: HttpHeaders,
-        path: String
+        url: HttpUrl
     )(using Frame): Unit < Async =
         Channel.initUnscopedWith[HttpWebSocket.Payload](wsHandler.wsConfig.bufferSize) { inbound =>
             Channel.initUnscopedWith[HttpWebSocket.Payload](wsHandler.wsConfig.bufferSize) { outbound =>
@@ -310,11 +308,8 @@ private[kyo] object UnsafeServerDispatch:
                             closeReasonRef.set(Present((code, reason))).andThen {
                                 outbound.close.unit
                             }
-                        val ws = new HttpWebSocket(inbound, outbound, closeReasonRef, peerClosedPromise, closeFn)
-                        val wsUrl = HttpUrl.parse(path) match
-                            case Result.Success(u) => u
-                            case _                 => HttpUrl.parse("/").getOrThrow
-                        val request = HttpRequest(HttpMethod.GET, wsUrl, headers, Record.empty)
+                        val ws      = new HttpWebSocket(inbound, outbound, closeReasonRef, peerClosedPromise, closeFn)
+                        val request = HttpRequest(HttpMethod.GET, url, headers, Record.empty)
 
                         Fiber.initUnscoped {
                             Loop(conn.read) { stream =>

--- a/kyo-http/shared/src/main/scala/kyo/internal/websocket/WebSocketCodec.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/websocket/WebSocketCodec.scala
@@ -146,7 +146,8 @@ private[kyo] object WebSocketCodec:
             if config.subprotocols.nonEmpty && callerSuppliedProtocol.isEmpty then
                 discard(request.append("Sec-WebSocket-Protocol: ").append(config.subprotocols.mkString(", ")).append("\r\n"))
             headers.foreach { (name, value) =>
-                discard(request.append(name).append(": ").append(value).append("\r\n"))
+                if !isRequiredClientUpgradeHeader(name) then
+                    discard(request.append(name).append(": ").append(value).append("\r\n"))
             }
             discard(request.append("\r\n"))
             conn.write(Span.fromUnsafe(request.toString.getBytes(Utf8))).andThen {
@@ -182,6 +183,13 @@ private[kyo] object WebSocketCodec:
     end requestUpgradeWith
 
     // ── Pure functions (unit testable) ──────────────────────────
+
+    private def isRequiredClientUpgradeHeader(name: String): Boolean =
+        name.equalsIgnoreCase("Host") ||
+            name.equalsIgnoreCase("Upgrade") ||
+            name.equalsIgnoreCase("Connection") ||
+            name.equalsIgnoreCase("Sec-WebSocket-Version") ||
+            name.equalsIgnoreCase("Sec-WebSocket-Key")
 
     private[internal] def computeAcceptKey(clientKey: String): String =
         val hash = Sha1.hash((clientKey + WsGuid).getBytes(Utf8))

--- a/kyo-http/shared/src/test/resources/META-INF/services/kyo.HttpFilter$Factory
+++ b/kyo-http/shared/src/test/resources/META-INF/services/kyo.HttpFilter$Factory
@@ -1,0 +1,1 @@
+kyo.HttpFilterTestFactory

--- a/kyo-http/shared/src/test/scala/demo/ImageProxy.scala
+++ b/kyo-http/shared/src/test/scala/demo/ImageProxy.scala
@@ -20,10 +20,10 @@ object ImageProxy extends KyoApp:
 
     val timingFilter =
         new HttpFilter.Passthrough[Nothing]:
-            def apply[In, Out, E2](
+            def apply[In, Out, E2, S](
                 request: HttpRequest[In],
-                next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-            )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+            )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                 Clock.stopwatch.map { sw =>
                     next(request).map { res =>
                         sw.elapsed.map { dur =>

--- a/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
@@ -132,10 +132,10 @@ class HttpClientTest extends BaseHttpTest:
             assert(!config.clientFilter.eq(HttpFilter.noop))
         }
 
-        "withoutFilters resets clientFilter" in {
+        "clearFilters resets clientFilter" in {
             val config = HttpClientConfig()
                 .filter(HttpFilter.client.addHeader("X-Test", "1"))
-                .withoutFilters
+                .clearFilters
             assert(config.clientFilter.eq(HttpFilter.noop))
         }
 

--- a/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
@@ -107,6 +107,7 @@ class HttpClientTest extends BaseHttpTest:
             assert(config.followRedirects == true)
             assert(config.maxRedirects == 10)
             assert(config.retrySchedule == Absent)
+            assert(config.clientFilter.eq(HttpFilter.noop))
         }
 
         "default retryOn checks server errors" in {
@@ -115,6 +116,20 @@ class HttpClientTest extends BaseHttpTest:
             assert(config.retryOn(HttpStatus.BadGateway) == true)
             assert(config.retryOn(HttpStatus.OK) == false)
             assert(config.retryOn(HttpStatus.BadRequest) == false)
+        }
+
+        "filter appends to clientFilter" in {
+            val filter = HttpFilter.client.addHeader("X-Test", "1")
+            val config = HttpClientConfig().filter(filter)
+            assert(!config.clientFilter.eq(HttpFilter.noop))
+        }
+
+        "filters appends multiple filters to clientFilter" in {
+            val config = HttpClientConfig().filters(Seq(
+                HttpFilter.client.addHeader("X-Test-1", "1"),
+                HttpFilter.client.addHeader("X-Test-2", "2")
+            ))
+            assert(!config.clientFilter.eq(HttpFilter.noop))
         }
 
         "negative maxRedirects throws" in {
@@ -1903,6 +1918,14 @@ class HttpClientTest extends BaseHttpTest:
 
     "client filters" - {
 
+        def appendHeader(name: String, value: String): HttpFilter.Passthrough[Nothing] =
+            new HttpFilter.Passthrough[Nothing]:
+                def apply[In, Out, E2](
+                    request: HttpRequest[In],
+                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next(request.addHeader(name, value))
+
         // Server endpoint that echoes back the Authorization header value
         def echoAuthEndpoint =
             val route = HttpRoute.getRaw("echo-auth")
@@ -1924,6 +1947,58 @@ class HttpClientTest extends BaseHttpTest:
                 HttpResponse.ok(s"X-Custom=$value")
             }
         end echoCustomHeaderEndpoint
+
+        "config filter applies to convenience methods" - {
+            runServer(echoCustomHeaderEndpoint) { url =>
+                HttpClient.withConfig(
+                    noTimeout.filter(HttpFilter.client.addHeader("X-Custom", "from-config"))
+                ) {
+                    HttpClient.getText(s"${url.scheme.getOrElse("http")}://${url.host}:${url.port}/echo-header").map { body =>
+                        assert(body == "X-Custom=from-config")
+                    }
+                }
+            }
+        }
+
+        "scoped filter applies only inside scope" - {
+            runServer(echoCustomHeaderEndpoint) { url =>
+                HttpClient.withConfig(noTimeout) {
+                    val target = s"${url.scheme.getOrElse("http")}://${url.host}:${url.port}/echo-header"
+                    HttpClient.withFilter(HttpFilter.client.addHeader("X-Custom", "scoped")) {
+                        HttpClient.getText(target).map { body =>
+                            assert(body == "X-Custom=scoped")
+                        }
+                    }.andThen {
+                        HttpClient.getText(target).map { body =>
+                            assert(body == "X-Custom=none")
+                        }
+                    }
+                }
+            }
+        }
+
+        "config scoped and route filters compose in order" - {
+            val route2 = HttpRoute.getRaw("echo-order")
+                .request(_.headerOpt[String]("x-order"))
+                .response(_.bodyText)
+            val ep = route2.handler { req =>
+                HttpResponse.ok(req.headers.getAll("X-Order").mkString(","))
+            }
+            runServer(ep) { url =>
+                HttpClient.withConfig(noTimeout.filter(appendHeader("X-Order", "config"))) {
+                    HttpClient.withFilter(appendHeader("X-Order", "scoped")) {
+                        withClient { c =>
+                            val route = HttpRoute.getRaw("echo-order").response(_.bodyText)
+                                .filter(appendHeader("X-Order", "route"))
+                            val request = HttpRequest.getRaw(HttpUrl(url.scheme, url.host, url.port, "/echo-order", Absent))
+                            c.sendWith(route, request) { resp =>
+                                assert(resp.fields.body == "config,scoped,route")
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         "basicAuth adds Authorization header" - {
             runServer(echoAuthEndpoint) { url =>

--- a/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
@@ -107,6 +107,7 @@ class HttpClientTest extends BaseHttpTest:
             assert(config.followRedirects == true)
             assert(config.maxRedirects == 10)
             assert(config.retrySchedule == Absent)
+            assert(config.autoFilters == true)
             assert(config.clientFilter.eq(HttpFilter.noop))
         }
 
@@ -139,6 +140,12 @@ class HttpClientTest extends BaseHttpTest:
             assert(config.clientFilter.eq(HttpFilter.noop))
         }
 
+        "withoutAutoFilters disables auto filters" in {
+            val config = HttpClientConfig()
+                .withoutAutoFilters
+            assert(config.autoFilters == false)
+        }
+
         "current config and filter can be inspected" in {
             HttpClient.withConfig(noTimeout.filter(HttpFilter.client.addHeader("X-Test", "1"))) {
                 HttpClient.useConfig { config =>
@@ -147,6 +154,12 @@ class HttpClientTest extends BaseHttpTest:
                 }.andThen {
                     HttpClient.useFilter { filter =>
                         assert(!filter.eq(HttpFilter.noop))
+                    }
+                }.andThen {
+                    HttpClient.withoutAutoFilters {
+                        HttpClient.useAutoFilter { filter =>
+                            assert(filter.eq(HttpFilter.noop))
+                        }
                     }
                 }
             }
@@ -1940,10 +1953,10 @@ class HttpClientTest extends BaseHttpTest:
 
         def appendHeader(name: String, value: String): HttpFilter.Passthrough[Nothing] =
             new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addHeader(name, value))
 
         // Server endpoint that echoes back the Authorization header value
@@ -2046,6 +2059,47 @@ class HttpClientTest extends BaseHttpTest:
                             c.sendWith(route, request) { resp =>
                                 assert(resp.fields.body == "config,scoped,route")
                             }
+                        }
+                    }
+                }
+            }
+        }
+
+        "auto filters apply before configured and route filters" - {
+            val route2 = HttpRoute.getRaw("auto-client")
+                .request(_.headerOpt[String]("x-order"))
+                .response(_.bodyText)
+            val ep = route2.handler { req =>
+                HttpResponse.ok(req.headers.getAll("X-Order").mkString(","))
+            }
+            runServer(ep) { url =>
+                HttpClient.withConfig(noTimeout.filter(appendHeader("X-Order", "config"))) {
+                    withClient { c =>
+                        val route = HttpRoute.getRaw("auto-client").response(_.bodyText)
+                            .filter(appendHeader("X-Order", "route"))
+                        val request = HttpRequest.getRaw(HttpUrl(url.scheme, url.host, url.port, "/auto-client", Absent))
+                        c.sendWith(route, request) { resp =>
+                            assert(resp.fields.body == "auto-client,config,route")
+                        }
+                    }
+                }
+            }
+        }
+
+        "withoutAutoFilters disables auto filters and preserves configured filters" - {
+            val route2 = HttpRoute.getRaw("auto-client")
+                .request(_.headerOpt[String]("x-order"))
+                .response(_.bodyText)
+            val ep = route2.handler { req =>
+                HttpResponse.ok(req.headers.getAll("X-Order").mkString(","))
+            }
+            runServer(ep) { url =>
+                HttpClient.withConfig(noTimeout.filter(appendHeader("X-Order", "config")).withoutAutoFilters) {
+                    withClient { c =>
+                        val route   = HttpRoute.getRaw("auto-client").response(_.bodyText)
+                        val request = HttpRequest.getRaw(HttpUrl(url.scheme, url.host, url.port, "/auto-client", Absent))
+                        c.sendWith(route, request) { resp =>
+                            assert(resp.fields.body == "config")
                         }
                     }
                 }

--- a/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
@@ -132,6 +132,26 @@ class HttpClientTest extends BaseHttpTest:
             assert(!config.clientFilter.eq(HttpFilter.noop))
         }
 
+        "withoutFilters resets clientFilter" in {
+            val config = HttpClientConfig()
+                .filter(HttpFilter.client.addHeader("X-Test", "1"))
+                .withoutFilters
+            assert(config.clientFilter.eq(HttpFilter.noop))
+        }
+
+        "current config and filter can be inspected" in {
+            HttpClient.withConfig(noTimeout.filter(HttpFilter.client.addHeader("X-Test", "1"))) {
+                HttpClient.useConfig { config =>
+                    assert(config.timeout == Duration.Infinity)
+                    assert(!config.clientFilter.eq(HttpFilter.noop))
+                }.andThen {
+                    HttpClient.useFilter { filter =>
+                        assert(!filter.eq(HttpFilter.noop))
+                    }
+                }
+            }
+        }
+
         "negative maxRedirects throws" in {
             interceptThrown[IllegalArgumentException] {
                 HttpClientConfig(maxRedirects = -1)
@@ -1971,6 +1991,38 @@ class HttpClientTest extends BaseHttpTest:
                     }.andThen {
                         HttpClient.getText(target).map { body =>
                             assert(body == "X-Custom=none")
+                        }
+                    }
+                }
+            }
+        }
+
+        "withoutFilters disables nested filters and restores outer scope" - {
+            val route = HttpRoute.getRaw("echo-header-values")
+                .response(_.bodyText)
+            val ep = route.handler { req =>
+                HttpResponse.ok(req.headers.getAll("X-Custom").mkString(","))
+            }
+            runServer(ep) { url =>
+                val target = s"${url.scheme.getOrElse("http")}://${url.host}:${url.port}/echo-header-values"
+                HttpClient.withConfig(noTimeout.filter(appendHeader("X-Custom", "from-config"))) {
+                    HttpClient.withFilter(appendHeader("X-Custom", "scoped")) {
+                        HttpClient.withoutFilters {
+                            HttpClient.useFilter { filter =>
+                                assert(filter.eq(HttpFilter.noop))
+                            }.andThen {
+                                HttpClient.getText(target).map { body =>
+                                    assert(body == "")
+                                }
+                            }
+                        }.andThen {
+                            HttpClient.useFilter { filter =>
+                                assert(!filter.eq(HttpFilter.noop))
+                            }.andThen {
+                                HttpClient.getText(target).map { body =>
+                                    assert(body == "from-config,scoped")
+                                }
+                            }
                         }
                     }
                 }

--- a/kyo-http/shared/src/test/scala/kyo/HttpFilterTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpFilterTest.scala
@@ -10,10 +10,10 @@ class HttpFilterTest extends BaseHttpTest:
 
         "reads request field" in {
             val filter = new HttpFilter.Request["name" ~ String, Any, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In & "name" ~ String],
-                    next: HttpRequest[In & "name" ~ String] => HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "name" ~ String] => HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     val _ = request.fields.name
                     next(request)
                 end apply
@@ -22,12 +22,12 @@ class HttpFilterTest extends BaseHttpTest:
 
         "adds field to request" in {
             val filter = new HttpFilter.Request["name" ~ String, "greeting" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In & "name" ~ String],
                     next: HttpRequest[In & "name" ~ String & "greeting" ~ String] => HttpResponse[
                         Out
-                    ] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    ] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("greeting", s"hello ${request.fields.name}"))
             typeCheck("""val _: HttpFilter["name" ~ String, "greeting" ~ String, Any, Any, Any] = filter""")
         }
@@ -37,10 +37,10 @@ class HttpFilterTest extends BaseHttpTest:
 
         "reads response field" in {
             val filter = new HttpFilter.Response["status" ~ Int, Any, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out & "status" ~ Int] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out & "status" ~ Int] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out & "status" ~ Int] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out & "status" ~ Int] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     next(request).map { res =>
                         val _ = res.fields.status
                         res
@@ -50,10 +50,12 @@ class HttpFilterTest extends BaseHttpTest:
 
         "adds response field" in {
             val filter = new HttpFilter.Response["status" ~ Int, "cached" ~ Boolean, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out & "status" ~ Int] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out & "status" ~ Int & "cached" ~ Boolean] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out & "status" ~ Int] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using
+                    Frame
+                ): HttpResponse[Out & "status" ~ Int & "cached" ~ Boolean] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     next(request).map { res =>
                         res.addField("cached", res.fields.status == 200)
                     }
@@ -67,20 +69,20 @@ class HttpFilterTest extends BaseHttpTest:
 
         "pure passthrough" in {
             val filter = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     next(request)
             typeCheck("""val _: HttpFilter[Any, Any, Any, Any, Any] = filter""")
         }
 
         "adds header" in {
             val filter = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     next(request).map(_.setHeader("X-Server", "kyo"))
             typeCheck("""val _: HttpFilter[Any, Any, Any, Any, Any] = filter""")
         }
@@ -98,16 +100,16 @@ class HttpFilterTest extends BaseHttpTest:
 
         "composes two passthrough filters" in {
             val f1 = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     next(request.setHeader("X-A", "1"))
             val f2 = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     next(request.setHeader("X-B", "2"))
             val composed = f1.andThen(f2)
             typeCheck("""val _: HttpFilter[Any, Any, Any, Any, Any] = composed""")
@@ -115,18 +117,18 @@ class HttpFilterTest extends BaseHttpTest:
 
         "composes request-reading and passthrough filters" in {
             val reqFilter = new HttpFilter.Request["auth" ~ String, Any, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In & "auth" ~ String],
-                    next: HttpRequest[In & "auth" ~ String] => HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "auth" ~ String] => HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     val _ = request.fields.auth
                     next(request)
                 end apply
             val passFilter = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     next(request)
             val composed = reqFilter.andThen(passFilter)
             typeCheck("""val _: HttpFilter["auth" ~ String, Any, Any, Any, Any] = composed""")
@@ -134,16 +136,16 @@ class HttpFilterTest extends BaseHttpTest:
 
         "composes request-adding filters" in {
             val f1 = new HttpFilter.Request[Any, "a" ~ Int, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "a" ~ Int] => HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "a" ~ Int] => HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("a", 1))
             val f2 = new HttpFilter.Request[Any, "b" ~ Int, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "b" ~ Int] => HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "b" ~ Int] => HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & kyo.Async & kyo.Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("b", 2))
             val composed = f1.andThen(f2)
             typeCheck("""val _: HttpFilter[Any, "a" ~ Int & "b" ~ Int, Any, Any, Any] = composed""")

--- a/kyo-http/shared/src/test/scala/kyo/HttpFilterTestFactory.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpFilterTestFactory.scala
@@ -1,0 +1,29 @@
+package kyo
+
+import kyo.*
+
+final class HttpFilterTestFactory extends HttpFilter.Factory:
+
+    override def clientFilter(using Frame, AllowUnsafe): Maybe[HttpFilter.Passthrough[Nothing]] =
+        Present(new HttpFilter.Passthrough[Nothing]:
+            def apply[In, Out, E2, S](
+                request: HttpRequest[In],
+                next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+            )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
+                val filtered =
+                    if request.url.path == "/auto-client" then request.addHeader("X-Order", "auto-client")
+                    else request
+                next(filtered))
+
+    override def serverFilter(using Frame, AllowUnsafe): Maybe[HttpFilter.Passthrough[Nothing]] =
+        Present(new HttpFilter.Passthrough[Nothing]:
+            def apply[In, Out, E2, S](
+                request: HttpRequest[In],
+                next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+            )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
+                next(request).map { response =>
+                    if request.url.path == "/auto-server" then response.addHeader("X-Auto-Server", "enabled")
+                    else response
+                })
+
+end HttpFilterTestFactory

--- a/kyo-http/shared/src/test/scala/kyo/HttpHandlerTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpHandlerTest.scala
@@ -70,10 +70,10 @@ class HttpHandlerTest extends BaseHttpTest:
 
         "filter E accumulates with route E" in {
             val filter = new HttpFilter.Passthrough[String]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[String | E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[String | E2 | HttpResponse.Halt]) =
                     next(request)
 
             val route = HttpRoute.getRaw("users")
@@ -89,10 +89,10 @@ class HttpHandlerTest extends BaseHttpTest:
 
         "filter-added request fields are accessible in handler" in {
             val filter = new HttpFilter.Request[Any, "user" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("user", "alice"))
 
             val route = HttpRoute.getRaw("users")
@@ -109,10 +109,10 @@ class HttpHandlerTest extends BaseHttpTest:
 
         "filter-added fields survive request builder chaining" in {
             val filter = new HttpFilter.Request[Any, "user" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("user", "alice"))
 
             val route = HttpRoute.getRaw("users")
@@ -209,7 +209,7 @@ class HttpHandlerTest extends BaseHttpTest:
         "cannot extend HttpHandler directly" in {
             typeCheckFailure("""
                 new HttpHandler[Any, Any, Nothing](HttpRoute.getRaw("test")):
-                    def apply(request: HttpRequest[Any])(using Frame): HttpResponse[Any] < (Async & Abort[Nothing | HttpResponse.Halt]) =
+                    def apply(request: HttpRequest[Any])(using Frame): HttpResponse[Any] < (S & Async & Abort[Nothing | HttpResponse.Halt]) =
                         HttpResponse.ok
             """)(
                 "Cannot extend"

--- a/kyo-http/shared/src/test/scala/kyo/HttpRequestTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpRequestTest.scala
@@ -49,6 +49,18 @@ class HttpRequestTest extends BaseHttpTest:
         }
     }
 
+    "HttpUrl" - {
+        "pathWithQuery includes raw query when present" in {
+            val url = HttpUrl.parse("https://example.com/search?q=hello&page=2").getOrThrow
+            assert(url.pathWithQuery == "/search?q=hello&page=2")
+        }
+
+        "pathWithQuery returns path when query is absent" in {
+            val url = HttpUrl.parse("https://example.com/search").getOrThrow
+            assert(url.pathWithQuery == "/search")
+        }
+    }
+
     "HttpUrl factory methods" - {
         "getRaw" in {
             val url = HttpUrl.parse("https://example.com").getOrThrow

--- a/kyo-http/shared/src/test/scala/kyo/HttpRouteTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpRouteTest.scala
@@ -804,10 +804,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "add passthrough filter" in {
             val f = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.setHeader("X-Test", "1"))
             val r = HttpRoute.getRaw("users").filter(f)
             typeCheck("""val _: HttpRoute[Any, Any, Any] = r""")
@@ -815,10 +815,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "filter with request field requirement needs matching route fields" in {
             val f = new HttpFilter.Request["auth" ~ String, Any, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In & "auth" ~ String],
-                    next: HttpRequest[In & "auth" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "auth" ~ String] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request)
                 end apply
             // Route must provide the field the filter requires
@@ -828,10 +828,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "filter with request field requirement rejected when route lacks field" in {
             val f = new HttpFilter.Request["auth" ~ String, Any, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In & "auth" ~ String],
-                    next: HttpRequest[In & "auth" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "auth" ~ String] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request)
                 end apply
             typeCheckFailure("""HttpRoute.getRaw("users").filter(f)""")(
@@ -841,10 +841,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "filter that adds request fields widens In" in {
             val f = new HttpFilter.Request[Any, "user" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("user", "test"))
             val r = HttpRoute.getRaw("users").filter(f)
             typeCheck("""val _: HttpRoute["user" ~ String, Any, Any] = r""")
@@ -852,10 +852,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "filter that adds response fields widens Out" in {
             val f = new HttpFilter.Response[Any, "cached" ~ Boolean, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out & "cached" ~ Boolean] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out & "cached" ~ Boolean] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request).map(_.addField("cached", true))
             val r = HttpRoute.getRaw("users").filter(f)
             typeCheck("""val _: HttpRoute[Any, "cached" ~ Boolean, Any] = r""")
@@ -863,16 +863,16 @@ class HttpRouteTest extends BaseHttpTest:
 
         "composing two filters via route" in {
             val f1 = new HttpFilter.Request[Any, "a" ~ Int, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "a" ~ Int] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "a" ~ Int] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("a", 1))
             val f2 = new HttpFilter.Request[Any, "b" ~ Int, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "b" ~ Int] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "b" ~ Int] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("b", 2))
             val r = HttpRoute.getRaw("users").filter(f1).filter(f2)
             typeCheck("""val _: HttpRoute["a" ~ Int & "b" ~ Int, Any, Any] = r""")
@@ -880,10 +880,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "filter preserved through pathAppend" in {
             val f = new HttpFilter.Request[Any, "user" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("user", "test"))
             val r = HttpRoute.getRaw("users").filter(f).pathAppend(HttpPath.Capture[Int]("id"))
             typeCheck("""val _: HttpRoute["user" ~ String & "id" ~ Int, Any, Any] = r""")
@@ -891,10 +891,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "filter preserved through pathPrepend" in {
             val f = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request)
             val r = HttpRoute.getRaw("users").filter(f).pathPrepend("api")
             typeCheck("""val _: HttpRoute[Any, Any, Any] = r""")
@@ -902,10 +902,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "filter preserved through request builder" in {
             val f = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request)
             val r = HttpRoute.getRaw("users").filter(f).request(_.query[Int]("limit"))
             typeCheck("""val _: HttpRoute["limit" ~ Int, Any, Any] = r""")
@@ -913,10 +913,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "filter preserved through response builder" in {
             val f = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request)
             val r = HttpRoute.getRaw("users").filter(f).response(_.bodyJson[User])
             typeCheck("""val _: HttpRoute[Any, "body" ~ User, Any] = r""")
@@ -924,10 +924,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "filter preserved through metadata" in {
             val f = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request)
             val r = HttpRoute.getRaw("users").filter(f).metadata(_.tag("Users"))
             typeCheck("""val _: HttpRoute[Any, Any, Any] = r""")
@@ -935,10 +935,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "full route with filter" in {
             val f = new HttpFilter.Request[Any, "user" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("user", "admin"))
             val r = HttpRoute.getRaw("users" / HttpPath.Capture[Int]("id"))
                 .request(_.query[Int]("limit"))
@@ -1136,19 +1136,21 @@ class HttpRouteTest extends BaseHttpTest:
             // with f2, the first filter's ReqUse=? means the composed filter
             // doesn't actually enforce "auth" ~ String at the filter level.
             val f1 = new HttpFilter.Request["auth" ~ String, "user" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In & "auth" ~ String],
-                    next: HttpRequest[In & "auth" ~ String & "user" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "auth" ~ String & "user" ~ String] => HttpResponse[
+                        Out
+                    ] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     val auth: String = request.fields.auth // must have auth
                     next(request.addField("user", auth))
                 end apply
 
             val f2 = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request)
 
             // Build route with f1 first
@@ -1175,19 +1177,19 @@ class HttpRouteTest extends BaseHttpTest:
             var f2Called = false
 
             val f1 = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     f1Called = true
                     next(request.setHeader("X-F1", "yes"))
                 end apply
 
             val f2 = new HttpFilter.Passthrough[Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     f2Called = true
                     next(request.setHeader("X-F2", "yes"))
                 end apply
@@ -1235,17 +1237,17 @@ class HttpRouteTest extends BaseHttpTest:
 
         "multiple filters via route.filter preserve all constraints in In/Out" in {
             val f1 = new HttpFilter.Request[Any, "user" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("user", "admin"))
 
             val f2 = new HttpFilter.Response[Any, "cached" ~ Boolean, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out & "cached" ~ Boolean] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out & "cached" ~ Boolean] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request).map(_.addField("cached", true))
 
             val route = HttpRoute.getRaw("users").filter(f1).filter(f2)
@@ -1255,10 +1257,10 @@ class HttpRouteTest extends BaseHttpTest:
         "filter requiring field can be applied to route without that field if field comes from path" in {
             // A filter requiring "id" ~ Int should work if the path captures "id"
             val f = new HttpFilter.Request["id" ~ Int, Any, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In & "id" ~ Int],
-                    next: HttpRequest[In & "id" ~ Int] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "id" ~ Int] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request)
 
             // Path captures contribute to In, so this should compile
@@ -1271,10 +1273,10 @@ class HttpRouteTest extends BaseHttpTest:
             // calling .request(newDef) replaces the entire request def.
             // Does the route's In still include "user" ~ String?
             val f = new HttpFilter.Request[Any, "user" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("user", "test"))
 
             val route = HttpRoute.getRaw("users")
@@ -1289,10 +1291,10 @@ class HttpRouteTest extends BaseHttpTest:
 
         "lambda overload that ignores input and drops filter fields is rejected" in {
             val f = new HttpFilter.Request[Any, "user" ~ String, Nothing]:
-                def apply[In, Out, E2](
+                def apply[In, Out, E2, S](
                     request: HttpRequest[In],
-                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-                )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                    next: HttpRequest[In & "user" ~ String] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+                )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                     next(request.addField("user", "test"))
 
             // Ignoring the input RequestDef and building a fresh one drops filter fields

--- a/kyo-http/shared/src/test/scala/kyo/HttpServerTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpServerTest.scala
@@ -2580,6 +2580,46 @@ class HttpServerTest extends BaseHttpTest:
 
     "filter runtime behavior" - {
 
+        "server auto filters are enabled by default" in {
+            val config = HttpServerConfig.default
+            assert(config.autoFilters == true)
+        }
+
+        "withoutAutoFilters disables server auto filters in config" in {
+            val config = HttpServerConfig.default.withoutAutoFilters
+            assert(config.autoFilters == false)
+        }
+
+        "applies server auto filters by default".notNative in {
+            val route = HttpRoute.getRaw("auto-server").response(_.bodyText)
+            val ep    = route.handler(_ => HttpResponse.ok("ok"))
+            HttpClient.init().map { httpClient =>
+                HttpServer.init(0, "localhost")(ep).map { server =>
+                    HttpClient.let(httpClient) {
+                        val url = HttpUrl.parse(s"http://localhost:${server.port}/auto-server").getOrThrow
+                        HttpClient.getTextResponse(url).map { response =>
+                            assert(response.headers.get("X-Auto-Server").contains("enabled"))
+                        }
+                    }
+                }
+            }
+        }
+
+        "withoutAutoFilters disables server auto filters".notNative in {
+            val route = HttpRoute.getRaw("auto-server").response(_.bodyText)
+            val ep    = route.handler(_ => HttpResponse.ok("ok"))
+            HttpClient.init().map { httpClient =>
+                HttpServer.init(HttpServerConfig.default.port(0).host("localhost").withoutAutoFilters)(ep).map { server =>
+                    HttpClient.let(httpClient) {
+                        val url = HttpUrl.parse(s"http://localhost:${server.port}/auto-server").getOrThrow
+                        HttpClient.getTextResponse(url).map { response =>
+                            assert(response.headers.get("X-Auto-Server") == Absent)
+                        }
+                    }
+                }
+            }
+        }
+
         "bearerAuth filter accept, reject, and missing header" - {
             val route = HttpRoute.getRaw("auth-test")
                 .request(_.headerOpt[String]("authorization"))
@@ -3461,30 +3501,34 @@ class HttpServerTest extends BaseHttpTest:
 
         "handler error after client disconnect does not crash".notNative in {
             val route = HttpRoute.getRaw("slow-fail").response(_.bodyText)
-            Latch.init(1).map { handlerDone =>
-                Promise.init[Unit, Any].map { clientDisconnected =>
-                    val ep = route.handler { _ =>
-                        // Wait for client to disconnect, then throw
-                        clientDisconnected.get.andThen {
-                            handlerDone.release.andThen {
-                                throw new RuntimeException("delayed boom")
-                                HttpResponse.ok("unreachable")
-                            }
-                        }
-                    }
-                    withServer(ep) { url =>
-                        // Send request, then disconnect before handler finishes via timeout
-                        Abort.run[Throwable] {
-                            Abort.catching[Throwable] {
-                                Async.timeout(50.millis) {
-                                    sendRaw(url, HttpMethod.GET, "/slow-fail")
+            Latch.init(1).map { handlerStarted =>
+                Latch.init(1).map { handlerDone =>
+                    Promise.init[Unit, Any].map { clientDisconnected =>
+                        val ep = route.handler { _ =>
+                            handlerStarted.release.andThen {
+                                clientDisconnected.get.andThen {
+                                    handlerDone.release.andThen {
+                                        throw new RuntimeException("delayed boom")
+                                        HttpResponse.ok("unreachable")
+                                    }
                                 }
                             }
-                        }.map { _ =>
-                            // Signal handler that client has disconnected
-                            clientDisconnected.complete(Result.succeed(())).andThen {
-                                // Wait for handler to complete and potentially try to write to closed connection
-                                handlerDone.await.map(_ => succeed("handler completed after client disconnect without crashing"))
+                        }
+                        withServer(ep) { url =>
+                            Fiber.initUnscoped(
+                                Abort.run[Throwable] {
+                                    sendRaw(url, HttpMethod.GET, "/slow-fail")
+                                }
+                            ).map { requestFiber =>
+                                handlerStarted.await.andThen {
+                                    requestFiber.interrupt.andThen {
+                                        clientDisconnected.complete(Result.succeed(())).andThen {
+                                            handlerDone.await.map(_ =>
+                                                succeed("handler completed after client disconnect without crashing")
+                                            )
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/kyo-http/shared/src/test/scala/kyo/HttpWebSocketTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpWebSocketTest.scala
@@ -1362,6 +1362,42 @@ class HttpWebSocketTest extends BaseHttpTest with internal.UnixSocketTestHelperI
             }.unit
         }
 
+        "webSocket applies config and scoped filters to handshake".notNative in {
+            val handler = HttpHandler.webSocket("ws/filter") { (req, ws) =>
+                val config = req.headers.get("X-Config").getOrElse("missing-config")
+                val scoped = req.headers.get("X-Scoped").getOrElse("missing-scoped")
+                ws.put(HttpWebSocket.Payload.Text(s"$config/$scoped")).andThen {
+                    Abort.run[Closed](ws.take()).unit
+                }
+            }
+            withWsServer(handler) { url =>
+                HttpClient.withConfig(
+                    HttpClientConfig()
+                        .filter(HttpFilter.client.addHeader("X-Config", "config"))
+                ) {
+                    HttpClient.withFilter(HttpFilter.client.addHeader("X-Scoped", "scoped")) {
+                        HttpClient.webSocket(s"ws://${url.host}:${url.port}/ws/filter") { ws =>
+                            ws.take().map(f => discard(assert(f == HttpWebSocket.Payload.Text("config/scoped"))))
+                        }
+                    }
+                }
+            }.andThen(succeed)
+        }
+
+        "webSocket preserves query string in handshake path".notNative in {
+            val handler = HttpHandler.webSocket("ws/query") { (req, ws) =>
+                val token = req.query("token").getOrElse("missing")
+                ws.put(HttpWebSocket.Payload.Text(token)).andThen {
+                    Abort.run[Closed](ws.take()).unit
+                }
+            }
+            withWsServer(handler) { url =>
+                HttpClient.webSocket(s"ws://${url.host}:${url.port}/ws/query?token=abc") { ws =>
+                    ws.take().map(f => discard(assert(f == HttpWebSocket.Payload.Text("abc"))))
+                }
+            }.andThen(succeed)
+        }
+
         "webSocket respects connectTimeout config".notNative in {
             // 192.0.2.0/24 is TEST-NET-1 (RFC 5737) — routable but no host responds,
             // so a TCP connect will hang until timeout rather than fail immediately.

--- a/kyo-http/shared/src/test/scala/kyo/HttpWebSocketTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpWebSocketTest.scala
@@ -1384,6 +1384,26 @@ class HttpWebSocketTest extends BaseHttpTest with internal.UnixSocketTestHelperI
             }.andThen(succeed)
         }
 
+        "webSocket preserves user effects through client filters".notNative in {
+            withWsServer(HttpHandler.webSocket("ws/echo")(echo)) { url =>
+                HttpClient.withFilter(HttpFilter.client.addHeader("X-Scoped", "scoped")) {
+                    Var.run(0) {
+                        HttpClient.webSocket(s"ws://${url.host}:${url.port}/ws/echo") { ws =>
+                            Var.update[Int](_ + 1).andThen {
+                                ws.put(HttpWebSocket.Payload.Text("var")).andThen {
+                                    ws.take().map { payload =>
+                                        discard(assert(payload == HttpWebSocket.Payload.Text("var")))
+                                    }
+                                }.andThen(Var.get[Int])
+                            }
+                        }.map { value =>
+                            assert(value == 1)
+                        }
+                    }
+                }
+            }.unit
+        }
+
         "webSocket preserves query string in handshake path".notNative in {
             val handler = HttpHandler.webSocket("ws/query") { (req, ws) =>
                 val token = req.query("token").getOrElse("missing")

--- a/kyo-pod/README.md
+++ b/kyo-pod/README.md
@@ -362,12 +362,12 @@ The network is removed when the scope exits. Containers are removed first (they'
 For networks that outlive the creating scope, use `Network.initUnscoped` and call `Network.remove(id)` manually:
 
 ```scala doctest:expect=skipped
-Container.Network.initUnscoped(cfg)   // returns Id, no scope cleanup
-Container.Network.list                // all networks
-Container.Network.list(filters = ...)   // filtered listing
-Container.Network.inspect(id)         // full network info
-Container.Network.disconnect(net, c)  // detach a container
-Container.Network.prune               // remove unused networks
+Container.Network.initUnscoped(cfg) // returns Id, no scope cleanup
+Container.Network.list              // all networks
+Container.Network.list(filters = Dict("name" -> Chunk("backend"))) // filtered listing
+Container.Network.inspect(id)        // full network info
+Container.Network.disconnect(net, c) // detach a container
+Container.Network.prune              // remove unused networks
 ```
 
 Per-container convenience methods are also available directly on the handle:

--- a/kyo-stats-otlp/shared/src/main/scala/kyo/stats/otlp/OTLPTraceContextFilter.scala
+++ b/kyo-stats-otlp/shared/src/main/scala/kyo/stats/otlp/OTLPTraceContextFilter.scala
@@ -19,10 +19,10 @@ object OTLPTraceContextFilter:
     /** Client-side filter that adds a `traceparent` header when the current span is propagatable. */
     val client: HttpFilter.Passthrough[Nothing] =
         new HttpFilter.Passthrough[Nothing]:
-            def apply[In, Out, E2](
+            def apply[In, Out, E2, S](
                 request: HttpRequest[In],
-                next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-            )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+            )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                 TraceSpan.current.map {
                     case Present(TraceSpan(span: UnsafeTraceSpan.Propagatable)) =>
                         val traceparent = s"00-${span.traceId}-${span.spanId}-01"
@@ -34,10 +34,10 @@ object OTLPTraceContextFilter:
     /** Server-side filter that parses the `traceparent` header and sets the remote span as the current trace context. */
     val server: HttpFilter.Passthrough[Nothing] =
         new HttpFilter.Passthrough[Nothing]:
-            def apply[In, Out, E2](
+            def apply[In, Out, E2, S](
                 request: HttpRequest[In],
-                next: HttpRequest[In] => HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt])
-            )(using Frame): HttpResponse[Out] < (Async & Abort[E2 | HttpResponse.Halt]) =
+                next: HttpRequest[In] => HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt])
+            )(using Frame): HttpResponse[Out] < (S & Async & Abort[E2 | HttpResponse.Halt]) =
                 request.headers.get("traceparent") match
                     case Present(traceparent) =>
                         parseTraceparent(traceparent) match

--- a/kyo-ui/shared/src/test/scala/kyo/internal/ReactiveUITeardownTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/internal/ReactiveUITeardownTest.scala
@@ -105,12 +105,33 @@ class ReactiveUITeardownTest extends kyo.test.Test[Any]:
             _ <- assertEventually(live.get.map(_ == 0))
             // Descendant witness: SET each leaf (swapping its promise, discarding the parked ghost). A leaked live region
             // fiber would re-park and keep waiters == 1; `== 0` proves every leaf observation was released by the cascade.
-            _  <- ref1.set("a2")
-            _  <- ref2.set("b2")
-            _  <- ref3.set("c2")
-            _  <- assertEventually(ref1.waiters.map(_ == 0))
-            _  <- assertEventually(ref2.waiters.map(_ == 0))
-            _  <- assertEventually(ref3.waiters.map(_ == 0))
+            _ <- ref1.set("a2")
+            _ <- ref2.set("b2")
+            _ <- ref3.set("c2")
+            // The cascade-close finalizers only SIGNAL each observer fiber's interrupt; the actual unwind happens
+            // asynchronously on the scheduler. Under load (observed on slow linux-arm64 CI), a not-yet-unwound observer
+            // can be woken by the old promise's completion (driven by the SET above), run a no-op render iteration, and
+            // re-park on the new promise, momentarily flipping waiters from 0 to 1 between a transient-zero catch and a
+            // trailing sync read. Poll each leaf until waiters has been 0 for `stableSamples` consecutive samples: once
+            // the observer's interrupt is finally delivered it dies and waiters stays 0 indefinitely, so a sustained zero
+            // proves every observation was released, not just briefly between a wake and the cascade's late arrival. The
+            // per-test 60s timeout bounds a genuinely-leaked observer (waiters stays 1 forever) so we fail loudly.
+            stableSamples = 5
+            pollSpacing   = 10.millis
+            _ <- Loop(0) { count =>
+                for
+                    w1 <- ref1.waiters
+                    w2 <- ref2.waiters
+                    w3 <- ref3.waiters
+                    out <-
+                        if w1 != 0 || w2 != 0 || w3 != 0 then
+                            Async.sleep(pollSpacing).andThen(Loop.continue(0))
+                        else if count + 1 >= stableSamples then
+                            Kyo.lift(Loop.done[Int])
+                        else
+                            Async.sleep(pollSpacing).andThen(Loop.continue(count + 1))
+                yield out
+            }
             w1 <- ref1.waiters
             w2 <- ref2.waiters
             w3 <- ref3.waiters


### PR DESCRIPTION
## Summary

This PR adds programmatic and scoped client filter configuration for `kyo-http`, building on the existing `HttpFilter` model and the existing `HttpFilter.Factory` SPI.

The goal is to make cross-cutting client concerns first-class without requiring every typed route or convenience call to repeat the same filter setup. Supported scenarios include auth headers, request IDs, logging, tracing, metrics, and other request/response middleware that should apply consistently across outgoing HTTP requests.

Closes #1660

## What changed

- Adds `clientFilter` to `HttpClientConfig`, defaulting to `HttpFilter.noop`.
- Adds `HttpClientConfig.filter(...)` and `HttpClientConfig.filters(...)` builder methods that append filters in order.
- Adds `HttpClient.withFilter(...)` and `HttpClient.withFilters(...)` for dynamic, scoped filter configuration.
- Composes client filters in this order:
  1. `HttpFilter.Factory` ServiceLoader filters
  2. `HttpClientConfig` filters
  3. scoped `HttpClient.withFilter` filters
  4. typed route filters
- Applies the same config and scoped client filters to WebSocket HTTP upgrade handshakes.
- Preserves WebSocket query strings in the client upgrade path and server dispatch path.
- Prevents user/filter-provided headers from duplicating required WebSocket upgrade headers such as `Host`, `Upgrade`, `Connection`, `Sec-WebSocket-Version`, and `Sec-WebSocket-Key`.
- Updates the `kyo-http` README with the new client filter configuration options and composition order.

## Why

`kyo-http` already has a solid filter abstraction and an SPI path through `HttpFilter.Factory`, but the client side had two important gaps:

- Programmatic factory-level configuration was awkward for application code that wants to construct one client config and pass it through a scope.
- Reusable client policy could be attached to typed routes, but not consistently applied to all convenience calls and WebSocket handshakes from a configured scope.

This PR keeps the existing route-level filter support, keeps SPI support for library-provided filters such as tracing, and adds config plus scoped layers for application-controlled middleware.

## Behavior notes

- Filters configured in `HttpClientConfig` apply to outgoing HTTP requests and WebSocket upgrade handshakes.
- Scoped filters apply only inside the `HttpClient.withFilter` or `HttpClient.withFilters` block.
- Route filters remain the most local layer and run after SPI, config, and scoped filters.
- WebSocket filters apply to the HTTP upgrade request only. They do not intercept WebSocket messages after the protocol upgrade.
- `HttpClientConfig` remains a case class. Its equality now includes the `clientFilter` field by reference, similar to the existing function-valued `retryOn` field.

## Pros

- Centralizes client auth, logging, tracing, and metrics setup.
- Lets applications choose SPI, config, scoped, or route-level filter installation based on ownership and lifetime.
- Reuses the existing `HttpFilter.Passthrough` abstraction instead of introducing a separate middleware type.
- Keeps the no-filter fast path in the backend.
- Makes HTTP and WebSocket handshake configuration consistent.

## Tradeoffs

- `HttpClientConfig` equality now includes the filter reference, so two configs with behaviorally equivalent but separately allocated filters will not compare equal.
- The WebSocket path has to bridge the HTTP filter abstraction around the upgrade handshake, which is narrower than full message-level WebSocket middleware.
- Filters that try to override required WebSocket upgrade headers are ignored for those specific headers to keep the handshake valid.

## Validation

- `sbt 'kyo-http/doctest'`: passed, 64 doctest blocks, 0 failures
- `sbt 'kyo-http/test'`: passed, 2,184 tests, 0 failed, 30 pending
- `git diff --check`: passed

## Related issue

- #1660
