### PR TITLE
[build] give JVM sbt project ids an explicit platform suffix

### DIFF
--- a/.claude/skills/readme-verify/SKILL.md
+++ b/.claude/skills/readme-verify/SKILL.md
@@ -22,7 +22,7 @@ Run:
 sbt '<module-sbt-name>/doctest' 2>&1 | tee /tmp/doctest-verify.log
 ```
 
-For kyo-jsonrpc that is `sbt 'kyo-jsonrpc/doctest'`. For kyo-http that is `sbt 'kyo-http/doctest'`. Use the project name `git grep -nE "^lazy val ..kyo-<name>." build.sbt` resolves to ; do not invent the sbt module name.
+For kyo-data that is `sbt 'kyo-dataJVM/doctest'`. For kyo-http that is `sbt 'kyo-httpJVM/doctest'`. Use the project name `git grep -nE "^lazy val ..kyo-<name>." build.sbt` resolves to ; do not invent the sbt module name.
 
 Parse the log's last summary line:
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -79,10 +79,10 @@ jobs:
           for EVENT in "${array[@]}"
           do
             ESCAPED_EVENT=$(printf '%q' "$EVENT")
-            sbt "kyo-bench/jmh:clean;kyo-bench/jmh:run -wi $WI -i $MI -r $IT -w $IT -f $FK -t $TH -foe true -prof \"async:event=$ESCAPED_EVENT;output=flamegraph\" $SE"
+            sbt "kyo-benchJVM/jmh:clean;kyo-benchJVM/jmh:run -wi $WI -i $MI -r $IT -w $IT -f $FK -t $TH -foe true -prof \"async:event=$ESCAPED_EVENT;output=flamegraph\" $SE"
           done
           
-          sbt "kyo-bench/jmh:clean;kyo-bench/jmh:run -wi $WI -i $MI -r $IT -w $IT -f $FK -t $TH -foe true -prof gc -rf json $SE"
+          sbt "kyo-benchJVM/jmh:clean;kyo-benchJVM/jmh:run -wi $WI -i $MI -r $IT -w $IT -f $FK -t $TH -foe true -prof gc -rf json $SE"
 
       - name: prepare results
         run: |

--- a/.github/workflows/build-dispatch.yml
+++ b/.github/workflows/build-dispatch.yml
@@ -1,7 +1,7 @@
 name: build-dispatch
 # Manually-triggered build/test for a single sbt command. Lets a maintainer run CI on a
 # branch on demand (without opening a PR) and scope to one module/platform for fast feedback,
-# e.g. `kyo-ui/test` (JVM), `kyo-uiJS/test`, `kyo-uiNative/test`, `kyo-uiWasm/test`. The full
+# e.g. `kyo-uiJVM/test` (JVM), `kyo-uiJS/test`, `kyo-uiNative/test`, `kyo-uiWasm/test`. The full
 # cross-platform matrix still runs via build-pr.yml on the PR; this is a focused, on-demand
 # complement.
 #
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       command:
-        description: 'sbt command to run, e.g. "kyo-ui/test", "kyo-uiJS/test", "kyo-uiNative/test", "kyo-uiWasm/test", or "testKyo JVM" (diff vs origin/main).'
+        description: 'sbt command to run, e.g. "kyo-uiJVM/test", "kyo-uiJS/test", "kyo-uiNative/test", "kyo-uiWasm/test", or "testKyo JVM" (diff vs origin/main).'
         type: string
         required: true
         default: 'testKyo JVM'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,10 +116,10 @@ export JAVA_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCo
 export JVM_OPTS="$JAVA_OPTS"
 
 # Test a specific module (JVM)
-sbt 'kyo-core/test'
+sbt 'kyo-coreJVM/test'
 
 # Test a specific test class
-sbt 'kyo-core/testOnly kyo.ChannelTest'
+sbt 'kyo-coreJVM/testOnly kyo.ChannelTest'
 ```
 
 ## Project Structure

--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ lazy val `kyo-settings` = Seq(
     // reconcileClasspath strips the mismatched scala3-library before the fork starts.
     Test / unmanagedJars ++= {
         if (scalaVersion.value == scala3Version)
-            (LocalProject("kyo-doctest") / Compile / fullClasspath).value
+            (LocalProject("kyo-doctestJVM") / Compile / fullClasspath).value
         else
             Seq.empty[Attributed[File]]
     },
@@ -120,7 +120,7 @@ lazy val `kyo-settings` = Seq(
         if (scalaVersion.value == scala3Version)
             Seq.empty[File]
         else
-            (LocalProject("kyo-doctest") / Compile / fullClasspath).value.files
+            (LocalProject("kyo-doctestJVM") / Compile / fullClasspath).value.files
     }
 )
 
@@ -387,7 +387,6 @@ lazy val kyoWasm = project
 
 lazy val `kyo-scheduler` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-stats-registry`)
         .in(file("kyo-scheduler"))
@@ -415,7 +414,6 @@ lazy val `kyo-scheduler` =
         )
 
 lazy val `kyo-scheduler-zio` = sbtcrossproject.CrossProject("kyo-scheduler-zio", file("kyo-scheduler-zio"))(JVMPlatform, NativePlatform)
-    .withoutSuffixFor(JVMPlatform)
     .crossType(CrossType.Full)
     .dependsOn(`kyo-scheduler`)
     .settings(
@@ -433,7 +431,6 @@ lazy val `kyo-scheduler-zio` = sbtcrossproject.CrossProject("kyo-scheduler-zio",
 
 lazy val `kyo-scheduler-cats` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-scheduler`)
         .in(file("kyo-scheduler-cats"))
@@ -450,7 +447,6 @@ lazy val `kyo-scheduler-cats` =
 
 lazy val `kyo-scheduler-pekko` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-scheduler`)
         .in(file("kyo-scheduler-pekko"))
@@ -468,7 +464,6 @@ lazy val `kyo-scheduler-pekko` =
 
 lazy val `kyo-scheduler-finagle` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-scheduler-finagle"))
         .settings(
@@ -502,7 +497,6 @@ lazy val `kyo-scheduler-finagle` =
 
 lazy val `kyo-data` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-stats-registry`)
         .in(file("kyo-data"))
@@ -519,7 +513,6 @@ lazy val `kyo-data` =
 
 lazy val `kyo-kernel` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-data`)
         .withKyoTest
@@ -539,7 +532,6 @@ lazy val `kyo-kernel` =
 
 lazy val `kyo-prelude` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-kernel`)
         .withKyoTest
@@ -556,7 +548,6 @@ lazy val `kyo-prelude` =
 
 lazy val `kyo-parse` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-prelude`)
         .withKyoTest
@@ -569,7 +560,6 @@ lazy val `kyo-parse` =
 
 lazy val `kyo-schema` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-data` % "test->test;compile->compile")
         .in(file("kyo-schema"))
@@ -582,7 +572,6 @@ lazy val `kyo-schema` =
 
 lazy val `kyo-core` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-scheduler`)
         .dependsOn(`kyo-prelude`)
@@ -606,7 +595,6 @@ lazy val `kyo-core` =
 
 lazy val `kyo-offheap` =
     crossProject(JVMPlatform, NativePlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-offheap"))
         .dependsOn(`kyo-core`)
@@ -623,7 +611,6 @@ lazy val `kyo-offheap` =
 
 lazy val `kyo-direct` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-direct"))
         .dependsOn(`kyo-core`)
@@ -646,7 +633,6 @@ lazy val `kyo-direct` =
 
 lazy val `kyo-stm` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-stm"))
         .dependsOn(`kyo-core`)
@@ -659,7 +645,6 @@ lazy val `kyo-stm` =
 
 lazy val `kyo-actor` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-actor"))
         .dependsOn(`kyo-core`)
@@ -672,7 +657,6 @@ lazy val `kyo-actor` =
 
 lazy val `kyo-logging-jpl` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-logging-jpl"))
         .dependsOn(`kyo-core`)
@@ -682,7 +666,6 @@ lazy val `kyo-logging-jpl` =
 
 lazy val `kyo-logging-slf4j` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-logging-slf4j"))
         .dependsOn(`kyo-core`)
@@ -696,7 +679,6 @@ lazy val `kyo-logging-slf4j` =
 
 lazy val `kyo-stats-registry` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-config`)
         .in(file("kyo-stats-registry"))
@@ -713,7 +695,6 @@ lazy val `kyo-stats-registry` =
 
 lazy val `kyo-config` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-config"))
         .settings(
@@ -729,7 +710,6 @@ lazy val `kyo-config` =
 
 lazy val `kyo-stats-otlp` =
     crossProject(JVMPlatform, JSPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-stats-otlp"))
         .dependsOn(`kyo-http`)
@@ -747,7 +727,6 @@ lazy val `kyo-stats-otlp` =
 
 lazy val `kyo-reactive-streams` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-reactive-streams"))
         .dependsOn(`kyo-core`)
@@ -769,7 +748,6 @@ lazy val `kyo-reactive-streams` =
 
 lazy val `kyo-aeron` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-aeron"))
         .dependsOn(`kyo-core`)
@@ -793,7 +771,6 @@ lazy val `kyo-aeron` =
 
 lazy val `kyo-http` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-http"))
         .dependsOn(`kyo-core`, `kyo-config`, `kyo-schema`)
@@ -816,7 +793,6 @@ lazy val `kyo-http` =
 
 lazy val `kyo-flow` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-flow"))
         .dependsOn(`kyo-http`)
@@ -833,7 +809,6 @@ lazy val `kyo-flow` =
 
 lazy val `kyo-caliban` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Pure)
         .in(file("kyo-caliban"))
         .dependsOn(`kyo-core`)
@@ -850,7 +825,6 @@ lazy val `kyo-caliban` =
 
 lazy val `kyo-zio-test` =
     crossProject(JVMPlatform, JSPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-zio-test"))
         .dependsOn(`kyo-core`)
@@ -872,7 +846,6 @@ lazy val `kyo-zio-test` =
 
 lazy val `kyo-zio` =
     crossProject(JVMPlatform, JSPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-zio"))
         .dependsOn(`kyo-core`)
@@ -894,7 +867,6 @@ lazy val `kyo-zio` =
 // TODO(wasm): re-enable once cats-effect supports WASM (typelevel/cats-effect#4608).
 lazy val `kyo-cats` =
     crossProject(JSPlatform, JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-cats"))
         .dependsOn(`kyo-core`)
@@ -910,7 +882,6 @@ lazy val `kyo-cats` =
 
 lazy val `kyo-compat-future` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-compat/bindings/future"))
         .settings(
@@ -948,7 +919,6 @@ lazy val `kyo-compat-future` =
 
 lazy val `kyo-compat-kyo` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-compat/bindings/kyo"))
         .dependsOn(`kyo-core`, `kyo-data`)
@@ -981,7 +951,6 @@ lazy val `kyo-compat-kyo` =
 
 lazy val `kyo-compat-zio` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-compat/bindings/zio"))
         .settings(
@@ -1017,7 +986,6 @@ lazy val `kyo-compat-zio` =
 // TODO(wasm): re-enable with cats-effect WASM support; depends on cats-effect (see kyo-cats).
 lazy val `kyo-compat-ce` =
     crossProject(JSPlatform, JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-compat/bindings/ce"))
         .settings(
@@ -1049,7 +1017,6 @@ lazy val `kyo-compat-ce` =
 
 lazy val `kyo-compat-ox` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-compat/bindings/ox"))
         .settings(
@@ -1079,7 +1046,6 @@ lazy val `kyo-compat-ox` =
 
 lazy val `kyo-compat-twitter-future` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-compat/bindings/twitter-future"))
         .settings(
@@ -1133,7 +1099,6 @@ lazy val `kyo-compat-tests` =
 
 lazy val `kyo-combinators` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-combinators"))
         .dependsOn(`kyo-core`)
@@ -1146,7 +1111,6 @@ lazy val `kyo-combinators` =
 
 lazy val `kyo-case-app` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-case-app"))
         .dependsOn(`kyo-core`)
@@ -1162,7 +1126,6 @@ lazy val `kyo-case-app` =
 
 lazy val `kyo-pod` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-pod"))
         .dependsOn(`kyo-core`, `kyo-http`)
@@ -1265,7 +1228,6 @@ lazy val `kyo-pod` =
 
 lazy val `kyo-browser` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-browser"))
         .dependsOn(`kyo-http`)
@@ -1322,7 +1284,6 @@ lazy val `kyo-browser` =
 
 lazy val `kyo-ui` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-ui"))
         .dependsOn(`kyo-core`, `kyo-http`)
@@ -1379,7 +1340,6 @@ lazy val `kyo-ui` =
 
 lazy val `kyo-examples` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-examples"))
         .dependsOn(`kyo-http`)
@@ -1401,7 +1361,6 @@ lazy val `kyo-examples` =
 
 lazy val `kyo-bench` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Pure)
         .in(file("kyo-bench"))
         .enablePlugins(JmhPlugin)
@@ -1474,7 +1433,6 @@ lazy val `kyo-bench` =
 
 lazy val `kyo-doctest` =
     crossProject(JVMPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-doctest"))
         .dependsOn(`kyo-core`)
@@ -1696,7 +1654,6 @@ lazy val `kyo-compat-plugin` = (project in file("kyo-compat/plugin"))
 
 lazy val `kyo-test-api` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-data`)
         .in(file("kyo-test/api"))
@@ -1707,13 +1664,13 @@ lazy val `kyo-test-api` =
         .jvmSettings(
             mimaCheck(false),
             Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-prelude") / Compile / fullClasspath).value,
+                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
             Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-core") / Compile / fullClasspath).value,
+                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value,
             Test / unmanagedClasspath ++=
-                (LocalProject("kyo-prelude") / Compile / fullClasspath).value,
+                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
             Test / unmanagedClasspath ++=
-                (LocalProject("kyo-core") / Compile / fullClasspath).value
+                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value
         )
         .nativeSettings(
             `native-settings`,
@@ -1751,7 +1708,6 @@ lazy val `kyo-test-api` =
 
 lazy val `kyo-test-runner` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-test-api`)
         .dependsOn(`kyo-scheduler`)
@@ -1766,13 +1722,13 @@ lazy val `kyo-test-runner` =
             mainClass                             := Some("kyo.test.runner.Cli"),
             libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0" % Provided,
             Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-prelude") / Compile / fullClasspath).value,
+                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
             Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-core") / Compile / fullClasspath).value,
+                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value,
             Test / unmanagedClasspath ++=
-                (LocalProject("kyo-prelude") / Compile / fullClasspath).value,
+                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
             Test / unmanagedClasspath ++=
-                (LocalProject("kyo-core") / Compile / fullClasspath).value
+                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value
         )
         .nativeSettings(
             `native-settings`,
@@ -1813,7 +1769,6 @@ lazy val `kyo-test-runner` =
 
 lazy val `kyo-test-prop` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-test-api`)
         .dependsOn(`kyo-data`)
@@ -1826,13 +1781,13 @@ lazy val `kyo-test-prop` =
         .jvmSettings(
             mimaCheck(false),
             Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-prelude") / Compile / fullClasspath).value,
+                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
             Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-core") / Compile / fullClasspath).value,
+                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value,
             Test / unmanagedClasspath ++=
-                (LocalProject("kyo-prelude") / Compile / fullClasspath).value,
+                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
             Test / unmanagedClasspath ++=
-                (LocalProject("kyo-core") / Compile / fullClasspath).value
+                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value
         )
         .nativeSettings(
             `native-settings`,
@@ -1870,7 +1825,6 @@ lazy val `kyo-test-prop` =
 
 lazy val `kyo-test-snapshot` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
-        .withoutSuffixFor(JVMPlatform)
         .crossType(CrossType.Full)
         .dependsOn(`kyo-test-api`)
         .dependsOn(`kyo-data`)
@@ -1883,13 +1837,13 @@ lazy val `kyo-test-snapshot` =
         .jvmSettings(
             mimaCheck(false),
             Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-prelude") / Compile / fullClasspath).value,
+                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
             Compile / unmanagedClasspath ++=
-                (LocalProject("kyo-core") / Compile / fullClasspath).value,
+                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value,
             Test / unmanagedClasspath ++=
-                (LocalProject("kyo-prelude") / Compile / fullClasspath).value,
+                (LocalProject("kyo-preludeJVM") / Compile / fullClasspath).value,
             Test / unmanagedClasspath ++=
-                (LocalProject("kyo-core") / Compile / fullClasspath).value,
+                (LocalProject("kyo-coreJVM") / Compile / fullClasspath).value,
             Compile / unmanagedSourceDirectories +=
                 baseDirectory.value.getParentFile / "jvm-native" / "src" / "main" / "scala",
             Test / unmanagedSourceDirectories +=

--- a/kyo-bench/src/main/scala/yamlbench/YamlBenchData.scala
+++ b/kyo-bench/src/main/scala/yamlbench/YamlBenchData.scala
@@ -57,7 +57,7 @@ object YamlBenchData:
                     steps = List(
                         YamlWorkflowStep("Checkout", Maybe("actions/checkout@v4"), Absent),
                         YamlWorkflowStep("Setup Java", Maybe("actions/setup-java@v4"), Absent),
-                        YamlWorkflowStep("Test", Absent, Maybe("sbt kyo-schema/test"))
+                        YamlWorkflowStep("Test", Absent, Maybe("sbt kyo-schemaJVM/test"))
                     )
                 ),
                 "lint" -> YamlWorkflowJob(

--- a/kyo-browser/README.md
+++ b/kyo-browser/README.md
@@ -584,7 +584,7 @@ A single CDP WebSocket carries every command and event for a Chrome process. A `
 
 ## Demos
 
-Runnable demos live in [`shared/src/test/scala/demo`](shared/src/test/scala/demo). Run any with `sbt 'kyo-browser/Test/runMain demo.<Name>'`.
+Runnable demos live in [`shared/src/test/scala/demo`](shared/src/test/scala/demo). Run any with `sbt 'kyo-browserJVM/Test/runMain demo.<Name>'`.
 
 - [**QuickstartApp**](shared/src/test/scala/demo/QuickstartDemo.scala): minimal quickstart against a self-contained page, exercising `goto`, `fill`, `click`, `assertText`, and `title`.
 - [**GitHubTrendingDemoApp**](shared/src/test/scala/demo/GitHubTrendingDemo.scala): SPA navigation that waits for client-rendered content, clicks into a repo, and switches the time range.

--- a/kyo-browser/shared/src/test/scala/demo/BrowserDemo.scala
+++ b/kyo-browser/shared/src/test/scala/demo/BrowserDemo.scala
@@ -9,7 +9,7 @@ import kyo.*
   * bodies can focus on the interaction being demonstrated.
   *
   * Demos are dual-purpose:
-  *   1. Runnable via `sbt 'kyo-browser/runMain demo.XxxApp'`: prints a narrated trace and renders screenshots inline.
+  *   1. Runnable via `sbt 'kyo-browserJVM/runMain demo.XxxApp'`: prints a narrated trace and renders screenshots inline.
   *   2. Validated in tests via `DemoValidationTest`: each demo's `flow` runs against the shared test Chrome and its `validate` hook must
   *      return `Absent`.
   */

--- a/kyo-browser/shared/src/test/scala/demo/QuickstartDemo.scala
+++ b/kyo-browser/shared/src/test/scala/demo/QuickstartDemo.scala
@@ -4,7 +4,7 @@ import kyo.*
 
 /** Minimal runnable Quickstart that mirrors the README's first code block.
   *
-  * Run via `sbt 'kyo-browser/runMain demo.QuickstartApp'`. On first invocation it downloads Chrome-for-Testing (cached under
+  * Run via `sbt 'kyo-browserJVM/runMain demo.QuickstartApp'`. On first invocation it downloads Chrome-for-Testing (cached under
   * `~/Library/Caches/kyo-browser/` thereafter), navigates to a self-contained HTML page (a `data:` URL, no third-party site needed), types
   * a query into an input, clicks a button to populate a result heading, asserts the heading became visible with the expected text, prints
   * the page title, and shuts everything down on scope exit. Demonstrates the five most common operations (`goto`, `fill`, `click`,

--- a/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatPlugin.scala
+++ b/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatPlugin.scala
@@ -88,8 +88,8 @@ object CompatPlugin extends AutoPlugin {
                 )
                 CompatLibrary.register(m.id, meta)
                 // Pin defaultAxes only for single-scala matrices so the canonical
-                // row drops the JVM + Scala suffixes (matching sbt-crossproject's
-                // `.withoutSuffixFor(JVMPlatform)` convention). Multi-scala
+                // row drops the JVM + Scala suffixes (the plugin's own choice;
+                // the root build's cross-projects carry explicit JVM suffixes). Multi-scala
                 // matrices intentionally keep the version suffix on every cell
                 // so rows like 3.3.4 and 3.4.0 stay distinguishable.
                 // We use the full-version `scalaVersionAxis(sv, sv)` (not

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/jvm-only/build.sbt
@@ -33,8 +33,8 @@ checkProjects := {
     val ext      = sbt.Project.extract(s)
     // compatLibrary pins defaultAxes to (jvm, scalaABIVersion(scalaVersions.head))
     // so the JVM and Scala suffixes are suppressed in project ids — leaving
-    // just the backend suffix (matching sbt-crossproject's
-    // `.withoutSuffixFor(JVMPlatform)` convention from the previous design).
+    // just the backend suffix (the plugin's own canonical-row id choice;
+    // the root build's cross-projects carry explicit JVM suffixes).
     val expected = Set("myLibFuture", "myLibKyo", "myLibZio", "myLibCe", "myLibOx")
     val actual   = ext.structure.allProjectRefs.map(_.project).toSet
     val missing  = expected -- actual

--- a/kyo-http/README.md
+++ b/kyo-http/README.md
@@ -1096,7 +1096,7 @@ For a complete working example, see [kyo-examples ledger](../kyo-examples/jvm/sr
 
 ## Demos
 
-Runnable end-to-end demos live in [`shared/src/test/scala/demo`](shared/src/test/scala/demo). Run any with `sbt 'kyo-http/Test/runMain demo.<Name>'`.
+Runnable end-to-end demos live in [`shared/src/test/scala/demo`](shared/src/test/scala/demo). Run any with `sbt 'kyo-httpJVM/Test/runMain demo.<Name>'`.
 
 - [**ChatRoom**](shared/src/test/scala/demo/ChatRoom.scala): text messages plus a live SSE activity feed, with server-level CORS and OpenAPI security metadata.
 - [**ApiGateway**](shared/src/test/scala/demo/ApiGateway.scala): aggregates weather and currency APIs through typed routes, parallel client calls, and OpenAPI generation.

--- a/kyo-pod/README.md
+++ b/kyo-pod/README.md
@@ -650,7 +650,7 @@ kyo-pod compiles on JVM, JavaScript (Node.js), and Scala Native from a single so
 
 ## Demos
 
-Runnable demos live in [`shared/src/test/scala/demo`](shared/src/test/scala/demo). Run any with `sbt 'kyo-pod/Test/runMain demo.<Name>'`.
+Runnable demos live in [`shared/src/test/scala/demo`](shared/src/test/scala/demo). Run any with `sbt 'kyo-podJVM/Test/runMain demo.<Name>'`.
 
 - [**ServiceMesh**](shared/src/test/scala/demo/ServiceMesh.scala): three-tier app (nginx edge, python api, redis cache) on a private network with container-name DNS.
 - [**PrometheusExporter**](shared/src/test/scala/demo/PrometheusExporter.scala): polls container `stats` on a schedule and emits Prometheus text-format metric families.

--- a/kyo-schema/jvm/src/main/scala/kyo/internal/tools/FastFloatPow10Gen.scala
+++ b/kyo-schema/jvm/src/main/scala/kyo/internal/tools/FastFloatPow10Gen.scala
@@ -129,7 +129,7 @@ import java.nio.file.Paths
     sb.append("    )\n")
 
     // Resolve the output path.
-    // When run via `sbt "kyo-schema/runMain ..."` (forked), user.dir = <worktree>/kyo-schema/jvm.
+    // When run via `sbt "kyo-schemaJVM/runMain ..."` (forked), user.dir = <worktree>/kyo-schema/jvm.
     // Walk up two levels to reach the worktree root, then resolve the shared path.
     val jvmDir   = Paths.get(System.getProperty("user.dir"))
     val worktree = jvmDir.getParent.getParent // kyo-schema/jvm -> kyo-schema -> worktree

--- a/kyo-schema/shared/src/test/scala/kyo/YamlParserTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/YamlParserTest.scala
@@ -272,7 +272,7 @@ class YamlParserTest extends kyo.test.Test[Any]:
                   |        uses: actions/checkout@v4
                   |      - name: Test
                   |        run: |-
-                  |          sbt 'kyo-schema/test'
+                  |          sbt 'kyo-schemaJVM/test'
                   |          echo done
                   |        with:
                   |          cache: sbt
@@ -286,7 +286,7 @@ class YamlParserTest extends kyo.test.Test[Any]:
                         "ubuntu-latest",
                         List(
                             YamlGithubStep(Some("Checkout"), Some("actions/checkout@v4"), None, None),
-                            YamlGithubStep(Some("Test"), None, Some("sbt 'kyo-schema/test'\necho done"), Some(Map("cache" -> "sbt")))
+                            YamlGithubStep(Some("Test"), None, Some("sbt 'kyo-schemaJVM/test'\necho done"), Some(Map("cache" -> "sbt")))
                         )
                     )
                 )

--- a/kyo-test/README.md
+++ b/kyo-test/README.md
@@ -515,10 +515,10 @@ You run a module's suites through sbt; the runner discovers every `Test` subclas
 
 ```sh
 # Run every suite in a module
-sbt 'kyo-core/test'
+sbt 'kyo-coreJVM/test'
 
 # Run a single suite
-sbt 'kyo-core/testOnly kyo.ChannelTest'
+sbt 'kyo-coreJVM/testOnly kyo.ChannelTest'
 ```
 
 ### CLI flags

--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -1620,7 +1620,7 @@ This is the same value you would pass to `UI.runHandlers("/todos")(todoApp.map(_
 
 ## Demos
 
-Demos live in [`shared/src/test/scala/demo`](shared/src/test/scala/demo) and cover all three runners. Run any with `sbt 'kyo-ui/Test/runMain demo.<NameDemo>'`; the server-push demos print a `localhost` URL to open.
+Demos live in [`shared/src/test/scala/demo`](shared/src/test/scala/demo) and cover all three runners. Run any with `sbt 'kyo-uiJVM/Test/runMain demo.<NameDemo>'`; the server-push demos print a `localhost` URL to open.
 
 - [**Kanban**](shared/src/test/scala/demo/KanbanDemo.scala): Trello-style board over server-push: add, move, and delete cards across columns.
 - [**Signup**](shared/src/test/scala/demo/SignupDemo.scala): registration form with live reactive validation, inline errors, and a submit gated until valid.

--- a/kyo-ui/shared/src/test/scala/demo/CartDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/CartDemo.scala
@@ -10,7 +10,7 @@ import kyo.UI.*
   * `SignalRef[Map[String, Int]]` on the server; the cart lines and the running total are derived signals, so the server pushes just the
   * affected DOM diffs over SSE.
   *
-  * Run via `sbt 'kyo-ui/Test/runMain demo.Cart'` (optional port as the first argument).
+  * Run via `sbt 'kyo-uiJVM/Test/runMain demo.Cart'` (optional port as the first argument).
   *
   * Demonstrates: a single source-of-truth `SignalRef`, derived `Signal`s via `.map` (cart lines and total), keyed list rendering with
   * `foreachKeyed`, per-row +/- steppers, `when` empty-state, and equal-column layout via `flexGrow(1).flexBasis(0.px)`.

--- a/kyo-ui/shared/src/test/scala/demo/DashboardDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/DashboardDemo.scala
@@ -11,7 +11,7 @@ import kyo.UI.Ast.HtmlContent
   * those same signals, so the server pushes fine-grained DOM diffs over SSE and the numbers update live with no client-side code and no
   * polling. This is the `UI.runHandlers` server-driven model end to end: the state lives on the server, the browser is a thin presenter.
   *
-  * Run via `sbt 'kyo-ui/Test/runMain demo.Dashboard'` (optional port as the first argument), then open the URL and watch the cards and the
+  * Run via `sbt 'kyo-uiJVM/Test/runMain demo.Dashboard'` (optional port as the first argument), then open the URL and watch the cards and the
   * activity log update on their own.
   *
   * Demonstrates: shared server-side state, a `Fiber` background updater, fine-grained reactive text via `signal.render`, a reactive list

--- a/kyo-ui/shared/src/test/scala/demo/FlamegraphDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/FlamegraphDemo.scala
@@ -17,7 +17,7 @@ import kyo.UI.*
   * re-layout smoothly through the reactive boundary. Hovering dims frames outside the hovered ancestor/descendant chain,
   * the mouse wheel zooms about the cursor, and Reset tweens back to the full domain.
   *
-  * Run via `sbt 'kyo-ui/Test/runMain demo.Flamegraph'` (optional port as the first argument).
+  * Run via `sbt 'kyo-uiJVM/Test/runMain demo.Flamegraph'` (optional port as the first argument).
   */
 object FlamegraphDemo extends KyoApp:
 

--- a/kyo-ui/shared/src/test/scala/demo/HtmlSnapshotDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/HtmlSnapshotDemo.scala
@@ -10,7 +10,7 @@ import kyo.UI.*
   * fresh full-page renders on any signal change). This demo takes that first frame, the canonical SSR snapshot, and prints it. The same
   * `UI` value would mount to the DOM with `UI.runMount` or drive a server-push app with `UI.runHandlers`; only the runner changes.
   *
-  * Run via `sbt 'kyo-ui/Test/runMain demo.HtmlSnapshot'`.
+  * Run via `sbt 'kyo-uiJVM/Test/runMain demo.HtmlSnapshot'`.
   *
   * Demonstrates: `UI.runRender` for SSR, and that one `UI` value renders to plain HTML with no DOM or browser.
   */

--- a/kyo-ui/shared/src/test/scala/demo/KanbanDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/KanbanDemo.scala
@@ -11,7 +11,7 @@ import kyo.UI.Ast.HtmlContent
   * is pushed to the browser as a fine-grained DOM diff over SSE. No JavaScript build step is involved: open the printed URL and the page is
   * driven entirely by the server.
   *
-  * Run via `sbt 'kyo-ui/runMain demo.Kanban'` (optional port as the first argument). Add a card with the form, then walk a card across the
+  * Run via `sbt 'kyo-uiJVM/runMain demo.Kanban'` (optional port as the first argument). Add a card with the form, then walk a card across the
   * three columns with the ◀/▶ buttons or remove it with ✕.
   *
   * Demonstrates: `UI.runHandlers` server-push deployment, a single `SignalRef[Board]` as the source of truth, three derived per-column

--- a/kyo-ui/shared/src/test/scala/demo/LinkedSelectionDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/LinkedSelectionDemo.scala
@@ -12,7 +12,7 @@ import kyo.UI.*
   * the clicked datum into it, and the detail title and line read it back. There is no event bus and no
   * callback plumbing; "interaction" is just another app signal.
   *
-  * Run via `sbt 'kyo-ui/Test/runMain demo.LinkedSelection'` (optional port as the first argument).
+  * Run via `sbt 'kyo-uiJVM/Test/runMain demo.LinkedSelection'` (optional port as the first argument).
   */
 object LinkedSelectionDemo extends KyoApp:
 

--- a/kyo-ui/shared/src/test/scala/demo/LiveDashboardDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/LiveDashboardDemo.scala
@@ -28,7 +28,7 @@ import kyo.UI.*
   * is ever blocked (the cadence is `Async.sleep`). A pause control flips a `SignalRef[Boolean]`; while paused the engine
   * idles on a short sleep and leaves every metric untouched.
   *
-  * Run via `sbt 'kyo-ui/Test/runMain demo.LiveDashboard'` (optional port as the first argument).
+  * Run via `sbt 'kyo-uiJVM/Test/runMain demo.LiveDashboard'` (optional port as the first argument).
   */
 object LiveDashboardDemo extends KyoApp:
 

--- a/kyo-ui/shared/src/test/scala/demo/PlaygroundDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/PlaygroundDemo.scala
@@ -9,7 +9,7 @@ import kyo.UI.*
   * Type HTML in the textarea on the left; a derived `data:` URL feeds an `iframe` on the right that renders it live. The textarea is
   * two-way bound to a `SignalRef[String]`; the iframe's `src` is that signal mapped to a `data:` URL, so each edit re-points the frame.
   *
-  * Run via `sbt 'kyo-ui/Test/runMain demo.Playground'` (optional port as the first argument).
+  * Run via `sbt 'kyo-uiJVM/Test/runMain demo.Playground'` (optional port as the first argument).
   *
   * Demonstrates: the `iframe` element with a reactive `src`, two-way `textarea` binding, derived signals via `.map`, and equal-column
   * layout via `flexGrow(1).flexBasis(0.px)`.

--- a/kyo-ui/shared/src/test/scala/demo/RouterDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/RouterDemo.scala
@@ -14,7 +14,7 @@ import kyo.UI.Ast.HtmlContent
   * `Signal[String]` of the path, with `push`/`replace`/`back`); plain anchor clicks are intercepted into history navigation. That path is
   * JS-only, so this server-push demo uses a route signal to show the same view-switching pattern in a form you can run with `runMain`.
   *
-  * Run via `sbt 'kyo-ui/Test/runMain demo.Router'` (optional port as the first argument).
+  * Run via `sbt 'kyo-uiJVM/Test/runMain demo.Router'` (optional port as the first argument).
   *
   * Demonstrates: `route.render` view switching, a parameterized route, nav driven by writing a `SignalRef`, and active-link styling derived
   * from the route signal.

--- a/kyo-ui/shared/src/test/scala/demo/SearchDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/SearchDemo.scala
@@ -11,7 +11,7 @@ import kyo.UI.*
   * matching DOM diffs over SSE. The event handler is a normal Kyo computation, so it can suspend on `Async`, perform the HTTP call, and
   * recover typed errors with `Abort.run`.
   *
-  * Run via `sbt 'kyo-ui/Test/runMain demo.Search'` (optional port as the first argument), then type in the box. (No debounce: every
+  * Run via `sbt 'kyo-uiJVM/Test/runMain demo.Search'` (optional port as the first argument), then type in the box. (No debounce: every
   * keystroke issues a request, which keeps the demo simple.)
   *
   * Demonstrates: an `Async` event handler calling `HttpClient.getJson`, typed error recovery with `Abort.run`, two-way `value` binding, a

--- a/kyo-ui/shared/src/test/scala/demo/SignupDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/SignupDemo.scala
@@ -10,7 +10,7 @@ import kyo.UI.*
   * inline error messages appear and disappear, and the submit button enables only once every field is valid. On submit the server records a
   * confirmation message that replaces the form.
   *
-  * Run via `sbt 'kyo-ui/Test/runMain demo.Signup'` (optional port as the first argument).
+  * Run via `sbt 'kyo-uiJVM/Test/runMain demo.Signup'` (optional port as the first argument).
   *
   * Demonstrates: the full input family (`input`, `emailInput`, `passwordInput`, `numberInput`, `dateInput`, `select`/`option`, `checkbox`),
   * two-way `value`/`checked` binding via `SignalRef`, per-field derived `Signal[Boolean]` validity, aggregate validity via

--- a/kyo-ui/shared/src/test/scala/demo/SnakeDemo.scala
+++ b/kyo-ui/shared/src/test/scala/demo/SnakeDemo.scala
@@ -17,7 +17,7 @@ import scala.annotation.tailrec
   *   - The board and the status line `render` off the ref, so each tick redraws the grid reactively.
   *
   * Click the board once to focus it, then steer with the arrow keys (the snake waits for the first key before it
-  * starts moving). Run via `sbt 'kyo-ui/Test/runMain demo.Snake'` (optional port as the first argument).
+  * starts moving). Run via `sbt 'kyo-uiJVM/Test/runMain demo.Snake'` (optional port as the first argument).
   */
 object SnakeDemo extends KyoApp:
 

--- a/project/TestKyo.scala
+++ b/project/TestKyo.scala
@@ -179,8 +179,10 @@ object TestKyo {
 
     // --- Helpers ---
 
-    /** Check if a project name matches the given platform. JVM projects use bare names (e.g. "kyo-core") while JS/Native use suffixed
-      * names.
+    /** Check if a project name matches the given platform. JS, Native, and Wasm projects are matched by their
+      * explicit suffix; JVM is the residual: cross-project JVM variants carry a `JVM` suffix, and the
+      * suffix-less plain projects (kyo-compat-plugin, kyo-doctest-plugin, and similar JVM-only definitions)
+      * carry no platform suffix and are JVM-only.
       */
     private def matchesPlatform(name: String, platform: String): Boolean =
         platform match {
@@ -214,11 +216,8 @@ object TestKyo {
                     case _                                               => allPlatforms
                 }
                 affectedPlatforms.flatMap { p =>
-                    // JVM projects may use bare name (e.g. "kyo-core") or suffixed (e.g. "kyo-coreJVM")
                     val suffixed = s"$module$p"
-                    if (allProjectNames.contains(suffixed)) Seq(suffixed)
-                    else if (p == "JVM" && allProjectNames.contains(module)) Seq(module)
-                    else Seq.empty
+                    if (allProjectNames.contains(suffixed)) Seq(suffixed) else Seq.empty
                 }.toSet
             case _ => Set.empty
         }

--- a/project/WithKyoTest.scala
+++ b/project/WithKyoTest.scala
@@ -27,7 +27,6 @@ import scalanativecrossproject.ScalaNativeCrossPlugin.autoImport.*
   * Example:
   *   lazy val `kyo-kernel` =
   *     crossProject(JSPlatform, JVMPlatform, NativePlatform)
-  *       .withoutSuffixFor(JVMPlatform)
   *       ...
   *       .withKyoTest
   */
@@ -39,7 +38,7 @@ object WithKyoTest {
             val base =
                 cp.jvmSettings(
                     Test / unmanagedClasspath ++=
-                        (LocalProject("kyo-test-runner") / Test / fullClasspath).value,
+                        (LocalProject("kyo-test-runnerJVM") / Test / fullClasspath).value,
                     Test / testFrameworks +=
                         new TestFramework("kyo.test.runner.SbtFramework")
                 )


### PR DESCRIPTION
## Problem

The JVM variant of each cross-platform module was the bare module name
(`kyo-core`), while its JS, Native, and Wasm variants carried explicit suffixes
(`kyo-coreJS`, `kyo-coreNative`, `kyo-coreWasm`). A bare id is easy to mistake
for the platform aggregate or for a platform-neutral target, and in practice it
is a recurring source of confusion (for tooling, for contributors, and for the
AI coding agents the project supports) over which sbt project a module's JVM
build actually is.

## Solution

Drop `.withoutSuffixFor(JVMPlatform)` from every cross-platform module so its
JVM project id carries a `JVM` suffix, matching the other three platforms:
`kyo-core` becomes `kyo-coreJVM`, `kyo-bench` becomes `kyo-benchJVM`, and so on.
The id is now predictable from the module name alone, without needing to know
which platforms a module targets, so JVM-only modules take the suffix too.

The build's internal project references and every in-repo reference (CI
workflows, module READMEs, and code comments) are updated to the suffixed ids.
Published artifact coordinates are not touched.

## Notes

Published Maven coordinates (`io.getkyo:kyo-core` and friends) are unchanged;
only the sbt project ids change, so nothing downstream is affected.

The bare `<module>/test` no longer resolves for a cross-platform module; use
`<module>JVM/test`. The platform aggregates (`kyoJVM`, `kyoJS`, ...) and the
`testKyo` command are unchanged. Suffix-less plain (non-cross) projects such as
`kyo-compat-plugin` are JVM-only by construction and keep their unsuffixed ids.