### PR TITLE
[schema] add MessagePack codec

### DIFF
--- a/kyo-schema/README.md
+++ b/kyo-schema/README.md
@@ -1,6 +1,6 @@
 # kyo-schema
 
-Define a case class and get JSON/YAML serialization, Protobuf encoding, field validation, type-safe lenses, structural diffs, and more, all derived from the type's structure. No annotations, no boilerplate. Works across JVM, JavaScript, and Scala Native. The module depends only on `kyo-data` (pure data structures) and has no dependency on Kyo's effect runtime, so it can be adopted as a standalone library.
+Define a case class and get JSON/YAML serialization, Protobuf and MessagePack encoding, field validation, type-safe lenses, structural diffs, and more, all derived from the type's structure. No annotations, no boilerplate. Works across JVM, JavaScript, and Scala Native. The module depends only on `kyo-data` (pure data structures) and has no dependency on Kyo's effect runtime, so it can be adopted as a standalone library.
 
 <!-- doctest:setup
 ```scala
@@ -31,13 +31,13 @@ Schema[User].focus(_.address.city).update(alice)(_.toUpperCase)
 
 Everything flows from `Schema[A]`, the central type that captures a type's structure at compile time. It's the single source of truth that powers serialization, validation, navigation, and conversion.
 
-The serialization format is chosen at the call site, not baked into the type. `Json.encode(value)`, `Ion.encode(value)`, and `Protobuf.encode(value)` summon the `Schema[A]` from implicit scope; a schema you reshaped or enriched only takes effect when you encode through that instance with `s.encode[Json](value)`.
+The serialization format is chosen at the call site, not baked into the type. `Json.encode(value)`, `Ion.encode(value)`, `Protobuf.encode(value)`, and `MsgPack.encode(value)` summon the `Schema[A]` from implicit scope; a schema you reshaped or enriched only takes effect when you encode through that instance with `s.encode[Json](value)`.
 
 These are the top-level entry points:
 
 | Entry point | Purpose |
 |-------------|---------|
-| `Json` / `Ion` / `Yaml` / `Protobuf` | Serialize to JSON strings, Ion text, YAML documents, or Protocol Buffers bytes |
+| `Json` / `Ion` / `Yaml` / `Protobuf` / `MsgPack` | Serialize to JSON strings, Ion text, YAML documents, Protocol Buffers bytes, or MessagePack bytes |
 | `Focus` | Type-safe lens for reading, writing, and updating fields at any depth |
 | `Compare` | Read-only field-by-field comparison of two values |
 | `Modify` | Batched field mutations applied as a single unit |
@@ -490,6 +490,46 @@ val proto = Protobuf.protoSchema[User]
 The field numbers in the generated `.proto` are assigned in declaration order (`1`, `2`, `3`, ...) and do **not** reflect the MurmurHash3-derived wire IDs that kyo-schema's own Protobuf codec uses on the wire. If you plan to interoperate with an external consumer of the `.proto`, pin field IDs explicitly with `fieldId(_.name)(1)` so the wire format matches the `.proto`.
 
 A few shapes that proto3 cannot express raise `IllegalArgumentException` at encode or `protoSchema` time: `Option[Option[_]]`, `List[Option[_]]`, `List[List[_]]`, `List[Map[_,_]]`, and `Unit`-typed fields. `BigInt` and `BigDecimal` serialize as proto3 `string`, since proto3 has no arbitrary-precision number type; this preserves exact round-trip values.
+
+### MsgPack
+
+MessagePack is a compact, self-describing binary format. Like Protobuf it produces `Span[Byte]`, but every value carries its own type tag on the wire, so the bytes are readable by any standard MessagePack decoder without the schema:
+
+```scala
+val bytes: Span[Byte] = MsgPack.encode(alice)
+
+MsgPack.decode[User](bytes)
+// Result.Success(alice)
+```
+
+Case classes encode as a MessagePack map keyed by field name, collections as arrays, `Option`/`Maybe` as the value or `nil`, and `Span[Byte]` as a binary blob. `MsgPack.decode` accepts the same `maxDepth` and `maxCollectionSize` safety limits as `Json.decode`.
+
+The wire shape is configurable through `MsgPack.Config`. For a more compact payload, switch field keys from names to the same stable MurmurHash3 IDs the Protobuf codec uses:
+
+```scala
+given MsgPack = MsgPack(MsgPack.Config(keyEncoding = MsgPack.KeyEncoding.FieldId))
+
+MsgPack.decode[User](MsgPack.encode(alice))
+// Result.Success(alice)
+```
+
+`KeyEncoding.FieldId` trades self-description for size. Dynamic `Map` keys and the `Result`/`Either` discriminators always stay strings, since a hash is not reversible. `Instant` and `Duration` default to a lossless `[seconds, nanos]` pair; `TemporalEncoding.Extension` writes them as MessagePack extension types (the reserved timestamp type for `Instant`) instead:
+
+```scala
+given MsgPack = MsgPack(MsgPack.Config(temporalEncoding = MsgPack.TemporalEncoding.Extension))
+
+MsgPack.decode[User](MsgPack.encode(alice))
+// Result.Success(alice)
+```
+
+Because MessagePack is self-describing, its reader can materialize an arbitrary payload into a `Structure.Value` without a schema. This makes MsgPack a binary transport for open-shaped wire protocols, the role JSON plays for JSON-RPC: an envelope can hold a `Structure.Value` slot whose concrete type is decided per message.
+
+```scala
+val bytes: Span[Byte] = MsgPack.encode(alice)
+
+summon[Schema[Structure.Value]].decode[MsgPack](bytes)
+// Result.Success(Structure.Value.Record(...))
+```
 
 ### Built-in Types
 

--- a/kyo-schema/README.md
+++ b/kyo-schema/README.md
@@ -513,14 +513,34 @@ MsgPack.decode[User](MsgPack.encode(alice))
 // Result.Success(alice)
 ```
 
-`KeyEncoding.FieldId` trades self-description for size. Dynamic `Map` keys and the `Result`/`Either` discriminators always stay strings, since a hash is not reversible. `Instant` and `Duration` default to a lossless `[seconds, nanos]` pair; `TemporalEncoding.Extension` writes them as MessagePack extension types (the reserved timestamp type for `Instant`) instead:
+`KeyEncoding.FieldId` trades self-description for size. Dynamic `Map` keys and the `Result`/`Either` discriminators always stay strings, since a hash is not reversible.
+
+`Instant` defaults to a lossless `[seconds, nanos]` array; `InstantEncoding.Extension` writes the spec-defined MessagePack timestamp extension (type -1), which standard MessagePack decoders in other languages read as a timestamp:
 
 ```scala
-given MsgPack = MsgPack(MsgPack.Config(temporalEncoding = MsgPack.TemporalEncoding.Extension))
+given MsgPack = MsgPack(MsgPack.Config(instantEncoding = MsgPack.InstantEncoding.Extension))
 
 MsgPack.decode[User](MsgPack.encode(alice))
 // Result.Success(alice)
 ```
+
+`Duration` has no MessagePack standard, so `DurationEncoding` lets you choose: `Lossless` (default, a `[seconds, nanos]` array keeping the full `java.time.Duration` range) or `Compat` (a string of total nanoseconds, wire-compatible with upickle/weePickle, limited to the `Long` nanosecond range). Schemas are provided for both `java.time.Duration` and `scala.concurrent.duration.{Duration, FiniteDuration}`. The reader auto-detects the wire shape either way:
+
+```scala
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+
+case class Timeout(connect: FiniteDuration, idle: Duration) derives Schema
+
+given MsgPack = MsgPack(MsgPack.Config(durationEncoding = MsgPack.DurationEncoding.Compat))
+
+val t = Timeout(5.seconds, Duration.Inf)
+MsgPack.decode[Timeout](MsgPack.encode(t))
+// Result.Success(Timeout(5 seconds, Duration.Inf))
+```
+
+`scala.concurrent.duration.Duration` (the possibly-infinite type) always uses the string form so it can carry `Inf`/`MinusInf`/`Undefined`; `FiniteDuration` and `java.time.Duration` follow the `DurationEncoding` setting.
 
 Because MessagePack is self-describing, its reader can materialize an arbitrary payload into a `Structure.Value` without a schema. This makes MsgPack a binary transport for open-shaped wire protocols, the role JSON plays for JSON-RPC: an envelope can hold a `Structure.Value` slot whose concrete type is decided per message.
 

--- a/kyo-schema/shared/src/main/scala/kyo/MsgPack.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/MsgPack.scala
@@ -12,9 +12,12 @@ package kyo
   *     interops with any MsgPack decoder) or `FieldId` (compact MurmurHash3 integers, like Protobuf). Dynamic `Map` keys and the
   *     `Result`/`Either`/tuple discriminator keys are always written as strings regardless of this setting, since they are not recoverable
   *     from a hash.
-  *   - [[MsgPack.TemporalEncoding]] selects how `Instant`/`Duration` are written: `Primitive` (default, lossless `[seconds, nanos]` array)
-  *     or `Extension` (MessagePack timestamp extension for `Instant`, a Kyo extension for `Duration`). The reader auto-detects the wire
-  *     shape, so bytes produced under either setting decode correctly regardless of the reader's config.
+  *   - [[MsgPack.InstantEncoding]] selects how `Instant` is written: `Primitive` (default, lossless `[seconds, nanos]` array) or
+  *     `Extension` (the spec-defined MessagePack timestamp extension, type -1). The reader auto-detects the wire shape, so bytes produced
+  *     under either setting decode correctly regardless of the reader's config.
+  *   - [[MsgPack.DurationEncoding]] selects how `Duration`/`FiniteDuration` are written: `Lossless` (default, `[seconds, nanos]` array,
+  *     full range) or `Compat` (a string of total nanoseconds, wire-compatible with upickle/weePickle). Schemas for both
+  *     `java.time.Duration` and `scala.concurrent.duration.{Duration, FiniteDuration}` are provided.
   *
   * @see
   *   [[kyo.Schema]] for the type-driven serialization model
@@ -47,25 +50,48 @@ object MsgPack:
         case FieldId
     end KeyEncoding
 
-    /** Selects how `java.time.Instant` and `java.time.Duration` are encoded. */
-    enum TemporalEncoding derives CanEqual:
+    /** Selects how `java.time.Instant` is encoded. */
+    enum InstantEncoding derives CanEqual:
         /** Lossless primitive encoding: a 2-element `[seconds, nanos]` array. */
         case Primitive
 
-        /** MessagePack timestamp extension (type -1) for `Instant`; a Kyo extension (type 1) for `Duration`. */
+        /** MessagePack reserved timestamp extension (type -1), the spec-defined cross-language form. */
         case Extension
-    end TemporalEncoding
+    end InstantEncoding
+
+    /** Selects how `java.time.Duration` and `scala.concurrent.duration.FiniteDuration` are encoded.
+      *
+      * MessagePack defines no Duration type and no cross-library convention exists, so this is a free choice:
+      *   - [[Lossless]] keeps full `java.time.Duration` range (seconds beyond a `Long` of nanoseconds).
+      *   - [[Compat]] matches upickle/weePickle, whose Duration wire form is a string of total nanoseconds.
+      *
+      * `scala.concurrent.duration.Duration` (the possibly-infinite abstract type) always uses the [[Compat]]
+      * string form regardless of this setting, since `Inf`/`MinusInf`/`Undefined` have no lossless numeric
+      * representation.
+      */
+    enum DurationEncoding derives CanEqual:
+        /** Lossless 2-element `[seconds, nanos]` array, preserving the full `java.time.Duration` range. */
+        case Lossless
+
+        /** A MessagePack string of total nanoseconds, wire-compatible with upickle/weePickle. Limited to the
+          * `Long` nanosecond range (about 292 years), matching those libraries.
+          */
+        case Compat
+    end DurationEncoding
 
     /** Wire-shape configuration for the MsgPack codec.
       *
       * @param keyEncoding
       *   how schema field/variant names are written (default [[KeyEncoding.StringName]])
-      * @param temporalEncoding
-      *   how `Instant`/`Duration` are written (default [[TemporalEncoding.Primitive]])
+      * @param instantEncoding
+      *   how `Instant` is written (default [[InstantEncoding.Primitive]])
+      * @param durationEncoding
+      *   how `Duration`/`FiniteDuration` is written (default [[DurationEncoding.Lossless]])
       */
     case class Config(
         keyEncoding: KeyEncoding = KeyEncoding.StringName,
-        temporalEncoding: TemporalEncoding = TemporalEncoding.Primitive
+        instantEncoding: InstantEncoding = InstantEncoding.Primitive,
+        durationEncoding: DurationEncoding = DurationEncoding.Lossless
     ) derives CanEqual
 
     object Config:

--- a/kyo-schema/shared/src/main/scala/kyo/MsgPack.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/MsgPack.scala
@@ -1,0 +1,111 @@
+package kyo
+
+/** A [[Codec]] for the MessagePack binary serialization format.
+  *
+  * MessagePack (https://msgpack.org) is a compact, self-describing binary format: every value carries a type tag on the wire, so a decoder
+  * can walk arbitrary data without a schema. This places MsgPack between [[Protobuf]] (compact but schema-required) and [[Json]]
+  * (self-describing but text). Because it is self-describing, [[kyo.internal.msgpack.MsgPackReader]] is a [[Codec.IntrospectingReader]],
+  * so `Structure.Value` and open-shaped wire protocols (JSON-RPC style envelopes) round-trip through MsgPack.
+  *
+  * The wire shape is controlled by [[MsgPack.Config]]:
+  *   - [[MsgPack.KeyEncoding]] selects how case-class field and sealed-variant names are written: `StringName` (default, self-describing,
+  *     interops with any MsgPack decoder) or `FieldId` (compact MurmurHash3 integers, like Protobuf). Dynamic `Map` keys and the
+  *     `Result`/`Either`/tuple discriminator keys are always written as strings regardless of this setting, since they are not recoverable
+  *     from a hash.
+  *   - [[MsgPack.TemporalEncoding]] selects how `Instant`/`Duration` are written: `Primitive` (default, lossless `[seconds, nanos]` array)
+  *     or `Extension` (MessagePack timestamp extension for `Instant`, a Kyo extension for `Duration`). The reader auto-detects the wire
+  *     shape, so bytes produced under either setting decode correctly regardless of the reader's config.
+  *
+  * @see
+  *   [[kyo.Schema]] for the type-driven serialization model
+  * @see
+  *   [[kyo.Protobuf]] for compact schema-required binary serialization
+  */
+final class MsgPack(val config: MsgPack.Config = MsgPack.Config.Default) extends Codec:
+    def newWriter(): Codec.Writer = kyo.internal.msgpack.MsgPackWriter(config)
+    def newReader(input: Span[Byte])(using Frame): Codec.Reader =
+        kyo.internal.msgpack.MsgPackReader(input.toArray, config)
+end MsgPack
+
+/** Entry point for MessagePack binary serialization.
+  *
+  * All encode methods are inline and require a `Schema[A]` and a `MsgPack` instance in scope (the default `given MsgPack` uses
+  * [[Config.Default]]; construct a configured `MsgPack(...)` for non-default wire shapes).
+  */
+object MsgPack:
+
+    given MsgPack = MsgPack()
+
+    /** Selects how case-class field names and sealed-trait variant names are encoded as MessagePack map keys. */
+    enum KeyEncoding derives CanEqual:
+        /** Write each schema field/variant name as its UTF-8 string. Self-describing and interoperable with generic MessagePack tooling. */
+        case StringName
+
+        /** Write each schema field/variant name as its stable MurmurHash3 `fieldId` integer. Compact, but not consumable without the
+          * schema.
+          */
+        case FieldId
+    end KeyEncoding
+
+    /** Selects how `java.time.Instant` and `java.time.Duration` are encoded. */
+    enum TemporalEncoding derives CanEqual:
+        /** Lossless primitive encoding: a 2-element `[seconds, nanos]` array. */
+        case Primitive
+
+        /** MessagePack timestamp extension (type -1) for `Instant`; a Kyo extension (type 1) for `Duration`. */
+        case Extension
+    end TemporalEncoding
+
+    /** Wire-shape configuration for the MsgPack codec.
+      *
+      * @param keyEncoding
+      *   how schema field/variant names are written (default [[KeyEncoding.StringName]])
+      * @param temporalEncoding
+      *   how `Instant`/`Duration` are written (default [[TemporalEncoding.Primitive]])
+      */
+    case class Config(
+        keyEncoding: KeyEncoding = KeyEncoding.StringName,
+        temporalEncoding: TemporalEncoding = TemporalEncoding.Primitive
+    ) derives CanEqual
+
+    object Config:
+        val Default: Config = Config()
+
+        given Config = Default
+    end Config
+
+    /** Encodes a value of type A to MessagePack binary bytes. */
+    inline def encode[A](value: A)(using schema: Schema[A], msgpack: MsgPack, frame: Frame): Span[Byte] =
+        val w = msgpack.newWriter()
+        schema.writeTo(value, w)
+        w.result()
+    end encode
+
+    /** Encodes a value of type A to MessagePack binary bytes. Alias of [[encode]] for naming symmetry with the other binary codecs. */
+    inline def encodeBytes[A](value: A)(using schema: Schema[A], msgpack: MsgPack, frame: Frame): Span[Byte] =
+        encode[A](value)
+
+    /** Decodes MessagePack binary bytes into a value of type A.
+      *
+      * @return
+      *   the decoded value, or a DecodeException if the input is malformed or does not match the schema
+      */
+    def decode[A](
+        input: Span[Byte],
+        maxDepth: Int = Json.DefaultMaxDepth,
+        maxCollectionSize: Int = Json.DefaultMaxCollectionSize
+    )(using msgpack: MsgPack, schema: Schema[A], frame: Frame): Result[DecodeException, A] =
+        val reader = msgpack.newReader(input)
+        reader.resetLimits(maxDepth, maxCollectionSize)
+        Result.catching[DecodeException](schema.readFrom(reader))
+    end decode
+
+    /** Decodes MessagePack binary bytes into a value of type A. Alias of [[decode]] for naming symmetry with the other binary codecs. */
+    def decodeBytes[A](
+        input: Span[Byte],
+        maxDepth: Int = Json.DefaultMaxDepth,
+        maxCollectionSize: Int = Json.DefaultMaxCollectionSize
+    )(using msgpack: MsgPack, schema: Schema[A], frame: Frame): Result[DecodeException, A] =
+        decode[A](input, maxDepth, maxCollectionSize)
+
+end MsgPack

--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -1259,6 +1259,46 @@ object Schema:
     given kyoDurationSchema: Schema[kyo.Duration] =
         longSchema.transform[kyo.Duration](kyo.Duration.fromNanos)(_.toNanos)
 
+    /** Schema for scala.concurrent.duration.FiniteDuration values.
+      *
+      * Encodes via the same wire primitive as `java.time.Duration` (so format codecs apply their own duration shape), round-tripping by
+      * total nanoseconds. The decoded value is normalized to the coarsest exact unit, matching how other libraries (e.g. upickle) decode.
+      */
+    given finiteDurationSchema: Schema[scala.concurrent.duration.FiniteDuration] =
+        durationSchema.transform[scala.concurrent.duration.FiniteDuration](jd => scala.concurrent.duration.Duration.fromNanos(jd.toNanos))(
+            fd => java.time.Duration.ofNanos(fd.toNanos)
+        )
+
+    /** Schema for scala.concurrent.duration.Duration values (the possibly-infinite abstract type).
+      *
+      * Always encoded as a string: the total nanoseconds for a finite value, or `"inf"`/`"-inf"`/`"undef"` for the infinite and undefined
+      * cases. This is the upickle/weePickle wire form, the only representation that can carry the infinite cases, so it is used regardless of
+      * any format-specific duration setting.
+      */
+    given scalaDurationSchema: Schema[scala.concurrent.duration.Duration] =
+        Schema.init[scala.concurrent.duration.Duration](
+            writeFn = (v, w) =>
+                w.string(
+                    if v eq scala.concurrent.duration.Duration.Undefined then "undef"
+                    else if v eq scala.concurrent.duration.Duration.Inf then "inf"
+                    else if v eq scala.concurrent.duration.Duration.MinusInf then "-inf"
+                    else v.toNanos.toString
+                ),
+            readFn = r =>
+                r.string() match
+                    case "inf"   => scala.concurrent.duration.Duration.Inf
+                    case "-inf"  => scala.concurrent.duration.Duration.MinusInf
+                    case "undef" => scala.concurrent.duration.Duration.Undefined
+                    case s =>
+                        try scala.concurrent.duration.Duration.fromNanos(s.toLong)
+                        catch case _: NumberFormatException => throw TypeMismatchException(Seq.empty, "Duration", s)(using r.frame)
+            ,
+            structure = Structure.Type.Primitive(
+                Structure.PrimitiveKind.String,
+                Tag[scala.concurrent.duration.Duration].asInstanceOf[Tag[Any]]
+            )
+        )
+
     /** Schema for kyo.Schedule values. Walks the sealed hierarchy via the generic macro derivation. */
     given scheduleSchema: Schema[kyo.Schedule] = Schema.derived
 

--- a/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
@@ -495,14 +495,26 @@ import scala.quoted.*
 
         // WRITE: static per-field emission, no runtime field walk.
         def writeBody(v: Expr[A], w: Expr[Writer]): Expr[Unit] =
-            val header: Expr[Unit] = '{ $w.objectStart(${ Expr(typeName) }, ${ Expr(n) }) }
-            val perField: List[Expr[Unit]] = fields.zipWithIndex.map { (f, idx) =>
+            val owner = Symbol.spliceOwner
+            // Pre-encode each field's UTF-8 name bytes once per serialization, mirroring the read side's
+            // nameByteSyms and the sealed-variant write path. Schema field keys go through `fieldBytes`
+            // (the canonical schema-field key method: the JSON writer's ASCII fast path, the Protobuf
+            // field tag, and the MsgPack key-encoding switch). Dynamic `Map` keys and the hand-written
+            // sum discriminator keys stay on `field`, which carries the raw String for escaping.
+            val nameByteSyms: List[Symbol] = fields.zipWithIndex.map { (f, idx) =>
+                Symbol.newVal(owner, s"_wnb${idx}", TypeRepr.of[Array[Byte]], Flags.EmptyFlags, Symbol.noSymbol)
+            }
+            val nameByteDefs: List[Statement] = fields.zipWithIndex.map { (f, idx) =>
                 val nameExpr = Expr(f.name)
+                ValDef(nameByteSyms(idx), Some('{ $nameExpr.getBytes(java.nio.charset.StandardCharsets.UTF_8) }.asTerm))
+            }
+            val header: Term = '{ $w.objectStart(${ Expr(typeName) }, ${ Expr(n) }) }.asTerm
+            val perField: List[Term] = fields.zipWithIndex.map { (f, idx) =>
                 // Field header tag MUST be the hash-based field ID (CodecMacro.fieldId), NOT the
-                // positional index. The JSON writer ignores this id (it writes names), but the
-                // Protobuf wire stores it as the field tag and the Protobuf reader dispatches by it.
-                // Computed at macro time as a literal; identical to the runtime's meta.fieldIds(i).
+                // positional index. Computed at macro time as a literal; identical to the runtime's
+                // meta.fieldIds(i).
                 val idxExpr = Expr(CodecMacro.fieldId(f.name))
+                val nbRef   = Ref(nameByteSyms(idx)).asExprOf[Array[Byte]]
                 if isMaybeFlags(idx) then
                     effectiveSchemaTypes(idx).asType match
                         case '[t] =>
@@ -511,11 +523,11 @@ import scala.quoted.*
                             '{
                                 $acc match
                                     case kyo.Present(inner) =>
-                                        $w.field($nameExpr, $idxExpr)
+                                        $w.fieldBytes($nbRef, $idxExpr)
                                         kyo.internal.writeField($s, inner, $w)
                                     case _ => ()
                                 end match
-                            }
+                            }.asTerm
                 else if isOptionFlags(idx) then
                     effectiveSchemaTypes(idx).asType match
                         case '[t] =>
@@ -524,22 +536,22 @@ import scala.quoted.*
                             '{
                                 val _opt = $acc
                                 if _opt.asInstanceOf[Option[?]].isDefined then
-                                    $w.field($nameExpr, $idxExpr)
+                                    $w.fieldBytes($nbRef, $idxExpr)
                                     kyo.internal.writeField($s, _opt, $w)
-                            }
+                            }.asTerm
                 else
                     effectiveSchemaTypes(idx).asType match
                         case '[t] =>
                             val s   = fieldSchemaExprTyped[t](idx)
                             val acc = Select(v.asTerm, f).asExprOf[t]
                             '{
-                                $w.field($nameExpr, $idxExpr)
+                                $w.fieldBytes($nbRef, $idxExpr)
                                 kyo.internal.writeField($s, $acc, $w)
-                            }
+                            }.asTerm
                 end if
             }
-            val trailer: Expr[Unit] = '{ $w.objectEnd() }
-            Expr.block(header :: perField, trailer)
+            val trailer: Term = '{ $w.objectEnd() }.asTerm
+            Block(nameByteDefs ++ (header :: perField), trailer).asExprOf[Unit]
         end writeBody
 
         // READ: static per-field name-matched loop.

--- a/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackFormat.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackFormat.scala
@@ -67,9 +67,6 @@ private[msgpack] object MsgPackFormat:
     /** MessagePack reserved extension type for timestamps (`-1`). */
     inline val ExtTypeTimestamp = -1
 
-    /** Kyo-specific extension type for `java.time.Duration` (seconds + nanos), not defined by the MessagePack spec. */
-    inline val ExtTypeDuration = 1
-
     // Open-container kinds tracked by the writer to decide whether `field` counts toward an object header.
     inline val KindObject = 0
     inline val KindArray  = 1

--- a/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackFormat.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackFormat.scala
@@ -1,0 +1,99 @@
+package kyo.internal.msgpack
+
+/** MessagePack format-byte constants and small classification helpers.
+  *
+  * Centralizes the wire-format prefix bytes shared by [[MsgPackWriter]] and [[MsgPackReader]] so the two stay in sync. Values follow the
+  * MessagePack specification (https://github.com/msgpack/msgpack/blob/master/spec.md). Ranges encoded in a single byte (fixint, fixstr,
+  * fixarray, fixmap) are expressed as base markers plus masks rather than enumerated. The `inline val`s carry no type ascription so each
+  * keeps its singleton literal type, which `inline` requires.
+  */
+private[msgpack] object MsgPackFormat:
+
+    // Single-byte-encoded ranges
+    inline val PositiveFixIntMax = 0x7f // 0x00..0x7f; 0xe0..0xff encode negative fixints -32..-1
+    inline val FixMapPrefix      = 0x80 // 0x80..0x8f, low nibble = size
+    inline val FixArrayPrefix    = 0x90 // 0x90..0x9f, low nibble = size
+    inline val FixStrPrefix      = 0xa0 // 0xa0..0xbf, low 5 bits = length
+    inline val FixMax            = 0x0f // max size/length for the fix* map/array forms; fixstr uses FixStrMax
+    inline val FixStrMax         = 0x1f
+
+    // Constant single-byte values
+    inline val Nil   = 0xc0
+    inline val False = 0xc2
+    inline val True  = 0xc3
+
+    // Length-prefixed binary
+    inline val Bin8  = 0xc4
+    inline val Bin16 = 0xc5
+    inline val Bin32 = 0xc6
+
+    // Extension types
+    inline val Ext8     = 0xc7
+    inline val Ext16    = 0xc8
+    inline val Ext32    = 0xc9
+    inline val FixExt1  = 0xd4
+    inline val FixExt2  = 0xd5
+    inline val FixExt4  = 0xd6
+    inline val FixExt8  = 0xd7
+    inline val FixExt16 = 0xd8
+
+    // Floating point
+    inline val Float32 = 0xca
+    inline val Float64 = 0xcb
+
+    // Unsigned integers
+    inline val UInt8  = 0xcc
+    inline val UInt16 = 0xcd
+    inline val UInt32 = 0xce
+    inline val UInt64 = 0xcf
+
+    // Signed integers
+    inline val Int8  = 0xd0
+    inline val Int16 = 0xd1
+    inline val Int32 = 0xd2
+    inline val Int64 = 0xd3
+
+    // Length-prefixed string
+    inline val Str8  = 0xd9
+    inline val Str16 = 0xda
+    inline val Str32 = 0xdb
+
+    // Length-prefixed array / map
+    inline val Array16 = 0xdc
+    inline val Array32 = 0xdd
+    inline val Map16   = 0xde
+    inline val Map32   = 0xdf
+
+    /** MessagePack reserved extension type for timestamps (`-1`). */
+    inline val ExtTypeTimestamp = -1
+
+    /** Kyo-specific extension type for `java.time.Duration` (seconds + nanos), not defined by the MessagePack spec. */
+    inline val ExtTypeDuration = 1
+
+    // Open-container kinds tracked by the writer to decide whether `field` counts toward an object header.
+    inline val KindObject = 0
+    inline val KindArray  = 1
+    inline val KindMap    = 2
+
+    def isPositiveFixInt(b: Int): Boolean = (b & 0x80) == 0x00         // 0x00..0x7f
+    def isNegativeFixInt(b: Int): Boolean = (b & 0xe0) == 0xe0         // 0xe0..0xff
+    def isFixMap(b: Int): Boolean         = (b & 0xf0) == FixMapPrefix // 0x80..0x8f
+    def isFixArray(b: Int): Boolean       = (b & 0xf0) == FixArrayPrefix
+    def isFixStr(b: Int): Boolean         = (b & 0xe0) == FixStrPrefix // 0xa0..0xbf
+
+    def isStr(b: Int): Boolean   = isFixStr(b) || b == Str8 || b == Str16 || b == Str32
+    def isMap(b: Int): Boolean   = isFixMap(b) || b == Map16 || b == Map32
+    def isArray(b: Int): Boolean = isFixArray(b) || b == Array16 || b == Array32
+    def isBin(b: Int): Boolean   = b == Bin8 || b == Bin16 || b == Bin32
+    def isExt(b: Int): Boolean =
+        b == Ext8 || b == Ext16 || b == Ext32 ||
+            b == FixExt1 || b == FixExt2 || b == FixExt4 || b == FixExt8 || b == FixExt16
+
+    def isInt(b: Int): Boolean =
+        isPositiveFixInt(b) || isNegativeFixInt(b) ||
+            b == UInt8 || b == UInt16 || b == UInt32 || b == UInt64 ||
+            b == Int8 || b == Int16 || b == Int32 || b == Int64
+
+    def isFloat(b: Int): Boolean = b == Float32 || b == Float64
+
+end MsgPackFormat

--- a/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackReader.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackReader.scala
@@ -1,0 +1,537 @@
+package kyo.internal.msgpack
+
+import java.nio.charset.StandardCharsets
+import kyo.*
+import kyo.Codec.IntrospectingReader
+import kyo.Codec.Reader
+import kyo.internal.CodecMacro
+import scala.annotation.tailrec
+
+/** Reads values from MessagePack wire format.
+  *
+  * MessagePack containers carry an explicit element count, so iteration is count-driven: `objectStart`/`arrayStart`/`mapStart` read the
+  * header count and push it on a stack, and `hasNextField`/`hasNextElement`/`hasNextEntry` decrement the top of that stack. This is simpler
+  * and more robust than a sentinel-scanning text reader.
+  *
+  * MessagePack is self-describing, so this reader is a [[Codec.IntrospectingReader]]: [[readStructure]] materializes an arbitrary wire value
+  * into a [[Structure.Value]], enabling open-shaped wire protocols.
+  *
+  * Key dispatch follows the [[MsgPackWriter]] split: macro-generated case-class reads use [[fieldParse]]/[[matchField]], which accept either
+  * a string key (byte comparison) or an integer `fieldId` key (compared against [[CodecMacro.fieldId]]), so bytes written under either
+  * [[MsgPack.KeyEncoding]] decode correctly. Dynamic map and sum-discriminator reads use [[field]], which the writer always emitted as a
+  * string.
+  */
+final class MsgPackReader(data: Array[Byte], config: MsgPack.Config)(using _frame: Frame) extends IntrospectingReader:
+    import MsgPackFormat.*
+
+    override def frame: Frame = _frame
+
+    private val self     = MsgPack(config)
+    private var pos: Int = 0
+
+    // Remaining-element counts for the open containers, indexed [0, depthTop).
+    private var counts   = new Array[Int](16)
+    private var depthTop = 0
+
+    // Last key parsed by fieldParse/field, for matchField/lastFieldName.
+    private var keyIsInt      = false
+    private var keyInt: Long  = 0L
+    private var keyStart: Int = 0
+    private var keyLen: Int   = 0
+
+    // --- low-level byte access ---
+
+    private def truncated(detail: String): Nothing =
+        throw TruncatedInputException(self, detail)(using _frame)
+
+    private def readByte(): Int =
+        if pos >= data.length then truncated("unexpected end of input")
+        val b = data(pos) & 0xff
+        pos += 1
+        b
+    end readByte
+
+    private def peekByte(): Int =
+        if pos >= data.length then truncated("unexpected end of input")
+        data(pos) & 0xff
+
+    private def readS8(): Int  = readByte().toByte.toInt
+    private def readU16(): Int = (readByte() << 8) | readByte()
+    private def readS16(): Int = readU16().toShort.toInt
+
+    private def readBE32(): Int =
+        (readByte() << 24) | (readByte() << 16) | (readByte() << 8) | readByte()
+
+    private def readU32Long(): Long = readBE32().toLong & 0xffffffffL
+
+    private def readBE64(): Long =
+        @tailrec def loop(i: Int, acc: Long): Long =
+            if i < 8 then loop(i + 1, (acc << 8) | (readByte().toLong & 0xffL)) else acc
+        loop(0, 0L)
+    end readBE64
+
+    /** Reads a 32-bit length field, rejecting values that do not fit a non-negative Int (which JVM arrays cannot address). */
+    private def readLen32(): Int =
+        val v = readBE32()
+        if v < 0 then truncated(s"length $v exceeds addressable range")
+        v
+    end readLen32
+
+    private def requireRemaining(n: Int): Unit =
+        // Widen to Long so a large positive `n` plus `pos` cannot overflow Int and slip past the bound,
+        // which would let a raw IndexOutOfBounds escape the Result[DecodeException, A] contract.
+        if n < 0 || pos.toLong + n.toLong > data.length.toLong then truncated(s"need $n more bytes")
+
+    private def readUtf8(len: Int): String =
+        requireRemaining(len)
+        val s = new String(data, pos, len, StandardCharsets.UTF_8)
+        pos += len
+        s
+    end readUtf8
+
+    private def formatName(b: Int): String =
+        if isInt(b) then "integer"
+        else if isStr(b) then "string"
+        else if isMap(b) then "map"
+        else if isArray(b) then "array"
+        else if isBin(b) then "binary"
+        else if isExt(b) then "extension"
+        else if isFloat(b) then "float"
+        else if b == Nil then "nil"
+        else if b == True || b == False then "boolean"
+        else f"unknown(0x$b%02x)"
+
+    private def mismatch(expected: String, b: Int): Nothing =
+        throw TypeMismatchException(Seq.empty, expected, formatName(b))(using _frame)
+
+    // --- container count stack ---
+
+    private def push(n: Int): Unit =
+        if depthTop >= counts.length then counts = java.util.Arrays.copyOf(counts, counts.length * 2)
+        counts(depthTop) = n
+        depthTop += 1
+    end push
+
+    private def pop(): Unit = depthTop -= 1
+
+    private def decTop(): Boolean =
+        val i = depthTop - 1
+        if i >= 0 && counts(i) > 0 then
+            counts(i) -= 1
+            true
+        else false
+        end if
+    end decTop
+
+    private def readMapHeader(): Int =
+        val b = readByte()
+        val n =
+            if isFixMap(b) then b & 0x0f
+            else if b == Map16 then readU16()
+            else if b == Map32 then readLen32()
+            else mismatch("map", b)
+        checkCollectionSize(n)
+        n
+    end readMapHeader
+
+    private def readArrayHeader(): Int =
+        val b = readByte()
+        val n =
+            if isFixArray(b) then b & 0x0f
+            else if b == Array16 then readU16()
+            else if b == Array32 then readLen32()
+            else mismatch("array", b)
+        checkCollectionSize(n)
+        n
+    end readArrayHeader
+
+    def objectStart(): Int =
+        checkDepth()
+        val n = readMapHeader()
+        push(n)
+        n
+    end objectStart
+
+    def objectEnd(): Unit =
+        pop()
+        decrementDepth()
+
+    def arrayStart(): Int =
+        checkDepth()
+        val n = readArrayHeader()
+        push(n)
+        n
+    end arrayStart
+
+    def arrayEnd(): Unit =
+        pop()
+        decrementDepth()
+
+    def mapStart(): Int = objectStart()
+    def mapEnd(): Unit  = objectEnd()
+
+    def hasNextField(): Boolean   = decTop()
+    def hasNextElement(): Boolean = decTop()
+    def hasNextEntry(): Boolean   = decTop()
+
+    // --- key parsing ---
+
+    private def parseKey(): Unit =
+        val b = peekByte()
+        if isStr(b) then
+            val hb = readByte()
+            val len =
+                if isFixStr(hb) then hb & 0x1f
+                else if hb == Str8 then readByte()
+                else if hb == Str16 then readU16()
+                else readLen32()
+            requireRemaining(len)
+            keyIsInt = false
+            keyStart = pos
+            keyLen = len
+            pos += len
+        else if isInt(b) then
+            keyIsInt = true
+            keyInt = readLongValue()
+        else mismatch("map key (string or integer)", b)
+        end if
+    end parseKey
+
+    def fieldParse(): Unit = parseKey()
+
+    def matchField(nameBytes: Array[Byte]): Boolean =
+        if keyIsInt then keyInt == CodecMacro.fieldId(new String(nameBytes, StandardCharsets.UTF_8)).toLong
+        else
+            keyLen == nameBytes.length && {
+                @tailrec def eq(i: Int): Boolean =
+                    if i >= keyLen then true
+                    else if data(keyStart + i) != nameBytes(i) then false
+                    else eq(i + 1)
+                eq(0)
+            }
+    end matchField
+
+    def lastFieldName(): String =
+        if keyIsInt then keyInt.toString
+        else new String(data, keyStart, keyLen, StandardCharsets.UTF_8)
+
+    def field(): String =
+        parseKey()
+        lastFieldName()
+
+    // --- scalar reads ---
+
+    private def readLongValue(): Long =
+        val b = readByte()
+        if (b & 0x80) == 0 then b.toLong                // positive fixint
+        else if (b & 0xe0) == 0xe0 then b.toByte.toLong // negative fixint
+        else if b == UInt8 then readByte().toLong
+        else if b == UInt16 then readU16().toLong
+        else if b == UInt32 then readU32Long()
+        // A uint64 >= 2^63 (only reachable from foreign input; this writer never emits one) returns as a
+        // negative Long, the inherent JVM limitation shared by every JVM MessagePack library.
+        else if b == UInt64 then readBE64()
+        else if b == Int8 then readS8().toLong
+        else if b == Int16 then readS16().toLong
+        else if b == Int32 then readBE32().toLong
+        else if b == Int64 then readBE64()
+        else mismatch("integer", b)
+        end if
+    end readLongValue
+
+    def long(): Long = readLongValue()
+
+    def int(): Int =
+        val v = readLongValue()
+        if v < Int.MinValue.toLong || v > Int.MaxValue.toLong then
+            throw RangeException(v, "Int", Int.MinValue.toLong, Int.MaxValue.toLong)(using _frame)
+        v.toInt
+    end int
+
+    def short(): Short =
+        val v = readLongValue()
+        if v < Short.MinValue.toLong || v > Short.MaxValue.toLong then
+            throw RangeException(v, "Short", Short.MinValue.toLong, Short.MaxValue.toLong)(using _frame)
+        v.toShort
+    end short
+
+    def byte(): Byte =
+        val v = readLongValue()
+        if v < Byte.MinValue.toLong || v > Byte.MaxValue.toLong then
+            throw RangeException(v, "Byte", Byte.MinValue.toLong, Byte.MaxValue.toLong)(using _frame)
+        v.toByte
+    end byte
+
+    def char(): Char =
+        val v = readLongValue()
+        if v < Char.MinValue.toInt.toLong || v > Char.MaxValue.toInt.toLong then
+            throw RangeException(v, "Char", Char.MinValue.toInt.toLong, Char.MaxValue.toInt.toLong)(using _frame)
+        v.toChar
+    end char
+
+    private def readDoubleValue(): Double =
+        val b = readByte()
+        if b == Float64 then java.lang.Double.longBitsToDouble(readBE64())
+        else if b == Float32 then java.lang.Float.intBitsToFloat(readBE32()).toDouble
+        else mismatch("float", b)
+    end readDoubleValue
+
+    def double(): Double = readDoubleValue()
+
+    def float(): Float =
+        val b = readByte()
+        if b == Float32 then java.lang.Float.intBitsToFloat(readBE32())
+        else if b == Float64 then java.lang.Double.longBitsToDouble(readBE64()).toFloat
+        else mismatch("float", b)
+    end float
+
+    def boolean(): Boolean =
+        val b = readByte()
+        if b == True then true
+        else if b == False then false
+        else mismatch("boolean", b)
+    end boolean
+
+    private def readStringValue(): String =
+        val b = readByte()
+        val len =
+            if isFixStr(b) then b & 0x1f
+            else if b == Str8 then readByte()
+            else if b == Str16 then readU16()
+            else if b == Str32 then readLen32()
+            else mismatch("string", b)
+        readUtf8(len)
+    end readStringValue
+
+    def string(): String = readStringValue()
+
+    def isNil(): Boolean =
+        if pos < data.length && (data(pos) & 0xff) == Nil then
+            pos += 1
+            true
+        else false
+    end isNil
+
+    def bytes(): Span[Byte] =
+        val b = readByte()
+        val len =
+            if b == Bin8 then readByte()
+            else if b == Bin16 then readU16()
+            else if b == Bin32 then readLen32()
+            else mismatch("binary", b)
+        requireRemaining(len)
+        val arr = java.util.Arrays.copyOfRange(data, pos, pos + len)
+        pos += len
+        Span.from(arr)
+    end bytes
+
+    def bigInt(): BigInt =
+        val s = readStringValue()
+        try BigInt(s)
+        catch case _: NumberFormatException => throw ParseException(self, s, "BigInt")(using _frame)
+    end bigInt
+
+    def bigDecimal(): BigDecimal =
+        val s = readStringValue()
+        try BigDecimal(s)
+        catch case _: NumberFormatException => throw ParseException(self, s, "BigDecimal")(using _frame)
+    end bigDecimal
+
+    // --- extension header ---
+
+    private def readExtHeader(): (Int, Int) =
+        val b = readByte()
+        val len =
+            if b == FixExt1 then 1
+            else if b == FixExt2 then 2
+            else if b == FixExt4 then 4
+            else if b == FixExt8 then 8
+            else if b == FixExt16 then 16
+            else if b == Ext8 then readByte()
+            else if b == Ext16 then readU16()
+            else if b == Ext32 then readLen32()
+            else mismatch("extension", b)
+        val tpe = readS8()
+        (tpe, len)
+    end readExtHeader
+
+    def instant(): java.time.Instant =
+        val b = peekByte()
+        if isExt(b) then
+            val (tpe, len) = readExtHeader()
+            if tpe != ExtTypeTimestamp.toInt then
+                throw ParseException(self, s"ext type $tpe", "Instant")(using _frame)
+            len match
+                case 4 => java.time.Instant.ofEpochSecond(readU32Long())
+                case 8 =>
+                    val d     = readBE64()
+                    val nanos = (d >>> 34).toInt
+                    val secs  = d & 0x3ffffffffL
+                    java.time.Instant.ofEpochSecond(secs, nanos.toLong)
+                case 12 =>
+                    val nanos = readBE32()
+                    val secs  = readBE64()
+                    java.time.Instant.ofEpochSecond(secs, nanos.toLong)
+                case other =>
+                    throw ParseException(self, s"timestamp ext length $other", "Instant")(using _frame)
+            end match
+        else if isArray(b) then
+            val n     = readArrayHeader()
+            val secs  = readLongValue()
+            val nanos = if n > 1 then readLongValue() else 0L
+            java.time.Instant.ofEpochSecond(secs, nanos)
+        else if isInt(b) then java.time.Instant.ofEpochMilli(readLongValue())
+        else mismatch("Instant (array, timestamp ext, or integer)", b)
+        end if
+    end instant
+
+    def duration(): java.time.Duration =
+        val b = peekByte()
+        if isExt(b) then
+            val (tpe, len) = readExtHeader()
+            if tpe != ExtTypeDuration.toInt then
+                throw ParseException(self, s"ext type $tpe", "Duration")(using _frame)
+            if len != 12 then
+                throw ParseException(self, s"duration ext length $len", "Duration")(using _frame)
+            val secs  = readBE64()
+            val nanos = readBE32()
+            java.time.Duration.ofSeconds(secs, nanos.toLong)
+        else if isArray(b) then
+            val n     = readArrayHeader()
+            val secs  = readLongValue()
+            val nanos = if n > 1 then readLongValue() else 0L
+            java.time.Duration.ofSeconds(secs, nanos)
+        else if isInt(b) then java.time.Duration.ofMillis(readLongValue())
+        else mismatch("Duration (array, ext, or integer)", b)
+        end if
+    end duration
+
+    // --- skip & capture ---
+
+    private def skipBytes(n: Int): Unit =
+        requireRemaining(n)
+        pos += n
+
+    // Skipped containers enforce the same depth and collection-size limits as the typed read path, so a
+    // malformed unknown field (reachable via the case-class decoder's `skip` and `captureValue`) cannot
+    // exceed `maxDepth`/`maxCollectionSize`. Recursion depth is therefore bounded by `maxDepth`, matching
+    // the typed path, which recurses through schema reads.
+    private def skipElems(n: Int): Unit =
+        checkCollectionSize(n)
+        checkDepth()
+        var i = 0
+        while i < n do
+            skip()
+            i += 1
+        decrementDepth()
+    end skipElems
+
+    private def skipEntries(n: Int): Unit =
+        checkCollectionSize(n)
+        checkDepth()
+        var i = 0
+        while i < n do
+            skip()
+            skip()
+            i += 1
+        end while
+        decrementDepth()
+    end skipEntries
+
+    def skip(): Unit =
+        val b = readByte()
+        if (b & 0x80) == 0 then ()         // positive fixint
+        else if (b & 0xe0) == 0xe0 then () // negative fixint
+        else if isFixStr(b) then skipBytes(b & 0x1f)
+        else if isFixArray(b) then skipElems(b & 0x0f)
+        else if isFixMap(b) then skipEntries(b & 0x0f)
+        else
+            b match
+                case Nil | True | False       => ()
+                case UInt8 | Int8             => skipBytes(1)
+                case UInt16 | Int16           => skipBytes(2)
+                case UInt32 | Int32 | Float32 => skipBytes(4)
+                case UInt64 | Int64 | Float64 => skipBytes(8)
+                case Str8 | Bin8              => skipBytes(readByte())
+                case Str16 | Bin16            => skipBytes(readU16())
+                case Str32 | Bin32            => skipBytes(readLen32())
+                case Array16                  => skipElems(readU16())
+                case Array32                  => skipElems(readLen32())
+                case Map16                    => skipEntries(readU16())
+                case Map32                    => skipEntries(readLen32())
+                case FixExt1                  => skipBytes(1 + 1)
+                case FixExt2                  => skipBytes(1 + 2)
+                case FixExt4                  => skipBytes(1 + 4)
+                case FixExt8                  => skipBytes(1 + 8)
+                case FixExt16                 => skipBytes(1 + 16)
+                case Ext8                     => skipBytes(1 + readByte())
+                case Ext16                    => skipBytes(1 + readU16())
+                case Ext32                    => skipBytes(1 + readLen32())
+                case _                        => mismatch("value", b)
+        end if
+    end skip
+
+    def captureValue(): Reader =
+        val start = pos
+        skip()
+        val slice = java.util.Arrays.copyOfRange(data, start, pos)
+        new MsgPackReader(slice, config)(using _frame)
+    end captureValue
+
+    // --- introspection (self-describing open value) ---
+
+    override def readStructure(): Structure.Value =
+        val b = peekByte()
+        if isMap(b) then readStructureMap()
+        else if isArray(b) then readStructureArray()
+        else if isStr(b) then Structure.Value.Str(readStringValue())
+        else if b == Nil then
+            pos += 1
+            Structure.Value.Null
+        else if b == True || b == False then Structure.Value.Bool(boolean())
+        else if isInt(b) then Structure.Value.Integer(readLongValue())
+        else if isFloat(b) then Structure.Value.Decimal(readDoubleValue())
+        else if isBin(b) then
+            throw ParseException(self, formatName(b), "Structure.Value (MessagePack binary is not representable)")(using _frame)
+        else if isExt(b) then
+            throw ParseException(self, formatName(b), "Structure.Value (MessagePack extension is not representable)")(using _frame)
+        else mismatch("Structure.Value", b)
+        end if
+    end readStructure
+
+    private def readStructureMap(): Structure.Value =
+        checkDepth()
+        val n       = readMapHeader()
+        val entries = new Array[(Structure.Value, Structure.Value)](n)
+        var allStr  = true
+        var i       = 0
+        while i < n do
+            val k = readStructure()
+            val v = readStructure()
+            if !k.isInstanceOf[Structure.Value.Str] then allStr = false
+            entries(i) = (k, v)
+            i += 1
+        end while
+        decrementDepth()
+        if allStr then
+            Structure.Value.Record(Chunk.from(entries.toIndexedSeq.map {
+                case (Structure.Value.Str(name), v) => (name, v)
+                case _                              => ("", Structure.Value.Null) // unreachable: allStr guarded
+            }))
+        else Structure.Value.MapEntries(Chunk.from(entries.toIndexedSeq))
+        end if
+    end readStructureMap
+
+    private def readStructureArray(): Structure.Value =
+        checkDepth()
+        val n   = readArrayHeader()
+        val arr = new Array[Structure.Value](n)
+        var i   = 0
+        while i < n do
+            arr(i) = readStructure()
+            i += 1
+        decrementDepth()
+        Structure.Value.Sequence(Chunk.from(arr.toIndexedSeq))
+    end readStructureArray
+
+end MsgPackReader

--- a/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackReader.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackReader.scala
@@ -387,22 +387,21 @@ final class MsgPackReader(data: Array[Byte], config: MsgPack.Config)(using _fram
 
     def duration(): java.time.Duration =
         val b = peekByte()
-        if isExt(b) then
-            val (tpe, len) = readExtHeader()
-            if tpe != ExtTypeDuration.toInt then
-                throw ParseException(self, s"ext type $tpe", "Duration")(using _frame)
-            if len != 12 then
-                throw ParseException(self, s"duration ext length $len", "Duration")(using _frame)
-            val secs  = readBE64()
-            val nanos = readBE32()
-            java.time.Duration.ofSeconds(secs, nanos.toLong)
-        else if isArray(b) then
+        if isArray(b) then
+            // Lossless form: [seconds, nanos].
             val n     = readArrayHeader()
             val secs  = readLongValue()
             val nanos = if n > 1 then readLongValue() else 0L
             java.time.Duration.ofSeconds(secs, nanos)
-        else if isInt(b) then java.time.Duration.ofMillis(readLongValue())
-        else mismatch("Duration (array, ext, or integer)", b)
+        else if isStr(b) then
+            // Compat form (upickle/weePickle): a string of total nanoseconds.
+            val s = readStringValue()
+            try java.time.Duration.ofNanos(s.toLong)
+            catch case _: NumberFormatException => throw ParseException(self, s, "Duration")(using _frame)
+        else if isInt(b) then
+            // Bare integer of total nanoseconds (e.g. a plain msgpack int produced by another encoder).
+            java.time.Duration.ofNanos(readLongValue())
+        else mismatch("Duration (array, string, or integer)", b)
         end if
     end duration
 

--- a/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackWriter.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackWriter.scala
@@ -189,12 +189,12 @@ final class MsgPackWriter(config: MsgPack.Config) extends Writer:
     def bigDecimal(value: BigDecimal): Unit = string(value.toString)
 
     def instant(value: java.time.Instant): Unit =
-        config.temporalEncoding match
-            case MsgPack.TemporalEncoding.Primitive =>
+        config.instantEncoding match
+            case MsgPack.InstantEncoding.Primitive =>
                 writeArrayHeaderTo(current, 2)
                 writeLongValue(value.getEpochSecond)
                 writeLongValue(value.getNano.toLong)
-            case MsgPack.TemporalEncoding.Extension =>
+            case MsgPack.InstantEncoding.Extension =>
                 // MessagePack timestamp 96: ext8, length 12, type -1, 32-bit nanos + 64-bit seconds.
                 writeByte(Ext8)
                 writeByte(12)
@@ -204,18 +204,15 @@ final class MsgPackWriter(config: MsgPack.Config) extends Writer:
     end instant
 
     def duration(value: java.time.Duration): Unit =
-        config.temporalEncoding match
-            case MsgPack.TemporalEncoding.Primitive =>
+        config.durationEncoding match
+            case MsgPack.DurationEncoding.Lossless =>
                 writeArrayHeaderTo(current, 2)
                 writeLongValue(value.getSeconds)
                 writeLongValue(value.getNano.toLong)
-            case MsgPack.TemporalEncoding.Extension =>
-                // Kyo duration extension: ext8, length 12, type 1, 64-bit seconds + 32-bit nanos.
-                writeByte(Ext8)
-                writeByte(12)
-                writeByte(ExtTypeDuration & 0xff)
-                writeBE64(value.getSeconds)
-                writeBE32(current, value.getNano)
+            case MsgPack.DurationEncoding.Compat =>
+                // upickle/weePickle wire form: a string of total nanoseconds. `toNanos` throws on overflow
+                // beyond the Long nanosecond range (~292 years), the same limit those libraries have.
+                string(value.toNanos.toString)
     end duration
 
     /** Materialized output as a raw byte array (for tests and the `result()` bridge). */

--- a/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackWriter.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/msgpack/MsgPackWriter.scala
@@ -1,0 +1,226 @@
+package kyo.internal.msgpack
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+import kyo.Codec.Writer
+import kyo.MsgPack
+import kyo.Span
+import scala.annotation.tailrec
+
+/** Writes values in MessagePack wire format.
+  *
+  * MessagePack containers are count-prefixed. Arrays and maps always receive an exact element count (the collection schemas never omit
+  * elements), so their headers are written immediately. Object bodies are buffered: the derivation omits absent `Option`/`Maybe` case-class
+  * fields, so the static field count handed to [[objectStart]] can exceed the number of entries actually written. The writer counts the
+  * [[field]]/[[fieldBytes]] calls inside each object and emits the real map header on [[objectEnd]], appending the buffered body to the
+  * parent. This mirrors `ProtobufWriter`'s buffer stack and keeps the count-prefixed header honest.
+  *
+  * Field keys: [[fieldBytes]] (the macro-generated case-class and sealed-variant path) honors [[MsgPack.KeyEncoding]]. [[field]] (dynamic
+  * `Map` keys and the `Result`/`Either`/tuple discriminator keys) always writes a string, because those keys are not recoverable from a
+  * hash.
+  */
+final class MsgPackWriter(config: MsgPack.Config) extends Writer:
+    import MsgPackFormat.*
+
+    private val root = new ByteArrayOutputStream(256)
+
+    // Output-target stack: the root plus one buffer per open object. Arrays/maps do not push (they
+    // write through to the current target). `current` is always the head.
+    private var bufStack: List[ByteArrayOutputStream] = List(root)
+
+    // Kind of each open container (object/array/map), for `field`'s count decision.
+    private var kindStack: List[Int] = List.empty[Int]
+
+    // Entry counters, one per open object, parallel to the object frames in `bufStack`.
+    private var objCounts: List[Int] = List.empty[Int]
+
+    private def current: ByteArrayOutputStream = bufStack.head
+
+    private def writeByte(b: Int): Unit = current.write(b & 0xff)
+
+    private def writeBytesRaw(bytes: Array[Byte]): Unit = current.write(bytes, 0, bytes.length)
+
+    private def writeBE16(out: ByteArrayOutputStream, v: Int): Unit =
+        out.write((v >>> 8) & 0xff)
+        out.write(v & 0xff)
+
+    private def writeBE32(out: ByteArrayOutputStream, v: Int): Unit =
+        out.write((v >>> 24) & 0xff)
+        out.write((v >>> 16) & 0xff)
+        out.write((v >>> 8) & 0xff)
+        out.write(v & 0xff)
+    end writeBE32
+
+    private def writeBE64(v: Long): Unit =
+        @tailrec def loop(shift: Int): Unit =
+            if shift >= 0 then
+                writeByte((v >>> shift).toInt)
+                loop(shift - 8)
+        loop(56)
+    end writeBE64
+
+    private def writeMapHeaderTo(out: ByteArrayOutputStream, size: Int): Unit =
+        if size <= FixMax then out.write(FixMapPrefix | size)
+        else if size <= 0xffff then
+            out.write(Map16); writeBE16(out, size)
+        else
+            out.write(Map32); writeBE32(out, size)
+
+    private def writeArrayHeaderTo(out: ByteArrayOutputStream, size: Int): Unit =
+        if size <= FixMax then out.write(FixArrayPrefix | size)
+        else if size <= 0xffff then
+            out.write(Array16); writeBE16(out, size)
+        else
+            out.write(Array32); writeBE32(out, size)
+
+    private def writeStringBytes(bytes: Array[Byte]): Unit =
+        val len = bytes.length
+        if len <= FixStrMax then writeByte(FixStrPrefix | len)
+        else if len <= 0xff then
+            writeByte(Str8); writeByte(len)
+        else if len <= 0xffff then
+            writeByte(Str16); writeBE16(current, len)
+        else
+            writeByte(Str32); writeBE32(current, len)
+        end if
+        writeBytesRaw(bytes)
+    end writeStringBytes
+
+    private def writeLongValue(value: Long): Unit =
+        if value >= 0 then
+            if value <= PositiveFixIntMax then writeByte(value.toInt)
+            else if value <= 0xffL then
+                writeByte(UInt8); writeByte(value.toInt)
+            else if value <= 0xffffL then
+                writeByte(UInt16); writeBE16(current, value.toInt)
+            else if value <= 0xffffffffL then
+                writeByte(UInt32); writeBE32(current, value.toInt)
+            else
+                writeByte(UInt64); writeBE64(value)
+        else if value >= -32 then writeByte(value.toInt) // negative fixint (0xe0..0xff)
+        else if value >= -128 then
+            writeByte(Int8); writeByte(value.toInt)
+        else if value >= -32768 then
+            writeByte(Int16); writeBE16(current, value.toInt)
+        else if value >= Int.MinValue.toLong then
+            writeByte(Int32); writeBE32(current, value.toInt)
+        else
+            writeByte(Int64); writeBE64(value)
+    end writeLongValue
+
+    def objectStart(name: String, size: Int): Unit =
+        bufStack = new ByteArrayOutputStream(64) :: bufStack
+        kindStack = KindObject :: kindStack
+        objCounts = 0 :: objCounts
+    end objectStart
+
+    def objectEnd(): Unit =
+        val body  = bufStack.head.toByteArray
+        val count = objCounts.head
+        bufStack = bufStack.tail
+        objCounts = objCounts.tail
+        kindStack = kindStack.tail
+        writeMapHeaderTo(current, count)
+        current.write(body, 0, body.length)
+    end objectEnd
+
+    def arrayStart(size: Int): Unit =
+        writeArrayHeaderTo(current, size)
+        kindStack = KindArray :: kindStack
+
+    def arrayEnd(): Unit = kindStack = kindStack.tail
+
+    def mapStart(size: Int): Unit =
+        writeMapHeaderTo(current, size)
+        kindStack = KindMap :: kindStack
+
+    def mapEnd(): Unit = kindStack = kindStack.tail
+
+    private def countObjectField(): Unit =
+        if kindStack.nonEmpty && kindStack.head == KindObject then
+            objCounts = (objCounts.head + 1) :: objCounts.tail
+
+    // Macro-generated schema field / variant keys: honor the configured key encoding.
+    def fieldBytes(nameBytes: Array[Byte], fieldId: Int): Unit =
+        countObjectField()
+        config.keyEncoding match
+            case MsgPack.KeyEncoding.StringName => writeStringBytes(nameBytes)
+            case MsgPack.KeyEncoding.FieldId    => writeLongValue(fieldId.toLong)
+    end fieldBytes
+
+    // Dynamic map keys and the hand-written sum discriminator keys: always string (not hash-recoverable).
+    override def field(name: String, fieldId: Int): Unit =
+        countObjectField()
+        writeStringBytes(name.getBytes(StandardCharsets.UTF_8))
+    end field
+
+    def string(value: String): Unit = writeStringBytes(value.getBytes(StandardCharsets.UTF_8))
+
+    def int(value: Int): Unit     = writeLongValue(value.toLong)
+    def long(value: Long): Unit   = writeLongValue(value)
+    def short(value: Short): Unit = writeLongValue(value.toLong)
+    def byte(value: Byte): Unit   = writeLongValue(value.toLong)
+    def char(value: Char): Unit   = writeLongValue(value.toInt.toLong) // Char is unsigned 0..65535
+
+    def float(value: Float): Unit =
+        writeByte(Float32); writeBE32(current, java.lang.Float.floatToIntBits(value))
+
+    def double(value: Double): Unit =
+        writeByte(Float64); writeBE64(java.lang.Double.doubleToLongBits(value))
+
+    def boolean(value: Boolean): Unit = writeByte(if value then True else False)
+
+    def nil(): Unit = writeByte(Nil)
+
+    def bytes(value: Span[Byte]): Unit =
+        val arr = value.toArray
+        val len = arr.length
+        if len <= 0xff then
+            writeByte(Bin8); writeByte(len)
+        else if len <= 0xffff then
+            writeByte(Bin16); writeBE16(current, len)
+        else
+            writeByte(Bin32); writeBE32(current, len)
+        end if
+        writeBytesRaw(arr)
+    end bytes
+
+    def bigInt(value: BigInt): Unit         = string(value.toString)
+    def bigDecimal(value: BigDecimal): Unit = string(value.toString)
+
+    def instant(value: java.time.Instant): Unit =
+        config.temporalEncoding match
+            case MsgPack.TemporalEncoding.Primitive =>
+                writeArrayHeaderTo(current, 2)
+                writeLongValue(value.getEpochSecond)
+                writeLongValue(value.getNano.toLong)
+            case MsgPack.TemporalEncoding.Extension =>
+                // MessagePack timestamp 96: ext8, length 12, type -1, 32-bit nanos + 64-bit seconds.
+                writeByte(Ext8)
+                writeByte(12)
+                writeByte(ExtTypeTimestamp & 0xff)
+                writeBE32(current, value.getNano)
+                writeBE64(value.getEpochSecond)
+    end instant
+
+    def duration(value: java.time.Duration): Unit =
+        config.temporalEncoding match
+            case MsgPack.TemporalEncoding.Primitive =>
+                writeArrayHeaderTo(current, 2)
+                writeLongValue(value.getSeconds)
+                writeLongValue(value.getNano.toLong)
+            case MsgPack.TemporalEncoding.Extension =>
+                // Kyo duration extension: ext8, length 12, type 1, 64-bit seconds + 32-bit nanos.
+                writeByte(Ext8)
+                writeByte(12)
+                writeByte(ExtTypeDuration & 0xff)
+                writeBE64(value.getSeconds)
+                writeBE32(current, value.getNano)
+    end duration
+
+    /** Materialized output as a raw byte array (for tests and the `result()` bridge). */
+    def resultBytes: Array[Byte] = root.toByteArray
+
+    def result(): Span[Byte] = Span.from(resultBytes)
+
+end MsgPackWriter

--- a/kyo-schema/shared/src/test/scala/kyo/MsgPackTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/MsgPackTest.scala
@@ -1,0 +1,477 @@
+package kyo
+
+import kyo.MsgPack.Config
+import kyo.MsgPack.KeyEncoding
+import kyo.MsgPack.TemporalEncoding
+import kyo.internal.msgpack.MsgPackReader
+import kyo.internal.msgpack.MsgPackWriter
+
+class MsgPackTest extends kyo.test.Test[Any]:
+
+    given CanEqual[Any, Any] = CanEqual.derived
+
+    private def roundTrip[A](value: A)(using Schema[A], CanEqual[A, A]): A =
+        MsgPack.decode[A](MsgPack.encode[A](value)).getOrThrow
+
+    // ===== writer/reader primitives =====
+
+    "writer/reader primitives" - {
+
+        "int boundaries round-trip across every size class" in {
+            val cases = List(0, 1, 127, 128, 255, 256, 65535, 65536, Int.MaxValue, -1, -32, -33, -128, -129, -32768, -32769, Int.MinValue)
+            cases.foreach { v =>
+                val w = new MsgPackWriter(Config.Default)
+                w.int(v)
+                val r = new MsgPackReader(w.resultBytes, Config.Default)
+                assert(r.int() == v, s"int $v failed")
+            }
+            succeed
+        }
+
+        "long boundaries round-trip" in {
+            val cases = List(0L, 255L, 65536L, 0xffffffffL, 0x100000000L, Long.MaxValue, -1L, -129L, Long.MinValue)
+            cases.foreach { v =>
+                val w = new MsgPackWriter(Config.Default)
+                w.long(v)
+                val r = new MsgPackReader(w.resultBytes, Config.Default)
+                assert(r.long() == v, s"long $v failed")
+            }
+            succeed
+        }
+
+        "string / boolean / double / float / nil round-trip" in {
+            val w = new MsgPackWriter(Config.Default)
+            w.string("hello é world")
+            w.boolean(true)
+            w.double(3.14159)
+            w.float(1.5f)
+            w.nil()
+            val r = new MsgPackReader(w.resultBytes, Config.Default)
+            assert(r.string() == "hello é world")
+            assert(r.boolean() == true)
+            assert(r.double() == 3.14159)
+            assert(r.float() == 1.5f)
+            assert(r.isNil())
+        }
+
+        "short / byte / char round-trip with range checks" in {
+            val w = new MsgPackWriter(Config.Default)
+            w.short(30000.toShort)
+            w.byte((-5).toByte)
+            w.char('Z')
+            val r = new MsgPackReader(w.resultBytes, Config.Default)
+            assert(r.short() == 30000.toShort)
+            assert(r.byte() == (-5).toByte)
+            assert(r.char() == 'Z')
+        }
+    }
+
+    // ===== wire sanity =====
+
+    "wire sanity" - {
+
+        "nil is 0xc0, true is 0xc3, false is 0xc2" in {
+            def first(f: MsgPackWriter => Unit): Int =
+                val w = new MsgPackWriter(Config.Default)
+                f(w)
+                w.resultBytes(0) & 0xff
+            end first
+            assert(first(_.nil()) == 0xc0)
+            assert(first(_.boolean(true)) == 0xc3)
+            assert(first(_.boolean(false)) == 0xc2)
+        }
+
+        "small map uses a fixmap header" in {
+            val bytes = MsgPack.encode(MPPerson("Alice", 30))
+            // 2-field map => fixmap header 0x82
+            assert((bytes.toArray(0) & 0xff) == 0x82)
+        }
+
+        "positive fixint encodes in one byte" in {
+            val w = new MsgPackWriter(Config.Default)
+            w.int(5)
+            assert(w.resultBytes.length == 1)
+            assert((w.resultBytes(0) & 0xff) == 5)
+        }
+    }
+
+    // ===== encode/decode =====
+
+    "encode/decode" - {
+
+        "simple case class round-trip" in {
+            assert(roundTrip(MPPerson("Alice", 30)) == MPPerson("Alice", 30))
+        }
+
+        "all-primitive case class round-trip" in {
+            val v = MPAllPrims(true, -7, 9_000_000_000L, 2.5f, 1.25, 12.toShort, (-3).toByte, 'k', "kyo")
+            assert(roundTrip(v) == v)
+        }
+
+        "deterministic encoding" in {
+            val v = MPPerson("Charlie", 40)
+            assert(MsgPack.encode(v).toArray.toSeq == MsgPack.encode(v).toArray.toSeq)
+        }
+
+        "distinct values encode distinctly" in {
+            assert(MsgPack.encode(MPPerson("Alice", 30)).toArray.toSeq != MsgPack.encode(MPPerson("Bob", 25)).toArray.toSeq)
+        }
+
+        "nested case class with collection round-trip" in {
+            val v = MPNested(MPPerson("Alice", 30), List("a", "b", "c"))
+            assert(roundTrip(v) == v)
+        }
+    }
+
+    // ===== collections / option / maybe / map / bytes =====
+
+    "containers" - {
+
+        "Option present and absent round-trip" in {
+            assert(roundTrip(MPOpt("a", Some("nick"), Maybe(7))) == MPOpt("a", Some("nick"), Maybe(7)))
+            assert(roundTrip(MPOpt("a", None, Maybe.empty)) == MPOpt("a", None, Maybe.empty))
+        }
+
+        "Map[String, Int] round-trip preserves arbitrary keys" in {
+            val v = MPMap(Map("x" -> 1, "really long key name" -> 2, "é" -> 3))
+            assert(roundTrip(v) == v)
+        }
+
+        "Span[Byte] round-trip" in {
+            val original = Span.from(Array[Byte](1, 2, 3, -1, 0, 127))
+            val bytes    = MsgPack.encode(MPBytes(original))
+            val decoded  = MsgPack.decode[MPBytes](bytes).getOrThrow
+            assert(decoded.data.toArray.toSeq == original.toArray.toSeq)
+        }
+
+        "BigInt and BigDecimal round-trip losslessly" in {
+            val v = MPBig(BigInt("123456789012345678901234567890"), BigDecimal("3.141592653589793238462643383279"))
+            assert(roundTrip(v) == v)
+        }
+
+        "recursive tree round-trip" in {
+            val tree = TreeNode(1, List(TreeNode(2, Nil), TreeNode(3, List(TreeNode(4, Nil)))))
+            assert(roundTrip(tree) == tree)
+        }
+
+        "Result round-trip" in {
+            val ok: Result[String, Int]  = Result.succeed(42)
+            val err: Result[String, Int] = Result.fail("boom")
+            assert(roundTrip(ok) == ok)
+            assert(roundTrip(err) == err)
+        }
+    }
+
+    // ===== sealed traits / enums =====
+
+    "sealed traits and enums" - {
+
+        "sealed trait variants discriminate" in {
+            val c: MPShape = MPCircle(2.0)
+            val d: MPShape = MPDot
+            assert(roundTrip(c) == c)
+            assert(roundTrip(d) == d)
+        }
+
+        "enum round-trips every case" in {
+            assert(roundTrip[MPColor](MPColor.Red) == MPColor.Red)
+            assert(roundTrip[MPColor](MPColor.Green) == MPColor.Green)
+            assert(roundTrip[MPColor](MPColor.Blue) == MPColor.Blue)
+        }
+
+        "shared MTShape via MTDrawing round-trip" in {
+            val v = MTDrawing("d", MTCircle(1.5))
+            assert(roundTrip(v) == v)
+        }
+    }
+
+    // ===== key encoding config =====
+
+    "key encoding" - {
+
+        "FieldId mode round-trips case classes" in {
+            given MsgPack = MsgPack(Config(keyEncoding = KeyEncoding.FieldId))
+            val v         = MPPerson("Alice", 30)
+            assert(MsgPack.decode[MPPerson](MsgPack.encode(v)).getOrThrow == v)
+        }
+
+        "FieldId mode still round-trips Map keys as strings" in {
+            given MsgPack = MsgPack(Config(keyEncoding = KeyEncoding.FieldId))
+            val v         = MPMap(Map("alpha" -> 1, "beta" -> 2))
+            assert(MsgPack.decode[MPMap](MsgPack.encode(v)).getOrThrow == v)
+        }
+
+        "FieldId mode is more compact than StringName for long field names" in {
+            val v = MPLongFields(1, 2)
+            val strBits =
+                MsgPack.encode(v)(using summon[Schema[MPLongFields]], MsgPack(Config(keyEncoding = KeyEncoding.StringName)), summon[Frame])
+            val idBits =
+                MsgPack.encode(v)(using summon[Schema[MPLongFields]], MsgPack(Config(keyEncoding = KeyEncoding.FieldId)), summon[Frame])
+            assert(idBits.size < strBits.size)
+        }
+
+        "FieldId mode still round-trips sealed variants and the Result discriminator" in {
+            given MsgPack                = MsgPack(Config(keyEncoding = KeyEncoding.FieldId))
+            val shape: MPShape           = MPCircle(2.0)
+            val res: Result[String, Int] = Result.fail("boom")
+            assert(MsgPack.decode[MPShape](MsgPack.encode(shape)).getOrThrow == shape)
+            assert(MsgPack.decode[Result[String, Int]](MsgPack.encode(res)).getOrThrow == res)
+        }
+
+        "reader decodes StringName bytes regardless of its own config" in {
+            val v = MPPerson("Alice", 30)
+            val strBytes =
+                MsgPack.encode(v)(using summon[Schema[MPPerson]], MsgPack(Config(keyEncoding = KeyEncoding.StringName)), summon[Frame])
+            val decoded = MsgPack.decode[MPPerson](strBytes)(using
+                MsgPack(Config(keyEncoding = KeyEncoding.FieldId)),
+                summon[Schema[MPPerson]],
+                summon[Frame]
+            )
+            assert(decoded.getOrThrow == v)
+        }
+    }
+
+    // ===== temporal config =====
+
+    "temporal encoding" - {
+
+        val instant  = java.time.Instant.ofEpochSecond(1_700_000_000L, 123_456_789L)
+        val duration = java.time.Duration.ofSeconds(86_400L, 250_000_000L)
+
+        "Primitive mode round-trips Instant/Duration losslessly at nanosecond precision" in {
+            val v = MPTime(instant, duration)
+            assert(roundTrip(v) == v)
+        }
+
+        "Extension mode round-trips Instant/Duration losslessly" in {
+            given MsgPack = MsgPack(Config(temporalEncoding = TemporalEncoding.Extension))
+            val v         = MPTime(instant, duration)
+            assert(MsgPack.decode[MPTime](MsgPack.encode(v)).getOrThrow == v)
+        }
+
+        "Extension-encoded bytes decode through a Primitive-config reader" in {
+            val v = MPTime(instant, duration)
+            val extBits = MsgPack.encode(v)(using
+                summon[Schema[MPTime]],
+                MsgPack(Config(temporalEncoding = TemporalEncoding.Extension)),
+                summon[Frame]
+            )
+            val decoded = MsgPack.decode[MPTime](extBits)(using
+                MsgPack(Config(temporalEncoding = TemporalEncoding.Primitive)),
+                summon[Schema[MPTime]],
+                summon[Frame]
+            )
+            assert(decoded.getOrThrow == v)
+        }
+    }
+
+    // ===== introspection / open value =====
+
+    "introspection" - {
+
+        "Structure.Value round-trips through MsgPack" in {
+            val v: Structure.Value = Structure.Value.Record(Chunk(
+                "name"   -> Structure.Value.Str("Alice"),
+                "age"    -> Structure.Value.Integer(30L),
+                "active" -> Structure.Value.Bool(true),
+                "tags"   -> Structure.Value.Sequence(Chunk(Structure.Value.Str("a"), Structure.Value.Str("b")))
+            ))
+            val schema = summon[Schema[Structure.Value]]
+            val bytes  = schema.encode[MsgPack](v)
+            val back   = schema.decode[MsgPack](bytes).getOrThrow
+            assert(back == v)
+        }
+
+        "readStructure materializes a plain map without a tagged wrapper" in {
+            val bytes  = MsgPack.encode(MPPerson("Alice", 30))
+            val reader = new MsgPackReader(bytes.toArray, Config.Default)
+            reader.readStructure() match
+                case Structure.Value.Record(fields) =>
+                    assert(fields.exists { case (k, v) => k == "name" && v == Structure.Value.Str("Alice") })
+                    assert(fields.exists { case (k, v) => k == "age" && v == Structure.Value.Integer(30L) })
+                case other => fail(s"expected Record, got $other")
+            end match
+        }
+    }
+
+    // ===== error paths =====
+
+    "error paths" - {
+
+        "truncated string length throws TruncatedInputException" in {
+            // fixstr header claiming length 5 but no payload
+            val data = Array[Byte](0xa5.toByte)
+            val r    = new MsgPackReader(data, Config.Default)
+            intercept[TruncatedInputException](r.string())
+            ()
+        }
+
+        "out-of-range Short throws RangeException" in {
+            val w = new MsgPackWriter(Config.Default)
+            w.int(40000)
+            val r = new MsgPackReader(w.resultBytes, Config.Default)
+            intercept[RangeException](r.short())
+            ()
+        }
+
+        "non-numeric BigInt payload throws ParseException" in {
+            val w = new MsgPackWriter(Config.Default)
+            w.string("not a number")
+            val r = new MsgPackReader(w.resultBytes, Config.Default)
+            intercept[ParseException](r.bigInt())
+            ()
+        }
+
+        "missing required field throws via decode" in {
+            val empty  = MsgPack.encode(MPEmpty())
+            val result = MsgPack.decode[MPPerson](empty)
+            assert(result.failure.exists(_.isInstanceOf[MissingFieldException]))
+        }
+
+        "collection-size limit is enforced" in {
+            val v      = MPList(List.fill(20)(1))
+            val bytes  = MsgPack.encode(v)
+            val result = MsgPack.decode[MPList](bytes, maxCollectionSize = 5)
+            assert(result.failure.exists(_.isInstanceOf[LimitExceededException]))
+        }
+
+        "nesting-depth limit is enforced" in {
+            val deep   = List.range(1, 6).foldRight(TreeNode(0, Nil)) { case (v, acc) => TreeNode(v, List(acc)) }
+            val bytes  = MsgPack.encode(deep)
+            val result = MsgPack.decode[TreeNode](bytes, maxDepth = 2)
+            assert(result.failure.exists(_.isInstanceOf[LimitExceededException]))
+        }
+
+        "skipping an unknown deeply-nested field still enforces the depth limit" in {
+            // A known type (MPPerson) plus an unknown field whose value is a deeply nested array. The
+            // decoder reaches the unknown field, calls skip(), and must honor maxDepth on that path.
+            val w = new MsgPackWriter(Config.Default)
+            w.objectStart("MPPerson", 3)
+            w.field("name", 0); w.string("Alice")
+            w.field("age", 0); w.int(30)
+            w.field("extra", 0)
+            val depth = 50
+            (1 to depth).foreach(_ => w.arrayStart(1))
+            w.nil()
+            (1 to depth).foreach(_ => w.arrayEnd())
+            w.objectEnd()
+            val result = MsgPack.decode[MPPerson](w.result(), maxDepth = 8)
+            assert(result.failure.exists(_.isInstanceOf[LimitExceededException]))
+        }
+
+        "skipping an unknown oversized collection still enforces the collection-size limit" in {
+            // The unknown field's value is an array header claiming a huge element count; skip() must
+            // reject it via checkCollectionSize before attempting to read elements.
+            val w = new MsgPackWriter(Config.Default)
+            w.objectStart("MPPerson", 3)
+            w.field("name", 0); w.string("Alice")
+            w.field("age", 0); w.int(30)
+            w.field("extra", 0); w.arrayStart(1_000_000) // header only; elements intentionally omitted
+            w.objectEnd()
+            val result = MsgPack.decode[MPPerson](w.result(), maxCollectionSize = 100)
+            assert(result.failure.exists(_.isInstanceOf[LimitExceededException]))
+        }
+    }
+
+    // ===== size-class boundaries and empty containers =====
+
+    "size-class boundaries" - {
+
+        "string lengths cross fixstr/str8/str16/str32 boundaries" in {
+            List(0, 31, 32, 255, 256, 65535, 65536).foreach { len =>
+                val s = "x" * len
+                val w = new MsgPackWriter(Config.Default)
+                w.string(s)
+                val r = new MsgPackReader(w.resultBytes, Config.Default)
+                assert(r.string() == s, s"string length $len failed")
+            }
+            succeed
+        }
+
+        "binary lengths cross bin8/bin16/bin32 boundaries" in {
+            List(0, 255, 256, 65535, 65536).foreach { len =>
+                val arr = Array.tabulate(len)(i => (i % 256).toByte)
+                val w   = new MsgPackWriter(Config.Default)
+                w.bytes(Span.from(arr))
+                val r = new MsgPackReader(w.resultBytes, Config.Default)
+                assert(r.bytes().toArray.toSeq == arr.toSeq, s"bin length $len failed")
+            }
+            succeed
+        }
+
+        "list sizes cross fixarray/array16/array32 boundaries" in {
+            List(0, 15, 16, 65535, 65536).foreach { n =>
+                val v = MPList(List.fill(n)(7))
+                assert(roundTrip(v) == v, s"list size $n failed")
+            }
+            succeed
+        }
+
+        "map sizes cross fixmap/map16/map32 boundaries" in {
+            List(0, 15, 16, 65536).foreach { n =>
+                val v = MPMap((0 until n).map(i => s"k$i" -> i).toMap)
+                assert(roundTrip(v) == v, s"map size $n failed")
+            }
+            succeed
+        }
+
+        "case class with more than 15 fields uses a map16 object header and round-trips" in {
+            val v = MPWide(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)
+            // 17 entries => map16 header 0xde
+            assert((MsgPack.encode(v).toArray(0) & 0xff) == 0xde)
+            assert(roundTrip(v) == v)
+        }
+
+        "empty containers round-trip" in {
+            assert(roundTrip(MPList(Nil)) == MPList(Nil))
+            assert(roundTrip(MPMap(Map.empty)) == MPMap(Map.empty))
+            assert(roundTrip(MPPerson("", 0)) == MPPerson("", 0))
+            val emptyBytes = MsgPack.decode[MPBytes](MsgPack.encode(MPBytes(Span.empty))).getOrThrow
+            assert(emptyBytes.data.toArray.isEmpty)
+        }
+    }
+
+end MsgPackTest
+
+// ===== test fixtures (each shares a name prefix with no source file; local to this suite) =====
+
+case class MPPerson(name: String, age: Int) derives Schema, CanEqual
+case class MPAllPrims(b: Boolean, i: Int, l: Long, f: Float, d: Double, s: Short, by: Byte, c: Char, str: String) derives Schema, CanEqual
+case class MPNested(person: MPPerson, tags: List[String]) derives Schema, CanEqual
+case class MPOpt(name: String, nick: Option[String], maybe: Maybe[Int]) derives Schema, CanEqual
+case class MPBytes(data: Span[Byte]) derives Schema
+case class MPMap(scores: Map[String, Int]) derives Schema, CanEqual
+case class MPBig(i: BigInt, d: BigDecimal) derives Schema, CanEqual
+case class MPTime(at: java.time.Instant, dur: java.time.Duration) derives Schema, CanEqual
+case class MPList(items: List[Int]) derives Schema, CanEqual
+case class MPEmpty() derives Schema, CanEqual
+case class MPLongFields(theFirstLongFieldName: Int, theSecondLongFieldName: Int) derives Schema, CanEqual
+case class MPWide(
+    f1: Int,
+    f2: Int,
+    f3: Int,
+    f4: Int,
+    f5: Int,
+    f6: Int,
+    f7: Int,
+    f8: Int,
+    f9: Int,
+    f10: Int,
+    f11: Int,
+    f12: Int,
+    f13: Int,
+    f14: Int,
+    f15: Int,
+    f16: Int,
+    f17: Int
+) derives Schema, CanEqual
+
+sealed trait MPShape derives Schema, CanEqual
+case class MPCircle(radius: Double) extends MPShape derives CanEqual
+case object MPDot                   extends MPShape derives CanEqual
+
+enum MPColor derives Schema, CanEqual:
+    case Red
+    case Green
+    case Blue
+end MPColor

--- a/kyo-schema/shared/src/test/scala/kyo/MsgPackTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/MsgPackTest.scala
@@ -1,10 +1,12 @@
 package kyo
 
 import kyo.MsgPack.Config
+import kyo.MsgPack.DurationEncoding
+import kyo.MsgPack.InstantEncoding
 import kyo.MsgPack.KeyEncoding
-import kyo.MsgPack.TemporalEncoding
 import kyo.internal.msgpack.MsgPackReader
 import kyo.internal.msgpack.MsgPackWriter
+import scala.concurrent.duration.*
 
 class MsgPackTest extends kyo.test.Test[Any]:
 
@@ -238,30 +240,108 @@ class MsgPackTest extends kyo.test.Test[Any]:
         val instant  = java.time.Instant.ofEpochSecond(1_700_000_000L, 123_456_789L)
         val duration = java.time.Duration.ofSeconds(86_400L, 250_000_000L)
 
-        "Primitive mode round-trips Instant/Duration losslessly at nanosecond precision" in {
+        "default (Primitive instant, Lossless duration) round-trips at nanosecond precision" in {
             val v = MPTime(instant, duration)
             assert(roundTrip(v) == v)
         }
 
-        "Extension mode round-trips Instant/Duration losslessly" in {
-            given MsgPack = MsgPack(Config(temporalEncoding = TemporalEncoding.Extension))
+        "Instant Extension mode round-trips losslessly" in {
+            given MsgPack = MsgPack(Config(instantEncoding = InstantEncoding.Extension))
             val v         = MPTime(instant, duration)
             assert(MsgPack.decode[MPTime](MsgPack.encode(v)).getOrThrow == v)
         }
 
-        "Extension-encoded bytes decode through a Primitive-config reader" in {
+        "Instant Extension uses the spec timestamp ext type -1 (0xc7, len 12, 0xff)" in {
+            given MsgPack = MsgPack(Config(instantEncoding = InstantEncoding.Extension))
+            // single Instant field: map header (0x81) + key "at" + ext header
+            val bytes = MsgPack.encode(MPInstant(instant)).toArray.map(_ & 0xff)
+            assert(bytes.containsSlice(Seq(0xc7, 12, 0xff)))
+        }
+
+        "Instant Extension bytes decode through a Primitive-config reader" in {
             val v = MPTime(instant, duration)
             val extBits = MsgPack.encode(v)(using
                 summon[Schema[MPTime]],
-                MsgPack(Config(temporalEncoding = TemporalEncoding.Extension)),
+                MsgPack(Config(instantEncoding = InstantEncoding.Extension)),
                 summon[Frame]
             )
             val decoded = MsgPack.decode[MPTime](extBits)(using
-                MsgPack(Config(temporalEncoding = TemporalEncoding.Primitive)),
+                MsgPack(Config(instantEncoding = InstantEncoding.Primitive)),
                 summon[Schema[MPTime]],
                 summon[Frame]
             )
             assert(decoded.getOrThrow == v)
+        }
+
+        "Duration Compat mode round-trips and matches the upickle nanos-string wire form" in {
+            given MsgPack = MsgPack(Config(durationEncoding = DurationEncoding.Compat))
+            val d         = java.time.Duration.ofSeconds(1L) // 1_000_000_000 nanos, like upickle's rw(1.second, "1000000000")
+            val bytes     = MsgPack.encode(MPDuration(d))
+            assert(MsgPack.decode[MPDuration](bytes).getOrThrow == MPDuration(d))
+            // wire: map(0x81) + key "d" + str "1000000000"; assert the nanos string is present as a msgpack str
+            val r = new MsgPackReader(bytes.toArray, Config(durationEncoding = DurationEncoding.Compat))
+            assert(r.objectStart() == 1)
+            assert(r.hasNextField())
+            r.fieldParse()
+            assert(r.duration() == d)
+        }
+
+        "Duration Compat string bytes decode through a Lossless-config reader (reader auto-detects)" in {
+            val d = java.time.Duration.ofSeconds(86_400L, 250_000_000L)
+            val compatBits = MsgPack.encode(MPDuration(d))(using
+                summon[Schema[MPDuration]],
+                MsgPack(Config(durationEncoding = DurationEncoding.Compat)),
+                summon[Frame]
+            )
+            val decoded = MsgPack.decode[MPDuration](compatBits)(using
+                MsgPack(Config(durationEncoding = DurationEncoding.Lossless)),
+                summon[Schema[MPDuration]],
+                summon[Frame]
+            )
+            assert(decoded.getOrThrow == MPDuration(d))
+        }
+    }
+
+    // ===== scala.concurrent.duration =====
+
+    "scala.concurrent.duration" - {
+
+        "FiniteDuration round-trips (Lossless and Compat)" in {
+            val v = MPFinite(5.seconds, 250.millis)
+            assert(roundTrip(v) == v)
+            given MsgPack = MsgPack(Config(durationEncoding = DurationEncoding.Compat))
+            assert(MsgPack.decode[MPFinite](MsgPack.encode(v)).getOrThrow == v)
+        }
+
+        "FiniteDuration Compat matches the upickle nanos-string form" in {
+            given MsgPack = MsgPack(Config(durationEncoding = DurationEncoding.Compat))
+            val bytes     = MsgPack.encode(MPFiniteOne(1.second))
+            // map(0x81) + key + str "1000000000"; confirm the nanos string is on the wire
+            val r = new MsgPackReader(bytes.toArray, Config(durationEncoding = DurationEncoding.Compat))
+            discard(r.objectStart()); discard(r.hasNextField()); r.fieldParse()
+            assert(r.string() == "1000000000")
+        }
+
+        "abstract Duration round-trips finite and infinite cases as the upickle string form" in {
+            List[Duration](7.seconds, Duration.Inf, Duration.MinusInf, Duration.Undefined).foreach { d =>
+                val bytes   = MsgPack.encode(MPScalaDur(d))
+                val decoded = MsgPack.decode[MPScalaDur](bytes).getOrThrow
+                if d eq Duration.Undefined then assert(decoded.dur eq Duration.Undefined)
+                else assert(decoded.dur == d, s"duration $d failed")
+            }
+            succeed
+        }
+
+        "abstract Duration encodes infinities as upickle sentinels" in {
+            def strOf(d: Duration): String =
+                val bytes = MsgPack.encode(MPScalaDur(d))
+                val r     = new MsgPackReader(bytes.toArray, Config.Default)
+                discard(r.objectStart()); discard(r.hasNextField()); r.fieldParse()
+                r.string()
+            end strOf
+            assert(strOf(Duration.Inf) == "inf")
+            assert(strOf(Duration.MinusInf) == "-inf")
+            assert(strOf(Duration.Undefined) == "undef")
         }
     }
 
@@ -443,6 +523,15 @@ case class MPBytes(data: Span[Byte]) derives Schema
 case class MPMap(scores: Map[String, Int]) derives Schema, CanEqual
 case class MPBig(i: BigInt, d: BigDecimal) derives Schema, CanEqual
 case class MPTime(at: java.time.Instant, dur: java.time.Duration) derives Schema, CanEqual
+case class MPInstant(at: java.time.Instant) derives Schema, CanEqual
+case class MPDuration(d: java.time.Duration) derives Schema, CanEqual
+
+given CanEqual[scala.concurrent.duration.FiniteDuration, scala.concurrent.duration.FiniteDuration] = CanEqual.derived
+given CanEqual[scala.concurrent.duration.Duration, scala.concurrent.duration.Duration]             = CanEqual.derived
+
+case class MPFinite(a: scala.concurrent.duration.FiniteDuration, b: scala.concurrent.duration.FiniteDuration) derives Schema, CanEqual
+case class MPFiniteOne(d: scala.concurrent.duration.FiniteDuration) derives Schema, CanEqual
+case class MPScalaDur(dur: scala.concurrent.duration.Duration) derives Schema, CanEqual
 case class MPList(items: List[Int]) derives Schema, CanEqual
 case class MPEmpty() derives Schema, CanEqual
 case class MPLongFields(theFirstLongFieldName: Int, theSecondLongFieldName: Int) derives Schema, CanEqual


### PR DESCRIPTION
## Summary

Adds a **MessagePack** codec to `kyo-schema`, the fourth serialization format alongside `Json`, `Yaml`, `Ion`, and `Protobuf`. It is hand-rolled from the ground up with **no third-party dependencies** and cross-compiles to **JVM, JS, and Native**. Format internals live in a dedicated `kyo.internal.msgpack` package, mirroring how the YAML codec keeps its machinery isolated.

MessagePack fills the gap between `Protobuf` (compact but schema-required) and `Json` (self-describing but text): a compact, **self-describing binary** format that interoperates with standard MessagePack tooling.

## Why

`kyo-schema` derives serialization from `Schema[A]` and dispatches to a pluggable `Codec` at the call site; the self-describing binary option was missing. Because every MessagePack value carries a type tag, the reader implements `Codec.IntrospectingReader` (introduced in #1682), so `Structure.Value` and open-shaped wire protocols (JSON-RPC-style envelopes) round-trip through MsgPack: the capability a non-self-describing binary format like Protobuf cannot offer.

## Usage

```scala
import kyo.*

case class Address(city: String, zip: String) derives Schema
case class User(id: Int, name: String, address: Address) derives Schema, CanEqual

val alice = User(1, "Alice", Address("Portland", "97201"))

val bytes: Span[Byte] = MsgPack.encode(alice)

MsgPack.decode[User](bytes)
// Result.Success(User(1, "Alice", Address("Portland", "97201")))
```

Case classes encode as a MessagePack map keyed by field name, collections as arrays, `Option`/`Maybe` as the value or `nil`, and `Span[Byte]` as a binary blob. `MsgPack.decode` accepts the same `maxDepth` / `maxCollectionSize` safety limits as `Json.decode`.

### Configurable key encoding

`KeyEncoding.StringName` (default) is self-describing and interoperable. `KeyEncoding.FieldId` is more compact, using the same stable MurmurHash3 IDs as Protobuf:

```scala
given MsgPack = MsgPack(MsgPack.Config(keyEncoding = MsgPack.KeyEncoding.FieldId))

MsgPack.decode[User](MsgPack.encode(alice))
// Result.Success(alice)  -- compact integer keys on the wire
```

Dynamic `Map` keys and the `Result`/`Either` discriminators always stay strings under `FieldId`, since a hash is not reversible.

### Configurable temporal encoding

`Instant` defaults to a lossless `[seconds, nanos]` array; `InstantEncoding.Extension` writes the spec-defined MessagePack **timestamp extension (type -1)**, which standard decoders in other languages read as a timestamp:

```scala
given MsgPack = MsgPack(MsgPack.Config(instantEncoding = MsgPack.InstantEncoding.Extension))
```

`Duration` has **no MessagePack standard** (see the compatibility note below), so `DurationEncoding` lets you choose, and schemas are provided for both `java.time.Duration` and `scala.concurrent.duration.{Duration, FiniteDuration}`:

- `Lossless` (default): a `[seconds, nanos]` array keeping the full `java.time.Duration` range.
- `Compat`: a string of total nanoseconds, **wire-compatible with upickle/weePickle** (limited to the `Long` nanosecond range, like those libraries).

```scala
import scala.concurrent.duration.{Duration, FiniteDuration, DurationInt}

case class Timeout(connect: FiniteDuration, idle: Duration) derives Schema

given MsgPack = MsgPack(MsgPack.Config(durationEncoding = MsgPack.DurationEncoding.Compat))

MsgPack.decode[Timeout](MsgPack.encode(Timeout(5.seconds, Duration.Inf)))
// Result.Success(Timeout(5 seconds, Duration.Inf))
```

`scala.concurrent.duration.Duration` (the possibly-infinite type) always uses the string form so it can carry `Inf`/`MinusInf`/`Undefined`; `FiniteDuration` and `java.time.Duration` follow the `DurationEncoding` setting. The reader auto-detects the wire shape (array, string, or bare integer of nanos), so bytes decode regardless of the reader's config.

### Open / type-safe wire protocols

Because MessagePack is self-describing, the reader is a `Codec.IntrospectingReader` and can materialize an arbitrary payload into a `Structure.Value` without a schema:

```scala
val bytes: Span[Byte] = MsgPack.encode(alice)

summon[Schema[Structure.Value]].decode[MsgPack](bytes)
// Result.Success(Structure.Value.Record(...))
```

This makes MsgPack a binary transport for open-shaped envelopes, the role JSON plays for JSON-RPC.

## Design notes

- **Single writer, buffered objects.** Arrays and maps are written with an exact count upfront. Object bodies are buffered because the derivation omits absent `Option`/`Maybe` fields, so the static field count can exceed the entries actually written; the writer counts real entries and emits the true map header on `objectEnd` (mirrors `ProtobufWriter`'s buffer stack).
- **Count-driven reader with limits on every path.** `maxDepth` and `maxCollectionSize` are enforced on the typed read path **and** on the `skip` path used for unknown fields and `captureValue`, so malformed input cannot exhaust depth or memory.
- **Shared change in `FocusMacro`.** Case-class product fields now emit `fieldBytes` (not `field`), so a codec can distinguish recoverable schema-field keys from dynamic `Map`/sum keys. This matches existing design intent (the JSON writer's `fieldBytes` ASCII fast path; the sealed-variant write path already used `fieldBytes`) and is verified against the full `kyo-schema` suite with no regressions.
- **Module-wide `scala.concurrent.duration` schemas.** `Schema[FiniteDuration]` and `Schema[Duration]` are added in `Schema.scala`, so all codecs (not just MsgPack) gain support; the abstract `Duration` uses the upickle string form for infinities.
- **No `build.sbt` change.** No change to `Schema` or `Codec`: `MsgPack <: Codec` plus a `given` makes `schema.encode[MsgPack](v)` / `schema.decode[MsgPack](bytes)` work for free.

## Spec compatibility

Audited byte-for-byte against the official MessagePack spec: format bytes, big-endian encoding, smallest-format integer selection with correct sign-extension, IEEE-754 floats, `str`/`bin` separation, the timestamp extension (32/64/96 including the 34/30-bit packing), map/array pair counts, and ext header layout all conform. Standard decoders (Python/JS/Go) read Kyo's output correctly.

**Duration interop:** MessagePack defines no Duration type, and a survey of the Scala ecosystem found no de-facto convention. The libraries that do encode a Duration (upickle/upack, weePickle) use a **string of total nanoseconds** for `scala.concurrent.duration`, and none encode `java.time.Duration` at all. `DurationEncoding.Compat` matches that string form exactly for interop; `Lossless` is the kyo-specific full-range default. This is the "no standard exists" case, not a divergence from one.

## Tests

`MsgPackTest` (52 tests) covers: primitive round-trips across every integer size class, wire-byte sanity, nested/recursive/sum/enum round-trips, `Option`/`Maybe`/`Map`/`Span[Byte]`/`BigInt`/`BigDecimal`, both `KeyEncoding` modes and both `InstantEncoding`/`DurationEncoding` modes (including cross-config decode and the upickle nanos-string wire form), `scala.concurrent.duration` `FiniteDuration` and `Duration` (finite and `Inf`/`MinusInf`/`Undefined`), introspection (`Structure.Value` and `readStructure`), size-class boundaries (fix -> 16 -> 32 for str/bin/array/map plus empty containers and a 17-field object hitting the `map16` header), and error paths (truncation, range, parse, missing field, and depth/collection limits on the skip path).

## Verification

- `kyo-schemaJVM/test`: full module green, no regressions
- `MsgPackTest`: 52 passed on JVM and JS
- `kyo-schemaNative/Test/compile`: compiles
- `kyo-schemaJVM/doctest`: all README blocks compile (the new MessagePack examples included)
- `scalafmtCheckAll`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
