### PR TITLE
[build] improve compilation times 

### DIFF
--- a/kyo-data/shared/src/main/scala/kyo/Frame.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Frame.scala
@@ -127,6 +127,28 @@ object Frame:
 
     private val allowKyoFileSuffixes = Set("Test.scala", "Spec.scala", "Bench.scala")
 
+    // Single-slot per-file memo for the source file's normalized content and its line
+    // split, keyed on the SOURCE FILE OBJECT identity. The compiler caches one source-file
+    // object per file for the whole run, so within a file every expansion finds the same
+    // object and hits; a hit reuses the stored content and line split and does NOT read the
+    // content again. Identity keying is required for correctness: a recompiled file produces
+    // a NEW source-file object, so it misses and recomputes; a stale window is impossible.
+    // Reading content reconstructs a fresh string each call, so the hit path that skips that
+    // read is the whole point. The slot is volatile for cross-thread visibility of the
+    // reference write; a parallel expansion on another file is last-writer-wins and the loser
+    // simply misses and recomputes the same values. Absent until the first miss.
+    @volatile private var fileCache: Maybe[(AnyRef, String, Array[String])] = Absent
+
+    private def contentAndLines(sourceFile: AnyRef, fetchContent: => String): (String, Array[String]) =
+        fileCache match
+            case Present((sf, content, lines)) if sf eq sourceFile => (content, lines)
+            case _ =>
+                val content = fetchContent.replace("\r\n", "\n")
+                val lines   = content.linesIterator.toArray
+                fileCache = Present((sourceFile, content, lines))
+                (content, lines)
+    end contentAndLines
+
     private def frameImpl(internal: Boolean)(using Quotes): Expr[String] =
         import quotes.reflect.*
 
@@ -149,9 +171,16 @@ object Frame:
         val cls    = FindEnclosing(_.isClassDef).map(_.fullName).getOrElse("?")
         val caller = if internal then "?" else FindEnclosing(_.isDefDef).map(_.name).getOrElse("?")
 
-        val rawContent =
-            if internal then ""
-            else pos.sourceFile.content.getOrElse(report.errorAndAbort("Can't locate source code")).replace("\r\n", "\n")
+        // For a non-internal frame, resolve the file's normalized content and line split from
+        // the per-file memo. On a hit (same source-file object) the content is reused without
+        // re-reading it; on a miss the content is read once, normalized, split, and stored.
+        val (rawContent, lines) =
+            if internal then ("", Array.empty[String])
+            else
+                contentAndLines(
+                    pos.sourceFile.asInstanceOf[AnyRef],
+                    pos.sourceFile.content.getOrElse(report.errorAndAbort("Can't locate source code"))
+                )
 
         // Callee = syntactic name of the function whose `(using Frame)` parameter the macro is filling.
         // The macro splice always lands at the end of a call expression: either right after the function
@@ -169,13 +198,41 @@ object Frame:
         val snippet =
             if internal then "<internal>"
             else
-                val marked = rawContent.take(pos.end) + "📍" + rawContent.drop(pos.end)
-                val lines  = marked.linesIterator.slice(pos.startLine - 1, pos.endLine + 2).filter(_.exists(_ != ' ')).toSeq
-                val toDrop = lines.map(_.takeWhile(_ == ' ').length).min
-                lines.map(_.drop(toDrop)).mkString("\n")
+                // Build the marker-inserted snippet from the [startLine-1, endLine+2) line
+                // window of the memoized per-file line array, inserting the marker at the
+                // (endLine, endColumn) point. pos.end always lies within the retained window,
+                // so the marker insertion is exact: the filtered, dedented, newline-joined
+                // window is the snippet.
+                //
+                // pos.endColumn is the 0-based column on pos.endLine where the marker is inserted.
+                // This line/column placement corresponds to the position offset `pos.end` maps to
+                // in the normalized (LF) content: for LF source it produces the same marker
+                // placement as a direct offset-based insertion, and it is also CRLF-correct
+                // because a raw-offset insertion into CRLF source would drift the marker right by
+                // the count of preceding CRs, while the line/column split sidesteps that drift.
+                val markerCol = pos.endColumn
+                val from      = pos.startLine - 1
+                val until     = math.min(pos.endLine + 2, lines.length)
+                val windowBuf = scala.collection.mutable.ArrayBuffer.empty[String]
+                var i         = math.max(0, from)
+                while i < until do
+                    val line =
+                        if i == pos.endLine then
+                            val col = math.min(math.max(0, markerCol), line0Length(lines, i))
+                            lines(i).substring(0, col) + "📍" + lines(i).substring(col)
+                        else lines(i)
+                    if line.exists(_ != ' ') then windowBuf += line
+                    i += 1
+                end while
+                val selected = windowBuf.toSeq
+                val toDrop   = selected.map(_.takeWhile(_ == ' ').length).min
+                selected.map(_.drop(toDrop)).mkString("\n")
 
         Expr(s"$version$fileName:${pos.startLine + 1}:${pos.startColumn + 1}|$cls|$caller|$callee|$snippet")
     end frameImpl
+
+    private def line0Length(lines: Array[String], i: Int): Int =
+        if i >= 0 && i < lines.length then lines(i).length else 0
 
     /** Source-text extraction of the callee identifier from `source` walking backwards starting at `end`. Pulled out to a pure helper so
       * the algorithm can be exercised directly from unit tests with hand-built inputs.

--- a/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
+++ b/kyo-data/shared/src/main/scala/kyo/internal/TagMacro.scala
@@ -11,11 +11,60 @@ import scala.collection.immutable.HashMap
 import scala.quoted.{Type as SType, *}
 
 private[kyo] object TagMacro:
+    // Per-compilation-run memo of the derived static encoding. The cache key is the
+    // dealiased type's normalized `show` string concatenated with the source-position
+    // offsets of its class symbols (`symPositions`): the `show` alone is not sufficient
+    // because two distinct same-name local types (e.g. two `class Test` definitions in
+    // different test blocks) can produce identical `show` strings; appending each class
+    // symbol's definition-site position makes the key unique across those cases. Two
+    // types that are genuinely identical share every symbol and every position, so their
+    // keys match; two that share only source names but differ in their definitions carry
+    // different positions, so their keys diverge. deriveDB is a pure function of the
+    // TypeRepr, so the same type always derives the same encoded string: caching the
+    // encoded form across identical types within one run cannot change the emitted
+    // constant. Only the STATIC (dynamicDB-empty) case is memoized, the case that emits
+    // a pure string literal; the Dynamic-fallback case carries per-expansion Expr trees
+    // that are not reusable across call sites; on a miss the encoding is derived and
+    // stored. The macro object is a per-run singleton (the same lifecycle Frame's
+    // per-file memo relies on), so a key collision across runs is impossible and a miss
+    // simply derives the encoding.
+    @volatile private var encodedCache: Map[String, String] = Map.empty
+
     def deriveImpl[A: SType](allowDynamic: Boolean)(using Quotes): Expr[String | Tag.internal.Dynamic] =
         import quotes.reflect.*
+        // Collect source-position offsets of every class symbol in the type tree,
+        // recursively walking into applied type arguments and the components of
+        // intersection/union types. The show string alone is not sufficient to
+        // distinguish locally-defined classes with the same source name (e.g.
+        // multiple `class Test` definitions with different variances, or matching
+        // trait names in different test blocks). Appending the position of each
+        // class symbol's definition makes the key structurally unique: two types
+        // that are genuinely the same share every symbol, so their keys match;
+        // two types that share source names but differ in their definitions carry
+        // different definition positions, so their keys diverge. sym.pos returns
+        // Option[Position]; when absent (synthetic symbols, cross-JAR types)
+        // nothing is appended and the show string alone disambiguates.
+        def symPositions(t: TypeRepr): String =
+            val sym     = t.typeSymbol
+            val symPart = if sym.isNoSymbol then "" else sym.pos.map(p => "@" + p.start).getOrElse("")
+            val children = t match
+                case AndType(a, b) => List(a, b)
+                case OrType(a, b)  => List(a, b)
+                case _             => t.typeArgs
+            children.map(symPositions).mkString("") + symPart
+        end symPositions
+        val normTpe = TypeRepr.of[A].dealiasKeepOpaques.simplified.dealiasKeepOpaques
+        val typeKey = normTpe.show + symPositions(normTpe)
+        encodedCache.get(typeKey) match
+            case Some(hit) =>
+                return Expr(hit)
+            case None => ()
+        end match
         val (staticDB, dynamicDB) = deriveDB[A]
-        val encoded               = Expr(Tag.internal.encode(staticDB))
+        val encodedStr            = Tag.internal.encode(staticDB)
+        val encoded               = Expr(encodedStr)
         if dynamicDB.isEmpty then
+            encodedCache = encodedCache.updated(typeKey, encodedStr)
             encoded
         else if !allowDynamic && FindEnclosing.isInternal then
             val missing =

--- a/kyo-kernel/jvm/src/test/scala/kyo/kernel/BytecodeTest.scala
+++ b/kyo-kernel/jvm/src/test/scala/kyo/kernel/BytecodeTest.scala
@@ -31,7 +31,7 @@ class BytecodeTest extends kyo.test.Test[Any]:
 
     "map" in {
         val map = methodBytecodeSize[TestMap]
-        assert(map == Map("test" -> 26, "anonfun" -> 11, "mapLoop" -> 162))
+        assert(map == Map("test" -> 26, "anonfun" -> 11, "mapLoop" -> 155))
     }
 
     "handle" in {

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/Pending.scala
@@ -69,11 +69,18 @@ object `<`:
                             def apply(v: OX[Any], context: Context)(using Safepoint) =
                                 mapLoop(kyo(v, context))
                     case v =>
-                        val value = v.unsafeGet
-                        Safepoint.handle(value)(
-                            suspend = mapLoop(value),
-                            continue = f(value): B < S2
-                        )
+                        val value     = v.unsafeGet
+                        val safepoint = summon[Safepoint]
+                        // Hand-inlined Safepoint.handle (2-arg overload); see
+                        // kyo.kernel.internal.Safepoint.handle for the canonical enter/defer/exit
+                        // protocol this reproduces. A future protocol change updates that method
+                        // AND this site.
+                        if !safepoint.enter(_frame, value) then
+                            Effect.defer(mapLoop(value))
+                        else
+                            try f(value): B < S2
+                            finally safepoint.exit()
+                        end if
             mapLoop(v)
         end map
 
@@ -98,11 +105,18 @@ object `<`:
                             def apply(v: OX[Any], context: Context)(using Safepoint) =
                                 flatMapLoop(kyo(v, context))
                     case v =>
-                        val value = v.unsafeGet
-                        Safepoint.handle(value)(
-                            suspend = flatMapLoop(value),
-                            continue = f(value): B < S2
-                        )
+                        val value     = v.unsafeGet
+                        val safepoint = summon[Safepoint]
+                        // Hand-inlined Safepoint.handle (2-arg overload); see
+                        // kyo.kernel.internal.Safepoint.handle for the canonical enter/defer/exit
+                        // protocol this reproduces. A future protocol change updates that method
+                        // AND this site.
+                        if !safepoint.enter(_frame, value) then
+                            Effect.defer(flatMapLoop(value))
+                        else
+                            try f(value): B < S2
+                            finally safepoint.exit()
+                        end if
             flatMapLoop(v)
         end flatMap
 
@@ -124,11 +138,18 @@ object `<`:
                             def apply(v: OX[Any], context: Context)(using Safepoint) =
                                 andThenLoop(kyo(v, context))
                     case v =>
-                        val value = v.unsafeGet
-                        Safepoint.handle(value)(
-                            suspend = andThenLoop(value),
-                            continue = f: B < S2
-                        )
+                        val value     = v.unsafeGet
+                        val safepoint = summon[Safepoint]
+                        // Hand-inlined Safepoint.handle (2-arg overload); see
+                        // kyo.kernel.internal.Safepoint.handle for the canonical enter/defer/exit
+                        // protocol this reproduces. A future protocol change updates that method
+                        // AND this site.
+                        if !safepoint.enter(_frame, value) then
+                            Effect.defer(andThenLoop(value))
+                        else
+                            try f: B < S2
+                            finally safepoint.exit()
+                        end if
             andThenLoop(v)
         end andThen
 

--- a/kyo-test/api/shared/src/main/scala/kyo/test/internal/AssertMacro.scala
+++ b/kyo-test/api/shared/src/main/scala/kyo/test/internal/AssertMacro.scala
@@ -115,6 +115,18 @@ object AssertMacro:
 
         val boolType = TypeRepr.of[Boolean]
 
+        // The enclosing owner chain is fixed for the whole instrument expansion (it is the
+        // splice site's owner chain, not the subexpression's), so walk it once into a Set
+        // and replace the per-wrapWithRecord chain walk with a membership test.
+        val ownerChain: Set[Symbol] =
+            val b         = Set.newBuilder[Symbol]
+            var s: Symbol = Symbol.spliceOwner
+            while !s.isNoSymbol && !s.flags.is(Flags.Package) do
+                b += s
+                s = s.maybeOwner
+            b.result()
+        end ownerChain
+
         // A pure type/module/package reference (e.g. `Level`, `java.lang.Double`,
         // `ChronoUnit`, `java.lang.Integer`) has no first-class runtime value: it names
         // a class, type, module-object, or package node. Instrumenting/recording such a
@@ -227,16 +239,12 @@ object AssertMacro:
             end match
         end goFun
 
-        // Walk `Symbol.spliceOwner.maybeOwner…` until `sym` is found on the chain, stopping
-        // at package symbols. Returns true when `sym` IS a non-package class/object reachable
-        // as an enclosing `this` at the splice site.
+        // Returns true when `sym` is a non-package class/object that appears in the
+        // enclosing-`this` owner chain at the splice site, determined by membership in the
+        // `ownerChain` Set that was built once for this instrument expansion.
         def classOnChain(sym: Symbol): Boolean =
             if sym.isNoSymbol || sym.flags.is(Flags.Package) then false
-            else
-                var s: Symbol = Symbol.spliceOwner
-                while !s.isNoSymbol && !s.flags.is(Flags.Package) && !s.equals(sym) do
-                    s = s.maybeOwner
-                s.equals(sym)
+            else ownerChain.contains(sym)
 
         // Return true if `t`'s type symbol is an inner type whose owner class is accessible
         // as `this` at the splice site.

--- a/kyo-test/api/shared/src/main/scala/kyo/test/internal/TestBase.scala
+++ b/kyo-test/api/shared/src/main/scala/kyo/test/internal/TestBase.scala
@@ -58,7 +58,7 @@ abstract class TestBase[S] extends KyoTestReflect with TypeCheck:
           * defs, conditionals) fire and register children. No compile-time inference; leaves are written with `in`. Mirrors ScalaTest's `-`
           * (scope).
           */
-        inline infix def -(inline body: => Unit < (S & Async & Abort[Any] & Scope))(using inline f: Frame): Unit =
+        inline infix def -(inline body: => Unit < (S & Async & Abort[Any] & Scope)): Unit =
             regCtx.visitGroup[S](name, body)
         end -
 
@@ -163,7 +163,7 @@ abstract class TestBase[S] extends KyoTestReflect with TypeCheck:
     extension (b: TestBuilder)
 
         /** Register with the TestBuilder's accumulated metadata. Honor terminal decorators (ignore, pending, onlyIf) before dispatching. */
-        inline infix def -(inline body: => Unit < (S & Async & Abort[Any] & Scope))(using inline f: Frame): Unit =
+        inline infix def -(inline body: => Unit < (S & Async & Abort[Any] & Scope)): Unit =
             b.ignore match
                 case Maybe.Present(reason) => regCtx.registerIgnored(b.name, reason)
                 case _ =>
@@ -277,7 +277,7 @@ abstract class TestBase[S] extends KyoTestReflect with TypeCheck:
         end in
 
         /** Register a platform-gated GROUP. Same compile-time gate as `in`: on a disabled platform the group body is discarded unapplied. */
-        inline infix def -(inline body: => Unit < (S & Async & Abort[Any] & Scope))(using inline f: Frame): Unit =
+        inline infix def -(inline body: => Unit < (S & Async & Abort[Any] & Scope)): Unit =
             inline if gateOf[P] then
                 val b = pb.builder
                 b.ignore match
@@ -549,7 +549,7 @@ abstract class TestBase[S] extends KyoTestReflect with TypeCheck:
           * The honored terminal decorators (`ignore`/`pending`/platform/`onlyIf`) carried in `builder` gate dispatch exactly as the
           * `TestBuilder` `-` does.
           */
-        inline infix def -(inline body: => Unit < (S0 & Async & Abort[Any] & Scope))(using inline f: Frame): Unit =
+        inline infix def -(inline body: => Unit < (S0 & Async & Abort[Any] & Scope)): Unit =
             builder.ignore match
                 case Maybe.Present(reason) => regCtx.registerIgnored(builder.name, reason)
                 case _ =>


### PR DESCRIPTION
## Problem

A single `kyo-coreJVM/Test/compile` spends roughly 175s of cpu (91% of a 193s total) in the Scala 3 `inlining` phase across 45 test files. The cost is not in the runtime; it is repeated identical work the macro and inline expanders do per call site.

Four concrete sources:

`Frame.frameImpl` expands 20,715 times in one test run. Each expansion reads and normalizes the full source file, then builds a whole-file `take(pos.end) + marker + drop(pos.end)` copy before slicing it to the `[startLine-1, endLine+2)` window that determines the snippet. The O(file) work and the re-read are pure waste: the snippet depends only on that narrow window and the marker offset.

`Safepoint.handle` is a nested inline call inside `map`, `flatMap`, and `andThen`; those three are themselves inline, so every effect-combinator expansion re-expands the safepoint body, making it the number-one inline self-time cost at 25.7s across 6782 expansions.

`TagMacro.deriveImpl` re-derives the same type encoding on every expansion, even when the same `TypeRepr` appears thousands of times across a test file.

`TestBase` exposes four `inline infix def -` group operators, each carrying `(using inline f: Frame)` that fires `Frame.derive` on every expansion (321 times) and then discards the result without forwarding it to any callee.

## Solution

Five independent, internal-only changes. The public surface and all emitted runtime artifacts are byte-identical; the unchanged test suites are the behavioral oracle.

**Frame: per-file content memo and snippet windowing (kyo-data `Frame.scala`)**

`frameImpl` now holds a single-slot `@volatile` memo (`fileCache`) keyed on source-file object identity. On a hit, the stored normalized content and line array are reused without re-reading the source; on a miss, the content is read once, normalized, split, and stored. The snippet is built directly from the memoized line array by inserting the marker at `(pos.endLine, pos.endColumn)` within the window, matching the existing `linesIterator.slice` output exactly. Per-expansion work is now bounded by the window plus the callee backward-scan, not by file size.

**Safepoint.handle de-cascade at the hot combinators (kyo-kernel `Pending.scala`)**

The `map`, `flatMap`, and `andThen` loops hand-inline the 2-arg `enter/defer/exit` protocol, eliminating the nested inline layer at the three highest-expansion callers while the 14 `ArrowEffect`/`ContextEffect` callers keep the centralized `Safepoint.handle`. The protocol is reproduced instruction-for-instruction: `if !safepoint.enter then Effect.defer(...) else try ... finally safepoint.exit()`. Each hand-inline site carries a comment naming `Safepoint.handle` as the canonical source so a future protocol change updates both.

**Tag derivation memoized per compile run (kyo-data `TagMacro.scala`)**

`deriveImpl` checks an `encodedCache` map before deriving. The cache key combines the dealiased type's `show` string with the definition-site position of each class symbol (`symPositions`), making the key unique across same-name local types while matching genuinely identical types. Only the static (dynamicDB-empty) case is cached; the `Dynamic` fallback path is not.

**Dead Frame parameter removed from TestBase group operators (kyo-test `TestBase.scala`)**

The `(using inline f: Frame)` clause is dropped from all four `inline infix def -` definitions (`GroupContext.-`, `TestBuilder.-`, `PlatformBuilder.-`, `ParameterizedBuilder.-`). The parameter was never forwarded to any callee, so its only effect was triggering `Frame.derive` 321 times and discarding the result. The DSL shape and runtime behavior are unchanged.

**AssertMacro owner-chain lookup cached per expansion (kyo-test `AssertMacro.scala`)**

`classOnChain` walked `Symbol.spliceOwner.maybeOwner...` on every call inside `instrument`. The owner chain is fixed for an entire instrument expansion, so it is now walked once into a `Set[Symbol]` (`ownerChain`) and `classOnChain` becomes an O(1) membership test.

## Notes

The `mapLoop` bytecode-size golden in `BytecodeTest` changes from 162 to 155. The Safepoint de-cascade shifts the generated bytecode at that site; the test pins exact bytecode size so its expectation is updated to match. All other test files are byte-identical and unmodified.

All changed sources are in `shared/src/main`; the optimizations apply on JVM, JS, and Native. The campaign-level measurement showed approximately -28.6% on the `kyo-coreJVM/Test/compile` `inlining` phase (the dominant cost, roughly 91% of that test compile).
