### PR TITLE
[ffi] fix invalid Scala codegen for nested-struct String fields (#1683)

### DIFF
--- a/kyo-ffi/codegen/src/main/scala/kyo/ffi/codegen/emitters/EmitterBase.scala
+++ b/kyo-ffi/codegen/src/main/scala/kyo/ffi/codegen/emitters/EmitterBase.scala
@@ -40,6 +40,15 @@ private[emitters] object EmitterBase:
     def safeName(n: String): String =
         if ReservedNames.contains(n) then s"`$n`" else n
 
+    /** Turn a Scala access expression (e.g. `contact.address.city`, or `contact.` `type` `) into a legal local
+      * identifier prefix by stripping the backticks `safeName` adds and replacing the member-selection dots with
+      * underscores. Used when an access path is reused as the name of a generated temporary `val`: nested struct
+      * marshalling recurses with the dotted access as the base, so `${access}_cs` would otherwise emit an identifier
+      * like `contact.address_city_cs`, which the parser reads as a member selection on `contact` rather than a local.
+      */
+    def localIdent(access: String): String =
+        access.replace("`", "").replace('.', '_')
+
     val ReservedNames: Set[String] = Set(
         "type",
         "val",
@@ -285,6 +294,7 @@ private[emitters] object EmitterBase:
         protected def scalaTypeOf(t: TypeRef): String                         = EmitterBase.scalaTypeOf(t)
         protected def returnType(r: ReturnShape): String                      = EmitterBase.returnType(r)
         protected def safeName(n: String): String                             = EmitterBase.safeName(n)
+        protected def localIdent(access: String): String                      = EmitterBase.localIdent(access)
         protected def structsByName(spec: TraitSpec): Map[String, StructSpec] = EmitterBase.structsByName(spec)
 
         protected def sizeAndAlign(t: TypeRef, structsByName: Map[String, StructSpec], packed: Boolean): (Long, Long) =

--- a/kyo-ffi/codegen/src/main/scala/kyo/ffi/codegen/emitters/JvmEmitter.scala
+++ b/kyo-ffi/codegen/src/main/scala/kyo/ffi/codegen/emitters/JvmEmitter.scala
@@ -779,7 +779,9 @@ object JvmEmitter extends EmitterBase.Ops with PlatformTypes:
                 case TypeRef.DoubleT =>
                     buf += s"$segExpr.set(JAVA_DOUBLE, $offExpr, $access)"
                 case TypeRef.StringT =>
-                    val tmp = s"${caseClassVal}_${f.name}_cs"
+                    // Derive the temp name from the full access path so nested-struct recursion (caseClassVal carries
+                    // dots) still yields a legal local identifier, e.g. `contact_address_city_cs` not `contact.address_city_cs`.
+                    val tmp = s"${localIdent(access)}_cs"
                     // Thread binding + method context so spill logs identify the struct-field marshalling call site.
                     buf += s"""val $tmp = __kyoScratch$$.allocUtf8($access, "$bindingFqn", "$methodName")"""
                     buf += s"$segExpr.set(ADDRESS, $offExpr, $tmp)"
@@ -806,8 +808,8 @@ object JvmEmitter extends EmitterBase.Ops with PlatformTypes:
                     // the stub address at the field offset.  The stub is allocated on cbArena which is
                     // emitted by emitPlainMethodBody when it detects FnPtrT struct fields, and closed
                     // in the finally block after the FFI call.
-                    val stubN  = s"${caseClassVal}_${f.name}_stub"
-                    val descId = s"${caseClassVal}_${f.name}_desc"
+                    val stubN  = s"${localIdent(access)}_stub"
+                    val descId = s"${localIdent(access)}_desc"
                     val arity  = params.size
                     val desc   = callbackFunctionDescriptor(params, ret)
                     buf += s"val $descId = $desc"

--- a/kyo-ffi/codegen/src/main/scala/kyo/ffi/codegen/emitters/NativeEmitter.scala
+++ b/kyo-ffi/codegen/src/main/scala/kyo/ffi/codegen/emitters/NativeEmitter.scala
@@ -509,7 +509,7 @@ object NativeEmitter extends EmitterBase.Ops with PlatformTypes:
                             n,
                             throw new IllegalStateException(s"nested struct '$n' not found")
                         )
-                        val childPtr = s"${caseClassVal}_${f.name}_ptr"
+                        val childPtr = s"${localIdent(fieldAcc)}_ptr"
                         buf += s"val $childPtr = ($ptrVal + $offset)"
                         buf ++= emitStructWrite(fieldAcc, childPtr, child, structsByName, bindingFqn, methodName, teardownCollector)
                     case TypeRef.HandleT(_) =>
@@ -528,7 +528,7 @@ object NativeEmitter extends EmitterBase.Ops with PlatformTypes:
                         val pushName = s"pushTransient_$shape"
                         val popName  = s"popTransient_$shape"
                         val cbType   = cFuncPtrType(params, ret)
-                        val ptrVal2  = s"${caseClassVal}_${f.name}_cfp"
+                        val ptrVal2  = s"${localIdent(fieldAcc)}_cfp"
                         val trampRef = s"kyo.ffi.internal.CallbackRegistry.${NativeCallbackCatalog.transientTrampolineName(shape)}"
                         val fromFn =
                             if params.isEmpty then s"CFuncPtr0.fromScalaFunction($trampRef)"
@@ -559,12 +559,12 @@ object NativeEmitter extends EmitterBase.Ops with PlatformTypes:
                             n,
                             throw new IllegalStateException(s"nested struct '$n' not found")
                         )
-                        val childPtr = s"${caseClassVal}_${f.name}_ptr"
+                        val childPtr = s"${localIdent(fieldAcc)}_ptr"
                         buf += s"val $childPtr = $ptrVal.at${i + 1}"
                         buf ++= emitStructWrite(fieldAcc, childPtr, child, structsByName, bindingFqn, methodName, teardownCollector)
                     case TypeRef.UnionT(variants) =>
                         // Union field: runtime type match at the field's offset in the struct.
-                        val unionPtr = s"${caseClassVal}_${f.name}_unionPtr"
+                        val unionPtr = s"${localIdent(fieldAcc)}_unionPtr"
                         buf += s"val $unionPtr = $ptrVal.at${i + 1}.asInstanceOf[Ptr[Byte]]"
                         buf ++= emitNativeUnionVariantMatch(fieldAcc, unionPtr, variants, structsByName, bindingFqn, methodName)
                     case TypeRef.HandleT(_) =>
@@ -588,7 +588,7 @@ object NativeEmitter extends EmitterBase.Ops with PlatformTypes:
                         val pushName = s"pushTransient_$shape"
                         val popName  = s"popTransient_$shape"
                         val cbType   = cFuncPtrType(params, ret)
-                        val ptrVal2  = s"${caseClassVal}_${f.name}_cfp"
+                        val ptrVal2  = s"${localIdent(fieldAcc)}_cfp"
                         val trampRef = s"kyo.ffi.internal.CallbackRegistry.${NativeCallbackCatalog.transientTrampolineName(shape)}"
                         val fromFn =
                             if params.isEmpty then s"CFuncPtr0.fromScalaFunction($trampRef)"

--- a/kyo-ffi/codegen/src/test/scala/kyo/ffi/codegen/emitters/JvmEmitterTest.scala
+++ b/kyo-ffi/codegen/src/test/scala/kyo/ffi/codegen/emitters/JvmEmitterTest.scala
@@ -352,6 +352,54 @@ class JvmEmitterTest extends kyo.test.Test[Any]:
         assert(src.contains("uSeg.set(JAVA_INT, 4L, u.value)"))
     }
 
+    "nested-struct param with a String field emits a legal local identifier (not a dotted member selection)" in {
+        // Regression for #1683: a struct param containing a nested struct that contains a String field made the
+        // emitter build the scratch-temp name from the dotted access path (`contact.address`), producing
+        // `val contact.address_city_cs = ...` which the parser reads as a member selection on `contact`.
+        val address = StructSpec(
+            "kyo.example.Address",
+            "Address",
+            List(StructField("zip", TypeRef.IntT), StructField("city", TypeRef.StringT)),
+            packed = false
+        )
+        val contact = StructSpec(
+            "kyo.example.Contact",
+            "Contact",
+            List(
+                StructField("id", TypeRef.IntT),
+                StructField("name", TypeRef.StringT),
+                StructField("address", TypeRef.StructT(address.fqcn))
+            ),
+            packed = false
+        )
+        val spec = mkTrait(
+            "ContactBindings",
+            "contacts",
+            List(mkMethod(
+                "contactsRouteCode",
+                "contacts_route_code",
+                List(ParamSpec("contact", TypeRef.StructT(contact.fqcn))),
+                ReturnShape.Primitive(TypeRef.IntT)
+            )),
+            structs = List(address, contact)
+        )
+        val src = JvmEmitter.emit(spec)
+        // The temp for the nested String field uses underscores throughout, and the allocUtf8 still reads from the
+        // real dotted access expression `contact.address.city`.
+        assert(src.contains(
+            """val contact_address_city_cs = __kyoScratch$.allocUtf8(contact.address.city, "kyo.example.ContactBindings", "contactsRouteCode")"""
+        ))
+        // The top-level String field keeps its existing flat name.
+        assert(src.contains(
+            """val contact_name_cs = __kyoScratch$.allocUtf8(contact.name, "kyo.example.ContactBindings", "contactsRouteCode")"""
+        ))
+        // The broken dotted local name must not appear.
+        assert(!src.contains("val contact.address_city_cs"))
+        // And the whole thing parses.
+        val (ok, errs) = ScalaParseProbe.parses(src)
+        assert(ok == true, s"emitted source did not parse:\n$src\n\nerrors:\n$errs\n")
+    }
+
     "struct-by-value param allocates scratch and writes each field" in {
         val ts = StructSpec(
             "kyo.example.Timespec",

--- a/kyo-ffi/codegen/src/test/scala/kyo/ffi/codegen/emitters/NativeEmitterTest.scala
+++ b/kyo-ffi/codegen/src/test/scala/kyo/ffi/codegen/emitters/NativeEmitterTest.scala
@@ -302,6 +302,50 @@ class NativeEmitterTest extends kyo.test.Test[Any]:
         assert(src.contains("ext.sleep_ts(tsPtr)"))
     }
 
+    "doubly-nested struct param emits legal local pointer identifiers (not dotted member selections)" in {
+        // Regression for #1683 (Native side): nested-struct recursion carries the dotted access path as the
+        // base, so the child-pointer temp name was built as `${o.mid}_inner_ptr` → `o.mid_inner_ptr`, which the
+        // parser reads as a member selection on `o` rather than a local val. Needs two levels of struct nesting:
+        // the first level's child ptr is built from the bare param name, the second from the dotted access.
+        val inner = StructSpec(
+            "kyo.example.Inner",
+            "Inner",
+            List(StructField("v", TypeRef.IntT)),
+            packed = false
+        )
+        val mid = StructSpec(
+            "kyo.example.Mid",
+            "Mid",
+            List(StructField("inner", TypeRef.StructT(inner.fqcn))),
+            packed = false
+        )
+        val outer = StructSpec(
+            "kyo.example.Outer",
+            "Outer",
+            List(StructField("mid", TypeRef.StructT(mid.fqcn))),
+            packed = false
+        )
+        val spec = mkTrait(
+            "Nest",
+            "kyo_nest",
+            List(mkMethod(
+                "take",
+                "take_nest",
+                List(ParamSpec("o", TypeRef.StructT(outer.fqcn))),
+                ReturnShape.Primitive(TypeRef.IntT)
+            )),
+            structs = List(inner, mid, outer)
+        )
+        val src = NativeEmitter.emit(spec)
+        // Both nesting levels produce underscore-joined local identifiers.
+        assert(src.contains("val o_mid_ptr = "))
+        assert(src.contains("val o_mid_inner_ptr = "))
+        // The deepest primitive is still written from the real dotted access expression.
+        assert(src.contains("= o.mid.inner.v"))
+        // The broken dotted local names must not appear.
+        assert(!src.contains("val o.mid_inner_ptr"))
+    }
+
     "Unit-return method calls ext and then `()`, no retVal" in {
         val spec = mkTrait(
             "Simple",


### PR DESCRIPTION
## Summary

Fixes #1683. `kyo-ffi` codegen emitted invalid Scala when a struct param contained a nested struct with a `String` field. The emitter built the scratch-temp `val` name from the case-class access path, which carries member-selection dots once `emitStructWrite` recurses into a nested struct:

```scala
val contact.address_city_cs = __kyoScratch$.allocUtf8(contact.address.city, ...)
```

The parser reads `contact.address_city_cs` as a member selection on `contact`, so compilation fails with `value address_city_cs is not a member of example.Contact`.

The same class of bug exists in the Native emitter, where it surfaces at two levels of struct nesting (the `childPtr` / `cfp` / `unionPtr` temps are built from the dotted base).

## Fix

- Add `EmitterBase.localIdent(access)`: turns an access expression into a legal local-identifier prefix by stripping the backticks `safeName` adds and replacing member-selection dots with underscores.
- Use it at every site that reuses an access path as a generated `val` name:
  - `JvmEmitter`: `_cs` (String), `_stub` / `_desc` (function-pointer) fields.
  - `NativeEmitter`: `_ptr` / `_cfp` / `_unionPtr` temps.

Top-level (non-nested) names are unchanged: `contact.name` still yields `contact_name_cs`.

## Tests

- `JvmEmitterTest`: reproduces the exact #1683 shape (`Contact` → `Address` → `String`). Asserts the legal `contact_address_city_cs` temp, the absence of the dotted local, and that the emitted source parses under the Scala 3 parser.
- `NativeEmitterTest`: doubly-nested struct param, asserts `o_mid_inner_ptr` and the absence of `o.mid_inner_ptr`.

Both new tests fail before the fix and pass after. Full suites: `JvmEmitterTest` 74/0, `NativeEmitterTest` 60/0.