### PR TITLE
Fix Windows drive letter dropped by Path segment reconstruction (#1678)

### DIFF
--- a/kyo-core/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-core/js-wasm/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -128,10 +128,14 @@ final private[kyo] class NodePathUnsafe(raw: String) extends Path.Unsafe:
     def parts: Chunk[String] =
         if pathStr.isEmpty then Chunk.empty
         else if NodePath.isAbsolute(pathStr) then
-            // Absolute: prepend "" to signal root
-            val stripped = if pathStr.startsWith("/") then pathStr.substring(1) else pathStr
-            val segs     = stripped.split("/", -1).filter(_.nonEmpty)
-            Chunk.from("" +: segs.toSeq)
+            if pathStr.startsWith("/") then
+                // POSIX root: the leading "" segment marks the root.
+                val segs = pathStr.substring(1).split("/", -1).filter(_.nonEmpty)
+                Chunk.from("" +: segs.toSeq)
+            else
+                // Windows drive root (e.g. "C:/Windows"): the drive designator segment marks
+                // the root, matching the JVM/Native representation so parts round-trip uniformly.
+                Chunk.from(pathStr.split("/", -1).filter(_.nonEmpty).toSeq)
         else
             Chunk.from(pathStr.split("/", -1).filter(_.nonEmpty).toSeq)
         end if

--- a/kyo-core/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/internal/PathPlatformSpecific.scala
@@ -30,8 +30,15 @@ final private[kyo] class NioPathUnsafe(val jpath: java.nio.file.Path) extends Pa
         if !jpath.isAbsolute && jpath.getNameCount == 1 && jpath.getName(0).toString.isEmpty then
             Chunk.empty // Path.of("") is the current-directory empty path
         else if jpath.isAbsolute then
-            // Preserve the leading "" representing the root
-            Chunk.from("" +: (0 until jpath.getNameCount).map(jpath.getName(_).toString))
+            // The leading segment encodes the filesystem root: "" for a POSIX root ("/")
+            // and the drive designator (e.g. "C:") for a Windows drive root ("C:\"). Carrying
+            // the drive here is what lets parts -> make round-trip without dropping the volume,
+            // which otherwise re-anchors the path to the process working directory's drive.
+            val root = jpath.getRoot
+            val rootSegment =
+                if root == null then ""
+                else root.toString.replace('\\', '/').stripSuffix("/")
+            Chunk.from(rootSegment +: (0 until jpath.getNameCount).map(jpath.getName(_).toString))
         else
             Chunk.from((0 until jpath.getNameCount).map(jpath.getName(_).toString))
         end if
@@ -519,6 +526,13 @@ abstract private[kyo] class PathPlatformSpecific extends PathDirectories:
         if nonEmpty.isEmpty then
             if isAbsolute then new NioPathUnsafe(java.nio.file.Path.of("/")).safe
             else new NioPathUnsafe(java.nio.file.Path.of("")).safe
+        else if isDriveRoot(nonEmpty.head) then
+            // Windows drive-rooted path: the leading segment is the volume root (e.g. "C:").
+            // Rebuild as "C:/rest" so the drive is preserved instead of being re-anchored to
+            // the process working directory's drive. Handles both ["C:", ...] and the
+            // ["", "C:", ...] shape, since the leading "" is dropped by `nonEmpty`.
+            val jpath = java.nio.file.Path.of(nonEmpty.head + "/" + nonEmpty.tail.mkString("/"))
+            new NioPathUnsafe(jpath.normalize()).safe
         else
             val jpath =
                 if isAbsolute then
@@ -538,6 +552,19 @@ abstract private[kyo] class PathPlatformSpecific extends PathDirectories:
             new NioPathUnsafe(jpath.normalize()).safe
         end if
     end make
+
+    /** True on Windows when `segment` is a drive designator like `C:` (the volume root).
+      *
+      * Gated to Windows so a POSIX directory literally named `C:` is never mistaken for a drive
+      * (e.g. `/C:/foo` must stay absolute on Unix rather than collapsing to a relative path).
+      * Uses `Platform.isWindows` — the idiom already used by the sibling `ProcessPlatformSpecific`,
+      * and a compile-time constant on Scala Native — rather than an ad-hoc separator check.
+      */
+    private def isDriveRoot(segment: String): Boolean =
+        Platform.isWindows && segment.length == 2 && segment.charAt(1) == ':' && {
+            val c = segment.charAt(0)
+            (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+        }
 
     private[kyo] def envOrEmpty(name: String): String =
         val v = java.lang.System.getenv(name)

--- a/kyo-core/shared/src/test/scala/kyo/PathTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/PathTest.scala
@@ -40,6 +40,80 @@ class PathTest extends kyo.test.Test[Any]:
         assert(p1.hashCode == p2.hashCode)
     }
 
+    // =========================================================================
+    // Windows drive root (issue #1678)
+    //
+    // On Windows an absolute path is rooted on a drive (e.g. C:\). Reconstructing
+    // a path from `parts` (via `/`, `apply`, `parent`, ...) must preserve that
+    // drive root; dropping it re-anchors the path to the process's CWD drive,
+    // silently corrupting real I/O and `confinedTo`.
+    // =========================================================================
+
+    "/ preserves the Windows drive letter" in {
+        assume(Platform.isWindows, "Windows drive-letter paths")
+        val p = Path("C:/Windows/System32")
+        assert(p.toString == "C:/Windows/System32")
+        assert((p / "drivers").toString == "C:/Windows/System32/drivers")
+    }
+
+    "parts retain the Windows drive root and round-trip via reconstruction" in {
+        assume(Platform.isWindows, "Windows drive-letter paths")
+        val p = Path("C:/Windows/System32")
+        assert(p.parts == Chunk("C:", "Windows", "System32"))
+        // Reconstructing from parts must yield the same drive-rooted path.
+        assert(Path(p.parts*).toString == "C:/Windows/System32")
+        assert(p.isAbsolute)
+    }
+
+    "native backslash Windows path (C:\\Windows\\System32) is handled like the forward-slash form" in {
+        assume(Platform.isWindows, "Windows drive-letter paths")
+        // The canonical Windows spelling uses backslashes; it must parse, preserve the drive,
+        // and derive children identically to the C:/... form.
+        val p = Path("C:\\Windows\\System32")
+        assert(p.parts == Chunk("C:", "Windows", "System32"))
+        assert(p.isAbsolute)
+        assert(p.toString == "C:/Windows/System32")
+        assert((p / "drivers").toString == "C:/Windows/System32/drivers")
+        // Equal to the forward-slash spelling of the same path.
+        assert(p == Path("C:/Windows/System32"))
+    }
+
+    "mixed-separator Windows path is parsed consistently" in {
+        assume(Platform.isWindows, "Windows drive-letter paths")
+        val p = Path("C:\\Windows/System32\\drivers")
+        assert(p.parts == Chunk("C:", "Windows", "System32", "drivers"))
+        assert(p.toString == "C:/Windows/System32/drivers")
+    }
+
+    "drive root alone (C:\\) preserves the drive and has no parent" in {
+        assume(Platform.isWindows, "Windows drive-letter paths")
+        val root = Path("C:\\")
+        assert(root.parts == Chunk("C:"))
+        assert(root.isAbsolute)
+        assert(root.toString == "C:/")
+        // The volume root is the top of the tree.
+        assert(root.parent == Absent)
+    }
+
+    "a /-derived child path stays under its root (drive preserved)" in {
+        // Cross-platform regression: on Windows with the CWD on a different drive
+        // than the temp dir, the drive letter was previously dropped so the child
+        // re-anchored to the CWD drive and landed outside the root.
+        for
+            root <- Path.tempDir("kyo-drive")
+            sub = root / "sub" / "f.txt"
+            _      <- sub.write("payload")
+            exists <- sub.exists
+            _      <- root.removeAll
+        yield
+            assert(
+                sub.toString.startsWith(root.toString),
+                s"child ${sub.toString} should be under root ${root.toString}"
+            )
+            assert(exists, "file written via a /-derived path should exist under the root")
+        end for
+    }
+
     "Path.basePaths fields are populated" in {
         val bp = Path.basePaths
         assert(bp.cache.toString.nonEmpty)


### PR DESCRIPTION
Fixes #1678.

## Problem

`kyo.Path` modeled an absolute path as a driveless segment list with a leading `""` marking the root. On Windows the JVM stores the drive in `java.nio.file.Path.getRoot` (`C:\`), **not** in the name components, so `parts` for `C:\Windows\System32` came back as `["", "Windows", "System32"]` — the drive dropped. Any reconstruction (`/`, `apply`, `parent`, `confinedTo`) then rebuilt a driveless absolute path, which the OS re-anchored to the **current process's drive**:

```
p.toString                = C:/Windows/System32          // correct
(p / "drivers").toString  = D:/Windows/System32/drivers  // WRONG: C: -> D:
```

This silently corrupted real I/O (writes landed on the CWD drive, not the path's drive) and made `confinedTo` drive-blind (a sandbox-escape footgun on multi-drive Windows).

## Fix

- **jvm-native** `PathPlatformSpecific`: `parts` now emits the drive designator (`C:`) as the leading root segment (POSIX `/` still maps to `""`), and `make` reconstructs drive-rooted paths instead of dropping the drive. Drive detection is gated via `Platform.isWindows` (a link-time constant on Scala Native) so a POSIX directory literally named `C:` is never mistaken for a drive (`/C:/foo` stays absolute on Unix).
- **js-wasm** `PathPlatformSpecific`: aligned `parts` to the same representation so both platforms round-trip identically.
- `confinedTo` becomes drive-aware automatically, since it compares `parts`.
- Added regression tests: `/` preserves the drive, `parts` round-trip through reconstruction, and a `/`-derived child stays under its `tempDir` root.

## Verification

On a multi-drive Windows box (repo on `D:`, temp on `C:`):

- `kyo-coreJVM` PathTest: **177 passed / 0 failed** (was 159 / 18 — the 15 `list`/`walk`/`remove` failures were the same bug, child paths landing on the wrong drive).
- `kyo-coreJS` compiles cleanly; Native shares the verified `jvm-native` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/getkyo/codesmith/kyo/pr/1679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784265509&installation_id=140673115&pr_number=1679&repository=getkyo%2Fkyo&return_to=https%3A%2F%2Fgithub.com%2Fgetkyo%2Fkyo%2Fpull%2F1679&signature=3c073d6950d4c1ed64ff25c7e8a7075cb5b6c5aef37532d34fba06ff41362196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->