### PR TITLE
[parse] fix Parse.repeat quadratic complexity via indexed ParseInput

### DIFF
--- a/kyo-parse/shared/src/main/scala/kyo/Parse.scala
+++ b/kyo-parse/shared/src/main/scala/kyo/Parse.scala
@@ -244,11 +244,12 @@ object Parse:
 
     def readOne[In, Out](f: In => Result[Chunk[String], Out])(using Tag[Parse[In]], Frame): Out < Parse[In] =
         read(input =>
-            if input.done then Result.fail(Chunk(ParseFailure("EOF", input.position)))
-            else
-                f(input.remaining.head) match
-                    case Result.Failure(messages) => Result.fail(messages.map(ParseFailure(_, input.position)))
-                    case Result.Success(out)      => Result.succeed((input.advance(1), out))
+            input.headMaybe match
+                case Absent => Result.fail(Chunk(ParseFailure("EOF", input.position)))
+                case Present(token) =>
+                    f(token) match
+                        case Result.Failure(messages) => Result.fail(messages.map(ParseFailure(_, input.position)))
+                        case Result.Success(out)      => Result.succeed((input.advance(1), out))
         )
 
     def readWhile[A](f: A => Boolean)(using Tag[Parse[A]], Frame): Chunk[A] < Parse[A] =
@@ -327,9 +328,11 @@ object Parse:
 
     def anyMatch[A](using Frame)[In](pf: PartialFunction[In, A])(using Tag[Parse[In]]): A < Parse[In] =
         Parse.read(in =>
-            if in.done then Result.fail(Chunk(ParseFailure("Unexpected token, got EOF", in.position)))
-            else if pf.isDefinedAt(in.remaining.head) then Result.succeed((in.advance(1), pf(in.remaining.head)))
-            else Result.fail(Chunk(ParseFailure("Unexpected token", in.position)))
+            in.headMaybe match
+                case Absent => Result.fail(Chunk(ParseFailure("Unexpected token, got EOF", in.position)))
+                case Present(token) =>
+                    if pf.isDefinedAt(token) then Result.succeed((in.advance(1), pf(token)))
+                    else Result.fail(Chunk(ParseFailure("Unexpected token", in.position)))
         )
 
     @targetName("anyInSeq")
@@ -375,7 +378,7 @@ object Parse:
       */
     def literal(text: String)(using Frame): String < Parse[Char] =
         read(in =>
-            if in.remaining.startsWith(text) then
+            if in.startsWith(text) then
                 Result.succeed((in.advance(text.length), text))
             else
                 Result.fail(Chunk(ParseFailure(s"Expected: $text", in.position)))
@@ -716,7 +719,7 @@ object Parse:
     def end[In](using Tag[Parse[In]], Frame): Unit < Parse[In] =
         read(input =>
             if input.done then Result.succeed(input, ())
-            else Result.fail(Chunk(ParseFailure(s"Expected: EOF, Got: ${input.remaining.head}", input.position)))
+            else Result.fail(Chunk(ParseFailure(s"Expected: EOF, Got: ${input.headMaybe.getOrElse("")}", input.position)))
         )
 
     def not[In, S](parser: Any < (Parse[In] & S))(using Tag[Parse[In]], Frame): Unit < (Parse[In] & S) =
@@ -827,8 +830,8 @@ object Parse:
       */
     def boolean(using Frame): Boolean < Parse[Char] =
         read(in =>
-            if in.remaining.startsWith("true") then Result.succeed((in.advance(4), true))
-            else if in.remaining.startsWith("false") then Result.succeed((in.advance(5), false))
+            if in.startsWith("true") then Result.succeed((in.advance(4), true))
+            else if in.startsWith("false") then Result.succeed((in.advance(5), false))
             else Result.fail(Chunk(ParseFailure("Invalid boolean", in.position)))
         )
 
@@ -839,9 +842,8 @@ object Parse:
       */
     def identifier(using Frame): String < Parse[Char] =
         Parse.read: in =>
-            val remaining = in.remaining
-            remaining.headMaybe.filter(c => c.isLetter || c == '_').map(_ =>
-                val text = remaining.takeWhile(c => c.isLetterOrDigit || c == '_')
+            in.headMaybe.filter(c => c.isLetter || c == '_').map(_ =>
+                val text = in.remaining.takeWhile(c => c.isLetterOrDigit || c == '_')
                 (in.advance(text.length), text.mkString)
             ).toResult(Result.fail(Chunk(ParseFailure("Invalid identifier", in.position))))
 

--- a/kyo-parse/shared/src/main/scala/kyo/ParseInput.scala
+++ b/kyo-parse/shared/src/main/scala/kyo/ParseInput.scala
@@ -2,7 +2,47 @@ package kyo
 
 case class ParseInput[In](tokens: Chunk[In], position: Int):
 
-    def remaining: Chunk[In] = tokens.drop(position)
+    // The backing tokens as an indexed chunk, so per-token reads index in O(1) instead of copying the tail.
+    private val indexed: Chunk.Indexed[In] = tokens.toIndexed
+
+    def remaining: Chunk[In] = indexed.drop(position)
+
+    /** The next token, or `Absent` at end of input. O(1).
+      *
+      * Reads the token at `position` by direct indexing rather than `remaining.head`. The latter routes through the generic `Seq.head`, which
+      * materializes a fresh copy of the entire remaining input on every call; driving a `repeat` over an n-token input that way is O(n^2).
+      */
+    def headMaybe: Maybe[In] =
+        if position < indexed.length then Maybe(indexed(position))
+        else Maybe.empty
+
+    /** True if the tokens from `position` start with `prefix`, compared by `==`. O(prefix.length), no tail copy. */
+    def startsWith(prefix: Seq[In])(using CanEqual[In, In]): Boolean =
+        val n = prefix.length
+        if position + n > indexed.length then false
+        else
+            var i  = 0
+            var ok = true
+            while ok && i < n do
+                if indexed(position + i) != prefix(i) then ok = false
+                i += 1
+            ok
+        end if
+    end startsWith
+
+    /** True if the tokens from `position` start with `prefix`. O(prefix.length), no tail copy. */
+    def startsWith(prefix: String)(using ev: In =:= Char): Boolean =
+        val n = prefix.length
+        if position + n > indexed.length then false
+        else
+            var i  = 0
+            var ok = true
+            while ok && i < n do
+                if !(ev(indexed(position + i)) == prefix.charAt(i)) then ok = false
+                i += 1
+            ok
+        end if
+    end startsWith
 
     /** Advances the position by n characters, not exceeding input length
       *
@@ -16,7 +56,7 @@ case class ParseInput[In](tokens: Chunk[In], position: Int):
 
     def advanceWhile(f: In => Boolean): ParseInput[In] =
         var pos = position
-        while pos < tokens.length && f(tokens(pos)) do
+        while pos < indexed.length && f(indexed(pos)) do
             pos += 1
 
         copy(position = pos)

--- a/kyo-parse/shared/src/test/scala/kyo/ParseTest.scala
+++ b/kyo-parse/shared/src/test/scala/kyo/ParseTest.scala
@@ -1487,4 +1487,51 @@ trait ParseTest(lazyTestLength: Int) extends ParseTestBase:
             }
         }
     }
+
+    "performance" - {
+        // Per-token reads must index into the input, not copy the remaining tail on every read.
+        // With the tail-copy bug, `repeat` over an n-token input is O(n^2): at this size the buggy
+        // code takes minutes (and churns O(n^2) garbage), while the fixed linear code finishes in well
+        // under a second. The 30s wall-clock bound fails against the bug with a wide margin and passes
+        // comfortably after the fix on the JVM/JS/Native runners.
+        val perfLen = 500000
+        def withinBudget(label: String)(body: kyo.test.AssertScope ?=> Unit)(using kyo.test.AssertScope): Unit =
+            val start = java.lang.System.nanoTime()
+            body
+            val elapsed = (java.lang.System.nanoTime() - start) / 1000000L
+            assert(elapsed < 30000L, s"$label took ${elapsed}ms (budget 30000ms): repeat is not linear")
+        end withinBudget
+
+        "repeat(any) over a large input is linear" in {
+            val text   = "a" * perfLen
+            val parser = Parse.repeat(Parse.any[Char])
+            Parse.runOrAbort(text)(parser).map { result =>
+                withinBudget("repeat(any)") {
+                    assert(result.length == perfLen)
+                }
+            }
+        }
+
+        "readWhile over a large input is linear" in {
+            val text   = "a" * perfLen
+            val parser = Parse.readWhile[Char](_ == 'a')
+            Parse.runOrAbort(text)(parser).map { result =>
+                withinBudget("readWhile") {
+                    assert(result.length == perfLen)
+                }
+            }
+        }
+
+        "literal in a repeat over a large input is linear" in {
+            // Each iteration probes a 1-char literal then consumes a char; the literal check must be
+            // O(prefix), not O(remaining).
+            val text   = "a" * perfLen
+            val parser = Parse.repeat(Parse.firstOf(Parse.literal("z").map(_ => 'z'), Parse.any[Char]))
+            Parse.runOrAbort(text)(parser).map { result =>
+                withinBudget("repeat(literal/any)") {
+                    assert(result.length == perfLen)
+                }
+            }
+        }
+    }
 end ParseTest


### PR DESCRIPTION
## Problem

`ParseInput.remaining` returned `tokens.drop(position)`, which materializes a copy of the entire remaining input on every call. Every per-token consumer (`readOne`, `anyMatch`, `literal`, `boolean`, `identifier`) called `remaining` to read the head or test a prefix, so running `Parse.repeat` over an n-token input made O(n) such calls, each copying O(n) data. The overall cost was O(n^2) in both time and allocation.

The `startsWith` check in `literal` and `boolean` shared the same problem: `in.remaining.startsWith(text)` routed through `Seq.head` after copying the tail, not through direct indexing.

## Solution

`ParseInput` now caches a `Chunk.Indexed[In]` (`indexed`) derived once from `tokens` at construction time. All per-token reads go through that field instead of re-deriving the tail.

Two targeted additions replace the problematic call sites:

- `headMaybe: Maybe[In]` reads `indexed(position)` in O(1) and returns `Absent` at end of input. `readOne`, `anyMatch`, and `end` are rewritten to use it.

- `startsWith(prefix: Seq[In])` and `startsWith(prefix: String)` walk `indexed` from `position` without any tail copy, both in O(prefix.length). `literal`, `boolean`, and `identifier` are rewritten to call `in.startsWith(...)` directly.

`advanceWhile` already indexed into `tokens` directly; it is updated to use `indexed` for consistency.

The `remaining` accessor is kept for callers that genuinely need a `Chunk[In]` slice (for example `identifier`, which calls `in.remaining.takeWhile` after the head check). Its cost is now paid only where a contiguous slice is actually required.

The performance test suite (`"performance"` suite in `ParseTest`) adds three regression guards at n=500000: `repeat(any)`, `readWhile`, and `repeat(literal/any)`. Each asserts correct output length and a 30s wall-clock budget. At that input size the pre-fix code takes minutes; the fixed code finishes in well under a second.

## Notes

`Chunk.Indexed` is constructed once at `ParseInput` construction, not lazily, so callers that discard `ParseInput` immediately (for example single-token parses) pay the indexing cost even if they never call `headMaybe`. That trade-off is acceptable because `ParseInput` is already a value object allocated once per `Parse.run` invocation; the `toIndexed` call is O(n) in the token count, which is dominated by the O(n) scan that `repeat` would perform anyway.

The `remaining` method signature is unchanged. Callers on `origin/main` that read `in.remaining.head` or `in.remaining.startsWith(...)` would still compile; the hot-path callers inside `Parse.scala` are the ones rewritten here.
