### PR TITLE
[build] require JDK 25 for foreign modules, enable compact headers

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -98,5 +98,5 @@ runs:
 
     - uses: coursier/setup-action@v3.0.0
       with:
-        jvm: corretto:24
+        jvm: corretto:25
         apps: sbt

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: coursier/cache-action@v8.1.1
       - uses: coursier/setup-action@v3.0.0
         with:
-          jvm: corretto:21
+          jvm: corretto:25
           apps: sbt
 
       - name: install async-profiler

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,8 @@ jobs:
       # build.sbt Test/javaOptions), and SBT_TASK_LIMIT=1 keeps compile and test from overlapping, so a low
       # floor lets G1 release the driver's compile heap back to the box during the test phase, leaving room
       # for the forks. Re-add a per-os ceiling override here if a memory-constrained arch is re-enabled.
-      JAVA_OPTS: '-Xmx12G -Xss10M -XX:+UseG1GC -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
-      JVM_OPTS:  '-Xmx12G -Xss10M -XX:+UseG1GC -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
+      JAVA_OPTS: '-Xmx12G -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
+      JVM_OPTS:  '-Xmx12G -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
 
     steps:
       - uses: actions/checkout@v6.0.3
@@ -92,7 +92,7 @@ jobs:
 
       # kyo-browser auto-downloads `chrome-headless-shell` (~120 MB) on first launch and caches it under the
       # platform's user cache dir; the setup action restores it. The action also installs Node, the native
-      # libraries, and podman conditionally on the target and os, and provisions corretto:24 + sbt.
+      # libraries, and podman conditionally on the target and os, and provisions corretto:25 + sbt.
 
       - name: ${{ inputs.mode }} ${{ matrix.target }} (${{ inputs.os }})
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SBT_TASK_LIMIT: 1
-      JAVA_OPTS: '-Xmx12G -Xss10M -XX:+UseG1GC -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
-      JVM_OPTS:  '-Xmx12G -Xss10M -XX:+UseG1GC -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
+      JAVA_OPTS: '-Xmx12G -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
+      JVM_OPTS:  '-Xmx12G -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
     steps:
       - uses: actions/checkout@v6.0.3
         with:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: coursier/cache-action@v8.1.1
       - uses: coursier/setup-action@v3.0.0
         with:
-          jvm: corretto:24
+          jvm: corretto:25
           apps: sbt
       - name: Link the browser bundle (fullLinkJS)
         run: sbt 'kyo-website-bundleJS/Compile/fullLinkJS'

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -13,8 +13,8 @@ jobs:
       # -Xmx14G (up from 12G): `sbt doctest` compiles every module's test sources in one driver session
       # and OOM'd at 12G. Dropped the -Xms8G floor and pinned G1 so the heap grows on demand and is
       # released between phases, leaving the box room (ubuntu-latest is 16G).
-      JAVA_OPTS: -Xmx14G -Xss10M -XX:+UseG1GC -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-      JVM_OPTS: -Xmx14G -Xss10M -XX:+UseG1GC -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      JAVA_OPTS: -Xmx14G -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      JVM_OPTS: -Xmx14G -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - uses: actions/checkout@v6.0.3
         with:
@@ -22,6 +22,6 @@ jobs:
       - uses: coursier/cache-action@v8.1.1
       - uses: coursier/setup-action@v3.0.0
         with:
-          jvm: corretto:24
+          jvm: corretto:25
           apps: sbt
       - run: sbt doctest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install -y libcurl4-openssl-dev libidn2-dev libh2o-evloop-dev=2.2.5+dfsg2-8.1ubuntu3
       - uses: coursier/setup-action@v3.0.0
         with:
-          jvm: corretto:24
+          jvm: corretto:25
           apps: sbt
       # Phase 1: build, sign, and stage EVERY platform into one local bundle (target/sona-staging).
       # dottydoc crashes intermittently while rendering per-module javadoc; that happens here, inside

--- a/.github/workflows/scalafmt.yml
+++ b/.github/workflows/scalafmt.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: coursier/cache-action@v8.1.1
       - uses: coursier/setup-action@v3.0.0
         with:
-          jvm: corretto:24
+          jvm: corretto:25
           apps: sbt
       - name: Check formatting
         run: |

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,7 @@
 -Xmx12G
 -Xss10M
 -XX:+UseG1GC
+-XX:+UseCompactObjectHeaders
 -XX:MaxMetaspaceSize=2G
 -XX:ReservedCodeCacheSize=256M
 -Dfile.encoding=UTF-8

--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,16 @@ Global / concurrentRestrictions := {
     )
 }
 
+// java.lang.foreign (the Foreign Function and Memory API) is final in JDK 22, so modules that use it
+// cannot target Java 17. They override the project-wide `-release 17` (added by kyo-settings) with
+// `-release 25` (current LTS). Because `-release 25` requires a JDK >= 25 to compile, the whole build
+// requires JDK 25 (see the Global/onLoad guard and the CI setup action). Modules that do not use the
+// API keep `-release 17`.
+lazy val foreignRelease = Seq(
+    scalacOptions --= scalacOptionTokens(Set(ScalacOptions.release("17"))).value,
+    scalacOptions ++= scalacOptionTokens(Set(ScalacOptions.release("25"))).value
+)
+
 lazy val `kyo-settings` = Seq(
     fork               := true,
     scalaVersion       := scala3Version,
@@ -121,6 +131,10 @@ lazy val `kyo-settings` = Seq(
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDG"),
     ThisBuild / versionScheme := Some("early-semver"),
     Test / javaOptions += "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    // Compact object headers (JEP 519, a product flag in JDK 25 which the build requires) shrink the
+    // per-object header from 12-16 to 8 bytes. The test forks allocate heavily (kyo-tasty decodes 80k
+    // symbols), so this cuts heap pressure where the forks run closest to their cap.
+    Test / javaOptions += "-XX:+UseCompactObjectHeaders",
     // Forked test JVMs otherwise inherit no -Xmx and fall back to 25% of RAM (4GB on the 16GB CI
     // runners), too little for the heavy classpath-loading suites (kyo-tasty loads 80k-symbol
     // classpaths under globalK-way leaf concurrency). Pin an explicit fork heap on CI; with the
@@ -155,9 +169,11 @@ Global / onLoad := {
 
     val javaVersion  = System.getProperty("java.version")
     val majorVersion = javaVersion.split("\\.")(0).toInt
-    if (majorVersion < 21) {
+    // The foreign-API modules (kyo-data, kyo-ffi, kyo-offheap, kyo-tasty) compile at -release 25, which
+    // requires a JDK >= 25; the rest of the build stays at -release 17. So the whole build needs JDK 25.
+    if (majorVersion < 25) {
         throw new IllegalStateException(
-            s"Java version $javaVersion is not supported. Please use Java 21 or higher."
+            s"Java version $javaVersion is not supported. Please use Java 25 (LTS) or higher."
         )
     }
 
@@ -559,6 +575,7 @@ lazy val `kyo-data` =
         .withKyoTest
         .settings(
             `kyo-settings`,
+            foreignRelease,
             libraryDependencies += "com.lihaoyi" %%% "pprint"        % "0.9.6",
             libraryDependencies += "dev.zio"     %%% "izumi-reflect" % "3.0.9" % Test
         )
@@ -656,10 +673,10 @@ lazy val `kyo-offheap` =
         .in(file("kyo-offheap"))
         .dependsOn(`kyo-core`)
         .withKyoTest
-        .settings(`kyo-settings`)
+        .settings(`kyo-settings`, foreignRelease)
         .jvmSettings(mimaCheck(false))
         .jvmConfigure(_.settings(
-            doctestScalacOptions := Seq("-release", "22")
+            doctestScalacOptions := Seq("-release", "25")
         ))
         .nativeSettings(
             `native-settings`,
@@ -672,9 +689,10 @@ lazy val `kyo-ffi` =
         .in(file("kyo-ffi"))
         .dependsOn(`kyo-core`)
         .withKyoTest
-        .settings(`kyo-settings`)
+        .settings(`kyo-settings`, foreignRelease)
         .jvmSettings(
             mimaCheck(false),
+            doctestScalacOptions := Seq("-release", "25"),
             Test / javaOptions += "--enable-native-access=ALL-UNNAMED",
             // Hint to module-path consumers that this JAR uses java.lang.foreign.
             Compile / packageBin / packageOptions +=
@@ -703,6 +721,7 @@ lazy val `kyo-ffi-it` =
         .withKyoTest
         .settings(
             `kyo-settings`,
+            foreignRelease,
             publish / skip := true,
             // In-repo bootstrap: hand the plugin the codegen project's own classpath so a cold
             // `kyo-ffi-it/test` builds the codegen first and generates the impls directly, with no
@@ -820,6 +839,7 @@ lazy val `kyo-ffi-codegen` =
         .dependsOn(`kyo-ffi`.jvm % Test)
         .settings(
             `kyo-settings`,
+            foreignRelease,
             libraryDependencies += "org.scala-lang" %% "scala3-tasty-inspector" % scalaVersion.value,
             libraryDependencies += "org.scala-lang" %% "scala3-compiler"        % scalaVersion.value % Test,
             // kyo-test framework wiring (the JVM-only equivalent of .withKyoTest, which only applies to crossProjects).
@@ -935,6 +955,7 @@ lazy val `kyo-ffi-bench` =
         .disablePlugins(MimaPlugin)
         .settings(
             `kyo-settings`,
+            foreignRelease,
             publish / skip := true,
             Compile / javaOptions ++= Seq("--enable-native-access=ALL-UNNAMED"),
             Test / javaOptions ++= Seq("--enable-native-access=ALL-UNNAMED"),
@@ -996,6 +1017,7 @@ lazy val `kyo-tasty` =
         .withKyoTest
         .settings(
             `kyo-settings`,
+            foreignRelease,
             doctestPredef := Seq("import kyo.*", "import kyo.Tasty.*")
         )
         .jvmSettings(

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,7 @@ fi
 # runners are 4 vCPU / 16 GB on both linux-x64 and linux-arm64. One place.
 CI_MEMORY="16g"
 CI_CPUS="4"
-CI_DRIVER_OPTS="-Xmx12G -Xss10M -XX:+UseG1GC -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
+CI_DRIVER_OPTS="-Xmx12G -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
 CONTAINER_IMAGE="${KYO_BUILD_IMAGE:-ubuntu:noble}"
 
 ENV_KIND="direct"
@@ -185,7 +185,7 @@ if ! command -v cs >/dev/null 2>&1; then
     curl -fsSL "https://github.com/coursier/coursier/releases/latest/download/cs-\$cs_arch.gz" \
         | gzip -d > /usr/local/bin/cs && chmod +x /usr/local/bin/cs
 fi
-eval "\$(cs java --jvm corretto:24 --env)"
+eval "\$(cs java --jvm corretto:25 --env)"
 command -v sbt >/dev/null 2>&1 || cs install sbt >/dev/null
 export PATH="/root/.local/share/coursier/bin:\$PATH"
 PROVISION


### PR DESCRIPTION
## Problem

`java.lang.foreign` (the Foreign Function and Memory API) is final in JDK 22, so the modules that use it cannot compile against the project-wide `-release 17` flag set by `kyo-settings`. The previous floor guard required JDK 21, which is not sufficient to compile those modules at their required release target.

The build also made no use of compact object headers (JEP 519), a product flag available in JDK 25 that reduces the per-object header from 12-16 bytes to 8 bytes, leaving heap pressure on the table for the test forks that allocate most heavily (kyo-tasty decodes roughly 80k symbols per run).

## Solution

Add a `foreignRelease` setting in `build.sbt` that strips the inherited `-release 17` and replaces it with `-release 25`. Apply it to the seven modules that use `java.lang.foreign`: `kyo-data`, `kyo-offheap`, `kyo-ffi`, `kyo-ffi-it`, `kyo-ffi-codegen`, `kyo-ffi-bench`, and `kyo-tasty`. All other modules keep `-release 17`.

Because `-release 25` requires a JDK >= 25 present at compile time, the whole build now requires JDK 25. The `Global / onLoad` version guard is raised from 21 to 25 with an updated error message. The CI toolchain is moved to `corretto:25` across the setup action, all workflow files, and `scripts/build.sh`.

`-XX:+UseCompactObjectHeaders` is added to the test fork `javaOptions` in `kyo-settings`, to `.jvmopts` for local builds, to the `JAVA_OPTS`/`JVM_OPTS` lines in every workflow that carried `-XX:+UseG1GC`, and to `CI_DRIVER_OPTS` in `scripts/build.sh`.

## Notes

`foreignRelease` is applied via `.settings(...)` without platform scoping, so `-release 25` reaches the JS, Native, and Wasm variants of the affected modules as well. All seven modules compile on every platform they target under `-release 25`, so the setting does not need to be scoped to JVM only.

The `doctestScalacOptions` for `kyo-offheap` (previously `-release 22`) and `kyo-ffi` are updated to `-release 25` to match.

<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->
