### PR TITLE
[browser,ui] visual-QA capture API, settle-on-read, element discovery and DSL additions

### DIFF
--- a/kyo-browser/CONTRIBUTING.md
+++ b/kyo-browser/CONTRIBUTING.md
@@ -1,0 +1,1254 @@
+# Contributing to kyo-browser
+
+This is module-specific guidance for kyo-browser. It complements, and does not
+replace, the root `CONTRIBUTING.md`.
+
+Before working on kyo-browser, read `CONTRIBUTING.md` at the repo root for global
+conventions covering naming, types, method signatures, `using`-clause ordering,
+inline guidelines, scaladoc structure, visibility tiers, overload delegation, the
+unsafe boundary, and the general test framework (base-trait hierarchy, `run {}`
+wrapper, `untilTrue`). Everything in this guide is specific to the CDP driver, the
+settlement model, and the Chrome test infrastructure that make this module
+different from the rest of the codebase.
+
+**The one thing to internalize:** kyo-browser's selling point is transparent
+settlement. Interactions and assertions auto-wait for an observable settled state,
+so callers never write explicit sleeps (`Browser.scala:37-39`). The waits that must
+catch a fast in-page transient run their entire loop inside one `awaitPromise=true`
+eval, because cross-CDP polling aliases or desyncs the in-page observer
+(`MutationSettlement.scala:177-182`, `StabilitySampler.scala:32-67`). If you break
+that constraint, the module silently stops catching the flickers it exists to
+catch. The settlement section below is the deepest in this guide for that reason.
+
+The module now also carries a visual-QA surface (captures, geometry/style reads,
+element discovery, frame recording, plus viewport/scroll/emulation/highlight/console
+controls). It is built on the same settlement spine: the new settling reads
+re-sample through the in-page stability loop and map a settled-absent element to the
+twin return (`SettleRead.scala:5-15`); captures hold the page still (await fonts,
+freeze animations, loop to two byte-identical frames) and are settlement-transparent
+because every injected overlay carries `data-kyo-internal` (`HoldStill.scala:5-39`,
+`MutationSettlement.scala:124-148`). The settlement section documents both halves.
+
+## Table of contents
+
+1. [Architecture at a glance](#architecture-at-a-glance)
+2. [Transparent settlement (the headline invariant)](#transparent-settlement-the-headline-invariant)
+3. [The visual-QA surface](#the-visual-qa-surface)
+4. [Conventions](#conventions)
+5. [Extension recipes](#extension-recipes)
+6. [Testing](#testing)
+7. [Adding a new method: decision checklist](#adding-a-new-method-decision-checklist)
+
+## Architecture at a glance
+
+The public surface is one opaque type: `opaque type Browser <: Async =
+Env[BrowserTab] & Async` (`Browser.scala:149`). The `Env` is hidden so callers
+cannot extract or share the tab directly, and so two fibers cannot accidentally
+share a single CDP tab (`Browser.scala:107-110, 149`). Because there is no safe
+default split for a single CDP session, the compiler refuses to derive an
+`Isolate` automatically, so concurrent combinators demand an explicit one.
+
+The module sits on top of `kyo-http`: the CDP transport is built on
+`HttpClient.webSocket`, so the layer above kyo-browser in the stack is the
+WebSocket client and below it is the Chrome process (`build.sbt:1139`,
+`internal/CdpClient.scala:249`).
+
+Internally the stack layers top-down, each layer composing the one below it:
+
+| Layer | Type | Responsibility |
+|-------|------|----------------|
+| Public API | `Browser` (`Browser.scala:149`) | Actions, reads, assertions, scoped wrappers, visual-QA surface |
+| Settlement / readiness | `Actionability`, `MutationSettlement`, `NavigationWatcher`, `BrowserAssertion` / `StabilitySampler`, `SettleRead`, `HoldStill` | The auto-wait gates plus the settle-this-read and hold-still-capture helpers |
+| Resolution / eval | `Resolver`, `BrowserEval`, `DiscoverJs` | `Selector` to typed `NodeRef`; page-side JS eval; the injected element-introspection probe |
+| Typed CDP commands | `CdpBackend` (`internal/CdpBackend.scala:6-13`) | One `private[kyo]` method per CDP endpoint |
+| Transport / multiplexing | `CdpClient` (`internal/CdpClient.scala:6-23`) | WebSocket exchange, dialog routing, frame fan-out |
+| Process | `BrowserLauncher`, `SharedChrome`, `ChromeDownloader` | Spawn / share / provision Chrome |
+
+`CdpBackend` wraps each CDP endpoint as a raw `sender.send(...)` plus a typed JSON
+decode, so call sites in `Browser` never write string-literal CDP calls
+(`internal/CdpBackend.scala:6-13`). `CdpClient` is the transport beneath it: it
+pairs each outbound command with its response over a single WebSocket via
+`Exchange`, routes dialogs, fans out frame events, and bounds in-flight commands
+(`internal/CdpClient.scala:6-23`). A single relay fiber inside `CdpClient.init`
+owns the WebSocket: an outbound stream pumps the `outbound` channel into `ws.put`,
+a receiver pumps `ws.stream` into the `inbound` channel, and `Async.race(sender,
+receiver)` runs both (`internal/CdpClient.scala:249-262`).
+
+`BrowserLauncher` is the process layer: it spawns Chrome with
+`--remote-debugging-port=0`, polls `${user-data-dir}/DevToolsActivePort` for the
+address Chrome writes, and returns the `ws://127.0.0.1:<port><path>` URL the
+transport connects to (`internal/BrowserLauncher.scala:12-21`). `SharedChrome`
+shares only the WebSocket URL (each caller still makes its own `CdpClient`),
+launching Chrome lazily inside a long-lived fiber held open by `Async.never` and
+torn down when the kyo scheduler shuts down (`internal/SharedChrome.scala:5-12`).
+`ChromeDownloader` is the binary-provisioning layer below launch: it downloads and
+caches `chrome-headless-shell` from Google's Chrome-for-Testing archive, derives
+the platform tuple from `kyo.System.operatingSystem` / `kyo.System.architecture`,
+and aborts on `linux-arm64` because no artifact is published
+(`internal/ChromeDownloader.scala:5-18`).
+
+`BrowserTab` is the per-session handle the `Browser` effect carries. It holds the
+`targetId`, `sessionId`, the shared `CdpClient`, the isolated `browserContextId`,
+and per-tab atomic state (frame contexts, root frame, console/response
+registration guards, the viewport and emulation overrides, download policy). Its
+`session` field is the `client.withSession(sessionId)` pair every CDP call issues
+against (`internal/BrowserTab.scala:19-37`). `BrowserTabSetup.attachAndSetupTab` is
+the single entry point that creates a fresh isolated browser context, attaches a CDP
+target, and installs the per-tab trackers; it is the one place the four-layer
+containment (process / context / tab / iframe) is assembled from the bottom
+(`internal/BrowserTab.scala:71`, `internal/BrowserTab.scala:253`). Every action path
+depends on four CDP domains (Page, Runtime, DOM, Network) being enabled;
+`enableDomains` fires them with `Async.zip` to amortise the round-trip, then
+enables focus emulation (`internal/BrowserTab.scala:284`).
+
+Element resolution is centralised in `Resolver`: it maps a `Selector` to a typed
+`NodeRef` via the `objectId + requestNode` pipeline (`Runtime.evaluate` ->
+`DOM.requestNode` -> `DOM.describeNode`), the shared substrate every interaction
+method resolves through (`internal/Resolver.scala:5-32`, `internal/Resolver.scala:35`).
+
+**Representative call flow.** `Browser.run(launch)` is the lifecycle end to end:
+launch Chrome -> connect a `CdpClient` -> attach and setup a tab -> run the body
+bound to that tab, all under one internal `Scope.run` so the caller's effect row
+does not carry `Scope` (`Browser.scala:252-266`). `click` is the representative
+action flow: dependency direction is top-down through the layers, a public
+`Browser.*` action composes the actionability and settlement gates -> `Resolver` /
+`BrowserEval` -> `CdpBackend` typed wrappers -> `CdpClient.send` transport ->
+Chrome (`Browser.scala:442-454`). Internal callers reach the hidden
+`Env[BrowserTab]` only through `Browser.use` (read the tab) and `Browser.runOn`
+(bind a tab), which wrap `Env.use` / `Env.run` so internal code never sees the
+opaque type's underlying `Env` (`Browser.scala:4356-4363`).
+
+CDP domain wrappers that need extra typing beyond `CdpBackend` live in the
+`kyo.internal.cdp` sub-package: `Accessibility` wraps `Accessibility.getFullAXTree`
+with a custom polymorphic `Schema`, and `PageDownload` wraps
+`Page.setDownloadBehavior` (`internal/cdp/Accessibility.scala:1-16`,
+`internal/cdp/PageDownload.scala:1-11`).
+
+### Visibility and cross-platform split
+
+All transport and protocol internals live under `kyo.internal` and are
+`private[kyo]`: `CdpBackend`, `CdpClient`, the wire helpers (`CdpWire`'s
+`CdpBase64Decode` / `CdpEvalDecoder` / `ExceptionDetailsFormat`), and `BrowserTab`
+are visible to `Browser` and internal helpers but not to external callers; only
+`kyo.Browser` and the `BrowserException` hierarchy are public
+(`internal/CdpBackend.scala:11-12`, `internal/BrowserTab.scala:19`).
+
+Almost all source is cross-platform: every file under
+`kyo-browser/shared/src/main/scala/kyo/**` (the entire `Browser` API plus all
+`internal` modules) compiles on JVM, JS, and Native; platform code is the
+exception, not the rule (`internal/BrowserLauncher.scala:99`). The only
+platform-specific main source is `BrowserLauncherPlatform`, a one-method seam
+(`registerShutdownHook`). JVM and Native share one implementation under
+`jvm-native/src/main` that registers a `Runtime.addShutdownHook` thread to
+SIGTERM-kill a leaked Chrome; the split exists because that hook is a JVM/Native
+runtime ABI with no JS equivalent (`jvm-native/src/main/scala/kyo/internal/BrowserLauncherPlatform.scala:5-25`).
+The JS copy is a no-op: JS has no JVM shutdown hooks, so process lifecycle is left
+to the JS runtime, which is why the seam is split rather than living in `shared/`
+(`js/src/main/scala/kyo/internal/BrowserLauncherPlatform.scala:7-9`).
+
+## Transparent settlement (the headline invariant)
+
+### The goal
+
+Browser automation usually fails not on the action itself but on the action firing
+before the page is ready (`Browser.scala:37-39`). `Browser` answers this so that
+callers never write `Async.sleep`: every interaction and every assertion
+auto-waits for an observable settled state, and the wait happens automatically
+inside the operation (`Browser.scala:37-39`). A contributor who adds a new method
+without wiring it into the right settlement mechanism reintroduces exactly the
+race the module exists to remove.
+
+There are four settlement mechanisms, each tied to one kind of operation. The
+first three (navigation, mutation, assertion) are the auto-wait gates the public
+docs name (`Browser.scala:37-39`); the actionability gate is the per-attempt
+readiness check that fronts every interaction (`Browser.scala:442-454, 504-514`).
+
+### The four mechanisms
+
+**1. Actionability gate (interactions: every `click` / `fill` / `hover` / `press`
+/ `check` / `select` / `dragAndDrop` / `focus` / `setFiles`).** Each interaction
+is wrapped as `Actionability.withRetry { Actionability.withActionable(selector,
+...) { ref => ... } }`. The actionability gate is the per-attempt readiness check;
+`withRetry` is the surrounding poll loop (`Browser.scala:442-454, 504-514`).
+`Actionability.check` runs seven sub-checks (attached -> fillable -> visible ->
+scroll-into-view -> stable -> hittable -> enabled) inside ONE `Runtime.evaluate`,
+ordered so the earliest failure wins, so a detached node surfaces as
+`Reason.NotAttached`, not `Reason.NotVisible`; success returns an `ActionableRef`
+carrying the rect center so the caller does not need a second round-trip
+(`Actionability.scala:7-31`). The stability sub-check samples the bounding rect
+across two ~16ms ticks driven by `setTimeout`, NOT `requestAnimationFrame`, because
+RAF callbacks stall on Chromium right after a JS dialog is dismissed, hanging the
+`awaitPromise=true` eval forever (`Actionability.scala:160-165`).
+
+**2. Mutation settlement (state-changing actions: `click` / `fill` / `check` /
+`select` / `press` / `uncheck`, plus `setViewport` / `resetViewport` / `scrollTo` /
+`scrollToElement` / `withViewport` / `withEmulation` apply).** After a
+state-changing action fires, `MutationSettlement.afterAction` installs a
+window-level `MutationObserver`, records the timestamp of the last mutation, and
+polls until `now - lastMutation >= quiescenceWindow`, so the caller sees the settled
+DOM, not the mid-render snapshot React/Vue are in (`MutationSettlement.scala:6-12`).
+The observer is ALWAYS rooted at `document.body` regardless of `scopeSelector`; the
+`scopeSelector` arg is retained for future opt-in scoping but is currently unused,
+because onclick handlers commonly mutate sibling DOM a target-scoped observer would
+never see (`MutationSettlement.scala:23-33`). Quiescence has two regimes keyed off a
+`startCount` snapshot taken at action-complete: if no mutation has landed it keeps
+polling only until `mutationFirstMutationGrace` elapses (the fast path for no-op
+clicks), otherwise it waits for `quiescenceWindow` of quiet bounded by
+`mutationSettlementTimeout`, raising a timeout if the DOM never stops churning
+(`MutationSettlement.scala:49-63`). A single window-level observer is shared across
+concurrent `afterAction` calls via a reference count (`window.__kyoMutObsRef`):
+install bumps, release decrements, and the observer disconnects when the count
+hits 0 (`MutationSettlement.scala:16-19`).
+
+The observer callback filters out `data-kyo-internal` mutations so injected
+overlays and the freeze stylesheet are settlement-transparent: see
+[The data-kyo-internal filter](#the-data-kyo-internal-filter-overlays-are-settlement-transparent)
+below. `afterAction` is not the only entry point. `MutationSettlement.waitForStable`
+is the strict no-action wait backing `Browser.waitForStable`: it installs the
+observer with no action, runs the same single-eval quiescence loop with
+`overallDeadline = timeout`, and ABORTS `BrowserAssertionTimedOutException` on
+timeout rather than swallowing it (`MutationSettlement.scala:72-89`).
+`MutationSettlement.settleForCapture` is the best-effort sibling: identical loop, but
+it recovers the timeout to `()` instead of aborting, so the hold-still capture path
+can pre-settle the DOM and proceed even when the page never fully quiesces
+(`MutationSettlement.scala:91-100`). Strict `waitForStable` vs best-effort
+`settleForCapture` is the load-bearing distinction: a read or assertion must surface
+a never-quiesced page as a typed failure; a capture must still produce an image.
+
+**3. Navigation settlement (navigation: `goto` / `back` / `forward` / `reload` /
+`expectNavigation`, and nav-intent clicks).** These arm `NavigationWatcher`, which
+installs an in-page recorder monkey-patching `history.pushState` / `replaceState`
+plus a `beforeunload` listener, then polls readyState (and optionally the
+network-idle window) until the requested `Settle` mode is satisfied. Detection is
+JS-polling, keeping the CDP event channel free (`NavigationWatcher.scala:5-19`).
+The three settle modes form a strictly-increasing strength order:
+`DomContentLoaded` (readyState >= interactive) < `Load` (readyState complete) <
+`NetworkIdle` (load fired AND no in-flight fetch/XHR for `networkIdleWindow`);
+`NetworkIdle` is the default for navigation methods (`Browser.scala:3922-3934, 321`).
+`armAround` (nav-neutral clicks) applies a fast path: after the trigger it polls
+within `navigationGraceWindow`, and if nothing navigated it returns immediately,
+making it safe to wrap around ANY click. `armAroundNavigation` (`goto` /
+`expectNavigation`) sets `assumeWillNavigate = true` and unconditionally waits for
+the URL to commit, because the caller explicitly asked Chrome to navigate
+(`NavigationWatcher.scala:36-47, 216-241`). Network tracking is reinstalled INSIDE
+the settle loop, not before the trigger, because a navigation wipes all JS state on
+the destination page (`NavigationWatcher.scala:283-299`). When `NetworkIdle` never
+quiesces within the load budget, the watcher degrades to `Load` semantics at the
+deadline (logs a warning and returns success if the load event fired, URL changed,
+and the response is OK) rather than failing; the deadline-exhaustion decision matrix
+is split into a pure `decidePending` function so it can be unit-tested without a
+live Browser (`NavigationWatcher.scala:333-362, 396`).
+
+**4. Assertion stability (assertions and retrying reads: `assert*` / `waitFor*`).**
+These route through `BrowserAssertion.withStability`: each attempt is one cheap
+in-page read, and only if that read matches the predicate does a
+`StabilitySampler.sampleWindow` run over the same JS expression; the outer `Retry`
+reschedules attempts per `retrySchedule` (`BrowserAssertion.scala:6-9, 26-35`). An
+assertion only succeeds when BOTH the first probe and the stability sample satisfy
+the predicate AND the value held constant for the entire `assertionStabilityWindow`;
+if it changed mid-window the attempt fails and retries, which is what makes a
+missing match a typed timeout, not an instant `false` (`BrowserAssertion.scala:29-35`).
+A transient JS exception mid-flicker (for example, reading a property of a node
+that just detached) is itself instability, so the in-page `read()` maps a thrown
+probe to a distinct sentinel that compares unequal to any real value, registering
+as a change; making `read()` swallow-and-return-empty would mask genuine flicker
+(`StabilitySampler.scala:52-56`).
+
+### The in-page awaitPromise loop constraint
+
+This is the constraint behind the headline. Two mechanisms run their ENTIRE wait
+loop inside one `awaitPromise`-backed JS eval, and neither can be rewritten to poll
+across CDP round-trips:
+
+- The whole mutation quiescence wait runs inside ONE `awaitPromise`-backed eval.
+  Polling the observer's state via repeated `Runtime.evaluate` calls desyncs on
+  Chrome: observer callbacks stop delivering after the first batch when CDP
+  interleaves between mutations. Driving the entire loop in-page lets the observer,
+  `setInterval`, and observer callbacks cooperate on the main thread without CDP
+  interruption (`MutationSettlement.scala:177-182`).
+- The stability sampler runs the ENTIRE sampling loop inside one `awaitPromise`-backed
+  eval. Sampling via N separate CDP round-trips aliases because round-trip latency
+  is load-dependent (hundreds of ms under Native full-suite load), so coarse samples
+  cannot see a flicker faster than the sample spacing; the in-page loop is
+  alias-proof (`StabilitySampler.scala:1-19`).
+
+`SettleRead.settle` (the settle-on-reads helper) and `Browser.waitForStable` both
+ride this same in-page loop: `SettleRead` calls `StabilitySampler.sampleWindow`
+directly, and `waitForStable` runs the `awaitQuiescence` single-eval loop. Neither
+adds a new transient-catching loop, so both inherit the constraint rather than
+restating it (`SettleRead.scala:13-14`, `MutationSettlement.scala:177-182`). The
+HoldStill capture loop is the deliberate exception: its two-identical-frames
+comparison is NOT an in-page transient loop (each iteration is a full CDP capture
+round-trip paced by `Clock.sleep`), so it is exempt from the single-eval rule
+(`HoldStill.scala:16-21`).
+
+There is also a hard single-round-trip invariant on the actionability check:
+`Actionability.check` must complete in exactly one CDP round trip; every JS bundle
+embeds a marker so the round-trip count is observable, and there must be exactly one
+evaluate carrying that marker per `check` call (`Actionability.scala:84-90`).
+
+If you add or change a wait that must catch a fast in-page transient, the loop must
+live entirely inside one `awaitPromise=true` eval. Do not "simplify" it into a
+sequence of separate `Runtime.evaluate` polls.
+
+### Settle-on-reads: the SettleRead helper
+
+The visual-QA reads (`boundingRect`, `computedStyle(s)`, `inViewport`,
+`scrollPosition`, `element`, `elementAt`, `elements`) are SETTLING reads: each
+re-samples its in-page value expression on the active `retrySchedule` until the value
+holds constant across `assertionStabilityWindow`, then decodes the stable string
+(`SettleRead.scala:5-15`). This is a DEDICATED helper, not a `BrowserAssertion.withStability`
+call. `withStability` raises `failure(first)` whenever the first probe fails the
+predicate, which is assert/waitFor semantics ("the predicate must hold"); a settling
+read instead needs a settled-ABSENT element to produce the read's twin return
+(`Absent` / `false` / abort / empty), not a stability timeout. So `SettleRead.settle`
+reuses `StabilitySampler.sampleWindow` (the identical in-page loop) but always feeds
+the stable string to the read's own `decode`, and absence is just a stable sentinel
+string that `decode` maps (`SettleRead.scala:27-40`). "Unstable" (the value changed
+mid-window) wraps in a typed `BrowserAssertionTimedOutException` so the outer
+`Retry[BrowserReadException]` re-samples; only genuine instability for the whole
+budget surfaces as a failure (`SettleRead.scala:18-22, 35-38`). A `decode` that itself
+aborts (a must-exist read finding an absent element) is treated as an unstable sample
+and retried for the full budget before the failure surfaces (`SettleRead.scala:10-11`).
+`assertionStabilityWindow = Duration.Zero` is the first-match escape hatch:
+`SettleRead` evaluates once and decodes, matching `withStability`'s zero-window path
+(`SettleRead.scala:33`).
+
+### Hold-still capture
+
+Captures (`screenshot`, `screenshotRegion`, `screenshotElement`, `screenshotFullPage`,
+`screenshotMarks`) do not settle the way reads do; they HOLD THE PAGE STILL. The
+protocol, in order, is: best-effort `settleForCapture` pre-settle, await
+`document.fonts.ready`, inject a `data-kyo-internal` freeze `<style>` (animations and
+transitions paused, caret hidden), then loop the base capture until two consecutive
+frames hash-identical or `captureHoldStillTimeout` elapses, returning the last frame
+(`HoldStill.scala:5-39`). It is best-effort: it NEVER aborts on timeout. Equality is
+`Image.hashCode` over the DECODED image bytes (a content hash via `MurmurHash3.bytesHash`),
+NOT an image-diff algorithm and NOT the base64 wire string; using `img.binary.hashCode`
+would compare `Array` reference identity and never converge (`HoldStill.scala:42-51`).
+
+The helper is split into two halves so a multi-band capture freezes ONCE rather than
+per band. `withFrozenPage` is the setup half (settle, await fonts, inject the freeze
+style under `Scope.acquireRelease`); `holdStillFrame` is the per-capture
+two-identical-frames loop assuming the page is already frozen; `withHoldStill` is
+`withFrozenPage { holdStillFrame(capture) }` for the single-call case
+(`HoldStill.scala:93-153`). `screenshotFullPage` calls `withFrozenPage` around the
+whole band loop and `holdStillFrame` per band, so all bands reflect the same frozen
+animation state (`Browser.scala:1978-2002`). `screenshotMarks` does the same to inject
+its badge overlay once inside the already-frozen scope (`Browser.scala:2121-2136`).
+
+### The data-kyo-internal filter (overlays are settlement-transparent)
+
+The freeze stylesheet, `withHighlights` boxes, and `screenshotMarks` badges all inject
+DOM under a live `MutationObserver`. They must NOT arm the mutation gate, or a capture
+or a `withEmulation` apply inside the same scope would wait on their own overlay. The
+observer callback filters them out via the `data-kyo-internal` attribute
+(`MutationSettlement.scala:124-148`). The filter has TWO branches, both load-bearing:
+
+- A record whose target sits inside a `[data-kyo-internal]` subtree is dropped (covers
+  attribute / characterData / childList mutations made WITHIN a tagged overlay)
+  (`MutationSettlement.scala:129-132`).
+- A `childList` record that INSERTS or REMOVES a tagged root is also dropped: the
+  target is the untagged parent (`document.body` / `document.head`), and the tagged
+  node is in `addedNodes` / `removedNodes`. The record is transparent only when EVERY
+  added AND removed node is (or is within) a tagged subtree, so a mixed batch that also
+  moves a real node still arms the gate (`MutationSettlement.scala:133-142`).
+
+Both branches matter: the first makes mutations inside an overlay transparent, the
+second makes overlay INJECTION and REMOVAL transparent. Without the second branch the
+`appendChild` / `remove` of the freeze style or the highlight container would itself be
+a settlement-arming `childList` mutation.
+
+`data-kyo-internal` is a RESERVED SENTINEL attribute. A page under test must not stamp
+its own nodes with it: any node carrying it (or sitting beneath one) becomes invisible
+to mutation settlement, so a self-stamped subtree would silently stop arming the gate.
+
+### Overlay teardown: per-handle token, never a shared global slot
+
+Every scoped in-page overlay (the freeze style, `withHighlights` boxes, `screenshotMarks`
+badges) mints a UNIQUE `data-kyo-token` in its inject JS, from an in-page monotonic
+counter `window.__kyoOverlayToken`, and tears down by removing ONLY the node carrying
+that token (`HoldStill.scala:53-78`, `Browser.scala:2101-2118, 2352-2382`). The inject
+eval returns the token to Scala; the `Scope.acquireRelease` release closure closes over
+it, so removal fires on success, failure, AND interruption but targets exactly the node
+this invocation injected.
+
+This replaced an earlier shared-single-slot design (each overlay wrote its node into one
+`window.__kyo*` slot and read it back to remove). Under nesting or interleaving the inner
+inject overwrote the slot, the inner exit deleted it, and the outer exit then found the
+slot `undefined` and leaked its node permanently. A leaked freeze `<style>` is the worst
+case: it pauses the whole page indefinitely. So the recipe for ANY new injected overlay
+is: mint a per-handle token in the inject JS, tag the node with both `data-kyo-internal`
+(for settlement transparency) and the unique `data-kyo-token`, return the token, and
+remove by token in the release. Never a shared global slot. `__kyoOverlayToken` is the
+only shared global here and it is append-only (never read back to identify a node), so it
+carries none of the single-slot hazard.
+
+### Config knobs
+
+All per-operation tuning lives in a single `SessionConfig` carried in a fiber
+`Local` (`configLocal`); every retry, settle, and assertion loop reads it via
+`configLocal.use`, and `withConfig` installs a scoped override (`Browser.scala:4348,
+213-214`). Config splits into launch-time (`LaunchConfig`, frozen once Chrome
+starts) and session-time (`SessionConfig`, mutable per scope); `withConfig` accepts
+ONLY `SessionConfig`, so a contributor cannot write `withConfig(_.executable(...))`
+and have it silently no-op. The compiler enforces the split (`Browser.scala:203,
+4075, 4185`).
+
+| Knob | Default | Role |
+|------|---------|------|
+| `retrySchedule` | `100ms` x up to `8s` | Outer poll loop for interactions, assertions, retrying reads, settling reads (`Browser.scala:4126`) |
+| `loadSchedule` | `100ms` x up to `5s` | Navigation load polling (`Browser.scala:4127`) |
+| `networkIdleWindow` | `500ms` | Quiet window required for `NetworkIdle` (`Browser.scala:4128`) |
+| `mutationQuiescenceWindow` | `50ms` | DOM-quiet window before mutation settlement returns (`Browser.scala:4129`) |
+| `mutationSettlementTimeout` | `2s` | Upper bound on mutation quiescence (`Browser.scala:4130`) |
+| `mutationFirstMutationGrace` | `100ms` | Fast-path grace when no mutation lands (`Browser.scala:4131`) |
+| `assertionStabilityWindow` | `100ms` | Window the assertion value must hold constant, also the settling-read stability window (`Browser.scala:4132`) |
+| `stabilitySampleInterval` | `4ms` | In-page sample spacing (`Browser.scala:4137`) |
+| `navigationGraceWindow` | `300ms` | Fast-path window for nav-neutral clicks (`Browser.scala:4136`) |
+| `navigationPostSettleWindow` | `300ms` | Post-settle window (`Browser.scala:4134`) |
+| `captureHoldStillTimeout` | `1s` | Total best-effort hold-still bound per capture (`Browser.scala:4140`) |
+| `captureHoldStillInterval` | `50ms` | Inter-capture pacing in the two-identical-frames loop (`Browser.scala:4141`) |
+
+The two `captureHoldStill*` knobs are the only ones the visual-QA surface added; the
+hold-still loop reads both from `configLocal` (`HoldStill.scala:117-119`). The `8s`
+`retrySchedule` budget is deliberately generous to accommodate SPA hydration
+(React/Vue/Angular shells painted before content); callsites that want fail-fast
+should install a tighter schedule via `withConfig(_.retrySchedule(...))`
+(`Browser.scala:4204`). `withTimeout(d)` is the shortcut that caps both
+`retrySchedule` and `loadSchedule` at `maxDuration(d)`; it bounds the retry budget,
+it does NOT abort the way `Async.timeout` does, so a failure to settle within `d`
+aborts with the usual typed assertion timeout (`Browser.scala:226-230`).
+
+Three knobs have `Duration.Zero` opt-outs:
+
+- `mutationQuiescenceWindow = Duration.Zero` opts out of mutation settlement
+  entirely (returns immediately after the action); useful in tests where DOM churn
+  is expected (`MutationSettlement.scala:31-33, 44`).
+- `assertionStabilityWindow = Duration.Zero` skips phase 2 entirely (first-match
+  behaviour); the escape hatch for callers needing raw speed via
+  `withConfig(_.assertionStabilityWindow(Duration.Zero))`. The `100ms` default is
+  one polling interval at the default retry schedule (`BrowserAssertion.scala:36-37`,
+  `Browser.scala:3274-3279`).
+
+### The retry-channel-narrowing trap
+
+`Actionability.withRetry` narrows its retry channel to `BrowserElementException`,
+NOT `BrowserMutationException`. If you widen it back, the retry will catch
+`MutationSettlement.afterAction`'s settlement timeout and loop the whole
+interaction, blowing past the `mutationSettlementTimeout` budget. Only
+element-not-found and not-actionable are legitimate retry triggers here
+(`Actionability.scala:479-495`). This trap matters because the exception hierarchy
+is nested by capability: `BrowserMutationException <: BrowserReadException` and
+`BrowserAssertionException <: BrowserMutationException`, so a single
+`Abort[BrowserReadException]` channel catches every settlement, interaction, and
+assertion failure uniformly (`BrowserException.scala:34-41, 71-79`). A
+mutation-settlement timeout surfaces as `BrowserAssertionTimedOutException` ("DOM
+never quiesced" is an assertion-like failure from the caller's perspective), which
+is why it is a `BrowserMutationException` subtype and must NOT be caught by the
+interaction retry loop (`MutationSettlement.scala:13-14, 196-204`).
+
+### Decision rules for a new method's settlement
+
+- A new interaction reuses `Actionability.withRetry { Actionability.withActionable(...)
+  { ref => MutationSettlement.afterAction(<action>)(scopeSelector = Present(selector))
+  } }` (`Browser.scala:445-453, 504-514`).
+- `requireEnabled = false` is passed by `hover` and `press` so the disabled probe is
+  skipped: real browsers still fire `mouseover` / `keydown` against disabled controls,
+  so blocking them would be wrong. Visibility, attached, stability, and hittable still
+  run (`Browser.scala:469-477, 668-676`, `Actionability.scala:46-48`). Decide per
+  method whether the disabled probe applies.
+- On a nav-intent click, `Browser.click` skips mutation settlement entirely and arms
+  the navigation watcher instead, because the destination is a fresh DOM and the old
+  page's observer is wiped by the navigation (`Browser.scala:447-452`). A new
+  nav-capable action must make the same choice.
+- A new navigation entry-point must replicate two traps or it will hang.
+  `goto` short-circuits to a no-op when the tab is already at the target URL, because
+  Chrome's `Page.navigate` against the current URL does NOT actually navigate, so the
+  watcher would wait for a URL-change signal that never arrives and time out;
+  refresh callers must use `reload` (`Browser.scala:329-336`). `goto` to a `data:`
+  URL auto-downgrades the default `NetworkIdle` to `Load`, because `data:` URLs
+  produce no network traffic so the idle window never opens; an explicit non-default
+  settle is honored as-is (`Browser.scala:324-328`).
+
+## The visual-QA surface
+
+The visual-QA surface turns `Browser` into a screenshot / inspection tool. Every
+member nests under the existing `Browser` opaque type or the `BrowserException`
+hierarchy; the visual-QA surface adds no new top-level types. The surface groups into four
+jobs plus controls.
+
+### SEE: captures
+
+| Method | Returns | Settlement | Citation |
+|--------|---------|------------|----------|
+| `screenshot(format, quality)` | `Image` | hold-still; live viewport, no clip | `Browser.scala:1916-1927` |
+| `screenshotRegion(x, y, width, height, format, quality)` | `Image` | hold-still; `captureBeyondViewport = true`; non-positive size aborts pre-CDP | `Browser.scala:1933-1956` |
+| `screenshotElement(selector, format, quality, transparentBackground)` | `Image` | `Actionability.withRetry` auto-wait, then hold-still | `Browser.scala:2029-2082` |
+| `screenshotFullPage(maxBands, format, quality)` | `Chunk[Image]` | freeze ONCE, hold-still per band; `bandCount > maxBands` aborts pre-capture | `Browser.scala:1963-2005` |
+
+`screenshot` dropped the legacy `1280x720` crop: it now captures whatever viewport
+`setViewport` / `withViewport` last established (`Browser.scala:1916-1927`).
+`screenshotElement` auto-waits inside `Actionability.withRetry` (channel
+`BrowserElementException`, never widened): it resolves, box-stability-checks (two
+`getBoundingClientRect` samples ~16ms apart agreeing within 1px), scrolls into view,
+re-reads the post-scroll rect for the clip, then captures ONCE outside the retry so a
+capture failure never re-enters the retry channel (`Browser.scala:2039-2081`).
+`transparentBackground = true` sets `Emulation.setDefaultBackgroundColorOverride` to
+fully transparent for the shot, cleared via `Scope.acquireRelease`
+(`Browser.scala:2142-2163`). `screenshotFullPage` reads content/viewport height in one
+eval, computes `bandCount = ceil(content / viewport)` in CSS px (DPR-independent), and
+freezes once around the band loop (`Browser.scala:1963-2002`).
+`screenshotMarks(marks, maxMarks, format, quality)` overlays numbered badges at each
+element's top-left corner inside a single `data-kyo-internal` token-tagged subtree,
+injected once inside the frozen scope; `marks.size > maxMarks` aborts pre-capture
+(`Browser.scala:2092-2136`).
+
+### VERIFY: settling reads
+
+These re-sample through `SettleRead.settle` (the settle-on-reads helper) until the
+value holds constant, then map a settled-absent element to the read's twin return:
+
+| Method | Returns | Settled-absent | Citation |
+|--------|---------|----------------|----------|
+| `boundingRect(selector)` | `Maybe[Bounds]` | `Absent` (twin `boundingBox`); authoritative geometry from `DOM.getBoxModel` after the JS rect stabilizes | `Browser.scala:1590-1619` |
+| `computedStyles(selector, properties)` | `Map[String, String]` | abort `BrowserElementNotFoundException` (twin `attribute`) | `Browser.scala:1624-1639` |
+| `computedStyle(selector, property)` | `String` | inherited; DELEGATES to `computedStyles(selector, Span(property))` | `Browser.scala:1644-1645` |
+| `inViewport(selector)` | `Boolean` | abort `BrowserElementNotFoundException` (twin `isVisible`) | `Browser.scala:1650-1662` |
+| `scrollPosition` | `ScrollPosition` | n/a (page always has a scroll position) | `Browser.scala:1667-1674` |
+| `waitForStable(timeout)` | `Unit` | n/a; STRICT quiescence wait, aborts `BrowserAssertionTimedOutException` on timeout | `Browser.scala:1680-1681` |
+
+`waitForStable` is the strict on-demand quiescence wait (delegates to
+`MutationSettlement.waitForStable`); it is the only VERIFY entry that does NOT route
+through `SettleRead`, because it waits for the WHOLE-page DOM to stop mutating rather
+than re-sampling one value expression (`Browser.scala:1680-1681`,
+`MutationSettlement.scala:72-89`). `computedStyle` delegates to `computedStyles` rather
+than re-issuing the read (`Browser.scala:1644-1645`).
+
+### DISCOVER: element introspection
+
+| Method | Returns | Settled-absent | Citation |
+|--------|---------|----------------|----------|
+| `elementAt(x, y)` | `Maybe[ElementInfo]` | `Absent`; negative coords abort `BrowserInvalidArgumentException` pre-eval | `Browser.scala:1687-1695` |
+| `element(selector)` | `Maybe[ElementInfo]` | `Absent` (twin `boundingRect`) | `Browser.scala:1700-1707` |
+| `elements(selector = Selector.all)` | `Chunk[ElementInfo]` | `Chunk.empty` via `locateCount` empty-fast-path (twin `textAll`) | `Browser.scala:1713-1727` |
+| `ElementInfo.leaves(elems)` | `Chunk[ElementInfo]` | pure filter, no `Frame`, no effect row | `Browser.scala:3866-3867` |
+
+All three reads go through one injected idempotent in-page helper, `DiscoverJs`, gated
+by `window.__kyoDiscoverInstalled`: it exposes `window.__kyoDiscoverProbe(el)`
+(returning the `ElementInfo` wire shape: tag, id, classes, truncated text, rect-derived
+`Bounds`, and the `visible` / `inViewport` / `topmost` / `interactive` flags) and
+`window.__kyoUniqueSelector(el)` (an id-anchored-else-nth-of-type CSS path)
+(`DiscoverJs.scala:5-80`). `elements` defaults to the net-new `Selector.all` constructor
+(`SelectorNode.Css("*")`, `internal/Selector.scala:129`). `ElementInfo.leaves` is PURE:
+it keeps elements that are not an ancestor of any other in the chunk, decided from the
+unique `selector` path (A is an ancestor of B when B's `selector` starts with A's
+`selector + " > "`), with no `Frame` or effect row (`Browser.scala:3861-3868`).
+
+`elementAt` returns `Absent` not only when no element occupies the point but also when
+the hit element IS `document.documentElement` or `document.body`: a point that lands on
+bare page chrome is treated as "no discoverable element there"
+(`Browser.scala:1691-1693`).
+
+### REPRODUCE: frame recording
+
+`screenshotFrames(maxDurationMs, maxFrames, format, quality)(body)` records a screencast
+WHILE `body` runs and returns `(Chunk[ScreenshotFrame], A)` events-first, the canonical
+`record*` shape (`Browser.scala:3279-3366`). It imposes NO settlement: the caller drives
+the visual change. It drives `Page.startScreencast` / `Page.screencastFrame` (event) /
+`Page.screencastFrameAck` (per frame) / `Page.stopScreencast` through a per-session
+dispatcher (see [Recorders](#recorders-onconsole--recordconsole--screenshotframes)).
+`Webp` has no screencast codec, so it maps to `jpeg` and the call still succeeds
+(`Browser.scala:3292-3295`). Two caps protect against an unbounded recording, checked
+frame-count-first: the frame cap reports `(maxFrames, frame-count)` and the duration cap
+reports `(maxDurationMs, elapsed-ms)`, so the abort's two numbers always share one unit
+(`Browser.scala:3296-3354`).
+
+### Controls
+
+| Method | Visibility | Settlement | Citation |
+|--------|-----------|------------|----------|
+| `setViewport(width, height, deviceScaleFactor)` | PUBLIC | settles after | `Browser.scala:2190-2199` |
+| `resetViewport` | PUBLIC | settles after | `Browser.scala:2206-2213` |
+| `withViewport(width, height, deviceScaleFactor)(body)` | PUBLIC | settles on apply, LIFO restore | `Browser.scala:2226-2249` |
+| `scrollTo(x, y)` | PUBLIC | settles after | `Browser.scala:2462-2465` |
+| `scrollToElement(selector)` | PUBLIC | `Actionability.withRetry`, settles after | `Browser.scala:2473-2486` |
+| `withEmulation(colorScheme, media, reducedMotion)(body)` | PUBLIC | settles on apply, LIFO restore | `Browser.scala:2264-2300` |
+| `withHighlights(annotations)(body)` | PUBLIC | settlement-transparent overlay | `Browser.scala:2343-2390` |
+
+`setViewport` / `resetViewport` are now PUBLIC and settle after via
+`MutationSettlement.afterAction` (`Browser.scala:2190-2213`). `setViewport` gained a
+`deviceScaleFactor: Double` (DPR), threaded into `ViewportParams.deviceScaleFactor` (a
+`Double` wire field) and cached on the tab as `BrowserTab.ViewportOverride(width,
+height, dpr)` so nested `withViewport` calls restore the prior DPR
+(`internal/CdpTypes.scala:269`, `internal/BrowserTab.scala:47`,
+`Browser.scala:2234-2245`). `scrollTo(x, y)` is the new coordinate form; the old
+selector-form scroll is renamed `scrollToElement` and auto-waits via
+`Actionability.withRetry` (channel `BrowserElementException`)
+(`Browser.scala:2462-2486`). `withEmulation` and `withHighlights` are documented under
+[Emulation](#emulation) and the [overlay teardown invariant](#overlay-teardown-per-handle-token-never-a-shared-global-slot)
+above.
+
+### New value types and exception leaf
+
+All nest under `Browser`: `Bounds` (with `right` / `bottom` / `area` derived
+accessors, `Browser.scala:3782-3786`), `ScrollPosition` (`3791`), `ElementInfo` (+ the
+companion `leaves`, `3845-3868`), `Annotation` (`3835-3839`), `ScreenshotFrame`
+(`3797`), `ConsoleMessage` (reshaped: `text` / `location: Maybe[String]` / `offsetMs:
+Long`, `3892-3897`), `ConsoleLevel` (extended 3 -> 5: `Log, Info, Warn, Error, Debug`,
+`3903-3904`), `ColorScheme` (`3804-3805`), `MediaType` (`3818-3819`), `ScreenshotFormat`
+(pre-existing, `3977-3978`). The one new exception is
+`BrowserCaptureLimitExceededException(operation, limit, reached)`, a read-channel leaf
+extending `BrowserReadException` (so an `Abort[BrowserReadException]` row catches a
+capture cap exactly like any other read failure), raised by `screenshotFullPage` /
+`screenshotMarks` / `screenshotFrames` (`BrowserException.scala:344-357`).
+
+### Recorders: onConsole / recordConsole / screenshotFrames
+
+Console recording mirrors the existing download precedent: `onConsole` is the
+subscriber, `recordConsole` is the convenience built on it, exactly as `onDownload` /
+`recordDownloads` (`Browser.scala:3157-3216`, `3047-3112`). `screenshotFrames` is a
+third recorder over the same template (`Browser.scala:3279-3366`). All four share one
+shape:
+
+- A per-session dispatcher on the `CdpClient` keyed by CDP session id
+  (`downloadEventDispatchers`, `consoleEventDispatchers`, `screencastEventDispatchers`),
+  registered BEFORE the body runs (`internal/CdpClient.scala:33-36`).
+- A bounded unscoped `Channel` plus a forked drainer fiber: the dispatcher offers
+  best-effort onto the channel (swallowing `Abort[Closed]` so a full or closed channel
+  drops the event rather than parking the CDP reader), and the drainer fiber applies the
+  user handler `f`, isolating `f`'s effect row `S` from the dispatcher's `Sync`-only
+  type (`Browser.scala:3171-3189`).
+- `(using Frame, Isolate[S, Sync, S])` and a row of `Browser & Async & Abort[BrowserReadException] & S`
+  (the `Async` is for the drainer fiber) (`Browser.scala:3157-3162, 3205-3208`).
+- Teardown (dispatcher restore + channel close) wired with `Scope.run { Scope.ensure(restore).andThen(Scope.ensure(channel.close)) }`
+  so it fires on success, failure, AND interruption; the caller's row does NOT carry
+  `Scope` (`Browser.scala:3185-3191`).
+
+Two recorder-specific invariants are load-bearing. First, structural-abort recovery to
+`Absent`: a `consoleAPICalled` whose CDP `type` is one of the 8 structural variants
+aborts inside `decodeConsoleApiCalled`, and `consoleEventToMessage` recovers that abort
+to a dropped event so it never poisons the reader fiber (`Browser.scala:3224-3232`,
+`2603-2632`). Second, the per-frame ack runs in a DETACHED fiber: the screencast
+dispatcher issues `Page.screencastFrameAck` from a `Fiber.initUnscoped` so the reader
+fiber stays `< Sync` (the ack carries `Async`; Chrome keeps delivering once it sees the
+ack) (`Browser.scala:3307-3314`). The awaited `Page.stopScreencast` on teardown is
+bounded by the send's own request timeout, so it never hangs a silent Chrome; a future
+fire-and-forget refactor of the stop must preserve that bound
+(`Browser.scala:3334-3337`).
+
+The two console paths use DIFFERENT spellings in DIFFERENT decoders, which never
+collide: the drain path (`consoleLogs` -> `decodeConsoleMessage`) reads the JS shim's
+`'warn'` (`Browser.scala:2578-2593`, `internal/BrowserTab.scala:193-194`), the CDP-event
+path (`recordConsole` -> `decodeConsoleApiCalled`) reads CDP's `'warning'`
+(`Browser.scala:2603-2632`). Both surface `offsetMs` relative to a baseline: the drain
+path uses the per-session `window.__kyoConsoleT0 = Date.now()` set at console-capture
+install (`internal/BrowserTab.scala:179`, `Browser.scala:2555-2557`); the recorder path
+uses the body's `t0` from `Clock.now` (`Browser.scala:3166-3167`).
+
+### Emulation
+
+`withEmulation(colorScheme, media, reducedMotion)(body)` emulates media features for the
+body's duration through a single `Emulation.setEmulatedMedia` send, then restores the
+prior state (`Browser.scala:2264-2300`). Two behaviors matter:
+
+- It emulates ONLY the requested features. `emulatedMediaParams` builds the feature list
+  from what was passed: `prefers-color-scheme` only when `colorScheme` is `Present`,
+  `prefers-reduced-motion: reduce` only when `reducedMotion = true`, omitted otherwise;
+  `media` set only when `Present` (`Browser.scala:2309-2319`). So a color-scheme-only
+  call leaves the page's real `prefers-reduced-motion` untouched, and `reducedMotion =
+  false` means "do not emulate reduced motion", not "force no-preference".
+  `ColorScheme.NoPreference` maps to the empty-string clear, not a literal value
+  (`Browser.scala:3810-3813`).
+- It restores to the HOST values on exit. When a prior override was active it re-applies
+  that exact prior state via the same `emulatedMediaParams` composer (apply and restore
+  stay in lockstep); when none was active it sends `clearEmulatedMediaParams`
+  (`SetEmulatedMediaParams(Present(""), Present(Seq.empty))`), an empty-features clear
+  that drops every `prefers-*` override back to the environment value rather than
+  enumerating each feature (`Browser.scala:2283-2295, 2326-2327`).
+
+Nesting is currently REPLACE-semantics: an inner `withEmulation` replaces the whole
+emulated-media state (it does not inherit the outer call's features inside the inner
+body), and the outer prior is restored on inner exit. Whether nesting should COMPOSE or
+REPLACE is an open design question, not yet resolved; do not assume composition.
+
+## Conventions
+
+### Effect row and signatures
+
+Every effectful `Browser` method declares an explicit return type of the form
+`A < (Browser & Abort[BrowserReadException])` and takes `Frame` as the trailing
+`using` parameter (`Browser.scala:1372, 1382`). `BrowserReadException` is the
+catch-all error row a new method aborts with; the hierarchy is built so that
+`BrowserMutationException` and `BrowserAssertionException` extend it, so an
+`Abort[BrowserReadException]` channel catches every browser failure except
+lifecycle/setup. New element/assertion exceptions must keep extending up to
+`BrowserReadException` (`BrowserException.scala:34, 41, 79`). The new capture-cap
+leaf `BrowserCaptureLimitExceededException` follows the rule: it extends
+`BrowserReadException` directly (`BrowserException.scala:355-357`).
+
+### Exception hierarchy
+
+The hierarchy layers two axes (`BrowserException.scala:34-96`):
+
+- An operation-row spine: `BrowserReadException` <- `BrowserMutationException` <-
+  `BrowserAssertionException`. This controls which `Abort[...]` rows catch what.
+- Orthogonal topical marker traits: `BrowserConnectionException`,
+  `BrowserElementException`, `BrowserNavigationException`, `BrowserScriptException`,
+  `BrowserIFrameException`, `BrowserSetupException`. A concrete case mixes one or
+  more in to declare its topic.
+
+A new exception picks one row position and one or more topical markers. Every
+concrete exception is a `final case class ... (using Frame) extends
+BrowserException(<rendered message>) with <markers> derives CanEqual`: the message
+is rendered in the `extends` clause from the case fields, and `derives CanEqual` is
+mandatory so the typed error can be pattern-matched in `Abort.recover`
+(`BrowserException.scala:174-177, 355-357`). An exception with more than one
+construction path gets a companion `object` of named smart constructors rather than
+overloaded `apply`s with bare strings; each constructor names the failure kind and
+formats the message (`BrowserException.scala:146-153, 373-389`). A single-construction
+leaf like `BrowserCaptureLimitExceededException` needs no companion
+(`BrowserException.scala:355-357`).
+
+`BrowserAssertionTimedOutException` is constructed via the `(expected, actual)`
+two-arg overload that auto-derives `check` from the enclosing method name through
+the implicit `Frame.calleeName`, so `assertVisible` failures already read
+`"assertVisible"` without the call site passing the name. New `assert*` / `waitFor*`
+methods rely on this rather than repeating the method name as a string literal
+(`BrowserException.scala:377-378`, `Browser.scala:950-953`).
+
+A method that only validates an argument before any CDP call aborts
+`BrowserInvalidArgumentException("<methodName>", <message>)` with the public method
+name as the first field, distinguishing "called the API wrong" from a runtime
+failure. `setFiles` and `setDownloadBehavior` gate absolute-path arguments, and the
+new captures/discovery gate their numeric arguments the same way: `screenshotRegion`
+rejects non-positive size, `elementAt` rejects negative coordinates, both BEFORE any
+CDP call (`Browser.scala:759, 3010, 1942, 1688`). When a public read decodes wire
+JSON, a malformed or unexpected payload is surfaced as a typed `Abort`
+(`BrowserProtocolErrorException.decodeFailure` / `BrowserAssertionTimedOutException`)
+rather than thrown, with the method name passed as the diagnostic tag; `consoleLogs`
+and the settling reads (`boundingRect`, `elements`, ...) all do this
+(`Browser.scala:2570, 1617, 1723`).
+
+### The return-type discriminator
+
+The return type of a read encodes what "nothing matched" means. Pick the row by
+the question the method asks, not by convenience.
+
+| Method kind | Return type | Selector miss behaviour | Examples / citation |
+|-------------|-------------|-------------------------|----------|
+| Geometry / discovery read (absence is legitimate) | `Maybe[...]` | `Absent` / `Maybe.empty`, no abort | `boundingRect`, `element`, `elementAt`, `role`, `accessibleName` (`Browser.scala:1590-1592, 1700-1707, 1782, 1789`) |
+| Content read requiring the element to exist | bare value (`String`, `Int`, `Map`) | abort `BrowserElementNotFoundException` via `selectorNodeDescription(Selector.toNode(selector))` | `text`, `attribute`, `value`, `computedStyles`, `inViewport` (`Browser.scala:1372, 1382, 1461, 1624-1639, 1650-1662`) |
+| Existence question ("is X here?") | `Boolean` | `false`, the negative answer IS the answer | `exists` (`Browser.scala:1524-1525`) |
+| Property predicate ("is X visible/enabled?") | `Boolean` | abort `BrowserElementNotFoundException` (property is undefined without an element) | `isVisible`, `isEnabled`, `isChecked`, `inViewport` (`Browser.scala:1488, 1497, 1506, 1650-1662`) |
+| Count read | `Int` | `0`, not an abort | `count` (retries CDP transients), `countNow` (point-in-time) (`Browser.scala:1431, 1445`) |
+| Bulk read (`*All` / discovery collection) | `Chunk[...]` | `Chunk.empty` via a single round-trip empty-fast-path before the retry loop | `textAll`, `attributeAll`, `elements` (`Browser.scala:1818, 1847, 1713-1727`) |
+
+The discriminator twins are the high-value pairs: `exists` returns `false` on miss,
+`isVisible` aborts on miss (`Browser.scala:1524-1525, 1488`); `count` retries
+`BrowserMutationException` CDP transients, `countNow` is the explicit no-retry
+point-in-time variant (`Browser.scala:1431, 1445`). The `<read>` vs `<read>Now` naming
+distinguishes "retry CDP transients" from "point-in-time, surface transients
+immediately." The visual-QA reads extend the SAME twin rule through `SettleRead.settle`:
+a settling read maps a stable-absent element to its twin return (settling `Maybe`
+-> `Absent`; must-exist -> typed abort; collection -> empty). `boundingRect` is the
+settling `Maybe` (twin of the removed `boundingBox`), `inViewport` is the property
+predicate that aborts (twin `isVisible`), and `elements` is the settling collection that
+empties (twin `textAll`) (`Browser.scala:1590-1592, 1650-1662, 1713-1727`,
+`SettleRead.scala:5-15`).
+
+Element presence is modeled in the return type via `Maybe[NodeRef]` /
+`Chunk[NodeRef]`, never a string sentinel; `Resolver` is the single resolution
+pipeline (`Resolver.scala:7-11`). When a single read could mean two things, the API
+splits into two intent-revealing methods rather than one ambiguous one, and each
+scaladoc points at its sibling: `assertNoVisibleText` / `hasNoVisibleText` read
+`textContent`, `assertValueEmpty` / `hasEmptyValue` read the `value` property, so a
+single `isEmpty`-style method's dual-semantics footgun is avoided
+(`Browser.scala:1539-1549, 1562-1572`).
+
+### Resolution safety
+
+Resolution is mutation-safe via the `objectId + requestNode` pipeline: `requestNode`
+is keyed by a stable JS objectId handle, NOT by document tree state, so DOM
+mutations between `Runtime.evaluate` and `requestNode` cannot invalidate the handle
+and concurrent clicks on the same tab do not race. Do not "simplify" this to
+`DOM.describeNode(objectId)` directly: that returns a placeholder backendNodeId that
+collides across distinct elements in a fresh tab, where every element comes back as
+backendNodeId 3 (`Resolver.scala:12-26`). A CDP "Could not find node with given id"
+(stale node) is a transient resolution miss, NOT a protocol fault: `resolveOne`
+drops it to `Absent` and `resolveAll` re-raises it as a retryable
+`BrowserElementNotFoundException` so the enclosing loop re-resolves a CLEAN
+snapshot. Dropping just the stale node in `resolveAll` would return a partial
+stable-looking set and mask a flickering page (`Resolver.scala:74, 158-164, 189-191`).
+
+### Scoped wrappers and event APIs
+
+A `with*` method is a scoped wrapper returning `A < (Browser & S)` (or `&
+Abort[BrowserReadException] & S`) that takes the body as a trailing by-name `A <
+(Browser & S)` parameter and restores the prior state on body exit (success,
+failure, OR interruption). Pure-config wrappers use `Local.let` (`withConfig`,
+`Browser.scala:203, 214`); tab/resource wrappers use `Scope.run` +
+`Scope.acquireRelease` / `Scope.ensure` (`withViewport`, `Browser.scala:2226-2249`).
+A `with*` wrapper over per-tab sticky CDP state caches the prior value on the
+`BrowserTab` (`tab.viewportOverride`, `tab.emulationOverride`, `tab.downloadPolicy`),
+and on exit re-applies the prior `Present(...)` override or clears/resets to the
+launch-time default on `Absent`, so nested `with*` calls compose
+(`Browser.scala:2231-2245`, `internal/BrowserTab.scala:28-30`). `withEmulation`
+follows the identical cache-and-restore shape; see [Emulation](#emulation) for its
+restore-to-host behavior. The scoped overlay wrappers (`withHighlights`, the freeze
+style, `screenshotMarks`) are a distinct case: they hold NO `BrowserTab` cache and
+instead tear down by per-handle `data-kyo-token` (see the
+[overlay teardown invariant](#overlay-teardown-per-handle-token-never-a-shared-global-slot)).
+
+An event-observation API ships as a pair: a callback `on*[A, S](f: Event => Unit <
+(Browser & S))(action: ...)(using Frame, Isolate[S, Sync, S])` that registers a
+per-session handler before `action` runs and tears it down via `Scope.run` /
+`Scope.ensure`, plus a `record*[A, S](body: ...)` convenience implemented on top
+that captures events into an `AtomicRef[Chunk[Event]]` and returns `(Chunk[Event],
+A)`. The two pairs are `onDownload` / `recordDownloads` and `onConsole` /
+`recordConsole`; new event surfaces add both (`Browser.scala:3047-3112, 3157-3216`).
+Per-session handler/recorder registries on the `CdpClient` are updated through
+`getAndUpdate` capturing the previous map, and the restore closure re-installs the
+prior entry (`Present`) or removes the key (`Absent`), giving LIFO nesting; the
+restore is wired with `Scope.run(Scope.ensure(restore).andThen(...))` so it fires on
+success, failure, AND interruption (`Browser.scala:3070-3077`). See
+[Recorders](#recorders-onconsole--recordconsole--screenshotframes) for the full
+dispatcher / channel / drainer shape `screenshotFrames` shares.
+
+A `waitFor*` read is the read-flavour twin of an `assert*` method: it returns the
+matched value (`String` / `Int`) instead of `Unit`, takes a `predicate` plus an
+optional `schedule`, and provides a convenience overload that uses equality against
+`expected` (delegating `_ == expected`). New retrying reads supply both forms
+(`Browser.scala:1139-1147, 1167-1170`). An assertion method is named `assert*`,
+returns `Unit`, delegates to a `BrowserAssertion.*` helper that retries the
+predicate against the active retry schedule, and raises
+`BrowserAssertionTimedOutException` on exhaustion; every `assert*` accepts an
+optional `schedule: Maybe[Schedule] = Absent` per-call override
+(`Browser.scala:950-953, 970-973`). Note the distinction from the visual-QA settling
+reads: `assert*` / `waitFor*` REQUIRE the predicate to hold (a non-match is a typed
+timeout), whereas a `SettleRead`-backed read accepts whatever value settles and maps
+absence to its twin return; `waitForStable` is the strict whole-page quiescence wait,
+not a settling-value read.
+
+### Internal-only API
+
+`private[kyo]` is the global convention (root `CONTRIBUTING.md`, "Visibility
+Tiers"). The browser-specific case worth naming: some raw CDP setters are hidden
+behind scoped wrappers as the public-safety guarantee. `allowDownloads` /
+`denyDownloads` / `setDownloadBehavior` are `private[kyo]`, exposed only to tests and
+to their public scoped wrapper `withDownloads` (`Browser.scala:2952, 2960, 3004`).
+
+`setViewport` / `resetViewport` are NOT in this category: they are PUBLIC. The
+visual-QA surface deliberately exposes them (they settle after via
+`MutationSettlement.afterAction`, so the sticky state they leave is observably
+quiesced) (`Browser.scala:2190, 2206`). `withViewport` remains the scoped form for
+callers who want the override bounded to a block, but the bare setters are a
+supported public surface, not a test-only seam.
+
+## Extension recipes
+
+### Add a new CDP command
+
+Following the screenshot/viewport family (`CdpBackend.scala:73-76, 97-100`,
+`CdpTypes.scala:327-334`):
+
+1. In `CdpTypes.scala`, add a `final private[kyo] case class ...Params(...) derives
+   Schema` for the request and (if the reply carries data) a `...Result(...) derives
+   Schema`, placed under the comment block for the owning CDP domain. The visual-QA
+   surface adds several here: `SetEmulatedMediaParams`, `StartScreencastParams`,
+   `ScreencastFrameAckParams`, the screencast/console wires, plus two fields on
+   `ScreenshotParams` (`captureBeyondViewport`, `fromSurface`)
+   (`CdpTypes.scala:272-316, 327-334`).
+2. In `CdpBackend.scala`, add a `private[kyo] def` under the matching `// ---
+   <Domain> domain ---` banner. For a command that returns data, decode via
+   `.map(decodeOrFail[Result](_, "Domain.method"))` (`CdpBackend.scala:73-76`); for a
+   fire-and-forget command, end in `.unit` (the new `setEmulatedMedia` /
+   `startScreencast` / `screencastFrameAck` all do, `CdpBackend.scala:110, 124, 134`).
+3. The wrapper's effect row is always `... < (Async & Abort[BrowserReadException])`
+   and its first param is `sender: CdpSender` (the trait, never the concrete
+   `CdpClient`), with `(using Frame)` (`CdpBackend.scala:73-75`).
+4. The `method` string passed to both `send` and `decodeOrFail` is the literal CDP
+   method name and must match exactly; it is what `decodeOrFail` reports in
+   `BrowserProtocolErrorException` on a CDP error reply (`CdpBackend.scala:25-40`).
+
+### Add a new public read/action method
+
+Following `history` / `cookies` / `reload` (`Browser.scala:346-354, 3419-3424`):
+
+1. Add the `CdpBackend` wrapper first (see the CDP-command recipe); the public
+   method calls it.
+2. Write the `Browser` method with return type `T < (Browser &
+   Abort[BrowserReadException])` (a read returns a typed value / `Chunk`; an action
+   returns `Unit`). Resolve the active tab with `Env.use[BrowserTab] { tab => ... }`
+   and issue the call against `tab.session` (the session-scoped client), not
+   `tab.client` (`Browser.scala:3419-3424`).
+3. Map the CDP wire result into a public value type at the boundary; do not leak
+   wire case classes outward (`CookieWire.toCookie` at `Browser.scala:3422`;
+   `CdpBase64Decode.decodeScreenshotImage` for `screenshot` at `Browser.scala:1925`).
+4. An action method returns `Unit` and ends at the `CdpBackend` call
+   (`Browser.scala:2462-2465`).
+5. A read that does NOT go through `CdpBackend` (page-side state) goes through
+   `BrowserEval.evalJs(...)` and decodes the JSON itself, surfacing decode failures
+   via `BrowserProtocolErrorException.decodeFailure` (`Browser.scala:2555-2571`). A
+   settling page-side read instead routes through `SettleRead.settle` and decodes the
+   stable string, mapping settled-absent to the twin return (`Browser.scala:1590-1619`,
+   `SettleRead.scala:24-40`).
+6. A filtering/convenience overload delegates to the canonical method rather than
+   re-issuing the CDP call (`consoleLogs(level)` delegates to `consoleLogs`,
+   `Browser.scala:2575-2576`; `computedStyle` delegates to `computedStyles`,
+   `Browser.scala:1644-1645`).
+
+### Add a new scoped `with*` wrapper
+
+For a wrapper that toggles per-tab CDP state for the duration of a body and restores
+it on exit, following `withViewport` (`Browser.scala:2226-2249`):
+
+1. If the wrapper needs to remember prior state, add an `AtomicRef` field to
+   `BrowserTab` and initialise it in `mkBrowserTab`. The existing override caches are
+   `viewportOverride: AtomicRef[Maybe[ViewportOverride]]` and `emulationOverride:
+   AtomicRef[Maybe[EmulatedMediaState]]` (`internal/BrowserTab.scala:28-29`),
+   initialised at `internal/BrowserTab.scala:89-90`.
+2. Signature shape: `def with...[A, S](args...)(body: A < (Browser & S))(using
+   Frame): A < (Browser & Abort[BrowserReadException] & S)` (`Browser.scala:2226-2228`).
+3. Body: `Env.use[BrowserTab] { tab => Scope.run { tab.<ref>.get.map { prior =>
+   Scope.acquireRelease(<set new state>) { _ => <restore prior> }.andThen(body) } }
+   }`. The release branch matches on `prior`: a previously-active value is re-applied
+   and `Absent` clears the override, giving correct LIFO nesting
+   (`Browser.scala:2231-2245`).
+4. Use `Scope.acquireRelease` (or `Scope.ensure`) inside an inner `Scope.run`, NOT
+   `Sync.ensure`: `Sync.ensure` does not fire on Abort short-circuits and leaks the
+   state; the inner `Scope.run` bounds the unwind to this call so nesting keeps LIFO
+   restore (`Browser.scala:2230-2248`).
+5. Variant: when restoring a per-session registry entry (not a per-tab `AtomicRef`),
+   snapshot the previous map with `getAndUpdate`, then in the restore re-insert
+   `Present(prev)` or `remove` the key when it was `Absent` (`Browser.scala:3070-3075`).
+6. Variant: a settlement-transparent overlay wrapper (`withHighlights`) caches NO
+   tab state. It injects a `data-kyo-internal` node carrying a unique `data-kyo-token`,
+   returns the token from the inject eval, and removes by token in the release. Never a
+   shared global slot (`Browser.scala:2343-2390`; see the
+   [overlay teardown invariant](#overlay-teardown-per-handle-token-never-a-shared-global-slot)).
+
+### Add a new CDP event with per-session fan-out
+
+For a CDP event Chrome pushes with no request id, routed to per-tab subscribers
+without stalling the reader, following the `Page.downloadWillBegin` /
+`downloadProgress` path and its two siblings (`screencastEventDispatchers` for
+`Page.screencastFrame`, `consoleEventDispatchers` for `Runtime.consoleAPICalled` /
+`exceptionThrown`) (`CdpClient.scala:33-36, 391-397, 544-552`):
+
+1. Add a per-session dispatcher registry field to `CdpClient`'s constructor and
+   initialise it in `CdpClient.init`. The three event registries are
+   `downloadEventDispatchers` / `screencastEventDispatchers` / `consoleEventDispatchers`,
+   each `AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]]`
+   (`CdpClient.scala:34-36`), initialised in `init` (`CdpClient.scala:301, 305`) and
+   threaded into the `decodeCdpMessage` signature (`CdpClient.scala:477-479`) and both
+   `new CdpClient(...)` constructions (`init` at `CdpClient.scala:365`, `withSession`
+   at `CdpClient.scala:121`).
+2. Add the event's method name(s) to `eventWhitelist`; un-whitelisted events are
+   dropped so the bounded event channel cannot fill when nobody is subscribed
+   (`CdpClient.scala:391-397`). Only five CDP event methods are whitelisted
+   (`Page.downloadWillBegin`, `Page.downloadProgress`, `Page.screencastFrame`,
+   `Runtime.consoleAPICalled`, `Runtime.exceptionThrown`); everything else is dropped
+   so Page/Network/Runtime lifecycle chatter cannot fill the bounded event channel and
+   stall the reader (`CdpClient.scala:391-397`).
+3. In `decodeCdpMessage`'s no-id whitelisted branch, route via `dispatchOrPush`: when a
+   per-session dispatcher is registered it consumes the event (`Exchange.Message.Skip`),
+   else the event is pushed to `exchange.events` (`Exchange.Message.Push`). The routing
+   is mutually exclusive (dispatch OR push, never both), and each domain dispatches to
+   its own registry map (`CdpClient.scala:409-421, 544-552`).
+4. Frame-context-style events that should NEVER reach the events channel (consumed
+   only inline) use a separate registry (`frameEventDispatchers`) and an
+   UNCONDITIONAL dispatch arm placed before the whitelist check, always ending in
+   `Exchange.Message.Skip` (`CdpClient.scala:521-534`).
+5. Add a typed wire case class for the event's `params` in the relevant file (for
+   example `DownloadWillBeginWire` / `DownloadProgressWire` in `PageDownload.scala`
+   at `PageDownload.scala:73-92`, or the screencast/console wires in
+   `CdpTypes.scala:279-316`) and a private `parse...Event` decoder in `Browser` that
+   decodes `CdpEventParams[Wire]` from `ev.paramsJson`, returning `Maybe[PublicEvent]`
+   (`Absent` on the wrong method or a decode failure, never an abort)
+   (`Browser.scala:3120-3135, 3373-3405`).
+6. Add the public subscriber method (`onDownload` / `onConsole`) that registers a
+   `CdpEvent.Generic => Unit < Sync` handler into the registry BEFORE the body runs,
+   drains events through a bounded unscoped `Channel` plus a forked drainer fiber (to
+   isolate the user handler's effect row `S` from the dispatcher's `Sync`-only type),
+   and unregisters via `Scope.ensure` inside an inner `Scope.run`. Requires `(using
+   Frame, Isolate[S, Sync, S])` (`Browser.scala:3047-3090, 3157-3196`).
+7. The dispatcher handler must never block the CDP reader fiber: it offers to the
+   channel best-effort and swallows `Abort[Closed]` (a full or closed channel drops
+   the event rather than parking the reader) (`Browser.scala:3059-3065, 3171-3178`).
+   When the handler itself needs to issue a CDP command (the screencast per-frame ack),
+   it forks a DETACHED fiber so the reader fiber stays `< Sync`
+   (`Browser.scala:3310-3314`).
+
+### Add a new recorder
+
+A `record*` / `.recorded` passive collector snapshots events into an in-memory
+`Chunk` and returns `(events, result)`, following `recordConsole` / `recordDownloads`
+and `withDialogs.recorded` (`Browser.scala:3205-3216, 3101-3112, 2722-2745`):
+
+1. Preferred form: implement the recorder in terms of the existing subscriber
+   (`onConsole` / `onDownload`) with a capture handler that appends each event to an
+   internal `AtomicRef[Chunk]`, then return `(collected.get, result)`. No new registry
+   or channel bookkeeping (`Browser.scala:3205-3216, 3101-3112`).
+2. Lower-level form (when the event is delivered by the CDP reader fiber rather than
+   a subscriber method): register an `AtomicRef[Chunk[Event]]` into a per-session
+   recorder registry on `CdpClient` (for example `dialogRecorders` at
+   `CdpClient.scala:480`), restore the previous registry entry via `Scope.ensure`, and
+   return `(recorder.get, result)`. The reader fiber appends in arrival order
+   (`Browser.scala:2722-2745`).
+3. For the lower-level form, add the append site in `CdpClient` where the reader
+   decodes the event (for example `recordDialogEvent` decodes `CdpEventParams[Wire]`
+   and appends a typed `Browser.<Event>` to the per-session recorder, no-op when none
+   is registered). The recorder is a passive observer and must NOT influence any
+   auto-handler decision (`CdpClient.scala:571-601, 517`).
+4. A recorder's signature requires `(using Frame, Isolate[S, Sync, S])` and returns
+   `(Chunk[Event], A) < (Browser & Async & Abort[BrowserReadException] & S)`; arrival
+   order is preserved because the single per-session fiber/reader serialises appends
+   (`Browser.scala:3205-3216, 3279-3287`). `screenshotFrames` is the screencast variant
+   of this shape: it adds a poison cell so a frame/duration cap aborts after `body`
+   returns rather than mid-stream (`Browser.scala:3296-3354`).
+
+## Testing
+
+### Base classes
+
+A suite that needs a working `Browser` effect extends `BrowserTest`, the
+integration-test base class (`shared/src/test/scala/kyo/BrowserTest.scala:74`).
+`BrowserTest` itself extends the module `Test` base, so every browser suite
+transitively gets the `Test` machinery (chrome-platform pre-flight, decode helpers,
+`orFail`, `timed`) (`shared/src/test/scala/kyo/BrowserTest.scala:74`). A suite that
+does NOT boot Chrome (pure parsing, wire/decoder, schema, percent-encode, snapshot,
+downloader) extends `Test` / `kyo.Test` directly, never `BrowserTest`: examples are
+`StabilitySamplerTest`, `CdpClientDecoderTest`, `BrowserExceptionHierarchyTest`
+(`shared/src/test/scala/kyo/internal/StabilitySamplerTest.scala:12`,
+`shared/src/test/scala/kyo/BrowserExceptionHierarchyTest.scala:3`). Runnable demos
+live in `shared/src/test/scala/demo` and extend `KyoApp` (not `Test`); they are
+example programs, not assertions, so they never go through the `Test` / `run`
+harness (`shared/src/test/scala/demo/QuickstartDemo.scala:13`).
+
+### Fixtures
+
+| Fixture | What it boots | When to use |
+|---------|---------------|-------------|
+| `withBrowser(body)` | shared Chrome, fresh tab via `Browser.run(url)` | universal SUT entry (`BrowserTest.scala:112-117`) |
+| `withBrowserOnLocalhost(body)` | tab navigated to `http://localhost:$port/json/version` | cookie/storage tests that need a real origin (`data:` URLs carry no cookies) (`BrowserTest.scala:119-129`) |
+| `withBrowserOnLocalhostIframe(outerHtml, innerHtml)(body)` | localhost server serving `/parent` and `/child`, tab on parent | real same-origin iframe lifecycle (srcdoc does not fire the same `Page.frameAttached` events) (`BrowserTest.scala:247-249`) |
+| `withLocalhostServer(handlers*)(f)` | localhost HTTP server on an OS-assigned port at `127.0.0.1` (NOT Chrome) | ad-hoc page fixtures, released when the surrounding `Scope` exits (`BrowserTest.scala:136-141`) |
+| `page(html)` / `srcdocPage(outer, srcdoc)` / `onPage(html)(body)` | `data:text/html;...` URLs, no I/O | one-shot scenarios that do not need a real origin (`BrowserTest.scala:226-232`) |
+
+`onPage` is sugar for `Browser.goto(page(html)).andThen(body)` with a by-name `body`
+so timing measurements inside it run after navigation (`BrowserTest.scala:226-232`).
+`withBrowser` returns an effect carrying `Async & Scope & Abort[BrowserReadException
+| BrowserSetupException]` (`BrowserTest.scala:112-117`).
+
+### Shared Chrome and the cold-boot reality
+
+The SUT's Chrome is shared across all callers in a run via `SharedChrome.init`,
+which returns the WebSocket debug URL and launches Chrome only on first call; only
+the URL is shared, each caller makes its own `CdpClient` / `Browser.run(url)`
+(`shared/src/main/scala/kyo/internal/SharedChrome.scala:37-38`). Chrome is held open
+by a detached fiber that parks on `Async.never`; when the kyo scheduler shuts down
+the fiber is interrupted and finalizers destroy Chrome and its temp user-data dir. A
+test never tears Chrome down itself (`SharedChrome.scala:104`).
+
+The first integration call pays a ~2.8s cold-Chrome boot. `BrowserTest` absorbs it
+with a one-time `warmupGate` (CAS-once `AtomicBoolean`, fires `Browser.eval("1+1")`
+exactly once per class instance) so later per-call schedule budgets in
+`BrowserPerCallScheduleTest` are not blown by the boot cost. Do not write per-call
+timing assertions that include the first call's boot (`BrowserTest.scala:76-91`).
+
+### Timeouts and forking
+
+Default per-test timeout is 60s (from `BaseKyoKernelTest.timeout`), with
+`Duration.Infinity` under debug. A Chrome-heavy suite raises it explicitly:
+`BrowserRunSharedJvmTest` sets `override def timeout = 3.minutes`,
+`CdpClientLifecycleJvmTest` sets `2.minutes`. Override `timeout` when a suite does
+multiple sequential Chrome round-trips under full-suite load
+(`kyo-kernel/shared/src/main/scala/kyo/internal/BaseKyoKernelTest.scala:61`,
+`jvm/src/test/scala/kyo/BrowserRunSharedJvmTest.scala:19`).
+
+kyo-browser JVM tests use per-suite JVM forking: each suite gets its own JVM and its
+own `SharedChrome`, via a `Test / testGrouping` that wraps every defined test in its
+own `Tests.SubProcess`. The reason is cross-suite Chrome-state degradation over 700+
+tests (`build.sbt:1145-1155`). `Test / parallelExecution := false` and `Test /
+testForkedParallel := false` on JVM serialize the per-suite forks because running
+them concurrently starves the Chrome processes and a dead Chrome cascades; new
+browser suites must not assume any cross-suite parallelism (`build.sbt:1149-1154`).
+Native tests set only `Test / parallelExecution := false` (no per-suite forking
+grouping): suites are serialized so each owns the shared Chrome WebSocket channel in
+turn. JS sets the `CommonJSModule` linker kind and no Chrome-serialization knob
+(`build.sbt:1177-1186`).
+
+### Platform gates
+
+The pre-flight platform gate lives in `Test.run`: it computes
+`chromeUnsupportedReason` from `ChromeDownloader.resolvePlatform` and, on an
+unsupported (OS, arch) tuple (linux-arm64, win-arm64), calls ScalaTest
+`cancel(reason)` instead of letting every Chrome test fail red. A test author does
+nothing extra (`shared/src/test/scala/kyo/Test.scala:69-72`).
+`BrowserTest.cancelOnUnsupportedPlatform` is the second cancel seam: it recovers a
+`BrowserSetupException` whose message contains the marker `"cannot auto-download
+chrome-headless-shell"` and routes it to `cancel(...)`; the `withBrowser*` fixtures
+wrap their bodies in it so unsupported platforms cancel with install instructions
+rather than fail (`BrowserTest.scala:103-110`).
+
+### Platform-split test suites
+
+A platform-specific test suite lives in `jvm/src/test`, `js/src/test`, or
+`native/src/test` ONLY when the behavior is genuinely platform-bound, and the
+scaladoc states the reason; a JVM-only suite documents why it cannot move to
+`shared/` (`jvm/src/test/scala/kyo/internal/BrowserLauncherJvmTest.scala:9-12`).
+JVM-only suites that need a real Chrome subprocess or kyo-http `HttpServer` carry the
+`JvmTest` name suffix and live under `jvm/src/test`: `BrowserRunSharedJvmTest`
+(Chrome boot is JVM/Native-only), `CdpClientLifecycleJvmTest` (fault-injecting CDP
+fixture built on `HttpServer`) (`jvm/src/test/scala/kyo/BrowserRunSharedJvmTest.scala:8-12`,
+`jvm/src/test/scala/kyo/internal/CdpClientLifecycleJvmTest.scala:144-148`). The same
+logical contract is split across all three platform test trees when its
+implementation differs per platform: `BrowserLauncherPlatformTest` exists in `jvm/`,
+`js/`, and `native/`, each pinning that platform's distinct `BrowserLauncherPlatform`
+(JVM installs a real shutdown hook; JS and Native are no-ops)
+(`native/src/test/scala/kyo/internal/BrowserLauncherPlatformTest.scala:7-10`).
+
+### Decode helpers
+
+CDP/wire tests use the `Test` decode helpers rather than re-deriving JSON:
+`decode[A]` for a bare payload, `decodeCdpResult[A]` for a full `{id, result,
+error}` envelope (the dispatcher carrier is the entire wire frame)
+(`shared/src/test/scala/kyo/Test.scala:84-93`). Outer effect results are folded with
+the `orFail(label)` extension, which fails the test on `Failure` / `Panic` and
+prefixes panics with `PANIC: ` so a programming bug is visually distinct from an
+expected typed-failure path. JVM fixture suites wrap the whole body in
+`Abort.run[...](...).orFail("Outer")` (`shared/src/test/scala/kyo/Test.scala:107-114`,
+`jvm/src/test/scala/kyo/internal/CdpClientLifecycleJvmTest.scala:170`).
+
+### Deterministic timing: gate on barriers, never sleeps
+
+This is the testing counterpart of the headline invariant. Every wait in a test is
+gated on an observable signal, not a `Thread.sleep` or `Async.sleep`:
+
+- A `Promise` is the explicit completion latch: complete it only on the path that
+  proves the awaited operation finished, then `Promise.get` to synchronise, and
+  assert on the resulting state. `NavigationWatcher`'s `waitForNext` test completes
+  `donePromise` only because `waitForNext` returned, gets it, then asserts the URL
+  (`shared/src/test/scala/kyo/internal/NavigationWatcherTest.scala:210-224`).
+- To wait for a JS-side condition, install the state and poll for a truthy JS string
+  with `Browser.waitFor("<expr returning '' or non-empty>")` instead of sleeping; the
+  network-tracker test waits for `__kyoResponseTrackingInstalled` to be defined
+  (`shared/src/test/scala/kyo/BrowserNetworkTest.scala:99`).
+- Settlement/navigation outcomes are gated on a real barrier: the slow-image
+  `Settle.Load` test asserts `document.readyState === 'complete'` AT RETURN (a
+  behavioural contract) rather than on elapsed time, and engineers a server-side
+  500ms image delay so `interactive` precedes `complete` by an observable margin
+  (`NavigationWatcherTest.scala:251-256, 441-444`).
+- Negative/timeout behaviour is asserted on the typed `Abort` SHAPE, not on elapsed
+  time: the mutation-quiescence timeout test drives an endless `setInterval` churn
+  and asserts the result is `Result.Failure(_: BrowserAssertionTimedOutException)`
+  (`shared/src/test/scala/kyo/internal/MutationSettlementTest.scala:185-189`).
+- Network completion is observed through a real network-idle barrier plus a DOM
+  side-effect: `waitForNetworkIdle` returns only after a scheduled `fetch` resolves,
+  and the test asserts `#status` flipped to `"done"`
+  (`shared/src/test/scala/kyo/BrowserNetworkTest.scala:38-45`).
+- When a test must wait for an internal fiber/atomic to reach a state, it uses a
+  bounded `Loop` + `Async.delay` poll on an observable signal (`relay.done`,
+  `inFlight.get`, fiber-done) with an attempt cap, NOT a fixed sleep. The relay-crash
+  test polls `client.relay.done` at 50ms intervals up to 20 attempts (<=1s)
+  (`jvm/src/test/scala/kyo/internal/CdpClientLifecycleJvmTest.scala:189-194`).
+- For elapsed-duration checks that ARE legitimate (a behavioural upper bound, e.g.
+  "close falls back to closeNow well before the server's 10s delay"), tests use the
+  `Test.timed` helper (monotonic clock) and assert a generous margin, not an exact
+  value (`shared/src/test/scala/kyo/Test.scala:96-99`,
+  `jvm/src/test/scala/kyo/internal/CdpClientLifecycleJvmTest.scala:235-238`).
+
+### Retry schedules in tests
+
+Flaky-but-correct assertions are bounded by a retry SCHEDULE installed via
+`Browser.withConfig(_.retrySchedule(...))`, exposed as the `tight` (50ms x 3, ~150ms
+cap) and `slow` (200ms x 15, ~3s cap) helpers: use `tight` for assertions that
+should settle in an animation frame or for fast negative tests, `slow` for scenarios
+gated on Chrome/page warmup. The cap is a ceiling, not a sleep: the assertion fires
+as soon as it holds (`BrowserTest.scala:186-192`). Reaching for a longer retry
+schedule usually masks a missing settle barrier rather than fixing a real flake; the
+fix is asserting on the right gate, not widening the budget (`BrowserTest.scala:177-179`).
+
+## Adding a new method: decision checklist
+
+Run through this before writing a new `Browser` method.
+
+1. **Pick the operation kind.** Read, action (interaction), navigation, assertion,
+   or scoped wrapper. The kind determines the settlement mechanism (below) and the
+   return type.
+2. **Pick the return type from the discriminator table.** `Maybe[...]` when absence
+   is legitimate; bare value with `BrowserElementNotFoundException` when the element
+   must exist; `Boolean` returning `false` for `exists`-style questions, aborting for
+   `is*` property predicates; `Int` returning `0` for counts; `Chunk[...]` with an
+   empty-fast-path for `*All` reads (`Browser.scala:1524-1525, 1488, 1431, 1818`). Use
+   `Maybe` / `Result` / `Chunk` / `Span`, never `null` or a string sentinel
+   (`Resolver.scala:7-11`). A SETTLING read follows the same twin rule via
+   `SettleRead.settle`: stable-`Maybe` -> `Absent`, must-exist -> typed abort,
+   collection -> empty (`SettleRead.scala:5-15`).
+3. **Declare the effect row.** `A < (Browser & Abort[BrowserReadException])` with
+   `Frame` as the trailing `using` parameter (`Browser.scala:1372, 1382`). A recorder
+   (`record*` / `screenshotFrames`) adds `& Async & S` and `(using Frame, Isolate[S,
+   Sync, S])` for its drainer fiber (`Browser.scala:3205-3208, 3279-3287`).
+4. **Wire in the right settlement mechanism:**
+   - Interaction: `Actionability.withRetry { Actionability.withActionable(selector,
+     requireFillable = ..., requireEnabled = ...) { ref =>
+     MutationSettlement.afterAction(<action>)(scopeSelector = Present(selector)) } }`
+     (`Browser.scala:445-453, 504-514`). Decide `requireEnabled` per the
+     hover/press rule (`Actionability.scala:46-48`). Skip mutation settlement and arm
+     the navigation watcher on a nav-intent path (`Browser.scala:447-452`).
+   - Navigation: arm `NavigationWatcher`, replicate the same-URL no-op and `data:`
+     URL auto-downgrade traps (`Browser.scala:329-336, 324-328`).
+   - Assertion or retrying read: route through `BrowserAssertion` /
+     `StabilitySampler`; name it `assert*` (returns `Unit`) or `waitFor*` (returns
+     the matched value), provide the optional `schedule: Maybe[Schedule] = Absent`
+     override, and for `waitFor*` supply both the predicate form and the equality
+     convenience overload (`Browser.scala:950-953, 1139-1147, 1167-1170`).
+   - Settling read (geometry / style / discovery): route through `SettleRead.settle`,
+     mapping settled-absent to the twin return; do NOT call `BrowserAssertion.withStability`
+     directly (`Browser.scala:1590-1619`, `SettleRead.scala:24-40`).
+   - Capture: wrap the base capture in `HoldStill.withHoldStill` (or
+     `withFrozenPage` + `holdStillFrame` for multi-band); it is best-effort and never
+     aborts on timeout (`HoldStill.scala:93-153`).
+   - Recorder: register a per-session dispatcher, drain through a bounded `Channel` +
+     forked drainer fiber, restore via `Scope.ensure`; events-first return
+     (`Browser.scala:3157-3216`).
+   - Pure read: page-side state through `BrowserEval.evalJs`, CDP-backed read through
+     a `CdpBackend` wrapper against `tab.session` (`Browser.scala:2555-2571,
+     3419-3424`).
+5. **If a new wait must catch a fast in-page transient, keep the entire loop inside
+   one `awaitPromise=true` eval.** Never split it into separate `Runtime.evaluate`
+   polls (`MutationSettlement.scala:177-182`, `StabilitySampler.scala:1-19`). The
+   hold-still capture loop is the documented exception (each iteration is a full CDP
+   round-trip) (`HoldStill.scala:16-21`).
+6. **Do not widen the actionability retry channel.** It is narrowed to
+   `BrowserElementException` on purpose; widening it back to
+   `BrowserMutationException` blows the mutation timeout budget
+   (`Actionability.scala:479-495`). This binds `screenshotElement` and
+   `scrollToElement` too: both wrap `Actionability.withRetry` (channel
+   `BrowserElementException`) (`Browser.scala:2039, 2476`).
+7. **Pick the exception.** One row position (`BrowserReadException` <-
+   `BrowserMutationException` <- `BrowserAssertionException`) plus one or more topical
+   markers; `final case class ... derives CanEqual` with the message rendered in the
+   `extends` clause; smart constructors for multi-path construction, none for a
+   single-construction leaf (`BrowserException.scala:34-96, 174-177, 146-153,
+   355-357`). Validate args before any CDP call with
+   `BrowserInvalidArgumentException("<methodName>", ...)` (`Browser.scala:759, 1688,
+   1942`).
+8. **Map wire to public types at the boundary.** Do not leak wire case classes;
+   surface decode failures as `BrowserProtocolErrorException.decodeFailure`
+   (`Browser.scala:3422, 2555-2571`).
+9. **Decide visibility deliberately.** Hide a raw CDP setter behind a scoped `with*`
+   wrapper and mark it `private[kyo]` ONLY when the bare setter is genuinely test-only
+   (the download setters, `Browser.scala:2952, 3004`). `setViewport` / `resetViewport`
+   are the counter-example: they are PUBLIC because they settle after, so the sticky
+   state they leave is observably quiesced (`Browser.scala:2190, 2206`). Either way,
+   follow the cache-and-restore recipe so a scoped wrapper composes with LIFO restore
+   on success, failure, AND interruption (`Browser.scala:2231-2245`). For an injected
+   overlay, use the per-handle `data-kyo-token` teardown, never a shared global slot
+   (`Browser.scala:2343-2390`).
+10. **Add cross-platform tests under `shared/src/test`.** Extend `BrowserTest` for a
+    Chrome-backed suite, `Test` for a pure suite. Gate every wait on a barrier, not a
+    sleep; split into a platform tree only when the behavior is genuinely
+    platform-bound and document why (`BrowserTest.scala:74`,
+    `jvm/src/test/scala/kyo/internal/BrowserLauncherJvmTest.scala:9-12`).

--- a/kyo-browser/shared/src/main/scala/kyo/Browser.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/Browser.scala
@@ -1581,35 +1581,186 @@ object Browser:
             case v => v == "empty"
         }
 
-    /** Returns the bounding box of the first element matching `selector` in the top-level viewport coordinate system. Returns `Absent` when
-      * the selector matches nothing or the element has no box model (e.g. `display: none`).
+    /** Returns the settled bounding rectangle of the first element matching `selector`. Re-samples until the geometry stabilizes, then
+      * performs an authoritative `DOM.getBoxModel` CDP read for the final value. Returns `Absent` when the selector matches nothing or the
+      * element has no box model (`display:none`). Coordinates are CSS pixels in the page's top-level viewport coordinate system.
       *
-      * Uses CDP `DOM.getBoxModel` (not JS `getBoundingClientRect`) so coordinates are correct for elements inside cross-origin iframes and
-      * shadow DOM where JS-side reads return iframe-local coords.
+      * Uses `SettleRead.settle` to wait for layout stability before the CDP box-model read.
       */
-    def boundingBox(selector: Selector)(using Frame): Maybe[BoundingBox] < (Browser & Abort[BrowserReadException]) =
-        Resolver.resolveOne(selector).map {
-            case Absent => Maybe.empty[BoundingBox]
-            case Present(ref) =>
-                Env.use[BrowserTab] { tab =>
-                    Abort.recover[BrowserProtocolErrorException] { _ => Maybe.empty[BoundingBox] } {
-                        CdpBackend.getBoxModel(tab.session, GetBoxModelParams(backendNodeId = ref.backendNodeId)).map { bm =>
-                            val c = bm.model.content
-                            if c.size < 8 then Maybe.empty[BoundingBox]
-                            else
-                                val xs = Chunk(c(0), c(2), c(4), c(6))
-                                val ys = Chunk(c(1), c(3), c(5), c(7))
-                                val x  = xs.min
-                                val y  = ys.min
-                                val w  = xs.max - x
-                                val h  = ys.max - y
-                                Present(BoundingBox(x, y, w, h))
-                            end if
-                        }
+    def boundingRect(selector: Selector)(using Frame): Maybe[Browser.Bounds] < (Browser & Abort[BrowserReadException]) =
+        val jsExpr = SelectorJs.resolveElementJs(Selector.toNode(selector))
+        val valueExpr =
+            s"""(() => { const el = $jsExpr; if (!el) return '{"present":false}'; const r = el.getBoundingClientRect(); return JSON.stringify({present:true, x:r.x, y:r.y, w:r.width, h:r.height}); })()"""
+        SettleRead.settle("boundingRect", valueExpr) { raw =>
+            Json.decode[PresentFlagWire](raw) match
+                case Result.Success(w) if !w.present => Maybe.empty[Browser.Bounds]
+                case Result.Success(_) =>
+                    Resolver.resolveOne(selector).map {
+                        case Absent => Maybe.empty[Browser.Bounds]
+                        case Present(ref) =>
+                            Env.use[BrowserTab] { tab =>
+                                Abort.recover[BrowserProtocolErrorException] { _ => Maybe.empty[Browser.Bounds] } {
+                                    CdpBackend.getBoxModel(tab.session, GetBoxModelParams(backendNodeId = ref.backendNodeId)).map { bm =>
+                                        val c = bm.model.content
+                                        if c.size < 8 then Maybe.empty[Browser.Bounds]
+                                        else
+                                            val xs = Chunk(c(0), c(2), c(4), c(6))
+                                            val ys = Chunk(c(1), c(3), c(5), c(7))
+                                            val x  = xs.min
+                                            val y  = ys.min
+                                            Present(Browser.Bounds(x, y, xs.max - x, ys.max - y))
+                                        end if
+                                    }
+                                }
+                            }
+                    }
+                case _ => Abort.fail(BrowserProtocolErrorException.decodeFailure("boundingRect", raw))
+        }
+    end boundingRect
+
+    /** Returns the settled computed CSS values for the named `properties` on the element matching `selector`. Re-samples until the values
+      * stabilize. Aborts `BrowserElementNotFoundException` when no element matches (twin: `attribute`).
+      */
+    def computedStyles(selector: Selector, properties: Span[String])(using
+        Frame
+    ): Map[String, String] < (Browser & Abort[BrowserReadException]) =
+        val jsExpr    = SelectorJs.resolveElementJs(Selector.toNode(selector))
+        val propsJson = properties.map(p => "\"" + p.replace("\\", "\\\\").replace("\"", "\\\"") + "\"").mkString("[", ",", "]")
+        val valueExpr =
+            s"""(() => { const el = $jsExpr; if (!el) return '{"present":false}'; const cs = window.getComputedStyle(el); const vals = {}; const props = $propsJson; for (const p of props) vals[p] = cs.getPropertyValue(p); return JSON.stringify({present:true, vals}); })()"""
+        SettleRead.settle("computedStyles", valueExpr) { raw =>
+            Json.decode[ComputedStylesWire](raw) match
+                case Result.Success(w) if !w.present =>
+                    Abort.fail(BrowserElementNotFoundException(selectorNodeDescription(Selector.toNode(selector))))
+                case Result.Success(w) =>
+                    w.vals.getOrElse(Map.empty)
+                case _ => Abort.fail(BrowserProtocolErrorException.decodeFailure("computedStyles", raw))
+        }
+    end computedStyles
+
+    /** Returns the settled computed CSS value for `property` on the element matching `selector`. Delegates to `computedStyles`. Aborts
+      * `BrowserElementNotFoundException` when no element matches.
+      */
+    def computedStyle(selector: Selector, property: String)(using Frame): String < (Browser & Abort[BrowserReadException]) =
+        computedStyles(selector, Span(property)).map(_(property))
+
+    /** Returns whether the element matching `selector` is currently in the visible viewport. Settled read: re-samples until the result
+      * stabilizes. Aborts `BrowserElementNotFoundException` when no element matches (twin: `isVisible`).
+      */
+    def inViewport(selector: Selector)(using Frame): Boolean < (Browser & Abort[BrowserReadException]) =
+        val jsExpr = SelectorJs.resolveElementJs(Selector.toNode(selector))
+        val valueExpr =
+            s"""(() => { const el = $jsExpr; if (!el) return '{"present":false}'; const r = el.getBoundingClientRect(); const iv = r.right > 0 && r.bottom > 0 && r.left < window.innerWidth && r.top < window.innerHeight; return JSON.stringify({present:true, value:iv}); })()"""
+        SettleRead.settle("inViewport", valueExpr) { raw =>
+            Json.decode[PresentBoolWire](raw) match
+                case Result.Success(w) if !w.present =>
+                    Abort.fail(BrowserElementNotFoundException(selectorNodeDescription(Selector.toNode(selector))))
+                case Result.Success(w) =>
+                    w.value.getOrElse(false)
+                case _ => Abort.fail(BrowserProtocolErrorException.decodeFailure("inViewport", raw))
+        }
+    end inViewport
+
+    /** Returns the current page scroll position (`window.scrollX` / `scrollY`, rounded to integers). Settled read: re-samples until the
+      * offset stabilizes (useful after scroll-snap or smooth-scroll finishes). Total read: no element needed, never aborts on absent.
+      */
+    def scrollPosition(using Frame): Browser.ScrollPosition < (Browser & Abort[BrowserReadException]) =
+        val valueExpr = "JSON.stringify({x: Math.round(window.scrollX), y: Math.round(window.scrollY)})"
+        SettleRead.settle("scrollPosition", valueExpr) { raw =>
+            Json.decode[Browser.ScrollPosition](raw) match
+                case Result.Success(sp) => sp
+                case _                  => Abort.fail(BrowserProtocolErrorException.decodeFailure("scrollPosition", raw))
+        }
+    end scrollPosition
+
+    /** Waits until the page DOM stops mutating for the configured quiescence window, then returns. Aborts `BrowserAssertionTimedOutException`
+      * when the DOM has not quiesced within `timeout`. Delegates to the strict `MutationSettlement.waitForStable` entry; the entire wait runs
+      * inside a single `awaitPromise=true` eval.
+      */
+    def waitForStable(timeout: Duration)(using Frame): Unit < (Browser & Abort[BrowserReadException]) =
+        MutationSettlement.waitForStable(timeout)
+
+    /** Returns the full DISCOVER snapshot for the element at page-document pixel `(x, y)` via `document.elementFromPoint`. Settled read:
+      * re-samples until stable. Returns `Absent` when no element occupies that point. Aborts `BrowserInvalidArgumentException` before any
+      * page eval when `x` or `y` is negative.
+      */
+    def elementAt(x: Int, y: Int)(using Frame): Maybe[Browser.ElementInfo] < (Browser & Abort[BrowserReadException]) =
+        if x < 0 || y < 0 then Abort.fail(BrowserInvalidArgumentException("elementAt", "coordinates must be non-negative"))
+        else
+            installDiscover.andThen {
+                val valueExpr =
+                    s"""(() => { const el = document.elementFromPoint($x, $y); if (!el || el === document.documentElement || el === document.body) return '{"present":false}'; return JSON.stringify({present:true, info:window.__kyoDiscoverProbe(el)}); })()"""
+                SettleRead.settle("elementAt", valueExpr)(decodeElementInfoMaybe("elementAt"))
+            }
+    end elementAt
+
+    /** Returns the full DISCOVER snapshot for the first element matching `selector`. Settled read: re-samples until stable. Returns `Absent`
+      * when no element matches (twin: `boundingRect`).
+      */
+    def element(selector: Selector)(using Frame): Maybe[Browser.ElementInfo] < (Browser & Abort[BrowserReadException]) =
+        installDiscover.andThen {
+            val jsExpr = SelectorJs.resolveElementJs(Selector.toNode(selector))
+            val valueExpr =
+                s"""(() => { const el = $jsExpr; if (!el) return '{"present":false}'; return JSON.stringify({present:true, info:window.__kyoDiscoverProbe(el)}); })()"""
+            SettleRead.settle("element", valueExpr)(decodeElementInfoMaybe("element"))
+        }
+    end element
+
+    /** Returns DISCOVER snapshots for all elements matching `selector` in document order. Empty fast-path: when `BrowserEval.locateCount`
+      * returns 0, returns `Chunk.empty` immediately without waiting for stability (twin: `textAll`). When elements are found, performs a
+      * settled read of the full array.
+      */
+    def elements(selector: Selector = Selector.all)(using Frame): Chunk[Browser.ElementInfo] < (Browser & Abort[BrowserReadException]) =
+        BrowserEval.locateCount(selector).map { n =>
+            if n == 0 then Chunk.empty
+            else
+                installDiscover.andThen {
+                    val jsExpr    = SelectorJs.resolveAllElementsJs(Selector.toNode(selector))
+                    val valueExpr = s"JSON.stringify(($jsExpr).map(el => window.__kyoDiscoverProbe(el)))"
+                    SettleRead.settle("elements", valueExpr) { raw =>
+                        Json.decode[Seq[DiscoverJs.ElementInfoWire]](raw) match
+                            case Result.Success(ws) => Chunk.from(ws).map(toElementInfo)
+                            case _                  => Abort.fail(BrowserProtocolErrorException.decodeFailure("elements", raw))
                     }
                 }
         }
-    end boundingBox
+    end elements
+
+    /** Installs the in-page DISCOVER helper (`window.__kyoDiscoverProbe` / `window.__kyoUniqueSelector`) idempotently. The helper is gated by
+      * `window.__kyoDiscoverInstalled` so repeated calls are cheap.
+      */
+    private def installDiscover(using Frame): Unit < (Browser & Abort[BrowserReadException]) =
+        BrowserEval.evalJs(DiscoverJs.installJs).unit
+
+    /** Converts the JSON wire record for one element into the public `Browser.ElementInfo`. */
+    private def toElementInfo(w: DiscoverJs.ElementInfoWire): Browser.ElementInfo =
+        Browser.ElementInfo(
+            selector = w.selector,
+            tag = w.tag,
+            id = w.id,
+            classes = w.classes,
+            text = w.text,
+            bounds = Browser.Bounds(w.x, w.y, w.width, w.height),
+            visible = w.visible,
+            inViewport = w.inViewport,
+            topmost = w.topmost,
+            interactive = w.interactive,
+            role = w.role
+        )
+
+    /** Curried decoder for a settled element-info read. Returns `Absent` when the JS side returns `present:false`; decodes the wire object
+      * and converts to `Browser.ElementInfo` on the present path.
+      */
+    private def decodeElementInfoMaybe(
+        callee: String
+    )(raw: String)(using Frame): Maybe[Browser.ElementInfo] < (Browser & Abort[BrowserReadException]) =
+        Json.decode[ElementInfoEnvelope](raw) match
+            case Result.Success(env) if !env.present => Maybe.empty[Browser.ElementInfo]
+            case Result.Success(env) =>
+                env.info match
+                    case Present(w) => Present(toElementInfo(w))
+                    case Absent     => Abort.fail(BrowserProtocolErrorException.decodeFailure(callee, raw))
+            case _ => Abort.fail(BrowserProtocolErrorException.decodeFailure(callee, raw))
 
     /** Returns the flat accessibility node list for the current page. Each entry captures the role, name, and properties for a node Chrome
       * considers exposed to assistive tech. The iframe context honoured is whatever [[withIFrame]] last set; absent that, the top-level
@@ -1757,34 +1908,100 @@ object Browser:
     def title(using Frame): String < (Browser & Abort[BrowserReadException]) =
         BrowserEval.evalJs(ProbesJs.titleJs)
 
-    /** Captures a screenshot of the current page and returns it as an Image. */
-    def screenshot(using Frame): Image < (Browser & Abort[BrowserReadException]) =
-        screenshot(width = 1280, height = 720)
-
-    /** Captures a `width × height` crop of the current page starting from `(0, 0)`.
-      *
-      * The page is rendered at its current viewport: `width` and `height` are the crop dimensions, NOT a render-size override. Use
-      * [[setViewport]] before calling this method when you need the page to render at a specific size (for example, exercising responsive
-      * design at a mobile viewport).
-      *
-      * `format` selects the encoding ([[ScreenshotFormat.Png]], [[ScreenshotFormat.Jpeg]], or [[ScreenshotFormat.Webp]]). `quality` is in
-      * the range `0..100` and applies only to lossy formats; Chrome ignores it for PNG.
+    /** Captures the live current viewport (whatever `setViewport` / `withViewport` last established, else the natural viewport). The legacy
+      * `1280x720` crop is dropped; this method no longer clips. Hold-still capture is the TARGET convention: animations are paused via a
+      * `data-kyo-internal` freeze stylesheet, fonts are awaited, and the capture loops until two consecutive frames are byte-identical or the
+      * `captureHoldStillTimeout` elapses.
       */
     def screenshot(
-        width: Int = 1280,
-        height: Int = 720,
         format: ScreenshotFormat = ScreenshotFormat.Png,
         quality: Int = 90
     )(using Frame): Image < (Browser & Abort[BrowserReadException]) =
-        Env.use[BrowserTab] { tab =>
-            CdpBackend.captureScreenshot(
-                tab.session,
-                ScreenshotParams(
-                    format,
-                    screenshotQuality(format, quality),
-                    clip = Present(ScreenshotClip(0.0, 0.0, width.toDouble, height.toDouble, scale = 1.0))
-                )
-            ).map(sr => CdpBase64Decode.decodeScreenshotImage("Page.captureScreenshot", sr.data))
+        HoldStill.withHoldStill {
+            Env.use[BrowserTab] { tab =>
+                CdpBackend.captureScreenshot(
+                    tab.session,
+                    ScreenshotParams(format, screenshotQuality(format, quality), clip = Absent)
+                ).map(sr => CdpBase64Decode.decodeScreenshotImage("Page.captureScreenshot", sr.data))
+            }
+        }
+
+    /** Captures a `width x height` region at document offset `(x, y)`. `captureBeyondViewport = true` allows the region to lie below or
+      * beside the visible fold. Aborts `BrowserInvalidArgumentException` BEFORE any CDP call when `width <= 0` or `height <= 0`. Clip
+      * coordinates are CSS px (`scale = 1.0`); an active DPR scales the output raster only. Hold-still capture is the TARGET convention.
+      */
+    def screenshotRegion(
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+        format: ScreenshotFormat = ScreenshotFormat.Png,
+        quality: Int = 90
+    )(using Frame): Image < (Browser & Abort[BrowserReadException]) =
+        if width <= 0 || height <= 0 then
+            Abort.fail(BrowserInvalidArgumentException("screenshotRegion", "width and height must be positive"))
+        else
+            HoldStill.withHoldStill {
+                Env.use[BrowserTab] { tab =>
+                    CdpBackend.captureScreenshot(
+                        tab.session,
+                        ScreenshotParams(
+                            format,
+                            screenshotQuality(format, quality),
+                            clip = Present(ScreenshotClip(x.toDouble, y.toDouble, width.toDouble, height.toDouble, scale = 1.0)),
+                            captureBeyondViewport = Present(true)
+                        )
+                    ).map(sr => CdpBase64Decode.decodeScreenshotImage("Page.captureScreenshot", sr.data))
+                }
+            }
+
+    /** Captures the entire scroll height as a `Chunk` of viewport-tall bands, top to bottom. Aborts
+      * `BrowserCaptureLimitExceededException` BEFORE any capture when the page needs more than `maxBands` bands. The freeze stylesheet is
+      * injected ONCE around the entire band loop so all bands reflect the same frozen animation state. Band coordinates are CSS px
+      * (DPR-independent).
+      */
+    def screenshotFullPage(
+        maxBands: Int = 50,
+        format: ScreenshotFormat = ScreenshotFormat.Png,
+        quality: Int = 90
+    )(using Frame): Chunk[Image] < (Browser & Abort[BrowserReadException]) =
+        BrowserEval.evalJs(
+            "JSON.stringify({content: Math.ceil(document.documentElement.scrollHeight), viewport: Math.ceil(window.innerHeight), width: Math.ceil(window.innerWidth)})"
+        ).map { raw =>
+            Json.decode[FullPageDimsWire](raw) match
+                case Result.Success(d) =>
+                    val bandCount = math.ceil(d.content.toDouble / d.viewport.toDouble).toInt.max(1)
+                    if bandCount > maxBands then
+                        Abort.fail(BrowserCaptureLimitExceededException("screenshotFullPage", maxBands, bandCount))
+                    else
+                        // Freeze ONCE around the whole band loop so all bands are frozen consistently.
+                        HoldStill.withFrozenPage {
+                            Env.use[BrowserTab] { tab =>
+                                Kyo.foreach(Chunk.from(0 until bandCount)) { i =>
+                                    HoldStill.holdStillFrame {
+                                        CdpBackend.captureScreenshot(
+                                            tab.session,
+                                            ScreenshotParams(
+                                                format,
+                                                screenshotQuality(format, quality),
+                                                clip = Present(
+                                                    ScreenshotClip(
+                                                        0.0,
+                                                        (i * d.viewport).toDouble,
+                                                        d.width.toDouble,
+                                                        d.viewport.toDouble,
+                                                        scale = 1.0
+                                                    )
+                                                ),
+                                                captureBeyondViewport = Present(true)
+                                            )
+                                        ).map(sr => CdpBase64Decode.decodeScreenshotImage("Page.captureScreenshot", sr.data))
+                                    }
+                                }
+                            }
+                        }
+                    end if
+                case _ => Abort.fail(BrowserProtocolErrorException.decodeFailure("screenshotFullPage", raw))
         }
 
     /** Extracts the main readable text content from the page using a readability algorithm. */
@@ -1802,40 +2019,44 @@ object Browser:
             )
         }
 
-    /** Captures a screenshot of a specific element.
-      *
-      * `format` selects the encoding ([[ScreenshotFormat.Png]], [[ScreenshotFormat.Jpeg]], or [[ScreenshotFormat.Webp]]). `quality` is in
-      * the range `0..100` and applies only to lossy formats; Chrome ignores it for PNG.
+    /** Captures a screenshot of a specific element. AUTO-WAITS for the element via `Actionability.withRetry` (retry channel
+      * `BrowserElementException`, NEVER widened to `BrowserMutationException`); performs a box-stable check (two bounding-rect samples 16 ms
+      * apart must agree within 1 px) and scrolls the element into view before capturing. Gains `transparentBackground`: when true, sets CDP
+      * `Emulation.setDefaultBackgroundColorOverride` to fully transparent for the shot and restores it via `Scope.acquireRelease`. Hold-still
+      * capture is the TARGET convention. Returns `Image` and ABORTS `BrowserElementNotFoundException` when the element never appears within
+      * the configured `retrySchedule`; NOT changed to `Maybe`.
       */
     def screenshotElement(
         selector: Selector,
         format: ScreenshotFormat = ScreenshotFormat.Png,
-        quality: Int = 90
-    )(using
-        Frame
-    )
-        : Image < (Browser & Abort[BrowserReadException]) =
-        Actionability.requireResolved(selector) {
-            val jsExpr = SelectorJs.resolveElementJs(Selector.toNode(selector))
-            BrowserEval.evalJs(s"""(() => {
-                const el = $jsExpr;
+        quality: Int = 90,
+        transparentBackground: Boolean = false
+    )(using Frame): Image < (Browser & Abort[BrowserReadException]) =
+        val jsExpr = SelectorJs.resolveElementJs(Selector.toNode(selector))
+        // AUTO-WAIT: the retry resolves the element and waits until its box is stable, returning the resolved clip box.
+        // The hold-still capture then runs ONCE outside the retry, threading that stable box through `.map`, so a capture
+        // failure never re-enters the retry channel.
+        Actionability.withRetry {
+            // Resolve, box-stable check (two samples ~16 ms apart, agree within 1 px), then scroll into view and re-read the post-scroll rect.
+            // found=false means the element does not exist (triggers BrowserElementNotFoundException for retry).
+            // ok=false with found=true means the element exists but its bounding rect is still moving (triggers NotActionable for retry).
+            BrowserEval.evalJsAwaiting(s"""(async () => {
+                const el = $jsExpr; if (!el) return JSON.stringify({found:false,ok:false});
+                const r1 = el.getBoundingClientRect();
+                await new Promise(res => setTimeout(res, 16));
+                const r2 = el.getBoundingClientRect();
+                if (Math.abs(r1.x - r2.x) > 1 || Math.abs(r1.y - r2.y) > 1 || Math.abs(r1.width - r2.width) > 1 || Math.abs(r1.height - r2.height) > 1)
+                    return JSON.stringify({found:true,ok:false});
+                el.scrollIntoViewIfNeeded ? el.scrollIntoViewIfNeeded(true) : el.scrollIntoView({block:'center'});
                 const r = el.getBoundingClientRect();
-                return JSON.stringify({x: r.x, y: r.y, width: r.width, height: r.height});
+                return JSON.stringify({found:true,ok:true, x:r.x, y:r.y, width:r.width, height:r.height});
             })()""").map { result =>
-                Json.decode[BoundingRectWire](result) match
-                    case Result.Success(r) =>
-                        Env.use[BrowserTab] { tab =>
-                            val clip = ScreenshotClip(r.x, r.y, r.width, r.height, scale = 1.0)
-                            CdpBackend.captureScreenshot(
-                                tab.session,
-                                ScreenshotParams(format, screenshotQuality(format, quality), clip = Present(clip))
-                            ).map { sr =>
-                                CdpBase64Decode.decodeScreenshotImage("Page.captureScreenshot", sr.data)
-                            }
-                        }
+                Json.decode[ElementClipWire](result) match
+                    case Result.Success(w) if w.ok =>
+                        ScreenshotClip(w.x, w.y, w.width, w.height, scale = 1.0)
+                    case Result.Success(w) if !w.found =>
+                        Abort.fail(BrowserElementNotFoundException(selectorNodeDescription(Selector.toNode(selector))))
                     case _ =>
-                        // A malformed bounding-rect payload means the element yielded no usable geometry, semantically the same as a
-                        // zero-size element, so surface it as NotVisible(ZeroComputedSize).
                         Abort.fail(
                             BrowserElementNotActionableException(
                                 selectorNodeDescription(Selector.toNode(selector)),
@@ -1845,8 +2066,101 @@ object Browser:
                             )
                         )
             }
+        }.map { clip =>
+            // Capture ONCE with the resolved (actionable, ok) clip box, outside the retry.
+            withTransparentBackground(transparentBackground) {
+                HoldStill.withHoldStill {
+                    Env.use[BrowserTab] { tab =>
+                        CdpBackend.captureScreenshot(
+                            tab.session,
+                            ScreenshotParams(format, screenshotQuality(format, quality), clip = Present(clip))
+                        ).map(sr => CdpBase64Decode.decodeScreenshotImage("Page.captureScreenshot", sr.data))
+                    }
+                }
+            }
         }
     end screenshotElement
+
+    /** Captures the viewport with numbered badges overlaid at each element in `marks` (1-based, top-left corner). The overlay is one
+      * settlement-transparent `data-kyo-internal` subtree. Aborts `BrowserCaptureLimitExceededException` when `marks.size > maxMarks`. The
+      * settle gate runs BEFORE mark injection (via `HoldStill.withFrozenPage`) so the marks overlay mutation does not reset quiescence;
+      * marks are injected exactly once inside the frozen scope and removed via `Scope.acquireRelease`.
+      *
+      * The injected container carries a unique `data-kyo-token` minted by the inject eval, and the removal targets only the node bearing
+      * that token rather than a shared global slot, so concurrent same-tab captures each tear down exactly their own overlay.
+      */
+    def screenshotMarks(
+        marks: Chunk[Browser.ElementInfo],
+        maxMarks: Int = 100,
+        format: ScreenshotFormat = ScreenshotFormat.Png,
+        quality: Int = 90
+    )(using Frame): Image < (Browser & Abort[BrowserReadException]) =
+        if marks.size > maxMarks then Abort.fail(BrowserCaptureLimitExceededException("screenshotMarks", maxMarks, marks.size))
+        else
+            val badges = marks.zipWithIndex.map((m, i) => s"""{x:${m.bounds.x},y:${m.bounds.y},n:${i + 1}}""").mkString("[", ",", "]")
+            val injectJs = s"""(() => {
+                const root = document.createElement('div');
+                const token = String((window.__kyoOverlayToken = (window.__kyoOverlayToken || 0) + 1));
+                root.setAttribute('data-kyo-internal', 'marks');
+                root.setAttribute('data-kyo-token', token);
+                root.style.cssText = 'position:fixed;inset:0;pointer-events:none;z-index:2147483647;';
+                for (const b of $badges) {
+                    const d = document.createElement('div');
+                    d.setAttribute('data-kyo-internal', 'mark');
+                    d.textContent = b.n;
+                    d.style.cssText = 'position:absolute;left:'+(b.x+2)+'px;top:'+(b.y+2)+'px;background:#d00;color:#fff;font:12px sans-serif;padding:1px 4px;border-radius:3px;';
+                    root.appendChild(d);
+                }
+                document.body.appendChild(root); return token;
+            })()"""
+            def removeJs(token: String) =
+                val escaped = JsStringUtil.escapeJsString(token)
+                s"""(() => { document.querySelectorAll('[data-kyo-token="$escaped"]').forEach(n => n.remove()); return 'unmarked'; })()"""
+            // Settle BEFORE injecting marks: withFrozenPage runs settleForCapture + fonts.ready + freeze injection before entering the body.
+            // Mark injection inside the frozen scope ensures the quiescence gate has already passed when the overlay mutation fires.
+            HoldStill.withFrozenPage {
+                Browser.use { tab =>
+                    Scope.run {
+                        Scope.acquireRelease(BrowserEval.evalJs(injectJs)) { token =>
+                            Browser.releaseHook(tab)(BrowserEval.evalJs(removeJs(token)).unit)
+                        }.andThen {
+                            HoldStill.holdStillFrame {
+                                CdpBackend.captureScreenshot(
+                                    tab.session,
+                                    ScreenshotParams(format, screenshotQuality(format, quality), clip = Absent)
+                                ).map(sr => CdpBase64Decode.decodeScreenshotImage("Page.captureScreenshot", sr.data))
+                            }
+                        }
+                    }
+                }
+            }
+
+    /** Applies a transparent default background for `body`'s duration when `enabled`. Sets
+      * `Emulation.setDefaultBackgroundColorOverride` to `{r:0,g:0,b:0,a:0}` on enter and clears it on exit (success, failure, or
+      * interruption) via `Scope.acquireRelease`. A no-op when `enabled` is false.
+      */
+    private def withTransparentBackground[A, S](enabled: Boolean)(
+        body: => A < (Browser & Abort[BrowserReadException] & S)
+    )(using Frame): A < (Browser & Abort[BrowserReadException] & S) =
+        if !enabled then body
+        else
+            Env.use[BrowserTab] { tab =>
+                Scope.run {
+                    Scope.acquireRelease(
+                        CdpBackend.setDefaultBackgroundColorOverride(
+                            tab.session,
+                            SetDefaultBackgroundColorOverrideParams(Present(RgbaColor(0, 0, 0, Present(0.0))))
+                        )
+                    )(_ =>
+                        Browser.releaseHook(tab)(
+                            CdpBackend.setDefaultBackgroundColorOverride(
+                                tab.session,
+                                SetDefaultBackgroundColorOverrideParams(Absent)
+                            )
+                        )
+                    ).andThen(body)
+                }
+            }
 
     /** Derives the CDP `quality` field for a screenshot. PNG output is lossless and Chrome ignores the field entirely, so we drop it via
       * [[Absent]] / `None` rather than send a value the server discards. JPEG and WEBP both clamp the integer to the wire range `0..100`.
@@ -1858,11 +2172,13 @@ object Browser:
 
     // --- Viewport ---
 
-    /** Overrides the rendered viewport to `width × height` until [[resetViewport]] is called.
+    /** Overrides the rendered viewport to `width × height` (and `deviceScaleFactor` for the device pixel ratio) until [[resetViewport]] is
+      * called.
       *
-      * Forwards to `Emulation.setDeviceMetricsOverride` with `deviceScaleFactor = 1` and `mobile = false`. The override affects how the
-      * page renders: responsive media queries match the new viewport, and elements re-layout. It is sticky: subsequent operations on the
-      * same tab observe the overridden viewport until the caller invokes [[resetViewport]] (or the tab is closed).
+      * Forwards to `Emulation.setDeviceMetricsOverride` with `deviceScaleFactor` (default `1.0`) and `mobile = false`. The override affects
+      * how the page renders: responsive media queries match the new viewport, elements re-layout, and `window.devicePixelRatio` reflects the
+      * override. It is sticky: subsequent operations on the same tab observe the overridden viewport until the caller invokes
+      * [[resetViewport]] (or the tab is closed). Settles after via `MutationSettlement.afterAction` so the re-layout has quiesced on return.
       *
       * The override persists until [[resetViewport]] is called or the tab is closed; not scope-managed.
       *
@@ -1871,51 +2187,59 @@ object Browser:
       * `isolate.clone`. Each child tab starts with its own natural viewport; re-apply `setViewport` inside the child if you need the same
       * override there. For a snapshot-driven workflow consider invoking `setViewport` per-tab as part of the child's setup.
       */
-    private[kyo] def setViewport(width: Int, height: Int)(using Frame): Unit < (Browser & Abort[BrowserReadException]) =
-        Env.use[BrowserTab] { tab =>
-            // Cache write FIRST, then issue the CDP call. If the CDP call fails, the cache reflects intent;
-            // the reverse order would risk a permanently-stale cache on a missed update following a successful CDP call.
-            tab.viewportOverride.set(Present((width, height))).andThen(
-                CdpBackend.setDeviceMetricsOverride(tab.session, ViewportParams(width, height))
-            )
-        }
+    def setViewport(width: Int, height: Int, deviceScaleFactor: Double = 1.0)(using Frame): Unit < (Browser & Abort[BrowserReadException]) =
+        MutationSettlement.afterAction {
+            Env.use[BrowserTab] { tab =>
+                // Cache write FIRST, then issue the CDP call. If the CDP call fails, the cache reflects intent;
+                // the reverse order would risk a permanently-stale cache on a missed update following a successful CDP call.
+                tab.viewportOverride.set(Present(BrowserTab.ViewportOverride(width, height, deviceScaleFactor))).andThen(
+                    CdpBackend.setDeviceMetricsOverride(tab.session, ViewportParams(width, height, deviceScaleFactor))
+                )
+            }
+        }(Absent)
 
     /** Removes any viewport override set by [[setViewport]], restoring the tab's natural viewport.
       *
-      * Forwards to `Emulation.clearDeviceMetricsOverride`. No-op when no override is currently active.
+      * Forwards to `Emulation.clearDeviceMetricsOverride`. No-op when no override is currently active. Settles after via
+      * `MutationSettlement.afterAction` so any re-layout from clearing the override has quiesced on return.
       */
-    private[kyo] def resetViewport(using Frame): Unit < (Browser & Abort[BrowserReadException]) =
-        Env.use[BrowserTab] { tab =>
-            tab.viewportOverride.set(Absent).andThen(
-                CdpBackend.clearDeviceMetricsOverride(tab.session)
-            )
-        }
+    def resetViewport(using Frame): Unit < (Browser & Abort[BrowserReadException]) =
+        MutationSettlement.afterAction {
+            Env.use[BrowserTab] { tab =>
+                tab.viewportOverride.set(Absent).andThen(
+                    CdpBackend.clearDeviceMetricsOverride(tab.session)
+                )
+            }
+        }(Absent)
 
-    /** Scoped form of [[setViewport]]: applies the `width × height` override for the duration of `body`, then clears the override on body
-      * exit (success, failure, or interruption).
+    /** Scoped form of [[setViewport]]: applies the `width x height` override (and `deviceScaleFactor` for the device pixel ratio) for the
+      * duration of `body`, then restores the prior override on body exit (success, failure, or interruption).
       *
       * Use this instead of `setViewport(w, h).andThen(...)` when you want the override bounded to a specific block. Composes naturally with
       * the rest of the API: viewport-dependent assertions inside `body` see the override, code after `body` does not.
       *
-      * The prior override (if any) is cached on the BrowserTab. On exit, the cache is consulted: if a prior `(w, h)` override was active
-      * at entry, it is re-applied via `setDeviceMetricsOverride`; otherwise the override is cleared via `clearDeviceMetricsOverride`. This
-      * lets nested `withViewport` calls compose correctly.
+      * The prior override (if any) is cached on the BrowserTab. On exit, the cache is consulted: if a prior override was active at entry, it
+      * is re-applied via `setDeviceMetricsOverride` carrying that prior override's own `deviceScaleFactor`; otherwise the override is cleared
+      * via `clearDeviceMetricsOverride`. This lets nested `withViewport` calls compose correctly in LIFO order. The apply settles via
+      * `MutationSettlement.afterAction` before `body` runs; the restore on teardown does not add settlement.
       */
-    def withViewport[A, S](width: Int, height: Int)(body: A < (Browser & S))(using
+    def withViewport[A, S](width: Int, height: Int, deviceScaleFactor: Double = 1.0)(body: A < (Browser & S))(using
         Frame
     ): A < (Browser & Abort[BrowserReadException] & S) =
         Env.use[BrowserTab] { tab =>
             Scope.run {
                 tab.viewportOverride.get.map { prior =>
                     Scope.acquireRelease(
-                        tab.viewportOverride.set(Present((width, height))).andThen(
-                            CdpBackend.setDeviceMetricsOverride(tab.session, ViewportParams(width, height))
-                        )
+                        MutationSettlement.afterAction {
+                            tab.viewportOverride.set(Present(BrowserTab.ViewportOverride(width, height, deviceScaleFactor))).andThen(
+                                CdpBackend.setDeviceMetricsOverride(tab.session, ViewportParams(width, height, deviceScaleFactor))
+                            )
+                        }(Absent)
                     ) { _ =>
                         tab.viewportOverride.set(prior).andThen(
                             prior match
-                                case Present((w, h)) =>
-                                    CdpBackend.setDeviceMetricsOverride(tab.session, ViewportParams(w, h))
+                                case Present(vo) =>
+                                    CdpBackend.setDeviceMetricsOverride(tab.session, ViewportParams(vo.width, vo.height, vo.dpr))
                                 case Absent =>
                                     CdpBackend.clearDeviceMetricsOverride(tab.session)
                         )
@@ -1923,6 +2247,147 @@ object Browser:
                 }
             }
         }
+
+    /** Scoped wrapper that applies emulated media features for the duration of `body`, then restores the prior state.
+      *
+      * Only the features the caller actually requests are sent in the single `Emulation.setEmulatedMedia` call: `media` selects the
+      * media type (`screen` / `print`) and is omitted when `Absent`; `colorScheme` sets `prefers-color-scheme` (`light` / `dark`, or
+      * the empty-string clear for [[Browser.ColorScheme.NoPreference]] since W3C dropped that value) and is omitted when `Absent`;
+      * `prefers-reduced-motion` is sent as `reduce` only when `reducedMotion = true` and is omitted otherwise. So a color-scheme-only
+      * call leaves the page's real `prefers-reduced-motion` untouched, and `reducedMotion = false` means "do not emulate reduced
+      * motion", not "force no-preference". The override is cached on the tab and re-applied on exit via `Scope.acquireRelease` inside
+      * an inner `Scope.run`, so nested calls compose in LIFO order and the restore fires on success, failure, AND interruption. When no
+      * prior override was active the restore clears all media emulation with an empty `Emulation.setEmulatedMedia` send, so the host's
+      * real media values return rather than a forced override. The apply settles via `MutationSettlement.afterAction` so any
+      * media-query re-layout has quiesced before `body` starts.
+      */
+    def withEmulation[A, S](
+        colorScheme: Maybe[Browser.ColorScheme] = Absent,
+        media: Maybe[Browser.MediaType] = Absent,
+        reducedMotion: Boolean = false
+    )(body: A < (Browser & S))(using Frame): A < (Browser & Abort[BrowserReadException] & S) =
+        Env.use[BrowserTab] { tab =>
+            val params = emulatedMediaParams(media.map(_.wire), colorScheme.map(_.wire), reducedMotion)
+            Scope.run {
+                tab.emulationOverride.get.map { prior =>
+                    Scope.acquireRelease(
+                        MutationSettlement.afterAction {
+                            tab.emulationOverride.set(Present(BrowserTab.EmulatedMediaState(
+                                colorScheme.map(_.wire),
+                                media.map(_.wire),
+                                reducedMotion
+                            ))).andThen(
+                                CdpBackend.setEmulatedMedia(tab.session, params)
+                            )
+                        }(Absent)
+                    ) { _ =>
+                        tab.emulationOverride.set(prior).andThen(
+                            prior match
+                                case Present(s) =>
+                                    CdpBackend.setEmulatedMedia(
+                                        tab.session,
+                                        emulatedMediaParams(s.media, s.colorScheme, s.reducedMotion)
+                                    )
+                                case Absent =>
+                                    // No prior override: clear all media emulation so the host's real values return. An empty
+                                    // features list with empty media drops every prefers-* override back to the environment value.
+                                    CdpBackend.setEmulatedMedia(tab.session, clearEmulatedMediaParams)
+                        )
+                    }.andThen(body)
+                }
+            }
+        }
+    end withEmulation
+
+    /** Composes a `SetEmulatedMediaParams` carrying only the features the caller requested.
+      *
+      * `media` becomes the top-level media-type override when `Present`, omitted otherwise. `colorScheme` (already a CDP wire string,
+      * `""` for the [[Browser.ColorScheme.NoPreference]] clear) contributes a `prefers-color-scheme` feature only when `Present`.
+      * `reducedMotion = true` contributes a `prefers-reduced-motion: reduce` feature; `false` contributes nothing, so an unrelated
+      * media feature is never perturbed. Used by both the apply path and the restore-to-a-prior-state path so the two stay in lockstep.
+      */
+    private[kyo] def emulatedMediaParams(
+        media: Maybe[String],
+        colorScheme: Maybe[String],
+        reducedMotion: Boolean
+    ): SetEmulatedMediaParams =
+        val features = Chunk(
+            colorScheme.map(cs => EmulatedMediaFeature("prefers-color-scheme", cs)),
+            if reducedMotion then Present(EmulatedMediaFeature("prefers-reduced-motion", "reduce")) else Absent
+        ).flatMap(_.toChunk)
+        SetEmulatedMediaParams(media, Present(features.toSeq))
+    end emulatedMediaParams
+
+    /** The `SetEmulatedMediaParams` that clears every media-feature override back to the host.
+      *
+      * Empty media plus an empty features list drops every `prefers-*` override back to the environment value, rather than enumerating
+      * each feature (which can silently miss one). Sent by the restore path when no prior override was active.
+      */
+    private[kyo] val clearEmulatedMediaParams: SetEmulatedMediaParams =
+        SetEmulatedMediaParams(Present(""), Present(Seq.empty))
+
+    /** Injects a settlement-transparent overlay (a dashed box per annotation, plus a label when one is provided) for the duration of
+      * `body`, then removes it on exit.
+      *
+      * The overlay is one container subtree tagged `data-kyo-internal`, so the mutation observer ignores both its insertion and its
+      * removal: the overlay does NOT arm the mutation gate, and a capture inside `body` sees the boxes while a settlement inside
+      * `body` stays transparent to them. Each annotation resolves its element via the same selector machinery the rest of the API
+      * uses; an annotation whose selector matches nothing is skipped. The inject eval completes before `body` runs, so screenshots
+      * taken inside `body` include the overlays. The container is removed via `Scope.acquireRelease` inside an inner `Scope.run`, so
+      * the removal fires on success, failure, AND interruption.
+      *
+      * Each invocation tags its container with a unique `data-kyo-token` minted by the inject eval (an in-page monotonic sequence) and
+      * removes ONLY the node carrying that token, never a shared global slot. Nested or interleaved `withHighlights` blocks therefore
+      * each tear down exactly their own overlay: an inner block's exit cannot make the outer block's removal a no-op.
+      */
+    def withHighlights[A, S](annotations: Span[Browser.Annotation])(body: A < (Browser & S))(using
+        Frame
+    ): A < (Browser & Abort[BrowserReadException] & S) =
+        val specs = annotations.map { a =>
+            val sel   = SelectorJs.resolveElementJs(Selector.toNode(a.selector))
+            val color = s""""${JsStringUtil.escapeJsString(a.color.getOrElse("#d00"))}""""
+            val label = s""""${JsStringUtil.escapeJsString(a.label.getOrElse(""))}""""
+            s"""{ sel: () => $sel, color: $color, label: $label }"""
+        }.mkString("[", ",", "]")
+        val injectJs = s"""(() => {
+            const root = document.createElement('div');
+            const token = String((window.__kyoOverlayToken = (window.__kyoOverlayToken || 0) + 1));
+            root.setAttribute('data-kyo-internal', 'highlights');
+            root.setAttribute('data-kyo-token', token);
+            root.style.cssText = 'position:fixed;inset:0;pointer-events:none;z-index:2147483646;';
+            for (const a of $specs) {
+                const el = a.sel(); if (!el) continue;
+                const r = el.getBoundingClientRect();
+                const box = document.createElement('div');
+                box.setAttribute('data-kyo-internal', 'highlight');
+                box.style.cssText = 'position:absolute;left:'+r.left+'px;top:'+r.top+'px;width:'+r.width+'px;height:'+r.height+'px;outline-width:2px;outline-style:dashed;outline-color:'+a.color+';';
+                if (a.label) {
+                    const b = document.createElement('div');
+                    b.setAttribute('data-kyo-internal', 'label');
+                    b.textContent = a.label;
+                    b.style.cssText = 'position:absolute;left:'+r.left+'px;top:'+(r.top-16)+'px;background:'+a.color+';color:#fff;font:11px sans-serif;padding:0 3px;';
+                    root.appendChild(b);
+                }
+                root.appendChild(box);
+            }
+            document.body.appendChild(root);
+            return token;
+        })()"""
+        def removeJs(token: String) =
+            val escaped = JsStringUtil.escapeJsString(token)
+            s"""(() => {
+            document.querySelectorAll('[data-kyo-token="$escaped"]').forEach(n => n.remove());
+            return 'unhighlighted';
+        })()"""
+        end removeJs
+        Env.use[BrowserTab] { tab =>
+            Scope.run {
+                Scope.acquireRelease(BrowserEval.evalJs(injectJs))(token =>
+                    releaseHook(tab)(BrowserEval.evalJs(removeJs(token)).unit)
+                ).andThen(body)
+            }
+        }
+    end withHighlights
 
     // --- Keyboard ---
 
@@ -1990,11 +2455,25 @@ object Browser:
 
     // --- Scrolling ---
 
-    /** Scrolls the page until the element matched by the selector is visible. */
-    def scrollTo(selector: Selector)(using Frame): Unit < (Browser & Abort[BrowserReadException]) =
+    /** Scrolls the window to the document coordinate `(x, y)` via `window.scrollTo`.
+      *
+      * Settles after via `MutationSettlement.afterAction` so any layout reaction to the scroll has quiesced on return.
+      */
+    def scrollTo(x: Int, y: Int)(using Frame): Unit < (Browser & Abort[BrowserReadException]) =
+        MutationSettlement.afterAction {
+            BrowserEval.evalJs(s"window.scrollTo($x, $y)").unit
+        }(Absent)
+
+    /** Scrolls the page until the element matched by the selector is visible.
+      *
+      * Auto-waits for the element via `Actionability.withRetry`: the read is retried over the configured `retrySchedule` until the element
+      * resolves, then `scrollIntoView` runs. The retry channel is `BrowserElementException` (never widened to `BrowserMutationException`).
+      * Aborts `BrowserElementNotFoundException` when the element never appears within the schedule. Settles after.
+      */
+    def scrollToElement(selector: Selector)(using Frame): Unit < (Browser & Abort[BrowserReadException]) =
         val jsExpr = SelectorJs.resolveElementJs(Selector.toNode(selector))
-        configLocal.use { cfg =>
-            Retry[BrowserMutationException](cfg.retrySchedule) {
+        MutationSettlement.afterAction {
+            Actionability.withRetry {
                 Actionability.requireResolved(selector) {
                     BrowserEval.evalJs(s"""(() => {
                         const el = $jsExpr;
@@ -2003,8 +2482,8 @@ object Browser:
                     })()""").unit
                 }
             }
-        }
-    end scrollTo
+        }(Absent)
+    end scrollToElement
 
     /** Scrolls the page to the top. */
     def scrollToTop(using Frame): Unit < (Browser & Abort[BrowserReadException]) =
@@ -2068,44 +2547,97 @@ object Browser:
 
     /** Returns all console messages captured since the last call (or since page load on the first call) and clears the buffer.
       *
-      * The `console.log`, `console.warn`, and `console.error` override is installed eagerly when the tab is attached, so messages emitted
-      * during page load are captured even before the first `consoleLogs` call. Each call drains and clears the buffer. Each entry carries a
-      * typed [[Browser.ConsoleLevel]], the original message, and the page-side `Date.now()` timestamp at emit time.
+      * The `console.debug` / `console.info` / `console.log` / `console.warn` / `console.error` override is installed eagerly when the tab is
+      * attached, so messages emitted during page load are captured even before the first `consoleLogs` call. Each call drains and clears the
+      * buffer. Each entry carries a typed [[Browser.ConsoleLevel]], the joined message text, and an `offsetMs` relative to the page-side
+      * capture baseline (`window.__kyoConsoleT0`, the `Date.now()` at install time).
       */
     def consoleLogs(using Frame): Chunk[Browser.ConsoleMessage] < (Browser & Abort[BrowserReadException]) =
-        BrowserEval.evalJs("""(() => {
-            const logs = window.__kyoConsoleLogs || [];
-            window.__kyoConsoleLogs = [];
-            return JSON.stringify(logs);
-        })()""").map { json =>
-            if json.isEmpty then Chunk.empty
-            else
-                Json.decode[Seq[ConsoleMessageWire]](json) match
-                    case Result.Success(list) =>
-                        Kyo.foreach(Chunk.from(list))(decodeConsoleMessage)
-                    case other =>
-                        Log.warn(s"consoleLogs: unexpected wire shape decoding Seq[ConsoleMessageWire]: $other; raw=$json")
-                            .andThen(Abort.fail(BrowserProtocolErrorException.decodeFailure("consoleLogs", s"$other; raw=$json")))
+        BrowserEval.evalJs("(window.__kyoConsoleT0 || 0)").map { t0Raw =>
+            val t0Ms = t0Raw.toLongOption.getOrElse(0L)
+            BrowserEval.evalJs("""(() => {
+                const logs = window.__kyoConsoleLogs || [];
+                window.__kyoConsoleLogs = [];
+                return JSON.stringify(logs);
+            })()""").map { json =>
+                if json.isEmpty then Chunk.empty
+                else
+                    Json.decode[Seq[ConsoleMessageWire]](json) match
+                        case Result.Success(list) =>
+                            Kyo.foreach(Chunk.from(list))(w => decodeConsoleMessage(w, t0Ms))
+                        case other =>
+                            Log.warn(s"consoleLogs: unexpected wire shape decoding Seq[ConsoleMessageWire]: $other; raw=$json")
+                                .andThen(Abort.fail(BrowserProtocolErrorException.decodeFailure("consoleLogs", s"$other; raw=$json")))
+            }
         }
 
     /** Filtering overload of [[consoleLogs]] that drains the buffer and returns only entries whose level equals `level`. */
     def consoleLogs(level: Browser.ConsoleLevel)(using Frame): Chunk[Browser.ConsoleMessage] < (Browser & Abort[BrowserReadException]) =
         consoleLogs.map(_.filter(_.level == level))
 
-    private def decodeConsoleMessage(wire: ConsoleMessageWire)(using
+    private[kyo] def decodeConsoleMessage(wire: ConsoleMessageWire, t0Ms: Long)(using
         Frame
     ): Browser.ConsoleMessage < Abort[BrowserReadException] =
         val levelE: Browser.ConsoleLevel < Abort[BrowserReadException] = wire.level match
             case "log"   => Browser.ConsoleLevel.Log
+            case "info"  => Browser.ConsoleLevel.Info
             case "warn"  => Browser.ConsoleLevel.Warn
             case "error" => Browser.ConsoleLevel.Error
+            case "debug" => Browser.ConsoleLevel.Debug
             case other =>
                 Abort.fail(BrowserProtocolErrorException.decodeFailure(
                     "consoleLogs",
-                    s"unknown level '$other' (expected log|warn|error)"
+                    s"unknown level '$other' (expected log|info|warn|error|debug)"
                 ))
-        levelE.map(lv => Browser.ConsoleMessage(lv, wire.message, Instant.fromJava(java.time.Instant.ofEpochMilli(wire.timestamp))))
+        levelE.map(lv => Browser.ConsoleMessage(lv, wire.message, Absent, wire.timestamp - t0Ms))
     end decodeConsoleMessage
+
+    /** Decodes a CDP `Runtime.consoleAPICalled` wire record into a typed [[Browser.ConsoleMessage]]. The 18 CDP `type` literals are mapped
+      * or aborted explicitly: the 10 non-structural types fold onto the five [[Browser.ConsoleLevel]] severities (`warning` maps to `Warn`,
+      * `trace` to `Debug`, `dir`/`dirxml`/`table` to `Log`, `assert` to `Error`), and the 8 structural types (`count`, `countReset`,
+      * `timeEnd`, `startGroup`, `startGroupCollapsed`, `endGroup`, `clear`, `profile`/`profileEnd`) abort
+      * [[BrowserProtocolErrorException.decodeFailure]] so a new CDP type surfaces as a typed protocol error rather than a silent `Log`.
+      *
+      * The CDP path knows `warning`, never the drain path's `warn` spelling; the two spellings never collide.
+      */
+    private[kyo] def decodeConsoleApiCalled(wire: ConsoleApiCalledWire, t0Ms: Long)(using
+        Frame
+    ): Browser.ConsoleMessage < Abort[BrowserReadException] =
+        val levelE: Browser.ConsoleLevel < Abort[BrowserReadException] = wire.`type` match
+            case "log"     => Browser.ConsoleLevel.Log
+            case "info"    => Browser.ConsoleLevel.Info
+            case "warning" => Browser.ConsoleLevel.Warn
+            case "error"   => Browser.ConsoleLevel.Error
+            case "debug"   => Browser.ConsoleLevel.Debug
+            case "trace"   => Browser.ConsoleLevel.Debug
+            case "dir"     => Browser.ConsoleLevel.Log
+            case "dirxml"  => Browser.ConsoleLevel.Log
+            case "table"   => Browser.ConsoleLevel.Log
+            case "assert"  => Browser.ConsoleLevel.Error
+            case structural @ ("count" | "countReset" | "timeEnd" | "startGroup" | "startGroupCollapsed" | "endGroup" | "clear" |
+                "profile" | "profileEnd") =>
+                Abort.fail(BrowserProtocolErrorException.decodeFailure(
+                    "recordConsole",
+                    s"unmapped structural console type '$structural'"
+                ))
+            case other =>
+                Abort.fail(BrowserProtocolErrorException.decodeFailure("recordConsole", s"unknown console type '$other'"))
+        levelE.map { lv =>
+            val text = wire.args.flatMap(a => a.value.orElse(a.description).toChunk).mkString(" ")
+            val location = wire.stackTrace.flatMap(st =>
+                Maybe.fromOption(st.callFrames.headOption).flatMap(cf => cf.url.map(u => u + ":" + cf.lineNumber.getOrElse(0)))
+            )
+            Browser.ConsoleMessage(lv, text, location, computeOffsetMs(wire.timestamp, t0Ms))
+        }
+    end decodeConsoleApiCalled
+
+    /** Converts a CDP event `timestamp` (milliseconds since epoch when present) into an offset relative to the recording baseline `t0Ms`.
+      * An absent timestamp yields `0L`.
+      */
+    private def computeOffsetMs(ts: Maybe[Double], t0Ms: Long): Long =
+        ts match
+            case Present(v) => math.round(v) - t0Ms
+            case Absent     => 0L
 
     /** Auto-handles JavaScript dialogs (alert, confirm, prompt, beforeunload) opened during the body's execution.
       *
@@ -2602,6 +3134,276 @@ object Browser:
             case _ => Absent
     end parseDownloadEvent
 
+    // --- Console recording ---
+
+    /** Bounded capacity for the per-tab console-event channel exposed via [[onConsole]] and [[recordConsole]]. Sized to ride out a short
+      * consumer stall without dropping events; the channel drops the oldest event on overflow.
+      */
+    private val consoleChannelCapacity: Int = 256
+
+    /** Subscribes `f` to every console message Chrome emits during `action`, mirroring [[onDownload]] in shape.
+      *
+      * Two CDP sources feed `f`: `Runtime.consoleAPICalled` (every `console.*` call) and `Runtime.exceptionThrown` (uncaught page errors,
+      * surfaced as a `ConsoleLevel.Error` message). A `consoleAPICalled` whose CDP `type` is one of the 8 structural variants aborts inside
+      * [[decodeConsoleApiCalled]]; that abort is recovered to a dropped event here so it never reaches the reader fiber. This recorder does
+      * NOT settle: it records the page exactly as it logs.
+      *
+      * Implementation: events flow from the CDP reader through a per-session dispatcher onto a bounded `Channel[ConsoleMessage]`; a forked
+      * drainer fiber takes events off the channel and applies `f`, isolating `f`'s effect row `S` from the dispatcher's `Sync`-only value
+      * type. The channel and drainer fiber are bound to an internal `Scope.run`, so teardown (dispatcher restore + channel close) fires when
+      * `action` completes (success, failure, OR interruption); the caller's effect row does NOT carry `Scope`. The handler is registered
+      * BEFORE `action` runs, so console output inside `action` is not missed.
+      */
+    def onConsole[A, S](f: Browser.ConsoleMessage => Unit < (Browser & S))(
+        action: A < (Browser & Async & Abort[BrowserReadException] & S)
+    )(using
+        Frame,
+        Isolate[S, Sync, S]
+    ): A < (Browser & Async & Abort[BrowserReadException] & S) =
+        Env.use[BrowserTab] { tab =>
+            val client = tab.client
+            val sidKey = tab.sessionId.value
+            Clock.now.map { t0 =>
+                val t0Ms = t0.toJava.toEpochMilli
+                // Bounded unscoped channel; closed explicitly via `Scope.ensure` inside the inner `Scope.run` so the effect row stays free
+                // of `Scope` while teardown is still bound to the body's lifetime.
+                Channel.initUnscoped[Browser.ConsoleMessage](consoleChannelCapacity).map { channel =>
+                    val handler: CdpEvent.Generic => Unit < Sync = ev =>
+                        consoleEventToMessage(ev, t0Ms).map {
+                            case Present(msg) =>
+                                // Best-effort offer: a full channel (drainer slow) or a closed channel (scope tearing down) drops the
+                                // event rather than blocking the CDP reader fiber. Abort[Closed] is swallowed.
+                                Abort.run[Closed](channel.offer(msg)).unit
+                            case Absent => Kyo.unit
+                        }
+                    client.consoleEventDispatchers.getAndUpdate(_.update(sidKey, handler)).map { previousMap =>
+                        val restoreDispatcher = client.consoleEventDispatchers.getAndUpdate { m =>
+                            previousMap.get(sidKey) match
+                                case Present(prev) => m.update(sidKey, prev)
+                                case Absent        => m.remove(sidKey)
+                        }.unit
+                        Scope.run {
+                            Scope.ensure(restoreDispatcher).andThen(Scope.ensure(channel.close.unit)).andThen {
+                                Fiber.init {
+                                    Abort.run[Closed](channel.stream().foreach(msg => Env.run(tab)(f(msg)))).unit
+                                }.andThen(action)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    end onConsole
+
+    /** Captures every [[ConsoleMessage]] Chrome emits during `body` into an in-memory [[Chunk]]. Returns a pair `(messages, result)` where
+      * `messages` is the arrival-ordered chunk of every console entry the page produced and `result` is the value `body` produced.
+      *
+      * Use this instead of [[onConsole]] when the test only needs to inspect the messages after the body completes; no manual `AtomicRef` or
+      * `Channel` bookkeeping is required. Implemented in terms of [[onConsole]] with a capture handler that appends each message to an
+      * internal `AtomicRef[Chunk]`; the drainer fiber inside [[onConsole]] is single-fiber per session, so arrival order is preserved.
+      */
+    def recordConsole[A, S](body: A < (Browser & Async & Abort[BrowserReadException] & S))(using
+        Frame,
+        Isolate[S, Sync, S]
+    ): (Chunk[Browser.ConsoleMessage], A) < (Browser & Async & Abort[BrowserReadException] & S) =
+        AtomicRef.init(Chunk.empty[Browser.ConsoleMessage]).map { collected =>
+            val captureHandler: Browser.ConsoleMessage => Unit < Sync =
+                msg => collected.updateAndGet(_.append(msg)).unit
+            onConsole(captureHandler)(body).map { result =>
+                collected.get.map(messages => (messages, result))
+            }
+        }
+    end recordConsole
+
+    /** Decodes a [[CdpEvent.Generic]] console event into a typed [[Browser.ConsoleMessage]] for the recorder handler. Reuses the wire-level
+      * [[kyo.internal.CdpClient.parseConsoleEvent]] decoder: a `Left` is a `Runtime.consoleAPICalled` mapped through
+      * [[decodeConsoleApiCalled]] (a structural-type abort recovers to `Absent` so the handler drops it), a `Right` is a
+      * `Runtime.exceptionThrown` surfaced as a `ConsoleLevel.Error` message at its `url:line`. Returns `Absent` for any non-console event or
+      * decode failure; never aborts.
+      */
+    private def consoleEventToMessage(ev: CdpEvent.Generic, t0Ms: Long)(using
+        Frame
+    ): Maybe[Browser.ConsoleMessage] < Sync =
+        CdpClient.parseConsoleEvent(ev) match
+            case Present(Left(consoleWire)) =>
+                Abort.run(decodeConsoleApiCalled(consoleWire, t0Ms)).map {
+                    case Result.Success(msg) => Present(msg)
+                    case _                   => Absent
+                }
+            case Present(Right(exWire)) =>
+                val d = exWire.exceptionDetails
+                // CDP reports `text` as the bare "Uncaught" prefix and carries the real error message in
+                // `exception.description`; join them so the message is meaningful.
+                val text = d.exception.flatMap(_.description) match
+                    case Present(desc) => d.text + " " + desc
+                    case Absent        => d.text
+                // Prefer the top-level `url:line`; fall back to the first stack frame when the throw carries no url.
+                val topFrame = d.stackTrace.flatMap(st => Maybe.fromOption(st.callFrames.headOption))
+                val location =
+                    d.url.map(u => u + ":" + d.lineNumber.getOrElse(0))
+                        .orElse(topFrame.flatMap(cf => cf.url.map(u => u + ":" + cf.lineNumber.getOrElse(0))))
+                Present(Browser.ConsoleMessage(
+                    Browser.ConsoleLevel.Error,
+                    text,
+                    location,
+                    computeOffsetMs(exWire.timestamp, t0Ms)
+                ))
+            case Absent => Absent
+    end consoleEventToMessage
+
+    // --- Screencast ---
+
+    /** Records a screencast of the page WHILE `body` runs. Drive an animation or transition inside `body` and get back the frames
+      * Chrome rendered while it ran, paired with the body's result: events-first `(Chunk[ScreenshotFrame], A)`, the canonical `record*`
+      * shape (twin [[recordDownloads]]). This method does NOT settle: it records the page exactly as it changes, so the caller is
+      * responsible for driving the visual change to record.
+      *
+      * Each frame carries its `Image`, an `offsetMs` relative to the cast start (from the screencast metadata `timestamp` when present,
+      * else a wall-clock fallback), and the page scroll offset at capture. Frames arrive in delivery order, so `offsetMs` is
+      * non-decreasing.
+      *
+      * Two bounds protect against an unbounded recording, checked frame-count-first: when the recorded frame count exceeds `maxFrames`,
+      * or the elapsed wall-clock time exceeds `maxDurationMs`, the cast is poisoned and the call aborts
+      * [[BrowserCaptureLimitExceededException]] after `body` returns. The exception's two numbers always share one unit: the frame cap
+      * reports `limit = maxFrames` against the frame count reached, and the duration cap reports `limit = maxDurationMs` against the
+      * elapsed milliseconds reached. `Webp` has no screencast codec, so it maps to the `jpeg` codec (CDP screencast supports `jpeg`
+      * and `png` only); the call still succeeds.
+      *
+      * Implementation: a per-session dispatcher is registered on `screencastEventDispatchers` BEFORE the cast starts. The dispatcher
+      * decodes each `Page.screencastFrame`, issues the per-frame `Page.screencastFrameAck` from inside the handler (a detached fiber so
+      * the CDP reader stays `Sync`-only and Chrome keeps delivering), appends the frame, and sets the poison flag on a cap. The dispatcher
+      * restore and `Page.stopScreencast` are bound to an inner `Scope.run`, so teardown fires on success, failure, OR interruption; the
+      * caller's effect row does NOT carry `Scope`. The body's effect row `S` is isolated from the dispatcher's `Sync`-only value type via
+      * `Isolate[S, Sync, S]`, exactly as [[recordDownloads]].
+      */
+    def screenshotFrames[A, S](
+        maxDurationMs: Long = 8000L,
+        maxFrames: Int = 240,
+        format: Browser.ScreenshotFormat = Browser.ScreenshotFormat.Jpeg,
+        quality: Int = 80
+    )(body: A < (Browser & Async & Abort[BrowserReadException] & S))(using
+        Frame,
+        Isolate[S, Sync, S]
+    ): (Chunk[Browser.ScreenshotFrame], A) < (Browser & Async & Abort[BrowserReadException] & S) =
+        Env.use[BrowserTab] { tab =>
+            val client  = tab.client
+            val session = tab.session
+            val sidKey  = tab.sessionId.value
+            val wireFormat = format match
+                case Browser.ScreenshotFormat.Png  => "png"
+                case Browser.ScreenshotFormat.Jpeg => "jpeg"
+                case Browser.ScreenshotFormat.Webp => "jpeg"
+            Clock.now.map { t0 =>
+                AtomicRef.init(Chunk.empty[Browser.ScreenshotFrame]).map { collected =>
+                    // The poison cell, when set, carries the exact `(limit, reached)` pair for the abort, computed at the
+                    // moment the cap is hit so both numbers share one unit: frame counts for the frame cap, milliseconds for
+                    // the duration cap. The first cap to trip wins (the dispatcher only sets the cell when it is still Absent).
+                    AtomicRef.init(Maybe.empty[(Int, Int)]).map { poisoned =>
+                        // The dispatcher decodes each frame, acks it from a detached fiber so the reader fiber stays < Sync (the ack
+                        // carries Async; Chrome keeps delivering once it sees the ack), appends to `collected`, then checks the caps
+                        // frame-count-first: `cur.size > maxFrames` poisons on the frame bound (limit = maxFrames, reached = frame
+                        // count); otherwise the elapsed-time check poisons on the duration bound (limit = maxDurationMs, reached =
+                        // elapsed ms), so the two reported numbers always share the same unit.
+                        val handler: CdpEvent.Generic => Unit < Sync = ev =>
+                            parseScreencastFrame(ev, t0).map {
+                                case Present((frame, sessionId)) =>
+                                    Fiber.initUnscoped(using Isolate.derive[Any, Sync, Any])(
+                                        Abort.run[BrowserReadException](
+                                            CdpBackend.screencastFrameAck(session, ScreencastFrameAckParams(sessionId))
+                                        ).unit
+                                    ).andThen(collected.updateAndGet(_.append(frame))).map { cur =>
+                                        def poison(cap: (Int, Int)): Unit < Sync =
+                                            poisoned.updateAndGet(prev => if prev.isDefined then prev else Present(cap)).unit
+                                        if cur.size > maxFrames then poison((maxFrames, cur.size))
+                                        else
+                                            Clock.now.map { now =>
+                                                val elapsedMs = now.toJava.toEpochMilli - t0.toJava.toEpochMilli
+                                                if elapsedMs > maxDurationMs then poison((maxDurationMs.toInt, elapsedMs.toInt))
+                                                else Kyo.unit
+                                            }
+                                        end if
+                                    }
+                                case Absent => Kyo.unit
+                            }
+                        client.screencastEventDispatchers.getAndUpdate(_.update(sidKey, handler)).map { previousMap =>
+                            val restore = client.screencastEventDispatchers.getAndUpdate { m =>
+                                previousMap.get(sidKey) match
+                                    case Present(prev) => m.update(sidKey, prev)
+                                    case Absent        => m.remove(sidKey)
+                            }.unit
+                            // Best-effort stop on teardown: await the send so the cast is actually ended on normal completion,
+                            // but swallow any read failure so a connection already tearing down (interruption) does not re-raise
+                            // into the finalizer. The send's own request timeout bounds a silent Chrome, so this never hangs.
+                            val stop = Abort.run[BrowserReadException](CdpBackend.stopScreencast(session)).unit
+                            Scope.run {
+                                Scope.ensure(restore).andThen(Scope.ensure(stop)).andThen {
+                                    CdpBackend.startScreencast(
+                                        session,
+                                        StartScreencastParams(Present(wireFormat), screenshotQuality(format, quality))
+                                    ).andThen {
+                                        body.map { result =>
+                                            poisoned.get.map { cap =>
+                                                collected.get.map { frames =>
+                                                    cap match
+                                                        case Present((limit, reached)) =>
+                                                            Abort.fail(BrowserCaptureLimitExceededException(
+                                                                "screenshotFrames",
+                                                                limit,
+                                                                reached
+                                                            ))
+                                                        case Absent => (frames, result)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    end screenshotFrames
+
+    /** Decodes a `Page.screencastFrame` event into a `(ScreenshotFrame, sessionId)` pair. Returns `Absent` on a wrong-method event or any
+      * decode failure (never aborts). `offsetMs` is `round(timestamp * 1000) - t0` when the metadata carries a `timestamp`, else the
+      * wall-clock fallback `now - t0`. Distinct from the routing-layer `CdpClient.parseScreencastFrame`, which decodes only the wire
+      * record; this variant materialises the `Image` and the public `ScreenshotFrame`.
+      */
+    private def parseScreencastFrame(ev: CdpEvent.Generic, t0: Instant)(using
+        Frame
+    )
+        : Maybe[(Browser.ScreenshotFrame, Int)] < Sync =
+        ev.method match
+            case "Page.screencastFrame" =>
+                Json.decode[CdpEventParams[ScreencastFrameWire]](ev.paramsJson) match
+                    case Result.Success(env) =>
+                        val w = env.params
+                        Abort.run(CdpBase64Decode.decodeScreenshotImage("Page.screencastFrame", w.data)).map {
+                            case Result.Success(img) =>
+                                val t0Ms = t0.toJava.toEpochMilli
+                                Clock.now.map { now =>
+                                    val offsetMs = w.metadata.timestamp match
+                                        case Present(ts) => math.round(ts * 1000) - t0Ms
+                                        case Absent      => now.toJava.toEpochMilli - t0Ms
+                                    Present((
+                                        Browser.ScreenshotFrame(
+                                            img,
+                                            offsetMs,
+                                            Browser.ScrollPosition(
+                                                math.round(w.metadata.scrollOffsetX).toInt,
+                                                math.round(w.metadata.scrollOffsetY).toInt
+                                            )
+                                        ),
+                                        w.sessionId
+                                    ))
+                                }
+                            case _ => (Absent: Maybe[(Browser.ScreenshotFrame, Int)])
+                        }
+                    case _ => Absent
+            case _ => Absent
+    end parseScreencastFrame
+
     // --- Cookies ---
 
     /** Returns all cookies for the current page.
@@ -2974,15 +3776,96 @@ object Browser:
         def current: NavigationEntry = entries(currentIndex)
     end NavigationHistory
 
-    /** A rectangle in the page's top-level viewport coordinate system. Used by [[boundingBox]] to report an element's geometry. Coordinates
-      * may be negative or exceed viewport size if the element is off-screen.
+    /** Geometry artifact returned by [[boundingRect]]. Fields are CSS pixels relative to the page document. `right`, `bottom`, and `area`
+      * are derived accessors (pure, total, no `Frame`).
       */
-    final case class BoundingBox(
-        x: Double,
-        y: Double,
-        width: Double,
-        height: Double
-    ) derives Schema, CanEqual
+    final case class Bounds(x: Double, y: Double, width: Double, height: Double) derives Schema, CanEqual:
+        def right: Double  = x + width
+        def bottom: Double = y + height
+        def area: Double   = width * height
+    end Bounds
+
+    /** Page scroll offset (`window.scrollX` / `scrollY`, rounded to integers). Returned by [[scrollPosition]] and carried by
+      * `ScreenshotFrame`.
+      */
+    final case class ScrollPosition(x: Int, y: Int) derives Schema, CanEqual
+
+    /** One frame recorded by [[screenshotFrames]]. `image` is the captured frame; `offsetMs` is `round(timestamp * 1000) - t0` from the
+      * screencast metadata (with a wall-clock fallback), relative to the cast start; `scrollOffset` is the page scroll at capture. Carries
+      * an `Image`, so derives only `CanEqual`.
+      */
+    final case class ScreenshotFrame(image: Image, offsetMs: Long, scrollOffset: Browser.ScrollPosition) derives CanEqual
+
+    /** Emulated `prefers-color-scheme` value for [[withEmulation]].
+      *
+      * [[NoPreference]] clears the override: the W3C dropped `no-preference` as a settable value for this feature, so it maps to the
+      * empty-string clear sent to `Emulation.setEmulatedMedia`.
+      */
+    enum ColorScheme derives CanEqual:
+        case Light, Dark, NoPreference
+
+    object ColorScheme:
+        /** CDP wire form for the `prefers-color-scheme` feature: `"light"` / `"dark"` / `""` (cleared). */
+        extension (c: ColorScheme)
+            private[kyo] def wire: String = c match
+                case Light        => "light"
+                case Dark         => "dark"
+                case NoPreference => ""
+        end extension
+    end ColorScheme
+
+    /** Emulated media type for [[withEmulation]]. */
+    enum MediaType derives CanEqual:
+        case Screen, Print
+
+    object MediaType:
+        /** CDP wire form for the emulated media type: `"screen"` / `"print"`. */
+        extension (m: MediaType)
+            private[kyo] def wire: String = m match
+                case Screen => "screen"
+                case Print  => "print"
+        end extension
+    end MediaType
+
+    /** Input to [[withHighlights]]: a dashed box drawn over the element matched by `selector`, with an optional `label` and `color`.
+      *
+      * `label` and `color` default to `Absent`; `color` is a CSS color string (defaulting to a red when absent). Carries a
+      * [[Selector]] (an opaque type), so it derives only `CanEqual`.
+      */
+    final case class Annotation(
+        selector: Selector,
+        label: Maybe[String] = Absent,
+        color: Maybe[String] = Absent
+    ) derives CanEqual
+
+    /** DISCOVER artifact: a resolved element snapshot. Optional fields (`id` / `text` / `role`) are `Maybe`, never null; `classes` is a
+      * `Chunk`; `selector` is the generated stable unique CSS path. The companion holds the pure `leaves` filter. `area` delegates to
+      * `bounds.area`.
+      */
+    final case class ElementInfo(
+        selector: String,
+        tag: String,
+        id: Maybe[String],
+        classes: Chunk[String],
+        text: Maybe[String],
+        bounds: Browser.Bounds,
+        visible: Boolean,
+        inViewport: Boolean,
+        topmost: Boolean,
+        interactive: Boolean,
+        role: Maybe[String]
+    ) derives Schema, CanEqual:
+        def area: Double = bounds.area
+    end ElementInfo
+
+    object ElementInfo:
+        /** Pure leaf filter: keeps elements that are NOT an ancestor of any other element in `elems`. Ancestry is determined from the unique
+          * `selector` path: A is an ancestor of B when B's `selector` starts with A's `selector + " > "`. Total function; no `Frame`, no
+          * effect row.
+          */
+        def leaves(elems: Chunk[Browser.ElementInfo]): Chunk[Browser.ElementInfo] =
+            elems.filter(a => !elems.exists(b => b.selector != a.selector && b.selector.startsWith(a.selector + " > ")))
+    end ElementInfo
 
     /** Accessibility-tree node: what a screen reader sees. Returned by [[accessibilityNodes]] and probed by [[role]] / [[accessibleName]] /
       * [[assertRole]] / [[assertAccessibleName]].
@@ -3000,21 +3883,25 @@ object Browser:
         properties: Dict[String, String]
     ) derives Schema, CanEqual
 
-    /** A single entry captured by the page-side `console.log` / `console.warn` / `console.error` override and returned by
-      * [[Browser.consoleLogs]].
+    /** A single console entry captured during a [[Browser.recordConsole]] body or drained by [[Browser.consoleLogs]].
       *
-      * `level` distinguishes log / warn / error without resorting to prefix smuggling in the message; `timestamp` is wall-clock at emit time
-      * (derived from page-side `Date.now()`).
+      * `level` distinguishes the five console severities without prefix smuggling in the text; `text` is the joined argument string;
+      * `location` is the originating `url:line` when the source carried a stack frame, else `Absent`; `offsetMs` is the milliseconds from
+      * the recording start (or buffer baseline for the drain path) to the moment the entry was emitted.
       */
     final case class ConsoleMessage(
         level: ConsoleLevel,
-        message: String,
-        timestamp: Instant
+        text: String,
+        location: Maybe[String],
+        offsetMs: Long
     ) derives Schema, CanEqual
 
-    /** Level enum for [[ConsoleMessage]]. Mirrors the three `console.*` overrides installed by [[kyo.internal.BrowserTabSetup]]. */
+    /** Level enum for [[ConsoleMessage]]. The five severities mirror the `console.*` overrides installed by
+      * [[kyo.internal.BrowserTabSetup]] (`debug`, `info`, `log`, `warn`, `error`) and the CDP `Runtime.consoleAPICalled` types folded onto
+      * them.
+      */
     enum ConsoleLevel derives Schema, CanEqual:
-        case Log, Warn, Error
+        case Log, Info, Warn, Error, Debug
 
     /** A single JavaScript dialog event captured by [[Browser.withDialogs.recorded]].
       *
@@ -3249,7 +4136,9 @@ object Browser:
             navigationGraceWindow = 300.millis,
             stabilitySampleInterval = 4.millis,
             defaultActionTimeout = 8.seconds,
-            defaultAssertionTimeout = 8.seconds
+            defaultAssertionTimeout = 8.seconds,
+            captureHoldStillTimeout = 1.second,
+            captureHoldStillInterval = 50.millis
         )
 
     end SessionConfig
@@ -3282,6 +4171,11 @@ object Browser:
       *   [[retrySchedule]].
       * @param defaultAssertionTimeout
       *   total time budget for a single assertion. Defaults to 8 seconds, the `maxDuration` of the default [[retrySchedule]].
+      * @param captureHoldStillTimeout
+      *   total best-effort bound for the two-identical-frames hold-still loop per capture. On timeout the last frame is returned; the loop
+      *   never aborts. Default 1 second.
+      * @param captureHoldStillInterval
+      *   inter-capture pacing delay in the two-identical-frames hold-still loop. Default 50 milliseconds.
       *
       * @see
       *   [[Browser.withConfig]]: install a session config for a scope
@@ -3302,7 +4196,9 @@ object Browser:
         navigationGraceWindow: Duration,
         stabilitySampleInterval: Duration,
         defaultActionTimeout: Duration,
-        defaultAssertionTimeout: Duration
+        defaultAssertionTimeout: Duration,
+        captureHoldStillTimeout: Duration,
+        captureHoldStillInterval: Duration
     ):
         /** Returns a copy with the [[retrySchedule]] set to `v`. */
         def retrySchedule(v: Schedule): SessionConfig = copy(retrySchedule = v)
@@ -3345,6 +4241,12 @@ object Browser:
 
         /** Returns a copy with the [[defaultAssertionTimeout]] set to `v`. */
         def defaultAssertionTimeout(v: Duration): SessionConfig = copy(defaultAssertionTimeout = v)
+
+        /** Returns a copy with the [[captureHoldStillTimeout]] set to `v` (total best-effort hold-still bound per capture). */
+        def captureHoldStillTimeout(v: Duration): SessionConfig = copy(captureHoldStillTimeout = v)
+
+        /** Returns a copy with the [[captureHoldStillInterval]] set to `v` (inter-capture pacing in the two-identical-frames loop). */
+        def captureHoldStillInterval(v: Duration): SessionConfig = copy(captureHoldStillInterval = v)
     end SessionConfig
 
     // CanEqual on SessionConfig powers the "explicit non-default session overrides; default inherits outer Local" gate inside
@@ -3512,3 +4414,17 @@ end Browser
   * Scala side decodes a `Seq[ConsoleMessageWire]` and maps to `Chunk[Browser.ConsoleMessage]`, parsing `level` via a small `match`.
   */
 final private[kyo] case class ConsoleMessageWire(level: String, message: String, timestamp: Long) derives Schema
+
+/** Wire record for reads whose JS probe returns `{present: Boolean, x?, y?, w?, h?}`. Used by `boundingRect` to detect a settled-absent
+  * element (when `present` is false) before the authoritative `DOM.getBoxModel` CDP read.
+  */
+final private[kyo] case class PresentFlagWire(present: Boolean, x: Double = 0, y: Double = 0, w: Double = 0, h: Double = 0) derives Schema
+
+/** Wire record for `computedStyles`: `{present: Boolean, vals?: {prop: value, ...}}`. `vals` is `Absent` on the absent-element path. */
+final private[kyo] case class ComputedStylesWire(present: Boolean, vals: Maybe[Map[String, String]] = Absent) derives Schema
+
+/** Wire record for `inViewport`: `{present: Boolean, value?: Boolean}`. `value` carries the boolean result on the present path. */
+final private[kyo] case class PresentBoolWire(present: Boolean, value: Maybe[Boolean] = Absent) derives Schema
+
+/** Wire envelope for a single-element DISCOVER read (`element` / `elementAt`): `{present: Boolean, info?: ElementInfoWire}`. */
+final private[kyo] case class ElementInfoEnvelope(present: Boolean, info: Maybe[DiscoverJs.ElementInfoWire] = Absent) derives Schema

--- a/kyo-browser/shared/src/main/scala/kyo/BrowserException.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/BrowserException.scala
@@ -341,6 +341,21 @@ final case class BrowserInvalidArgumentException(method: String, message: String
     extends BrowserException(s"$method: $message")
     with BrowserReadException derives CanEqual
 
+/** A capture operation exceeded its configured unit limit.
+  *
+  * `operation` names the public method ("screenshotFullPage", "screenshotMarks", "screenshotFrames").
+  * `limit` and `reached` always share one unit. For band and mark caps `limit` is the cap (`maxBands`,
+  * `maxMarks`) and `reached` is the count the page demanded, raised BEFORE any capture (the call is rejected
+  * without partial work). For `screenshotFrames` the cap is checked frame-count-first: the frame cap reports
+  * `limit = maxFrames` against the frame count reached, and the duration cap reports `limit = maxDurationMs`
+  * against the elapsed milliseconds reached, so a caller can interpret the pair without knowing which cap fired.
+  * Pre-CDP argument errors (negative coords, non-positive size) use [[BrowserInvalidArgumentException]] instead,
+  * not this leaf.
+  */
+final case class BrowserCaptureLimitExceededException(operation: String, limit: Int, reached: Int)(using Frame)
+    extends BrowserException(s"Capture limit exceeded for $operation: limit $limit, reached $reached")
+    with BrowserReadException derives CanEqual
+
 // --- Assertion failures ---
 
 /** A waited-for condition did not become true before the deadline.

--- a/kyo-browser/shared/src/main/scala/kyo/internal/BrowserTab.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/BrowserTab.scala
@@ -25,7 +25,8 @@ final private[kyo] class BrowserTab(
     val rootFrameId: AtomicRef[Maybe[FrameId]],
     val consoleCaptureRegistered: AtomicBoolean,
     val responseTrackerRegistered: AtomicBoolean,
-    val viewportOverride: AtomicRef[Maybe[(Int, Int)]],
+    val viewportOverride: AtomicRef[Maybe[BrowserTab.ViewportOverride]],
+    val emulationOverride: AtomicRef[Maybe[BrowserTab.EmulatedMediaState]],
     val downloadPolicy: AtomicRef[Maybe[(Browser.DownloadBehavior, Maybe[String])]]
 ):
     /** Session-scoped CDP client. Every interaction path issues CDP commands against this tab's specific session; capturing the
@@ -33,6 +34,31 @@ final private[kyo] class BrowserTab(
       * at every CDP call site.
       */
     val session: CdpClient = client.withSession(sessionId)
+end BrowserTab
+
+/** Companion for [[BrowserTab]], holding nested types shared across the internal module. */
+private[kyo] object BrowserTab:
+    /** Cached per-tab viewport override carrying the device-scale-factor (DPR).
+      *
+      * Stored in the per-tab `viewportOverride: AtomicRef[Maybe[ViewportOverride]]`. A value
+      * of `Absent` means no active override (natural viewport). `dpr` defaults to `1.0` for
+      * the no-DPR-override case. Consumed by `setViewport`/`withViewport`.
+      */
+    final case class ViewportOverride(width: Int, height: Int, dpr: Double) derives CanEqual
+
+    /** Cached per-tab emulated-media state backing the scoped restore in `Browser.withEmulation`.
+      *
+      * Stored in the per-tab `emulationOverride: AtomicRef[Maybe[EmulatedMediaState]]`. A value of `Absent` means no active
+      * override (the page sees its real media features). `colorScheme` and `media` hold the CDP wire strings sent to
+      * `Emulation.setEmulatedMedia` (`"light"`, `"dark"`, `"screen"`, `"print"`, or `""` for a cleared / unset feature);
+      * `reducedMotion` mirrors the `reducedMotion: Boolean` argument passed to `withEmulation`. On scope exit `withEmulation`
+      * re-applies the cached prior state, or clears the override when the prior was `Absent`.
+      */
+    final case class EmulatedMediaState(
+        colorScheme: Maybe[String],
+        media: Maybe[String],
+        reducedMotion: Boolean
+    ) derives CanEqual
 end BrowserTab
 
 /** All tab-attachment plumbing lives here; `Browser.scala` retains only the `Env[BrowserTab]` binding.
@@ -60,7 +86,8 @@ private[kyo] object BrowserTabSetup:
             rootRef          <- AtomicRef.init[Maybe[FrameId]](Absent)
             consoleRegister  <- AtomicBoolean.init(false)
             responseRegister <- AtomicBoolean.init(false)
-            viewportRef      <- AtomicRef.init[Maybe[(Int, Int)]](Absent)
+            viewportRef      <- AtomicRef.init[Maybe[BrowserTab.ViewportOverride]](Absent)
+            emulationRef     <- AtomicRef.init[Maybe[BrowserTab.EmulatedMediaState]](Absent)
             downloadRef      <- AtomicRef.init[Maybe[(Browser.DownloadBehavior, Maybe[String])]](Absent)
         yield new BrowserTab(
             targetId,
@@ -72,6 +99,7 @@ private[kyo] object BrowserTabSetup:
             consoleRegister,
             responseRegister,
             viewportRef,
+            emulationRef,
             downloadRef
         )
 
@@ -148,12 +176,19 @@ private[kyo] object BrowserTabSetup:
         """(() => {
             window.__kyoConsoleInstalled = true;
             window.__kyoConsoleLogs = [];
+            window.__kyoConsoleT0 = Date.now();
             const origLog = console.log;
+            const origInfo = console.info;
             const origWarn = console.warn;
             const origError = console.error;
+            const origDebug = console.debug;
             console.log = function() {
                 window.__kyoConsoleLogs.push({ level: 'log', message: Array.from(arguments).join(' '), timestamp: Date.now() });
                 origLog.apply(console, arguments);
+            };
+            console.info = function() {
+                window.__kyoConsoleLogs.push({ level: 'info', message: Array.from(arguments).join(' '), timestamp: Date.now() });
+                origInfo.apply(console, arguments);
             };
             console.warn = function() {
                 window.__kyoConsoleLogs.push({ level: 'warn', message: Array.from(arguments).join(' '), timestamp: Date.now() });
@@ -162,6 +197,10 @@ private[kyo] object BrowserTabSetup:
             console.error = function() {
                 window.__kyoConsoleLogs.push({ level: 'error', message: Array.from(arguments).join(' '), timestamp: Date.now() });
                 origError.apply(console, arguments);
+            };
+            console.debug = function() {
+                window.__kyoConsoleLogs.push({ level: 'debug', message: Array.from(arguments).join(' '), timestamp: Date.now() });
+                origDebug.apply(console, arguments);
             };
             return 'ok';
         })()"""

--- a/kyo-browser/shared/src/main/scala/kyo/internal/CdpBackend.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/CdpBackend.scala
@@ -103,6 +103,36 @@ private[kyo] object CdpBackend:
     private[kyo] def clearDeviceMetricsOverride(sender: CdpSender)(using Frame): Unit < (Async & Abort[BrowserReadException]) =
         sender.send("Emulation.clearDeviceMetricsOverride").unit
 
+    /** Sets the emulated media type and/or media features (e.g. prefers-color-scheme). */
+    private[kyo] def setEmulatedMedia(sender: CdpSender, params: SetEmulatedMediaParams)(using
+        Frame
+    ): Unit < (Async & Abort[BrowserReadException]) =
+        sender.send("Emulation.setEmulatedMedia", params).unit
+
+    /** Overrides the default background color (used for transparent-background captures). */
+    private[kyo] def setDefaultBackgroundColorOverride(sender: CdpSender, params: SetDefaultBackgroundColorOverrideParams)(using
+        Frame
+    ): Unit < (Async & Abort[BrowserReadException]) =
+        sender.send("Emulation.setDefaultBackgroundColorOverride", params).unit
+
+    // --- Page domain (screencast) ---
+
+    /** Starts a screencast session, delivering frames via `Page.screencastFrame` events. */
+    private[kyo] def startScreencast(sender: CdpSender, params: StartScreencastParams)(using
+        Frame
+    ): Unit < (Async & Abort[BrowserReadException]) =
+        sender.send("Page.startScreencast", params).unit
+
+    /** Stops the current screencast session. */
+    private[kyo] def stopScreencast(sender: CdpSender)(using Frame): Unit < (Async & Abort[BrowserReadException]) =
+        sender.send("Page.stopScreencast").unit
+
+    /** Acknowledges a screencast frame, allowing Chrome to deliver the next one. */
+    private[kyo] def screencastFrameAck(sender: CdpSender, params: ScreencastFrameAckParams)(using
+        Frame
+    ): Unit < (Async & Abort[BrowserReadException]) =
+        sender.send("Page.screencastFrameAck", params).unit
+
     // --- Input domain ---
 
     /** Dispatches a keyboard event (keyDown / keyUp / char) to the focused element. */

--- a/kyo-browser/shared/src/main/scala/kyo/internal/CdpClient.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/CdpClient.scala
@@ -32,6 +32,8 @@ final class CdpClient private[kyo] (
     private[kyo] val drainSignal: AtomicRef[Fiber.Promise[Unit, Any]],
     private[kyo] val frameEventDispatchers: AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]],
     private[kyo] val downloadEventDispatchers: AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]],
+    private[kyo] val screencastEventDispatchers: AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]],
+    private[kyo] val consoleEventDispatchers: AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]],
     private[kyo] val dialogRecorders: AtomicRef[Dict[String, AtomicRef[Chunk[Browser.DialogEvent]]]],
     private[kyo] val lastEvaluateParams: AtomicRef[Maybe[String]],
     private[kyo] val cdpMeter: Meter,
@@ -128,6 +130,8 @@ final class CdpClient private[kyo] (
             drainSignal,
             frameEventDispatchers,
             downloadEventDispatchers,
+            screencastEventDispatchers,
+            consoleEventDispatchers,
             dialogRecorders,
             lastEvaluateParams,
             cdpMeter,
@@ -291,6 +295,14 @@ object CdpClient:
             // cross-talk. Dispatch is ADDITIVE: events continue to flow through the events channel
             // via the whitelist branch so internal consumers (`session.exchange.events`) keep working.
             downloadEventDispatchers <- AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty)
+            // Per-connection registry for `Page.screencastFrame` handlers installed by screencast
+            // subscribers. Keyed by CDP session ID. Dispatch is mutually exclusive: a registered
+            // handler consumes the event (returns Skip); no handler pushes to exchange.events.
+            screencastEventDispatchers <- AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty)
+            // Per-connection registry for `Runtime.consoleAPICalled` and `Runtime.exceptionThrown`
+            // handlers. Keyed by CDP session ID. Same mutually-exclusive dispatch semantics as
+            // screencastEventDispatchers.
+            consoleEventDispatchers <- AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty)
             // Per-session dialog recorders installed by `Browser.withDialogs.recorded`. Keyed by CDP session ID so
             // concurrent tabs do not cross-talk. Each entry holds an `AtomicRef[Chunk[DialogEvent]]` updated in
             // arrival order by the CDP reader fiber after the auto-handler decision is made.
@@ -306,6 +318,8 @@ object CdpClient:
                         dialogQueue,
                         frameEventDispatchers,
                         downloadEventDispatchers,
+                        screencastEventDispatchers,
+                        consoleEventDispatchers,
                         dialogRecorders
                     )
             )
@@ -360,6 +374,8 @@ object CdpClient:
             drainSignal,
             frameEventDispatchers,
             downloadEventDispatchers,
+            screencastEventDispatchers,
+            consoleEventDispatchers,
             dialogRecorders,
             lastEvaluateParams,
             cdpMeter,
@@ -374,10 +390,89 @@ object CdpClient:
       */
     private[kyo] val eventWhitelist: Set[String] = Set(
         "Page.downloadWillBegin",
-        "Page.downloadProgress"
+        "Page.downloadProgress",
+        "Page.screencastFrame",
+        "Runtime.consoleAPICalled",
+        "Runtime.exceptionThrown"
     )
 
     private[kyo] def isWhitelistedEvent(method: String): Boolean = eventWhitelist.contains(method)
+
+    /** Routes `ev` to the per-session handler when one is registered for `sid`, returning `Skip` so the event is not also pushed. When no
+      * handler is registered (or `sid` is `Absent`), pushes the event to `exchange.events` for any subscribed consumer. Mirrors the
+      * semantics of the prior inlined download-routing block exactly.
+      *
+      * The handler type `CdpEvent.Generic => Unit < Sync` requires callers to resolve all effects (including `Abort[Closed]` from a closed
+      * backing channel) before storing the handler in the map. `dispatchOrPush` therefore stays `< Sync` with no `Abort` in its own effect
+      * row; the handler is responsible for swallowing `Abort[Closed]` internally via `Abort.run[Closed](...).unit`.
+      */
+    private def dispatchOrPush(
+        dispatchers: AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]],
+        sid: Maybe[SessionId],
+        ev: CdpEvent.Generic
+    )(using Frame): Exchange.Message[Int, String, CdpEvent] < Sync =
+        dispatchers.use { d =>
+            sid match
+                case Present(s) =>
+                    d.get(s.value) match
+                        case Present(handler) => handler(ev).andThen(Exchange.Message.Skip)
+                        case Absent           => Exchange.Message.Push(ev)
+                case Absent => Exchange.Message.Push(ev)
+        }
+
+    /** Like [[dispatchOrPush]] but DROPS the event (returns Skip) when no per-session handler is registered, instead of pushing it to the
+      * bounded `exchange.events` channel. Used for opt-in `Runtime.consoleAPICalled` / `Runtime.exceptionThrown` events, which only a
+      * `withConsole`-style subscriber observes (via a registered handler). When no subscriber is active, no consumer drains these events
+      * from `exchange.events`; pushing them there lets a high-frequency emitter (e.g. a page in a tight throw/console loop) fill the bounded
+      * channel and block the reader fiber, wedging every CDP response. Dropping when unsubscribed keeps the reader fiber free; the subscribe
+      * path stays unchanged (its handler does the best-effort offer).
+      */
+    private def dispatchOrDrop(
+        dispatchers: AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]],
+        sid: Maybe[SessionId],
+        ev: CdpEvent.Generic
+    )(using Frame): Exchange.Message[Int, String, CdpEvent] < Sync =
+        dispatchers.use { d =>
+            sid match
+                case Present(s) =>
+                    d.get(s.value) match
+                        case Present(handler) => handler(ev).andThen(Exchange.Message.Skip)
+                        case Absent           => Exchange.Message.Skip
+                case Absent => Exchange.Message.Skip
+        }
+
+    /** Decodes a `Page.screencastFrame` event into a `(ScreencastFrameWire, sessionId: Int)` pair. Returns `Absent` on a wrong-method event
+      * or any decode failure. The decoder is `Maybe`-returning and never aborts; decode failures are treated as unknown frames.
+      *
+      * The caller (registered by the screencast subscriber) issues `Page.screencastFrameAck(sessionId)` from inside the handler body after
+      * decoding, keeping Chrome delivering subsequent frames.
+      */
+    private[kyo] def parseScreencastFrame(ev: CdpEvent.Generic)(using Frame): Maybe[(ScreencastFrameWire, Int)] =
+        ev.method match
+            case "Page.screencastFrame" =>
+                Json.decode[CdpEventParams[ScreencastFrameWire]](ev.paramsJson) match
+                    case Result.Success(env) => Present((env.params, env.params.sessionId))
+                    case _                   => Absent
+            case _ => Absent
+
+    /** Decodes a `Runtime.consoleAPICalled` or `Runtime.exceptionThrown` event. Returns `Absent` on a wrong-method event or any decode
+      * failure. The decoder is `Maybe`-returning and never aborts.
+      *
+      * The return type discriminates between the two CDP event shapes using `Either`: `Left` carries `ConsoleApiCalledWire` and `Right`
+      * carries `ExceptionThrownWire`. This discriminator is internal to the routing layer; the console-event subscriber (installed later)
+      * unwraps it to produce `ConsoleMessage` values.
+      */
+    private[kyo] def parseConsoleEvent(ev: CdpEvent.Generic)(using Frame): Maybe[Either[ConsoleApiCalledWire, ExceptionThrownWire]] =
+        ev.method match
+            case "Runtime.consoleAPICalled" =>
+                Json.decode[CdpEventParams[ConsoleApiCalledWire]](ev.paramsJson) match
+                    case Result.Success(env) => Present(Left(env.params))
+                    case _                   => Absent
+            case "Runtime.exceptionThrown" =>
+                Json.decode[CdpEventParams[ExceptionThrownWire]](ev.paramsJson) match
+                    case Result.Success(env) => Present(Right(env.params))
+                    case _                   => Absent
+            case _ => Absent
 
     /** Decodes a CDP wire message and routes it.
       *
@@ -401,6 +496,8 @@ object CdpClient:
         dialogQueue: Channel[(Boolean, String, Maybe[SessionId])],
         frameEventDispatchers: AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]],
         downloadEventDispatchers: AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]],
+        screencastEventDispatchers: AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]],
+        consoleEventDispatchers: AtomicRef[Dict[String, CdpEvent.Generic => Unit < Sync]],
         dialogRecorders: AtomicRef[Dict[String, AtomicRef[Chunk[Browser.DialogEvent]]]]
     )(using Frame): Exchange.Message[Int, String, CdpEvent] < Sync =
         // The dispatcher peeks `{id, method, sessionId, error}` via [[CdpWireMessage]] for routing; the method-
@@ -457,35 +554,20 @@ object CdpClient:
                                             case Absent => Kyo.unit
                                     }.andThen(Exchange.Message.Skip)
                                 else if isWhitelistedEvent(method) then
-                                    // Whitelisted download events route via the per-session dispatcher when one is
-                                    // registered (Browser.onDownload subscriber). When NO dispatcher is registered
-                                    // (or the event is non-download), the event is pushed to `exchange.events` so
-                                    // internal consumers (via `session.exchange.events`) can observe it.
+                                    // Whitelisted events route via the per-session dispatcher when one is registered.
+                                    // Each domain has its own dispatcher map; events not matching any dispatcher are
+                                    // pushed to exchange.events so internal consumers can observe them.
                                     //
-                                    // Mutually exclusive routing: pushing to `exchange.events` regardless would
-                                    // stockpile events in a bounded channel (default capacity 16) when no internal
-                                    // consumer drains. Once full, the CDP reader fiber parks (backpressure), and
-                                    // subsequent download events for ANY tab are blocked from being decoded,
-                                    // including the terminal `state="completed"` Progress that downstream code
-                                    // (Browser.onDownload's collectEvents) awaits. Concurrent tabs each generate
-                                    // their own streams of WillBegin and Progress events; without a dispatcher to
-                                    // consume them, events accumulate across tabs until the channel saturates and
-                                    // the reader stops draining.
+                                    // Mutually exclusive routing: a registered dispatcher consumes the event (Skip)
+                                    // so the same event is never both dispatched and pushed. This prevents unbounded
+                                    // accumulation in the bounded events channel when no consumer is subscribed.
                                     val ev = CdpEvent.Generic(method, paramsStr, sid)
                                     if method == "Page.downloadWillBegin" || method == "Page.downloadProgress" then
-                                        downloadEventDispatchers.use { dispatchers =>
-                                            sid match
-                                                case Present(s) =>
-                                                    dispatchers.get(s.value) match
-                                                        case Present(handler) =>
-                                                            // Dispatcher consumed the event; do NOT also push.
-                                                            handler(ev).andThen(Exchange.Message.Skip)
-                                                        case Absent =>
-                                                            // No dispatcher: push so `exchange.events` consumers see it.
-                                                            Exchange.Message.Push(ev)
-                                                case Absent =>
-                                                    Exchange.Message.Push(ev)
-                                        }
+                                        dispatchOrPush(downloadEventDispatchers, sid, ev)
+                                    else if method == "Page.screencastFrame" then
+                                        dispatchOrPush(screencastEventDispatchers, sid, ev)
+                                    else if method == "Runtime.consoleAPICalled" || method == "Runtime.exceptionThrown" then
+                                        dispatchOrDrop(consoleEventDispatchers, sid, ev)
                                     else
                                         Exchange.Message.Push(ev)
                                     end if

--- a/kyo-browser/shared/src/main/scala/kyo/internal/CdpTypes.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/CdpTypes.scala
@@ -266,7 +266,54 @@ final private[kyo] case class GetPropertiesResult(
 ) derives Schema
 
 /** Emulation domain. */
-final private[kyo] case class ViewportParams(width: Int, height: Int, deviceScaleFactor: Int = 1, mobile: Boolean = false) derives Schema
+final private[kyo] case class ViewportParams(width: Int, height: Int, deviceScaleFactor: Double = 1.0, mobile: Boolean = false)
+    derives Schema
+
+// Emulation media + background-color override
+final private[kyo] case class EmulatedMediaFeature(name: String, value: String) derives Schema
+final private[kyo] case class SetEmulatedMediaParams(media: Maybe[String] = Absent, features: Maybe[Seq[EmulatedMediaFeature]] = Absent)
+    derives Schema
+final private[kyo] case class RgbaColor(r: Int, g: Int, b: Int, a: Maybe[Double] = Absent) derives Schema
+final private[kyo] case class SetDefaultBackgroundColorOverrideParams(color: Maybe[RgbaColor] = Absent) derives Schema
+
+// Screencast (Page domain)
+final private[kyo] case class StartScreencastParams(
+    format: Maybe[String] = Absent,
+    quality: Maybe[Int] = Absent,
+    everyNthFrame: Maybe[Int] = Absent
+) derives Schema
+final private[kyo] case class ScreencastFrameAckParams(sessionId: Int) derives Schema
+final private[kyo] case class ScreencastFrameMetadata(
+    scrollOffsetX: Double,
+    scrollOffsetY: Double,
+    timestamp: Maybe[Double] = Absent,
+    offsetTop: Maybe[Double] = Absent,
+    pageScaleFactor: Maybe[Double] = Absent,
+    deviceWidth: Maybe[Double] = Absent,
+    deviceHeight: Maybe[Double] = Absent
+) derives Schema
+final private[kyo] case class ScreencastFrameWire(data: String, metadata: ScreencastFrameMetadata, sessionId: Int) derives Schema
+
+// Runtime console events
+final private[kyo] case class RemoteObjectValue(`type`: String, value: Maybe[String] = Absent, description: Maybe[String] = Absent)
+    derives Schema
+final private[kyo] case class CallFrameWire(url: Maybe[String] = Absent, lineNumber: Maybe[Int] = Absent, columnNumber: Maybe[Int] = Absent)
+    derives Schema
+final private[kyo] case class StackTraceWire(callFrames: Seq[CallFrameWire] = Nil) derives Schema
+final private[kyo] case class ConsoleApiCalledWire(
+    `type`: String,
+    args: Seq[RemoteObjectValue] = Nil,
+    timestamp: Maybe[Double] = Absent,
+    stackTrace: Maybe[StackTraceWire] = Absent
+) derives Schema
+final private[kyo] case class ExceptionDetailsWire(
+    text: String,
+    url: Maybe[String] = Absent,
+    lineNumber: Maybe[Int] = Absent,
+    stackTrace: Maybe[StackTraceWire] = Absent,
+    exception: Maybe[RemoteObjectValue] = Absent
+) derives Schema
+final private[kyo] case class ExceptionThrownWire(timestamp: Maybe[Double] = Absent, exceptionDetails: ExceptionDetailsWire) derives Schema
 
 /** `Emulation.setFocusEmulationEnabled`: makes Chrome treat the page as if the tab were the system-focused window. Without this,
   * programmatic `el.focus()` calls update `document.activeElement` but do NOT dispatch focus/blur DOM events; framework listeners (kyo-ui,
@@ -280,7 +327,9 @@ final private[kyo] case class ScreenshotClip(x: Double, y: Double, width: Double
 final private[kyo] case class ScreenshotParams(
     format: Browser.ScreenshotFormat = Browser.ScreenshotFormat.Png,
     quality: Maybe[Int] = Absent,
-    clip: Maybe[ScreenshotClip] = Absent
+    clip: Maybe[ScreenshotClip] = Absent,
+    captureBeyondViewport: Maybe[Boolean] = Absent,
+    fromSurface: Maybe[Boolean] = Absent
 ) derives Schema
 final private[kyo] case class ScreenshotResult(data: String) derives Schema
 
@@ -440,6 +489,24 @@ final private[kyo] case class ActionabilityResponse(
 
 /** Wire shape for the in-page `getBoundingClientRect()` snapshot used by `Browser.screenshotElement`. */
 final private[kyo] case class BoundingRectWire(x: Double, y: Double, width: Double, height: Double) derives Schema
+
+/** Wire shape for the full-page dimension probe used by `Browser.screenshotFullPage`. `content` is the total scroll height in CSS px,
+  * `viewport` is the inner height, and `width` is the inner width (all from `window` / `document.documentElement`).
+  */
+final private[kyo] case class FullPageDimsWire(content: Int, viewport: Int, width: Int) derives Schema
+
+/** Wire shape for the box-stable check in `Browser.screenshotElement`. `found` is false when the element does not exist; `ok` is false when
+  * the element exists but its bounding rect is still moving. When both `found` and `ok` are true, the remaining fields hold the post-scroll
+  * rect in CSS px.
+  */
+final private[kyo] case class ElementClipWire(
+    found: Boolean = true,
+    ok: Boolean,
+    x: Double = 0,
+    y: Double = 0,
+    width: Double = 0,
+    height: Double = 0
+) derives Schema
 
 /** Wire envelope used by `Browser.mockFetchResponse` to pass the mock definition to the JS interceptor via `JSON.parse`.
   *

--- a/kyo-browser/shared/src/main/scala/kyo/internal/DiscoverJs.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/DiscoverJs.scala
@@ -1,0 +1,80 @@
+package kyo.internal
+
+import kyo.*
+
+/** The single injected idempotent in-page DISCOVER helper. Installed once per page (gated by `window.__kyoDiscoverInstalled`, like the
+  * console-capture install), it exposes `window.__kyoDiscoverProbe(el)` returning the `ElementInfo` wire shape for one element and
+  * `window.__kyoUniqueSelector(el)` building a stable unique CSS path. `element` / `elements` / `elementAt` call it via `Runtime.evaluate`,
+  * settled through `SettleRead`.
+  */
+private[kyo] object DiscoverJs:
+
+    /** Wire shape for one probed element, decoded into `Browser.ElementInfo`. All fields have defaults so missing JSON keys decode to
+      * `Absent` / zero / false without error.
+      */
+    final private[kyo] case class ElementInfoWire(
+        selector: String = "",
+        tag: String = "",
+        id: Maybe[String] = Absent,
+        classes: Chunk[String] = Chunk.empty,
+        text: Maybe[String] = Absent,
+        x: Double = 0.0,
+        y: Double = 0.0,
+        width: Double = 0.0,
+        height: Double = 0.0,
+        visible: Boolean = false,
+        inViewport: Boolean = false,
+        topmost: Boolean = false,
+        interactive: Boolean = false,
+        role: Maybe[String] = Absent
+    ) derives Schema
+
+    /** Idempotent install of `window.__kyoDiscoverProbe` and `window.__kyoUniqueSelector`. `text` is truncated to 200 chars; empty-post-trim
+      * maps to null. `interactive` is tag/role/tabindex/onclick. `topmost` is a single rect-center `elementFromPoint` resolving to `el` or a
+      * descendant. `inViewport` is shared with the VERIFY `inViewport` JS.
+      */
+    private[kyo] val installJs: String =
+        """(() => {
+            if (window.__kyoDiscoverInstalled) return 'shared';
+            window.__kyoDiscoverInstalled = true;
+            const INTERACTIVE_TAGS = new Set(['A','BUTTON','INPUT','SELECT','TEXTAREA','OPTION','LABEL']);
+            const INTERACTIVE_ROLES = new Set(['button','link','checkbox','radio','tab','menuitem','textbox']);
+            window.__kyoUniqueSelector = (el) => {
+                const parts = [];
+                for (let n = el; n && n.nodeType === 1; n = n.parentElement) {
+                    if (n.id && document.querySelectorAll('#' + CSS.escape(n.id)).length === 1) {
+                        parts.unshift('#' + CSS.escape(n.id));
+                        break;
+                    }
+                    const tag = n.tagName.toLowerCase();
+                    let k = 1; for (let s = n.previousElementSibling; s; s = s.previousElementSibling) if (s.tagName === n.tagName) k++;
+                    parts.unshift(tag + ':nth-of-type(' + k + ')');
+                }
+                return parts.join(' > ');
+            };
+            window.__kyoDiscoverProbe = (el) => {
+                const r = el.getBoundingClientRect();
+                const t = (el.textContent || '').trim().slice(0, 200);
+                const role = el.getAttribute('role');
+                const cx = r.left + r.width / 2, cy = r.top + r.height / 2;
+                const hit = document.elementFromPoint(cx, cy);
+                const topmost = !!(hit && (hit === el || el.contains(hit)));
+                const visible = (typeof el.checkVisibility === 'function' ? el.checkVisibility() : true) && r.width > 0 && r.height > 0;
+                const inViewport = r.right > 0 && r.bottom > 0 && r.left < window.innerWidth && r.top < window.innerHeight;
+                const interactive = INTERACTIVE_TAGS.has(el.tagName) || el.hasAttribute('onclick')
+                    || (role && INTERACTIVE_ROLES.has(role)) || el.tabIndex >= 0;
+                const obj = {
+                    selector: window.__kyoUniqueSelector(el),
+                    tag: el.tagName.toLowerCase(),
+                    classes: Array.from(el.classList),
+                    x: r.x, y: r.y, width: r.width, height: r.height,
+                    visible: visible, inViewport: inViewport, topmost: topmost, interactive: interactive
+                };
+                if (el.id) obj.id = el.id;
+                if (t) obj.text = t;
+                if (role) obj.role = role;
+                return obj;
+            };
+            return 'installed';
+        })()"""
+end DiscoverJs

--- a/kyo-browser/shared/src/main/scala/kyo/internal/HoldStill.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/HoldStill.scala
@@ -1,0 +1,155 @@
+package kyo.internal
+
+import kyo.*
+
+/** Hold-still capture: a TARGET convention (the legacy `Browser.screenshot` is a plain direct
+  * capture that predates hold-still; each public capture method that adopts this convention notes
+  * it in scaladoc). This helper wraps any base capture thunk and is best-effort: it NEVER aborts
+  * on timeout (returns the last frame). Order of operations:
+  *
+  *   1. Best-effort `settleForCapture` (pre-capture DOM settle, proceeds on timeout).
+  *   2. Await `document.fonts.ready` via `evalJsAwaiting` (the expression returns a Promise).
+  *   3. Inject a `data-kyo-internal` freeze `<style>` (animations/transitions paused, caret
+  *      hidden; removed via `Scope.acquireRelease` on success/failure/interruption).
+  *   4. Loop the base capture until two consecutive frames share a `frameHash` or
+  *      `captureHoldStillTimeout` elapses; returns the last frame.
+  *
+  * The cross-CDP per-frame loop (paced by `Clock.sleep(captureHoldStillInterval)`) is exempt from
+  * the in-page `awaitPromise` single-eval constraint: that constraint binds only
+  * in-page transient loops. The JS-side font/freeze evals are each a single non-splitting eval.
+  * The hold-still loop is NOT an in-page transient loop; each iteration issues a full CDP
+  * round-trip.
+  *
+  * `Async` used internally (`Clock.sleep`, capture suspension) is absorbed by the `Browser` effect
+  * at the `Browser.run` boundary and does not appear in callers' public rows (`Browser <:
+  * Async` at the run boundary; the locked public signatures stay `Browser &
+  * Abort[BrowserReadException]` without `Async`).
+  *
+  * The freeze `<style data-kyo-internal>` injection produces ONE unfiltered `childList` mutation
+  * because the insertion targets the untagged `document.head` parent. A live `settleForCapture`
+  * gate tolerates this single mutation as one quiet-window; `settleForCapture` runs BEFORE the
+  * injection (step 1 above), so the mutation lands within its quiet-window. HoldStill convergence
+  * is FRAME-HASH based (two byte-identical consecutive frames), not settlement-gate based, so the
+  * injection mutation does not break convergence.
+  *
+  * For multi-band captures (e.g. full-page strips) use `withFrozenPage` to settle and freeze ONCE
+  * around the whole loop, then call `holdStillFrame` per band. This guarantees all bands are
+  * captured from the same frozen animation state, preventing visual inconsistencies between strips.
+  * `withHoldStill` remains the single-call form: settle + freeze + hold-still loop + teardown.
+  */
+private[kyo] object HoldStill:
+
+    /** Hash of the DECODED image bytes.
+      *
+      * `Image.hashCode` is overridden to use `MurmurHash3.bytesHash` over the underlying byte
+      * array, giving content-equality semantics. Using `img.hashCode` (not `img.binary.hashCode`)
+      * is correct because `Span[Byte]` is opaque over `Array[Byte]` and `Array.hashCode` is
+      * reference identity, meaning two byte-identical frames would never match with
+      * `img.binary.hashCode`, making the loop never converge on identical content.
+      * `Image.hashCode` already implements the content hash the loop needs.
+      */
+    private[kyo] def frameHash(img: Image): Int = img.hashCode
+
+    /** Injects the freeze `<style>`, tagging it with a unique `data-kyo-token` minted from an in-page monotonic sequence, and returns
+      * that token. The matching [[removeFreezeStyleJs]] removes only the node carrying the returned token rather than a shared global
+      * slot, so nested or interleaved freezes each lift exactly their own style node: an inner freeze's teardown cannot leave the outer
+      * freeze stuck (a leaked page-wide `animation-play-state: paused`).
+      */
+    private[kyo] val freezeStyleJs: String =
+        """(() => {
+            const s = document.createElement('style');
+            const token = String((window.__kyoOverlayToken = (window.__kyoOverlayToken || 0) + 1));
+            s.setAttribute('data-kyo-internal', 'freeze');
+            s.setAttribute('data-kyo-token', token);
+            s.textContent = [
+                '*, *::before, *::after { animation-play-state: paused !important; transition: none !important; }',
+                'input, textarea, [contenteditable] { caret-color: transparent !important; }'
+            ].join(' ');
+            document.head.appendChild(s);
+            return token;
+        })()"""
+
+    private[kyo] def removeFreezeStyleJs(token: String): String =
+        val escaped = JsStringUtil.escapeJsString(token)
+        s"""(() => {
+            document.querySelectorAll('[data-kyo-token="$escaped"]').forEach(n => n.remove());
+            return 'unfrozen';
+        })()"""
+    end removeFreezeStyleJs
+
+    /** Awaits `document.fonts.ready` via an async promise eval (`evalJsAwaiting`, not `evalJs`,
+      * since the expression returns a Promise). Wrapped in try/catch so a page without a fonts API
+      * does not abort the capture.
+      */
+    private[kyo] val fontsReadyJs: String =
+        "(async () => { try { await document.fonts.ready; } catch (e) {} return 'ready'; })()"
+
+    /** Settles the page for capture, awaits fonts, and injects the freeze stylesheet for the
+      * duration of `body`. The freeze style is removed via `Scope.acquireRelease` on
+      * success/failure/interruption. This is the setup half of the hold-still protocol; use it
+      * directly when multiple captures need to share a single frozen animation state (e.g. full-page
+      * bands). Pair with `holdStillFrame` per individual capture.
+      */
+    private[kyo] def withFrozenPage[A, S](
+        body: => A < (Browser & Abort[BrowserReadException] & S)
+    )(using Frame): A < (Browser & Abort[BrowserReadException] & S) =
+        MutationSettlement.settleForCapture.andThen {
+            BrowserEval.evalJsAwaiting(fontsReadyJs).andThen {
+                Browser.use { tab =>
+                    Scope.run {
+                        Scope.acquireRelease(BrowserEval.evalJs(freezeStyleJs)) { token =>
+                            Browser.releaseHook(tab)(BrowserEval.evalJs(removeFreezeStyleJs(token)).unit)
+                        }.andThen(body)
+                    }
+                }
+            }
+        }
+    end withFrozenPage
+
+    /** Runs `capture` in the two-identical-frames hold-still loop, assuming the page is already
+      * settled and frozen (i.e. called inside `withFrozenPage`). Reads
+      * `captureHoldStillTimeout`/`captureHoldStillInterval` from `Browser.configLocal`. Never
+      * aborts on timeout; returns the last captured frame.
+      */
+    private[kyo] def holdStillFrame[S](
+        capture: => Image < (Browser & Abort[BrowserReadException] & S)
+    )(using Frame): Image < (Browser & Abort[BrowserReadException] & S) =
+        Browser.configLocal.use { cfg =>
+            val timeout  = cfg.captureHoldStillTimeout
+            val interval = cfg.captureHoldStillInterval
+            Clock.nowMonotonic.map { start =>
+                capture.map { first =>
+                    Loop(first, frameHash(first)) { (prev, prevHash) =>
+                        Clock.nowMonotonic.map { now =>
+                            if now - start >= timeout then Loop.done(prev)
+                            else
+                                Clock.sleep(interval).andThen {
+                                    capture.map { next =>
+                                        val h = frameHash(next)
+                                        if h == prevHash then Loop.done(next)
+                                        else Loop.continue(next, h)
+                                    }
+                                }
+                        }
+                    }
+                }
+            }
+        }
+    end holdStillFrame
+
+    /** Awaits fonts.ready, injects the freeze style (removed on scope exit), then loops `capture`
+      * until `frameHash` repeats or `captureHoldStillTimeout` elapses; returns the last captured
+      * frame. The loop reads `captureHoldStillTimeout`/`captureHoldStillInterval` from
+      * `Browser.configLocal`. Never aborts on timeout.
+      *
+      * Equivalent to `withFrozenPage { holdStillFrame(capture) }`. Use this for single captures;
+      * use `withFrozenPage` + `holdStillFrame` directly when capturing multiple bands that must all
+      * reflect the same frozen animation state.
+      */
+    private[kyo] def withHoldStill[S](
+        capture: => Image < (Browser & Abort[BrowserReadException] & S)
+    )(using Frame): Image < (Browser & Abort[BrowserReadException] & S) =
+        withFrozenPage(holdStillFrame(capture))
+    end withHoldStill
+
+end HoldStill

--- a/kyo-browser/shared/src/main/scala/kyo/internal/MutationSettlement.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/MutationSettlement.scala
@@ -69,6 +69,36 @@ private[kyo] object MutationSettlement:
         }
     end afterAction
 
+    /** STRICT on-demand quiescence wait backing `Browser.waitForStable`. Installs the observer with no action to settle after, runs the
+      * existing single-`awaitPromise` `awaitQuiescence` loop with `overallDeadline = timeout`, and ABORTS `BrowserAssertionTimedOutException`
+      * on timeout (it does NOT swallow the `SettlementResult.Timeout` path). The startCount baseline is captured at observer-install, so the
+      * loop waits for quiescence from the current moment.
+      */
+    private[kyo] def waitForStable(timeout: Duration)(using Frame): Unit < (Browser & Async & Abort[BrowserReadException]) =
+        Browser.configLocal.use { cfg =>
+            val quiescenceWindow = cfg.mutationQuiescenceWindow
+            val firstGrace       = cfg.mutationFirstMutationGrace
+            val pollInterval     = cfg.mutationPollInterval
+            Scope.run {
+                Browser.use { tab =>
+                    Scope.acquireRelease(installObserver())(_ => releaseObserver(tab)).andThen {
+                        awaitQuiescence(quiescenceWindow, timeout, firstGrace, pollInterval)
+                    }
+                }
+            }
+        }
+
+    /** Best-effort CAPTURE-SETTLE entry: same as `waitForStable` but maps the timeout outcome to `()` instead of aborting (recovers the
+      * `BrowserAssertionTimedOutException` to unit). The hold-still capture path calls it once before injecting the freeze stylesheet, so a
+      * pre-capture DOM settle runs first; on timeout it proceeds to capture rather than aborting.
+      */
+    private[kyo] def settleForCapture(using Frame): Unit < (Browser & Async & Abort[BrowserReadException]) =
+        Browser.configLocal.use { cfg =>
+            Abort.recover[BrowserAssertionTimedOutException](_ => ()) {
+                waitForStable(cfg.mutationSettlementTimeout)
+            }
+        }
+
     // --- Internal ---
 
     /** Installs (or increments the ref count on) the window-level mutation observer. Idempotent: a subsequent install while an observer
@@ -92,7 +122,28 @@ private[kyo] object MutationSettlement:
             window.__kyoMutCount = 0;
             window.__kyoMutObsRef = 1;
             window.__kyoMutObs = new MutationObserver((records) => {
-                window.__kyoMutCount = (window.__kyoMutCount || 0) + records.length;
+                const inInternal = (n) => {
+                    const el = (n && n.nodeType === 1) ? n : (n && n.parentElement);
+                    return !!(el && el.closest && el.closest('[data-kyo-internal]'));
+                };
+                const real = records.filter(r => {
+                    // Transparent when the record's target sits inside a data-kyo-internal subtree (covers attribute /
+                    // characterData / childList mutations made WITHIN a tagged overlay).
+                    if (inInternal(r.target)) return false;
+                    // Transparent when the record INSERTS or REMOVES a tagged root: the target is the untagged parent
+                    // (e.g. document.body), and the tagged node is in addedNodes / removedNodes. Treat the record as
+                    // transparent only when it touches at least one node and EVERY added AND removed node is (or is
+                    // within) a tagged subtree, so a mixed batch that also moves real nodes still arms the gate.
+                    const touched = (r.addedNodes ? r.addedNodes.length : 0) + (r.removedNodes ? r.removedNodes.length : 0);
+                    if (r.type === 'childList' && touched > 0) {
+                        const added = Array.prototype.every.call(r.addedNodes || [], inInternal);
+                        const removed = Array.prototype.every.call(r.removedNodes || [], inInternal);
+                        if (added && removed) return false;
+                    }
+                    return true;
+                });
+                if (real.length === 0) return;
+                window.__kyoMutCount = (window.__kyoMutCount || 0) + real.length;
                 window.__kyoMutLast = Date.now();
             });
             const opts = { childList: true, subtree: true, attributes: true, characterData: true };

--- a/kyo-browser/shared/src/main/scala/kyo/internal/Selector.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/Selector.scala
@@ -125,6 +125,9 @@ object Selector:
     /** Matches an element by a raw CSS selector string. */
     def css(value: String): Selector = SelectorNode.Css(value)
 
+    /** Matches every element on the page (CSS `*`). The default for `Browser.elements`. */
+    def all: Selector = css("*")
+
     /** Matches an element by its `data-testid` attribute. */
     def testId(value: String): Selector = SelectorNode.TestId(value)
 

--- a/kyo-browser/shared/src/main/scala/kyo/internal/SettleRead.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/SettleRead.scala
@@ -1,0 +1,41 @@
+package kyo.internal
+
+import kyo.*
+
+/** Settle-on-reads helper: re-samples a single in-page value expression on the active `retrySchedule` until it holds constant across
+  * `assertionStabilityWindow`, then lifts the stable string to `A` via `decode`. Unlike `BrowserAssertion.withStability`, which raises on a
+  * non-matching FIRST probe, this keeps the value regardless of presence: a settled-ABSENT element produces a stable sentinel string that
+  * `decode` maps to the read's twin return (`Absent` / `false` / abort / empty), so absence is detected WITHOUT raising a stability timeout.
+  *
+  * When `decode` itself aborts (a must-exist read finding an absent element), that abort is treated as an unstable sample and re-tried for the
+  * full `retrySchedule` budget before the failure is surfaced to the caller.
+  *
+  * The whole in-page sampling loop runs inside `StabilitySampler.sampleWindow`'s single `awaitPromise=true` eval, and the bound is
+  * the configurable `retrySchedule` from `SessionConfig`, never a hardcoded value.
+  */
+private[kyo] object SettleRead:
+
+    /** Builds the typed instability failure used to retry the outer schedule when a value changed mid-window. It is a
+      * `BrowserAssertionTimedOutException` (a `BrowserReadException`), so the read's `Abort[BrowserReadException]` row carries it.
+      */
+    private[kyo] def unstable(callee: String, raw: String)(using Frame): BrowserReadException =
+        BrowserAssertionTimedOutException(callee, "stable value", raw)
+
+    /** Settles a single read. `valueExpr` is a self-contained JS expression coercible to a string; `decode` maps the stable string to `A`,
+      * mapping a settled-absent sentinel to the twin return.
+      */
+    private[kyo] def settle[A](callee: String, valueExpr: String)(decode: String => A < (Browser & Abort[BrowserReadException]))(using
+        Frame
+    ): A < (Browser & Async & Abort[BrowserReadException]) =
+        Browser.configLocal.use { cfg =>
+            val window = cfg.assertionStabilityWindow
+            Retry[BrowserReadException](cfg.retrySchedule) {
+                if window == Duration.Zero then BrowserEval.evalJs(valueExpr).map(decode)
+                else
+                    StabilitySampler.sampleWindow(valueExpr, window).map {
+                        case StabilitySampler.Outcome.Stable(raw)   => decode(raw)
+                        case StabilitySampler.Outcome.Unstable(raw) => Abort.fail(unstable(callee, raw))
+                    }
+            }
+        }
+end SettleRead

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserCaptureTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserCaptureTest.scala
@@ -1,0 +1,662 @@
+package kyo
+
+import kyo.internal.*
+import kyo.internal.CdpTypes.*
+
+/** Behavior tests for the HoldStill capture helper.
+  *
+  * Tests 1-3 and the convergence-despite-injection test require Chrome (extend BrowserTest).
+  * Test 4 (frameHash equality/inequality) is a pure computation and does not require Chrome;
+  * it lives in this class for the 1:1 source-to-test match with HoldStill.scala.
+  */
+class BrowserCaptureTest extends BrowserTest:
+
+    override def timeout = 90.seconds
+
+    // A single raw viewport capture with no internal hold-still loop, used as the body of an explicit
+    // HoldStill.withHoldStill block so the loop under test drives the captures (nesting screenshot()
+    // would inject a second freeze stylesheet inside the outer one).
+    private def rawCapture(using Frame): Image < (Browser & Abort[BrowserReadException]) =
+        Browser.use { tab =>
+            CdpBackend.captureScreenshot(tab.session, ScreenshotParams(clip = Absent))
+                .map(sr => CdpBase64Decode.decodeScreenshotImage("Page.captureScreenshot", sr.data))
+        }
+
+    // ---- frameHash equates byte-identical images and distinguishes different ones (pure, no Chrome).
+    //
+    // This test does NOT use ImageDiff: it asserts on hash values of decoded bytes directly.
+    // The "no ImageDiff symbol exists" constraint is prose only, never an assertion (test discipline).
+    // Uses Image.fromBase64 with small known byte arrays encoded as PNG-like payloads.
+
+    "frameHash equates byte-identical images and distinguishes different ones" in {
+        // Minimal 1x1 PNG bytes (valid PNG magic + IHDR + IDAT + IEND).
+        val pngA = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        // Same bytes again.
+        val pngB = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        // Different 1x1 PNG, different payload.
+        val pngC = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADklEQVQI12P4z8BQDwAEgAF/QualIQAAAABJRU5ErkJggg=="
+
+        val imgA = Browser.Image.fromBase64(pngA).getOrElse(fail("pngA decode failed"))
+        val imgB = Browser.Image.fromBase64(pngB).getOrElse(fail("pngB decode failed"))
+        val imgC = Browser.Image.fromBase64(pngC).getOrElse(fail("pngC decode failed"))
+
+        val h1 = HoldStill.frameHash(imgA)
+        val h2 = HoldStill.frameHash(imgB)
+        val h3 = HoldStill.frameHash(imgC)
+
+        assert(h1 == h2, s"byte-identical images must share a hash: h1=$h1 h2=$h2")
+        assert(h1 != h3, s"different images should differ in hash: h1=$h1 h3=$h3")
+        succeed
+    }
+
+    // ---- hold-still returns an Image on a never-quiescing page.
+    //
+    // Page has a perpetual @keyframes animation cycling through background-color every 100ms.
+    // Two consecutive captures will never be hash-identical. A tight captureHoldStillTimeout of
+    // 300ms is installed via withConfig. Assert: returns an Image (not an abort), and the elapsed
+    // time is bounded (well under 600ms).
+
+    "hold-still returns an Image on a never-quiescing page" in {
+        val html = """<body>
+            <style>
+              @keyframes spin {
+                0%   { background-color: red; }
+                25%  { background-color: blue; }
+                50%  { background-color: green; }
+                75%  { background-color: yellow; }
+                100% { background-color: red; }
+              }
+              body { animation: spin 0.1s linear infinite; }
+            </style>
+            <div>animated</div>
+        </body>"""
+        withBrowser {
+            onPage(html) {
+                Browser.withConfig(_.captureHoldStillTimeout(300.millis).captureHoldStillInterval(30.millis)) {
+                    timed {
+                        Abort.run[BrowserReadException] {
+                            HoldStill.withHoldStill {
+                                rawCapture
+                            }
+                        }
+                    }.map { case (elapsed, result) =>
+                        result match
+                            case Result.Success(img) =>
+                                assert(
+                                    img.binary.size > 0,
+                                    "returned Image must have non-empty bytes"
+                                )
+                                assert(
+                                    elapsed < 600.millis,
+                                    s"elapsed $elapsed exceeds 600ms ceiling (tight timeout is 300ms)"
+                                )
+                                succeed
+                            case Result.Failure(ex) =>
+                                fail(s"hold-still must never abort on timeout; got Failure: ${ex.getMessage}")
+                            case Result.Panic(ex) =>
+                                fail(s"PANIC: $ex")
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- hold-still converges on a static page.
+    //
+    // A fully static page with no animation, no JS timers, fonts loaded. Two consecutive captures
+    // of the same static page will be hash-identical. Assert: returns quickly (well under
+    // captureHoldStillTimeout), and the hash of the result equals the hash of a second immediate
+    // screenshot (the page did not change during or after the hold-still).
+
+    "hold-still converges on a static page" in {
+        val html = """<!DOCTYPE html><html><body>
+            <p style="color:black;font-size:16px;">static page</p>
+        </body></html>"""
+        withBrowser {
+            onPage(html) {
+                Browser.withConfig(_.captureHoldStillTimeout(1.second).captureHoldStillInterval(50.millis)) {
+                    timed {
+                        HoldStill.withHoldStill {
+                            rawCapture
+                        }
+                    }.map { case (elapsed, img) =>
+                        assert(
+                            elapsed < 800.millis,
+                            s"static page should converge well before 1s timeout; elapsed=$elapsed"
+                        )
+                        // Re-capture: hash should match (page is still static).
+                        Browser.screenshot().map { img2 =>
+                            assert(
+                                HoldStill.frameHash(img) == HoldStill.frameHash(img2),
+                                "hash of hold-still result should equal hash of immediate re-capture on static page"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- the freeze stylesheet is injected during capture and removed on exit.
+    //
+    // After HoldStill.withHoldStill returns:
+    //   - document.querySelectorAll('style[data-kyo-internal]').length === 0  (0)
+    //
+    // The injection-during guarantee is covered by Test 1 and Test 2 converging correctly (if the
+    // freeze style were not injected, animations would not pause and the convergence behavior would
+    // differ). The explicit teardown assertion here checks that the removal targets the freeze
+    // node by its unique token, so the actual DOM node count is the correctness witness.
+
+    "the freeze stylesheet is injected during capture and removed on exit" in {
+        val html = """<!DOCTYPE html><html><body><div>test</div></body></html>"""
+        withBrowser {
+            onPage(html) {
+                HoldStill.withHoldStill {
+                    rawCapture
+                }.andThen {
+                    // After withHoldStill returns, the freeze style node must be gone.
+                    Browser.eval("String(document.querySelectorAll('style[data-kyo-internal]').length)").map {
+                        styleCount =>
+                            assert(
+                                styleCount == "0",
+                                s"no style[data-kyo-internal] should remain after withHoldStill; got count: $styleCount"
+                            )
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- Nested hold-still: a freeze nested inside another freeze tears down both, leaving the
+    //      page unfrozen (no stuck animation-play-state: paused).
+    //
+    // The freeze style is removed by its unique token, so an inner freeze's scope exit removes only
+    // the inner node and cannot clobber the outer node's teardown. This composition (a hold-still
+    // capture inside an outer frozen scope) is the supported nesting two callers compose; under the
+    // old single-global-slot model the inner exit deleted the slot and the outer freeze leaked,
+    // freezing the page permanently. After the outer scope exits:
+    //   - document.querySelectorAll('style[data-kyo-internal]').length === 0  (no stuck freeze)
+    //   - getComputedStyle(document.body).animationPlayState is NOT stuck 'paused'.
+
+    "nested hold-still freezes tear down both and leave the page unfrozen" in {
+        val html = """<!DOCTYPE html><html><head><style>
+            @keyframes spin { from { opacity: 1; } to { opacity: 0.5; } }
+            body { animation: spin 1s linear infinite; }
+        </style></head><body><div id="content">nested</div></body></html>"""
+        withBrowser {
+            onPage(html) {
+                Browser.withConfig(_.captureHoldStillTimeout(400.millis).captureHoldStillInterval(50.millis)) {
+                    // Outer freeze wraps an inner hold-still capture (which freezes again): a genuine nest.
+                    HoldStill.withFrozenPage {
+                        HoldStill.withHoldStill {
+                            rawCapture
+                        }
+                    }.andThen {
+                        // Both freeze style nodes must be gone after the outer scope exits.
+                        Browser.eval("String(document.querySelectorAll('style[data-kyo-internal]').length)").map { freezeCount =>
+                            assert(
+                                freezeCount == "0",
+                                s"no freeze style[data-kyo-internal] should remain after nested hold-still; got count: $freezeCount"
+                            )
+                            // The page must not be stuck paused: a leaked freeze would force 'paused' page-wide.
+                            Browser.eval("getComputedStyle(document.body).animationPlayState").map { playState =>
+                                assert(
+                                    playState != "paused",
+                                    s"page animation-play-state must not be stuck 'paused' after nested hold-still; got: $playState"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- Convergence-despite-injection: HoldStill converges despite its own freeze injection
+    //      producing an unfiltered childList mutation on document.head.
+    //
+    // Injecting the freeze <style data-kyo-internal> produces ONE unfiltered childList mutation
+    // (the insertion targets the untagged document.head parent). A live settleForCapture gate
+    // tolerates this as one quiet-window. HoldStill convergence is FRAME-HASH based, not
+    // settlement-gate based, so the injection mutation does not break convergence.
+    //
+    // This test asserts HoldStill converges and returns a stable Image on a static page despite
+    // the freeze injection side-effect. It is a behavioral assertion: we observe the returned
+    // Image is non-null and the freeze style is cleaned up, proving end-to-end convergence held.
+
+    "hold-still converges despite its own freeze injection mutation" in {
+        val html = """<!DOCTYPE html><html><body><div id="content">stable</div></body></html>"""
+        withBrowser {
+            onPage(html) {
+                Browser.withConfig(_.captureHoldStillTimeout(1.second).captureHoldStillInterval(50.millis)) {
+                    Abort.run[BrowserReadException] {
+                        HoldStill.withHoldStill {
+                            rawCapture
+                        }
+                    }.map { result =>
+                        result match
+                            case Result.Success(img) =>
+                                // Convergence succeeded: verify cleanup too (freeze style node gone).
+                                Browser.eval("String(document.querySelectorAll('style[data-kyo-internal]').length)").map { r =>
+                                    assert(
+                                        r == "0",
+                                        s"freeze style must be removed after convergence; got count: $r"
+                                    )
+                                    // Verify the returned Image is non-empty.
+                                    assert(
+                                        img.binary.size > 0,
+                                        "returned Image must have non-empty bytes"
+                                    )
+                                }
+                            case Result.Failure(ex) =>
+                                fail(s"hold-still must not abort despite freeze injection mutation; got: ${ex.getMessage}")
+                            case Result.Panic(ex) =>
+                                fail(s"PANIC: $ex")
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- screenshot captures the live viewport size.
+    //
+    // Set the viewport to 390x844 then take a screenshot. The returned Image bytes must decode to
+    // dimensions 390x844, confirming the live-viewport path (NOT the legacy 1280x720 crop).
+    // PNG dimensions live at bytes 16-23 of the IHDR chunk (bytes 16-19 = width, 20-23 = height,
+    // big-endian int32).
+
+    "screenshot captures the live viewport size" in {
+        withBrowser {
+            onPage("""<!DOCTYPE html><html><body><div style="background:blue;width:100%;height:100%;">vp</div></body></html>""") {
+                Browser.withConfig(_.captureHoldStillTimeout(500.millis).captureHoldStillInterval(50.millis)) {
+                    Browser.setViewport(390, 844).andThen {
+                        Browser.screenshot().map { img =>
+                            val bytes = img.binary.toArray
+                            // PNG IHDR width at offset 16 (big-endian int32)
+                            val w = ((bytes(16) & 0xff) << 24) | ((bytes(17) & 0xff) << 16) | ((bytes(18) & 0xff) << 8) | (bytes(19) & 0xff)
+                            val h = ((bytes(20) & 0xff) << 24) | ((bytes(21) & 0xff) << 16) | ((bytes(22) & 0xff) << 8) | (bytes(23) & 0xff)
+                            assert(w == 390, s"expected screenshot width 390 but got $w")
+                            assert(h == 844, s"expected screenshot height 844 but got $h")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- Test 7-2: screenshot returns a valid PNG by default.
+    //
+    // On a static page, screenshot() must return non-empty bytes starting with the PNG magic bytes
+    // 0x89 'P' 'N' 'G'.
+
+    "screenshot returns a valid PNG by default" in {
+        withBrowser {
+            onPage("""<!DOCTYPE html><html><body><div style="background:red;width:100px;height:50px;">box</div></body></html>""") {
+                Browser.withConfig(_.captureHoldStillTimeout(500.millis).captureHoldStillInterval(50.millis)) {
+                    Browser.screenshot().map { img =>
+                        assert(img.binary.size > 0, "screenshot must return non-empty bytes")
+                        val bytes = img.binary.toArray
+                        assert(bytes(0) == 0x89.toByte, "byte 0 must be 0x89 (PNG magic)")
+                        assert(bytes(1) == 'P'.toByte, "byte 1 must be 'P'")
+                        assert(bytes(2) == 'N'.toByte, "byte 2 must be 'N'")
+                        assert(bytes(3) == 'G'.toByte, "byte 3 must be 'G'")
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- Test 7-3: screenshotRegion captures a below-the-fold region.
+    //
+    // A tall page (body height = 5000px). screenshotRegion(0, 2000, 400, 300) must return a
+    // 400x300 PNG (captureBeyondViewport allowed the out-of-viewport region). Verify dimensions
+    // via PNG IHDR as above.
+
+    "screenshotRegion captures a below-the-fold region" in {
+        withBrowser {
+            onPage("""<!DOCTYPE html><html><body style="height:5000px;background:green;"></body></html>""") {
+                Browser.withConfig(_.captureHoldStillTimeout(500.millis).captureHoldStillInterval(50.millis)) {
+                    Browser.screenshotRegion(0, 2000, 400, 300).map { img =>
+                        assert(img.binary.size > 0, "screenshotRegion must return non-empty bytes")
+                        val bytes = img.binary.toArray
+                        val w     = ((bytes(16) & 0xff) << 24) | ((bytes(17) & 0xff) << 16) | ((bytes(18) & 0xff) << 8) | (bytes(19) & 0xff)
+                        val h     = ((bytes(20) & 0xff) << 24) | ((bytes(21) & 0xff) << 16) | ((bytes(22) & 0xff) << 8) | (bytes(23) & 0xff)
+                        assert(w == 400, s"expected width 400 but got $w")
+                        assert(h == 300, s"expected height 300 but got $h")
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- screenshotRegion aborts on non-positive size.
+    //
+    // Both screenshotRegion(0, 0, 0, 300) and screenshotRegion(0, 0, 100, -1) must abort with
+    // BrowserInvalidArgumentException BEFORE any CDP call (the abort fires synchronously, not
+    // after a network round-trip).
+
+    "screenshotRegion aborts on non-positive size" in {
+        withBrowser {
+            onPage("""<html><body></body></html>""") {
+                Abort.run[BrowserReadException](Browser.screenshotRegion(0, 0, 0, 300)).map { r1 =>
+                    Abort.run[BrowserReadException](Browser.screenshotRegion(0, 0, 100, -1)).map { r2 =>
+                        r1 match
+                            case Result.Failure(ex: BrowserInvalidArgumentException) =>
+                                assert(
+                                    ex.getMessage.contains("screenshotRegion"),
+                                    s"exception message must mention 'screenshotRegion' but was: ${ex.getMessage}"
+                                )
+                            case other => fail(s"expected BrowserInvalidArgumentException for width=0 but got: $other")
+                        end match
+                        r2 match
+                            case Result.Failure(ex: BrowserInvalidArgumentException) =>
+                                assert(
+                                    ex.getMessage.contains("screenshotRegion"),
+                                    s"exception message must mention 'screenshotRegion' but was: ${ex.getMessage}"
+                                )
+                            case other => fail(s"expected BrowserInvalidArgumentException for height=-1 but got: $other")
+                        end match
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- Test 7-5: screenshotFullPage returns one band per viewport-height.
+    //
+    // Set the viewport to 800x400. Set the body height to exactly 3 * 400 = 1200px. The band
+    // count = ceil(1200 / 400) = 3. screenshotFullPage() must return a Chunk[Image] of 3 elements,
+    // each non-empty.
+
+    "screenshotFullPage returns one band per viewport-height" in {
+        withBrowser {
+            onPage("""<!DOCTYPE html><html style="margin:0;padding:0;"><body style="margin:0;padding:0;"></body></html>""") {
+                Browser.withConfig(_.captureHoldStillTimeout(500.millis).captureHoldStillInterval(50.millis)) {
+                    Browser.setViewport(800, 400).andThen {
+                        // Set body height to exactly 3 * viewport-height; zero margins so scrollHeight == 1200.
+                        Browser.eval(
+                            "document.documentElement.style.margin='0';document.documentElement.style.padding='0';document.body.style.margin='0';document.body.style.padding='0';document.body.style.height='1200px'; ''"
+                        ).andThen {
+                            Browser.screenshotFullPage().map { bands =>
+                                assert(bands.size == 3, s"expected 3 bands but got ${bands.size}")
+                                bands.foreach { band =>
+                                    assert(band.binary.size > 0, "each band must be non-empty")
+                                }
+                                succeed
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- Test 7-5b: screenshotFullPage injects the freeze style exactly once across all bands.
+    //
+    // A page whose content height spans multiple bands (bands > 1) forces the multi-band path.
+    // A MutationObserver is armed before the call to count how many times a freeze
+    // style[data-kyo-internal="freeze"] node is ADDED to document.head. After the call:
+    //   (a) bands.size > 1 (multi-band path was genuinely exercised),
+    //   (b) freeze-install count == 1 (freeze was injected exactly once for the whole capture,
+    //       not once per band),
+    //   (c) document.querySelectorAll('style[data-kyo-internal="freeze"]').length === 0
+    //       (freeze style was torn down after the call).
+    // A regression to per-band withHoldStill would make the install count equal the band count
+    // and fail assertion (b).
+
+    "screenshotFullPage injects the freeze style exactly once across all bands" in {
+        withBrowser {
+            onPage("""<!DOCTYPE html><html style="margin:0;padding:0;"><body style="margin:0;padding:0;"></body></html>""") {
+                Browser.withConfig(_.captureHoldStillTimeout(500.millis).captureHoldStillInterval(50.millis)) {
+                    Browser.setViewport(800, 400).andThen {
+                        // Set body to 2 * viewport-height so we get exactly 2 bands (multi-band path exercised).
+                        Browser.eval(
+                            "document.documentElement.style.margin='0';document.documentElement.style.padding='0';document.body.style.margin='0';document.body.style.padding='0';document.body.style.height='800px'; ''"
+                        ).andThen {
+                            // Arm a MutationObserver that counts additions of freeze style nodes.
+                            // The observer targets document.head, watching childList. On each added node
+                            // it checks whether the node is a style element with data-kyo-internal="freeze".
+                            // The count is stored in window.__kyoFreezeCount so we can read it after the call.
+                            Browser.eval("""(() => {
+                                window.__kyoFreezeCount = 0;
+                                const obs = new MutationObserver(mutations => {
+                                    for (const m of mutations) {
+                                        for (const n of m.addedNodes) {
+                                            if (n.nodeName === 'STYLE' && n.getAttribute('data-kyo-internal') === 'freeze') {
+                                                window.__kyoFreezeCount++;
+                                            }
+                                        }
+                                    }
+                                });
+                                obs.observe(document.head, { childList: true });
+                                window.__kyoFreezeObs = obs;
+                                return 'armed';
+                            })()""").andThen {
+                                Browser.screenshotFullPage().map { bands =>
+                                    // Disconnect the observer (cleanup).
+                                    Browser.eval("window.__kyoFreezeObs && window.__kyoFreezeObs.disconnect(); 'done'").andThen {
+                                        // (a) multi-band path was exercised.
+                                        assert(
+                                            bands.size > 1,
+                                            s"expected multiple bands but got ${bands.size}; multi-band path not exercised"
+                                        )
+                                        // (b) freeze style was installed exactly once.
+                                        Browser.eval("String(window.__kyoFreezeCount)").map { countStr =>
+                                            assert(
+                                                countStr == "1",
+                                                s"freeze style must be injected exactly once for all bands but MutationObserver counted: $countStr"
+                                            )
+                                            // (c) freeze style was torn down after the call.
+                                            Browser.eval(
+                                                "String(document.querySelectorAll('style[data-kyo-internal=\"freeze\"]').length)"
+                                            ).map {
+                                                remainingStr =>
+                                                    assert(
+                                                        remainingStr == "0",
+                                                        s"no freeze style should remain after screenshotFullPage but got count: $remainingStr"
+                                                    )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- screenshotFullPage aborts over maxBands BEFORE any capture.
+    //
+    // Set body height to 7 * viewport-height. screenshotFullPage(maxBands = 3) must abort with
+    // BrowserCaptureLimitExceededException("screenshotFullPage", 3, 7) before producing any
+    // partial output.
+
+    "screenshotFullPage aborts over maxBands before any capture" in {
+        withBrowser {
+            onPage("""<!DOCTYPE html><html style="margin:0;padding:0;"><body style="margin:0;padding:0;"></body></html>""") {
+                Browser.setViewport(800, 400).andThen {
+                    // Set body height to exactly 7 * 400 = 2800px with zero margins so scrollHeight == 2800.
+                    Browser.eval(
+                        "document.documentElement.style.margin='0';document.documentElement.style.padding='0';document.body.style.margin='0';document.body.style.padding='0';document.body.style.height='2800px'; ''"
+                    ).andThen {
+                        Abort.run[BrowserReadException] {
+                            Browser.screenshotFullPage(maxBands = 3)
+                        }.map { result =>
+                            result match
+                                case Result.Failure(ex: BrowserCaptureLimitExceededException) =>
+                                    assert(
+                                        ex.operation == "screenshotFullPage",
+                                        s"expected operation=screenshotFullPage but got ${ex.operation}"
+                                    )
+                                    assert(ex.limit == 3, s"expected limit=3 but got ${ex.limit}")
+                                    assert(ex.reached == 7, s"expected reached=7 but got ${ex.reached}")
+                                case other => fail(s"expected BrowserCaptureLimitExceededException but got: $other")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- screenshotElement auto-waits for a late-appearing element.
+    //
+    // A page with a setTimeout that inserts .badge after 200ms. screenshotElement issued
+    // immediately must auto-wait (withRetry) and return the badge's Image when it appears.
+
+    "screenshotElement auto-waits for a late-appearing element" in {
+        val html = """<!DOCTYPE html><html><body>
+            <script>setTimeout(() => {
+                const d = document.createElement('div');
+                d.className = 'badge';
+                d.style.cssText = 'background:red;width:40px;height:20px;';
+                d.textContent = 'X';
+                document.body.appendChild(d);
+            }, 200);</script>
+        </body></html>"""
+        withBrowser {
+            onPage(html) {
+                Browser.withConfig(
+                    _.captureHoldStillTimeout(500.millis)
+                        .captureHoldStillInterval(50.millis)
+                        .retrySchedule(Schedule.fixed(100.millis).take(20))
+                ) {
+                    Browser.screenshotElement(Browser.Selector.css(".badge")).map { img =>
+                        assert(img.binary.size > 0, "screenshotElement must return non-empty bytes for late-appearing element")
+                        val bytes = img.binary.toArray
+                        assert(bytes(0) == 0x89.toByte, "result must be a PNG")
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- screenshotElement aborts BrowserElementNotFoundException when the element never appears.
+    //
+    // A page with no .never element. Under a tight retrySchedule, screenshotElement must abort
+    // BrowserElementNotFoundException within the schedule budget.
+
+    "screenshotElement aborts BrowserElementNotFoundException for missing element" in {
+        withBrowser {
+            onPage("""<html><body><div>no match here</div></body></html>""") {
+                tight {
+                    Abort.run[BrowserReadException] {
+                        Browser.screenshotElement(Browser.Selector.css(".never"))
+                    }.map { result =>
+                        result match
+                            case Result.Failure(_: BrowserElementNotFoundException) => succeed
+                            case other => fail(s"expected BrowserElementNotFoundException but got: $other")
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- screenshotElement with transparentBackground produces a transparent background.
+    //
+    // The .badge element has a TRANSPARENT background of its own and contains a small opaque dot, so
+    // the badge's bounding box has the page's default background showing through the surrounding gap.
+    // The page sets NO opaque background, so the default-background override is what fills that gap:
+    // `Emulation.setDefaultBackgroundColorOverride({a:0})` paints it transparent, while the default
+    // (no override) is opaque. If the page painted its own opaque background the override would have
+    // nothing to show through, so the page is left background-less on purpose.
+    //
+    //   - With transparentBackground = true the gap is alpha=0, so Chrome emits a PNG with an alpha
+    //     channel: IHDR color type == 6 (truecolor with alpha / RGBA).
+    //   - The same capture WITHOUT transparentBackground fills the gap with Chrome's default opaque
+    //     background, so its bytes DIFFER from the transparent capture. This distinguishes a real
+    //     transparent output from an opaque one: if the override were a no-op the two captures would
+    //     be byte-identical and the assertion would FAIL.
+    //
+    // PNG IHDR color type lives at byte offset 25 (8-byte signature + 4-byte length + 4-byte "IHDR"
+    // + width(4) + height(4) + bit depth(1)).
+    //
+    // The override-restore property is also pinned: after the transparent capture, screenshot()
+    // succeeds, confirming the override was cleared (Scope.acquireRelease teardown).
+
+    "screenshotElement with transparentBackground produces a transparent background" in {
+        val html = """<!DOCTYPE html><html><body style="margin:0;">
+            <div class="badge" style="background:transparent;width:50px;height:30px;">
+                <div style="background:blue;width:10px;height:10px;"></div>
+            </div>
+        </body></html>"""
+        withBrowser {
+            onPage(html) {
+                Browser.withConfig(_.captureHoldStillTimeout(500.millis).captureHoldStillInterval(50.millis)) {
+                    Browser.screenshotElement(
+                        Browser.Selector.css(".badge"),
+                        format = Browser.ScreenshotFormat.Png,
+                        transparentBackground = true
+                    ).map { transparent =>
+                        Browser.screenshotElement(
+                            Browser.Selector.css(".badge"),
+                            format = Browser.ScreenshotFormat.Png,
+                            transparentBackground = false
+                        ).map { opaque =>
+                            val tBytes = transparent.binary.toArray
+                            val oBytes = opaque.binary.toArray
+                            assert(tBytes.length > 0, "transparent-background screenshot must be non-empty")
+                            assert(tBytes(0) == 0x89.toByte, "result must be a valid PNG")
+                            // IHDR color type 6 == RGBA: the transparent capture carries an alpha channel.
+                            val colorType = tBytes(25) & 0xff
+                            assert(
+                                colorType == 6,
+                                s"transparent capture must have an alpha channel (IHDR color type 6) but got $colorType"
+                            )
+                            // The transparent gap (alpha=0) must differ from the opaque gap (default opaque
+                            // background): if the override were a no-op, the two captures would be byte-identical.
+                            assert(
+                                !java.util.Arrays.equals(tBytes, oBytes),
+                                "transparent and opaque captures must differ; identical bytes mean the override did not take effect"
+                            )
+                            // The override must not persist: a subsequent screenshot() still succeeds.
+                            Browser.screenshot().map { subsequent =>
+                                assert(subsequent.binary.size > 0, "subsequent screenshot must also be non-empty")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- screenshotElement never widens the retry channel.
+    //
+    // A page that perpetually mutates (setInterval DOM mutation) AND has no .never element.
+    // screenshotElement under a tight retrySchedule must abort BrowserElementNotFoundException
+    // (the element channel), NOT a BrowserMutationException from the perpetual mutations.
+    // The Test.timed bound confirms it exits within the schedule budget.
+
+    "screenshotElement does not widen the retry channel to BrowserMutationException" in {
+        val html = """<!DOCTYPE html><html><body>
+            <script>setInterval(() => {
+                const p = document.createElement('p');
+                p.textContent = 'mut' + Date.now();
+                document.body.appendChild(p);
+            }, 50);</script>
+        </body></html>"""
+        withBrowser {
+            onPage(html) {
+                tight {
+                    timed {
+                        Abort.run[BrowserReadException] {
+                            Browser.screenshotElement(Browser.Selector.css(".never"))
+                        }
+                    }.map { case (elapsed, result) =>
+                        result match
+                            case Result.Failure(_: BrowserElementNotFoundException) =>
+                                assert(
+                                    elapsed < 1.second,
+                                    s"must abort within tight schedule budget but took $elapsed"
+                                )
+                            case Result.Failure(other) =>
+                                fail(s"expected BrowserElementNotFoundException but got ${other.getClass.getName}: $other")
+                            case other => fail(s"expected Failure but got: $other")
+                    }
+                }
+            }
+        }
+    }
+
+end BrowserCaptureTest

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserCaptureWireTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserCaptureWireTest.scala
@@ -1,0 +1,67 @@
+package kyo
+
+import kyo.internal.*
+import kyo.internal.CdpTypes.*
+
+/** Pure wire encode/decode tests for the new CDP type additions.
+  *
+  * All tests are synchronous (no Chrome, no `withBrowser`). Each test exercises the derived `Schema`
+  * by encoding or decoding a concrete value and asserting on the result. No reflection is used.
+  */
+class BrowserCaptureWireTest extends BrowserTest:
+
+    "ViewportParams DPR serializes as a JSON number (not integer)" in {
+        val vp   = ViewportParams(390, 844, deviceScaleFactor = 3.0)
+        val json = Json.encode(vp)
+        val rt   = decode[ViewportParams](json)
+        assert(rt.deviceScaleFactor == 3.0, s"expected 3.0, got ${rt.deviceScaleFactor}")
+        assert(!json.contains("\"deviceScaleFactor\":3,"), s"unexpected integer-3 in JSON: $json")
+        succeed
+    }
+
+    "ViewportParams default DPR is 1.0" in {
+        val vp   = ViewportParams(800, 600)
+        val json = Json.encode(vp)
+        val rt   = decode[ViewportParams](json)
+        assert(rt.deviceScaleFactor == 1.0, s"expected 1.0, got ${rt.deviceScaleFactor}")
+        succeed
+    }
+
+    "ScreenshotParams carries captureBeyondViewport and fromSurface" in {
+        val sp   = ScreenshotParams(captureBeyondViewport = Present(true), fromSurface = Present(true))
+        val json = Json.encode(sp)
+        assert(json.contains("\"captureBeyondViewport\":true"), s"missing captureBeyondViewport in: $json")
+        assert(json.contains("\"fromSurface\":true"), s"missing fromSurface in: $json")
+        val empty = Json.encode(ScreenshotParams())
+        assert(!empty.contains("captureBeyondViewport"), s"unexpected captureBeyondViewport in: $empty")
+        assert(!empty.contains("fromSurface"), s"unexpected fromSurface in: $empty")
+        succeed
+    }
+
+    "SetEmulatedMediaParams encodes media and features in one object" in {
+        val params = SetEmulatedMediaParams(
+            media = Present("print"),
+            features = Present(Seq(EmulatedMediaFeature("prefers-color-scheme", "dark")))
+        )
+        val json = Json.encode(params)
+        assert(json.contains("\"media\":\"print\""), s"missing media in: $json")
+        assert(json.contains("\"name\":\"prefers-color-scheme\""), s"missing feature name in: $json")
+        assert(json.contains("\"value\":\"dark\""), s"missing feature value in: $json")
+        val rt = decode[SetEmulatedMediaParams](json)
+        assert(rt.media == Present("print"), s"expected Present(print), got ${rt.media}")
+        succeed
+    }
+
+    "ScreencastFrameMetadata decodes with only the consumed fields present" in {
+        val json = """{"scrollOffsetX":0,"scrollOffsetY":120,"timestamp":1700.5}"""
+        val meta = decode[ScreencastFrameMetadata](json)
+        assert(meta.scrollOffsetY == 120.0, s"expected 120.0, got ${meta.scrollOffsetY}")
+        assert(meta.timestamp == Present(1700.5), s"expected Present(1700.5), got ${meta.timestamp}")
+        assert(meta.offsetTop == Absent, s"expected Absent, got ${meta.offsetTop}")
+        assert(meta.pageScaleFactor == Absent, s"expected Absent, got ${meta.pageScaleFactor}")
+        assert(meta.deviceWidth == Absent, s"expected Absent, got ${meta.deviceWidth}")
+        assert(meta.deviceHeight == Absent, s"expected Absent, got ${meta.deviceHeight}")
+        succeed
+    }
+
+end BrowserCaptureWireTest

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserConsoleDecodeTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserConsoleDecodeTest.scala
@@ -1,0 +1,136 @@
+package kyo
+
+import kyo.internal.CdpClient
+import kyo.internal.CdpEvent
+import kyo.internal.ConsoleApiCalledWire
+
+/** Pure decoder tests for the console reshape: the CDP `Runtime.consoleAPICalled` type map (`decodeConsoleApiCalled`), the drain-path level
+  * map (`decodeConsoleMessage`), and the wire-level `CdpClient.parseConsoleEvent` Absent paths.
+  *
+  * These need no Chrome: they construct the wire records directly and call the `private[kyo]` decoders. The CDP `'warning'` spelling and the
+  * drain `'warn'` spelling live in separate decoders and never collide.
+  */
+class BrowserConsoleDecodeTest extends BrowserTest:
+
+    // ---- decodeConsoleApiCalled: non-structural type map ----
+
+    "decodeConsoleApiCalled maps each non-structural type to the right level" in {
+        val cases = Chunk(
+            ("log", Browser.ConsoleLevel.Log),
+            ("info", Browser.ConsoleLevel.Info),
+            ("warning", Browser.ConsoleLevel.Warn),
+            ("error", Browser.ConsoleLevel.Error),
+            ("debug", Browser.ConsoleLevel.Debug),
+            ("trace", Browser.ConsoleLevel.Debug),
+            ("dir", Browser.ConsoleLevel.Log),
+            ("dirxml", Browser.ConsoleLevel.Log),
+            ("table", Browser.ConsoleLevel.Log),
+            ("assert", Browser.ConsoleLevel.Error)
+        )
+        Kyo.foreach(cases) { case (cdpType, expected) =>
+            Abort.run[BrowserReadException](Browser.decodeConsoleApiCalled(ConsoleApiCalledWire(cdpType), 0L)).map { result =>
+                result match
+                    case Result.Success(msg) =>
+                        assert(msg.level == expected, s"type '$cdpType' expected level $expected but got ${msg.level}")
+                    case other =>
+                        fail(s"type '$cdpType' expected Success but got $other")
+            }
+        }.andThen(succeed)
+    }
+
+    // ---- decodeConsoleApiCalled: structural types abort ----
+
+    "decodeConsoleApiCalled aborts on each of the 8 structural types" in {
+        val structural =
+            Chunk("count", "countReset", "timeEnd", "startGroup", "startGroupCollapsed", "endGroup", "clear", "profile", "profileEnd")
+        Kyo.foreach(structural) { cdpType =>
+            Abort.run[BrowserReadException](Browser.decodeConsoleApiCalled(ConsoleApiCalledWire(cdpType), 0L)).map { result =>
+                result match
+                    case Result.Failure(ex) =>
+                        assert(
+                            ex.getMessage.contains(cdpType),
+                            s"structural type '$cdpType' aborted but the message did not mention it: ${ex.getMessage}"
+                        )
+                        assert(
+                            ex.getMessage.contains("unmapped structural console type"),
+                            s"structural type '$cdpType' aborted with an unexpected message: ${ex.getMessage}"
+                        )
+                    case other =>
+                        fail(s"structural type '$cdpType' expected Failure but got $other")
+            }
+        }.andThen(succeed)
+    }
+
+    // ---- decodeConsoleMessage (drain): warn vs warning ----
+
+    "decodeConsoleMessage (drain) maps 'warn' not 'warning'" in {
+        Abort.run[BrowserReadException](Browser.decodeConsoleMessage(ConsoleMessageWire("warn", "w", 0L), 0L)).map { warnResult =>
+            warnResult match
+                case Result.Success(msg) =>
+                    assert(msg.level == Browser.ConsoleLevel.Warn, s"'warn' expected Warn but got ${msg.level}")
+                case other =>
+                    fail(s"'warn' expected Success but got $other")
+            end match
+            Abort.run[BrowserReadException](Browser.decodeConsoleMessage(ConsoleMessageWire("warning", "w", 0L), 0L)).map {
+                case Result.Failure(ex) =>
+                    assert(
+                        ex.getMessage.contains("warning"),
+                        s"drain 'warning' aborted but the message did not mention it: ${ex.getMessage}"
+                    )
+                case other =>
+                    fail(s"drain 'warning' expected Failure (drain does not know 'warning') but got $other")
+            }
+        }
+    }
+
+    // ---- decodeConsoleMessage (drain): new info/debug levels ----
+
+    "decodeConsoleMessage maps the new info/debug levels" in {
+        Abort.run[BrowserReadException](Browser.decodeConsoleMessage(ConsoleMessageWire("info", "i", 0L), 0L)).map { infoResult =>
+            infoResult match
+                case Result.Success(msg) =>
+                    assert(
+                        msg.level == Browser.ConsoleLevel.Info && msg.text == "i",
+                        s"expected (Info, 'i') but got (${msg.level}, '${msg.text}')"
+                    )
+                case other =>
+                    fail(s"'info' expected Success but got $other")
+            end match
+            Abort.run[BrowserReadException](Browser.decodeConsoleMessage(ConsoleMessageWire("debug", "d", 0L), 0L)).map {
+                case Result.Success(msg) =>
+                    assert(
+                        msg.level == Browser.ConsoleLevel.Debug && msg.text == "d",
+                        s"expected (Debug, 'd') but got (${msg.level}, '${msg.text}')"
+                    )
+                case other =>
+                    fail(s"'debug' expected Success but got $other")
+            }
+        }
+    }
+
+    // ---- decodeConsoleMessage (drain): offsetMs relative to t0 ----
+
+    "decodeConsoleMessage computes offsetMs relative to t0" in {
+        Abort.run[BrowserReadException](Browser.decodeConsoleMessage(ConsoleMessageWire("log", "x", 5000L), 4000L)).map {
+            case Result.Success(msg) =>
+                assert(msg.offsetMs == 1000L, s"expected offsetMs 1000 but got ${msg.offsetMs}")
+                assert(msg.location == Absent, s"expected location Absent but got ${msg.location}")
+                assert(msg.text == "x", s"expected text 'x' but got '${msg.text}'")
+            case other =>
+                fail(s"expected Success but got $other")
+        }
+    }
+
+    // ---- N2: CdpClient.parseConsoleEvent Absent paths (mirrors the screencast decoder tests) ----
+
+    "parseConsoleEvent returns Absent on a wrong-method event and on malformed payloads" in {
+        val wrongMethod      = CdpEvent.Generic(method = "Page.loadEventFired", paramsJson = "{}", sessionId = Absent)
+        val malformedConsole = CdpEvent.Generic(method = "Runtime.consoleAPICalled", paramsJson = "not-valid-json", sessionId = Absent)
+        val malformedException =
+            CdpEvent.Generic(method = "Runtime.exceptionThrown", paramsJson = "not-valid-json", sessionId = Absent)
+        assert(CdpClient.parseConsoleEvent(wrongMethod) == Absent, "wrong-method event should decode to Absent")
+        assert(CdpClient.parseConsoleEvent(malformedConsole) == Absent, "malformed consoleAPICalled should decode to Absent")
+        assert(CdpClient.parseConsoleEvent(malformedException) == Absent, "malformed exceptionThrown should decode to Absent")
+    }
+
+end BrowserConsoleDecodeTest

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserConsoleTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserConsoleTest.scala
@@ -13,9 +13,9 @@ class BrowserConsoleTest extends BrowserTest:
                 Browser.eval("console.log('message1'); console.log('message2'); 'ok'").andThen {
                     Browser.consoleLogs.map { logs =>
                         assert(logs.size == 2, s"Expected 2 log messages but got ${logs.size}: $logs")
-                        assert(logs(0).message == "message1", s"Expected 'message1' but got '${logs(0).message}'")
+                        assert(logs(0).text == "message1", s"Expected 'message1' but got '${logs(0).text}'")
                         assert(logs(0).level == Browser.ConsoleLevel.Log, s"Expected level=Log but got '${logs(0).level}'")
-                        assert(logs(1).message == "message2", s"Expected 'message2' but got '${logs(1).message}'")
+                        assert(logs(1).text == "message2", s"Expected 'message2' but got '${logs(1).text}'")
                         assert(logs(1).level == Browser.ConsoleLevel.Log, s"Expected level=Log but got '${logs(1).level}'")
                     }
                 }
@@ -49,7 +49,7 @@ class BrowserConsoleTest extends BrowserTest:
             </body></html>""") {
                 Browser.consoleLogs.map { logs =>
                     assert(
-                        logs.exists(_.message == "at-load-message"),
+                        logs.exists(_.text == "at-load-message"),
                         s"Expected 'at-load-message' in first consoleLogs call but got: $logs"
                     )
                 }
@@ -64,16 +64,16 @@ class BrowserConsoleTest extends BrowserTest:
                 Browser.consoleLogs.unit.andThen {
                     Browser.eval("console.log('batch-one'); 'ok'").andThen {
                         Browser.consoleLogs.map { batch1 =>
-                            assert(batch1.exists(_.message == "batch-one"), s"Expected 'batch-one' in first batch but got: $batch1")
+                            assert(batch1.exists(_.text == "batch-one"), s"Expected 'batch-one' in first batch but got: $batch1")
                         }.andThen {
                             Browser.eval("console.log('batch-two'); 'ok'").andThen {
                                 Browser.consoleLogs.map { batch2 =>
                                     assert(
-                                        batch2.exists(_.message == "batch-two"),
+                                        batch2.exists(_.text == "batch-two"),
                                         s"Expected 'batch-two' in second batch but got: $batch2"
                                     )
                                     assert(
-                                        !batch2.exists(_.message == "batch-one"),
+                                        !batch2.exists(_.text == "batch-one"),
                                         s"Expected 'batch-one' to be cleared before second read but got: $batch2"
                                     )
                                 }
@@ -93,15 +93,15 @@ class BrowserConsoleTest extends BrowserTest:
                     Browser.eval("console.log('info-msg'); console.warn('warn-msg'); console.error('error-msg'); 'ok'").andThen {
                         Browser.consoleLogs.map { logs =>
                             assert(
-                                logs.exists(m => m.level == Browser.ConsoleLevel.Log && m.message == "info-msg"),
+                                logs.exists(m => m.level == Browser.ConsoleLevel.Log && m.text == "info-msg"),
                                 s"Expected (Log, 'info-msg') in logs but got: $logs"
                             )
                             assert(
-                                logs.exists(m => m.level == Browser.ConsoleLevel.Warn && m.message == "warn-msg"),
+                                logs.exists(m => m.level == Browser.ConsoleLevel.Warn && m.text == "warn-msg"),
                                 s"Expected (Warn, 'warn-msg') in logs but got: $logs"
                             )
                             assert(
-                                logs.exists(m => m.level == Browser.ConsoleLevel.Error && m.message == "error-msg"),
+                                logs.exists(m => m.level == Browser.ConsoleLevel.Error && m.text == "error-msg"),
                                 s"Expected (Error, 'error-msg') in logs but got: $logs"
                             )
                         }
@@ -120,9 +120,9 @@ class BrowserConsoleTest extends BrowserTest:
                     Browser.eval("console.log('hi'); console.warn('warn-msg'); console.error('err-msg'); 'ok'").andThen {
                         Browser.consoleLogs.map { logs =>
                             assert(logs.size == 3, s"Expected exactly 3 entries but got ${logs.size}: $logs")
-                            assert(logs(0).level == Browser.ConsoleLevel.Log && logs(0).message == "hi")
-                            assert(logs(1).level == Browser.ConsoleLevel.Warn && logs(1).message == "warn-msg")
-                            assert(logs(2).level == Browser.ConsoleLevel.Error && logs(2).message == "err-msg")
+                            assert(logs(0).level == Browser.ConsoleLevel.Log && logs(0).text == "hi")
+                            assert(logs(1).level == Browser.ConsoleLevel.Warn && logs(1).text == "warn-msg")
+                            assert(logs(2).level == Browser.ConsoleLevel.Error && logs(2).text == "err-msg")
                         }
                     }
                 }
@@ -137,7 +137,7 @@ class BrowserConsoleTest extends BrowserTest:
                     Browser.eval("console.log('l1'); console.warn('w1'); console.error('e1'); 'ok'").andThen {
                         Browser.consoleLogs(Browser.ConsoleLevel.Error).map { errors =>
                             assert(errors.size == 1, s"Expected 1 error-level entry but got ${errors.size}: $errors")
-                            assert(errors.head.message == "e1", s"Expected 'e1' but got '${errors.head.message}'")
+                            assert(errors.head.text == "e1", s"Expected 'e1' but got '${errors.head.text}'")
                             assert(errors.head.level == Browser.ConsoleLevel.Error)
                         }
                     }
@@ -159,7 +159,7 @@ class BrowserConsoleTest extends BrowserTest:
                     </body></html>""") {
                         Browser.consoleLogs.map { logs =>
                             assert(
-                                logs.exists(_.message == "popup-marker-load"),
+                                logs.exists(_.text == "popup-marker-load"),
                                 s"Expected 'popup-marker-load' in popup consoleLogs on first call but got: $logs"
                             )
                         }
@@ -178,7 +178,7 @@ class BrowserConsoleTest extends BrowserTest:
                     </body></html>""") {
                         Browser.consoleLogs.map { logs =>
                             assert(
-                                logs.exists(_.message == "newtab-marker-load"),
+                                logs.exists(_.text == "newtab-marker-load"),
                                 s"Expected 'newtab-marker-load' in new-tab consoleLogs on first call but got: $logs"
                             )
                         }
@@ -196,8 +196,95 @@ class BrowserConsoleTest extends BrowserTest:
                 </body></html>""") {
                     Browser.consoleLogs.map { logs =>
                         assert(
-                            logs.exists(_.message == "clone-marker-load"),
+                            logs.exists(_.text == "clone-marker-load"),
                             s"Expected 'clone-marker-load' in clone consoleLogs on first call but got: $logs"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- recordConsole (Chrome-backed) ----
+
+    "recordConsole captures log/warn/error emitted during the body" in {
+        withBrowser {
+            onPage("<html><body><div>rec</div></body></html>") {
+                Browser.recordConsole {
+                    Browser.eval("console.log('a'); console.warn('b'); console.error('c'); 'ok'")
+                        .andThen(Browser.waitForStable(1.second))
+                }.map { case (messages, _) =>
+                    val byLevel = messages.map(m => (m.level, m.text))
+                    assert(
+                        byLevel.contains((Browser.ConsoleLevel.Log, "a")),
+                        s"Expected (Log, 'a') in $byLevel"
+                    )
+                    assert(
+                        byLevel.contains((Browser.ConsoleLevel.Warn, "b")),
+                        s"Expected (Warn, 'b') in $byLevel"
+                    )
+                    assert(
+                        byLevel.contains((Browser.ConsoleLevel.Error, "c")),
+                        s"Expected (Error, 'c') in $byLevel"
+                    )
+                }
+            }
+        }
+    }
+
+    "recordConsole captures uncaught errors via exceptionThrown" in {
+        withBrowser {
+            onPage("<html><body><div>throw</div></body></html>") {
+                Browser.recordConsole {
+                    Browser.eval("setTimeout(() => { throw new Error('boom') }, 0); 'ok'")
+                        .andThen(Browser.waitForStable(1.second))
+                }.map { case (messages, _) =>
+                    val err = messages.find(m => m.level == Browser.ConsoleLevel.Error && m.text.contains("boom"))
+                    assert(err.isDefined, s"Expected an Error message containing 'boom' but got: $messages")
+                    assert(err.exists(_.location.isDefined), s"Expected the exceptionThrown message to carry a location but got: $err")
+                }
+            }
+        }
+    }
+
+    "recordConsole captures the new Info and Debug levels" in {
+        withBrowser {
+            onPage("<html><body><div>levels</div></body></html>") {
+                Browser.recordConsole {
+                    Browser.eval("console.info('i'); console.debug('d'); 'ok'")
+                        .andThen(Browser.waitForStable(1.second))
+                }.map { case (messages, _) =>
+                    val byLevel = messages.map(m => (m.level, m.text))
+                    assert(
+                        byLevel.contains((Browser.ConsoleLevel.Info, "i")),
+                        s"Expected (Info, 'i') in $byLevel"
+                    )
+                    assert(
+                        byLevel.contains((Browser.ConsoleLevel.Debug, "d")),
+                        s"Expected (Debug, 'd') in $byLevel"
+                    )
+                }
+            }
+        }
+    }
+
+    "recordConsole tears down the dispatcher on body exit" in {
+        withBrowser {
+            onPage("<html><body><div>teardown</div></body></html>") {
+                Browser.recordConsole {
+                    Browser.eval("console.log('first'); 'ok'").andThen(Browser.waitForStable(1.second))
+                }.andThen {
+                    Browser.recordConsole {
+                        Browser.eval("console.log('x'); 'ok'").andThen(Browser.waitForStable(1.second))
+                    }.map { case (messages, _) =>
+                        val logTexts = messages.filter(_.level == Browser.ConsoleLevel.Log).map(_.text)
+                        assert(
+                            logTexts.contains("x"),
+                            s"Expected the second block to capture 'x' but got: $logTexts"
+                        )
+                        assert(
+                            !logTexts.contains("first"),
+                            s"Expected the first block's dispatcher to be torn down (no 'first' in the second chunk) but got: $logTexts"
                         )
                     }
                 }

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserCoreTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserCoreTest.scala
@@ -1221,7 +1221,7 @@ class BrowserCoreTest extends BrowserTest:
                 val before = beforeStr.toDouble
                 assert(before > 1000.0, s"Expected target initially below viewport (top > 1000) but got top=$before")
             }.andThen {
-                Browser.scrollTo(Browser.Selector.id("target")).andThen {
+                Browser.scrollToElement(Browser.Selector.id("target")).andThen {
                     Browser.eval(
                         "(() => { const r = document.getElementById('target').getBoundingClientRect(); return r.top + '|' + window.innerHeight; })()"
                     ).map { vh =>
@@ -1230,7 +1230,7 @@ class BrowserCoreTest extends BrowserTest:
                         val viewportHeight = parts(1).toDouble
                         assert(
                             top >= 0.0 && top <= viewportHeight,
-                            s"Expected target's top within viewport [0, $viewportHeight] after scrollTo but got top=$top"
+                            s"Expected target's top within viewport [0, $viewportHeight] after scrollToElement but got top=$top"
                         )
                     }
                 }
@@ -1946,14 +1946,14 @@ class BrowserCoreTest extends BrowserTest:
         }
     }
 
-    // ---- scrollTo(selector) ----
+    // ---- scrollToElement(selector) ----
 
     "scrollTo(selector) scrolls a deeply-positioned element into viewport" in {
         withBrowser {
             onPage(
                 """<div style='height:5000px'></div><div id='far' style='height:40px;background:red'>far</div>"""
             ) {
-                Browser.scrollTo(Browser.Selector.id("far")).andThen {
+                Browser.scrollToElement(Browser.Selector.id("far")).andThen {
                     Browser.eval(
                         """(() => {
                             const el = document.getElementById('far');
@@ -1963,7 +1963,7 @@ class BrowserCoreTest extends BrowserTest:
                     ).map { v =>
                         assert(
                             v == "true",
-                            s"Expected element to be in viewport after scrollTo but getBoundingClientRect check returned '$v'"
+                            s"Expected element to be in viewport after scrollToElement but getBoundingClientRect check returned '$v'"
                         )
                     }
                 }
@@ -1976,7 +1976,7 @@ class BrowserCoreTest extends BrowserTest:
             onPage("<div>no matching element here</div>") {
                 tight {
                     Abort.run[BrowserElementException] {
-                        Browser.scrollTo(Browser.Selector.id("no-such-element"))
+                        Browser.scrollToElement(Browser.Selector.id("no-such-element"))
                     }.map {
                         case Result.Failure(_: BrowserElementNotFoundException) => ()
                         case other =>

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserDiscoverTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserDiscoverTest.scala
@@ -1,0 +1,275 @@
+package kyo
+
+class BrowserDiscoverTest extends BrowserTest:
+
+    override def timeout = 90.seconds
+
+    // element returns full ElementInfo for a present match.
+    // A #submit button with known geometry and classes.
+    "element returns full ElementInfo for a present match" in {
+        withBrowser {
+            onPage("""<html><body style="margin:0;padding:0;">
+                <button id="submit" class="primary action" style="position:absolute;left:10px;top:20px;width:80px;height:32px;">Submit</button>
+            </body></html>""") {
+                Browser.element(Browser.Selector.css("#submit")).map { result =>
+                    result match
+                        case Absent => fail("expected Present(ElementInfo) but got Absent")
+                        case Present(info) =>
+                            assert(info.tag == "button", s"expected tag=button but got ${info.tag}")
+                            assert(info.id == Present("submit"), s"expected id=Present(submit) but got ${info.id}")
+                            assert(
+                                info.classes.toSeq.contains("primary"),
+                                s"expected classes to contain 'primary' but got ${info.classes}"
+                            )
+                            assert(
+                                info.classes.toSeq.contains("action"),
+                                s"expected classes to contain 'action' but got ${info.classes}"
+                            )
+                            assert(info.text == Present("Submit"), s"expected text=Present(Submit) but got ${info.text}")
+                            assert(info.interactive == true, s"expected interactive=true but got ${info.interactive}")
+                            assert(info.bounds.width == 80.0, s"expected bounds.width=80.0 but got ${info.bounds.width}")
+                            assert(info.bounds.height == 32.0, s"expected bounds.height=32.0 but got ${info.bounds.height}")
+                            assert(info.selector.nonEmpty, "expected non-empty selector string")
+                }
+            }
+        }
+    }
+
+    // element returns Absent on no match.
+    "element returns Absent on no match" in {
+        withBrowser {
+            onPage("<html><body></body></html>") {
+                Browser.element(Browser.Selector.css("#nope")).map { result =>
+                    assert(result == Absent, s"expected Absent but got $result")
+                }
+            }
+        }
+    }
+
+    // elementAt hit-tests the topmost element at a pixel.
+    // A #box at (120,48,100,60). Hit point (130,58) is inside it.
+    "elementAt hit-tests the topmost element at a pixel" in {
+        withBrowser {
+            onPage("""<html><body style="margin:0;padding:0;">
+                <div id="box" style="position:absolute;left:120px;top:48px;width:100px;height:60px;background:blue;"></div>
+            </body></html>""") {
+                Browser.elementAt(130, 58).map { result =>
+                    result match
+                        case Absent => fail("expected Present(ElementInfo) but got Absent at (130,58)")
+                        case Present(info) =>
+                            assert(
+                                info.bounds.x <= 130.0 && info.bounds.x + info.bounds.width >= 130.0,
+                                s"point (130,58) should be within element bounds but got bounds=${info.bounds}"
+                            )
+                }
+            }
+        }
+    }
+
+    // elementAt returns Absent for an empty point and aborts on negative coords.
+    // (a) a point over blank background returns Absent; (b) negative coords abort
+    // BrowserInvalidArgumentException BEFORE any page eval.
+    "elementAt returns Absent for empty point and aborts on negative coordinates" in {
+        withBrowser {
+            onPage("""<html><body style="margin:0;padding:0;background:white;"></body></html>""") {
+                // sub-case (a): blank point returns Absent
+                Browser.elementAt(5, 5).map { absentResult =>
+                    // sub-case (b): negative coords abort BrowserInvalidArgumentException
+                    Abort.run[BrowserReadException] {
+                        Browser.elementAt(-5, 10)
+                    }.map { negResult =>
+                        assert(absentResult == Absent, s"expected Absent for (5,5) on blank page but got $absentResult")
+                        assert(negResult.isFailure, s"expected Failure for negative coords but got $negResult")
+                        negResult match
+                            case Result.Failure(ex: BrowserInvalidArgumentException) => succeed
+                            case other => fail(s"expected BrowserInvalidArgumentException but got $other")
+                    }
+                }
+            }
+        }
+    }
+
+    // elements returns a Chunk in document order, empty-fast-paths, and
+    // ElementInfo.leaves filters ancestors.
+    // Three sub-cases in one test.
+    "elements document order, empty fast-path, and ElementInfo.leaves pure filter" in {
+
+        // Sub-case C (pure, no Chrome needed): build a Chunk directly and verify leaves filters ancestors.
+        val defaultBounds = Browser.Bounds(0, 0, 10, 10)
+        val a = Browser.ElementInfo(
+            selector = "#a",
+            tag = "div",
+            id = Present("a"),
+            classes = Chunk.empty,
+            text = Absent,
+            bounds = defaultBounds,
+            visible = true,
+            inViewport = true,
+            topmost = false,
+            interactive = false,
+            role = Absent
+        )
+        val ab = Browser.ElementInfo(
+            selector = "#a > div:nth-of-type(1)",
+            tag = "div",
+            id = Absent,
+            classes = Chunk.empty,
+            text = Absent,
+            bounds = defaultBounds,
+            visible = true,
+            inViewport = true,
+            topmost = false,
+            interactive = false,
+            role = Absent
+        )
+        val b = Browser.ElementInfo(
+            selector = "#b",
+            tag = "div",
+            id = Present("b"),
+            classes = Chunk.empty,
+            text = Absent,
+            bounds = defaultBounds,
+            visible = true,
+            inViewport = true,
+            topmost = false,
+            interactive = false,
+            role = Absent
+        )
+        val chunk  = Chunk(a, ab, b)
+        val leaves = Browser.ElementInfo.leaves(chunk)
+        assert(leaves.size == 2, s"expected 2 leaves but got ${leaves.size}: $leaves")
+        assert(!leaves.exists(_.selector == "#a"), "ancestor #a should be filtered out by leaves")
+        assert(leaves.exists(_.selector == "#a > div:nth-of-type(1)"), "descendant should be kept by leaves")
+        assert(leaves.exists(_.selector == "#b"), "unrelated #b should be kept by leaves")
+
+        // Sub-cases A and B require Chrome.
+        withBrowser {
+            // Sub-case A: three buttons in document order.
+            onPage("""<html><body style="margin:0;padding:0;">
+                <button id="btn1">One</button>
+                <button id="btn2">Two</button>
+                <button id="btn3">Three</button>
+            </body></html>""") {
+                Browser.elements(Browser.Selector.css("button")).map { buttonsResult =>
+                    assert(buttonsResult.size == 3, s"expected 3 elements but got ${buttonsResult.size}")
+                    assert(buttonsResult(0).tag == "button", s"expected tag=button for first element but got ${buttonsResult(0).tag}")
+                    assert(
+                        buttonsResult(0).selector.contains("btn1"),
+                        s"expected first element selector to contain btn1 but got ${buttonsResult(0).selector}"
+                    )
+                    // Sub-case B: empty fast-path.
+                    Browser.elements(Browser.Selector.css(".row")).map { emptyResult =>
+                        assert(emptyResult.isEmpty, s"expected Chunk.empty for .row but got $emptyResult")
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- screenshotMarks overlays numbered badges and is settlement-transparent.
+    //
+    // A page with 3 buttons. Issue screenshotMarks on the buttons. Assert:
+    //   (a) returns a non-empty PNG,
+    //   (b) the marks overlay node is gone afterward (zero [data-kyo-internal="marks"] nodes).
+    //
+    // The marks node is removed by its unique token, so the actual DOM node count is the teardown
+    // witness. The mutation count assertion is NOT used here because the marks childList mutation
+    // targets document.body, which is untagged, so the MutationObserver filter does not suppress it
+    // and the count increments for a correct impl.
+
+    "screenshotMarks overlays numbered badges and removes them afterward" in {
+        val html = """<!DOCTYPE html><html><body style="margin:0;padding:0;">
+            <button id="b1" style="position:absolute;left:10px;top:10px;width:80px;height:30px;">One</button>
+            <button id="b2" style="position:absolute;left:10px;top:50px;width:80px;height:30px;">Two</button>
+            <button id="b3" style="position:absolute;left:10px;top:90px;width:80px;height:30px;">Three</button>
+        </body></html>"""
+        withBrowser {
+            onPage(html) {
+                Browser.withConfig(_.captureHoldStillTimeout(500.millis).captureHoldStillInterval(50.millis)) {
+                    Browser.elements(Browser.Selector.css("button")).map { elems =>
+                        assert(elems.size == 3, s"expected 3 buttons but got ${elems.size}")
+                        Browser.screenshotMarks(elems).map { img =>
+                            assert(img.binary.size > 0, "screenshotMarks must return non-empty bytes")
+                            val bytes = img.binary.toArray
+                            assert(bytes(0) == 0x89.toByte && bytes(1) == 'P'.toByte, "result must be a valid PNG")
+                            // Overlay node must be removed after the call.
+                            Browser.eval("String(document.querySelectorAll('[data-kyo-internal=\"marks\"]').length)").map { countStr =>
+                                assert(countStr == "0", s"no data-kyo-internal=marks node should remain but got count: $countStr")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- screenshotMarks called twice in sequence leaves zero mark nodes (token-scoped teardown).
+    //
+    // Two back-to-back screenshotMarks calls each inject their own token-tagged overlay and tear
+    // down exactly that overlay. Under the old single-global-slot model a second call would clobber
+    // the slot the first call reads back; the per-token removal makes each call self-contained.
+    // After both calls, zero [data-kyo-internal] nodes (marks or otherwise) may remain.
+
+    "screenshotMarks called twice leaves zero mark nodes" in {
+        val html = """<!DOCTYPE html><html><body style="margin:0;padding:0;">
+            <button id="b1" style="position:absolute;left:10px;top:10px;width:80px;height:30px;">One</button>
+            <button id="b2" style="position:absolute;left:10px;top:50px;width:80px;height:30px;">Two</button>
+        </body></html>"""
+        withBrowser {
+            onPage(html) {
+                Browser.withConfig(_.captureHoldStillTimeout(500.millis).captureHoldStillInterval(50.millis)) {
+                    Browser.elements(Browser.Selector.css("button")).map { elems =>
+                        Browser.screenshotMarks(elems).map { first =>
+                            assert(first.binary.size > 0, "first screenshotMarks must return non-empty bytes")
+                            Browser.screenshotMarks(elems).map { second =>
+                                assert(second.binary.size > 0, "second screenshotMarks must return non-empty bytes")
+                                Browser.eval("String(document.querySelectorAll('[data-kyo-internal]').length)").map { countStr =>
+                                    assert(
+                                        countStr == "0",
+                                        s"no data-kyo-internal node should remain after two screenshotMarks calls but got count: $countStr"
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- screenshotMarks aborts over maxMarks.
+    //
+    // Build a Chunk of 5 ElementInfo stubs. screenshotMarks(marks, maxMarks = 3) must abort with
+    // BrowserCaptureLimitExceededException("screenshotMarks", 3, 5) before any CDP call.
+
+    "screenshotMarks aborts over maxMarks" in {
+        val dummyBounds = Browser.Bounds(0, 0, 10, 10)
+        def mkInfo(n: Int) = Browser.ElementInfo(
+            selector = s"#el$n",
+            tag = "div",
+            id = Absent,
+            classes = Chunk.empty,
+            text = Absent,
+            bounds = dummyBounds,
+            visible = true,
+            inViewport = true,
+            topmost = false,
+            interactive = false,
+            role = Absent
+        )
+        val marks = Chunk(mkInfo(1), mkInfo(2), mkInfo(3), mkInfo(4), mkInfo(5))
+        withBrowser {
+            onPage("""<html><body></body></html>""") {
+                Abort.run[BrowserReadException](Browser.screenshotMarks(marks, maxMarks = 3)).map { result =>
+                    result match
+                        case Result.Failure(ex: BrowserCaptureLimitExceededException) =>
+                            assert(ex.operation == "screenshotMarks", s"expected operation=screenshotMarks but got ${ex.operation}")
+                            assert(ex.limit == 3, s"expected limit=3 but got ${ex.limit}")
+                            assert(ex.reached == 5, s"expected reached=5 but got ${ex.reached}")
+                        case other => fail(s"expected BrowserCaptureLimitExceededException but got: $other")
+                }
+            }
+        }
+    }
+
+end BrowserDiscoverTest

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserEmulationParamsTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserEmulationParamsTest.scala
@@ -1,0 +1,118 @@
+package kyo
+
+import kyo.internal.EmulatedMediaFeature
+import kyo.internal.SetEmulatedMediaParams
+
+/** Pure unit tests for the `withEmulation` param-composition contract.
+  *
+  * All tests are synchronous (no Chrome, no `withBrowser`). They call `Browser.emulatedMediaParams` and
+  * `Browser.clearEmulatedMediaParams` directly and assert concrete values on the returned
+  * `SetEmulatedMediaParams`. The composed feature list IS the CDP wire contract that `withEmulation` sends to
+  * `Emulation.setEmulatedMedia`, so these asserts pin the exact contract: a feature is emitted only when the
+  * caller requested it, and the no-prior restore clears every override rather than forcing a value.
+  *
+  * An end-to-end behavioral test cannot discriminate this contract on headless Chrome: the host's
+  * `prefers-reduced-motion` is `no-preference`, the same value an unconditional apply would force, and
+  * `setEmulatedMedia` is replace-semantics, so a raw-CDP baseline is cleared by the apply regardless. The pure
+  * contract test here is the genuine regression guard. No reflection: the function is called and its result is
+  * asserted. Feature comparisons decompose to `(name, value)` String pairs because the internal CDP case classes
+  * derive `Schema` but not `CanEqual`.
+  */
+class BrowserEmulationParamsTest extends BrowserTest:
+
+    // Convenience accessors for the CDP wire strings of the public enums, the exact values withEmulation feeds
+    // into emulatedMediaParams (it calls colorScheme.map(_.wire) / media.map(_.wire)).
+    private val dark: Maybe[String]   = Present(Browser.ColorScheme.Dark).map(_.wire)
+    private val print: Maybe[String]  = Present(Browser.MediaType.Print).map(_.wire)
+    private val screen: Maybe[String] = Present(Browser.MediaType.Screen).map(_.wire)
+
+    // Decompose the feature list into comparable (name, value) String pairs.
+    private def pairsOf(params: SetEmulatedMediaParams)(using kyo.test.AssertScope): Seq[(String, String)] =
+        params.features match
+            case Present(fs) => fs.map(f => (f.name, f.value))
+            case Absent      => fail(s"expected features to be Present but got Absent in $params")
+
+    // A color-scheme-only apply (reducedMotion = false) must emit ONLY prefers-color-scheme and NO
+    // prefers-reduced-motion feature, so an unrelated media feature is never perturbed.
+    "color-scheme-only with reducedMotion=false emits only prefers-color-scheme" in {
+        val params = Browser.emulatedMediaParams(media = Absent, colorScheme = dark, reducedMotion = false)
+        val pairs  = pairsOf(params)
+        assert(
+            pairs == Seq(("prefers-color-scheme", "dark")),
+            s"expected exactly prefers-color-scheme=dark and NO prefers-reduced-motion entry but got $pairs"
+        )
+        assert(
+            !pairs.exists(_._1 == "prefers-reduced-motion"),
+            s"a prefers-reduced-motion feature must not leak into a color-scheme-only call: $pairs"
+        )
+        assert(params.media == Absent, s"expected no media override but got ${params.media}")
+        succeed
+    }
+
+    // reducedMotion = true must add prefers-reduced-motion: reduce alongside the requested color-scheme.
+    "color-scheme with reducedMotion=true adds prefers-reduced-motion=reduce" in {
+        val params = Browser.emulatedMediaParams(media = Absent, colorScheme = dark, reducedMotion = true)
+        val pairs  = pairsOf(params)
+        assert(
+            pairs.contains(("prefers-reduced-motion", "reduce")),
+            s"expected prefers-reduced-motion=reduce when reducedMotion=true but got $pairs"
+        )
+        assert(
+            pairs.contains(("prefers-color-scheme", "dark")),
+            s"expected prefers-color-scheme=dark to remain present but got $pairs"
+        )
+        succeed
+    }
+
+    // Requesting nothing (no color-scheme, no reduced-motion, no media) emits an EMPTY feature list: nothing is
+    // emulated, so no prefers-* feature is forced.
+    "nothing requested emits empty features and no media" in {
+        val params = Browser.emulatedMediaParams(media = Absent, colorScheme = Absent, reducedMotion = false)
+        assert(
+            pairsOf(params) == Seq.empty,
+            s"expected an empty feature list when nothing is emulated but got ${params.features}"
+        )
+        assert(params.media == Absent, s"expected no media override but got ${params.media}")
+        succeed
+    }
+
+    // All three requested together: media on the top-level field, both features present with correct values.
+    "all three requested compose media plus both features with correct values" in {
+        val params = Browser.emulatedMediaParams(media = print, colorScheme = dark, reducedMotion = true)
+        val pairs  = pairsOf(params)
+        assert(params.media == Present("print"), s"expected media=print on the top-level field but got ${params.media}")
+        assert(
+            pairs.toSet == Set(("prefers-color-scheme", "dark"), ("prefers-reduced-motion", "reduce")),
+            s"expected both prefers-color-scheme=dark and prefers-reduced-motion=reduce but got $pairs"
+        )
+        succeed
+    }
+
+    // The no-prior restore CLEAR params drop every media-feature override back to the host: empty media plus an
+    // empty features list is the true clear, rather than a non-empty feature that would leave an active forced
+    // override after exit.
+    "clear params are empty media and empty features" in {
+        val params = Browser.clearEmulatedMediaParams
+        assert(params.media == Present(""), s"expected empty media on the clear params but got ${params.media}")
+        assert(
+            pairsOf(params) == Seq.empty,
+            s"the clear must send an EMPTY feature list (no forced override) but got ${params.features}"
+        )
+        succeed
+    }
+
+    // The NoPreference color-scheme clears via the empty-string wire value (W3C dropped no-preference as a settable
+    // value). The feature is still Present (so the page's color-scheme override is cleared, not left untouched).
+    "NoPreference color-scheme emits an empty-string prefers-color-scheme feature" in {
+        val noPref = Present(Browser.ColorScheme.NoPreference).map(_.wire)
+        val params = Browser.emulatedMediaParams(media = screen, colorScheme = noPref, reducedMotion = false)
+        val pairs  = pairsOf(params)
+        assert(
+            pairs == Seq(("prefers-color-scheme", "")),
+            s"expected a single empty-string prefers-color-scheme feature but got $pairs"
+        )
+        assert(params.media == Present("screen"), s"expected media=screen but got ${params.media}")
+        succeed
+    }
+
+end BrowserEmulationParamsTest

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserEmulationTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserEmulationTest.scala
@@ -1,0 +1,346 @@
+package kyo
+
+import kyo.internal.BrowserTab
+import kyo.internal.CdpBackend
+import kyo.internal.EmulatedMediaFeature
+import kyo.internal.SetEmulatedMediaParams
+
+class BrowserEmulationTest extends BrowserTest:
+
+    override def timeout = 90.seconds
+
+    // ---- withEmulation ----
+
+    // colorScheme = Dark applies prefers-color-scheme: dark inside the body. The single setEmulatedMedia send
+    // composes the prefers-color-scheme feature; matchMedia reports the emulated value.
+    "withEmulation dark color-scheme matches inside the body" in {
+        withBrowser {
+            onPage("<html><body>emulation-dark</body></html>") {
+                Browser.withEmulation(colorScheme = Present(Browser.ColorScheme.Dark)) {
+                    Browser.eval("String(window.matchMedia('(prefers-color-scheme: dark)').matches)")
+                }.map { matched =>
+                    assert(matched == "true", s"expected prefers-color-scheme: dark to match inside the body but got $matched")
+                }
+            }
+        }
+    }
+
+    // nested withEmulation restores the prior scheme on exit (LIFO). Outer Light wraps inner Dark; after the inner
+    // block exits, the outer block reads prefers-color-scheme: dark as false because the inner Dark was restored to the
+    // outer Light from the per-tab cache.
+    "withEmulation restores the prior scheme after the body" in {
+        withBrowser {
+            onPage("<html><body>emulation-lifo</body></html>") {
+                Browser.withEmulation(colorScheme = Present(Browser.ColorScheme.Light)) {
+                    Browser.withEmulation(colorScheme = Present(Browser.ColorScheme.Dark)) {
+                        Browser.eval("String(window.matchMedia('(prefers-color-scheme: dark)').matches)")
+                    }.map { inside =>
+                        assert(inside == "true", s"expected dark to match inside the inner block but got $inside")
+                        Browser.eval("String(window.matchMedia('(prefers-color-scheme: dark)').matches)")
+                    }
+                }.map { afterInner =>
+                    assert(afterInner == "false", s"expected the inner Dark to be restored to the outer Light but got $afterInner")
+                }
+            }
+        }
+    }
+
+    // media = Print applies the print media type inside the body. matchMedia('print') reports the emulated media
+    // type.
+    "withEmulation media=print is applied" in {
+        withBrowser {
+            onPage("<html><body>emulation-print</body></html>") {
+                Browser.withEmulation(media = Present(Browser.MediaType.Print)) {
+                    Browser.eval("String(window.matchMedia('print').matches)")
+                }.map { matched =>
+                    assert(matched == "true", s"expected print media to match inside the body but got $matched")
+                }
+            }
+        }
+    }
+
+    // reducedMotion = true sends prefers-reduced-motion: reduce inside the body. matchMedia reports the emulated
+    // value, proving the reduced-motion feature rides the single setEmulatedMedia send.
+    "withEmulation reducedMotion is applied" in {
+        withBrowser {
+            onPage("<html><body>emulation-reduced-motion</body></html>") {
+                Browser.withEmulation(reducedMotion = true) {
+                    Browser.eval("String(window.matchMedia('(prefers-reduced-motion: reduce)').matches)")
+                }.map { matched =>
+                    assert(matched == "true", s"expected prefers-reduced-motion: reduce to match inside the body but got $matched")
+                }
+            }
+        }
+    }
+
+    // withEmulation restores the prior state on interruption. The Browser effect carries Env[BrowserTab] with no same-tab
+    // isolate, so the interrupted body is a self-contained Browser.run (the established interruption pattern in
+    // BrowserViewportTest / BrowserIsolateTest). The scenario is driven by an explicit fiber plus two Promises so it is
+    // deterministic across the JVM and the single-threaded Scala.js / Scala Native runtimes:
+    //   - the body runs in its own fiber (Fiber.initUnscoped), not under Async.timeout, so the test owns the interruption.
+    //   - readyLatch is completed AFTER withEmulation's override is applied, so the test interrupts only once the body is
+    //     provably inside the scope with the Dark override active, never before the acquire ran.
+    //   - tabRef captures the tab so its emulationOverride cache (a plain AtomicRef readable under Sync) can be inspected.
+    // After readyLatch resolves the test interrupts the fiber and awaits its Result. The withEmulation release clears the
+    // override back to Absent (no prior override existed at entry) then does an async CDP send; on JS / Native the
+    // interrupted fiber's Result can resolve before that finalizer chain has run its `.set(Absent)` (the ordering only holds
+    // on the JVM). So the cache is read by polling until the clear lands, bounded by a fixed schedule, then asserted
+    // concretely. The poll re-reads the AtomicRef directly; the tab object outlives its CDP teardown.
+    "withEmulation restores on interruption" in {
+        val p = page("<html><body>emulation-interrupt</body></html>")
+        kyo.internal.SharedChrome.init.map { wsUrl =>
+            Promise.init[BrowserTab, Any].map { tabRef =>
+                Promise.init[Unit, Any].map { readyLatch =>
+                    val body: Unit < (Async & Abort[BrowserReadException]) =
+                        Browser.run(wsUrl) {
+                            Browser.goto(p).andThen {
+                                Browser.use { tab =>
+                                    tabRef.completeDiscard(Result.succeed(tab)).andThen {
+                                        Browser.withEmulation(colorScheme = Present(Browser.ColorScheme.Dark)) {
+                                            // Signal the override is applied, then block interruptibly until the test
+                                            // interrupts the fiber with the Dark override active.
+                                            readyLatch.completeDiscard(Result.succeed(())).andThen {
+                                                Async.sleep(30.seconds)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    Fiber.initUnscoped(body).map { fiber =>
+                        // Wait until the body is fully inside withEmulation (override applied), then interrupt and await the
+                        // interrupted Result so the fiber has finished unwinding before the cache is inspected.
+                        readyLatch.get.andThen {
+                            fiber.interrupt.andThen {
+                                fiber.getResult.map { result =>
+                                    assert(result.isPanic, s"expected the interrupt to abort the body but got $result")
+                                    tabRef.get.map { tab =>
+                                        // Poll the AtomicRef cache until the release cleared the override back to Absent.
+                                        Retry[BrowserReadException](Schedule.fixed(20.millis).take(150)) {
+                                            tab.emulationOverride.get.map { current =>
+                                                if current == Absent then ()
+                                                else
+                                                    Abort.fail(
+                                                        BrowserAssertionTimedOutException(
+                                                            "withEmulation interrupt clear",
+                                                            "Absent",
+                                                            current.toString
+                                                        )
+                                                    )
+                                            }
+                                        }.andThen {
+                                            // The release cleared the override back to Absent (no prior override existed at
+                                            // entry), not the body's Dark override.
+                                            tab.emulationOverride.get.map { restored =>
+                                                assert(
+                                                    restored == Absent,
+                                                    s"withEmulation did not clear the override on interruption: got $restored"
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // A color-scheme-only withEmulation composes ONLY the prefers-color-scheme feature, so it must not perturb the page's
+    // real prefers-reduced-motion. The body reads matchMedia('(prefers-reduced-motion: reduce)') before and inside the block
+    // and asserts the value is identical, while also confirming the color-scheme emulation actually took effect inside.
+    "withEmulation color-scheme-only leaves prefers-reduced-motion untouched" in {
+        withBrowser {
+            onPage("<html><body>emulation-cs-only</body></html>") {
+                Browser.eval("String(window.matchMedia('(prefers-reduced-motion: reduce)').matches)").map { hostReduce =>
+                    Browser.withEmulation(colorScheme = Present(Browser.ColorScheme.Dark)) {
+                        Browser.eval("String(window.matchMedia('(prefers-reduced-motion: reduce)').matches)").map { insideReduce =>
+                            Browser.eval("String(window.matchMedia('(prefers-color-scheme: dark)').matches)").map { insideDark =>
+                                assert(
+                                    insideDark == "true",
+                                    s"expected the color-scheme emulation to apply dark inside the body but got $insideDark"
+                                )
+                                assert(
+                                    insideReduce == hostReduce,
+                                    s"color-scheme-only withEmulation must not change prefers-reduced-motion (host=$hostReduce) but got $insideReduce inside the body"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // On scope exit with NO prior emulation, the restore CLEARS all media emulation so the host's real values return, rather than
+    // forcing prefers-reduced-motion: no-preference. To witness the full clear independently of the host's own reduced-motion
+    // value (which is no-preference in headless Chrome), a raw CDP override forces prefers-color-scheme: dark BEFORE the block; the
+    // block's emulationOverride cache is still Absent, so its release takes the clear path. After the block, both prefers-color-scheme
+    // and prefers-reduced-motion report their host values, proving the clear removed every media override, not just some of them.
+    "withEmulation restore with no prior clears all media emulation back to host" in {
+        withBrowser {
+            onPage("<html><body>emulation-clear</body></html>") {
+                Browser.use { tab =>
+                    // Read the host values first (no emulation active).
+                    Browser.eval("String(window.matchMedia('(prefers-color-scheme: dark)').matches)").map { hostDark =>
+                        Browser.eval("String(window.matchMedia('(prefers-reduced-motion: reduce)').matches)").map { hostReduce =>
+                            // Force a NON-host color-scheme via raw CDP. This bypasses the emulationOverride cache, so the
+                            // withEmulation below still sees prior = Absent and takes the clear path on exit.
+                            CdpBackend.setEmulatedMedia(
+                                tab.session,
+                                SetEmulatedMediaParams(Present(""), Present(Seq(EmulatedMediaFeature("prefers-color-scheme", "dark"))))
+                            ).andThen {
+                                Browser.eval("String(window.matchMedia('(prefers-color-scheme: dark)').matches)").map { forcedDark =>
+                                    Browser.withEmulation(reducedMotion = true) {
+                                        Browser.eval("String(window.matchMedia('(prefers-reduced-motion: reduce)').matches)")
+                                    }.map { insideReduce =>
+                                        Browser.eval("String(window.matchMedia('(prefers-color-scheme: dark)').matches)").map { afterDark =>
+                                            Browser.eval("String(window.matchMedia('(prefers-reduced-motion: reduce)').matches)").map {
+                                                afterReduce =>
+                                                    assert(
+                                                        forcedDark == "true",
+                                                        s"expected the raw override to force dark before the block but got $forcedDark"
+                                                    )
+                                                    assert(
+                                                        insideReduce == "true",
+                                                        s"expected reducedMotion emulation to apply inside the block but got $insideReduce"
+                                                    )
+                                                    assert(
+                                                        afterDark == hostDark,
+                                                        s"expected prefers-color-scheme cleared back to host=$hostDark after the block but got $afterDark"
+                                                    )
+                                                    assert(
+                                                        afterReduce == hostReduce,
+                                                        s"expected prefers-reduced-motion cleared back to host=$hostReduce after the block but got $afterReduce"
+                                                    )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // A nested color-scheme-only withEmulation inside an outer reducedMotion=true block must restore the OUTER reduced-motion on
+    // inner exit, not clear it: the inner exit re-applies the outer's prior state from the per-tab cache. Inside the inner block
+    // the reduced-motion is the host value (the inner color-scheme-only apply replaces the feature set); after the inner exits but
+    // still inside the outer body, prefers-reduced-motion: reduce matches again because the outer state was re-applied.
+    "withEmulation inner color-scheme-only restores the outer reduced-motion on exit" in {
+        withBrowser {
+            onPage("<html><body>emulation-nested-rm</body></html>") {
+                Browser.withEmulation(reducedMotion = true) {
+                    Browser.eval("String(window.matchMedia('(prefers-reduced-motion: reduce)').matches)").map { outerReduce =>
+                        Browser.withEmulation(colorScheme = Present(Browser.ColorScheme.Dark)) {
+                            Browser.eval("String(window.matchMedia('(prefers-color-scheme: dark)').matches)")
+                        }.map { innerDark =>
+                            Browser.eval("String(window.matchMedia('(prefers-reduced-motion: reduce)').matches)").map { afterInner =>
+                                assert(outerReduce == "true", s"expected the outer reducedMotion emulation to apply but got $outerReduce")
+                                assert(innerDark == "true", s"expected the inner color-scheme emulation to apply dark but got $innerDark")
+                                assert(
+                                    afterInner == "true",
+                                    s"expected the outer reduced-motion restored after the inner color-scheme block exits but got $afterInner"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- withHighlights ----
+
+    // the highlights overlay is settlement-transparent. The observer is installed via a
+    // no-op afterAction so __kyoMutCount is initialized; injecting the data-kyo-internal overlay does NOT change the
+    // counter (the observer filters the tagged-subtree insertion), and the overlay is removed after the body.
+    "withHighlights overlay is settlement-transparent" in {
+        withBrowser {
+            onPage("<html><body><div id='cta'>cta</div></body></html>") {
+                // Install the observer via a no-op afterAction so __kyoMutCount exists.
+                kyo.internal.MutationSettlement.afterAction(Browser.eval("'noop'"))(Absent).andThen {
+                    Browser.eval("String(window.__kyoMutCount || 0)").map { beforeStr =>
+                        Browser.withHighlights(Span(Browser.Annotation(Browser.Selector.css("#cta")))) {
+                            Browser.eval("String(window.__kyoMutCount || 0)")
+                        }.map { duringStr =>
+                            Browser.eval("String(document.querySelectorAll('[data-kyo-internal=\"highlight\"]').length)").map { afterStr =>
+                                assert(
+                                    duringStr == beforeStr,
+                                    s"expected __kyoMutCount unchanged after the overlay injection (before=$beforeStr) but got $duringStr"
+                                )
+                                assert(afterStr == "0", s"expected the overlay removed after the body but found $afterStr highlight boxes")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // withHighlights draws a box at the matched element and removes it on exit.
+    // Inside the body exactly one data-kyo-internal highlight box exists for the single annotation; after the body the
+    // overlay is removed by the Scope.acquireRelease release.
+    "withHighlights draws a box at the element and removes it after" in {
+        withBrowser {
+            onPage("<html><body><div id='cta'>CTA</div></body></html>") {
+                Browser.withHighlights(Span(Browser.Annotation(Browser.Selector.css("#cta"), label = Present("CTA")))) {
+                    Browser.eval("String(document.querySelectorAll('[data-kyo-internal=\"highlight\"]').length)")
+                }.map { countInside =>
+                    Browser.eval("String(document.querySelectorAll('[data-kyo-internal=\"highlight\"]').length)").map { countAfter =>
+                        assert(countInside == "1", s"expected exactly 1 highlight box inside the body but got $countInside")
+                        assert(countAfter == "0", s"expected the highlight box removed after the body but got $countAfter")
+                    }
+                }
+            }
+        }
+    }
+
+    // Test 8: nested withHighlights each tear down exactly their own overlay (token-scoped removal).
+    //
+    // withHighlights takes a body, so withHighlights(outer) { withHighlights(inner) { ... } } type-checks
+    // and is the supported LIFO composition. Each invocation tags its container with a unique token and
+    // removes only that container. The nest asserts, via the same eval path the code uses:
+    //   - inside the inner body: BOTH overlay containers present (2 [data-kyo-internal="highlights"]),
+    //   - after the inner scope exits but still inside the outer body: the OUTER overlay is STILL present
+    //     (exactly 1 [data-kyo-internal="highlights"]); the inner exit did not clobber it,
+    //   - after the outer scope exits: ZERO [data-kyo-internal] nodes remain (no leak).
+    // Under the old single-global-slot model the inner exit deleted the slot and the outer overlay leaked.
+    "nested withHighlights each remove only their own overlay and leave no leak" in {
+        withBrowser {
+            onPage("<html><body><div id='a'>A</div><div id='b'>B</div></body></html>") {
+                val highlightsCount = "String(document.querySelectorAll('[data-kyo-internal=\"highlights\"]').length)"
+                Browser.withHighlights(Span(Browser.Annotation(Browser.Selector.css("#a")))) {
+                    Browser.withHighlights(Span(Browser.Annotation(Browser.Selector.css("#b")))) {
+                        Browser.eval(highlightsCount)
+                    }.map { countInsideInner =>
+                        // Inner scope has exited here; still inside the outer body.
+                        Browser.eval(highlightsCount).map { countAfterInner =>
+                            (countInsideInner, countAfterInner)
+                        }
+                    }
+                }.map { case (countInsideInner, countAfterInner) =>
+                    Browser.eval("String(document.querySelectorAll('[data-kyo-internal]').length)").map { countAfterOuter =>
+                        assert(
+                            countInsideInner == "2",
+                            s"expected BOTH overlays present inside the inner body but got $countInsideInner highlights containers"
+                        )
+                        assert(
+                            countAfterInner == "1",
+                            s"expected the OUTER overlay still present after the inner scope exits but got $countAfterInner highlights containers"
+                        )
+                        assert(
+                            countAfterOuter == "0",
+                            s"expected ZERO data-kyo-internal nodes after the outer scope exits but got $countAfterOuter (overlay leaked)"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+end BrowserEmulationTest

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserExceptionTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserExceptionTest.scala
@@ -280,4 +280,17 @@ class BrowserExceptionTest extends BrowserTest:
         }
     }
 
+    "BrowserCaptureLimitExceededException renders message and is a BrowserReadException" in {
+        val ex  = BrowserCaptureLimitExceededException("screenshotFullPage", 3, 7)
+        val ex2 = BrowserCaptureLimitExceededException("screenshotFullPage", 3, 7)
+        val msg = ex.getMessage
+        assert(msg.contains("screenshotFullPage"), s"expected message to contain operation name, got: $msg")
+        assert(msg.contains("3"), s"expected message to contain limit, got: $msg")
+        assert(msg.contains("7"), s"expected message to contain reached, got: $msg")
+        val asRead: BrowserReadException = ex
+        assert(asRead.getMessage == msg, "upcasted value preserves message")
+        assert(ex == ex2, "expected two equal instances to compare equal (CanEqual)")
+        succeed
+    }
+
 end BrowserExceptionTest

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserIsolateTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserIsolateTest.scala
@@ -684,12 +684,13 @@ class BrowserIsolateTest extends BrowserTest:
         withBrowser {
             Browser.use { parent =>
                 for
-                    fctx     <- AtomicRef.init[Dict[FrameId, ExecutionContextId]](Dict.empty)
-                    root     <- AtomicRef.init[Maybe[FrameId]](Absent)
-                    console  <- AtomicBoolean.init(false)
-                    response <- AtomicBoolean.init(false)
-                    viewport <- AtomicRef.init[Maybe[(Int, Int)]](Absent)
-                    download <- AtomicRef.init[Maybe[(Browser.DownloadBehavior, Maybe[String])]](Absent)
+                    fctx      <- AtomicRef.init[Dict[FrameId, ExecutionContextId]](Dict.empty)
+                    root      <- AtomicRef.init[Maybe[FrameId]](Absent)
+                    console   <- AtomicBoolean.init(false)
+                    response  <- AtomicBoolean.init(false)
+                    viewport  <- AtomicRef.init[Maybe[BrowserTab.ViewportOverride]](Absent)
+                    emulation <- AtomicRef.init[Maybe[BrowserTab.EmulatedMediaState]](Absent)
+                    download  <- AtomicRef.init[Maybe[(Browser.DownloadBehavior, Maybe[String])]](Absent)
                     tab = new BrowserTab(
                         TargetId("t-test"),
                         SessionId("s-test"),
@@ -700,6 +701,7 @@ class BrowserIsolateTest extends BrowserTest:
                         console,
                         response,
                         viewport,
+                        emulation,
                         download
                     )
                 yield tab.browserContextId match

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserReadTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserReadTest.scala
@@ -174,7 +174,7 @@ class BrowserReadTest extends BrowserTest:
                 "<div id='b' style='position:absolute;left:50px;top:30px;width:120px;height:80px;background:red'></div>"
             ) {
                 Browser.setViewport(1024, 768).andThen {
-                    Browser.boundingBox(Browser.Selector.id("b")).map {
+                    Browser.boundingRect(Browser.Selector.id("b")).map {
                         case Present(box) =>
                             assert(
                                 (box.width - 120.0).abs <= 1.0,
@@ -200,7 +200,7 @@ class BrowserReadTest extends BrowserTest:
                 "<div id='b' style='position:absolute;left:-500px;top:5000px;width:50px;height:50px;background:blue'></div>"
             ) {
                 Browser.setViewport(1024, 768).andThen {
-                    Browser.boundingBox(Browser.Selector.id("b")).map {
+                    Browser.boundingRect(Browser.Selector.id("b")).map {
                         case Present(box) =>
                             assert(box.x < 0.0, s"Expected x < 0 but got ${box.x}")
                             assert(box.y > 768.0, s"Expected y > viewport-height but got ${box.y}")
@@ -224,7 +224,7 @@ class BrowserReadTest extends BrowserTest:
         withBrowser {
             onPage("<div>nothing matching</div>") {
                 Browser.setViewport(1024, 768).andThen {
-                    Browser.boundingBox(Browser.Selector.id("nope")).map { result =>
+                    Browser.boundingRect(Browser.Selector.id("nope")).map { result =>
                         assert(result.isEmpty, s"Expected Absent but got $result")
                     }
                 }
@@ -238,7 +238,7 @@ class BrowserReadTest extends BrowserTest:
                 "<div id='b' style='display:none;width:100px;height:100px'></div>"
             ) {
                 Browser.setViewport(1024, 768).andThen {
-                    Browser.boundingBox(Browser.Selector.id("b")).map { result =>
+                    Browser.boundingRect(Browser.Selector.id("b")).map { result =>
                         assert(
                             result.isEmpty,
                             s"Expected Absent for display:none element but got $result"
@@ -255,7 +255,7 @@ class BrowserReadTest extends BrowserTest:
                 "<div id='b' style='position:absolute;left:10px;top:20px;width:200px;height:100px;background:green'></div>"
             ) {
                 Browser.setViewport(1024, 768).andThen {
-                    Browser.boundingBox(Browser.Selector.id("b")).map {
+                    Browser.boundingRect(Browser.Selector.id("b")).map {
                         case Present(box) =>
                             Browser.eval("document.getElementById('b').getBoundingClientRect().x").map { xStr =>
                                 Browser.eval("document.getElementById('b').getBoundingClientRect().y").map { yStr =>
@@ -309,7 +309,7 @@ class BrowserReadTest extends BrowserTest:
                             Browser.iframe(Browser.Selector.testId("frame")).map { f =>
                                 Browser.withIFrame(f) {
                                     Browser.assertExists(Browser.Selector.id("inner")).andThen {
-                                        Browser.boundingBox(Browser.Selector.id("inner")).map {
+                                        Browser.boundingRect(Browser.Selector.id("inner")).map {
                                             case Present(box) =>
                                                 // Inner offset = iframe.left(100) + inner.left(20) = 120;
                                                 // similarly y = iframe.top(50) + inner.top(30) = 80.
@@ -345,12 +345,12 @@ class BrowserReadTest extends BrowserTest:
                 Browser.withConfig(_.retrySchedule(Schedule.fixed(50.millis).take(40))) {
                     Browser.assertExists(Browser.Selector.testId("frame")).andThen {
                         // Outer iframe rect in top-level viewport coords.
-                        Browser.boundingBox(Browser.Selector.testId("frame")).map {
+                        Browser.boundingRect(Browser.Selector.testId("frame")).map {
                             case Present(outer) =>
                                 Browser.iframe(Browser.Selector.testId("frame")).map { f =>
                                     Browser.withIFrame(f) {
                                         Browser.assertExists(Browser.Selector.id("inner")).andThen {
-                                            Browser.boundingBox(Browser.Selector.id("inner")).map {
+                                            Browser.boundingRect(Browser.Selector.id("inner")).map {
                                                 case Present(inner) =>
                                                     assert(
                                                         inner.x >= outer.x - 1.0 && inner.x <= outer.x + outer.width + 1.0,
@@ -381,8 +381,8 @@ class BrowserReadTest extends BrowserTest:
                 "<div id='b' style='position:absolute;left:50px;top:30px;width:120px;height:80px;background:red'></div>"
             ) {
                 Browser.setViewport(1024, 768).andThen {
-                    Browser.boundingBox(Browser.Selector.id("b")).map { first =>
-                        Browser.boundingBox(Browser.Selector.id("b")).map { second =>
+                    Browser.boundingRect(Browser.Selector.id("b")).map { first =>
+                        Browser.boundingRect(Browser.Selector.id("b")).map { second =>
                             assert(first == second, s"Expected $first == $second")
                         }
                     }
@@ -711,7 +711,7 @@ class BrowserReadTest extends BrowserTest:
             onPage("<html><body><div id='marker'>X</div></body></html>") {
                 Browser.eval("window.innerWidth").map { preWidthStr =>
                     Browser.eval("window.innerHeight").map { preHeightStr =>
-                        Browser.screenshot(width = 400, height = 300).map { img =>
+                        Browser.screenshotRegion(0, 0, 400, 300, Browser.ScreenshotFormat.Png, 90).map { img =>
                             assert(img.binary.size > 0, "Screenshot should be non-empty")
                             Browser.eval("window.innerWidth").map { postWidthStr =>
                                 Browser.eval("window.innerHeight").map { postHeightStr =>
@@ -745,7 +745,7 @@ class BrowserReadTest extends BrowserTest:
                             val sentinel = new RuntimeException("deterministic abort sentinel")
                             Abort.run[Throwable] {
                                 Async.raceFirst[Throwable, Any, Any](
-                                    Browser.runOn(tab)(Browser.screenshot(width = 1234, height = 567)),
+                                    Browser.runOn(tab)(Browser.screenshotRegion(0, 0, 1234, 567, Browser.ScreenshotFormat.Png, 90)),
                                     Abort.fail[Throwable](sentinel)
                                 )
                             }.map { result =>
@@ -927,8 +927,8 @@ class BrowserReadTest extends BrowserTest:
         // quality 30 and quality 90 must therefore yield identical byte payloads.
         withBrowser {
             onPage(gradientPageHtml) {
-                Browser.screenshot(width = 400, height = 300, format = Browser.ScreenshotFormat.Png, quality = 30).map { low =>
-                    Browser.screenshot(width = 400, height = 300, format = Browser.ScreenshotFormat.Png, quality = 90).map { high =>
+                Browser.screenshotRegion(0, 0, 400, 300, format = Browser.ScreenshotFormat.Png, quality = 30).map { low =>
+                    Browser.screenshotRegion(0, 0, 400, 300, format = Browser.ScreenshotFormat.Png, quality = 90).map { high =>
                         assert(low.binary.size > 0, "expected non-empty PNG at quality 30")
                         assert(high.binary.size > 0, "expected non-empty PNG at quality 90")
                         assert(
@@ -944,8 +944,8 @@ class BrowserReadTest extends BrowserTest:
     "screenshot in JPEG format produces a smaller payload at quality 30 than at quality 90" in {
         withBrowser {
             onPage(gradientPageHtml) {
-                Browser.screenshot(width = 400, height = 300, format = Browser.ScreenshotFormat.Jpeg, quality = 30).map { low =>
-                    Browser.screenshot(width = 400, height = 300, format = Browser.ScreenshotFormat.Jpeg, quality = 90).map { high =>
+                Browser.screenshotRegion(0, 0, 400, 300, format = Browser.ScreenshotFormat.Jpeg, quality = 30).map { low =>
+                    Browser.screenshotRegion(0, 0, 400, 300, format = Browser.ScreenshotFormat.Jpeg, quality = 90).map { high =>
                         assert(low.binary.size > 0, "expected non-empty JPEG at quality 30")
                         assert(high.binary.size > 0, "expected non-empty JPEG at quality 90")
                         assert(
@@ -961,7 +961,7 @@ class BrowserReadTest extends BrowserTest:
     "screenshot in WEBP format produces a valid image" in {
         withBrowser {
             onPage(gradientPageHtml) {
-                Browser.screenshot(width = 400, height = 300, format = Browser.ScreenshotFormat.Webp).map { img =>
+                Browser.screenshotRegion(0, 0, 400, 300, format = Browser.ScreenshotFormat.Webp, quality = 90).map { img =>
                     val bytes = img.binary
                     assert(bytes.size > 0, "expected non-empty WEBP image")
                     // RIFF header; every WEBP file starts with 'R' 'I' 'F' 'F' (0x52 0x49 0x46 0x46).
@@ -1025,9 +1025,9 @@ class BrowserReadTest extends BrowserTest:
             onPage("<html><body>nested</body></html>") {
                 Browser.eval("window.innerWidth").map { preWidthStr =>
                     Browser.eval("window.innerHeight").map { preHeightStr =>
-                        Browser.screenshot(width = 640, height = 480).map { outerImg =>
+                        Browser.screenshotRegion(0, 0, 640, 480, Browser.ScreenshotFormat.Png, 90).map { outerImg =>
                             assert(outerImg.binary.size > 0, "outer screenshot should be non-empty")
-                            Browser.screenshot(width = 320, height = 240).map { innerImg =>
+                            Browser.screenshotRegion(0, 0, 320, 240, Browser.ScreenshotFormat.Png, 90).map { innerImg =>
                                 assert(innerImg.binary.size > 0, "inner screenshot should be non-empty")
                                 Browser.eval("window.innerWidth").map { postWidthStr =>
                                     Browser.eval("window.innerHeight").map { postHeightStr =>
@@ -1389,22 +1389,24 @@ class BrowserReadTest extends BrowserTest:
     "screenshot(using Frame) captures the viewport with default dims, same as screenshot(1280, 720, 90)" in {
         val p = page("<html><body><h1>Screenshot Test</h1></body></html>")
         withBrowser {
-            Browser.goto(p).map { _ =>
-                Browser.screenshot.map { img =>
-                    assert(img.binary.size > 0, "Expected non-empty screenshot bytes")
-                    val bytes = img.binary.toArray
-                    assert(bytes.length >= 24, "Expected at least 24 bytes for PNG header + IHDR chunk")
-                    assert(bytes(0) == 0x89.toByte, "Expected PNG signature byte 0")
-                    assert(bytes(1) == 'P'.toByte, "Expected PNG signature byte 1")
-                    assert(bytes(2) == 'N'.toByte, "Expected PNG signature byte 2")
-                    assert(bytes(3) == 'G'.toByte, "Expected PNG signature byte 3")
-                    // Width and height are at offsets 16 and 20 in the IHDR chunk (big-endian 4-byte ints)
-                    val width =
-                        ((bytes(16) & 0xff) << 24) | ((bytes(17) & 0xff) << 16) | ((bytes(18) & 0xff) << 8) | (bytes(19) & 0xff)
-                    val height =
-                        ((bytes(20) & 0xff) << 24) | ((bytes(21) & 0xff) << 16) | ((bytes(22) & 0xff) << 8) | (bytes(23) & 0xff)
-                    assert(width == 1280, s"Expected default screenshot width 1280 but got $width")
-                    assert(height == 720, s"Expected default screenshot height 720 but got $height")
+            Browser.goto(p).andThen {
+                Browser.setViewport(1024, 768).andThen {
+                    Browser.screenshot().map { img =>
+                        assert(img.binary.size > 0, "Expected non-empty screenshot bytes")
+                        val bytes = img.binary.toArray
+                        assert(bytes.length >= 24, "Expected at least 24 bytes for PNG header + IHDR chunk")
+                        assert(bytes(0) == 0x89.toByte, "Expected PNG signature byte 0")
+                        assert(bytes(1) == 'P'.toByte, "Expected PNG signature byte 1")
+                        assert(bytes(2) == 'N'.toByte, "Expected PNG signature byte 2")
+                        assert(bytes(3) == 'G'.toByte, "Expected PNG signature byte 3")
+                        // Width and height are at offsets 16 and 20 in the IHDR chunk (big-endian 4-byte ints)
+                        val width =
+                            ((bytes(16) & 0xff) << 24) | ((bytes(17) & 0xff) << 16) | ((bytes(18) & 0xff) << 8) | (bytes(19) & 0xff)
+                        val height =
+                            ((bytes(20) & 0xff) << 24) | ((bytes(21) & 0xff) << 16) | ((bytes(22) & 0xff) << 8) | (bytes(23) & 0xff)
+                        assert(width == 1024, s"Expected live-viewport screenshot width 1024 but got $width")
+                        assert(height == 768, s"Expected live-viewport screenshot height 768 but got $height")
+                    }
                 }
             }
         }

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserScreencastTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserScreencastTest.scala
@@ -1,0 +1,431 @@
+package kyo
+
+import kyo.internal.BrowserTab
+import kyo.internal.CdpBackend
+import kyo.internal.CdpClient
+import kyo.internal.CdpEvent
+import kyo.internal.CdpTypes.*
+import kyo.internal.ScreencastFrameAckParams
+import kyo.internal.ScreencastFrameMetadata
+import kyo.internal.ScreencastFrameWire
+import kyo.internal.StartScreencastParams
+
+/** Behavioral tests for screencast and console event routing.
+  *
+  * Tests 1, 3, 4, 5, and 6 are pure unit tests (no Chrome required). Test 2 is Chrome-backed and verifies the full ack loop.
+  */
+class BrowserScreencastTest extends BrowserTest:
+
+    override def timeout = 90.seconds
+
+    // CanEqual for Exchange.Message pattern matches in tests 3 and 6.
+    given CanEqual[Exchange.Message[Int, String, CdpEvent], Exchange.Message[Int, String, CdpEvent]] =
+        CanEqual.derived
+
+    // -------------------------------------------------------------------------
+    // Test 1: whitelist membership (pure, no Chrome)
+    // -------------------------------------------------------------------------
+
+    "eventWhitelist contains Page.screencastFrame, Runtime.consoleAPICalled, Runtime.exceptionThrown" in {
+        assert(CdpClient.eventWhitelist.contains("Page.screencastFrame"))
+        assert(CdpClient.eventWhitelist.contains("Runtime.consoleAPICalled"))
+        assert(CdpClient.eventWhitelist.contains("Runtime.exceptionThrown"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: registered dispatcher receives frames and the cast does not stall
+    // -------------------------------------------------------------------------
+
+    // Registers a raw screencast handler on `screencastEventDispatchers`, starts a screencast on the
+    // tab session, and waits until the body completes. Chrome sends `Page.screencastFrame` events on
+    // the tab session; the handler acks each frame (via a detached fiber) and offers it to `frameChannel`.
+    private def withRawScreencastFrames[A](
+        body: Channel[ScreencastFrameWire] => A < (Browser & Async & Abort[BrowserReadException])
+    )(using Frame): A < (Browser & Async & Abort[BrowserReadException]) =
+        Browser.use { tab =>
+            val session = tab.session // session-scoped client; commands carry the tab's session ID
+            val sidKey  = tab.sessionId.value
+            Channel.initUnscoped[ScreencastFrameWire](16).map { frameChannel =>
+                val handler: CdpEvent.Generic => Unit < Sync = ev =>
+                    CdpClient.parseScreencastFrame(ev) match
+                        case Present((frame, sessionId)) =>
+                            // Ack via a detached fiber so the reader fiber stays < Sync.
+                            // The ack fiber runs concurrently; Chrome sees it promptly and
+                            // keeps delivering frames. BrowserReadException swallowed so
+                            // the fiber does not escape into background noise.
+                            Fiber.initUnscoped(
+                                Abort.run[BrowserReadException](
+                                    CdpBackend.screencastFrameAck(session, ScreencastFrameAckParams(sessionId))
+                                ).unit
+                            ).andThen(Abort.run[Closed](frameChannel.offer(frame)).unit)
+                        case Absent =>
+                            Kyo.unit
+                // Dispatcher maps live on the root client that all sessions share.
+                session.screencastEventDispatchers.getAndUpdate(_.update(sidKey, handler)).map { previousMap =>
+                    val restoreDispatcher = session.screencastEventDispatchers.getAndUpdate { m =>
+                        previousMap.get(sidKey) match
+                            case Present(prev) => m.update(sidKey, prev)
+                            case Absent        => m.remove(sidKey)
+                    }.unit
+                    Scope.run {
+                        Scope.ensure(restoreDispatcher).andThen(Scope.ensure(frameChannel.close.unit)).andThen {
+                            CdpBackend.startScreencast(
+                                session,
+                                StartScreencastParams(quality = Present(50), everyNthFrame = Present(1))
+                            ).andThen(body(frameChannel))
+                        }
+                    }
+                }
+            }
+        }
+
+    "a registered screencast dispatcher receives frames and the cast does not stall" in {
+        withBrowser {
+            val html = page(
+                """<html><head><style>
+                  |@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+                  |#box { width: 40px; height: 40px; background: red; animation: spin 0.1s linear infinite; }
+                  |</style></head><body><div id="box"></div></body></html>""".stripMargin
+            )
+            Browser.goto(html).andThen {
+                withRawScreencastFrames { frameChannel =>
+                    // Two successful takes prove the ack loop delivered at least 2 frames.
+                    Abort.run[Closed](frameChannel.take.andThen(frameChannel.take)).map {
+                        case Result.Success(_) => succeed
+                        case Result.Failure(_) => fail("Channel closed before two frames arrived")
+                    }
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: no dispatcher registered, whitelisted event is pushed not dropped
+    // -------------------------------------------------------------------------
+
+    "with no dispatcher a whitelisted screencast event is pushed not dropped" in {
+        val wire =
+            """{"method":"Page.screencastFrame","params":{"data":"AAAA","metadata":{"scrollOffsetX":0,"scrollOffsetY":0},"sessionId":1}}"""
+        for
+            handlers              <- AtomicRef.init[Dict[String, (Boolean, String)]](Dict.empty)
+            queue                 <- Channel.initUnscoped[(Boolean, String, Maybe[SessionId])](16)
+            frameDispatchers      <- AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty)
+            downloadDispatchers   <- AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty)
+            screencastDispatchers <- AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty)
+            consoleDispatchers    <- AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty)
+            recorders             <- AtomicRef.init[Dict[String, AtomicRef[Chunk[Browser.DialogEvent]]]](Dict.empty)
+            result <- CdpClient.decodeCdpMessage(
+                wire,
+                handlers,
+                queue,
+                frameDispatchers,
+                downloadDispatchers,
+                screencastDispatchers,
+                consoleDispatchers,
+                recorders
+            )
+        yield result match
+            case Exchange.Message.Push(ev: CdpEvent.Generic) =>
+                assert(ev.method == "Page.screencastFrame", s"method mismatch: ${ev.method}")
+            case other =>
+                fail(s"Expected Push for unregistered dispatcher but got: $other")
+        end for
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4: parseScreencastFrame returns Absent on wrong-method event (pure)
+    // -------------------------------------------------------------------------
+
+    "parseScreencastFrame returns Absent on a wrong-method event" in {
+        val ev = CdpEvent.Generic(method = "Page.loadEventFired", paramsJson = "{}", sessionId = Absent)
+        assert(CdpClient.parseScreencastFrame(ev) == Absent)
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 5: parseScreencastFrame returns Absent on malformed params (pure)
+    // -------------------------------------------------------------------------
+
+    "parseScreencastFrame returns Absent on malformed params JSON" in {
+        val ev = CdpEvent.Generic(method = "Page.screencastFrame", paramsJson = "not-valid-json", sessionId = Absent)
+        assert(CdpClient.parseScreencastFrame(ev) == Absent)
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 6: dispatcher handler swallows Abort[Closed] and never blocks reader
+    // -------------------------------------------------------------------------
+
+    "dispatcher handler swallows Abort[Closed] and never blocks the reader" in {
+        val ev = CdpEvent.Generic("Page.screencastFrame", "{}", Absent)
+        // Create a channel and immediately close it so any offer inside the handler raises Abort[Closed].
+        Channel.initUnscoped[ScreencastFrameWire](1).map { closedChannel =>
+            closedChannel.close.andThen {
+                // Build a handler that matches the dispatcher type CdpEvent.Generic => Unit < Sync.
+                // The Abort.run[Closed](...).unit pattern is the same one used by onDownload.
+                // If Abort[Closed] were not swallowed, the lambda type would not unify to Unit < Sync.
+                val handler: CdpEvent.Generic => Unit < Sync = _ =>
+                    Abort.run[Closed](closedChannel.offer(
+                        ScreencastFrameWire("AAAA", ScreencastFrameMetadata(0.0, 0.0), 1)
+                    )).unit
+                // Invoke the handler and assert the result is Unit (no Abort leaked to the caller).
+                handler(ev).map { _ =>
+                    succeed
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // screenshotFrames screencast recorder (Chrome-backed)
+    // -------------------------------------------------------------------------
+
+    // A page driving a perpetual visual change AND a perpetual DOM mutation. The CSS animation makes Chrome
+    // re-render so the screencast keeps delivering frames; the `setInterval` DOM mutation keeps the page from
+    // ever quiescing so `waitForStable` runs for its whole window (it never returns early on a still DOM). The
+    // result is a deterministic, sleep-free recorder driver whose duration is exactly the `waitForStable` budget.
+    private val spinPage =
+        """<html><head><style>
+          |@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+          |#box { width: 60px; height: 60px; background: red; animation: spin 0.1s linear infinite; }
+          |</style></head><body><div id="box"></div>
+          |<script>setInterval(function(){ document.body.appendChild(document.createElement('span')); }, 20);</script>
+          |</body></html>""".stripMargin
+
+    // Drives the recorder body for a bounded window. The spin page never quiesces (its setInterval keeps mutating
+    // the DOM), so `waitForStable` runs the whole window and aborts at its timeout; swallowing that abort lets the
+    // body return cleanly after the window so the recorder can read its poison flag and surface the cap. The wait
+    // is the bound, never a sleep.
+    private def spinFor(window: Duration)(using Frame): Unit < (Browser & Async & Abort[BrowserReadException]) =
+        Abort.run[BrowserReadException](Browser.waitForStable(window)).unit
+
+    // -------------------------------------------------------------------------
+    // Test 7: records frames of an animation, events-first
+    // -------------------------------------------------------------------------
+
+    "screenshotFrames records frames of an animation with non-decreasing offsetMs" in {
+        withBrowser {
+            onPage(spinPage) {
+                Browser.screenshotFrames(maxDurationMs = 2000L, maxFrames = 90) {
+                    spinFor(300.millis)
+                }.map { case (frames, _) =>
+                    assert(frames.nonEmpty, "expected at least one recorded frame")
+                    // Every frame carries non-empty image bytes starting with the JPEG magic (default format).
+                    frames.foreach { f =>
+                        val bytes = f.image.binary
+                        assert(bytes.size > 0, "expected non-empty frame image")
+                        val b0 = bytes(0) & 0xff
+                        val b1 = bytes(1) & 0xff
+                        assert(b0 == 0xff && b1 == 0xd8, s"expected JPEG magic FF D8 but got ${"%02x %02x".format(b0, b1)}")
+                    }
+                    // offsetMs is non-negative and non-decreasing across the delivery-ordered chunk.
+                    assert(frames.forall(_.offsetMs >= 0L), s"expected non-negative offsetMs but got ${frames.map(_.offsetMs)}")
+                    val offsets = frames.map(_.offsetMs)
+                    assert(
+                        offsets.zip(offsets.drop(1)).forall((a, b) => b >= a),
+                        s"expected non-decreasing offsetMs but got $offsets"
+                    )
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 8: offsetMs is relative to the cast start (t0), not raw epoch
+    // -------------------------------------------------------------------------
+
+    "screenshotFrames offsetMs is measured relative to the cast start" in {
+        withBrowser {
+            onPage(spinPage) {
+                Browser.screenshotFrames(maxDurationMs = 2000L, maxFrames = 60) {
+                    spinFor(400.millis)
+                }.map { case (frames, _) =>
+                    assert(frames.nonEmpty, "expected at least one recorded frame")
+                    // Relative to t0: a wall-clock epoch (~1.7e12) would be far larger than the cast duration.
+                    // Every offset must sit well under one minute, proving it is a cast-relative delta, not raw epoch millis.
+                    assert(
+                        frames.forall(f => f.offsetMs >= 0L && f.offsetMs < 60000L),
+                        s"expected cast-relative offsets under 60s but got ${frames.map(_.offsetMs)}"
+                    )
+                    // The last frame's offset is at least the first frame's (monotonic delivery).
+                    assert(frames.last.offsetMs >= frames.head.offsetMs, "expected later frames to have larger or equal offsetMs")
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 9: aborts on the frame cap, frame-count-first
+    // -------------------------------------------------------------------------
+
+    "screenshotFrames aborts on the frame cap with limit equal to maxFrames" in {
+        withBrowser {
+            onPage(spinPage) {
+                Abort.run[BrowserReadException] {
+                    Browser.screenshotFrames[Unit, Any](maxDurationMs = 60000L, maxFrames = 3) {
+                        spinFor(800.millis)
+                    }
+                }.map {
+                    case Result.Failure(ex: BrowserCaptureLimitExceededException) =>
+                        assert(ex.operation == "screenshotFrames", s"unexpected operation ${ex.operation}")
+                        assert(ex.limit == 3, s"expected limit 3 (frame cap) but got ${ex.limit}")
+                        assert(ex.reached >= 3, s"expected reached >= 3 but got ${ex.reached}")
+                    case other =>
+                        fail(s"expected BrowserCaptureLimitExceededException on the frame cap but got $other")
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 10: aborts on the duration cap while frames stay under maxFrames
+    // -------------------------------------------------------------------------
+
+    "screenshotFrames aborts on the duration cap with reached and limit both in milliseconds" in {
+        withBrowser {
+            onPage(spinPage) {
+                Abort.run[BrowserReadException] {
+                    Browser.screenshotFrames[Unit, Any](maxDurationMs = 300L, maxFrames = 10000) {
+                        spinFor(800.millis)
+                    }
+                }.map {
+                    case Result.Failure(ex: BrowserCaptureLimitExceededException) =>
+                        assert(ex.operation == "screenshotFrames", s"unexpected operation ${ex.operation}")
+                        // The duration cap reports BOTH numbers in milliseconds: limit == maxDurationMs, reached == elapsed ms.
+                        assert(ex.limit == 300, s"expected limit 300 (duration cap ms) but got ${ex.limit}")
+                        // reached is the elapsed ms at the cap, so it must exceed the 300ms limit (that is why the cap fired) and
+                        // stay well under the 800ms window cap. A frame count (a handful of frames) could never satisfy reached > 300.
+                        assert(
+                            ex.reached > ex.limit,
+                            s"expected reached (elapsed ms) to exceed the 300ms limit but got ${ex.reached}"
+                        )
+                        assert(
+                            ex.reached < 10000,
+                            s"expected reached (elapsed ms) under the spin window but got ${ex.reached}"
+                        )
+                    case other =>
+                        fail(s"expected BrowserCaptureLimitExceededException on the duration cap but got $other")
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 11: Webp maps to the screencast jpeg codec without aborting
+    // -------------------------------------------------------------------------
+
+    "screenshotFrames Webp format records via the jpeg codec without aborting" in {
+        withBrowser {
+            onPage(spinPage) {
+                Browser.screenshotFrames(maxDurationMs = 800L, maxFrames = 240, format = Browser.ScreenshotFormat.Webp) {
+                    spinFor(300.millis)
+                }.map { case (frames, _) =>
+                    assert(frames.nonEmpty, "expected Webp cast to record at least one frame")
+                    // The screencast has no webp codec, so the frames are jpeg; assert the JPEG magic to prove the substitution.
+                    val bytes = frames.head.image.binary
+                    assert(bytes.size > 0, "expected non-empty frame image")
+                    val b0 = bytes(0) & 0xff
+                    val b1 = bytes(1) & 0xff
+                    assert(b0 == 0xff && b1 == 0xd8, s"expected JPEG magic FF D8 (webp->jpeg) but got ${"%02x %02x".format(b0, b1)}")
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 12: teardown on interruption deregisters the dispatcher; a later cast works
+    // -------------------------------------------------------------------------
+
+    // The Browser effect carries Env[BrowserTab] and the module provides no same-tab isolate, so the interrupted cast runs
+    // inside a self-contained Browser.run (the established interruption pattern in BrowserViewportTest /
+    // BrowserEmulationTest). The scenario is driven by an explicit fiber plus two Promises so it is deterministic across the
+    // JVM and the single-threaded Scala.js / Scala Native runtimes:
+    //   - the cast runs in its own fiber (Fiber.initUnscoped), not under Async.timeout, so the test owns the interruption.
+    //   - readyLatch is completed AFTER the cast is registered, so the test interrupts only once the body is provably inside
+    //     the recorder scope, never before startScreencast ran.
+    //   - tabRef captures the tab so its dispatcher map can be read.
+    // After readyLatch resolves the test interrupts the fiber and awaits its Result. The recorder's Scope.ensure(restore)
+    // removes the session entry then does an async stopScreencast send; on JS / Native the interrupted fiber's Result can
+    // resolve before that finalizer chain has removed the entry (the ordering only holds on the JVM). So the dispatcher map
+    // is read by polling until the entry is gone, bounded by a fixed schedule, then asserted concretely. The poll re-reads
+    // the AtomicRef directly; the tab object outlives its CDP teardown. A second, independent cast then records frames,
+    // proving the recorder is reusable and stopScreencast left Chrome in a clean state.
+    "screenshotFrames tears down the dispatcher on interruption and a later cast still works" in {
+        // A static page carrying only the CSS animation: Chrome keeps re-rendering it (so the cast records frames)
+        // while the DOM stays still, so `goto` settles promptly and the interruption window is deterministic.
+        val animOnlyPage =
+            """<html><head><style>
+              |@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+              |#box { width: 60px; height: 60px; background: red; animation: spin 0.1s linear infinite; }
+              |</style></head><body><div id="box"></div></body></html>""".stripMargin
+        kyo.internal.SharedChrome.init.map { wsUrl =>
+            Promise.init[BrowserTab, Any].map { tabRef =>
+                Promise.init[Unit, Any].map { readyLatch =>
+                    val cast: Unit < (Async & Abort[BrowserReadException]) =
+                        Browser.run(wsUrl) {
+                            Browser.goto(page(animOnlyPage)).andThen {
+                                Browser.use { tab =>
+                                    tabRef.completeDiscard(Result.succeed(tab)).andThen {
+                                        Browser.screenshotFrames[Unit, Any](maxDurationMs = 60000L, maxFrames = 10000) {
+                                            // Signal the cast is registered, then block interruptibly until the test
+                                            // interrupts the fiber while the cast is active.
+                                            readyLatch.completeDiscard(Result.succeed(())).andThen {
+                                                Async.sleep(30.seconds)
+                                            }
+                                        }.unit
+                                    }
+                                }
+                            }
+                        }
+                    Fiber.initUnscoped(cast).map { fiber =>
+                        // Wait until the cast is registered, then interrupt and await the interrupted Result so the fiber has
+                        // finished unwinding before the dispatcher map is inspected.
+                        readyLatch.get.andThen {
+                            fiber.interrupt.andThen {
+                                fiber.getResult.map { result =>
+                                    assert(result.isPanic, s"expected the interrupt to abort the cast but got $result")
+                                    tabRef.get.map { tab =>
+                                        val sidKey = tab.sessionId.value
+                                        // Poll the dispatcher map until the recorder's Scope.ensure(restore) removed the entry.
+                                        Retry[BrowserReadException](Schedule.fixed(20.millis).take(150)) {
+                                            tab.client.screencastEventDispatchers.get.map { map =>
+                                                if map.get(sidKey) == Absent then ()
+                                                else
+                                                    Abort.fail(
+                                                        BrowserAssertionTimedOutException(
+                                                            "screencast interrupt teardown",
+                                                            "Absent",
+                                                            "present"
+                                                        )
+                                                    )
+                                            }
+                                        }.andThen {
+                                            // The recorder's Scope.ensure(restore) removed the dispatcher entry on interruption.
+                                            tab.client.screencastEventDispatchers.get.map { map =>
+                                                assert(
+                                                    map.get(sidKey) == Absent,
+                                                    s"expected the screencast dispatcher for $sidKey to be removed on interruption but it is still present"
+                                                )
+                                            }
+                                        }
+                                    }.andThen {
+                                        // A fresh, independent cast records frames: the recorder is reusable and Chrome is in
+                                        // a clean state.
+                                        Browser.run(wsUrl) {
+                                            Browser.goto(page(animOnlyPage)).andThen {
+                                                Browser.screenshotFrames[Unit, Any](maxDurationMs = 1500L, maxFrames = 60) {
+                                                    spinFor(300.millis)
+                                                }.map { case (frames, _) =>
+                                                    assert(frames.nonEmpty, "expected the later cast to record frames after teardown")
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+end BrowserScreencastTest

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserSettlementTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserSettlementTest.scala
@@ -1191,4 +1191,256 @@ class BrowserSettlementTest extends BrowserTest:
         }
     }
 
+    // ── data-kyo-internal filter + waitForStable + settleForCapture ──
+
+    // Test 1: injecting a data-kyo-internal node leaves __kyoMutCount unchanged.
+    // The observer is installed via a no-op afterAction call so __kyoMutCount and the
+    // observer exist; subsequent mutations inside the tagged subtree are filtered out
+    // and must not change the counter.
+    "data-kyo-internal mutations do not arm the settlement gate" in {
+        withBrowser {
+            onPage("<body><div id='real'>initial</div></body>") {
+                // Install the observer via a no-op afterAction so __kyoMutCount is initialized.
+                kyo.internal.MutationSettlement.afterAction(Browser.eval("'noop'"))(Absent).andThen {
+                    // Read the count right after the no-op action settled.
+                    Browser.eval("String(window.__kyoMutCount || 0)").map { beforeStr =>
+                        val before = beforeStr.toLong
+                        // Inject a data-kyo-internal subtree and mutate it several times.
+                        Browser.eval("""(() => {
+                            const d = document.createElement('div');
+                            d.setAttribute('data-kyo-internal', 'overlay');
+                            d.id = 'overlay';
+                            document.body.appendChild(d);
+                            d.textContent = 'x';
+                            d.textContent = 'y';
+                            d.textContent = 'z';
+                            const child = document.createElement('span');
+                            child.textContent = 'child';
+                            d.appendChild(child);
+                            return 'done';
+                        })()""").andThen {
+                            Browser.eval("String(window.__kyoMutCount || 0)").map { afterStr =>
+                                val after = afterStr.toLong
+                                assert(
+                                    after == before,
+                                    s"expected __kyoMutCount to remain $before after data-kyo-internal mutations but got $after"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Test 2: real DOM mutations still arm the gate after the filter is applied.
+    // Proves the filter is narrow: untagged elements still increment __kyoMutCount.
+    // Strategy: use evalJsAwaiting (awaitPromise=true) to flush microtasks after the DOM mutation
+    // so the MutationObserver callback fires (MutationObserver delivers as a microtask; a
+    // synchronous eval cannot observe the post-callback count because microtasks run after the
+    // current script task, not between its statements). The async eval yields via setTimeout(0)
+    // to let the callback run, then reads the updated count.
+    "real DOM mutations still arm the gate after the data-kyo-internal filter" in {
+        withBrowser {
+            onPage("<body><div id='real'>initial</div></body>") {
+                // The action installs the observer, triggers a real DOM mutation, then yields via
+                // setTimeout(0) inside an async block so the MutationObserver microtask fires.
+                // Returns "before,after" counts for assertion.
+                val action = kyo.internal.BrowserEval.evalJsAwaiting("""(async () => {
+                    const before = window.__kyoMutCount || 0;
+                    document.getElementById('real').textContent = 'changed';
+                    await new Promise(r => setTimeout(r, 0));
+                    const after = window.__kyoMutCount || 0;
+                    return String(before) + ',' + String(after);
+                })()""")
+                kyo.internal.MutationSettlement.afterAction(action)(Absent).map { result =>
+                    val parts  = result.split(",")
+                    val before = parts(0).toLong
+                    val after  = parts(1).toLong
+                    assert(
+                        after > before,
+                        s"expected __kyoMutCount to increase from $before after an untagged mutation but got $after (filter must not suppress untagged mutations)"
+                    )
+                }
+            }
+        }
+    }
+
+    // Test 2b: APPENDING a data-kyo-internal root to document.body does NOT arm the gate.
+    // This is the overlay-injection case: the childList record's target is the UNTAGGED parent (document.body) and the
+    // tagged node is in addedNodes, so the original target-ancestor-only filter would have armed the gate. The extended
+    // filter treats a childList record as transparent when every added/removed node is (or is within) a tagged subtree.
+    // evalJsAwaiting flushes the MutationObserver microtask (via setTimeout(0)) before reading the post-callback count.
+    "appending a data-kyo-internal node does not arm the settlement gate" in {
+        withBrowser {
+            onPage("<body><div id='real'>initial</div></body>") {
+                val action = kyo.internal.BrowserEval.evalJsAwaiting("""(async () => {
+                    const before = window.__kyoMutCount || 0;
+                    const d = document.createElement('div');
+                    d.setAttribute('data-kyo-internal', 'overlay');
+                    d.id = 'kyo-overlay-root';
+                    const child = document.createElement('span');
+                    child.textContent = 'box';
+                    d.appendChild(child);
+                    document.body.appendChild(d);
+                    await new Promise(r => setTimeout(r, 0));
+                    const after = window.__kyoMutCount || 0;
+                    return String(before) + ',' + String(after);
+                })()""")
+                kyo.internal.MutationSettlement.afterAction(action)(Absent).map { result =>
+                    val parts  = result.split(",")
+                    val before = parts(0).toLong
+                    val after  = parts(1).toLong
+                    assert(
+                        after == before,
+                        s"expected __kyoMutCount to remain $before after appending a data-kyo-internal node but got $after"
+                    )
+                }
+            }
+        }
+    }
+
+    // Test 2c: REMOVING a data-kyo-internal root from document.body does NOT arm the gate.
+    // The childList record's target is document.body (untagged) and the tagged node is in removedNodes. A detached removed
+    // tagged element still satisfies closest('[data-kyo-internal]') on itself, so the extended filter treats the removal as
+    // transparent. Pre-seeds the tagged root before the observer is installed so the only mutation under measurement is the
+    // removal.
+    "removing a data-kyo-internal node does not arm the settlement gate" in {
+        withBrowser {
+            onPage("<body><div id='real'>initial</div></body>") {
+                // Pre-seed the tagged overlay root before installing the observer.
+                Browser.eval("""(() => {
+                    const d = document.createElement('div');
+                    d.setAttribute('data-kyo-internal', 'overlay');
+                    d.id = 'kyo-overlay-root';
+                    document.body.appendChild(d);
+                    return 'seeded';
+                })()""").andThen {
+                    val action = kyo.internal.BrowserEval.evalJsAwaiting("""(async () => {
+                        const before = window.__kyoMutCount || 0;
+                        const d = document.getElementById('kyo-overlay-root');
+                        document.body.removeChild(d);
+                        await new Promise(r => setTimeout(r, 0));
+                        const after = window.__kyoMutCount || 0;
+                        return String(before) + ',' + String(after);
+                    })()""")
+                    kyo.internal.MutationSettlement.afterAction(action)(Absent).map { result =>
+                        val parts  = result.split(",")
+                        val before = parts(0).toLong
+                        val after  = parts(1).toLong
+                        assert(
+                            after == before,
+                            s"expected __kyoMutCount to remain $before after removing a data-kyo-internal node but got $after"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // Test 2d: appending a NON-tagged node STILL arms the gate (regression guard for the childList filter extension).
+    // Proves the extended filter is narrow: a childList record whose added node is untagged increments __kyoMutCount.
+    "appending a non-tagged node still arms the settlement gate" in {
+        withBrowser {
+            onPage("<body><div id='real'>initial</div></body>") {
+                val action = kyo.internal.BrowserEval.evalJsAwaiting("""(async () => {
+                    const before = window.__kyoMutCount || 0;
+                    const d = document.createElement('div');
+                    d.id = 'plain-node';
+                    d.textContent = 'plain';
+                    document.body.appendChild(d);
+                    await new Promise(r => setTimeout(r, 0));
+                    const after = window.__kyoMutCount || 0;
+                    return String(before) + ',' + String(after);
+                })()""")
+                kyo.internal.MutationSettlement.afterAction(action)(Absent).map { result =>
+                    val parts  = result.split(",")
+                    val before = parts(0).toLong
+                    val after  = parts(1).toLong
+                    assert(
+                        after > before,
+                        s"expected __kyoMutCount to increase from $before after appending an untagged node but got $after (the filter must not suppress untagged insertions)"
+                    )
+                }
+            }
+        }
+    }
+
+    // Test 3: waitForStable returns () once the DOM quiesces.
+    // A burst of 5 mutations fires at ~20ms intervals then stops; waitForStable must
+    // return within the 2s timeout. Uses Test.timed for the upper-bound assertion.
+    "waitForStable returns once the DOM quiesces after a mutation burst" in {
+        withBrowser {
+            onPage("""<body>
+                <div id='burst'>0</div>
+                <script>
+                    let n = 0;
+                    const id = setInterval(() => {
+                        document.getElementById('burst').textContent = String(++n);
+                        if (n >= 5) clearInterval(id);
+                    }, 20);
+                </script>
+            </body>""") {
+                timed(kyo.internal.MutationSettlement.waitForStable(2.seconds)).map {
+                    case (elapsedDur, ()) =>
+                        val elapsedMs = elapsedDur.toMillis
+                        assert(
+                            elapsedMs <= 2500L,
+                            s"expected waitForStable to return within 2500ms after quiescence but took ${elapsedMs}ms"
+                        )
+                }
+            }
+        }
+    }
+
+    // Test 4: waitForStable aborts with BrowserAssertionTimedOutException on a never-quiescing page.
+    // A perpetual setInterval mutation at 10ms never lets the observer quiesce; the call must abort
+    // with the typed exception. Result shape (not elapsed time) is the deterministic contract.
+    "waitForStable aborts BrowserAssertionTimedOutException on a never-quiescing page" in {
+        withBrowser {
+            onPage("""<body>
+                <div id='churn'>0</div>
+                <script>
+                    let n = 0;
+                    setInterval(() => { document.getElementById('churn').textContent = String(++n); }, 10);
+                </script>
+            </body>""") {
+                Browser.withConfig(_.mutationSettlementTimeout(300.millis)) {
+                    Abort.run[BrowserReadException] {
+                        kyo.internal.MutationSettlement.waitForStable(300.millis)
+                    }.map {
+                        case Result.Failure(_: BrowserAssertionTimedOutException) => succeed
+                        case other =>
+                            fail(s"expected Result.Failure(BrowserAssertionTimedOutException) but got $other")
+                    }
+                }
+            }
+        }
+    }
+
+    // Test 5: settleForCapture proceeds (returns Success(())) on a perpetually-mutating page.
+    // Same never-quiescing fixture as test 4; settleForCapture must recover the timeout to ()
+    // and NEVER abort. Asserted via Abort.run shape.
+    "settleForCapture returns Result.Success(()) on a never-quiescing page (never aborts)" in {
+        withBrowser {
+            onPage("""<body>
+                <div id='churn2'>0</div>
+                <script>
+                    let n = 0;
+                    setInterval(() => { document.getElementById('churn2').textContent = String(++n); }, 10);
+                </script>
+            </body>""") {
+                Browser.withConfig(_.mutationSettlementTimeout(300.millis)) {
+                    Abort.run[BrowserReadException] {
+                        kyo.internal.MutationSettlement.settleForCapture
+                    }.map {
+                        case Result.Success(()) => succeed
+                        case other =>
+                            fail(s"expected Result.Success(()) from settleForCapture on never-quiescing page but got $other")
+                    }
+                }
+            }
+        }
+    }
+
 end BrowserSettlementTest

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserVerifyReadTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserVerifyReadTest.scala
@@ -1,0 +1,492 @@
+package kyo
+
+import kyo.internal.SettleRead
+
+class BrowserVerifyReadTest extends BrowserTest:
+
+    override def timeout = 90.seconds
+
+    // settle returns the stabilized value of a converging expression.
+    // The page-side JS counter starts at 0, increments by 1 every 20ms, and stops at 42 after ~840ms.
+    // With assertionStabilityWindow = 100ms (default), settle must wait until the counter holds at 42
+    // for 100ms before returning. The result must be 42, not an early intermediate value.
+    "settle returns the stabilized value of a converging expression" in {
+        withBrowser {
+            onPage("""<body>
+                <script>
+                    window.__kyoVal = 0;
+                    setInterval(() => { if (window.__kyoVal < 42) window.__kyoVal++; }, 20);
+                </script>
+            </body>""") {
+                SettleRead.settle("settle-stabilizes", "String(window.__kyoVal)") { raw =>
+                    raw.toInt
+                }.map { result =>
+                    assert(result == 42, s"expected 42 but got $result")
+                }
+            }
+        }
+    }
+
+    // settle maps a stable-absent sentinel through decode without raising.
+    // The JS expression always returns the literal string "__absent__". With a tight assertionStabilityWindow,
+    // the sentinel is trivially stable and decode maps it to Absent. No BrowserAssertionTimedOutException is raised.
+    "settle maps a stable-absent sentinel through decode without raising" in {
+        withBrowser {
+            onPage("<body></body>") {
+                Browser.withConfig(_.assertionStabilityWindow(50.millis)) {
+                    SettleRead.settle("settle-absent", "'__absent__'") { raw =>
+                        if raw == "__absent__" then Absent
+                        else Present(raw)
+                    }.map { result =>
+                        assert(result == Absent, s"expected Absent but got $result")
+                    }
+                }
+            }
+        }
+    }
+
+    // settle re-samples on a never-converging expression and aborts.
+    // The JS counter flickers at 5ms, faster than the 100ms assertionStabilityWindow, so sampleWindow
+    // always returns Unstable. The retrySchedule is capped at 300ms so the test completes quickly.
+    // The result must be a Failure containing a BrowserReadException.
+    "settle re-samples on a never-converging expression and aborts" in {
+        withBrowser {
+            onPage("""<body>
+                <script>
+                    window.__kyoFlicker = Date.now();
+                    setInterval(() => { window.__kyoFlicker = Date.now(); }, 5);
+                </script>
+            </body>""") {
+                Browser.withConfig(
+                    _.retrySchedule(Schedule.fixed(50.millis).maxDuration(300.millis))
+                        .assertionStabilityWindow(100.millis)
+                ) {
+                    Abort.run[BrowserReadException] {
+                        SettleRead.settle("settle-never-converges", "String(window.__kyoFlicker)") { raw =>
+                            raw
+                        }
+                    }.map { result =>
+                        assert(result.isFailure, s"expected a Failure but got $result")
+                    }
+                }
+            }
+        }
+    }
+
+    // settle reads its bound from configLocal, not a hardcoded literal.
+    // Two runs use the same never-converging counter. Override A uses a tight 200ms retrySchedule;
+    // override B uses a wider 600ms retrySchedule. Both must abort a BrowserReadException.
+    // The elapsed time under A must be strictly less than the elapsed time under B,
+    // proving the bound comes from configLocal rather than a hardcoded constant.
+    "settle reads its bound from configLocal and not a hardcoded constant" in {
+        withBrowser {
+            onPage("""<body>
+                <script>
+                    window.__kyoFlicker2 = Date.now();
+                    setInterval(() => { window.__kyoFlicker2 = Date.now(); }, 5);
+                </script>
+            </body>""") {
+                val runSettle =
+                    Abort.run[BrowserReadException] {
+                        SettleRead.settle("settle-config-bound", "String(window.__kyoFlicker2)") { raw =>
+                            raw
+                        }
+                    }
+                timed(Browser.withConfig(
+                    _.retrySchedule(Schedule.fixed(50.millis).maxDuration(200.millis))
+                        .assertionStabilityWindow(80.millis)
+                )(runSettle)).map { case (elapsedA, resultA) =>
+                    timed(Browser.withConfig(
+                        _.retrySchedule(Schedule.fixed(50.millis).maxDuration(600.millis))
+                            .assertionStabilityWindow(80.millis)
+                    )(runSettle)).map { case (elapsedB, resultB) =>
+                        assert(resultA.isFailure, s"expected Failure under override A but got $resultA")
+                        assert(resultB.isFailure, s"expected Failure under override B but got $resultB")
+                        assert(elapsedA < 500.millis, s"override A elapsed ${elapsedA} exceeds 500ms ceiling")
+                        assert(elapsedB < 900.millis, s"override B elapsed ${elapsedB} exceeds 900ms ceiling")
+                        assert(
+                            elapsedA < elapsedB,
+                            s"expected override A ($elapsedA) to finish before override B ($elapsedB)"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // boundingRect returns Bounds for a present element.
+    // A <div> at absolute position 20,30 with 100x50 dimensions. After settle, boundingRect must return
+    // Present(Bounds(20.0, 30.0, 100.0, 50.0)) and the derived accessors must be right=120.0, area=5000.0.
+    "boundingRect returns Bounds for a present element" in {
+        withBrowser {
+            onPage("""<html><body style="margin:0;padding:0;">
+                <div class="panel" style="position:absolute;left:20px;top:30px;width:100px;height:50px;background:red;"></div>
+            </body></html>""") {
+                Browser.boundingRect(Browser.Selector.css(".panel")).map { result =>
+                    result match
+                        case Absent => fail("expected Present(Bounds) but got Absent")
+                        case Present(b) =>
+                            assert(b.x == 20.0, s"expected x=20.0 but got ${b.x}")
+                            assert(b.y == 30.0, s"expected y=30.0 but got ${b.y}")
+                            assert(b.width == 100.0, s"expected width=100.0 but got ${b.width}")
+                            assert(b.height == 50.0, s"expected height=50.0 but got ${b.height}")
+                            assert(b.right == 120.0, s"expected right=120.0 but got ${b.right}")
+                            assert(b.area == 5000.0, s"expected area=5000.0 but got ${b.area}")
+                }
+            }
+        }
+    }
+
+    // boundingRect returns Absent for a missing element and display:none element.
+    // No BrowserElementNotFoundException must be raised.
+    "boundingRect returns Absent for a missing and a display-none element" in {
+        withBrowser {
+            onPage("""<html><body style="margin:0;">
+                <div class="hidden" style="display:none;"></div>
+            </body></html>""") {
+                Browser.boundingRect(Browser.Selector.css(".gone")).map { goneResult =>
+                    Browser.boundingRect(Browser.Selector.css(".hidden")).map { hiddenResult =>
+                        assert(goneResult == Absent, s"expected Absent for .gone but got $goneResult")
+                        assert(hiddenResult == Absent, s"expected Absent for .hidden but got $hiddenResult")
+                    }
+                }
+            }
+        }
+    }
+
+    // boundingRect settles on a moving element.
+    // A .box starts at left:0 and CSS-transitions to left:200px over 400ms. boundingRect issued
+    // mid-transition must return a settled x > 150.0 (close to the final position, not the start).
+    "boundingRect settles on a moving element" in {
+        withBrowser {
+            onPage("""<html><body style="margin:0;padding:0;">
+                <div class="box" style="position:absolute;top:0;left:0;width:50px;height:50px;background:blue;transition:left 400ms linear;"></div>
+                <script>
+                    setTimeout(() => { document.querySelector('.box').style.left = '200px'; }, 50);
+                </script>
+            </body></html>""") {
+                Browser.withConfig(
+                    _.retrySchedule(Schedule.fixed(50.millis).maxDuration(3.seconds))
+                        .assertionStabilityWindow(120.millis)
+                ) {
+                    Browser.boundingRect(Browser.Selector.css(".box")).map { result =>
+                        result match
+                            case Absent => fail("expected Present(Bounds) but got Absent")
+                            case Present(b) =>
+                                assert(b.x > 150.0, s"expected settled x > 150.0 (near 200.0) but got ${b.x}")
+                    }
+                }
+            }
+        }
+    }
+
+    // boundingRect reports the actual rect for an off-viewport element: negative left and a top below the
+    // viewport must be reflected in the returned coordinates (not clamped to the viewport).
+    "boundingRect reports the actual rect for an off-viewport element" in {
+        withBrowser {
+            onPage(
+                "<div id='b' style='position:absolute;left:-500px;top:5000px;width:50px;height:50px;background:blue'></div>"
+            ) {
+                Browser.setViewport(1024, 768).andThen {
+                    Browser.boundingRect(Browser.Selector.id("b")).map {
+                        case Present(b) =>
+                            assert(b.x < 0.0, s"expected x < 0 but got ${b.x}")
+                            assert(b.y > 768.0, s"expected y > viewport-height but got ${b.y}")
+                            assert((b.width - 50.0).abs <= 1.0, s"expected width ~50 but got ${b.width}")
+                            assert((b.height - 50.0).abs <= 1.0, s"expected height ~50 but got ${b.height}")
+                        case Absent =>
+                            fail("expected Present(Bounds) for off-viewport element, got Absent")
+                    }
+                }
+            }
+        }
+    }
+
+    // boundingRect inside a same-origin iframe returns coordinates in the top-level viewport: the inner
+    // element's offset carries the iframe's own position (CDP DOM.getBoxModel, not JS getBoundingClientRect).
+    "boundingRect inside a same-origin iframe returns coords in top-level viewport" in {
+        val parent =
+            """<body>
+                <iframe id="f" data-testid="frame" srcdoc="{srcdoc}"
+                        style="position:absolute;left:100px;top:50px;width:300px;height:200px;border:0"></iframe>
+            </body>"""
+        val inner =
+            """<body><div id="inner" style="position:absolute;left:20px;top:30px;width:40px;height:40px;background:orange"></div></body>"""
+        withBrowser {
+            Browser.setViewport(1024, 768).andThen {
+                Browser.goto(srcdocPage(parent, inner)).andThen {
+                    Browser.withConfig(_.retrySchedule(Schedule.fixed(50.millis).take(40))) {
+                        Browser.assertExists(Browser.Selector.testId("frame")).andThen {
+                            Browser.iframe(Browser.Selector.testId("frame")).map { f =>
+                                Browser.withIFrame(f) {
+                                    Browser.assertExists(Browser.Selector.id("inner")).andThen {
+                                        Browser.boundingRect(Browser.Selector.id("inner")).map {
+                                            case Present(b) =>
+                                                // Inner offset = iframe.left(100) + inner.left(20) = 120;
+                                                // similarly y = iframe.top(50) + inner.top(30) = 80.
+                                                assert(b.x >= 119.0, s"expected x carrying iframe offset (>=119) but got ${b.x}")
+                                                assert(b.y >= 79.0, s"expected y carrying iframe offset (>=79) but got ${b.y}")
+                                            case Absent =>
+                                                fail("expected Present(Bounds) inside iframe, got Absent")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // boundingRect inside a cross-origin iframe returns coordinates within the outer iframe's rect: the inner
+    // element's top-level coordinates land inside the outer iframe box.
+    "boundingRect inside a cross-origin iframe returns coords within outer iframe rect" in {
+        val outerHtml =
+            """<html><body><iframe id="f" data-testid="frame" src="{iframe-src}"
+                        style="position:absolute;left:100px;top:50px;width:300px;height:200px;border:0"></iframe></body></html>"""
+        val innerHtml =
+            """<html><body><div id="inner" style="position:absolute;left:20px;top:30px;width:40px;height:40px;background:purple"></div></body></html>"""
+        withBrowserOnLocalhostIframe(outerHtml, innerHtml) {
+            Browser.setViewport(1024, 768).andThen {
+                Browser.withConfig(_.retrySchedule(Schedule.fixed(50.millis).take(40))) {
+                    Browser.assertExists(Browser.Selector.testId("frame")).andThen {
+                        // Outer iframe rect in top-level viewport coords.
+                        Browser.boundingRect(Browser.Selector.testId("frame")).map {
+                            case Present(outer) =>
+                                Browser.iframe(Browser.Selector.testId("frame")).map { f =>
+                                    Browser.withIFrame(f) {
+                                        Browser.assertExists(Browser.Selector.id("inner")).andThen {
+                                            Browser.boundingRect(Browser.Selector.id("inner")).map {
+                                                case Present(inner) =>
+                                                    assert(
+                                                        inner.x >= outer.x - 1.0 && inner.x <= outer.x + outer.width + 1.0,
+                                                        s"expected inner.x in outer rect [${outer.x}, ${outer.x + outer.width}] but got ${inner.x}"
+                                                    )
+                                                    assert(
+                                                        inner.y >= outer.y - 1.0 && inner.y <= outer.y + outer.height + 1.0,
+                                                        s"expected inner.y in outer rect [${outer.y}, ${outer.y + outer.height}] but got ${inner.y}"
+                                                    )
+                                                case Absent =>
+                                                    fail("expected Present(Bounds) for inner element, got Absent")
+                                            }
+                                        }
+                                    }
+                                }
+                            case Absent =>
+                                fail("expected Present(Bounds) for outer iframe, got Absent")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // computedStyles returns resolved values for a present element.
+    "computedStyles returns the resolved values for a present element" in {
+        withBrowser {
+            onPage("""<html><body style="margin:0;">
+                <button class="btn" style="color:rgb(255, 0, 0);display:block;">Click</button>
+            </body></html>""") {
+                Browser.computedStyles(Browser.Selector.css(".btn"), Span("color", "display")).map { result =>
+                    assert(result("color").contains("255"), s"expected color to contain 255 but got ${result("color")}")
+                    assert(result("display") == "block", s"expected display=block but got ${result("display")}")
+                }
+            }
+        }
+    }
+
+    // computedStyles aborts BrowserElementNotFoundException on missing element.
+    // Schedule is tightened so the test does not wait the full default budget.
+    "computedStyles aborts not-found on a missing element" in {
+        withBrowser {
+            onPage("<html><body></body></html>") {
+                Browser.withConfig(
+                    _.retrySchedule(Schedule.fixed(30.millis).maxDuration(300.millis))
+                        .assertionStabilityWindow(60.millis)
+                ) {
+                    Abort.run[BrowserReadException] {
+                        Browser.computedStyles(Browser.Selector.css(".gone"), Span("color"))
+                    }.map { result =>
+                        assert(result.isFailure, s"expected Failure but got $result")
+                        result match
+                            case Result.Failure(ex: BrowserElementNotFoundException) => succeed
+                            case other => fail(s"expected BrowserElementNotFoundException but got $other")
+                    }
+                }
+            }
+        }
+    }
+
+    // computedStyle delegates and returns the single property value.
+    // The single value must contain "0, 0, 255" from the blue color.
+    "computedStyle delegates and returns the single value" in {
+        withBrowser {
+            onPage("""<html><body style="margin:0;">
+                <button class="btn" style="color:rgb(0, 0, 255);">Click</button>
+            </body></html>""") {
+                Browser.computedStyle(Browser.Selector.css(".btn"), "color").map { result =>
+                    assert(result.contains("0, 0, 255"), s"expected color to contain '0, 0, 255' but got $result")
+                }
+            }
+        }
+    }
+
+    // computedStyle aborts BrowserElementNotFoundException on missing element.
+    // Schedule is tightened to avoid waiting the full default budget.
+    "computedStyle aborts not-found on a missing element" in {
+        withBrowser {
+            onPage("<html><body></body></html>") {
+                Browser.withConfig(
+                    _.retrySchedule(Schedule.fixed(30.millis).maxDuration(300.millis))
+                        .assertionStabilityWindow(60.millis)
+                ) {
+                    Abort.run[BrowserReadException] {
+                        Browser.computedStyle(Browser.Selector.css(".gone"), "color")
+                    }.map { result =>
+                        assert(result.isFailure, s"expected Failure but got $result")
+                    }
+                }
+            }
+        }
+    }
+
+    // inViewport returns true for an on-screen element, false for a scrolled-off one.
+    // #cta is near the top (y=50px), #footer is at y=2500px; viewport height 768px.
+    "inViewport true for on-screen element and false for scrolled-off" in {
+        withBrowser {
+            onPage("""<html><body style="height:3000px;margin:0;padding:0;">
+                <style>body{height:3000px;} #cta{position:absolute;top:50px;left:0;width:50px;height:50px;background:green;} #footer{position:absolute;top:2500px;left:0;width:50px;height:50px;background:red;}</style>
+                <div id="cta"></div>
+                <div id="footer"></div>
+            </body></html>""") {
+                Browser.setViewport(1280, 768).andThen {
+                    Browser.inViewport(Browser.Selector.css("#cta")).map { ctaResult =>
+                        Browser.inViewport(Browser.Selector.css("#footer")).map { footerResult =>
+                            assert(ctaResult == true, s"expected #cta to be in viewport but got $ctaResult")
+                            assert(footerResult == false, s"expected #footer to be out of viewport but got $footerResult")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // inViewport aborts BrowserElementNotFoundException on missing element.
+    // Schedule tightened to avoid waiting the full budget.
+    "inViewport aborts not-found on a missing element" in {
+        withBrowser {
+            onPage("<html><body></body></html>") {
+                Browser.withConfig(
+                    _.retrySchedule(Schedule.fixed(30.millis).maxDuration(300.millis))
+                        .assertionStabilityWindow(60.millis)
+                ) {
+                    Abort.run[BrowserReadException] {
+                        Browser.inViewport(Browser.Selector.css(".gone"))
+                    }.map { result =>
+                        assert(result.isFailure, s"expected Failure but got $result")
+                        result match
+                            case Result.Failure(ex: BrowserElementNotFoundException) => succeed
+                            case other => fail(s"expected BrowserElementNotFoundException but got $other")
+                    }
+                }
+            }
+        }
+    }
+
+    // scrollPosition reads the current offset after a JS scroll.
+    // After scrolling to y=1200, scrollPosition must return ScrollPosition(0, 1200).
+    "scrollPosition reads the current offset" in {
+        withBrowser {
+            onPage("""<html><body style="height:3000px;margin:0;"></body></html>""") {
+                Browser.eval("window.scrollTo(0, 1200)").andThen {
+                    Browser.scrollPosition.map { result =>
+                        assert(result.x == 0, s"expected scrollX=0 but got ${result.x}")
+                        assert(result.y == 1200, s"expected scrollY=1200 but got ${result.y}")
+                    }
+                }
+            }
+        }
+    }
+
+    // scrollPosition returns the snapped (settled) window offset, not the
+    // in-flight intermediate. The document itself is the snap scroller: html/body carry
+    // scroll-snap-type:y mandatory with two 800px sections (matching the fixed 800px viewport height),
+    // so window snap points are y=0 and y=800. Scrolling to y=600 (past the 400px midpoint) must snap
+    // to the second section. Browser.scrollPosition must return exactly 800, not 0 or the intermediate 600.
+    "scrollPosition returns the snapped window offset after scroll-snap settles" in {
+        withBrowser {
+            Browser.setViewport(1280, 800).andThen {
+                onPage("""<html style="margin:0;padding:0;scroll-snap-type:y mandatory;"><body style="margin:0;padding:0;">
+                    <section style="scroll-snap-align:start;height:800px;background:lightblue;"></section>
+                    <section style="scroll-snap-align:start;height:800px;background:lightcoral;"></section>
+                </body></html>""") {
+                    Browser.withConfig(
+                        _.retrySchedule(Schedule.fixed(50.millis).maxDuration(4.seconds))
+                            .assertionStabilityWindow(150.millis)
+                    ) {
+                        Browser.eval("window.scrollTo({top:600,behavior:'instant'})").andThen {
+                            Browser.scrollPosition.map { result =>
+                                assert(
+                                    result.y == 800,
+                                    s"expected scrollY=800 (snapped to second section) but got ${result.y}"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // waitForStable returns after the DOM quiesces.
+    // A setInterval mutates the DOM 10 times over ~200ms then stops.
+    // waitForStable(2.seconds) must return within the timeout.
+    "waitForStable returns after the DOM quiesces" in {
+        withBrowser {
+            onPage("""<html><body>
+                <div id="target"></div>
+                <script>
+                    var count = 0;
+                    var interval = setInterval(() => {
+                        var el = document.createElement('span');
+                        document.getElementById('target').appendChild(el);
+                        count++;
+                        if (count >= 10) clearInterval(interval);
+                    }, 20);
+                </script>
+            </body></html>""") {
+                timed(Browser.waitForStable(2.seconds)).map { case (elapsed, _) =>
+                    assert(elapsed < 2.seconds, s"waitForStable took too long: $elapsed")
+                }
+            }
+        }
+    }
+
+    // waitForStable aborts BrowserAssertionTimedOutException on a never-quiescing page.
+    // A perpetual setInterval mutates forever.
+    // waitForStable(300.millis) must abort BrowserAssertionTimedOutException.
+    "waitForStable aborts on a never-quiescing page" in {
+        withBrowser {
+            onPage("""<html><body>
+                <div id="target"></div>
+                <script>
+                    setInterval(() => {
+                        var el = document.createElement('span');
+                        document.getElementById('target').appendChild(el);
+                    }, 10);
+                </script>
+            </body></html>""") {
+                Abort.run[BrowserReadException] {
+                    Browser.waitForStable(300.millis)
+                }.map { result =>
+                    assert(result.isFailure, s"expected Failure but got $result")
+                    result match
+                        case Result.Failure(ex: BrowserAssertionTimedOutException) => succeed
+                        case other => fail(s"expected BrowserAssertionTimedOutException but got $other")
+                }
+            }
+        }
+    }
+
+end BrowserVerifyReadTest

--- a/kyo-browser/shared/src/test/scala/kyo/BrowserViewportTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/BrowserViewportTest.scala
@@ -1,0 +1,263 @@
+package kyo
+
+import kyo.internal.BrowserTab
+
+class BrowserViewportTest extends BrowserTest:
+
+    override def timeout = 90.seconds
+
+    // ---- setViewport ----
+
+    // setViewport applies the CDP override; window.innerWidth reflects it.
+    "setViewport changes the rendered viewport width" in {
+        withBrowser {
+            onPage("<html><body>set-viewport-width</body></html>") {
+                Browser.setViewport(390, 844).andThen {
+                    Browser.eval("String(window.innerWidth)").map { width =>
+                        assert(width == "390", s"expected innerWidth=390 but got $width")
+                    }
+                }
+            }
+        }
+    }
+
+    // setViewport threads deviceScaleFactor to both the per-tab cache and the CDP send.
+    // devicePixelRatio reports the DPR and the cache holds the ViewportOverride triple.
+    "setViewport threads the DPR to the cache and the CDP send" in {
+        withBrowser {
+            onPage("<html><body>set-viewport-dpr</body></html>") {
+                Browser.setViewport(390, 844, deviceScaleFactor = 3.0).andThen {
+                    Browser.eval("String(window.devicePixelRatio)").map { dpr =>
+                        assert(dpr == "3", s"expected devicePixelRatio=3 but got $dpr")
+                        Browser.use { tab =>
+                            tab.viewportOverride.get.map { cached =>
+                                assert(
+                                    cached == Present(BrowserTab.ViewportOverride(390, 844, 3.0)),
+                                    s"expected cache Present(ViewportOverride(390, 844, 3.0)) but got $cached"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // setViewport settles after, so the re-layout has quiesced on return. Reading innerWidth
+    // immediately after setViewport returns observes the post-resize value, never a mid-resize race.
+    "setViewport settles after so the re-layout has quiesced on return" in {
+        withBrowser {
+            // A responsive page: a media query swaps the marker text when the viewport narrows below 500px.
+            val html =
+                """<html><head><style>
+                  |#marker::after { content: 'wide'; }
+                  |@media (max-width: 500px) { #marker::after { content: 'narrow'; } }
+                  |</style></head><body><span id="marker"></span></body></html>""".stripMargin
+            onPage(html) {
+                Browser.setViewport(390, 844).andThen {
+                    Browser.eval(
+                        "window.innerWidth + ',' + getComputedStyle(document.querySelector('#marker'), '::after').content.replace(/\"/g, '')"
+                    ).map { observed =>
+                        assert(observed == "390,narrow", s"expected post-resize layout 390,narrow but got $observed")
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- resetViewport ----
+
+    // resetViewport clears the CDP override and the cache. innerWidth returns to
+    // the natural width and the per-tab cache returns to Absent.
+    "resetViewport clears the override and the cache" in {
+        withBrowser {
+            onPage("<html><body>reset-viewport</body></html>") {
+                Browser.eval("String(window.innerWidth)").map { natural =>
+                    Browser.setViewport(390, 844).andThen {
+                        Browser.eval("String(window.innerWidth)").map { overridden =>
+                            assert(overridden == "390", s"override not applied: got $overridden")
+                            Browser.resetViewport.andThen {
+                                Browser.eval("String(window.innerWidth)").map { restored =>
+                                    assert(restored == natural, s"resetViewport did not restore: natural=$natural after=$restored")
+                                    assert(restored != "390", s"viewport still overridden after reset: got $restored")
+                                    Browser.use { tab =>
+                                        tab.viewportOverride.get.map { cached =>
+                                            assert(cached == Absent, s"expected cache Absent after reset but got $cached")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- withViewport ----
+
+    // withViewport applies the override for the body and restores the prior DPR-carrying override
+    // on exit (LIFO). A prior setViewport(800, 600, 2.0) establishes the override to restore.
+    "withViewport applies for the body and restores the prior DPR-carrying override after" in {
+        withBrowser {
+            onPage("<html><body>with-viewport-lifo</body></html>") {
+                Browser.setViewport(800, 600, deviceScaleFactor = 2.0).andThen {
+                    Browser.withViewport(390, 844, deviceScaleFactor = 3.0) {
+                        Browser.eval("window.innerWidth + ',' + String(window.devicePixelRatio)").map { inside =>
+                            assert(inside == "390,3", s"override not active in body: got $inside")
+                        }
+                    }.andThen {
+                        Browser.eval("window.innerWidth + ',' + String(window.devicePixelRatio)").map { after =>
+                            assert(after == "800,2", s"withViewport did not restore prior 800x600 dpr=2 (LIFO): got $after")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // withViewport restores the prior override on interruption. The Browser effect carries Env[BrowserTab] and the module
+    // deliberately provides no same-tab isolate, so the interrupted body is a self-contained Browser.run (the established
+    // interruption pattern in BrowserIsolateTest). The scenario is driven by an explicit fiber plus two Promises so it is
+    // deterministic across the JVM and the single-threaded Scala.js / Scala Native runtimes:
+    //   - the body runs in its own fiber (Fiber.initUnscoped), not under Async.timeout, so the test owns the interruption.
+    //   - readyLatch is completed AFTER withViewport's override is applied, so the test interrupts only once the body is
+    //     provably inside the scope with the override active, never before the acquire ran.
+    //   - tabRef captures the tab so its viewportOverride cache (a plain AtomicRef, readable under Sync) can be inspected.
+    // After readyLatch resolves the test interrupts the fiber and awaits its Result. The withViewport release does
+    // `tab.viewportOverride.set(prior)` then an async CDP send; on interruption the inner Browser.run's Scope.run awaits its
+    // finalizers, but on JS / Native the interrupted fiber's Result can resolve before that finalizer chain has run its
+    // `.set(prior)` (the ordering only holds on the JVM). So the cache is read by polling until the restore lands, bounded by
+    // a fixed schedule, then asserted concretely. The poll re-reads the AtomicRef directly; the tab object outlives its CDP
+    // teardown.
+    "withViewport restores on interruption" in {
+        val priorOverride = BrowserTab.ViewportOverride(800, 600, 2.0)
+        val p             = page("<html><body>with-viewport-interrupt</body></html>")
+        kyo.internal.SharedChrome.init.map { wsUrl =>
+            Promise.init[BrowserTab, Any].map { tabRef =>
+                Promise.init[Unit, Any].map { readyLatch =>
+                    val body: Unit < (Async & Abort[BrowserReadException]) =
+                        Browser.run(wsUrl) {
+                            Browser.goto(p).andThen {
+                                // Establish a prior override (800, 600, dpr 2.0) that the restore must re-apply.
+                                Browser.setViewport(800, 600, deviceScaleFactor = 2.0).andThen {
+                                    Browser.use { tab =>
+                                        tabRef.completeDiscard(Result.succeed(tab)).andThen {
+                                            Browser.withViewport(390, 844, deviceScaleFactor = 3.0) {
+                                                // Signal the override is applied, then block interruptibly until the test
+                                                // interrupts the fiber with the override active.
+                                                readyLatch.completeDiscard(Result.succeed(())).andThen {
+                                                    Async.sleep(30.seconds)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    Fiber.initUnscoped(body).map { fiber =>
+                        // Wait until the body is fully inside withViewport (override applied), then interrupt and await the
+                        // interrupted Result so the fiber has finished unwinding before the cache is inspected.
+                        readyLatch.get.andThen {
+                            fiber.interrupt.andThen {
+                                fiber.getResult.map { result =>
+                                    assert(result.isPanic, s"expected the interrupt to abort the body but got $result")
+                                    tabRef.get.map { tab =>
+                                        // Poll the AtomicRef cache until the release re-applied the prior override.
+                                        Retry[BrowserReadException](Schedule.fixed(20.millis).take(150)) {
+                                            tab.viewportOverride.get.map { current =>
+                                                if current == Present(priorOverride) then ()
+                                                else
+                                                    Abort.fail(
+                                                        BrowserAssertionTimedOutException(
+                                                            "withViewport interrupt restore",
+                                                            s"Present($priorOverride)",
+                                                            current.toString
+                                                        )
+                                                    )
+                                            }
+                                        }.andThen {
+                                            // The release re-applied the prior override (800, 600, dpr 2.0), not the body's
+                                            // (390, 844, 3.0) and not Absent.
+                                            tab.viewportOverride.get.map { restored =>
+                                                assert(
+                                                    restored == Present(priorOverride),
+                                                    s"withViewport did not restore the prior override on interruption: got $restored"
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- scrollTo(x, y) ----
+
+    // scrollTo(x, y) moves the scroll position to the coordinate and settles after.
+    // A tall page makes the y-offset reachable; window.scrollY reports the landed offset.
+    "scrollTo(x, y) scrolls to the coordinate and settles" in {
+        withBrowser {
+            onPage("""<html><body style="margin:0"><div style="height:5000px"></div></body></html>""") {
+                Browser.scrollTo(0, 1200).andThen {
+                    Browser.eval("String(window.scrollY)").map { y =>
+                        assert(y == "1200", s"expected scrollY=1200 but got $y")
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- scrollToElement ----
+
+    // scrollToElement scrolls an off-screen element into view and auto-waits for a late-appearing
+    // element. The #footer below the fold is inserted after ~150ms; the auto-wait retries until it
+    // appears, then scrolls it into view. The raw getBoundingClientRect check confirms it is fully within the viewport.
+    "scrollToElement scrolls the element into view and auto-waits for a late-appearing element" in {
+        val html =
+            """<html><body style="margin:0">
+              |<div style="height:3000px"></div>
+              |<script>
+              |  setTimeout(() => {
+              |    const f = document.createElement('div');
+              |    f.id = 'footer';
+              |    f.style.height = '40px';
+              |    document.body.appendChild(f);
+              |  }, 150);
+              |</script>
+              |</body></html>""".stripMargin
+        withBrowser {
+            onPage(html) {
+                slow(Browser.scrollToElement(Browser.Selector.css("#footer"))).andThen {
+                    Browser.eval(
+                        "const r = document.querySelector('#footer').getBoundingClientRect(); String(r.top >= 0 && r.bottom <= window.innerHeight)"
+                    ).map { inViewport =>
+                        assert(inViewport == "true", s"expected #footer fully in viewport after scroll but got $inViewport")
+                    }
+                }
+            }
+        }
+    }
+
+    // scrollToElement aborts BrowserElementNotFoundException for a never-appearing element via the
+    // narrow retry channel. The abort is BrowserElementNotFoundException, never a
+    // BrowserMutationException (proving the channel is BrowserElementException, not widened).
+    "scrollToElement aborts BrowserElementNotFoundException for a never-appearing element via the narrow channel" in {
+        withBrowser {
+            onPage("<html><body>scroll-to-missing</body></html>") {
+                Abort.run[BrowserReadException] {
+                    tight(Browser.scrollToElement(Browser.Selector.css("#never")))
+                }.map {
+                    case Result.Failure(e: BrowserElementNotFoundException) => succeed
+                    case other =>
+                        fail(s"expected BrowserElementNotFoundException but got $other")
+                }
+            }
+        }
+    }
+
+end BrowserViewportTest

--- a/kyo-browser/shared/src/test/scala/kyo/internal/CdpClientDecoderTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/internal/CdpClientDecoderTest.scala
@@ -47,8 +47,21 @@ class CdpClientDecoderTest extends kyo.BaseBrowserTest:
         makeDialogFixtures.map { (handlers, queue) =>
             AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty).map { dispatchers =>
                 AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty).map { downloadDispatchers =>
-                    AtomicRef.init[Dict[String, AtomicRef[Chunk[Browser.DialogEvent]]]](Dict.empty).map { recorders =>
-                        CdpClient.decodeCdpMessage(wire, handlers, queue, dispatchers, downloadDispatchers, recorders)
+                    AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty).map { screencastDispatchers =>
+                        AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty).map { consoleDispatchers =>
+                            AtomicRef.init[Dict[String, AtomicRef[Chunk[Browser.DialogEvent]]]](Dict.empty).map { recorders =>
+                                CdpClient.decodeCdpMessage(
+                                    wire,
+                                    handlers,
+                                    queue,
+                                    dispatchers,
+                                    downloadDispatchers,
+                                    screencastDispatchers,
+                                    consoleDispatchers,
+                                    recorders
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -161,7 +174,73 @@ class CdpClientDecoderTest extends kyo.BaseBrowserTest:
     }
 
     // -------------------------------------------------------------------------
-    // 5. eventWhitelist negative-assertion
+    // 5. dispatchOrDrop: console/exception events skip when no subscriber
+    // -------------------------------------------------------------------------
+
+    /** Build a decoder call with a caller-supplied consoleEventDispatchers map. All other registries are empty. */
+    private def decodeWithConsoleDispatchers(
+        wire: String,
+        consoleDispatchersMap: Dict[String, CdpEvent.Generic => Unit < Sync]
+    )(using Frame): Exchange.Message[Int, String, CdpEvent] < Sync =
+        makeDialogFixtures.map { (handlers, queue) =>
+            AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty).map { dispatchers =>
+                AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty).map { downloadDispatchers =>
+                    AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](Dict.empty).map { screencastDispatchers =>
+                        AtomicRef.init[Dict[String, CdpEvent.Generic => Unit < Sync]](consoleDispatchersMap).map { consoleDispatchers =>
+                            AtomicRef.init[Dict[String, AtomicRef[Chunk[Browser.DialogEvent]]]](Dict.empty).map { recorders =>
+                                CdpClient.decodeCdpMessage(
+                                    wire,
+                                    handlers,
+                                    queue,
+                                    dispatchers,
+                                    downloadDispatchers,
+                                    screencastDispatchers,
+                                    consoleDispatchers,
+                                    recorders
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    "dispatchOrDrop: Runtime.consoleAPICalled with no subscriber returns Skip (drop)" in {
+        val wire =
+            """{"method": "Runtime.consoleAPICalled", "params": {"type": "log", "args": [], "executionContextId": 1, "timestamp": 0, "stackTrace": null}}"""
+        decodeWithConsoleDispatchers(wire, Dict.empty).map { msg =>
+            assert(msg == Exchange.Message.Skip, s"Expected Skip (drop) for consoleAPICalled with no subscriber, got: $msg")
+        }
+    }
+
+    "dispatchOrDrop: Runtime.exceptionThrown with no subscriber returns Skip (drop)" in {
+        val wire =
+            """{"method": "Runtime.exceptionThrown", "params": {"timestamp": 0, "exceptionDetails": {"exceptionId": 1, "text": "Uncaught", "lineNumber": 0, "columnNumber": 0}}}"""
+        decodeWithConsoleDispatchers(wire, Dict.empty).map { msg =>
+            assert(msg == Exchange.Message.Skip, s"Expected Skip (drop) for exceptionThrown with no subscriber, got: $msg")
+        }
+    }
+
+    "dispatchOrDrop: Runtime.consoleAPICalled with a registered subscriber invokes the handler (not a silent drop)" in {
+        val consoleWire =
+            """{"method": "Runtime.consoleAPICalled", "sessionId": "test-session-1", "params": {"type": "log", "args": [], "executionContextId": 1, "timestamp": 0, "stackTrace": null}}"""
+        AtomicInt.init(0).map { invocationCount =>
+            val handler: CdpEvent.Generic => Unit < Sync = (_: CdpEvent.Generic) =>
+                invocationCount.incrementAndGet.unit
+            val sessionKey = "test-session-1"
+            decodeWithConsoleDispatchers(consoleWire, Dict(sessionKey -> handler)).map { msg =>
+                // With a registered handler the result is still Skip (the handler consumed the event),
+                // but invocationCount must be 1: the handler was called, not silently dropped.
+                assert(msg == Exchange.Message.Skip, s"Expected Skip (handler path) for consoleAPICalled with subscriber, got: $msg")
+                invocationCount.get.map { n =>
+                    assert(n == 1, s"Expected handler invocation count 1, got: $n")
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // 6. eventWhitelist negative-assertion
     // -------------------------------------------------------------------------
 
     "eventWhitelist: non-whitelisted event is NOT emitted as CdpEvent" in {

--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -804,6 +804,35 @@ val noPadding: Style                   = base.without[Style.Prop.Padding]
 
 The `Style.Prop` sum is the full property AST: `BgColor`, `TextColor`, `Padding`, `Width`, `Height`, `BorderWidthProp`, `HoverProp(style: Style)`, etc. You will rarely name these in app code, but they are useful for theme transforms (drop one property kind across an entire merged style, or query whether a hover variant exists).
 
+### Document stylesheets (`Stylesheet`)
+
+`Style` styles a single element with inline declarations. `Stylesheet` is the document-level counterpart: an ordered, immutable collection of CSS rules keyed by a stable selector, plus `@media` breakpoints, `:root` CSS variables, and `@font-face` declarations. It reuses `Style` for the declaration bodies, so the same `Color`, `Length`, and pseudo-state values apply.
+
+The primary element hook is `UI.cssClass(name)`: it emits `class="name"` on the element, giving a `Stylesheet` rule something stable to target. Call it multiple times to space-join classes. `style(...)` and `cssClass(...)` coexist on one element.
+
+```scala
+import UI.*
+import kyo.*
+import kyo.Style.Color
+
+val sheet: Stylesheet =
+    Stylesheet.vars("accent" -> "#4E46E0")
+        .rule("btn", Style.bg(Color.blue).color(Color.white).hover(_.bg(Color.indigo)))
+        .media(Stylesheet.MediaQuery.maxWidth(640.px))(
+            Stylesheet.rule("btn", Style.padding(8.px))
+        )
+
+// SSG: pass the rendered CSS to PageHead
+val css: String = sheet.render
+
+// Client (Scala.js): inject into the live document stylesheet
+// UI.runStylesheet(sheet): Unit < Sync
+```
+
+Selectors: `Selector.cls("btn")` (`.btn`), `Selector.id("hero")` (`#hero`), `Selector.data("open")` (`[data-open]`), `Selector.tag("body")`. Combine with `.descendant(child)` and `.pseudo("hover")`.
+
+Reference a `:root` variable in a declaration with `Color.variable("accent")`, which renders as `var(--accent)`.
+
 ## Charts
 
 A `Chart` is a pure immutable spec, not a `UI` node. You describe what to plot from your data and a list of marks, and nothing renders until you call `.lower`, which yields an `Svg.Root`. `Svg.Root` is the one SVG type that is also `HtmlContent` (the typed [SVG](#svg) layer, covered later), so a lowered chart drops into any `UI` container exactly where an `<svg>` root fits. Lowering suspends in `Sync` because it allocates the chart's reactive state and samples live data once, so you thread it like any other effect.
@@ -1208,6 +1237,59 @@ val firstFrame: String < Async       = snapshots.take(1).run.map(_.headMaybe.get
 
 When to use which target. `UI.runMount` is the right answer for any Scala.js client. `UI.runHandlers` is the right answer when you want server-rendered + server-driven (the server holds the state, the client is a thin presenter over a WebSocket). `UI.runRender` is for everything else: a test that asserts on HTML, an SSR pre-render, or a custom transport you want to write yourself.
 
+### `UI.runRenderPage(head)(ui)` (SSG / static-site generation)
+
+`runRenderPage` wraps `runRender` in a complete HTML document with a configurable head. Use it for static-site generation or any case where `runRender`'s body fragment is not enough and you need the full `<!DOCTYPE html>` wrapper with title, meta tags, links (e.g. web fonts), an inline stylesheet, and an optional module `<script>`. `UI.baseCss` is always emitted before `head.css` so your custom rules override the framework reset.
+
+`UI.baseCss` is the base CSS reset kyo-ui injects automatically in every runner. It is public for the one case where you hand-assemble a document: emit it before your custom stylesheet. Normally you do not reference it directly; `runRenderPage` handles the ordering for you.
+
+```scala
+import UI.*
+import kyo.*
+
+val ssgPage: Stream[String, Async] =
+    runRenderPage(
+        PageHead(
+            title = "My Site",
+            meta = Seq("description" -> "A kyo-ui SSG page"),
+            links = Seq("canonical" -> "https://example.com/"),
+            css = "",
+            moduleScript = Present("main.js")
+        )
+    )(div(h1("Hello from SSG")))
+
+val html: String < Async = ssgPage.take(1).run.map(_.headMaybe.getOrElse(""))
+```
+
+### Data islands and JSON-LD (`UI.dataIsland`, `PageHead.jsonLd`, `PageHead.dataIslands`)
+
+A data island is a `<script type="...">` element used to pass structured data from the server render into the page without running any JavaScript. `UI.dataIsland(scriptType, id, json)` builds a `UI.DataIsland` value; the renderer escapes `<` and `>` inside `json` so a `</script>` substring in any field cannot close the element early. You never call an escape function yourself.
+
+```scala
+import UI.*
+import kyo.*
+
+// JSON-LD structured data in <head>:
+val ldIsland: UI.DataIsland =
+    dataIsland("application/ld+json", Absent, """{"@context":"https://schema.org","@type":"WebPage"}""")
+
+// Boot-payload island injected before </body>:
+val bootIsland: UI.DataIsland =
+    dataIsland("application/json", Present("my-island"), """{"version":"1.0"}""")
+
+val page: Stream[String, Async] =
+    runRenderPage(
+        PageHead(
+            title = "My Site",
+            css = "",
+            jsonLd = Present(ldIsland),
+            dataIslands = Seq(bootIsland)
+        )
+    )(div(h1("Hello")))
+```
+
+`PageHead.jsonLd` is an `Maybe[UI.DataIsland]`; when `Present`, the renderer emits it as a `<script type="application/ld+json">` block inside `<head>`. `PageHead.dataIslands` is a `Seq[UI.DataIsland]`; each is emitted in order immediately before `</body>`. `UI.DataIsland` does NOT extend `UI`: it is a head/body-end payload, not a tree node, so placing it as a child of a `div` or other element is a compile error.
+
 ## Window and routing (Scala.js)
 
 `UIWindow` and `UILocation` are JS-only namespaces useful inside `UI.runMount` apps. Both expose reactive `Signal`s for browser state plus thin wrappers over the underlying browser APIs, so a Scala.js component reads window size or the current path the same way it reads any other signal.
@@ -1242,6 +1324,33 @@ val keyboardShortcuts: Unit < (Async & Scope) =
 ```
 
 The handler closure receives a `UI.KeyboardEvent` (key, modifiers, targetId), matching the typed payload from in-element `onKeyDown` handlers.
+
+`UIWindow.onClick` is the document-level counterpart for clicks. It fires in the capture phase for the lifetime of the enclosing scope and delivers a `UI.MouseEvent`. The primary use cases are clicks on targets inside `UI.rawHtml`-injected content (which carries no `data-kyo-path` so the element-level `.onClick` cannot reach them) and dismiss-on-outside-click patterns. Inside the handler, `e.targetClosest(selector)` walks from the click target to the nearest matching ancestor, returning `Maybe[kyo.ElementRef]`.
+
+```scala doctest:platform=js expect=skipped
+import UI.*
+import kyo.*
+
+val copyButtons: Unit < (Async & Scope) =
+    UIWindow.onClick { e =>
+        e.targetClosest("[data-copy]") match
+            case Present(el) =>
+                val text = el.getAttribute("data-copy").getOrElse("")
+                UIWindow.writeClipboard(text)
+            case Absent => Kyo.unit
+    }
+```
+
+`kyo.ElementRef` is an opaque handle over a DOM element. Its extension methods are `closest(selector)`, `querySelector(selector)`, `getAttribute(name)`, `setAttribute(name, value)`, `removeAttribute(name)`, and `textContent`. All return `Maybe` or `Unit`; no `null` escapes the boundary. `ElementRef` is only built by `UI.MouseEvent.targetClosest`; you never construct one directly.
+
+Additional `UIWindow` members (all JS-only, all return typed Kyo effects):
+
+- `UIWindow.prefersColorScheme: Signal[Boolean]` is `true` when the OS prefers dark. Updates on the media query `change` event; backed by a single process-lifetime listener installed lazily on first read.
+- `UIWindow.writeClipboard(text): Unit < Sync` writes to the system clipboard (fire-and-forget; rejection is non-fatal).
+- `UIWindow.storageGet(key): Maybe[String] < Sync` / `UIWindow.storageSet(key, value): Unit < Sync` read/write `localStorage`; `null` is mapped to `Absent`.
+- `UIWindow.setTitle(title): Unit < Sync` sets `document.title`.
+- `UIWindow.scrollToTop: Unit < Sync` scrolls to `(0, 0)`.
+- `UIWindow.scrollIntoViewById(id): Boolean < Sync` scrolls the element with `id` into view, returning `true` when found, `false` when absent (total, no throw).
 
 ### `UILocation`: client-side routing
 
@@ -1282,6 +1391,8 @@ val navBar: UI =
         a.href(Href.External("https", "example.com"), Target.Blank)("external") // not intercepted
     )
 ```
+
+`UILocation.assign(uri): Unit < Sync` performs a full browser navigation via `window.location.assign`. Unlike `push`/`replace` (History-API client-side routing that keeps the SPA mounted), `assign` hands control to the browser entirely. Use it for off-tree routes the SPA cannot resolve client-side.
 
 ## SVG
 
@@ -1515,7 +1626,7 @@ end board
 
 ## Pattern-matching on UI (AST access)
 
-Every element factory returns an `UI.Ast.*` case class. `UI.Ast.Element` is the sealed base trait; the case classes are `Div`, `P`, `Section`, `Main`, `Header`, `Footer`, `Pre`, `Code`, `Ul`, `Ol`, `Table`, `H1`..`H6`, `SpanElement`, `Nav`, `Li`, `Tr`, `Form`, `Textarea`, `Select`, `Hr`, `Br`, `Td`, `Th`, `Label`, `Opt`, `Button`, `Checkbox`, `Radio`, `Input`, `PasswordInput`, `EmailInput`, `TelInput`, `UrlInput`, `SearchInput`, `NumberInput`, `DateInput`, `TimeInput`, `ColorInput`, `RangeInput`, `FileInput`, `HiddenInput`, `Anchor`, `Img`, `Dropdown`. The non-element AST cases are `Text(value)`, `Reactive(signal)`, `Foreach[A](signal, key, render)`, `Fragment(children)`.
+Every element factory returns an `UI.Ast.*` case class. `UI.Ast.Element` is the sealed base trait; the case classes are `Div`, `P`, `Section`, `Main`, `Header`, `Footer`, `Pre`, `Code`, `Ul`, `Ol`, `Table`, `H1`..`H6`, `SpanElement`, `Nav`, `Li`, `Tr`, `Form`, `Textarea`, `Select`, `Hr`, `Br`, `Td`, `Th`, `Label`, `Opt`, `Button`, `Checkbox`, `Radio`, `Input`, `PasswordInput`, `EmailInput`, `TelInput`, `UrlInput`, `SearchInput`, `NumberInput`, `DateInput`, `TimeInput`, `ColorInput`, `RangeInput`, `FileInput`, `HiddenInput`, `Anchor`, `Img`, `Dropdown`. The non-element AST cases are `Text(value)`, `Reactive(signal)`, `Foreach[A](signal, key, render)`, `Fragment(children)`, and `RawHtml(value)` (the verbatim inline HTML passthrough described below).
 
 Capability traits surface here too: `Interactive`, `Block`, `Inline`, `Void`, `Focusable`, `HasDisabled`, `TextInput`, `PickerInput`, `BooleanInput`, `Activatable`, `Clickable`. They let you pattern-match on capability rather than a specific element class.
 
@@ -1559,6 +1670,30 @@ val isInputWithRef: Boolean < Async =
 ```
 
 `Foreach[A]` carries an existential `A`. To re-introduce the type parameter inside a custom backend, use `applyTyped` (the source documents it as the audited single-cast escape hatch).
+
+### Inline HTML passthrough (escape hatch)
+
+`UI.rawHtml(html: String)` is the single named escape hatch for content that cannot be expressed as a `UI` subtree. It returns an `Ast.RawHtml(value)` node that the renderer emits byte-for-byte with no HTML escaping.
+
+> **Caution:** `rawHtml` bypasses all escaping. Passing user-supplied, externally-sourced, or otherwise untrusted content here creates an XSS vulnerability. Use only for trusted, controlled HTML strings, such as inline `<img>` or `<a><img></a>` snippets from your own templates.
+
+The safe alternative is a plain string child or `Ast.Text(s)`, both of which always HTML-escape their argument:
+
+```scala
+import UI.*
+import kyo.*
+
+// verbatim: renders <b>x</b>
+val raw: UI = rawHtml("<b>x</b>")
+
+// escaped: renders &lt;b&gt;x&lt;/b&gt; (string auto-lifts to Ast.Text)
+val safe: UI = Ast.Text("<b>x</b>")
+
+// pattern-match the AST node directly
+val matched: Boolean = raw match
+    case Ast.RawHtml("<b>x</b>") => true
+    case _                       => false
+```
 
 ## Putting it together: a todo list
 

--- a/kyo-ui/js-wasm/src/main/scala/kyo/UILocation.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/UILocation.scala
@@ -53,9 +53,20 @@ object UILocation:
                     val sameOrigin = a.host == dom.window.location.host
                     val noModifier = !me.ctrlKey && !me.metaKey && !me.shiftKey && !me.altKey && me.button == 0
                     val notBlank   = a.target != "_blank"
-                    if sameOrigin && noModifier && notBlank then
+                    // A same-document link (only the hash differs, e.g. a `#section` table-of-contents
+                    // or scroll anchor) must keep the browser's native in-page scrolling: intercepting
+                    // it would preventDefault the scroll and push a hash-less path, so the anchor would
+                    // appear dead. Only same-origin cross-document navigations are routed client-side.
+                    val sameDocument =
+                        a.pathname == dom.window.location.pathname && a.search == dom.window.location.search
+                    if sameOrigin && noModifier && notBlank && !sameDocument then
                         me.preventDefault()
-                        dom.window.history.pushState(null, "", a.pathname + a.search)
+                        // Preserve the anchor's hash so a cross-document link that targets a heading
+                        // (e.g. /docs/mod/#section from a search result) keeps the fragment in the URL.
+                        // The route signal stays pathname+search (readWindowPath drops the hash), so
+                        // route-keyed logic is unaffected; the app scrolls to the fragment after it
+                        // renders the new document's content.
+                        dom.window.history.pushState(null, "", a.pathname + a.search + a.hash)
                         currentRef.unsafe.set(readWindowPath())
                     end if
                 }
@@ -112,6 +123,16 @@ object UILocation:
         Sync.defer {
             ensureInit()
             dom.window.history.go(delta)
+        }
+
+    /** Hard browser navigation to `uri` via `window.location.assign`. Unlike [[push]] / [[replace]]
+      * (History-API client-side routing that keeps the SPA mounted), `assign` hands the route to a full
+      * browser navigation, used for off-tree routes the SPA cannot resolve client-side.
+      */
+    def assign(uri: String)(using Frame): Unit < Sync =
+        Sync.defer {
+            ensureInit()
+            dom.window.location.assign(uri)
         }
 
     private def readWindowPath(): String =

--- a/kyo-ui/js-wasm/src/main/scala/kyo/UIMount.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/UIMount.scala
@@ -12,4 +12,13 @@ extension (ui: UI.type)
     def runMount(u: UI, selector: String)(using Frame): Unit < (Async & Scope) =
         DomBackend.mount(u, selector)
 
+    /** Injects a [[kyo.Stylesheet]] into the live document (`<head>` `<style>`), client-side.
+      * JS-only. Idempotent: a second call with the same rendered CSS text is a no-op and does
+      * not append duplicate rules. Reuses the existing kyo-ui document stylesheet (the same
+      * `<style>` element `runMount` appends per-element rules to), so a mounted app's authored
+      * stylesheet and its per-element styles share one sheet.
+      */
+    def runStylesheet(sheet: Stylesheet)(using Frame): Unit < Sync =
+        DomBackend.injectStylesheet(sheet)
+
 end extension

--- a/kyo-ui/js-wasm/src/main/scala/kyo/UIMouseEventOps.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/UIMouseEventOps.scala
@@ -1,0 +1,82 @@
+package kyo
+
+import org.scalajs.dom
+import scala.scalajs.js
+
+/** Associates the native `dom.MouseEvent` with the shared [[kyo.UI.MouseEvent]] payload built by
+  * [[kyo.UIWindow.onClick]], so the [[kyo.UI.MouseEvent.targetClosest]] extension can walk from the
+  * click target to a matching ancestor without a `dom.*` field on the shared, platform-neutral
+  * `UI.MouseEvent`.
+  *
+  * The association lives in a `js.WrappedMap` (backed by a native `js.Map`) keyed by the
+  * `UI.MouseEvent` instance, with an explicit per-click lifecycle: [[kyo.UIWindow.onClick]] calls
+  * `remember` before running the user handler and `forget` via `Sync.ensure` after the handler
+  * effect completes (on success, failure, and interrupt). The table holds one live entry per
+  * in-flight click handler: each entry is keyed by reference identity on its own distinct
+  * `UI.MouseEvent` instance, and it is removed when that handler's effect finishes. Concurrent
+  * suspended handlers each hold their own entry and none collides with another, so the table is
+  * bounded by the number of concurrently in-flight handlers and never leaks.
+  */
+private[kyo] object UIMouseEventOps:
+
+    private val table = new js.WrappedMap(js.Map.empty[UI.MouseEvent, dom.MouseEvent])
+
+    private[kyo] def remember(m: UI.MouseEvent, native: dom.MouseEvent): Unit =
+        table.update(m, native)
+
+    private[kyo] def forget(m: UI.MouseEvent): Unit =
+        table -= m
+        ()
+
+    private[kyo] def nativeOf(m: UI.MouseEvent): Maybe[dom.MouseEvent] =
+        Maybe(table.getOrElse(m, null))
+
+end UIMouseEventOps
+
+/** A narrow typed handle over a DOM element matched outside the reactive tree (the elements injected
+  * by [[kyo.UI.rawHtml]], which carry no `data-kyo-path`). It exposes only what a document-level
+  * click handler needs: walk to an ancestor or descendant, read/write attributes, read text. The
+  * opaque-type boundary lives here, keeping the raw `dom.Element` out of public signatures without
+  * any runtime cast.
+  *
+  * Built by [[kyo.UI.MouseEvent.targetClosest]]; a top-level js-wasm type paralleling
+  * [[kyo.UIWindow]] and [[kyo.UILocation]].
+  */
+opaque type ElementRef = dom.Element
+
+object ElementRef:
+    private[kyo] def apply(e: dom.Element): ElementRef = e
+
+extension (r: ElementRef)
+    /** The nearest ancestor (or self) matching `selector`, `Absent` when none matches. */
+    def closest(selector: String): Maybe[ElementRef] =
+        Maybe(r.closest(selector)).map(ElementRef(_))
+
+    /** The first descendant matching `selector`, `Absent` when none matches. */
+    def querySelector(selector: String): Maybe[ElementRef] =
+        Maybe(r.querySelector(selector)).map(ElementRef(_))
+
+    /** The value of attribute `name`, `Absent` when the attribute is not present. */
+    def getAttribute(name: String): Maybe[String] = Maybe(r.getAttribute(name))
+
+    /** Set attribute `name` to `value`. */
+    def setAttribute(name: String, value: String): Unit = r.setAttribute(name, value)
+
+    /** Remove attribute `name`. */
+    def removeAttribute(name: String): Unit = r.removeAttribute(name)
+
+    /** The element's text content. */
+    def textContent: String = r.textContent
+end extension
+
+extension (e: UI.MouseEvent)
+    /** The nearest ancestor (or self) of the click target matching `selector`, `Absent` when no
+      * ancestor matches or the event was not produced by [[kyo.UIWindow.onClick]].
+      */
+    def targetClosest(selector: String): Maybe[kyo.ElementRef] =
+        UIMouseEventOps.nativeOf(e).flatMap { native =>
+            native.target match
+                case el: dom.Element => Maybe(el.closest(selector)).map(ElementRef(_))
+                case _               => Absent
+        }
+end extension

--- a/kyo-ui/js-wasm/src/main/scala/kyo/UIWindow.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/UIWindow.scala
@@ -4,25 +4,32 @@ import kyo.*
 import org.scalajs.dom
 import scala.scalajs.js
 
-/** Window-level reactive signals and document-wide key subscriptions. JS-only.
+/** Window-level reactive signals and document-wide event subscriptions. JS-only.
   *
-  * Browser state that lives on `window` / `document` rather than on any single element: the viewport size, the page-visibility flag, and
-  * keystrokes that should be handled regardless of focus. Each is surfaced as a [[kyo.Signal]] or a scope-bound subscription so a Scala.js
-  * component consumes it the same way it consumes any other signal, without writing raw DOM listener code.
+  * Browser state that lives on `window` / `document` rather than on any single element: the viewport
+  * size, the page-visibility flag, the OS color-scheme preference, and keystrokes or clicks that
+  * should be handled regardless of focus. Each is surfaced as a [[kyo.Signal]] or a scope-bound
+  * subscription so a Scala.js component consumes it the same way it consumes any other signal,
+  * without writing raw DOM listener code.
   *
-  *   - [[size]] and [[visibility]] are `Signal`s backed by a single process-lifetime listener installed lazily on first read.
-  *   - [[onKeyDown]] and [[onKeyUp]] register document-level capture-phase listeners for the lifetime of the enclosing [[kyo.Scope]];
-  *     closing the scope removes the listener.
+  *   - [[size]], [[visibility]], and [[prefersColorScheme]] are `Signal`s backed by a single
+  *     process-lifetime listener installed lazily on first read.
+  *   - [[onKeyDown]], [[onKeyUp]], and [[onClick]] register document-level capture-phase listeners
+  *     for the lifetime of the enclosing [[kyo.Scope]]; closing the scope removes the listener.
+  *   - [[writeClipboard]], [[storageGet]], [[storageSet]], [[setTitle]], [[scrollToTop]], and
+  *     [[scrollIntoViewById]] are typed `Unit < Sync` / `Maybe[String] < Sync` / `Boolean < Sync`
+  *     wrappers over the corresponding browser APIs; no `null` escapes their boundaries.
   *
-  * Note: only meaningful inside a [[kyo.UI.runMount]] single-page app, where Scala.js runs in the browser. There is no server-side
-  * equivalent.
+  * Note: only meaningful inside a [[kyo.UI.runMount]] single-page app, where Scala.js runs in the
+  * browser. There is no server-side equivalent.
   *
   * @see
-  *   [[size]], [[visibility]] for window-state signals
+  *   [[size]], [[visibility]], [[prefersColorScheme]] for window-state signals
   * @see
-  *   [[onKeyDown]], [[onKeyUp]] for document-wide key handlers
+  *   [[onKeyDown]], [[onKeyUp]], [[onClick]] for document-wide event handlers
   * @see
-  *   [[kyo.UILocation]] for the routing counterpart, and [[kyo.UI.KeyboardEvent]] for the handler payload
+  *   [[kyo.UILocation]] for the routing counterpart, [[kyo.UI.KeyboardEvent]] for keyboard payloads,
+  *   and [[kyo.UI.MouseEvent]] / [[kyo.UI.MouseEvent.targetClosest]] for click-target walking
   */
 object UIWindow:
 
@@ -33,6 +40,10 @@ object UIWindow:
     private lazy val visibilityRef: SignalRef[Boolean] =
         import AllowUnsafe.embrace.danger
         SignalRef.Unsafe.init(!dom.document.hidden).safe
+
+    private lazy val prefersDarkRef: SignalRef[Boolean] =
+        import AllowUnsafe.embrace.danger
+        SignalRef.Unsafe.init(dom.window.matchMedia("(prefers-color-scheme: dark)").matches).safe
 
     // Single process-lifetime resize listener. `lazy val` runs the side effect exactly once on
     // first access, matching the `DomStyleSheet.baseInjected` pattern.
@@ -58,11 +69,30 @@ object UIWindow:
         true
     end visibilityInstalled
 
+    // Single process-lifetime media-query listener. A color-scheme preference is page-lifetime
+    // (like resize/visibility), so the listener installs once via the `lazy val` and is never
+    // removed. `MediaQueryList extends EventTarget`, so `addEventListener("change", ...)` is the
+    // typed, non-deprecated path.
+    private lazy val prefersColorSchemeInstalled: Boolean =
+        import AllowUnsafe.embrace.danger
+        dom.window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener(
+                "change",
+                { (_: dom.Event) =>
+                    prefersDarkRef.unsafe.set(dom.window.matchMedia("(prefers-color-scheme: dark)").matches)
+                }
+            )
+        true
+    end prefersColorSchemeInstalled
+
     private def ensureInit(): Unit =
         val _ = sizeRef
         val _ = visibilityRef
+        val _ = prefersDarkRef
         val _ = resizeInstalled
         val _ = visibilityInstalled
+        val _ = prefersColorSchemeInstalled
     end ensureInit
 
     /** The viewport size as `(width, height)` in CSS pixels. Updates on the window `resize` event. */
@@ -86,6 +116,129 @@ object UIWindow:
     /** Subscribe to document-level `keyup` events for the lifetime of the enclosing [[kyo.Scope]]. See [[onKeyDown]]. */
     def onKeyUp(f: UI.KeyboardEvent => Any < Async)(using Frame): Unit < (Async & Scope) =
         registerKeyListener("keyup", f)
+
+    /** Subscribe to document-level capture-phase `click` events for the lifetime of the enclosing
+      * [[kyo.Scope]]; closing the scope removes the listener. The handler receives a typed
+      * [[kyo.UI.MouseEvent]] on which [[kyo.UI.MouseEvent.targetClosest]] walks from the click target to
+      * a matching ancestor. This is the document-level primitive for clicks the per-element `onClick`
+      * DSL cannot reach: targets inside [[kyo.UI.rawHtml]]-injected HTML (no `data-kyo-path`) and clicks
+      * outside any element (a dismiss-on-outside-click).
+      */
+    def onClick(f: UI.MouseEvent => Any < Async)(using Frame): Unit < (Async & Scope) =
+        registerClickListener(f)
+
+    /** Write `text` to the system clipboard via `navigator.clipboard.writeText`. The returned Promise is
+      * discarded (fire-and-forget); a rejection in this notification-class UI context is non-fatal.
+      */
+    def writeClipboard(text: String)(using Frame): Unit < Sync =
+        Sync.defer(discard(dom.window.navigator.clipboard.writeText(text)))
+
+    /** Read `key` from `localStorage`, total: `Present` for a stored value, `Absent` for a missing key
+      * (`localStorage.getItem` returns `null`, mapped to `Absent`, so no `null` escapes).
+      */
+    def storageGet(key: String)(using Frame): Maybe[String] < Sync =
+        Sync.defer(Maybe(dom.window.localStorage.getItem(key)))
+
+    /** Write `value` under `key` in `localStorage`. */
+    def storageSet(key: String, value: String)(using Frame): Unit < Sync =
+        Sync.defer(dom.window.localStorage.setItem(key, value))
+
+    /** A `Signal[Boolean]` that is `true` when the OS prefers a dark color scheme, tracking
+      * `matchMedia("(prefers-color-scheme: dark)").matches` and updating on the media query's `change`
+      * event. Read [[kyo.Signal.current]] for a one-shot snapshot. Backed by a single process-lifetime
+      * listener installed lazily on first read, mirroring [[size]] and [[visibility]].
+      */
+    def prefersColorScheme(using Frame): Signal[Boolean] =
+        ensureInit()
+        prefersDarkRef
+
+    /** Set `document.title`. */
+    def setTitle(title: String)(using Frame): Unit < Sync =
+        Sync.defer(dom.document.title = title)
+
+    /** Scroll the window to `(0, 0)`. */
+    def scrollToTop(using Frame): Unit < Sync =
+        Sync.defer(dom.window.scrollTo(0, 0))
+
+    /** Scroll the element with `id` into view, returning `true` when it was found and scrolled, `false`
+      * when no element has that `id` (total: no `null` escapes, no throw; the caller decides whether to
+      * retry on `false`).
+      */
+    def scrollIntoViewById(id: String)(using Frame): Boolean < Sync =
+        Sync.defer {
+            val el = dom.document.getElementById(id)
+            if el == null then false
+            else
+                el.scrollIntoView()
+                true
+            end if
+        }
+
+    /** Run `action` once, the first time the element with `id` scrolls into view (any part of it crosses
+      * `minVisible`, the visible fraction, default `0.2`), then stop observing it. Backed by an
+      * `IntersectionObserver` bound to the enclosing [[kyo.Scope]]: closing the scope disconnects it. A
+      * missing `id` installs no observer and never fires (total: no throw, no `null` escapes). This is the
+      * reveal-on-scroll primitive: a below-the-fold element runs its entrance the moment the reader
+      * reaches it, rather than on page load where the motion plays unseen.
+      */
+    def onIntersectById(id: String, minVisible: Double = 0.2)(action: => Any < Async)(using Frame): Unit < (Async & Scope) =
+        Sync.defer {
+            val el = dom.document.getElementById(id)
+            if el == null then Maybe.empty[dom.IntersectionObserver]
+            else
+                val thresholds = js.Array[Double](minVisible)
+                val observer = new dom.IntersectionObserver(
+                    (entries, obs) =>
+                        var hit = false
+                        entries.foreach(e => if e.isIntersecting then hit = true)
+                        if hit then
+                            // Fire once: disconnect before running so a second batch cannot re-enter.
+                            obs.disconnect()
+                            import AllowUnsafe.embrace.danger
+                            // Unsafe: bridges the native IntersectionObserver callback into the Kyo effect
+                            // system; Fiber.initUnscoped detaches the fiber so the callback returns at once.
+                            discard(Sync.Unsafe.evalOrThrow(Fiber.initUnscoped(action.unit)))
+                        end if
+                    ,
+                    new dom.IntersectionObserverInit:
+                        threshold = thresholds
+                )
+                observer.observe(el)
+                Maybe(observer)
+            end if
+        }.map { observer =>
+            Scope.ensure(Sync.defer(observer.foreach(_.disconnect())))
+        }
+
+    private def registerClickListener(
+        f: UI.MouseEvent => Any < Async
+    )(using Frame): Unit < (Async & Scope) =
+        Sync.defer {
+            val jsHandler: js.Function1[dom.MouseEvent, Unit] = (e: dom.MouseEvent) =>
+                // `e.target` for a document-level listener can be the Document itself (synthetic test
+                // events dispatch on `document` directly), not an Element. Pattern-match guards the
+                // Element shape and falls back to Absent, matching registerKeyListener.
+                val targetId = e.target match
+                    case el: dom.Element => Maybe(el.id).filter(_.nonEmpty)
+                    case _               => Absent
+                val mEvent = UI.MouseEvent(targetId, UI.Modifiers(e.ctrlKey, e.altKey, e.shiftKey, e.metaKey))
+                // Associate the native event with this payload so targetClosest can reach `.target`,
+                // then drop the association once the handler effect completes. Sync.ensure runs forget
+                // on success, failure, AND interrupt, so the side table holds the entry for the whole
+                // handler lifetime (sync prefix and across async suspension) and never leaks it.
+                UIMouseEventOps.remember(mEvent, e)
+                import AllowUnsafe.embrace.danger
+                // Unsafe: bridges a native JS callback boundary into the Kyo effect system;
+                // Fiber.initUnscoped detaches the fiber from the current scope so the callback
+                // can return immediately while the handler runs asynchronously.
+                discard(Sync.Unsafe.evalOrThrow(
+                    Fiber.initUnscoped(Sync.ensure(UIMouseEventOps.forget(mEvent))(f(mEvent).unit))
+                ))
+            dom.document.addEventListener("click", jsHandler, useCapture = true)
+            jsHandler
+        }.map { jsHandler =>
+            Scope.ensure(Sync.defer(dom.document.removeEventListener("click", jsHandler, useCapture = true)))
+        }
 
     private def registerKeyListener(
         eventName: String,

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -21,6 +21,19 @@ private[kyo] object DomBackend:
         }
     end mount
 
+    /** Injects a rendered stylesheet CSS string into the live document.
+      *
+      * The base reset is injected first (idempotently) so it precedes the authored CSS in document
+      * order, matching the SSG page head where `baseCss` is emitted before `head.css`. The reset is a
+      * foundational layer authored stylesheets are meant to override (e.g. `body { font-family }`); if
+      * it were appended AFTER the sheet (as happens when an app calls `runStylesheet` before `runMount`,
+      * which injects the reset), its equal-specificity `body` rule would win on document order and clobber
+      * the app's own `body` font, producing a fallback-font flash. Injecting the reset first here makes the
+      * cascade order independent of which entry point runs first.
+      */
+    private[kyo] def injectStylesheet(sheet: Stylesheet)(using Frame): Unit < Sync =
+        DomStyleSheet.injectBase().andThen(Sync.defer(DomStyleSheet.injectStylesheet(sheet.render)))
+
     private def mountInto(ui: UI, container: dom.Element)(using Frame): Unit < (Async & Scope) =
         for
             _    <- DomStyleSheet.injectBase()
@@ -54,26 +67,82 @@ private[kyo] object DomBackend:
 
         def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async =
             HtmlRenderer.render(ui, path).map { html =>
-                // In SVG context an empty reactive zone needs a <g> placeholder (a <span> is invalid
-                // inside <svg>); the non-empty branch already carries the correct tags from HtmlRenderer.
-                val tag = if svgContextAt(path) then "g" else "span"
-                val finalHtml =
-                    if html.isEmpty then
-                        s"""<$tag data-kyo-path="${path.mkString(".")}" data-kyo-reactive></$tag>"""
-                    else html
-                val pathAttr = path.mkString(".")
+                // Always wrap the rendered html in the reactive boundary element so the node carrying
+                // data-kyo-path=path survives subsequent replacements. A Fragment, Text, or RawHtml value
+                // renders without a path-carrying root, so an unwrapped replace would drop the marker and
+                // the next update could not locate the node. In SVG context the boundary is a <g> (a <span>
+                // is invalid inside <svg>); otherwise a <span> (CSS sets `display: contents` so it is layout-
+                // transparent).
+                val tag       = if svgContextAt(path) then "g" else "span"
+                val pathAttr  = path.mkString(".")
+                val finalHtml = s"""<$tag data-kyo-path="$pathAttr" data-kyo-reactive>$html</$tag>"""
                 Sync.defer {
                     val el = document.querySelector(s"""[data-kyo-path="$pathAttr"]""")
                     if el != null && el.outerHTML != finalHtml then
+                        // Capture focus and caret of the active element inside the replaced region,
+                        // keyed on data-kyo-path identity (mirrors HtmlRenderer.clientJs:576-583 on
+                        // the JS DOM API). Plain DOM inside the already-suspended Sync.defer; no new
+                        // AllowUnsafe crossing.
+                        val ae = document.activeElement
+                        val insideRegion = ae != null && (ae ne document.body) &&
+                            (ae.getAttribute("data-kyo-path") == pathAttr || el.contains(ae))
+                        // Use the active element's own data-kyo-path when it carries one (nested
+                        // reactive region), otherwise fall back to pathAttr so the region wrapper
+                        // itself is queried (common case: value-bound input inside the region has
+                        // no data-kyo-path of its own).
+                        val activePath =
+                            if insideRegion then
+                                if ae.hasAttribute("data-kyo-path") then ae.getAttribute("data-kyo-path")
+                                else pathAttr
+                            else null
+                        val (selStart, selEnd) = if insideRegion then readSelection(ae) else (Absent, Absent)
                         el.outerHTML = finalHtml
                         val updated = document.querySelector(s"""[data-kyo-path="$pathAttr"]""")
                         if updated != null then
                             applyJsPropsSync(updated)
                             beginAnimationsSync(updated)
+                        if activePath != null then
+                            restoreFocus(activePath, selStart, selEnd)
                     end if
                 }
             }
     end LocalExchange
+
+    private def readSelection(el: dom.Element): (Maybe[Int], Maybe[Int]) =
+        val dyn = el.asInstanceOf[scalajs.js.Dynamic]
+        def asInt(v: scalajs.js.Dynamic): Maybe[Int] =
+            if scalajs.js.typeOf(v) == "number" then Present(v.asInstanceOf[Int]) else Absent
+        (asInt(dyn.selectionStart), asInt(dyn.selectionEnd))
+    end readSelection
+
+    private def restoreFocus(capturedPath: String, selStart: Maybe[Int], selEnd: Maybe[Int]): Unit =
+        val located = document.querySelector(s"""[data-kyo-path="$capturedPath"]""")
+        if located != null then
+            val focusTarget =
+                if located.hasAttribute("data-kyo-reactive") then
+                    val inner = located.querySelector("input,textarea,select,[contenteditable]")
+                    if inner != null then inner else located
+                else located
+            val _ = focusTarget.asInstanceOf[scalajs.js.Dynamic].focus()
+            (selStart, selEnd) match
+                case (Present(s), Present(e)) =>
+                    val dyn = focusTarget.asInstanceOf[scalajs.js.Dynamic]
+                    if scalajs.js.typeOf(dyn.setSelectionRange) == "function" then
+                        try
+                            val _ = dyn.setSelectionRange(s, e)
+                        catch
+                            // setSelectionRange throws InvalidStateError on input types that do not
+                            // support text selection (e.g. email, number). Mirrors HtmlRenderer.clientJs:583:
+                            // `catch(e){if(e.name!=='InvalidStateError')throw e;}`. Re-throw any other
+                            // JS exception so genuine failures are not silently dropped.
+                            case ex: scalajs.js.JavaScriptException
+                                if ex.exception.asInstanceOf[scalajs.js.Dynamic].name.asInstanceOf[String] == "InvalidStateError" =>
+                                ()
+                    end if
+                case _ => ()
+            end match
+        end if
+    end restoreFocus
 
     // Bridge a Kyo Async computation from a JS callback boundary by offering it to the page-scoped drain
     // channel. The single AllowUnsafe site narrows to the offer crossing (the JS callback has no Kyo
@@ -94,9 +163,12 @@ private[kyo] object DomBackend:
 
     private def applyJsPropsSync(root: dom.Element): Unit =
         val propPrefix = "data-kyo-prop-"
-        val elements   = root.querySelectorAll(s"[$propPrefix*]")
+        // CSS has no attribute-name-prefix selector, so `[data-kyo-prop-*]` is not a valid selector and
+        // throws SyntaxError. Collect the root plus every descendant and keep those carrying any
+        // data-kyo-prop-* attribute; the apply loop reads the prop name off each attribute.
+        val elements = root.querySelectorAll("*")
         val self =
-            if root.hasAttribute(s"${propPrefix}indeterminate") || hasAnyKyoProp(root) then
+            if hasAnyKyoProp(root) then
                 Seq(root)
             else
                 Seq.empty
@@ -156,8 +228,12 @@ private[kyo] object DomBackend:
                             modifiers = UI.Modifiers(me.ctrlKey, me.altKey, me.shiftKey, me.metaKey),
                             targetId = targetId
                         )
-                        // Speculatively prevent navigation on anchor elements with a kyo handler
-                        if target.tagName.toLowerCase == "a" then e.preventDefault()
+                        // Prevent the browser's default navigation only when the anchor carries a kyo
+                        // click handler (so the handler, not the href, drives the action). A plain href
+                        // keeps native behavior: an in-page `#anchor` scrolls, and a cross-document route
+                        // is handled by UILocation's interceptor. Prevent-defaulting every anchor here
+                        // would also kill those.
+                        if target.tagName.toLowerCase == "a" && evTypes.contains("click") then e.preventDefault()
                         Present(UIEvent.Click(path, mouse))
                     else if t == "input" && evTypes.contains("input") then
                         Present(UIEvent.Input(path, e.target.asInstanceOf[dom.html.Input].value))

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomStyleSheet.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomStyleSheet.scala
@@ -17,19 +17,13 @@ private[kyo] object DomStyleSheet:
         el
     end styleElement
 
-    private val baseCss =
-        """*, *::before, *::after { box-sizing: border-box; }
-          |body { font-family: system-ui, -apple-system, sans-serif; margin: 0; padding: 0; }
-          |div, section, main, header, footer, form, article, aside, p, ul, ol, pre, code, h1, h2, h3, h4, h5, h6, label { display: flex; flex-direction: column; }
-          |nav, li, span, button, a { display: flex; flex-direction: row; align-items: center; }
-          |[data-kyo-reactive] { display: contents; }
-          |ul, ol { list-style: none; padding: 0; margin: 0; }
-          |h1, h2, h3, h4, h5, h6, p { margin: 0; }
-          |a { color: inherit; text-decoration: none; }
-          |table { border-collapse: collapse; width: 100%; }
-          |""".stripMargin
+    private val baseCss = HtmlRenderer.baseCss
 
     private var baseInjected = false
+
+    // Tracks CSS strings already injected via injectStylesheet to avoid duplicate appends.
+    // The browser is single-threaded so a plain mutable Set is safe here.
+    private val injectedSheets = scala.collection.mutable.Set.empty[String]
 
     /** Injects the base CSS reset once. Idempotent: the first call appends the reset rules; later calls are no-ops.
       * (kyo-ui is JS-only and the browser is single-threaded, so a plain flag is sufficient.)
@@ -86,6 +80,16 @@ private[kyo] object DomStyleSheet:
             end if
         end if
     end apply
+
+    /** Appends a CSS string to the kyo-ui document stylesheet if it has not been appended
+      * before. Idempotent: a second call with the same CSS text is a no-op. Reuses the same
+      * injection point as the per-element auto-class mechanism, so authored stylesheet rules
+      * and per-element pseudo-state rules share one `<style>` element.
+      */
+    private[kyo] def injectStylesheet(css: String): Unit =
+        if !injectedSheets.contains(css) then
+            val _ = injectedSheets.add(css)
+            inject(css)
 
     private def nextClass(using Frame): String < Sync =
         ids.incrementAndGet.map(n => s"kyo-s$n")

--- a/kyo-ui/js-wasm/src/test/scala/kyo/UILocationTest.scala
+++ b/kyo-ui/js-wasm/src/test/scala/kyo/UILocationTest.scala
@@ -1,0 +1,31 @@
+package kyo
+
+/** Pure-seam tests for [[UILocation]] members that do not require a real browser DOM.
+  *
+  * The Node.js test environment (NodeJSEnv) has no DOM globals. The following UILocation members
+  * require a real browser DOM and are therefore validated by exercising the compiled bundle in a
+  * real browser:
+  *
+  *   - `assign(uri)` invoking `window.location.assign` (requires `window.location`)
+  *   - `push`, `replace`, `back`, `forward`, `go` (require `window.history`)
+  *   - `current` reactive signal (requires `window.location.pathname`)
+  *
+  * Browser-side behavior is validated by real use in the compiled bundle, matching the module
+  * convention: UILocation and UIWindow have no committed JS browser tests because the NodeJS test
+  * environment has no DOM.
+  */
+class UILocationTest extends kyo.test.Test[Any]:
+
+    "UILocation Sync-effect members compile to the expected effect types (type-level gate)" in {
+        // Each val ascription is a compile-time witness: it fails if the member's return type
+        // drifts. The lambdas are never called, so no DOM global is accessed at runtime.
+        val _: String => Unit < Sync = uri => UILocation.assign(uri)
+        val _: String => Unit < Sync = uri => UILocation.push(uri)
+        val _: String => Unit < Sync = uri => UILocation.replace(uri)
+        val _: Unit < Sync           = UILocation.back
+        val _: Unit < Sync           = UILocation.forward
+        val _: Int => Unit < Sync    = n => UILocation.go(n)
+        succeed
+    }
+
+end UILocationTest

--- a/kyo-ui/js-wasm/src/test/scala/kyo/UIMouseEventOpsTest.scala
+++ b/kyo-ui/js-wasm/src/test/scala/kyo/UIMouseEventOpsTest.scala
@@ -1,0 +1,58 @@
+package kyo
+
+/** Pure side-table miss-path tests for [[UIMouseEventOps]] and the [[kyo.UI.MouseEvent.targetClosest]]
+  * extension. These run in the Node.js test environment, which has no DOM globals.
+  *
+  * Tests that require instantiating a `dom.MouseEvent` or a real DOM element tree cannot run in
+  * Node.js because the `MouseEvent` constructor is a browser global (not a Node.js builtin). The
+  * following scenarios are exercised by running the compiled bundle in a real browser (NodeJSEnv has
+  * no DOM globals):
+  *
+  *   - remember/forget/nativeOf round-trip with a real `dom.MouseEvent` instance: requires
+  *     `new dom.MouseEvent(...)` which is undefined in Node.js.
+  *   - `targetClosest` returns `Present(ElementRef)` for a matching ancestor: requires DOM
+  *     `createElement` / `appendChild` and a real `dom.MouseEvent` with a `.target` element.
+  *   - `targetClosest` returns `Absent` when no ancestor matches: same DOM requirement.
+  *   - `ElementRef.closest` / `querySelector` / attribute set/get/remove: all require real DOM
+  *     elements that cannot be constructed in the Node.js NodeJSEnv.
+  *
+  * Each such member is exercised by its real effect when the compiled bundle runs in a browser. No
+  * DOM test infrastructure is added here because the Node.js environment structurally cannot support
+  * it.
+  *
+  * The scenarios below cover the pure miss paths and the table's identity-keying contract using
+  * only `UI.MouseEvent` values (JVM-constructible, no DOM dependency).
+  */
+class UIMouseEventOpsTest extends kyo.test.Test[Any]:
+
+    "nativeOf returns Absent for a payload that was never remembered" in {
+        val m = UI.MouseEvent(Absent, UI.Modifiers.none)
+        assert(UIMouseEventOps.nativeOf(m) == Absent)
+    }
+
+    "targetClosest returns Absent for a payload that was never remembered" in {
+        val m = UI.MouseEvent(Absent, UI.Modifiers.none)
+        assert(m.targetClosest("button") == Absent)
+    }
+
+    "targetClosest returns Absent for any selector when the payload is un-remembered" in {
+        val m = UI.MouseEvent(Present("some-id"), UI.Modifiers(ctrl = true, alt = false, shift = false, meta = false))
+        assert(m.targetClosest(".code-block") == Absent)
+        assert(m.targetClosest("*") == Absent)
+    }
+
+    "forget on an un-remembered payload is a no-op (does not throw)" in {
+        val m = UI.MouseEvent(Absent, UI.Modifiers.none)
+        UIMouseEventOps.forget(m)
+        assert(UIMouseEventOps.nativeOf(m) == Absent)
+    }
+
+    "two distinct UI.MouseEvent instances that are structurally equal but different refs each miss independently" in {
+        val m1 = UI.MouseEvent(Absent, UI.Modifiers.none)
+        val m2 = UI.MouseEvent(Absent, UI.Modifiers.none)
+        // Neither has been remembered; both must miss independently.
+        assert(UIMouseEventOps.nativeOf(m1) == Absent)
+        assert(UIMouseEventOps.nativeOf(m2) == Absent)
+    }
+
+end UIMouseEventOpsTest

--- a/kyo-ui/js-wasm/src/test/scala/kyo/UIWindowTest.scala
+++ b/kyo-ui/js-wasm/src/test/scala/kyo/UIWindowTest.scala
@@ -1,0 +1,39 @@
+package kyo
+
+/** Pure-seam tests for [[UIWindow]] members that do not require a real browser DOM.
+  *
+  * The Node.js test environment (NodeJSEnv) has no DOM globals: `window`, `document`,
+  * `localStorage`, and `matchMedia` are all undefined. The following UIWindow members require a
+  * real browser DOM and are therefore validated by exercising the compiled bundle in a real browser:
+  *
+  *   - `onClick` listener registration and scope teardown (requires `document.addEventListener`)
+  *   - `writeClipboard` (requires `navigator.clipboard`)
+  *   - `storageGet` / `storageSet` round-trip (requires `localStorage`)
+  *   - `prefersColorScheme` initial value and reactive update (requires `matchMedia`)
+  *   - `setTitle` observable effect (requires `document.title`)
+  *   - `scrollToTop` scroll-position reset (requires `window.scrollTo`)
+  *   - `scrollIntoViewById` element lookup and scroll (requires `document.getElementById`)
+  *
+  * Each such member is exercised by its real effect when the compiled bundle runs in a browser. No
+  * DOM test infrastructure is added here because the Node.js environment structurally cannot support
+  * it (no jsdom configured), matching the module convention: UILocation and UIWindow have no
+  * committed JS browser tests because the test environment has no DOM.
+  *
+  * The one Node-runnable contract verified here is the [[UIMouseEventOps]] side-table lifecycle
+  * wired by [[UIWindow.onClick]]: that lifecycle is tested independently in
+  * [[UIMouseEventOpsTest]], which covers the remember/forget/nativeOf pure seam.
+  */
+class UIWindowTest extends kyo.test.Test[Any]:
+
+    "UIWindow Sync-effect members compile to the expected effect types (type-level gate)" in {
+        // Each val ascription is a compile-time witness: it fails if the member's return type
+        // drifts. The lambdas are never called, so no DOM global is accessed at runtime.
+        val _: String => Unit < Sync           = s => UIWindow.writeClipboard(s)
+        val _: String => Maybe[String] < Sync  = k => UIWindow.storageGet(k)
+        val _: (String, String) => Unit < Sync = (k, v) => UIWindow.storageSet(k, v)
+        val _: String => Unit < Sync           = t => UIWindow.setTitle(t)
+        val _: String => Boolean < Sync        = id => UIWindow.scrollIntoViewById(id)
+        succeed
+    }
+
+end UIWindowTest

--- a/kyo-ui/shared/src/main/scala/kyo/Length.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/Length.scala
@@ -13,6 +13,11 @@ import scala.language.implicitConversions
   *     `Length.Px | Length.Em` (e.g. `gap`, `fontSize`, `letterSpacing`, `border` widths).
   *   - `Em(value: Double)`: relative to the element's font size. Mapped to the CSS `em` unit. Accepted wherever `Px` is accepted unless
   *     the signature is restricted to `Length.Px` only (border widths, shadows). Its numeric value is directly accessible via `.value`.
+  *   - `Vh(value: Double)`: percentage of the viewport height. Mapped to the CSS `vh` unit. Used for heights tied to the visible window
+  *     (e.g. a sticky rail capped to the viewport so it scrolls within itself rather than the page).
+  *   - `Calc(expr: String)`: an arbitrary CSS `calc()` expression. Mapped to `calc(<expr>)` verbatim. Used for the rare value that mixes
+  *     units the typed variants cannot express on their own, e.g. `Calc("100vh - 60px")` for a viewport-height box offset below a fixed
+  *     header. The expression is not validated; callers pass a well-formed CSS calc body without the surrounding `calc(...)`.
   *   - `Auto`: automatic sizing; the browser fills or shrinks the dimension based on context. Accepted by `margin`, `width`, `height`,
   *     `minWidth`, `maxWidth`, `minHeight`, `maxHeight`. Not accepted by `padding`, `gap`, `fontSize`, `letterSpacing`, or any border-width
   *     parameter, all of which require a concrete `Px | Pct | Em` union.
@@ -26,11 +31,12 @@ import scala.language.implicitConversions
   *
   * #### Extension methods
   *
-  * `Int` and `Double` values gain three suffix methods for explicit construction:
+  * `Int` and `Double` values gain four suffix methods for explicit construction:
   *
   *   - `.px`: e.g. `16.px` produces `Length.Px(16.0)`
   *   - `.pct`: e.g. `50.pct` produces `Length.Pct(50.0)`
   *   - `.em`: e.g. `1.5.em` produces `Length.Em(1.5)`
+  *   - `.vh`: e.g. `100.vh` produces `Length.Vh(100.0)`
   *
   * #### Resolution helpers
   *
@@ -45,17 +51,21 @@ extension (v: Int)
     def px: Length.Px   = Length.Px(v.toDouble)
     def pct: Length.Pct = Length.Pct(v.toDouble)
     def em: Length.Em   = Length.Em(v.toDouble)
+    def vh: Length.Vh   = Length.Vh(v.toDouble)
 end extension
 extension (v: Double)
     def px: Length.Px   = Length.Px(v)
     def pct: Length.Pct = Length.Pct(v)
     def em: Length.Em   = Length.Em(v)
+    def vh: Length.Vh   = Length.Vh(v)
 end extension
 
 object Length:
     final case class Px(value: Double)  extends Length
     final case class Pct(value: Double) extends Length
     final case class Em(value: Double)  extends Length
+    final case class Vh(value: Double)  extends Length
+    final case class Calc(expr: String) extends Length
     case object Auto                    extends Length
 
     /** Zero pixels (`Px(0)`). */
@@ -67,14 +77,17 @@ object Length:
     /** Auto-lifts a `Double` literal to `Px`, so a bare number can be passed where a `Length.Px` is expected (e.g. `Style.width(12.5)`). */
     implicit def doubleToPx(v: Double): Px = Px(v)
 
-    /** Resolve a Length to pixels given the parent's pixel size. Auto fills the parent. Pct is relative to parent. Em is treated as pixels
-      * (1 em maps to 1 px).
+    /** Resolve a Length to pixels given the parent's pixel size. Auto fills the parent. Pct and Vh are taken relative to `parentPx` (there is
+      * no separate viewport dimension at this layer, so `Vh` approximates against the parent like `Pct`). Em is treated as pixels (1 em maps
+      * to 1 px). Calc is opaque (its expression is not parsed here), so it resolves to `parentPx` as a neutral fallback.
       */
     def resolve(length: Length, parentPx: Int): Int = length match
-        case Px(v)  => v.toInt
-        case Pct(v) => (v * parentPx / 100).toInt
-        case Em(v)  => v.toInt
-        case Auto   => parentPx
+        case Px(v)   => v.toInt
+        case Pct(v)  => (v * parentPx / 100).toInt
+        case Em(v)   => v.toInt
+        case Vh(v)   => (v * parentPx / 100).toInt
+        case Calc(_) => parentPx
+        case Auto    => parentPx
 
     /** Resolve a Length, returning Absent for Auto (caller decides what Auto means). */
     def resolveOrAuto(length: Length, parentPx: Int): Maybe[Int] = length match

--- a/kyo-ui/shared/src/main/scala/kyo/Selector.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/Selector.scala
@@ -1,0 +1,56 @@
+package kyo
+
+/** A CSS selector targeting elements for a [[kyo.Stylesheet]] rule.
+  *
+  * The primary case is a class selector ([[kyo.Selector.cls]]) targeting elements that carry a
+  * matching [[kyo.UI.cssClass]]. `id` and `data-*` selectors are also provided for the existing
+  * `UI.id`/`UI.data` hooks. A pseudo-class/element variant (`:hover`, `:focus`, `::before`, ...)
+  * is attached with [[kyo.Selector.pseudo]]; a descendant combinator with [[kyo.Selector.descendant]]
+  * and a direct-child combinator with [[kyo.Selector.child]]. Selectors are immutable values;
+  * building one never mutates the receiver.
+  *
+  * @see
+  *   [[kyo.Stylesheet.rule]] for the rule a selector heads
+  * @see
+  *   [[kyo.UI.cssClass]] for the element class a class selector matches
+  */
+final case class Selector private[kyo] (css: String) derives CanEqual:
+
+    /** A pseudo-class or pseudo-element variant of this selector, e.g. `Selector.cls("btn").pseudo("hover")`
+      * yields `.btn:hover`. Pass the suffix WITHOUT the leading colon for a pseudo-class; use
+      * [[pseudoElement]] for `::` pseudo-elements.
+      */
+    def pseudo(name: String): Selector = Selector(css + ":" + name)
+
+    /** A pseudo-element variant of this selector using the `::` prefix, e.g. `Selector.cls("btn").pseudoElement("before")`
+      * yields `.btn::before`.
+      */
+    def pseudoElement(name: String): Selector = Selector(css + "::" + name)
+
+    /** A descendant combinator: `parent.descendant(child)` yields `parent child`. */
+    def descendant(child: Selector): Selector = Selector(css + " " + child.css)
+
+    /** A direct-child combinator: `parent.child(c)` yields `parent > c`, matching only `c` elements
+      * that are immediate children of `parent` (not deeper descendants). Use this when a descendant
+      * combinator would over-reach into a nested subtree that must keep its own styling.
+      */
+    def child(c: Selector): Selector = Selector(css + " > " + c.css)
+
+end Selector
+
+object Selector:
+    /** A class selector: `Selector.cls("feat-grid")` is `.feat-grid`. */
+    def cls(name: String): Selector = Selector("." + name)
+
+    /** An id selector: `Selector.id("hero")` is `#hero`. */
+    def id(name: String): Selector = Selector("#" + name)
+
+    /** An attribute selector on a `data-*` attribute: `Selector.data("active", "true")` is
+      * `[data-active="true"]`; omit `value` for a presence selector `[data-active]`.
+      */
+    def data(name: String, value: String): Selector = Selector(s"""[data-$name="$value"]""")
+    def data(name: String): Selector                = Selector(s"[data-$name]")
+
+    /** A raw element/tag selector for the rare case a rule must hit a bare tag (e.g. `body`). */
+    def tag(name: String): Selector = Selector(name)
+end Selector

--- a/kyo-ui/shared/src/main/scala/kyo/Style.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/Style.scala
@@ -4,7 +4,7 @@ import scala.annotation.tailrec
 
 /** An immutable, ordered list of style properties to attach to a [[kyo.UI]] element.
   *
-  * A `Style` is a pure value: it holds a `Span[Style.Prop]` and nothing else. Every setter (`bg`, `padding`, `width`, ...) returns a *new*
+  * A `Style` is a pure value: it holds a `Chunk[Style.Prop]` and nothing else. Every setter (`bg`, `padding`, `width`, ...) returns a *new*
   * `Style` with the property appended, leaving the receiver untouched, so a `Style` is safe to share and reuse across elements. Attach one to
   * an element with its `.style(...)` setter.
   *
@@ -32,7 +32,7 @@ import scala.annotation.tailrec
   * @see
   *   [[kyo.UI]] for the element tree a `Style` attaches to
   */
-final case class Style private[kyo] (props: Span[Style.Prop]) derives CanEqual:
+final case class Style private[kyo] (props: Chunk[Style.Prop]) derives CanEqual:
 
     import Style.*
     import Style.Prop.*
@@ -46,10 +46,12 @@ final case class Style private[kyo] (props: Span[Style.Prop]) derives CanEqual:
             case s => Style(s.props :+ p)
 
     private def clampSize(s: Length): Length = s match
-        case Length.Px(v)  => if v < 0 then Length.Px(0) else s
-        case Length.Pct(v) => if v < 0 then Length.Pct(0) else s
-        case Length.Em(v)  => if v < 0 then Length.Em(0) else s
-        case Length.Auto   => s
+        case Length.Px(v)   => if v < 0 then Length.Px(0) else s
+        case Length.Pct(v)  => if v < 0 then Length.Pct(0) else s
+        case Length.Em(v)   => if v < 0 then Length.Em(0) else s
+        case Length.Vh(v)   => if v < 0 then Length.Vh(0) else s
+        case Length.Calc(_) => s
+        case Length.Auto    => s
 
     private def clampSizeMin1(s: Length): Length = s match
         case Length.Px(v) => if v < 1 then Length.Px(1) else s
@@ -132,6 +134,13 @@ final case class Style private[kyo] (props: Span[Style.Prop]) derives CanEqual:
     def bg(c: Color): Style               = appendProp(Prop.BgColor(c))
     def bg(f: Color.type => Color): Style = bg(f(Color))
 
+    /** Maps to the CSS `background-clip` property: `paddingBox` clips the background to the padding box so
+      * a transparent border insets the painted fill (the standard way to float a scrollbar thumb inside its
+      * track), `contentBox` clips to the content box, `borderBox` is the default.
+      */
+    def backgroundClip(v: BackgroundClip): Style                        = appendProp(Prop.BackgroundClipProp(v))
+    def backgroundClip(f: BackgroundClip.type => BackgroundClip): Style = backgroundClip(f(BackgroundClip))
+
     // Text color
 
     def color(c: Color): Style               = appendProp(Prop.TextColor(c))
@@ -168,8 +177,10 @@ final case class Style private[kyo] (props: Span[Style.Prop]) derives CanEqual:
 
     // Layout direction
 
-    def row: Style    = appendProp(Prop.FlexDirectionProp(FlexDirection.row))
-    def column: Style = appendProp(Prop.FlexDirectionProp(FlexDirection.column))
+    def row: Style           = appendProp(Prop.FlexDirectionProp(FlexDirection.row))
+    def column: Style        = appendProp(Prop.FlexDirectionProp(FlexDirection.column))
+    def rowReverse: Style    = appendProp(Prop.FlexDirectionProp(FlexDirection.rowReverse))
+    def columnReverse: Style = appendProp(Prop.FlexDirectionProp(FlexDirection.columnReverse))
 
     def flexWrap(v: FlexWrap): Style                  = appendProp(Prop.FlexWrapProp(v))
     def flexWrap(f: FlexWrap.type => FlexWrap): Style = flexWrap(f(FlexWrap))
@@ -185,6 +196,42 @@ final case class Style private[kyo] (props: Span[Style.Prop]) derives CanEqual:
 
     def overflow(v: Overflow): Style                  = appendProp(Prop.OverflowProp(v))
     def overflow(f: Overflow.type => Overflow): Style = overflow(f(Overflow))
+
+    /** Maps to the CSS `overflow-x` property: clips/scrolls the HORIZONTAL axis only, leaving the
+      * vertical axis at its default. Use over [[overflow]] when only one axis should scroll, so the
+      * other axis never reserves space for a scrollbar nor draws a stray scrollbar track.
+      */
+    def overflowX(v: Overflow): Style                  = appendProp(Prop.OverflowXProp(v))
+    def overflowX(f: Overflow.type => Overflow): Style = overflowX(f(Overflow))
+
+    /** Maps to the CSS `overflow-y` property: clips/scrolls the VERTICAL axis only, leaving the
+      * horizontal axis at its default. Use over [[overflow]] when only one axis should scroll, so the
+      * other axis never reserves space for a scrollbar nor draws a stray scrollbar track.
+      */
+    def overflowY(v: Overflow): Style                  = appendProp(Prop.OverflowYProp(v))
+    def overflowY(f: Overflow.type => Overflow): Style = overflowY(f(Overflow))
+
+    /** Maps to the standard CSS `scrollbar-width` property: `thin` renders a slimmer scrollbar than the
+      * platform default, `none` hides it while keeping the element scrollable, `auto` is the default.
+      * Pairs with [[scrollbarColor]] to theme an overflow container's scrollbar (current Chrome, Firefox,
+      * and Safari honor both; other engines fall back to the native scrollbar).
+      */
+    def scrollbarWidth(v: ScrollbarWidth): Style                        = appendProp(Prop.ScrollbarWidthProp(v))
+    def scrollbarWidth(f: ScrollbarWidth.type => ScrollbarWidth): Style = scrollbarWidth(f(ScrollbarWidth))
+
+    /** Maps to the standard CSS `scrollbar-color` property: the first color paints the scrollbar thumb,
+      * the second paints the track. Use a subtle thumb and a transparent or near-page track so the
+      * scrollbar reads as part of the surface rather than an OS chrome slab.
+      */
+    def scrollbarColor(thumb: Color, track: Color): Style = appendProp(Prop.ScrollbarColorProp(thumb, track))
+
+    /** Maps to the standard CSS `scrollbar-gutter` property: `stable` reserves space for the scrollbar
+      * even while the content is short enough not to scroll, so a container whose content grows past the
+      * viewport (or shrinks back) does not shift its layout sideways as the classic scrollbar appears and
+      * disappears. Apply to the page scroll root (`html`) to stop SPA route swaps from nudging the layout.
+      */
+    def scrollbarGutter(v: ScrollbarGutter): Style                         = appendProp(Prop.ScrollbarGutterProp(v))
+    def scrollbarGutter(f: ScrollbarGutter.type => ScrollbarGutter): Style = scrollbarGutter(f(ScrollbarGutter))
 
     // Sizing: any size including auto
 
@@ -361,6 +408,72 @@ final case class Style private[kyo] (props: Span[Style.Prop]) derives CanEqual:
     def position(v: Position): Style                  = appendProp(Prop.PositionProp(v))
     def position(f: Position.type => Position): Style = position(f(Position))
 
+    /** Sets the CSS `top` offset, the distance from the top edge of the containing block (or the
+      * sticky/fixed reference). Pairs with `position(_.sticky)` or `position(_.relative)` to place a
+      * pinned element, e.g. `top(60.px)` to stick a rail directly under a 60px header.
+      */
+    def top(v: Length): Style = appendProp(Prop.Top(v))
+
+    /** Sets the CSS `right` / `bottom` / `left` offsets of a positioned element (the counterparts of
+      * [[top]]); e.g. `position(_.absolute).top(8.px).right(8.px)` floats a control in the top-right
+      * corner of a `position(_.relative)` container.
+      */
+    def right(v: Length): Style  = appendProp(Prop.Right(v))
+    def bottom(v: Length): Style = appendProp(Prop.Bottom(v))
+    def left(v: Length): Style   = appendProp(Prop.Left(v))
+
+    /** Sets the CSS `z-index` stacking order of a positioned element. Higher values layer above lower
+      * ones, e.g. `zIndex(100)` to keep a sticky header above scrolling page content.
+      */
+    def zIndex(v: Int): Style = appendProp(Prop.ZIndexProp(v))
+
+    /** Sets the CSS `align-self`, overriding the parent flex container's `align-items` for this one
+      * child. `align-self: flex-start` keeps a flex item at the cross-axis start instead of stretching
+      * to the row height, e.g. a sticky rail in a flex row that must not grow to the article's height.
+      */
+    def alignSelf(v: Alignment): Style                   = appendProp(Prop.AlignSelf(v))
+    def alignSelf(f: Alignment.type => Alignment): Style = alignSelf(f(Alignment))
+
+    /** Sets the CSS `scroll-margin-top`, the extra space kept above an element when it is scrolled into
+      * view (by a `#anchor` jump or `scrollIntoView`). Use it so a heading targeted by an in-page link
+      * stops just below a sticky header rather than under it, e.g. `scrollMarginTop(72.px)` for a 60px
+      * header plus a 12px gap.
+      */
+    def scrollMarginTop(v: Length): Style = appendProp(Prop.ScrollMarginTopProp(v))
+
+    // Display
+
+    /** Sets the CSS `display` mode, opting an element out of the default flex layout into normal
+      * document flow (`block`/`inline`/`inline-block`) or list-item rendering. Use this for flowing
+      * prose where inline runs must wrap within a line rather than stack as flex children.
+      */
+    def display(v: Display): Style                 = appendProp(Prop.DisplayProp(v))
+    def display(f: Display.type => Display): Style = display(f(Display))
+    def block: Style                               = display(Display.block)
+    def inline: Style                              = display(Display.inline)
+    def inlineBlock: Style                         = display(Display.inlineBlock)
+    def listItem: Style                            = display(Display.listItem)
+    def table: Style                               = display(Display.table)
+    def tableRow: Style                            = display(Display.tableRow)
+    def tableCell: Style                           = display(Display.tableCell)
+
+    // List marker
+
+    /** Sets the CSS `list-style-type` marker for a list (`disc`/`decimal`/`none`). The base reset
+      * suppresses markers with `list-style: none`, so a flowing prose list restores them by setting
+      * this back to `disc` (unordered) or `decimal` (ordered) on its `ul`/`ol`.
+      */
+    def listStyle(v: ListStyle): Style                   = appendProp(Prop.ListStyleProp(v))
+    def listStyle(f: ListStyle.type => ListStyle): Style = listStyle(f(ListStyle))
+
+    // Tables
+
+    /** Sets the CSS `border-collapse` of a table. `collapse` merges adjacent cell borders into single
+      * shared dividers so rows and columns read as one crisp grid; `separate` is the UA default.
+      */
+    def borderCollapse(v: BorderCollapse): Style                        = appendProp(Prop.BorderCollapseProp(v))
+    def borderCollapse(f: BorderCollapse.type => BorderCollapse): Style = borderCollapse(f(BorderCollapse))
+
     // Flex grow/shrink
 
     def flexGrow(v: Double): Style   = appendProp(Prop.FlexGrowProp(math.max(0.0, v)))
@@ -386,19 +499,45 @@ final case class Style private[kyo] (props: Span[Style.Prop]) derives CanEqual:
 
     /** A linear-gradient background. Each stop is a `(Color, percentage-along-the-axis)` pair; at least two stops are required. This
       * overload takes the direction as a `GradientDirection.type => GradientDirection` selector for inline use (`bgGradient(_.toRight, ...)`).
+      * Interpolates in sRGB (the CSS default); use the [[GradientColorSpace]] overload to interpolate in OKLCH/OKLAB.
       */
     def bgGradient(
         direction: GradientDirection.type => GradientDirection,
         stop1: (Color, Length.Pct),
         stop2: (Color, Length.Pct),
         stops: (Color, Length.Pct)*
-    ): Style = bgGradient(direction(GradientDirection), stop1, stop2, stops*)
+    ): Style = bgGradient(direction(GradientDirection), GradientColorSpace.srgb, stop1, stop2, stops*)
 
     /** A linear-gradient background with an explicit [[kyo.Style.GradientDirection]]. Each stop is a `(Color, percentage)` pair; at least
-      * two stops are required.
+      * two stops are required. Interpolates in sRGB (the CSS default).
       */
     def bgGradient(
         direction: GradientDirection,
+        stop1: (Color, Length.Pct),
+        stop2: (Color, Length.Pct),
+        stops: (Color, Length.Pct)*
+    ): Style = bgGradient(direction, GradientColorSpace.srgb, stop1, stop2, stops*)
+
+    /** A linear-gradient background interpolated in the given [[kyo.Style.GradientColorSpace]]. The selector overload takes the direction
+      * inline (`bgGradient(_.toBottom, GradientColorSpace.oklch, ...)`). Interpolating in `oklch`/`oklab` keeps the path between two colors
+      * perceptually even, so a transition from a tinted color to a near-black does not sag through a muddy grey midtone and bands far less at
+      * 8-bit sRGB output than the default `srgb` interpolation.
+      */
+    def bgGradient(
+        direction: GradientDirection.type => GradientDirection,
+        colorSpace: GradientColorSpace,
+        stop1: (Color, Length.Pct),
+        stop2: (Color, Length.Pct),
+        stops: (Color, Length.Pct)*
+    ): Style = bgGradient(direction(GradientDirection), colorSpace, stop1, stop2, stops*)
+
+    /** A linear-gradient background with an explicit [[kyo.Style.GradientDirection]] and an explicit [[kyo.Style.GradientColorSpace]] to
+      * interpolate in. Each stop is a `(Color, percentage)` pair; at least two stops are required. This is the canonical overload the others
+      * delegate to.
+      */
+    def bgGradient(
+        direction: GradientDirection,
+        colorSpace: GradientColorSpace,
         stop1: (Color, Length.Pct),
         stop2: (Color, Length.Pct),
         stops: (Color, Length.Pct)*
@@ -412,8 +551,50 @@ final case class Style private[kyo] (props: Span[Style.Prop]) derives CanEqual:
                 positions(i) = math.max(0.0, math.min(100.0, allStops(i)._2.value))
                 loop(i + 1)
         loop(0)
-        appendProp(Prop.BgGradientProp(direction, Span.from(colors), Span.from(positions)))
+        appendProp(Prop.BgGradientProp(direction, colorSpace, Chunk.from(colors), Chunk.from(positions)))
     end bgGradient
+
+    // Motion
+
+    /** A CSS `transition` on a single property: `transition: <property> <durationMs>ms <easing>;`. The
+      * duration is given in milliseconds and clamped to non-negative. Pass `TransitionProperty.all` (or
+      * the no-property overload) to transition every animatable property at once. Use it so a hover or
+      * active state's color/background change fades in smoothly rather than snapping.
+      */
+    def transition(property: TransitionProperty, durationMs: Int, easing: Easing): Style =
+        appendProp(Prop.TransitionProp(property, math.max(0, durationMs), easing))
+    def transition(property: TransitionProperty.type => TransitionProperty, durationMs: Int, easing: Easing.type => Easing): Style =
+        transition(property(TransitionProperty), durationMs, easing(Easing))
+
+    /** A CSS `transition: all <durationMs>ms <easing>;` shorthand transitioning every animatable
+      * property. Equivalent to `transition(TransitionProperty.all, durationMs, easing)`.
+      */
+    def transition(durationMs: Int, easing: Easing): Style =
+        transition(TransitionProperty.all, durationMs, easing)
+
+    /** A CSS `animation: <name> <durationMs>ms <easing> both;` referencing a `@keyframes` block of the
+      * given `name` (registered on the [[kyo.Stylesheet]] with [[kyo.Stylesheet.keyframes]]). The
+      * `both` fill mode holds the keyframes' first frame before the animation starts and its last frame
+      * after it ends, so an entrance animation does not flash the un-animated state. Duration is in
+      * milliseconds, clamped to non-negative.
+      */
+    def animation(name: String, durationMs: Int, easing: Easing): Style =
+        appendProp(Prop.AnimationProp(name, math.max(0, durationMs), easing))
+    def animation(name: String, durationMs: Int, easing: Easing.type => Easing): Style =
+        animation(name, durationMs, easing(Easing))
+
+    /** Sets `animation-delay` in milliseconds: the offset before the element's [[animation]] starts. Pairs
+      * with [[animation]] to stagger siblings into a cascade by giving each an increasing delay. A negative
+      * value starts the animation as if it had already been running for that long.
+      */
+    def animationDelay(ms: Int): Style = appendProp(Prop.AnimationDelayProp(ms))
+
+    /** Sets `stroke-dashoffset` (unitless) on an SVG element. Paired with an SVG path's `pathLength`
+      * normalization, a keyframe that tweens this from 1 (the dash shifted fully off, line hidden) to 0
+      * (line drawn) animates a stroke-draw without knowing the path's real length. Used by the landing
+      * gap chart's scroll-revealed line.
+      */
+    def strokeDashoffset(v: Double): Style = appendProp(Prop.StrokeDashoffsetProp(v))
 
 end Style
 
@@ -433,13 +614,15 @@ object Style:
     // ---- Style factory methods ----
 
     /** The identity `Style` with no properties; the unit for `++`. */
-    val empty: Style = Style(Span.empty[Prop])
+    val empty: Style = Style(Chunk.empty[Prop])
 
-    def bg(c: Color): Style                                     = empty.bg(c)
-    def bg(f: Color.type => Color): Style                       = empty.bg(f)
-    def color(c: Color): Style                                  = empty.color(c)
-    def color(f: Color.type => Color): Style                    = empty.color(f)
-    def padding(all: Length.Px | Length.Pct | Length.Em): Style = empty.padding(all)
+    def bg(c: Color): Style                                             = empty.bg(c)
+    def bg(f: Color.type => Color): Style                               = empty.bg(f)
+    def backgroundClip(v: BackgroundClip): Style                        = empty.backgroundClip(v)
+    def backgroundClip(f: BackgroundClip.type => BackgroundClip): Style = empty.backgroundClip(f)
+    def color(c: Color): Style                                          = empty.color(c)
+    def color(f: Color.type => Color): Style                            = empty.color(f)
+    def padding(all: Length.Px | Length.Pct | Length.Em): Style         = empty.padding(all)
     def padding(vertical: Length.Px | Length.Pct | Length.Em, horizontal: Length.Px | Length.Pct | Length.Em): Style =
         empty.padding(vertical, horizontal)
     def padding(
@@ -454,6 +637,8 @@ object Style:
     def gap(v: Length.Px | Length.Em): Style                                        = empty.gap(v)
     def row: Style                                                                  = empty.row
     def column: Style                                                               = empty.column
+    def rowReverse: Style                                                           = empty.rowReverse
+    def columnReverse: Style                                                        = empty.columnReverse
     def flexWrap(v: FlexWrap): Style                                                = empty.flexWrap(v)
     def flexWrap(f: FlexWrap.type => FlexWrap): Style                               = empty.flexWrap(f)
     def align(v: Alignment): Style                                                  = empty.align(v)
@@ -462,6 +647,15 @@ object Style:
     def justify(f: Justification.type => Justification): Style                      = empty.justify(f)
     def overflow(v: Overflow): Style                                                = empty.overflow(v)
     def overflow(f: Overflow.type => Overflow): Style                               = empty.overflow(f)
+    def overflowX(v: Overflow): Style                                               = empty.overflowX(v)
+    def overflowX(f: Overflow.type => Overflow): Style                              = empty.overflowX(f)
+    def overflowY(v: Overflow): Style                                               = empty.overflowY(v)
+    def overflowY(f: Overflow.type => Overflow): Style                              = empty.overflowY(f)
+    def scrollbarWidth(v: ScrollbarWidth): Style                                    = empty.scrollbarWidth(v)
+    def scrollbarWidth(f: ScrollbarWidth.type => ScrollbarWidth): Style             = empty.scrollbarWidth(f)
+    def scrollbarColor(thumb: Color, track: Color): Style                           = empty.scrollbarColor(thumb, track)
+    def scrollbarGutter(v: ScrollbarGutter): Style                                  = empty.scrollbarGutter(v)
+    def scrollbarGutter(f: ScrollbarGutter.type => ScrollbarGutter): Style          = empty.scrollbarGutter(f)
     def width(v: Length): Style                                                     = empty.width(v)
     def height(v: Length): Style                                                    = empty.height(v)
     def minWidth(v: Length): Style                                                  = empty.minWidth(v)
@@ -533,6 +727,27 @@ object Style:
     def translate(x: Length.Px | Length.Pct, y: Length.Px | Length.Pct): Style = empty.translate(x, y)
     def position(v: Position): Style                                           = empty.position(v)
     def position(f: Position.type => Position): Style                          = empty.position(f)
+    def top(v: Length): Style                                                  = empty.top(v)
+    def right(v: Length): Style                                                = empty.right(v)
+    def bottom(v: Length): Style                                               = empty.bottom(v)
+    def left(v: Length): Style                                                 = empty.left(v)
+    def zIndex(v: Int): Style                                                  = empty.zIndex(v)
+    def alignSelf(v: Alignment): Style                                         = empty.alignSelf(v)
+    def alignSelf(f: Alignment.type => Alignment): Style                       = empty.alignSelf(f)
+    def scrollMarginTop(v: Length): Style                                      = empty.scrollMarginTop(v)
+    def display(v: Display): Style                                             = empty.display(v)
+    def display(f: Display.type => Display): Style                             = empty.display(f)
+    def block: Style                                                           = empty.block
+    def inline: Style                                                          = empty.inline
+    def inlineBlock: Style                                                     = empty.inlineBlock
+    def listItem: Style                                                        = empty.listItem
+    def table: Style                                                           = empty.table
+    def tableRow: Style                                                        = empty.tableRow
+    def tableCell: Style                                                       = empty.tableCell
+    def listStyle(v: ListStyle): Style                                         = empty.listStyle(v)
+    def listStyle(f: ListStyle.type => ListStyle): Style                       = empty.listStyle(f)
+    def borderCollapse(v: BorderCollapse): Style                               = empty.borderCollapse(v)
+    def borderCollapse(f: BorderCollapse.type => BorderCollapse): Style        = empty.borderCollapse(f)
     def flexGrow(v: Double): Style                                             = empty.flexGrow(v)
     def flexShrink(v: Double): Style                                           = empty.flexShrink(v)
     def flexBasis(v: Length): Style                                            = empty.flexBasis(v)
@@ -558,6 +773,30 @@ object Style:
         stop2: (Color, Length.Pct),
         stops: (Color, Length.Pct)*
     ): Style = empty.bgGradient(direction, stop1, stop2, stops*)
+    def bgGradient(
+        direction: GradientDirection,
+        colorSpace: GradientColorSpace,
+        stop1: (Color, Length.Pct),
+        stop2: (Color, Length.Pct),
+        stops: (Color, Length.Pct)*
+    ): Style = empty.bgGradient(direction, colorSpace, stop1, stop2, stops*)
+    def bgGradient(
+        direction: GradientDirection.type => GradientDirection,
+        colorSpace: GradientColorSpace,
+        stop1: (Color, Length.Pct),
+        stop2: (Color, Length.Pct),
+        stops: (Color, Length.Pct)*
+    ): Style = empty.bgGradient(direction, colorSpace, stop1, stop2, stops*)
+    def transition(property: TransitionProperty, durationMs: Int, easing: Easing): Style =
+        empty.transition(property, durationMs, easing)
+    def transition(property: TransitionProperty.type => TransitionProperty, durationMs: Int, easing: Easing.type => Easing): Style =
+        empty.transition(property, durationMs, easing)
+    def transition(durationMs: Int, easing: Easing): Style              = empty.transition(durationMs, easing)
+    def animation(name: String, durationMs: Int, easing: Easing): Style = empty.animation(name, durationMs, easing)
+    def animation(name: String, durationMs: Int, easing: Easing.type => Easing): Style =
+        empty.animation(name, durationMs, easing)
+    def animationDelay(ms: Int): Style          = empty.animationDelay(ms)
+    def strokeDashoffset(v: Double): Style      = empty.strokeDashoffset(v)
     def hover(s: Style): Style                  = empty.hover(s)
     def hover(f: Style.type => Style): Style    = empty.hover(f)
     def focus(s: Style): Style                  = empty.focus(s)
@@ -586,6 +825,7 @@ object Style:
         final case class Rgb private[kyo] (r: Int, g: Int, b: Int)             extends Color
         final case class Rgba private[kyo] (r: Int, g: Int, b: Int, a: Double) extends Color
         case object Transparent                                                extends Color
+        final case class Var private[kyo] (name: String)                       extends Color
 
         private def clamp255(v: Int): Int      = math.max(0, math.min(255, v))
         private def clamp01(v: Double): Double = math.max(0.0, math.min(1.0, v))
@@ -626,12 +866,18 @@ object Style:
         val pink: Color        = Hex("#ec4899")
         val gray: Color        = Hex("#6b7280")
         val slate: Color       = Hex("#64748b")
+
+        /** A CSS custom-property reference: `Color.variable("accent")` renders as `var(--accent)` in
+          * declarations. Use it with [[kyo.Stylesheet.vars]] to define the property and [[kyo.Style.color]]/
+          * [[kyo.Style.bg]] to reference it.
+          */
+        def variable(name: String): Color = Var(name)
     end Color
 
     // ---- Enums ----
 
     enum FlexDirection derives CanEqual:
-        case row, column
+        case row, column, rowReverse, columnReverse
 
     /** Maps to the CSS `flex-wrap` property. */
     enum FlexWrap derives CanEqual:
@@ -648,6 +894,22 @@ object Style:
     /** Maps to the CSS `overflow` property. */
     enum Overflow derives CanEqual:
         case visible, hidden, scroll, auto
+
+    /** Maps to the standard CSS `scrollbar-width` property: `auto` is the platform default, `thin`
+      * requests a slimmer scrollbar, `none` hides it while the element stays scrollable.
+      */
+    enum ScrollbarWidth derives CanEqual:
+        case auto, thin, none
+
+    /** Maps to the standard CSS `scrollbar-gutter` property: `auto` is the default (the gutter exists only
+      * while scrolling), `stable` always reserves the gutter, `stableBothEdges` reserves it on both edges.
+      */
+    enum ScrollbarGutter derives CanEqual:
+        case auto, stable, stableBothEdges
+
+    /** Maps to the CSS `background-clip` property. */
+    enum BackgroundClip derives CanEqual:
+        case borderBox, paddingBox, contentBox
 
     /** Maps to the CSS `font-weight` property. */
     enum FontWeight derives CanEqual:
@@ -672,9 +934,17 @@ object Style:
     enum TextOverflow derives CanEqual:
         case clip, ellipsis
 
-    /** Maps to the CSS `text-wrap` / `white-space` behavior. */
+    /** Maps to the CSS `text-wrap` / `white-space` behavior.
+      *
+      *   - `wrap`: allow long words to break so an overflowing token wraps within the box (`overflow-wrap: break-word`).
+      *   - `noWrap`: keep words intact, never breaking inside one (`overflow-wrap: normal`).
+      *   - `ellipsis`: keep words intact and mark clipped overflow with an ellipsis.
+      *   - `balance`: balance the lines of a short block (a heading) so each line is close to the same width (`text-wrap: balance`),
+      *     avoiding a last line stranding a single short word.
+      *   - `pretty`: optimize the last few lines of a longer block (body prose) to avoid orphans and bad breaks (`text-wrap: pretty`).
+      */
     enum TextWrap derives CanEqual:
-        case wrap, noWrap, ellipsis
+        case wrap, noWrap, ellipsis, balance, pretty
 
     /** Maps to the CSS `font-family` property; `Custom` carries an arbitrary family name. */
     enum FontFamily derives CanEqual:
@@ -690,19 +960,108 @@ object Style:
     enum Cursor derives CanEqual:
         case defaultCursor, pointer, text, move, notAllowed, crosshair, help, wait_, grab, grabbing
 
-    /** Maps to the CSS `position` property: `flow` for normal layout, `overlay` for an absolutely positioned overlay. */
+    /** Maps to the CSS `position` property.
+      *
+      *   - `flow`: normal layout (`position: static`).
+      *   - `overlay`: a full-viewport fixed overlay (`position: fixed` pinned to all four edges).
+      *   - `relative`: a positioned containing block (`position: relative`) for absolutely-positioned
+      *     descendants, without shifting the element itself.
+      *   - `dropdown`: an absolutely-positioned panel anchored under the right edge of its nearest
+      *     positioned ancestor (`position: absolute; top: 100%; right: 0`), layered above sibling
+      *     content. Used for menus and result panels that drop below a trigger.
+      *   - `sticky`: a sticky-positioned element (`position: sticky`) that scrolls with the document
+      *     until it reaches its sticky offset, then pins in place. `sticky` emits ONLY the
+      *     `position: sticky` declaration; the offset and stacking are set separately with
+      *     [[kyo.Style.top]] and [[kyo.Style.zIndex]], so a sticky element can pin at the viewport top
+      *     (`top(0.px).zIndex(100)`, e.g. a site header) or just below another sticky element
+      *     (`top(60.px)`, e.g. a rail under a 60px header) without a baked-in offset.
+      *   - `absolute`: a positioned element (`position: absolute`) taken out of flow and placed against
+      *     its nearest positioned ancestor; the offsets and size are set separately.
+      *   - `fixed`: a viewport-pinned element (`position: fixed`) taken out of flow, with the offsets and
+      *     size set separately (unlike `overlay`, which bakes in all-four-edges full-viewport sizing). For
+      *     a partial pinned element: a corner floating button (`fixed` + `left`/`bottom`) or an edge
+      *     drawer (`fixed` + `top`/`left`/`bottom` + `width`).
+      */
     enum Position derives CanEqual:
-        case flow, overlay
+        case flow, overlay, relative, dropdown, sticky, absolute, fixed
+
+    /** Maps to the CSS `display` property for opting out of the default flex layout.
+      *
+      *   - `block`: a block-level box (`display: block`) that stacks vertically and fills its line.
+      *   - `inline`: an inline box (`display: inline`) that flows within a line of text and wraps with
+      *     it, so inline runs (code, links, emphasis) sit within a sentence instead of stacking.
+      *   - `inlineBlock`: an inline-level box that still honors width/height and padding
+      *     (`display: inline-block`), used for inline pills that need box metrics yet flow in a line.
+      *   - `listItem`: a list item (`display: list-item`) so the element renders its list marker.
+      *   - `table`: a table box (`display: table`) that runs the CSS table-layout algorithm, so an
+      *     explicit `width` is distributed across columns instead of shrinking each column to content.
+      *   - `tableRow`: a table row (`display: table-row`), the row box inside a `table`.
+      *   - `tableCell`: a table cell (`display: table-cell`) that participates in the shared column
+      *     widths and border grid of its `table`.
+      *   - `flex` / `inlineFlex`: a flex container (`display: flex` / `display: inline-flex`). The
+      *     `Style.row`/`Style.column` direction helpers only set `flex-direction` and rely on an element
+      *     already being a flex box; use `flex` to force it where a more specific rule (e.g. a prose
+      *     `a { display: inline }`) would otherwise win the cascade.
+      */
+    enum Display derives CanEqual:
+        case block, inline, inlineBlock, flex, inlineFlex, listItem, table, tableRow, tableCell
+
+    /** Maps to the CSS `list-style-type` property: the marker a `list-item` renders. `disc` is the
+      * filled bullet for unordered lists, `decimal` the number for ordered lists, `none` suppresses
+      * the marker (the base reset default).
+      */
+    enum ListStyle derives CanEqual:
+        case disc, decimal, none
+
+    /** Maps to the CSS `border-collapse` property of a table: `collapse` merges adjacent cell borders
+      * into single shared lines (so row and column dividers render as one crisp rule), `separate` is
+      * the UA default where each cell keeps its own border separated by `border-spacing`.
+      */
+    enum BorderCollapse derives CanEqual:
+        case collapse, separate
 
     /** Direction of a background gradient (the `to ...` keyword of a CSS `linear-gradient`). */
     enum GradientDirection derives CanEqual:
         case toRight, toLeft, toTop, toBottom, toTopRight, toTopLeft, toBottomRight, toBottomLeft
 
+    /** The color space a `linear-gradient` interpolates its stops in (the `in <space>` keyword of a CSS gradient).
+      *
+      *   - `srgb`: the CSS default. Interpolation is linear in the sRGB channels, which can sag through a muddy desaturated midtone
+      *     between a saturated color and a dark/near-black, and bands visibly at 8-bit output across a long, low-contrast span.
+      *   - `oklch`: interpolates in the perceptually-uniform OKLCH space (lightness, chroma, hue). The path between two colors stays even
+      *     and the hue does not pass through grey, so the same two stops read smooth instead of muddy and band far less.
+      *   - `oklab`: the Cartesian OKLAB sibling of `oklch`; also perceptually uniform, interpolating the a/b axes rather than chroma/hue.
+      */
+    enum GradientColorSpace derives CanEqual:
+        case srgb, oklch, oklab
+
+    /** A CSS timing function for a `transition` or `animation`.
+      *
+      *   - `ease`: the UA default, a gentle accelerate-then-decelerate curve.
+      *   - `linear`: constant velocity from start to end.
+      *   - `easeIn`: starts slow, accelerates into the end.
+      *   - `easeOut`: starts fast, decelerates into the end (the natural feel for an element settling
+      *     into place, e.g. a panel sliding in).
+      *   - `easeInOut`: slow at both ends, faster in the middle.
+      */
+    enum Easing derives CanEqual:
+        case ease, linear, easeIn, easeOut, easeInOut
+
+    /** The CSS property a `transition` animates. `all` transitions every animatable property at once
+      * (the common shorthand); the named cases target a single property so an element can fade its
+      * background and color without animating layout. `Custom` carries an arbitrary CSS property name
+      * for the rare case the named set does not cover.
+      */
+    enum TransitionProperty derives CanEqual:
+        case all, backgroundColor, color, borderColor, opacity, transform
+        case Custom(name: String)
+    end TransitionProperty
+
     // ---- Prop ADT ----
 
     /** The encoded representation of a single style property that a [[kyo.Style]] stores.
       *
-      * Each setter on `Style` produces exactly one `Prop` case, and a `Style` is just the ordered `Span` of these. The enum case is the
+      * Each setter on `Style` produces exactly one `Prop` case, and a `Style` is just the ordered `Chunk` of these. The enum case is the
       * "kind" key that drives last-write-wins dedup and `++` merging, so two writes of the same case (e.g. two `Width` props) collapse to the
       * last one. Pseudo-states are themselves props (`HoverProp`, `FocusProp`, ...) carrying a nested `Style`.
       *
@@ -725,6 +1084,12 @@ object Style:
         case Align(value: Alignment)
         case Justify(value: Justification)
         case OverflowProp(value: Overflow)
+        case OverflowXProp(value: Overflow)
+        case OverflowYProp(value: Overflow)
+        case ScrollbarWidthProp(value: ScrollbarWidth)
+        case ScrollbarColorProp(thumb: Color, track: Color)
+        case ScrollbarGutterProp(value: ScrollbarGutter)
+        case BackgroundClipProp(value: BackgroundClip)
         // Sizing
         case Width(value: Length)
         case Height(value: Length)
@@ -758,6 +1123,19 @@ object Style:
         case TranslateProp(x: Length, y: Length)
         // Position
         case PositionProp(value: Position)
+        case Top(value: Length)
+        case Right(value: Length)
+        case Bottom(value: Length)
+        case Left(value: Length)
+        case ZIndexProp(value: Int)
+        case AlignSelf(value: Alignment)
+        case ScrollMarginTopProp(value: Length)
+        // Display
+        case DisplayProp(value: Display)
+        // List marker
+        case ListStyleProp(value: ListStyle)
+        // Tables
+        case BorderCollapseProp(value: BorderCollapse)
         // Visibility
         case HiddenProp
         // Flex grow/shrink
@@ -774,7 +1152,12 @@ object Style:
         case HueRotateProp(value: Double)
         case BlurProp(value: Length)
         // Background gradient
-        case BgGradientProp(direction: GradientDirection, colors: Span[Color], positions: Span[Double])
+        case BgGradientProp(direction: GradientDirection, colorSpace: GradientColorSpace, colors: Chunk[Color], positions: Chunk[Double])
+        // Motion
+        case TransitionProp(property: TransitionProperty, durationMs: Int, easing: Easing)
+        case AnimationProp(name: String, durationMs: Int, easing: Easing)
+        case AnimationDelayProp(ms: Int)
+        case StrokeDashoffsetProp(value: Double)
         // Pseudo-states
         case HoverProp(style: Style)
         case FocusProp(style: Style)

--- a/kyo-ui/shared/src/main/scala/kyo/Stylesheet.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/Stylesheet.scala
@@ -1,0 +1,269 @@
+package kyo
+
+import kyo.internal.CssStyleRenderer
+import kyo.internal.NumberFormat
+
+/** A document-level stylesheet: an ordered, immutable collection of CSS rules, media queries,
+  * top-level custom properties (CSS variables), font-face declarations, and `@keyframes` animation
+  * definitions, rendered to one CSS string. This is the document counterpart to [[kyo.Style]] (which
+  * styles a single element): `Style` carries the declarations, `Stylesheet` carries the SELECTORS,
+  * breakpoints, variables, fonts, and keyframes that a per-element `Style` cannot express.
+  *
+  * A `Stylesheet` is a pure value built by appending entries (`rule`, `media`, `vars`,
+  * `fontFace`, `keyframes`); every builder returns a new `Stylesheet`, so it is safe to share and
+  * compose with `++`. Render it with [[kyo.Stylesheet.render]] to a CSS string for a document
+  * `<head>` (pass it as [[kyo.UI.PageHead.css]] to [[kyo.UI.runRenderPage]]) or inject it
+  * client-side with [[kyo.UI.runStylesheet]]. Declarations reuse [[kyo.Style]] verbatim, so the same
+  * value types (`Color`, `Length`, the pseudo-state nesting) apply; the selector targets elements
+  * that carry a matching [[kyo.UI.cssClass]] (or an `id`/`data-*` selector).
+  *
+  * Emission order is preserved (CSS is last-declaration-wins at equal specificity), so author
+  * base rules before overrides and place `@media` blocks after the rules they refine.
+  *
+  * @see
+  *   [[kyo.Stylesheet.rule]], [[kyo.Stylesheet.media]], [[kyo.Stylesheet.vars]],
+  *   [[kyo.Stylesheet.fontFace]], [[kyo.Stylesheet.keyframes]] for the builders
+  * @see
+  *   [[kyo.Style]] for the per-element declaration value the rules reuse
+  * @see
+  *   [[kyo.Style.animation]] for the element-side `animation:` prop that references a `@keyframes`
+  *   block by name
+  * @see
+  *   [[kyo.UI.cssClass]] for the element-side class hook a class selector targets
+  */
+final case class Stylesheet private[kyo] (entries: Chunk[Stylesheet.Entry]) derives CanEqual:
+
+    /** Appends a single rule (a selector and the [[kyo.Style]] declarations applied to it). */
+    def rule(selector: Selector, style: Style): Stylesheet =
+        Stylesheet(entries :+ Stylesheet.Entry.Rule(selector, style))
+
+    /** Appends a rule whose selector is the given CSS class name (shorthand for
+      * `rule(Selector.cls(name), style)`).
+      */
+    def rule(className: String, style: Style): Stylesheet =
+        rule(Selector.cls(className), style)
+
+    /** Appends an `@media` block: the `query` (a [[kyo.Stylesheet.MediaQuery]]) wrapping the rules
+      * of the nested `Stylesheet`. Nested media is flattened to a single level on render.
+      */
+    def media(query: Stylesheet.MediaQuery)(nested: Stylesheet): Stylesheet =
+        Stylesheet(entries :+ Stylesheet.Entry.Media(query, nested))
+
+    /** Appends a `:root` block of CSS custom properties (variables). Each pair is `(name, value)`
+      * emitted as `--name: value;`. Reference a variable in a declaration with
+      * [[kyo.Style.Color.variable]] or [[kyo.Length]]'s variable form.
+      */
+    def vars(pairs: (String, String)*): Stylesheet =
+        Stylesheet(entries :+ Stylesheet.Entry.Vars(pairs.toList))
+
+    /** Appends a block of CSS custom properties (variables) scoped to an arbitrary `selector` rather
+      * than `:root`. Each pair is `(name, value)` emitted as `--name: value;` inside
+      * `selector { ... }`. Used to override the root variables for a theme or state, e.g.
+      * `scopedVars(Selector.data("theme", "dark"), "bg" -> "#14130D", ...)` to re-theme on a
+      * `data-theme="dark"` root. Reference a variable with [[kyo.Style.Color.variable]] or
+      * [[kyo.Length]]'s variable form.
+      */
+    def scopedVars(selector: Selector, pairs: (String, String)*): Stylesheet =
+        Stylesheet(entries :+ Stylesheet.Entry.ScopedVars(selector, pairs.toList))
+
+    /** Appends an `@font-face` declaration (a [[kyo.Stylesheet.FontFace]]). */
+    def fontFace(face: Stylesheet.FontFace): Stylesheet =
+        Stylesheet(entries :+ Stylesheet.Entry.Font(face))
+
+    /** Appends a `@keyframes <name> { ... }` animation definition. Each frame is a
+      * `([[kyo.Stylesheet.Keyframe]], [[kyo.Style]])` pair: the keyframe selector (a percentage
+      * along the timeline, or the `from`/`to` shorthands for `0%`/`100%`) and the declarations that
+      * apply at that point. Reference the block from an element with [[kyo.Style.animation]], passing
+      * the same `name`.
+      */
+    def keyframes(name: String, frames: (Stylesheet.Keyframe, Style)*): Stylesheet =
+        Stylesheet(entries :+ Stylesheet.Entry.Keyframes(name, frames.toList))
+
+    /** Concatenates another stylesheet's entries after this one's (order preserved). */
+    def ++(other: Stylesheet): Stylesheet =
+        Stylesheet(entries ++ other.entries)
+
+    def isEmpty: Boolean  = entries.isEmpty
+    def nonEmpty: Boolean = entries.nonEmpty
+
+    /** Renders the whole stylesheet to a single CSS string: each rule as `selector { declarations }`
+      * (declarations from [[kyo.internal.CssStyleRenderer]], including nested pseudo-state rules),
+      * each media block as `@media query { ... }`, each `vars` block as `:root { --k: v; }`, and each
+      * font-face as `@font-face { ... }`. Entry order is preserved.
+      */
+    def render(using Frame): String = Stylesheet.renderSheet(this)
+
+end Stylesheet
+
+object Stylesheet:
+
+    /** The empty stylesheet; the identity for `++`. */
+    val empty: Stylesheet = Stylesheet(Chunk.empty[Entry])
+
+    /** Starts a stylesheet from a single rule. */
+    def rule(selector: Selector, style: Style): Stylesheet = empty.rule(selector, style)
+
+    /** Starts a stylesheet from a single class-name rule. */
+    def rule(className: String, style: Style): Stylesheet = empty.rule(className, style)
+
+    /** Starts a stylesheet with a single `@media` block. */
+    def media(query: MediaQuery)(nested: Stylesheet): Stylesheet = empty.media(query)(nested)
+
+    /** Starts a stylesheet with a `:root` variables block. */
+    def vars(pairs: (String, String)*): Stylesheet = empty.vars(pairs*)
+
+    /** Starts a stylesheet with a selector-scoped variables block. */
+    def scopedVars(selector: Selector, pairs: (String, String)*): Stylesheet = empty.scopedVars(selector, pairs*)
+
+    /** Starts a stylesheet with a single `@font-face` declaration. */
+    def fontFace(face: FontFace): Stylesheet = empty.fontFace(face)
+
+    /** Starts a stylesheet with a single `@keyframes` block. */
+    def keyframes(name: String, frames: (Keyframe, Style)*): Stylesheet = empty.keyframes(name, frames*)
+
+    /** One entry in a [[kyo.Stylesheet]]: a plain rule, an `@media` block, a `:root` variables block,
+      * an `@font-face`, or a `@keyframes` animation definition. Pattern-matchable for inspection and
+      * testing.
+      */
+    enum Entry derives CanEqual:
+        case Rule(selector: Selector, style: Style)
+        case Media(query: MediaQuery, nested: Stylesheet)
+        case Vars(pairs: List[(String, String)])
+        case ScopedVars(selector: Selector, pairs: List[(String, String)])
+        case Font(face: FontFace)
+        case Keyframes(name: String, frames: List[(Keyframe, Style)])
+    end Entry
+
+    /** A keyframe selector inside an `@keyframes` block: a percentage along the animation timeline.
+      * Build it with [[kyo.Stylesheet.Keyframe.at]] (an explicit percentage, clamped to `0..100`),
+      * or the `from`/`to` shorthands for the `0%`/`100%` endpoints.
+      */
+    final case class Keyframe private[kyo] (percent: Double) derives CanEqual
+
+    object Keyframe:
+        /** A keyframe at the given percentage along the timeline, clamped to `0..100`. */
+        def at(percent: Double): Keyframe = Keyframe(math.max(0.0, math.min(100.0, percent)))
+
+        /** The `0%` (start) keyframe. */
+        val from: Keyframe = Keyframe(0.0)
+
+        /** The `100%` (end) keyframe. */
+        val to: Keyframe = Keyframe(100.0)
+    end Keyframe
+
+    /** A media query for an `@media` block. Built from the typed factories (`minWidth`, `maxWidth`,
+      * `prefersDark`, `prefersReducedMotion`) and combined with `and`, so common responsive
+      * breakpoints are expressible without a raw string; `raw` is the escape hatch for an arbitrary
+      * media condition.
+      */
+    final case class MediaQuery private[kyo] (condition: String) derives CanEqual:
+        /** Combines two media queries with `and`, e.g. `minWidth(768.px).and(prefersDark)`. */
+        def and(other: MediaQuery): MediaQuery = MediaQuery(condition + " and " + other.condition)
+    end MediaQuery
+
+    object MediaQuery:
+        /** A `(min-width: Npx)` media query. */
+        def minWidth(px: Length.Px): MediaQuery = MediaQuery(s"(min-width: ${px.value.toInt}px)")
+
+        /** A `(max-width: Npx)` media query. */
+        def maxWidth(px: Length.Px): MediaQuery = MediaQuery(s"(max-width: ${px.value.toInt}px)")
+
+        /** Targets `prefers-color-scheme: dark`. */
+        val prefersDark: MediaQuery = MediaQuery("(prefers-color-scheme: dark)")
+
+        /** Targets `prefers-reduced-motion: reduce`. */
+        val prefersReducedMotion: MediaQuery = MediaQuery("(prefers-reduced-motion: reduce)")
+
+        /** Targets `prefers-reduced-motion: no-preference`: the user has NOT asked to reduce motion.
+          * Gate enhancement animations behind this so the default (no media match) is the still, fully
+          * visible state, and motion is opt-in for users who tolerate it.
+          */
+        val prefersReducedMotionNoPreference: MediaQuery = MediaQuery("(prefers-reduced-motion: no-preference)")
+
+        /** An arbitrary media condition string, for cases the typed factories do not cover. */
+        def raw(condition: String): MediaQuery = MediaQuery(condition)
+    end MediaQuery
+
+    /** An `@font-face` declaration: the font `family` name, the `src` entries (each a `(url, format)`
+      * pair, e.g. `("/fonts/inter.woff2", "woff2")`), the `weight` (a [[kyo.Style.FontWeight]]), the
+      * `style` (a [[kyo.Style.FontStyle]]), and the `display` strategy. Reuses kyo-ui's existing
+      * `FontWeight`/`FontStyle` enums rather than introducing new ones.
+      */
+    final case class FontFace(
+        family: String,
+        src: Seq[(String, String)],
+        weight: Style.FontWeight = Style.FontWeight.normal,
+        style: Style.FontStyle = Style.FontStyle.normal,
+        display: FontFace.Display = FontFace.Display.swap
+    ) derives CanEqual
+
+    object FontFace:
+        /** The CSS `font-display` strategy. */
+        enum Display derives CanEqual:
+            case auto, block, swap, fallback, optional
+        end Display
+    end FontFace
+
+    /** Renders a `Stylesheet` to a CSS string. Called by `Stylesheet.render`. */
+    private[kyo] def renderSheet(sheet: Stylesheet)(using Frame): String =
+        val sb = new StringBuilder
+        sheet.entries.foreach {
+            case Entry.Rule(sel, style) =>
+                val base = CssStyleRenderer.render(
+                    style
+                        .without[Style.Prop.HoverProp]
+                        .without[Style.Prop.FocusProp]
+                        .without[Style.Prop.ActiveProp]
+                        .without[Style.Prop.DisabledProp]
+                )
+                if base.nonEmpty then sb.append(s"${sel.css} { $base }\n")
+                style.find[Style.Prop.HoverProp].foreach(p =>
+                    sb.append(s"${sel.css}:hover { ${CssStyleRenderer.render(p.style)} }\n")
+                )
+                style.find[Style.Prop.FocusProp].foreach(p =>
+                    sb.append(s"${sel.css}:focus { ${CssStyleRenderer.render(p.style)} }\n")
+                )
+                style.find[Style.Prop.ActiveProp].foreach(p =>
+                    sb.append(s"${sel.css}:active { ${CssStyleRenderer.render(p.style)} }\n")
+                )
+                style.find[Style.Prop.DisabledProp].foreach(p =>
+                    sb.append(s"${sel.css}:disabled { ${CssStyleRenderer.render(p.style)} }\n")
+                )
+            case Entry.Media(q, nested) =>
+                sb.append(s"@media ${q.condition} {\n")
+                sb.append(renderSheet(nested))
+                sb.append("}\n")
+            case Entry.Vars(pairs) =>
+                sb.append(":root {")
+                pairs.foreach((k, v) => sb.append(s" --$k: $v;"))
+                sb.append(" }\n")
+            case Entry.ScopedVars(selector, pairs) =>
+                sb.append(s"${selector.css} {")
+                pairs.foreach((k, v) => sb.append(s" --$k: $v;"))
+                sb.append(" }\n")
+            case Entry.Font(f) =>
+                val srcs = f.src.map((url, fmt) => s"""url("$url") format("$fmt")""").mkString(", ")
+                sb.append(s"""@font-face { font-family: "${f.family}"; src: $srcs;""")
+                sb.append(s" font-weight: ${CssStyleRenderer.fontWeightCss(f.weight)};")
+                sb.append(s" font-style: ${CssStyleRenderer.fontStyleCss(f.style)};")
+                sb.append(s" font-display: ${f.display.toString}; }\n")
+            case Entry.Keyframes(name, frames) =>
+                sb.append(s"@keyframes $name {\n")
+                frames.foreach { (frame, style) =>
+                    // A keyframe is a plain declaration block: pseudo-states are not valid inside
+                    // @keyframes, so render base props only (drop any nested hover/focus/active/disabled).
+                    val decls = CssStyleRenderer.render(
+                        style
+                            .without[Style.Prop.HoverProp]
+                            .without[Style.Prop.FocusProp]
+                            .without[Style.Prop.ActiveProp]
+                            .without[Style.Prop.DisabledProp]
+                    )
+                    sb.append(s"  ${NumberFormat.double(frame.percent)}% { $decls }\n")
+                }
+                sb.append("}\n")
+        }
+        sb.toString
+    end renderSheet
+
+end Stylesheet

--- a/kyo-ui/shared/src/main/scala/kyo/Svg.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/Svg.scala
@@ -160,13 +160,26 @@ object Svg:
         case ArcTo(rx: Double, ry: Double, xRot: Double, largeArc: Boolean, sweep: Boolean, x: Double, y: Double)
         case ArcBy(rx: Double, ry: Double, xRot: Double, largeArc: Boolean, sweep: Boolean, dx: Double, dy: Double)
         case Close
+
+        /** A pre-formatted `d` fragment emitted verbatim, the escape for embedding an external path (a
+          * brand mark, an icon-set glyph) whose command list would be impractical to transcribe. The
+          * counterpart to [[kyo.Selector.raw]] / [[kyo.Stylesheet.MediaQuery.raw]].
+          */
+        case Raw(d: String)
     end PathCommand
 
-    /** A typed path-command list backing the `d` attribute; no raw `d` string. */
+    /** A typed path-command list backing the `d` attribute. Prefer the typed builders; [[kyo.Svg.PathData.raw]]
+      * is the escape for embedding an external path string verbatim.
+      */
     opaque type PathData = Chunk[PathCommand]
     object PathData:
-        def from(x: Double, y: Double): PathData                   = Chunk(PathCommand.MoveTo(x, y))
-        def from(x: Int, y: Int): PathData                         = from(x.toDouble, y.toDouble)
+        def from(x: Double, y: Double): PathData = Chunk(PathCommand.MoveTo(x, y))
+        def from(x: Int, y: Int): PathData       = from(x.toDouble, y.toDouble)
+
+        /** A path whose `d` attribute is the given string verbatim, for embedding an external/standard path
+          * (a brand mark, an icon-set glyph) that the typed builders would be impractical to express.
+          */
+        def raw(d: String): PathData                               = Chunk(PathCommand.Raw(d))
         val empty: PathData                                        = Chunk.empty
         private[kyo] def commands(p: PathData): Chunk[PathCommand] = p
         given CanEqual[PathData, PathData]                         = CanEqual.derived
@@ -332,6 +345,14 @@ object Svg:
         case Translate, Scale, Rotate, SkewX, SkewY
     end TransformType
 
+    /** SMIL animation `fill`: what the animated attribute does once the animation ends. `Freeze`
+      * holds the final value (`fill="freeze"`); `Remove` reverts to the base value (`fill="remove"`,
+      * the SMIL default). Use `Freeze` for a draw-on-load effect that must stay drawn.
+      */
+    enum AnimFill derives CanEqual:
+        case Freeze, Remove
+    end AnimFill
+
     /** `animate` `calcMode`: the interpolation mode between keyframe values. Cases render to their lowercase SVG
       * tokens (`Discrete -> "discrete"`, `Spline -> "spline"`, ...). `Spline` is the mode that activates
       * `keySplines`.
@@ -364,6 +385,7 @@ object Svg:
         strokeDasharray: Maybe[Chunk[Double]] = Absent,
         strokeDashoffset: Maybe[SvgLength] = Absent,
         strokeMiterlimit: Maybe[Double] = Absent,
+        pathLength: Maybe[Double] = Absent,
         opacity: Maybe[Double] = Absent,
         transform: Chunk[Transform] = Chunk.empty,
         // geometry (coords are Double; an explicit SvgLength is stored boxed)
@@ -452,7 +474,8 @@ object Svg:
         animCalcMode: Maybe[String] = Absent,
         animKeyTimes: Maybe[String] = Absent,
         animKeySplines: Maybe[String] = Absent,
-        animType: Maybe[TransformType] = Absent
+        animType: Maybe[TransformType] = Absent,
+        animFill: Maybe[AnimFill] = Absent
     )
 
     /** A geometry value that is either a plain user-space `Double` or an `SvgLength`. */
@@ -733,10 +756,15 @@ object Svg:
     ) extends SvgElement with HasId with HasFill with HasStroke with HasOpacity with HasTransform with HasFilter
         with UI.Ast.SvgInteractiveNode:
         type Self = Path
-        def withAttrs(a: Attrs): Path          = copy(attrs = a)
-        def withSvg(s: SvgAttrs): Path         = copy(svgAttrs = s)
-        def apply(cs: ShapeChild*): Path       = copy(children = children ++ liftSvg(cs))
-        def d(data: PathData): Path            = withSvg(svgAttrs.copy(d = Present(data)))
+        def withAttrs(a: Attrs): Path    = copy(attrs = a)
+        def withSvg(s: SvgAttrs): Path   = copy(svgAttrs = s)
+        def apply(cs: ShapeChild*): Path = copy(children = children ++ liftSvg(cs))
+        def d(data: PathData): Path      = withSvg(svgAttrs.copy(d = Present(data)))
+        // `pathLength` reparameterizes the path so dash and offset values are read in `pathLength`
+        // units rather than user units. Setting it to 1 normalizes the geometry, so a CSS stroke-draw
+        // keyframe can tween `stroke-dashoffset` from 1 (hidden) to 0 (drawn) without knowing the real
+        // length. Used by the landing gap chart's scroll-revealed line draw.
+        def pathLength(v: Double): Path        = withSvg(svgAttrs.copy(pathLength = Present(v)))
         override def id(v: String): Path       = withSvg(svgAttrs.copy(defId = Present(v)))
         def markerStart(ref: Marker.Ref): Path = withSvg(svgAttrs.copy(markerStart = Present(ref.id)))
         def markerMid(ref: Marker.Ref): Path   = withSvg(svgAttrs.copy(markerMid = Present(ref.id)))
@@ -1122,6 +1150,7 @@ object Svg:
         def dur(v: String): Animate           = withSvg(svgAttrs.copy(animDur = Present(v)))
         def repeatCount(v: String): Animate   = withSvg(svgAttrs.copy(animRepeatCount = Present(v)))
         def begin(v: String): Animate         = withSvg(svgAttrs.copy(animBegin = Present(v)))
+        def fill(v: AnimFill): Animate        = withSvg(svgAttrs.copy(animFill = Present(v)))
 
         /** Sets the interpolation mode between keyframe values. `CalcMode.Spline` is the mode that activates
           * `keySplines`; the other modes ignore it.
@@ -1163,6 +1192,7 @@ object Svg:
         def dur(v: String): AnimateTransform           = withSvg(svgAttrs.copy(animDur = Present(v)))
         def repeatCount(v: String): AnimateTransform   = withSvg(svgAttrs.copy(animRepeatCount = Present(v)))
         def begin(v: String): AnimateTransform         = withSvg(svgAttrs.copy(animBegin = Present(v)))
+        def fill(v: AnimFill): AnimateTransform        = withSvg(svgAttrs.copy(animFill = Present(v)))
     end AnimateTransform
 
     /** `<animateMotion>`: the SMIL element that moves its parent element along a motion path over time.
@@ -1183,6 +1213,7 @@ object Svg:
         def path(v: PathData): AnimateMotion      = withSvg(svgAttrs.copy(d = Present(v)))
         def dur(v: String): AnimateMotion         = withSvg(svgAttrs.copy(animDur = Present(v)))
         def repeatCount(v: String): AnimateMotion = withSvg(svgAttrs.copy(animRepeatCount = Present(v)))
+        def fill(v: AnimFill): AnimateMotion      = withSvg(svgAttrs.copy(animFill = Present(v)))
     end AnimateMotion
 
     /** `<set>`: the SMIL element that sets an attribute of its parent shape to a single value at a given time.
@@ -1203,6 +1234,7 @@ object Svg:
         def attributeName(v: String): SetAnim = withSvg(svgAttrs.copy(animAttributeName = Present(v)))
         def to(v: String): SetAnim            = withSvg(svgAttrs.copy(animTo = Present(v)))
         def begin(v: String): SetAnim         = withSvg(svgAttrs.copy(animBegin = Present(v)))
+        def fill(v: AnimFill): SetAnim        = withSvg(svgAttrs.copy(animFill = Present(v)))
     end SetAnim
 
     // ---- metadata ----

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -112,6 +112,7 @@ object UI:
     def main(using Frame): Main                   = Main()
     def label(using Frame): Label                 = Label()
     def pre(using Frame): Pre                     = Pre()
+    def blockquote(using Frame): Blockquote       = Blockquote()
     def code(using Frame): Code                   = Code()
     def table(using Frame): Table                 = Table()
     def tr(using Frame): Tr                       = Tr()
@@ -166,6 +167,73 @@ object UI:
       */
     def fragment[C <: UI](cs: C*)(using Frame): Fragment[C] = Fragment[C](Chunk.from(cs))
 
+    /** Inline HTML passthrough: emits `html` verbatim into the rendered output without any escaping.
+      *
+      * This is the framework's single deliberate escape hatch for trusted HTML content that cannot be expressed through the normal `UI`
+      * element API. Use it only for content you control and trust completely: strings from external sources, user input, or any untrusted
+      * origin must NOT be passed here as doing so creates an XSS vulnerability. There is no sanitization.
+      *
+      * Intended for the bounded case of inline HTML snippets (such as `<img>` or `<a><img></a>` nodes found in module README files) that
+      * the Markdown transpiler encounters and must pass through verbatim. The article body itself is always a real `UI` subtree; this node
+      * appears only at the leaf positions where raw HTML snippets exist in the source.
+      *
+      * The rendered bytes are byte-identical to `html`. Contrast with `UI.text`, which HTML-escapes its argument:
+      * `UI.text("<b>x</b>")` renders `&lt;b&gt;x&lt;/b&gt;`; `UI.rawHtml("<b>x</b>")` renders `<b>x</b>`.
+      *
+      * @param html
+      *   Trusted HTML string to emit verbatim. Must come from a controlled, trusted source.
+      * @see
+      *   [[kyo.UI.Ast.RawHtml]] for the AST node this factory returns
+      * @see
+      *   [[kyo.UI.text]] for the safe alternative that HTML-escapes its argument
+      */
+    def rawHtml(html: String)(using Frame): UI = Ast.RawHtml(html)
+
+    /** Build a `<script type="...">` data island carrying a verbatim JSON body and an optional `id`.
+      *
+      * A data island is an inert structured-data block read back by a script (the JSON-LD
+      * SEO block, the SSG-seeded boot payload), NOT a reactive element. It returns a
+      * [[kyo.UI.DataIsland]], which does NOT extend [[kyo.UI]], so the type system rejects
+      * placing it as a live tree child: it can be placed ONLY through the [[kyo.UI.PageHead]]
+      * `jsonLd` (head) / `dataIslands` (body-end) fields. `scriptType` is
+      * `application/ld+json` for the JSON-LD block and `application/json` for a data island;
+      * `id` is `Present` for an addressable island (read back by `querySelector("#id")`) and
+      * `Absent` for the JSON-LD block.
+      *
+      * The `json` body is stored verbatim at construction and escaped only at render time
+      * (`<` becomes `<`, `>` becomes `>`), so a literal `</script>` substring in
+      * any field renders as inert text that cannot close the element. This factory owns the
+      * one escape; callers pass trusted JSON and never pre-escape it.
+      *
+      * @param scriptType
+      *   the `type` attribute (`application/ld+json` or `application/json`)
+      * @param id
+      *   the element `id` (`Present` for an addressable island, `Absent` for the JSON-LD block)
+      * @param json
+      *   the verbatim JSON body (trusted; escaped at render time)
+      * @see
+      *   [[kyo.UI.PageHead.jsonLd]], [[kyo.UI.PageHead.dataIslands]] for the fields that place it
+      * @see
+      *   [[kyo.UI.rawHtml]] for the verbatim-HTML leaf
+      */
+    def dataIsland(scriptType: String, id: Maybe[String], json: String)(using Frame): UI.DataIsland =
+        UI.DataIsland(scriptType, id, json)
+
+    /** A `<script type="..." id="...?">json</script>` document-level payload, built by
+      * [[kyo.UI.dataIsland]] and carried on [[kyo.UI.PageHead]] (the `jsonLd` head field and the
+      * `dataIslands` body-end field).
+      *
+      * It does NOT extend [[kyo.UI]]: a data island is a `PageHead` payload, not a renderable UI
+      * node. Because it is not a `UI`, the type system rejects placing it as a live tree child,
+      * and the renderer never sees it as a tree node; it is rendered only from the `PageHead`
+      * fields that carry it, as an inert, position-stable block with no `data-kyo-path`, no
+      * attributes, and no event handler. The `json` body is verbatim at construction and escaped
+      * at render time. `derives CanEqual` because [[kyo.UI.PageHead]] carries these values and
+      * itself `derives CanEqual`.
+      */
+    final case class DataIsland(scriptType: String, id: Maybe[String], json: String)
+        derives CanEqual
+
     /** Conditional rendering: shows `body` while `condition` is true and an empty node otherwise, re-evaluating when the signal emits. */
     def when[C <: UI](condition: Signal[Boolean])(body: => C)(using Frame): Reactive[C] =
         Reactive[C](condition.map(v => if v then body else UI.empty))
@@ -216,6 +284,76 @@ object UI:
                 }
             }
         }
+
+    /** The base CSS reset kyo-ui relies on for correct layout: `box-sizing: border-box`, the
+      * flex-column / flex-row element defaults, `[data-kyo-reactive] { display: contents }`, the
+      * list/heading/anchor/table normalizations, and `[hidden] { display: none }`.
+      *
+      * Every kyo-ui runner injects this automatically (`runMount` via the DOM stylesheet,
+      * `runHandlers` and the page runner via the document `<head>`), so a normal app never names
+      * it. It is public for one case: a static site that hand-builds its own HTML document and
+      * wants the framework reset in its `<head>`. Emit it BEFORE any custom stylesheet so custom
+      * rules win at equal specificity (CSS is last-declaration-wins). `UI.runRenderPage` already
+      * does this ordering for you; reach for `UI.baseCss` directly only when you assemble the
+      * document yourself.
+      */
+    val baseCss: String = HtmlRenderer.baseCss
+
+    /** Configuration for the `<head>` of a full HTML document produced by [[kyo.UI.runRenderPage]].
+      *
+      * `title` becomes the `<title>` (attribute-escaped). `meta` is a sequence of
+      * `(name, content)` pairs each emitted as `<meta name="..." content="...">` (both escaped),
+      * for SEO/OpenGraph/viewport tags; the renderer always prepends `charset=utf-8` and a
+      * responsive `viewport` so a minimal `PageHead` is still a valid document. `links` is a
+      * sequence of `(rel, href)` pairs each emitted as `<link rel="..." href="...">` (escaped),
+      * for canonical, icons, preconnect, and stylesheet links such as web fonts. `css` is extra
+      * stylesheet text emitted in a `<style>` block AFTER [[kyo.UI.baseCss]] so site rules win at
+      * equal specificity. `moduleScript` is an optional `<script type="module" src="...">` ESModule
+      * reference (a custom Scala.js bundle); `Absent` emits no script. `jsonLd` is an optional
+      * head-level data island (a `<script type="application/ld+json">` structured-data
+      * block) rendered immediately before `</head>`; `Absent` (the default) emits none.
+      * `dataIslands` is an ordered list of body-end data islands (`<script
+      * type="application/json" id="...">` blocks) rendered immediately before `</body>`;
+      * empty (the default) emits none. Both carry [[kyo.UI.DataIsland]] values built by
+      * [[kyo.UI.dataIsland]]; the renderer escapes their JSON bodies so a `</script>`
+      * substring cannot close the element early.
+      */
+    final case class PageHead(
+        title: String,
+        meta: Seq[(String, String)] = Seq.empty,
+        links: Seq[(String, String)] = Seq.empty,
+        css: String = "",
+        moduleScript: Maybe[String] = Absent,
+        jsonLd: Maybe[UI.DataIsland] = Absent,
+        dataIslands: Seq[UI.DataIsland] = Seq.empty
+    ) derives CanEqual
+
+    /** Read-only stream of a COMPLETE HTML document (`<!DOCTYPE html>` ... `</html>`) for static-site
+      * generation and SSR. Like [[kyo.UI.runRender]], the first emission is the initial render and each
+      * later emission is a full re-render whenever any signal changes; unlike `runRender` (which emits
+      * a body FRAGMENT), this wraps the fragment in a document with a configurable head and an
+      * optional module `<script>`.
+      *
+      * The head is built from `head`: charset + viewport are always present, then the `meta`/`links`
+      * pairs, then a single `<style>` block containing [[kyo.UI.baseCss]] strictly before `head.css` so
+      * custom rules override the framework reset. The body holds the rendered UI fragment; the
+      * optional module script is emitted last, before `</html>`, so the page paints before the bundle
+      * loads. Take the first emission for a one-shot SSG snapshot.
+      *
+      * This is the SSG counterpart to [[kyo.UI.runHandlers]] (which serves a server-push page with the
+      * SSE client baked in): `runRenderPage` produces a static document that links YOUR bundle, with
+      * no kyo-ui server-push client injected.
+      */
+    def runRenderPage(head: PageHead)(ui: UI)(using Frame): Stream[String, Async] =
+        runRender(ui).map(fragment => HtmlRenderer.page(head, fragment))
+
+    /** The base CSS plus a stylesheet, ready to drop into [[kyo.UI.PageHead.css]]: returns
+      * `sheet.render` (the stylesheet alone). [[kyo.UI.runRenderPage]] already prepends [[kyo.UI.baseCss]],
+      * so pass `sheet.render` as `PageHead.css` directly; this helper is the named, discoverable
+      * bridge from a `Stylesheet` value to the page head, parallel to how `baseCss` is the bridge for
+      * the reset.
+      */
+    def stylesheetCss(sheet: Stylesheet)(using Frame): String = sheet.render
 
     /** A property value that is either a constant or a reactive [[kyo.SignalRef]].
       *
@@ -506,6 +644,14 @@ object UI:
                 withAttrs(attrs.copy(dataAttrs = attrs.dataAttrs ++ pairs))
             end data
 
+            /** Adds a CSS class to this element (emitted as `class="..."`); repeated calls space-join.
+              * The class is the stable hook a [[kyo.Stylesheet]] class rule ([[kyo.Selector.cls]])
+              * targets, so document-level rules (`@media`, shared component styles, `:hover` against a
+              * named class) apply to it. For per-element one-off styling use [[style]] instead; the two
+              * coexist on one element.
+              */
+            def cssClass(name: String): Self = withAttrs(attrs.copy(cssClasses = attrs.cssClasses :+ name))
+
             // Internal JS property setter (used by Checkbox.indeterminate, etc.)
             private[kyo] def jsProp(name: String, value: String): Self =
                 withAttrs(attrs.copy(jsProps = attrs.jsProps.updated(name, value)))
@@ -570,9 +716,11 @@ object UI:
           *
           * Recursive givens cover: direct `HtmlContent` values, `Reactive[C]`/`Foreach[A,C]`/`Fragment[C]` where `C` has an
           * `AsHtmlChild` witness (so a nested `Fragment[Fragment[...]]` and a `foreach`/`when` returning a `Fragment` are
-          * accepted), and union types `A | B` where both sides have witnesses. `AsHtmlChild[UI]` has no given, so a value
-          * statically typed as bare `UI` is still rejected; `AsHtmlChild[Svg.Circle]` has no given (SVG primitives do not extend
-          * `HtmlContent`), so SVG nodes are rejected. Each child is checked individually at the call site via the `HtmlChildVal`
+          * accepted), and union types `A | B` where both sides have witnesses. A lowest-priority
+          * `AsHtmlChild[UI]` given (in `AsHtmlChildLowestPriority`) accepts bare `UI` values as children; it resolves only
+          * when no higher-priority given matches, so named `HtmlContent` subtypes, wrappers, and fragments all resolve first.
+          * `AsHtmlChild[Svg.Circle]` has no given (SVG primitives do not extend `HtmlContent`), so SVG nodes are rejected.
+          * Each child is checked individually at the call site via the `HtmlChildVal`
           * implicit conversion, which avoids the LUB-widening that varargs would otherwise cause for heterogeneous arg lists.
           *
           * The `if cond then elem else UI.empty` idiom infers the branch union `A | Fragment[Nothing]`. The general `A | B`
@@ -594,11 +742,23 @@ object UI:
           */
         trait AsHtmlChild[T]
 
+        /** Lowest-priority `AsHtmlChild` given: allows bare `UI` values as children. This is the fallback
+          * for callers whose helpers return `UI` (rather than a specific `HtmlContent` subtype); the
+          * typed givens in `AsHtmlChild` and `AsHtmlChildLowPriority` take precedence for all named types.
+          * Correctness is maintained by `HtmlRenderer`, which handles every `UI` variant at runtime.
+          */
+        sealed trait AsHtmlChildLowestPriority:
+            given AsHtmlChild_UI: AsHtmlChild[UI] = new AsHtmlChild[UI] {}
+
         /** Lower-priority `AsHtmlChild` givens. Holds the `emptyOr` given for the `A | Fragment[Nothing]` branch union so it does
           * not create an ambiguity with the direct `Fragment` given when the static type is a bare `Fragment[Nothing]`.
           */
-        sealed trait AsHtmlChildLowPriority:
+        sealed trait AsHtmlChildLowPriority extends AsHtmlChildLowestPriority:
             given emptyOr[A <: UI](using AsHtmlChild[A]): AsHtmlChild[A | Fragment[Nothing]] = new AsHtmlChild[A | Fragment[Nothing]] {}
+            // RawHtml extends UI (not HtmlContent); given here at low priority so the
+            // HtmlContent-based given in AsHtmlChild takes precedence for HtmlContent subtypes.
+            given AsHtmlChild_RawHtml: AsHtmlChild[RawHtml] = new AsHtmlChild[RawHtml] {}
+        end AsHtmlChildLowPriority
 
         object AsHtmlChild extends AsHtmlChildLowPriority:
             given [T <: HtmlContent]: AsHtmlChild[T]                               = new AsHtmlChild[T] {}
@@ -765,6 +925,7 @@ object UI:
             ariaAttrs: Map[String, String] = Map.empty,
             dataAttrs: Map[String, String] = Map.empty,
             jsProps: Map[String, String] = Map.empty,
+            cssClasses: Chunk[String] = Chunk.empty,
             role: Maybe[String] = Absent
         )
 
@@ -772,6 +933,18 @@ object UI:
 
         /** A literal text node; a bare `String` child auto-lifts to one. */
         case class Text(value: String)(using val frame: Frame) extends UI with HtmlContent
+
+        /** Verbatim inline HTML passthrough node. The `value` string is emitted byte-for-byte into the rendered output with no HTML
+          * escaping. This is the AST counterpart to [[kyo.UI.rawHtml]].
+          *
+          * Security contract: `value` must come from a trusted, controlled source. There is no sanitization; passing user-supplied or
+          * externally-sourced strings here creates an XSS vulnerability. Use [[kyo.UI.Ast.Text]] (which escapes its argument) for any
+          * content that is not fully trusted.
+          *
+          * @param value
+          *   Trusted HTML string; rendered verbatim, no escaping applied.
+          */
+        case class RawHtml(value: String)(using val frame: Frame) extends UI
 
         /** A subtree driven by a `Signal[UI]`: re-renders the bound region whenever the signal emits a new value. The type parameter `C`
           * is a phantom bound that records the content type at the construction site; it erases to `UI` at runtime.
@@ -849,6 +1022,13 @@ object UI:
             def withAttrs(a: Attrs): Pre      = copy(attrs = a)
             def apply(cs: HtmlChildVal*): Pre = copy(children = children ++ Chunk.from(cs.map(_.value)))
         end Pre
+
+        final case class Blockquote(attrs: Attrs = Attrs(), children: Chunk[UI] = Chunk.empty)(using val frame: Frame) extends Block
+            with Interactive:
+            type Self = Blockquote
+            def withAttrs(a: Attrs): Blockquote      = copy(attrs = a)
+            def apply(cs: HtmlChildVal*): Blockquote = copy(children = children ++ Chunk.from(cs.map(_.value)))
+        end Blockquote
 
         final case class Code(attrs: Attrs = Attrs(), children: Chunk[UI] = Chunk.empty)(using val frame: Frame) extends Block
             with Interactive:

--- a/kyo-ui/shared/src/main/scala/kyo/internal/CssStyleRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/CssStyleRenderer.scala
@@ -14,12 +14,15 @@ private[kyo] object CssStyleRenderer:
         case Color.Rgb(r, g, b)     => s"rgb($r, $g, $b)"
         case Color.Rgba(r, g, b, a) => s"rgba($r, $g, $b, ${fmt(a)})"
         case Color.Transparent      => "transparent"
+        case Color.Var(name)        => s"var(--$name)"
 
     def size(s: Length): String = s match
-        case Length.Px(v)  => if v == 0 then "0" else s"${fmt(v)}px"
-        case Length.Pct(v) => s"${fmt(v)}%"
-        case Length.Em(v)  => s"${fmt(v)}em"
-        case Length.Auto   => "auto"
+        case Length.Px(v)   => if v == 0 then "0" else s"${fmt(v)}px"
+        case Length.Pct(v)  => s"${fmt(v)}%"
+        case Length.Em(v)   => s"${fmt(v)}em"
+        case Length.Vh(v)   => s"${fmt(v)}vh"
+        case Length.Calc(e) => s"calc($e)"
+        case Length.Auto    => "auto"
 
     def render(style: Style): String =
         val sb      = new StringBuilder
@@ -79,7 +82,22 @@ private[kyo] object CssStyleRenderer:
         case Overflow.scroll  => "scroll"
         case Overflow.auto    => "auto"
 
-    private def fontWeight(v: FontWeight): String = v match
+    private def scrollbarWidth(v: ScrollbarWidth): String = v match
+        case ScrollbarWidth.auto => "auto"
+        case ScrollbarWidth.thin => "thin"
+        case ScrollbarWidth.none => "none"
+
+    private def scrollbarGutter(v: ScrollbarGutter): String = v match
+        case ScrollbarGutter.auto            => "auto"
+        case ScrollbarGutter.stable          => "stable"
+        case ScrollbarGutter.stableBothEdges => "stable both-edges"
+
+    private def backgroundClip(v: BackgroundClip): String = v match
+        case BackgroundClip.borderBox  => "border-box"
+        case BackgroundClip.paddingBox => "padding-box"
+        case BackgroundClip.contentBox => "content-box"
+
+    private[kyo] def fontWeightCss(v: FontWeight): String = v match
         case FontWeight.normal => "normal"
         case FontWeight.bold   => "bold"
         case FontWeight.w100   => "100"
@@ -92,7 +110,7 @@ private[kyo] object CssStyleRenderer:
         case FontWeight.w800   => "800"
         case FontWeight.w900   => "900"
 
-    private def fontStyle(v: FontStyle): String = v match
+    private[kyo] def fontStyleCss(v: FontStyle): String = v match
         case FontStyle.normal => "normal"
         case FontStyle.italic => "italic"
 
@@ -135,6 +153,22 @@ private[kyo] object CssStyleRenderer:
         case Cursor.grab          => "grab"
         case Cursor.grabbing      => "grabbing"
 
+    private def easing(v: Easing): String = v match
+        case Easing.ease      => "ease"
+        case Easing.linear    => "linear"
+        case Easing.easeIn    => "ease-in"
+        case Easing.easeOut   => "ease-out"
+        case Easing.easeInOut => "ease-in-out"
+
+    private def transitionProperty(v: TransitionProperty): String = v match
+        case TransitionProperty.all             => "all"
+        case TransitionProperty.backgroundColor => "background-color"
+        case TransitionProperty.color           => "color"
+        case TransitionProperty.borderColor     => "border-color"
+        case TransitionProperty.opacity         => "opacity"
+        case TransitionProperty.transform       => "transform"
+        case TransitionProperty.Custom(name)    => name
+
     private def renderProp(prop: Prop): String = prop match
         case BgColor(c)          => s"background-color: ${color(c)};"
         case TextColor(c)        => s"color: ${color(c)};"
@@ -142,20 +176,28 @@ private[kyo] object CssStyleRenderer:
         case Margin(t, r, b, l)  => s"margin: ${size(t)} ${size(r)} ${size(b)} ${size(l)};"
         case Gap(v)              => s"gap: ${size(v)};"
         case FlexDirectionProp(d) => d match
-                case FlexDirection.row    => "flex-direction: row;"
-                case FlexDirection.column => "flex-direction: column;"
-        case Align(v)          => s"align-items: ${alignment(v)};"
-        case Justify(v)        => s"justify-content: ${justification(v)};"
-        case OverflowProp(v)   => s"overflow: ${overflow(v)};"
-        case Width(v)          => s"width: ${size(v)};"
-        case Height(v)         => s"height: ${size(v)};"
-        case MinWidth(v)       => s"min-width: ${size(v)};"
-        case MaxWidth(v)       => s"max-width: ${size(v)};"
-        case MinHeight(v)      => s"min-height: ${size(v)};"
-        case MaxHeight(v)      => s"max-height: ${size(v)};"
-        case FontSizeProp(v)   => s"font-size: ${size(v)};"
-        case FontWeightProp(v) => s"font-weight: ${fontWeight(v)};"
-        case FontStyleProp(v)  => s"font-style: ${fontStyle(v)};"
+                case FlexDirection.row           => "flex-direction: row;"
+                case FlexDirection.column        => "flex-direction: column;"
+                case FlexDirection.rowReverse    => "flex-direction: row-reverse;"
+                case FlexDirection.columnReverse => "flex-direction: column-reverse;"
+        case Align(v)                   => s"align-items: ${alignment(v)};"
+        case Justify(v)                 => s"justify-content: ${justification(v)};"
+        case OverflowProp(v)            => s"overflow: ${overflow(v)};"
+        case OverflowXProp(v)           => s"overflow-x: ${overflow(v)};"
+        case OverflowYProp(v)           => s"overflow-y: ${overflow(v)};"
+        case ScrollbarWidthProp(v)      => s"scrollbar-width: ${scrollbarWidth(v)};"
+        case ScrollbarColorProp(th, tr) => s"scrollbar-color: ${color(th)} ${color(tr)};"
+        case ScrollbarGutterProp(v)     => s"scrollbar-gutter: ${scrollbarGutter(v)};"
+        case BackgroundClipProp(v)      => s"background-clip: ${backgroundClip(v)};"
+        case Width(v)                   => s"width: ${size(v)};"
+        case Height(v)                  => s"height: ${size(v)};"
+        case MinWidth(v)                => s"min-width: ${size(v)};"
+        case MaxWidth(v)                => s"max-width: ${size(v)};"
+        case MinHeight(v)               => s"min-height: ${size(v)};"
+        case MaxHeight(v)               => s"max-height: ${size(v)};"
+        case FontSizeProp(v)            => s"font-size: ${size(v)};"
+        case FontWeightProp(v)          => s"font-weight: ${fontWeightCss(v)};"
+        case FontStyleProp(v)           => s"font-style: ${fontStyleCss(v)};"
         case FontFamilyProp(v) =>
             val cssValue = v match
                 case FontFamily.SansSerif    => "sans-serif"
@@ -176,6 +218,8 @@ private[kyo] object CssStyleRenderer:
                 case TextWrap.wrap     => "overflow-wrap: break-word;"
                 case TextWrap.noWrap   => "overflow-wrap: normal;"
                 case TextWrap.ellipsis => "overflow-wrap: normal; text-overflow: ellipsis;"
+                case TextWrap.balance  => "text-wrap: balance;"
+                case TextWrap.pretty   => "text-wrap: pretty;"
         case BorderColorProp(t, r, b, l)      => s"border-color: ${color(t)} ${color(r)} ${color(b)} ${color(l)};"
         case BorderWidthProp(t, r, b, l)      => s"border-width: ${size(t)} ${size(r)} ${size(b)} ${size(l)};"
         case BorderStyleProp(v)               => s"border-style: ${borderStyle(v)};"
@@ -186,15 +230,44 @@ private[kyo] object CssStyleRenderer:
         case CursorProp(v)       => s"cursor: ${cursor(v)};"
         case TranslateProp(x, y) => s"transform: translate(${size(x)}, ${size(y)});"
         case PositionProp(v) => v match
-                case Position.flow    => "position: static;"
-                case Position.overlay => "position: fixed; top: 0; left: 0; width: 100%; height: 100%;"
+                case Position.flow     => "position: static;"
+                case Position.overlay  => "position: fixed; top: 0; left: 0; width: 100%; height: 100%;"
+                case Position.relative => "position: relative;"
+                case Position.dropdown => "position: absolute; top: 100%; right: 0; z-index: 50;"
+                case Position.sticky   => "position: sticky;"
+                case Position.absolute => "position: absolute;"
+                case Position.fixed    => "position: fixed;"
+        case Top(v)                 => s"top: ${size(v)};"
+        case Right(v)               => s"right: ${size(v)};"
+        case Bottom(v)              => s"bottom: ${size(v)};"
+        case Left(v)                => s"left: ${size(v)};"
+        case ZIndexProp(v)          => s"z-index: $v;"
+        case AlignSelf(v)           => s"align-self: ${alignment(v)};"
+        case ScrollMarginTopProp(v) => s"scroll-margin-top: ${size(v)};"
+        case DisplayProp(v) => v match
+                case Display.block       => "display: block;"
+                case Display.inline      => "display: inline;"
+                case Display.inlineBlock => "display: inline-block;"
+                case Display.flex        => "display: flex;"
+                case Display.inlineFlex  => "display: inline-flex;"
+                case Display.listItem    => "display: list-item;"
+                case Display.table       => "display: table;"
+                case Display.tableRow    => "display: table-row;"
+                case Display.tableCell   => "display: table-cell;"
+        case ListStyleProp(v) => v match
+                case ListStyle.disc    => "list-style-type: disc;"
+                case ListStyle.decimal => "list-style-type: decimal;"
+                case ListStyle.none    => "list-style-type: none;"
+        case BorderCollapseProp(v) => v match
+                case BorderCollapse.collapse => "border-collapse: collapse;"
+                case BorderCollapse.separate => "border-collapse: separate;"
         case HiddenProp        => "display: none;"
         case FlexGrowProp(v)   => s"flex-grow: ${fmt(v)};"
         case FlexShrinkProp(v) => s"flex-shrink: ${fmt(v)};"
         case FlexBasisProp(v)  => s"flex-basis: ${size(v)};"
         case _: BrightnessProp | _: ContrastProp | _: GrayscaleProp | _: SepiaProp |
             _: InvertProp | _: SaturateProp | _: HueRotateProp | _: BlurProp => ""
-        case BgGradientProp(dir, colors, positions) =>
+        case BgGradientProp(dir, space, colors, positions) =>
             val cssDir = dir match
                 case GradientDirection.toRight       => "to right"
                 case GradientDirection.toLeft        => "to left"
@@ -204,7 +277,15 @@ private[kyo] object CssStyleRenderer:
                 case GradientDirection.toTopLeft     => "to top left"
                 case GradientDirection.toBottomRight => "to bottom right"
                 case GradientDirection.toBottomLeft  => "to bottom left"
-            val sb = new StringBuilder(s"background: linear-gradient($cssDir")
+            // The default sRGB space emits the bare direction; oklch/oklab append `in <space>` after the
+            // direction so the browser interpolates perceptually (no muddy grey midtone, far less 8-bit
+            // banding). The CSS spec order is `linear-gradient([<direction>] [in <color-space>]?, <stops>)`,
+            // so the color-interpolation-method comes AFTER the direction; the reversed form is rejected.
+            val prelude = space match
+                case GradientColorSpace.srgb  => cssDir
+                case GradientColorSpace.oklch => s"$cssDir in oklch"
+                case GradientColorSpace.oklab => s"$cssDir in oklab"
+            val sb = new StringBuilder(s"background: linear-gradient($prelude")
             (0 until colors.size).foreach { i =>
                 sb.append(s", ${color(colors(i))} ${fmt(positions(i))}%")
             }
@@ -213,6 +294,14 @@ private[kyo] object CssStyleRenderer:
         case FlexWrapProp(v) => v match
                 case FlexWrap.wrap   => "flex-wrap: wrap;"
                 case FlexWrap.noWrap => "flex-wrap: nowrap;"
+        case TransitionProp(prop, durationMs, ease) =>
+            s"transition: ${transitionProperty(prop)} ${durationMs}ms ${easing(ease)};"
+        case AnimationProp(name, durationMs, ease) =>
+            s"animation: $name ${durationMs}ms ${easing(ease)} both;"
+        case AnimationDelayProp(ms) =>
+            s"animation-delay: ${ms}ms;"
+        case StrokeDashoffsetProp(v) =>
+            s"stroke-dashoffset: ${fmt(v)};"
         case _: HoverProp | _: FocusProp | _: ActiveProp | _: DisabledProp => ""
 
 end CssStyleRenderer

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -46,6 +46,56 @@ private[kyo] object HtmlRenderer:
            |</body>
            |</html>""".stripMargin
 
+    /** Wrap body HTML in a complete static HTML document with a configurable head (for SSG/SSR).
+      *
+      * Unlike `renderPage` (which injects the SSE client JS for server-push), this helper emits a
+      * clean static document with an optional module script: the caller's bundle or nothing. The
+      * `baseCss` reset is always emitted before `head.css` so framework defaults can be overridden.
+      * Called by `UI.runRenderPage`.
+      */
+    private[kyo] def page(head: UI.PageHead, body: String): String =
+        val metaTags = head.meta.map((n, c) => s"""<meta name="${esc(n)}" content="${esc(c)}">""").mkString
+        val linkTags = head.links.map((r, h) => s"""<link rel="${esc(r)}" href="${esc(h)}">""").mkString
+        val script = head.moduleScript match
+            case Present(src) => s"""<script type="module" src="${esc(src)}"></script>"""
+            case Absent       => ""
+        val ldBlock = head.jsonLd match
+            case Present(di) => renderDataIsland(di)
+            case Absent      => ""
+        val islands = head.dataIslands.map(renderDataIsland).mkString
+        s"""<!DOCTYPE html>
+           |<html lang="en">
+           |<head>
+           |<meta charset="utf-8">
+           |<meta name="viewport" content="width=device-width, initial-scale=1">
+           |<title>${esc(head.title)}</title>
+           |$metaTags$linkTags
+           |<style>$baseCss${head.css}</style>
+           |$ldBlock</head>
+           |<body>$body$islands</body>
+           |$script
+           |</html>""".stripMargin
+    end page
+
+    // Render a data island as `<script type="..."[ id="..."]>ESCAPED-JSON</script>`. The type
+    // and id attributes use the HTML-entity escape (`esc`); the JSON body uses the JS-unicode
+    // escape (`escScript`) so a `</script>` substring renders as `</script>`, inert
+    // text the consumer's JSON.parse still reads, rather than the HTML-entity form `&lt;` that
+    // would change the bytes and break JSON.parse on read-back.
+    private def renderDataIsland(di: UI.DataIsland): String =
+        val idAttr = di.id match
+            case Present(v) => s""" id="${esc(v)}""""
+            case Absent     => ""
+        s"""<script type="${esc(di.scriptType)}"$idAttr>${escScript(di.json)}</script>"""
+    end renderDataIsland
+
+    // The single owner of the data-island body escape: a literal "</script>" in the JSON body
+    // would close the element early, so "<"/">" become their JSON unicode escapes. This is the
+    // JS-unicode form ("<"/">"), NOT the HTML-entity esc(...) form, because the body
+    // is JSON read back by JSON.parse, not HTML re-parsed.
+    private def escScript(json: String): String =
+        json.replace("<", "\\u003c").replace(">", "\\u003e")
+
     // ---- Core rendering ----
 
     private def renderTo(sb: StringBuilder, ui: UI, path: Seq[String], svg: Boolean = false)(using Frame): Unit < Sync =
@@ -92,6 +142,9 @@ private[kyo] object HtmlRenderer:
                         )
                     end if
                 end for
+
+            case UI.Ast.RawHtml(value) =>
+                w(sb, value)
 
             case UI.Ast.Text(value) =>
                 w(sb, esc(value))
@@ -170,6 +223,9 @@ private[kyo] object HtmlRenderer:
         val tabAttr   = dd.attrs.tabIndex.map(n => s""" tabindex="$n"""").getOrElse("")
         val styleAttr = CssStyleRenderer.render(dd.attrs.uiStyle)
         val styleStr  = if styleAttr.nonEmpty then s""" style="${esc(styleAttr)}"""" else ""
+        // The dropdown wrapper carries its cssClasses (the same `.cssClass(...)` hook every other
+        // element honors) so callers can style the trigger container via a class selector.
+        val clsStr = if dd.attrs.cssClasses.nonEmpty then s""" class="${esc(dd.attrs.cssClasses.mkString(" "))}"""" else ""
         // Determine initial trigger label
         val firstLabel    = dd.options.headMaybe.map(_._1).getOrElse("")
         val currentLabel  = Maybe.fromOption(dd.options.toSeq.find(_._2 == currentVal)).map(_._1).getOrElse(firstLabel)
@@ -179,7 +235,10 @@ private[kyo] object HtmlRenderer:
         val triggerDdAttr = if baseId.nonEmpty then s""" data-kyo-dropdown-trigger="${esc(baseId)}"""" else ""
         val optionsDdAttr = if baseId.nonEmpty then s""" data-kyo-dropdown-options="${esc(baseId)}"""" else ""
         // Wrapper div
-        w(sb, s"""<div data-kyo-path="$pathStr"$idAttr$ddAttr data-kyo-ev="click,keydown,change"$hidAttr$disAttr$tabAttr$styleStr>""")
+        w(
+            sb,
+            s"""<div data-kyo-path="$pathStr"$idAttr$clsStr$ddAttr data-kyo-ev="click,keydown,change"$hidAttr$disAttr$tabAttr$styleStr>"""
+        )
         // Trigger button
         w(sb, s"""<button$triggerId type="button"$triggerDdAttr tabindex="0">$triggerLabel</button>""")
         // Options container (hidden by default)
@@ -202,6 +261,7 @@ private[kyo] object HtmlRenderer:
         case _: Header         => "header"
         case _: Footer         => "footer"
         case _: Pre            => "pre"
+        case _: Blockquote     => "blockquote"
         case _: Code           => "code"
         case _: Ul             => "ul"
         case _: Ol             => "ol"
@@ -257,6 +317,7 @@ private[kyo] object HtmlRenderer:
 
     private def renderCommonAttrs(sb: StringBuilder, attrs: Attrs): Unit =
         attrs.identifier.foreach(id => w(sb, s""" id="${esc(id)}""""))
+        if attrs.cssClasses.nonEmpty then w(sb, s""" class="${esc(attrs.cssClasses.mkString(" "))}"""")
         attrs.hidden.foreach(v => if v then w(sb, " hidden"))
         attrs.tabIndex.foreach(n => w(sb, s""" tabindex="$n""""))
         attrs.focusTrap.foreach(v => if v then w(sb, """ data-kyo-focus-trap="1""""))
@@ -514,7 +575,7 @@ private[kyo] object HtmlRenderer:
 
     // ---- Helpers ----
 
-    private val baseCss =
+    private[kyo] val baseCss =
         """*, *::before, *::after { box-sizing: border-box; }
           |body { font-family: system-ui, -apple-system, sans-serif; margin: 0; padding: 0; }
           |div, section, main, header, footer, form, article, aside, p, ul, ol, pre, code, h1, h2, h3, h4, h5, h6, label { display: flex; flex-direction: column; }
@@ -1176,6 +1237,7 @@ private[kyo] object HtmlRenderer:
                 s.animKeySplines.foreach(v => svgAttr(sb, "keySplines", v))
                 s.animRepeatCount.foreach(v => svgAttr(sb, "repeatCount", v))
                 s.animBegin.foreach(v => svgAttr(sb, "begin", v))
+                s.animFill.foreach(v => svgAttr(sb, "fill", animFill(v)))
             case _: Svg.AnimateTransform =>
                 s.animAttributeName.foreach(v => svgAttr(sb, "attributeName", v))
                 s.animType.foreach(v => svgAttr(sb, "type", transformType(v)))
@@ -1184,14 +1246,17 @@ private[kyo] object HtmlRenderer:
                 s.animDur.foreach(v => svgAttr(sb, "dur", v))
                 s.animRepeatCount.foreach(v => svgAttr(sb, "repeatCount", v))
                 s.animBegin.foreach(v => svgAttr(sb, "begin", v))
+                s.animFill.foreach(v => svgAttr(sb, "fill", animFill(v)))
             case _: Svg.AnimateMotion =>
                 s.d.foreach(d => svgAttr(sb, "path", pathData(d)))
                 s.animDur.foreach(v => svgAttr(sb, "dur", v))
                 s.animRepeatCount.foreach(v => svgAttr(sb, "repeatCount", v))
+                s.animFill.foreach(v => svgAttr(sb, "fill", animFill(v)))
             case _: Svg.SetAnim =>
                 s.animAttributeName.foreach(v => svgAttr(sb, "attributeName", v))
                 s.animTo.foreach(v => svgAttr(sb, "to", v))
                 s.animBegin.foreach(v => svgAttr(sb, "begin", v))
+                s.animFill.foreach(v => svgAttr(sb, "fill", animFill(v)))
         end match
     end renderSvgAttrs
 
@@ -1209,6 +1274,7 @@ private[kyo] object HtmlRenderer:
         }
         s.strokeDashoffset.foreach(l => svgAttr(sb, "stroke-dashoffset", svgLength(l)))
         s.strokeMiterlimit.foreach(v => svgAttr(sb, "stroke-miterlimit", fmtD(v)))
+        s.pathLength.foreach(v => svgAttr(sb, "pathLength", fmtD(v)))
         s.opacity.foreach(v => svgAttr(sb, "opacity", fmtD(v)))
         if s.transform.nonEmpty then
             svgAttr(sb, "transform", s.transform.map(transform).mkString(" "))
@@ -1325,7 +1391,8 @@ private[kyo] object HtmlRenderer:
             val la = if largeArc then 1 else 0
             val sw = if sweep then 1 else 0
             s"a${fmtD(rx)} ${fmtD(ry)} ${fmtD(xRot)} $la $sw ${fmtD(dx)} ${fmtD(dy)}"
-        case Svg.PathCommand.Close => "Z"
+        case Svg.PathCommand.Close  => "Z"
+        case Svg.PathCommand.Raw(d) => d
 
     private def fillRule(r: Svg.FillRule): String = r match
         case Svg.FillRule.NonZero => "nonzero"
@@ -1418,5 +1485,9 @@ private[kyo] object HtmlRenderer:
         case Svg.TransformType.Rotate    => "rotate"
         case Svg.TransformType.SkewX     => "skewX"
         case Svg.TransformType.SkewY     => "skewY"
+
+    private def animFill(f: Svg.AnimFill): String = f match
+        case Svg.AnimFill.Freeze => "freeze"
+        case Svg.AnimFill.Remove => "remove"
 
 end HtmlRenderer

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
@@ -376,7 +376,9 @@ private[kyo] object ReactiveUI:
                             targetSatisfies(e.children(i), nodePath :+ seg, targetPath, predicate)
                         case _ => false
                     end match
-            case _: Text => false
+            // Text and RawHtml are leaf content with no kyo-addressable Element children, so no event
+            // target can resolve through them: neither can satisfy an Element predicate.
+            case _: Text | _: RawHtml => false
 
     private def isTargetDisabled(elem: Element, myPath: Seq[String], targetPath: Seq[String])(using Frame): Boolean < Sync =
         targetSatisfies(elem, myPath, targetPath, isDisabled)

--- a/kyo-ui/shared/src/test/scala/kyo/FormDemoQaItTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/FormDemoQaItTest.scala
@@ -560,7 +560,7 @@ class FormDemoQaItTest extends UITest:
         val rows = (1 to 60).map(i => UI.span(s"r$i").id(s"r$i"))
         withUI(UI.div(rows.map(UI.Ast.HtmlChildVal.lift(_))*).id("root")) {
             for
-                _ <- Browser.scrollTo(Selector.id("r60"))
+                _ <- Browser.scrollToElement(Selector.id("r60"))
                 _ <- Browser.assertText(Selector.id("r60"), "r60")
             yield ()
         }
@@ -954,7 +954,7 @@ class FormDemoQaItTest extends UITest:
         val rows = (1 to 60).map(i => UI.span(s"line$i").id(s"l$i"))
         withUI(UI.div(rows.map(UI.Ast.HtmlChildVal.lift(_))*).id("root")) {
             for
-                _ <- Browser.scrollTo(Selector.id("l60"))
+                _ <- Browser.scrollToElement(Selector.id("l60"))
                 _ <- Browser.assertText(Selector.id("l60"), "line60")
             yield ()
         }

--- a/kyo-ui/shared/src/test/scala/kyo/FormDemoRenderItTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/FormDemoRenderItTest.scala
@@ -101,7 +101,7 @@ class FormDemoRenderItTest extends UITest:
         withUI(app) {
             for
                 _ <- Browser.assertText(Selector.id("r0"), "row0")
-                _ <- Browser.scrollTo(Selector.id("r150"))
+                _ <- Browser.scrollToElement(Selector.id("r150"))
                 _ <- Browser.assertVisible(Selector.id("r150"))
                 _ <- Browser.assertText(Selector.id("r150"), "row150")
             yield ()

--- a/kyo-ui/shared/src/test/scala/kyo/LengthTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/LengthTest.scala
@@ -24,6 +24,32 @@ class LengthTest extends kyo.test.Test[Any]:
         assert(Length.resolve(Auto, 150) == 150)
     }
 
+    "Vh resolves as a percentage of the parent dimension" in {
+        assert(Length.resolve(Vh(50), 200) == 100)
+    }
+
+    "Calc resolves to the parent dimension (opaque expression)" in {
+        assert(Length.resolve(Calc("100vh - 60px"), 150) == 150)
+    }
+
+    "int extension .vh creates Vh" in {
+        assert((100.vh) == Vh(100.0))
+    }
+
+    "double extension .vh creates Vh" in {
+        assert((33.5.vh) == Vh(33.5))
+    }
+
+    "Vh equality" in {
+        assert(Vh(100) == Vh(100))
+        assert(Vh(100) != Vh(50))
+    }
+
+    "Calc equality" in {
+        assert(Calc("100vh - 60px") == Calc("100vh - 60px"))
+        assert(Calc("100vh - 60px") != Calc("100vh"))
+    }
+
     "resolveOrAuto on Px returns Present" in {
         assert(Length.resolveOrAuto(Px(10), 100) == kyo.Present(10))
     }

--- a/kyo-ui/shared/src/test/scala/kyo/RawHtmlTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/RawHtmlTest.scala
@@ -1,0 +1,92 @@
+package kyo
+
+import kyo.UI.*
+
+class RawHtmlTest extends kyo.test.Test[Any]:
+
+    // Helper: run the SSG renderer on a UI value and return the HTML string.
+    private def render(ui: UI)(using Frame): String < Async =
+        UI.runRender(ui).take(1).run.map(_.headMaybe.getOrElse(""))
+
+    "rawHtml emits verbatim, bypasses esc" in {
+        // <b>x</b> must appear byte-identical, not escaped.
+        render(rawHtml("<b>x</b>")).map { html =>
+            assert(html.contains("<b>x</b>"))
+            assert(!html.contains("&lt;b&gt;"))
+        }
+    }
+
+    "text escapes (boundary side by side)" in {
+        // UI.text must HTML-escape the same string.
+        render(Ast.Text("<b>x</b>")).map { html =>
+            assert(html.contains("&lt;b&gt;x&lt;/b&gt;"))
+            assert(!html.contains("<b>x</b>"))
+        }
+    }
+
+    "rawHtml inside an element renders inside its tags" in {
+        // the raw table must appear verbatim inside the div tags.
+        val snippet = "<table><tr><td>1</td></tr></table>"
+        render(div(rawHtml(snippet))).map { html =>
+            assert(html.contains(snippet))
+            assert(html.contains("<div"))
+        }
+    }
+
+    "inline-HTML snippet round-trips byte-identical" in {
+        // an inline <img>/<a><img></a> snippet with attributes must be byte-identical.
+        val snippet = """<a href="https://example.com"><img src="kyo.png" width="200" alt="Kyo"></a>"""
+        render(div(rawHtml(snippet))).map { html =>
+            assert(html.contains(snippet))
+        }
+    }
+
+    "rawHtml of empty string renders empty, no crash" in {
+        // empty rawHtml is valid: Ast.RawHtml("") writes its value verbatim (an empty
+        // string), so the rendered output is exactly the empty string with no injected markup.
+        render(rawHtml("")).map { html =>
+            assert(html == "", s"Expected empty string, got: '$html'")
+            assert(!html.contains("null"), s"Must not contain 'null': '$html'")
+            assert(!html.contains("undefined"), s"Must not contain 'undefined': '$html'")
+        }
+    }
+
+    "rawHtml under the page path renders verbatim in body (cross-addition)" in {
+        // inside a full HTML document the raw <p> appears verbatim in the body.
+        val doc = UI.runRenderPage(UI.PageHead(title = "t"))(div(rawHtml("<p>hi</p>")))
+        doc.take(1).run.map { frames =>
+            val html = frames.headMaybe.getOrElse("")
+            assert(html.contains("<p>hi</p>"))
+            assert(!html.contains("&lt;p&gt;hi&lt;/p&gt;"))
+        }
+    }
+
+    "reactive rawHtml re-renders on change" in {
+        // driving a SignalRef whose value is mapped through UI.rawHtml produces
+        // distinct frames, each containing the then-current raw HTML.
+        for
+            ref <- Signal.initRef("<b>initial</b>")
+            ui = ref.render(rawHtml(_))
+            html1 <- render(ui)
+            _     <- ref.set("<i>updated</i>")
+            html2 <- render(ui)
+        yield
+            assert(html1.contains("<b>initial</b>"), s"First frame: $html1")
+            assert(html2.contains("<i>updated</i>"), s"Second frame: $html2")
+        end for
+    }
+
+    "rawHtml pattern-matches as Ast.RawHtml (AST access)" in {
+        // UI.rawHtml returns Ast.RawHtml; case-class equality holds.
+        val node: UI = rawHtml("x")
+        val matched = node match
+            case Ast.RawHtml("x") => true
+            case _                => false
+        assert(matched)
+        assert(node == Ast.RawHtml("x"))
+    }
+
+    // The JS in-Chrome case folds into the existing in-Chrome smoke and is not
+    // represented as a shared JVM test here.
+
+end RawHtmlTest

--- a/kyo-ui/shared/src/test/scala/kyo/ReactiveTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/ReactiveTest.scala
@@ -610,6 +610,32 @@ class ReactiveTest extends UITest:
         }
     }
 
+    "signal render updates when the ref is set from a separate forked fiber (route-driven pattern)" in {
+        val app: UI < Async =
+            for
+                trigger <- Signal.initRef(0)
+                content <- Signal.initRef("before")
+                _ <- Fiber.initUnscoped {
+                    Loop.forever {
+                        for
+                            _ <- trigger.next
+                            _ <- content.set("after")
+                        yield Loop.continue(())
+                    }
+                }
+            yield UI.div(
+                content.render(v => UI.span(v).id("v")),
+                UI.button("Go").id("btn").onClick(trigger.set(1))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("v"), "before")
+                _ <- Browser.click(Selector.id("btn"))
+                _ <- Browser.assertText(Selector.id("v"), "after")
+            yield succeed
+        }
+    }
+
     "signal render switches element type" in {
         val app: UI < Async =
             for flag <- Signal.initRef(false)

--- a/kyo-ui/shared/src/test/scala/kyo/StyleTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/StyleTest.scala
@@ -210,6 +210,18 @@ class StyleTest extends kyo.test.Test[Any]:
             assert(Length.Auto.css == "auto")
         }
 
+        "vh" in {
+            assert(100.vh.css == "100vh")
+        }
+
+        "vh from double" in {
+            assert(33.5.vh.css == "33.5vh")
+        }
+
+        "calc" in {
+            assert(Length.Calc("100vh - 60px").css == "calc(100vh - 60px)")
+        }
+
         "zero" in {
             assert(0.px.css == "0")
         }
@@ -421,6 +433,22 @@ class StyleTest extends kyo.test.Test[Any]:
             assert(Style.textOverflow(Style.TextOverflow.clip).toCss == "text-overflow: clip;")
             assert(Style.textOverflow(Style.TextOverflow.ellipsis).toCss == "text-overflow: ellipsis;")
         }
+
+        "textWrap wrap/noWrap/ellipsis render overflow-wrap" in {
+            assert(Style.textWrap(Style.TextWrap.wrap).toCss == "overflow-wrap: break-word;")
+            assert(Style.textWrap(Style.TextWrap.noWrap).toCss == "overflow-wrap: normal;")
+            assert(Style.textWrap(Style.TextWrap.ellipsis).toCss == "overflow-wrap: normal; text-overflow: ellipsis;")
+        }
+
+        "textWrap balance and pretty render the CSS text-wrap property" in {
+            assert(Style.textWrap(Style.TextWrap.balance).toCss == "text-wrap: balance;")
+            assert(Style.textWrap(Style.TextWrap.pretty).toCss == "text-wrap: pretty;")
+        }
+
+        "textWrap selector overload builds the same prop as the direct form" in {
+            assert(Style.textWrap(_.balance).props(0) == Style.textWrap(Style.TextWrap.balance).props(0))
+            assert(Style.textWrap(_.pretty).toCss == "text-wrap: pretty;")
+        }
     }
 
     "borders" - {
@@ -598,6 +626,63 @@ class StyleTest extends kyo.test.Test[Any]:
             assert(Style.overflow(Style.Overflow.auto).toCss == "overflow: auto;")
         }
 
+        "overflowX single axis" in {
+            assert(Style.overflowX(Style.Overflow.auto).toCss == "overflow-x: auto;")
+            assert(Style.overflowX(Style.Overflow.hidden).toCss == "overflow-x: hidden;")
+            assert(Style.overflowX(_.scroll).toCss == "overflow-x: scroll;")
+        }
+
+        "overflowY single axis" in {
+            assert(Style.overflowY(Style.Overflow.auto).toCss == "overflow-y: auto;")
+            assert(Style.overflowY(Style.Overflow.hidden).toCss == "overflow-y: hidden;")
+            assert(Style.overflowY(_.visible).toCss == "overflow-y: visible;")
+        }
+
+        "overflowX and overflowY are distinct kinds that coexist" in {
+            // overflow-x and overflow-y are separate Prop cases, so both survive on one style; this is
+            // the rail's case (vertical scroll, horizontal clipped) without enabling both axes via the
+            // single `overflow` shorthand.
+            assert(
+                Style.overflowY(_.auto).overflowX(_.hidden).toCss == "overflow-y: auto; overflow-x: hidden;"
+            )
+        }
+
+        "single-axis overflow does not collapse into the both-axis overflow" in {
+            // The shorthand `overflow` is a different Prop kind from `overflowY`, so setting one does not
+            // replace the other under last-write-wins.
+            val s = Style.overflow(_.hidden).overflowY(_.auto)
+            assert(s.toCss == "overflow: hidden; overflow-y: auto;")
+        }
+
+        "scrollbarWidth renders the standard scrollbar-width keyword" in {
+            assert(Style.scrollbarWidth(Style.ScrollbarWidth.thin).toCss == "scrollbar-width: thin;")
+            assert(Style.scrollbarWidth(_.none).toCss == "scrollbar-width: none;")
+            assert(Style.scrollbarWidth(_.auto).toCss == "scrollbar-width: auto;")
+        }
+
+        "scrollbarColor renders thumb then track as the two-color scrollbar-color value" in {
+            val css = Style.scrollbarColor(Style.Color.rgba(0, 0, 0, 0.3), Style.Color.transparent).toCss
+            assert(css == "scrollbar-color: rgba(0, 0, 0, 0.3) transparent;")
+        }
+
+        "scrollbarWidth and scrollbarColor coexist with the axis overflow on one rail style" in {
+            val s = Style.overflowY(_.auto).scrollbarWidth(_.thin).scrollbarColor(Style.Color.rgba(0, 0, 0, 0.2), Style.Color.transparent)
+            assert(
+                s.toCss == "overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(0, 0, 0, 0.2) transparent;"
+            )
+        }
+
+        "scrollbarGutter renders the standard scrollbar-gutter keyword" in {
+            assert(Style.scrollbarGutter(Style.ScrollbarGutter.stable).toCss == "scrollbar-gutter: stable;")
+            assert(Style.scrollbarGutter(_.auto).toCss == "scrollbar-gutter: auto;")
+            assert(Style.scrollbarGutter(_.stableBothEdges).toCss == "scrollbar-gutter: stable both-edges;")
+        }
+
+        "backgroundClip renders the background-clip keyword (padding-box insets a transparent border)" in {
+            assert(Style.backgroundClip(Style.BackgroundClip.paddingBox).toCss == "background-clip: padding-box;")
+            assert(Style.backgroundClip(_.borderBox).toCss == "background-clip: border-box;")
+            assert(Style.backgroundClip(_.contentBox).toCss == "background-clip: content-box;")
+        }
     }
 
     "pseudo-states" - {
@@ -646,8 +731,319 @@ class StyleTest extends kyo.test.Test[Any]:
             assert(s.props(0) == Style.Prop.PositionProp(Position.overlay))
         }
 
+        "relative" in {
+            val s = Style.position(Position.relative)
+            assert(s.props(0) == Style.Prop.PositionProp(Position.relative))
+        }
+
+        "dropdown" in {
+            val s = Style.position(Position.dropdown)
+            assert(s.props(0) == Style.Prop.PositionProp(Position.dropdown))
+        }
+
+        "sticky emits only position: sticky (no bundled top/z-index)" in {
+            val s = Style.position(Position.sticky)
+            assert(s.props(0) == Style.Prop.PositionProp(Position.sticky))
+            assert(s.toCss == "position: sticky;")
+            assert(!s.toCss.contains("top:"))
+            assert(!s.toCss.contains("z-index:"))
+        }
+
+        "fixed emits only position: fixed (offsets/size set separately, unlike overlay)" in {
+            val s = Style.position(Position.fixed)
+            assert(s.props(0) == Style.Prop.PositionProp(Position.fixed))
+            assert(s.toCss == "position: fixed;")
+            assert(!s.toCss.contains("top:"))
+            assert(!s.toCss.contains("width:"))
+        }
+
+        "fixed composed with corner offsets (a floating button)" in {
+            val s = Style.position(_.fixed).left(16.px).bottom(16.px).zIndex(95)
+            assert(s.toCss.contains("position: fixed;"))
+            assert(s.toCss.contains("left: 16px;"))
+            assert(s.toCss.contains("bottom: 16px;"))
+        }
+
+        "sticky composed with explicit top + z-index" in {
+            val s = Style.position(_.sticky).top(60.px).zIndex(100)
+            assert(s.toCss.contains("position: sticky;"))
+            assert(s.toCss.contains("top: 60px;"))
+            assert(s.toCss.contains("z-index: 100;"))
+        }
+
         "enum values" in {
             assert(Position.flow != Position.overlay)
+            assert(Position.relative != Position.dropdown)
+            assert(Position.overlay != Position.dropdown)
+            assert(Position.sticky != Position.flow)
+            assert(Position.sticky != Position.overlay)
+            assert(Position.sticky != Position.relative)
+            assert(Position.sticky != Position.dropdown)
+        }
+    }
+
+    "top" - {
+        "px offset" in {
+            val s = Style.top(60.px)
+            assert(s.props(0) == Style.Prop.Top(Length.Px(60)))
+            assert(s.toCss == "top: 60px;")
+        }
+
+        "zero offset" in {
+            assert(Style.top(0.px).toCss == "top: 0;")
+        }
+
+        "last-write-wins" in {
+            val s = Style.top(10.px).top(20.px)
+            assert(s.props.size == 1)
+            assert(s.toCss == "top: 20px;")
+        }
+
+        "companion equals instance" in {
+            assert(Style.top(5.px).props(0) == Style.empty.top(5.px).props(0))
+        }
+    }
+
+    "right/bottom/left offsets" - {
+        "each renders its own CSS property" in {
+            assert(Style.right(8.px).toCss == "right: 8px;")
+            assert(Style.bottom(0.px).toCss == "bottom: 0;")
+            assert(Style.left(12.px).toCss == "left: 12px;")
+        }
+
+        "top and right are distinct kinds that coexist for a corner float" in {
+            val s = Style.position(_.absolute).top(8.px).right(8.px)
+            assert(s.toCss.contains("top: 8px;"))
+            assert(s.toCss.contains("right: 8px;"))
+        }
+    }
+
+    "zIndex" - {
+        "renders z-index" in {
+            val s = Style.zIndex(100)
+            assert(s.props(0) == Style.Prop.ZIndexProp(100))
+            assert(s.toCss == "z-index: 100;")
+        }
+
+        "last-write-wins" in {
+            val s = Style.zIndex(1).zIndex(50)
+            assert(s.props.size == 1)
+            assert(s.toCss == "z-index: 50;")
+        }
+
+        "companion equals instance" in {
+            assert(Style.zIndex(7).props(0) == Style.empty.zIndex(7).props(0))
+        }
+    }
+
+    "alignSelf" - {
+        "flex-start" in {
+            val s = Style.alignSelf(Alignment.start)
+            assert(s.props(0) == Style.Prop.AlignSelf(Alignment.start))
+            assert(s.toCss == "align-self: flex-start;")
+        }
+
+        "center" in {
+            assert(Style.alignSelf(Alignment.center).toCss == "align-self: center;")
+        }
+
+        "stretch" in {
+            assert(Style.alignSelf(Alignment.stretch).toCss == "align-self: stretch;")
+        }
+
+        "selector overload" in {
+            val s = Style.alignSelf(_.start)
+            assert(s.props(0) == Style.Prop.AlignSelf(Alignment.start))
+        }
+
+        "companion equals instance" in {
+            assert(Style.alignSelf(Alignment.start).props(0) == Style.empty.alignSelf(Alignment.start).props(0))
+        }
+    }
+
+    "scrollMarginTop" - {
+        "px value" in {
+            val s = Style.scrollMarginTop(72.px)
+            assert(s.props(0) == Style.Prop.ScrollMarginTopProp(Length.Px(72)))
+            assert(s.toCss == "scroll-margin-top: 72px;")
+        }
+
+        "last-write-wins" in {
+            val s = Style.scrollMarginTop(60.px).scrollMarginTop(72.px)
+            assert(s.props.size == 1)
+            assert(s.toCss == "scroll-margin-top: 72px;")
+        }
+
+        "companion equals instance" in {
+            assert(Style.scrollMarginTop(72.px).props(0) == Style.empty.scrollMarginTop(72.px).props(0))
+        }
+    }
+
+    "display" - {
+        "block" in {
+            val s = Style.display(Display.block)
+            assert(s.nonEmpty)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.block))
+            assert(s.toCss == "display: block;")
+        }
+
+        "inline" in {
+            val s = Style.display(Display.inline)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.inline))
+            assert(s.toCss == "display: inline;")
+        }
+
+        "inlineBlock" in {
+            val s = Style.display(Display.inlineBlock)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.inlineBlock))
+            assert(s.toCss == "display: inline-block;")
+        }
+
+        "flex" in {
+            val s = Style.display(Display.flex)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.flex))
+            assert(s.toCss == "display: flex;")
+        }
+
+        "inlineFlex" in {
+            val s = Style.display(Display.inlineFlex)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.inlineFlex))
+            assert(s.toCss == "display: inline-flex;")
+        }
+
+        "listItem" in {
+            val s = Style.display(Display.listItem)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.listItem))
+            assert(s.toCss == "display: list-item;")
+        }
+
+        "table" in {
+            val s = Style.display(Display.table)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.table))
+            assert(s.toCss == "display: table;")
+        }
+
+        "tableRow" in {
+            val s = Style.display(Display.tableRow)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.tableRow))
+            assert(s.toCss == "display: table-row;")
+        }
+
+        "tableCell" in {
+            val s = Style.display(Display.tableCell)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.tableCell))
+            assert(s.toCss == "display: table-cell;")
+        }
+
+        "block convenience" in {
+            assert(Style.block.props(0) == Style.Prop.DisplayProp(Display.block))
+            assert(Style.block.toCss == "display: block;")
+        }
+
+        "inline convenience" in {
+            assert(Style.inline.props(0) == Style.Prop.DisplayProp(Display.inline))
+            assert(Style.inline.toCss == "display: inline;")
+        }
+
+        "inlineBlock convenience" in {
+            assert(Style.inlineBlock.props(0) == Style.Prop.DisplayProp(Display.inlineBlock))
+            assert(Style.inlineBlock.toCss == "display: inline-block;")
+        }
+
+        "listItem convenience" in {
+            assert(Style.listItem.props(0) == Style.Prop.DisplayProp(Display.listItem))
+            assert(Style.listItem.toCss == "display: list-item;")
+        }
+
+        "table convenience" in {
+            assert(Style.table.props(0) == Style.Prop.DisplayProp(Display.table))
+            assert(Style.table.toCss == "display: table;")
+        }
+
+        "tableRow convenience" in {
+            assert(Style.tableRow.props(0) == Style.Prop.DisplayProp(Display.tableRow))
+            assert(Style.tableRow.toCss == "display: table-row;")
+        }
+
+        "tableCell convenience" in {
+            assert(Style.tableCell.props(0) == Style.Prop.DisplayProp(Display.tableCell))
+            assert(Style.tableCell.toCss == "display: table-cell;")
+        }
+
+        "selector overload" in {
+            val s = Style.display(_.inline)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.inline))
+        }
+
+        "dedup keeps last write" in {
+            val s = Style.block.inline
+            assert(s.props.size == 1)
+            assert(s.props(0) == Style.Prop.DisplayProp(Display.inline))
+            assert(s.toCss == "display: inline;")
+        }
+
+        "enum values" in {
+            assert(Display.block != Display.inline)
+            assert(Display.inline != Display.inlineBlock)
+            assert(Display.inlineBlock != Display.listItem)
+            assert(Display.listItem != Display.block)
+            assert(Display.table != Display.tableRow)
+            assert(Display.tableRow != Display.tableCell)
+            assert(Display.tableCell != Display.block)
+        }
+    }
+
+    "listStyle" - {
+        "disc" in {
+            val s = Style.listStyle(ListStyle.disc)
+            assert(s.props(0) == Style.Prop.ListStyleProp(ListStyle.disc))
+            assert(s.toCss == "list-style-type: disc;")
+        }
+
+        "decimal" in {
+            val s = Style.listStyle(ListStyle.decimal)
+            assert(s.props(0) == Style.Prop.ListStyleProp(ListStyle.decimal))
+            assert(s.toCss == "list-style-type: decimal;")
+        }
+
+        "none" in {
+            val s = Style.listStyle(ListStyle.none)
+            assert(s.props(0) == Style.Prop.ListStyleProp(ListStyle.none))
+            assert(s.toCss == "list-style-type: none;")
+        }
+
+        "selector overload" in {
+            val s = Style.listStyle(_.decimal)
+            assert(s.props(0) == Style.Prop.ListStyleProp(ListStyle.decimal))
+        }
+
+        "enum values" in {
+            assert(ListStyle.disc != ListStyle.decimal)
+            assert(ListStyle.decimal != ListStyle.none)
+            assert(ListStyle.none != ListStyle.disc)
+        }
+    }
+
+    "borderCollapse" - {
+        "collapse" in {
+            val s = Style.borderCollapse(BorderCollapse.collapse)
+            assert(s.props(0) == Style.Prop.BorderCollapseProp(BorderCollapse.collapse))
+            assert(s.toCss == "border-collapse: collapse;")
+        }
+
+        "separate" in {
+            val s = Style.borderCollapse(BorderCollapse.separate)
+            assert(s.props(0) == Style.Prop.BorderCollapseProp(BorderCollapse.separate))
+            assert(s.toCss == "border-collapse: separate;")
+        }
+
+        "selector overload" in {
+            val s = Style.borderCollapse(_.collapse)
+            assert(s.props(0) == Style.Prop.BorderCollapseProp(BorderCollapse.collapse))
+        }
+
+        "enum values" in {
+            assert(BorderCollapse.collapse != BorderCollapse.separate)
         }
     }
 
@@ -682,6 +1078,31 @@ class StyleTest extends kyo.test.Test[Any]:
         "flexBasis renders flex-basis css" in {
             assert(Style.flexBasis(Length.zero).toCss == "flex-basis: 0;")
             assert(Style.flexBasis(50.pct).toCss == "flex-basis: 50%;")
+        }
+    }
+
+    "flex direction" - {
+        "row sets FlexDirectionProp(row)" in {
+            assert(Style.row.props(0) == Style.Prop.FlexDirectionProp(Style.FlexDirection.row))
+        }
+
+        "column sets FlexDirectionProp(column)" in {
+            assert(Style.column.props(0) == Style.Prop.FlexDirectionProp(Style.FlexDirection.column))
+        }
+
+        "rowReverse sets FlexDirectionProp(rowReverse)" in {
+            assert(Style.rowReverse.props(0) == Style.Prop.FlexDirectionProp(Style.FlexDirection.rowReverse))
+        }
+
+        "columnReverse sets FlexDirectionProp(columnReverse)" in {
+            assert(Style.columnReverse.props(0) == Style.Prop.FlexDirectionProp(Style.FlexDirection.columnReverse))
+        }
+
+        "renders flex-direction css for every direction" in {
+            assert(Style.row.toCss == "flex-direction: row;")
+            assert(Style.column.toCss == "flex-direction: column;")
+            assert(Style.rowReverse.toCss == "flex-direction: row-reverse;")
+            assert(Style.columnReverse.toCss == "flex-direction: column-reverse;")
         }
     }
 
@@ -794,6 +1215,169 @@ class StyleTest extends kyo.test.Test[Any]:
             )
             assert(s.props.size == 2)
         }
+
+        "default color space is srgb" in {
+            val s = Style.bgGradient(GradientDirection.toBottom, (Color.hex("#fff").get, 0.pct), (Color.hex("#000").get, 100.pct))
+            val prop = s.props(0) match
+                case p: Style.Prop.BgGradientProp => p
+                case other                        => fail(s"Expected BgGradientProp, got ${other.getClass.getSimpleName}")
+            assert(prop.colorSpace == GradientColorSpace.srgb)
+        }
+
+        "explicit oklch color space is stored on the prop" in {
+            val s = Style.bgGradient(
+                GradientDirection.toBottom,
+                GradientColorSpace.oklch,
+                (Color.hex("#fff").get, 0.pct),
+                (Color.hex("#000").get, 100.pct)
+            )
+            val prop = s.props(0) match
+                case p: Style.Prop.BgGradientProp => p
+                case other                        => fail(s"Expected BgGradientProp, got ${other.getClass.getSimpleName}")
+            assert(prop.colorSpace == GradientColorSpace.oklch)
+            assert(prop.colors.size == 2)
+        }
+
+        "oklab color space via the inline-direction overload" in {
+            val s = Style.bgGradient(
+                _.toBottom,
+                GradientColorSpace.oklab,
+                (Color.hex("#fff").get, 0.pct),
+                (Color.hex("#123").get, 40.pct),
+                (Color.hex("#000").get, 100.pct)
+            )
+            val prop = s.props(0) match
+                case p: Style.Prop.BgGradientProp => p
+                case other                        => fail(s"Expected BgGradientProp, got ${other.getClass.getSimpleName}")
+            assert(prop.colorSpace == GradientColorSpace.oklab)
+            assert(prop.direction == GradientDirection.toBottom)
+            assert(prop.colors.size == 3)
+        }
+
+        "color space renders to the `in <space>` gradient prelude" in {
+            val srgb = Style.bgGradient(GradientDirection.toBottom, (Color.red, 0.pct), (Color.blue, 100.pct)).toCss
+            assert(srgb.contains("linear-gradient(to bottom"), srgb)
+            assert(!srgb.contains("in oklch"), srgb)
+            val oklch = Style.bgGradient(
+                GradientDirection.toBottom,
+                GradientColorSpace.oklch,
+                (Color.red, 0.pct),
+                (Color.blue, 100.pct)
+            ).toCss
+            // CSS spec order: the color-interpolation-method follows the direction.
+            assert(oklch.contains("linear-gradient(to bottom in oklch,"), oklch)
+        }
+    }
+
+    "transition" - {
+        "single property renders transition css" in {
+            val s = Style.transition(TransitionProperty.backgroundColor, 150, Easing.ease)
+            assert(s.toCss == "transition: background-color 150ms ease;")
+        }
+
+        "all shorthand renders transition: all" in {
+            val s = Style.transition(200, Easing.easeOut)
+            assert(s.toCss == "transition: all 200ms ease-out;")
+        }
+
+        "selector overloads build the same prop as direct" in {
+            val a = Style.transition(_.color, 100, _.easeInOut)
+            val b = Style.transition(TransitionProperty.color, 100, Easing.easeInOut)
+            assert(a.props(0) == b.props(0))
+            assert(a.toCss == "transition: color 100ms ease-in-out;")
+        }
+
+        "negative duration clamps to zero" in {
+            val s = Style.transition(TransitionProperty.opacity, -50, Easing.linear)
+            assert(s.toCss == "transition: opacity 0ms linear;")
+        }
+
+        "every TransitionProperty renders its css name" in {
+            assert(Style.transition(TransitionProperty.all, 1, Easing.ease).toCss == "transition: all 1ms ease;")
+            assert(Style.transition(TransitionProperty.backgroundColor, 1, Easing.ease).toCss == "transition: background-color 1ms ease;")
+            assert(Style.transition(TransitionProperty.color, 1, Easing.ease).toCss == "transition: color 1ms ease;")
+            assert(Style.transition(TransitionProperty.borderColor, 1, Easing.ease).toCss == "transition: border-color 1ms ease;")
+            assert(Style.transition(TransitionProperty.opacity, 1, Easing.ease).toCss == "transition: opacity 1ms ease;")
+            assert(Style.transition(TransitionProperty.transform, 1, Easing.ease).toCss == "transition: transform 1ms ease;")
+            assert(Style.transition(TransitionProperty.Custom("left"), 1, Easing.ease).toCss == "transition: left 1ms ease;")
+        }
+
+        "every Easing renders its css name" in {
+            assert(Style.transition(0, Easing.ease).toCss == "transition: all 0ms ease;")
+            assert(Style.transition(0, Easing.linear).toCss == "transition: all 0ms linear;")
+            assert(Style.transition(0, Easing.easeIn).toCss == "transition: all 0ms ease-in;")
+            assert(Style.transition(0, Easing.easeOut).toCss == "transition: all 0ms ease-out;")
+            assert(Style.transition(0, Easing.easeInOut).toCss == "transition: all 0ms ease-in-out;")
+        }
+
+        "last-write-wins on the transition kind" in {
+            val s = Style.transition(150, Easing.ease).transition(300, Easing.linear)
+            assert(s.props.size == 1)
+            assert(s.toCss == "transition: all 300ms linear;")
+        }
+    }
+
+    "animation" - {
+        "renders animation css with both fill mode" in {
+            val s = Style.animation("fade-in", 200, Easing.easeOut)
+            assert(s.toCss == "animation: fade-in 200ms ease-out both;")
+        }
+
+        "selector easing overload builds the same prop" in {
+            val a = Style.animation("fade-in", 200, (_: Easing.type).easeOut)
+            val b = Style.animation("fade-in", 200, Easing.easeOut)
+            assert(a.props(0) == b.props(0))
+        }
+
+        "negative duration clamps to zero" in {
+            val s = Style.animation("x", -10, Easing.ease)
+            assert(s.toCss == "animation: x 0ms ease both;")
+        }
+
+        "last-write-wins on the animation kind" in {
+            val s = Style.animation("a", 100, Easing.ease).animation("b", 200, Easing.linear)
+            assert(s.props.size == 1)
+            assert(s.toCss == "animation: b 200ms linear both;")
+        }
+
+        "coexists with transition (distinct kinds)" in {
+            val s = Style.transition(150, Easing.ease).animation("slide", 180, Easing.easeOut)
+            assert(s.props.size == 2)
+            assert(s.toCss.contains("transition: all 150ms ease;"))
+            assert(s.toCss.contains("animation: slide 180ms ease-out both;"))
+        }
+    }
+
+    "animationDelay" - {
+        "renders animation-delay css" in {
+            assert(Style.animationDelay(150).toCss == "animation-delay: 150ms;")
+        }
+
+        "allows a negative delay (starts mid-animation)" in {
+            assert(Style.animationDelay(-200).toCss == "animation-delay: -200ms;")
+        }
+
+        "is a distinct kind that coexists with animation, for staggered cascades" in {
+            val s = Style.animation("heroline", 320, Easing.easeOut).animationDelay(96)
+            assert(s.props.size == 2)
+            assert(s.toCss.contains("animation: heroline 320ms ease-out both;"))
+            assert(s.toCss.contains("animation-delay: 96ms;"))
+        }
+    }
+
+    "strokeDashoffset" - {
+        "renders unitless stroke-dashoffset css (for a pathLength-normalized stroke draw)" in {
+            assert(Style.strokeDashoffset(1.0).toCss == "stroke-dashoffset: 1;")
+            assert(Style.strokeDashoffset(0.0).toCss == "stroke-dashoffset: 0;")
+        }
+
+        "is the keyframe value an SVG stroke-draw animation tweens between" in {
+            // The gap chart's `gapdraw` keyframe goes from offset 1 (hidden) to 0 (drawn).
+            val from = Style.strokeDashoffset(1.0)
+            val to   = Style.strokeDashoffset(0.0)
+            assert(from.toCss == "stroke-dashoffset: 1;")
+            assert(to.toCss == "stroke-dashoffset: 0;")
+        }
     }
 
     "disabled pseudo-state" - {
@@ -853,6 +1437,18 @@ class StyleTest extends kyo.test.Test[Any]:
             assert(Style.position(Position.flow).props(0) == Style.empty.position(Position.flow).props(0))
         }
 
+        "display" in {
+            assert(Style.display(Display.block).props(0) == Style.empty.display(Display.block).props(0))
+            assert(Style.block.props(0) == Style.empty.block.props(0))
+            assert(Style.inline.props(0) == Style.empty.inline.props(0))
+            assert(Style.inlineBlock.props(0) == Style.empty.inlineBlock.props(0))
+            assert(Style.listItem.props(0) == Style.empty.listItem.props(0))
+        }
+
+        "listStyle" in {
+            assert(Style.listStyle(ListStyle.disc).props(0) == Style.empty.listStyle(ListStyle.disc).props(0))
+        }
+
         "flexGrow" in {
             assert(Style.flexGrow(1.0).props(0) == Style.empty.flexGrow(1.0).props(0))
         }
@@ -885,6 +1481,18 @@ class StyleTest extends kyo.test.Test[Any]:
             assert(pa.direction == pb.direction)
             assert(pa.colors.size == pb.colors.size)
             assert(pa.positions.size == pb.positions.size)
+        }
+
+        "transition" in {
+            assert(Style.transition(150, Easing.ease).props(0) == Style.empty.transition(150, Easing.ease).props(0))
+            assert(
+                Style.transition(TransitionProperty.color, 100, Easing.linear).props(0) ==
+                    Style.empty.transition(TransitionProperty.color, 100, Easing.linear).props(0)
+            )
+        }
+
+        "animation" in {
+            assert(Style.animation("x", 200, Easing.easeOut).props(0) == Style.empty.animation("x", 200, Easing.easeOut).props(0))
         }
 
         "disabled" in {

--- a/kyo-ui/shared/src/test/scala/kyo/StylesheetTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/StylesheetTest.scala
@@ -1,0 +1,213 @@
+package kyo
+
+import scala.language.implicitConversions
+
+class StylesheetTest extends kyo.test.Test[Any]:
+
+    import Stylesheet.*
+
+    "rule with class name renders selector plus CssStyleRenderer body" in {
+        val css = Stylesheet.rule("btn", Style.bg(Style.Color.blue)).render
+        assert(css.contains(".btn {"))
+        assert(css.contains("background-color: #3b82f6;"))
+    }
+
+    "rule with hover pseudo-state renders base block and :hover block" in {
+        val css = Stylesheet.rule("btn", Style.bg(Style.Color.blue).hover(_.bg(_.indigo))).render
+        assert(css.contains(".btn {"))
+        assert(css.contains(".btn:hover {"))
+        assert(css.contains("background-color: #6366f1;"))
+    }
+
+    "Selector.cls descendant pseudo hover" in {
+        val sel = Selector.cls("a").descendant(Selector.cls("b")).pseudo("hover")
+        assert(sel.css == ".a .b:hover")
+    }
+
+    "Selector factories produce correct CSS text" in {
+        assert(Selector.id("hero").css == "#hero")
+        assert(Selector.data("active", "true").css == "[data-active=\"true\"]")
+        assert(Selector.data("open").css == "[data-open]")
+        assert(Selector.tag("body").css == "body")
+    }
+
+    "media query wraps inner rule in @media block" in {
+        val css = Stylesheet.media(MediaQuery.minWidth(768.px))(
+            Stylesheet.rule("grid", Style.column)
+        ).render
+        assert(css.contains("@media (min-width: 768px)"))
+        assert(css.contains(".grid {"))
+        assert(css.contains("flex-direction: column;"))
+    }
+
+    "MediaQuery.and combines conditions" in {
+        val q = MediaQuery.minWidth(768.px).and(MediaQuery.prefersDark)
+        assert(q.condition == "(min-width: 768px) and (prefers-color-scheme: dark)")
+    }
+
+    "reduced-motion media queries target reduce and no-preference" in {
+        assert(MediaQuery.prefersReducedMotion.condition == "(prefers-reduced-motion: reduce)")
+        assert(MediaQuery.prefersReducedMotionNoPreference.condition == "(prefers-reduced-motion: no-preference)")
+        val css = Stylesheet.media(MediaQuery.prefersReducedMotionNoPreference)(
+            Stylesheet.rule("hl", Style.animation("heroline", 320, Style.Easing.easeOut))
+        ).render
+        assert(css.contains("@media (prefers-reduced-motion: no-preference)"))
+        assert(css.contains("animation: heroline 320ms ease-out both;"))
+    }
+
+    "vars produces :root { --k: v; } block" in {
+        val css = Stylesheet.vars("accent" -> "#3b82f6", "gap" -> "16px").render
+        assert(css.contains(":root {"))
+        assert(css.contains("--accent: #3b82f6;"))
+        assert(css.contains("--gap: 16px;"))
+    }
+
+    "scopedVars produces selector { --k: v; } block (theme override)" in {
+        val css = Stylesheet.scopedVars(Selector.data("theme", "dark"), "bg" -> "#14130D", "ink" -> "#F4F1EA").render
+        assert(css.contains("[data-theme=\"dark\"] {"))
+        assert(css.contains("--bg: #14130D;"))
+        assert(css.contains("--ink: #F4F1EA;"))
+    }
+
+    "Color.variable renders as var(--name) in a rule" in {
+        val css = Stylesheet.rule("x", Style.color(Style.Color.variable("accent"))).render
+        assert(css.contains("color: var(--accent);"))
+    }
+
+    "fontFace renders @font-face block with family, src, and font-display: swap" in {
+        val css = Stylesheet.fontFace(
+            FontFace("Inter", Seq("/f/inter.woff2" -> "woff2"))
+        ).render
+        assert(css.contains("@font-face {"))
+        assert(css.contains("font-family: \"Inter\""))
+        assert(css.contains("url(\"/f/inter.woff2\") format(\"woff2\")"))
+        assert(css.contains("font-display: swap"))
+    }
+
+    "keyframes renders @keyframes block with from/to frames" in {
+        val css = Stylesheet.keyframes(
+            "fade-in",
+            Stylesheet.Keyframe.from -> Style.opacity(0.0).translate(0.px, (-6).px),
+            Stylesheet.Keyframe.to   -> Style.opacity(1.0).translate(0.px, 0.px)
+        ).render
+        assert(css.contains("@keyframes fade-in {"))
+        assert(css.contains("0% {"))
+        assert(css.contains("100% {"))
+        assert(css.contains("opacity: 0;"))
+        assert(css.contains("opacity: 1;"))
+        assert(css.contains("transform: translate(0, -6px);"))
+        assert(css.contains("transform: translate(0, 0);"))
+        assert(css.trim.endsWith("}"))
+    }
+
+    "Keyframe.at clamps percentage to 0..100 and renders an integer percent" in {
+        val css = Stylesheet.keyframes(
+            "mid",
+            Stylesheet.Keyframe.at(-10) -> Style.opacity(0.0),
+            Stylesheet.Keyframe.at(50)  -> Style.opacity(0.5),
+            Stylesheet.Keyframe.at(150) -> Style.opacity(1.0)
+        ).render
+        assert(css.contains("0% {"))
+        assert(css.contains("50% {"))
+        assert(css.contains("100% {"))
+    }
+
+    "an animation prop references a registered @keyframes block by name" in {
+        val css = (
+            Stylesheet.keyframes("fade-in", Stylesheet.Keyframe.from -> Style.opacity(0.0), Stylesheet.Keyframe.to -> Style.opacity(1.0)) ++
+                Stylesheet.rule("panel", Style.animation("fade-in", 200, Style.Easing.easeOut))
+        ).render
+        assert(css.contains("@keyframes fade-in {"))
+        assert(css.contains(".panel {"))
+        assert(css.contains("animation: fade-in 200ms ease-out both;"))
+    }
+
+    "keyframes drops nested pseudo-states (not valid inside @keyframes)" in {
+        val css = Stylesheet.keyframes(
+            "x",
+            Stylesheet.Keyframe.from -> Style.opacity(0.0).hover(_.opacity(0.9)),
+            Stylesheet.Keyframe.to   -> Style.opacity(1.0)
+        ).render
+        assert(css.contains("@keyframes x {"))
+        assert(!css.contains(":hover"))
+        assert(css.contains("opacity: 0;"))
+    }
+
+    "entry order is preserved: rule A before media M before vars V" in {
+        val css = (
+            Stylesheet.rule("a", Style.row) ++
+                Stylesheet.media(MediaQuery.raw("screen"))(Stylesheet.rule("b", Style.column)) ++
+                Stylesheet.vars("x" -> "1")
+        ).render
+        val idxA = css.indexOf(".a {")
+        val idxM = css.indexOf("@media screen")
+        val idxV = css.indexOf(":root {")
+        assert(idxA >= 0 && idxM >= 0 && idxV >= 0)
+        assert(idxA < idxM && idxM < idxV)
+    }
+
+    "Stylesheet.empty.render is empty string; ++ identity laws hold" in {
+        assert(Stylesheet.empty.render == "")
+        val a = Stylesheet.rule("a", Style.row)
+        assert((a ++ Stylesheet.empty) == a)
+        assert((Stylesheet.empty ++ a) == a)
+    }
+
+    "Stylesheet and Entry derive CanEqual; equal sheets compare equal" in {
+        val a = Stylesheet.rule("btn", Style.bg(Style.Color.blue))
+        val b = Stylesheet.rule("btn", Style.bg(Style.Color.blue))
+        assert(a == b)
+        assert(Stylesheet.empty == Stylesheet.empty)
+    }
+
+    "runRenderPage with sheet.render: baseCss strictly before .feat-grid rule" in {
+        val sheet = Stylesheet.rule("feat-grid", Style.row)
+        val css   = sheet.render
+        val head  = UI.PageHead(title = "t", css = css)
+        UI.runRenderPage(head)(UI.div).take(1).run.map { frames =>
+            val html       = frames.headMaybe.getOrElse("")
+            val styleStart = html.indexOf("<style>")
+            val styleEnd   = html.indexOf("</style>")
+            val style      = html.substring(styleStart, styleEnd)
+            val baseCssIdx = style.indexOf(UI.baseCss.take(30))
+            val gridIdx    = style.indexOf(".feat-grid {")
+            assert(baseCssIdx >= 0)
+            assert(gridIdx >= 0)
+            assert(baseCssIdx < gridIdx)
+        }
+    }
+
+    "gradient Style and Stylesheet compare equal by value (regression: BgGradientProp Chunk equality)" in {
+        // Two independently-built gradient styles must compare equal and share a hashCode.
+        // BgGradientProp holds Chunk[Color] and Chunk[Double]; Chunk has structural Seq equality,
+        // so the auto-derived case-class equality compares them by value (no hand-written equals).
+        val a = Style.bgGradient(_.toRight, Style.Color.white -> 0.pct, Style.Color.black -> 100.pct)
+        val b = Style.bgGradient(_.toRight, Style.Color.white -> 0.pct, Style.Color.black -> 100.pct)
+        assert(a == b)
+        assert(a.hashCode == b.hashCode)
+        // A differing gradient must compare unequal
+        val c = Style.bgGradient(_.toLeft, Style.Color.white -> 0.pct, Style.Color.black -> 100.pct)
+        assert(a != c)
+        // Stylesheet equality must also hold when a rule carries a gradient
+        val sheetA = Stylesheet.rule("hero", a)
+        val sheetB = Stylesheet.rule("hero", b)
+        assert(sheetA == sheetB)
+        assert(sheetA.hashCode == sheetB.hashCode)
+        // Non-gradient control: still correct
+        val ng1 = Style.bg(Style.Color.blue)
+        val ng2 = Style.bg(Style.Color.blue)
+        assert(ng1 == ng2)
+    }
+
+    "cssClass renders class attribute and coexists with style attribute" in {
+        val html = kyo.internal.HtmlRenderer.render(
+            UI.div.cssClass("feat-grid").cssClass("dark").style(Style.bg(Style.Color.blue)),
+            Seq.empty
+        )
+        html.map { s =>
+            assert(s.contains("class=\"feat-grid dark\""))
+            assert(s.contains("style="))
+        }
+    }
+
+end StylesheetTest

--- a/kyo-ui/shared/src/test/scala/kyo/SvgRendererTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/SvgRendererTest.scala
@@ -43,6 +43,25 @@ class SvgRendererTest extends kyo.test.Test[Any]:
         yield assert(html.contains("""d="M50 50 L90 50 A40 40 0 0 1 50 90 Z""""))
     }
 
+    "PathData.raw emits the d string verbatim (for external/brand paths)" in {
+        val p = Svg.path.d(Svg.PathData.raw("M12 0a12 12 0 100 24z"))
+        for html <- HtmlRenderer.render(p, Seq.empty)
+        yield assert(html.contains("""d="M12 0a12 12 0 100 24z""""), s"raw d must pass through: $html")
+    }
+
+    "path pathLength normalizes the path length (for CSS stroke-draw)" in {
+        // pathLength=1 reparameterizes dash/offset to 0..1, so a CSS keyframe can tween
+        // stroke-dashoffset 1 -> 0 independent of the path's real length.
+        val p = Svg.path.d(Svg.PathData.from(0, 0).lineTo(10, 0)).pathLength(1.0)
+            .strokeDasharray(Seq(1.0)).strokeDashoffset(Svg.SvgLength.user(0.0))
+        for html <- HtmlRenderer.render(p, Seq.empty)
+        yield
+            assert(html.contains("""pathLength="1""""), s"pathLength must render camelCase: $html")
+            assert(html.contains("""stroke-dasharray="1""""), s"dash base must render: $html")
+            assert(html.contains("""stroke-dashoffset="0""""), s"offset base must render unitless: $html")
+        end for
+    }
+
     // transform list joins
     "transform list renders as space-separated functions" in {
         val g = Svg.g.transform(Svg.Transform.Translate(10, 20), Svg.Transform.Scale(2))
@@ -353,6 +372,24 @@ class SvgRendererTest extends kyo.test.Test[Any]:
             assert(html.contains("""to="30""""))
             assert(html.contains("""dur="1s""""))
             assert(html.contains("""repeatCount="indefinite""""))
+        end for
+    }
+
+    // animate fill freeze/remove: a draw-on-load tween must freeze its final value or it reverts to the
+    // base on end (the SMIL default), so the drawn line would vanish without fill="freeze".
+    "animate renders fill=freeze and fill=remove" in {
+        for
+            freeze <- HtmlRenderer.render(
+                Svg.circle.cx(50).cy(50).r(20)(Svg.animate.attributeName("r").to(30.0).dur("1s").fill(Svg.AnimFill.Freeze)),
+                Seq.empty
+            )
+            remove <- HtmlRenderer.render(
+                Svg.circle.cx(50).cy(50).r(20)(Svg.animate.attributeName("r").to(30.0).dur("1s").fill(Svg.AnimFill.Remove)),
+                Seq.empty
+            )
+        yield
+            assert(freeze.contains("""fill="freeze""""), s"freeze: $freeze")
+            assert(remove.contains("""fill="remove""""), s"remove: $remove")
         end for
     }
 

--- a/kyo-ui/shared/src/test/scala/kyo/UIBaseCssTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIBaseCssTest.scala
@@ -1,0 +1,32 @@
+package kyo
+
+class UIBaseCssTest extends kyo.test.Test[Any]:
+
+    "UI.baseCss is non-empty and contains box-sizing: border-box" in {
+        assert(UI.baseCss.nonEmpty)
+        assert(UI.baseCss.contains("box-sizing: border-box"))
+    }
+
+    "UI.baseCss contains the data-kyo-reactive display:contents rule" in {
+        assert(UI.baseCss.contains("[data-kyo-reactive]"))
+        assert(UI.baseCss.contains("display: contents"))
+    }
+
+    "runRenderPage output contains UI.baseCss verbatim" in {
+        for
+            frames <- UI.runRenderPage(UI.PageHead(title = "t"))(UI.div).take(1).run
+            html = frames.headMaybe.getOrElse("")
+        yield
+            // baseCss must appear inside the document
+            assert(html.contains(UI.baseCss.take(30)))
+        end for
+    }
+
+    "UI.baseCss returns the same string on repeated reads (stable val)" in {
+        val s1 = UI.baseCss
+        val s2 = UI.baseCss
+        assert(s1 == s2)
+        assert(s1 eq s2) // same reference
+    }
+
+end UIBaseCssTest

--- a/kyo-ui/shared/src/test/scala/kyo/UIContentModelTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIContentModelTest.scala
@@ -34,6 +34,15 @@ class UIContentModelTest extends kyo.test.Test[Any]:
         }
     }
 
+    "blockquote renders as a <blockquote> element wrapping its children" in {
+        val ui: UI = UI.blockquote.cssClass("pull")(UI.span("quoted"))
+        renderHtml(ui).map { html =>
+            assert(html.contains("<blockquote"), s"must render a blockquote tag: $html")
+            assert(html.contains("</blockquote>"), s"must close the blockquote: $html")
+            assert(html.contains("quoted"), s"must render the children: $html")
+        }
+    }
+
     // Svg.Root IS HtmlContent and compiles inside a div
     "div accepts Svg.svg (Root extends HtmlContent and Inline)" in {
         val root: HtmlContent = Svg.svg

--- a/kyo-ui/shared/src/test/scala/kyo/UICssClassTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UICssClassTest.scala
@@ -1,0 +1,38 @@
+package kyo
+
+import kyo.internal.HtmlRenderer
+import scala.language.implicitConversions
+
+class UICssClassTest extends kyo.test.Test[Any]:
+
+    private def renderHtml(ui: UI)(using Frame): String < Sync =
+        HtmlRenderer.render(ui, Seq.empty)
+
+    "single cssClass renders class attribute" in {
+        renderHtml(UI.div.cssClass("hero")).map { s =>
+            assert(s.contains("class=\"hero\""))
+        }
+    }
+
+    "multiple cssClass calls space-join in call order" in {
+        renderHtml(UI.div.cssClass("a").cssClass("b").cssClass("c")).map { s =>
+            assert(s.contains("class=\"a b c\""))
+        }
+    }
+
+    "cssClass with a double-quote is attribute-escaped" in {
+        renderHtml(UI.div.cssClass("a\"b")).map { s =>
+            assert(s.contains("class=\"a&quot;b\""))
+            assert(!s.contains("a\"b"))
+        }
+    }
+
+    "cssClass coexists with id and data attributes" in {
+        renderHtml(UI.div.id("x").data("k", "v").cssClass("c")).map { s =>
+            assert(s.contains("id=\"x\""))
+            assert(s.contains("data-k=\"v\""))
+            assert(s.contains("class=\"c\""))
+        }
+    }
+
+end UICssClassTest

--- a/kyo-ui/shared/src/test/scala/kyo/UIRunRenderPageTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIRunRenderPageTest.scala
@@ -1,0 +1,225 @@
+package kyo
+
+import scala.language.implicitConversions
+
+class UIRunRenderPageTest extends kyo.test.Test[Any]:
+
+    private def renderPage(head: UI.PageHead, ui: UI)(using Frame): String < Async =
+        UI.runRenderPage(head)(ui).take(1).run.map(_.headMaybe.getOrElse(""))
+
+    "document structure: doctype, html lang, head, body, closing html" in {
+        renderPage(UI.PageHead(title = "t"), UI.div).map { html =>
+            assert(html.startsWith("<!DOCTYPE html>"))
+            assert(html.contains("<html lang=\"en\""))
+            assert(html.contains("<head>"))
+            assert(html.contains("<body>"))
+            assert(html.endsWith("</html>"))
+        }
+    }
+
+    "baseCss appears strictly before head.css in the style block" in {
+        val css = "custom-marker-xyz"
+        renderPage(UI.PageHead(title = "t", css = css), UI.div).map { html =>
+            val styleStart = html.indexOf("<style>")
+            val styleEnd   = html.indexOf("</style>")
+            assert(styleStart >= 0 && styleEnd > styleStart)
+            val styleContent = html.substring(styleStart, styleEnd)
+            val baseCssIdx   = styleContent.indexOf(UI.baseCss.take(30))
+            val customIdx    = styleContent.indexOf(css)
+            assert(baseCssIdx >= 0)
+            assert(customIdx >= 0)
+            assert(baseCssIdx < customIdx)
+        }
+    }
+
+    "title is rendered into <title> and attribute-escaped" in {
+        renderPage(UI.PageHead(title = "<Hello & World>"), UI.div).map { html =>
+            assert(html.contains("<title>&lt;Hello &amp; World&gt;</title>"))
+        }
+    }
+
+    "meta pairs render <meta name=... content=...> with both escaped; charset and viewport always present" in {
+        renderPage(
+            UI.PageHead(title = "t", meta = Seq("description" -> "a<b&c")),
+            UI.div
+        ).map { html =>
+            assert(html.contains("""<meta charset="utf-8">"""))
+            assert(html.contains("""<meta name="viewport" content="width=device-width, initial-scale=1">"""))
+            assert(html.contains("""<meta name="description" content="a&lt;b&amp;c">"""))
+        }
+    }
+
+    "link pairs render <link rel=... href=...> escaped" in {
+        renderPage(
+            UI.PageHead(title = "t", links = Seq("canonical" -> "https://example.com/path?a=1&b=2")),
+            UI.div
+        ).map { html =>
+            assert(html.contains("""<link rel="canonical" href="https://example.com/path?a=1&amp;b=2">"""))
+        }
+    }
+
+    "moduleScript = Present emits script tag after body; Absent emits no script" in {
+        for
+            withScript    <- renderPage(UI.PageHead(title = "t", moduleScript = Present("main.js")), UI.div)
+            withoutScript <- renderPage(UI.PageHead(title = "t", moduleScript = Absent), UI.div)
+        yield
+            assert(withScript.contains("""<script type="module" src="main.js">"""))
+            // script must come after </body>
+            assert(withScript.indexOf("""<script type="module"""") > withScript.indexOf("</body>"))
+            assert(!withoutScript.contains("<script"))
+        end for
+    }
+
+    "body contains the rendered UI fragment" in {
+        renderPage(UI.PageHead(title = "t"), UI.div(UI.h1("Hi"))).map { html =>
+            val bodyStart = html.indexOf("<body>")
+            val bodyEnd   = html.indexOf("</body>")
+            val body      = html.substring(bodyStart, bodyEnd)
+            assert(body.contains(">Hi<"))
+        }
+    }
+
+    "reactive UI re-emits complete document on signal change" in {
+        // runRenderPage re-emits a full document on every signal change (inherited from runRender).
+        // The subscribe step also triggers an immediate re-render; the stream produces:
+        // (1) the initial render, (2) the subscribe-triggered re-render, (3) the signal-change
+        // re-render. All carry complete documents; the third reflects the updated signal value.
+        //
+        // A Channel is used as the stream sink so we can take emissions one at a time and
+        // synchronize deterministically: after taking 2 emissions the subscription waiter is
+        // guaranteed to be registered, so ref.set is safe to call without any sleep.
+        for
+            ref <- Signal.initRef("initial")
+            buf <- Channel.init[String](8)
+            stream = UI.runRenderPage(UI.PageHead(title = "re-emit"))(ref.map(v => UI.span(v)))
+            _     <- Fiber.initUnscoped(stream.take(3).foreach(buf.put(_)))
+            first <- buf.take
+            _     <- buf.take // subscribe-triggered re-render; discard, just confirms subscription is ready
+            _     <- ref.set("updated")
+            third <- buf.take
+        yield
+            // First emission is a complete document with the initial value
+            assert(first.startsWith("<!DOCTYPE html>"))
+            assert(first.contains("initial"))
+            assert(first.contains("</html>"))
+            // Signal-change emission is a complete document with the updated value
+            assert(third.startsWith("<!DOCTYPE html>"))
+            assert(third.contains("updated"))
+            assert(third.contains("</html>"))
+        end for
+    }
+
+    "PageHead derives CanEqual: two equal PageHead instances compare equal" in {
+        val h1 = UI.PageHead(title = "t")
+        val h2 = UI.PageHead(title = "t")
+        assert(h1 == h2)
+    }
+
+    "minimal PageHead produces valid document with charset+viewport and style only carrying baseCss" in {
+        renderPage(UI.PageHead(title = "t"), UI.div).map { html =>
+            assert(html.contains("""<meta charset="utf-8">"""))
+            assert(html.contains("""<meta name="viewport""""))
+            val styleStart = html.indexOf("<style>")
+            val styleEnd   = html.indexOf("</style>")
+            val style      = html.substring(styleStart + "<style>".length, styleEnd)
+            // with empty css, the style block is exactly baseCss
+            assert(style == UI.baseCss)
+        }
+    }
+
+    "jsonLd renders an ld+json block before </head> with no id" in {
+        val head = UI.PageHead(
+            title = "t",
+            jsonLd = Present(UI.dataIsland("application/ld+json", Absent, """{"@type":"Thing"}"""))
+        )
+        renderPage(head, UI.div).map { html =>
+            assert(html.contains("""<script type="application/ld+json">{"@type":"Thing"}</script>"""))
+            assert(html.indexOf("application/ld+json") < html.indexOf("</head>"))
+            assert(!html.substring(0, html.indexOf("</head>")).contains("id="))
+        }
+    }
+
+    "dataIslands render both id-carrying json blocks before </body> in order" in {
+        val head = UI.PageHead(
+            title = "t",
+            dataIslands = Seq(
+                UI.dataIsland("application/json", Present("docs-island"), """{"a":1}"""),
+                UI.dataIsland("application/json", Present("versions-island"), """[{"t":"v1"}]""")
+            )
+        )
+        renderPage(head, UI.div).map { html =>
+            assert(html.contains("""<script type="application/json" id="docs-island">{"a":1}</script>"""))
+            assert(html.contains("""<script type="application/json" id="versions-island">[{"t":"v1"}]</script>"""))
+            assert(html.indexOf("docs-island") < html.indexOf("versions-island"))
+            assert(html.indexOf("docs-island") < html.indexOf("</body>"))
+            assert(html.indexOf("versions-island") < html.indexOf("</body>"))
+        }
+    }
+
+    "a </script> substring in a JSON body is escaped to the JS-unicode form" in {
+        val head = UI.PageHead(
+            title = "t",
+            dataIslands = Seq(
+                UI.dataIsland("application/json", Present("x"), """{"s": "</script><script>alert(1)"}""")
+            )
+        )
+        renderPage(head, UI.div).map { html =>
+            // The escape replaces < with < and > with > (literal backslash-u sequences).
+            assert(html.contains("\\u003c/script\\u003e\\u003cscript\\u003ealert(1)"))
+            // The only literal </script> in the document is the island's own closing tag, not inside the body.
+            val bodyStart  = html.indexOf("""<script type="application/json" id="x">""")
+            val bodyEnd    = html.indexOf("</script>", bodyStart)
+            val islandBody = html.substring(bodyStart, bodyEnd)
+            assert(!islandBody.contains("</script>"))
+        }
+    }
+
+    "the escape uses the JS-unicode form, not the HTML-entity &lt; form" in {
+        val head = UI.PageHead(
+            title = "t",
+            jsonLd = Present(UI.dataIsland("application/ld+json", Absent, """{"x":"<a>"}"""))
+        )
+        renderPage(head, UI.div).map { html =>
+            val ldStart = html.indexOf("""<script type="application/ld+json">""")
+            val ldEnd   = html.indexOf("</script>", ldStart)
+            val ldBody  = html.substring(ldStart, ldEnd)
+            // The body must contain the JS-unicode escaped form (literal < / >), not HTML entities.
+            assert(ldBody.contains("\\u003ca\\u003e"))
+            assert(!ldBody.contains("&lt;a&gt;"))
+        }
+    }
+
+    "a PageHead with no islands renders neither block" in {
+        val head = UI.PageHead(title = "t")
+        renderPage(head, UI.div).map { html =>
+            assert(!html.contains("application/ld+json"))
+            assert(!html.contains("application/json"))
+        }
+    }
+
+    "an existing minimal PageHead still renders the prior document shape" in {
+        renderPage(UI.PageHead(title = "t"), UI.div(UI.h1("Hi"))).map { html =>
+            assert(html.startsWith("<!DOCTYPE html>"))
+            assert(html.contains(">Hi<"))
+            assert(html.endsWith("</html>"))
+            val styleStart = html.indexOf("<style>")
+            val styleEnd   = html.indexOf("</style>")
+            val style      = html.substring(styleStart + "<style>".length, styleEnd)
+            assert(style == UI.baseCss)
+        }
+    }
+
+    "UI.dataIsland returns a DataIsland value with the verbatim json" in {
+        val di = UI.dataIsland("application/json", Present("k"), """{"v":2}""")
+        assert(di.scriptType == "application/json")
+        assert(di.id == Present("k"))
+        assert(di.json == """{"v":2}""")
+    }
+
+    "two DataIsland values with equal fields compare equal (CanEqual)" in {
+        val a = UI.dataIsland("application/json", Present("k"), "{}")
+        val b = UI.dataIsland("application/json", Present("k"), "{}")
+        assert(a == b)
+    }
+
+end UIRunRenderPageTest

--- a/kyo-ui/shared/src/test/scala/kyo/UITestSpaReactiveInputFocusTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UITestSpaReactiveInputFocusTest.scala
@@ -1,0 +1,67 @@
+package kyo
+
+import kyo.Browser.*
+import scala.language.implicitConversions
+
+/** Genuine guard: a focused, caret-positioned input survives a structural re-render of the region that
+  * contains it, keeping both its focus and its caret.
+  *
+  * The app nests a value-bound input inside an OUTER reactive region (driven by a separate signal). The
+  * input is typed into (a real input event, so the bound signal holds "kyo") and the caret is placed at
+  * position 2. Bumping the outer signal then re-renders the WHOLE region: the input's `data-kyo-path`
+  * differs from the region's path, so the client's morph-in-place fast path (which only fires for an
+  * input echoing its OWN value, where the paths match) does NOT apply. The region is therefore replaced
+  * via `outerHTML`, detaching the focused input. This is the structural variant of the originating bug
+  * (a reactive input losing focus and caret on each surrounding re-render).
+  *
+  * Without the focus capture/restore around the `outerHTML` replace, `document.activeElement` falls back
+  * to `body` and the observation reads `":null"`. With the fix, the new input is re-focused with the
+  * caret restored, and the observation reads `"focus-input:2"`.
+  *
+  * The observation uses `Browser.evalJson[String]` (a bare CDP `Runtime.evaluate`), which has no focus
+  * side effect. No `focus()` or `setSelectionRange()` runs after the replace in the observation: any
+  * such call would re-focus the input and mask the defect.
+  */
+class UITestSpaReactiveInputFocusTest extends UITest:
+
+    "a focused input keeps focus and caret across a structural re-render of its region" in {
+        val app: UI < Async =
+            for
+                text  <- Signal.initRef[String]("")
+                outer <- Signal.initRef[Int](0)
+            yield UI.div(
+                outer.map(o =>
+                    UI.div(
+                        UI.input.value(text).id("focus-input"),
+                        // Status span mirrors the outer signal: assertText on it settles the re-render.
+                        UI.span(s"o=$o").id("status")
+                    )
+                ),
+                UI.button("bump").id("bump-btn").onClick(outer.getAndUpdate(_ + 1).unit)
+            )
+        withUI(app) {
+            for
+                // Type into the input via a real input event so the bound signal holds "kyo", then place
+                // the caret at position 2. This is legitimate pre-replace setup of the focused state.
+                _ <- Browser.fill(Selector.id("focus-input"), "kyo")
+                _ <- Browser.evalDiscard(
+                    "var el = document.getElementById('focus-input'); el.focus(); el.setSelectionRange(2,2);"
+                )
+                // Bump the outer signal via a programmatic click that does NOT steal focus. CDP's
+                // Browser.click dispatches a real mouse event that moves focus to the button; JavaScript's
+                // HTMLElement.click() fires the synthetic click (triggering the kyo-ui delegated listener
+                // and the onClick callback) without changing the active element.
+                _ <- Browser.evalDiscard("document.getElementById('bump-btn').click()")
+                // Settle on the structural re-render having applied: wait until the status span shows "o=1".
+                _ <- Browser.assertText(Selector.id("status"), "o=1")
+                // Read the post-replace active-element state WITHOUT any focus/setSelectionRange call.
+                result <- Browser.evalJson[String](
+                    "document.activeElement.id + ':' + " +
+                        "(typeof document.activeElement.selectionStart === 'number' ? " +
+                        "document.activeElement.selectionStart : 'null')"
+                )
+            yield assert(result == "focus-input:2")
+        }
+    }
+
+end UITestSpaReactiveInputFocusTest

--- a/kyo-ui/shared/src/test/scala/kyo/UITestSpaRunMountTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UITestSpaRunMountTest.scala
@@ -1,0 +1,42 @@
+package kyo
+
+import kyo.Browser.*
+import scala.language.implicitConversions
+
+/** Guards the client DomBackend mount path for reactive Fragment values.
+  *
+  * Every other reactive test goes through the server `runHandlers`/WebSocket path. This test exercises
+  * `DomBackend.mount` directly, covering two bugs that the server path cannot reach:
+  *   - `applyJsProps` building an invalid `querySelectorAll("[data-kyo-prop-*]")` that threw on mount,
+  *     preventing any update from landing.
+  *   - `LocalExchange.onChange` dropping the `data-kyo-path` boundary for Fragment values that render
+  *     without a path-carrying root, causing only the first update to land.
+  */
+class UITestSpaRunMountTest extends UITest:
+
+    "reactive Fragment advances A -> B -> C via click-driven signal updates" in {
+        val app: UI < Async =
+            for ref <- Signal.initRef[String]("A")
+            yield
+                def advance: Unit < Async =
+                    ref.get.map {
+                        case "A" => ref.set("B")
+                        case "B" => ref.set("C")
+                        case _   => ()
+                    }
+                UI.div(
+                    UI.button("next").id("adv").onClick(advance),
+                    UI.Ast.Reactive(ref.map(s => UI.fragment(UI.span(s).id("frag-a"), UI.span(s).id("frag-b"))))
+                )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("frag-a"), "A")
+                _ <- Browser.click(Selector.id("adv"))
+                _ <- Browser.assertText(Selector.id("frag-a"), "B")
+                _ <- Browser.click(Selector.id("adv"))
+                _ <- Browser.assertText(Selector.id("frag-a"), "C")
+            yield ()
+        }
+    }
+
+end UITestSpaRunMountTest

--- a/kyo-ui/shared/src/test/scala/kyo/internal/CssStyleRendererTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/internal/CssStyleRendererTest.scala
@@ -120,6 +120,40 @@ class CssStyleRendererTest extends kyo.test.Test[Any]:
         )
         assert(css.contains("linear-gradient"))
         assert(css.contains("to right"))
+        // The default sRGB space emits no `in <space>` prelude.
+        assert(!css.contains("in oklch"))
+        assert(!css.contains("in oklab"))
+    }
+
+    "render oklch gradient with the in-space prelude" in {
+        val css = CssStyleRenderer.render(
+            Style.bgGradient(
+                Style.GradientDirection.toBottom,
+                Style.GradientColorSpace.oklch,
+                (Color.red, 0.pct),
+                (Color.blue, 100.pct)
+            )
+        )
+        // CSS spec order: the color-interpolation-method follows the direction.
+        assert(css.contains("linear-gradient(to bottom in oklch,"), css)
+    }
+
+    "render oklab gradient with the in-space prelude" in {
+        val css = CssStyleRenderer.render(
+            Style.bgGradient(
+                Style.GradientDirection.toBottom,
+                Style.GradientColorSpace.oklab,
+                (Color.red, 0.pct),
+                (Color.blue, 100.pct)
+            )
+        )
+        // CSS spec order: the color-interpolation-method follows the direction.
+        assert(css.contains("linear-gradient(to bottom in oklab,"), css)
+    }
+
+    "render text-wrap balance and pretty" in {
+        assert(CssStyleRenderer.render(Style.textWrap(Style.TextWrap.balance)).contains("text-wrap: balance"))
+        assert(CssStyleRenderer.render(Style.textWrap(Style.TextWrap.pretty)).contains("text-wrap: pretty"))
     }
 
     "render cursor pointer" in {


### PR DESCRIPTION

## Problem

**kyo-browser**

`Browser.screenshot` captured a hard-coded `1280x720` crop and offered no way to target a region, capture the full scrollable page in bands, or record frames over a live animation. The legacy `scrollTo(selector)` scroll-to-element overload conflated coordinate scrolling and element scrolling under one name. `setViewport` and `resetViewport` were `private[kyo]`, giving tests no public way to set the device pixel ratio or to override and restore the viewport in a scoped block. `withEmulation` (CSS media / color scheme emulation) and `withHighlights` (annotated overlay boxes) did not exist.

Geometry and style reads (`boundingBox`, now renamed `boundingRect`) performed a direct CDP `DOM.getBoxModel` read without waiting for layout to stabilize, so they returned stale coordinates for elements still animating or reflecting a pending re-layout. There was no settled read for computed styles, viewport intersection, scroll position, or element discovery.

`Browser.ConsoleMessage` carried an `Instant` timestamp and a single `message: String` field. The timestamp was wall-clock absolute rather than relative to the recording start, and the decoder covered only the three synthetic `console.*` overrides injected by the tab setup, not the 18 CDP `Runtime.consoleAPICalled` types. `onConsole` existed; `recordConsole` (collect-and-return) did not. The capture methods that needed hold-still behavior (freeze animations, await fonts, loop to two byte-identical frames) had to be coded ad hoc or were absent.

`BrowserException` had no exception type for capture operations that exceeded a configured unit cap (band count, mark count, frame count).

`kyo-browser/CONTRIBUTING.md` did not exist.

**kyo-ui**

`Style` had no `Display.flex`/`inlineFlex`, no reverse flex directions (`rowReverse`, `columnReverse`), no `Position.fixed`, no `TextWrap.balance`/`pretty`, no `strokeDashoffset`, no `animationDelay`, no scrollbar properties (`scrollbarWidth`, `scrollbarColor`, `scrollbarGutter`), no `backgroundClip`, and no OKLCH/OKLAB gradient color-space support.

`Svg.PathData` had no `raw` escape for pre-built path strings. SMIL animation elements had no `fill` attribute (the `AnimFill` enum controlling freeze-vs-remove behavior). `Svg.Path` had no `pathLength` attribute.

There was no document-level `Stylesheet` type (selector-targeted rules, `@media` queries including `prefers-reduced-motion`, `@keyframes`, `@font-face`, CSS variables). `Selector` as a kyo-ui type did not exist. `UI.runRenderPage` (full-document SSR streaming), `UI.PageHead` (head configuration), `UI.dataIsland` / `UI.DataIsland` (`<script type="...">` JSON payloads), `UI.blockquote`, `UI.rawHtml`, and `UI.cssClass` did not exist.

`UIWindow` lacked `prefersColorScheme` (a `Signal[Boolean]` backed by a `matchMedia` listener), `onClick` (document-level capture-phase click subscription returning `UI.MouseEvent`), clipboard write, local-storage get/set, `setTitle`, `scrollToTop`, and `scrollIntoViewById`. `UILocation.assign` did not exist. `ElementRef` (an opaque handle over a DOM element, built by `UI.MouseEvent.targetClosest`) was absent, making it impossible to walk the DOM from a document-level click target into `rawHtml`-injected content.

On the JS mount path, a structural re-render of a reactive region replaced the region's `outerHTML` without capturing and restoring the focused element and its caret position, causing a focused, caret-positioned input to lose both focus and selection whenever a surrounding reactive region re-rendered.

## Solution

**kyo-browser: capture API**

`Browser.screenshot` drops the `1280x720` crop; it now captures the live viewport with no clip. Two new methods cover the removed behaviors: `screenshotRegion(x, y, width, height)` for an explicit clip region (aborts `BrowserInvalidArgumentException` before any CDP call on non-positive dimensions), and `screenshotFullPage(maxBands)` for full-scroll band capture (aborts `BrowserCaptureLimitExceededException` before any capture when the page exceeds `maxBands`). A `screenshotMarks(marks, maxMarks)` method overlays `Browser.Annotation` highlight boxes then captures, used with `withHighlights` for annotated QA shots. `screenshotFrames` records CDP screencast frames for the duration of a scoped body, returning `(Chunk[ScreenshotFrame], result)`.

All capture methods use the `HoldStill` protocol: `settleForCapture` (best-effort DOM quiescence), `document.fonts.ready`, a tokenized freeze stylesheet (`data-kyo-internal`/`data-kyo-token`) injected via `Scope.acquireRelease`, and a loop comparing consecutive frame hashes until two frames are byte-identical or `captureHoldStillTimeout` elapses. Multi-band captures use `withFrozenPage` + `holdStillFrame` directly so the freeze stylesheet is injected once for the whole band sequence. The freeze stylesheet is tagged with a monotonic per-page token so nested or interleaved `withHoldStill` calls each tear down only their own node.

**kyo-browser: settle-on-read**

`SettleRead.settle` is a new internal primitive that re-samples a JS expression through `StabilitySampler.sampleWindow` until the value is stable across `assertionStabilityWindow`, then decodes it. A settled-absent element produces a stable sentinel that `decode` maps to the read's `Absent`/`false`/empty twin return without raising a stability timeout. All new geometry and element reads use it: `boundingRect` (renamed from `boundingBox`, now stable-settled before the authoritative `DOM.getBoxModel` CDP read), `computedStyles`, `computedStyle`, `inViewport`, `scrollPosition`, `element`, `elements`, and `elementAt`.

`Browser.waitForStable(timeout)` is a new public method delegating to `MutationSettlement.waitForStable`: a strict quiescence wait that aborts `BrowserAssertionTimedOutException` on timeout. `MutationSettlement.settleForCapture` is the best-effort variant that swallows the timeout and proceeds.

**kyo-browser: element discovery**

`DiscoverJs` injects `window.__kyoDiscoverProbe` and `window.__kyoUniqueSelector` idempotently (gated by `window.__kyoDiscoverInstalled`). `Browser.element(selector)`, `Browser.elements(selector)`, and `Browser.elementAt(x, y)` use it to return `Browser.ElementInfo` records carrying bounding geometry, visibility, viewport membership, interactivity, role, classes, id, and a stable unique CSS path. `elements` fast-paths the empty case via `BrowserEval.locateCount` before any stability wait.

**kyo-browser: renamed and reshaped types**

`BoundingBox` is renamed to `Browser.Bounds` (shared with `ElementInfo`). `Browser.ScrollPosition` is new. `Browser.ScreenshotFrame` carries `image`, `offsetMs`, and `scrollOffset`. `Browser.ConsoleMessage` replaces `message: String` and `timestamp: Instant` with `text: String`, `location: Maybe[String]`, and `offsetMs: Long` (milliseconds from the recording start). The console decoder now covers the 18 CDP `Runtime.consoleAPICalled` types, folded onto five `ConsoleLevel` severities. `recordConsole` collects all console events during a body into a `Chunk[ConsoleMessage]` using `onConsole` internally. `BrowserCaptureLimitExceededException` is a new leaf of `BrowserReadException`.

**kyo-browser: viewport, scroll, emulation, highlight**

`setViewport` and `resetViewport` are now public and accept `deviceScaleFactor: Double`. `withViewport` gains the same parameter. `withEmulation` applies a CSS media type and `prefers-color-scheme` override for the duration of a scoped body. `withHighlights` draws tokenized dashed-box overlays over elements for the body's duration. `scrollTo(x, y)` takes integer coordinates; `scrollToElement(selector)` is the new selector-targeting scroll (the old `scrollTo(selector)` is removed). `kyo-browser/CONTRIBUTING.md` documents the settlement model, capture conventions, extension recipes, and the decision checklist for new methods.

**kyo-ui: Style and DSL additions**

`Display` gains `flex` and `inlineFlex`. `Style.rowReverse` and `columnReverse` are added alongside the existing `row`/`column`. `Position.fixed` is added to the existing position enum. `TextWrap` gains `balance` and `pretty`. `Style.strokeDashoffset`, `Style.animationDelay`, `Style.scrollbarWidth`, `Style.scrollbarColor`, `Style.scrollbarGutter`, and `Style.backgroundClip` are new. Gradient color-space interpolation is added: `GradientColorSpace.oklch` and `oklab` allow `bgGradient` to interpolate in perceptually uniform spaces rather than sRGB.

`Svg.PathData.raw(d)` accepts a pre-built path string. `Svg.Path.pathLength(v)` sets the `pathLength` SVG attribute for dash reparameterization. SMIL animation elements (`Animate`, `AnimateTransform`, `AnimateMotion`, `SetAnim`) gain a `fill(AnimFill)` method covering `freeze` and `remove`.

**kyo-ui: Stylesheet and Selector**

`Stylesheet` is a new pure-value document-level stylesheet type: ordered rules (`rule`), `@media` blocks (`media`), `:root` and scoped CSS variables (`vars`, `scopedVars`), `@font-face` (`fontFace`), and `@keyframes` (`keyframes`). `Stylesheet.MediaQuery` provides typed media query values including `prefersDark`, `prefersReducedMotion`, and `prefersReducedMotionNoPreference`. `Selector` is a new pure-value CSS selector type with `cls`, `id`, `data`, `tag`, `pseudo`, `pseudoElement`, `descendant`, and `child` combinators.

**kyo-ui: document rendering and data islands**

`UI.runRenderPage(head)(ui)` streams a complete HTML document. `UI.PageHead` configures the `<head>`: title, viewport meta, base CSS, per-page CSS, links, an optional ESModule script, an optional JSON-LD data island, and a body-end data-island list. `UI.dataIsland(scriptType, id, json)` builds a `<script type="...">` block (JSON special characters escaped) for placement in `PageHead`. `UI.cssClass(name)` attaches a CSS class hook for `Stylesheet` class selectors. `UI.runStylesheet(sheet)` injects a stylesheet into the DOM client-side. `UI.blockquote` and `UI.rawHtml` are new element kinds.

**kyo-ui: browser-interop additions (JS/WASM)**

`UIWindow` gains `prefersColorScheme` (a `Signal[Boolean]`), `onClick` (document-level capture-phase click subscription delivering `UI.MouseEvent`), `writeClipboard`, `storageGet`, `storageSet`, `setTitle`, `scrollToTop`, `scrollIntoViewById`, and `onIntersectById`. `UILocation.assign` navigates to a URI. `ElementRef` is a new opaque type over `dom.Element`, built only by `UI.MouseEvent.targetClosest`, exposing `closest`, `querySelector`, `getAttribute`, `setAttribute`, `removeAttribute`, and `textContent` with `Maybe`-returning signatures. `UIMouseEventOps` maintains a bounded per-click side table associating each `UI.MouseEvent` instance with its native `dom.MouseEvent` for the duration of the handler, used by `targetClosest` to walk the DOM without a `dom.*` field on the shared platform-neutral type.

**kyo-ui: reactive input focus fix**

On the JS mount path, `DomBackend` now captures the focused element and its caret position (via `selectionStart`) before replacing a reactive region's `outerHTML`, then re-focuses and restores the caret on the new node. The guard distinguishes whether the region wrapper itself carries the focus (common: a value-bound input inside a reactive region) from a deeply focused descendant, and handles `setSelectionRange` `InvalidStateError` on input types that do not support it (date, file, etc.). `UITestSpaReactiveInputFocusTest` is the regression guard: a focused, caret-positioned input nested inside an OUTER reactive region survives a structural re-render triggered by bumping the outer signal.

**kyo-ui: kyo-browser API migration**

Existing kyo-ui integration tests that called `Browser.scrollTo(Selector.id(...))` are migrated to `Browser.scrollToElement(Selector.id(...))`.

## Notes

`Browser.ConsoleMessage` is a breaking change: the `timestamp: Instant` and `message: String` fields are replaced by `offsetMs: Long`, `text: String`, and `location: Maybe[String]`. Any caller that pattern-matched on the old shape must update.

`BoundingBox` is removed; callers use `Browser.Bounds`. `Browser.scrollTo(selector: Selector)` is removed; callers use `Browser.scrollToElement(selector)`.

`setViewport` and `resetViewport` moving from `private[kyo]` to public is not a binary-incompatible change but was a deliberate visibility promotion: they were previously accessible only within the module.

The hold-still freeze stylesheet produces one unfiltered `childList` DOM mutation because its insertion targets `document.head` rather than a `data-kyo-internal`-tagged node. `settleForCapture` runs before the injection; the HoldStill convergence loop is frame-hash based, so the injection mutation does not break convergence.

`UIMouseEventOps` uses a `js.WrappedMap` keyed by reference identity on each `UI.MouseEvent` instance. Entries are inserted before the handler runs and removed via `Sync.ensure` after it completes, so the table is bounded by concurrently in-flight click handlers and does not leak.

`UI.DataIsland` does not extend `UI`: a data island is a `PageHead` payload emitted only from the renderer, never a tree node the diff algorithm sees.
