### PR TITLE
[lsp] Language Server Protocol server and client on kyo-jsonrpc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -279,6 +279,7 @@ lazy val kyoJVM: Project = project
         `kyo-flow`.jvm,
         `kyo-jsonrpc`.jvm,
         `kyo-jsonrpc-http`.jvm,
+        `kyo-lsp`.jvm,
         `kyo-caliban`.jvm,
         `kyo-bench`.jvm,
         `kyo-zio-test`.jvm,
@@ -346,6 +347,7 @@ lazy val kyoJS = project
         `kyo-flow`.js,
         `kyo-jsonrpc`.js,
         `kyo-jsonrpc-http`.js,
+        `kyo-lsp`.js,
         `kyo-browser`.js,
         `kyo-slack`.js,
         `kyo-ui`.js,
@@ -393,6 +395,7 @@ lazy val kyoNative = project
         `kyo-flow`.native,
         `kyo-jsonrpc`.native,
         `kyo-jsonrpc-http`.native,
+        `kyo-lsp`.native,
         `kyo-scheduler-zio`.native,
         `kyo-zio`.native,
         `kyo-zio-test`.native,
@@ -445,6 +448,7 @@ lazy val kyoWasm = project
         `kyo-flow`.wasm,
         `kyo-jsonrpc`.wasm,
         `kyo-jsonrpc-http`.wasm,
+        `kyo-lsp`.wasm,
         `kyo-pod`.wasm,
         `kyo-browser`.wasm,
         `kyo-slack`.wasm,
@@ -1242,6 +1246,18 @@ lazy val `kyo-jsonrpc-http` =
             `js-settings`,
             scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
         )
+
+lazy val `kyo-lsp` =
+    crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-lsp"))
+        .withKyoTest
+        .dependsOn(`kyo-jsonrpc`)
+        .settings(`kyo-settings`)
+        .jvmSettings(mimaCheck(false))
+        .nativeSettings(`native-settings`)
+        .wasmSettings(`wasm-settings`)
+        .jsSettings(`js-settings`)
 
 lazy val `kyo-caliban` =
     crossProject(JVMPlatform)

--- a/kyo-lsp/README.md
+++ b/kyo-lsp/README.md
@@ -1,0 +1,634 @@
+<!-- doctest:setup
+```scala
+import kyo.*
+import kyo.Maybe.Absent
+import kyo.Maybe.Present
+
+case class TodoEntry(keyword: String, body: String, line: Int) derives Schema, CanEqual
+case class ReindexResult(scanned: Int) derives Schema, CanEqual
+case class TodoLintFailure(line: Int, reason: String) derives Schema, CanEqual
+
+val todoUri: LspHandler.LspDocument.Uri =
+    LspHandler.LspDocument.Uri.parse("file:///tasks.todo").getOrElse(throw new IllegalStateException("uri"))
+
+def parseEntry(text: String, line: Int): Maybe[TodoEntry] =
+    text.linesIterator.zipWithIndex.find(_._2 == line - 1) match
+        case Some((l, _)) =>
+            val parts = l.trim.split(" ", 2)
+            if parts.length >= 1 then Maybe(TodoEntry(parts(0), parts.lift(1).getOrElse(""), line))
+            else Maybe.empty
+        case None => Maybe.empty
+
+val longRunningWork: LspHandler.DocumentSymbolResult < Async =
+    Async.sleep(1.second).andThen(LspHandler.DocumentSymbolResult.symbols())
+```
+-->
+
+# kyo-lsp
+
+Language Server Protocol 3.17 implementation for building editor-tooling servers (and clients) on top of `kyo-jsonrpc`. A server is a `JsonRpcTransport` plus a list of typed `LspHandler[In, Out, +E]` values, one per LSP endpoint (`textDocument/hover`, `workspace/executeCommand`, ...). The engine drives the `initialize` handshake, advertises capabilities, maintains an in-memory document registry, runs progress and cancellation, and dispatches each inbound message to the matching handler. Handler bodies receive typed parameter records, return typed responses, and reach for per-request state (the live server, the document registry, the cancellation promise) through `Lsp.*` accessors.
+
+The same handler vocabulary works in both directions. Server-handled endpoints come from `LspHandler.TextDocument.*` and `LspHandler.Workspace.*`; the corresponding reverse-direction (server-initiated) endpoints that a client must answer come from `LspHandler.Window.*` and `LspHandler.Client.*`. One sealed `LspException` hierarchy carries every protocol error: two per-operation failure traits (`LspRequestFailure` for every request, `LspInitFailure` for the eager handshake) name exactly what each call can produce, and a closed transport is the typed `LspConnectionClosedException` rather than a raw `Closed`. User-domain errors are registered per-handler via `.error[E2](code, message)` and arrive on the peer as `LspRemoteException`. The module is `shared/`-only Scala source; tests run on JVM, JavaScript, and Scala Native against an in-memory `JsonRpcTransport`.
+
+```scala doctest:scope=inherited
+val hover =
+    LspHandler.TextDocument.hover { params =>
+        Lsp.documents.map(_.get(params.textDocument.uri)).map {
+            case Present(doc) =>
+                val line = params.position.line + 1
+                parseEntry(doc.text, line) match
+                    case Present(entry) =>
+                        Present(LspHandler.Hover.plainText(s"${entry.keyword}: ${entry.body}"))
+                    case Absent => Absent
+                end match
+            case Absent => Absent
+        }
+    }
+```
+
+The single handler above is a complete server-side route. The sections below wire it into a live server, pair it with a client, walk through each handler namespace, explain the per-request context the engine binds around every dispatch, cover the document registry and edit vocabulary, the progress and cancellation surface, errors, capabilities, configuration, lifecycle, and cross-platform behavior.
+
+## Building a server
+
+A server is a transport plus a list of handlers. `LspServer.init` takes both and returns `LspServer < (Async & Scope)`. `Async` because background fibers drive the JSON-RPC dispatch loop; `Scope` because those fibers and the transport are released when the enclosing scope exits.
+
+The minimal server is a transport plus handlers handed to `LspServer.initWith`, with the main fiber parked while the dispatch loop runs. Each handler receives a typed parameter record decoded from the request's `params`, and capabilities are advertised automatically from the handlers you register (registering `TextDocument.completion` advertises `completionProvider`).
+
+`initWith(transport, handlers*)(f)` runs `f(server)` and releases at scope exit; `init(transport, handlers*)` returns the bare `LspServer < (Async & Scope)` when you need to thread it into a larger flow. Both take a curried `(transport, config)(handlers*)` form for a non-default `LspConfig`.
+
+The handshake is invisible: the engine owns `initialize`, `initialized`, `shutdown`, `exit`, and the `$/` lifecycle methods, and rejects any attempt to register one of those reserved names with `LspReservedMethodException`.
+
+### Running a server as a process
+
+An `LspServer.initWith(...)` expression is an effect description, not a running process. Wrap it in a `KyoApp` to produce a `main`-method-bearing object the JVM can launch:
+
+```scala doctest:scope=inherited expect=compiles
+object TodoServer extends KyoApp:
+    run {
+        JsonRpcTransport.contentLengthStdio(java.lang.System.in, java.lang.System.out).map { t =>
+            LspServer.initWith(t, hover) { _ =>
+                Async.never
+            }
+        }
+    }
+end TodoServer
+```
+
+`KyoApp.run { ... }` accepts any `Any < (Async & Scope & ...)`, runs the effect, and releases the scope when the body completes. `Async.never` parks the main fiber forever; the inbound stdio dispatch fiber drives all work, so the main fiber has nothing to do besides hold the scope open until the JVM is killed (Ctrl-C, parent process exit).
+
+## Building a client
+
+A client needs three things the server does not: an identity record, a capability tree to advertise, and a willingness to wait for the handshake before issuing requests. `LspClient.init` takes them in a locked argument order (`transport, clientInfo, capabilities, [config,] handlers*`) and performs the LSP `initialize` / `initialized` handshake eagerly before returning. The result type is `LspClient < (Async & Scope & Abort[LspInitFailure])` because handshake failures (a server that rejects `initialize`, or a transport closed mid-handshake) surface directly in the effect row.
+
+```scala doctest:scope=inherited
+val info = LspInfo(name = "todo-tester")
+val caps = LspCapabilities.Client.empty
+
+val program: Maybe[LspHandler.Hover] < (Async & Scope & Abort[LspInitFailure | LspRequestFailure]) =
+    JsonRpcTransport.inMemory.map { case (serverT, clientT) =>
+        LspServer.initWith(serverT, hover) { _ =>
+            LspClient.initWith(clientT, info, caps) { client =>
+                client.hover(LspHandler.HoverParams(
+                    textDocument = LspHandler.TextDocumentIdentifier(todoUri),
+                    position = LspHandler.Position(line = 0, character = 0)
+                ))
+            }
+        }
+    }
+```
+
+When `LspClient.init` returns, the handshake has already completed, so `client.serverCapabilities`, `client.serverInfo`, and `client.positionEncoding` are populated; each reads its cached value as a `< Sync` effect, with no network round-trip.
+
+The client exposes one typed extension method per server-handled endpoint. Each returns a typed result inside `(Async & Abort[LspRequestFailure])`:
+
+| Family | Methods |
+|--|--|
+| Code intelligence | `completion`, `completionItemResolve`, `hover`, `signatureHelp` |
+| Navigation | `declaration`, `definition`, `typeDefinition`, `implementation`, `references`, `documentHighlight` |
+| Outline / lens | `documentSymbol`, `codeAction`, `codeActionResolve`, `codeLens`, `codeLensResolve`, `documentLink`, `documentLinkResolve` |
+| Color / format | `documentColor`, `colorPresentation`, `formatting`, `rangeFormatting`, `onTypeFormatting` |
+| Rename / fold | `rename`, `prepareRename`, `foldingRange`, `selectionRange`, `linkedEditingRange` |
+| Hierarchy | `prepareCallHierarchy`, `callHierarchyIncomingCalls`, `callHierarchyOutgoingCalls`, `prepareTypeHierarchy`, `typeHierarchySupertypes`, `typeHierarchySubtypes` |
+| Semantic tokens | `semanticTokensFull`, `semanticTokensFullDelta`, `semanticTokensRange` |
+| Inlay / inline | `moniker`, `inlayHint`, `inlayHintResolve`, `inlineValue` |
+| Diagnostics | `documentDiagnostic`, `workspaceDiagnostic` |
+| Sync | `didOpen`, `didChange`, `didSave`, `didClose`, `willSave`, `willSaveWaitUntil` |
+| Workspace | `workspaceSymbol`, `executeCommand[T]` |
+| Lifecycle | `workDoneProgressCancel`, `setTrace`, `cancel` |
+| Session | `specVersion`, `positionEncoding`, `serverCapabilities`, `serverInfo`, `awaitDrain`, `close` / `closeNow` |
+
+`executeCommand[T]` is typed-only; there is no untyped overload. The `T` requires a `Schema[T]` because the engine decodes the wire result into `Maybe[T]`. When the command returns no result, the wire value is `null` and the method yields `Absent`.
+
+```scala doctest:scope=inherited
+val res: Maybe[ReindexResult] < (Async & Scope & Abort[LspInitFailure | LspRequestFailure]) =
+    JsonRpcTransport.inMemory.map { case (_, clientT) =>
+        LspClient.initWith(clientT, info, caps) { client =>
+            client.executeCommand[ReindexResult](
+                LspHandler.ExecuteCommandParams(command = "todo-indexer.reindex", arguments = Chunk.empty)
+            )
+        }
+    }
+```
+
+Reverse-direction requests are handled by passing client-side handlers to `LspClient.init`. The same factory shape applies: `LspHandler.Window.showMessage { params => ... }` registers an observer for `window/showMessage` notifications the server may send. Passing a server-side handler (anything from `TextDocument.*` or the request-shaped `Workspace.*` factories) to `LspClient.init` aborts at init time with `LspWrongDirectionException`, before any transport traffic flows; the engine catalog checks every registered handler's `direction` against the side that owns the call. When you need to issue a raw JSON-RPC call the typed client API does not cover, reach for `client.underlying: JsonRpcHandler`.
+
+## Handlers
+
+Every endpoint is constructed through a namespaced factory and yields an `LspHandler[In, Out, +E]`. The namespaces mirror LSP method-name prefixes:
+
+| Namespace | Direction | Examples |
+|--|--|--|
+| `LspHandler.TextDocument.*` | server-handled | `completion`, `hover`, `definition`, `formatting`, `codeAction`, `didOpen`, `didChange` |
+| `LspHandler.Workspace.*` | mixed | `symbol`, `executeCommand[Out]`, `didChangeConfiguration[T]`, the `willCreateFiles`/`willRenameFiles`/`willDeleteFiles` file-operation family with their `did*` notification counterparts (server-handled); `applyEdit`, `configuration[T]`, `workspaceFolders`, `refreshSemanticTokens` (client-handled) |
+| `LspHandler.NotebookDocument.*` | server-handled | `didOpen`, `didChange`, `didSave`, `didClose` |
+| `LspHandler.Window.*` | client-handled | `showMessage`, `showMessageRequest`, `showDocument`, `logMessage`, `createWorkDoneProgress` |
+| `LspHandler.Client.*` | client-handled | `registerCapability`, `unregisterCapability` |
+| `LspHandler.General.*` | bidirectional observers | `cancelRequest`, `progress[T]`, `setTrace`, `logTrace` |
+| `LspHandler.custom[In]` / `customClient[In]` | escape hatch | vendor extensions, unmodelled methods |
+
+The `General` factories register user observers that run AFTER the engine's built-in handling. The engine already drives cancellation (completing `Lsp.cancelled`) and progress dispatch; these observers are for logging and instrumentation. Registering `General.cancelRequest` to "implement" cancellation is a silent no-op: the cancellation already happened.
+
+Direction is validated at `init` time: a server registering `LspHandler.Window.showMessage`, or a client registering `LspHandler.TextDocument.completion`, is rejected before any traffic flows.
+
+### Opaque data carriers
+
+Several LSP request/response shapes carry an optional protocol field named `data` whose value is opaque to the protocol but meaningful between a "list" call and its corresponding "resolve" call. The engine stores the field as an opaque encoded string and exposes a typed round-trip:
+
+```scala
+// Producing side: encode typed state into the carrier.
+val richItem =
+    LspHandler.CompletionItem.of("TODO", LspHandler.CompletionItemKind.Keyword)
+        .withData[TodoEntry](TodoEntry("TODO", "Implement parser", 12))
+
+// Resolving side: decode back into the typed shape.
+val decoded: Maybe[TodoEntry] < Abort[LspDecodeException] =
+    richItem.dataAs[TodoEntry]
+```
+
+The carriers are `CompletionItem`, `CodeAction`, `CodeLens`, `DocumentLink`, `InlayHint`, `CallHierarchyItem`, `TypeHierarchyItem`, and `WorkspaceSymbol`. The rule: never construct one of these case classes with a public `data` field, because there is none; reach for `.withData[X]` when producing and `.dataAs[X]` when consuming. The carrier's wire shape stays `Schema`-encoded JSON regardless of `X`; only the encode/decode boundary needs to agree on the type.
+
+### Adding domain errors with `.error[E2]`
+
+A handler's `+E` type-parameter grows by one each time the user calls `.error[E2](code, message)`. The engine then maps any `Abort[E2]` inside the body to a JSON-RPC error response carrying the registered code and message:
+
+```scala
+val lintCmd =
+    LspHandler.Workspace.executeCommand[ReindexResult] { _ =>
+        Abort.fail(TodoLintFailure(line = 3, reason = "unknown keyword"))
+            .andThen((Absent: Maybe[ReindexResult]): Maybe[ReindexResult] < Async)
+    }.error[TodoLintFailure](code = -32099, message = "Todo lint failure")
+```
+
+`-32099` falls in the JSON-RPC user-defined error code range (`-32000` to `-32099`). On the receiving peer, the error arrives shaped as `LspRemoteException`; see [Errors](#errors) below for the round-trip teaching.
+
+## Inside a handler
+
+A handler closure runs inside a per-request context the engine sets up before dispatch and tears down after. The context carries the live `LspServer` (or `LspClient`, on reverse-direction handlers), the read-only document registry, the JSON-RPC request id, a cancellation promise, the progress tokens from the params, the negotiated position encoding, and typed accessors for the raw extensibility slots. Inside a handler body, all of this is reachable through `Lsp.*` accessors that read a `Local`:
+
+| Accessor | Returns | Use |
+|--|--|--|
+| `Lsp.server` | `LspServer < Sync` | reverse-direction calls (server side only) |
+| `Lsp.client` | `LspClient < Sync` | reverse-direction calls (client side only) |
+| `Lsp.documents` | `Lsp.DocumentRegistry < Sync` | open document snapshot |
+| `Lsp.requestId` | `Maybe[JsonRpcId] < Sync` | the inbound request's id |
+| `Lsp.cancelled` | `Fiber.Promise[Unit, Sync] < Sync` | resolves when the peer cancels |
+| `Lsp.workDoneToken` | `Maybe[ProgressToken] < Sync` | client-supplied progress token |
+| `Lsp.partialResultToken` | `Maybe[ProgressToken] < Sync` | client-supplied partial-result token |
+| `Lsp.positionEncoding` | `PositionEncodingKind < Sync` | session-level negotiated encoding |
+| `Lsp.trace` | `TraceValue < Sync` | session trace level |
+| `Lsp.extras[T]` | `Maybe[T] < (Sync & Abort[LspInvalidParamsException])` | typed JSON-RPC extras |
+
+Calling any of these accessors outside an active handler dispatch raises an `IllegalStateException`. This is a programmer-error path, not a recoverable effect; no typed `Abort` row is added to the signature. `Lsp.server` and `Lsp.client` are additionally side-correct: calling `Lsp.server` from a client-handled handler body (or `Lsp.client` from a server-handled body) raises the same `IllegalStateException`. The engine binds exactly one of the two for any given dispatch.
+
+A typical hover handler reaches for the document registry:
+
+```scala
+val docSizeHover =
+    LspHandler.TextDocument.hover { params =>
+        Lsp.documents.map(_.get(params.textDocument.uri)).map {
+            case Present(doc) =>
+                Present(LspHandler.Hover.plainText(s"${doc.text.length} chars"))
+            case Absent => Absent
+        }
+    }
+```
+
+When `documents.get(uri)` returns `Absent`, the engine does not have an open document for that URI (the request fired before a `didOpen`, or after a `didClose`). The handler is free to return `Absent` to skip producing a hover.
+
+### Typed accessors for raw extensibility slots
+
+Several LSP wire fields are typed as "arbitrary JSON" in the spec: `InitializeParams.initializationOptions`, `clientCapabilities.experimental`, `serverCapabilities.experimental`, `NotebookDocument.metadata`, `NotebookCell.metadata`, and `Registration.registerOptions`. The engine stores each as a private `String` (encoded JSON); `Lsp` exposes typed decoders:
+
+```scala
+case class TodoInit(workspaceRoot: String) derives Schema, CanEqual
+
+val init =
+    LspHandler.TextDocument.didOpen { _ =>
+        Lsp.initializationOptions[TodoInit].map {
+            case Present(opts) => () // configure from opts.workspaceRoot
+            case Absent        => ()
+        }
+    }
+```
+
+The decoders are `Lsp.initializationOptions[X]`, `Lsp.clientExperimentalCapabilities[X]`, `Lsp.serverExperimentalCapabilities[X]`, `Lsp.notebookMetadataAs[X]`, `Lsp.notebookCellMetadataAs[X]`, and `Lsp.registerOptionsAs[X]`. All return `Maybe[X]` inside `Sync & Abort[LspDecodeException]`; a decode failure is a typed effect, not a panic.
+
+The encoder counterpart is `LspConfig.default.experimentalServerCapabilities[X](value)`, which serializes the typed `value` via `Schema[X]` into the capability tree's `experimental` slot at handshake time. Servers wiring their own experimental extension use this to publish; peers decode via `Lsp.serverExperimentalCapabilities[X]`.
+
+## Reverse-direction calls
+
+A handler runs inside the engine's per-request context, so `Lsp.server` returns the live `LspServer` handle for the same session. That handle exposes the full set of server-initiated (client-bound) calls as extension methods on `LspServer`. They divide along the protocol's reverse-direction families: user-visible messaging, diagnostics, edits, configuration queries, client-cache invalidations, dynamic capability registration, and a few engine-substrate helpers.
+
+The messaging family targets the editor's UI: `showMessage(ShowMessageParams)` and `logMessage(LogMessageParams)` fire-and-forget notifications (the latter is silent, intended for the trace/output panel; the former pops up). `showMessageRequest(ShowMessageRequestParams)` is the request-shaped variant; the client answers with `Maybe[MessageActionItem]` telling the server which action button the user clicked. `showDocument(ShowDocumentParams)` asks the client to navigate to a URI (file or web), optionally taking focus, optionally selecting a `Range`; the result `ShowDocumentResult.success` confirms whether the client honored the request. For the common `showMessage` cases, `showError`, `showWarning`, and `showInfo` are message-type shorthands, and a `showMessage(messageType, message)` overload skips the `ShowMessageParams` wrapper.
+
+```scala
+val notifyOnLint =
+    LspHandler.TextDocument.didChange { _ =>
+        Lsp.server.map(_.showInfo("Re-scanning TODOs"))
+    }
+```
+
+`publishDiagnostics(PublishDiagnosticsParams)` is how a server delivers lint / type-check / parse results to the editor's gutter and problems panel. The params carry the document URI, an optional version the client uses to discard diagnostics for a stale revision, and the `Chunk[Diagnostic]` itself. A diagnostic without a corresponding `publishDiagnostics` call is invisible; the registry does not auto-derive diagnostics from handler return values.
+
+```scala
+val validKeywords = Set("TODO", "DONE", "WAIT")
+
+val onOpenLint =
+    LspHandler.TextDocument.didOpen { params =>
+        Lsp.documents.map(_.get(params.textDocument.uri)).map { maybeDoc =>
+            val diags: Chunk[LspHandler.Diagnostic] = maybeDoc match
+                case Absent => Chunk.empty
+                case Present(doc) =>
+                    Chunk.from(doc.text.linesIterator.zipWithIndex.flatMap { case (l, i) =>
+                        val line = i + 1
+                        parseEntry(doc.text, line) match
+                            case Present(entry) if !validKeywords.contains(entry.keyword) =>
+                                Chunk(LspHandler.Diagnostic.warning(
+                                    LspHandler.Range.of(i, 0, i, entry.keyword.length),
+                                    s"Unknown keyword '${entry.keyword}'; expected TODO, DONE, or WAIT"
+                                ))
+                            case _ => Chunk.empty
+                        end match
+                    }.toSeq)
+            Lsp.server.map(_.publishDiagnostics(
+                params.textDocument.uri,
+                diags,
+                version = Present(params.textDocument.version)
+            ))
+        }
+    }
+```
+
+`applyEdit(ApplyWorkspaceEditParams)` asks the client to apply a `WorkspaceEdit` to its file buffers; the server-side use case is code actions, refactorings, and quick fixes that need to modify files other than (or beyond) the one the action was triggered on. The signature is `applyEdit(params): ApplyWorkspaceEditResult < (Async & Abort[LspRequestFailure])`; the returned `ApplyWorkspaceEditResult` reports `applied`, an optional `failureReason`, and (for `documentChanges`) the index of the first failed change.
+
+```scala
+val applyAcrossFiles =
+    LspHandler.Workspace.executeCommand[Unit] { _ =>
+        val edit = LspHandler.WorkspaceEdit(
+            changes = Present(Map(
+                "file:///workspace/a.todo" -> Chunk(
+                    LspHandler.TextEdit(
+                        range = LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0)),
+                        newText = "DONE Migrate\n"
+                    )
+                )
+            ))
+        )
+        Lsp.server.map(_.applyEdit(LspHandler.ApplyWorkspaceEditParams(edit = edit)))
+            .map(_ => Present(()))
+    }
+```
+
+`getConfiguration[T](ConfigurationParams)` and `getWorkspaceFolders` are the inbound queries: ask the client what its current settings look like, ask which folders are open. `getConfiguration[T]` is typed; each `ConfigurationItem` (scoped to a URI and/or section) is decoded into `T` via `Schema[T]`. `getWorkspaceFolders` returns `Maybe[Chunk[WorkspaceFolder]]` (`Absent` if the client did not advertise the capability). The post-handshake snapshot is cached as `server.workspaceFolders: Maybe[Chunk[WorkspaceFolder]] < Sync`; reach for it when you need the folders without re-issuing `getWorkspaceFolders`.
+
+The `refresh*` family invalidates client-side caches after server state changes that affect rendered output: `refreshSemanticTokens`, `refreshCodeLens`, `refreshInlayHint`, `refreshDiagnostic`, `refreshInlineValue`. Each is a parameter-less notification the client treats as "redraw next time"; the typical trigger is the server finishing an index rebuild and noticing every previously-issued token / lens / hint is now stale. They are workspace-wide; there is no URI-scoped variant.
+
+`registerCapability(RegistrationParams)` and `unregisterCapability(UnregistrationParams)` are the dynamic-capability surface: at runtime, after the static `initialize` exchange, advertise (or retract) a method the server wants the client to start routing to it. The `Registration` carries an opaque `registerOptions` slot whose typed shape is decoded peer-side via `Lsp.registerOptionsAs[X]`. Most servers do not need dynamic registration; static capabilities advertised in the `InitializeResult` cover the common case.
+
+`telemetry[T](payload)` ships an arbitrary typed payload to the client's telemetry sink (the `telemetry/event` notification); editors generally surface telemetry to their own analytics rather than to the user. `logTrace(message, verbose)` is the `$/logTrace` channel, used when the client has enabled tracing via `$/setTrace`.
+
+`createWorkDoneProgress(WorkDoneProgressCreateParams)` is the server-initiated half of the work-done progress lifecycle; see [Progress and cancellation](#progress-and-cancellation) below for the begin/report/end pattern that consumes the created token.
+
+The complete reverse-direction surface, as extension methods on `LspServer`:
+
+| Family | Methods |
+|--|--|
+| Messaging | `showMessage`, `showMessageRequest`, `showDocument`, `logMessage` |
+| Diagnostics | `publishDiagnostics` |
+| Edits | `applyEdit` |
+| Queries | `getConfiguration[T]`, `getWorkspaceFolders` |
+| Cache invalidation | `refreshSemanticTokens`, `refreshCodeLens`, `refreshInlayHint`, `refreshDiagnostic`, `refreshInlineValue` |
+| Dynamic registration | `registerCapability`, `unregisterCapability` |
+| Telemetry / trace | `telemetry[T]`, `logTrace` |
+| Progress | `createWorkDoneProgress`, `workDoneProgress` |
+| Session control | `cancel` |
+
+Each method returns its result inside `(Async & Abort[LspRequestFailure])` (or just `Abort[LspConnectionClosedException]` for the pure notification shapes); the engine routes the call through the same JSON-RPC layer that serves inbound traffic, so a closed transport mid-call surfaces as `LspConnectionClosedException` in the effect row.
+
+## Document registry
+
+When the client opens a file via `textDocument/didOpen`, the engine stores the text in an in-memory registry. Subsequent `didChange` notifications update it incrementally, `didSave` marks it as saved, `didClose` removes it. The registry is the source of truth handlers read through `Lsp.documents`. Users never write to it directly. All sync notification handlers (`didOpen`, `didChange`, `didSave`, `didClose`) run AFTER the registry has been updated, so a handler reading `documents.get(uri)` after a `didChange` observes the new text, not the old.
+
+The read interface is sealed:
+
+```scala
+val tableOfContents =
+    LspHandler.TextDocument.documentSymbol { _ =>
+        Lsp.documents.map { docs =>
+            docs.listOpen.map { open =>
+                LspHandler.DocumentSymbolResult.Symbols(
+                    open.map(d =>
+                        LspHandler.DocumentSymbol(
+                            name = d.uri.asString,
+                            detail = Present(s"v${d.version}"),
+                            kind = LspHandler.SymbolKind.File,
+                            range = LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0)),
+                            selectionRange = LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0))
+                        )
+                    )
+                )
+            }
+        }
+    }
+```
+
+The accessors are `get(uri)`, `version(uri)`, `listOpen`, `listOpenUris`, and `isOpen(uri)`.
+
+A document's `uri` is an opaque type:
+
+```scala
+LspHandler.LspDocument.Uri.parse("file:///todo/tasks.todo") // Present(...)
+LspHandler.LspDocument.Uri.parse("   ")                     // Absent
+LspHandler.LspDocument.Uri.parse("")                        // Absent
+```
+
+`parse` rejects empty and whitespace-only inputs by returning `Absent`, so user code that builds a URI from external input gets the validation for free.
+
+### Applying edits
+
+The protocol describes edits as `TextEdit(range, newText)` and `AnnotatedTextEdit(range, newText, annotationId)`. A `WorkspaceEdit` groups them into either `changes: Map[String, Chunk[TextEdit]]` (URI to edits) or the richer `documentChanges: Chunk[WorkspaceEditDocumentChange]` (which supports versioned text edits and resource operations). Resource operations are `CreateFile`, `RenameFile`, `DeleteFile`, each tagged by `ResourceOperationKind` (`Create`, `Rename`, `Delete`). A `ChangeAnnotation` (`label`, `needsConfirmation`, `description`) attaches user-visible metadata to one or more edits via `annotationId`.
+
+The reverse-direction `workspace/applyEdit` shape carries the entire `WorkspaceEdit`:
+
+```scala
+val applyOnce =
+    LspHandler.TextDocument.codeAction { params =>
+        val edit = LspHandler.WorkspaceEdit.changes(
+            params.textDocument.uri -> Chunk(
+                LspHandler.TextEdit(
+                    range = LspHandler.Range.of(0, 0, 0, 0),
+                    newText = "TODO Take a break\n"
+                )
+            )
+        )
+        val action = LspHandler.CodeAction.quickFix("Insert TODO", edit)
+        Chunk(LspHandler.CommandOrCodeAction.action(action))
+    }
+```
+
+For incremental in-memory updates against the registry's snapshot, `LspHandler.LspDocument.applyChanges(doc, changes)` is pure: it takes a document and a chunk of `TextDocumentContentChangeEvent` values (each `Full(text)` or `Incremental(range, text)`) and returns the new document with the new text and an incremented version. The engine uses the same function inside the registry; user code can call it on any `LspDocument` it has in hand (for example, to preview an edit before submitting it).
+
+The sync mode the engine negotiates with the client is controlled by `LspConfig.documentSync: TextDocumentSyncKind`, with three values:
+
+- `None`: the engine does not request document open/change/close notifications.
+- `Full`: each change carries the entire new text.
+- `Incremental` (default): each change carries a `range` and the replacement text.
+
+Position encodings are negotiated similarly. `LspConfig.positionEncodings: Chunk[PositionEncodingKind]` (default `Chunk(UTF16)`) lists the server's accepted set; the engine intersects with the client's advertised set at handshake time and stamps the chosen encoding into every registered document. `LspHandler.PositionEncodingKind` carries three opaque-string values: `UTF8`, `UTF16`, `UTF32`. UTF-16 is the LSP 3.17 default.
+
+## Notebook integration
+
+Notebooks (Jupyter, VS Code interactive windows) ride alongside text documents. The engine treats every notebook cell as a separate `LspDocument` inside the same registry, keyed by the cell URI. Handlers receive the cell document through `Lsp.documents.get(cellUri)` just like any other text document.
+
+The notebook-specific factories are `LspHandler.NotebookDocument.didOpen`, `didChange`, `didSave`, `didClose`. The notebook itself is described by `LspHandler.Notebook` (with cells), and each cell by `LspHandler.NotebookCell`. Both carry an opaque `metadata` slot; `Lsp.notebookMetadataAs[X]` and `Lsp.notebookCellMetadataAs[X]` decode it on demand.
+
+```scala
+case class CellMeta(executionCount: Int) derives Schema, CanEqual
+
+val onCellOpen =
+    LspHandler.NotebookDocument.didOpen { params =>
+        params.cellTextDocuments.foldLeft((): Unit < Async) { (acc, _) =>
+            acc // the engine has already populated each cell into Lsp.documents
+        }
+    }
+```
+
+`workspace/didChangeConfiguration[T]` and `workspace/executeCommand[Out]` take a `Schema`-typed parameter so user-defined configuration shapes and command results round-trip without manual JSON wrangling.
+
+## Progress and cancellation
+
+Long-running operations report progress through LSP's `$/progress` notification family. The protocol distinguishes two flavors:
+
+- **Work-done progress** announces an indeterminate or percentage-based job's lifecycle (`Begin` → many `Report` → `End`).
+- **Partial result progress** streams intermediate chunks of an otherwise-large response on a request-scoped token.
+
+When the client supplies a `workDoneToken` in the request params, the server emits progress on that token directly. When it does not, the server allocates a fresh token via `LspServer.createWorkDoneProgress` (the `window/workDoneProgress/create` reverse-direction request), then reports against it.
+
+### Work-done progress
+
+```scala
+val reindex =
+    LspHandler.Workspace.executeCommand[ReindexResult] { params =>
+        if params.command != "todo-indexer.reindex" then
+            ((Absent: Maybe[ReindexResult]): Maybe[ReindexResult] < Async)
+        else
+            for
+                supplied <- Lsp.workDoneToken
+                token <- supplied match
+                    case Present(t) => (t: LspHandler.ProgressToken < Async)
+                    case Absent =>
+                        val fresh = LspHandler.ProgressToken.StringToken(s"reindex-${java.util.UUID.randomUUID()}")
+                        Lsp.server.map(_.createWorkDoneProgress(LspHandler.WorkDoneProgressCreateParams(fresh)))
+                            .map(_ => fresh)
+                            .handle(Abort.recover[LspRequestFailure](_ => fresh))
+                _ <- Lsp.workDoneBegin(token, title = "Reindexing TODOs", percentage = Present(0))
+                _ <- Lsp.workDoneReport(token, message = Present("scanning"), percentage = Present(50))
+                _ <- Lsp.workDoneEnd(token, message = Present("done"))
+            yield Present(ReindexResult(scanned = 42))
+            end for
+        end if
+    }
+```
+
+When `Lsp.workDoneToken` is `Absent`, the handler must FIRST ask the client to create a token via `Lsp.server.map(_.createWorkDoneProgress(...))` before calling `workDoneBegin`. Skipping the create-then-report dance is silent breakage: `workDoneBegin` on an uncreated token reaches the client as an unrecognized progress stream. The pattern above is the canonical one.
+
+### Partial-result progress
+
+For requests that return a sequence (`textDocument/completion`, `workspace/symbol`, ...), the client may supply a `partialResultToken` to opt into streaming. The handler emits intermediate chunks through `Lsp.emitPartialResult[T]`:
+
+```scala doctest:scope=inherited
+val streamingSymbols =
+    LspHandler.Workspace.symbol { _ =>
+        Lsp.partialResultToken.map {
+            case Present(token) =>
+                val firstBatch: Chunk[LspHandler.WorkspaceSymbol] = Chunk.empty
+                Lsp.emitPartialResult[Chunk[LspHandler.WorkspaceSymbol]](token, firstBatch)
+                    .andThen(Chunk.empty[LspHandler.WorkspaceSymbol])
+            case Absent =>
+                Chunk.empty[LspHandler.WorkspaceSymbol]
+        }
+    }
+```
+
+The final return value is the last chunk; intermediate values flow through `emitPartialResult`. The `T` type parameter must carry a `Schema[T]`; the engine `Json.encode`s each partial chunk into a `$/progress` notification.
+
+### Cancellation
+
+When the client cancels a request, the engine completes `Lsp.cancelled` (a `Fiber.Promise[Unit, Sync]`). A long-running handler races its work against the cancellation promise:
+
+```scala doctest:scope=inherited
+val cancellable =
+    LspHandler.TextDocument.documentSymbol { _ =>
+        Lsp.cancelled.map { cancel =>
+            // race the long-running body against the cancellation promise
+            Async.race(longRunningWork, cancel.get.andThen(LspHandler.DocumentSymbolResult.symbols()))
+        }
+    }
+```
+
+`Lsp.cancelled` is a kernel-level promise; reading it never aborts. A handler that wants to interrupt itself when the client cancels can use `Async.race` between the body and the promise's `.get`. The engine has already published the cancellation by the time the promise resolves; the `General.cancelRequest` observer factory is for logging, not for driving the cancellation effect.
+
+## Errors
+
+Every protocol error in `kyo-lsp` lives under one sealed root, `LspException`. The hierarchy is flat: there are no stage subcategories. Two sealed per-operation traits name the failure set of each public call, and each concrete leaf mixes in the traits it can occur on.
+
+- `LspRequestFailure` is the row of every client request and every server reverse-request. Exactly two leaves mix it in: `LspConnectionClosedException` (the typed closed-transport leaf) and `LspRemoteException(remoteCode, remoteMessage, remoteData)` (a user-domain error received from the peer). The engine funnels every server-side `JsonRpcError` into `LspRemoteException`, so a request never discriminates per method beyond these two leaves.
+- `LspInitFailure` is the row of the eager client `initialize` / `initialized` handshake. The same two leaves mix it in: a server that rejects `initialize` arrives as `LspRemoteException`, a transport closed mid-handshake as `LspConnectionClosedException`.
+
+The remaining leaves never appear on a client-facing row. The server gate raises `LspNotInitializedException`, `LspShutdownInProgressException`, and `LspCapabilityNotAdvertisedException`; each crosses the wire as a `JsonRpcError` and reaches the client re-encoded as `LspRemoteException`. The handler-body decoders raise `LspDecodeException` and `LspInvalidParamsException` on their own narrow rows. Three construction-time programmer errors (`LspWrongDirectionException`, `LspReservedMethodException`, `LspDuplicateHandlerException`) are thrown synchronously inside `init`, and `LspConfigurationError` is thrown by `LspConfig.require`; none of these appear on a tracked `Abort` row.
+
+Library code never returns subclasses of `LspException` other than these leaves; user code never subclasses `LspException` directly. New user-domain errors enter the protocol exclusively through `handler.error[E2](code, message)` on the SENDING side.
+
+```scala
+val abortingCmd =
+    LspHandler.Workspace.executeCommand[ReindexResult] { params =>
+        if params.command == "todo-indexer.reindex" then
+            Abort.fail(TodoLintFailure(line = 1, reason = "empty body"))
+                .andThen((Absent: Maybe[ReindexResult]): Maybe[ReindexResult] < Async)
+        else
+            ((Absent: Maybe[ReindexResult]): Maybe[ReindexResult] < Async
+        )
+    }.error[TodoLintFailure](code = -32099, message = "Todo lint failure")
+```
+
+A `.error[E2]`-registered error arrives on the peer as `LspRemoteException(remoteCode, remoteMessage, remoteData)`, NOT as the original `E2`. The peer recovers the discriminator by matching on `remoteCode`, not by runtime type. On the receiving side:
+
+```scala doctest:scope=inherited
+import kyo.LspRemoteException
+
+val handled: Maybe[ReindexResult] < (Async & Scope & Abort[LspInitFailure | LspRequestFailure]) =
+    JsonRpcTransport.inMemory.map { case (_, clientT) =>
+        LspClient.initWith(clientT, LspInfo(name = "todo-tester"), LspCapabilities.Client.empty) { client =>
+            client.executeCommand[ReindexResult](
+                LspHandler.ExecuteCommandParams(command = "todo-indexer.reindex", arguments = Chunk.empty)
+            ).handle(Abort.recover[LspRequestFailure] {
+                case LspRemoteException(-32099, _, _) => (Absent: Maybe[ReindexResult]) // recognized todo-lint failure
+                case other                            => Abort.fail(other)
+            })
+        }
+    }
+```
+
+`Remote.remoteCode` is the wire-level JSON-RPC code; pattern-match on it to discriminate user-defined error families. The wire-stable contract is `(code, message, data)`, not the sending side's Scala type. This keeps the cross-language case (a TypeScript client talking to a Scala server, or vice versa) honest.
+
+The JSON-RPC codes carried by the leaves:
+
+- `-32002`: `LspNotInitializedException` (a method reached the server before `initialize`).
+- `-32600`: `LspShutdownInProgressException`.
+- `-32601`: `LspCapabilityNotAdvertisedException`.
+- `-32602`: the handler-body decoders `LspDecodeException` and `LspInvalidParamsException`.
+- `-32603`: `LspConnectionClosedException`, `LspConfigurationError`, and the construction-time `LspWrongDirectionException` / `LspReservedMethodException` / `LspDuplicateHandlerException`.
+- `-32099` through `-32000`: the implementation-defined user-error range you advertise via `.error[E2]`; such errors arrive on the peer as `LspRemoteException` carrying the wire code.
+
+Request cancellation (`-32800` / `-32801` / `-32802`) is handled by the JSON-RPC cancellation policy on the wire, not by an `LspException` leaf.
+
+## Configuring a server or client
+
+The protocol negotiates a session at `initialize` time: the server advertises its capabilities, the client confirms which it consumes, both pick the position encoding. `LspConfig` collects the server-side knobs (handler-registration cross-field constraints, capability tree mode, JSON-RPC underlying config); `LspCapabilities` describes the trees themselves. The supported protocol version is `LspConfig.SpecVersion` (currently `"3.17"`); use it for runtime version checks or to print the negotiated version in logs.
+
+### The capability trees
+
+`LspCapabilities.Server.Server` and `LspCapabilities.Client.Client` are the capability trees the protocol negotiates. The type aliases `LspCapabilities.Server` and `LspCapabilities.Client` resolve to the inner case classes so callers write `LspCapabilities.Server` and get the record. `LspCapabilities.Server.empty` and `LspCapabilities.Client.empty` provide zero-capability baselines.
+
+When `LspConfig.declaredServerCapabilities = Absent` (the default), the engine auto-derives the tree from the registered handlers at init time: a server that registers `TextDocument.completion` and `TextDocument.hover` advertises `completionProvider` and `hoverProvider` automatically. Declaring an explicit tree disables the derivation; the explicit tree wins. Either way, `LspConfig.enforceCapabilities = true` (the default) rejects requests for methods not advertised in the tree with `LspCapabilityNotAdvertisedException`. Set it to `false` to permit unadvertised methods to dispatch (useful for vendor extensions that ride alongside the standard capability tree).
+
+```scala
+val explicit =
+    LspCapabilities.Server.empty.copy(
+        hoverProvider = Present(LspHandler.BooleanOr.on),
+        completionProvider = Present(LspHandler.CompletionOptions(
+            triggerCharacters = Chunk(".", ":")
+        ))
+    )
+
+val cfg: LspConfig =
+    LspConfig.default
+        .withDeclaredServerCapabilities(explicit)
+```
+
+Many capability slots accept either a plain boolean ("yes, I provide this, with default options") or a typed options record ("yes, with these specific settings"). `BooleanOr[T]` and `StringOr[T]` are the sealed unions that carry this choice on the wire:
+
+```scala
+val asFlag =
+    LspCapabilities.Server.empty.copy(
+        hoverProvider = Present(LspHandler.BooleanOr.on)
+    )
+
+val asOptions =
+    LspCapabilities.Server.empty.copy(
+        hoverProvider = Present(LspHandler.BooleanOr.options(LspHandler.HoverOptions()))
+    )
+```
+
+`BooleanOr` has `Bool(value: Boolean)` and `Options(value: T)` cases; `StringOr` has `Str(value: String)` and `Options(value: T)`. For the common flag case, `BooleanOr.on` is shorthand for `Bool(true)` and `BooleanOr.options(value)` for `Options(value)`; because `on` is a `BooleanOr[Nothing]`, it fits any provider slot. The `Schema` reads the wire bytes and branches by JSON shape: `true`/`false` becomes `Bool`/`Str`, an object becomes `Options`. Use these everywhere the LSP spec writes "either a flag or an options record", which is most of the capability tree. The `BooleanOr` and `StringOr` sealed unions are also re-exported as `LspCapabilities.BooleanOr` and `LspCapabilities.StringOr` for ergonomic import at the capability use site.
+
+`LspCapabilities.Name` is a typed discriminator used by `LspCapabilityNotAdvertisedException` to identify which capability the rejected method needed.
+
+### Document and sync options
+
+Configure the sync kind via `LspConfig.default.withDocumentSync(TextDocumentSyncKind.Incremental)` and the position encoding via `LspConfig.default.withPositionEncodings(Chunk(PositionEncodingKind.UTF16))`. See [Document registry](#document-registry) for the semantics of each sync mode.
+
+Several handler kinds require a cross-field config setting, validated by the engine catalog at init time (after `LspConfig.require`):
+
+- `TextDocument.onTypeFormatting` requires `LspConfig.withOnTypeFormattingTriggers(...)` (non-empty `Chunk[String]`).
+- Any `semanticTokensFull` / `semanticTokensRange` handler requires `LspConfig.withSemanticTokensLegend(...)`.
+- `Workspace.executeCommand[Out]` requires `LspConfig.withExecuteCommandCommands(...)` listing the supported command names.
+
+Registering one of these handlers without the matching config setting aborts at `LspServer.init` time. The catalog enumerates the requirement; the error message names the missing field.
+
+### Lifecycle
+
+`LspServer.init` is `Scope`-managed: the server is closed (with the default 30-second grace period) when the enclosing scope exits. The unscoped variant has no automatic cleanup:
+
+```scala doctest:scope=inherited
+// Scoped: closes automatically at scope exit.
+val scoped: Unit < (Async & Scope) =
+    JsonRpcTransport.inMemory.map { case (serverT, _) =>
+        LspServer.initWith(serverT) { _ => () }
+    }
+
+// Unscoped: caller is responsible for close.
+val unscoped: Unit < Async =
+    for
+        transport <- JsonRpcTransport.inMemory.map(_._1)
+        server    <- LspServer.initUnscoped(transport)
+        _         <- server.close
+    yield ()
+```
+
+Pick `init` / `initWith` (Scope-managed) by default. Reach for `initUnscoped` / `initUnscopedWith` when the server's lifetime must outlive any single Scope; the caller then must invoke `close` (default 30-second grace) or `closeNow` (immediate, equivalent to `close(Duration.Zero)`) explicitly.
+
+`LspClient.init` mirrors the same quartet (`init`, `initWith`, `initUnscoped`, `initUnscopedWith`) with the eager-handshake post-condition described in [Building a client](#building-a-client).
+
+## Transports
+
+`kyo-lsp` does not define its own transport; it reuses every `JsonRpcTransport` factory from `kyo-jsonrpc`. The two everyday choices for an LSP wire are `contentLengthStdio` (the LSP spec's framed stdio, JVM-only) and `stdio` (line-delimited JSON, for testing and bespoke peers):
+
+- `JsonRpcTransport.contentLengthStdio(in, out)` (JVM only): the LSP standard wire framing. Each message is preceded by a `Content-Length: N\r\n\r\n` header. This is what editors expect from a stdio server.
+- `JsonRpcTransport.inMemory` and `JsonRpcTransport.inMemory(capacity)`: returns a paired `(t1, t2)` for in-process tests. Each end's `send` becomes the other's `incoming`.
+
+The transport seam is intentionally thin (`send`, `incoming`, `close`); other framings (line-delimited stdio, Unix domain sockets, custom byte streams) are available through `JsonRpcTransport.stdio()`, `JsonRpcTransport.unixDomain(...)` (JVM only), and `JsonRpcTransport.fromWire(...)`.
+
+## Cross-platform behavior
+
+Source lives entirely under `shared/` and compiles on JVM, JavaScript, and Scala Native. The integration test suite exercises every handler factory and the engine policies against `JsonRpcTransport.inMemory` on all three platforms. The Content-Length stdio framer (`JsonRpcTransport.contentLengthStdio`) and the Unix-domain-socket transport are JVM-only; JS and Native servers run against in-memory or custom-framed transports the host supplies.

--- a/kyo-lsp/shared/src/main/scala/kyo/Lsp.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/Lsp.scala
@@ -1,0 +1,353 @@
+package kyo
+
+/** Handler-side accessors for the per-request LSP context.
+  *
+  * The engine binds a per-request [[Lsp.RequestContext]] into a [[Local]] for the lifetime of a
+  * single handler invocation. Handler code reaches into that local through these accessors:
+  *
+  *   - [[Lsp.server]]              ; the live [[LspServer]] for reverse-direction calls (server-side handlers)
+  *   - [[Lsp.client]]              ; the live [[LspClient]] for reverse-direction calls (client-side handlers)
+  *   - [[Lsp.documents]]           ; the read-only document registry snapshot for this session
+  *   - [[Lsp.requestId]]           ; the JSON-RPC id of the inbound request
+  *   - [[Lsp.cancelled]]           ; promise that completes when the peer cancels this request
+  *   - [[Lsp.workDoneToken]]       ; workDoneToken from the request params, if any
+  *   - [[Lsp.partialResultToken]]  ; partialResultToken from the request params, if any
+  *   - [[Lsp.positionEncoding]]    ; the session-level negotiated position encoding
+  *   - [[Lsp.extras]]              ; typed accessor for protocol extension fields
+  *
+  * Calling any of these outside an active route-handler invocation raises an
+  * `IllegalStateException` (kernel panic). This is a programmer-error path; no typed `Abort` row
+  * is added to the signature.
+  *
+  * [[DocumentRegistry]] is the public read-interface for the document registry. Only `get`,
+  * `version`, `listOpen`, `listOpenUris`, and `isOpen` are exposed.
+  */
+object Lsp:
+
+    /** Public read-interface for the live document registry. */
+    sealed trait DocumentRegistry:
+        def get(uri: LspHandler.LspDocument.Uri)(using Frame): Maybe[LspHandler.LspDocument] < Sync
+        def version(uri: LspHandler.LspDocument.Uri)(using Frame): Maybe[Int] < Sync
+        def listOpen(using Frame): Chunk[LspHandler.LspDocument] < Sync
+        def listOpenUris(using Frame): Chunk[LspHandler.LspDocument.Uri] < Sync
+        def isOpen(uri: LspHandler.LspDocument.Uri)(using Frame): Boolean < Sync
+    end DocumentRegistry
+
+    /** Per-request context bound by the engine for the lifetime of a single dispatch. */
+    final private[kyo] case class RequestContext(
+        jsonRpc: JsonRpcRoute.Context,
+        peer: Peer,
+        workDoneToken: Maybe[LspHandler.ProgressToken],
+        partialResultToken: Maybe[LspHandler.ProgressToken],
+        documents: DocumentRegistry,
+        positionEncoding: LspHandler.PositionEncodingKind,
+        trace: LspHandler.TraceValue = LspHandler.TraceValue.Off,
+        _rawInitializationOptions: Maybe[String] = Absent,
+        _rawClientExperimental: Maybe[String] = Absent,
+        _rawServerExperimental: Maybe[String] = Absent
+    )
+
+    /** Identifies which side of the connection the handler is executing on. */
+    private[kyo] enum Peer derives CanEqual:
+        case Server(local: LspServer)
+        case Client(local: LspClient)
+    end Peer
+
+    /** Local holding the current request context. Absent outside handler dispatch. */
+    private[kyo] val local: Local[Maybe[RequestContext]] = Local.init(Absent)
+
+    // =========================================================================
+    // Internal helpers
+    // =========================================================================
+
+    private def decodeRaw[X](raw: Maybe[String], target: String)(using
+        Frame,
+        Schema[X]
+    ): Maybe[X] < (Sync & Abort[LspDecodeException]) =
+        raw match
+            case Absent => Absent
+            case Present(s) =>
+                Json.decode[X](s) match
+                    case Result.Success(v) => Present(v)
+                    case Result.Failure(e) => Abort.fail(LspDecodeException(target, e.toString, e))
+                    case Result.Panic(e)   => Abort.fail(LspDecodeException(target, e.getMessage, e))
+
+    private def ctx(method: String)(using Frame): RequestContext < Sync =
+        local.use {
+            case Present(c) => Sync.defer(c)
+            case Absent =>
+                Sync.defer(throw new IllegalStateException(s"Lsp.$method called outside an LSP route handler"))
+        }
+
+    // =========================================================================
+    // Public accessors
+    // =========================================================================
+
+    /** The live server handle for the current request (server-side handlers only). */
+    def server(using Frame): LspServer < Sync =
+        ctx("server").map(c =>
+            c.peer match
+                case Peer.Server(s) => s
+                case Peer.Client(_) => throw new IllegalStateException("Lsp.server called from a client-side handler")
+        )
+
+    /** The live client handle for the current request (client-side handlers only). */
+    def client(using Frame): LspClient < Sync =
+        ctx("client").map(c =>
+            c.peer match
+                case Peer.Client(cl) => cl
+                case Peer.Server(_)  => throw new IllegalStateException("Lsp.client called from a server-side handler")
+        )
+
+    /** The document registry snapshot for this session. */
+    def documents(using Frame): DocumentRegistry < Sync =
+        ctx("documents").map(_.documents)
+
+    /** The JSON-RPC request id for the current request, if any. */
+    def requestId(using Frame): Maybe[JsonRpcId] < Sync =
+        ctx("requestId").map(_.jsonRpc.requestId)
+
+    /** A promise that resolves when the peer cancels this request. */
+    def cancelled(using Frame): Fiber.Promise[Unit, Sync] < Sync =
+        ctx("cancelled").map(_.jsonRpc.cancelled)
+
+    /** The work-done progress token for the current request, if any. */
+    def workDoneToken(using Frame): Maybe[LspHandler.ProgressToken] < Sync =
+        ctx("workDoneToken").map(_.workDoneToken)
+
+    /** The partial-result token for the current request, if any. */
+    def partialResultToken(using Frame): Maybe[LspHandler.ProgressToken] < Sync =
+        ctx("partialResultToken").map(_.partialResultToken)
+
+    /** The session-level negotiated position encoding. */
+    def positionEncoding(using Frame): LspHandler.PositionEncodingKind < Sync =
+        ctx("positionEncoding").map(_.positionEncoding)
+
+    /** Typed accessor for protocol extension fields from the current request extras. */
+    def extras[T](using Frame, Schema[T]): Maybe[T] < (Sync & Abort[LspInvalidParamsException]) =
+        ctx("extras").map { c =>
+            c.jsonRpc.extras match
+                case Absent => Absent
+                case Present(sv) =>
+                    Structure.decode[T](sv) match
+                        case Result.Success(v) => Present(v)
+                        case Result.Failure(e) =>
+                            Abort.fail(LspInvalidParamsException("extras", e.getMessage, e))
+                        case Result.Panic(e) =>
+                            Abort.fail(LspInvalidParamsException("extras", e.getMessage, e))
+        }
+
+    /** The current trace level for the session. */
+    def trace(using Frame): LspHandler.TraceValue < Sync =
+        ctx("trace").map(_.trace)
+
+    // =========================================================================
+    // Progress and trace operations
+    // =========================================================================
+
+    /** Begins a work-done progress notification on the given token. */
+    def workDoneBegin(
+        token: LspHandler.ProgressToken,
+        title: String,
+        message: Maybe[String] = Absent,
+        percentage: Maybe[Int] = Absent,
+        cancellable: Boolean = false
+    )(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+        server.map(_.workDoneProgress(
+            token,
+            LspHandler.WorkDoneProgressValue.Begin(
+                title = title,
+                cancellable = Present(cancellable),
+                message = message,
+                percentage = percentage
+            )
+        ))
+
+    /** Reports progress on a work-done token. */
+    def workDoneReport(
+        token: LspHandler.ProgressToken,
+        message: Maybe[String] = Absent,
+        percentage: Maybe[Int] = Absent,
+        cancellable: Maybe[Boolean] = Absent
+    )(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+        server.map(_.workDoneProgress(
+            token,
+            LspHandler.WorkDoneProgressValue.Report(
+                cancellable = cancellable,
+                message = message,
+                percentage = percentage
+            )
+        ))
+
+    /** Ends a work-done progress notification on the given token. */
+    def workDoneEnd(
+        token: LspHandler.ProgressToken,
+        message: Maybe[String] = Absent
+    )(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+        server.map(_.workDoneProgress(token, LspHandler.WorkDoneProgressValue.End(message)))
+
+    /** Emits a partial result on the given token. */
+    def emitPartialResult[T](
+        token: LspHandler.ProgressToken,
+        value: T
+    )(using Frame, Schema[T]): Unit < (Async & Abort[LspConnectionClosedException]) =
+        given Schema[LspHandler.ProgressParams[T]] = Schema.derived
+        server.map(_.underlying.notify[LspHandler.ProgressParams[T]]("$/progress", LspHandler.ProgressParams(token, value)))
+            .handle(Abort.recover[Closed] { _ => Abort.fail(LspConnectionClosedException()) })
+    end emitPartialResult
+
+    /** Logs a trace message to the client. */
+    def logTrace(
+        message: String,
+        verbose: Maybe[String] = Absent
+    )(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+        server.map(_.logTrace(message, verbose))
+
+    // =========================================================================
+    // Typed raw-payload accessors
+    // =========================================================================
+
+    /** Decodes the `initializationOptions` field from the `initialize` request. */
+    def initializationOptions[X](using Frame, Schema[X]): Maybe[X] < (Sync & Abort[LspDecodeException]) =
+        ctx("initializationOptions").map(c => decodeRaw[X](c._rawInitializationOptions, "initializationOptions"))
+
+    /** Decodes the client's experimental capabilities. */
+    def clientExperimentalCapabilities[X](using Frame, Schema[X]): Maybe[X] < (Sync & Abort[LspDecodeException]) =
+        ctx("clientExperimentalCapabilities").map(c => decodeRaw[X](c._rawClientExperimental, "clientExperimental"))
+
+    /** Decodes the server's experimental capabilities. */
+    def serverExperimentalCapabilities[X](using Frame, Schema[X]): Maybe[X] < (Sync & Abort[LspDecodeException]) =
+        ctx("serverExperimentalCapabilities").map(c => decodeRaw[X](c._rawServerExperimental, "serverExperimental"))
+
+    /** Decodes the metadata of a notebook document. */
+    def notebookMetadataAs[X](nb: LspHandler.Notebook)(using
+        Frame,
+        Schema[X]
+    ): Maybe[X] < (Sync & Abort[LspDecodeException]) =
+        decodeRaw[X](nb._rawMetadata, "notebookDocument.metadata")
+
+    /** Decodes the metadata of a notebook cell. */
+    def notebookCellMetadataAs[X](cell: LspHandler.NotebookCell)(using
+        Frame,
+        Schema[X]
+    ): Maybe[X] < (Sync & Abort[LspDecodeException]) =
+        decodeRaw[X](cell._rawMetadata, "notebookCell.metadata")
+
+    /** Decodes the `registerOptions` field from a `Registration`. */
+    def registerOptionsAs[X](reg: LspHandler.Registration)(using
+        Frame,
+        Schema[X]
+    ): Maybe[X] < (Sync & Abort[LspDecodeException]) =
+        reg.registerOptionsAs[X]
+
+end Lsp
+
+/** `AtomicRef`-backed implementation of `Lsp.DocumentRegistry`.
+  *
+  * Must live in the same source file as `Lsp` because `Lsp.DocumentRegistry` is a sealed trait.
+  * Used exclusively by the internal engine; `private[kyo]` visibility prevents external construction.
+  *
+  * Edge-case policies: unknown-URI mutator calls are no-ops (log-and-skip);
+  * duplicate didOpen is an overwrite. The encoding ref is read on every insert so the registry
+  * always stamps the negotiated session encoding.
+  *
+  * All mutators are `private[kyo]`.
+  */
+final private[kyo] class LspDocumentRegistryImpl private (
+    encodingRef: AtomicRef[LspHandler.PositionEncodingKind],
+    mapRef: AtomicRef[Map[LspHandler.LspDocument.Uri, LspHandler.LspDocument]]
+) extends Lsp.DocumentRegistry:
+
+    private def currentEncoding(using Frame): LspHandler.PositionEncodingKind < Sync =
+        encodingRef.get
+
+    // =========================================================================
+    // Public read interface
+    // =========================================================================
+
+    def get(uri: LspHandler.LspDocument.Uri)(using Frame): Maybe[LspHandler.LspDocument] < Sync =
+        mapRef.get.map(m => Maybe.fromOption(m.get(uri)))
+
+    def version(uri: LspHandler.LspDocument.Uri)(using Frame): Maybe[Int] < Sync =
+        mapRef.get.map(m => Maybe.fromOption(m.get(uri).map(_.version)))
+
+    def listOpen(using Frame): Chunk[LspHandler.LspDocument] < Sync =
+        mapRef.get.map(m => Chunk.from(m.values))
+
+    def listOpenUris(using Frame): Chunk[LspHandler.LspDocument.Uri] < Sync =
+        mapRef.get.map(m => Chunk.from(m.keys))
+
+    def isOpen(uri: LspHandler.LspDocument.Uri)(using Frame): Boolean < Sync =
+        mapRef.get.map(m => m.contains(uri))
+
+    // =========================================================================
+    // Private[kyo] mutators
+    // =========================================================================
+
+    /** Inserts a text document, stamping the current session encoding.
+      * Duplicate didOpen (same URI) is treated as implicit re-open.
+      */
+    private[kyo] def insert(item: LspHandler.TextDocumentItem)(using Frame): Unit < Sync =
+        currentEncoding.flatMap { enc =>
+            val doc = LspHandler.LspDocument(
+                uri = item.uri,
+                languageId = item.languageId,
+                version = item.version,
+                text = item.text,
+                encoding = enc
+            )
+            mapRef.updateAndGet(m => m.updated(doc.uri, doc)).andThen(())
+        }
+    end insert
+
+    /** Applies incremental or full changes; silently skips if URI is unknown. */
+    private[kyo] def applyChanges(
+        uri: LspHandler.LspDocument.Uri,
+        version: Int,
+        changes: Chunk[LspHandler.TextDocumentContentChangeEvent]
+    )(using Frame): Unit < Sync =
+        mapRef.updateAndGet { m =>
+            m.get(uri) match
+                case None => m
+                case Some(doc) =>
+                    m.updated(uri, LspHandler.LspDocument.applyChanges(doc, changes).copy(version = version))
+        }.andThen(())
+    end applyChanges
+
+    /** Marks as saved; no-op for unknown URI. */
+    private[kyo] def setSaved(uri: LspHandler.LspDocument.Uri)(using Frame): Unit < Sync =
+        Sync.defer(())
+
+    /** Removes the document; no-op for unknown URI. */
+    private[kyo] def remove(uri: LspHandler.LspDocument.Uri)(using Frame): Unit < Sync =
+        mapRef.updateAndGet(m => m.removed(uri)).andThen(())
+
+    /** Inserts a notebook cell document with session encoding. */
+    private[kyo] def insertNotebookCell(
+        uri: LspHandler.LspDocument.Uri,
+        languageId: String,
+        text: String,
+        version: Int
+    )(using Frame): Unit < Sync =
+        currentEncoding.flatMap { enc =>
+            val doc = LspHandler.LspDocument(
+                uri = uri,
+                languageId = languageId,
+                version = version,
+                text = text,
+                encoding = enc
+            )
+            mapRef.updateAndGet(m => m.updated(uri, doc)).andThen(())
+        }
+    end insertNotebookCell
+
+end LspDocumentRegistryImpl
+
+private[kyo] object LspDocumentRegistryImpl:
+    /** Creates a registry, allocating its document-map ref through the safe `AtomicRef.init` so no
+      * state is created by an unsuspended side effect.
+      */
+    def init(encodingRef: AtomicRef[LspHandler.PositionEncodingKind])(using Frame): LspDocumentRegistryImpl < Sync =
+        AtomicRef.init(Map.empty[LspHandler.LspDocument.Uri, LspHandler.LspDocument])
+            .map(mapRef => new LspDocumentRegistryImpl(encodingRef, mapRef))
+end LspDocumentRegistryImpl

--- a/kyo-lsp/shared/src/main/scala/kyo/LspCapabilities.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/LspCapabilities.scala
@@ -1,0 +1,617 @@
+package kyo
+
+/** Server and client capability trees for the LSP 3.17 initialize handshake.
+  *
+  * The top-level `object LspCapabilities` nests two sub-objects, `Server` and `Client`, each
+  * containing the matching capability case class and all its nested option records. The `Name`
+  * enum provides a typed discriminator for every standard capability, used by the engine to
+  * report `LspCapabilityNotAdvertisedException`.
+  *
+  * Canonical type aliases `BooleanOr[T]` and `StringOr[T]` re-export the sealed unions declared
+  * inside `LspHandler`; they are provided here for ergonomic import at capability use sites.
+  *
+  * `Server.empty` and `Client.empty` provide zero-capability baselines for use in tests and as
+  * starting points for builder calls.
+  *
+  * @see [[LspCapabilities.Server]]
+  * @see [[LspCapabilities.Client]]
+  * @see [[LspCapabilities.Name]]
+  */
+object LspCapabilities:
+
+    /** Type alias resolving `LspCapabilities.Server` to the inner case class.
+      *
+      * External code writes `LspCapabilities.Server` and gets the case class directly.
+      * The inner `object Server` is still the namespace for all nested option records.
+      */
+    type Server = Server.Server
+
+    /** Type alias resolving `LspCapabilities.Client` to the inner case class.
+      *
+      * External code writes `LspCapabilities.Client` and gets the case class directly.
+      * The inner `object Client` is still the namespace for all nested option records.
+      */
+    type Client = Client.Client
+
+    type BooleanOr[T] = LspHandler.BooleanOr[T]
+    type StringOr[T]  = LspHandler.StringOr[T]
+
+    // =========================================================================
+    // Server capabilities
+    // =========================================================================
+
+    /** The capabilities that the server provides. */
+    object Server:
+
+        /** All capabilities a server may advertise in the `InitializeResult`. */
+        final case class Server(
+            positionEncoding: Maybe[LspHandler.PositionEncodingKind] = Absent,
+            textDocumentSync: Maybe[LspHandler.TextDocumentSyncValue] = Absent,
+            completionProvider: Maybe[LspHandler.CompletionOptions] = Absent,
+            hoverProvider: Maybe[LspHandler.BooleanOr[LspHandler.HoverOptions]] = Absent,
+            signatureHelpProvider: Maybe[LspHandler.SignatureHelpOptions] = Absent,
+            declarationProvider: Maybe[LspHandler.BooleanOr[LspHandler.DeclarationOptions]] = Absent,
+            definitionProvider: Maybe[LspHandler.BooleanOr[LspHandler.DefinitionOptions]] = Absent,
+            typeDefinitionProvider: Maybe[LspHandler.BooleanOr[LspHandler.TypeDefinitionOptions]] = Absent,
+            implementationProvider: Maybe[LspHandler.BooleanOr[LspHandler.ImplementationOptions]] = Absent,
+            referencesProvider: Maybe[LspHandler.BooleanOr[LspHandler.ReferenceOptions]] = Absent,
+            documentHighlightProvider: Maybe[LspHandler.BooleanOr[LspHandler.DocumentHighlightOptions]] = Absent,
+            documentSymbolProvider: Maybe[LspHandler.BooleanOr[LspHandler.DocumentSymbolOptions]] = Absent,
+            codeActionProvider: Maybe[LspHandler.BooleanOr[LspHandler.CodeActionOptions]] = Absent,
+            codeLensProvider: Maybe[LspHandler.CodeLensOptions] = Absent,
+            documentLinkProvider: Maybe[LspHandler.DocumentLinkOptions] = Absent,
+            colorProvider: Maybe[LspHandler.BooleanOr[WorkspaceColorProviderOptions]] = Absent,
+            documentFormattingProvider: Maybe[LspHandler.BooleanOr[DocumentFormattingOptions]] = Absent,
+            documentRangeFormattingProvider: Maybe[LspHandler.BooleanOr[DocumentRangeFormattingOptions]] = Absent,
+            documentOnTypeFormattingProvider: Maybe[LspHandler.DocumentOnTypeFormattingOptions] = Absent,
+            renameProvider: Maybe[LspHandler.BooleanOr[LspHandler.RenameOptions]] = Absent,
+            foldingRangeProvider: Maybe[LspHandler.BooleanOr[LspHandler.FoldingRangeOptions]] = Absent,
+            executeCommandProvider: Maybe[LspHandler.ExecuteCommandOptions] = Absent,
+            selectionRangeProvider: Maybe[LspHandler.BooleanOr[SelectionRangeOptions]] = Absent,
+            linkedEditingRangeProvider: Maybe[LspHandler.BooleanOr[LspHandler.LinkedEditingRangeOptions]] = Absent,
+            callHierarchyProvider: Maybe[LspHandler.BooleanOr[LspHandler.CallHierarchyOptions]] = Absent,
+            semanticTokensProvider: Maybe[LspHandler.SemanticTokensOptions] = Absent,
+            monikerProvider: Maybe[LspHandler.BooleanOr[LspHandler.MonikerOptions]] = Absent,
+            typeHierarchyProvider: Maybe[LspHandler.BooleanOr[LspHandler.TypeHierarchyOptions]] = Absent,
+            inlineValueProvider: Maybe[LspHandler.BooleanOr[LspHandler.InlineValueOptions]] = Absent,
+            inlayHintProvider: Maybe[LspHandler.BooleanOr[LspHandler.InlayHintOptions]] = Absent,
+            diagnosticProvider: Maybe[DiagnosticOptions] = Absent,
+            workspaceSymbolProvider: Maybe[LspHandler.BooleanOr[LspHandler.WorkspaceSymbolOptions]] = Absent,
+            notebookDocumentSync: Maybe[NotebookDocumentSyncOptions] = Absent,
+            workspace: Maybe[WorkspaceServerCapabilities] = Absent,
+            private[kyo] _rawExperimental: Maybe[String] = Absent
+        ) derives CanEqual
+
+        object Server:
+            given Schema[Server] = Schema.derived
+
+        val empty: Server = Server()
+
+        // --- Nested option records ---
+
+        /** Options for workspace color providers. */
+        final case class WorkspaceColorProviderOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Options for document formatting registration. */
+        final case class DocumentFormattingOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Options for document range formatting registration. */
+        final case class DocumentRangeFormattingOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Options for selection range registration. */
+        final case class SelectionRangeOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Options for diagnostic providers. */
+        final case class DiagnosticOptions(
+            identifier: Maybe[String] = Absent,
+            interFileDependencies: Boolean = false,
+            workspaceDiagnostics: Boolean = false,
+            workDoneProgress: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Options for notebook document synchronization. */
+        final case class NotebookDocumentSyncOptions(
+            notebookSelector: Chunk[NotebookSelector],
+            save: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** A notebook selector item. */
+        final case class NotebookSelector(
+            notebook: Maybe[NotebookSelectorItem] = Absent,
+            cells: Chunk[CellSelectorItem] = Chunk.empty
+        ) derives Schema, CanEqual
+
+        /** A notebook selector item (by notebook type, scheme, or pattern). */
+        final case class NotebookSelectorItem(
+            notebookType: Maybe[String] = Absent,
+            scheme: Maybe[String] = Absent,
+            pattern: Maybe[String] = Absent
+        ) derives Schema, CanEqual
+
+        /** A cell selector item. */
+        final case class CellSelectorItem(language: String) derives Schema, CanEqual
+
+        /** Workspace-level server capabilities. */
+        final case class WorkspaceServerCapabilities(
+            workspaceFolders: Maybe[WorkspaceFoldersServerCapabilities] = Absent,
+            fileOperations: Maybe[FileOperationsServerCapabilities] = Absent
+        ) derives Schema, CanEqual
+
+        /** Workspace folders server capabilities. */
+        final case class WorkspaceFoldersServerCapabilities(
+            supported: Maybe[Boolean] = Absent,
+            changeNotifications: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** File operations server capabilities. */
+        final case class FileOperationsServerCapabilities(
+            didCreate: Maybe[LspHandler.FileOperationRegistrationOptions] = Absent,
+            willCreate: Maybe[LspHandler.FileOperationRegistrationOptions] = Absent,
+            didRename: Maybe[LspHandler.FileOperationRegistrationOptions] = Absent,
+            willRename: Maybe[LspHandler.FileOperationRegistrationOptions] = Absent,
+            didDelete: Maybe[LspHandler.FileOperationRegistrationOptions] = Absent,
+            willDelete: Maybe[LspHandler.FileOperationRegistrationOptions] = Absent
+        ) derives Schema, CanEqual
+
+    end Server
+
+    // =========================================================================
+    // Client capabilities
+    // =========================================================================
+
+    /** The capabilities that the client provides. */
+    object Client:
+
+        /** All capabilities a client may send in the `initialize` request. */
+        final case class Client(
+            workspace: Maybe[WorkspaceClientCapabilities] = Absent,
+            textDocument: Maybe[TextDocumentClientCapabilities] = Absent,
+            notebookDocument: Maybe[NotebookDocumentClientCapabilities] = Absent,
+            window: Maybe[WindowClientCapabilities] = Absent,
+            general: Maybe[GeneralClientCapabilities] = Absent,
+            private[kyo] _rawExperimental: Maybe[String] = Absent
+        ) derives CanEqual
+
+        object Client:
+            given Schema[Client] = Schema.derived
+
+        val empty: Client = Client()
+
+        // --- Workspace client capabilities ---
+
+        /** Workspace-related client capabilities. */
+        final case class WorkspaceClientCapabilities(
+            applyEdit: Maybe[Boolean] = Absent,
+            workspaceEdit: Maybe[WorkspaceEditClientCapabilities] = Absent,
+            didChangeConfiguration: Maybe[DidChangeConfigurationClientCapabilities] = Absent,
+            didChangeWatchedFiles: Maybe[DidChangeWatchedFilesClientCapabilities] = Absent,
+            symbol: Maybe[WorkspaceSymbolClientCapabilities] = Absent,
+            executeCommand: Maybe[ExecuteCommandClientCapabilities] = Absent,
+            workspaceFolders: Maybe[Boolean] = Absent,
+            configuration: Maybe[Boolean] = Absent,
+            semanticTokens: Maybe[SemanticTokensWorkspaceClientCapabilities] = Absent,
+            codeLens: Maybe[CodeLensWorkspaceClientCapabilities] = Absent,
+            fileOperations: Maybe[FileOperationsClientCapabilities] = Absent,
+            inlineValue: Maybe[InlineValueWorkspaceClientCapabilities] = Absent,
+            inlayHint: Maybe[InlayHintWorkspaceClientCapabilities] = Absent,
+            diagnostics: Maybe[DiagnosticWorkspaceClientCapabilities] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for workspace edit operations (apply edits, resource operations). */
+        final case class WorkspaceEditClientCapabilities(
+            documentChanges: Maybe[Boolean] = Absent,
+            resourceOperations: Chunk[String] = Chunk.empty,
+            failureHandling: Maybe[String] = Absent,
+            normalizesLineEndings: Maybe[Boolean] = Absent,
+            changeAnnotationSupport: Maybe[ChangeAnnotationSupportOptions] = Absent
+        ) derives Schema, CanEqual
+
+        /** Whether the client groups workspace edit change annotations by label on display. */
+        final case class ChangeAnnotationSupportOptions(groupsOnLabel: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `workspace/didChangeConfiguration` notifications. */
+        final case class DidChangeConfigurationClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `workspace/didChangeWatchedFiles` notifications. */
+        final case class DidChangeWatchedFilesClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            relativePatternSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `workspace/symbol` requests. */
+        final case class WorkspaceSymbolClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            symbolKind: Maybe[SymbolKindOptions] = Absent,
+            tagSupport: Maybe[SymbolTagSupportOptions] = Absent,
+            resolveSupport: Maybe[ResolveSupport] = Absent
+        ) derives Schema, CanEqual
+
+        /** Which symbol kind values the client can display. */
+        final case class SymbolKindOptions(valueSet: Chunk[LspHandler.SymbolKind] = Chunk.empty) derives Schema, CanEqual
+
+        /** Which symbol tag values the client can display. */
+        final case class SymbolTagSupportOptions(valueSet: Chunk[LspHandler.SymbolTag] = Chunk.empty) derives Schema, CanEqual
+
+        /** Properties a client can resolve in a second request for a symbol or item. */
+        final case class ResolveSupport(properties: Chunk[String]) derives Schema, CanEqual
+
+        /** Client capabilities for `workspace/executeCommand` requests. */
+        final case class ExecuteCommandClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Whether the client can refresh semantic tokens workspace-wide on a server request. */
+        final case class SemanticTokensWorkspaceClientCapabilities(refreshSupport: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Whether the client can refresh code lenses workspace-wide on a server request. */
+        final case class CodeLensWorkspaceClientCapabilities(refreshSupport: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for workspace file operation notifications and requests. */
+        final case class FileOperationsClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            didCreate: Maybe[Boolean] = Absent,
+            willCreate: Maybe[Boolean] = Absent,
+            didRename: Maybe[Boolean] = Absent,
+            willRename: Maybe[Boolean] = Absent,
+            didDelete: Maybe[Boolean] = Absent,
+            willDelete: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Whether the client can refresh inline values workspace-wide on a server request. */
+        final case class InlineValueWorkspaceClientCapabilities(refreshSupport: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Whether the client can refresh inlay hints workspace-wide on a server request. */
+        final case class InlayHintWorkspaceClientCapabilities(refreshSupport: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Whether the client can refresh diagnostics workspace-wide on a server request. */
+        final case class DiagnosticWorkspaceClientCapabilities(refreshSupport: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        // --- TextDocument client capabilities ---
+
+        /** Text document related client capabilities. */
+        final case class TextDocumentClientCapabilities(
+            synchronization: Maybe[TextDocumentSyncClientCapabilities] = Absent,
+            completion: Maybe[CompletionClientCapabilities] = Absent,
+            hover: Maybe[HoverClientCapabilities] = Absent,
+            signatureHelp: Maybe[SignatureHelpClientCapabilities] = Absent,
+            declaration: Maybe[DeclarationClientCapabilities] = Absent,
+            definition: Maybe[DefinitionClientCapabilities] = Absent,
+            typeDefinition: Maybe[TypeDefinitionClientCapabilities] = Absent,
+            implementation: Maybe[ImplementationClientCapabilities] = Absent,
+            references: Maybe[ReferenceClientCapabilities] = Absent,
+            documentHighlight: Maybe[DocumentHighlightClientCapabilities] = Absent,
+            documentSymbol: Maybe[DocumentSymbolClientCapabilities] = Absent,
+            codeAction: Maybe[CodeActionClientCapabilities] = Absent,
+            codeLens: Maybe[CodeLensClientCapabilities] = Absent,
+            documentLink: Maybe[DocumentLinkClientCapabilities] = Absent,
+            colorProvider: Maybe[DocumentColorClientCapabilities] = Absent,
+            formatting: Maybe[DocumentFormattingClientCapabilities] = Absent,
+            rangeFormatting: Maybe[DocumentRangeFormattingClientCapabilities] = Absent,
+            onTypeFormatting: Maybe[DocumentOnTypeFormattingClientCapabilities] = Absent,
+            rename: Maybe[RenameClientCapabilities] = Absent,
+            publishDiagnostics: Maybe[PublishDiagnosticsClientCapabilities] = Absent,
+            foldingRange: Maybe[FoldingRangeClientCapabilities] = Absent,
+            selectionRange: Maybe[SelectionRangeClientCapabilities] = Absent,
+            linkedEditingRange: Maybe[LinkedEditingRangeClientCapabilities] = Absent,
+            callHierarchy: Maybe[CallHierarchyClientCapabilities] = Absent,
+            semanticTokens: Maybe[SemanticTokensClientCapabilities] = Absent,
+            moniker: Maybe[MonikerClientCapabilities] = Absent,
+            typeHierarchy: Maybe[TypeHierarchyClientCapabilities] = Absent,
+            inlineValue: Maybe[InlineValueClientCapabilities] = Absent,
+            inlayHint: Maybe[InlayHintClientCapabilities] = Absent,
+            diagnostic: Maybe[DiagnosticClientCapabilities] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for text document synchronization events. */
+        final case class TextDocumentSyncClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            willSave: Maybe[Boolean] = Absent,
+            willSaveWaitUntil: Maybe[Boolean] = Absent,
+            didSave: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/completion` requests. */
+        final case class CompletionClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            completionItem: Maybe[CompletionItemClientCapabilities] = Absent,
+            completionItemKind: Maybe[CompletionItemKindOptions] = Absent,
+            insertTextMode: Maybe[LspHandler.InsertTextMode] = Absent,
+            contextSupport: Maybe[Boolean] = Absent,
+            completionList: Maybe[CompletionListClientCapabilities] = Absent
+        ) derives Schema, CanEqual
+
+        /** Fine-grained completion item capabilities (snippet, tags, insert mode, etc.). */
+        final case class CompletionItemClientCapabilities(
+            snippetSupport: Maybe[Boolean] = Absent,
+            commitCharactersSupport: Maybe[Boolean] = Absent,
+            documentationFormat: Chunk[LspHandler.MarkupKind] = Chunk.empty,
+            deprecatedSupport: Maybe[Boolean] = Absent,
+            preselectSupport: Maybe[Boolean] = Absent,
+            tagSupport: Maybe[CompletionItemTagSupportOptions] = Absent,
+            insertReplaceSupport: Maybe[Boolean] = Absent,
+            resolveSupport: Maybe[ResolveSupport] = Absent,
+            insertTextModeSupport: Maybe[InsertTextModeSupport] = Absent,
+            labelDetailsSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Which completion item tags the client can display. */
+        final case class CompletionItemTagSupportOptions(valueSet: Chunk[LspHandler.CompletionItemTag]) derives Schema, CanEqual
+
+        /** Which insert text modes the client can apply. */
+        final case class InsertTextModeSupport(valueSet: Chunk[LspHandler.InsertTextMode]) derives Schema, CanEqual
+
+        /** Which completion item kind values the client can display. */
+        final case class CompletionItemKindOptions(valueSet: Chunk[LspHandler.CompletionItemKind] = Chunk.empty) derives Schema, CanEqual
+
+        /** Client-supported default properties for completion lists. */
+        final case class CompletionListClientCapabilities(itemDefaults: Chunk[String] = Chunk.empty) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/hover` requests. */
+        final case class HoverClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            contentFormat: Chunk[LspHandler.MarkupKind] = Chunk.empty
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/signatureHelp` requests. */
+        final case class SignatureHelpClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            signatureInformation: Maybe[SignatureInformationClientCapabilities] = Absent,
+            contextSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Signature information details the client can display. */
+        final case class SignatureInformationClientCapabilities(
+            documentationFormat: Chunk[LspHandler.MarkupKind] = Chunk.empty,
+            parameterInformation: Maybe[ParameterInformationClientCapabilities] = Absent,
+            activeParameterSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Whether the client supports label offsets in parameter information. */
+        final case class ParameterInformationClientCapabilities(labelOffsetSupport: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/declaration` requests. */
+        final case class DeclarationClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            linkSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/definition` requests. */
+        final case class DefinitionClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            linkSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/typeDefinition` requests. */
+        final case class TypeDefinitionClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            linkSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/implementation` requests. */
+        final case class ImplementationClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            linkSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/references` requests. */
+        final case class ReferenceClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/documentHighlight` requests. */
+        final case class DocumentHighlightClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/documentSymbol` requests. */
+        final case class DocumentSymbolClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            symbolKind: Maybe[SymbolKindOptions] = Absent,
+            hierarchicalDocumentSymbolSupport: Maybe[Boolean] = Absent,
+            tagSupport: Maybe[SymbolTagSupportOptions] = Absent,
+            labelSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/codeAction` requests. */
+        final case class CodeActionClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            codeActionLiteralSupport: Maybe[CodeActionLiteralSupportOptions] = Absent,
+            isPreferredSupport: Maybe[Boolean] = Absent,
+            disabledSupport: Maybe[Boolean] = Absent,
+            dataSupport: Maybe[Boolean] = Absent,
+            resolveSupport: Maybe[ResolveSupport] = Absent,
+            honorsChangeAnnotations: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Code action kind subsets the client can display. */
+        final case class CodeActionLiteralSupportOptions(
+            codeActionKind: CodeActionKindOptions
+        ) derives Schema, CanEqual
+
+        /** Which code action kind values the client can display. */
+        final case class CodeActionKindOptions(valueSet: Chunk[LspHandler.CodeActionKind]) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/codeLens` requests. */
+        final case class CodeLensClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/documentLink` requests. */
+        final case class DocumentLinkClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            tooltipSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/documentColor` requests. */
+        final case class DocumentColorClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/formatting` requests. */
+        final case class DocumentFormattingClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/rangeFormatting` requests. */
+        final case class DocumentRangeFormattingClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/onTypeFormatting` requests. */
+        final case class DocumentOnTypeFormattingClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/rename` requests. */
+        final case class RenameClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            prepareSupport: Maybe[Boolean] = Absent,
+            prepareSupportDefaultBehavior: Maybe[Int] = Absent,
+            honorsChangeAnnotations: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/publishDiagnostics` notifications. */
+        final case class PublishDiagnosticsClientCapabilities(
+            relatedInformation: Maybe[Boolean] = Absent,
+            tagSupport: Maybe[DiagnosticTagSupportOptions] = Absent,
+            versionSupport: Maybe[Boolean] = Absent,
+            codeDescriptionSupport: Maybe[Boolean] = Absent,
+            dataSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Which diagnostic tag values the client can display. */
+        final case class DiagnosticTagSupportOptions(valueSet: Chunk[LspHandler.DiagnosticTag]) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/foldingRange` requests. */
+        final case class FoldingRangeClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            rangeLimit: Maybe[Int] = Absent,
+            lineFoldingOnly: Maybe[Boolean] = Absent,
+            foldingRangeKind: Maybe[FoldingRangeKindOptions] = Absent,
+            foldingRange: Maybe[FoldingRangeOptions] = Absent
+        ) derives Schema, CanEqual
+
+        /** Which folding range kind values the client can display. */
+        final case class FoldingRangeKindOptions(valueSet: Chunk[LspHandler.FoldingRangeKind] = Chunk.empty) derives Schema, CanEqual
+
+        /** Folding range display options (e.g. collapsed text support). */
+        final case class FoldingRangeOptions(collapsedText: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/selectionRange` requests. */
+        final case class SelectionRangeClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/linkedEditingRange` requests. */
+        final case class LinkedEditingRangeClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/prepareCallHierarchy` requests. */
+        final case class CallHierarchyClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/semanticTokens` requests. */
+        final case class SemanticTokensClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            requests: SemanticTokensRequestsCapabilities,
+            tokenTypes: Chunk[LspHandler.SemanticTokenTypes],
+            tokenModifiers: Chunk[LspHandler.SemanticTokenModifiers],
+            formats: Chunk[String],
+            overlappingTokenSupport: Maybe[Boolean] = Absent,
+            multilineTokenSupport: Maybe[Boolean] = Absent,
+            serverCancelSupport: Maybe[Boolean] = Absent,
+            augmentsSyntaxTokens: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Which semantic token request types (range / full) the client supports. */
+        final case class SemanticTokensRequestsCapabilities(
+            range: Maybe[Boolean] = Absent,
+            full: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/moniker` requests. */
+        final case class MonikerClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/prepareTypeHierarchy` requests. */
+        final case class TypeHierarchyClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/inlineValue` requests. */
+        final case class InlineValueClientCapabilities(dynamicRegistration: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/inlayHint` requests. */
+        final case class InlayHintClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            resolveSupport: Maybe[ResolveSupport] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `textDocument/diagnostic` requests. */
+        final case class DiagnosticClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            relatedDocumentSupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        // --- Notebook document client capabilities ---
+
+        /** Notebook document related client capabilities. */
+        final case class NotebookDocumentClientCapabilities(
+            synchronization: Maybe[NotebookDocumentSyncClientCapabilities] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for notebook document synchronization. */
+        final case class NotebookDocumentSyncClientCapabilities(
+            dynamicRegistration: Maybe[Boolean] = Absent,
+            executionSummarySupport: Maybe[Boolean] = Absent
+        ) derives Schema, CanEqual
+
+        // --- Window client capabilities ---
+
+        /** Window-related client capabilities. */
+        final case class WindowClientCapabilities(
+            workDoneProgress: Maybe[Boolean] = Absent,
+            showMessage: Maybe[ShowMessageRequestClientCapabilities] = Absent,
+            showDocument: Maybe[ShowDocumentClientCapabilities] = Absent
+        ) derives Schema, CanEqual
+
+        /** Client capabilities for `window/showMessageRequest` requests. */
+        final case class ShowMessageRequestClientCapabilities(
+            messageActionItem: Maybe[MessageActionItemClientCapabilities] = Absent
+        ) derives Schema, CanEqual
+
+        /** Whether the client supports additional properties on message action items. */
+        final case class MessageActionItemClientCapabilities(additionalPropertiesSupport: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+        /** Whether the client supports the `window/showDocument` request. */
+        final case class ShowDocumentClientCapabilities(support: Boolean) derives Schema, CanEqual
+
+        // --- General client capabilities ---
+
+        /** General client capabilities. */
+        final case class GeneralClientCapabilities(
+            staleRequestSupport: Maybe[StaleRequestSupportOptions] = Absent,
+            regularExpressions: Maybe[RegularExpressionsClientCapabilities] = Absent,
+            markdown: Maybe[MarkdownClientCapabilities] = Absent,
+            positionEncodings: Chunk[LspHandler.PositionEncodingKind] = Chunk.empty
+        ) derives Schema, CanEqual
+
+        /** Options for stale request handling (cancel vs retry on content modified). */
+        final case class StaleRequestSupportOptions(
+            cancel: Boolean,
+            retryOnContentModified: Chunk[String]
+        ) derives Schema, CanEqual
+
+        /** Client's regular expression engine name and version. */
+        final case class RegularExpressionsClientCapabilities(engine: String, version: Maybe[String] = Absent) derives Schema, CanEqual
+
+        /** Client's Markdown parser name, version, and allowed HTML tags. */
+        final case class MarkdownClientCapabilities(
+            parser: String,
+            version: Maybe[String] = Absent,
+            allowedTags: Chunk[String] = Chunk.empty
+        ) derives Schema, CanEqual
+
+    end Client
+
+    // =========================================================================
+    // Capability name enum
+    // =========================================================================
+
+    /** Typed discriminator for every standard LSP 3.17 capability.
+      *
+      * Used by `LspCapabilityNotAdvertisedException` and by the engine
+      * capability gate to identify which capability was missing.
+      */
+    enum Name derives CanEqual:
+        case Completion, Hover, SignatureHelp, Declaration, Definition, TypeDefinition
+        case Implementation, References, DocumentHighlight, DocumentSymbol
+        case CodeAction, CodeLens, DocumentLink, DocumentColor, Formatting
+        case RangeFormatting, OnTypeFormatting, Rename, FoldingRange, SelectionRange
+        case CallHierarchy, TypeHierarchy, SemanticTokens, Moniker, LinkedEditingRange
+        case InlayHint, InlineValue, Diagnostic, NotebookDocumentSync
+        case ExecuteCommand, WorkspaceSymbol, WorkspaceFolders, FileOperations
+    end Name
+
+    object Name:
+        given Schema[Name] = internal.lsp.LspWireEnumSchemas.lspCapabilityNameSchema
+    end Name
+
+end LspCapabilities

--- a/kyo-lsp/shared/src/main/scala/kyo/LspClient.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/LspClient.scala
@@ -1,0 +1,618 @@
+package kyo
+
+/** Live LSP client handle managing one connection to an LSP server over a [[JsonRpcTransport]].
+  *
+  * Obtain via `LspClient.init` (Scope-managed) or `LspClient.initUnscoped` (manual close).
+  * The client eagerly performs the LSP `initialize` / `initialized` handshake during `init`
+  * before returning the handle. The argument order for all `init` overloads is
+  * `(transport, clientInfo, capabilities, handlers*)`.
+  *
+  * `LspClient` is an opaque alias for `LspClient.Unsafe`.
+  *
+  * Typed methods for every server-handled request and notification are exposed as extension
+  * methods. The `executeCommand[T]` method is typed-only; no untyped variant exists.
+  * The `getConfiguration[T]` method is on `LspServer` (the server issues it to the client);
+  * the client sends `workspace/executeCommand` to the server instead.
+  *
+  * @see [[LspClient.init]]
+  * @see [[LspClient.initUnscoped]]
+  */
+opaque type LspClient = LspClient.Unsafe
+
+object LspClient:
+
+    // =========================================================================
+    // Scoped init quartet
+    // =========================================================================
+
+    /** Initializes an LSP client using default configuration and performs the handshake eagerly. */
+    def init(
+        transport: JsonRpcTransport,
+        clientInfo: LspInfo,
+        capabilities: LspCapabilities.Client.Client,
+        handlers: LspHandler[?, ?, ?]*
+    )(using Frame): LspClient < (Async & Scope & Abort[LspInitFailure]) =
+        init(transport, clientInfo, capabilities, LspConfig.default, handlers*)
+
+    /** Initializes an LSP client with explicit config and performs the handshake eagerly. */
+    def init(
+        transport: JsonRpcTransport,
+        clientInfo: LspInfo,
+        capabilities: LspCapabilities.Client.Client,
+        config: LspConfig,
+        handlers: LspHandler[?, ?, ?]*
+    )(using Frame): LspClient < (Async & Scope & Abort[LspInitFailure]) =
+        Scope.acquireRelease(
+            internal.lsp.LspClientEngine.initClient(transport, clientInfo, capabilities, handlers, config)
+        )(c => Sync.Unsafe.defer(c.close(Duration.Zero).safe.get))
+
+    /** Initializes and passes the client handle to the given function in a Scope context. */
+    def initWith[A, S](
+        transport: JsonRpcTransport,
+        clientInfo: LspInfo,
+        capabilities: LspCapabilities.Client.Client,
+        handlers: LspHandler[?, ?, ?]*
+    )(f: LspClient => A < S)(using Frame): A < (S & Async & Scope & Abort[LspInitFailure]) =
+        init(transport, clientInfo, capabilities, LspConfig.default, handlers*).map(f)
+
+    /** Initializes and passes the client handle to the given function in a Scope context with explicit config. */
+    def initWith[A, S](
+        transport: JsonRpcTransport,
+        clientInfo: LspInfo,
+        capabilities: LspCapabilities.Client.Client,
+        config: LspConfig,
+        handlers: LspHandler[?, ?, ?]*
+    )(f: LspClient => A < S)(using Frame): A < (S & Async & Scope & Abort[LspInitFailure]) =
+        init(transport, clientInfo, capabilities, config, handlers*).map(f)
+
+    // =========================================================================
+    // Unscoped init quartet
+    // =========================================================================
+
+    /** Initializes an LSP client without automatic resource cleanup. */
+    def initUnscoped(
+        transport: JsonRpcTransport,
+        clientInfo: LspInfo,
+        capabilities: LspCapabilities.Client.Client,
+        handlers: LspHandler[?, ?, ?]*
+    )(using Frame): LspClient < (Async & Abort[LspInitFailure]) =
+        internal.lsp.LspClientEngine.initClient(transport, clientInfo, capabilities, handlers, LspConfig.default)
+
+    /** Initializes an LSP client with config, without automatic resource cleanup. */
+    def initUnscoped(
+        transport: JsonRpcTransport,
+        clientInfo: LspInfo,
+        capabilities: LspCapabilities.Client.Client,
+        config: LspConfig,
+        handlers: LspHandler[?, ?, ?]*
+    )(using Frame): LspClient < (Async & Abort[LspInitFailure]) =
+        internal.lsp.LspClientEngine.initClient(transport, clientInfo, capabilities, handlers, config)
+
+    /** Initializes unscoped and passes the client handle to the given function. */
+    def initUnscopedWith[A, S](
+        transport: JsonRpcTransport,
+        clientInfo: LspInfo,
+        capabilities: LspCapabilities.Client.Client,
+        handlers: LspHandler[?, ?, ?]*
+    )(f: LspClient => A < S)(using Frame): A < (S & Async & Abort[LspInitFailure]) =
+        initUnscoped(transport, clientInfo, capabilities, LspConfig.default, handlers*).map(f)
+
+    /** Initializes unscoped with explicit config and passes the client handle to the given function. */
+    def initUnscopedWith[A, S](
+        transport: JsonRpcTransport,
+        clientInfo: LspInfo,
+        capabilities: LspCapabilities.Client.Client,
+        config: LspConfig,
+        handlers: LspHandler[?, ?, ?]*
+    )(f: LspClient => A < S)(using Frame): A < (S & Async & Abort[LspInitFailure]) =
+        initUnscoped(transport, clientInfo, capabilities, config, handlers*).map(f)
+
+    // =========================================================================
+    // Extension methods (safe-tier bridge over Unsafe)
+    // =========================================================================
+
+    extension (self: LspClient)
+
+        // textDocument requests
+
+        def completion(params: LspHandler.CompletionParams)(using
+            Frame
+        ): Maybe[LspHandler.CompletionResult] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.completion(params).safe.get)
+
+        def completionItemResolve(item: LspHandler.CompletionItem)(using
+            Frame
+        ): LspHandler.CompletionItem < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.completionItemResolve(item).safe.get)
+
+        def hover(params: LspHandler.HoverParams)(using Frame): Maybe[LspHandler.Hover] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.hover(params).safe.get)
+
+        def signatureHelp(params: LspHandler.SignatureHelpParams)(using
+            Frame
+        ): Maybe[LspHandler.SignatureHelp] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.signatureHelp(params).safe.get)
+
+        def declaration(params: LspHandler.DeclarationParams)(using
+            Frame
+        ): Maybe[LspHandler.DeclarationResult] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.declaration(params).safe.get)
+
+        def definition(params: LspHandler.DefinitionParams)(using
+            Frame
+        ): Maybe[LspHandler.DefinitionResult] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.definition(params).safe.get)
+
+        def typeDefinition(params: LspHandler.TypeDefinitionParams)(using
+            Frame
+        ): Maybe[LspHandler.TypeDefinitionResult] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.typeDefinition(params).safe.get)
+
+        def implementation(params: LspHandler.ImplementationParams)(using
+            Frame
+        ): Maybe[LspHandler.ImplementationResult] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.implementation(params).safe.get)
+
+        def references(params: LspHandler.ReferenceParams)(using
+            Frame
+        ): Chunk[LspHandler.Location] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.references(params).safe.get)
+
+        def documentHighlight(params: LspHandler.DocumentHighlightParams)(using
+            Frame
+        ): Chunk[LspHandler.DocumentHighlight] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.documentHighlight(params).safe.get)
+
+        def documentSymbol(params: LspHandler.DocumentSymbolParams)(using
+            Frame
+        ): Maybe[LspHandler.DocumentSymbolResult] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.documentSymbol(params).safe.get)
+
+        def codeAction(params: LspHandler.CodeActionParams)(using
+            Frame
+        ): Chunk[LspHandler.CommandOrCodeAction] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.codeAction(params).safe.get)
+
+        def codeActionResolve(action: LspHandler.CodeAction)(using Frame): LspHandler.CodeAction < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.codeActionResolve(action).safe.get)
+
+        def codeLens(params: LspHandler.CodeLensParams)(using Frame): Chunk[LspHandler.CodeLens] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.codeLens(params).safe.get)
+
+        def codeLensResolve(lens: LspHandler.CodeLens)(using Frame): LspHandler.CodeLens < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.codeLensResolve(lens).safe.get)
+
+        def documentLink(params: LspHandler.DocumentLinkParams)(using
+            Frame
+        ): Chunk[LspHandler.DocumentLink] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.documentLink(params).safe.get)
+
+        def documentLinkResolve(link: LspHandler.DocumentLink)(using
+            Frame
+        ): LspHandler.DocumentLink < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.documentLinkResolve(link).safe.get)
+
+        def documentColor(params: LspHandler.DocumentColorParams)(using
+            Frame
+        ): Chunk[LspHandler.ColorInformation] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.documentColor(params).safe.get)
+
+        def colorPresentation(params: LspHandler.ColorPresentationParams)(using
+            Frame
+        ): Chunk[LspHandler.ColorPresentation] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.colorPresentation(params).safe.get)
+
+        def formatting(params: LspHandler.DocumentFormattingParams)(using
+            Frame
+        ): Chunk[LspHandler.TextEdit] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.formatting(params).safe.get)
+
+        def rangeFormatting(params: LspHandler.DocumentRangeFormattingParams)(using
+            Frame
+        ): Chunk[LspHandler.TextEdit] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.rangeFormatting(params).safe.get)
+
+        def onTypeFormatting(params: LspHandler.DocumentOnTypeFormattingParams)(using
+            Frame
+        ): Chunk[LspHandler.TextEdit] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.onTypeFormatting(params).safe.get)
+
+        def rename(params: LspHandler.RenameParams)(using Frame): Maybe[LspHandler.WorkspaceEdit] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.rename(params).safe.get)
+
+        def prepareRename(params: LspHandler.PrepareRenameParams)(using
+            Frame
+        ): Maybe[LspHandler.PrepareRenameResult] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.prepareRename(params).safe.get)
+
+        def foldingRange(params: LspHandler.FoldingRangeParams)(using
+            Frame
+        ): Chunk[LspHandler.FoldingRange] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.foldingRange(params).safe.get)
+
+        def selectionRange(params: LspHandler.SelectionRangeParams)(using
+            Frame
+        ): Chunk[LspHandler.SelectionRange] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.selectionRange(params).safe.get)
+
+        def linkedEditingRange(params: LspHandler.LinkedEditingRangeParams)(using
+            Frame
+        ): Maybe[LspHandler.LinkedEditingRanges] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.linkedEditingRange(params).safe.get)
+
+        def prepareCallHierarchy(params: LspHandler.CallHierarchyPrepareParams)(using
+            Frame
+        ): Chunk[LspHandler.CallHierarchyItem] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.prepareCallHierarchy(params).safe.get)
+
+        def callHierarchyIncomingCalls(params: LspHandler.CallHierarchyIncomingCallsParams)(using
+            Frame
+        ): Chunk[LspHandler.CallHierarchyIncomingCall] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.callHierarchyIncomingCalls(params).safe.get)
+
+        def callHierarchyOutgoingCalls(params: LspHandler.CallHierarchyOutgoingCallsParams)(using
+            Frame
+        ): Chunk[LspHandler.CallHierarchyOutgoingCall] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.callHierarchyOutgoingCalls(params).safe.get)
+
+        def prepareTypeHierarchy(params: LspHandler.TypeHierarchyPrepareParams)(using
+            Frame
+        ): Chunk[LspHandler.TypeHierarchyItem] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.prepareTypeHierarchy(params).safe.get)
+
+        def typeHierarchySupertypes(params: LspHandler.TypeHierarchySupertypesParams)(using
+            Frame
+        ): Chunk[LspHandler.TypeHierarchyItem] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.typeHierarchySupertypes(params).safe.get)
+
+        def typeHierarchySubtypes(params: LspHandler.TypeHierarchySubtypesParams)(using
+            Frame
+        ): Chunk[LspHandler.TypeHierarchyItem] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.typeHierarchySubtypes(params).safe.get)
+
+        def semanticTokensFull(params: LspHandler.SemanticTokensParams)(using
+            Frame
+        ): Maybe[LspHandler.SemanticTokens] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.semanticTokensFull(params).safe.get)
+
+        def semanticTokensFullDelta(params: LspHandler.SemanticTokensDeltaParams)(using
+            Frame
+        ): Maybe[LspHandler.SemanticTokensResult] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.semanticTokensFullDelta(params).safe.get)
+
+        def semanticTokensRange(params: LspHandler.SemanticTokensRangeParams)(using
+            Frame
+        ): Maybe[LspHandler.SemanticTokens] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.semanticTokensRange(params).safe.get)
+
+        def moniker(params: LspHandler.MonikerParams)(using Frame): Chunk[LspHandler.Moniker] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.moniker(params).safe.get)
+
+        def inlayHint(params: LspHandler.InlayHintParams)(using
+            Frame
+        ): Chunk[LspHandler.InlayHint] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.inlayHint(params).safe.get)
+
+        def inlayHintResolve(hint: LspHandler.InlayHint)(using Frame): LspHandler.InlayHint < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.inlayHintResolve(hint).safe.get)
+
+        def inlineValue(params: LspHandler.InlineValueParams)(using
+            Frame
+        ): Chunk[LspHandler.InlineValue] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.inlineValue(params).safe.get)
+
+        def documentDiagnostic(params: LspHandler.DocumentDiagnosticParams)(using
+            Frame
+        ): LspHandler.DocumentDiagnosticReport < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.documentDiagnostic(params).safe.get)
+
+        def willSaveWaitUntil(params: LspHandler.WillSaveTextDocumentParams)(using
+            Frame
+        ): Chunk[LspHandler.TextEdit] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.willSaveWaitUntil(params).safe.get)
+
+        // textDocument notifications
+
+        def didOpen(params: LspHandler.DidOpenTextDocumentParams)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.didOpen(params).safe.get)
+
+        def didChange(params: LspHandler.DidChangeTextDocumentParams)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.didChange(params).safe.get)
+
+        def didSave(params: LspHandler.DidSaveTextDocumentParams)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.didSave(params).safe.get)
+
+        def didClose(params: LspHandler.DidCloseTextDocumentParams)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.didClose(params).safe.get)
+
+        def willSave(params: LspHandler.WillSaveTextDocumentParams)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.willSave(params).safe.get)
+
+        // workspace methods
+
+        def workspaceSymbol(params: LspHandler.WorkspaceSymbolParams)(using
+            Frame
+        ): Chunk[LspHandler.WorkspaceSymbol] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.workspaceSymbol(params).safe.get)
+
+        def executeCommand[T](params: LspHandler.ExecuteCommandParams)(using
+            Frame,
+            Schema[T]
+        ): Maybe[T] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.executeCommand[T](params).safe.get)
+
+        def workspaceDiagnostic(params: LspHandler.WorkspaceDiagnosticParams)(using
+            Frame
+        ): LspHandler.WorkspaceDiagnosticReport < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.workspaceDiagnostic(params).safe.get)
+
+        // lifecycle methods
+
+        def workDoneProgressCancel(params: LspHandler.WorkDoneProgressCancelParams)(using
+            Frame
+        ): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.workDoneProgressCancel(params).safe.get)
+
+        def setTrace(params: LspHandler.SetTraceParams)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.setTrace(params).safe.get)
+
+        def cancel(id: JsonRpcId)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.cancel(id).safe.get)
+
+        // session properties
+
+        def specVersion: String = self.specVersion
+
+        def positionEncoding(using Frame): LspHandler.PositionEncodingKind < Sync = self.positionEncoding
+
+        def serverCapabilities(using Frame): Maybe[LspCapabilities.Server.Server] < Sync = self.serverCapabilities
+
+        def serverInfo(using Frame): Maybe[LspInfo] < Sync = self.serverInfo
+
+        def underlying: JsonRpcHandler = self.underlying
+
+        def awaitDrain(using Frame): Unit < Async = Sync.Unsafe.defer(self.awaitDrain.safe.get)
+
+        def close(using Frame): Unit < Async = Sync.Unsafe.defer(self.close(30.seconds).safe.get)
+
+        def close(gracePeriod: Duration)(using Frame): Unit < Async = Sync.Unsafe.defer(self.close(gracePeriod).safe.get)
+
+        def closeNow(using Frame): Unit < Async = Sync.Unsafe.defer(self.close(Duration.Zero).safe.get)
+
+        def unsafe: Unsafe = self
+
+    end extension
+
+    // =========================================================================
+    // Unsafe abstract class
+    // =========================================================================
+
+    /** The underlying unsafe implementation contract for the LSP client.
+      *
+      * All methods return `Fiber.Unsafe`. Bridge to safe tier through the extension methods
+      * declared above. Concrete implementations are produced by the engine.
+      */
+    abstract class Unsafe:
+        // textDocument requests
+        def completion(params: LspHandler.CompletionParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.CompletionResult], Abort[LspRequestFailure]]
+        def completionItemResolve(item: LspHandler.CompletionItem)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[LspHandler.CompletionItem, Abort[LspRequestFailure]]
+        def hover(params: LspHandler.HoverParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.Hover], Abort[LspRequestFailure]]
+        def signatureHelp(params: LspHandler.SignatureHelpParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.SignatureHelp], Abort[LspRequestFailure]]
+        def declaration(params: LspHandler.DeclarationParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.DeclarationResult], Abort[LspRequestFailure]]
+        def definition(params: LspHandler.DefinitionParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.DefinitionResult], Abort[LspRequestFailure]]
+        def typeDefinition(params: LspHandler.TypeDefinitionParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.TypeDefinitionResult], Abort[LspRequestFailure]]
+        def implementation(params: LspHandler.ImplementationParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.ImplementationResult], Abort[LspRequestFailure]]
+        def references(params: LspHandler.ReferenceParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.Location], Abort[LspRequestFailure]]
+        def documentHighlight(params: LspHandler.DocumentHighlightParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.DocumentHighlight], Abort[LspRequestFailure]]
+        def documentSymbol(params: LspHandler.DocumentSymbolParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.DocumentSymbolResult], Abort[LspRequestFailure]]
+        def codeAction(params: LspHandler.CodeActionParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.CommandOrCodeAction], Abort[LspRequestFailure]]
+        def codeActionResolve(action: LspHandler.CodeAction)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[LspHandler.CodeAction, Abort[LspRequestFailure]]
+        def codeLens(params: LspHandler.CodeLensParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.CodeLens], Abort[LspRequestFailure]]
+        def codeLensResolve(lens: LspHandler.CodeLens)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[LspHandler.CodeLens, Abort[LspRequestFailure]]
+        def documentLink(params: LspHandler.DocumentLinkParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.DocumentLink], Abort[LspRequestFailure]]
+        def documentLinkResolve(link: LspHandler.DocumentLink)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[LspHandler.DocumentLink, Abort[LspRequestFailure]]
+        def documentColor(params: LspHandler.DocumentColorParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.ColorInformation], Abort[LspRequestFailure]]
+        def colorPresentation(params: LspHandler.ColorPresentationParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.ColorPresentation], Abort[LspRequestFailure]]
+        def formatting(params: LspHandler.DocumentFormattingParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.TextEdit], Abort[LspRequestFailure]]
+        def rangeFormatting(params: LspHandler.DocumentRangeFormattingParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.TextEdit], Abort[LspRequestFailure]]
+        def onTypeFormatting(params: LspHandler.DocumentOnTypeFormattingParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.TextEdit], Abort[LspRequestFailure]]
+        def rename(params: LspHandler.RenameParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.WorkspaceEdit], Abort[LspRequestFailure]]
+        def prepareRename(params: LspHandler.PrepareRenameParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.PrepareRenameResult], Abort[LspRequestFailure]]
+        def foldingRange(params: LspHandler.FoldingRangeParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.FoldingRange], Abort[LspRequestFailure]]
+        def selectionRange(params: LspHandler.SelectionRangeParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.SelectionRange], Abort[LspRequestFailure]]
+        def linkedEditingRange(params: LspHandler.LinkedEditingRangeParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.LinkedEditingRanges], Abort[LspRequestFailure]]
+        def prepareCallHierarchy(params: LspHandler.CallHierarchyPrepareParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.CallHierarchyItem], Abort[LspRequestFailure]]
+        def callHierarchyIncomingCalls(params: LspHandler.CallHierarchyIncomingCallsParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.CallHierarchyIncomingCall], Abort[LspRequestFailure]]
+        def callHierarchyOutgoingCalls(params: LspHandler.CallHierarchyOutgoingCallsParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.CallHierarchyOutgoingCall], Abort[LspRequestFailure]]
+        def prepareTypeHierarchy(params: LspHandler.TypeHierarchyPrepareParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.TypeHierarchyItem], Abort[LspRequestFailure]]
+        def typeHierarchySupertypes(params: LspHandler.TypeHierarchySupertypesParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.TypeHierarchyItem], Abort[LspRequestFailure]]
+        def typeHierarchySubtypes(params: LspHandler.TypeHierarchySubtypesParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.TypeHierarchyItem], Abort[LspRequestFailure]]
+        def semanticTokensFull(params: LspHandler.SemanticTokensParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.SemanticTokens], Abort[LspRequestFailure]]
+        def semanticTokensFullDelta(params: LspHandler.SemanticTokensDeltaParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.SemanticTokensResult], Abort[LspRequestFailure]]
+        def semanticTokensRange(params: LspHandler.SemanticTokensRangeParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.SemanticTokens], Abort[LspRequestFailure]]
+        def moniker(params: LspHandler.MonikerParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.Moniker], Abort[LspRequestFailure]]
+        def inlayHint(params: LspHandler.InlayHintParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.InlayHint], Abort[LspRequestFailure]]
+        def inlayHintResolve(hint: LspHandler.InlayHint)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[LspHandler.InlayHint, Abort[LspRequestFailure]]
+        def inlineValue(params: LspHandler.InlineValueParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.InlineValue], Abort[LspRequestFailure]]
+        def documentDiagnostic(params: LspHandler.DocumentDiagnosticParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[LspHandler.DocumentDiagnosticReport, Abort[LspRequestFailure]]
+        def willSaveWaitUntil(params: LspHandler.WillSaveTextDocumentParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.TextEdit], Abort[LspRequestFailure]]
+        // textDocument notifications
+        def didOpen(params: LspHandler.DidOpenTextDocumentParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def didChange(params: LspHandler.DidChangeTextDocumentParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def didSave(params: LspHandler.DidSaveTextDocumentParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def didClose(params: LspHandler.DidCloseTextDocumentParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def willSave(params: LspHandler.WillSaveTextDocumentParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        // workspace
+        def workspaceSymbol(params: LspHandler.WorkspaceSymbolParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Chunk[LspHandler.WorkspaceSymbol], Abort[LspRequestFailure]]
+        def executeCommand[T](params: LspHandler.ExecuteCommandParams)(using
+            AllowUnsafe,
+            Frame,
+            Schema[T]
+        ): Fiber.Unsafe[Maybe[T], Abort[LspRequestFailure]]
+        def workspaceDiagnostic(params: LspHandler.WorkspaceDiagnosticParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[LspHandler.WorkspaceDiagnosticReport, Abort[LspRequestFailure]]
+        // lifecycle
+        def workDoneProgressCancel(params: LspHandler.WorkDoneProgressCancelParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def setTrace(params: LspHandler.SetTraceParams)(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def cancel(id: JsonRpcId)(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        // session properties
+        def specVersion: String
+        def positionEncoding(using Frame): LspHandler.PositionEncodingKind < Sync
+        def serverCapabilities(using Frame): Maybe[LspCapabilities.Server.Server] < Sync
+        def serverInfo(using Frame): Maybe[LspInfo] < Sync
+        def underlying: JsonRpcHandler
+        def awaitDrain(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Any]
+        def close(gracePeriod: Duration)(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Any]
+        final def safe: LspClient = this
+    end Unsafe
+
+end LspClient

--- a/kyo-lsp/shared/src/main/scala/kyo/LspConfig.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/LspConfig.scala
@@ -1,0 +1,105 @@
+package kyo
+
+/** Configuration for an LSP server or client.
+  *
+  * `LspConfig.default` is the recommended starting point; override individual fields via the
+  * fluent setter methods. Call `LspConfig.require(config)` before passing to `LspServer.init`
+  * or `LspClient.init` to validate cross-field constraints.
+  *
+  * The `jsonRpc` field is pre-populated by `LspConfig.defaultJsonRpcConfig`. The engine
+  * installs LSP-specific policy adapters (cancellation, progress, unknown-method) at init time
+  * by extending the config. `positionEncodings` configures the server's accepted encoding set;
+  * the engine intersects with the client's advertised set at handshake time and defaults to
+  * UTF-16 per LSP 3.17.
+  *
+  * @param serverInfo                     server identity advertised in the initialize response
+  * @param positionEncodings              server-preferred position encoding list (default UTF-16)
+  * @param documentSync                   sync kind offered to clients (default Incremental)
+  * @param declaredServerCapabilities     explicit capability tree; Absent triggers auto-derivation
+  * @param enforceCapabilities            reject unadvertised capability calls (default true)
+  * @param onTypeFormattingTriggers       required when onTypeFormatting handler is registered
+  * @param semanticTokensLegend           required when any semanticTokens factory is registered
+  * @param executeCommandCommands         required when executeCommand handler is registered
+  * @param completionTriggerCharacters    optional trigger characters for completion
+  * @param signatureHelpTriggerCharacters optional trigger characters for signature help
+  * @param jsonRpc                        underlying JSON-RPC handler configuration
+  */
+final case class LspConfig(
+    serverInfo: LspInfo = LspInfo(name = "kyo-lsp"),
+    positionEncodings: Chunk[LspHandler.PositionEncodingKind] = Chunk(LspHandler.PositionEncodingKind.UTF16),
+    documentSync: LspHandler.TextDocumentSyncKind = LspHandler.TextDocumentSyncKind.Incremental,
+    declaredServerCapabilities: Maybe[LspCapabilities.Server] = Absent,
+    enforceCapabilities: Boolean = true,
+    onTypeFormattingTriggers: Chunk[String] = Chunk.empty,
+    semanticTokensLegend: Maybe[LspHandler.SemanticTokensLegend] = Absent,
+    executeCommandCommands: Chunk[String] = Chunk.empty,
+    completionTriggerCharacters: Chunk[String] = Chunk.empty,
+    signatureHelpTriggerCharacters: Chunk[String] = Chunk.empty,
+    jsonRpc: JsonRpcHandler.Config = LspConfig.defaultJsonRpcConfig,
+    private[kyo] _rawExperimental: Maybe[String] = Absent
+) derives CanEqual:
+    def withServerInfo(i: LspInfo): LspConfig                                       = copy(serverInfo = i)
+    def withPositionEncodings(e: Chunk[LspHandler.PositionEncodingKind]): LspConfig = copy(positionEncodings = e)
+    def withDocumentSync(k: LspHandler.TextDocumentSyncKind): LspConfig             = copy(documentSync = k)
+    def withDeclaredServerCapabilities(c: LspCapabilities.Server): LspConfig        = copy(declaredServerCapabilities = Present(c))
+    def withEnforceCapabilities(b: Boolean): LspConfig                              = copy(enforceCapabilities = b)
+    def withOnTypeFormattingTriggers(ts: Chunk[String]): LspConfig                  = copy(onTypeFormattingTriggers = ts)
+    def withSemanticTokensLegend(l: LspHandler.SemanticTokensLegend): LspConfig     = copy(semanticTokensLegend = Present(l))
+    def withExecuteCommandCommands(cmds: Chunk[String]): LspConfig                  = copy(executeCommandCommands = cmds)
+    def withCompletionTriggerCharacters(cs: Chunk[String]): LspConfig               = copy(completionTriggerCharacters = cs)
+    def withSignatureHelpTriggerCharacters(cs: Chunk[String]): LspConfig            = copy(signatureHelpTriggerCharacters = cs)
+    def withJsonRpc(c: JsonRpcHandler.Config): LspConfig                            = copy(jsonRpc = c)
+
+    /** Sets the experimental server capabilities slot using a typed value encoded to JSON.
+      *
+      * The value is encoded via `Json.encode[X]` into a wire-level JSON string stored in
+      * `_rawExperimental`. The engine reads it back via `Lsp.serverExperimentalCapabilities[X]`
+      * which decodes with `Json.decode[X]`.
+      */
+    def experimentalServerCapabilities[X](x: X)(using Schema[X], Frame): LspConfig =
+        copy(_rawExperimental = Present(Json.encode(x)))
+
+end LspConfig
+
+object LspConfig:
+
+    /** The LSP specification version implemented by this library. */
+    val SpecVersion: String = "3.17"
+
+    /** JSON-RPC handler config used by `default`.
+      *
+      * The three LSP-specific policy slots (cancellation, progress, unknownMethod) are
+      * installed by the engine after this default is constructed. The gate slot is also set
+      * by the engine after computing or reading the capability tree. This value provides a
+      * safe baseline; overriding `jsonRpc` directly is an escape hatch.
+      */
+    val defaultJsonRpcConfig: JsonRpcHandler.Config = JsonRpcHandler.Config.default
+
+    /** Default configuration using auto-derived capabilities and sensible LSP defaults.
+      *
+      * - positionEncodings: UTF-16 only (matches LSP 3.17 default)
+      * - documentSync: Incremental
+      * - enforceCapabilities: true
+      * - All other optional fields: Absent / empty
+      */
+    val default: LspConfig = LspConfig()
+
+    /** Validates structural constraints on `config`.
+      *
+      * Checks:
+      *   - `positionEncodings` is non-empty; the engine must have at least one encoding to
+      *     negotiate at handshake time.
+      *   - Delegates to `JsonRpcHandler.Config.require` for the `jsonRpc` slot.
+      *
+      * Cross-field semantic validations (e.g. onTypeFormattingTriggers required when the
+      * corresponding handler is registered) are performed by the engine catalog at init time,
+      * not here.
+      */
+    def require(c: LspConfig)(using Frame): Unit =
+        if c.positionEncodings.isEmpty then
+            throw LspConfigurationError("positionEncodings", "must be non-empty")
+        end if
+        JsonRpcHandler.Config.require(c.jsonRpc)
+    end require
+
+end LspConfig

--- a/kyo-lsp/shared/src/main/scala/kyo/LspException.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/LspException.scala
@@ -1,0 +1,217 @@
+package kyo
+
+/** Base class for all LSP exceptions, organized by the operation that can raise them.
+  *
+  * The kyo-lsp boundary is flat: both engines re-encode every server-side `JsonRpcError` into one
+  * [[LspRemoteException]] and never discriminate per method, so all request operations share the
+  * identical producible-failure set. Two sealed per-operation traits name those sets:
+  *   - [[LspRequestFailure]]: every client request and every server reverse-request can raise a
+  *     remote application error or observe a closed connection.
+  *   - [[LspInitFailure]]: the eager client `initialize` / `initialized` handshake.
+  *
+  * A trait names exactly the leaves that operation can produce, so a caller matches one and the
+  * compiler narrows the row to prove what remains. Concrete leaves mix in every trait they belong
+  * to, so [[LspConnectionClosedException]] (observable by every operation) lists both traits while a
+  * notification, whose only failure is a closed transport, carries [[LspConnectionClosedException]]
+  * directly with no trait.
+  *
+  * Extends [[JsonRpcApplicationError]], the cross-module extension point for JSON-RPC errors.
+  * [[JsonRpcApplicationError]] itself extends [[JsonRpcError]], so every `LspException` is a valid
+  * [[JsonRpcError]] and travels through `Abort[JsonRpcError | ...]` rows transparently. The inherited
+  * `Schema[JsonRpcError]` encodes any `LspException` as the wire triple `(code, message, data)`. No
+  * separate `Schema[LspException]` is needed.
+  *
+  * User-domain errors are registered per-handler via `handler.error[E2](code, message)` rather than
+  * by extending this hierarchy directly; the hierarchy is sealed so callers exhaust pattern matches
+  * on a given operation's trait without an open extension surface.
+  *
+  * @see [[LspRequestFailure]]
+  * @see [[LspInitFailure]]
+  * @see [[LspConnectionClosedException]]
+  * @see [[LspRemoteException]]
+  */
+sealed abstract class LspException(
+    code: Int,
+    message: String,
+    // Structure carve-out: data forwarded to JsonRpcApplicationError
+    data: Maybe[Structure.Value] = Absent,
+    cause: String | Throwable = ""
+)(using Frame)
+    extends JsonRpcApplicationError(
+        code,
+        message,
+        data,
+        cause
+    )
+
+// =============================================================================
+// Per-operation failure traits
+// =============================================================================
+//
+// One sealed trait per producible-failure shape; the trait IS the operation's `Abort` row. A
+// concrete leaf mixes in every trait whose operation can produce it (see the leaf definitions
+// below). LSP needs only two traits because the engine funnels all remote variation through one
+// re-encoded leaf and never discriminates per method.
+
+/** Failure row for every client request (`LspClient.completion`, `hover`, ...) and every server
+  * reverse-request (`LspServer.showMessageRequest`, `applyEdit`, ...).
+  */
+sealed trait LspRequestFailure extends LspException
+
+/** Failure row for the eager client `initialize` / `initialized` handshake (`LspClient.init`). */
+sealed trait LspInitFailure extends LspException
+
+// =============================================================================
+// Connection / configuration leaves
+// =============================================================================
+
+/** The transport or peer closed the connection (-32603).
+  *
+  * The typed boundary leaf for a closed transport: every request, notification, and init operation
+  * maps the underlying `Closed` signal from the JSON-RPC transport into this leaf, so no raw `Closed`
+  * reaches a public row. Mixes into both operation-traits because any operation can observe a closed
+  * connection; a notification carries it directly as the whole row.
+  */
+final case class LspConnectionClosedException()(using Frame)
+    extends LspException(code = -32603, message = "Connection closed.")
+    with LspRequestFailure
+    with LspInitFailure
+
+/** Invalid LSP configuration detected at initialization (-32603).
+  *
+  * Thrown as a panic by `LspConfig.require` when a configuration field is rejected (for example an
+  * empty `positionEncodings` list). These are construction-time programmer errors, not recoverable
+  * runtime failures, so they panic rather than appear on a tracked `Abort` row, matching the sibling
+  * `JsonRpcHandler.Config.require`. The `setting` field names the offending configuration slot and
+  * `reason` describes the violation.
+  *
+  * @param setting the configuration setting that is invalid
+  * @param reason  a brief description of why the setting is invalid
+  */
+final case class LspConfigurationError(setting: String, reason: String)(using Frame)
+    extends LspException(code = -32603, message = s"Invalid LSP configuration for '$setting': $reason")
+
+// =============================================================================
+// Remote-forward leaf (the universal client-observable failure)
+// =============================================================================
+
+/** Remote application error received from the peer.
+  *
+  * The universal remote-forward leaf: both engines re-encode every non-recovered wire `JsonRpcError`
+  * into this leaf, so it is the only `LspException` leaf a request or init row carries besides
+  * [[LspConnectionClosedException]]. The wire `code`, `message`, and `data` triple are preserved
+  * verbatim; the caller pattern-matches on `remoteCode` to discriminate across the error families the
+  * peer registered via `handler.error[E2](code, message)` (and the engine-internal gate rejections,
+  * which arrive flattened into this leaf).
+  *
+  * @param remoteCode    the JSON-RPC error code from the wire response
+  * @param remoteMessage the JSON-RPC error message from the wire response
+  * @param remoteData    the Schema-encoded `data` payload (Absent when the peer did not include one)
+  */
+// Structure carve-out: passes wire data through to LspException
+final case class LspRemoteException(
+    remoteCode: Int,
+    remoteMessage: String,
+    remoteData: Maybe[Structure.Value] = Absent
+)(using Frame)
+    extends LspException(code = remoteCode, message = remoteMessage, data = remoteData)
+    with LspRequestFailure
+    with LspInitFailure
+
+// =============================================================================
+// Engine-internal gate leaves (raised server-side; reach the client as LspRemoteException)
+// =============================================================================
+//
+// These are the only LspException leaves the server gate constructs. Each becomes a wire
+// JsonRpcResponse.failure; the client's engine re-encodes it to LspRemoteException. They mix no
+// operation-trait because they never appear on a client-facing row as themselves.
+
+/** A method was called before the `initialize` handshake completed (-32002).
+  *
+  * Raised server-side when the gate rejects any request other than `initialize` before the handshake
+  * is done. The `attemptedMethod` field names the premature request.
+  *
+  * @param attemptedMethod the method name that was called before initialization
+  */
+final case class LspNotInitializedException(attemptedMethod: String)(using Frame)
+    extends LspException(code = -32002, message = s"Method '$attemptedMethod' called before initialize.")
+
+/** A method was rejected because shutdown is in progress (-32600).
+  *
+  * Raised server-side when the gate rejects a request after `shutdown` was received.
+  *
+  * @param attemptedMethod the method name that was rejected
+  */
+final case class LspShutdownInProgressException(attemptedMethod: String)(using Frame)
+    extends LspException(code = -32600, message = s"Shutdown in progress; '$attemptedMethod' rejected.")
+
+/** A required server or client capability was not advertised (-32601).
+  *
+  * Raised server-side when the capability gate rejects a method whose required capability was not
+  * declared during the handshake.
+  *
+  * @param name the capability name that was not advertised
+  */
+final case class LspCapabilityNotAdvertisedException(name: LspCapabilities.Name)(using Frame)
+    extends LspException(code = -32601, message = s"Required capability '$name' was not advertised.")
+
+// =============================================================================
+// Construction-time programmer-error leaves (THROWN inside init, off every tracked row)
+// =============================================================================
+//
+// Constructed via `throw` in LspCatalog while building the handler set synchronously inside
+// LspServer.init / LspClient.init. They are construction-time programmer errors, not recoverable
+// runtime failures, so they panic rather than appear on a tracked Abort row. They mix no
+// operation-trait.
+
+/** A handler was registered for a method that does not match its expected direction (-32603).
+  *
+  * @param handlerKind  the handler kind that was registered
+  * @param registeredOn the direction it was registered on
+  */
+final case class LspWrongDirectionException(handlerKind: LspHandler.Kind, registeredOn: LspHandler.Direction)(using Frame)
+    extends LspException(code = -32603, message = s"Handler for '$handlerKind' cannot be registered on $registeredOn.")
+
+/** A handler attempted to register for an engine-reserved method (-32603).
+  *
+  * @param method the reserved method name
+  */
+final case class LspReservedMethodException(method: String)(using Frame)
+    extends LspException(code = -32603, message = s"Method '$method' is engine-reserved and cannot be user-registered.")
+
+/** A duplicate handler was registered for a method kind (-32603).
+  *
+  * @param kind the handler kind that was registered more than once
+  */
+final case class LspDuplicateHandlerException(kind: LspHandler.Kind)(using Frame)
+    extends LspException(code = -32603, message = s"Duplicate handler registration for kind '$kind'.")
+
+// =============================================================================
+// Handler-body decode leaves (own narrow Lsp.* rows; mix no operation-trait)
+// =============================================================================
+
+/** A field in the wire payload could not be decoded to the expected type (-32602).
+  *
+  * Raised by the typed open-payload readers (`Lsp.initializationOptions`, the `*As` projections, the
+  * `LspHandler.*Result.dataAs` readers) when a value is present but does not conform to the requested
+  * type. Carries its own narrow row on those helpers (`Abort[LspDecodeException]`), so it mixes into
+  * no operation-trait.
+  *
+  * @param target the slot being decoded
+  * @param reason the decode failure detail
+  * @param cause  the underlying decode throwable or string cause
+  */
+final case class LspDecodeException(target: String, reason: String, cause: String | Throwable = "")(using Frame)
+    extends LspException(code = -32602, message = s"Decode error for '$target': $reason", cause = cause)
+
+/** A required parameter field was invalid (-32602).
+  *
+  * Raised by `Lsp.extras` when the request's extra parameters do not decode. Carries its own narrow
+  * row (`Abort[LspInvalidParamsException]`), so it mixes into no operation-trait.
+  *
+  * @param method the method whose parameter failed validation
+  * @param reason a brief description of the validation failure
+  * @param cause  the underlying throwable or string cause
+  */
+final case class LspInvalidParamsException(method: String, reason: String, cause: String | Throwable = "")(using Frame)
+    extends LspException(code = -32602, message = s"Invalid params for '$method': $reason", cause = cause)

--- a/kyo-lsp/shared/src/main/scala/kyo/LspHandler.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/LspHandler.scala
@@ -1,0 +1,2929 @@
+package kyo
+
+import scala.annotation.nowarn
+
+/** Unified route and handler for an LSP endpoint.
+  *
+  * An `LspHandler[In, Out, +E]` pairs the declarative metadata (method name, direction, schemas,
+  * capability hints) for a single LSP 3.17 endpoint with the implementation closure the engine
+  * invokes on each inbound request or outbound notification. The engine lifts each value to a
+  * `JsonRpcRoute` at `LspServer.init` / `LspClient.init` time, wrapping the handler closure in
+  * `Lsp.local.let` so route bodies can reach the per-request context through the `Lsp.*`
+  * accessors.
+  *
+  * Construct values via the namespaced factory companions:
+  *
+  *   - [[LspHandler.textDocument]]      ; 38+ server-handled textDocument/X endpoints
+  *   - [[LspHandler.workspace]]         ; workspace/X endpoints (mixed direction)
+  *   - [[LspHandler.notebookDocument]]  ; notebookDocument/X endpoints
+  *   - [[LspHandler.window]]            ; window/X client-handled reverse-direction endpoints
+  *   - [[LspHandler.client]]            ; client/X reverse-direction endpoints
+  *   - [[LspHandler.custom]]            ; arbitrary server-handled extension method
+  *   - [[LspHandler.customClient]]      ; arbitrary client-handled extension method
+  *
+  * Domain-error mappings are added with `.error[E2](code, message)`, mirroring `JsonRpcRoute.error`.
+  *
+  * Every feature-specific LSP 3.17 ADT (Position, Range, Location, CompletionItem, CodeAction,
+  * Diagnostic, WorkspaceEdit, SemanticTokens, etc.) is nested inside `object LspHandler`.
+  * Import `kyo.LspHandler.*` at the use site to bring all ADTs into scope.
+  *
+  * @tparam In  the request parameter type
+  * @tparam Out the response payload type
+  * @tparam E   the union of user-registered domain error types
+  */
+sealed trait LspHandler[In, Out, +E]:
+    /** The endpoint's wire-level method name (e.g. `"textDocument/completion"`). */
+    def name: String
+
+    /** Engine dispatch flavor for this handler. */
+    private[kyo] def kind: LspHandler.Kind
+
+    /** The direction this handler runs in. */
+    private[kyo] def direction: LspHandler.Direction
+
+    /** Per-handler error mappings registered via `.error[E2]`. */
+    private[kyo] def errorMappings: Chunk[LspHandler.ErrorMapping[?]]
+
+    /** Adds a typed-error mapping. When the handler aborts with a value of type `E2`, the engine
+      * emits a JSON-RPC error with the supplied `code` and `message`. Mirrors `JsonRpcRoute.error[E2]`.
+      */
+    def error[E2](using schema: Schema[E2], tag: ConcreteTag[E2])(code: Int, message: String): LspHandler[In, Out, E | E2]
+end LspHandler
+
+// =============================================================================
+// companion
+// =============================================================================
+
+object LspHandler:
+
+    // MARK: -- Kind, Direction, ErrorMapping, Lifeable (internal types)
+
+    /** Engine dispatch flavor: one value per distinct LSP method. */
+    private[kyo] enum Kind derives CanEqual:
+        // General
+        case CancelRequest, Progress, SetTrace, LogTrace
+        // textDocument sync
+        case TextDocumentDidOpen, TextDocumentDidChange, TextDocumentDidSave, TextDocumentDidClose
+        case TextDocumentWillSave, TextDocumentWillSaveWaitUntil
+        // textDocument language features
+        case Completion, CompletionItemResolve
+        case Hover, SignatureHelp
+        case Declaration, Definition, TypeDefinition, Implementation, References
+        case DocumentHighlight, DocumentSymbol
+        case CodeAction, CodeActionResolve, CodeLens, CodeLensResolve
+        case DocumentLink, DocumentLinkResolve
+        case DocumentColor, ColorPresentation
+        case Formatting, RangeFormatting, OnTypeFormatting
+        case Rename, PrepareRename
+        case FoldingRange, SelectionRange
+        case PrepareCallHierarchy, CallHierarchyIncomingCalls, CallHierarchyOutgoingCalls
+        case PrepareTypeHierarchy, TypeHierarchySupertypes, TypeHierarchySubtypes
+        case SemanticTokensFull, SemanticTokensFullDelta, SemanticTokensRange
+        case LinkedEditingRange, Moniker
+        case InlayHint, InlayHintResolve, InlineValue
+        case DocumentDiagnostic, PublishDiagnostics
+        // workspace
+        case DidChangeWorkspaceFolders, DidChangeConfiguration, DidChangeWatchedFiles
+        case DidCreateFiles, DidRenameFiles, DidDeleteFiles
+        case WillCreateFiles, WillRenameFiles, WillDeleteFiles
+        case WorkspaceSymbol, WorkspaceSymbolResolve
+        case ExecuteCommand
+        case ApplyEdit, Configuration, WorkspaceFolders
+        case RefreshSemanticTokens, RefreshInlineValue, RefreshInlayHint
+        case RefreshDiagnostic, RefreshCodeLens
+        case WorkspaceDiagnostic
+        // notebookDocument
+        case NotebookDidOpen, NotebookDidChange, NotebookDidSave, NotebookDidClose
+        // window
+        case ShowMessage, ShowMessageRequest, ShowDocument, LogMessage
+        case WorkDoneProgressCreate, WorkDoneProgressCancel
+        case Telemetry
+        // client
+        case RegisterCapability, UnregisterCapability
+        // escape hatch
+        case Custom
+    end Kind
+
+    /** The direction a handler runs in: server-handled, client-handled, or either. */
+    private[kyo] enum Direction derives CanEqual:
+        case ServerHandled
+        case ClientHandled
+        case Either
+    end Direction
+
+    /** Maps Kind to its runtime direction. */
+    private[kyo] def direction(kind: Kind): Direction = kind match
+        case Kind.ShowMessage | Kind.ShowMessageRequest | Kind.ShowDocument | Kind.LogMessage
+            | Kind.WorkDoneProgressCreate | Kind.Telemetry
+            | Kind.ApplyEdit | Kind.Configuration | Kind.WorkspaceFolders
+            | Kind.RefreshSemanticTokens | Kind.RefreshInlineValue | Kind.RefreshInlayHint
+            | Kind.RefreshDiagnostic | Kind.RefreshCodeLens
+            | Kind.RegisterCapability | Kind.UnregisterCapability
+            | Kind.PublishDiagnostics | Kind.LogTrace => Direction.ClientHandled
+        case Kind.CancelRequest | Kind.Progress => Direction.Either
+        case _                                  => Direction.ServerHandled
+
+    /** A single `.error[E2]` registration: the type tag, the schema, and the wire code/message. */
+    final private[kyo] class ErrorMapping[E](val code: Int, val message: String)(using val tag: ConcreteTag[E], val schema: Schema[E]):
+        def matches(e: Any): Boolean = tag.accepts(e)
+    end ErrorMapping
+
+    // Internal factory helpers to avoid repeating summon calls at every factory site.
+    private[kyo] def initRequest[In: Schema, Out: Schema, E](
+        name: String,
+        kind: Kind,
+        fn: In => Out < (Async & Abort[JsonRpcResponse.Halt | E]),
+        errorMappings: Chunk[ErrorMapping[?]] = Chunk.empty
+    ): RequestHandler[In, Out, E] =
+        new RequestHandler(name, kind, fn, errorMappings, summon[Schema[In]], summon[Schema[Out]])
+
+    private[kyo] def initNotification[In: Schema, E](
+        name: String,
+        kind: Kind,
+        fn: In => Unit < (Async & Abort[JsonRpcResponse.Halt | E]),
+        errorMappings: Chunk[ErrorMapping[?]] = Chunk.empty
+    ): NotificationHandler[In, E] =
+        new NotificationHandler(name, kind, fn, errorMappings, summon[Schema[In]])
+
+    private[kyo] def initCustom[In: Schema, Out: Schema, E](
+        name: String,
+        dir: Direction,
+        fn: In => Out < (Async & Abort[JsonRpcResponse.Halt | E]),
+        errorMappings: Chunk[ErrorMapping[?]] = Chunk.empty
+    ): CustomHandler[In, Out, E] =
+        new CustomHandler(name, dir, fn, errorMappings, summon[Schema[In]], summon[Schema[Out]])
+
+    // MARK: -- Core types (Position, Range, Location, LocationLink, Color, ...)
+
+    /** A zero-based line and character position in a text document. */
+    final case class Position(line: Int, character: Int) derives Schema, CanEqual
+
+    /** A range in a text document expressed as start and end positions. */
+    final case class Range(start: Position, end: Position) derives Schema, CanEqual
+
+    object Range:
+        /** A range built from explicit zero-based line/character coordinates. */
+        def of(startLine: Int, startCharacter: Int, endLine: Int, endCharacter: Int): Range =
+            Range(Position(startLine, startCharacter), Position(endLine, endCharacter))
+
+        /** A zero-width range collapsed at a single position. */
+        def at(position: Position): Range = Range(position, position)
+    end Range
+
+    /** A location inside a resource, such as a line inside a text file. */
+    final case class Location(uri: LspDocument.Uri, range: Range) derives Schema, CanEqual
+
+    /** A link between a source and a target location. */
+    final case class LocationLink(
+        originSelectionRange: Maybe[Range] = Absent,
+        targetUri: LspDocument.Uri,
+        targetRange: Range,
+        targetSelectionRange: Range
+    ) derives Schema, CanEqual
+
+    /** An RGBA color. */
+    final case class Color(red: Double, green: Double, blue: Double, alpha: Double) derives Schema, CanEqual
+
+    /** A color range inside a text document. */
+    final case class ColorInformation(range: Range, color: Color) derives Schema, CanEqual
+
+    /** A presentation for a color value. */
+    final case class ColorPresentation(
+        label: String,
+        textEdit: Maybe[TextEdit] = Absent,
+        additionalTextEdits: Chunk[TextEdit] = Chunk.empty
+    ) derives Schema, CanEqual
+
+    /** A highlight in a text document. */
+    final case class DocumentHighlight(range: Range, kind: Maybe[DocumentHighlightKind] = Absent) derives Schema, CanEqual
+
+    /** The kind of a document highlight. */
+    enum DocumentHighlightKind derives CanEqual:
+        case Text, Read, Write
+
+    object DocumentHighlightKind:
+        given Schema[DocumentHighlightKind] = internal.lsp.LspWireEnumSchemas.documentHighlightKindSchema
+
+    // MARK: -- Document types (LspDocument + Uri opaque + identifier records + TextDocumentContentChangeEvent + TextDocumentSyncKind)
+
+    /** A managed text document tracked by the document registry.
+      *
+      * Users receive instances through `Lsp.documents.get(uri)`. The `encoding` field is stamped
+      * by the engine at insert time and is not part of the public constructor surface.
+      */
+    final case class LspDocument(
+        uri: LspDocument.Uri,
+        languageId: String,
+        version: Int,
+        text: String,
+        private[kyo] encoding: PositionEncodingKind = PositionEncodingKind.UTF16
+    ) derives CanEqual
+
+    object LspDocument:
+
+        /** Opaque URI for a text document. Use [[parse]] to construct; the engine uses [[fromWire]].
+          *
+          * Validation: non-empty, not all-whitespace. Mirrors `McpResourceUri` shape.
+          */
+        opaque type Uri = String
+
+        object Uri:
+            /** Constructs a URI from a string, returning `Absent` if empty or blank. */
+            def parse(s: String): Maybe[Uri] =
+                if s.nonEmpty && !s.forall(_.isWhitespace) then Present(s) else Absent
+
+            private[kyo] def fromWire(s: String): Uri = s
+
+            extension (u: Uri)
+                def asString: String = u
+
+            given Schema[Uri]        = Schema.stringSchema.transform[Uri](fromWire)(_.asString)
+            given CanEqual[Uri, Uri] = CanEqual.derived
+        end Uri
+
+        given Schema[LspDocument] = Schema.derived
+
+        /** Applies a sequence of incremental or full text changes to a document.
+          * Returns the updated document with the new text and incremented version.
+          */
+        def applyChanges(doc: LspDocument, changes: Chunk[TextDocumentContentChangeEvent]): LspDocument =
+            changes.foldLeft(doc) { (current, change) =>
+                change match
+                    case TextDocumentContentChangeEvent.Full(text) =>
+                        current.copy(text = text, version = current.version + 1)
+                    case TextDocumentContentChangeEvent.Incremental(range, text) =>
+                        val lines     = current.text.split("\n", -1)
+                        val before    = lines.take(range.start.line)
+                        val startLine = if range.start.line < lines.length then lines(range.start.line) else ""
+                        val endLine   = if range.end.line < lines.length then lines(range.end.line) else ""
+                        val prefix    = startLine.take(range.start.character)
+                        val suffix    = if range.end.character <= endLine.length then endLine.drop(range.end.character) else ""
+                        val after     = lines.drop(range.end.line + 1)
+                        val newLine   = prefix + text + suffix
+                        val allLines  = before ++ Array(newLine) ++ after
+                        current.copy(text = allLines.mkString("\n"), version = current.version + 1)
+            }
+
+    end LspDocument
+
+    /** A text document identifier (URI only, no version). */
+    final case class TextDocumentIdentifier(uri: LspDocument.Uri) derives Schema, CanEqual
+
+    /** A text document identifier with a version number. */
+    final case class VersionedTextDocumentIdentifier(uri: LspDocument.Uri, version: Int) derives Schema, CanEqual
+
+    /** A text document identifier with an optional version number. */
+    final case class OptionalVersionedTextDocumentIdentifier(uri: LspDocument.Uri, version: Maybe[Int] = Absent) derives Schema, CanEqual
+
+    /** Describes a text document to be opened. */
+    final case class TextDocumentItem(uri: LspDocument.Uri, languageId: String, version: Int, text: String) derives Schema, CanEqual
+
+    /** Describes how text document synchronization is achieved. */
+    enum TextDocumentSyncKind derives CanEqual:
+        case None, Incremental, Full
+
+    object TextDocumentSyncKind:
+        given Schema[TextDocumentSyncKind] = internal.lsp.LspWireEnumSchemas.textDocumentSyncKindSchema
+
+    /** Options for text document synchronization. */
+    final case class TextDocumentSyncOptions(
+        openClose: Maybe[Boolean] = Absent,
+        change: Maybe[TextDocumentSyncKind] = Absent,
+        willSave: Maybe[Boolean] = Absent,
+        willSaveWaitUntil: Maybe[Boolean] = Absent,
+        save: Maybe[BooleanOr[SaveOptions]] = Absent
+    ) derives Schema, CanEqual
+
+    /** Options for save notifications. */
+    final case class SaveOptions(includeText: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** A text document content change event. Full or incremental. */
+    sealed trait TextDocumentContentChangeEvent derives CanEqual
+
+    object TextDocumentContentChangeEvent:
+        /** A full document content change (no range). */
+        final case class Full(text: String) extends TextDocumentContentChangeEvent
+
+        /** An incremental document content change within a specific range. */
+        final case class Incremental(range: Range, text: String) extends TextDocumentContentChangeEvent
+
+        given Schema[TextDocumentContentChangeEvent] = internal.lsp.LspContentSchemas.textDocumentContentChangeEventSchema
+    end TextDocumentContentChangeEvent
+
+    /** The reason why a text document is saved. */
+    enum TextDocumentSaveReason derives CanEqual:
+        case Manual, AfterDelay, FocusOut
+
+    object TextDocumentSaveReason:
+        given Schema[TextDocumentSaveReason] = internal.lsp.LspWireEnumSchemas.textDocumentSaveReasonSchema
+
+    /** The kind of position encoding. */
+    opaque type PositionEncodingKind = String
+
+    object PositionEncodingKind:
+        val UTF8: PositionEncodingKind  = "utf-8"
+        val UTF16: PositionEncodingKind = "utf-16"
+        val UTF32: PositionEncodingKind = "utf-32"
+
+        def apply(s: String): PositionEncodingKind = s
+
+        extension (k: PositionEncodingKind)
+            def asString: String = k
+
+        given Schema[PositionEncodingKind]                         = Schema.stringSchema.transform[PositionEncodingKind](apply)(_.asString)
+        given CanEqual[PositionEncodingKind, PositionEncodingKind] = CanEqual.derived
+    end PositionEncodingKind
+
+    // MARK: -- Progress types (ProgressToken + WorkDoneProgressValue + WorkDoneProgress* records)
+
+    /** An LSP progress token: either an integer or a string. */
+    sealed trait ProgressToken derives CanEqual
+
+    object ProgressToken:
+        final case class IntToken(value: Int)       extends ProgressToken
+        final case class StringToken(value: String) extends ProgressToken
+        given Schema[ProgressToken] = internal.lsp.LspContentSchemas.progressTokenSchema
+    end ProgressToken
+
+    /** The value of a work-done progress notification. */
+    sealed trait WorkDoneProgressValue derives CanEqual
+
+    object WorkDoneProgressValue:
+        final case class Begin(
+            title: String,
+            cancellable: Maybe[Boolean] = Absent,
+            message: Maybe[String] = Absent,
+            percentage: Maybe[Int] = Absent
+        ) extends WorkDoneProgressValue
+
+        final case class Report(
+            cancellable: Maybe[Boolean] = Absent,
+            message: Maybe[String] = Absent,
+            percentage: Maybe[Int] = Absent
+        ) extends WorkDoneProgressValue
+
+        final case class End(message: Maybe[String] = Absent) extends WorkDoneProgressValue
+
+        given (using Frame): Schema[WorkDoneProgressValue] =
+            Schema.derived[WorkDoneProgressValue]
+                .discriminator("kind")
+                .renameAllVariants(Schema.NameCase.CamelCase)
+    end WorkDoneProgressValue
+
+    /** Options for work-done progress support. */
+    final case class WorkDoneProgressOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** Parameters carrying an optional work-done progress token. */
+    final case class WorkDoneProgressParams(workDoneToken: Maybe[ProgressToken] = Absent) derives Schema, CanEqual
+
+    /** Parameters carrying an optional partial-result token. */
+    final case class PartialResultParams(partialResultToken: Maybe[ProgressToken] = Absent) derives Schema, CanEqual
+
+    /** Parameters for the `window/workDoneProgress/create` request. */
+    final case class WorkDoneProgressCreateParams(token: ProgressToken) derives Schema, CanEqual
+
+    /** Parameters for the `window/workDoneProgress/cancel` notification. */
+    final case class WorkDoneProgressCancelParams(token: ProgressToken) derives Schema, CanEqual
+
+    /** Parameters for the `$/progress` notification. The value type T is application-defined: servers emit work-done
+      * progress shapes (WorkDoneProgressBegin, WorkDoneProgressReport, WorkDoneProgressEnd) and clients emit
+      * partial-result chunks whose shape is specific to the originating request. The Schema constraint is enforced at
+      * factory and encode sites.
+      */
+    final case class ProgressParams[T](token: ProgressToken, value: T) derives CanEqual
+
+    // MARK: -- Markup types (MarkupContent, MarkupKind, MarkedString, HoverContents)
+
+    /** The kind of markup content. */
+    enum MarkupKind derives CanEqual:
+        case PlainText, Markdown
+
+    object MarkupKind:
+        given Schema[MarkupKind] = internal.lsp.LspWireEnumSchemas.markupKindSchema
+
+    /** A human-readable string that can be rendered as plain text or markdown. */
+    final case class MarkupContent(kind: MarkupKind, value: String) derives Schema, CanEqual
+
+    object MarkupContent:
+        /** Plain-text markup content. */
+        def plainText(value: String): MarkupContent = MarkupContent(MarkupKind.PlainText, value)
+
+        /** Markdown markup content. */
+        def markdown(value: String): MarkupContent = MarkupContent(MarkupKind.Markdown, value)
+    end MarkupContent
+
+    /** A marked string can be used to render human readable text. Deprecated in LSP 3.x; use MarkupContent. */
+    sealed trait MarkedString derives CanEqual
+
+    object MarkedString:
+        final case class Plain(value: String)                  extends MarkedString
+        final case class Code(language: String, value: String) extends MarkedString
+
+        /** A plain marked string. */
+        def plain(value: String): MarkedString = Plain(value)
+
+        /** A language-tagged code marked string. */
+        def code(language: String, value: String): MarkedString = Code(language, value)
+
+        given Schema[MarkedString] = internal.lsp.LspContentSchemas.markedStringSchema
+    end MarkedString
+
+    /** The content of a hover response: either MarkupContent or one/more MarkedStrings. */
+    sealed trait HoverContents derives CanEqual
+
+    object HoverContents:
+        final case class Markup(value: MarkupContent)        extends HoverContents
+        final case class Strings(value: Chunk[MarkedString]) extends HoverContents
+
+        /** Hover contents from a single markup block. */
+        def markup(content: MarkupContent): HoverContents = Markup(content)
+
+        given Schema[HoverContents] = internal.lsp.LspContentSchemas.hoverContentsSchema
+    end HoverContents
+
+    // MARK: -- Diagnostic types
+
+    /** Represents the severity of a diagnostic. */
+    enum DiagnosticSeverity derives CanEqual:
+        case Error, Warning, Information, Hint
+
+    object DiagnosticSeverity:
+        given Schema[DiagnosticSeverity] = internal.lsp.LspWireEnumSchemas.diagnosticSeveritySchema
+
+    /** Diagnostic tags to flag special kinds of diagnostics. */
+    enum DiagnosticTag derives CanEqual:
+        case Unnecessary, Deprecated
+
+    object DiagnosticTag:
+        given Schema[DiagnosticTag] = internal.lsp.LspWireEnumSchemas.diagnosticTagSchema
+
+    /** Structure to capture a description for an error code. `href` is a plain `String`, not an
+      * `LspDocument.Uri`: it points at human-readable documentation (typically a web URL), not a
+      * workspace document.
+      */
+    final case class CodeDescription(href: String) derives Schema, CanEqual
+
+    /** Represents a related message and source code location for a diagnostic. */
+    final case class DiagnosticRelatedInformation(location: Location, message: String) derives Schema, CanEqual
+
+    /** Represents a diagnostic, such as a compiler error or warning. */
+    final case class Diagnostic(
+        range: Range,
+        severity: Maybe[DiagnosticSeverity] = Absent,
+        code: Maybe[String] = Absent,
+        codeDescription: Maybe[CodeDescription] = Absent,
+        source: Maybe[String] = Absent,
+        message: String,
+        tags: Chunk[DiagnosticTag] = Chunk.empty,
+        relatedInformation: Chunk[DiagnosticRelatedInformation] = Chunk.empty
+    ) derives Schema, CanEqual
+
+    object Diagnostic:
+        /** An error-severity diagnostic. */
+        def error(range: Range, message: String): Diagnostic =
+            Diagnostic(range = range, severity = Present(DiagnosticSeverity.Error), message = message)
+
+        /** A warning-severity diagnostic. */
+        def warning(range: Range, message: String): Diagnostic =
+            Diagnostic(range = range, severity = Present(DiagnosticSeverity.Warning), message = message)
+
+        /** An information-severity diagnostic. */
+        def info(range: Range, message: String): Diagnostic =
+            Diagnostic(range = range, severity = Present(DiagnosticSeverity.Information), message = message)
+
+        /** A hint-severity diagnostic. */
+        def hint(range: Range, message: String): Diagnostic =
+            Diagnostic(range = range, severity = Present(DiagnosticSeverity.Hint), message = message)
+    end Diagnostic
+
+    /** Parameters for the `textDocument/publishDiagnostics` notification. */
+    final case class PublishDiagnosticsParams(
+        uri: LspDocument.Uri,
+        version: Maybe[Int] = Absent,
+        diagnostics: Chunk[Diagnostic]
+    ) derives Schema, CanEqual
+
+    /** A document diagnostic report. */
+    sealed trait DocumentDiagnosticReport derives CanEqual
+
+    object DocumentDiagnosticReport:
+        final case class Full(resultId: Maybe[String] = Absent, items: Chunk[Diagnostic])
+            extends DocumentDiagnosticReport
+        final case class Unchanged(resultId: String) extends DocumentDiagnosticReport
+
+        /** A full report carrying the current diagnostics. */
+        def full(items: Chunk[Diagnostic], resultId: Maybe[String] = Absent): DocumentDiagnosticReport =
+            Full(resultId = resultId, items = items)
+
+        /** An unchanged report referencing a prior result. */
+        def unchanged(resultId: String): DocumentDiagnosticReport = Unchanged(resultId = resultId)
+
+        given (using Frame): Schema[DocumentDiagnosticReport] =
+            Schema.derived[DocumentDiagnosticReport]
+                .discriminator("kind")
+                .renameAllVariants(Schema.NameCase.CamelCase)
+    end DocumentDiagnosticReport
+
+    /** A workspace diagnostic report. */
+    sealed trait WorkspaceDocumentDiagnosticReport derives CanEqual
+
+    object WorkspaceDocumentDiagnosticReport:
+        final case class Full(
+            uri: LspDocument.Uri,
+            version: Maybe[Int] = Absent,
+            resultId: Maybe[String] = Absent,
+            items: Chunk[Diagnostic]
+        ) extends WorkspaceDocumentDiagnosticReport
+        final case class Unchanged(uri: LspDocument.Uri, version: Maybe[Int] = Absent, resultId: String)
+            extends WorkspaceDocumentDiagnosticReport
+        given (using Frame): Schema[WorkspaceDocumentDiagnosticReport] =
+            Schema.derived[WorkspaceDocumentDiagnosticReport]
+                .discriminator("kind")
+                .renameAllVariants(Schema.NameCase.CamelCase)
+    end WorkspaceDocumentDiagnosticReport
+
+    /** The result of a workspace diagnostic request. */
+    final case class WorkspaceDiagnosticReport(items: Chunk[WorkspaceDocumentDiagnosticReport]) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/diagnostic`. */
+    final case class DocumentDiagnosticParams(
+        textDocument: TextDocumentIdentifier,
+        identifier: Maybe[String] = Absent,
+        previousResultId: Maybe[String] = Absent,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `workspace/diagnostic`. */
+    final case class WorkspaceDiagnosticParams(
+        identifier: Maybe[String] = Absent,
+        previousResultIds: Chunk[PreviousResultId] = Chunk.empty,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** A previous result id in a workspace pull request. */
+    final case class PreviousResultId(uri: LspDocument.Uri, value: String) derives Schema, CanEqual
+
+    // MARK: -- Symbol types
+
+    /** A symbol kind. */
+    enum SymbolKind derives CanEqual:
+        case File, Module, Namespace, Package, Class, Method, Property, Field, Constructor
+        case Enum, Interface, Function, Variable, Constant, String, Number, Boolean, Array
+        case Object, Key, Null, EnumMember, Struct, Event, Operator, TypeParameter
+    end SymbolKind
+
+    object SymbolKind:
+        given Schema[SymbolKind] = internal.lsp.LspWireEnumSchemas.symbolKindSchema
+
+    /** A symbol tag. */
+    enum SymbolTag derives CanEqual:
+        case Deprecated
+
+    object SymbolTag:
+        given Schema[SymbolTag] = internal.lsp.LspWireEnumSchemas.symbolTagSchema
+
+    /** Represents programming constructs like variables, classes, interfaces etc. that appear in a document. */
+    final case class DocumentSymbol(
+        name: String,
+        detail: Maybe[String] = Absent,
+        kind: SymbolKind,
+        tags: Chunk[SymbolTag] = Chunk.empty,
+        deprecated: Maybe[Boolean] = Absent,
+        range: Range,
+        selectionRange: Range,
+        children: Chunk[DocumentSymbol] = Chunk.empty
+    ) derives Schema, CanEqual
+
+    object DocumentSymbol:
+        /** A document symbol with the four required fields. */
+        def of(name: String, kind: SymbolKind, range: Range, selectionRange: Range): DocumentSymbol =
+            DocumentSymbol(name = name, kind = kind, range = range, selectionRange = selectionRange)
+    end DocumentSymbol
+
+    /** Represents information about programming constructs like variables, classes, interfaces etc. */
+    final case class SymbolInformation(
+        name: String,
+        kind: SymbolKind,
+        tags: Chunk[SymbolTag] = Chunk.empty,
+        deprecated: Maybe[Boolean] = Absent,
+        location: Location,
+        containerName: Maybe[String] = Absent
+    ) derives Schema, CanEqual
+
+    /** A document symbol result: either a list of DocumentSymbol or SymbolInformation. */
+    sealed trait DocumentSymbolResult derives CanEqual
+
+    object DocumentSymbolResult:
+        final case class Symbols(items: Chunk[DocumentSymbol])        extends DocumentSymbolResult
+        final case class Information(items: Chunk[SymbolInformation]) extends DocumentSymbolResult
+
+        /** A hierarchical document-symbol result. */
+        def symbols(items: DocumentSymbol*): DocumentSymbolResult = Symbols(Chunk.from(items))
+
+        /** A flat symbol-information result. */
+        def information(items: SymbolInformation*): DocumentSymbolResult = Information(Chunk.from(items))
+
+        given Schema[DocumentSymbolResult] = internal.lsp.LspContentSchemas.documentSymbolResultSchema
+    end DocumentSymbolResult
+
+    /** A workspace symbol with typed data carrier. */
+    final case class WorkspaceSymbol(
+        name: String,
+        kind: SymbolKind,
+        tags: Chunk[SymbolTag] = Chunk.empty,
+        containerName: Maybe[String] = Absent,
+        location: WorkspaceSymbolLocation,
+        private[kyo] _rawData: Maybe[String] = Absent
+    ) derives CanEqual:
+        def withData[X](x: X)(using Schema[X], Frame): WorkspaceSymbol = copy(_rawData = Present(Json.encode[X](x)))
+        def dataAs[X](using frame: Frame, schema: Schema[X]): Maybe[X] < Abort[LspDecodeException] =
+            _rawData match
+                case Absent => Absent
+                case Present(s) =>
+                    Json.decode[X](s) match
+                        case Result.Success(v) => Present(v)
+                        case Result.Failure(e) => Abort.fail(LspDecodeException("workspace/symbol", e.toString, e))
+                        case Result.Panic(e)   => Abort.fail(LspDecodeException("workspace/symbol", e.getMessage, e))
+    end WorkspaceSymbol
+
+    object WorkspaceSymbol:
+        given Schema[WorkspaceSymbol] = Schema.derived
+
+    /** The location of a workspace symbol: either a URI with range or a URI only. */
+    sealed trait WorkspaceSymbolLocation derives CanEqual
+
+    object WorkspaceSymbolLocation:
+        final case class WithRange(uri: LspDocument.Uri, range: Range) extends WorkspaceSymbolLocation
+        final case class UriOnly(uri: LspDocument.Uri)                 extends WorkspaceSymbolLocation
+        given Schema[WorkspaceSymbolLocation] = internal.lsp.LspContentSchemas.workspaceSymbolLocationSchema
+    end WorkspaceSymbolLocation
+
+    // MARK: -- Completion types
+
+    /** The kind of a completion item. */
+    enum CompletionItemKind derives CanEqual:
+        case Text, Method, Function, Constructor, Field, Variable, Class, Interface, Module
+        case Property, Unit, Value, Enum, Keyword, Snippet, Color, File, Reference, Folder
+        case EnumMember, Constant, Struct, Event, Operator, TypeParameter
+    end CompletionItemKind
+
+    object CompletionItemKind:
+        given Schema[CompletionItemKind] = internal.lsp.LspWireEnumSchemas.completionItemKindSchema
+
+    /** A tag for completion items. */
+    enum CompletionItemTag derives CanEqual:
+        case Deprecated
+
+    object CompletionItemTag:
+        given Schema[CompletionItemTag] = internal.lsp.LspWireEnumSchemas.completionItemTagSchema
+
+    /** How whitespace and indentation is handled during completion item insertion. */
+    enum InsertTextFormat derives CanEqual:
+        case PlainText, Snippet
+
+    object InsertTextFormat:
+        given Schema[InsertTextFormat] = internal.lsp.LspWireEnumSchemas.insertTextFormatSchema
+
+    /** How the insert text of a completion item is treated. */
+    enum InsertTextMode derives CanEqual:
+        case AsIs, AdjustIndentation
+
+    object InsertTextMode:
+        given Schema[InsertTextMode] = internal.lsp.LspWireEnumSchemas.insertTextModeSchema
+
+    /** The trigger kind for a completion request. */
+    enum CompletionTriggerKind derives CanEqual:
+        case Invoked, TriggerCharacter, TriggerForIncompleteCompletions
+
+    object CompletionTriggerKind:
+        given Schema[CompletionTriggerKind] = internal.lsp.LspWireEnumSchemas.completionTriggerKindSchema
+
+    /** Contains additional information about the context in which a completion request is triggered. */
+    final case class CompletionContext(
+        triggerKind: CompletionTriggerKind,
+        triggerCharacter: Maybe[String] = Absent
+    ) derives Schema, CanEqual
+
+    /** Additional details for a completion item label. */
+    final case class CompletionItemLabelDetails(
+        detail: Maybe[String] = Absent,
+        description: Maybe[String] = Absent
+    ) derives Schema, CanEqual
+
+    /** A special text edit to provide an insert and a replace operation. */
+    final case class InsertReplaceEdit(newText: String, insert: Range, replace: Range) derives Schema, CanEqual
+
+    /** A completion item with typed data carrier. */
+    final case class CompletionItem(
+        label: String,
+        labelDetails: Maybe[CompletionItemLabelDetails] = Absent,
+        kind: Maybe[CompletionItemKind] = Absent,
+        tags: Chunk[CompletionItemTag] = Chunk.empty,
+        detail: Maybe[String] = Absent,
+        documentation: Maybe[MarkupContent] = Absent,
+        deprecated: Maybe[Boolean] = Absent,
+        preselect: Maybe[Boolean] = Absent,
+        sortText: Maybe[String] = Absent,
+        filterText: Maybe[String] = Absent,
+        insertText: Maybe[String] = Absent,
+        insertTextFormat: Maybe[InsertTextFormat] = Absent,
+        insertTextMode: Maybe[InsertTextMode] = Absent,
+        textEdit: Maybe[TextEdit] = Absent,
+        textEditText: Maybe[String] = Absent,
+        additionalTextEdits: Chunk[TextEdit] = Chunk.empty,
+        commitCharacters: Chunk[String] = Chunk.empty,
+        command: Maybe[Command] = Absent,
+        private[kyo] _rawData: Maybe[String] = Absent
+    ) derives CanEqual:
+        def withData[X](x: X)(using Schema[X], Frame): CompletionItem = copy(_rawData = Present(Json.encode[X](x)))
+        def dataAs[X](using frame: Frame, schema: Schema[X]): Maybe[X] < Abort[LspDecodeException] =
+            _rawData match
+                case Absent => Absent
+                case Present(s) =>
+                    Json.decode[X](s) match
+                        case Result.Success(v) => Present(v)
+                        case Result.Failure(e) => Abort.fail(LspDecodeException("textDocument/completion", e.toString, e))
+                        case Result.Panic(e)   => Abort.fail(LspDecodeException("textDocument/completion", e.getMessage, e))
+    end CompletionItem
+
+    object CompletionItem:
+        /** A completion item carrying only a label. */
+        def of(label: String): CompletionItem = CompletionItem(label = label)
+
+        /** A completion item carrying a label and kind. */
+        def of(label: String, kind: CompletionItemKind): CompletionItem =
+            CompletionItem(label = label, kind = Present(kind))
+
+        given Schema[CompletionItem] = Schema.derived
+    end CompletionItem
+
+    /** Optional default values for completions returned by the server. */
+    final case class CompletionItemDefaults(
+        commitCharacters: Chunk[String] = Chunk.empty,
+        editRange: Maybe[Range] = Absent,
+        insertTextFormat: Maybe[InsertTextFormat] = Absent,
+        insertTextMode: Maybe[InsertTextMode] = Absent
+    ) derives Schema, CanEqual
+
+    /** Represents a collection of completion items to be presented in the editor. */
+    final case class CompletionList(
+        isIncomplete: Boolean,
+        itemDefaults: Maybe[CompletionItemDefaults] = Absent,
+        items: Chunk[CompletionItem]
+    ) derives Schema, CanEqual
+
+    /** The completion result: either a list of CompletionItem or a CompletionList. */
+    sealed trait CompletionResult derives CanEqual
+
+    object CompletionResult:
+        final case class Items(items: Chunk[CompletionItem]) extends CompletionResult
+        final case class List(list: CompletionList)          extends CompletionResult
+
+        /** A result of plain-label completion items. */
+        def of(labels: String*): CompletionResult = Items(Chunk.from(labels.map(l => CompletionItem.of(l))))
+
+        /** A result from explicit completion items. */
+        def items(items: CompletionItem*): CompletionResult = Items(Chunk.from(items))
+
+        /** A result wrapping a (possibly incomplete) completion list. */
+        def list(list: CompletionList): CompletionResult = List(list)
+
+        given Schema[CompletionResult] = internal.lsp.LspContentSchemas.completionResultSchema
+    end CompletionResult
+
+    /** Options to register for completion. */
+    final case class CompletionOptions(
+        workDoneProgress: Maybe[Boolean] = Absent,
+        triggerCharacters: Chunk[String] = Chunk.empty,
+        allCommitCharacters: Chunk[String] = Chunk.empty,
+        resolveProvider: Maybe[Boolean] = Absent,
+        completionItem: Maybe[CompletionOptions.ItemOptions] = Absent
+    ) derives Schema, CanEqual
+
+    object CompletionOptions:
+        final case class ItemOptions(labelDetailsSupport: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    // MARK: -- Signature help types
+
+    /** How a signature help was triggered. */
+    enum SignatureHelpTriggerKind derives CanEqual:
+        case Invoked, TriggerCharacter, ContentChange
+
+    object SignatureHelpTriggerKind:
+        given Schema[SignatureHelpTriggerKind] = internal.lsp.LspWireEnumSchemas.signatureHelpTriggerKindSchema
+
+    /** Additional information about the context in which a signature help request was triggered. */
+    final case class SignatureHelpContext(
+        triggerKind: SignatureHelpTriggerKind,
+        triggerCharacter: Maybe[String] = Absent,
+        isRetrigger: Boolean,
+        activeSignatureHelp: Maybe[SignatureHelp] = Absent
+    ) derives Schema, CanEqual
+
+    /** The label in a parameter information can be a range or a string. */
+    sealed trait ParameterLabel derives CanEqual
+
+    object ParameterLabel:
+        final case class StringLabel(value: String)       extends ParameterLabel
+        final case class RangeLabel(start: Int, end: Int) extends ParameterLabel
+        given Schema[ParameterLabel] = internal.lsp.LspContentSchemas.parameterLabelSchema
+    end ParameterLabel
+
+    /** Represents a parameter of a callable-signature. */
+    final case class ParameterInformation(
+        label: ParameterLabel,
+        documentation: Maybe[MarkupContent] = Absent
+    ) derives Schema, CanEqual
+
+    object ParameterInformation:
+        /** A parameter labelled by a plain string. */
+        def of(label: String): ParameterInformation = ParameterInformation(ParameterLabel.StringLabel(label))
+    end ParameterInformation
+
+    /** Represents the signature of a callable. */
+    final case class SignatureInformation(
+        label: String,
+        documentation: Maybe[MarkupContent] = Absent,
+        parameters: Chunk[ParameterInformation] = Chunk.empty,
+        activeParameter: Maybe[Int] = Absent
+    ) derives Schema, CanEqual
+
+    object SignatureInformation:
+        /** A signature from a label and its parameters. */
+        def of(label: String, parameters: ParameterInformation*): SignatureInformation =
+            SignatureInformation(label = label, parameters = Chunk.from(parameters))
+    end SignatureInformation
+
+    /** Signature help represents the signature of a callable (a function, a method, etc.). */
+    final case class SignatureHelp(
+        signatures: Chunk[SignatureInformation],
+        activeSignature: Maybe[Int] = Absent,
+        activeParameter: Maybe[Int] = Absent
+    ) derives Schema, CanEqual
+
+    object SignatureHelp:
+        /** Signature help from one or more signatures. */
+        def of(signatures: SignatureInformation*): SignatureHelp =
+            SignatureHelp(signatures = Chunk.from(signatures))
+    end SignatureHelp
+
+    /** Registration options for signature help. */
+    final case class SignatureHelpOptions(
+        workDoneProgress: Maybe[Boolean] = Absent,
+        triggerCharacters: Chunk[String] = Chunk.empty,
+        retriggerCharacters: Chunk[String] = Chunk.empty
+    ) derives Schema, CanEqual
+
+    // MARK: -- Code action + command types
+
+    /** A reference to a command. */
+    final case class Command(title: String, command: String, arguments: Chunk[String] = Chunk.empty) derives Schema, CanEqual
+
+    /** An opaque string code action kind (extensible set). */
+    opaque type CodeActionKind = String
+
+    object CodeActionKind:
+        val Empty: CodeActionKind                 = ""
+        val QuickFix: CodeActionKind              = "quickfix"
+        val Refactor: CodeActionKind              = "refactor"
+        val RefactorExtract: CodeActionKind       = "refactor.extract"
+        val RefactorInline: CodeActionKind        = "refactor.inline"
+        val RefactorRewrite: CodeActionKind       = "refactor.rewrite"
+        val Source: CodeActionKind                = "source"
+        val SourceOrganizeImports: CodeActionKind = "source.organizeImports"
+        val SourceFixAll: CodeActionKind          = "source.fixAll"
+
+        def apply(s: String): CodeActionKind = s
+
+        extension (k: CodeActionKind)
+            def asString: String = k
+
+        given Schema[CodeActionKind]                   = Schema.stringSchema.transform[CodeActionKind](apply)(_.asString)
+        given CanEqual[CodeActionKind, CodeActionKind] = CanEqual.derived
+    end CodeActionKind
+
+    /** The trigger kind for a code action request. */
+    enum CodeActionTriggerKind derives CanEqual:
+        case Invoked, Automatic
+
+    object CodeActionTriggerKind:
+        given Schema[CodeActionTriggerKind] = internal.lsp.LspWireEnumSchemas.codeActionTriggerKindSchema
+
+    /** Contains additional diagnostic information about the context in which a code action is run. */
+    final case class CodeActionContext(
+        diagnostics: Chunk[Diagnostic],
+        only: Chunk[CodeActionKind] = Chunk.empty,
+        triggerKind: Maybe[CodeActionTriggerKind] = Absent
+    ) derives Schema, CanEqual
+
+    /** A code action disabled info. */
+    final case class CodeActionDisabled(reason: String) derives Schema, CanEqual
+
+    /** A code action with typed data carrier. */
+    final case class CodeAction(
+        title: String,
+        kind: Maybe[CodeActionKind] = Absent,
+        diagnostics: Chunk[Diagnostic] = Chunk.empty,
+        isPreferred: Maybe[Boolean] = Absent,
+        disabled: Maybe[CodeActionDisabled] = Absent,
+        edit: Maybe[WorkspaceEdit] = Absent,
+        command: Maybe[Command] = Absent,
+        private[kyo] _rawData: Maybe[String] = Absent
+    ) derives CanEqual:
+        def withData[X](x: X)(using Schema[X], Frame): CodeAction = copy(_rawData = Present(Json.encode[X](x)))
+        def dataAs[X](using frame: Frame, schema: Schema[X]): Maybe[X] < Abort[LspDecodeException] =
+            _rawData match
+                case Absent => Absent
+                case Present(s) =>
+                    Json.decode[X](s) match
+                        case Result.Success(v) => Present(v)
+                        case Result.Failure(e) => Abort.fail(LspDecodeException("textDocument/codeAction", e.toString, e))
+                        case Result.Panic(e)   => Abort.fail(LspDecodeException("textDocument/codeAction", e.getMessage, e))
+    end CodeAction
+
+    object CodeAction:
+        /** A code action with a title and kind. */
+        def of(title: String, kind: CodeActionKind): CodeAction = CodeAction(title = title, kind = Present(kind))
+
+        /** A quick-fix code action carrying a workspace edit. */
+        def quickFix(title: String, edit: WorkspaceEdit): CodeAction =
+            CodeAction(title = title, kind = Present(CodeActionKind.QuickFix), edit = Present(edit))
+
+        given Schema[CodeAction] = Schema.derived
+    end CodeAction
+
+    /** A command-or-code-action discriminated union. */
+    sealed trait CommandOrCodeAction derives CanEqual
+
+    object CommandOrCodeAction:
+        final case class Cmd(value: Command)       extends CommandOrCodeAction
+        final case class Action(value: CodeAction) extends CommandOrCodeAction
+
+        /** A code-action entry. */
+        def action(value: CodeAction): CommandOrCodeAction = Action(value)
+
+        /** A bare-command entry. */
+        def command(value: Command): CommandOrCodeAction = Cmd(value)
+
+        given Schema[CommandOrCodeAction] = internal.lsp.LspContentSchemas.commandOrCodeActionSchema
+    end CommandOrCodeAction
+
+    /** Options for code action registration. */
+    final case class CodeActionOptions(
+        workDoneProgress: Maybe[Boolean] = Absent,
+        codeActionKinds: Chunk[CodeActionKind] = Chunk.empty,
+        resolveProvider: Maybe[Boolean] = Absent
+    ) derives Schema, CanEqual
+
+    // MARK: -- Code lens types
+
+    /** A code lens with typed data carrier. */
+    final case class CodeLens(
+        range: Range,
+        command: Maybe[Command] = Absent,
+        private[kyo] _rawData: Maybe[String] = Absent
+    ) derives CanEqual:
+        def withData[X](x: X)(using Schema[X], Frame): CodeLens = copy(_rawData = Present(Json.encode[X](x)))
+        def dataAs[X](using frame: Frame, schema: Schema[X]): Maybe[X] < Abort[LspDecodeException] =
+            _rawData match
+                case Absent => Absent
+                case Present(s) =>
+                    Json.decode[X](s) match
+                        case Result.Success(v) => Present(v)
+                        case Result.Failure(e) => Abort.fail(LspDecodeException("textDocument/codeLens", e.toString, e))
+                        case Result.Panic(e)   => Abort.fail(LspDecodeException("textDocument/codeLens", e.getMessage, e))
+    end CodeLens
+
+    object CodeLens:
+        given Schema[CodeLens] = Schema.derived
+
+    /** Code lens registration options. */
+    final case class CodeLensOptions(workDoneProgress: Maybe[Boolean] = Absent, resolveProvider: Maybe[Boolean] = Absent) derives Schema,
+          CanEqual
+
+    // MARK: -- Document link types
+
+    /** A document link with typed data carrier. */
+    final case class DocumentLink(
+        range: Range,
+        target: Maybe[String] = Absent,
+        tooltip: Maybe[String] = Absent,
+        private[kyo] _rawData: Maybe[String] = Absent
+    ) derives CanEqual:
+        def withData[X](x: X)(using Schema[X], Frame): DocumentLink = copy(_rawData = Present(Json.encode[X](x)))
+        def dataAs[X](using frame: Frame, schema: Schema[X]): Maybe[X] < Abort[LspDecodeException] =
+            _rawData match
+                case Absent => Absent
+                case Present(s) =>
+                    Json.decode[X](s) match
+                        case Result.Success(v) => Present(v)
+                        case Result.Failure(e) => Abort.fail(LspDecodeException("textDocument/documentLink", e.toString, e))
+                        case Result.Panic(e)   => Abort.fail(LspDecodeException("textDocument/documentLink", e.getMessage, e))
+    end DocumentLink
+
+    object DocumentLink:
+        given Schema[DocumentLink] = Schema.derived
+
+    /** Document link registration options. */
+    final case class DocumentLinkOptions(workDoneProgress: Maybe[Boolean] = Absent, resolveProvider: Maybe[Boolean] = Absent)
+        derives Schema, CanEqual
+
+    // MARK: -- Formatting types
+
+    /** A text edit applicable to a text document. */
+    final case class TextEdit(range: Range, newText: String) derives Schema, CanEqual
+
+    /** An annotated text edit. */
+    final case class AnnotatedTextEdit(range: Range, newText: String, annotationId: String) derives Schema, CanEqual
+
+    /** An identifier for a change annotation. */
+    final case class ChangeAnnotation(label: String, needsConfirmation: Maybe[Boolean] = Absent, description: Maybe[String] = Absent)
+        derives Schema, CanEqual
+
+    /** A text document edit (versioned). */
+    final case class TextDocumentEdit(
+        textDocument: OptionalVersionedTextDocumentIdentifier,
+        edits: Chunk[TextEdit]
+    ) derives Schema, CanEqual
+
+    /** The kind of a file create/rename/delete operation. */
+    enum ResourceOperationKind derives CanEqual:
+        case Create, Rename, Delete
+
+    object ResourceOperationKind:
+        given Schema[ResourceOperationKind] = internal.lsp.LspWireEnumSchemas.resourceOperationKindSchema
+
+    /** Options for creating a file. */
+    final case class CreateFileOptions(overwrite: Maybe[Boolean] = Absent, ignoreIfExists: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** Options for renaming a file. */
+    final case class RenameFileOptions(overwrite: Maybe[Boolean] = Absent, ignoreIfExists: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** Options for deleting a file. */
+    final case class DeleteFileOptions(recursive: Maybe[Boolean] = Absent, ignoreIfNotExists: Maybe[Boolean] = Absent) derives Schema,
+          CanEqual
+
+    /** Create file operation. */
+    final case class CreateFile(
+        kind: String = "create",
+        uri: LspDocument.Uri,
+        options: Maybe[CreateFileOptions] = Absent,
+        annotationId: Maybe[String] = Absent
+    ) derives Schema, CanEqual
+
+    /** Rename file operation. */
+    final case class RenameFile(
+        kind: String = "rename",
+        oldUri: LspDocument.Uri,
+        newUri: LspDocument.Uri,
+        options: Maybe[RenameFileOptions] = Absent,
+        annotationId: Maybe[String] = Absent
+    ) derives Schema, CanEqual
+
+    /** Delete file operation. */
+    final case class DeleteFile(
+        kind: String = "delete",
+        uri: LspDocument.Uri,
+        options: Maybe[DeleteFileOptions] = Absent,
+        annotationId: Maybe[String] = Absent
+    ) derives Schema, CanEqual
+
+    /** A document change can be a TextDocumentEdit, CreateFile, RenameFile, or DeleteFile. */
+    sealed trait WorkspaceEditDocumentChange derives CanEqual
+
+    object WorkspaceEditDocumentChange:
+        final case class Edit(value: TextDocumentEdit) extends WorkspaceEditDocumentChange
+        final case class Create(value: CreateFile)     extends WorkspaceEditDocumentChange
+        final case class Rename(value: RenameFile)     extends WorkspaceEditDocumentChange
+        final case class Delete(value: DeleteFile)     extends WorkspaceEditDocumentChange
+        given Schema[WorkspaceEditDocumentChange] = internal.lsp.LspContentSchemas.workspaceEditDocumentChangeSchema
+    end WorkspaceEditDocumentChange
+
+    /** A workspace edit represents changes to many resources managed in the workspace. */
+    final case class WorkspaceEdit(
+        changes: Maybe[Map[String, Chunk[TextEdit]]] = Absent,
+        documentChanges: Chunk[WorkspaceEditDocumentChange] = Chunk.empty,
+        changeAnnotations: Maybe[Map[String, ChangeAnnotation]] = Absent
+    ) derives Schema, CanEqual
+
+    object WorkspaceEdit:
+        /** A workspace edit from versioned document changes and resource operations. */
+        def of(documentChanges: WorkspaceEditDocumentChange*): WorkspaceEdit =
+            WorkspaceEdit(documentChanges = Chunk.from(documentChanges))
+
+        /** A workspace edit from per-document text-edit groups. */
+        def changes(entries: (LspDocument.Uri, Chunk[TextEdit])*): WorkspaceEdit =
+            WorkspaceEdit(changes = Present(entries.iterator.map((uri, edits) => uri.asString -> edits).toMap))
+    end WorkspaceEdit
+
+    /** Value-object describing what options formatting should use. */
+    final case class FormattingOptions(
+        tabSize: Int,
+        insertSpaces: Boolean,
+        trimTrailingWhitespace: Maybe[Boolean] = Absent,
+        insertFinalNewline: Maybe[Boolean] = Absent,
+        trimFinalNewlines: Maybe[Boolean] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/formatting`. */
+    final case class DocumentFormattingParams(
+        textDocument: TextDocumentIdentifier,
+        options: FormattingOptions,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/rangeFormatting`. */
+    final case class DocumentRangeFormattingParams(
+        textDocument: TextDocumentIdentifier,
+        range: Range,
+        options: FormattingOptions,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/onTypeFormatting`. */
+    final case class DocumentOnTypeFormattingParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        ch: String,
+        options: FormattingOptions
+    ) derives Schema, CanEqual
+
+    /** On-type formatting registration options. */
+    final case class DocumentOnTypeFormattingOptions(
+        firstTriggerCharacter: String,
+        moreTriggerCharacter: Chunk[String] = Chunk.empty
+    ) derives Schema, CanEqual
+
+    // MARK: -- Navigation types (declaration, definition, typeDefinition, implementation, references, documentHighlight, prepareRename)
+
+    /** A reference context. */
+    final case class ReferenceContext(includeDeclaration: Boolean) derives Schema, CanEqual
+
+    /** A hover response. */
+    final case class Hover(contents: HoverContents, range: Maybe[Range] = Absent) derives Schema, CanEqual
+
+    object Hover:
+        /** A plain-text hover, optionally scoped to a range. */
+        def plainText(value: String, range: Maybe[Range] = Absent): Hover =
+            Hover(HoverContents.Markup(MarkupContent.plainText(value)), range)
+
+        /** A markdown hover, optionally scoped to a range. */
+        def markdown(value: String, range: Maybe[Range] = Absent): Hover =
+            Hover(HoverContents.Markup(MarkupContent.markdown(value)), range)
+    end Hover
+
+    /** Options for the rename operation. */
+    final case class RenameOptions(workDoneProgress: Maybe[Boolean] = Absent, prepareProvider: Maybe[Boolean] = Absent) derives Schema,
+          CanEqual
+
+    /** The result of a prepare rename request. */
+    sealed trait PrepareRenameResult derives CanEqual
+
+    object PrepareRenameResult:
+        final case class JustRange(range: Range)                                 extends PrepareRenameResult
+        final case class RangeWithPlaceholder(range: Range, placeholder: String) extends PrepareRenameResult
+        final case class DefaultBehavior(defaultBehavior: Boolean)               extends PrepareRenameResult
+        given Schema[PrepareRenameResult] = internal.lsp.LspContentSchemas.prepareRenameResultSchema
+    end PrepareRenameResult
+
+    /** A definition result: one or more locations. */
+    sealed trait DefinitionResult derives CanEqual
+
+    object DefinitionResult:
+        final case class One(location: Location)           extends DefinitionResult
+        final case class Many(locations: Chunk[Location])  extends DefinitionResult
+        final case class Links(links: Chunk[LocationLink]) extends DefinitionResult
+
+        /** A single-location result. */
+        def one(location: Location): DefinitionResult = One(location)
+
+        /** A single-location result from a URI and range. */
+        def at(uri: LspDocument.Uri, range: Range): DefinitionResult = One(Location(uri, range))
+
+        /** A multi-location result. */
+        def many(locations: Location*): DefinitionResult = Many(Chunk.from(locations))
+
+        /** A link-based result. */
+        def links(links: LocationLink*): DefinitionResult = Links(Chunk.from(links))
+
+        given Schema[DefinitionResult] = internal.lsp.LspContentSchemas.definitionResultSchema
+    end DefinitionResult
+
+    /** A declaration result: one or more locations. */
+    sealed trait DeclarationResult derives CanEqual
+
+    object DeclarationResult:
+        final case class One(location: Location)           extends DeclarationResult
+        final case class Many(locations: Chunk[Location])  extends DeclarationResult
+        final case class Links(links: Chunk[LocationLink]) extends DeclarationResult
+
+        /** A single-location result. */
+        def one(location: Location): DeclarationResult = One(location)
+
+        /** A single-location result from a URI and range. */
+        def at(uri: LspDocument.Uri, range: Range): DeclarationResult = One(Location(uri, range))
+
+        /** A multi-location result. */
+        def many(locations: Location*): DeclarationResult = Many(Chunk.from(locations))
+
+        /** A link-based result. */
+        def links(links: LocationLink*): DeclarationResult = Links(Chunk.from(links))
+
+        given Schema[DeclarationResult] = internal.lsp.LspContentSchemas.declarationResultSchema
+    end DeclarationResult
+
+    /** A type definition result: one or more locations. */
+    sealed trait TypeDefinitionResult derives CanEqual
+
+    object TypeDefinitionResult:
+        final case class One(location: Location)           extends TypeDefinitionResult
+        final case class Many(locations: Chunk[Location])  extends TypeDefinitionResult
+        final case class Links(links: Chunk[LocationLink]) extends TypeDefinitionResult
+
+        /** A single-location result. */
+        def one(location: Location): TypeDefinitionResult = One(location)
+
+        /** A single-location result from a URI and range. */
+        def at(uri: LspDocument.Uri, range: Range): TypeDefinitionResult = One(Location(uri, range))
+
+        /** A multi-location result. */
+        def many(locations: Location*): TypeDefinitionResult = Many(Chunk.from(locations))
+
+        /** A link-based result. */
+        def links(links: LocationLink*): TypeDefinitionResult = Links(Chunk.from(links))
+
+        given Schema[TypeDefinitionResult] = internal.lsp.LspContentSchemas.typeDefinitionResultSchema
+    end TypeDefinitionResult
+
+    /** An implementation result: one or more locations. */
+    sealed trait ImplementationResult derives CanEqual
+
+    object ImplementationResult:
+        final case class One(location: Location)           extends ImplementationResult
+        final case class Many(locations: Chunk[Location])  extends ImplementationResult
+        final case class Links(links: Chunk[LocationLink]) extends ImplementationResult
+
+        /** A single-location result. */
+        def one(location: Location): ImplementationResult = One(location)
+
+        /** A single-location result from a URI and range. */
+        def at(uri: LspDocument.Uri, range: Range): ImplementationResult = One(Location(uri, range))
+
+        /** A multi-location result. */
+        def many(locations: Location*): ImplementationResult = Many(Chunk.from(locations))
+
+        /** A link-based result. */
+        def links(links: LocationLink*): ImplementationResult = Links(Chunk.from(links))
+
+        given Schema[ImplementationResult] = internal.lsp.LspContentSchemas.implementationResultSchema
+    end ImplementationResult
+
+    /** Options for hover registration. */
+    final case class HoverOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** Options for definition registration. */
+    final case class DefinitionOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** Options for declaration registration. */
+    final case class DeclarationOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** Options for type definition registration. */
+    final case class TypeDefinitionOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** Options for implementation registration. */
+    final case class ImplementationOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** Options for references registration. */
+    final case class ReferenceOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** Options for document highlight registration. */
+    final case class DocumentHighlightOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** Options for document symbol registration. */
+    final case class DocumentSymbolOptions(workDoneProgress: Maybe[Boolean] = Absent, label: Maybe[String] = Absent) derives Schema,
+          CanEqual
+
+    // MARK: -- Hierarchy types (call hierarchy, type hierarchy, monikers)
+
+    /** A call hierarchy item with typed data carrier. */
+    final case class CallHierarchyItem(
+        name: String,
+        kind: SymbolKind,
+        tags: Chunk[SymbolTag] = Chunk.empty,
+        detail: Maybe[String] = Absent,
+        uri: LspDocument.Uri,
+        range: Range,
+        selectionRange: Range,
+        private[kyo] _rawData: Maybe[String] = Absent
+    ) derives CanEqual:
+        def withData[X](x: X)(using Schema[X], Frame): CallHierarchyItem = copy(_rawData = Present(Json.encode[X](x)))
+        def dataAs[X](using frame: Frame, schema: Schema[X]): Maybe[X] < Abort[LspDecodeException] =
+            _rawData match
+                case Absent => Absent
+                case Present(s) =>
+                    Json.decode[X](s) match
+                        case Result.Success(v) => Present(v)
+                        case Result.Failure(e) => Abort.fail(LspDecodeException("callHierarchy/prepare", e.toString, e))
+                        case Result.Panic(e)   => Abort.fail(LspDecodeException("callHierarchy/prepare", e.getMessage, e))
+    end CallHierarchyItem
+
+    object CallHierarchyItem:
+        given Schema[CallHierarchyItem] = Schema.derived
+
+    /** Represents an incoming call to a call hierarchy item. */
+    final case class CallHierarchyIncomingCall(
+        from: CallHierarchyItem,
+        fromRanges: Chunk[Range]
+    ) derives Schema, CanEqual
+
+    /** Represents an outgoing call from a call hierarchy item. */
+    final case class CallHierarchyOutgoingCall(
+        to: CallHierarchyItem,
+        fromRanges: Chunk[Range]
+    ) derives Schema, CanEqual
+
+    /** Options for call hierarchy registration. */
+    final case class CallHierarchyOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** A type hierarchy item with typed data carrier. */
+    final case class TypeHierarchyItem(
+        name: String,
+        kind: SymbolKind,
+        tags: Chunk[SymbolTag] = Chunk.empty,
+        detail: Maybe[String] = Absent,
+        uri: LspDocument.Uri,
+        range: Range,
+        selectionRange: Range,
+        private[kyo] _rawData: Maybe[String] = Absent
+    ) derives CanEqual:
+        def withData[X](x: X)(using Schema[X], Frame): TypeHierarchyItem = copy(_rawData = Present(Json.encode[X](x)))
+        def dataAs[X](using frame: Frame, schema: Schema[X]): Maybe[X] < Abort[LspDecodeException] =
+            _rawData match
+                case Absent => Absent
+                case Present(s) =>
+                    Json.decode[X](s) match
+                        case Result.Success(v) => Present(v)
+                        case Result.Failure(e) => Abort.fail(LspDecodeException("typeHierarchy/prepare", e.toString, e))
+                        case Result.Panic(e)   => Abort.fail(LspDecodeException("typeHierarchy/prepare", e.getMessage, e))
+    end TypeHierarchyItem
+
+    object TypeHierarchyItem:
+        given Schema[TypeHierarchyItem] = Schema.derived
+
+    /** Options for type hierarchy registration. */
+    final case class TypeHierarchyOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** The moniker kind. */
+    enum MonikerKind derives CanEqual:
+        case Import, Export, Local
+
+    object MonikerKind:
+        given Schema[MonikerKind] = internal.lsp.LspWireEnumSchemas.monikerKindSchema
+
+    /** The degree of uniqueness for a moniker. */
+    enum UniquenessLevel derives CanEqual:
+        case Document, Project, Group, Scheme, Global
+
+    object UniquenessLevel:
+        given Schema[UniquenessLevel] = internal.lsp.LspWireEnumSchemas.uniquenessLevelSchema
+
+    /** A moniker is a language-agnostic name for a symbol. */
+    final case class Moniker(
+        scheme: String,
+        identifier: String,
+        unique: UniquenessLevel,
+        kind: Maybe[MonikerKind] = Absent
+    ) derives Schema, CanEqual
+
+    /** Options for moniker registration. */
+    final case class MonikerOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    // MARK: -- Folding and selection types
+
+    /** An opaque string folding range kind (extensible set). */
+    opaque type FoldingRangeKind = String
+
+    object FoldingRangeKind:
+        val Comment: FoldingRangeKind = "comment"
+        val Imports: FoldingRangeKind = "imports"
+        val Region: FoldingRangeKind  = "region"
+
+        def apply(s: String): FoldingRangeKind = s
+
+        extension (k: FoldingRangeKind)
+            def asString: String = k
+
+        given Schema[FoldingRangeKind]                     = Schema.stringSchema.transform[FoldingRangeKind](apply)(_.asString)
+        given CanEqual[FoldingRangeKind, FoldingRangeKind] = CanEqual.derived
+    end FoldingRangeKind
+
+    /** Represents a folding range inside a document. */
+    final case class FoldingRange(
+        startLine: Int,
+        startCharacter: Maybe[Int] = Absent,
+        endLine: Int,
+        endCharacter: Maybe[Int] = Absent,
+        kind: Maybe[FoldingRangeKind] = Absent,
+        collapsedText: Maybe[String] = Absent
+    ) derives Schema, CanEqual
+
+    object FoldingRange:
+        /** A folding range spanning whole lines. */
+        def of(startLine: Int, endLine: Int): FoldingRange = FoldingRange(startLine = startLine, endLine = endLine)
+    end FoldingRange
+
+    /** Options for folding range registration. */
+    final case class FoldingRangeOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** A selection range in a document. */
+    final case class SelectionRange(range: Range, parent: Maybe[SelectionRange] = Absent) derives Schema, CanEqual
+
+    /** Linked editing ranges. */
+    final case class LinkedEditingRanges(ranges: Chunk[Range], wordPattern: Maybe[String] = Absent) derives Schema, CanEqual
+
+    /** Options for linked editing range registration. */
+    final case class LinkedEditingRangeOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    // MARK: -- Semantic token types
+
+    /** An opaque string semantic token type (extensible set). */
+    opaque type SemanticTokenTypes = String
+
+    object SemanticTokenTypes:
+        val Namespace: SemanticTokenTypes     = "namespace"
+        val Type: SemanticTokenTypes          = "type"
+        val Class: SemanticTokenTypes         = "class"
+        val Enum: SemanticTokenTypes          = "enum"
+        val Interface: SemanticTokenTypes     = "interface"
+        val Struct: SemanticTokenTypes        = "struct"
+        val TypeParameter: SemanticTokenTypes = "typeParameter"
+        val Parameter: SemanticTokenTypes     = "parameter"
+        val Variable: SemanticTokenTypes      = "variable"
+        val Property: SemanticTokenTypes      = "property"
+        val EnumMember: SemanticTokenTypes    = "enumMember"
+        val Event: SemanticTokenTypes         = "event"
+        val Function: SemanticTokenTypes      = "function"
+        val Method: SemanticTokenTypes        = "method"
+        val Macro: SemanticTokenTypes         = "macro"
+        val Keyword: SemanticTokenTypes       = "keyword"
+        val Modifier: SemanticTokenTypes      = "modifier"
+        val Comment: SemanticTokenTypes       = "comment"
+        val String: SemanticTokenTypes        = "string"
+        val Number: SemanticTokenTypes        = "number"
+        val Regexp: SemanticTokenTypes        = "regexp"
+        val Operator: SemanticTokenTypes      = "operator"
+        val Decorator: SemanticTokenTypes     = "decorator"
+
+        def apply(s: String): SemanticTokenTypes = s
+
+        extension (t: SemanticTokenTypes)
+            def asString: String = t
+
+        given Schema[SemanticTokenTypes]                       = Schema.stringSchema.transform[SemanticTokenTypes](apply)(_.asString)
+        given CanEqual[SemanticTokenTypes, SemanticTokenTypes] = CanEqual.derived
+    end SemanticTokenTypes
+
+    /** An opaque string semantic token modifier (extensible set). */
+    opaque type SemanticTokenModifiers = String
+
+    object SemanticTokenModifiers:
+        val Declaration: SemanticTokenModifiers    = "declaration"
+        val Definition: SemanticTokenModifiers     = "definition"
+        val Readonly: SemanticTokenModifiers       = "readonly"
+        val Static: SemanticTokenModifiers         = "static"
+        val Deprecated: SemanticTokenModifiers     = "deprecated"
+        val Abstract: SemanticTokenModifiers       = "abstract"
+        val Async: SemanticTokenModifiers          = "async"
+        val Modification: SemanticTokenModifiers   = "modification"
+        val Documentation: SemanticTokenModifiers  = "documentation"
+        val DefaultLibrary: SemanticTokenModifiers = "defaultLibrary"
+
+        def apply(s: String): SemanticTokenModifiers = s
+
+        extension (m: SemanticTokenModifiers)
+            def asString: String = m
+
+        given Schema[SemanticTokenModifiers] = Schema.stringSchema.transform[SemanticTokenModifiers](apply)(_.asString)
+        given CanEqual[SemanticTokenModifiers, SemanticTokenModifiers] = CanEqual.derived
+    end SemanticTokenModifiers
+
+    /** Describes the semantic tokens legend. */
+    final case class SemanticTokensLegend(
+        tokenTypes: Chunk[SemanticTokenTypes],
+        tokenModifiers: Chunk[SemanticTokenModifiers]
+    ) derives Schema, CanEqual
+
+    /** Semantic tokens for the full document. */
+    final case class SemanticTokens(resultId: Maybe[String] = Absent, data: Chunk[Int]) derives Schema, CanEqual
+
+    /** An edit to semantic tokens. */
+    final case class SemanticTokensEdit(start: Int, deleteCount: Int, data: Chunk[Int] = Chunk.empty) derives Schema, CanEqual
+
+    /** A delta of semantic tokens. */
+    final case class SemanticTokensDelta(resultId: Maybe[String] = Absent, edits: Chunk[SemanticTokensEdit]) derives Schema, CanEqual
+
+    /** The result of a semantic tokens full request: either tokens or a delta. */
+    sealed trait SemanticTokensResult derives CanEqual
+
+    object SemanticTokensResult:
+        final case class Full(tokens: SemanticTokens)      extends SemanticTokensResult
+        final case class Delta(delta: SemanticTokensDelta) extends SemanticTokensResult
+
+        /** A full token set from raw encoded data. */
+        def full(data: Chunk[Int], resultId: Maybe[String] = Absent): SemanticTokensResult =
+            Full(SemanticTokens(resultId = resultId, data = data))
+
+        /** A delta token set from semantic-token edits. */
+        def delta(edits: Chunk[SemanticTokensEdit], resultId: Maybe[String] = Absent): SemanticTokensResult =
+            Delta(SemanticTokensDelta(resultId = resultId, edits = edits))
+
+        given Schema[SemanticTokensResult] = internal.lsp.LspContentSchemas.semanticTokensResultSchema
+    end SemanticTokensResult
+
+    /** Options for semantic tokens registration. */
+    final case class SemanticTokensOptions(
+        legend: SemanticTokensLegend,
+        range: Maybe[Boolean] = Absent,
+        full: Maybe[BooleanOr[SemanticTokensOptions.FullOptions]] = Absent,
+        workDoneProgress: Maybe[Boolean] = Absent
+    ) derives Schema, CanEqual
+
+    object SemanticTokensOptions:
+        final case class FullOptions(delta: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    // MARK: -- Inlay hint + inline value types
+
+    /** The kind of an inlay hint. */
+    enum InlayHintKind derives CanEqual:
+        case Type, Parameter
+
+    object InlayHintKind:
+        given Schema[InlayHintKind] = internal.lsp.LspWireEnumSchemas.inlayHintKindSchema
+
+    /** An inlay hint label part: either a plain string or a structured part. */
+    sealed trait InlayHintLabelPart derives CanEqual
+
+    object InlayHintLabelPart:
+        final case class StringPart(value: String) extends InlayHintLabelPart
+        final case class StructuredPart(
+            value: String,
+            tooltip: Maybe[MarkupContent] = Absent,
+            location: Maybe[Location] = Absent,
+            command: Maybe[Command] = Absent
+        ) extends InlayHintLabelPart
+        given Schema[InlayHintLabelPart] = internal.lsp.LspContentSchemas.inlayHintLabelPartSchema
+    end InlayHintLabelPart
+
+    /** An inlay hint label: either a plain string or a list of parts. */
+    sealed trait InlayHintLabel derives CanEqual
+
+    object InlayHintLabel:
+        final case class PlainString(value: String)              extends InlayHintLabel
+        final case class Parts(value: Chunk[InlayHintLabelPart]) extends InlayHintLabel
+        given Schema[InlayHintLabel] = internal.lsp.LspContentSchemas.inlayHintLabelSchema
+    end InlayHintLabel
+
+    /** An inlay hint with typed data carrier. */
+    final case class InlayHint(
+        position: Position,
+        label: InlayHintLabel,
+        kind: Maybe[InlayHintKind] = Absent,
+        textEdits: Chunk[TextEdit] = Chunk.empty,
+        tooltip: Maybe[MarkupContent] = Absent,
+        paddingLeft: Maybe[Boolean] = Absent,
+        paddingRight: Maybe[Boolean] = Absent,
+        private[kyo] _rawData: Maybe[String] = Absent
+    ) derives CanEqual:
+        def withData[X](x: X)(using Schema[X], Frame): InlayHint = copy(_rawData = Present(Json.encode[X](x)))
+        def dataAs[X](using frame: Frame, schema: Schema[X]): Maybe[X] < Abort[LspDecodeException] =
+            _rawData match
+                case Absent => Absent
+                case Present(s) =>
+                    Json.decode[X](s) match
+                        case Result.Success(v) => Present(v)
+                        case Result.Failure(e) => Abort.fail(LspDecodeException("textDocument/inlayHint", e.toString, e))
+                        case Result.Panic(e)   => Abort.fail(LspDecodeException("textDocument/inlayHint", e.getMessage, e))
+    end InlayHint
+
+    object InlayHint:
+        /** An inlay hint with a plain-string label at a position. */
+        def of(position: Position, label: String): InlayHint =
+            InlayHint(position = position, label = InlayHintLabel.PlainString(label))
+
+        given Schema[InlayHint] = Schema.derived
+    end InlayHint
+
+    /** Options for inlay hints registration. */
+    final case class InlayHintOptions(workDoneProgress: Maybe[Boolean] = Absent, resolveProvider: Maybe[Boolean] = Absent) derives Schema,
+          CanEqual
+
+    /** Context for an inline value request. */
+    final case class InlineValueContext(frameId: Int, stoppedLocation: Range) derives Schema, CanEqual
+
+    /** An inline value: either plain text, a variable lookup, or an evaluatable expression. */
+    sealed trait InlineValue derives CanEqual
+
+    object InlineValue:
+        final case class Text(range: Range, text: String) extends InlineValue
+        final case class VariableLookup(range: Range, variableName: Maybe[String] = Absent, caseSensitiveLookup: Boolean)
+            extends InlineValue
+        final case class EvaluatableExpression(range: Range, expression: Maybe[String] = Absent) extends InlineValue
+        given Schema[InlineValue] = internal.lsp.LspContentSchemas.inlineValueSchema
+    end InlineValue
+
+    /** Options for inline value registration. */
+    final case class InlineValueOptions(workDoneProgress: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    // MARK: -- Notebook types
+
+    /** The kind of a notebook cell. */
+    enum NotebookCellKind derives CanEqual:
+        case Markup, Code
+
+    object NotebookCellKind:
+        given Schema[NotebookCellKind] = internal.lsp.LspWireEnumSchemas.notebookCellKindSchema
+
+    /** An execution summary for a notebook cell. */
+    final case class ExecutionSummary(executionOrder: Int, success: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** A notebook cell with optional metadata wire slot. */
+    final case class NotebookCell(
+        kind: NotebookCellKind,
+        document: LspDocument.Uri,
+        metadata: Maybe[NotebookCell.Metadata] = Absent,
+        executionSummary: Maybe[ExecutionSummary] = Absent,
+        private[kyo] _rawMetadata: Maybe[String] = Absent
+    ) derives CanEqual
+
+    object NotebookCell:
+        final case class Metadata() derives Schema, CanEqual
+        given Schema[NotebookCell] = Schema.derived
+
+    /** A notebook document with optional metadata wire slot. */
+    final case class Notebook(
+        uri: String,
+        notebookType: String,
+        version: Int,
+        cells: Chunk[NotebookCell],
+        private[kyo] _rawMetadata: Maybe[String] = Absent
+    ) derives CanEqual
+
+    object Notebook:
+        given Schema[Notebook] = Schema.derived
+
+    /** A notebook document filter. */
+    sealed trait NotebookDocumentFilter derives CanEqual
+
+    object NotebookDocumentFilter:
+        final case class WithNotebookType(notebookType: String, scheme: Maybe[String] = Absent, pattern: Maybe[String] = Absent)
+            extends NotebookDocumentFilter
+        final case class WithScheme(notebookType: Maybe[String] = Absent, scheme: String, pattern: Maybe[String] = Absent)
+            extends NotebookDocumentFilter
+        final case class WithPattern(notebookType: Maybe[String] = Absent, scheme: Maybe[String] = Absent, pattern: String)
+            extends NotebookDocumentFilter
+        given Schema[NotebookDocumentFilter] = internal.lsp.LspContentSchemas.notebookDocumentFilterSchema
+    end NotebookDocumentFilter
+
+    /** A notebook cell text document filter. */
+    final case class NotebookCellTextDocumentFilter(
+        notebook: NotebookDocumentFilter,
+        language: Maybe[String] = Absent
+    ) derives Schema, CanEqual
+
+    /** A notebook cell array change. */
+    final case class NotebookCellArrayChange(
+        start: Int,
+        deleteCount: Int,
+        cells: Chunk[NotebookCell] = Chunk.empty
+    ) derives Schema, CanEqual
+
+    /** A change to notebook cell text content. */
+    final case class NotebookCellTextDocumentChange(
+        document: VersionedTextDocumentIdentifier,
+        changes: Chunk[TextDocumentContentChangeEvent]
+    ) derives Schema, CanEqual
+
+    /** A change event for a notebook document. */
+    final case class NotebookDocumentChangeEvent(
+        metadata: Maybe[Notebook] = Absent,
+        cells: Maybe[NotebookDocumentChangeEvent.CellChanges] = Absent
+    ) derives Schema, CanEqual
+
+    object NotebookDocumentChangeEvent:
+        final case class CellChanges(
+            structure: Maybe[CellStructureChange] = Absent,
+            data: Chunk[NotebookCell] = Chunk.empty,
+            textContent: Chunk[NotebookCellTextDocumentChange] = Chunk.empty
+        ) derives Schema, CanEqual
+        final case class CellStructureChange(
+            array: NotebookCellArrayChange,
+            didOpen: Chunk[TextDocumentItem] = Chunk.empty,
+            didClose: Chunk[TextDocumentIdentifier] = Chunk.empty
+        ) derives Schema, CanEqual
+    end NotebookDocumentChangeEvent
+
+    /** Parameters for `notebookDocument/didOpen`. */
+    final case class DidOpenNotebookDocumentParams(
+        notebookDocument: Notebook,
+        cellTextDocuments: Chunk[TextDocumentItem]
+    ) derives Schema, CanEqual
+
+    /** Parameters for `notebookDocument/didChange`. */
+    final case class DidChangeNotebookDocumentParams(
+        notebookDocument: VersionedNotebookDocumentIdentifier,
+        change: NotebookDocumentChangeEvent
+    ) derives Schema, CanEqual
+
+    /** A versioned notebook document identifier. */
+    final case class VersionedNotebookDocumentIdentifier(version: Int, uri: LspDocument.Uri) derives Schema, CanEqual
+
+    /** Parameters for `notebookDocument/didSave`. */
+    final case class DidSaveNotebookDocumentParams(notebookDocument: NotebookDocumentIdentifier) derives Schema, CanEqual
+
+    /** An unversioned notebook document identifier. */
+    final case class NotebookDocumentIdentifier(uri: LspDocument.Uri) derives Schema, CanEqual
+
+    /** Parameters for `notebookDocument/didClose`. */
+    final case class DidCloseNotebookDocumentParams(
+        notebookDocument: NotebookDocumentIdentifier,
+        cellTextDocuments: Chunk[TextDocumentIdentifier]
+    ) derives Schema, CanEqual
+
+    // MARK: -- Window / messaging types
+
+    /** The type of a message. */
+    enum MessageType derives CanEqual:
+        case Error, Warning, Info, Log, Debug
+
+    object MessageType:
+        given Schema[MessageType] = internal.lsp.LspWireEnumSchemas.messageTypeSchema
+
+    /** An action item of a message. */
+    final case class MessageActionItem(title: String) derives Schema, CanEqual
+
+    /** Parameters for the `window/showMessage` notification. */
+    final case class ShowMessageParams(messageType: MessageType, message: String) derives Schema, CanEqual
+
+    /** Parameters for the `window/showMessageRequest` request. */
+    final case class ShowMessageRequestParams(
+        messageType: MessageType,
+        message: String,
+        actions: Chunk[MessageActionItem] = Chunk.empty
+    ) derives Schema, CanEqual
+
+    /** Parameters for the `window/logMessage` notification. */
+    final case class LogMessageParams(messageType: MessageType, message: String) derives Schema, CanEqual
+
+    /** Parameters for the `window/showDocument` request. `uri` is a plain `String`, not an
+      * `LspDocument.Uri`: `window/showDocument` accepts an external web URI as well as a workspace
+      * document, so the field is deliberately not narrowed to the document-URI type.
+      */
+    final case class ShowDocumentParams(
+        uri: String,
+        external: Maybe[Boolean] = Absent,
+        takeFocus: Maybe[Boolean] = Absent,
+        selection: Maybe[Range] = Absent
+    ) derives Schema, CanEqual
+
+    /** The result of a `window/showDocument` request. */
+    final case class ShowDocumentResult(success: Boolean) derives Schema, CanEqual
+
+    /** The trace value setting. */
+    opaque type TraceValue = String
+
+    object TraceValue:
+        val Off: TraceValue      = "off"
+        val Messages: TraceValue = "messages"
+        val Verbose: TraceValue  = "verbose"
+
+        def apply(s: String): TraceValue = s
+
+        extension (v: TraceValue)
+            def asString: String = v
+
+        given Schema[TraceValue]               = Schema.stringSchema.transform[TraceValue](apply)(_.asString)
+        given CanEqual[TraceValue, TraceValue] = CanEqual.derived
+    end TraceValue
+
+    /** Parameters for the `$/cancelRequest` notification. The `id` field identifies the request to cancel. */
+    final case class CancelParams(id: JsonRpcId) derives Schema, CanEqual
+
+    /** Parameters for the `$/setTrace` notification. */
+    final case class SetTraceParams(value: TraceValue) derives Schema, CanEqual
+
+    /** Parameters for the `$/logTrace` notification. */
+    final case class LogTraceParams(message: String, verbose: Maybe[String] = Absent) derives Schema, CanEqual
+
+    // MARK: -- Workspace types (WorkspaceFolder, Registration, Configuration, FileOperations, ...)
+
+    /** A workspace folder. */
+    final case class WorkspaceFolder(uri: LspDocument.Uri, name: String) derives Schema, CanEqual
+
+    /** A workspace folders change event. */
+    final case class WorkspaceFoldersChangeEvent(
+        added: Chunk[WorkspaceFolder],
+        removed: Chunk[WorkspaceFolder]
+    ) derives Schema, CanEqual
+
+    /** Parameters for `workspace/didChangeWorkspaceFolders`. */
+    final case class DidChangeWorkspaceFoldersParams(event: WorkspaceFoldersChangeEvent) derives Schema, CanEqual
+
+    /** Parameters for `workspace/didChangeConfiguration`. The settings type T is application-defined: the client sends
+      * whatever configuration shape the server registered for. The Schema constraint is enforced at the factory site
+      * (didChangeConfiguration[T]) so the engine can decode the wire payload into T.
+      */
+    final case class DidChangeConfigurationParams[T](settings: T) derives CanEqual
+
+    /** A file event. */
+    final case class FileEvent(uri: LspDocument.Uri, fileChangeType: FileChangeType) derives Schema, CanEqual
+
+    /** The kind of a file event. */
+    enum FileChangeType derives CanEqual:
+        case Created, Changed, Deleted
+
+    object FileChangeType:
+        given Schema[FileChangeType] = internal.lsp.LspWireEnumSchemas.fileChangeTypeSchema
+
+    /** Parameters for `workspace/didChangeWatchedFiles`. */
+    final case class DidChangeWatchedFilesParams(changes: Chunk[FileEvent]) derives Schema, CanEqual
+
+    /** A configuration item. */
+    final case class ConfigurationItem(scopeUri: Maybe[LspDocument.Uri] = Absent, section: Maybe[String] = Absent) derives Schema, CanEqual
+
+    /** Parameters for `workspace/configuration`. */
+    final case class ConfigurationParams(items: Chunk[ConfigurationItem]) derives Schema, CanEqual
+
+    /** Parameters for `workspace/applyEdit`. */
+    final case class ApplyWorkspaceEditParams(label: Maybe[String] = Absent, edit: WorkspaceEdit) derives Schema, CanEqual
+
+    /** The result of `workspace/applyEdit`. */
+    final case class ApplyWorkspaceEditResult(applied: Boolean, failureReason: Maybe[String] = Absent, failedChange: Maybe[Int] = Absent)
+        derives Schema, CanEqual
+
+    /** Parameters for `workspace/executeCommand`. */
+    final case class ExecuteCommandParams(
+        command: String,
+        arguments: Chunk[String] = Chunk.empty,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** File operation filter options. */
+    final case class FileOperationPatternOptions(ignoreCase: Maybe[Boolean] = Absent) derives Schema, CanEqual
+
+    /** The kind of a file operation pattern. */
+    enum FileOperationPatternKind derives CanEqual:
+        case File, Folder
+
+    object FileOperationPatternKind:
+        given Schema[FileOperationPatternKind] = internal.lsp.LspWireEnumSchemas.fileOperationPatternKindSchema
+
+    /** A file operation pattern. */
+    final case class FileOperationPattern(
+        glob: String,
+        matches: Maybe[FileOperationPatternKind] = Absent,
+        options: Maybe[FileOperationPatternOptions] = Absent
+    ) derives Schema, CanEqual
+
+    /** A filter for file operations. */
+    final case class FileOperationFilter(scheme: Maybe[String] = Absent, pattern: FileOperationPattern) derives Schema, CanEqual
+
+    /** Registration options for file operations. */
+    final case class FileOperationRegistrationOptions(filters: Chunk[FileOperationFilter]) derives Schema, CanEqual
+
+    /** A file create event. */
+    final case class FileCreate(uri: LspDocument.Uri) derives Schema, CanEqual
+
+    /** A file rename event. */
+    final case class FileRename(oldUri: LspDocument.Uri, newUri: LspDocument.Uri) derives Schema, CanEqual
+
+    /** A file delete event. */
+    final case class FileDelete(uri: LspDocument.Uri) derives Schema, CanEqual
+
+    /** Parameters for `workspace/willCreateFiles` / `workspace/didCreateFiles`. */
+    final case class CreateFilesParams(files: Chunk[FileCreate]) derives Schema, CanEqual
+
+    /** Parameters for `workspace/willRenameFiles` / `workspace/didRenameFiles`. */
+    final case class RenameFilesParams(files: Chunk[FileRename]) derives Schema, CanEqual
+
+    /** Parameters for `workspace/willDeleteFiles` / `workspace/didDeleteFiles`. */
+    final case class DeleteFilesParams(files: Chunk[FileDelete]) derives Schema, CanEqual
+
+    /** Options for workspace symbols registration. */
+    final case class WorkspaceSymbolOptions(workDoneProgress: Maybe[Boolean] = Absent, resolveProvider: Maybe[Boolean] = Absent)
+        derives Schema, CanEqual
+
+    /** Options for execute command registration. */
+    final case class ExecuteCommandOptions(workDoneProgress: Maybe[Boolean] = Absent, commands: Chunk[String] = Chunk.empty) derives Schema,
+          CanEqual
+
+    // Registration types
+
+    /** A document filter. */
+    final case class DocumentFilter(
+        language: Maybe[String] = Absent,
+        scheme: Maybe[String] = Absent,
+        pattern: Maybe[String] = Absent
+    ) derives Schema, CanEqual
+
+    /** A document selector is the combination of one or more document filters. */
+    type DocumentSelector = Chunk[DocumentFilter]
+
+    /** Static registration options. */
+    final case class StaticRegistrationOptions(id: Maybe[String] = Absent) derives Schema, CanEqual
+
+    /** Text document registration options. */
+    final case class TextDocumentRegistrationOptions(documentSelector: Maybe[DocumentSelector] = Absent) derives Schema, CanEqual
+
+    /** Represents a registration for a given method. */
+    final class Registration private[kyo] (
+        val id: String,
+        val method: String,
+        private[kyo] val _rawRegisterOptions: Maybe[String]
+    ) derives CanEqual:
+        def registerOptionsAs[X](using frame: Frame, schema: Schema[X]): Maybe[X] < Abort[LspDecodeException] =
+            _rawRegisterOptions match
+                case Absent => Absent
+                case Present(s) =>
+                    Json.decode[X](s) match
+                        case Result.Success(v) => Present(v)
+                        case Result.Failure(e) =>
+                            Abort.fail(LspDecodeException("client/registerCapability", e.toString, e))
+                        case Result.Panic(e) =>
+                            Abort.fail(LspDecodeException("client/registerCapability", e.getMessage, e))
+    end Registration
+
+    object Registration:
+        def apply[X](id: String, method: String, options: X)(using Schema[X], Frame): Registration =
+            new Registration(id, method, Present(Json.encode[X](options)))
+        def apply(id: String, method: String): Registration =
+            new Registration(id, method, Absent)
+        given Schema[Registration] = internal.lsp.LspContentSchemas.registrationSchema
+    end Registration
+
+    /** Represents an unregistration. */
+    final case class Unregistration(id: String, method: String) derives Schema, CanEqual
+
+    /** Parameters for `client/registerCapability`. */
+    final case class RegistrationParams(registrations: Chunk[Registration]) derives Schema, CanEqual
+
+    /** Parameters for `client/unregisterCapability`. */
+    final case class UnregistrationParams(unregisterations: Chunk[Unregistration]) derives Schema, CanEqual
+
+    // Initialize types
+
+    /** Information about the client. */
+    final case class ClientInfo(name: String, version: Maybe[String] = Absent) derives Schema, CanEqual
+
+    /** Information about the server. */
+    final case class ServerInfo(name: String, version: Maybe[String] = Absent) derives Schema, CanEqual
+
+    /** Parameters for the `initialize` request. */
+    final case class InitializeParams(
+        processId: Maybe[Int] = Absent,
+        clientInfo: Maybe[ClientInfo] = Absent,
+        locale: Maybe[String] = Absent,
+        rootPath: Maybe[String] = Absent,
+        rootUri: Maybe[String] = Absent,
+        capabilities: LspCapabilities.Client.Client,
+        trace: Maybe[TraceValue] = Absent,
+        workspaceFolders: Maybe[Chunk[WorkspaceFolder]] = Absent,
+        private[kyo] _rawInitializationOptions: Maybe[String] = Absent
+    ) derives CanEqual
+
+    object InitializeParams:
+        given Schema[InitializeParams] = Schema.derived
+
+    /** Parameters for the `initialized` notification. */
+    final case class InitializedParams() derives Schema, CanEqual
+
+    /** The result of the `initialize` request. */
+    final case class InitializeResult(
+        capabilities: LspCapabilities.Server.Server,
+        serverInfo: Maybe[ServerInfo] = Absent
+    ) derives Schema, CanEqual
+
+    /** The error of the `initialize` request. */
+    final case class InitializeError(retry: Boolean) derives Schema, CanEqual
+
+    // textDocument request/notification params
+
+    /** Parameters for `textDocument/didOpen`. */
+    final case class DidOpenTextDocumentParams(textDocument: TextDocumentItem) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/didChange`. */
+    final case class DidChangeTextDocumentParams(
+        textDocument: VersionedTextDocumentIdentifier,
+        contentChanges: Chunk[TextDocumentContentChangeEvent]
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/willSave`. */
+    final case class WillSaveTextDocumentParams(textDocument: TextDocumentIdentifier, reason: TextDocumentSaveReason) derives Schema,
+          CanEqual
+
+    /** Parameters for `textDocument/didSave`. */
+    final case class DidSaveTextDocumentParams(textDocument: TextDocumentIdentifier, text: Maybe[String] = Absent) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/didClose`. */
+    final case class DidCloseTextDocumentParams(textDocument: TextDocumentIdentifier) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/completion`. */
+    final case class CompletionParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent,
+        context: Maybe[CompletionContext] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/hover`. */
+    final case class HoverParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/signatureHelp`. */
+    final case class SignatureHelpParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        context: Maybe[SignatureHelpContext] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/declaration`. */
+    final case class DeclarationParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/definition`. */
+    final case class DefinitionParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/typeDefinition`. */
+    final case class TypeDefinitionParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/implementation`. */
+    final case class ImplementationParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/references`. */
+    final case class ReferenceParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent,
+        context: ReferenceContext
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/documentHighlight`. */
+    final case class DocumentHighlightParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/documentSymbol`. */
+    final case class DocumentSymbolParams(
+        textDocument: TextDocumentIdentifier,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/codeAction`. */
+    final case class CodeActionParams(
+        textDocument: TextDocumentIdentifier,
+        range: Range,
+        context: CodeActionContext,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/codeLens`. */
+    final case class CodeLensParams(
+        textDocument: TextDocumentIdentifier,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/documentLink`. */
+    final case class DocumentLinkParams(
+        textDocument: TextDocumentIdentifier,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/documentColor`. */
+    final case class DocumentColorParams(
+        textDocument: TextDocumentIdentifier,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/colorPresentation`. */
+    final case class ColorPresentationParams(
+        textDocument: TextDocumentIdentifier,
+        color: Color,
+        range: Range,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/rename`. */
+    final case class RenameParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        newName: String,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/prepareRename`. */
+    final case class PrepareRenameParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/foldingRange`. */
+    final case class FoldingRangeParams(
+        textDocument: TextDocumentIdentifier,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/selectionRange`. */
+    final case class SelectionRangeParams(
+        textDocument: TextDocumentIdentifier,
+        positions: Chunk[Position],
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/linkedEditingRange`. */
+    final case class LinkedEditingRangeParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/prepareCallHierarchy`. */
+    final case class CallHierarchyPrepareParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `callHierarchy/incomingCalls`. */
+    final case class CallHierarchyIncomingCallsParams(
+        item: CallHierarchyItem,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `callHierarchy/outgoingCalls`. */
+    final case class CallHierarchyOutgoingCallsParams(
+        item: CallHierarchyItem,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/prepareTypeHierarchy`. */
+    final case class TypeHierarchyPrepareParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `typeHierarchy/supertypes`. */
+    final case class TypeHierarchySupertypesParams(
+        item: TypeHierarchyItem,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `typeHierarchy/subtypes`. */
+    final case class TypeHierarchySubtypesParams(
+        item: TypeHierarchyItem,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/semanticTokens/full`. */
+    final case class SemanticTokensParams(
+        textDocument: TextDocumentIdentifier,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/semanticTokens/full/delta`. */
+    final case class SemanticTokensDeltaParams(
+        textDocument: TextDocumentIdentifier,
+        previousResultId: String,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/semanticTokens/range`. */
+    final case class SemanticTokensRangeParams(
+        textDocument: TextDocumentIdentifier,
+        range: Range,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/moniker`. */
+    final case class MonikerParams(
+        textDocument: TextDocumentIdentifier,
+        position: Position,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/inlayHint`. */
+    final case class InlayHintParams(
+        textDocument: TextDocumentIdentifier,
+        range: Range,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `textDocument/inlineValue`. */
+    final case class InlineValueParams(
+        textDocument: TextDocumentIdentifier,
+        range: Range,
+        context: InlineValueContext,
+        workDoneToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    /** Parameters for `workspace/symbol`. */
+    final case class WorkspaceSymbolParams(
+        query: String,
+        workDoneToken: Maybe[ProgressToken] = Absent,
+        partialResultToken: Maybe[ProgressToken] = Absent
+    ) derives Schema, CanEqual
+
+    // MARK: -- BooleanOr / StringOr sealed unions
+
+    /** A value that is either a boolean or a typed options record. */
+    sealed trait BooleanOr[+T] derives CanEqual
+
+    object BooleanOr:
+        final case class Bool[+T](value: Boolean) extends BooleanOr[T]
+        final case class Options[+T](value: T)    extends BooleanOr[T]
+
+        /** Enabled with default options (`Bool(true)`). Assignable to any `BooleanOr[T]` field. */
+        val on: BooleanOr[Nothing] = Bool(true)
+
+        /** Enabled with the given options record. */
+        def options[T](value: T): BooleanOr[T] = Options(value)
+
+        given [T: Schema](using Tag[BooleanOr[T]]): Schema[BooleanOr[T]] = internal.lsp.LspWireEnumSchemas.given_Schema_BooleanOr
+    end BooleanOr
+
+    /** A value that is either a string or a typed options record. */
+    sealed trait StringOr[+T] derives CanEqual
+
+    object StringOr:
+        final case class Str[+T](value: String) extends StringOr[T]
+        final case class Options[+T](value: T)  extends StringOr[T]
+        given [T: Schema](using Tag[StringOr[T]]): Schema[StringOr[T]] = internal.lsp.LspWireEnumSchemas.given_Schema_StringOr
+    end StringOr
+
+    /** A `textDocumentSync` capability value: either a sync-kind ordinal or a full options record.
+      *
+      * LSP 3.17 spec declares `ServerCapabilities.textDocumentSync` as `TextDocumentSyncKind |
+      * TextDocumentSyncOptions`. The `Kind` case carries the numeric sync mode; the `Options`
+      * case carries the full options record with per-notification granularity.
+      */
+    sealed trait TextDocumentSyncValue derives CanEqual
+
+    object TextDocumentSyncValue:
+        /** Numeric sync mode: None (0), Incremental (1), or Full (2). */
+        final case class Kind(value: TextDocumentSyncKind) extends TextDocumentSyncValue
+
+        /** Full sync options record with per-notification control. */
+        final case class Options(value: TextDocumentSyncOptions) extends TextDocumentSyncValue
+
+        private def writeSyncValue(v: TextDocumentSyncValue, w: Codec.Writer): Unit =
+            v match
+                case Kind(k)    => summon[Schema[TextDocumentSyncKind]].serializeWrite(k, w)
+                case Options(o) => summon[Schema[TextDocumentSyncOptions]].serializeWrite(o, w)
+
+        private def readSyncValue(reader: Codec.Reader): TextDocumentSyncValue =
+            val captured = reader.captureValue()
+            try Kind(summon[Schema[TextDocumentSyncKind]].serializeRead(captured))
+            catch case _: Exception => Options(summon[Schema[TextDocumentSyncOptions]].serializeRead(captured))
+        end readSyncValue
+
+        @nowarn("msg=anonymous")
+        given Schema[TextDocumentSyncValue] = Schema.init[TextDocumentSyncValue](
+            writeFn = writeSyncValue,
+            readFn = readSyncValue,
+            structure = Structure.Type.Open(Tag[TextDocumentSyncValue].asInstanceOf[Tag[Any]])
+        )
+    end TextDocumentSyncValue
+
+    // MARK: -- TextDocument namespace factory object
+
+    /** Namespaced factories for `textDocument/X` server-handled LSP endpoints. */
+    object TextDocument:
+
+        def completion[E](
+            handler: CompletionParams => CompletionResult < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CompletionParams, CompletionResult, E] =
+            initRequest("textDocument/completion", Kind.Completion, handler)
+
+        def completionItemResolve[E](
+            handler: CompletionItem => CompletionItem < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CompletionItem, CompletionItem, E] =
+            initRequest("completionItem/resolve", Kind.CompletionItemResolve, handler)
+
+        def hover[E](
+            handler: HoverParams => Maybe[Hover] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[HoverParams, Maybe[Hover], E] =
+            initRequest("textDocument/hover", Kind.Hover, handler)
+
+        def signatureHelp[E](
+            handler: SignatureHelpParams => Maybe[SignatureHelp] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[SignatureHelpParams, Maybe[SignatureHelp], E] =
+            initRequest("textDocument/signatureHelp", Kind.SignatureHelp, handler)
+
+        def declaration[E](
+            handler: DeclarationParams => DeclarationResult < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DeclarationParams, DeclarationResult, E] =
+            initRequest("textDocument/declaration", Kind.Declaration, handler)
+
+        def definition[E](
+            handler: DefinitionParams => DefinitionResult < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DefinitionParams, DefinitionResult, E] =
+            initRequest("textDocument/definition", Kind.Definition, handler)
+
+        def typeDefinition[E](
+            handler: TypeDefinitionParams => DefinitionResult < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[TypeDefinitionParams, DefinitionResult, E] =
+            initRequest("textDocument/typeDefinition", Kind.TypeDefinition, handler)
+
+        def implementation[E](
+            handler: ImplementationParams => DefinitionResult < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[ImplementationParams, DefinitionResult, E] =
+            initRequest("textDocument/implementation", Kind.Implementation, handler)
+
+        def references[E](
+            handler: ReferenceParams => Chunk[Location] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[ReferenceParams, Chunk[Location], E] =
+            initRequest("textDocument/references", Kind.References, handler)
+
+        def documentHighlight[E](
+            handler: DocumentHighlightParams => Chunk[DocumentHighlight] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DocumentHighlightParams, Chunk[DocumentHighlight], E] =
+            initRequest("textDocument/documentHighlight", Kind.DocumentHighlight, handler)
+
+        def documentSymbol[E](
+            handler: DocumentSymbolParams => DocumentSymbolResult < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DocumentSymbolParams, DocumentSymbolResult, E] =
+            initRequest("textDocument/documentSymbol", Kind.DocumentSymbol, handler)
+
+        def codeAction[E](
+            handler: CodeActionParams => Chunk[CommandOrCodeAction] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CodeActionParams, Chunk[CommandOrCodeAction], E] =
+            initRequest("textDocument/codeAction", Kind.CodeAction, handler)
+
+        def codeActionResolve[E](
+            handler: CodeAction => CodeAction < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CodeAction, CodeAction, E] =
+            initRequest("codeAction/resolve", Kind.CodeActionResolve, handler)
+
+        def codeLens[E](
+            handler: CodeLensParams => Chunk[CodeLens] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CodeLensParams, Chunk[CodeLens], E] =
+            initRequest("textDocument/codeLens", Kind.CodeLens, handler)
+
+        def codeLensResolve[E](
+            handler: CodeLens => CodeLens < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CodeLens, CodeLens, E] =
+            initRequest("codeLens/resolve", Kind.CodeLensResolve, handler)
+
+        def documentLink[E](
+            handler: DocumentLinkParams => Chunk[DocumentLink] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DocumentLinkParams, Chunk[DocumentLink], E] =
+            initRequest("textDocument/documentLink", Kind.DocumentLink, handler)
+
+        def documentLinkResolve[E](
+            handler: DocumentLink => DocumentLink < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DocumentLink, DocumentLink, E] =
+            initRequest("documentLink/resolve", Kind.DocumentLinkResolve, handler)
+
+        def documentColor[E](
+            handler: DocumentColorParams => Chunk[ColorInformation] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DocumentColorParams, Chunk[ColorInformation], E] =
+            initRequest("textDocument/documentColor", Kind.DocumentColor, handler)
+
+        def colorPresentation[E](
+            handler: ColorPresentationParams => Chunk[ColorPresentation] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[ColorPresentationParams, Chunk[ColorPresentation], E] =
+            initRequest("textDocument/colorPresentation", Kind.ColorPresentation, handler)
+
+        def formatting[E](
+            handler: DocumentFormattingParams => Chunk[TextEdit] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DocumentFormattingParams, Chunk[TextEdit], E] =
+            initRequest("textDocument/formatting", Kind.Formatting, handler)
+
+        def rangeFormatting[E](
+            handler: DocumentRangeFormattingParams => Chunk[TextEdit] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DocumentRangeFormattingParams, Chunk[TextEdit], E] =
+            initRequest("textDocument/rangeFormatting", Kind.RangeFormatting, handler)
+
+        def onTypeFormatting[E](
+            handler: DocumentOnTypeFormattingParams => Chunk[TextEdit] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DocumentOnTypeFormattingParams, Chunk[TextEdit], E] =
+            initRequest("textDocument/onTypeFormatting", Kind.OnTypeFormatting, handler)
+
+        def rename[E](
+            handler: RenameParams => Maybe[WorkspaceEdit] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[RenameParams, Maybe[WorkspaceEdit], E] =
+            initRequest("textDocument/rename", Kind.Rename, handler)
+
+        def prepareRename[E](
+            handler: PrepareRenameParams => Maybe[PrepareRenameResult] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[PrepareRenameParams, Maybe[PrepareRenameResult], E] =
+            initRequest("textDocument/prepareRename", Kind.PrepareRename, handler)
+
+        def foldingRange[E](
+            handler: FoldingRangeParams => Chunk[FoldingRange] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[FoldingRangeParams, Chunk[FoldingRange], E] =
+            initRequest("textDocument/foldingRange", Kind.FoldingRange, handler)
+
+        def selectionRange[E](
+            handler: SelectionRangeParams => Chunk[SelectionRange] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[SelectionRangeParams, Chunk[SelectionRange], E] =
+            initRequest("textDocument/selectionRange", Kind.SelectionRange, handler)
+
+        def linkedEditingRange[E](
+            handler: LinkedEditingRangeParams => Maybe[LinkedEditingRanges] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[LinkedEditingRangeParams, Maybe[LinkedEditingRanges], E] =
+            initRequest("textDocument/linkedEditingRange", Kind.LinkedEditingRange, handler)
+
+        def prepareCallHierarchy[E](
+            handler: CallHierarchyPrepareParams => Chunk[CallHierarchyItem] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CallHierarchyPrepareParams, Chunk[CallHierarchyItem], E] =
+            initRequest("textDocument/prepareCallHierarchy", Kind.PrepareCallHierarchy, handler)
+
+        def callHierarchyIncomingCalls[E](
+            handler: CallHierarchyIncomingCallsParams => Chunk[
+                CallHierarchyIncomingCall
+            ] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CallHierarchyIncomingCallsParams, Chunk[CallHierarchyIncomingCall], E] =
+            initRequest("callHierarchy/incomingCalls", Kind.CallHierarchyIncomingCalls, handler)
+
+        def callHierarchyOutgoingCalls[E](
+            handler: CallHierarchyOutgoingCallsParams => Chunk[
+                CallHierarchyOutgoingCall
+            ] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CallHierarchyOutgoingCallsParams, Chunk[CallHierarchyOutgoingCall], E] =
+            initRequest("callHierarchy/outgoingCalls", Kind.CallHierarchyOutgoingCalls, handler)
+
+        def prepareTypeHierarchy[E](
+            handler: TypeHierarchyPrepareParams => Chunk[TypeHierarchyItem] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[TypeHierarchyPrepareParams, Chunk[TypeHierarchyItem], E] =
+            initRequest("textDocument/prepareTypeHierarchy", Kind.PrepareTypeHierarchy, handler)
+
+        def typeHierarchySupertypes[E](
+            handler: TypeHierarchySupertypesParams => Chunk[TypeHierarchyItem] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[TypeHierarchySupertypesParams, Chunk[TypeHierarchyItem], E] =
+            initRequest("typeHierarchy/supertypes", Kind.TypeHierarchySupertypes, handler)
+
+        def typeHierarchySubtypes[E](
+            handler: TypeHierarchySubtypesParams => Chunk[TypeHierarchyItem] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[TypeHierarchySubtypesParams, Chunk[TypeHierarchyItem], E] =
+            initRequest("typeHierarchy/subtypes", Kind.TypeHierarchySubtypes, handler)
+
+        def semanticTokensFull[E](
+            handler: SemanticTokensParams => Maybe[SemanticTokens] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[SemanticTokensParams, Maybe[SemanticTokens], E] =
+            initRequest("textDocument/semanticTokens/full", Kind.SemanticTokensFull, handler)
+
+        def semanticTokensFullDelta[E](
+            handler: SemanticTokensDeltaParams => Maybe[SemanticTokensResult] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[SemanticTokensDeltaParams, Maybe[SemanticTokensResult], E] =
+            initRequest("textDocument/semanticTokens/full/delta", Kind.SemanticTokensFullDelta, handler)
+
+        def semanticTokensRange[E](
+            handler: SemanticTokensRangeParams => Maybe[SemanticTokens] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[SemanticTokensRangeParams, Maybe[SemanticTokens], E] =
+            initRequest("textDocument/semanticTokens/range", Kind.SemanticTokensRange, handler)
+
+        def moniker[E](
+            handler: MonikerParams => Chunk[Moniker] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[MonikerParams, Chunk[Moniker], E] =
+            initRequest("textDocument/moniker", Kind.Moniker, handler)
+
+        def inlayHint[E](
+            handler: InlayHintParams => Chunk[InlayHint] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[InlayHintParams, Chunk[InlayHint], E] =
+            initRequest("textDocument/inlayHint", Kind.InlayHint, handler)
+
+        def inlayHintResolve[E](
+            handler: InlayHint => InlayHint < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[InlayHint, InlayHint, E] =
+            initRequest("inlayHint/resolve", Kind.InlayHintResolve, handler)
+
+        def inlineValue[E](
+            handler: InlineValueParams => Chunk[InlineValue] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[InlineValueParams, Chunk[InlineValue], E] =
+            initRequest("textDocument/inlineValue", Kind.InlineValue, handler)
+
+        def diagnostic[E](
+            handler: DocumentDiagnosticParams => DocumentDiagnosticReport < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DocumentDiagnosticParams, DocumentDiagnosticReport, E] =
+            initRequest("textDocument/diagnostic", Kind.DocumentDiagnostic, handler)
+
+        def willSaveWaitUntil[E](
+            handler: WillSaveTextDocumentParams => Chunk[TextEdit] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[WillSaveTextDocumentParams, Chunk[TextEdit], E] =
+            initRequest("textDocument/willSaveWaitUntil", Kind.TextDocumentWillSaveWaitUntil, handler)
+
+        def didOpen[E](
+            handler: DidOpenTextDocumentParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidOpenTextDocumentParams, Unit, E] =
+            initNotification("textDocument/didOpen", Kind.TextDocumentDidOpen, handler)
+
+        def didChange[E](
+            handler: DidChangeTextDocumentParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidChangeTextDocumentParams, Unit, E] =
+            initNotification("textDocument/didChange", Kind.TextDocumentDidChange, handler)
+
+        def didSave[E](
+            handler: DidSaveTextDocumentParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidSaveTextDocumentParams, Unit, E] =
+            initNotification("textDocument/didSave", Kind.TextDocumentDidSave, handler)
+
+        def didClose[E](
+            handler: DidCloseTextDocumentParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidCloseTextDocumentParams, Unit, E] =
+            initNotification("textDocument/didClose", Kind.TextDocumentDidClose, handler)
+
+        def willSave[E](
+            handler: WillSaveTextDocumentParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[WillSaveTextDocumentParams, Unit, E] =
+            initNotification("textDocument/willSave", Kind.TextDocumentWillSave, handler)
+
+    end TextDocument
+
+    // MARK: -- Workspace namespace factory object
+
+    /** Namespaced factories for `workspace/X` LSP endpoints. */
+    object Workspace:
+
+        def symbol[E](
+            handler: WorkspaceSymbolParams => Chunk[WorkspaceSymbol] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[WorkspaceSymbolParams, Chunk[WorkspaceSymbol], E] =
+            initRequest("workspace/symbol", Kind.WorkspaceSymbol, handler)
+
+        def symbolResolve[E](
+            handler: WorkspaceSymbol => WorkspaceSymbol < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[WorkspaceSymbol, WorkspaceSymbol, E] =
+            initRequest("workspaceSymbol/resolve", Kind.WorkspaceSymbolResolve, handler)
+
+        def executeCommand[Out](using
+            outSchema: Schema[Out]
+        )[E](
+            handler: ExecuteCommandParams => Maybe[Out] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using frame: Frame): LspHandler[ExecuteCommandParams, Maybe[Out], E] =
+            initRequest("workspace/executeCommand", Kind.ExecuteCommand, handler)
+
+        def didChangeConfiguration[T](using
+            Schema[T]
+        )[E](
+            handler: DidChangeConfigurationParams[T] => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidChangeConfigurationParams[T], Unit, E] =
+            initNotification("workspace/didChangeConfiguration", Kind.DidChangeConfiguration, handler)
+
+        def didChangeWatchedFiles[E](
+            handler: DidChangeWatchedFilesParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidChangeWatchedFilesParams, Unit, E] =
+            initNotification("workspace/didChangeWatchedFiles", Kind.DidChangeWatchedFiles, handler)
+
+        def didChangeWorkspaceFolders[E](
+            handler: DidChangeWorkspaceFoldersParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidChangeWorkspaceFoldersParams, Unit, E] =
+            initNotification("workspace/didChangeWorkspaceFolders", Kind.DidChangeWorkspaceFolders, handler)
+
+        def willCreateFiles[E](
+            handler: CreateFilesParams => Maybe[WorkspaceEdit] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CreateFilesParams, Maybe[WorkspaceEdit], E] =
+            initRequest("workspace/willCreateFiles", Kind.WillCreateFiles, handler)
+
+        def didCreateFiles[E](
+            handler: CreateFilesParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[CreateFilesParams, Unit, E] =
+            initNotification("workspace/didCreateFiles", Kind.DidCreateFiles, handler)
+
+        def willRenameFiles[E](
+            handler: RenameFilesParams => Maybe[WorkspaceEdit] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[RenameFilesParams, Maybe[WorkspaceEdit], E] =
+            initRequest("workspace/willRenameFiles", Kind.WillRenameFiles, handler)
+
+        def didRenameFiles[E](
+            handler: RenameFilesParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[RenameFilesParams, Unit, E] =
+            initNotification("workspace/didRenameFiles", Kind.DidRenameFiles, handler)
+
+        def willDeleteFiles[E](
+            handler: DeleteFilesParams => Maybe[WorkspaceEdit] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DeleteFilesParams, Maybe[WorkspaceEdit], E] =
+            initRequest("workspace/willDeleteFiles", Kind.WillDeleteFiles, handler)
+
+        def didDeleteFiles[E](
+            handler: DeleteFilesParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DeleteFilesParams, Unit, E] =
+            initNotification("workspace/didDeleteFiles", Kind.DidDeleteFiles, handler)
+
+        def diagnostic[E](
+            handler: WorkspaceDiagnosticParams => WorkspaceDiagnosticReport < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[WorkspaceDiagnosticParams, WorkspaceDiagnosticReport, E] =
+            initRequest("workspace/diagnostic", Kind.WorkspaceDiagnostic, handler)
+
+        // Reverse-direction (ClientHandled) workspace factories
+
+        def applyEdit[E](
+            handler: ApplyWorkspaceEditParams => ApplyWorkspaceEditResult < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[ApplyWorkspaceEditParams, ApplyWorkspaceEditResult, E] =
+            initRequest("workspace/applyEdit", Kind.ApplyEdit, handler)
+
+        def configuration[T](using
+            outSchema: Schema[T]
+        )[E](
+            handler: ConfigurationParams => Chunk[T] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using frame: Frame): LspHandler[ConfigurationParams, Chunk[T], E] =
+            initRequest("workspace/configuration", Kind.Configuration, handler)
+
+        def workspaceFolders[E](
+            handler: Unit => Maybe[Chunk[WorkspaceFolder]] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[Unit, Maybe[Chunk[WorkspaceFolder]], E] =
+            initRequest("workspace/workspaceFolders", Kind.WorkspaceFolders, handler)
+
+        def refreshSemanticTokens(using Frame): LspHandler[Unit, Unit, Nothing] =
+            initNotification[Unit, Nothing]("workspace/semanticTokens/refresh", Kind.RefreshSemanticTokens, _ => ())
+
+        def refreshInlineValue(using Frame): LspHandler[Unit, Unit, Nothing] =
+            initNotification[Unit, Nothing]("workspace/inlineValue/refresh", Kind.RefreshInlineValue, _ => ())
+
+        def refreshInlayHint(using Frame): LspHandler[Unit, Unit, Nothing] =
+            initNotification[Unit, Nothing]("workspace/inlayHint/refresh", Kind.RefreshInlayHint, _ => ())
+
+        def refreshDiagnostic(using Frame): LspHandler[Unit, Unit, Nothing] =
+            initNotification[Unit, Nothing]("workspace/diagnostic/refresh", Kind.RefreshDiagnostic, _ => ())
+
+        def refreshCodeLens(using Frame): LspHandler[Unit, Unit, Nothing] =
+            initNotification[Unit, Nothing]("workspace/codeLens/refresh", Kind.RefreshCodeLens, _ => ())
+
+    end Workspace
+
+    // MARK: -- NotebookDocument namespace factory object
+
+    /** Namespaced factories for `notebookDocument/X` LSP endpoints. */
+    object NotebookDocument:
+
+        def didOpen[E](
+            handler: DidOpenNotebookDocumentParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidOpenNotebookDocumentParams, Unit, E] =
+            initNotification("notebookDocument/didOpen", Kind.NotebookDidOpen, handler)
+
+        def didChange[E](
+            handler: DidChangeNotebookDocumentParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidChangeNotebookDocumentParams, Unit, E] =
+            initNotification("notebookDocument/didChange", Kind.NotebookDidChange, handler)
+
+        def didSave[E](
+            handler: DidSaveNotebookDocumentParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidSaveNotebookDocumentParams, Unit, E] =
+            initNotification("notebookDocument/didSave", Kind.NotebookDidSave, handler)
+
+        def didClose[E](
+            handler: DidCloseNotebookDocumentParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[DidCloseNotebookDocumentParams, Unit, E] =
+            initNotification("notebookDocument/didClose", Kind.NotebookDidClose, handler)
+
+    end NotebookDocument
+
+    // MARK: -- Window namespace factory object
+
+    /** Namespaced factories for `window/X` client-handled reverse-direction LSP endpoints. */
+    object Window:
+
+        def showMessage[E](
+            handler: ShowMessageParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[ShowMessageParams, Unit, E] =
+            initNotification("window/showMessage", Kind.ShowMessage, handler)
+
+        def showMessageRequest[E](
+            handler: ShowMessageRequestParams => Maybe[MessageActionItem] < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[ShowMessageRequestParams, Maybe[MessageActionItem], E] =
+            initRequest("window/showMessageRequest", Kind.ShowMessageRequest, handler)
+
+        def showDocument[E](
+            handler: ShowDocumentParams => ShowDocumentResult < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[ShowDocumentParams, ShowDocumentResult, E] =
+            initRequest("window/showDocument", Kind.ShowDocument, handler)
+
+        def logMessage[E](
+            handler: LogMessageParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[LogMessageParams, Unit, E] =
+            initNotification("window/logMessage", Kind.LogMessage, handler)
+
+        def createWorkDoneProgress[E](
+            handler: WorkDoneProgressCreateParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[WorkDoneProgressCreateParams, Unit, E] =
+            initRequest("window/workDoneProgress/create", Kind.WorkDoneProgressCreate, handler)
+
+        def workDoneProgressCancel[E](
+            handler: WorkDoneProgressCancelParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[WorkDoneProgressCancelParams, Unit, E] =
+            initNotification("window/workDoneProgress/cancel", Kind.WorkDoneProgressCancel, handler)
+
+        def telemetry[T](using
+            outSchema: Schema[T]
+        )[E](
+            handler: T => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using frame: Frame): LspHandler[T, Unit, E] =
+            initNotification("telemetry/event", Kind.Telemetry, handler)
+
+    end Window
+
+    // MARK: -- Client namespace factory object
+
+    /** Namespaced factories for `client/X` reverse-direction LSP endpoints. */
+    object Client:
+
+        def registerCapability[E](
+            handler: RegistrationParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[RegistrationParams, Unit, E] =
+            initRequest("client/registerCapability", Kind.RegisterCapability, handler)
+
+        def unregisterCapability[E](
+            handler: UnregistrationParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[UnregistrationParams, Unit, E] =
+            initRequest("client/unregisterCapability", Kind.UnregisterCapability, handler)
+
+    end Client
+
+    // MARK: -- General namespace factory object
+
+    /** Namespaced factories for `$/X` bidirectional general LSP endpoints.
+      *
+      * The engine ALWAYS handles `$/cancelRequest` and `$/progress` at the substrate level.
+      * Factories in this namespace register USER observers that run AFTER the engine's built-in
+      * handling, enabling logging and instrumentation. `$/setTrace` (server-side from client)
+      * and `$/logTrace` (client-side from server) are similarly user-registerable.
+      *
+      * Engine-reserved methods (`initialize`, `shutdown`, `exit`, `initialized`) are NOT in this
+      * namespace; they are engine-owned and never user-registerable.
+      */
+    object General:
+
+        /** Observer for inbound `$/cancelRequest`. The engine has already completed the matching
+          * `JsonRpcRoute.Context.cancelled` promise; this hook lets user code log or instrument
+          * cancellation after the fact.
+          */
+        def cancelRequest[E](handler: CancelParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E]))(using
+            Frame
+        ): LspHandler[CancelParams, Unit, E] =
+            initNotification("$/cancelRequest", Kind.CancelRequest, handler)
+
+        /** Observer for inbound `$/progress`. The engine has already dispatched the value to the
+          * per-token stream subscription; this hook lets user code observe progress notifications
+          * for ad-hoc instrumentation.
+          */
+        def progress[T](using
+            Schema[T]
+        )[E](
+            handler: ProgressParams[T] => Unit < (Async & Abort[JsonRpcResponse.Halt | E])
+        )(using Frame): LspHandler[ProgressParams[T], Unit, E] =
+            initNotification("$/progress", Kind.Progress, handler)
+
+        /** Server-side observer for `$/setTrace` notifications from the client. */
+        def setTrace[E](handler: SetTraceParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E]))(using
+            Frame
+        ): LspHandler[SetTraceParams, Unit, E] =
+            initNotification("$/setTrace", Kind.SetTrace, handler)
+
+        /** Client-side observer for `$/logTrace` notifications from the server. */
+        def logTrace[E](handler: LogTraceParams => Unit < (Async & Abort[JsonRpcResponse.Halt | E]))(using
+            Frame
+        ): LspHandler[LogTraceParams, Unit, E] =
+            initNotification("$/logTrace", Kind.LogTrace, handler)
+
+    end General
+
+    // MARK: -- custom / customClient escape hatches
+
+    /** Creates a custom server-handled extension method handler.
+      *
+      * Use for vendor extensions and future spec methods not yet covered by the typed factories.
+      * The `method` string must not collide with a standard LSP method name.
+      */
+    def custom[In](method: String)(using
+        inSchema: Schema[In]
+    )[Out, E](
+        handler: In => Out < (Async & Abort[JsonRpcResponse.Halt | E])
+    )(using outSchema: Schema[Out], frame: Frame): LspHandler[In, Out, E] =
+        initCustom(method, Direction.ServerHandled, handler)
+
+    /** Creates a custom client-handled extension method handler.
+      *
+      * Use for client-direction vendor extensions.
+      */
+    def customClient[In](method: String)(using
+        inSchema: Schema[In]
+    )[Out, E](
+        handler: In => Out < (Async & Abort[JsonRpcResponse.Halt | E])
+    )(using outSchema: Schema[Out], frame: Frame): LspHandler[In, Out, E] =
+        initCustom(method, Direction.ClientHandled, handler)
+
+    // MARK: -- Private[kyo] carrier subclasses
+
+    /** Carrier for server-handled request handlers. */
+    final private[kyo] class RequestHandler[In, Out, +E] private[kyo] (
+        val wireName: String,
+        val handlerKind: Kind,
+        val handlerFn: In => Out < (Async & Abort[JsonRpcResponse.Halt | E]),
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val inSchema: Schema[In],
+        val outSchema: Schema[Out]
+    ) extends LspHandler[In, Out, E]:
+        def name: String         = wireName
+        def kind: Kind           = handlerKind
+        def direction: Direction = LspHandler.direction(handlerKind)
+        def error[E2](using schema: Schema[E2], tag: ConcreteTag[E2])(code: Int, message: String): LspHandler[In, Out, E | E2] =
+            new RequestHandler[In, Out, E | E2](
+                wireName,
+                handlerKind,
+                handlerFn,
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                inSchema,
+                outSchema
+            )
+    end RequestHandler
+
+    /** Carrier for server-handled notification handlers. */
+    final private[kyo] class NotificationHandler[In, +E] private[kyo] (
+        val wireName: String,
+        val handlerKind: Kind,
+        val handlerFn: In => Unit < (Async & Abort[JsonRpcResponse.Halt | E]),
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val inSchema: Schema[In]
+    ) extends LspHandler[In, Unit, E]:
+        def name: String         = wireName
+        def kind: Kind           = handlerKind
+        def direction: Direction = LspHandler.direction(handlerKind)
+        def error[E2](using schema: Schema[E2], tag: ConcreteTag[E2])(code: Int, message: String): LspHandler[In, Unit, E | E2] =
+            new NotificationHandler[In, E | E2](
+                wireName,
+                handlerKind,
+                handlerFn,
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                inSchema
+            )
+    end NotificationHandler
+
+    /** Carrier for custom (escape-hatch) handlers. */
+    final private[kyo] class CustomHandler[In, Out, +E] private[kyo] (
+        val wireName: String,
+        val handlerDirection: Direction,
+        val handlerFn: In => Out < (Async & Abort[JsonRpcResponse.Halt | E]),
+        val errorMappings: Chunk[ErrorMapping[?]],
+        val inSchema: Schema[In],
+        val outSchema: Schema[Out]
+    ) extends LspHandler[In, Out, E]:
+        def name: String         = wireName
+        def kind: Kind           = Kind.Custom
+        def direction: Direction = handlerDirection
+        def error[E2](using schema: Schema[E2], tag: ConcreteTag[E2])(code: Int, message: String): LspHandler[In, Out, E | E2] =
+            new CustomHandler[In, Out, E | E2](
+                wireName,
+                handlerDirection,
+                handlerFn,
+                errorMappings.append(new ErrorMapping[E2](code, message)),
+                inSchema,
+                outSchema
+            )
+    end CustomHandler
+
+end LspHandler

--- a/kyo-lsp/shared/src/main/scala/kyo/LspInfo.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/LspInfo.scala
@@ -1,0 +1,22 @@
+package kyo
+
+/** Identifies a client or server in the LSP initialize handshake.
+  *
+  * The `name` and `version` fields correspond to the `clientInfo` / `serverInfo` shape in the
+  * LSP 3.17 initialize exchange. Both are free-form strings; no version-format constraint is
+  * imposed at this level.
+  *
+  * `version` is the IMPLEMENTATION version of this client or server (e.g. "1.0.0"), not the
+  * LSP specification version. The LSP spec version ("3.17") is a separate wire field on the
+  * `InitializeResult` envelope and is always fixed to `LspConfig.SpecVersion`. Ship a real
+  * implementation version string in production code; the default `"0.0.0"` is a safe placeholder.
+  *
+  * The `title` field is an optional human-readable display name; it is omitted from the wire
+  * when `Absent`.
+  *
+  * @param name    human-readable name of the implementation (e.g. "my-language-server")
+  * @param version implementation version string; defaults to `"0.0.0"`
+  * @param title   optional display title distinct from the wire-stable `name`
+  */
+final case class LspInfo(name: String, version: String = "0.0.0", title: Maybe[String] = Absent)
+    derives Schema, CanEqual

--- a/kyo-lsp/shared/src/main/scala/kyo/LspServer.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/LspServer.scala
@@ -1,0 +1,355 @@
+package kyo
+
+/** Live LSP server handle managing one peer over a [[JsonRpcTransport]].
+  *
+  * Obtain via `LspServer.init` (Scope-managed) or `LspServer.initUnscoped` (manual close).
+  * Mirrors `McpServer` at kyo-mcp. The opaque alias means `LspServer` is simply the abstract
+  * class `LspServer.Unsafe` with a safety wrapper; use the extension methods in the companion
+  * for all interactions.
+  *
+  * Reverse-direction request types (`ShowMessageParams`, `ApplyWorkspaceEditParams`, etc.)
+  * live inside `object LspHandler`. This companion holds only the init quartet, extension
+  * methods, and the `Unsafe` abstract class.
+  *
+  * @see [[LspServer.init]]
+  * @see [[LspServer.initUnscoped]]
+  */
+opaque type LspServer = LspServer.Unsafe
+
+object LspServer:
+
+    // =========================================================================
+    // Scoped init quartet
+    // =========================================================================
+
+    /** Initializes an LSP server over the given transport using default configuration. */
+    def init(transport: JsonRpcTransport, handlers: LspHandler[?, ?, ?]*)(using Frame): LspServer < (Async & Scope) =
+        init(transport, handlers, LspConfig.default)
+
+    /** Initializes an LSP server with the given configuration. */
+    def init(transport: JsonRpcTransport, config: LspConfig)(handlers: LspHandler[?, ?, ?]*)(using Frame): LspServer < (Async & Scope) =
+        init(transport, handlers, config)
+
+    /** Initializes an LSP server with explicit handler list and optional config. */
+    def init(transport: JsonRpcTransport, handlers: Seq[LspHandler[?, ?, ?]], config: LspConfig = LspConfig.default)(using
+        Frame
+    ): LspServer < (Async & Scope) =
+        LspConfig.require(config)
+        Scope.acquireRelease(
+            internal.lsp.LspEngine.initServer(transport, handlers, config).map(_.safe)
+        )(_.closeNow)
+    end init
+
+    /** Initializes and passes the server handle to the given function in a Scope context. */
+    def initWith[A, S](transport: JsonRpcTransport, handlers: LspHandler[?, ?, ?]*)(f: LspServer => A < S)(using
+        Frame
+    ): A < (S & Async & Scope) =
+        init(transport, handlers*).map(f)
+
+    /** Initializes with config and passes the server handle to the given function. */
+    def initWith[A, S](transport: JsonRpcTransport, config: LspConfig)(handlers: LspHandler[?, ?, ?]*)(f: LspServer => A < S)(using
+        Frame
+    ): A < (S & Async & Scope) =
+        init(transport, config)(handlers*).map(f)
+
+    // =========================================================================
+    // Unscoped init quartet
+    // =========================================================================
+
+    /** Initializes an LSP server without automatic resource cleanup. */
+    def initUnscoped(transport: JsonRpcTransport, handlers: LspHandler[?, ?, ?]*)(using Frame): LspServer < Async =
+        initUnscoped(transport, handlers, LspConfig.default)
+
+    /** Initializes an LSP server with config, without automatic resource cleanup. */
+    def initUnscoped(transport: JsonRpcTransport, config: LspConfig)(handlers: LspHandler[?, ?, ?]*)(using Frame): LspServer < Async =
+        initUnscoped(transport, handlers, config)
+
+    /** Initializes an LSP server with explicit handler list, without automatic resource cleanup. */
+    def initUnscoped(transport: JsonRpcTransport, handlers: Seq[LspHandler[?, ?, ?]], config: LspConfig = LspConfig.default)(using
+        Frame
+    ): LspServer < Async =
+        LspConfig.require(config)
+        internal.lsp.LspEngine.initServer(transport, handlers, config).map(_.safe)
+    end initUnscoped
+
+    /** Initializes unscoped and passes the server handle to the given function. */
+    def initUnscopedWith[A, S](transport: JsonRpcTransport, handlers: LspHandler[?, ?, ?]*)(f: LspServer => A < S)(using
+        Frame
+    ): A < (S & Async) =
+        initUnscoped(transport, handlers*).map(f)
+
+    /** Initializes unscoped with config and passes the server handle to the given function. */
+    def initUnscopedWith[A, S](transport: JsonRpcTransport, config: LspConfig)(handlers: LspHandler[?, ?, ?]*)(f: LspServer => A < S)(using
+        Frame
+    ): A < (S & Async) =
+        initUnscoped(transport, config)(handlers*).map(f)
+
+    // =========================================================================
+    // Extension methods (safe-tier bridge over Unsafe)
+    // =========================================================================
+
+    extension (self: LspServer)
+
+        /** Sends a `window/showMessage` notification to the client. */
+        def showMessage(params: LspHandler.ShowMessageParams)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.showMessage(params).safe.get)
+
+        /** Sends a `window/showMessage` notification with an explicit message type. */
+        def showMessage(messageType: LspHandler.MessageType, message: String)(using
+            Frame
+        ): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.showMessage(LspHandler.ShowMessageParams(messageType, message)).safe.get)
+
+        /** Shows an error message to the client. */
+        def showError(message: String)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            self.showMessage(LspHandler.MessageType.Error, message)
+
+        /** Shows a warning message to the client. */
+        def showWarning(message: String)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            self.showMessage(LspHandler.MessageType.Warning, message)
+
+        /** Shows an informational message to the client. */
+        def showInfo(message: String)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            self.showMessage(LspHandler.MessageType.Info, message)
+
+        /** Sends a `window/logMessage` notification with an explicit message type. */
+        def logMessage(messageType: LspHandler.MessageType, message: String)(using
+            Frame
+        ): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.logMessage(LspHandler.LogMessageParams(messageType, message)).safe.get)
+
+        /** Publishes a document's current diagnostics to the client. */
+        def publishDiagnostics(
+            uri: LspHandler.LspDocument.Uri,
+            diagnostics: Chunk[LspHandler.Diagnostic],
+            version: Maybe[Int] = Absent
+        )(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.publishDiagnostics(LspHandler.PublishDiagnosticsParams(
+                uri = uri,
+                version = version,
+                diagnostics = diagnostics
+            )).safe.get)
+
+        /** Asks the client to show a document identified by a URI. */
+        def showDocument(
+            uri: String,
+            external: Maybe[Boolean] = Absent,
+            takeFocus: Maybe[Boolean] = Absent,
+            selection: Maybe[LspHandler.Range] = Absent
+        )(using Frame): LspHandler.ShowDocumentResult < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.showDocument(LspHandler.ShowDocumentParams(
+                uri = uri,
+                external = external,
+                takeFocus = takeFocus,
+                selection = selection
+            )).safe.get)
+
+        /** Sends a `window/showMessageRequest` request to the client. */
+        def showMessageRequest(params: LspHandler.ShowMessageRequestParams)(using
+            Frame
+        ): Maybe[LspHandler.MessageActionItem] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.showMessageRequest(params).safe.get)
+
+        /** Sends a `window/showDocument` request to the client. */
+        def showDocument(params: LspHandler.ShowDocumentParams)(using
+            Frame
+        ): LspHandler.ShowDocumentResult < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.showDocument(params).safe.get)
+
+        /** Sends a `window/logMessage` notification to the client. */
+        def logMessage(params: LspHandler.LogMessageParams)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.logMessage(params).safe.get)
+
+        /** Sends a `window/workDoneProgress/create` request to the client. */
+        def createWorkDoneProgress(params: LspHandler.WorkDoneProgressCreateParams)(using
+            Frame
+        ): Unit < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.createWorkDoneProgress(params).safe.get)
+
+        /** Sends a `telemetry/event` notification to the client with a typed payload. */
+        def telemetry[T](payload: T)(using Frame, Schema[T]): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.telemetry(payload).safe.get)
+
+        /** Sends a `workspace/applyEdit` request to the client. */
+        def applyEdit(params: LspHandler.ApplyWorkspaceEditParams)(using
+            Frame
+        ): LspHandler.ApplyWorkspaceEditResult < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.applyEdit(params).safe.get)
+
+        /** Sends a `workspace/configuration` request to the client and decodes the results. */
+        def getConfiguration[T](params: LspHandler.ConfigurationParams)(using
+            Frame,
+            Schema[T]
+        ): Chunk[T] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.getConfiguration[T](params).safe.get)
+
+        /** Sends a `workspace/workspaceFolders` request to the client. */
+        def getWorkspaceFolders(using Frame): Maybe[Chunk[LspHandler.WorkspaceFolder]] < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.getWorkspaceFolders.safe.get)
+
+        /** Requests the client to refresh semantic tokens. */
+        def refreshSemanticTokens(using Frame): Unit < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.refreshSemanticTokens.safe.get)
+
+        /** Requests the client to refresh inline values. */
+        def refreshInlineValue(using Frame): Unit < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.refreshInlineValue.safe.get)
+
+        /** Requests the client to refresh inlay hints. */
+        def refreshInlayHint(using Frame): Unit < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.refreshInlayHint.safe.get)
+
+        /** Requests the client to refresh diagnostics. */
+        def refreshDiagnostic(using Frame): Unit < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.refreshDiagnostic.safe.get)
+
+        /** Requests the client to refresh code lens. */
+        def refreshCodeLens(using Frame): Unit < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.refreshCodeLens.safe.get)
+
+        /** Registers a capability with the client. */
+        def registerCapability(params: LspHandler.RegistrationParams)(using Frame): Unit < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.registerCapability(params).safe.get)
+
+        /** Unregisters a capability from the client. */
+        def unregisterCapability(params: LspHandler.UnregistrationParams)(using Frame): Unit < (Async & Abort[LspRequestFailure]) =
+            Sync.Unsafe.defer(self.unregisterCapability(params).safe.get)
+
+        /** Sends `textDocument/publishDiagnostics` to the client. */
+        def publishDiagnostics(params: LspHandler.PublishDiagnosticsParams)(using
+            Frame
+        ): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.publishDiagnostics(params).safe.get)
+
+        /** Logs a trace message to the client. */
+        def logTrace(message: String, verbose: Maybe[String] = Absent)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.logTrace(message, verbose).safe.get)
+
+        /** Sends a `$/progress` notification to the client. */
+        def workDoneProgress(token: LspHandler.ProgressToken, value: LspHandler.WorkDoneProgressValue)(using
+            Frame
+        ): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.workDoneProgress(token, value).safe.get)
+
+        /** Sends a `$/cancelRequest` notification. */
+        def cancel(id: JsonRpcId)(using Frame): Unit < (Async & Abort[LspConnectionClosedException]) =
+            Sync.Unsafe.defer(self.cancel(id).safe.get)
+
+        /** The LSP spec version this server implements. */
+        def specVersion: String = self.specVersion
+
+        /** The negotiated position encoding, read from session state once a client has connected. */
+        def positionEncoding(using Frame): LspHandler.PositionEncodingKind < Sync = self.positionEncoding
+
+        /** The client capabilities, populated once the client sends `initialize`. */
+        def clientCapabilities(using Frame): Maybe[LspCapabilities.Client.Client] < Sync = self.clientCapabilities
+
+        /** The client info, populated once the client sends `initialize`. */
+        def clientInfo(using Frame): Maybe[LspInfo] < Sync = self.clientInfo
+
+        /** The workspace folders, populated once the client sends `initialize`. */
+        def workspaceFolders(using Frame): Maybe[Chunk[LspHandler.WorkspaceFolder]] < Sync = self.workspaceFolders
+
+        /** The underlying JSON-RPC handler. */
+        def underlying: JsonRpcHandler = self.underlying
+
+        /** Waits for all in-flight requests to complete. */
+        def awaitDrain(using Frame): Unit < Async = Sync.Unsafe.defer(self.awaitDrain.safe.get)
+
+        /** Closes the server gracefully with the default 30-second grace period. */
+        def close(using Frame): Unit < Async = Sync.Unsafe.defer(self.close(30.seconds).safe.get)
+
+        /** Closes the server gracefully with the specified grace period. */
+        def close(gracePeriod: Duration)(using Frame): Unit < Async = Sync.Unsafe.defer(self.close(gracePeriod).safe.get)
+
+        /** Closes the server immediately (Duration.Zero grace period). */
+        def closeNow(using Frame): Unit < Async = Sync.Unsafe.defer(self.close(Duration.Zero).safe.get)
+
+        /** The raw unsafe handle. */
+        def unsafe: Unsafe = self
+
+    end extension
+
+    // =========================================================================
+    // Unsafe abstract class
+    // =========================================================================
+
+    /** The underlying unsafe implementation contract.
+      *
+      * All methods return `Fiber.Unsafe` (non-effect-typed futures). Bridge to safe tier
+      * through the extension methods declared above. Concrete implementations are produced
+      * by the engine.
+      */
+    abstract class Unsafe:
+        def showMessage(params: LspHandler.ShowMessageParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def showMessageRequest(params: LspHandler.ShowMessageRequestParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[LspHandler.MessageActionItem], Abort[LspRequestFailure]]
+        def showDocument(params: LspHandler.ShowDocumentParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[LspHandler.ShowDocumentResult, Abort[LspRequestFailure]]
+        def logMessage(params: LspHandler.LogMessageParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def createWorkDoneProgress(params: LspHandler.WorkDoneProgressCreateParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspRequestFailure]]
+        def telemetry[T](payload: T)(using AllowUnsafe, Frame, Schema[T]): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def applyEdit(params: LspHandler.ApplyWorkspaceEditParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[LspHandler.ApplyWorkspaceEditResult, Abort[LspRequestFailure]]
+        def getConfiguration[T](params: LspHandler.ConfigurationParams)(using
+            AllowUnsafe,
+            Frame,
+            Schema[T]
+        ): Fiber.Unsafe[Chunk[T], Abort[LspRequestFailure]]
+        def getWorkspaceFolders(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Maybe[Chunk[LspHandler.WorkspaceFolder]], Abort[LspRequestFailure]]
+        def refreshSemanticTokens(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspRequestFailure]]
+        def refreshInlineValue(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspRequestFailure]]
+        def refreshInlayHint(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspRequestFailure]]
+        def refreshDiagnostic(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspRequestFailure]]
+        def refreshCodeLens(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspRequestFailure]]
+        def registerCapability(params: LspHandler.RegistrationParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspRequestFailure]]
+        def unregisterCapability(params: LspHandler.UnregistrationParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspRequestFailure]]
+        def publishDiagnostics(params: LspHandler.PublishDiagnosticsParams)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def logTrace(message: String, verbose: Maybe[String])(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def workDoneProgress(token: LspHandler.ProgressToken, value: LspHandler.WorkDoneProgressValue)(using
+            AllowUnsafe,
+            Frame
+        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def cancel(id: JsonRpcId)(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]
+        def specVersion: String
+        def positionEncoding(using Frame): LspHandler.PositionEncodingKind < Sync
+        def clientCapabilities(using Frame): Maybe[LspCapabilities.Client.Client] < Sync
+        def clientInfo(using Frame): Maybe[LspInfo] < Sync
+        def workspaceFolders(using Frame): Maybe[Chunk[LspHandler.WorkspaceFolder]] < Sync
+        def underlying: JsonRpcHandler
+        def awaitDrain(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Any]
+        def close(gracePeriod: Duration)(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Any]
+        final def safe: LspServer = this
+    end Unsafe
+
+end LspServer

--- a/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspBuiltInRoutes.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspBuiltInRoutes.scala
@@ -1,0 +1,371 @@
+package kyo.internal.lsp
+
+import kyo.*
+
+/** Engine-owned `JsonRpcRoute` instances for the LSP lifecycle and text-document sync.
+  *
+  * Built-in routes (registered ahead of user routes):
+  *   - `initialize` + `initialized` handshake
+  *   - `shutdown` + `exit` graceful teardown
+  *   - `$/setTrace` trace level update
+  *   - 5 textDocument sync routes that auto-feed `LspDocumentRegistryImpl` BEFORE invoking
+  *     the user-registered handler (if any)
+  *   - 4 notebookDocument sync routes that insert cell documents into the same registry
+  *
+  * The initialize handler performs encoding negotiation, populates the client-capabilities
+  * and client-info refs, and returns the server's `InitializeResult` with spec version "3.17".
+  *
+  * Sync edge-case policies live in `LspDocumentRegistryImpl` mutators; the routes here call
+  * those mutators unconditionally.
+  */
+private[kyo] object LspBuiltInRoutes:
+
+    // Wire shapes for initialize exchange.
+    final private case class InitializeParams(
+        processId: Maybe[Int] = Absent,
+        clientInfo: Maybe[LspInfo] = Absent,
+        locale: Maybe[String] = Absent,
+        rootUri: Maybe[String] = Absent,
+        capabilities: LspCapabilities.Client.Client = LspCapabilities.Client.empty,
+        workspaceFolders: Maybe[Chunk[LspHandler.WorkspaceFolder]] = Absent,
+        private[kyo] _rawInitializationOptions: Maybe[String] = Absent
+    ) derives Schema
+
+    final private case class GeneralCapabilities(
+        positionEncodings: Chunk[LspHandler.PositionEncodingKind] = Chunk.empty
+    ) derives Schema
+
+    final private case class InitializeResult(
+        capabilities: LspCapabilities.Server.Server,
+        serverInfo: LspInfo
+    ) derives Schema
+
+    final private case class EmptyParams() derives Schema
+    final private case class EmptyResult() derives Schema
+
+    final private case class SetTraceParams(
+        value: LspHandler.TraceValue
+    ) derives Schema
+
+    // Sync notification wire shapes.
+    final private case class DidOpenParams(textDocument: LspHandler.TextDocumentItem) derives Schema
+    final private case class DidChangeParams(
+        textDocument: LspHandler.VersionedTextDocumentIdentifier,
+        contentChanges: Chunk[LspHandler.TextDocumentContentChangeEvent]
+    ) derives Schema
+    final private case class DidSaveParams(textDocument: LspHandler.TextDocumentIdentifier) derives Schema
+    final private case class DidCloseParams(textDocument: LspHandler.TextDocumentIdentifier) derives Schema
+    final private case class WillSaveParams(
+        textDocument: LspHandler.TextDocumentIdentifier,
+        reason: LspHandler.TextDocumentSaveReason
+    ) derives Schema
+
+    // Notebook sync wire shapes.
+    final private case class NotebookDocumentItem(
+        uri: String,
+        notebookType: String,
+        version: Int,
+        cells: Chunk[NotebookCellItem]
+    ) derives Schema
+    final private case class NotebookCellItem(
+        kind: Int,
+        document: String,
+        source: Maybe[String] = Absent,
+        language: Maybe[String] = Absent
+    ) derives Schema
+    final private case class DidOpenNotebookParams(notebookDocument: NotebookDocumentItem) derives Schema
+    final private case class DidChangeNotebookParams(
+        notebookDocument: NotebookDocumentVersioned,
+        change: LspHandler.NotebookDocumentChangeEvent = LspHandler.NotebookDocumentChangeEvent()
+    ) derives Schema
+    final private case class NotebookDocumentVersioned(uri: String, version: Int) derives Schema
+    final private case class DidSaveNotebookParams(notebookDocument: NotebookDocumentVersioned) derives Schema
+    final private case class DidCloseNotebookParams(
+        notebookDocument: NotebookDocumentVersioned,
+        cellTextDocuments: Chunk[LspHandler.TextDocumentIdentifier] = Chunk.empty
+    ) derives Schema
+
+    // =========================================================================
+    // Handshake routes
+    // =========================================================================
+
+    def initialize(
+        config: LspConfig,
+        serverCaps: LspCapabilities.Server,
+        negotiatedEncodingRef: AtomicRef[LspHandler.PositionEncodingKind],
+        clientCapabilitiesRef: AtomicRef[Maybe[LspCapabilities.Client.Client]],
+        clientInfoRef: AtomicRef[Maybe[LspInfo]],
+        workspaceFoldersRef: AtomicRef[Maybe[Chunk[LspHandler.WorkspaceFolder]]]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        JsonRpcRoute.request[InitializeParams, InitializeResult]("initialize") { (params, _) =>
+            // Negotiate position encoding: first match of client's list against server's list.
+            val clientEncodings: Chunk[LspHandler.PositionEncodingKind] =
+                params.capabilities.general.fold(Chunk.empty[LspHandler.PositionEncodingKind])(_.positionEncodings)
+            val negotiated = config.positionEncodings.find(e => clientEncodings.contains(e))
+                .getOrElse(LspHandler.PositionEncodingKind.UTF16)
+            negotiatedEncodingRef.set(negotiated)
+                .andThen(clientCapabilitiesRef.set(Present(params.capabilities)))
+                .andThen(clientInfoRef.set(params.clientInfo))
+                .andThen(workspaceFoldersRef.set(params.workspaceFolders))
+                .andThen {
+                    // Return InitializeResult with spec version 3.17 embedded in serverInfo.
+                    val serverInfo = config.serverInfo.copy(version = LspConfig.SpecVersion)
+                    InitializeResult(capabilities = serverCaps, serverInfo = serverInfo)
+                }
+        }
+    end initialize
+
+    def initialized()(using Frame): JsonRpcRoute[?, ?, ?] =
+        JsonRpcRoute.notification[EmptyParams]("initialized") { (_, _) => () }
+
+    // =========================================================================
+    // Lifecycle routes
+    // =========================================================================
+
+    def shutdown()(using Frame): JsonRpcRoute[?, ?, ?] =
+        // The shutdown gate already transitions state; this route just returns success.
+        JsonRpcRoute.request[EmptyParams, EmptyResult]("shutdown") { (_, _) => EmptyResult() }
+
+    def exit()(using Frame): JsonRpcRoute[?, ?, ?] =
+        // The shutdown gate triggers handler.close on exit; this route is a no-op handler.
+        JsonRpcRoute.notification[EmptyParams]("exit") { (_, _) => () }
+
+    def setTrace(traceRef: AtomicRef[LspHandler.TraceValue])(using Frame): JsonRpcRoute[?, ?, ?] =
+        JsonRpcRoute.notification[SetTraceParams]("$/setTrace") { (params, _) =>
+            traceRef.set(params.value)
+        }
+
+    // =========================================================================
+    // textDocument sync routes (registry update BEFORE user handler)
+    // =========================================================================
+
+    /** Reads the forward server ref and the negotiated encoding via the safe `Sync` API and, when the
+      * server peer is present, builds the per-request context the built-in sync routes bind before
+      * invoking a user notification handler.
+      */
+    private def resolveServerContext(
+        serverRef: AtomicRef[Maybe[LspServer.Unsafe]],
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind],
+        registry: LspDocumentRegistryImpl,
+        jrCtx: JsonRpcRoute.Context
+    )(using Frame): Maybe[Lsp.RequestContext] < Sync =
+        encodingRef.get.map { enc =>
+            serverRef.get.map {
+                case Present(srv) =>
+                    Present(Lsp.RequestContext(
+                        jsonRpc = jrCtx,
+                        peer = Lsp.Peer.Server(srv.safe),
+                        workDoneToken = Absent,
+                        partialResultToken = Absent,
+                        documents = registry,
+                        positionEncoding = enc
+                    ))
+                case Absent => Absent
+            }
+        }
+    end resolveServerContext
+
+    /** Builds a `textDocument` sync-notification route: runs `registryOp` (the built-in registry
+      * update) first, then, if a user notification handler is registered, binds the per-request
+      * context and invokes it with the reconstructed public params.
+      */
+    private def syncRoute[In, P](
+        name: String,
+        userHandler: Maybe[LspHandler[?, ?, ?]],
+        serverRef: AtomicRef[Maybe[LspServer.Unsafe]],
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind],
+        registry: LspDocumentRegistryImpl
+    )(
+        registryOp: In => Unit < (Async & Abort[JsonRpcResponse.Halt]),
+        reconstruct: In => P
+    )(using Schema[In], Frame): JsonRpcRoute[?, ?, ?] =
+        JsonRpcRoute.notification[In](name) { (params, jrCtx) =>
+            registryOp(params).andThen {
+                userHandler match
+                    case Present(h: LspHandler.NotificationHandler[P, ?] @unchecked) =>
+                        resolveServerContext(serverRef, encodingRef, registry, jrCtx).map {
+                            case Present(ctx) => Lsp.local.let(Present(ctx))(h.handlerFn(reconstruct(params)))
+                            case Absent       => ()
+                        }
+                    case _ => ()
+            }
+        }
+    end syncRoute
+
+    def textDocumentDidOpen(
+        registry: LspDocumentRegistryImpl,
+        userHandler: Maybe[LspHandler[?, ?, ?]],
+        serverRef: AtomicRef[Maybe[LspServer.Unsafe]],
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        syncRoute[DidOpenParams, LspHandler.DidOpenTextDocumentParams](
+            "textDocument/didOpen",
+            userHandler,
+            serverRef,
+            encodingRef,
+            registry
+        )(
+            p => registry.insert(p.textDocument),
+            p => LspHandler.DidOpenTextDocumentParams(p.textDocument)
+        )
+    end textDocumentDidOpen
+
+    def textDocumentDidChange(
+        registry: LspDocumentRegistryImpl,
+        userHandler: Maybe[LspHandler[?, ?, ?]],
+        serverRef: AtomicRef[Maybe[LspServer.Unsafe]],
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        syncRoute[DidChangeParams, LspHandler.DidChangeTextDocumentParams](
+            "textDocument/didChange",
+            userHandler,
+            serverRef,
+            encodingRef,
+            registry
+        )(
+            p => registry.applyChanges(p.textDocument.uri, p.textDocument.version, p.contentChanges),
+            p => LspHandler.DidChangeTextDocumentParams(p.textDocument, p.contentChanges)
+        )
+    end textDocumentDidChange
+
+    def textDocumentDidSave(
+        registry: LspDocumentRegistryImpl,
+        userHandler: Maybe[LspHandler[?, ?, ?]],
+        serverRef: AtomicRef[Maybe[LspServer.Unsafe]],
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        syncRoute[DidSaveParams, LspHandler.DidSaveTextDocumentParams](
+            "textDocument/didSave",
+            userHandler,
+            serverRef,
+            encodingRef,
+            registry
+        )(
+            p => registry.setSaved(p.textDocument.uri),
+            p => LspHandler.DidSaveTextDocumentParams(p.textDocument)
+        )
+    end textDocumentDidSave
+
+    def textDocumentDidClose(
+        registry: LspDocumentRegistryImpl,
+        userHandler: Maybe[LspHandler[?, ?, ?]],
+        serverRef: AtomicRef[Maybe[LspServer.Unsafe]],
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        syncRoute[DidCloseParams, LspHandler.DidCloseTextDocumentParams](
+            "textDocument/didClose",
+            userHandler,
+            serverRef,
+            encodingRef,
+            registry
+        )(
+            p => registry.remove(p.textDocument.uri),
+            p => LspHandler.DidCloseTextDocumentParams(p.textDocument)
+        )
+    end textDocumentDidClose
+
+    def textDocumentWillSave(
+        userHandler: Maybe[LspHandler[?, ?, ?]],
+        serverRef: AtomicRef[Maybe[LspServer.Unsafe]],
+        registry: LspDocumentRegistryImpl,
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        syncRoute[WillSaveParams, LspHandler.WillSaveTextDocumentParams](
+            "textDocument/willSave",
+            userHandler,
+            serverRef,
+            encodingRef,
+            registry
+        )(
+            _ => (),
+            p => LspHandler.WillSaveTextDocumentParams(p.textDocument, p.reason)
+        )
+    end textDocumentWillSave
+
+    // =========================================================================
+    // notebookDocument sync routes
+    // =========================================================================
+
+    def notebookDocumentDidOpen(
+        registry: LspDocumentRegistryImpl,
+        userHandler: Maybe[LspHandler[?, ?, ?]],
+        serverRef: AtomicRef[Maybe[LspServer.Unsafe]],
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        JsonRpcRoute.notification[DidOpenNotebookParams]("notebookDocument/didOpen") { (params, _) =>
+            // Insert each cell text document into the registry with the session encoding.
+            val cells = params.notebookDocument.cells
+            cells.foldLeft(().asInstanceOf[Unit < Sync]) { (acc, cell) =>
+                acc.andThen {
+                    val uri     = LspHandler.LspDocument.Uri.fromWire(cell.document)
+                    val lang    = cell.language.getOrElse("plaintext")
+                    val text    = cell.source.getOrElse("")
+                    val version = params.notebookDocument.version
+                    registry.insertNotebookCell(uri, lang, text, version)
+                }
+            }
+        }
+    end notebookDocumentDidOpen
+
+    def notebookDocumentDidChange(
+        registry: LspDocumentRegistryImpl
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        JsonRpcRoute.notification[DidChangeNotebookParams]("notebookDocument/didChange") { (params, _) =>
+            // Process cell structural changes.
+            // Silent log-and-skip for missing-doc cases.
+            val cellChanges: Unit < Sync =
+                params.change.cells match
+                    case Absent      => ()
+                    case Present(cc) =>
+                        // Structure changes: insert newly opened cells, remove closed cells.
+                        val structureEffect: Unit < Sync =
+                            cc.structure match
+                                case Absent => ()
+                                case Present(sc) =>
+                                    val opens: Unit < Sync =
+                                        sc.didOpen.foldLeft(().asInstanceOf[Unit < Sync]) { (acc, item) =>
+                                            acc.andThen(registry.insert(item))
+                                        }
+                                    val closes: Unit < Sync =
+                                        sc.didClose.foldLeft(().asInstanceOf[Unit < Sync]) { (acc, id) =>
+                                            acc.andThen(registry.remove(id.uri))
+                                        }
+                                    opens.andThen(closes)
+                            end match
+                        end structureEffect
+
+                        // Text content changes: apply incremental changes to existing cell docs.
+                        val contentEffect: Unit < Sync =
+                            cc.textContent.foldLeft(().asInstanceOf[Unit < Sync]) { (acc, tc) =>
+                                acc.andThen(
+                                    registry.applyChanges(tc.document.uri, tc.document.version, tc.changes)
+                                )
+                            }
+
+                        structureEffect.andThen(contentEffect)
+                end match
+            end cellChanges
+            cellChanges
+        }
+    end notebookDocumentDidChange
+
+    def notebookDocumentDidSave(
+        registry: LspDocumentRegistryImpl
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        JsonRpcRoute.notification[DidSaveNotebookParams]("notebookDocument/didSave") { (_, _) =>
+            ()
+        }
+    end notebookDocumentDidSave
+
+    def notebookDocumentDidClose(
+        registry: LspDocumentRegistryImpl
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        JsonRpcRoute.notification[DidCloseNotebookParams]("notebookDocument/didClose") { (params, _) =>
+            // Remove all cell text documents from the registry.
+            params.cellTextDocuments.foldLeft(().asInstanceOf[Unit < Sync]) { (acc, td) =>
+                acc.andThen(registry.remove(td.uri))
+            }
+        }
+    end notebookDocumentDidClose
+
+end LspBuiltInRoutes

--- a/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspCancellationPolicy.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspCancellationPolicy.scala
@@ -1,0 +1,48 @@
+package kyo.internal.lsp
+
+import kyo.*
+
+/** LSP-specific `JsonRpcCancellationPolicy` for `$/cancelRequest`.
+  *
+  * LSP uses `$/cancelRequest` with a `params.id` field (integer or string). When a request is
+  * cancelled via `$/cancelRequest`, the server MUST reply with a JSON-RPC error response with
+  * code -32800 ("Request cancelled"), so `expectReplyForCancelledRequest = true`.
+  *
+  * The `initialize` method is protected from cancellation per the LSP spec.
+  */
+private[kyo] object LspCancellationPolicy:
+
+    val default: JsonRpcCancellationPolicy =
+        JsonRpcCancellationPolicy(
+            cancelMethod = "$/cancelRequest",
+            encodeParams = (id, reason) =>
+                Sync.defer {
+                    val idField = "id" -> id.fold(
+                        n => Structure.Value.Integer(n),
+                        s => Structure.Value.Str(s)
+                    )
+                    val fields = reason match
+                        case Present(r) => Chunk(idField, "reason" -> Structure.Value.Str(r))
+                        case Absent     => Chunk(idField)
+                    Structure.Value.Record(fields)
+                },
+            decodeParams = sv =>
+                Sync.defer {
+                    sv match
+                        case Structure.Value.Record(fields) =>
+                            fields.iterator.collectFirst {
+                                case (k, v) if k == "id" =>
+                                    v match
+                                        case Structure.Value.Integer(n) => Present(JsonRpcId(n))
+                                        case Structure.Value.Str(s)     => Present(JsonRpcId(s))
+                                        case _                          => Absent
+                            }.getOrElse(Absent)
+                        case _ => Absent
+                },
+            // LSP requires the server to reply to a cancelled request with -32800.
+            expectReplyForCancelledRequest = true,
+            cancelledError = Absent,
+            protectedMethods = Set("initialize")
+        )
+
+end LspCancellationPolicy

--- a/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspCatalog.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspCatalog.scala
@@ -1,0 +1,160 @@
+package kyo.internal.lsp
+
+import kyo.*
+
+/** Frozen handler index built once at `LspEngine.initServer` time.
+  *
+  * `LspCatalog.fromHandlers` partitions handlers by `LspHandler.Direction`, rejects wrong-direction
+  * registrations with `LspWrongDirectionException`, rejects duplicate non-Custom Kinds
+  * with `LspDuplicateHandlerException`, and rejects reserved-method `CustomHandler`
+  * registrations with `LspReservedMethodException`. No mutation is possible after
+  * construction.
+  *
+  * `autoDeriveServerCapabilities` walks the registered Kinds and builds a `LspCapabilities.Server`
+  * matching the handler set when `config.declaredServerCapabilities` is `Absent`.
+  */
+final private[kyo] class LspCatalog private (val handlers: Seq[LspHandler[?, ?, ?]]):
+
+    /** All handlers indexed by Kind for O(1) lookup. */
+    val byKind: Map[LspHandler.Kind, LspHandler[?, ?, ?]] =
+        handlers.map(h => h.kind -> h).toMap
+
+    /** True if a handler for this Kind is registered. */
+    def hasKind(k: LspHandler.Kind): Boolean = byKind.contains(k)
+
+    /** Returns the handler for this Kind, or Absent. */
+    def handlerFor(k: LspHandler.Kind): Maybe[LspHandler[?, ?, ?]] =
+        Maybe.fromOption(byKind.get(k))
+
+    /** Custom handlers (Kind.Custom) keyed by wire name. */
+    val customHandlers: Map[String, LspHandler[?, ?, ?]] =
+        handlers.collect {
+            case h if h.kind == LspHandler.Kind.Custom => h.name -> h
+        }.toMap
+
+    /** Auto-derives server capabilities from registered handler Kinds.
+      *
+      * When `declaredServerCapabilities` is `Present`, returns it verbatim. Otherwise walks
+      * registered Kinds and builds the capability tree.
+      */
+    def autoDeriveServerCapabilities(config: LspConfig): LspCapabilities.Server =
+        config.declaredServerCapabilities match
+            case Present(c) => c
+            case Absent     => LspCatalog.deriveFromKinds(handlers.map(_.kind).toSet)
+
+end LspCatalog
+
+private[kyo] object LspCatalog:
+
+    /** Reserved wire method names that user-registered CustomHandlers may not claim. */
+    val ReservedMethods: Set[String] = Set(
+        "initialize",
+        "initialized",
+        "shutdown",
+        "exit",
+        "$/cancelRequest",
+        "$/progress",
+        "$/setTrace"
+    )
+
+    /** Constructs a `LspCatalog` from `handlers`, validating direction, duplicates, and reserved names.
+      *
+      * Throws synchronously for programmer-error violations:
+      *   - `WrongDirection`: handler direction does not match `expectedDirection`
+      *   - `DuplicateHandler`: two handlers share a non-Custom Kind, or two Custom handlers share a wire name
+      *   - `ReservedMethod`: a CustomHandler claims a reserved wire method name
+      *
+      * Direction.Either handlers (`CancelRequest`, `Progress`) are accepted on both sides.
+      */
+    def fromHandlers(
+        handlers: Seq[LspHandler[?, ?, ?]],
+        expectedDirection: LspHandler.Direction
+    )(using Frame): LspCatalog =
+        val seenKinds   = scala.collection.mutable.Set[LspHandler.Kind]()
+        val seenCustoms = scala.collection.mutable.Set[String]()
+        handlers.foreach { h =>
+            val handlerDir = h.direction
+            val allowed = handlerDir == LspHandler.Direction.Either ||
+                handlerDir == expectedDirection
+            if !allowed then
+                throw LspWrongDirectionException(h.kind, expectedDirection)
+            end if
+
+            if h.kind == LspHandler.Kind.Custom then
+                if ReservedMethods.contains(h.name) then
+                    throw LspReservedMethodException(h.name)
+                end if
+                if seenCustoms.contains(h.name) then
+                    throw LspDuplicateHandlerException(h.kind)
+                end if
+                seenCustoms += h.name
+            else
+                if seenKinds.contains(h.kind) then
+                    throw LspDuplicateHandlerException(h.kind)
+                end if
+                seenKinds += h.kind
+            end if
+        }
+        new LspCatalog(handlers)
+    end fromHandlers
+
+    /** Derives `LspCapabilities.Server` from the set of registered Kinds. */
+    private[lsp] def deriveFromKinds(kinds: Set[LspHandler.Kind]): LspCapabilities.Server =
+        val K  = LspHandler.Kind
+        val H  = LspHandler
+        val cs = LspCapabilities.Server
+        cs.Server(
+            completionProvider = if kinds.contains(K.Completion) then Present(H.CompletionOptions()) else Absent,
+            hoverProvider = if kinds.contains(K.Hover) then Present(H.BooleanOr.Bool(true)) else Absent,
+            signatureHelpProvider = if kinds.contains(K.SignatureHelp) then Present(H.SignatureHelpOptions()) else Absent,
+            declarationProvider = if kinds.contains(K.Declaration) then Present(H.BooleanOr.Bool(true)) else Absent,
+            definitionProvider = if kinds.contains(K.Definition) then Present(H.BooleanOr.Bool(true)) else Absent,
+            typeDefinitionProvider = if kinds.contains(K.TypeDefinition) then Present(H.BooleanOr.Bool(true)) else Absent,
+            implementationProvider = if kinds.contains(K.Implementation) then Present(H.BooleanOr.Bool(true)) else Absent,
+            referencesProvider = if kinds.contains(K.References) then Present(H.BooleanOr.Bool(true)) else Absent,
+            documentHighlightProvider = if kinds.contains(K.DocumentHighlight) then Present(H.BooleanOr.Bool(true)) else Absent,
+            documentSymbolProvider = if kinds.contains(K.DocumentSymbol) then Present(H.BooleanOr.Bool(true)) else Absent,
+            codeActionProvider = if kinds.contains(K.CodeAction) then Present(H.BooleanOr.Bool(true)) else Absent,
+            codeLensProvider = if kinds.contains(K.CodeLens) then Present(H.CodeLensOptions()) else Absent,
+            documentLinkProvider = if kinds.contains(K.DocumentLink) then Present(H.DocumentLinkOptions()) else Absent,
+            colorProvider = if kinds.contains(K.DocumentColor) then Present(H.BooleanOr.Bool(true)) else Absent,
+            documentFormattingProvider = if kinds.contains(K.Formatting) then Present(H.BooleanOr.Bool(true)) else Absent,
+            documentRangeFormattingProvider = if kinds.contains(K.RangeFormatting) then Present(H.BooleanOr.Bool(true)) else Absent,
+            documentOnTypeFormattingProvider = if kinds.contains(K.OnTypeFormatting) then
+                Present(H.DocumentOnTypeFormattingOptions(firstTriggerCharacter = ""))
+            else Absent,
+            renameProvider = if kinds.contains(K.Rename) then Present(H.BooleanOr.Bool(true)) else Absent,
+            foldingRangeProvider = if kinds.contains(K.FoldingRange) then Present(H.BooleanOr.Bool(true)) else Absent,
+            executeCommandProvider = if kinds.contains(K.ExecuteCommand) then Present(H.ExecuteCommandOptions()) else Absent,
+            selectionRangeProvider = if kinds.contains(K.SelectionRange) then Present(H.BooleanOr.Bool(true)) else Absent,
+            linkedEditingRangeProvider = if kinds.contains(K.LinkedEditingRange) then Present(H.BooleanOr.Bool(true)) else Absent,
+            callHierarchyProvider = if kinds.contains(K.PrepareCallHierarchy) then Present(H.BooleanOr.Bool(true)) else Absent,
+            semanticTokensProvider =
+                if kinds.exists(k => k == K.SemanticTokensFull || k == K.SemanticTokensFullDelta || k == K.SemanticTokensRange)
+                then Present(H.SemanticTokensOptions(legend = H.SemanticTokensLegend(Chunk.empty, Chunk.empty)))
+                else Absent,
+            monikerProvider = if kinds.contains(K.Moniker) then Present(H.BooleanOr.Bool(true)) else Absent,
+            typeHierarchyProvider = if kinds.contains(K.PrepareTypeHierarchy) then Present(H.BooleanOr.Bool(true)) else Absent,
+            inlineValueProvider = if kinds.contains(K.InlineValue) then Present(H.BooleanOr.Bool(true)) else Absent,
+            inlayHintProvider = if kinds.contains(K.InlayHint) then Present(H.BooleanOr.Bool(true)) else Absent,
+            diagnosticProvider = if kinds.contains(K.DocumentDiagnostic) then
+                Present(cs.DiagnosticOptions(interFileDependencies = false, workspaceDiagnostics = false))
+            else Absent,
+            workspaceSymbolProvider = if kinds.contains(K.WorkspaceSymbol) then Present(H.BooleanOr.Bool(true)) else Absent,
+            notebookDocumentSync =
+                if kinds.exists(k =>
+                        k == K.NotebookDidOpen || k == K.NotebookDidChange || k == K.NotebookDidSave || k == K.NotebookDidClose
+                    )
+                then Present(cs.NotebookDocumentSyncOptions(Chunk.empty))
+                else Absent,
+            textDocumentSync =
+                if kinds.exists(k =>
+                        k == K.TextDocumentDidOpen || k == K.TextDocumentDidChange ||
+                            k == K.TextDocumentDidSave || k == K.TextDocumentDidClose
+                    )
+                then Present(H.TextDocumentSyncValue.Kind(H.TextDocumentSyncKind.Incremental))
+                else Absent
+        )
+    end deriveFromKinds
+
+end LspCatalog

--- a/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspClientEngine.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspClientEngine.scala
@@ -1,0 +1,653 @@
+package kyo.internal.lsp
+
+import kyo.*
+
+/** Composes all LSP engine components into a live `LspClient.Unsafe` instance.
+  *
+  * Client-side composition. Wiring order:
+  *   1. Build `LspCatalog` from user handlers (throws synchronously for direction/duplicate errors).
+  *   2. Create `LspDocumentRegistryImpl` with initial UTF-16 encoding.
+  *   3. Install LSP policies on `config.jsonRpc` (cancellation, progress, unknownMethod).
+  *   4. Lift user (client-direction) handlers via `LspHandlerLift.liftClient`.
+  *   5. Call `JsonRpcHandler.initUnscoped` with all routes.
+  *   6. Perform eager `initialize` / `initialized` handshake.
+  *   7. Store negotiated server caps and encoding from `InitializeResult`.
+  *   8. Return the concrete `LspClient.Unsafe` anonymous implementation.
+  *
+  * The argument order for all public variants is `(transport, clientInfo, capabilities, handlers)`.
+  */
+private[kyo] object LspClientEngine:
+
+    // Wire shapes for the initialize exchange (client side).
+    final private case class GeneralClientCapabilities(
+        positionEncodings: Chunk[LspHandler.PositionEncodingKind] = Chunk.empty
+    ) derives Schema
+
+    final private case class InitializeClientParams(
+        processId: Maybe[Int] = Absent,
+        clientInfo: Maybe[LspInfo] = Absent,
+        capabilities: LspCapabilities.Client.Client = LspCapabilities.Client.empty,
+        locale: Maybe[String] = Absent
+    ) derives Schema
+
+    final private case class InitializeResult(
+        capabilities: LspCapabilities.Server.Server,
+        serverInfo: Maybe[LspInfo] = Absent
+    ) derives Schema
+
+    final private case class EmptyParams() derives Schema
+
+    // Wire shapes for reverse-direction server notifications the client may receive.
+    final private case class LogTraceParams(message: String, verbose: Maybe[String] = Absent) derives Schema
+    final private case class ProgressParams(token: LspHandler.ProgressToken, value: LspHandler.WorkDoneProgressValue) derives Schema
+
+    /** The session state refs an LSP client engine threads through its routes and handshake. The
+      * forward ref (`clientRef`) is populated once the handler is constructed.
+      */
+    final private case class ClientRefs(
+        negotiatedEncodingRef: AtomicRef[LspHandler.PositionEncodingKind],
+        serverCapsRef: AtomicRef[Maybe[LspCapabilities.Server.Server]],
+        serverInfoRef: AtomicRef[Maybe[LspInfo]],
+        clientRef: AtomicRef[Maybe[LspClient.Unsafe]],
+        registryImpl: LspDocumentRegistryImpl
+    )
+
+    private def initClientRefs(using Frame): ClientRefs < Sync =
+        for
+            negotiatedEncodingRef <- AtomicRef.init[LspHandler.PositionEncodingKind](LspHandler.PositionEncodingKind.UTF16)
+            serverCapsRef         <- AtomicRef.init[Maybe[LspCapabilities.Server.Server]](Absent)
+            serverInfoRef         <- AtomicRef.init[Maybe[LspInfo]](Absent)
+            clientRef             <- AtomicRef.init[Maybe[LspClient.Unsafe]](Absent)
+            registryImpl          <- LspDocumentRegistryImpl.init(negotiatedEncodingRef)
+        yield ClientRefs(negotiatedEncodingRef, serverCapsRef, serverInfoRef, clientRef, registryImpl)
+
+    def initClient(
+        transport: JsonRpcTransport,
+        clientInfo: LspInfo,
+        capabilities: LspCapabilities.Client.Client,
+        userHandlers: Seq[LspHandler[?, ?, ?]],
+        config: LspConfig
+    )(using Frame): LspClient.Unsafe < (Async & Abort[LspInitFailure]) =
+        initClientRefs.flatMap { refs =>
+            import refs.*
+
+            // --- Catalog (throws synchronously on direction / duplicate / reserved errors) ---
+            val catalog = LspCatalog.fromHandlers(userHandlers, LspHandler.Direction.ClientHandled)
+
+            // registryImpl comes from initClientRefs
+
+            // --- Config with policies installed ---
+            val jsonRpcConfig = config.jsonRpc
+                .cancellation(LspCancellationPolicy.default)
+                .progress(LspProgressPolicy.default)
+                .unknownMethod(JsonRpcUnknownMethodPolicy.minimal)
+
+            // --- Lift user (client-direction) handlers ---
+            val userRoutes: Seq[JsonRpcRoute[?, ?, ?]] = userHandlers
+                .map(h => LspHandlerLift.liftClient(h, clientRef, registryImpl, negotiatedEncodingRef))
+
+            JsonRpcHandler.initUnscoped(transport, userRoutes, jsonRpcConfig).map { handler =>
+
+                // Perform the eager initialize / initialized handshake.
+                // Build params with the client's position encoding preferences.
+                val clientEncodings: Chunk[LspHandler.PositionEncodingKind] =
+                    capabilities.general.fold(Chunk.empty[LspHandler.PositionEncodingKind])(_.positionEncodings)
+
+                // Use server's preferred list from config as the advertised set if client has none.
+                val advertisedEncodings: Chunk[LspHandler.PositionEncodingKind] =
+                    if clientEncodings.isEmpty then config.positionEncodings else clientEncodings
+
+                // Patch general capabilities to include the negotiated encoding list.
+                val generalWithEncodings = LspCapabilities.Client.GeneralClientCapabilities(
+                    positionEncodings = advertisedEncodings
+                )
+                val capsWithEncodings = capabilities.copy(general = Present(generalWithEncodings))
+
+                val initParams = InitializeClientParams(
+                    processId = Absent,
+                    clientInfo = Present(clientInfo),
+                    capabilities = capsWithEncodings
+                )
+
+                // Send initialize request and receive InitializeResult.
+                val handshakeEffect: Unit < (Async & Abort[LspInitFailure | Closed]) =
+                    handler.call[InitializeClientParams, InitializeResult]("initialize", initParams)
+                        .handle(Abort.recover[JsonRpcError] { e =>
+                            Abort.fail(LspRemoteException(e.code, e.message, e.data))
+                        })
+                        .flatMap { result =>
+                            // Negotiate position encoding: first match of server's list against our preferences.
+                            val serverEncoding = result.capabilities.positionEncoding.getOrElse(LspHandler.PositionEncodingKind.UTF16)
+                            val negotiated =
+                                if advertisedEncodings.contains(serverEncoding) then serverEncoding
+                                else advertisedEncodings.headOption.getOrElse(LspHandler.PositionEncodingKind.UTF16)
+                            // Store server capabilities, server info, and the negotiated encoding.
+                            serverCapsRef.set(Present(result.capabilities))
+                                .andThen(serverInfoRef.set(result.serverInfo))
+                                .andThen(negotiatedEncodingRef.set(negotiated))
+                        }
+                        .andThen(handler.notify[EmptyParams]("initialized", EmptyParams()))
+
+                // Run the handshake. On failure, abort the client construction with the error.
+                val handshakeRun: Unit < (Async & Abort[LspInitFailure]) =
+                    handshakeEffect
+                        .handle(Abort.recover[Closed] { _ =>
+                            Abort.fail(LspConnectionClosedException())
+                        })
+
+                handshakeRun.andThen {
+                    val unsafe: LspClient.Unsafe = new LspClient.Unsafe:
+
+                        private def notifyEffect[In: Schema](method: String, params: In)(using
+                            Frame
+                        ): Unit < (Async & Abort[LspConnectionClosedException]) =
+                            handler.notify[In](method, params)
+                                .handle(Abort.recover[Closed] { _ => Abort.fail(LspConnectionClosedException()) })
+
+                        private def callEffect[In: Schema, Out: Schema](method: String, params: In)(using
+                            Frame
+                        ): Out < (Async & Abort[LspRequestFailure]) =
+                            handler.call[In, Out](method, params)
+                                .handle(Abort.recover[JsonRpcError] { e =>
+                                    Abort.fail(LspRemoteException(e.code, e.message, e.data))
+                                })
+                                .handle(Abort.recover[Closed] { _ =>
+                                    Abort.fail(LspConnectionClosedException())
+                                })
+
+                        // textDocument requests
+
+                        def completion(params: LspHandler.CompletionParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.CompletionResult], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.CompletionParams, Maybe[LspHandler.CompletionResult]](
+                                "textDocument/completion",
+                                params
+                            ))
+
+                        def completionItemResolve(item: LspHandler.CompletionItem)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[LspHandler.CompletionItem, Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.CompletionItem, LspHandler.CompletionItem](
+                                "completionItem/resolve",
+                                item
+                            ))
+
+                        def hover(params: LspHandler.HoverParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.Hover], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.HoverParams, Maybe[LspHandler.Hover]](
+                                "textDocument/hover",
+                                params
+                            ))
+
+                        def signatureHelp(params: LspHandler.SignatureHelpParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.SignatureHelp], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.SignatureHelpParams, Maybe[LspHandler.SignatureHelp]](
+                                "textDocument/signatureHelp",
+                                params
+                            ))
+
+                        def declaration(params: LspHandler.DeclarationParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.DeclarationResult], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DeclarationParams, Maybe[LspHandler.DeclarationResult]](
+                                "textDocument/declaration",
+                                params
+                            ))
+
+                        def definition(params: LspHandler.DefinitionParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.DefinitionResult], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DefinitionParams, Maybe[LspHandler.DefinitionResult]](
+                                "textDocument/definition",
+                                params
+                            ))
+
+                        def typeDefinition(params: LspHandler.TypeDefinitionParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.TypeDefinitionResult], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.TypeDefinitionParams, Maybe[LspHandler.TypeDefinitionResult]](
+                                "textDocument/typeDefinition",
+                                params
+                            ))
+
+                        def implementation(params: LspHandler.ImplementationParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.ImplementationResult], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.ImplementationParams, Maybe[LspHandler.ImplementationResult]](
+                                "textDocument/implementation",
+                                params
+                            ))
+
+                        def references(params: LspHandler.ReferenceParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.Location], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.ReferenceParams, Chunk[LspHandler.Location]](
+                                "textDocument/references",
+                                params
+                            ))
+
+                        def documentHighlight(params: LspHandler.DocumentHighlightParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.DocumentHighlight], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DocumentHighlightParams, Chunk[LspHandler.DocumentHighlight]](
+                                "textDocument/documentHighlight",
+                                params
+                            ))
+
+                        def documentSymbol(params: LspHandler.DocumentSymbolParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.DocumentSymbolResult], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DocumentSymbolParams, Maybe[LspHandler.DocumentSymbolResult]](
+                                "textDocument/documentSymbol",
+                                params
+                            ))
+
+                        def codeAction(params: LspHandler.CodeActionParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.CommandOrCodeAction], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.CodeActionParams, Chunk[LspHandler.CommandOrCodeAction]](
+                                "textDocument/codeAction",
+                                params
+                            ))
+
+                        def codeActionResolve(action: LspHandler.CodeAction)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[LspHandler.CodeAction, Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.CodeAction, LspHandler.CodeAction](
+                                "codeAction/resolve",
+                                action
+                            ))
+
+                        def codeLens(params: LspHandler.CodeLensParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.CodeLens], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.CodeLensParams, Chunk[LspHandler.CodeLens]](
+                                "textDocument/codeLens",
+                                params
+                            ))
+
+                        def codeLensResolve(lens: LspHandler.CodeLens)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[LspHandler.CodeLens, Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.CodeLens, LspHandler.CodeLens](
+                                "codeLens/resolve",
+                                lens
+                            ))
+
+                        def documentLink(params: LspHandler.DocumentLinkParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.DocumentLink], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DocumentLinkParams, Chunk[LspHandler.DocumentLink]](
+                                "textDocument/documentLink",
+                                params
+                            ))
+
+                        def documentLinkResolve(link: LspHandler.DocumentLink)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[LspHandler.DocumentLink, Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DocumentLink, LspHandler.DocumentLink](
+                                "documentLink/resolve",
+                                link
+                            ))
+
+                        def documentColor(params: LspHandler.DocumentColorParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.ColorInformation], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DocumentColorParams, Chunk[LspHandler.ColorInformation]](
+                                "textDocument/documentColor",
+                                params
+                            ))
+
+                        def colorPresentation(params: LspHandler.ColorPresentationParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.ColorPresentation], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.ColorPresentationParams, Chunk[LspHandler.ColorPresentation]](
+                                "textDocument/colorPresentation",
+                                params
+                            ))
+
+                        def formatting(params: LspHandler.DocumentFormattingParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.TextEdit], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DocumentFormattingParams, Chunk[LspHandler.TextEdit]](
+                                "textDocument/formatting",
+                                params
+                            ))
+
+                        def rangeFormatting(params: LspHandler.DocumentRangeFormattingParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.TextEdit], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DocumentRangeFormattingParams, Chunk[LspHandler.TextEdit]](
+                                "textDocument/rangeFormatting",
+                                params
+                            ))
+
+                        def onTypeFormatting(params: LspHandler.DocumentOnTypeFormattingParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.TextEdit], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DocumentOnTypeFormattingParams, Chunk[LspHandler.TextEdit]](
+                                "textDocument/onTypeFormatting",
+                                params
+                            ))
+
+                        def rename(params: LspHandler.RenameParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.WorkspaceEdit], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.RenameParams, Maybe[LspHandler.WorkspaceEdit]](
+                                "textDocument/rename",
+                                params
+                            ))
+
+                        def prepareRename(params: LspHandler.PrepareRenameParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.PrepareRenameResult], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.PrepareRenameParams, Maybe[LspHandler.PrepareRenameResult]](
+                                "textDocument/prepareRename",
+                                params
+                            ))
+
+                        def foldingRange(params: LspHandler.FoldingRangeParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.FoldingRange], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.FoldingRangeParams, Chunk[LspHandler.FoldingRange]](
+                                "textDocument/foldingRange",
+                                params
+                            ))
+
+                        def selectionRange(params: LspHandler.SelectionRangeParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.SelectionRange], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.SelectionRangeParams, Chunk[LspHandler.SelectionRange]](
+                                "textDocument/selectionRange",
+                                params
+                            ))
+
+                        def linkedEditingRange(params: LspHandler.LinkedEditingRangeParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.LinkedEditingRanges], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.LinkedEditingRangeParams, Maybe[LspHandler.LinkedEditingRanges]](
+                                "textDocument/linkedEditingRange",
+                                params
+                            ))
+
+                        def prepareCallHierarchy(params: LspHandler.CallHierarchyPrepareParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.CallHierarchyItem], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.CallHierarchyPrepareParams, Chunk[LspHandler.CallHierarchyItem]](
+                                "textDocument/prepareCallHierarchy",
+                                params
+                            ))
+
+                        def callHierarchyIncomingCalls(params: LspHandler.CallHierarchyIncomingCallsParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.CallHierarchyIncomingCall], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(
+                                callEffect[LspHandler.CallHierarchyIncomingCallsParams, Chunk[LspHandler.CallHierarchyIncomingCall]](
+                                    "callHierarchy/incomingCalls",
+                                    params
+                                )
+                            )
+
+                        def callHierarchyOutgoingCalls(params: LspHandler.CallHierarchyOutgoingCallsParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.CallHierarchyOutgoingCall], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(
+                                callEffect[LspHandler.CallHierarchyOutgoingCallsParams, Chunk[LspHandler.CallHierarchyOutgoingCall]](
+                                    "callHierarchy/outgoingCalls",
+                                    params
+                                )
+                            )
+
+                        def prepareTypeHierarchy(params: LspHandler.TypeHierarchyPrepareParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.TypeHierarchyItem], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.TypeHierarchyPrepareParams, Chunk[LspHandler.TypeHierarchyItem]](
+                                "textDocument/prepareTypeHierarchy",
+                                params
+                            ))
+
+                        def typeHierarchySupertypes(params: LspHandler.TypeHierarchySupertypesParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.TypeHierarchyItem], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.TypeHierarchySupertypesParams, Chunk[LspHandler.TypeHierarchyItem]](
+                                "typeHierarchy/supertypes",
+                                params
+                            ))
+
+                        def typeHierarchySubtypes(params: LspHandler.TypeHierarchySubtypesParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.TypeHierarchyItem], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.TypeHierarchySubtypesParams, Chunk[LspHandler.TypeHierarchyItem]](
+                                "typeHierarchy/subtypes",
+                                params
+                            ))
+
+                        def semanticTokensFull(params: LspHandler.SemanticTokensParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.SemanticTokens], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.SemanticTokensParams, Maybe[LspHandler.SemanticTokens]](
+                                "textDocument/semanticTokens/full",
+                                params
+                            ))
+
+                        def semanticTokensFullDelta(params: LspHandler.SemanticTokensDeltaParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.SemanticTokensResult], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.SemanticTokensDeltaParams, Maybe[LspHandler.SemanticTokensResult]](
+                                "textDocument/semanticTokens/full/delta",
+                                params
+                            ))
+
+                        def semanticTokensRange(params: LspHandler.SemanticTokensRangeParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Maybe[LspHandler.SemanticTokens], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.SemanticTokensRangeParams, Maybe[LspHandler.SemanticTokens]](
+                                "textDocument/semanticTokens/range",
+                                params
+                            ))
+
+                        def moniker(params: LspHandler.MonikerParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.Moniker], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.MonikerParams, Chunk[LspHandler.Moniker]](
+                                "textDocument/moniker",
+                                params
+                            ))
+
+                        def inlayHint(params: LspHandler.InlayHintParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.InlayHint], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.InlayHintParams, Chunk[LspHandler.InlayHint]](
+                                "textDocument/inlayHint",
+                                params
+                            ))
+
+                        def inlayHintResolve(hint: LspHandler.InlayHint)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[LspHandler.InlayHint, Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.InlayHint, LspHandler.InlayHint](
+                                "inlayHint/resolve",
+                                hint
+                            ))
+
+                        def inlineValue(params: LspHandler.InlineValueParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.InlineValue], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.InlineValueParams, Chunk[LspHandler.InlineValue]](
+                                "textDocument/inlineValue",
+                                params
+                            ))
+
+                        def documentDiagnostic(params: LspHandler.DocumentDiagnosticParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[LspHandler.DocumentDiagnosticReport, Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.DocumentDiagnosticParams, LspHandler.DocumentDiagnosticReport](
+                                "textDocument/diagnostic",
+                                params
+                            ))
+
+                        def willSaveWaitUntil(params: LspHandler.WillSaveTextDocumentParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.TextEdit], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.WillSaveTextDocumentParams, Chunk[LspHandler.TextEdit]](
+                                "textDocument/willSaveWaitUntil",
+                                params
+                            ))
+
+                        // textDocument notifications
+
+                        def didOpen(params: LspHandler.DidOpenTextDocumentParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                            Fiber.Unsafe.init(notifyEffect("textDocument/didOpen", params))
+
+                        def didChange(params: LspHandler.DidChangeTextDocumentParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                            Fiber.Unsafe.init(notifyEffect("textDocument/didChange", params))
+
+                        def didSave(params: LspHandler.DidSaveTextDocumentParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                            Fiber.Unsafe.init(notifyEffect("textDocument/didSave", params))
+
+                        def didClose(params: LspHandler.DidCloseTextDocumentParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                            Fiber.Unsafe.init(notifyEffect("textDocument/didClose", params))
+
+                        def willSave(params: LspHandler.WillSaveTextDocumentParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                            Fiber.Unsafe.init(notifyEffect("textDocument/willSave", params))
+
+                        // workspace
+
+                        def workspaceSymbol(params: LspHandler.WorkspaceSymbolParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Chunk[LspHandler.WorkspaceSymbol], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.WorkspaceSymbolParams, Chunk[LspHandler.WorkspaceSymbol]](
+                                "workspace/symbol",
+                                params
+                            ))
+
+                        def executeCommand[T](params: LspHandler.ExecuteCommandParams)(using
+                            AllowUnsafe,
+                            Frame,
+                            Schema[T]
+                        ): Fiber.Unsafe[Maybe[T], Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.ExecuteCommandParams, Maybe[T]](
+                                "workspace/executeCommand",
+                                params
+                            ))
+
+                        def workspaceDiagnostic(params: LspHandler.WorkspaceDiagnosticParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[LspHandler.WorkspaceDiagnosticReport, Abort[LspRequestFailure]] =
+                            Fiber.Unsafe.init(callEffect[LspHandler.WorkspaceDiagnosticParams, LspHandler.WorkspaceDiagnosticReport](
+                                "workspace/diagnostic",
+                                params
+                            ))
+
+                        // lifecycle
+
+                        def workDoneProgressCancel(params: LspHandler.WorkDoneProgressCancelParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                            Fiber.Unsafe.init(notifyEffect("window/workDoneProgress/cancel", params))
+
+                        def setTrace(params: LspHandler.SetTraceParams)(using
+                            AllowUnsafe,
+                            Frame
+                        ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                            Fiber.Unsafe.init(notifyEffect("$/setTrace", params))
+
+                        def cancel(id: JsonRpcId)(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                            Fiber.Unsafe.init(
+                                handler.cancel(id).handle(Abort.recover[Closed] { _ => Abort.fail(LspConnectionClosedException()) })
+                            )
+
+                        // session properties
+
+                        def specVersion: String = LspConfig.SpecVersion
+
+                        def positionEncoding(using Frame): LspHandler.PositionEncodingKind < Sync =
+                            negotiatedEncodingRef.get
+
+                        def serverCapabilities(using Frame): Maybe[LspCapabilities.Server.Server] < Sync =
+                            serverCapsRef.get
+
+                        def serverInfo(using Frame): Maybe[LspInfo] < Sync =
+                            serverInfoRef.get
+
+                        def underlying: JsonRpcHandler = handler
+
+                        def awaitDrain(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Any] =
+                            Fiber.Unsafe.init(handler.awaitDrain)
+
+                        def close(gracePeriod: Duration)(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Any] =
+                            Fiber.Unsafe.init(handler.close(gracePeriod))
+
+                    end unsafe
+
+                    // Populate clientRef so lifted client handlers can bind it into Lsp.local.
+                    clientRef.set(Present(unsafe)).andThen(unsafe)
+                }
+            }
+        }
+    end initClient
+
+end LspClientEngine

--- a/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspContentSchemas.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspContentSchemas.scala
@@ -1,0 +1,1805 @@
+package kyo.internal.lsp
+
+import kyo.*
+import scala.annotation.nowarn
+import scala.annotation.publicInBinary
+
+/** Hand-rolled discriminator Schemas for LSP 3.17 sealed-union types.
+  *
+  * Each val is a singleton. The discriminator strategy varies per type and mirrors the LSP 3.17
+  * wire format exactly (no extra `_type` wrapping). Precedent: `McpContentSchema` at
+  * kyo/internal/McpContentSchema.scala.
+  *
+  * TODO(kyo-schema#1695): these are hand-rolled only because kyo-schema cannot yet serialize a sum
+  * type untagged (selecting a variant by JSON shape rather than a discriminator field), which is
+  * what LSP 3.17 requires for these types. Once the untagged sum-type wire representation tracked in
+  * https://github.com/getkyo/kyo/issues/1695 lands, every schema below that discriminates by node
+  * type or field presence collapses to a derived sealed trait with `.untagged`; the bare-scalar
+  * variants (e.g. `ProgressToken`) additionally need single-field unwrapping. The three kind-tagged
+  * report types already migrated to the shipped `.discriminator("kind").renameAllVariants(...)`.
+  *
+  * Strategies used:
+  *   - `TextDocumentContentChangeEvent`: field presence (`range` present -> Incremental, absent -> Full)
+  *   - `ProgressToken`: JSON node type (integer -> IntToken, string -> StringToken)
+  *   - `WorkDoneProgressValue`: `kind` field ("begin" / "report" / "end")
+  *   - `MarkedString`: JSON node type (string -> Plain, object -> Code)
+  *   - `HoverContents`: node type (object with `kind` field -> Markup, array -> Strings)
+  *   - `DocumentDiagnosticReport`: `kind` field ("full" / "unchanged")
+  *   - `WorkspaceDocumentDiagnosticReport`: `kind` field ("full" / "unchanged")
+  *   - `DocumentSymbolResult`: array element peek (`children` -> Symbols, `location` -> Information)
+  *   - `WorkspaceSymbolLocation`: `range` field presence
+  *   - `CompletionResult`: JSON node type (array -> Items, object -> List)
+  *   - `ParameterLabel`: JSON node type (string -> StringLabel, array -> RangeLabel)
+  *   - `CommandOrCodeAction`: field presence (`edit`/`diagnostics`/`isPreferred` -> Action, else Cmd)
+  *   - `WorkspaceEditDocumentChange`: `kind` field (absent -> Edit, "create"/"rename"/"delete")
+  *   - `PrepareRenameResult`: field presence (`placeholder` -> RangeWithPlaceholder, `defaultBehavior` -> DefaultBehavior, else JustRange)
+  *   - `DefinitionResult` family: JSON node type + first element shape
+  *   - `SemanticTokensResult`: field presence (`edits` -> Delta, `data` -> Full)
+  *   - `InlayHintLabelPart`: JSON node type (string -> StringPart, object -> StructuredPart)
+  *   - `InlayHintLabel`: JSON node type (string -> PlainString, array -> Parts)
+  *   - `InlineValue`: field presence (`expression` -> EvaluatableExpression, `variableName`/`caseSensitiveLookup` -> VariableLookup, else Text)
+  *   - `NotebookDocumentFilter`: required-field presence
+  *   - `Registration`: hand-rolled `{id, method, registerOptions?}` with raw JSON pass-through
+  */
+private[kyo] object LspContentSchemas:
+
+    // MARK: -- TextDocumentContentChangeEvent
+
+    @nowarn("msg=anonymous")
+    val textDocumentContentChangeEventSchema: Schema[LspHandler.TextDocumentContentChangeEvent] =
+        new Schema[LspHandler.TextDocumentContentChangeEvent](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.TextDocumentContentChangeEvent, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.TextDocumentContentChangeEvent.Full(text) =>
+                        w.objectStart("TextDocumentContentChangeEvent.Full", 1)
+                        w.field("text", 1)
+                        w.string(text)
+                        w.objectEnd()
+                    case LspHandler.TextDocumentContentChangeEvent.Incremental(range, text) =>
+                        w.objectStart("TextDocumentContentChangeEvent.Incremental", 2)
+                        w.field("range", 1)
+                        summon[Schema[LspHandler.Range]].serializeWrite(range, w)
+                        w.field("text", 2)
+                        w.string(text)
+                        w.objectEnd()
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.TextDocumentContentChangeEvent =
+                var text: String            = ""
+                var range: LspHandler.Range = null
+                discard(reader.objectStart())
+                while reader.hasNextField() do
+                    reader.fieldParse()
+                    if reader.matchField("range".getBytes("UTF-8")) then
+                        range = summon[Schema[LspHandler.Range]].serializeRead(reader)
+                    else if reader.matchField("text".getBytes("UTF-8")) then
+                        text = reader.string()
+                    else
+                        reader.skip()
+                    end if
+                end while
+                reader.objectEnd()
+                if range != null then
+                    LspHandler.TextDocumentContentChangeEvent.Incremental(range, text)
+                else
+                    LspHandler.TextDocumentContentChangeEvent.Full(text)
+                end if
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.TextDocumentContentChangeEvent): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(
+                value: LspHandler.TextDocumentContentChangeEvent,
+                next: Any
+            ): LspHandler.TextDocumentContentChangeEvent =
+                next match
+                    case c: LspHandler.TextDocumentContentChangeEvent => c
+                    case _                                            => value
+            // Open: see JsonRpcId for rationale. Same pattern applies at every other
+            // `Structure.Type.Open` site in this file.
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.TextDocumentContentChangeEvent].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.TextDocumentContentChangeEvent] =
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.iterator.toMap
+                        val textR = m.get("text") match
+                            case Some(Structure.Value.Str(s)) => Result.Success(s)
+                            case _                            => Result.Success("")
+                        m.get("range") match
+                            case Some(rangeSv) =>
+                                for
+                                    r <- summon[Schema[LspHandler.Range]].fromStructureValue(rangeSv)
+                                    t <- textR
+                                yield LspHandler.TextDocumentContentChangeEvent.Incremental(r, t)
+                            case scala.None =>
+                                textR.map(t => LspHandler.TextDocumentContentChangeEvent.Full(t))
+                        end match
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Record", sv.toString))
+
+    // MARK: -- ProgressToken
+
+    @nowarn("msg=anonymous")
+    val progressTokenSchema: Schema[LspHandler.ProgressToken] =
+        new Schema[LspHandler.ProgressToken](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.ProgressToken, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.ProgressToken.IntToken(n)    => w.int(n)
+                    case LspHandler.ProgressToken.StringToken(s) => w.string(s)
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.ProgressToken =
+                val captured = reader.captureValue()
+                try LspHandler.ProgressToken.IntToken(captured.int())
+                catch case _: Exception => LspHandler.ProgressToken.StringToken(captured.string())
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.ProgressToken): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.ProgressToken, next: Any): LspHandler.ProgressToken =
+                next match
+                    case t: LspHandler.ProgressToken => t
+                    case _                           => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.ProgressToken].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.ProgressToken] =
+                sv match
+                    case Structure.Value.Integer(n) => Result.Success(LspHandler.ProgressToken.IntToken(n.toInt))
+                    case Structure.Value.Str(s)     => Result.Success(LspHandler.ProgressToken.StringToken(s))
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Integer|String", sv.toString))
+
+    // MARK: -- MarkedString
+
+    @nowarn("msg=anonymous")
+    val markedStringSchema: Schema[LspHandler.MarkedString] =
+        new Schema[LspHandler.MarkedString](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.MarkedString, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.MarkedString.Plain(value) => w.string(value)
+                    case LspHandler.MarkedString.Code(language, value) =>
+                        w.objectStart("MarkedString.Code", 2)
+                        w.field("language", 1)
+                        w.string(language)
+                        w.field("value", 2)
+                        w.string(value)
+                        w.objectEnd()
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.MarkedString =
+                val captured = reader.captureValue()
+                try LspHandler.MarkedString.Plain(captured.string())
+                catch
+                    case _: Exception =>
+                        var language: String = ""
+                        var value: String    = ""
+                        discard(captured.objectStart())
+                        while captured.hasNextField() do
+                            captured.fieldParse()
+                            if captured.matchField("language".getBytes("UTF-8")) then language = captured.string()
+                            else if captured.matchField("value".getBytes("UTF-8")) then value = captured.string()
+                            else captured.skip()
+                        end while
+                        captured.objectEnd()
+                        LspHandler.MarkedString.Code(language, value)
+                end try
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.MarkedString): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.MarkedString, next: Any): LspHandler.MarkedString =
+                next match
+                    case m: LspHandler.MarkedString => m
+                    case _                          => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.MarkedString].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.MarkedString] =
+                sv match
+                    case Structure.Value.Str(s) => Result.Success(LspHandler.MarkedString.Plain(s))
+                    case Structure.Value.Record(fields) =>
+                        val m        = fields.iterator.toMap
+                        val language = m.get("language").collect { case Structure.Value.Str(s) => s }.getOrElse("")
+                        val value    = m.get("value").collect { case Structure.Value.Str(s) => s }.getOrElse("")
+                        Result.Success(LspHandler.MarkedString.Code(language, value))
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "String|Record", sv.toString))
+
+    // MARK: -- HoverContents
+
+    @nowarn("msg=anonymous")
+    val hoverContentsSchema: Schema[LspHandler.HoverContents] =
+        new Schema[LspHandler.HoverContents](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.HoverContents, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.HoverContents.Markup(value) =>
+                        summon[Schema[LspHandler.MarkupContent]].serializeWrite(value, w)
+                    case LspHandler.HoverContents.Strings(value) =>
+                        w.arrayStart(value.size)
+                        value.foreach { ms => markedStringSchema.serializeWrite(ms, w) }
+                        w.arrayEnd()
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.HoverContents =
+                val captured = reader.captureValue()
+                // Try to read as array (Strings case) - if captureValue starts '[' it's an array
+                try
+                    discard(captured.arrayStart())
+                    val buf = scala.collection.mutable.ArrayBuffer[LspHandler.MarkedString]()
+                    while captured.hasNextElement() do
+                        buf += markedStringSchema.serializeRead(captured)
+                    captured.arrayEnd()
+                    LspHandler.HoverContents.Strings(Chunk.from(buf))
+                catch
+                    case _: Exception =>
+                        LspHandler.HoverContents.Markup(summon[Schema[LspHandler.MarkupContent]].serializeRead(captured))
+                end try
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.HoverContents): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.HoverContents, next: Any): LspHandler.HoverContents =
+                next match
+                    case h: LspHandler.HoverContents => h
+                    case _                           => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.HoverContents].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.HoverContents] =
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.iterator.toMap
+                        if m.contains("kind") then
+                            summon[Schema[LspHandler.MarkupContent]].fromStructureValue(sv).map(LspHandler.HoverContents.Markup(_))
+                        else
+                            // MarkedString object (language + value)
+                            markedStringSchema.fromStructureValue(sv).map(ms => LspHandler.HoverContents.Strings(Chunk(ms)))
+                        end if
+                    case Structure.Value.Sequence(elems) =>
+                        val results = elems.map(e => markedStringSchema.fromStructureValue(e))
+                        val init: Result[DecodeException, Chunk[LspHandler.MarkedString]] = Result.Success(Chunk.empty)
+                        results.foldLeft(init) { (acc, r) =>
+                            acc.flatMap(chunk => r.map(ms => chunk.append(ms)))
+                        }.map(LspHandler.HoverContents.Strings(_))
+                    case Structure.Value.Str(s) =>
+                        Result.Success(LspHandler.HoverContents.Strings(Chunk(LspHandler.MarkedString.Plain(s))))
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Record|Sequence|String", sv.toString))
+
+    // MARK: -- DocumentSymbolResult
+
+    @nowarn("msg=anonymous")
+    val documentSymbolResultSchema: Schema[LspHandler.DocumentSymbolResult] =
+        new Schema[LspHandler.DocumentSymbolResult](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.DocumentSymbolResult, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.DocumentSymbolResult.Symbols(items) =>
+                        w.arrayStart(items.size)
+                        items.foreach { s => summon[Schema[LspHandler.DocumentSymbol]].serializeWrite(s, w) }
+                        w.arrayEnd()
+                    case LspHandler.DocumentSymbolResult.Information(items) =>
+                        w.arrayStart(items.size)
+                        items.foreach { s => summon[Schema[LspHandler.SymbolInformation]].serializeWrite(s, w) }
+                        w.arrayEnd()
+
+            private def readOneElement(r: Codec.Reader): Either[LspHandler.DocumentSymbol, LspHandler.SymbolInformation] =
+                // Read one object in a single pass; detect type from field presence
+                var name: String                               = ""
+                var kind: LspHandler.SymbolKind                = LspHandler.SymbolKind.File
+                var tags: Chunk[LspHandler.SymbolTag]          = Chunk.empty
+                var deprecated: Maybe[Boolean]                 = Absent
+                var detail: Maybe[String]                      = Absent
+                var range: Maybe[LspHandler.Range]             = Absent
+                var selectionRange: Maybe[LspHandler.Range]    = Absent
+                var children: Chunk[LspHandler.DocumentSymbol] = Chunk.empty
+                var location: Maybe[LspHandler.Location]       = Absent
+                var containerName: Maybe[String]               = Absent
+                discard(r.objectStart())
+                while r.hasNextField() do
+                    r.fieldParse()
+                    if r.matchField("name".getBytes("UTF-8")) then name = r.string()
+                    else if r.matchField("kind".getBytes("UTF-8")) then
+                        kind = summon[Schema[LspHandler.SymbolKind]].serializeRead(r)
+                    else if r.matchField("tags".getBytes("UTF-8")) then
+                        val cnt = r.arrayStart()
+                        val b   = scala.collection.mutable.ArrayBuffer[LspHandler.SymbolTag]()
+                        if cnt < 0 then while r.hasNextElement() do b += summon[Schema[LspHandler.SymbolTag]].serializeRead(r)
+                        else
+                            var j = 0;
+                            while j < cnt do
+                                b += summon[Schema[LspHandler.SymbolTag]].serializeRead(r); j += 1
+                        end if
+                        r.arrayEnd()
+                        tags = Chunk.from(b)
+                    else if r.matchField("deprecated".getBytes("UTF-8")) then deprecated = Present(r.boolean())
+                    else if r.matchField("detail".getBytes("UTF-8")) then detail = Present(r.string())
+                    else if r.matchField("range".getBytes("UTF-8")) then
+                        range = Present(summon[Schema[LspHandler.Range]].serializeRead(r))
+                    else if r.matchField("selectionRange".getBytes("UTF-8")) then
+                        selectionRange = Present(summon[Schema[LspHandler.Range]].serializeRead(r))
+                    else if r.matchField("children".getBytes("UTF-8")) then
+                        val cnt = r.arrayStart()
+                        val b   = scala.collection.mutable.ArrayBuffer[LspHandler.DocumentSymbol]()
+                        if cnt < 0 then
+                            while r.hasNextElement() do
+                                b += summon[Schema[LspHandler.DocumentSymbol]].serializeRead(r)
+                        else
+                            var j = 0;
+                            while j < cnt do
+                                b += summon[Schema[LspHandler.DocumentSymbol]].serializeRead(r); j += 1
+                        end if
+                        r.arrayEnd()
+                        children = Chunk.from(b)
+                    else if r.matchField("location".getBytes("UTF-8")) then
+                        location = Present(summon[Schema[LspHandler.Location]].serializeRead(r))
+                    else if r.matchField("containerName".getBytes("UTF-8")) then containerName = Present(r.string())
+                    else r.skip()
+                    end if
+                end while
+                r.objectEnd()
+                location match
+                    case Present(loc) =>
+                        Right(LspHandler.SymbolInformation(name, kind, tags, deprecated, loc, containerName))
+                    case Absent =>
+                        Left(LspHandler.DocumentSymbol(
+                            name,
+                            detail,
+                            kind,
+                            tags,
+                            deprecated,
+                            range.getOrElse(LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0))),
+                            selectionRange.getOrElse(LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0))),
+                            children
+                        ))
+                end match
+            end readOneElement
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.DocumentSymbolResult =
+                val count = reader.arrayStart()
+                if count == 0 then
+                    reader.arrayEnd()
+                    LspHandler.DocumentSymbolResult.Symbols(Chunk.empty)
+                else
+                    val symbols      = scala.collection.mutable.ArrayBuffer[LspHandler.DocumentSymbol]()
+                    val infos        = scala.collection.mutable.ArrayBuffer[LspHandler.SymbolInformation]()
+                    var isSymbol     = true
+                    var isDetermined = false
+
+                    def readAll(): Unit =
+                        if count < 0 then
+                            while reader.hasNextElement() do
+                                val elem = readOneElement(reader)
+                                elem match
+                                    case Left(ds) =>
+                                        if !isDetermined then
+                                            isSymbol = true; isDetermined = true; symbols += ds
+                                    case Right(si) =>
+                                        if !isDetermined then
+                                            isSymbol = false; isDetermined = true; infos += si
+                                end match
+                        else
+                            var j = 0
+                            while j < count do
+                                val elem = readOneElement(reader)
+                                elem match
+                                    case Left(ds) =>
+                                        if !isDetermined then
+                                            isSymbol = true; isDetermined = true; symbols += ds
+                                    case Right(si) =>
+                                        if !isDetermined then
+                                            isSymbol = false; isDetermined = true; infos += si
+                                end match
+                                j += 1
+                            end while
+                    end readAll
+
+                    readAll()
+                    reader.arrayEnd()
+                    if isSymbol then LspHandler.DocumentSymbolResult.Symbols(Chunk.from(symbols))
+                    else LspHandler.DocumentSymbolResult.Information(Chunk.from(infos))
+                end if
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.DocumentSymbolResult): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.DocumentSymbolResult, next: Any): LspHandler.DocumentSymbolResult =
+                next match
+                    case r: LspHandler.DocumentSymbolResult => r
+                    case _                                  => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.DocumentSymbolResult].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.DocumentSymbolResult] =
+                sv match
+                    case Structure.Value.Sequence(elems) =>
+                        if elems.isEmpty then Result.Success(LspHandler.DocumentSymbolResult.Symbols(Chunk.empty))
+                        else
+                            // Peek first element to determine type
+                            val first = elems.head
+                            val isSymbolInfo = first match
+                                case Structure.Value.Record(fields) =>
+                                    val m = fields.iterator.toMap
+                                    m.contains("location") && !m.contains("children")
+                                case _ => false
+                            if isSymbolInfo then
+                                val results = elems.map(e => summon[Schema[LspHandler.SymbolInformation]].fromStructureValue(e))
+                                val initAcc: Result[DecodeException, Chunk[LspHandler.SymbolInformation]] = Result.Success(Chunk.empty)
+                                results.foldLeft(initAcc) { (acc, r) =>
+                                    acc.flatMap(chunk => r.map(si => chunk.append(si)))
+                                }.map(LspHandler.DocumentSymbolResult.Information(_))
+                            else
+                                val results = elems.map(e => summon[Schema[LspHandler.DocumentSymbol]].fromStructureValue(e))
+                                val initAcc: Result[DecodeException, Chunk[LspHandler.DocumentSymbol]] = Result.Success(Chunk.empty)
+                                results.foldLeft(initAcc) { (acc, r) =>
+                                    acc.flatMap(chunk => r.map(ds => chunk.append(ds)))
+                                }.map(LspHandler.DocumentSymbolResult.Symbols(_))
+                            end if
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Sequence", sv.toString))
+
+    // MARK: -- WorkspaceSymbolLocation
+
+    @nowarn("msg=anonymous")
+    val workspaceSymbolLocationSchema: Schema[LspHandler.WorkspaceSymbolLocation] =
+        new Schema[LspHandler.WorkspaceSymbolLocation](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.WorkspaceSymbolLocation, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.WorkspaceSymbolLocation.WithRange(uri, range) =>
+                        w.objectStart("WorkspaceSymbolLocation.WithRange", 2)
+                        w.field("uri", 1)
+                        summon[Schema[LspHandler.LspDocument.Uri]].serializeWrite(uri, w)
+                        w.field("range", 2)
+                        summon[Schema[LspHandler.Range]].serializeWrite(range, w)
+                        w.objectEnd()
+                    case LspHandler.WorkspaceSymbolLocation.UriOnly(uri) =>
+                        w.objectStart("WorkspaceSymbolLocation.UriOnly", 1)
+                        w.field("uri", 1)
+                        summon[Schema[LspHandler.LspDocument.Uri]].serializeWrite(uri, w)
+                        w.objectEnd()
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.WorkspaceSymbolLocation =
+                var uri: LspHandler.LspDocument.Uri = LspHandler.LspDocument.Uri.fromWire("")
+                var range: Maybe[LspHandler.Range]  = Absent
+                discard(reader.objectStart())
+                while reader.hasNextField() do
+                    reader.fieldParse()
+                    if reader.matchField("uri".getBytes("UTF-8")) then
+                        uri = summon[Schema[LspHandler.LspDocument.Uri]].serializeRead(reader)
+                    else if reader.matchField("range".getBytes("UTF-8")) then
+                        range = Present(summon[Schema[LspHandler.Range]].serializeRead(reader))
+                    else reader.skip()
+                    end if
+                end while
+                reader.objectEnd()
+                range match
+                    case Present(r) => LspHandler.WorkspaceSymbolLocation.WithRange(uri, r)
+                    case Absent     => LspHandler.WorkspaceSymbolLocation.UriOnly(uri)
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.WorkspaceSymbolLocation): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(
+                value: LspHandler.WorkspaceSymbolLocation,
+                next: Any
+            ): LspHandler.WorkspaceSymbolLocation =
+                next match
+                    case l: LspHandler.WorkspaceSymbolLocation => l
+                    case _                                     => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.WorkspaceSymbolLocation].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.WorkspaceSymbolLocation] =
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m      = fields.iterator.toMap
+                        val uriStr = m.get("uri").collect { case Structure.Value.Str(s) => s }.getOrElse("")
+                        val uri    = LspHandler.LspDocument.Uri.fromWire(uriStr)
+                        m.get("range") match
+                            case Some(rangeSv) =>
+                                summon[Schema[LspHandler.Range]].fromStructureValue(rangeSv).map { r =>
+                                    LspHandler.WorkspaceSymbolLocation.WithRange(uri, r)
+                                }
+                            case scala.None =>
+                                Result.Success(LspHandler.WorkspaceSymbolLocation.UriOnly(uri))
+                        end match
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Record", sv.toString))
+
+    // MARK: -- CompletionResult
+
+    @nowarn("msg=anonymous")
+    val completionResultSchema: Schema[LspHandler.CompletionResult] =
+        new Schema[LspHandler.CompletionResult](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.CompletionResult, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.CompletionResult.Items(items) =>
+                        w.arrayStart(items.size)
+                        items.foreach { i => summon[Schema[LspHandler.CompletionItem]].serializeWrite(i, w) }
+                        w.arrayEnd()
+                    case LspHandler.CompletionResult.List(list) =>
+                        summon[Schema[LspHandler.CompletionList]].serializeWrite(list, w)
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.CompletionResult =
+                val captured = reader.captureValue()
+                try
+                    discard(captured.arrayStart())
+                    val buf = scala.collection.mutable.ArrayBuffer[LspHandler.CompletionItem]()
+                    while captured.hasNextElement() do
+                        buf += summon[Schema[LspHandler.CompletionItem]].serializeRead(captured)
+                    captured.arrayEnd()
+                    LspHandler.CompletionResult.Items(Chunk.from(buf))
+                catch
+                    case _: Exception =>
+                        LspHandler.CompletionResult.List(summon[Schema[LspHandler.CompletionList]].serializeRead(captured))
+                end try
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.CompletionResult): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.CompletionResult, next: Any): LspHandler.CompletionResult =
+                next match
+                    case r: LspHandler.CompletionResult => r
+                    case _                              => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.CompletionResult].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.CompletionResult] =
+                sv match
+                    case Structure.Value.Sequence(elems) =>
+                        val results = elems.map(e => summon[Schema[LspHandler.CompletionItem]].fromStructureValue(e))
+                        val initAcc: Result[DecodeException, Chunk[LspHandler.CompletionItem]] = Result.Success(Chunk.empty)
+                        results.foldLeft(initAcc) { (acc, r) =>
+                            acc.flatMap(chunk => r.map(ci => chunk.append(ci)))
+                        }.map(LspHandler.CompletionResult.Items(_))
+                    case Structure.Value.Record(_) =>
+                        summon[Schema[LspHandler.CompletionList]].fromStructureValue(sv).map(LspHandler.CompletionResult.List(_))
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Sequence|Record", sv.toString))
+
+    // MARK: -- ParameterLabel
+
+    @nowarn("msg=anonymous")
+    val parameterLabelSchema: Schema[LspHandler.ParameterLabel] =
+        new Schema[LspHandler.ParameterLabel](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.ParameterLabel, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.ParameterLabel.StringLabel(value) => w.string(value)
+                    case LspHandler.ParameterLabel.RangeLabel(start, end) =>
+                        w.arrayStart(2)
+                        w.int(start)
+                        w.int(end)
+                        w.arrayEnd()
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.ParameterLabel =
+                val captured = reader.captureValue()
+                try LspHandler.ParameterLabel.StringLabel(captured.string())
+                catch
+                    case _: Exception =>
+                        discard(captured.arrayStart())
+                        var start = 0
+                        var end   = 0
+                        if captured.hasNextElement() then start = captured.int()
+                        if captured.hasNextElement() then end = captured.int()
+                        captured.arrayEnd()
+                        LspHandler.ParameterLabel.RangeLabel(start, end)
+                end try
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.ParameterLabel): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.ParameterLabel, next: Any): LspHandler.ParameterLabel =
+                next match
+                    case l: LspHandler.ParameterLabel => l
+                    case _                            => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.ParameterLabel].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.ParameterLabel] =
+                sv match
+                    case Structure.Value.Str(s) => Result.Success(LspHandler.ParameterLabel.StringLabel(s))
+                    case Structure.Value.Sequence(elems) if elems.size == 2 =>
+                        val startR = elems(0) match
+                            case Structure.Value.Integer(n) => Result.Success(n.toInt)
+                            case other                      => Result.Failure(TypeMismatchException(Seq("start"), "Int", other.toString))
+                        val endR = elems(1) match
+                            case Structure.Value.Integer(n) => Result.Success(n.toInt)
+                            case other                      => Result.Failure(TypeMismatchException(Seq("end"), "Int", other.toString))
+                        for s <- startR; e <- endR yield LspHandler.ParameterLabel.RangeLabel(s, e)
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "String|[Int,Int]", sv.toString))
+
+    // MARK: -- CommandOrCodeAction
+
+    @nowarn("msg=anonymous")
+    val commandOrCodeActionSchema: Schema[LspHandler.CommandOrCodeAction] =
+        new Schema[LspHandler.CommandOrCodeAction](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.CommandOrCodeAction, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.CommandOrCodeAction.Cmd(value)    => summon[Schema[LspHandler.Command]].serializeWrite(value, w)
+                    case LspHandler.CommandOrCodeAction.Action(value) => summon[Schema[LspHandler.CodeAction]].serializeWrite(value, w)
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.CommandOrCodeAction =
+                // Discriminate: CodeAction has `edit`, `diagnostics`, `isPreferred`, `disabled` fields.
+                // `command` is a string in Command but a nested object in CodeAction.
+                // `arguments` are LSPAny[]; capture as raw JSON snippets via captureValue.
+                var title: String                                  = ""
+                var commandStr: String                             = ""
+                var commandObj: Maybe[LspHandler.Command]          = Absent
+                var arguments: Chunk[String]                       = Chunk.empty
+                var hasEdit                                        = false
+                var hasDiagnostics                                 = false
+                var hasIsPreferred                                 = false
+                var hasDisabled                                    = false
+                var commandIsObject                                = false
+                var kind: Maybe[LspHandler.CodeActionKind]         = Absent
+                var edit: Maybe[LspHandler.WorkspaceEdit]          = Absent
+                var diags: Chunk[LspHandler.Diagnostic]            = Chunk.empty
+                var isPreferred: Maybe[Boolean]                    = Absent
+                var disabled: Maybe[LspHandler.CodeActionDisabled] = Absent
+
+                discard(reader.objectStart())
+                while reader.hasNextField() do
+                    reader.fieldParse()
+                    if reader.matchField("title".getBytes("UTF-8")) then title = reader.string()
+                    else if reader.matchField("command".getBytes("UTF-8")) then
+                        // `command` can be a string (standalone Command) or object (Command nested inside CodeAction)
+                        val captured = reader.captureValue()
+                        try
+                            commandStr = captured.string()
+                            commandIsObject = false
+                        catch
+                            case _: Exception =>
+                                commandIsObject = true
+                                commandObj = Present(summon[Schema[LspHandler.Command]].serializeRead(captured))
+                        end try
+                    else if reader.matchField("arguments".getBytes("UTF-8")) then
+                        // LSPAny[] - each element may be any JSON value.
+                        // String elements are read directly; non-string elements are skipped (stored as empty string).
+                        // This preserves string arguments (most common case) without crashing on typed JSON args.
+                        val count = reader.arrayStart()
+                        val buf   = scala.collection.mutable.ArrayBuffer[String]()
+                        if count < 0 then
+                            while reader.hasNextElement() do
+                                val cap = reader.captureValue()
+                                val v =
+                                    try cap.string()
+                                    catch case _: Exception => ""
+                                buf += v
+                        else
+                            var j = 0;
+                            while j < count do
+                                val cap = reader.captureValue()
+                                val v =
+                                    try cap.string()
+                                    catch case _: Exception => ""
+                                buf += v; j += 1
+                            end while
+                        end if
+                        reader.arrayEnd()
+                        arguments = Chunk.from(buf)
+                    else if reader.matchField("kind".getBytes("UTF-8")) then
+                        kind = Present(LspHandler.CodeActionKind(reader.string()))
+                    else if reader.matchField("edit".getBytes("UTF-8")) then
+                        hasEdit = true
+                        edit = Present(summon[Schema[LspHandler.WorkspaceEdit]].serializeRead(reader))
+                    else if reader.matchField("diagnostics".getBytes("UTF-8")) then
+                        hasDiagnostics = true
+                        val count = reader.arrayStart()
+                        val buf   = scala.collection.mutable.ArrayBuffer[LspHandler.Diagnostic]()
+                        if count < 0 then
+                            while reader.hasNextElement() do
+                                buf += summon[Schema[LspHandler.Diagnostic]].serializeRead(reader)
+                        else
+                            var j = 0
+                            while j < count do
+                                buf += summon[Schema[LspHandler.Diagnostic]].serializeRead(reader)
+                                j += 1
+                            end while
+                        end if
+                        reader.arrayEnd()
+                        diags = Chunk.from(buf)
+                    else if reader.matchField("isPreferred".getBytes("UTF-8")) then
+                        hasIsPreferred = true
+                        isPreferred = Present(reader.boolean())
+                    else if reader.matchField("disabled".getBytes("UTF-8")) then
+                        hasDisabled = true
+                        disabled = Present(summon[Schema[LspHandler.CodeActionDisabled]].serializeRead(reader))
+                    else reader.skip()
+                    end if
+                end while
+                reader.objectEnd()
+
+                // If any CodeAction-specific field is present, or command field was an object, it's a CodeAction
+                if hasEdit || hasDiagnostics || hasIsPreferred || hasDisabled || commandIsObject then
+                    LspHandler.CommandOrCodeAction.Action(
+                        LspHandler.CodeAction(title, kind, diags, isPreferred, disabled, edit, commandObj, Absent)
+                    )
+                else
+                    // It's a Command (title + command-string + optional arguments)
+                    LspHandler.CommandOrCodeAction.Cmd(LspHandler.Command(title, commandStr, arguments))
+                end if
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.CommandOrCodeAction): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.CommandOrCodeAction, next: Any): LspHandler.CommandOrCodeAction =
+                next match
+                    case c: LspHandler.CommandOrCodeAction => c
+                    case _                                 => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.CommandOrCodeAction].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.CommandOrCodeAction] =
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.iterator.toMap
+                        if m.contains("edit") || m.contains("diagnostics") || m.contains("isPreferred") || m.contains("disabled") then
+                            summon[Schema[LspHandler.CodeAction]].fromStructureValue(sv).map(LspHandler.CommandOrCodeAction.Action(_))
+                        else
+                            summon[Schema[LspHandler.Command]].fromStructureValue(sv).map(LspHandler.CommandOrCodeAction.Cmd(_))
+                        end if
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Record", sv.toString))
+
+    // MARK: -- WorkspaceEditDocumentChange
+
+    @nowarn("msg=anonymous")
+    val workspaceEditDocumentChangeSchema: Schema[LspHandler.WorkspaceEditDocumentChange] =
+        new Schema[LspHandler.WorkspaceEditDocumentChange](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.WorkspaceEditDocumentChange, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.WorkspaceEditDocumentChange.Edit(value) =>
+                        summon[Schema[LspHandler.TextDocumentEdit]].serializeWrite(value, w)
+                    case LspHandler.WorkspaceEditDocumentChange.Create(value) =>
+                        summon[Schema[LspHandler.CreateFile]].serializeWrite(value, w)
+                    case LspHandler.WorkspaceEditDocumentChange.Rename(value) =>
+                        summon[Schema[LspHandler.RenameFile]].serializeWrite(value, w)
+                    case LspHandler.WorkspaceEditDocumentChange.Delete(value) =>
+                        summon[Schema[LspHandler.DeleteFile]].serializeWrite(value, w)
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.WorkspaceEditDocumentChange =
+                // Read ALL fields in one pass, collect them, then dispatch based on kind
+                var kindStr: String                               = ""
+                var hasKind: Boolean                              = false
+                var textDocumentEdit: LspHandler.TextDocumentEdit = null
+                var createFile: LspHandler.CreateFile             = null
+                var renameFile: LspHandler.RenameFile             = null
+                var deleteFile: LspHandler.DeleteFile             = null
+                // For TextDocumentEdit: read textDocument + edits
+                var tdTextDocument: LspHandler.OptionalVersionedTextDocumentIdentifier = null
+                var tdEdits: Chunk[LspHandler.TextEdit]                                = Chunk.empty
+                // For CreateFile: uri + options + annotationId
+                var cfUri: String                                  = ""
+                var cfOptions: Maybe[LspHandler.CreateFileOptions] = Absent
+                var cfAnnotationId: Maybe[String]                  = Absent
+                // For RenameFile: oldUri + newUri + options + annotationId
+                var rfOldUri: String                               = ""
+                var rfNewUri: String                               = ""
+                var rfOptions: Maybe[LspHandler.RenameFileOptions] = Absent
+                var rfAnnotationId: Maybe[String]                  = Absent
+                // For DeleteFile: uri + options + annotationId
+                var dfUri: String                                  = ""
+                var dfOptions: Maybe[LspHandler.DeleteFileOptions] = Absent
+                var dfAnnotationId: Maybe[String]                  = Absent
+
+                discard(reader.objectStart())
+                while reader.hasNextField() do
+                    reader.fieldParse()
+                    if reader.matchField("kind".getBytes("UTF-8")) then
+                        kindStr = reader.string()
+                        hasKind = true
+                    else if reader.matchField("textDocument".getBytes("UTF-8")) then
+                        tdTextDocument =
+                            summon[Schema[LspHandler.OptionalVersionedTextDocumentIdentifier]].serializeRead(reader)
+                    else if reader.matchField("edits".getBytes("UTF-8")) then
+                        val count = reader.arrayStart()
+                        val buf   = scala.collection.mutable.ArrayBuffer[LspHandler.TextEdit]()
+                        if count < 0 then while reader.hasNextElement() do buf += summon[Schema[LspHandler.TextEdit]].serializeRead(reader)
+                        else
+                            var j = 0;
+                            while j < count do
+                                buf += summon[Schema[LspHandler.TextEdit]].serializeRead(reader); j += 1
+                        end if
+                        reader.arrayEnd()
+                        tdEdits = Chunk.from(buf)
+                    else if reader.matchField("uri".getBytes("UTF-8")) then
+                        val u = reader.string()
+                        cfUri = u; dfUri = u
+                    else if reader.matchField("oldUri".getBytes("UTF-8")) then rfOldUri = reader.string()
+                    else if reader.matchField("newUri".getBytes("UTF-8")) then rfNewUri = reader.string()
+                    else if reader.matchField("annotationId".getBytes("UTF-8")) then
+                        val a = Present(reader.string())
+                        cfAnnotationId = a; rfAnnotationId = a; dfAnnotationId = a
+                    else if reader.matchField("options".getBytes("UTF-8")) then
+                        // Parse options based on the kind we've seen so far; defer until end if kind unknown yet.
+                        // For simplicity, parse as CreateFileOptions shape (overwrite + ignoreIfExists) which covers
+                        // Create, and try RenameFileOptions (overwrite + ignoreIfExists), and DeleteFileOptions
+                        // (recursive + ignoreIfNotExists). We capture raw and parse after.
+                        var overwrite: Maybe[Boolean]         = Absent
+                        var ignoreIfExists: Maybe[Boolean]    = Absent
+                        var recursive: Maybe[Boolean]         = Absent
+                        var ignoreIfNotExists: Maybe[Boolean] = Absent
+                        discard(reader.objectStart())
+                        while reader.hasNextField() do
+                            reader.fieldParse()
+                            if reader.matchField("overwrite".getBytes("UTF-8")) then overwrite = Present(reader.boolean())
+                            else if reader.matchField("ignoreIfExists".getBytes("UTF-8")) then ignoreIfExists = Present(reader.boolean())
+                            else if reader.matchField("recursive".getBytes("UTF-8")) then recursive = Present(reader.boolean())
+                            else if reader.matchField("ignoreIfNotExists".getBytes("UTF-8")) then
+                                ignoreIfNotExists = Present(reader.boolean())
+                            else reader.skip()
+                            end if
+                        end while
+                        reader.objectEnd()
+                        cfOptions = Present(LspHandler.CreateFileOptions(overwrite, ignoreIfExists))
+                        rfOptions = Present(LspHandler.RenameFileOptions(overwrite, ignoreIfExists))
+                        dfOptions = Present(LspHandler.DeleteFileOptions(recursive, ignoreIfNotExists))
+                    else reader.skip()
+                    end if
+                end while
+                reader.objectEnd()
+
+                if !hasKind && tdTextDocument != null then
+                    LspHandler.WorkspaceEditDocumentChange.Edit(LspHandler.TextDocumentEdit(tdTextDocument, tdEdits))
+                else
+                    kindStr match
+                        case "create" => LspHandler.WorkspaceEditDocumentChange.Create(
+                                LspHandler.CreateFile(kindStr, LspHandler.LspDocument.Uri.fromWire(cfUri), cfOptions, cfAnnotationId)
+                            )
+                        case "rename" => LspHandler.WorkspaceEditDocumentChange.Rename(
+                                LspHandler.RenameFile(
+                                    kindStr,
+                                    LspHandler.LspDocument.Uri.fromWire(rfOldUri),
+                                    LspHandler.LspDocument.Uri.fromWire(rfNewUri),
+                                    rfOptions,
+                                    rfAnnotationId
+                                )
+                            )
+                        case "delete" => LspHandler.WorkspaceEditDocumentChange.Delete(
+                                LspHandler.DeleteFile(kindStr, LspHandler.LspDocument.Uri.fromWire(dfUri), dfOptions, dfAnnotationId)
+                            )
+                        case _ =>
+                            val td = if tdTextDocument != null then tdTextDocument
+                            else
+                                LspHandler.OptionalVersionedTextDocumentIdentifier(LspHandler.LspDocument.Uri.fromWire(""), Absent)
+                            LspHandler.WorkspaceEditDocumentChange.Edit(LspHandler.TextDocumentEdit(td, tdEdits))
+                end if
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.WorkspaceEditDocumentChange): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(
+                value: LspHandler.WorkspaceEditDocumentChange,
+                next: Any
+            ): LspHandler.WorkspaceEditDocumentChange =
+                next match
+                    case c: LspHandler.WorkspaceEditDocumentChange => c
+                    case _                                         => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.WorkspaceEditDocumentChange].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.WorkspaceEditDocumentChange] =
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m    = fields.iterator.toMap
+                        val kind = m.get("kind").collect { case Structure.Value.Str(s) => s }
+                        kind match
+                            case Some("create") =>
+                                summon[Schema[LspHandler.CreateFile]].fromStructureValue(
+                                    sv
+                                ).map(LspHandler.WorkspaceEditDocumentChange.Create(_))
+                            case Some("rename") =>
+                                summon[Schema[LspHandler.RenameFile]].fromStructureValue(
+                                    sv
+                                ).map(LspHandler.WorkspaceEditDocumentChange.Rename(_))
+                            case Some("delete") =>
+                                summon[Schema[LspHandler.DeleteFile]].fromStructureValue(
+                                    sv
+                                ).map(LspHandler.WorkspaceEditDocumentChange.Delete(_))
+                            case _ =>
+                                // No kind field: TextDocumentEdit
+                                summon[Schema[LspHandler.TextDocumentEdit]].fromStructureValue(
+                                    sv
+                                ).map(LspHandler.WorkspaceEditDocumentChange.Edit(_))
+                        end match
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Record", sv.toString))
+
+    // MARK: -- PrepareRenameResult
+
+    @nowarn("msg=anonymous")
+    val prepareRenameResultSchema: Schema[LspHandler.PrepareRenameResult] =
+        new Schema[LspHandler.PrepareRenameResult](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.PrepareRenameResult, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.PrepareRenameResult.JustRange(range) =>
+                        summon[Schema[LspHandler.Range]].serializeWrite(range, w)
+                    case LspHandler.PrepareRenameResult.RangeWithPlaceholder(range, placeholder) =>
+                        w.objectStart("PrepareRenameResult.RangeWithPlaceholder", 2)
+                        w.field("range", 1)
+                        summon[Schema[LspHandler.Range]].serializeWrite(range, w)
+                        w.field("placeholder", 2)
+                        w.string(placeholder)
+                        w.objectEnd()
+                    case LspHandler.PrepareRenameResult.DefaultBehavior(defaultBehavior) =>
+                        w.objectStart("PrepareRenameResult.DefaultBehavior", 1)
+                        w.field("defaultBehavior", 1)
+                        w.boolean(defaultBehavior)
+                        w.objectEnd()
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.PrepareRenameResult =
+                var placeholder: Maybe[String]      = Absent
+                var defaultBehavior: Maybe[Boolean] = Absent
+                var startLine: Maybe[Int]           = Absent
+                var startChar: Maybe[Int]           = Absent
+                var endLine: Maybe[Int]             = Absent
+                var endChar: Maybe[Int]             = Absent
+                discard(reader.objectStart())
+                while reader.hasNextField() do
+                    reader.fieldParse()
+                    if reader.matchField("placeholder".getBytes("UTF-8")) then placeholder = Present(reader.string())
+                    else if reader.matchField("defaultBehavior".getBytes("UTF-8")) then defaultBehavior = Present(reader.boolean())
+                    else if reader.matchField("start".getBytes("UTF-8")) then
+                        discard(reader.objectStart())
+                        while reader.hasNextField() do
+                            reader.fieldParse()
+                            if reader.matchField("line".getBytes("UTF-8")) then startLine = Present(reader.int())
+                            else if reader.matchField("character".getBytes("UTF-8")) then startChar = Present(reader.int())
+                            else reader.skip()
+                        end while
+                        reader.objectEnd()
+                    else if reader.matchField("end".getBytes("UTF-8")) then
+                        discard(reader.objectStart())
+                        while reader.hasNextField() do
+                            reader.fieldParse()
+                            if reader.matchField("line".getBytes("UTF-8")) then endLine = Present(reader.int())
+                            else if reader.matchField("character".getBytes("UTF-8")) then endChar = Present(reader.int())
+                            else reader.skip()
+                        end while
+                        reader.objectEnd()
+                    else reader.skip()
+                    end if
+                end while
+                reader.objectEnd()
+                defaultBehavior match
+                    case Present(b) => LspHandler.PrepareRenameResult.DefaultBehavior(b)
+                    case Absent =>
+                        val range = LspHandler.Range(
+                            LspHandler.Position(startLine.getOrElse(0), startChar.getOrElse(0)),
+                            LspHandler.Position(endLine.getOrElse(0), endChar.getOrElse(0))
+                        )
+                        placeholder match
+                            case Present(p) => LspHandler.PrepareRenameResult.RangeWithPlaceholder(range, p)
+                            case Absent     => LspHandler.PrepareRenameResult.JustRange(range)
+                end match
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.PrepareRenameResult): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.PrepareRenameResult, next: Any): LspHandler.PrepareRenameResult =
+                next match
+                    case r: LspHandler.PrepareRenameResult => r
+                    case _                                 => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.PrepareRenameResult].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.PrepareRenameResult] =
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.iterator.toMap
+                        if m.contains("defaultBehavior") then
+                            m.get("defaultBehavior") match
+                                case Some(Structure.Value.Bool(b)) => Result.Success(LspHandler.PrepareRenameResult.DefaultBehavior(b))
+                                case other => Result.Failure(TypeMismatchException(
+                                        Seq("defaultBehavior"),
+                                        "Boolean",
+                                        other.fold("absent")(_.toString)
+                                    ))
+                        else if m.contains("placeholder") then
+                            for
+                                range <- summon[Schema[LspHandler.Range]].fromStructureValue(sv)
+                                placeholder <- m.get("placeholder") match
+                                    case Some(Structure.Value.Str(s)) => Result.Success(s)
+                                    case other => Result.Failure(TypeMismatchException(
+                                            Seq("placeholder"),
+                                            "String",
+                                            other.fold("absent")(_.toString)
+                                        ))
+                            yield LspHandler.PrepareRenameResult.RangeWithPlaceholder(range, placeholder)
+                        else
+                            summon[Schema[LspHandler.Range]].fromStructureValue(sv).map(LspHandler.PrepareRenameResult.JustRange(_))
+                        end if
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Record", sv.toString))
+
+    // MARK: -- Location-family result schemas (DefinitionResult, DeclarationResult, TypeDefinitionResult, ImplementationResult)
+
+    private def readOneLocationOrLink(reader: Codec.Reader): Either[LspHandler.Location, LspHandler.LocationLink] =
+        // Read one Location or LocationLink object in a single pass; detect type from field presence
+        var uri: String                                   = ""
+        var range: Maybe[LspHandler.Range]                = Absent
+        var originSelectionRange: Maybe[LspHandler.Range] = Absent
+        var targetUri: String                             = ""
+        var targetRange: Maybe[LspHandler.Range]          = Absent
+        var targetSelectionRange: Maybe[LspHandler.Range] = Absent
+        var hasTargetUri                                  = false
+        discard(reader.objectStart())
+        while reader.hasNextField() do
+            reader.fieldParse()
+            if reader.matchField("uri".getBytes("UTF-8")) then uri = reader.string()
+            else if reader.matchField("range".getBytes("UTF-8")) then
+                range = Present(summon[Schema[LspHandler.Range]].serializeRead(reader))
+            else if reader.matchField("targetUri".getBytes("UTF-8")) then
+                hasTargetUri = true
+                targetUri = reader.string()
+            else if reader.matchField("targetRange".getBytes("UTF-8")) then
+                targetRange = Present(summon[Schema[LspHandler.Range]].serializeRead(reader))
+            else if reader.matchField("targetSelectionRange".getBytes("UTF-8")) then
+                targetSelectionRange = Present(summon[Schema[LspHandler.Range]].serializeRead(reader))
+            else if reader.matchField("originSelectionRange".getBytes("UTF-8")) then
+                originSelectionRange = Present(summon[Schema[LspHandler.Range]].serializeRead(reader))
+            else reader.skip()
+            end if
+        end while
+        reader.objectEnd()
+        if hasTargetUri then
+            val defaultRange = LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0))
+            Right(LspHandler.LocationLink(
+                originSelectionRange,
+                LspHandler.LspDocument.Uri.fromWire(targetUri),
+                targetRange.getOrElse(defaultRange),
+                targetSelectionRange.getOrElse(defaultRange)
+            ))
+        else
+            Left(LspHandler.Location(
+                LspHandler.LspDocument.Uri.fromWire(uri),
+                range.getOrElse(LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0)))
+            ))
+        end if
+    end readOneLocationOrLink
+
+    private def readLocationFamilyFromReader[T](
+        reader: Codec.Reader,
+        oneFactory: LspHandler.Location => T,
+        manyFactory: Chunk[LspHandler.Location] => T,
+        linksFactory: Chunk[LspHandler.LocationLink] => T
+    ): T =
+        val captured = reader.captureValue()
+        try
+            // Try as array
+            val count = captured.arrayStart()
+            if count == 0 then
+                captured.arrayEnd()
+                manyFactory(Chunk.empty)
+            else
+                val locations    = scala.collection.mutable.ArrayBuffer[LspHandler.Location]()
+                val links        = scala.collection.mutable.ArrayBuffer[LspHandler.LocationLink]()
+                var isLink       = false
+                var isDetermined = false
+
+                def readElements(): Unit =
+                    if count < 0 then
+                        while captured.hasNextElement() do
+                            val elem = readOneLocationOrLink(captured)
+                            elem match
+                                case Left(loc) =>
+                                    if !isDetermined then
+                                        isLink = false; isDetermined = true
+                                    locations += loc
+                                case Right(ll) =>
+                                    if !isDetermined then
+                                        isLink = true; isDetermined = true
+                                    links += ll
+                            end match
+                    else
+                        var j = 0
+                        while j < count do
+                            val elem = readOneLocationOrLink(captured)
+                            elem match
+                                case Left(loc) =>
+                                    if !isDetermined then
+                                        isLink = false; isDetermined = true
+                                    locations += loc
+                                case Right(ll) =>
+                                    if !isDetermined then
+                                        isLink = true; isDetermined = true
+                                    links += ll
+                            end match
+                            j += 1
+                        end while
+                end readElements
+
+                readElements()
+                captured.arrayEnd()
+                if isLink then linksFactory(Chunk.from(links))
+                else manyFactory(Chunk.from(locations))
+            end if
+        catch
+            case _: Exception =>
+                // Single object - Location
+                oneFactory(summon[Schema[LspHandler.Location]].serializeRead(captured))
+        end try
+    end readLocationFamilyFromReader
+
+    private def readLocationFamilyFromSv[T](
+        sv: Structure.Value,
+        oneFactory: LspHandler.Location => T,
+        manyFactory: Chunk[LspHandler.Location] => T,
+        linksFactory: Chunk[LspHandler.LocationLink] => T
+    )(using Frame): Result[DecodeException, T] =
+        sv match
+            case Structure.Value.Sequence(elems) =>
+                if elems.isEmpty then Result.Success(manyFactory(Chunk.empty))
+                else
+                    // Check first element for targetUri (LocationLink indicator)
+                    val isLink = elems.head match
+                        case Structure.Value.Record(fields) =>
+                            fields.iterator.toMap.contains("targetUri")
+                        case _ => false
+                    if isLink then
+                        val results = elems.map(e => summon[Schema[LspHandler.LocationLink]].fromStructureValue(e))
+                        val initAcc: Result[DecodeException, Chunk[LspHandler.LocationLink]] = Result.Success(Chunk.empty)
+                        results.foldLeft(initAcc) { (acc, r) =>
+                            acc.flatMap(chunk => r.map(ll => chunk.append(ll)))
+                        }.map(linksFactory)
+                    else
+                        val results = elems.map(e => summon[Schema[LspHandler.Location]].fromStructureValue(e))
+                        val initAcc: Result[DecodeException, Chunk[LspHandler.Location]] = Result.Success(Chunk.empty)
+                        results.foldLeft(initAcc) { (acc, r) =>
+                            acc.flatMap(chunk => r.map(l => chunk.append(l)))
+                        }.map(manyFactory)
+                    end if
+            case Structure.Value.Record(_) =>
+                summon[Schema[LspHandler.Location]].fromStructureValue(sv).map(oneFactory)
+            case _ =>
+                Result.Failure(TypeMismatchException(Seq.empty, "Sequence|Record", sv.toString))
+
+    @nowarn("msg=anonymous")
+    val definitionResultSchema: Schema[LspHandler.DefinitionResult] =
+        new Schema[LspHandler.DefinitionResult](Seq.empty):
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.DefinitionResult, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.DefinitionResult.One(l) => summon[Schema[LspHandler.Location]].serializeWrite(l, w)
+                    case LspHandler.DefinitionResult.Many(ls) =>
+                        w.arrayStart(ls.size); ls.foreach { l => summon[Schema[LspHandler.Location]].serializeWrite(l, w) }; w.arrayEnd()
+                    case LspHandler.DefinitionResult.Links(lls) =>
+                        w.arrayStart(lls.size); lls.foreach { ll => summon[Schema[LspHandler.LocationLink]].serializeWrite(ll, w) };
+                        w.arrayEnd()
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.DefinitionResult =
+                readLocationFamilyFromReader(
+                    reader,
+                    LspHandler.DefinitionResult.One(_),
+                    LspHandler.DefinitionResult.Many(_),
+                    LspHandler.DefinitionResult.Links(_)
+                )
+            @publicInBinary private[kyo] def getter(value: LspHandler.DefinitionResult): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.DefinitionResult, next: Any): LspHandler.DefinitionResult =
+                next match
+                    case r: LspHandler.DefinitionResult => r;
+                    case _                              => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.DefinitionResult].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.DefinitionResult] =
+                readLocationFamilyFromSv(
+                    sv,
+                    LspHandler.DefinitionResult.One(_),
+                    LspHandler.DefinitionResult.Many(_),
+                    LspHandler.DefinitionResult.Links(_)
+                )
+
+    @nowarn("msg=anonymous")
+    val declarationResultSchema: Schema[LspHandler.DeclarationResult] =
+        new Schema[LspHandler.DeclarationResult](Seq.empty):
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.DeclarationResult, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.DeclarationResult.One(l) => summon[Schema[LspHandler.Location]].serializeWrite(l, w)
+                    case LspHandler.DeclarationResult.Many(ls) =>
+                        w.arrayStart(ls.size); ls.foreach { l => summon[Schema[LspHandler.Location]].serializeWrite(l, w) }; w.arrayEnd()
+                    case LspHandler.DeclarationResult.Links(lls) =>
+                        w.arrayStart(lls.size); lls.foreach { ll => summon[Schema[LspHandler.LocationLink]].serializeWrite(ll, w) };
+                        w.arrayEnd()
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.DeclarationResult =
+                readLocationFamilyFromReader(
+                    reader,
+                    LspHandler.DeclarationResult.One(_),
+                    LspHandler.DeclarationResult.Many(_),
+                    LspHandler.DeclarationResult.Links(_)
+                )
+            @publicInBinary private[kyo] def getter(value: LspHandler.DeclarationResult): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.DeclarationResult, next: Any): LspHandler.DeclarationResult =
+                next match
+                    case r: LspHandler.DeclarationResult => r;
+                    case _                               => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.DeclarationResult].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.DeclarationResult] =
+                readLocationFamilyFromSv(
+                    sv,
+                    LspHandler.DeclarationResult.One(_),
+                    LspHandler.DeclarationResult.Many(_),
+                    LspHandler.DeclarationResult.Links(_)
+                )
+
+    @nowarn("msg=anonymous")
+    val typeDefinitionResultSchema: Schema[LspHandler.TypeDefinitionResult] =
+        new Schema[LspHandler.TypeDefinitionResult](Seq.empty):
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.TypeDefinitionResult, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.TypeDefinitionResult.One(l) => summon[Schema[LspHandler.Location]].serializeWrite(l, w)
+                    case LspHandler.TypeDefinitionResult.Many(ls) =>
+                        w.arrayStart(ls.size); ls.foreach { l => summon[Schema[LspHandler.Location]].serializeWrite(l, w) }; w.arrayEnd()
+                    case LspHandler.TypeDefinitionResult.Links(lls) =>
+                        w.arrayStart(lls.size); lls.foreach { ll => summon[Schema[LspHandler.LocationLink]].serializeWrite(ll, w) };
+                        w.arrayEnd()
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.TypeDefinitionResult =
+                readLocationFamilyFromReader(
+                    reader,
+                    LspHandler.TypeDefinitionResult.One(_),
+                    LspHandler.TypeDefinitionResult.Many(_),
+                    LspHandler.TypeDefinitionResult.Links(_)
+                )
+            @publicInBinary private[kyo] def getter(value: LspHandler.TypeDefinitionResult): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.TypeDefinitionResult, next: Any): LspHandler.TypeDefinitionResult =
+                next match
+                    case r: LspHandler.TypeDefinitionResult => r;
+                    case _                                  => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.TypeDefinitionResult].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.TypeDefinitionResult] =
+                readLocationFamilyFromSv(
+                    sv,
+                    LspHandler.TypeDefinitionResult.One(_),
+                    LspHandler.TypeDefinitionResult.Many(_),
+                    LspHandler.TypeDefinitionResult.Links(_)
+                )
+
+    @nowarn("msg=anonymous")
+    val implementationResultSchema: Schema[LspHandler.ImplementationResult] =
+        new Schema[LspHandler.ImplementationResult](Seq.empty):
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.ImplementationResult, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.ImplementationResult.One(l) => summon[Schema[LspHandler.Location]].serializeWrite(l, w)
+                    case LspHandler.ImplementationResult.Many(ls) =>
+                        w.arrayStart(ls.size); ls.foreach { l => summon[Schema[LspHandler.Location]].serializeWrite(l, w) }; w.arrayEnd()
+                    case LspHandler.ImplementationResult.Links(lls) =>
+                        w.arrayStart(lls.size); lls.foreach { ll => summon[Schema[LspHandler.LocationLink]].serializeWrite(ll, w) };
+                        w.arrayEnd()
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.ImplementationResult =
+                readLocationFamilyFromReader(
+                    reader,
+                    LspHandler.ImplementationResult.One(_),
+                    LspHandler.ImplementationResult.Many(_),
+                    LspHandler.ImplementationResult.Links(_)
+                )
+            @publicInBinary private[kyo] def getter(value: LspHandler.ImplementationResult): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.ImplementationResult, next: Any): LspHandler.ImplementationResult =
+                next match
+                    case r: LspHandler.ImplementationResult => r;
+                    case _                                  => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.ImplementationResult].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.ImplementationResult] =
+                readLocationFamilyFromSv(
+                    sv,
+                    LspHandler.ImplementationResult.One(_),
+                    LspHandler.ImplementationResult.Many(_),
+                    LspHandler.ImplementationResult.Links(_)
+                )
+
+    // MARK: -- SemanticTokensResult
+
+    @nowarn("msg=anonymous")
+    val semanticTokensResultSchema: Schema[LspHandler.SemanticTokensResult] =
+        new Schema[LspHandler.SemanticTokensResult](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.SemanticTokensResult, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.SemanticTokensResult.Full(tokens) =>
+                        summon[Schema[LspHandler.SemanticTokens]].serializeWrite(tokens, w)
+                    case LspHandler.SemanticTokensResult.Delta(delta) =>
+                        summon[Schema[LspHandler.SemanticTokensDelta]].serializeWrite(delta, w)
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.SemanticTokensResult =
+                // Read all fields in one pass, dispatch after
+                var hasEdits                                    = false
+                var resultId: Maybe[String]                     = Absent
+                var data: Chunk[Int]                            = Chunk.empty
+                var edits: Chunk[LspHandler.SemanticTokensEdit] = Chunk.empty
+                discard(reader.objectStart())
+                while reader.hasNextField() do
+                    reader.fieldParse()
+                    if reader.matchField("resultId".getBytes("UTF-8")) then resultId = Present(reader.string())
+                    else if reader.matchField("data".getBytes("UTF-8")) then
+                        val count = reader.arrayStart()
+                        val buf   = scala.collection.mutable.ArrayBuffer[Int]()
+                        if count < 0 then while reader.hasNextElement() do buf += reader.int()
+                        else
+                            var j = 0;
+                            while j < count do
+                                buf += reader.int(); j += 1
+                        end if
+                        reader.arrayEnd()
+                        data = Chunk.from(buf)
+                    else if reader.matchField("edits".getBytes("UTF-8")) then
+                        hasEdits = true
+                        val count = reader.arrayStart()
+                        val buf   = scala.collection.mutable.ArrayBuffer[LspHandler.SemanticTokensEdit]()
+                        if count < 0 then
+                            while reader.hasNextElement() do
+                                buf += summon[Schema[LspHandler.SemanticTokensEdit]].serializeRead(reader)
+                        else
+                            var j = 0
+                            while j < count do
+                                buf += summon[Schema[LspHandler.SemanticTokensEdit]].serializeRead(reader)
+                                j += 1
+                            end while
+                        end if
+                        reader.arrayEnd()
+                        edits = Chunk.from(buf)
+                    else reader.skip()
+                    end if
+                end while
+                reader.objectEnd()
+                if hasEdits then
+                    LspHandler.SemanticTokensResult.Delta(LspHandler.SemanticTokensDelta(resultId, edits))
+                else
+                    LspHandler.SemanticTokensResult.Full(LspHandler.SemanticTokens(resultId, data))
+                end if
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.SemanticTokensResult): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.SemanticTokensResult, next: Any): LspHandler.SemanticTokensResult =
+                next match
+                    case r: LspHandler.SemanticTokensResult => r
+                    case _                                  => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.SemanticTokensResult].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.SemanticTokensResult] =
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.iterator.toMap
+                        if m.contains("edits") then
+                            summon[Schema[LspHandler.SemanticTokensDelta]].fromStructureValue(
+                                sv
+                            ).map(LspHandler.SemanticTokensResult.Delta(_))
+                        else
+                            summon[Schema[LspHandler.SemanticTokens]].fromStructureValue(sv).map(LspHandler.SemanticTokensResult.Full(_))
+                        end if
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Record", sv.toString))
+
+    // MARK: -- InlayHintLabelPart
+
+    @nowarn("msg=anonymous")
+    val inlayHintLabelPartSchema: Schema[LspHandler.InlayHintLabelPart] =
+        new Schema[LspHandler.InlayHintLabelPart](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.InlayHintLabelPart, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.InlayHintLabelPart.StringPart(value) => w.string(value)
+                    case LspHandler.InlayHintLabelPart.StructuredPart(value, tooltip, location, command) =>
+                        val count = 1 + (if tooltip.isDefined then 1 else 0) + (if location.isDefined then 1
+                                                                                else 0) + (if command.isDefined then 1 else 0)
+                        w.objectStart("InlayHintLabelPart.StructuredPart", count)
+                        w.field("value", 1)
+                        w.string(value)
+                        var idx = 2
+                        tooltip.foreach { t =>
+                            w.field("tooltip", idx); idx += 1; summon[Schema[LspHandler.MarkupContent]].serializeWrite(t, w)
+                        }
+                        location.foreach { l =>
+                            w.field("location", idx); idx += 1; summon[Schema[LspHandler.Location]].serializeWrite(l, w)
+                        }
+                        command.foreach { c =>
+                            w.field("command", idx); idx += 1; summon[Schema[LspHandler.Command]].serializeWrite(c, w)
+                        }
+                        w.objectEnd()
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.InlayHintLabelPart =
+                val captured = reader.captureValue()
+                try LspHandler.InlayHintLabelPart.StringPart(captured.string())
+                catch
+                    case _: Exception =>
+                        var value: String                            = ""
+                        var tooltip: Maybe[LspHandler.MarkupContent] = Absent
+                        var location: Maybe[LspHandler.Location]     = Absent
+                        var command: Maybe[LspHandler.Command]       = Absent
+                        discard(captured.objectStart())
+                        while captured.hasNextField() do
+                            captured.fieldParse()
+                            if captured.matchField("value".getBytes("UTF-8")) then value = captured.string()
+                            else if captured.matchField("tooltip".getBytes("UTF-8")) then
+                                tooltip = Present(summon[Schema[LspHandler.MarkupContent]].serializeRead(captured))
+                            else if captured.matchField("location".getBytes("UTF-8")) then
+                                location = Present(summon[Schema[LspHandler.Location]].serializeRead(captured))
+                            else if captured.matchField("command".getBytes("UTF-8")) then
+                                command = Present(summon[Schema[LspHandler.Command]].serializeRead(captured))
+                            else captured.skip()
+                            end if
+                        end while
+                        captured.objectEnd()
+                        LspHandler.InlayHintLabelPart.StructuredPart(value, tooltip, location, command)
+                end try
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.InlayHintLabelPart): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.InlayHintLabelPart, next: Any): LspHandler.InlayHintLabelPart =
+                next match
+                    case l: LspHandler.InlayHintLabelPart => l
+                    case _                                => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.InlayHintLabelPart].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.InlayHintLabelPart] =
+                sv match
+                    case Structure.Value.Str(s) => Result.Success(LspHandler.InlayHintLabelPart.StringPart(s))
+                    case Structure.Value.Record(fields) =>
+                        val m        = fields.iterator.toMap
+                        val value    = m.get("value").collect { case Structure.Value.Str(s) => s }.getOrElse("")
+                        val tooltip  = m.get("tooltip").map { tsv => summon[Schema[LspHandler.MarkupContent]].fromStructureValue(tsv) }
+                        val location = m.get("location").map { lsv => summon[Schema[LspHandler.Location]].fromStructureValue(lsv) }
+                        val command  = m.get("command").map { csv => summon[Schema[LspHandler.Command]].fromStructureValue(csv) }
+                        for
+                            t <- tooltip.map(_.map(Present(_))).getOrElse(Result.Success(Absent))
+                            l <- location.map(_.map(Present(_))).getOrElse(Result.Success(Absent))
+                            c <- command.map(_.map(Present(_))).getOrElse(Result.Success(Absent))
+                        yield LspHandler.InlayHintLabelPart.StructuredPart(value, t, l, c)
+                        end for
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "String|Record", sv.toString))
+
+    // MARK: -- InlayHintLabel
+
+    @nowarn("msg=anonymous")
+    val inlayHintLabelSchema: Schema[LspHandler.InlayHintLabel] =
+        new Schema[LspHandler.InlayHintLabel](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.InlayHintLabel, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.InlayHintLabel.PlainString(value) => w.string(value)
+                    case LspHandler.InlayHintLabel.Parts(parts) =>
+                        w.arrayStart(parts.size)
+                        parts.foreach { p => inlayHintLabelPartSchema.serializeWrite(p, w) }
+                        w.arrayEnd()
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.InlayHintLabel =
+                val captured = reader.captureValue()
+                try LspHandler.InlayHintLabel.PlainString(captured.string())
+                catch
+                    case _: Exception =>
+                        discard(captured.arrayStart())
+                        val buf = scala.collection.mutable.ArrayBuffer[LspHandler.InlayHintLabelPart]()
+                        while captured.hasNextElement() do buf += inlayHintLabelPartSchema.serializeRead(captured)
+                        captured.arrayEnd()
+                        LspHandler.InlayHintLabel.Parts(Chunk.from(buf))
+                end try
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.InlayHintLabel): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.InlayHintLabel, next: Any): LspHandler.InlayHintLabel =
+                next match
+                    case l: LspHandler.InlayHintLabel => l
+                    case _                            => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.InlayHintLabel].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.InlayHintLabel] =
+                sv match
+                    case Structure.Value.Str(s) => Result.Success(LspHandler.InlayHintLabel.PlainString(s))
+                    case Structure.Value.Sequence(elems) =>
+                        val results = elems.map(e => inlayHintLabelPartSchema.fromStructureValue(e))
+                        val initAcc: Result[DecodeException, Chunk[LspHandler.InlayHintLabelPart]] = Result.Success(Chunk.empty)
+                        results.foldLeft(initAcc) { (acc, r) =>
+                            acc.flatMap(chunk => r.map(p => chunk.append(p)))
+                        }.map(LspHandler.InlayHintLabel.Parts(_))
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "String|Sequence", sv.toString))
+
+    // MARK: -- InlineValue
+
+    @nowarn("msg=anonymous")
+    val inlineValueSchema: Schema[LspHandler.InlineValue] =
+        new Schema[LspHandler.InlineValue](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.InlineValue, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.InlineValue.Text(range, text) =>
+                        w.objectStart("InlineValue.Text", 2)
+                        w.field("range", 1)
+                        summon[Schema[LspHandler.Range]].serializeWrite(range, w)
+                        w.field("text", 2)
+                        w.string(text)
+                        w.objectEnd()
+                    case LspHandler.InlineValue.VariableLookup(range, variableName, caseSensitiveLookup) =>
+                        val count = 2 + (if variableName.isDefined then 1 else 0)
+                        w.objectStart("InlineValue.VariableLookup", count)
+                        w.field("range", 1)
+                        summon[Schema[LspHandler.Range]].serializeWrite(range, w)
+                        var idx = 2
+                        variableName.foreach { vn =>
+                            w.field("variableName", idx); idx += 1; w.string(vn)
+                        }
+                        w.field("caseSensitiveLookup", idx)
+                        w.boolean(caseSensitiveLookup)
+                        w.objectEnd()
+                    case LspHandler.InlineValue.EvaluatableExpression(range, expression) =>
+                        val count = 1 + (if expression.isDefined then 1 else 0)
+                        w.objectStart("InlineValue.EvaluatableExpression", count)
+                        w.field("range", 1)
+                        summon[Schema[LspHandler.Range]].serializeWrite(range, w)
+                        expression.foreach { e =>
+                            w.field("expression", 2); w.string(e)
+                        }
+                        w.objectEnd()
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.InlineValue =
+                var range: LspHandler.Range             = null
+                var text: Maybe[String]                 = Absent
+                var variableName: Maybe[String]         = Absent
+                var caseSensitiveLookup: Maybe[Boolean] = Absent
+                var expression: Maybe[String]           = Absent
+                discard(reader.objectStart())
+                while reader.hasNextField() do
+                    reader.fieldParse()
+                    if reader.matchField("range".getBytes("UTF-8")) then
+                        range = summon[Schema[LspHandler.Range]].serializeRead(reader)
+                    else if reader.matchField("text".getBytes("UTF-8")) then text = Present(reader.string())
+                    else if reader.matchField("variableName".getBytes("UTF-8")) then variableName = Present(reader.string())
+                    else if reader.matchField("caseSensitiveLookup".getBytes("UTF-8")) then caseSensitiveLookup = Present(reader.boolean())
+                    else if reader.matchField("expression".getBytes("UTF-8")) then expression = Present(reader.string())
+                    else reader.skip()
+                    end if
+                end while
+                reader.objectEnd()
+                val r = if range != null then range else LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0))
+                (expression, caseSensitiveLookup, text) match
+                    case (Present(e), _, _)   => LspHandler.InlineValue.EvaluatableExpression(r, Present(e))
+                    case (_, Present(csl), _) => LspHandler.InlineValue.VariableLookup(r, variableName, csl)
+                    case (_, _, Present(t))   => LspHandler.InlineValue.Text(r, t)
+                    case _                    => LspHandler.InlineValue.Text(r, "")
+                end match
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.InlineValue): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.InlineValue, next: Any): LspHandler.InlineValue =
+                next match
+                    case v: LspHandler.InlineValue => v
+                    case _                         => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.InlineValue].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.InlineValue] =
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.iterator.toMap
+                        val rangeR = m.get("range") match
+                            case Some(rsv)  => summon[Schema[LspHandler.Range]].fromStructureValue(rsv)
+                            case scala.None => Result.Success(LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0)))
+                        val expression = m.get("expression").collect { case Structure.Value.Str(s) => s }.map(Present(_)).getOrElse(Absent)
+                        val variableName =
+                            m.get("variableName").collect { case Structure.Value.Str(s) => s }.map(Present(_)).getOrElse(Absent)
+                        val caseSens = m.get("caseSensitiveLookup").collect { case Structure.Value.Bool(b) => b }
+                        val text     = m.get("text").collect { case Structure.Value.Str(s) => s }
+                        rangeR.map { r =>
+                            (expression, caseSens, text) match
+                                case (Present(e), _, _) => LspHandler.InlineValue.EvaluatableExpression(r, Present(e))
+                                case (_, Some(csl), _)  => LspHandler.InlineValue.VariableLookup(r, variableName, csl)
+                                case (_, _, Some(t))    => LspHandler.InlineValue.Text(r, t)
+                                case _                  => LspHandler.InlineValue.Text(r, "")
+                        }
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Record", sv.toString))
+
+    // MARK: -- NotebookDocumentFilter
+
+    @nowarn("msg=anonymous")
+    val notebookDocumentFilterSchema: Schema[LspHandler.NotebookDocumentFilter] =
+        new Schema[LspHandler.NotebookDocumentFilter](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.NotebookDocumentFilter, w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.NotebookDocumentFilter.WithNotebookType(notebookType, scheme, pattern) =>
+                        val count = 1 + (if scheme.isDefined then 1 else 0) + (if pattern.isDefined then 1 else 0)
+                        w.objectStart("NotebookDocumentFilter.WithNotebookType", count)
+                        w.field("notebookType", 1)
+                        w.string(notebookType)
+                        var idx = 2
+                        scheme.foreach { s =>
+                            w.field("scheme", idx); idx += 1; w.string(s)
+                        }
+                        pattern.foreach { p =>
+                            w.field("pattern", idx); idx += 1; w.string(p)
+                        }
+                        w.objectEnd()
+                    case LspHandler.NotebookDocumentFilter.WithScheme(notebookType, scheme, pattern) =>
+                        val count = 1 + (if notebookType.isDefined then 1 else 0) + (if pattern.isDefined then 1 else 0)
+                        w.objectStart("NotebookDocumentFilter.WithScheme", count)
+                        notebookType.foreach { nt =>
+                            w.field("notebookType", 1); w.string(nt)
+                        }
+                        w.field("scheme", 2)
+                        w.string(scheme)
+                        pattern.foreach { p =>
+                            w.field("pattern", 3); w.string(p)
+                        }
+                        w.objectEnd()
+                    case LspHandler.NotebookDocumentFilter.WithPattern(notebookType, scheme, pattern) =>
+                        val count = 1 + (if notebookType.isDefined then 1 else 0) + (if scheme.isDefined then 1 else 0)
+                        w.objectStart("NotebookDocumentFilter.WithPattern", count)
+                        notebookType.foreach { nt =>
+                            w.field("notebookType", 1); w.string(nt)
+                        }
+                        scheme.foreach { s =>
+                            w.field("scheme", 2); w.string(s)
+                        }
+                        w.field("pattern", 3)
+                        w.string(pattern)
+                        w.objectEnd()
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.NotebookDocumentFilter =
+                given Frame                     = reader.frame
+                var notebookType: Maybe[String] = Absent
+                var scheme: Maybe[String]       = Absent
+                var pattern: Maybe[String]      = Absent
+                discard(reader.objectStart())
+                while reader.hasNextField() do
+                    reader.fieldParse()
+                    if reader.matchField("notebookType".getBytes("UTF-8")) then notebookType = Present(reader.string())
+                    else if reader.matchField("scheme".getBytes("UTF-8")) then scheme = Present(reader.string())
+                    else if reader.matchField("pattern".getBytes("UTF-8")) then pattern = Present(reader.string())
+                    else reader.skip()
+                    end if
+                end while
+                reader.objectEnd()
+                (notebookType, scheme, pattern) match
+                    case (Present(nt), _, _) => LspHandler.NotebookDocumentFilter.WithNotebookType(nt, scheme, pattern)
+                    case (_, Present(s), _)  => LspHandler.NotebookDocumentFilter.WithScheme(notebookType, s, pattern)
+                    case (_, _, Present(p))  => LspHandler.NotebookDocumentFilter.WithPattern(notebookType, scheme, p)
+                    case _ =>
+                        throw TypeMismatchException(Seq.empty, "notebookType|scheme|pattern", "all absent")
+                end match
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.NotebookDocumentFilter): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(
+                value: LspHandler.NotebookDocumentFilter,
+                next: Any
+            ): LspHandler.NotebookDocumentFilter =
+                next match
+                    case f: LspHandler.NotebookDocumentFilter => f
+                    case _                                    => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.NotebookDocumentFilter].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.NotebookDocumentFilter] =
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.iterator.toMap
+                        val notebookType =
+                            m.get("notebookType").collect { case Structure.Value.Str(s) => s }.map(Present(_)).getOrElse(Absent)
+                        val scheme  = m.get("scheme").collect { case Structure.Value.Str(s) => s }.map(Present(_)).getOrElse(Absent)
+                        val pattern = m.get("pattern").collect { case Structure.Value.Str(s) => s }.map(Present(_)).getOrElse(Absent)
+                        (notebookType, scheme, pattern) match
+                            case (Present(nt), _, _) =>
+                                Result.Success(LspHandler.NotebookDocumentFilter.WithNotebookType(nt, scheme, pattern))
+                            case (_, Present(s), _) =>
+                                Result.Success(LspHandler.NotebookDocumentFilter.WithScheme(notebookType, s, pattern))
+                            case (_, _, Present(p)) =>
+                                Result.Success(LspHandler.NotebookDocumentFilter.WithPattern(notebookType, scheme, p))
+                            case _ =>
+                                Result.Failure(TypeMismatchException(Seq.empty, "notebookType|scheme|pattern", "all absent"))
+                        end match
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Record", sv.toString))
+
+    // MARK: -- Registration (hand-rolled; registerOptions is raw JSON pass-through)
+
+    @nowarn("msg=anonymous")
+    val registrationSchema: Schema[LspHandler.Registration] =
+        new Schema[LspHandler.Registration](Seq.empty):
+
+            @publicInBinary private[kyo] def serializeWrite(r: LspHandler.Registration, w: Codec.Writer): Unit =
+                val count = 2 + (if r._rawRegisterOptions.isDefined then 1 else 0)
+                w.objectStart("Registration", count)
+                w.field("id", 1)
+                w.string(r.id)
+                w.field("method", 2)
+                w.string(r.method)
+                r._rawRegisterOptions.foreach { raw =>
+                    w.field("registerOptions", 3)
+                    // Diverges from LSP §3.17 (which encodes registerOptions as an
+                    // arbitrary JSON value): writes the raw JSON text as a JSON string,
+                    // because Codec.Writer has no raw-JSON write primitive. Clients
+                    // reading this field must JSON-decode the string to recover the
+                    // underlying value.
+                    w.string(raw)
+                }
+                w.objectEnd()
+            end serializeWrite
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.Registration =
+                var id: String                = ""
+                var method: String            = ""
+                var rawOptions: Maybe[String] = Absent
+                discard(reader.objectStart())
+                while reader.hasNextField() do
+                    reader.fieldParse()
+                    if reader.matchField("id".getBytes("UTF-8")) then id = reader.string()
+                    else if reader.matchField("method".getBytes("UTF-8")) then method = reader.string()
+                    else if reader.matchField("registerOptions".getBytes("UTF-8")) then
+                        // Capture raw JSON string for later typed access
+                        rawOptions = Present(reader.string())
+                    else reader.skip()
+                    end if
+                end while
+                reader.objectEnd()
+                new LspHandler.Registration(id, method, rawOptions)
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.Registration): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.Registration, next: Any): LspHandler.Registration =
+                next match
+                    case r: LspHandler.Registration => r
+                    case _                          => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.Registration].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.Registration] =
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m      = fields.iterator.toMap
+                        val id     = m.get("id").collect { case Structure.Value.Str(s) => s }.getOrElse("")
+                        val method = m.get("method").collect { case Structure.Value.Str(s) => s }.getOrElse("")
+                        val rawOpts =
+                            m.get("registerOptions").collect { case Structure.Value.Str(s) => s }.map(Present(_)).getOrElse(Absent)
+                        Result.Success(new LspHandler.Registration(id, method, rawOpts))
+                    case _ =>
+                        Result.Failure(TypeMismatchException(Seq.empty, "Record", sv.toString))
+
+end LspContentSchemas

--- a/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspEngine.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspEngine.scala
@@ -1,0 +1,365 @@
+package kyo.internal.lsp
+
+import kyo.*
+
+/** Composes all LSP engine components into a live `LspServer.Unsafe` instance.
+  *
+  * Wiring order:
+  *   1. Build `LspCatalog` from user handlers (throws synchronously for direction/duplicate errors).
+  *   2. Auto-derive or use declared `LspCapabilities.Server`.
+  *   3. Create `LspDocumentRegistryImpl` with the initial encoding (UTF-16; updated after handshake).
+  *   4. Build gate chain (handshake -> shutdown -> capability).
+  *   5. Install LSP policies on `config.jsonRpc` (cancellation, progress, unknownMethod).
+  *   6. Build built-in routes (initialize, initialized, shutdown, exit, setTrace, sync routes).
+  *   7. Lift user handlers via `LspHandlerLift.liftServer`.
+  *   8. Call `JsonRpcHandler.initUnscoped` with all routes.
+  *   9. Return the concrete `LspServer.Unsafe` anonymous implementation.
+  */
+private[kyo] object LspEngine:
+
+    // Wire shapes for reverse-direction calls.
+    final private case class EmptyParams() derives Schema
+    final private case class WorkspaceFoldersResult(workspaceFolders: Maybe[Chunk[LspHandler.WorkspaceFolder]] = Absent) derives Schema
+    final private case class ConfigurationResult[T](result: Chunk[T])
+    final private case class LogTraceParams(message: String, verbose: Maybe[String] = Absent) derives Schema
+    final private case class ProgressParams(token: LspHandler.ProgressToken, value: LspHandler.WorkDoneProgressValue) derives Schema
+
+    /** The session state refs an LSP server engine threads through its routes and gates. The two
+      * forward refs (`serverRef`, `handlerRef`) are populated once the handler is constructed.
+      */
+    final private case class ServerRefs(
+        negotiatedEncodingRef: AtomicRef[LspHandler.PositionEncodingKind],
+        clientCapabilitiesRef: AtomicRef[Maybe[LspCapabilities.Client.Client]],
+        clientInfoRef: AtomicRef[Maybe[LspInfo]],
+        workspaceFoldersRef: AtomicRef[Maybe[Chunk[LspHandler.WorkspaceFolder]]],
+        traceRef: AtomicRef[LspHandler.TraceValue],
+        serverRef: AtomicRef[Maybe[LspServer.Unsafe]],
+        handlerRef: AtomicRef[Maybe[JsonRpcHandler]],
+        registryImpl: LspDocumentRegistryImpl,
+        handshakeGate: JsonRpcMessageGate,
+        shutdownGate: JsonRpcMessageGate
+    )
+
+    private def initServerRefs(using Frame): ServerRefs < Sync =
+        for
+            negotiatedEncodingRef <- AtomicRef.init[LspHandler.PositionEncodingKind](LspHandler.PositionEncodingKind.UTF16)
+            clientCapabilitiesRef <- AtomicRef.init[Maybe[LspCapabilities.Client.Client]](Absent)
+            clientInfoRef         <- AtomicRef.init[Maybe[LspInfo]](Absent)
+            workspaceFoldersRef   <- AtomicRef.init[Maybe[Chunk[LspHandler.WorkspaceFolder]]](Absent)
+            traceRef              <- AtomicRef.init[LspHandler.TraceValue](LspHandler.TraceValue.Off)
+            serverRef             <- AtomicRef.init[Maybe[LspServer.Unsafe]](Absent)
+            handlerRef            <- AtomicRef.init[Maybe[JsonRpcHandler]](Absent)
+            registryImpl          <- LspDocumentRegistryImpl.init(negotiatedEncodingRef)
+            handshakeGate         <- LspHandshakeGate.server()
+            shutdownGate          <- LspShutdownGate.server(handlerRef)
+        yield ServerRefs(
+            negotiatedEncodingRef,
+            clientCapabilitiesRef,
+            clientInfoRef,
+            workspaceFoldersRef,
+            traceRef,
+            serverRef,
+            handlerRef,
+            registryImpl,
+            handshakeGate,
+            shutdownGate
+        )
+
+    def initServer(
+        transport: JsonRpcTransport,
+        userHandlers: Seq[LspHandler[?, ?, ?]],
+        config: LspConfig
+    )(using Frame): LspServer.Unsafe < Async =
+        initServerRefs.flatMap { refs =>
+            import refs.*
+
+            // --- Catalog (throws synchronously on direction / duplicate / reserved errors) ---
+            val catalog    = LspCatalog.fromHandlers(userHandlers, LspHandler.Direction.ServerHandled)
+            val serverCaps = catalog.autoDeriveServerCapabilities(config)
+
+            // --- Gates (registryImpl and the handshake/shutdown gates come from initServerRefs) ---
+            val capabilityGate = LspCapabilityGate.server(serverCaps, config.enforceCapabilities)
+            val composedGate   = LspGate.compose(handshakeGate, shutdownGate, capabilityGate)
+
+            // --- Config with policies installed ---
+            val jsonRpcConfig = config.jsonRpc
+                .cancellation(LspCancellationPolicy.default)
+                .progress(LspProgressPolicy.default)
+                .unknownMethod(JsonRpcUnknownMethodPolicy.minimal)
+                .gate(composedGate)
+
+            // --- Built-in routes ---
+            val initRoute = LspBuiltInRoutes.initialize(
+                config,
+                serverCaps,
+                negotiatedEncodingRef,
+                clientCapabilitiesRef,
+                clientInfoRef,
+                workspaceFoldersRef
+            )
+            val initializedRoute = LspBuiltInRoutes.initialized()
+            val shutdownRoute    = LspBuiltInRoutes.shutdown()
+            val exitRoute        = LspBuiltInRoutes.exit()
+            val setTraceRoute    = LspBuiltInRoutes.setTrace(traceRef)
+
+            val didOpenRoute = LspBuiltInRoutes.textDocumentDidOpen(
+                registryImpl,
+                catalog.handlerFor(LspHandler.Kind.TextDocumentDidOpen),
+                serverRef,
+                negotiatedEncodingRef
+            )
+            val didChangeRoute = LspBuiltInRoutes.textDocumentDidChange(
+                registryImpl,
+                catalog.handlerFor(LspHandler.Kind.TextDocumentDidChange),
+                serverRef,
+                negotiatedEncodingRef
+            )
+            val didSaveRoute = LspBuiltInRoutes.textDocumentDidSave(
+                registryImpl,
+                catalog.handlerFor(LspHandler.Kind.TextDocumentDidSave),
+                serverRef,
+                negotiatedEncodingRef
+            )
+            val didCloseRoute = LspBuiltInRoutes.textDocumentDidClose(
+                registryImpl,
+                catalog.handlerFor(LspHandler.Kind.TextDocumentDidClose),
+                serverRef,
+                negotiatedEncodingRef
+            )
+            val willSaveRoute = LspBuiltInRoutes.textDocumentWillSave(
+                catalog.handlerFor(LspHandler.Kind.TextDocumentWillSave),
+                serverRef,
+                registryImpl,
+                negotiatedEncodingRef
+            )
+
+            val nbDidOpenRoute   = LspBuiltInRoutes.notebookDocumentDidOpen(registryImpl, Absent, serverRef, negotiatedEncodingRef)
+            val nbDidChangeRoute = LspBuiltInRoutes.notebookDocumentDidChange(registryImpl)
+            val nbDidSaveRoute   = LspBuiltInRoutes.notebookDocumentDidSave(registryImpl)
+            val nbDidCloseRoute  = LspBuiltInRoutes.notebookDocumentDidClose(registryImpl)
+
+            // --- Sync Kinds that are handled by built-in routes (not lifted from user handlers) ---
+            val syncKinds = Set(
+                LspHandler.Kind.TextDocumentDidOpen,
+                LspHandler.Kind.TextDocumentDidChange,
+                LspHandler.Kind.TextDocumentDidSave,
+                LspHandler.Kind.TextDocumentDidClose,
+                LspHandler.Kind.TextDocumentWillSave,
+                LspHandler.Kind.NotebookDidOpen,
+                LspHandler.Kind.NotebookDidChange,
+                LspHandler.Kind.NotebookDidSave,
+                LspHandler.Kind.NotebookDidClose
+            )
+
+            // --- Lift user handlers (skip sync kinds handled by built-in routes) ---
+            val userRoutes: Seq[JsonRpcRoute[?, ?, ?]] = userHandlers
+                .filterNot(h => syncKinds.contains(h.kind))
+                .map(h => LspHandlerLift.liftServer(h, serverRef, registryImpl, negotiatedEncodingRef))
+
+            val allRoutes: Seq[JsonRpcRoute[?, ?, ?]] = Seq(
+                initRoute,
+                initializedRoute,
+                shutdownRoute,
+                exitRoute,
+                setTraceRoute,
+                didOpenRoute,
+                didChangeRoute,
+                didSaveRoute,
+                didCloseRoute,
+                willSaveRoute,
+                nbDidOpenRoute,
+                nbDidChangeRoute,
+                nbDidSaveRoute,
+                nbDidCloseRoute
+            ) ++ userRoutes
+
+            JsonRpcHandler.initUnscoped(transport, allRoutes, jsonRpcConfig).flatMap { handler =>
+
+                val unsafe: LspServer.Unsafe = new LspServer.Unsafe:
+
+                    private def notifyEffect[In: Schema](method: String, params: In)(using
+                        Frame
+                    ): Unit < (Async & Abort[LspConnectionClosedException]) =
+                        handler.notify[In](method, params)
+                            .handle(Abort.recover[Closed] { _ => Abort.fail(LspConnectionClosedException()) })
+
+                    private def callEffect[In: Schema, Out: Schema](method: String, params: In)(using
+                        Frame
+                    ): Out < (Async & Abort[LspRequestFailure]) =
+                        handler.call[In, Out](method, params)
+                            .handle(Abort.recover[JsonRpcError] { e =>
+                                Abort.fail(LspRemoteException(e.code, e.message, e.data))
+                            })
+                            .handle(Abort.recover[Closed] { _ =>
+                                Abort.fail(LspConnectionClosedException())
+                            })
+
+                    def showMessage(params: LspHandler.ShowMessageParams)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                        Fiber.Unsafe.init(notifyEffect("window/showMessage", params))
+
+                    def showMessageRequest(params: LspHandler.ShowMessageRequestParams)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[Maybe[LspHandler.MessageActionItem], Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[LspHandler.ShowMessageRequestParams, Maybe[LspHandler.MessageActionItem]](
+                            "window/showMessageRequest",
+                            params
+                        ))
+
+                    def showDocument(params: LspHandler.ShowDocumentParams)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[LspHandler.ShowDocumentResult, Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[LspHandler.ShowDocumentParams, LspHandler.ShowDocumentResult](
+                            "window/showDocument",
+                            params
+                        ))
+
+                    def logMessage(params: LspHandler.LogMessageParams)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                        Fiber.Unsafe.init(notifyEffect("window/logMessage", params))
+
+                    def createWorkDoneProgress(params: LspHandler.WorkDoneProgressCreateParams)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[Unit, Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(
+                            callEffect[LspHandler.WorkDoneProgressCreateParams, EmptyParams](
+                                "window/workDoneProgress/create",
+                                params
+                            ).andThen(())
+                        )
+
+                    def telemetry[T](payload: T)(using
+                        AllowUnsafe,
+                        Frame,
+                        Schema[T]
+                    ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                        Fiber.Unsafe.init(notifyEffect("telemetry/event", payload))
+
+                    def applyEdit(params: LspHandler.ApplyWorkspaceEditParams)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[LspHandler.ApplyWorkspaceEditResult, Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[LspHandler.ApplyWorkspaceEditParams, LspHandler.ApplyWorkspaceEditResult](
+                            "workspace/applyEdit",
+                            params
+                        ))
+
+                    def getConfiguration[T](params: LspHandler.ConfigurationParams)(using
+                        AllowUnsafe,
+                        Frame,
+                        Schema[T]
+                    ): Fiber.Unsafe[Chunk[T], Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[LspHandler.ConfigurationParams, Chunk[T]]("workspace/configuration", params))
+
+                    def getWorkspaceFolders(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[Maybe[Chunk[LspHandler.WorkspaceFolder]], Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(
+                            callEffect[EmptyParams, WorkspaceFoldersResult]("workspace/workspaceFolders", EmptyParams())
+                                .map(_.workspaceFolders)
+                        )
+
+                    def refreshSemanticTokens(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[EmptyParams, EmptyParams](
+                            "workspace/semanticTokens/refresh",
+                            EmptyParams()
+                        ).andThen(()))
+
+                    def refreshInlineValue(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[EmptyParams, EmptyParams]("workspace/inlineValue/refresh", EmptyParams()).andThen(()))
+
+                    def refreshInlayHint(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[EmptyParams, EmptyParams]("workspace/inlayHint/refresh", EmptyParams()).andThen(()))
+
+                    def refreshDiagnostic(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[EmptyParams, EmptyParams]("workspace/diagnostic/refresh", EmptyParams()).andThen(()))
+
+                    def refreshCodeLens(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[EmptyParams, EmptyParams]("workspace/codeLens/refresh", EmptyParams()).andThen(()))
+
+                    def registerCapability(params: LspHandler.RegistrationParams)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[Unit, Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[LspHandler.RegistrationParams, EmptyParams](
+                            "client/registerCapability",
+                            params
+                        ).andThen(()))
+
+                    def unregisterCapability(params: LspHandler.UnregistrationParams)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[Unit, Abort[LspRequestFailure]] =
+                        Fiber.Unsafe.init(callEffect[LspHandler.UnregistrationParams, EmptyParams](
+                            "client/unregisterCapability",
+                            params
+                        ).andThen(()))
+
+                    def publishDiagnostics(params: LspHandler.PublishDiagnosticsParams)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                        Fiber.Unsafe.init(notifyEffect("textDocument/publishDiagnostics", params))
+
+                    def logTrace(message: String, verbose: Maybe[String])(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                        Fiber.Unsafe.init(notifyEffect("$/logTrace", LogTraceParams(message, verbose)))
+
+                    def workDoneProgress(token: LspHandler.ProgressToken, value: LspHandler.WorkDoneProgressValue)(using
+                        AllowUnsafe,
+                        Frame
+                    ): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                        Fiber.Unsafe.init(notifyEffect("$/progress", ProgressParams(token, value)))
+
+                    def cancel(id: JsonRpcId)(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]] =
+                        Fiber.Unsafe.init(
+                            handler.cancel(id).handle(Abort.recover[Closed] { _ => Abort.fail(LspConnectionClosedException()) })
+                        )
+
+                    def specVersion: String = LspConfig.SpecVersion
+
+                    def positionEncoding(using Frame): LspHandler.PositionEncodingKind < Sync =
+                        negotiatedEncodingRef.get
+
+                    def clientCapabilities(using Frame): Maybe[LspCapabilities.Client.Client] < Sync =
+                        clientCapabilitiesRef.get
+
+                    def clientInfo(using Frame): Maybe[LspInfo] < Sync =
+                        clientInfoRef.get
+
+                    def workspaceFolders(using Frame): Maybe[Chunk[LspHandler.WorkspaceFolder]] < Sync =
+                        workspaceFoldersRef.get
+
+                    def underlying: JsonRpcHandler = handler
+
+                    def awaitDrain(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Any] =
+                        Fiber.Unsafe.init(handler.awaitDrain)
+
+                    def close(gracePeriod: Duration)(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Any] =
+                        Fiber.Unsafe.init(handler.close(gracePeriod))
+
+                end unsafe
+
+                // Populate the forward refs so the shutdown gate and each lift can reach the
+                // handler and the server, then yield the server handle.
+                handlerRef.set(Present(handler))
+                    .andThen(serverRef.set(Present(unsafe)))
+                    .andThen(unsafe)
+            }
+        }
+    end initServer
+
+end LspEngine
+
+// LspDocumentRegistryImpl is declared in Lsp.scala (same file as the sealed DocumentRegistry trait).
+// It is accessible here via private[kyo] visibility.

--- a/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspGate.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspGate.scala
@@ -1,0 +1,240 @@
+package kyo.internal.lsp
+
+import kyo.*
+
+/** Composed LSP gate chain: handshake gate, shutdown gate, and capability gate.
+  *
+  * The three gates are always composed in fixed order:
+  *   1. `LspHandshakeGate` - admits only `initialize` before the handshake completes.
+  *   2. `LspShutdownGate` - admits only `exit` after `shutdown` is received.
+  *   3. `LspCapabilityGate` - rejects methods whose capability is not advertised.
+  *
+  * Each gate is constructed independently and composed via `LspGate.compose`.
+  * The composed gate's `beforeDispatch` short-circuits on `Reject`.
+  *
+  * @see [[LspHandshakeGate]]
+  * @see [[LspShutdownGate]]
+  * @see [[LspCapabilityGate]]
+  */
+private[kyo] object LspGate:
+
+    /** Composes three gates in the fixed order: handshake -> shutdown -> capability. */
+    def compose(
+        handshake: JsonRpcMessageGate,
+        shutdown: JsonRpcMessageGate,
+        capability: JsonRpcMessageGate
+    ): JsonRpcMessageGate =
+        new JsonRpcMessageGate:
+            def beforeDispatch(env: JsonRpcEnvelope)(using Frame): JsonRpcMessageGate.Decision < Sync =
+                handshake.beforeDispatch(env).map {
+                    case JsonRpcMessageGate.Decision.Allow =>
+                        shutdown.beforeDispatch(env).map {
+                            case JsonRpcMessageGate.Decision.Allow => capability.beforeDispatch(env)
+                            case other                             => other
+                        }
+                    case other => other
+                }
+        end new
+    end compose
+
+end LspGate
+
+/** LSP handshake gate: admits requests only after `initialize` is received.
+  *
+  * State machine: `Pending` -> `Initialized`. The `initialize` request transitions to
+  * `Initialized` and is always admitted. The `initialized` notification is always admitted
+  * (it completes the second stage of the handshake for clients that require it). All other
+  * requests before `Initialized` are rejected with `LspNotInitializedException`.
+  * Notifications (other than `initialized`) are admitted unconditionally to avoid breaking
+  * the fire-and-forget notification contract.
+  */
+private[kyo] object LspHandshakeGate:
+
+    def server()(using Frame): JsonRpcMessageGate < Sync =
+        AtomicBoolean.init(false).map { initSeen =>
+            new JsonRpcMessageGate:
+                def beforeDispatch(env: JsonRpcEnvelope)(using Frame): JsonRpcMessageGate.Decision < Sync =
+                    env match
+                        case JsonRpcRequest(_, "initialize", _, _) =>
+                            initSeen.set(true).andThen(JsonRpcMessageGate.Decision.Allow)
+
+                        case JsonRpcNotification("initialized", _, _) =>
+                            Sync.defer(JsonRpcMessageGate.Decision.Allow)
+
+                        case JsonRpcNotification(_, _, _) =>
+                            Sync.defer(JsonRpcMessageGate.Decision.Allow)
+
+                        case req: JsonRpcRequest =>
+                            initSeen.get.map { seen =>
+                                if seen then
+                                    JsonRpcMessageGate.Decision.Allow
+                                else
+                                    val err = LspNotInitializedException(req.method)
+                                    JsonRpcMessageGate.Decision.Reject(JsonRpcResponse.failure(req.id, err))
+                            }
+
+                        case _ =>
+                            Sync.defer(JsonRpcMessageGate.Decision.Allow)
+                    end match
+                end beforeDispatch
+            end new
+        }
+    end server
+
+end LspHandshakeGate
+
+/** LSP shutdown gate: enforces the two-phase shutdown / exit sequence.
+  *
+  * State machine: `Running` -> `Shutdown` (on inbound `shutdown` request) -> `Exited`
+  * (on inbound `exit` notification; triggers `handler.close`).
+  *
+  * After `Shutdown`, only the `exit` notification is admitted; all other requests are
+  * rejected with `LspShutdownInProgressException`.
+  *
+  * The `handlerRef` forward reference is populated after the engine constructs the
+  * `JsonRpcHandler`; the shutdown gate stores it to trigger `handler.close`.
+  */
+private[kyo] object LspShutdownGate:
+
+    enum State derives CanEqual:
+        case Running, Shutdown, Exited
+
+    def server(handlerRef: AtomicRef[Maybe[JsonRpcHandler]])(using Frame): JsonRpcMessageGate < Sync =
+        AtomicRef.init[State](State.Running).map { stateRef =>
+            new JsonRpcMessageGate:
+                def beforeDispatch(env: JsonRpcEnvelope)(using Frame): JsonRpcMessageGate.Decision < Sync =
+                    stateRef.get.map { state =>
+                        env match
+                            case JsonRpcRequest(id, "shutdown", _, _) =>
+                                stateRef.set(State.Shutdown).andThen(JsonRpcMessageGate.Decision.Allow)
+
+                            case JsonRpcNotification("exit", _, _) =>
+                                stateRef.set(State.Exited).andThen {
+                                    handlerRef.get.map {
+                                        case Present(h) =>
+                                            // Unsafe: fire-and-forget close on exit; the gate decision must be
+                                            // returned synchronously, so the close fiber is started and discarded.
+                                            Sync.Unsafe.defer {
+                                                val _ = h.unsafe.close(Duration.Zero)
+                                                JsonRpcMessageGate.Decision.Allow
+                                            }
+                                        case Absent =>
+                                            JsonRpcMessageGate.Decision.Allow
+                                    }
+                                }
+
+                            case req: JsonRpcRequest if state == State.Shutdown =>
+                                val err = LspShutdownInProgressException(req.method)
+                                Sync.defer(JsonRpcMessageGate.Decision.Reject(JsonRpcResponse.failure(req.id, err)))
+
+                            case _ =>
+                                Sync.defer(JsonRpcMessageGate.Decision.Allow)
+                        end match
+                    }
+                end beforeDispatch
+            end new
+        }
+    end server
+
+end LspShutdownGate
+
+/** LSP capability gate: rejects inbound requests whose required server capability is not advertised.
+  *
+  * Only applies when `LspConfig.enforceCapabilities = true`. Methods not covered by any standard
+  * capability are always admitted (the gate does not know about custom extensions).
+  */
+private[kyo] object LspCapabilityGate:
+
+    def server(caps: LspCapabilities.Server, enforce: Boolean): JsonRpcMessageGate =
+        if !enforce then JsonRpcMessageGate.noop
+        else
+            new JsonRpcMessageGate:
+                def beforeDispatch(env: JsonRpcEnvelope)(using Frame): JsonRpcMessageGate.Decision < Sync =
+                    env match
+                        case req: JsonRpcRequest =>
+                            Sync.defer {
+                                missingCapability(req.method, caps) match
+                                    case Absent =>
+                                        JsonRpcMessageGate.Decision.Allow
+                                    case Present(name) =>
+                                        val err = LspCapabilityNotAdvertisedException(name)
+                                        JsonRpcMessageGate.Decision.Reject(JsonRpcResponse.failure(req.id, err))
+                            }
+                        case _ =>
+                            Sync.defer(JsonRpcMessageGate.Decision.Allow)
+                    end match
+                end beforeDispatch
+            end new
+        end if
+    end server
+
+    // Returns the missing capability name, or Absent if the method is admitted.
+    private def missingCapability(method: String, caps: LspCapabilities.Server): Maybe[LspCapabilities.Name] =
+        method match
+            case "textDocument/completion" | "completionItem/resolve" =>
+                if caps.completionProvider.isDefined then Absent else Present(LspCapabilities.Name.Completion)
+            case "textDocument/hover" =>
+                if caps.hoverProvider.isDefined then Absent else Present(LspCapabilities.Name.Hover)
+            case "textDocument/signatureHelp" =>
+                if caps.signatureHelpProvider.isDefined then Absent else Present(LspCapabilities.Name.SignatureHelp)
+            case "textDocument/declaration" =>
+                if caps.declarationProvider.isDefined then Absent else Present(LspCapabilities.Name.Declaration)
+            case "textDocument/definition" =>
+                if caps.definitionProvider.isDefined then Absent else Present(LspCapabilities.Name.Definition)
+            case "textDocument/typeDefinition" =>
+                if caps.typeDefinitionProvider.isDefined then Absent else Present(LspCapabilities.Name.TypeDefinition)
+            case "textDocument/implementation" =>
+                if caps.implementationProvider.isDefined then Absent else Present(LspCapabilities.Name.Implementation)
+            case "textDocument/references" =>
+                if caps.referencesProvider.isDefined then Absent else Present(LspCapabilities.Name.References)
+            case "textDocument/documentHighlight" =>
+                if caps.documentHighlightProvider.isDefined then Absent else Present(LspCapabilities.Name.DocumentHighlight)
+            case "textDocument/documentSymbol" =>
+                if caps.documentSymbolProvider.isDefined then Absent else Present(LspCapabilities.Name.DocumentSymbol)
+            case "textDocument/codeAction" | "codeAction/resolve" =>
+                if caps.codeActionProvider.isDefined then Absent else Present(LspCapabilities.Name.CodeAction)
+            case "textDocument/codeLens" | "codeLens/resolve" =>
+                if caps.codeLensProvider.isDefined then Absent else Present(LspCapabilities.Name.CodeLens)
+            case "textDocument/documentLink" | "documentLink/resolve" =>
+                if caps.documentLinkProvider.isDefined then Absent else Present(LspCapabilities.Name.DocumentLink)
+            case "textDocument/documentColor" | "textDocument/colorPresentation" =>
+                if caps.colorProvider.isDefined then Absent else Present(LspCapabilities.Name.DocumentColor)
+            case "textDocument/formatting" =>
+                if caps.documentFormattingProvider.isDefined then Absent else Present(LspCapabilities.Name.Formatting)
+            case "textDocument/rangeFormatting" =>
+                if caps.documentRangeFormattingProvider.isDefined then Absent else Present(LspCapabilities.Name.RangeFormatting)
+            case "textDocument/onTypeFormatting" =>
+                if caps.documentOnTypeFormattingProvider.isDefined then Absent else Present(LspCapabilities.Name.OnTypeFormatting)
+            case "textDocument/rename" | "textDocument/prepareRename" =>
+                if caps.renameProvider.isDefined then Absent else Present(LspCapabilities.Name.Rename)
+            case "textDocument/foldingRange" =>
+                if caps.foldingRangeProvider.isDefined then Absent else Present(LspCapabilities.Name.FoldingRange)
+            case "textDocument/selectionRange" =>
+                if caps.selectionRangeProvider.isDefined then Absent else Present(LspCapabilities.Name.SelectionRange)
+            case "textDocument/prepareCallHierarchy" | "callHierarchy/incomingCalls" | "callHierarchy/outgoingCalls" =>
+                if caps.callHierarchyProvider.isDefined then Absent else Present(LspCapabilities.Name.CallHierarchy)
+            case "textDocument/prepareTypeHierarchy" | "typeHierarchy/supertypes" | "typeHierarchy/subtypes" =>
+                if caps.typeHierarchyProvider.isDefined then Absent else Present(LspCapabilities.Name.TypeHierarchy)
+            case "textDocument/semanticTokens/full" | "textDocument/semanticTokens/full/delta" | "textDocument/semanticTokens/range" =>
+                if caps.semanticTokensProvider.isDefined then Absent else Present(LspCapabilities.Name.SemanticTokens)
+            case "textDocument/moniker" =>
+                if caps.monikerProvider.isDefined then Absent else Present(LspCapabilities.Name.Moniker)
+            case "textDocument/linkedEditingRange" =>
+                if caps.linkedEditingRangeProvider.isDefined then Absent else Present(LspCapabilities.Name.LinkedEditingRange)
+            case "textDocument/inlayHint" | "inlayHint/resolve" =>
+                if caps.inlayHintProvider.isDefined then Absent else Present(LspCapabilities.Name.InlayHint)
+            case "textDocument/inlineValue" =>
+                if caps.inlineValueProvider.isDefined then Absent else Present(LspCapabilities.Name.InlineValue)
+            case "textDocument/diagnostic" | "workspace/diagnostic" =>
+                if caps.diagnosticProvider.isDefined then Absent else Present(LspCapabilities.Name.Diagnostic)
+            case "workspace/symbol" | "workspaceSymbol/resolve" =>
+                if caps.workspaceSymbolProvider.isDefined then Absent else Present(LspCapabilities.Name.WorkspaceSymbol)
+            case "workspace/executeCommand" =>
+                if caps.executeCommandProvider.isDefined then Absent else Present(LspCapabilities.Name.ExecuteCommand)
+            case _ =>
+                // Unknown or built-in methods always admitted.
+                Absent
+        end match
+    end missingCapability
+
+end LspCapabilityGate

--- a/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspHandlerLift.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspHandlerLift.scala
@@ -1,0 +1,171 @@
+package kyo.internal.lsp
+
+import kyo.*
+
+/** Lifts each `LspHandler` carrier to a `JsonRpcRoute` that wraps the user closure in
+  * `Lsp.local.let(Present(ctx))` so the body can reach the per-request context through the
+  * `Lsp.*` accessors.
+  *
+  * The `serverRef` / `clientRef` forward references are populated after `JsonRpcHandler.initUnscoped`
+  * completes; the wrapped closure reads them lazily on every invocation.
+  *
+  * Error mappings are folded onto the produced `JsonRpcRoute` via `.error[E2]` for each
+  * registered `LspHandler.ErrorMapping`.
+  *
+  * Token extraction reads `workDoneToken` and `partialResultToken` from the encoded
+  * `Structure.Value` representation of the params, then threads them into `Lsp.RequestContext`.
+  */
+private[kyo] object LspHandlerLift:
+
+    import LspHandler.*
+
+    // =========================================================================
+    // Public entry points
+    // =========================================================================
+
+    def liftServer(
+        handler: LspHandler[?, ?, ?],
+        serverRef: AtomicRef[Maybe[LspServer.Unsafe]],
+        registry: LspDocumentRegistryImpl,
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        val base = buildRoute(handler, serverRef, "LspServer", (s: LspServer.Unsafe) => Lsp.Peer.Server(s.safe), registry, encodingRef)
+        applyErrors(base, handler.errorMappings)
+    end liftServer
+
+    def liftClient(
+        handler: LspHandler[?, ?, ?],
+        clientRef: AtomicRef[Maybe[LspClient.Unsafe]],
+        registry: LspDocumentRegistryImpl,
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        val base = buildRoute(handler, clientRef, "LspClient", (c: LspClient.Unsafe) => Lsp.Peer.Client(c.safe), registry, encodingRef)
+        applyErrors(base, handler.errorMappings)
+    end liftClient
+
+    // =========================================================================
+    // Error mapping fold
+    // =========================================================================
+
+    private def applyErrors(base: JsonRpcRoute[?, ?, ?], mappings: Chunk[ErrorMapping[?]]): JsonRpcRoute[?, ?, ?] =
+        mappings.foldLeft(base) { (acc, m) => applyOne(acc, m) }
+
+    private def applyOne[E](base: JsonRpcRoute[?, ?, ?], m: ErrorMapping[E]): JsonRpcRoute[?, ?, ?] =
+        given Schema[E]      = m.schema
+        given ConcreteTag[E] = m.tag
+        base.asInstanceOf[JsonRpcRoute[Any, Any, Nothing]].error[E](m.code, m.message)
+    end applyOne
+
+    // =========================================================================
+    // Token extraction from Structure.Value params
+    // =========================================================================
+
+    private def extractToken(sv: Structure.Value, field: String): Maybe[ProgressToken] =
+        sv match
+            case Structure.Value.Record(fields) =>
+                fields.iterator.collectFirst {
+                    case (k, v) if k == field =>
+                        v match
+                            case Structure.Value.Integer(n) => Present(ProgressToken.IntToken(n.toInt))
+                            case Structure.Value.Str(s)     => Present(ProgressToken.StringToken(s))
+                            case _                          => Absent
+                }.getOrElse(Absent)
+            case _ => Absent
+
+    // =========================================================================
+    // Shared route builder
+    // =========================================================================
+
+    /** The per-invocation body shared by every lifted route: reads the forward-populated peer ref
+      * and the negotiated encoding through the safe `Sync` API, binds the per-request `Lsp` context,
+      * and dispatches the handler under `Lsp.local`. A still-empty peer ref is a framework invariant
+      * violation (the engine populates it before any route runs), surfaced as a panic rather than a
+      * typed error.
+      */
+    private def contextualBody[In, Out, E, P](
+        name: String,
+        handlerFn: In => Out < (Async & Abort[JsonRpcResponse.Halt | E]),
+        peerRef: AtomicRef[Maybe[P]],
+        peerKind: String,
+        mkPeer: P => Lsp.Peer,
+        registry: LspDocumentRegistryImpl,
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Schema[In], Frame): (In, JsonRpcRoute.Context) => Out < (Async & Abort[JsonRpcResponse.Halt | E]) =
+        (in, jrCtx) =>
+            peerRef.get.map { mPeer =>
+                encodingRef.get.map { enc =>
+                    mPeer match
+                        case Present(peer) =>
+                            val paramsValue = Structure.encode[In](in)
+                            val ctx = Lsp.RequestContext(
+                                jsonRpc = jrCtx,
+                                peer = mkPeer(peer),
+                                workDoneToken = extractToken(paramsValue, "workDoneToken"),
+                                partialResultToken = extractToken(paramsValue, "partialResultToken"),
+                                documents = registry,
+                                positionEncoding = enc
+                            )
+                            Lsp.local.let(Present(ctx))(handlerFn(in))
+                        case Absent =>
+                            Abort.panic(new IllegalStateException(s"$peerKind not initialised for '$name'"))
+                }
+            }
+    end contextualBody
+
+    /** Dispatches a handler to a `JsonRpcRoute` of the matching wire shape (request, notification, or
+      * custom-as-request), wiring in the peer-specific context through [[contextualBody]].
+      */
+    private def buildRoute[P](
+        handler: LspHandler[?, ?, ?],
+        peerRef: AtomicRef[Maybe[P]],
+        peerKind: String,
+        mkPeer: P => Lsp.Peer,
+        registry: LspDocumentRegistryImpl,
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        handler match
+            case h: RequestHandler[?, ?, ?]   => requestRoute(h, peerRef, peerKind, mkPeer, registry, encodingRef)
+            case h: NotificationHandler[?, ?] => notificationRoute(h, peerRef, peerKind, mkPeer, registry, encodingRef)
+            case h: CustomHandler[?, ?, ?]    => customRoute(h, peerRef, peerKind, mkPeer, registry, encodingRef)
+        end match
+    end buildRoute
+
+    private def requestRoute[In, Out, E, P](
+        h: RequestHandler[In, Out, E],
+        peerRef: AtomicRef[Maybe[P]],
+        peerKind: String,
+        mkPeer: P => Lsp.Peer,
+        registry: LspDocumentRegistryImpl,
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        given Schema[In]  = h.inSchema
+        given Schema[Out] = h.outSchema
+        JsonRpcRoute.request[In, Out](h.name)(contextualBody(h.name, h.handlerFn, peerRef, peerKind, mkPeer, registry, encodingRef))
+    end requestRoute
+
+    private def notificationRoute[In, E, P](
+        h: NotificationHandler[In, E],
+        peerRef: AtomicRef[Maybe[P]],
+        peerKind: String,
+        mkPeer: P => Lsp.Peer,
+        registry: LspDocumentRegistryImpl,
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        given Schema[In] = h.inSchema
+        JsonRpcRoute.notification[In](h.name)(contextualBody(h.name, h.handlerFn, peerRef, peerKind, mkPeer, registry, encodingRef))
+    end notificationRoute
+
+    private def customRoute[In, Out, E, P](
+        h: CustomHandler[In, Out, E],
+        peerRef: AtomicRef[Maybe[P]],
+        peerKind: String,
+        mkPeer: P => Lsp.Peer,
+        registry: LspDocumentRegistryImpl,
+        encodingRef: AtomicRef[LspHandler.PositionEncodingKind]
+    )(using Frame): JsonRpcRoute[?, ?, ?] =
+        given Schema[In]  = h.inSchema
+        given Schema[Out] = h.outSchema
+        JsonRpcRoute.request[In, Out](h.name)(contextualBody(h.name, h.handlerFn, peerRef, peerKind, mkPeer, registry, encodingRef))
+    end customRoute
+
+end LspHandlerLift

--- a/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspProgressPolicy.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspProgressPolicy.scala
@@ -1,0 +1,69 @@
+package kyo.internal.lsp
+
+import kyo.*
+
+/** LSP-specific `JsonRpcProgressPolicy` installation for `$/progress`.
+  *
+  * LSP progress tokens live at:
+  *   - `params.token` on inbound `$/progress` notifications.
+  *   - `params.workDoneToken` on request params (for work-done progress).
+  *   - `params.partialResultToken` on request params (for partial-result streaming).
+  *
+  * The policy extracts `workDoneToken` first; if absent, falls back to `partialResultToken`.
+  * This mirrors the LSP 3.17 spec §3.15 where both token types use the same `$/progress`
+  * notification channel but represent different progress flavors.
+  *
+  * `enforceMonotonic = false` because the LSP spec does not mandate monotonically increasing
+  * percentage values.
+  */
+private[kyo] object LspProgressPolicy:
+
+    // Inbound $/progress: token is at top-level params.token
+    private val extractInbound: Structure.Value => (Maybe[Structure.Value] < Sync) =
+        paramsValue => JsonRpcProgressPolicy.field(paramsValue, "token")
+
+    // Request params: prefer workDoneToken, fall back to partialResultToken
+    private val extractRequest: Structure.Value => (Maybe[Structure.Value] < Sync) =
+        paramsValue =>
+            JsonRpcProgressPolicy.field(paramsValue, "workDoneToken") match
+                case Present(v) => Present(v)
+                case Absent     => JsonRpcProgressPolicy.field(paramsValue, "partialResultToken")
+
+    // Stamp outbound token: adds workDoneToken to outbound request params
+    private val stampOutbound: (Structure.Value, Structure.Value) => (Structure.Value < Sync) =
+        (params, token) =>
+            params match
+                case Structure.Value.Record(fs) =>
+                    Structure.Value.Record(fs.filterNot(_._1 == "workDoneToken") :+ ("workDoneToken" -> token))
+                case _ =>
+                    Structure.Value.Record(Chunk("workDoneToken" -> token))
+
+    // Encode $/progress notification params: { token, value }
+    private val encodeProgress: (Structure.Value, Structure.Value) => (Structure.Value < Sync) =
+        (token, value) =>
+            value match
+                case Structure.Value.Record(fs) =>
+                    Structure.Value.Record(Chunk("token" -> token) ++ fs)
+                case other =>
+                    Structure.Value.Record(Chunk("token" -> token, "value" -> other))
+
+    // Extract progress value: strip token, return rest
+    private val extractProgress: Structure.Value => (Maybe[Structure.Value] < Sync) =
+        params =>
+            params match
+                case Structure.Value.Record(fs) =>
+                    Present(Structure.Value.Record(fs.filterNot(_._1 == "token")))
+                case _ => Absent
+
+    val default: JsonRpcProgressPolicy =
+        JsonRpcProgressPolicy(
+            progressMethod = "$/progress",
+            extractInboundToken = extractInbound,
+            extractRequestToken = extractRequest,
+            stampOutboundToken = stampOutbound,
+            encodeProgressParams = encodeProgress,
+            extractProgressValue = extractProgress,
+            enforceMonotonic = false
+        )
+
+end LspProgressPolicy

--- a/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspWireEnumSchemas.scala
+++ b/kyo-lsp/shared/src/main/scala/kyo/internal/lsp/LspWireEnumSchemas.scala
@@ -1,0 +1,591 @@
+package kyo.internal.lsp
+
+import kyo.*
+import scala.annotation.publicInBinary
+
+/** Hand-rolled Schemas for numeric-keyed and string-keyed LSP 3.17 enums, plus the
+  * parameterized BooleanOr[T] and StringOr[T] discriminator schemas.
+  *
+  * Numeric enums are built with `Schema.init` over `Schema.intSchema`; string enums over
+  * `Schema.stringSchema`. Each `readFn` receives the `Codec.Reader`, so the
+  * `TypeMismatchException` raised on an unknown wire value is attached to the user's decode
+  * site (`reader.frame`, the propagated decode-call frame), exactly like kyo-schema's
+  * `StructureValueReader`. The wire shape is identical to the underlying int / string schema:
+  * encode emits a plain JSON number or string, decode reads one, and `structure` is the
+  * underlying schema's structure. Every instance is a `val` singleton (BooleanOr / StringOr
+  * are `given [T: Schema]` because they are parameterized). None of these enums use
+  * `derives Schema`.
+  *
+  * All numeric wire values are taken verbatim from the LSP 3.17 specification.
+  * `TextDocumentSyncKind.None` is the only case with wire value 0.
+  */
+private[kyo] object LspWireEnumSchemas:
+
+    // MARK: -- Numeric-keyed enum schemas
+
+    /** Schema[DocumentHighlightKind]: Text=1, Read=2, Write=3. */
+    @publicInBinary val documentHighlightKindSchema: Schema[LspHandler.DocumentHighlightKind] =
+        Schema.init[LspHandler.DocumentHighlightKind](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.DocumentHighlightKind.Text
+                    case 2 => LspHandler.DocumentHighlightKind.Read
+                    case 3 => LspHandler.DocumentHighlightKind.Write
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2|3", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[TextDocumentSyncKind]: None=0, Incremental=1, Full=2. */
+    @publicInBinary val textDocumentSyncKindSchema: Schema[LspHandler.TextDocumentSyncKind] =
+        Schema.init[LspHandler.TextDocumentSyncKind](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 0 => LspHandler.TextDocumentSyncKind.None
+                    case 1 => LspHandler.TextDocumentSyncKind.Incremental
+                    case 2 => LspHandler.TextDocumentSyncKind.Full
+                    case _ => throw TypeMismatchException(Seq.empty, "0|1|2", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[TextDocumentSaveReason]: Manual=1, AfterDelay=2, FocusOut=3. */
+    @publicInBinary val textDocumentSaveReasonSchema: Schema[LspHandler.TextDocumentSaveReason] =
+        Schema.init[LspHandler.TextDocumentSaveReason](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.TextDocumentSaveReason.Manual
+                    case 2 => LspHandler.TextDocumentSaveReason.AfterDelay
+                    case 3 => LspHandler.TextDocumentSaveReason.FocusOut
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2|3", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[DiagnosticSeverity]: Error=1, Warning=2, Information=3, Hint=4. */
+    @publicInBinary val diagnosticSeveritySchema: Schema[LspHandler.DiagnosticSeverity] =
+        Schema.init[LspHandler.DiagnosticSeverity](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.DiagnosticSeverity.Error
+                    case 2 => LspHandler.DiagnosticSeverity.Warning
+                    case 3 => LspHandler.DiagnosticSeverity.Information
+                    case 4 => LspHandler.DiagnosticSeverity.Hint
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2|3|4", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[DiagnosticTag]: Unnecessary=1, Deprecated=2. */
+    @publicInBinary val diagnosticTagSchema: Schema[LspHandler.DiagnosticTag] =
+        Schema.init[LspHandler.DiagnosticTag](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.DiagnosticTag.Unnecessary
+                    case 2 => LspHandler.DiagnosticTag.Deprecated
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[SymbolKind]: File=1..TypeParameter=26 (all cases shift by +1 from ordinal). */
+    @publicInBinary val symbolKindSchema: Schema[LspHandler.SymbolKind] =
+        Schema.init[LspHandler.SymbolKind](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                if n >= 1 && n <= 26 then LspHandler.SymbolKind.fromOrdinal(n - 1)
+                else throw TypeMismatchException(Seq.empty, "1..26", n.toString)
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[SymbolTag]: Deprecated=1. */
+    @publicInBinary val symbolTagSchema: Schema[LspHandler.SymbolTag] =
+        Schema.init[LspHandler.SymbolTag](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.SymbolTag.Deprecated
+                    case _ => throw TypeMismatchException(Seq.empty, "1", n.toString)
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[CompletionItemKind]: Text=1..TypeParameter=25. */
+    @publicInBinary val completionItemKindSchema: Schema[LspHandler.CompletionItemKind] =
+        Schema.init[LspHandler.CompletionItemKind](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                if n >= 1 && n <= 25 then LspHandler.CompletionItemKind.fromOrdinal(n - 1)
+                else throw TypeMismatchException(Seq.empty, "1..25", n.toString)
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[CompletionItemTag]: Deprecated=1. */
+    @publicInBinary val completionItemTagSchema: Schema[LspHandler.CompletionItemTag] =
+        Schema.init[LspHandler.CompletionItemTag](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.CompletionItemTag.Deprecated
+                    case _ => throw TypeMismatchException(Seq.empty, "1", n.toString)
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[InsertTextFormat]: PlainText=1, Snippet=2. */
+    @publicInBinary val insertTextFormatSchema: Schema[LspHandler.InsertTextFormat] =
+        Schema.init[LspHandler.InsertTextFormat](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.InsertTextFormat.PlainText
+                    case 2 => LspHandler.InsertTextFormat.Snippet
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[InsertTextMode]: AsIs=1, AdjustIndentation=2. */
+    @publicInBinary val insertTextModeSchema: Schema[LspHandler.InsertTextMode] =
+        Schema.init[LspHandler.InsertTextMode](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.InsertTextMode.AsIs
+                    case 2 => LspHandler.InsertTextMode.AdjustIndentation
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[CompletionTriggerKind]: Invoked=1, TriggerCharacter=2, TriggerForIncompleteCompletions=3. */
+    @publicInBinary val completionTriggerKindSchema: Schema[LspHandler.CompletionTriggerKind] =
+        Schema.init[LspHandler.CompletionTriggerKind](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.CompletionTriggerKind.Invoked
+                    case 2 => LspHandler.CompletionTriggerKind.TriggerCharacter
+                    case 3 => LspHandler.CompletionTriggerKind.TriggerForIncompleteCompletions
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2|3", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[SignatureHelpTriggerKind]: Invoked=1, TriggerCharacter=2, ContentChange=3. */
+    @publicInBinary val signatureHelpTriggerKindSchema: Schema[LspHandler.SignatureHelpTriggerKind] =
+        Schema.init[LspHandler.SignatureHelpTriggerKind](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.SignatureHelpTriggerKind.Invoked
+                    case 2 => LspHandler.SignatureHelpTriggerKind.TriggerCharacter
+                    case 3 => LspHandler.SignatureHelpTriggerKind.ContentChange
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2|3", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[CodeActionTriggerKind]: Invoked=1, Automatic=2. */
+    @publicInBinary val codeActionTriggerKindSchema: Schema[LspHandler.CodeActionTriggerKind] =
+        Schema.init[LspHandler.CodeActionTriggerKind](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.CodeActionTriggerKind.Invoked
+                    case 2 => LspHandler.CodeActionTriggerKind.Automatic
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[InlayHintKind]: Type=1, Parameter=2. */
+    @publicInBinary val inlayHintKindSchema: Schema[LspHandler.InlayHintKind] =
+        Schema.init[LspHandler.InlayHintKind](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.InlayHintKind.Type
+                    case 2 => LspHandler.InlayHintKind.Parameter
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[NotebookCellKind]: Markup=1, Code=2. */
+    @publicInBinary val notebookCellKindSchema: Schema[LspHandler.NotebookCellKind] =
+        Schema.init[LspHandler.NotebookCellKind](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.NotebookCellKind.Markup
+                    case 2 => LspHandler.NotebookCellKind.Code
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[MessageType]: Error=1, Warning=2, Info=3, Log=4, Debug=5. */
+    @publicInBinary val messageTypeSchema: Schema[LspHandler.MessageType] =
+        Schema.init[LspHandler.MessageType](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.MessageType.Error
+                    case 2 => LspHandler.MessageType.Warning
+                    case 3 => LspHandler.MessageType.Info
+                    case 4 => LspHandler.MessageType.Log
+                    case 5 => LspHandler.MessageType.Debug
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2|3|4|5", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    /** Schema[FileChangeType]: Created=1, Changed=2, Deleted=3. */
+    @publicInBinary val fileChangeTypeSchema: Schema[LspHandler.FileChangeType] =
+        Schema.init[LspHandler.FileChangeType](
+            writeFn = (k, w) => Schema.intSchema.serializeWrite(k.ordinal + 1, w),
+            readFn = reader =>
+                given Frame = reader.frame
+                val n       = Schema.intSchema.serializeRead(reader)
+                n match
+                    case 1 => LspHandler.FileChangeType.Created
+                    case 2 => LspHandler.FileChangeType.Changed
+                    case 3 => LspHandler.FileChangeType.Deleted
+                    case _ => throw TypeMismatchException(Seq.empty, "1|2|3", n.toString)
+                end match
+            ,
+            structure = Schema.intSchema.structure
+        )
+
+    // MARK: -- String-keyed enum schemas
+
+    /** Schema[MarkupKind]: PlainText="plaintext", Markdown="markdown". */
+    @publicInBinary val markupKindSchema: Schema[LspHandler.MarkupKind] =
+        Schema.init[LspHandler.MarkupKind](
+            writeFn = (k, w) =>
+                val s = k match
+                    case LspHandler.MarkupKind.PlainText => "plaintext"
+                    case LspHandler.MarkupKind.Markdown  => "markdown"
+                Schema.stringSchema.serializeWrite(s, w)
+            ,
+            readFn = reader =>
+                given Frame = reader.frame
+                val s       = Schema.stringSchema.serializeRead(reader)
+                s match
+                    case "plaintext" => LspHandler.MarkupKind.PlainText
+                    case "markdown"  => LspHandler.MarkupKind.Markdown
+                    case _           => throw TypeMismatchException(Seq.empty, "plaintext|markdown", s)
+                end match
+            ,
+            structure = Schema.stringSchema.structure
+        )
+
+    /** Schema[ResourceOperationKind]: Create="create", Rename="rename", Delete="delete". */
+    @publicInBinary val resourceOperationKindSchema: Schema[LspHandler.ResourceOperationKind] =
+        Schema.init[LspHandler.ResourceOperationKind](
+            writeFn = (k, w) =>
+                val s = k match
+                    case LspHandler.ResourceOperationKind.Create => "create"
+                    case LspHandler.ResourceOperationKind.Rename => "rename"
+                    case LspHandler.ResourceOperationKind.Delete => "delete"
+                Schema.stringSchema.serializeWrite(s, w)
+            ,
+            readFn = reader =>
+                given Frame = reader.frame
+                val s       = Schema.stringSchema.serializeRead(reader)
+                s match
+                    case "create" => LspHandler.ResourceOperationKind.Create
+                    case "rename" => LspHandler.ResourceOperationKind.Rename
+                    case "delete" => LspHandler.ResourceOperationKind.Delete
+                    case _        => throw TypeMismatchException(Seq.empty, "create|rename|delete", s)
+                end match
+            ,
+            structure = Schema.stringSchema.structure
+        )
+
+    /** Schema[MonikerKind]: Import="import", Export="export", Local="local". */
+    @publicInBinary val monikerKindSchema: Schema[LspHandler.MonikerKind] =
+        Schema.init[LspHandler.MonikerKind](
+            writeFn = (k, w) =>
+                val s = k match
+                    case LspHandler.MonikerKind.Import => "import"
+                    case LspHandler.MonikerKind.Export => "export"
+                    case LspHandler.MonikerKind.Local  => "local"
+                Schema.stringSchema.serializeWrite(s, w)
+            ,
+            readFn = reader =>
+                given Frame = reader.frame
+                val s       = Schema.stringSchema.serializeRead(reader)
+                s match
+                    case "import" => LspHandler.MonikerKind.Import
+                    case "export" => LspHandler.MonikerKind.Export
+                    case "local"  => LspHandler.MonikerKind.Local
+                    case _        => throw TypeMismatchException(Seq.empty, "import|export|local", s)
+                end match
+            ,
+            structure = Schema.stringSchema.structure
+        )
+
+    /** Schema[UniquenessLevel]: Document="document", Project="project", Group="group", Scheme="scheme", Global="global". */
+    @publicInBinary val uniquenessLevelSchema: Schema[LspHandler.UniquenessLevel] =
+        Schema.init[LspHandler.UniquenessLevel](
+            writeFn = (k, w) =>
+                val s = k match
+                    case LspHandler.UniquenessLevel.Document => "document"
+                    case LspHandler.UniquenessLevel.Project  => "project"
+                    case LspHandler.UniquenessLevel.Group    => "group"
+                    case LspHandler.UniquenessLevel.Scheme   => "scheme"
+                    case LspHandler.UniquenessLevel.Global   => "global"
+                Schema.stringSchema.serializeWrite(s, w)
+            ,
+            readFn = reader =>
+                given Frame = reader.frame
+                val s       = Schema.stringSchema.serializeRead(reader)
+                s match
+                    case "document" => LspHandler.UniquenessLevel.Document
+                    case "project"  => LspHandler.UniquenessLevel.Project
+                    case "group"    => LspHandler.UniquenessLevel.Group
+                    case "scheme"   => LspHandler.UniquenessLevel.Scheme
+                    case "global"   => LspHandler.UniquenessLevel.Global
+                    case _          => throw TypeMismatchException(Seq.empty, "document|project|group|scheme|global", s)
+                end match
+            ,
+            structure = Schema.stringSchema.structure
+        )
+
+    /** Schema[FileOperationPatternKind]: File="file", Folder="folder". */
+    @publicInBinary val fileOperationPatternKindSchema: Schema[LspHandler.FileOperationPatternKind] =
+        Schema.init[LspHandler.FileOperationPatternKind](
+            writeFn = (k, w) =>
+                val s = k match
+                    case LspHandler.FileOperationPatternKind.File   => "file"
+                    case LspHandler.FileOperationPatternKind.Folder => "folder"
+                Schema.stringSchema.serializeWrite(s, w)
+            ,
+            readFn = reader =>
+                given Frame = reader.frame
+                val s       = Schema.stringSchema.serializeRead(reader)
+                s match
+                    case "file"   => LspHandler.FileOperationPatternKind.File
+                    case "folder" => LspHandler.FileOperationPatternKind.Folder
+                    case _        => throw TypeMismatchException(Seq.empty, "file|folder", s)
+                end match
+            ,
+            structure = Schema.stringSchema.structure
+        )
+
+    // MARK: -- Parameterized BooleanOr / StringOr schemas (Category C)
+
+    /** Schema[BooleanOr[T]]: boolean JSON node -> Bool(v); object JSON node -> Options(schema.read(T)).
+      *
+      * Uses captureValue() to snapshot the next JSON token, then attempts to read it as boolean.
+      * If that fails (the token is an object, not a boolean), falls back to reading via Schema[T].
+      * The fromStructureValue override handles the Structure.Value path directly.
+      */
+    given [T](using Schema[T], Tag[LspHandler.BooleanOr[T]]): Schema[LspHandler.BooleanOr[T]] =
+        new Schema[LspHandler.BooleanOr[T]](Seq.empty):
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.BooleanOr[T], w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.BooleanOr.Bool(b)    => w.boolean(b)
+                    case LspHandler.BooleanOr.Options(t) => summon[Schema[T]].serializeWrite(t, w)
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.BooleanOr[T] =
+                val captured = reader.captureValue()
+                try LspHandler.BooleanOr.Bool(captured.boolean())
+                catch case _: Exception => LspHandler.BooleanOr.Options(summon[Schema[T]].serializeRead(captured))
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.BooleanOr[T]): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.BooleanOr[T], next: Any): LspHandler.BooleanOr[T] =
+                next match
+                    case b: LspHandler.BooleanOr[?] => b.asInstanceOf[LspHandler.BooleanOr[T]]
+                    case _                          => value
+            // Open: see JsonRpcId for rationale. Same pattern applies at every other
+            // `Structure.Type.Open` site in this file.
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.BooleanOr[T]].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.BooleanOr[T]] =
+                sv match
+                    case Structure.Value.Bool(b) => Result.Success(LspHandler.BooleanOr.Bool(b))
+                    case other =>
+                        summon[Schema[T]].fromStructureValue(other).map(t => LspHandler.BooleanOr.Options(t))
+
+    /** Schema[StringOr[T]]: string JSON node -> Str(v); object JSON node -> Options(schema.read(T)).
+      *
+      * Uses captureValue() to snapshot the next JSON token, then attempts to read it as string.
+      * If that fails (the token is an object, not a string), falls back to reading via Schema[T].
+      * The fromStructureValue override handles the Structure.Value path directly.
+      */
+    given [T](using Schema[T], Tag[LspHandler.StringOr[T]]): Schema[LspHandler.StringOr[T]] =
+        new Schema[LspHandler.StringOr[T]](Seq.empty):
+            @publicInBinary private[kyo] def serializeWrite(v: LspHandler.StringOr[T], w: Codec.Writer): Unit =
+                v match
+                    case LspHandler.StringOr.Str(s)     => w.string(s)
+                    case LspHandler.StringOr.Options(t) => summon[Schema[T]].serializeWrite(t, w)
+
+            @publicInBinary private[kyo] def serializeRead(reader: Codec.Reader): LspHandler.StringOr[T] =
+                val captured = reader.captureValue()
+                try LspHandler.StringOr.Str(captured.string())
+                catch case _: Exception => LspHandler.StringOr.Options(summon[Schema[T]].serializeRead(captured))
+            end serializeRead
+
+            @publicInBinary private[kyo] def getter(value: LspHandler.StringOr[T]): Maybe[Any] = Maybe(value)
+            @publicInBinary private[kyo] def setter(value: LspHandler.StringOr[T], next: Any): LspHandler.StringOr[T] =
+                next match
+                    case s: LspHandler.StringOr[?] => s.asInstanceOf[LspHandler.StringOr[T]]
+                    case _                         => value
+            private lazy val _structure: Structure.Type =
+                Structure.Type.Open(Tag[LspHandler.StringOr[T]].asInstanceOf[Tag[Any]])
+            override def structure: Structure.Type = _structure
+            override private[kyo] def fromStructureValue(sv: Structure.Value)(using
+                Frame
+            ): Result[DecodeException, LspHandler.StringOr[T]] =
+                sv match
+                    case Structure.Value.Str(s) => Result.Success(LspHandler.StringOr.Str(s))
+                    case other =>
+                        summon[Schema[T]].fromStructureValue(other).map(t => LspHandler.StringOr.Options(t))
+
+    // MARK: -- LspCapabilities.Name string schema
+
+    /** Schema[LspCapabilities.Name]: every case maps to its LSP 3.17 spec-canonical string. */
+    @publicInBinary val lspCapabilityNameSchema: Schema[LspCapabilities.Name] =
+        Schema.init[LspCapabilities.Name](
+            writeFn = (n, w) =>
+                val s = n match
+                    case LspCapabilities.Name.Completion           => "completion"
+                    case LspCapabilities.Name.Hover                => "hover"
+                    case LspCapabilities.Name.SignatureHelp        => "signatureHelp"
+                    case LspCapabilities.Name.Declaration          => "declaration"
+                    case LspCapabilities.Name.Definition           => "definition"
+                    case LspCapabilities.Name.TypeDefinition       => "typeDefinition"
+                    case LspCapabilities.Name.Implementation       => "implementation"
+                    case LspCapabilities.Name.References           => "references"
+                    case LspCapabilities.Name.DocumentHighlight    => "documentHighlight"
+                    case LspCapabilities.Name.DocumentSymbol       => "documentSymbol"
+                    case LspCapabilities.Name.CodeAction           => "codeAction"
+                    case LspCapabilities.Name.CodeLens             => "codeLens"
+                    case LspCapabilities.Name.DocumentLink         => "documentLink"
+                    case LspCapabilities.Name.DocumentColor        => "colorProvider"
+                    case LspCapabilities.Name.Formatting           => "documentFormattingProvider"
+                    case LspCapabilities.Name.RangeFormatting      => "documentRangeFormattingProvider"
+                    case LspCapabilities.Name.OnTypeFormatting     => "documentOnTypeFormattingProvider"
+                    case LspCapabilities.Name.Rename               => "rename"
+                    case LspCapabilities.Name.FoldingRange         => "foldingRange"
+                    case LspCapabilities.Name.SelectionRange       => "selectionRange"
+                    case LspCapabilities.Name.CallHierarchy        => "callHierarchy"
+                    case LspCapabilities.Name.TypeHierarchy        => "typeHierarchy"
+                    case LspCapabilities.Name.SemanticTokens       => "semanticTokens"
+                    case LspCapabilities.Name.Moniker              => "moniker"
+                    case LspCapabilities.Name.LinkedEditingRange   => "linkedEditingRange"
+                    case LspCapabilities.Name.InlayHint            => "inlayHint"
+                    case LspCapabilities.Name.InlineValue          => "inlineValue"
+                    case LspCapabilities.Name.Diagnostic           => "diagnostic"
+                    case LspCapabilities.Name.NotebookDocumentSync => "notebookDocumentSync"
+                    case LspCapabilities.Name.ExecuteCommand       => "executeCommand"
+                    case LspCapabilities.Name.WorkspaceSymbol      => "workspaceSymbol"
+                    case LspCapabilities.Name.WorkspaceFolders     => "workspaceFolders"
+                    case LspCapabilities.Name.FileOperations       => "fileOperations"
+                Schema.stringSchema.serializeWrite(s, w)
+            ,
+            readFn = reader =>
+                given Frame = reader.frame
+                val s       = Schema.stringSchema.serializeRead(reader)
+                s match
+                    case "completion"                       => LspCapabilities.Name.Completion
+                    case "hover"                            => LspCapabilities.Name.Hover
+                    case "signatureHelp"                    => LspCapabilities.Name.SignatureHelp
+                    case "declaration"                      => LspCapabilities.Name.Declaration
+                    case "definition"                       => LspCapabilities.Name.Definition
+                    case "typeDefinition"                   => LspCapabilities.Name.TypeDefinition
+                    case "implementation"                   => LspCapabilities.Name.Implementation
+                    case "references"                       => LspCapabilities.Name.References
+                    case "documentHighlight"                => LspCapabilities.Name.DocumentHighlight
+                    case "documentSymbol"                   => LspCapabilities.Name.DocumentSymbol
+                    case "codeAction"                       => LspCapabilities.Name.CodeAction
+                    case "codeLens"                         => LspCapabilities.Name.CodeLens
+                    case "documentLink"                     => LspCapabilities.Name.DocumentLink
+                    case "colorProvider"                    => LspCapabilities.Name.DocumentColor
+                    case "documentFormattingProvider"       => LspCapabilities.Name.Formatting
+                    case "documentRangeFormattingProvider"  => LspCapabilities.Name.RangeFormatting
+                    case "documentOnTypeFormattingProvider" => LspCapabilities.Name.OnTypeFormatting
+                    case "rename"                           => LspCapabilities.Name.Rename
+                    case "foldingRange"                     => LspCapabilities.Name.FoldingRange
+                    case "selectionRange"                   => LspCapabilities.Name.SelectionRange
+                    case "callHierarchy"                    => LspCapabilities.Name.CallHierarchy
+                    case "typeHierarchy"                    => LspCapabilities.Name.TypeHierarchy
+                    case "semanticTokens"                   => LspCapabilities.Name.SemanticTokens
+                    case "moniker"                          => LspCapabilities.Name.Moniker
+                    case "linkedEditingRange"               => LspCapabilities.Name.LinkedEditingRange
+                    case "inlayHint"                        => LspCapabilities.Name.InlayHint
+                    case "inlineValue"                      => LspCapabilities.Name.InlineValue
+                    case "diagnostic"                       => LspCapabilities.Name.Diagnostic
+                    case "notebookDocumentSync"             => LspCapabilities.Name.NotebookDocumentSync
+                    case "executeCommand"                   => LspCapabilities.Name.ExecuteCommand
+                    case "workspaceSymbol"                  => LspCapabilities.Name.WorkspaceSymbol
+                    case "workspaceFolders"                 => LspCapabilities.Name.WorkspaceFolders
+                    case "fileOperations"                   => LspCapabilities.Name.FileOperations
+                    case _                                  => throw TypeMismatchException(Seq.empty, "LSP capability name string", s)
+                end match
+            ,
+            structure = Schema.stringSchema.structure
+        )
+
+end LspWireEnumSchemas

--- a/kyo-lsp/shared/src/test/scala/kyo/LspBooleanOrTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspBooleanOrTest.scala
@@ -1,0 +1,177 @@
+package kyo
+
+/** Tests for BooleanOr[T] and StringOr[T] parameterized schemas.
+  *
+  * Verifies that boolean JSON nodes decode to Bool(v), object JSON nodes decode to Options(T),
+  * and that round-trips preserve value identity. Also confirms the fromStructureValue path
+  * dispatches correctly.
+  */
+class LspBooleanOrTest extends Test:
+
+    private def encode[A: Schema](value: A): String = Json.encode[A](value)
+    private def decode[A: Schema](json: String): A  = Json.decode[A](json).getOrThrow
+    private def roundtrip[A: Schema](value: A): A   = decode[A](encode[A](value))
+
+    given CanEqual[Any, Any] = CanEqual.canEqualAny
+
+    // ---- BooleanOr[T] encode tests ----
+
+    "BooleanOr.Bool(true) encodes to true" in {
+        val v: LspHandler.BooleanOr[LspHandler.SaveOptions] = LspHandler.BooleanOr.Bool(true)
+        assert(encode(v) == "true")
+    }
+
+    "BooleanOr.Bool(false) encodes to false" in {
+        val v: LspHandler.BooleanOr[LspHandler.SaveOptions] = LspHandler.BooleanOr.Bool(false)
+        assert(encode(v) == "false")
+    }
+
+    "BooleanOr.Options(T) encodes as T object" in {
+        val opts                                            = LspHandler.SaveOptions(includeText = Present(true))
+        val v: LspHandler.BooleanOr[LspHandler.SaveOptions] = LspHandler.BooleanOr.Options(opts)
+        val json                                            = encode(v)
+        assert(json.contains("includeText"))
+        assert(json.contains("true"))
+    }
+
+    // ---- BooleanOr[T] decode tests ----
+
+    "BooleanOr decodes true -> Bool(true)" in {
+        val v = decode[LspHandler.BooleanOr[LspHandler.SaveOptions]]("true")
+        assert(v == LspHandler.BooleanOr.Bool(true))
+    }
+
+    "BooleanOr decodes false -> Bool(false)" in {
+        val v = decode[LspHandler.BooleanOr[LspHandler.SaveOptions]]("false")
+        assert(v == LspHandler.BooleanOr.Bool(false))
+    }
+
+    "BooleanOr decodes object -> Options(T)" in {
+        val v = decode[LspHandler.BooleanOr[LspHandler.SaveOptions]]("""{"includeText":true}""")
+        v match
+            case LspHandler.BooleanOr.Options(opts) => assert(opts.includeText == Present(true))
+            case other                              => assert(false, s"Expected Options, got $other")
+    }
+
+    "BooleanOr decodes empty object -> Options(T)" in {
+        val v = decode[LspHandler.BooleanOr[LspHandler.SaveOptions]]("{}")
+        v match
+            case LspHandler.BooleanOr.Options(opts) =>
+                // Verify decoded case and that the nested options is the right type.
+                assert(opts.isInstanceOf[LspHandler.SaveOptions], s"Expected SaveOptions inside Options, got ${opts.getClass}")
+            case other => assert(false, s"Expected Options, got $other")
+        end match
+    }
+
+    // ---- BooleanOr[T] round-trip tests ----
+
+    "BooleanOr.Bool(true) round-trips" in {
+        val v: LspHandler.BooleanOr[LspHandler.SaveOptions] = LspHandler.BooleanOr.Bool(true)
+        assert(roundtrip(v) == v)
+    }
+
+    "BooleanOr.Bool(false) round-trips" in {
+        val v: LspHandler.BooleanOr[LspHandler.SaveOptions] = LspHandler.BooleanOr.Bool(false)
+        assert(roundtrip(v) == v)
+    }
+
+    "BooleanOr.Options round-trips" in {
+        val opts                                            = LspHandler.SaveOptions(includeText = Present(false))
+        val v: LspHandler.BooleanOr[LspHandler.SaveOptions] = LspHandler.BooleanOr.Options(opts)
+        assert(roundtrip(v) == v)
+    }
+
+    "BooleanOr works with CompletionOptions.ItemOptions" in {
+        val opts = LspHandler.CompletionOptions.ItemOptions(labelDetailsSupport = Present(true))
+        val v: LspHandler.BooleanOr[LspHandler.CompletionOptions.ItemOptions] = LspHandler.BooleanOr.Options(opts)
+        val back                                                              = roundtrip(v)
+        assert(back == v)
+    }
+
+    // ---- StringOr[T] encode tests ----
+
+    "StringOr.Str encodes to JSON string" in {
+        val v: LspHandler.StringOr[LspHandler.SaveOptions] = LspHandler.StringOr.Str("auto")
+        assert(encode(v) == "\"auto\"")
+    }
+
+    "StringOr.Options(T) encodes as T object" in {
+        val opts                                           = LspHandler.SaveOptions(includeText = Present(true))
+        val v: LspHandler.StringOr[LspHandler.SaveOptions] = LspHandler.StringOr.Options(opts)
+        val json                                           = encode(v)
+        assert(json.contains("includeText"))
+    }
+
+    // ---- StringOr[T] decode tests ----
+
+    "StringOr decodes JSON string -> Str(v)" in {
+        val v = decode[LspHandler.StringOr[LspHandler.SaveOptions]]("\"auto\"")
+        assert(v == LspHandler.StringOr.Str("auto"))
+    }
+
+    "StringOr decodes object -> Options(T)" in {
+        val v = decode[LspHandler.StringOr[LspHandler.SaveOptions]]("""{"includeText":false}""")
+        v match
+            case LspHandler.StringOr.Options(opts) => assert(opts.includeText == Present(false))
+            case other                             => assert(false, s"Expected Options, got $other")
+    }
+
+    // ---- StringOr[T] round-trip tests ----
+
+    "StringOr.Str round-trips" in {
+        val v: LspHandler.StringOr[LspHandler.SaveOptions] = LspHandler.StringOr.Str("full")
+        assert(roundtrip(v) == v)
+    }
+
+    "StringOr.Options round-trips" in {
+        val opts                                           = LspHandler.SaveOptions(includeText = Present(true))
+        val v: LspHandler.StringOr[LspHandler.SaveOptions] = LspHandler.StringOr.Options(opts)
+        assert(roundtrip(v) == v)
+    }
+
+    "StringOr empty string round-trips" in {
+        val v: LspHandler.StringOr[LspHandler.SaveOptions] = LspHandler.StringOr.Str("")
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- Nested BooleanOr in a record (TextDocumentSyncOptions.save field) ----
+
+    "TextDocumentSyncOptions with BooleanOr.Bool save round-trips" in {
+        val opts = LspHandler.TextDocumentSyncOptions(
+            openClose = Present(true),
+            save = Present(LspHandler.BooleanOr.Bool(true))
+        )
+        val back = roundtrip(opts)
+        assert(back.openClose == Present(true))
+        back.save match
+            case Present(LspHandler.BooleanOr.Bool(b)) =>
+                assert(b, s"Expected BooleanOr.Bool(true), got BooleanOr.Bool(false)")
+            case other => assert(false, s"Expected BooleanOr.Bool(true), got $other")
+        end match
+    }
+
+    "TextDocumentSyncOptions with BooleanOr.Options save round-trips" in {
+        val opts = LspHandler.TextDocumentSyncOptions(
+            save = Present(LspHandler.BooleanOr.Options(LspHandler.SaveOptions(includeText = Present(true))))
+        )
+        val back = roundtrip(opts)
+        back.save match
+            case Present(LspHandler.BooleanOr.Options(savedOpts)) =>
+                assert(savedOpts.includeText == Present(true))
+            case other => assert(false, s"Unexpected: $other")
+        end match
+    }
+
+    // ---- Schema singleton check ----
+
+    "BooleanOr schema has empty segments (transform-based)" in {
+        val s = summon[Schema[LspHandler.BooleanOr[LspHandler.SaveOptions]]]
+        assert(s.segments.isEmpty)
+    }
+
+    "StringOr schema has empty segments (transform-based)" in {
+        val s = summon[Schema[LspHandler.StringOr[LspHandler.SaveOptions]]]
+        assert(s.segments.isEmpty)
+    }
+
+end LspBooleanOrTest

--- a/kyo-lsp/shared/src/test/scala/kyo/LspCapabilitiesTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspCapabilitiesTest.scala
@@ -1,0 +1,535 @@
+package kyo
+
+class LspCapabilitiesTest extends Test:
+
+    given CanEqual[Any, Any] = CanEqual.canEqualAny
+
+    private def roundtrip[A: Schema](value: A): A = Json.decode[A](Json.encode(value)).getOrThrow
+
+    // =========================================================================
+    // Type alias correctness
+    // =========================================================================
+
+    "type aliases" - {
+        "LspCapabilities.Server resolves to the inner case class" in {
+            val s: LspCapabilities.Server = LspCapabilities.Server.empty
+            assert(s == LspCapabilities.Server.Server())
+        }
+        "LspCapabilities.Client resolves to the inner case class" in {
+            val c: LspCapabilities.Client = LspCapabilities.Client.empty
+            assert(c == LspCapabilities.Client.Client())
+        }
+        "alias and inner class are the same type" in {
+            val byAlias: LspCapabilities.Server       = LspCapabilities.Server.empty
+            val byFull: LspCapabilities.Server.Server = LspCapabilities.Server.empty
+            assert(byAlias == byFull)
+        }
+    }
+
+    // =========================================================================
+    // Server capabilities
+    // =========================================================================
+
+    "Server.empty" - {
+        "all fields Absent" in {
+            val s = LspCapabilities.Server.empty
+            assert(s.positionEncoding.isEmpty)
+            assert(s.textDocumentSync.isEmpty)
+            assert(s.completionProvider.isEmpty)
+            assert(s.hoverProvider.isEmpty)
+            assert(s.signatureHelpProvider.isEmpty)
+            assert(s.declarationProvider.isEmpty)
+            assert(s.definitionProvider.isEmpty)
+            assert(s.typeDefinitionProvider.isEmpty)
+            assert(s.implementationProvider.isEmpty)
+            assert(s.referencesProvider.isEmpty)
+            assert(s.documentHighlightProvider.isEmpty)
+            assert(s.documentSymbolProvider.isEmpty)
+            assert(s.codeActionProvider.isEmpty)
+            assert(s.codeLensProvider.isEmpty)
+            assert(s.documentLinkProvider.isEmpty)
+            assert(s.colorProvider.isEmpty)
+            assert(s.documentFormattingProvider.isEmpty)
+            assert(s.documentRangeFormattingProvider.isEmpty)
+            assert(s.documentOnTypeFormattingProvider.isEmpty)
+            assert(s.renameProvider.isEmpty)
+            assert(s.foldingRangeProvider.isEmpty)
+            assert(s.executeCommandProvider.isEmpty)
+            assert(s.selectionRangeProvider.isEmpty)
+            assert(s.linkedEditingRangeProvider.isEmpty)
+            assert(s.callHierarchyProvider.isEmpty)
+            assert(s.semanticTokensProvider.isEmpty)
+            assert(s.monikerProvider.isEmpty)
+            assert(s.typeHierarchyProvider.isEmpty)
+            assert(s.inlineValueProvider.isEmpty)
+            assert(s.inlayHintProvider.isEmpty)
+            assert(s.diagnosticProvider.isEmpty)
+            assert(s.workspaceSymbolProvider.isEmpty)
+            assert(s.notebookDocumentSync.isEmpty)
+            assert(s.workspace.isEmpty)
+        }
+    }
+
+    "Schema[Server.Server] round-trip empty" in {
+        val s = LspCapabilities.Server.empty
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] round-trip with populated fields" in {
+        val s = LspCapabilities.Server.empty.copy(
+            positionEncoding = Present(LspHandler.PositionEncodingKind.UTF16),
+            hoverProvider = Present(LspHandler.BooleanOr.Bool(true)),
+            completionProvider = Present(LspHandler.CompletionOptions(
+                triggerCharacters = Chunk(".", ":"),
+                resolveProvider = Present(true)
+            )),
+            renameProvider = Present(LspHandler.BooleanOr.Options(
+                LspHandler.RenameOptions(prepareProvider = Present(true))
+            ))
+        )
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] BooleanOr.Bool(true) round-trips for hoverProvider" in {
+        val s = LspCapabilities.Server.empty.copy(
+            hoverProvider = Present(LspHandler.BooleanOr.Bool(true))
+        )
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] BooleanOr.Bool(false) round-trips for hoverProvider" in {
+        val s = LspCapabilities.Server.empty.copy(
+            hoverProvider = Present(LspHandler.BooleanOr.Bool(false))
+        )
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] BooleanOr.Options round-trips for hoverProvider" in {
+        val opts = LspHandler.HoverOptions(workDoneProgress = Present(true))
+        val s = LspCapabilities.Server.empty.copy(
+            hoverProvider = Present(LspHandler.BooleanOr.Options(opts))
+        )
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] with workspace field" in {
+        val ws = LspCapabilities.Server.WorkspaceServerCapabilities(
+            workspaceFolders = Present(
+                LspCapabilities.Server.WorkspaceFoldersServerCapabilities(supported = Present(true))
+            )
+        )
+        val s = LspCapabilities.Server.empty.copy(workspace = Present(ws))
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] with diagnosticProvider" in {
+        val diag = LspCapabilities.Server.DiagnosticOptions(
+            interFileDependencies = true,
+            workspaceDiagnostics = false
+        )
+        val s = LspCapabilities.Server.empty.copy(diagnosticProvider = Present(diag))
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] textDocumentSync with Kind" in {
+        val s = LspCapabilities.Server.empty.copy(
+            textDocumentSync = Present(LspHandler.TextDocumentSyncValue.Kind(LspHandler.TextDocumentSyncKind.Incremental))
+        )
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] textDocumentSync with Options" in {
+        val s = LspCapabilities.Server.empty.copy(
+            textDocumentSync = Present(LspHandler.TextDocumentSyncValue.Options(
+                LspHandler.TextDocumentSyncOptions(openClose = Present(true))
+            ))
+        )
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] with notebookDocumentSync" in {
+        val notebookSync = LspCapabilities.Server.NotebookDocumentSyncOptions(
+            notebookSelector = Chunk(
+                LspCapabilities.Server.NotebookSelector(
+                    cells = Chunk(LspCapabilities.Server.CellSelectorItem("scala"))
+                )
+            )
+        )
+        val s = LspCapabilities.Server.empty.copy(notebookDocumentSync = Present(notebookSync))
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] with fileOperations" in {
+        val fileOps = LspCapabilities.Server.FileOperationsServerCapabilities(
+            didCreate = Present(LspHandler.FileOperationRegistrationOptions(filters = Chunk.empty))
+        )
+        val ws = LspCapabilities.Server.WorkspaceServerCapabilities(fileOperations = Present(fileOps))
+        val s  = LspCapabilities.Server.empty.copy(workspace = Present(ws))
+        assert(roundtrip(s) == s)
+    }
+
+    "Schema[Server.Server] with semanticTokensProvider" in {
+        val stOpts = LspHandler.SemanticTokensOptions(
+            legend = LspHandler.SemanticTokensLegend(
+                tokenTypes = Chunk(LspHandler.SemanticTokenTypes("type")),
+                tokenModifiers = Chunk(LspHandler.SemanticTokenModifiers("readonly"))
+            ),
+            full = Present(LspHandler.BooleanOr.Bool(true))
+        )
+        val s = LspCapabilities.Server.empty.copy(semanticTokensProvider = Present(stOpts))
+        assert(roundtrip(s) == s)
+    }
+
+    // =========================================================================
+    // Client capabilities
+    // =========================================================================
+
+    "Client.empty" - {
+        "all group fields Absent" in {
+            val c = LspCapabilities.Client.empty
+            assert(c.workspace.isEmpty)
+            assert(c.textDocument.isEmpty)
+            assert(c.notebookDocument.isEmpty)
+            assert(c.window.isEmpty)
+            assert(c.general.isEmpty)
+        }
+    }
+
+    "Schema[Client.Client] round-trip empty" in {
+        val c = LspCapabilities.Client.empty
+        assert(roundtrip(c) == c)
+    }
+
+    "Schema[Client.Client] round-trip with workspace capabilities" in {
+        val c = LspCapabilities.Client.empty.copy(
+            workspace = Present(LspCapabilities.Client.WorkspaceClientCapabilities(
+                applyEdit = Present(true),
+                workspaceFolders = Present(true),
+                configuration = Present(true)
+            ))
+        )
+        assert(roundtrip(c) == c)
+    }
+
+    "Schema[Client.Client] round-trip with general positionEncodings" in {
+        val c = LspCapabilities.Client.empty.copy(
+            general = Present(LspCapabilities.Client.GeneralClientCapabilities(
+                positionEncodings = Chunk(LspHandler.PositionEncodingKind.UTF16, LspHandler.PositionEncodingKind.UTF8)
+            ))
+        )
+        assert(roundtrip(c) == c)
+    }
+
+    "Schema[Client.Client] round-trip with window capabilities" in {
+        val c = LspCapabilities.Client.empty.copy(
+            window = Present(LspCapabilities.Client.WindowClientCapabilities(
+                workDoneProgress = Present(true),
+                showDocument = Present(LspCapabilities.Client.ShowDocumentClientCapabilities(support = true))
+            ))
+        )
+        assert(roundtrip(c) == c)
+    }
+
+    "Schema[Client.Client] round-trip with textDocument completion" in {
+        val c = LspCapabilities.Client.empty.copy(
+            textDocument = Present(LspCapabilities.Client.TextDocumentClientCapabilities(
+                completion = Present(LspCapabilities.Client.CompletionClientCapabilities(
+                    dynamicRegistration = Present(true),
+                    contextSupport = Present(true)
+                ))
+            ))
+        )
+        assert(roundtrip(c) == c)
+    }
+
+    "Schema[Client.Client] round-trip with notebookDocument" in {
+        val c = LspCapabilities.Client.empty.copy(
+            notebookDocument = Present(LspCapabilities.Client.NotebookDocumentClientCapabilities(
+                synchronization = Present(LspCapabilities.Client.NotebookDocumentSyncClientCapabilities(
+                    dynamicRegistration = Present(true),
+                    executionSummarySupport = Present(true)
+                ))
+            ))
+        )
+        assert(roundtrip(c) == c)
+    }
+
+    "Schema[Client.Client] with semanticTokens client capabilities" in {
+        val c = LspCapabilities.Client.empty.copy(
+            textDocument = Present(LspCapabilities.Client.TextDocumentClientCapabilities(
+                semanticTokens = Present(LspCapabilities.Client.SemanticTokensClientCapabilities(
+                    requests = LspCapabilities.Client.SemanticTokensRequestsCapabilities(
+                        range = Present(true),
+                        full = Present(true)
+                    ),
+                    tokenTypes = Chunk(LspHandler.SemanticTokenTypes("keyword")),
+                    tokenModifiers = Chunk(LspHandler.SemanticTokenModifiers("declaration")),
+                    formats = Chunk("relative"),
+                    multilineTokenSupport = Present(true)
+                ))
+            ))
+        )
+        assert(roundtrip(c) == c)
+    }
+
+    "Schema[Client.Client] with codeAction capabilities" in {
+        val c = LspCapabilities.Client.empty.copy(
+            textDocument = Present(LspCapabilities.Client.TextDocumentClientCapabilities(
+                codeAction = Present(LspCapabilities.Client.CodeActionClientCapabilities(
+                    dynamicRegistration = Present(true),
+                    isPreferredSupport = Present(true),
+                    disabledSupport = Present(true),
+                    dataSupport = Present(true),
+                    codeActionLiteralSupport = Present(
+                        LspCapabilities.Client.CodeActionLiteralSupportOptions(
+                            codeActionKind = LspCapabilities.Client.CodeActionKindOptions(
+                                valueSet = Chunk(LspHandler.CodeActionKind("quickfix"))
+                            )
+                        )
+                    )
+                ))
+            ))
+        )
+        assert(roundtrip(c) == c)
+    }
+
+    // =========================================================================
+    // LspCapabilities.Name enum
+    // =========================================================================
+
+    "Name Schema individual cases" - {
+        "Completion encodes to completion" in {
+            assert(Json.encode(LspCapabilities.Name.Completion) == """"completion"""")
+        }
+        "Hover encodes to hover" in {
+            assert(Json.encode(LspCapabilities.Name.Hover) == """"hover"""")
+        }
+        "SignatureHelp encodes to signatureHelp" in {
+            assert(Json.encode(LspCapabilities.Name.SignatureHelp) == """"signatureHelp"""")
+        }
+        "Declaration encodes to declaration" in {
+            assert(Json.encode(LspCapabilities.Name.Declaration) == """"declaration"""")
+        }
+        "Definition encodes to definition" in {
+            assert(Json.encode(LspCapabilities.Name.Definition) == """"definition"""")
+        }
+        "TypeDefinition encodes to typeDefinition" in {
+            assert(Json.encode(LspCapabilities.Name.TypeDefinition) == """"typeDefinition"""")
+        }
+        "Implementation encodes to implementation" in {
+            assert(Json.encode(LspCapabilities.Name.Implementation) == """"implementation"""")
+        }
+        "References encodes to references" in {
+            assert(Json.encode(LspCapabilities.Name.References) == """"references"""")
+        }
+        "DocumentHighlight encodes to documentHighlight" in {
+            assert(Json.encode(LspCapabilities.Name.DocumentHighlight) == """"documentHighlight"""")
+        }
+        "DocumentSymbol encodes to documentSymbol" in {
+            assert(Json.encode(LspCapabilities.Name.DocumentSymbol) == """"documentSymbol"""")
+        }
+        "CodeAction encodes to codeAction" in {
+            assert(Json.encode(LspCapabilities.Name.CodeAction) == """"codeAction"""")
+        }
+        "CodeLens encodes to codeLens" in {
+            assert(Json.encode(LspCapabilities.Name.CodeLens) == """"codeLens"""")
+        }
+        "DocumentLink encodes to documentLink" in {
+            assert(Json.encode(LspCapabilities.Name.DocumentLink) == """"documentLink"""")
+        }
+        "DocumentColor encodes to colorProvider" in {
+            assert(Json.encode(LspCapabilities.Name.DocumentColor) == """"colorProvider"""")
+        }
+        "Formatting encodes to documentFormattingProvider" in {
+            assert(Json.encode(LspCapabilities.Name.Formatting) == """"documentFormattingProvider"""")
+        }
+        "RangeFormatting encodes to documentRangeFormattingProvider" in {
+            assert(Json.encode(LspCapabilities.Name.RangeFormatting) == """"documentRangeFormattingProvider"""")
+        }
+        "OnTypeFormatting encodes to documentOnTypeFormattingProvider" in {
+            assert(Json.encode(LspCapabilities.Name.OnTypeFormatting) == """"documentOnTypeFormattingProvider"""")
+        }
+        "Rename encodes to rename" in {
+            assert(Json.encode(LspCapabilities.Name.Rename) == """"rename"""")
+        }
+        "FoldingRange encodes to foldingRange" in {
+            assert(Json.encode(LspCapabilities.Name.FoldingRange) == """"foldingRange"""")
+        }
+        "SelectionRange encodes to selectionRange" in {
+            assert(Json.encode(LspCapabilities.Name.SelectionRange) == """"selectionRange"""")
+        }
+        "CallHierarchy encodes to callHierarchy" in {
+            assert(Json.encode(LspCapabilities.Name.CallHierarchy) == """"callHierarchy"""")
+        }
+        "TypeHierarchy encodes to typeHierarchy" in {
+            assert(Json.encode(LspCapabilities.Name.TypeHierarchy) == """"typeHierarchy"""")
+        }
+        "SemanticTokens encodes to semanticTokens" in {
+            assert(Json.encode(LspCapabilities.Name.SemanticTokens) == """"semanticTokens"""")
+        }
+        "Moniker encodes to moniker" in {
+            assert(Json.encode(LspCapabilities.Name.Moniker) == """"moniker"""")
+        }
+        "LinkedEditingRange encodes to linkedEditingRange" in {
+            assert(Json.encode(LspCapabilities.Name.LinkedEditingRange) == """"linkedEditingRange"""")
+        }
+        "InlayHint encodes to inlayHint" in {
+            assert(Json.encode(LspCapabilities.Name.InlayHint) == """"inlayHint"""")
+        }
+        "InlineValue encodes to inlineValue" in {
+            assert(Json.encode(LspCapabilities.Name.InlineValue) == """"inlineValue"""")
+        }
+        "Diagnostic encodes to diagnostic" in {
+            assert(Json.encode(LspCapabilities.Name.Diagnostic) == """"diagnostic"""")
+        }
+        "NotebookDocumentSync encodes to notebookDocumentSync" in {
+            assert(Json.encode(LspCapabilities.Name.NotebookDocumentSync) == """"notebookDocumentSync"""")
+        }
+        "ExecuteCommand encodes to executeCommand" in {
+            assert(Json.encode(LspCapabilities.Name.ExecuteCommand) == """"executeCommand"""")
+        }
+        "WorkspaceSymbol encodes to workspaceSymbol" in {
+            assert(Json.encode(LspCapabilities.Name.WorkspaceSymbol) == """"workspaceSymbol"""")
+        }
+        "WorkspaceFolders encodes to workspaceFolders" in {
+            assert(Json.encode(LspCapabilities.Name.WorkspaceFolders) == """"workspaceFolders"""")
+        }
+        "FileOperations encodes to fileOperations" in {
+            assert(Json.encode(LspCapabilities.Name.FileOperations) == """"fileOperations"""")
+        }
+    }
+
+    "Name Schema covers all 33 cases round-trip" in {
+        val allCases = LspCapabilities.Name.values.toSeq
+        assert(allCases.size == 33)
+        val allRoundTrip = allCases.forall(n => roundtrip(n) == n)
+        assert(allRoundTrip)
+    }
+
+    "Name Schema decodes case-insensitively fails on wrong string" in {
+        val result = Json.decode[LspCapabilities.Name](""""COMPLETION"""")
+        assert(result.isFailure)
+    }
+
+    // =========================================================================
+    // BooleanOr / StringOr at capability use sites
+    // =========================================================================
+
+    "BooleanOr aliases" - {
+        "LspCapabilities.BooleanOr is same as LspHandler.BooleanOr" in {
+            val v: LspCapabilities.BooleanOr[LspHandler.HoverOptions] =
+                LspHandler.BooleanOr.Bool(true)
+            assert(v == LspHandler.BooleanOr.Bool(true))
+        }
+        "StringOr alias works at call site" in {
+            val v: LspCapabilities.StringOr[LspHandler.FoldingRangeOptions] =
+                LspHandler.StringOr.Str("custom")
+            assert(v == LspHandler.StringOr.Str("custom"))
+        }
+    }
+
+    // =========================================================================
+    // Server nested records
+    // =========================================================================
+
+    "Server nested records" - {
+        "WorkspaceColorProviderOptions round-trips" in {
+            val opts = LspCapabilities.Server.WorkspaceColorProviderOptions(workDoneProgress = Present(true))
+            assert(roundtrip(opts) == opts)
+        }
+        "DocumentFormattingOptions round-trips" in {
+            val opts = LspCapabilities.Server.DocumentFormattingOptions(workDoneProgress = Present(false))
+            assert(roundtrip(opts) == opts)
+        }
+        "DocumentRangeFormattingOptions round-trips" in {
+            val opts = LspCapabilities.Server.DocumentRangeFormattingOptions(workDoneProgress = Present(true))
+            assert(roundtrip(opts) == opts)
+        }
+        "DiagnosticOptions round-trips" in {
+            val opts = LspCapabilities.Server.DiagnosticOptions(
+                identifier = Present("myDiagnostics"),
+                interFileDependencies = true,
+                workspaceDiagnostics = true
+            )
+            assert(roundtrip(opts) == opts)
+        }
+        "WorkspaceServerCapabilities round-trips" in {
+            val ws = LspCapabilities.Server.WorkspaceServerCapabilities(
+                workspaceFolders = Present(
+                    LspCapabilities.Server.WorkspaceFoldersServerCapabilities(
+                        supported = Present(true),
+                        changeNotifications = Present(true)
+                    )
+                )
+            )
+            assert(roundtrip(ws) == ws)
+        }
+        "FileOperationsServerCapabilities round-trips" in {
+            val fileOps = LspCapabilities.Server.FileOperationsServerCapabilities(
+                didCreate = Present(LspHandler.FileOperationRegistrationOptions(filters = Chunk.empty)),
+                willDelete = Present(LspHandler.FileOperationRegistrationOptions(filters = Chunk.empty))
+            )
+            assert(roundtrip(fileOps) == fileOps)
+        }
+    }
+
+    // =========================================================================
+    // Client nested records
+    // =========================================================================
+
+    "Client nested records" - {
+        "WorkspaceEditClientCapabilities round-trips" in {
+            val caps = LspCapabilities.Client.WorkspaceEditClientCapabilities(
+                documentChanges = Present(true),
+                resourceOperations = Chunk("create", "rename", "delete"),
+                normalizesLineEndings = Present(true)
+            )
+            assert(roundtrip(caps) == caps)
+        }
+        "SemanticTokensClientCapabilities round-trips" in {
+            val caps = LspCapabilities.Client.SemanticTokensClientCapabilities(
+                requests = LspCapabilities.Client.SemanticTokensRequestsCapabilities(
+                    range = Present(true),
+                    full = Present(false)
+                ),
+                tokenTypes = Chunk(LspHandler.SemanticTokenTypes("class")),
+                tokenModifiers = Chunk(LspHandler.SemanticTokenModifiers("static")),
+                formats = Chunk("relative"),
+                overlappingTokenSupport = Present(false),
+                augmentsSyntaxTokens = Present(true)
+            )
+            assert(roundtrip(caps) == caps)
+        }
+        "FoldingRangeClientCapabilities round-trips" in {
+            val caps = LspCapabilities.Client.FoldingRangeClientCapabilities(
+                dynamicRegistration = Present(true),
+                rangeLimit = Present(5000),
+                lineFoldingOnly = Present(false),
+                foldingRangeKind = Present(
+                    LspCapabilities.Client.FoldingRangeKindOptions(
+                        valueSet = Chunk(LspHandler.FoldingRangeKind("comment"))
+                    )
+                )
+            )
+            assert(roundtrip(caps) == caps)
+        }
+        "StaleRequestSupportOptions round-trips" in {
+            val opts = LspCapabilities.Client.StaleRequestSupportOptions(
+                cancel = true,
+                retryOnContentModified = Chunk("textDocument/completion")
+            )
+            assert(roundtrip(opts) == opts)
+        }
+        "PublishDiagnosticsClientCapabilities round-trips" in {
+            val caps = LspCapabilities.Client.PublishDiagnosticsClientCapabilities(
+                relatedInformation = Present(true),
+                tagSupport = Present(LspCapabilities.Client.DiagnosticTagSupportOptions(
+                    valueSet = Chunk(LspHandler.DiagnosticTag.Unnecessary)
+                )),
+                versionSupport = Present(true)
+            )
+            assert(roundtrip(caps) == caps)
+        }
+    }
+
+end LspCapabilitiesTest

--- a/kyo-lsp/shared/src/test/scala/kyo/LspClientTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspClientTest.scala
@@ -1,0 +1,452 @@
+package kyo
+
+/** Tests for LspClient init quartet, argument order, handshake correctness, and typed method surface.
+  *
+  * Covers scope-managed init defaulting, the (transport, clientInfo, capabilities, handlers*) argument
+  * order, eager initialize/initialized handshake, and the typed-only executeCommand[T] surface.
+  */
+class LspClientTest extends Test:
+
+    private val clientInfo = LspInfo("test-client", "0.0.0")
+    private val clientCaps = LspCapabilities.Client.empty
+
+    private val mainUri = LspHandler.LspDocument.Uri.parse("file:///Main.scala").get
+
+    /** Starts a server with `handlers` and a connected client over an in-memory transport pair,
+      * runs `call(client)` against the live session, and returns its `Result`. Scope-managed: both
+      * server and client are released at scope exit.
+      */
+    private def serve[A](handlers: LspHandler[?, ?, ?]*)(
+        call: LspClient => A < (Async & Abort[LspException])
+    )(using Frame): Result[LspException, A] < (Async & Scope) =
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.init(ta, handlers*).flatMap { _ =>
+                Abort.run[LspException](LspClient.init(tb, clientInfo, clientCaps).flatMap(call))
+            }
+        }
+
+    // =========================================================================
+    // Init quartet smoke tests
+    // =========================================================================
+
+    "initUnscoped with no handlers requires a connected server to complete handshake" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        client.closeNow.andThen(server.closeNow).andThen(succeed)
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected client init to succeed, got error: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "initUnscoped with explicit config smoke test" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps, LspConfig.default)).flatMap {
+                    case Result.Success(client) =>
+                        client.closeNow.andThen(server.closeNow).andThen(succeed)
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "initUnscopedWith applies function and returns result" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](
+                    LspClient.initUnscopedWith(tb, clientInfo, clientCaps) { client =>
+                        client.specVersion
+                    }
+                ).flatMap {
+                    case Result.Success(version) =>
+                        server.closeNow.andThen(assert(version == "3.17"))
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "initUnscopedWith with explicit config applies function" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](
+                    LspClient.initUnscopedWith(tb, clientInfo, clientCaps, LspConfig.default) { client =>
+                        client.specVersion
+                    }
+                ).flatMap {
+                    case Result.Success(version) =>
+                        server.closeNow.andThen(assert(version == "3.17"))
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "init (scoped) releases client when Scope exits" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](
+                    Scope.run {
+                        LspClient.init(tb, clientInfo, clientCaps).map { client =>
+                            assert(client.specVersion == "3.17")
+                        }
+                    }
+                ).flatMap {
+                    case Result.Success(_)   => server.closeNow.andThen(succeed)
+                    case Result.Failure(err) => server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex)    => server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "initWith applies function and client is live inside the function" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](
+                    Scope.run {
+                        LspClient.initWith(tb, clientInfo, clientCaps) { client =>
+                            client.specVersion
+                        }
+                    }
+                ).flatMap {
+                    case Result.Success(version) =>
+                        server.closeNow.andThen(assert(version == "3.17"))
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "initWith with explicit config applies function" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](
+                    Scope.run {
+                        LspClient.initWith(tb, clientInfo, clientCaps, LspConfig.default) { client =>
+                            client.specVersion
+                        }
+                    }
+                ).flatMap {
+                    case Result.Success(version) =>
+                        server.closeNow.andThen(assert(version == "3.17"))
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Argument order locked
+    // =========================================================================
+
+    "init argument order is (transport, clientInfo, capabilities, handlers*)" in {
+        // Compile-time check: the signature must accept arguments in this exact order.
+        // If the order changes, this test fails to compile.
+        JsonRpcTransport.inMemory.flatMap { (_, tb) =>
+            val transport: JsonRpcTransport         = tb
+            val info: LspInfo                       = clientInfo
+            val caps: LspCapabilities.Client.Client = clientCaps
+            val handlers: Seq[LspHandler[?, ?, ?]]  = Seq.empty
+            // The type annotation is the assertion: this must compile with the exact row.
+            // If the argument order changed, this would not compile.
+            val _: LspClient < (Async & Abort[LspInitFailure]) =
+                LspClient.initUnscoped(transport, info, caps, handlers*)
+            succeed
+        }
+    }
+
+    // =========================================================================
+    // Eager handshake
+    // =========================================================================
+
+    "serverCapabilities is Present immediately after init" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        client.serverCapabilities.map { caps =>
+                            client.closeNow.andThen(server.closeNow).andThen {
+                                assert(caps.isDefined, s"Expected serverCapabilities to be Present after init, got $caps")
+                            }
+                        }
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected client init to succeed, got error: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "serverInfo is Present immediately after init when server advertises info" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        client.serverInfo.map { info =>
+                            client.closeNow.andThen(server.closeNow).andThen {
+                                // Server includes serverInfo in InitializeResult by default.
+                                assert(info.isDefined, s"Expected serverInfo to be Present after init, got $info")
+                            }
+                        }
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected client init to succeed, got error: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "positionEncoding defaults to UTF16 when server does not advertise encoding" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        client.positionEncoding.map { enc =>
+                            client.closeNow.andThen(server.closeNow).andThen {
+                                assert(enc == LspHandler.PositionEncodingKind.UTF16)
+                            }
+                        }
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected client init to succeed, got error: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "specVersion returns 3.17 after handshake" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        val ver = client.specVersion
+                        client.closeNow.andThen(server.closeNow).andThen {
+                            assert(ver == "3.17")
+                        }
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected client init to succeed, got error: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Typed-only executeCommand[T]
+    // =========================================================================
+
+    "executeCommand[T] is the only variant and is typed-only" in {
+        // Compile-time check: the extension method exists with the typed signature.
+        // The type parameter [T] proves it is typed-only; no untyped alias exists
+        // because that would have a different name (executeCommandUntyped, etc.).
+        // Here we verify via the safe-tier extension call site.
+        case class TestOut(value: String) derives Schema
+        val params = LspHandler.ExecuteCommandParams("test")
+        // This compile-time annotation is the assertion: only one executeCommand variant exists.
+        def typedOnly(client: LspClient)(using Frame): Maybe[TestOut] < (Async & Abort[LspRequestFailure]) =
+            client.executeCommand[TestOut](params)
+        assert(typedOnly != null, "executeCommand extension method must exist and be callable")
+    }
+
+    "executeCommand[T] return type is Maybe[T] < (Async & Abort[LspRequestFailure])" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        case class MyResult(value: Int) derives Schema
+                        val params = LspHandler.ExecuteCommandParams("myCommand")
+                        // Compile-time type annotation confirms the return row.
+                        val _: Maybe[MyResult] < (Async & Abort[LspRequestFailure]) =
+                            client.executeCommand[MyResult](params)
+                        client.closeNow.andThen(server.closeNow).andThen(succeed)
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Session accessors
+    // =========================================================================
+
+    "underlying returns a JsonRpcHandler instance" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        val _ = client.underlying
+                        client.closeNow.andThen(server.closeNow).andThen(succeed)
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "unsafe accessor returns LspClient.Unsafe" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        val unsafe = client.unsafe
+                        val back   = unsafe.safe
+                        client.closeNow.andThen(server.closeNow).andThen {
+                            assert(back.specVersion == "3.17")
+                        }
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Close / closeNow / awaitDrain
+    // =========================================================================
+
+    "close(using Frame) completes without error" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        client.close.andThen(server.closeNow).andThen(succeed)
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "closeNow completes without error" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        client.closeNow.andThen(server.closeNow).andThen(succeed)
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    "awaitDrain completes on an idle client" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                Abort.run[LspException](LspClient.initUnscoped(tb, clientInfo, clientCaps)).flatMap {
+                    case Result.Success(client) =>
+                        client.awaitDrain.andThen(client.closeNow).andThen(server.closeNow).andThen(succeed)
+                    case Result.Failure(err) =>
+                        server.closeNow.andThen(fail(s"Expected success, got: $err"))
+                    case Result.Panic(ex) =>
+                        server.closeNow.andThen(throw ex)
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Direction filtering at init time
+    // =========================================================================
+
+    "initUnscoped rejects a ServerHandled handler at init time" in {
+        // A server-handled handler (completion) passed to client init must throw WrongDirection.
+        val serverHandler = LspHandler.TextDocument.completion { _ =>
+            LspHandler.CompletionResult.Items(Chunk.empty)
+        }
+        JsonRpcTransport.inMemory.map { (_, _) =>
+            val result = scala.util.Try(
+                kyo.internal.lsp.LspCatalog.fromHandlers(Seq(serverHandler), LspHandler.Direction.ClientHandled)
+            )
+            assert(result.isFailure)
+            assert(result.failed.get.isInstanceOf[LspWrongDirectionException])
+        }
+    }
+
+    // =========================================================================
+    // Typed request effect rows (compile-time)
+    // =========================================================================
+
+    "hover request round-trips through a registered server handler" in {
+        val hover  = LspHandler.TextDocument.hover { _ => Present(LspHandler.Hover.plainText("the docs")) }
+        val params = LspHandler.HoverParams(LspHandler.TextDocumentIdentifier(mainUri), LspHandler.Position(0, 0))
+        Scope.run(serve(hover)(_.hover(params))).map {
+            case Result.Success(result) => assert(result == Present(LspHandler.Hover.plainText("the docs")))
+            case other                  => fail(s"hover: $other")
+        }
+    }
+
+    "definition request round-trips a result union (Location) through the custom schema" in {
+        val target = LspHandler.Location(mainUri, LspHandler.Range.of(2, 0, 2, 4))
+        val definition = LspHandler.TextDocument.definition { _ =>
+            LspHandler.DefinitionResult.One(target)
+        }
+        val params = LspHandler.DefinitionParams(LspHandler.TextDocumentIdentifier(mainUri), LspHandler.Position(0, 0))
+        Scope.run(serve(definition)(_.definition(params))).map {
+            case Result.Success(result) => assert(result == Present(LspHandler.DefinitionResult.One(target)))
+            case other                  => fail(s"definition: $other")
+        }
+    }
+
+    "executeCommand[T] decodes the typed result the server returns" in {
+        val command = LspHandler.Workspace.executeCommand[ReindexResult] { _ => Present(ReindexResult(7)) }
+        val params  = LspHandler.ExecuteCommandParams(command = "todo.reindex", arguments = Chunk.empty)
+        Scope.run(serve(command)(_.executeCommand[ReindexResult](params))).map {
+            case Result.Success(result) => assert(result == Present(ReindexResult(7)))
+            case other                  => fail(s"executeCommand: $other")
+        }
+    }
+
+    "a .error[E2] handler failure arrives on the client as LspRemoteException" in {
+        val command = LspHandler.Workspace.executeCommand[ReindexResult] { _ =>
+            Abort.fail(TodoLintFailure(3, "unknown keyword"))
+                .andThen((Absent: Maybe[ReindexResult]): Maybe[ReindexResult] < Async)
+        }.error[TodoLintFailure](code = -32099, message = "todo lint failure")
+        val params = LspHandler.ExecuteCommandParams(command = "todo.reindex", arguments = Chunk.empty)
+        Scope.run(serve(command)(_.executeCommand[ReindexResult](params))).map {
+            case Result.Failure(LspRemoteException(code, _, _)) => assert(code == -32099)
+            case other                                          => fail(s"expected LspRemoteException(-32099), got: $other")
+        }
+    }
+
+end LspClientTest
+
+private case class ReindexResult(scanned: Int) derives Schema, CanEqual
+private case class TodoLintFailure(line: Int, reason: String) derives Schema, CanEqual

--- a/kyo-lsp/shared/src/test/scala/kyo/LspConfigTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspConfigTest.scala
@@ -1,0 +1,181 @@
+package kyo
+
+class LspConfigTest extends Test:
+
+    given CanEqual[Any, Any] = CanEqual.canEqualAny
+
+    private def decode[A: Schema](json: String): A = Json.decode[A](json).getOrThrow
+
+    "SpecVersion constant" - {
+        "equals 3.17" in {
+            assert(LspConfig.SpecVersion == "3.17")
+        }
+        "no ProtocolVersionMismatch reference" in {
+            // The library uses SpecVersion "3.17"; no LspProtocolVersionMismatchException exists.
+            assert(LspConfig.SpecVersion == "3.17")
+        }
+    }
+
+    "LspConfig.default" - {
+        "enforceCapabilities is true" in {
+            assert(LspConfig.default.enforceCapabilities)
+        }
+        "positionEncodings contains UTF16" in {
+            assert(LspConfig.default.positionEncodings.contains(LspHandler.PositionEncodingKind.UTF16))
+        }
+        "positionEncodings is non-empty" in {
+            assert(LspConfig.default.positionEncodings.nonEmpty)
+        }
+        "documentSync is Incremental" in {
+            assert(LspConfig.default.documentSync == LspHandler.TextDocumentSyncKind.Incremental)
+        }
+        "declaredServerCapabilities is Absent" in {
+            assert(LspConfig.default.declaredServerCapabilities.isEmpty)
+        }
+        "serverInfo has name kyo-lsp" in {
+            assert(LspConfig.default.serverInfo.name == "kyo-lsp")
+        }
+        "onTypeFormattingTriggers is empty" in {
+            assert(LspConfig.default.onTypeFormattingTriggers.isEmpty)
+        }
+        "executeCommandCommands is empty" in {
+            assert(LspConfig.default.executeCommandCommands.isEmpty)
+        }
+        "completionTriggerCharacters is empty" in {
+            assert(LspConfig.default.completionTriggerCharacters.isEmpty)
+        }
+        "signatureHelpTriggerCharacters is empty" in {
+            assert(LspConfig.default.signatureHelpTriggerCharacters.isEmpty)
+        }
+        "semanticTokensLegend is Absent" in {
+            assert(LspConfig.default.semanticTokensLegend.isEmpty)
+        }
+    }
+
+    "require" - {
+        "passes for default config" in {
+            // Should not throw; also verify the validated config matches default.
+            LspConfig.require(LspConfig.default)
+            assert(LspConfig.default.positionEncodings.nonEmpty)
+        }
+        "throws LspConfigurationError when positionEncodings is empty" in {
+            val bad = LspConfig.default.withPositionEncodings(Chunk.empty)
+            val ex  = intercept[LspConfigurationError](LspConfig.require(bad))
+            assert(ex.setting == "positionEncodings")
+            assert(ex.reason == "must be non-empty")
+        }
+        "error message mentions positionEncodings" in {
+            val bad = LspConfig.default.withPositionEncodings(Chunk.empty)
+            val ex  = intercept[LspConfigurationError](LspConfig.require(bad))
+            assert(ex.getMessage.contains("positionEncodings"))
+        }
+        "passes with multiple encodings" in {
+            val cfg = LspConfig.default.withPositionEncodings(
+                Chunk(LspHandler.PositionEncodingKind.UTF16, LspHandler.PositionEncodingKind.UTF8)
+            )
+            LspConfig.require(cfg)
+            assert(cfg.positionEncodings.size == 2)
+        }
+    }
+
+    "withServerInfo" in {
+        val info = LspInfo(name = "my-server", version = "1.0.0")
+        val cfg  = LspConfig.default.withServerInfo(info)
+        assert(cfg.serverInfo == info)
+    }
+
+    "withPositionEncodings" in {
+        val encs = Chunk(LspHandler.PositionEncodingKind.UTF8)
+        val cfg  = LspConfig.default.withPositionEncodings(encs)
+        assert(cfg.positionEncodings == encs)
+    }
+
+    "withDocumentSync" in {
+        val cfg = LspConfig.default.withDocumentSync(LspHandler.TextDocumentSyncKind.Full)
+        assert(cfg.documentSync == LspHandler.TextDocumentSyncKind.Full)
+    }
+
+    "withDeclaredServerCapabilities" in {
+        val caps = LspCapabilities.Server.empty
+        val cfg  = LspConfig.default.withDeclaredServerCapabilities(caps)
+        assert(cfg.declaredServerCapabilities == Present(caps))
+    }
+
+    "withEnforceCapabilities" in {
+        val cfg = LspConfig.default.withEnforceCapabilities(false)
+        assert(!cfg.enforceCapabilities)
+    }
+
+    "withOnTypeFormattingTriggers" in {
+        val ts  = Chunk(".", ">")
+        val cfg = LspConfig.default.withOnTypeFormattingTriggers(ts)
+        assert(cfg.onTypeFormattingTriggers == ts)
+    }
+
+    "withSemanticTokensLegend" in {
+        val legend = LspHandler.SemanticTokensLegend(
+            tokenTypes = Chunk(LspHandler.SemanticTokenTypes("type")),
+            tokenModifiers = Chunk(LspHandler.SemanticTokenModifiers("readonly"))
+        )
+        val cfg = LspConfig.default.withSemanticTokensLegend(legend)
+        assert(cfg.semanticTokensLegend == Present(legend))
+    }
+
+    "withExecuteCommandCommands" in {
+        val cmds = Chunk("editor.action.rename", "editor.action.quickFix")
+        val cfg  = LspConfig.default.withExecuteCommandCommands(cmds)
+        assert(cfg.executeCommandCommands == cmds)
+    }
+
+    "withCompletionTriggerCharacters" in {
+        val cs  = Chunk(".", ":")
+        val cfg = LspConfig.default.withCompletionTriggerCharacters(cs)
+        assert(cfg.completionTriggerCharacters == cs)
+    }
+
+    "withSignatureHelpTriggerCharacters" in {
+        val cs  = Chunk("(", ",")
+        val cfg = LspConfig.default.withSignatureHelpTriggerCharacters(cs)
+        assert(cfg.signatureHelpTriggerCharacters == cs)
+    }
+
+    "withJsonRpc" in {
+        val jrc = JsonRpcHandler.Config.default
+        val cfg = LspConfig.default.withJsonRpc(jrc)
+        assert(cfg.jsonRpc == jrc)
+    }
+
+    "experimentalServerCapabilities" - {
+        "sets _rawExperimental to Present" in {
+            final case class Marker(enabled: Boolean) derives Schema, CanEqual
+            val cfg = LspConfig.default.experimentalServerCapabilities(Marker(true))
+            assert(cfg._rawExperimental.isDefined)
+        }
+        "encoded JSON contains field values" in {
+            final case class Flags(fast: Boolean, verbose: Boolean) derives Schema, CanEqual
+            val cfg  = LspConfig.default.experimentalServerCapabilities(Flags(fast = true, verbose = false))
+            val json = cfg._rawExperimental.get
+            assert(json.contains("fast"))
+        }
+        "round-trips a typed value via JSON" in {
+            final case class MyExp(tag: String) derives Schema, CanEqual
+            val exp     = MyExp("test-feature")
+            val cfg     = LspConfig.default.experimentalServerCapabilities(exp)
+            val rawJson = cfg._rawExperimental.get
+            val decoded = decode[MyExp](rawJson)
+            assert(decoded == exp)
+        }
+    }
+
+    "derives CanEqual" - {
+        "two identical configs are equal" in {
+            assert(LspConfig.default == LspConfig.default)
+        }
+        "different configs are not equal" in {
+            val a = LspConfig.default.withEnforceCapabilities(true)
+            val b = LspConfig.default.withEnforceCapabilities(false)
+            assert(a != b)
+        }
+    }
+
+end LspConfigTest

--- a/kyo-lsp/shared/src/test/scala/kyo/LspDocumentTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspDocumentTest.scala
@@ -1,0 +1,96 @@
+package kyo
+
+/** Tests for LspHandler.LspDocument and LspDocument.Uri. */
+class LspDocumentTest extends Test:
+
+    import LspHandler.*
+
+    // =========================================================================
+    // LspDocument.Uri
+    // =========================================================================
+
+    "LspDocument.Uri.parse accepts non-empty string" in {
+        val result = LspDocument.Uri.parse("file:///workspace/Main.scala")
+        assert(result.isDefined)
+        assert(result.get.asString == "file:///workspace/Main.scala")
+    }
+
+    "LspDocument.Uri.parse rejects empty string" in {
+        val result = LspDocument.Uri.parse("")
+        assert(result == Absent)
+    }
+
+    "LspDocument.Uri.parse rejects whitespace-only string" in {
+        val result = LspDocument.Uri.parse("   ")
+        assert(result == Absent)
+    }
+
+    // =========================================================================
+    // LspDocument.applyChanges - full replace
+    // =========================================================================
+
+    "applyChanges - full replace" in {
+        val uri     = LspDocument.Uri.parse("file:///test.scala").get
+        val doc     = LspDocument(uri = uri, languageId = "scala", version = 1, text = "old content")
+        val change  = TextDocumentContentChangeEvent.Full("new content")
+        val updated = LspDocument.applyChanges(doc, Chunk(change))
+        assert(updated.text == "new content")
+        assert(updated.version == 2)
+    }
+
+    // =========================================================================
+    // LspDocument.applyChanges - incremental
+    // =========================================================================
+
+    "applyChanges - incremental at start of first line" in {
+        val uri     = LspDocument.Uri.parse("file:///test.scala").get
+        val doc     = LspDocument(uri = uri, languageId = "scala", version = 1, text = "hello world")
+        val range   = Range(Position(0, 0), Position(0, 5))
+        val change  = TextDocumentContentChangeEvent.Incremental(range, "goodbye")
+        val updated = LspDocument.applyChanges(doc, Chunk(change))
+        assert(updated.text == "goodbye world")
+        assert(updated.version == 2)
+    }
+
+    "applyChanges - incremental at end of first line" in {
+        val uri     = LspDocument.Uri.parse("file:///test.scala").get
+        val doc     = LspDocument(uri = uri, languageId = "scala", version = 1, text = "hello world")
+        val range   = Range(Position(0, 6), Position(0, 11))
+        val change  = TextDocumentContentChangeEvent.Incremental(range, "scala")
+        val updated = LspDocument.applyChanges(doc, Chunk(change))
+        assert(updated.text == "hello scala")
+    }
+
+    "applyChanges - multiple sequential changes" in {
+        val uri     = LspDocument.Uri.parse("file:///test.scala").get
+        val doc     = LspDocument(uri = uri, languageId = "scala", version = 1, text = "aaa")
+        val change1 = TextDocumentContentChangeEvent.Full("bbb")
+        val change2 = TextDocumentContentChangeEvent.Full("ccc")
+        val updated = LspDocument.applyChanges(doc, Chunk(change1, change2))
+        assert(updated.text == "ccc")
+        assert(updated.version == 3)
+    }
+
+    // =========================================================================
+    // LspDocument construction
+    // =========================================================================
+
+    "LspDocument construction with defaults" in {
+        val uri = LspDocument.Uri.parse("file:///Main.scala").get
+        val doc = LspDocument(uri = uri, languageId = "scala", version = 1, text = "object Main")
+        assert(doc.uri == uri)
+        assert(doc.languageId == "scala")
+        assert(doc.version == 1)
+        assert(doc.text == "object Main")
+        assert(doc.encoding == PositionEncodingKind.UTF16) // default private field
+    }
+
+    "LspDocument equality ignores encoding" in {
+        val uri  = LspDocument.Uri.parse("file:///Main.scala").get
+        val doc1 = LspDocument(uri = uri, languageId = "scala", version = 1, text = "hello")
+        val doc2 = LspDocument(uri = uri, languageId = "scala", version = 1, text = "hello", encoding = PositionEncodingKind.UTF8)
+        // case class equality includes all fields including private[kyo] ones
+        assert(doc1 != doc2) // encoding differs
+    }
+
+end LspDocumentTest

--- a/kyo-lsp/shared/src/test/scala/kyo/LspExceptionTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspExceptionTest.scala
@@ -1,0 +1,136 @@
+package kyo
+
+/** Tests for the flat LspException hierarchy.
+  *
+  * Verifies the two per-operation traits ([[LspRequestFailure]], [[LspInitFailure]]), the
+  * trait membership of each concrete leaf, and the JSON-RPC error codes. The hierarchy is flat
+  * (no stage subcategories); leaves mix in exactly the operation-traits they can occur on.
+  */
+class LspExceptionTest extends Test:
+
+    given CanEqual[Any, Any] = CanEqual.canEqualAny
+
+    // =========================================================================
+    // Connection / remote leaves (the only client-observable leaves on a request row)
+    // =========================================================================
+
+    "LspConnectionClosedException - code -32603, mixes both operation-traits" in {
+        val e = LspConnectionClosedException()
+        assert(e.code == -32603)
+        assert(e.message == "Connection closed.")
+        assert(e.isInstanceOf[LspException])
+        assert(e.isInstanceOf[JsonRpcApplicationError])
+        assert(e.isInstanceOf[LspRequestFailure])
+        assert(e.isInstanceOf[LspInitFailure])
+    }
+
+    "LspRemoteException - passes wire code/message through, mixes both operation-traits" in {
+        val e = LspRemoteException(-32000, "remote boom")
+        assert(e.code == -32000)
+        assert(e.message == "remote boom")
+        assert(e.isInstanceOf[LspRequestFailure])
+        assert(e.isInstanceOf[LspInitFailure])
+    }
+
+    "LspConfigurationError - code -32603, mixes no operation-trait" in {
+        val e = LspConfigurationError("positionEncodings", "must be non-empty")
+        assert(e.code == -32603)
+        assert(e.message.contains("positionEncodings"))
+        assert(e.message.contains("must be non-empty"))
+        assert(e.isInstanceOf[LspException])
+        assert(!(e: LspException).isInstanceOf[LspRequestFailure])
+        assert(!(e: LspException).isInstanceOf[LspInitFailure])
+    }
+
+    // =========================================================================
+    // Engine-internal gate leaves (reach the client as LspRemoteException; no trait)
+    // =========================================================================
+
+    "LspNotInitializedException - code -32002, no operation-trait" in {
+        val e = LspNotInitializedException("textDocument/completion")
+        assert(e.code == -32002)
+        assert(e.message.contains("textDocument/completion"))
+        assert(e.isInstanceOf[LspException])
+        assert(!(e: LspException).isInstanceOf[LspRequestFailure])
+        assert(!(e: LspException).isInstanceOf[LspInitFailure])
+    }
+
+    "LspShutdownInProgressException - code -32600, no operation-trait" in {
+        val e = LspShutdownInProgressException("textDocument/hover")
+        assert(e.code == -32600)
+        assert(e.message.contains("textDocument/hover"))
+        assert(!(e: LspException).isInstanceOf[LspRequestFailure])
+    }
+
+    "LspCapabilityNotAdvertisedException - code -32601, no operation-trait" in {
+        val e = LspCapabilityNotAdvertisedException(LspCapabilities.Name.Completion)
+        assert(e.code == -32601)
+        assert(e.message.contains("Completion"))
+        assert(!(e: LspException).isInstanceOf[LspRequestFailure])
+    }
+
+    // =========================================================================
+    // Construction-time programmer-error leaves (thrown inside init; no trait)
+    // =========================================================================
+
+    "LspWrongDirectionException - code -32603" in {
+        val e = LspWrongDirectionException(LspHandler.Kind.ShowMessage, LspHandler.Direction.ServerHandled)
+        assert(e.code == -32603)
+        assert(e.message.contains("ShowMessage"))
+        assert(e.message.contains("ServerHandled"))
+        assert(!(e: LspException).isInstanceOf[LspRequestFailure])
+    }
+
+    "LspReservedMethodException - code -32603" in {
+        val e = LspReservedMethodException("initialize")
+        assert(e.code == -32603)
+        assert(e.message.contains("initialize"))
+    }
+
+    "LspDuplicateHandlerException - code -32603" in {
+        val e = LspDuplicateHandlerException(LspHandler.Kind.Completion)
+        assert(e.code == -32603)
+        assert(e.message.contains("Completion"))
+    }
+
+    // =========================================================================
+    // Handler-body decode leaves (own narrow rows; no operation-trait)
+    // =========================================================================
+
+    "LspDecodeException - code -32602, no operation-trait" in {
+        val e = LspDecodeException("textDocument/completion", "expected int")
+        assert(e.code == -32602)
+        assert(e.message.contains("textDocument/completion"))
+        assert(e.message.contains("expected int"))
+        assert(!(e: LspException).isInstanceOf[LspRequestFailure])
+    }
+
+    "LspInvalidParamsException - code -32602, no operation-trait" in {
+        val e = LspInvalidParamsException("textDocument/completion", "missing line field")
+        assert(e.code == -32602)
+        assert(e.message.contains("textDocument/completion"))
+        assert(e.message.contains("missing line field"))
+        assert(!(e: LspException).isInstanceOf[LspRequestFailure])
+    }
+
+    // =========================================================================
+    // Operation-trait exhaustiveness
+    // =========================================================================
+
+    "LspRequestFailure narrows to exactly the closed/remote leaves" in {
+        def classify(e: LspRequestFailure): String = e match
+            case _: LspConnectionClosedException => "closed"
+            case _: LspRemoteException           => "remote"
+        assert(classify(LspConnectionClosedException()) == "closed")
+        assert(classify(LspRemoteException(-32000, "x")) == "remote")
+    }
+
+    "LspInitFailure narrows to exactly the closed/remote leaves" in {
+        def classify(e: LspInitFailure): String = e match
+            case _: LspConnectionClosedException => "closed"
+            case _: LspRemoteException           => "remote"
+        assert(classify(LspConnectionClosedException()) == "closed")
+        assert(classify(LspRemoteException(-32002, "y")) == "remote")
+    }
+
+end LspExceptionTest

--- a/kyo-lsp/shared/src/test/scala/kyo/LspExtrasTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspExtrasTest.scala
@@ -1,0 +1,45 @@
+package kyo
+
+/** Tests for Lsp.extras[T] typed accessor and protocol-extension decode path. */
+class LspExtrasTest extends Test:
+
+    "Lsp.extras[T] method exists on the Lsp object" in {
+        // Verify the method is in scope and type-checks correctly.
+        // The type annotation confirms the return row; compilation is the assertion.
+        val _: Maybe[Int] < (Sync & Abort[LspInvalidParamsException]) = Lsp.extras[Int]
+        succeed
+    }
+
+    "LspInfo name field carries the provided string" in {
+        val info = LspInfo(name = "my-server")
+        assert(info.name == "my-server")
+    }
+
+    "LspInfo version defaults to 0.0.0" in {
+        val info = LspInfo(name = "srv")
+        assert(info.version == "0.0.0")
+    }
+
+    "LspInfo title is Absent by default" in {
+        val info = LspInfo(name = "srv")
+        assert(info.title == Absent)
+    }
+
+    "LspInfo title carries the provided value when set" in {
+        val info = LspInfo(name = "srv", title = Present("Server Display"))
+        assert(info.title == Present("Server Display"))
+    }
+
+    "LspConfig.SpecVersion is the literal string 3.17" in {
+        assert(LspConfig.SpecVersion == "3.17")
+    }
+
+    "LspConfig.default has UTF-16 position encoding" in {
+        assert(LspConfig.default.positionEncodings == Chunk(LspHandler.PositionEncodingKind.UTF16))
+    }
+
+    "LspConfig.default enforces capabilities" in {
+        assert(LspConfig.default.enforceCapabilities)
+    }
+
+end LspExtrasTest

--- a/kyo-lsp/shared/src/test/scala/kyo/LspHandlerConstructorsTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspHandlerConstructorsTest.scala
@@ -1,0 +1,186 @@
+package kyo
+
+import kyo.LspHandler.*
+
+/** Tests for the value-type smart constructors on `LspHandler.*` companions.
+  *
+  * Each assertion pins the factory's output to the equivalent hand-built case-class tree, so a
+  * wiring mistake (wrong markup kind, wrong severity, wrong nesting) is caught.
+  */
+class LspHandlerConstructorsTest extends Test:
+
+    given CanEqual[Any, Any] = CanEqual.canEqualAny
+
+    val pos   = Position(1, 2)
+    val pos2  = Position(3, 4)
+    val range = Range(pos, pos2)
+    val uriA  = LspDocument.Uri.parse("file:///a.scala").get
+    val uriB  = LspDocument.Uri.parse("file:///b.scala").get
+
+    // -------------------------------------------------------------------------
+    // Core coordinates
+    // -------------------------------------------------------------------------
+
+    "Range.of builds from coordinates" in {
+        assert(Range.of(1, 2, 3, 4) == Range(Position(1, 2), Position(3, 4)))
+    }
+
+    "Range.at collapses to a zero-width range" in {
+        assert(Range.at(pos) == Range(pos, pos))
+    }
+
+    // -------------------------------------------------------------------------
+    // Markup / hover
+    // -------------------------------------------------------------------------
+
+    "MarkupContent.plainText / markdown set the kind" in {
+        assert(MarkupContent.plainText("x") == MarkupContent(MarkupKind.PlainText, "x"))
+        assert(MarkupContent.markdown("**x**") == MarkupContent(MarkupKind.Markdown, "**x**"))
+    }
+
+    "Hover.plainText nests markup and defaults the range" in {
+        assert(Hover.plainText("docs") == Hover(HoverContents.Markup(MarkupContent(MarkupKind.PlainText, "docs")), Absent))
+    }
+
+    "Hover.markdown carries an explicit range" in {
+        assert(Hover.markdown("**d**", Present(range)) ==
+            Hover(HoverContents.Markup(MarkupContent(MarkupKind.Markdown, "**d**")), Present(range)))
+    }
+
+    // -------------------------------------------------------------------------
+    // Diagnostics
+    // -------------------------------------------------------------------------
+
+    "Diagnostic severity presets" in {
+        assert(Diagnostic.error(range, "e").severity == Present(DiagnosticSeverity.Error))
+        assert(Diagnostic.warning(range, "w").severity == Present(DiagnosticSeverity.Warning))
+        assert(Diagnostic.info(range, "i").severity == Present(DiagnosticSeverity.Information))
+        assert(Diagnostic.hint(range, "h").severity == Present(DiagnosticSeverity.Hint))
+        assert(Diagnostic.error(range, "e").message == "e")
+        assert(Diagnostic.error(range, "e").range == range)
+    }
+
+    // -------------------------------------------------------------------------
+    // Completion
+    // -------------------------------------------------------------------------
+
+    "CompletionItem.of carries label and optional kind" in {
+        assert(CompletionItem.of("foldLeft") == CompletionItem(label = "foldLeft"))
+        assert(CompletionItem.of("foldLeft", CompletionItemKind.Method).kind == Present(CompletionItemKind.Method))
+    }
+
+    "CompletionResult.of / items" in {
+        assert(CompletionResult.of("a", "b") ==
+            CompletionResult.Items(Chunk(CompletionItem(label = "a"), CompletionItem(label = "b"))))
+        assert(CompletionResult.items(CompletionItem.of("a")) == CompletionResult.Items(Chunk(CompletionItem(label = "a"))))
+    }
+
+    // -------------------------------------------------------------------------
+    // Location result unions
+    // -------------------------------------------------------------------------
+
+    "DefinitionResult.at / many / links" in {
+        assert(DefinitionResult.at(uriA, range) == DefinitionResult.One(Location(uriA, range)))
+        assert(DefinitionResult.many(Location(uriA, range)) ==
+            DefinitionResult.Many(Chunk(Location(uriA, range))))
+        val link = LocationLink(targetUri = uriA, targetRange = range, targetSelectionRange = range)
+        assert(DefinitionResult.links(link) == DefinitionResult.Links(Chunk(link)))
+    }
+
+    "ImplementationResult.at mirrors the shared shape" in {
+        assert(ImplementationResult.at(uriB, range) == ImplementationResult.One(Location(uriB, range)))
+    }
+
+    // -------------------------------------------------------------------------
+    // Symbols, signatures, diagnostic reports
+    // -------------------------------------------------------------------------
+
+    "DocumentSymbol.of places the four required fields" in {
+        val sym = DocumentSymbol.of("main", SymbolKind.Function, range, range)
+        assert(sym == DocumentSymbol(name = "main", kind = SymbolKind.Function, range = range, selectionRange = range))
+    }
+
+    "DocumentSymbolResult.symbols" in {
+        val sym = DocumentSymbol.of("main", SymbolKind.Function, range, range)
+        assert(DocumentSymbolResult.symbols(sym) == DocumentSymbolResult.Symbols(Chunk(sym)))
+    }
+
+    "SignatureHelp.of / SignatureInformation.of / ParameterInformation.of" in {
+        val param = ParameterInformation.of("x: Int")
+        assert(param == ParameterInformation(ParameterLabel.StringLabel("x: Int")))
+        val sig = SignatureInformation.of("def f(x: Int)", param)
+        assert(sig == SignatureInformation(label = "def f(x: Int)", parameters = Chunk(param)))
+        assert(SignatureHelp.of(sig) == SignatureHelp(signatures = Chunk(sig)))
+    }
+
+    "DocumentDiagnosticReport.full / unchanged" in {
+        val diags = Chunk(Diagnostic.error(range, "e"))
+        assert(DocumentDiagnosticReport.full(diags) == DocumentDiagnosticReport.Full(items = diags))
+        assert(DocumentDiagnosticReport.unchanged("r1") == DocumentDiagnosticReport.Unchanged(resultId = "r1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Code actions, edits, tokens, marked strings
+    // -------------------------------------------------------------------------
+
+    "CommandOrCodeAction.action / command" in {
+        val action = CodeAction.of("Fix it", CodeActionKind.QuickFix)
+        assert(CommandOrCodeAction.action(action) == CommandOrCodeAction.Action(action))
+        val cmd = Command(title = "Run", command = "run")
+        assert(CommandOrCodeAction.command(cmd) == CommandOrCodeAction.Cmd(cmd))
+    }
+
+    "CodeAction.quickFix presets the kind and carries the edit" in {
+        val edit = WorkspaceEdit.changes(LspDocument.Uri.parse("file:///a.scala").get -> Chunk.empty)
+        val ca   = CodeAction.quickFix("Apply", edit)
+        assert(ca.kind == Present(CodeActionKind.QuickFix))
+        assert(ca.edit == Present(edit))
+    }
+
+    "WorkspaceEdit.changes keys by URI string" in {
+        val uri  = LspDocument.Uri.parse("file:///a.scala").get
+        val edit = TextEdit(range, "x")
+        assert(WorkspaceEdit.changes(uri -> Chunk(edit)).changes == Present(Map(uri.asString -> Chunk(edit))))
+    }
+
+    "SemanticTokensResult.full wraps raw data" in {
+        assert(SemanticTokensResult.full(Chunk(0, 0, 1, 2, 3)) ==
+            SemanticTokensResult.Full(SemanticTokens(data = Chunk(0, 0, 1, 2, 3))))
+    }
+
+    "MarkedString.plain / code" in {
+        assert(MarkedString.plain("hi") == MarkedString.Plain("hi"))
+        assert(MarkedString.code("scala", "val x = 1") == MarkedString.Code("scala", "val x = 1"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Folding ranges, semantic-token deltas, inlay hints
+    // -------------------------------------------------------------------------
+
+    "FoldingRange.of spans whole lines" in {
+        assert(FoldingRange.of(3, 7) == FoldingRange(startLine = 3, endLine = 7))
+    }
+
+    "SemanticTokensResult.delta wraps raw edits" in {
+        val edit = SemanticTokensEdit(start = 0, deleteCount = 2)
+        assert(SemanticTokensResult.delta(Chunk(edit)) ==
+            SemanticTokensResult.Delta(SemanticTokensDelta(edits = Chunk(edit))))
+    }
+
+    "InlayHint.of wraps a plain-string label" in {
+        assert(InlayHint.of(pos, ": Int") == InlayHint(position = pos, label = InlayHintLabel.PlainString(": Int")))
+    }
+
+    // -------------------------------------------------------------------------
+    // Capability toggles
+    // -------------------------------------------------------------------------
+
+    "BooleanOr.on / options" in {
+        assert(BooleanOr.on == BooleanOr.Bool(true))
+        assert(BooleanOr.options("x") == BooleanOr.Options("x"))
+        // `on` is `BooleanOr[Nothing]`, so it slots into any typed capability field.
+        val hover: Maybe[BooleanOr[HoverOptions]] = Present(BooleanOr.on)
+        assert(hover == Present(BooleanOr.Bool(true)))
+    }
+
+end LspHandlerConstructorsTest

--- a/kyo-lsp/shared/src/test/scala/kyo/LspInfoTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspInfoTest.scala
@@ -1,0 +1,37 @@
+package kyo
+
+/** Tests for LspInfo Schema round-trip and default values. */
+class LspInfoTest extends Test:
+
+    "LspInfo default version" in {
+        val info = LspInfo(name = "test-server")
+        assert(info.version == "0.0.0")
+    }
+
+    "LspInfo with all fields" in {
+        val info = LspInfo(name = "test", version = "1.0.0", title = Present("Test Server"))
+        assert(info.name == "test")
+        assert(info.version == "1.0.0")
+        assert(info.title == Present("Test Server"))
+    }
+
+    "LspInfo with absent title" in {
+        val info = LspInfo(name = "test")
+        assert(info.title == Absent)
+    }
+
+    "LspInfo Schema round-trip" in {
+        val info    = LspInfo(name = "kyo-lsp", version = "0.1.0", title = Present("Kyo LSP"))
+        val encoded = Json.encode[LspInfo](info)
+        val decoded = Json.decode[LspInfo](encoded)
+        assert(decoded == Result.Success(info))
+    }
+
+    "LspInfo Schema round-trip with absent title" in {
+        val info    = LspInfo(name = "minimal")
+        val encoded = Json.encode[LspInfo](info)
+        val decoded = Json.decode[LspInfo](encoded)
+        assert(decoded == Result.Success(info))
+    }
+
+end LspInfoTest

--- a/kyo-lsp/shared/src/test/scala/kyo/LspPositionEncodingScopeTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspPositionEncodingScopeTest.scala
@@ -1,0 +1,43 @@
+package kyo
+
+/** Tests that Lsp.DocumentRegistry does not expose a public encoding accessor.
+  *
+  * The position encoding lives at session level via `Lsp.positionEncoding`, not per-document.
+  * This test verifies the API shape is correct.
+  */
+class LspPositionEncodingScopeTest extends Test:
+
+    "Lsp.DocumentRegistry compile-time API shape" in {
+        // Verify the DocumentRegistry API shape at compile time:
+        // the trait must define get, version, listOpen, listOpenUris, isOpen
+        // and must NOT define a public encoding accessor.
+        // This is a compile-time check: if any required method is missing, this block
+        // fails to compile. If 'encoding' is added, it would pass (false negative)
+        // since we can only use positive assertions here.
+        //
+        // The negative check (no 'encoding') is enforced via source-level lint
+        // and by the absence of an 'encoding' overload in the trait's explicit definition.
+        def checkApiShape(r: Lsp.DocumentRegistry)(using Frame): Boolean < Sync =
+            val uri = LspHandler.LspDocument.Uri.parse("file:///x.scala").get
+            r.get(uri).flatMap { _ =>
+                r.version(uri).flatMap { _ =>
+                    r.listOpen.flatMap { _ =>
+                        r.listOpenUris.flatMap { _ =>
+                            r.isOpen(uri).map(_ => true)
+                        }
+                    }
+                }
+            }
+        end checkApiShape
+        // If this compiles, the API shape is correct.
+        succeed
+    }
+
+    "PositionEncodingKind constants are accessible" in {
+        import LspHandler.PositionEncodingKind
+        assert(PositionEncodingKind.UTF8.asString == "utf-8", s"Expected 'utf-8', got ${PositionEncodingKind.UTF8.asString}")
+        assert(PositionEncodingKind.UTF16.asString == "utf-16", s"Expected 'utf-16', got ${PositionEncodingKind.UTF16.asString}")
+        assert(PositionEncodingKind.UTF32.asString == "utf-32", s"Expected 'utf-32', got ${PositionEncodingKind.UTF32.asString}")
+    }
+
+end LspPositionEncodingScopeTest

--- a/kyo-lsp/shared/src/test/scala/kyo/LspServerTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/LspServerTest.scala
@@ -1,0 +1,324 @@
+package kyo
+
+/** Tests for LspServer init quartet, lifecycle, and accessor behaviour. */
+class LspServerTest extends Test:
+
+    // =========================================================================
+    // Init quartet: basic smoke tests
+    // =========================================================================
+
+    "initUnscoped with no handlers produces a live server" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "initUnscoped with default config smoke test" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta, LspConfig.default)().flatMap { server =>
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "initUnscoped with Seq overload produces a live server" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta, Seq.empty, LspConfig.default).flatMap { server =>
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "initUnscopedWith applies function to the server and returns result" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscopedWith(ta) { server =>
+                server.specVersion
+            }
+        }.map { version =>
+            assert(version == "3.17")
+        }
+    }
+
+    "initUnscopedWith with config applies function to the server" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscopedWith(ta, LspConfig.default)() { server =>
+                server.specVersion
+            }
+        }.map { version =>
+            assert(version == "3.17")
+        }
+    }
+
+    // =========================================================================
+    // Scoped init quartet
+    // =========================================================================
+
+    "init (scoped) releases server when Scope exits" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, _) =>
+            Scope.run {
+                LspServer.init(ta).map { server =>
+                    assert(server.specVersion == "3.17")
+                }
+            }
+        }
+    }
+
+    "init (scoped) with config releases server when Scope exits" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, _) =>
+            Scope.run {
+                LspServer.init(ta, LspConfig.default)().map { server =>
+                    assert(server.specVersion == "3.17")
+                }
+            }
+        }
+    }
+
+    "initWith applies function and server is live inside the function" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, _) =>
+            Scope.run {
+                LspServer.initWith(ta) { server =>
+                    server.specVersion
+                }
+            }.map { version =>
+                assert(version == "3.17")
+            }
+        }
+    }
+
+    "initWith with config applies function to the server" in {
+        JsonRpcTransport.inMemory.flatMap { (ta, _) =>
+            Scope.run {
+                LspServer.initWith(ta, LspConfig.default)() { server =>
+                    server.specVersion
+                }
+            }.map { version =>
+                assert(version == "3.17")
+            }
+        }
+    }
+
+    // =========================================================================
+    // Accessors before handshake
+    // =========================================================================
+
+    "specVersion returns 3.17 before handshake" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val ver = server.specVersion
+                server.closeNow.andThen {
+                    assert(ver == "3.17")
+                }
+            }
+        }
+    }
+
+    "clientCapabilities returns Absent before handshake" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                server.clientCapabilities.map { caps =>
+                    server.closeNow.andThen(assert(caps == Absent))
+                }
+            }
+        }
+    }
+
+    "clientInfo returns Absent before handshake" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                server.clientInfo.map { info =>
+                    server.closeNow.andThen(assert(info == Absent))
+                }
+            }
+        }
+    }
+
+    "workspaceFolders returns Absent before handshake" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                server.workspaceFolders.map { folders =>
+                    server.closeNow.andThen(assert(folders == Absent))
+                }
+            }
+        }
+    }
+
+    "positionEncoding returns UTF16 as default before handshake" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                server.positionEncoding.map { enc =>
+                    server.closeNow.andThen(assert(enc == LspHandler.PositionEncodingKind.UTF16))
+                }
+            }
+        }
+    }
+
+    "underlying returns a JsonRpcHandler instance" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _ = server.underlying
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "unsafe returns the Unsafe handle (opaque identity)" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val unsafe = server.unsafe
+                val back   = unsafe.safe
+                server.closeNow.andThen {
+                    // LspServer = LspServer.Unsafe; safe returns `this`. Check via specVersion equality.
+                    assert(back.specVersion == server.specVersion)
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // close / closeNow / awaitDrain
+    // =========================================================================
+
+    "close(using Frame) completes without error (30-second grace)" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                server.close.andThen(succeed)
+            }
+        }
+    }
+
+    "closeNow completes without error (Duration.Zero grace)" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "close(gracePeriod) with explicit duration completes without error" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                server.close(1.seconds).andThen(succeed)
+            }
+        }
+    }
+
+    "awaitDrain completes without error on idle server" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                server.awaitDrain.andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    // =========================================================================
+    // LspConfig.require fires before transport
+    // =========================================================================
+
+    "init aborts when positionEncodings is empty" in {
+        val badConfig = LspConfig.default.withPositionEncodings(Chunk.empty)
+        val result    = scala.util.Try(LspConfig.require(badConfig))
+        assert(result.isFailure)
+        assert(result.failed.get.getMessage.contains("positionEncodings"))
+    }
+
+    // =========================================================================
+    // Direction filtering at init time
+    // =========================================================================
+
+    "initUnscoped rejects a ClientHandled handler at init time" in {
+        val wrongHandler = LspHandler.initNotification[LspHandler.ShowMessageParams, Nothing](
+            "window/showMessage",
+            LspHandler.Kind.ShowMessage,
+            _ => ()
+        )
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            val result = scala.util.Try(
+                kyo.internal.lsp.LspCatalog.fromHandlers(Seq(wrongHandler), LspHandler.Direction.ServerHandled)
+            )
+            assert(result.isFailure)
+            assert(result.failed.get.isInstanceOf[LspWrongDirectionException])
+        }
+    }
+
+    // =========================================================================
+    // Reverse-direction extension method types
+    // =========================================================================
+
+    "showMessage return type is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params = LspHandler.ShowMessageParams(LspHandler.MessageType.Info, "hello")
+                val effect: Unit < (Async & Abort[LspConnectionClosedException]) = server.showMessage(params)
+                Abort.run[Closed](effect).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "logMessage return type is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params = LspHandler.LogMessageParams(LspHandler.MessageType.Log, "debug info")
+                val effect: Unit < (Async & Abort[LspConnectionClosedException]) = server.logMessage(params)
+                Abort.run[Closed](effect).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "publishDiagnostics return type is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val uri    = LspHandler.LspDocument.Uri.parse("file:///Main.scala").get
+                val params = LspHandler.PublishDiagnosticsParams(uri, Absent, Chunk.empty)
+                val effect: Unit < (Async & Abort[LspConnectionClosedException]) = server.publishDiagnostics(params)
+                Abort.run[Closed](effect).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "telemetry return type is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        case class Payload(msg: String) derives Schema
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val effect: Unit < (Async & Abort[LspConnectionClosedException]) = server.telemetry(Payload("test"))
+                Abort.run[Closed](effect).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "logTrace return type is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val effect: Unit < (Async & Abort[LspConnectionClosedException]) = server.logTrace("trace message")
+                Abort.run[Closed](effect).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "applyEdit return type compiles as ApplyWorkspaceEditResult < (Async & Abort[LspRequestFailure])" in {
+        // Compile-time type check only; the method signature must accept the return type annotation.
+        // Not awaited: reverse-direction requests need a connected client peer.
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params = LspHandler.ApplyWorkspaceEditParams(edit = LspHandler.WorkspaceEdit())
+                // The type annotation confirms the compile-time return row.
+                val _: LspHandler.ApplyWorkspaceEditResult < (Async & Abort[LspRequestFailure]) = server.applyEdit(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "showMessageRequest return type compiles as Maybe[MessageActionItem] < (Async & Abort[LspRequestFailure])" in {
+        // Compile-time type check only; not awaited (needs a connected client peer).
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params = LspHandler.ShowMessageRequestParams(LspHandler.MessageType.Warning, "choose", Chunk.empty)
+                val _: Maybe[LspHandler.MessageActionItem] < (Async & Abort[LspRequestFailure]) =
+                    server.showMessageRequest(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+end LspServerTest

--- a/kyo-lsp/shared/src/test/scala/kyo/Test.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/Test.scala
@@ -1,0 +1,3 @@
+package kyo
+
+abstract class Test extends kyo.test.Test[Any]

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspBuiltInRoutesTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspBuiltInRoutesTest.scala
@@ -1,0 +1,210 @@
+package kyo.internal
+
+import kyo.*
+import kyo.internal.lsp.*
+
+class LspBuiltInRoutesTest extends Test:
+
+    private def encRef(enc: LspHandler.PositionEncodingKind = LspHandler.PositionEncodingKind.UTF16) =
+        AtomicRef.Unsafe.init[LspHandler.PositionEncodingKind](enc)(using AllowUnsafe.embrace.danger).safe
+
+    private def noServerRef =
+        AtomicRef.Unsafe.init[Maybe[LspServer.Unsafe]](Absent)(using AllowUnsafe.embrace.danger).safe
+
+    private def mkRegistry(enc: LspHandler.PositionEncodingKind = LspHandler.PositionEncodingKind.UTF16): LspDocumentRegistryImpl < Sync =
+        LspDocumentRegistryImpl.init(encRef(enc))
+
+    private def uri(s: String): LspHandler.LspDocument.Uri = LspHandler.LspDocument.Uri.fromWire(s)
+
+    private def makeTestCtx: JsonRpcRoute.Context < Sync =
+        Fiber.Promise.init[Unit, Sync].map(p => JsonRpcRoute.Context.forTest(p, Absent, Absent, Absent))
+
+    /** Builds the `notebookDocument/didChange` wire value (the route's params type is private), so a
+      * test can drive the actual route via `route.handle` rather than calling the registry directly.
+      */
+    private def notebookChangeWire(uri: String, version: Int, change: LspHandler.NotebookDocumentChangeEvent)(
+        using Frame
+    ): Structure.Value =
+        Structure.Value.Record(Chunk(
+            "notebookDocument" -> Structure.Value.Record(Chunk(
+                "uri"     -> Structure.Value.Str(uri),
+                "version" -> Structure.Value.Integer(version.toLong)
+            )),
+            "change" -> Structure.encode[LspHandler.NotebookDocumentChangeEvent](change)
+        ))
+
+    "LspBuiltInRoutesTest" - {
+
+        "textDocumentDidOpen route is named textDocument/didOpen" in {
+            mkRegistry().map { registry =>
+                val route = LspBuiltInRoutes.textDocumentDidOpen(registry, Absent, noServerRef, encRef())
+                assert(route.name == "textDocument/didOpen")
+            }
+        }
+
+        "textDocumentDidOpen route inserts the opened document into the registry" in {
+            mkRegistry().flatMap { registry =>
+                val route  = LspBuiltInRoutes.textDocumentDidOpen(registry, Absent, noServerRef, encRef())
+                val docUri = uri("file:///Open.scala")
+                val item   = LspHandler.TextDocumentItem(docUri, "scala", 1, "object Open")
+                val params = Structure.Value.Record(Chunk("textDocument" -> Structure.encode[LspHandler.TextDocumentItem](item)))
+                makeTestCtx.flatMap { ctx =>
+                    route.handle(params, ctx).andThen(registry.get(docUri)).map {
+                        case Present(doc) =>
+                            assert(doc.languageId == "scala")
+                            assert(doc.text == "object Open")
+                        case Absent =>
+                            fail("opened document should have been inserted by the route")
+                    }
+                }
+            }
+        }
+
+        "textDocumentDidChange route is named textDocument/didChange" in {
+            mkRegistry().map { registry =>
+                val route = LspBuiltInRoutes.textDocumentDidChange(registry, Absent, noServerRef, encRef())
+                assert(route.name == "textDocument/didChange")
+            }
+        }
+
+        "textDocumentDidSave route is named textDocument/didSave" in {
+            mkRegistry().map { registry =>
+                val route = LspBuiltInRoutes.textDocumentDidSave(registry, Absent, noServerRef, encRef())
+                assert(route.name == "textDocument/didSave")
+            }
+        }
+
+        "textDocumentDidClose route is named textDocument/didClose" in {
+            mkRegistry().map { registry =>
+                val route = LspBuiltInRoutes.textDocumentDidClose(registry, Absent, noServerRef, encRef())
+                assert(route.name == "textDocument/didClose")
+            }
+        }
+
+        "textDocumentWillSave route is named textDocument/willSave" in {
+            mkRegistry().map { registry =>
+                val route = LspBuiltInRoutes.textDocumentWillSave(Absent, noServerRef, registry, encRef())
+                assert(route.name == "textDocument/willSave")
+            }
+        }
+
+        "initialize route is named initialize" in {
+            val enc  = encRef()
+            val caps = AtomicRef.Unsafe.init[Maybe[LspCapabilities.Client.Client]](Absent)(using AllowUnsafe.embrace.danger).safe
+            val info = AtomicRef.Unsafe.init[Maybe[LspInfo]](Absent)(using AllowUnsafe.embrace.danger).safe
+            val wf   = AtomicRef.Unsafe.init[Maybe[Chunk[LspHandler.WorkspaceFolder]]](Absent)(using AllowUnsafe.embrace.danger).safe
+            val route = LspBuiltInRoutes.initialize(
+                LspConfig.default,
+                LspCapabilities.Server.empty,
+                enc,
+                caps,
+                info,
+                wf
+            )
+            assert(route.name == "initialize")
+        }
+
+        "shutdown route is named shutdown" in {
+            val route = LspBuiltInRoutes.shutdown()
+            assert(route.name == "shutdown")
+        }
+
+        "exit route is named exit" in {
+            val route = LspBuiltInRoutes.exit()
+            assert(route.name == "exit")
+        }
+
+        "setTrace route is named $/setTrace" in {
+            val traceRef = AtomicRef.Unsafe.init[LspHandler.TraceValue](LspHandler.TraceValue.Off)(using AllowUnsafe.embrace.danger).safe
+            val route    = LspBuiltInRoutes.setTrace(traceRef)
+            assert(route.name == "$/setTrace")
+        }
+
+        "notebookDocument/didOpen route is named correctly" in {
+            mkRegistry().map { registry =>
+                val route = LspBuiltInRoutes.notebookDocumentDidOpen(registry, Absent, noServerRef, encRef())
+                assert(route.name == "notebookDocument/didOpen")
+            }
+        }
+
+        "notebookDocument/didClose route is named correctly" in {
+            mkRegistry().map { registry =>
+                val route = LspBuiltInRoutes.notebookDocumentDidClose(registry)
+                assert(route.name == "notebookDocument/didClose")
+            }
+        }
+
+        "notebookDocumentDidChange route is named correctly" in {
+            mkRegistry().map { registry =>
+                val route = LspBuiltInRoutes.notebookDocumentDidChange(registry)
+                assert(route.name == "notebookDocument/didChange")
+            }
+        }
+
+        "notebookDocumentDidChange route inserts newly opened cells into the registry" in {
+            mkRegistry().flatMap { registry =>
+                val route    = LspBuiltInRoutes.notebookDocumentDidChange(registry)
+                val cellUri  = uri("notebook-cell:///nb.ipynb#cell1")
+                val cellItem = LspHandler.TextDocumentItem(cellUri, "python", 1, "print('hello')")
+                val change = LspHandler.NotebookDocumentChangeEvent(cells =
+                    Present(
+                        LspHandler.NotebookDocumentChangeEvent.CellChanges(
+                            structure = Present(LspHandler.NotebookDocumentChangeEvent.CellStructureChange(
+                                array = LspHandler.NotebookCellArrayChange(0, 0),
+                                didOpen = Chunk(cellItem),
+                                didClose = Chunk.empty
+                            )),
+                            textContent = Chunk.empty
+                        )
+                    )
+                )
+                val params = notebookChangeWire("notebook:///nb.ipynb", 1, change)
+                makeTestCtx.flatMap { ctx =>
+                    route.handle(params, ctx).andThen(registry.get(cellUri)).map {
+                        case Present(doc) =>
+                            assert(doc.languageId == "python")
+                            assert(doc.text == "print('hello')")
+                        case Absent =>
+                            fail("Cell document should have been inserted by the route")
+                    }
+                }
+            }
+        }
+
+        "notebookDocumentDidChange removes closed cells from registry" in {
+            mkRegistry().flatMap { registry =>
+                val cellUri  = uri("notebook-cell:///nb.ipynb#cell2")
+                val cellItem = LspHandler.TextDocumentItem(cellUri, "scala", 1, "val x = 1")
+                registry.insert(cellItem).flatMap { _ =>
+                    registry.remove(cellUri).flatMap { _ =>
+                        registry.get(cellUri).map {
+                            case Absent     => succeed
+                            case Present(_) => fail("Cell document should have been removed")
+                        }
+                    }
+                }
+            }
+        }
+
+        "notebookDocumentDidChange applies text content changes to existing cells" in {
+            mkRegistry().flatMap { registry =>
+                val cellUri  = uri("notebook-cell:///nb.ipynb#cell3")
+                val cellItem = LspHandler.TextDocumentItem(cellUri, "python", 1, "x = 1")
+                val change   = LspHandler.TextDocumentContentChangeEvent.Full("x = 2")
+                registry.insert(cellItem).flatMap { _ =>
+                    registry.applyChanges(cellUri, 2, Chunk(change)).flatMap { _ =>
+                        registry.get(cellUri).map {
+                            case Present(doc) =>
+                                assert(doc.text == "x = 2")
+                                assert(doc.version == 2)
+                            case Absent =>
+                                fail("Cell document should exist after update")
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+end LspBuiltInRoutesTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspCancellationPolicyTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspCancellationPolicyTest.scala
@@ -1,0 +1,78 @@
+package kyo.internal
+
+import kyo.*
+import kyo.internal.lsp.*
+
+class LspCancellationPolicyTest extends Test:
+
+    "LspCancellationPolicyTest" - {
+
+        "cancelMethod is $/cancelRequest" in {
+            assert(LspCancellationPolicy.default.cancelMethod == "$/cancelRequest")
+        }
+
+        "expectReplyForCancelledRequest is true" in {
+            assert(LspCancellationPolicy.default.expectReplyForCancelledRequest)
+        }
+
+        "protectedMethods includes initialize" in {
+            assert(LspCancellationPolicy.default.protectedMethods.contains("initialize"))
+        }
+
+        "cancelledError is Absent" in {
+            assert(LspCancellationPolicy.default.cancelledError == Absent)
+        }
+
+        "encodeParams produces { id: <integer> } for integer id" in {
+            LspCancellationPolicy.default.encodeParams(JsonRpcId(42), Absent).map { sv =>
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.toMap
+                        assert(m.get("id").contains(Structure.Value.Integer(42)))
+                    case _ => fail("Expected Record")
+            }
+        }
+
+        "encodeParams produces { id: <string> } for string id" in {
+            LspCancellationPolicy.default.encodeParams(JsonRpcId("req-1"), Absent).map { sv =>
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.toMap
+                        assert(m.get("id").contains(Structure.Value.Str("req-1")))
+                    case _ => fail("Expected Record")
+            }
+        }
+
+        "encodeParams includes reason when Present" in {
+            LspCancellationPolicy.default.encodeParams(JsonRpcId(1), Present("timeout")).map { sv =>
+                sv match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.toMap
+                        assert(m.get("reason").contains(Structure.Value.Str("timeout")))
+                    case _ => fail("Expected Record")
+            }
+        }
+
+        "decodeParams extracts integer id" in {
+            val sv = Structure.Value.Record(Chunk("id" -> Structure.Value.Integer(99)))
+            LspCancellationPolicy.default.decodeParams(sv).map { id =>
+                assert(id == Present(JsonRpcId(99)))
+            }
+        }
+
+        "decodeParams extracts string id" in {
+            val sv = Structure.Value.Record(Chunk("id" -> Structure.Value.Str("abc")))
+            LspCancellationPolicy.default.decodeParams(sv).map { id =>
+                assert(id == Present(JsonRpcId("abc")))
+            }
+        }
+
+        "decodeParams returns Absent for non-Record" in {
+            LspCancellationPolicy.default.decodeParams(Structure.Value.Null).map { id =>
+                assert(id == Absent)
+            }
+        }
+
+    }
+
+end LspCancellationPolicyTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspCatalogTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspCatalogTest.scala
@@ -1,0 +1,124 @@
+package kyo.internal
+
+import kyo.*
+import kyo.internal.lsp.*
+
+class LspCatalogTest extends Test:
+
+    // Helper: build a minimal server-handled request handler
+    private def serverHandler(kind: LspHandler.Kind, name: String): LspHandler[Unit, Unit, LspException] =
+        LspHandler.initRequest[Unit, Unit, Nothing](name, kind, _ => ())
+
+    private def notifHandler(kind: LspHandler.Kind, name: String): LspHandler[Unit, Unit, LspException] =
+        LspHandler.initNotification[Unit, Nothing](name, kind, _ => ())
+
+    private def clientHandler(kind: LspHandler.Kind, name: String): LspHandler[Unit, Unit, LspException] =
+        LspHandler.initRequest[Unit, Unit, Nothing](name, kind, _ => ())
+
+    // Client-handled handler: window/showMessage
+    private def showMessageHandler: LspHandler[LspHandler.ShowMessageParams, Unit, LspException] =
+        LspHandler.initNotification[LspHandler.ShowMessageParams, Nothing]("window/showMessage", LspHandler.Kind.ShowMessage, _ => ())
+
+    "LspCatalogTest" - {
+
+        "ClientHandled handler on server init throws WrongDirection" in {
+            val h = showMessageHandler
+            val result = scala.util.Try(
+                LspCatalog.fromHandlers(Seq(h), LspHandler.Direction.ServerHandled)
+            )
+            assert(result.isFailure)
+            assert(result.failed.get.isInstanceOf[LspWrongDirectionException])
+        }
+
+        "Direction.Either handler is accepted on server" in {
+            val h = LspHandler.initNotification[Unit, Nothing]("$/cancelRequest", LspHandler.Kind.CancelRequest, _ => ())
+            val result = scala.util.Try(
+                LspCatalog.fromHandlers(Seq(h), LspHandler.Direction.ServerHandled)
+            )
+            assert(result.isSuccess)
+        }
+
+        "Direction.Either handler is accepted on client" in {
+            val h = LspHandler.initNotification[Unit, Nothing]("$/cancelRequest", LspHandler.Kind.CancelRequest, _ => ())
+            val result = scala.util.Try(
+                LspCatalog.fromHandlers(Seq(h), LspHandler.Direction.ClientHandled)
+            )
+            assert(result.isSuccess)
+        }
+
+        "Reserved method in CustomHandler throws ReservedMethod" in {
+            val h = LspHandler.custom[Unit]("initialize")(_ => ())
+            val result = scala.util.Try(
+                LspCatalog.fromHandlers(Seq(h), LspHandler.Direction.ServerHandled)
+            )
+            assert(result.isFailure)
+            assert(result.failed.get.isInstanceOf[LspReservedMethodException])
+        }
+
+        "All reserved method names are blocked" in {
+            val reserved = Seq("initialize", "initialized", "shutdown", "exit", "$/cancelRequest", "$/progress", "$/setTrace")
+            reserved.foreach { name =>
+                val h = LspHandler.custom[Unit](name)(_ => ())
+                val result = scala.util.Try(
+                    LspCatalog.fromHandlers(Seq(h), LspHandler.Direction.ServerHandled)
+                )
+                assert(result.isFailure, s"Expected failure for reserved '$name'")
+                assert(result.failed.get.isInstanceOf[LspReservedMethodException], s"Wrong exception for '$name'")
+            }
+            succeed
+        }
+
+        "Duplicate Kind (non-Custom) throws DuplicateHandler" in {
+            val h1 = serverHandler(LspHandler.Kind.Completion, "textDocument/completion")
+            val h2 = serverHandler(LspHandler.Kind.Completion, "textDocument/completion")
+            val result = scala.util.Try(
+                LspCatalog.fromHandlers(Seq(h1, h2), LspHandler.Direction.ServerHandled)
+            )
+            assert(result.isFailure)
+            assert(result.failed.get.isInstanceOf[LspDuplicateHandlerException])
+        }
+
+        "Duplicate Custom name throws DuplicateHandler" in {
+            val h1 = LspHandler.custom[Unit]("vendor/foo")(_ => ())
+            val h2 = LspHandler.custom[Unit]("vendor/foo")(_ => ())
+            val result = scala.util.Try(
+                LspCatalog.fromHandlers(Seq(h1, h2), LspHandler.Direction.ServerHandled)
+            )
+            assert(result.isFailure)
+            assert(result.failed.get.isInstanceOf[LspDuplicateHandlerException])
+        }
+
+        "Auto-derive capabilities when declaredServerCapabilities = Absent" in {
+            val h1      = serverHandler(LspHandler.Kind.Completion, "textDocument/completion")
+            val h2      = serverHandler(LspHandler.Kind.Definition, "textDocument/definition")
+            val catalog = LspCatalog.fromHandlers(Seq(h1, h2), LspHandler.Direction.ServerHandled)
+            val config  = LspConfig.default
+            val caps    = catalog.autoDeriveServerCapabilities(config)
+            assert(caps.completionProvider.isDefined)
+            assert(caps.definitionProvider.isDefined)
+            assert(!caps.hoverProvider.isDefined)
+        }
+
+        "Declared capabilities returned verbatim when Present" in {
+            val declared = LspCapabilities.Server.empty
+            val config   = LspConfig.default.withDeclaredServerCapabilities(declared)
+            val catalog  = LspCatalog.fromHandlers(Seq.empty, LspHandler.Direction.ServerHandled)
+            val caps     = catalog.autoDeriveServerCapabilities(config)
+            assert(caps == declared)
+        }
+
+        "handlerFor returns Present for registered Kind" in {
+            val h       = serverHandler(LspHandler.Kind.Hover, "textDocument/hover")
+            val catalog = LspCatalog.fromHandlers(Seq(h), LspHandler.Direction.ServerHandled)
+            assert(catalog.handlerFor(LspHandler.Kind.Hover).isDefined)
+            assert(!catalog.handlerFor(LspHandler.Kind.Completion).isDefined)
+        }
+
+        "empty catalog has no handlers" in {
+            val catalog = LspCatalog.fromHandlers(Seq.empty, LspHandler.Direction.ServerHandled)
+            assert(catalog.handlers.isEmpty)
+        }
+
+    }
+
+end LspCatalogTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspClientEngineTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspClientEngineTest.scala
@@ -1,0 +1,40 @@
+package kyo.internal
+
+import kyo.*
+import kyo.internal.lsp.*
+
+class LspClientEngineTest extends Test:
+
+    "LspClientEngineTest" - {
+
+        "LspClientEngine.initClient catalog rejects wrong-direction handlers" in {
+            // A server-handled handler passed to client-side init should throw WrongDirection.
+            val serverHandler = LspHandler.initRequest[LspHandler.CompletionParams, Maybe[LspHandler.CompletionResult], Nothing](
+                "textDocument/completion",
+                LspHandler.Kind.Completion,
+                _ => ???
+            )
+            val err = scala.util.Try(
+                LspCatalog.fromHandlers(Seq(serverHandler), LspHandler.Direction.ClientHandled)
+            ).failed.get
+            assert(err.isInstanceOf[LspWrongDirectionException])
+        }
+
+        "LspClientEngine.initClient catalog accepts empty handlers" in {
+            val catalog = LspCatalog.fromHandlers(Seq.empty, LspHandler.Direction.ClientHandled)
+            assert(catalog.handlers.isEmpty)
+        }
+
+        "LspClientEngine.initClient catalog accepts client-direction handlers" in {
+            val clientHandler = LspHandler.initNotification[LspHandler.ShowMessageParams, Nothing](
+                "window/showMessage",
+                LspHandler.Kind.ShowMessage,
+                _ => ()
+            )
+            val catalog = LspCatalog.fromHandlers(Seq(clientHandler), LspHandler.Direction.ClientHandled)
+            assert(catalog.handlers.size == 1)
+        }
+
+    }
+
+end LspClientEngineTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspConfigRequireTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspConfigRequireTest.scala
@@ -1,0 +1,70 @@
+package kyo.internal
+
+import kyo.*
+
+/** Validates LspConfig.require cross-field constraint behaviour.
+  *
+  * LspConfig.require must fire synchronously before any transport is touched. Invalid
+  * configurations cause an LspConfigurationError before the engine starts.
+  */
+class LspConfigRequireTest extends Test:
+
+    // =========================================================================
+    // Valid configurations
+    // =========================================================================
+
+    "require passes for default config" in {
+        val result = scala.util.Try(LspConfig.require(LspConfig.default))
+        assert(result.isSuccess)
+    }
+
+    "require passes for config with multiple encodings" in {
+        val config = LspConfig.default.withPositionEncodings(
+            Chunk(LspHandler.PositionEncodingKind.UTF8, LspHandler.PositionEncodingKind.UTF16)
+        )
+        val result = scala.util.Try(LspConfig.require(config))
+        assert(result.isSuccess)
+    }
+
+    // =========================================================================
+    // Invalid configurations
+    // =========================================================================
+
+    "require fails when positionEncodings is empty" in {
+        val badConfig = LspConfig.default.withPositionEncodings(Chunk.empty)
+        val result    = scala.util.Try(LspConfig.require(badConfig))
+        assert(result.isFailure)
+        assert(result.failed.get.isInstanceOf[LspConfigurationError])
+        assert(result.failed.get.getMessage.contains("positionEncodings"))
+    }
+
+    // =========================================================================
+    // require fires before transport in init
+    // =========================================================================
+
+    "LspConfig.require fires before transport bytes are consumed" in {
+        // Use an invalid config and confirm the error precedes any server init work.
+        val badConfig = LspConfig.default.withPositionEncodings(Chunk.empty)
+        // The require() call inside initUnscoped must throw before LspEngine.initServer is called.
+        val result = scala.util.Try(LspConfig.require(badConfig))
+        assert(result.isFailure, "require must throw for empty positionEncodings")
+        assert(result.failed.get.getMessage.contains("positionEncodings"))
+    }
+
+    "LspConfig.SpecVersion is 3.17" in {
+        assert(LspConfig.SpecVersion == "3.17")
+    }
+
+    "LspConfig.default.enforceCapabilities is true" in {
+        assert(LspConfig.default.enforceCapabilities)
+    }
+
+    "LspConfig.default.positionEncodings contains UTF16" in {
+        assert(LspConfig.default.positionEncodings.contains(LspHandler.PositionEncodingKind.UTF16))
+    }
+
+    "LspConfig.default.documentSync is Incremental" in {
+        assert(LspConfig.default.documentSync == LspHandler.TextDocumentSyncKind.Incremental)
+    }
+
+end LspConfigRequireTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspDataCarrierTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspDataCarrierTest.scala
@@ -1,0 +1,83 @@
+package kyo
+
+/** Verifies that every public LSP data-carrier record carries a `private[kyo] _rawData: Maybe[String]`
+  * field and a typed `withData[X]` / `dataAs[X]` accessor pair.
+  */
+class LspDataCarrierTest extends Test:
+
+    "CompletionItem has _rawData field" in {
+        val item = LspHandler.CompletionItem(label = "foo")
+        assert(item._rawData == Absent)
+        succeed
+    }
+
+    "CompletionItem.withData stores encoded JSON" in {
+        val item    = LspHandler.CompletionItem(label = "foo")
+        val data    = Map("key" -> "value")
+        val updated = item.withData(data)
+        assert(updated._rawData.isDefined)
+        succeed
+    }
+
+    "CodeAction has _rawData field" in {
+        val action = LspHandler.CodeAction(title = "fix")
+        assert(action._rawData == Absent)
+        succeed
+    }
+
+    "CodeLens has _rawData field" in {
+        val lens = LspHandler.CodeLens(range = LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0)))
+        assert(lens._rawData == Absent)
+        succeed
+    }
+
+    "DocumentLink has _rawData field" in {
+        val link = LspHandler.DocumentLink(range = LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 0)))
+        assert(link._rawData == Absent)
+        succeed
+    }
+
+    "InlayHint has _rawData field" in {
+        val hint = LspHandler.InlayHint(
+            position = LspHandler.Position(0, 0),
+            label = LspHandler.InlayHintLabel.PlainString("type: Int")
+        )
+        assert(hint._rawData == Absent)
+        succeed
+    }
+
+    "WorkspaceSymbol has _rawData field" in {
+        val sym = LspHandler.WorkspaceSymbol(
+            name = "MyClass",
+            kind = LspHandler.SymbolKind.Class,
+            location = LspHandler.WorkspaceSymbolLocation.UriOnly(LspHandler.LspDocument.Uri.parse("file:///Main.scala").get)
+        )
+        assert(sym._rawData == Absent)
+        succeed
+    }
+
+    "CallHierarchyItem has _rawData field" in {
+        val item = LspHandler.CallHierarchyItem(
+            name = "myMethod",
+            kind = LspHandler.SymbolKind.Method,
+            uri = LspHandler.LspDocument.Uri.parse("file:///Main.scala").get,
+            range = LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(1, 0)),
+            selectionRange = LspHandler.Range(LspHandler.Position(0, 4), LspHandler.Position(0, 12))
+        )
+        assert(item._rawData == Absent)
+        succeed
+    }
+
+    "TypeHierarchyItem has _rawData field" in {
+        val item = LspHandler.TypeHierarchyItem(
+            name = "MyTrait",
+            kind = LspHandler.SymbolKind.Interface,
+            uri = LspHandler.LspDocument.Uri.parse("file:///Main.scala").get,
+            range = LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(1, 0)),
+            selectionRange = LspHandler.Range(LspHandler.Position(0, 6), LspHandler.Position(0, 13))
+        )
+        assert(item._rawData == Absent)
+        succeed
+    }
+
+end LspDataCarrierTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspDocumentRegistryTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspDocumentRegistryTest.scala
@@ -1,0 +1,177 @@
+package kyo.internal
+
+import kyo.*
+
+class LspDocumentRegistryTest extends Test:
+
+    private val defaultEncRef: AtomicRef[LspHandler.PositionEncodingKind] =
+        AtomicRef.Unsafe.init[LspHandler.PositionEncodingKind](LspHandler.PositionEncodingKind.UTF16)(
+            using AllowUnsafe.embrace.danger
+        ).safe
+
+    private def mkRegistry(enc: LspHandler.PositionEncodingKind = LspHandler.PositionEncodingKind.UTF16): LspDocumentRegistryImpl < Sync =
+        val ref = AtomicRef.Unsafe.init[LspHandler.PositionEncodingKind](enc)(using AllowUnsafe.embrace.danger).safe
+        LspDocumentRegistryImpl.init(ref)
+
+    private def uri(s: String): LspHandler.LspDocument.Uri = LspHandler.LspDocument.Uri.fromWire(s)
+
+    private def item(u: String, text: String = "hello"): LspHandler.TextDocumentItem =
+        LspHandler.TextDocumentItem(uri(u), "plaintext", 1, text)
+
+    "LspDocumentRegistryTest" - {
+
+        "insert stamps session encoding on document" in {
+            mkRegistry(LspHandler.PositionEncodingKind.UTF8).flatMap { reg =>
+                reg.insert(item("file:///a.txt")).flatMap { _ =>
+                    reg.get(uri("file:///a.txt")).map {
+                        case Present(doc) =>
+                            assert(doc.encoding == LspHandler.PositionEncodingKind.UTF8)
+                        case Absent =>
+                            fail("Expected document")
+                    }
+                }
+            }
+        }
+
+        "insert and get round-trip" in {
+            mkRegistry().flatMap { reg =>
+                reg.insert(item("file:///b.txt", "world")).flatMap { _ =>
+                    reg.get(uri("file:///b.txt")).map {
+                        case Present(doc) =>
+                            assert(doc.text == "world")
+                            assert(doc.version == 1)
+                        case Absent =>
+                            fail("Expected document")
+                    }
+                }
+            }
+        }
+
+        "applyChanges for unknown URI is a no-op" in {
+            mkRegistry().flatMap { reg =>
+                reg.applyChanges(
+                    uri("file:///unknown.txt"),
+                    2,
+                    Chunk(LspHandler.TextDocumentContentChangeEvent.Full("new content"))
+                ).flatMap { _ =>
+                    reg.get(uri("file:///unknown.txt")).map {
+                        case Absent     => succeed
+                        case Present(_) => fail("Should have been a no-op for unknown URI")
+                    }
+                }
+            }
+        }
+
+        "duplicate didOpen (same URI) replaces document" in {
+            mkRegistry().flatMap { reg =>
+                reg.insert(item("file:///c.txt", "original")).flatMap { _ =>
+                    reg.insert(item("file:///c.txt", "re-opened")).flatMap { _ =>
+                        reg.get(uri("file:///c.txt")).map {
+                            case Present(doc) =>
+                                assert(doc.text == "re-opened")
+                            case Absent =>
+                                fail("Expected document after re-open")
+                        }
+                    }
+                }
+            }
+        }
+
+        "applyChanges updates text and version" in {
+            mkRegistry().flatMap { reg =>
+                reg.insert(item("file:///d.txt", "hello world")).flatMap { _ =>
+                    reg.applyChanges(
+                        uri("file:///d.txt"),
+                        2,
+                        Chunk(LspHandler.TextDocumentContentChangeEvent.Full("goodbye"))
+                    ).flatMap { _ =>
+                        reg.get(uri("file:///d.txt")).map {
+                            case Present(doc) =>
+                                assert(doc.text == "goodbye")
+                                assert(doc.version == 2)
+                            case Absent =>
+                                fail("Expected document")
+                        }
+                    }
+                }
+            }
+        }
+
+        "remove for unknown URI is a no-op" in {
+            mkRegistry().flatMap { reg =>
+                reg.remove(uri("file:///nonexistent.txt")).flatMap { _ =>
+                    reg.get(uri("file:///nonexistent.txt")).map {
+                        case Absent     => succeed
+                        case Present(_) => fail("Should be absent")
+                    }
+                }
+            }
+        }
+
+        "remove existing document succeeds" in {
+            mkRegistry().flatMap { reg =>
+                reg.insert(item("file:///e.txt")).flatMap { _ =>
+                    reg.remove(uri("file:///e.txt")).flatMap { _ =>
+                        reg.get(uri("file:///e.txt")).map {
+                            case Absent     => succeed
+                            case Present(_) => fail("Should be removed")
+                        }
+                    }
+                }
+            }
+        }
+
+        "isOpen reflects insertion and removal" in {
+            mkRegistry().flatMap { reg =>
+                reg.insert(item("file:///f.txt")).flatMap { _ =>
+                    reg.isOpen(uri("file:///f.txt")).flatMap { open =>
+                        assert(open)
+                        reg.remove(uri("file:///f.txt")).flatMap { _ =>
+                            reg.isOpen(uri("file:///f.txt")).map { closed =>
+                                assert(!closed)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        "listOpenUris returns all inserted URIs" in {
+            mkRegistry().flatMap { reg =>
+                reg.insert(item("file:///g.txt")).flatMap { _ =>
+                    reg.insert(item("file:///h.txt")).flatMap { _ =>
+                        reg.listOpenUris.map { uris =>
+                            assert(uris.size == 2)
+                            assert(uris.contains(uri("file:///g.txt")))
+                            assert(uris.contains(uri("file:///h.txt")))
+                        }
+                    }
+                }
+            }
+        }
+
+        "version returns Absent for unknown URI" in {
+            mkRegistry().flatMap { reg =>
+                reg.version(uri("file:///missing.txt")).map { v =>
+                    assert(v == Absent)
+                }
+            }
+        }
+
+        "insertNotebookCell stamps session encoding" in {
+            mkRegistry(LspHandler.PositionEncodingKind.UTF8).flatMap { reg =>
+                reg.insertNotebookCell(uri("file:///cell1.py"), "python", "print('hello')", 1).flatMap { _ =>
+                    reg.get(uri("file:///cell1.py")).map {
+                        case Present(doc) =>
+                            assert(doc.encoding == LspHandler.PositionEncodingKind.UTF8)
+                            assert(doc.languageId == "python")
+                        case Absent =>
+                            fail("Expected cell document")
+                    }
+                }
+            }
+        }
+
+    }
+
+end LspDocumentRegistryTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspEffectRowsTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspEffectRowsTest.scala
@@ -1,0 +1,159 @@
+package kyo.internal
+
+import kyo.*
+
+/** Compile-time effect-row assertions for LspServer methods.
+  *
+  * Notification methods return `Fiber.Unsafe[Unit, Abort[LspConnectionClosedException]]`.
+  * Request methods return `Fiber.Unsafe[T, Abort[LspRequestFailure]]`.
+  * Lifecycle methods (awaitDrain, close) return `Unit < Async` on the safe tier.
+  *
+  * These compile-time evidence tests confirm the return rows at the safe-extension level.
+  */
+class LspEffectRowsTest extends Test:
+
+    // Safe-tier notify methods: Unit < (Async & Abort[LspConnectionClosedException]).
+    "showMessage safe row is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params = LspHandler.ShowMessageParams(LspHandler.MessageType.Info, "hello")
+                val e: Unit < (Async & Abort[LspConnectionClosedException]) = server.showMessage(params)
+                Abort.run[Closed](e).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "logMessage safe row is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params                                                  = LspHandler.LogMessageParams(LspHandler.MessageType.Log, "log")
+                val e: Unit < (Async & Abort[LspConnectionClosedException]) = server.logMessage(params)
+                Abort.run[Closed](e).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "publishDiagnostics safe row is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val uri                                                     = LspHandler.LspDocument.Uri.parse("file:///Main.scala").get
+                val params                                                  = LspHandler.PublishDiagnosticsParams(uri, Absent, Chunk.empty)
+                val e: Unit < (Async & Abort[LspConnectionClosedException]) = server.publishDiagnostics(params)
+                Abort.run[Closed](e).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "telemetry safe row is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        case class Event(name: String) derives Schema
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val e: Unit < (Async & Abort[LspConnectionClosedException]) = server.telemetry(Event("test"))
+                Abort.run[Closed](e).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "logTrace safe row is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val e: Unit < (Async & Abort[LspConnectionClosedException]) = server.logTrace("msg")
+                Abort.run[Closed](e).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "workDoneProgress safe row is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val token                                                   = LspHandler.ProgressToken.StringToken("t")
+                val value                                                   = LspHandler.WorkDoneProgressValue.Begin(title = "Working")
+                val e: Unit < (Async & Abort[LspConnectionClosedException]) = server.workDoneProgress(token, value)
+                Abort.run[Closed](e).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "cancel safe row is Unit < (Async & Abort[LspConnectionClosedException])" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val e: Unit < (Async & Abort[LspConnectionClosedException]) = server.cancel(JsonRpcId(1L))
+                Abort.run[Closed](e).andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    // Safe-tier request methods: T < (Async & Abort[LspRequestFailure]).
+    // Type-check only; not awaited (reverse-direction requests need a connected client peer).
+    "showMessageRequest safe row is Maybe[MessageActionItem] < (Async & Abort[LspRequestFailure]) (type check only)" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params = LspHandler.ShowMessageRequestParams(LspHandler.MessageType.Info, "choose", Chunk.empty)
+                val _: Maybe[LspHandler.MessageActionItem] < (Async & Abort[LspRequestFailure]) =
+                    server.showMessageRequest(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "applyEdit safe row is ApplyWorkspaceEditResult < (Async & Abort[LspRequestFailure]) (type check only)" in {
+        // Compile-time type check; not awaited (reverse-direction request needs a connected client).
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params = LspHandler.ApplyWorkspaceEditParams(edit = LspHandler.WorkspaceEdit())
+                val _: LspHandler.ApplyWorkspaceEditResult < (Async & Abort[LspRequestFailure]) = server.applyEdit(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "getWorkspaceFolders safe row is Maybe[Chunk[WorkspaceFolder]] < (Async & Abort[LspRequestFailure]) (type check only)" in {
+        // Compile-time type check; not awaited (reverse-direction request needs a connected client).
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Maybe[Chunk[LspHandler.WorkspaceFolder]] < (Async & Abort[LspRequestFailure]) =
+                    server.getWorkspaceFolders
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "refreshSemanticTokens safe row is Unit < (Async & Abort[LspRequestFailure]) (type check only)" in {
+        // Compile-time type check; not awaited (reverse-direction request needs a connected client).
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Unit < (Async & Abort[LspRequestFailure]) = server.refreshSemanticTokens
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    // Lifecycle rows.
+    "awaitDrain safe row is Unit < Async" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val e: Unit < Async = server.awaitDrain
+                e.andThen(server.closeNow).andThen(succeed)
+            }
+        }
+    }
+
+    "close safe row is Unit < Async" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val e: Unit < Async = server.close
+                e.andThen(succeed)
+            }
+        }
+    }
+
+    "closeNow safe row is Unit < Async" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val e: Unit < Async = server.closeNow
+                e.andThen(succeed)
+            }
+        }
+    }
+
+end LspEffectRowsTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspEngineTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspEngineTest.scala
@@ -1,0 +1,64 @@
+package kyo.internal
+
+import kyo.*
+import kyo.AllowUnsafe.embrace.danger
+import kyo.internal.lsp.*
+
+class LspEngineTest extends Test:
+
+    "LspEngineTest" - {
+
+        "cancellation policy is installed (cancelMethod = $/cancelRequest)" in {
+            // Verify the policy constant independently (no need for full engine init).
+            assert(LspCancellationPolicy.default.cancelMethod == "$/cancelRequest")
+        }
+
+        "progress policy is installed (progressMethod = $/progress)" in {
+            assert(LspProgressPolicy.default.progressMethod == "$/progress")
+        }
+
+        "expectReplyForCancelledRequest is true (LSP diverges from MCP)" in {
+            assert(LspCancellationPolicy.default.expectReplyForCancelledRequest)
+        }
+
+        "gate compose order is handshake -> shutdown -> capability" in {
+            // Compose with a handshake gate that is not yet initialized.
+            // Send a non-initialize request; should be rejected by handshake, not reached by capability.
+            val caps       = LspCapabilities.Server.empty.copy(completionProvider = Present(LspHandler.CompletionOptions()))
+            val handlerRef = AtomicRef.Unsafe.init[Maybe[JsonRpcHandler]](Absent)(using AllowUnsafe.embrace.danger).safe
+            LspHandshakeGate.server().flatMap { handshake =>
+                LspShutdownGate.server(handlerRef).flatMap { shutdown =>
+                    val capability = LspCapabilityGate.server(caps, enforce = true)
+                    val composed   = LspGate.compose(handshake, shutdown, capability)
+                    // completion IS in caps, so if composition were wrong order (capability before handshake),
+                    // this would Allow. Since handshake goes first, it should Reject.
+                    val env = JsonRpcRequest(JsonRpcId(1), "textDocument/completion", Absent, Absent)
+                    composed.beforeDispatch(env).map {
+                        case JsonRpcMessageGate.Decision.Reject(response) =>
+                            // The rejection carries a JsonRpcResponse; verify it is an error response.
+                            assert(response.error.isDefined, s"Expected error response, got: $response")
+                        case JsonRpcMessageGate.Decision.Allow => fail("Should have been rejected by handshake gate")
+                        case JsonRpcMessageGate.Decision.Drop  => fail("Should have been rejected by handshake gate")
+                    }
+                }
+            }
+        }
+
+        "LspCatalog.fromHandlers WrongDirection error message contains Kind name" in {
+            val h = LspHandler.initNotification[LspHandler.ShowMessageParams, Nothing](
+                "window/showMessage",
+                LspHandler.Kind.ShowMessage,
+                _ => ()
+            )
+            val err = scala.util.Try(LspCatalog.fromHandlers(Seq(h), LspHandler.Direction.ServerHandled)).failed.get
+            assert(err.getMessage.contains("ShowMessage"))
+        }
+
+        "LspCatalog.fromHandlers with empty handlers succeeds" in {
+            val catalog = LspCatalog.fromHandlers(Seq.empty, LspHandler.Direction.ServerHandled)
+            assert(catalog.handlers.isEmpty)
+        }
+
+    }
+
+end LspEngineTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspGateTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspGateTest.scala
@@ -1,0 +1,124 @@
+package kyo.internal
+
+import kyo.*
+import kyo.internal.lsp.*
+
+class LspGateTest extends Test:
+
+    "LspHandshakeGate" - {
+
+        "permits initialize before handshake" in {
+            LspHandshakeGate.server().flatMap { gate =>
+                val env = JsonRpcRequest(JsonRpcId(1), "initialize", Absent, Absent)
+                gate.beforeDispatch(env).map { d =>
+                    assert(d == JsonRpcMessageGate.Decision.Allow)
+                }
+            }
+        }
+
+        "rejects other requests before initialize" in {
+            LspHandshakeGate.server().flatMap { gate =>
+                val env = JsonRpcRequest(JsonRpcId(1), "textDocument/completion", Absent, Absent)
+                gate.beforeDispatch(env).map { d =>
+                    assert(d.isInstanceOf[JsonRpcMessageGate.Decision.Reject])
+                }
+            }
+        }
+
+        "permits requests after initialize" in {
+            LspHandshakeGate.server().flatMap { gate =>
+                val init  = JsonRpcRequest(JsonRpcId(1), "initialize", Absent, Absent)
+                val other = JsonRpcRequest(JsonRpcId(2), "textDocument/completion", Absent, Absent)
+                for
+                    _ <- gate.beforeDispatch(init)
+                    d <- gate.beforeDispatch(other)
+                yield assert(d == JsonRpcMessageGate.Decision.Allow)
+                end for
+            }
+        }
+
+        "permits initialized notification before and after initialize" in {
+            LspHandshakeGate.server().flatMap { gate =>
+                val notif = JsonRpcNotification("initialized", Absent, Absent)
+                gate.beforeDispatch(notif).map { d =>
+                    assert(d == JsonRpcMessageGate.Decision.Allow)
+                }
+            }
+        }
+
+        "permits other notifications before initialize (fire-and-forget)" in {
+            LspHandshakeGate.server().flatMap { gate =>
+                val notif = JsonRpcNotification("$/cancelRequest", Absent, Absent)
+                gate.beforeDispatch(notif).map { d =>
+                    assert(d == JsonRpcMessageGate.Decision.Allow)
+                }
+            }
+        }
+
+    }
+
+    "LspCapabilityGate" - {
+
+        "rejects method whose capability is not advertised" in {
+            val caps = LspCapabilities.Server.empty
+            val gate = LspCapabilityGate.server(caps, enforce = true)
+            val env  = JsonRpcRequest(JsonRpcId(1), "textDocument/completion", Absent, Absent)
+            gate.beforeDispatch(env).map { d =>
+                assert(d.isInstanceOf[JsonRpcMessageGate.Decision.Reject])
+            }
+        }
+
+        "permits method whose capability is advertised" in {
+            val caps = LspCapabilities.Server.empty.copy(completionProvider = Present(LspHandler.CompletionOptions()))
+            val gate = LspCapabilityGate.server(caps, enforce = true)
+            val env  = JsonRpcRequest(JsonRpcId(1), "textDocument/completion", Absent, Absent)
+            gate.beforeDispatch(env).map { d =>
+                assert(d == JsonRpcMessageGate.Decision.Allow)
+            }
+        }
+
+        "capability gate off: always admits" in {
+            val caps = LspCapabilities.Server.empty
+            val gate = LspCapabilityGate.server(caps, enforce = false)
+            val env  = JsonRpcRequest(JsonRpcId(1), "textDocument/completion", Absent, Absent)
+            gate.beforeDispatch(env).map { d =>
+                assert(d == JsonRpcMessageGate.Decision.Allow)
+            }
+        }
+
+        "capability gate: permits notifications unconditionally" in {
+            val caps  = LspCapabilities.Server.empty
+            val gate  = LspCapabilityGate.server(caps, enforce = true)
+            val notif = JsonRpcNotification("textDocument/didOpen", Absent, Absent)
+            gate.beforeDispatch(notif).map { d =>
+                assert(d == JsonRpcMessageGate.Decision.Allow)
+            }
+        }
+
+    }
+
+    "LspGate.compose" - {
+
+        "handshake gate is checked first (not-initialized returns NotInitialized)" in {
+            val caps       = LspCapabilities.Server.empty
+            val handlerRef = AtomicRef.Unsafe.init[Maybe[JsonRpcHandler]](Absent)(using AllowUnsafe.embrace.danger).safe
+            LspHandshakeGate.server().flatMap { handshake =>
+                LspShutdownGate.server(handlerRef).flatMap { shutdown =>
+                    val capability = LspCapabilityGate.server(caps, enforce = true)
+                    val composed   = LspGate.compose(handshake, shutdown, capability)
+                    val env        = JsonRpcRequest(JsonRpcId(1), "textDocument/completion", Absent, Absent)
+                    composed.beforeDispatch(env).map { d =>
+                        // Should be a Reject from handshake gate, not capability gate.
+                        d match
+                            case JsonRpcMessageGate.Decision.Reject(resp) =>
+                                assert(resp.result.isEmpty)
+                            case _ =>
+                                fail("Expected Reject from handshake gate")
+                    }
+                }
+            }
+        }
+
+    }
+
+end LspGateTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspHandlerFactoryTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspHandlerFactoryTest.scala
@@ -1,0 +1,917 @@
+package kyo.internal
+
+import kyo.*
+import kyo.internal.lsp.LspContentSchemas
+
+class LspHandlerFactoryTest extends kyo.Test:
+
+    // MARK: -- textDocument namespace factory tests
+
+    "textDocument namespace factories produce valid handlers" - {
+        "completion factory returns non-null handler with correct name and kind" in {
+            val h = LspHandler.TextDocument.completion(_ => LspHandler.CompletionResult.Items(Chunk.empty))
+            assert(h.name == "textDocument/completion")
+            assert(h.kind == LspHandler.Kind.Completion)
+            assert(h.direction == LspHandler.Direction.ServerHandled)
+            assert(h.errorMappings.isEmpty)
+            succeed
+        }
+
+        "completionItemResolve factory" in {
+            val h = LspHandler.TextDocument.completionItemResolve(item => item)
+            assert(h.name == "completionItem/resolve")
+            assert(h.kind == LspHandler.Kind.CompletionItemResolve)
+            succeed
+        }
+
+        "hover factory" in {
+            val h = LspHandler.TextDocument.hover(_ => Absent)
+            assert(h.name == "textDocument/hover")
+            assert(h.kind == LspHandler.Kind.Hover)
+            succeed
+        }
+
+        "signatureHelp factory" in {
+            val h = LspHandler.TextDocument.signatureHelp(_ => Absent)
+            assert(h.name == "textDocument/signatureHelp")
+            assert(h.kind == LspHandler.Kind.SignatureHelp)
+            succeed
+        }
+
+        "declaration factory returns DeclarationResult directly" in {
+            val h = LspHandler.TextDocument.declaration(_ => LspHandler.DeclarationResult.Many(Chunk.empty))
+            assert(h.name == "textDocument/declaration")
+            assert(h.kind == LspHandler.Kind.Declaration)
+            succeed
+        }
+
+        "definition factory returns DefinitionResult directly" in {
+            val h = LspHandler.TextDocument.definition(_ => LspHandler.DefinitionResult.Many(Chunk.empty))
+            assert(h.name == "textDocument/definition")
+            assert(h.kind == LspHandler.Kind.Definition)
+            succeed
+        }
+
+        "typeDefinition factory returns DefinitionResult directly" in {
+            val h = LspHandler.TextDocument.typeDefinition(_ => LspHandler.DefinitionResult.Many(Chunk.empty))
+            assert(h.name == "textDocument/typeDefinition")
+            assert(h.kind == LspHandler.Kind.TypeDefinition)
+            succeed
+        }
+
+        "implementation factory returns DefinitionResult directly" in {
+            val h = LspHandler.TextDocument.implementation(_ => LspHandler.DefinitionResult.Many(Chunk.empty))
+            assert(h.name == "textDocument/implementation")
+            assert(h.kind == LspHandler.Kind.Implementation)
+            succeed
+        }
+
+        "references factory" in {
+            val h = LspHandler.TextDocument.references(_ => Chunk.empty)
+            assert(h.name == "textDocument/references")
+            assert(h.kind == LspHandler.Kind.References)
+            succeed
+        }
+
+        "documentHighlight factory" in {
+            val h = LspHandler.TextDocument.documentHighlight(_ => Chunk.empty)
+            assert(h.name == "textDocument/documentHighlight")
+            assert(h.kind == LspHandler.Kind.DocumentHighlight)
+            succeed
+        }
+
+        "documentSymbol factory" in {
+            val h = LspHandler.TextDocument.documentSymbol(_ => LspHandler.DocumentSymbolResult.Symbols(Chunk.empty))
+            assert(h.name == "textDocument/documentSymbol")
+            assert(h.kind == LspHandler.Kind.DocumentSymbol)
+            succeed
+        }
+
+        "codeAction factory" in {
+            val h = LspHandler.TextDocument.codeAction(_ => Chunk.empty)
+            assert(h.name == "textDocument/codeAction")
+            assert(h.kind == LspHandler.Kind.CodeAction)
+            succeed
+        }
+
+        "codeActionResolve factory" in {
+            val h = LspHandler.TextDocument.codeActionResolve(ca => ca)
+            assert(h.name == "codeAction/resolve")
+            assert(h.kind == LspHandler.Kind.CodeActionResolve)
+            succeed
+        }
+
+        "codeLens factory" in {
+            val h = LspHandler.TextDocument.codeLens(_ => Chunk.empty)
+            assert(h.name == "textDocument/codeLens")
+            assert(h.kind == LspHandler.Kind.CodeLens)
+            succeed
+        }
+
+        "codeLensResolve factory" in {
+            val h = LspHandler.TextDocument.codeLensResolve(cl => cl)
+            assert(h.name == "codeLens/resolve")
+            assert(h.kind == LspHandler.Kind.CodeLensResolve)
+            succeed
+        }
+
+        "documentLink factory" in {
+            val h = LspHandler.TextDocument.documentLink(_ => Chunk.empty)
+            assert(h.name == "textDocument/documentLink")
+            assert(h.kind == LspHandler.Kind.DocumentLink)
+            succeed
+        }
+
+        "documentLinkResolve factory" in {
+            val h = LspHandler.TextDocument.documentLinkResolve(dl => dl)
+            assert(h.name == "documentLink/resolve")
+            assert(h.kind == LspHandler.Kind.DocumentLinkResolve)
+            succeed
+        }
+
+        "documentColor factory" in {
+            val h = LspHandler.TextDocument.documentColor(_ => Chunk.empty)
+            assert(h.name == "textDocument/documentColor")
+            assert(h.kind == LspHandler.Kind.DocumentColor)
+            succeed
+        }
+
+        "colorPresentation factory" in {
+            val h = LspHandler.TextDocument.colorPresentation(_ => Chunk.empty)
+            assert(h.name == "textDocument/colorPresentation")
+            assert(h.kind == LspHandler.Kind.ColorPresentation)
+            succeed
+        }
+
+        "formatting factory" in {
+            val h = LspHandler.TextDocument.formatting(_ => Chunk.empty)
+            assert(h.name == "textDocument/formatting")
+            assert(h.kind == LspHandler.Kind.Formatting)
+            succeed
+        }
+
+        "rangeFormatting factory" in {
+            val h = LspHandler.TextDocument.rangeFormatting(_ => Chunk.empty)
+            assert(h.name == "textDocument/rangeFormatting")
+            assert(h.kind == LspHandler.Kind.RangeFormatting)
+            succeed
+        }
+
+        "onTypeFormatting factory" in {
+            val h = LspHandler.TextDocument.onTypeFormatting(_ => Chunk.empty)
+            assert(h.name == "textDocument/onTypeFormatting")
+            assert(h.kind == LspHandler.Kind.OnTypeFormatting)
+            succeed
+        }
+
+        "rename factory" in {
+            val h = LspHandler.TextDocument.rename(_ => Absent)
+            assert(h.name == "textDocument/rename")
+            assert(h.kind == LspHandler.Kind.Rename)
+            succeed
+        }
+
+        "prepareRename factory" in {
+            val h = LspHandler.TextDocument.prepareRename(_ => Absent)
+            assert(h.name == "textDocument/prepareRename")
+            assert(h.kind == LspHandler.Kind.PrepareRename)
+            succeed
+        }
+
+        "foldingRange factory" in {
+            val h = LspHandler.TextDocument.foldingRange(_ => Chunk.empty)
+            assert(h.name == "textDocument/foldingRange")
+            assert(h.kind == LspHandler.Kind.FoldingRange)
+            succeed
+        }
+
+        "selectionRange factory" in {
+            val h = LspHandler.TextDocument.selectionRange(_ => Chunk.empty)
+            assert(h.name == "textDocument/selectionRange")
+            assert(h.kind == LspHandler.Kind.SelectionRange)
+            succeed
+        }
+
+        "linkedEditingRange factory" in {
+            val h = LspHandler.TextDocument.linkedEditingRange(_ => Absent)
+            assert(h.name == "textDocument/linkedEditingRange")
+            assert(h.kind == LspHandler.Kind.LinkedEditingRange)
+            succeed
+        }
+
+        "prepareCallHierarchy factory" in {
+            val h = LspHandler.TextDocument.prepareCallHierarchy(_ => Chunk.empty)
+            assert(h.name == "textDocument/prepareCallHierarchy")
+            assert(h.kind == LspHandler.Kind.PrepareCallHierarchy)
+            succeed
+        }
+
+        "callHierarchyIncomingCalls factory" in {
+            val h = LspHandler.TextDocument.callHierarchyIncomingCalls(_ => Chunk.empty)
+            assert(h.name == "callHierarchy/incomingCalls")
+            assert(h.kind == LspHandler.Kind.CallHierarchyIncomingCalls)
+            succeed
+        }
+
+        "callHierarchyOutgoingCalls factory" in {
+            val h = LspHandler.TextDocument.callHierarchyOutgoingCalls(_ => Chunk.empty)
+            assert(h.name == "callHierarchy/outgoingCalls")
+            assert(h.kind == LspHandler.Kind.CallHierarchyOutgoingCalls)
+            succeed
+        }
+
+        "prepareTypeHierarchy factory" in {
+            val h = LspHandler.TextDocument.prepareTypeHierarchy(_ => Chunk.empty)
+            assert(h.name == "textDocument/prepareTypeHierarchy")
+            assert(h.kind == LspHandler.Kind.PrepareTypeHierarchy)
+            succeed
+        }
+
+        "typeHierarchySupertypes factory uses TypeHierarchySupertypesParams" in {
+            val params = LspHandler.TypeHierarchySupertypesParams(
+                item = LspHandler.TypeHierarchyItem(
+                    "SomeName",
+                    LspHandler.SymbolKind.Class,
+                    Chunk.empty,
+                    Absent,
+                    LspHandler.LspDocument.Uri.fromWire("file:///a.scala"),
+                    LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(1, 0)),
+                    LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(0, 4))
+                )
+            )
+            val h = LspHandler.TextDocument.typeHierarchySupertypes(_ => Chunk.empty)
+            assert(h.name == "typeHierarchy/supertypes")
+            assert(h.kind == LspHandler.Kind.TypeHierarchySupertypes)
+            succeed
+        }
+
+        "typeHierarchySubtypes factory uses TypeHierarchySubtypesParams" in {
+            val h = LspHandler.TextDocument.typeHierarchySubtypes(_ => Chunk.empty)
+            assert(h.name == "typeHierarchy/subtypes")
+            assert(h.kind == LspHandler.Kind.TypeHierarchySubtypes)
+            succeed
+        }
+
+        "semanticTokensFull factory" in {
+            val h = LspHandler.TextDocument.semanticTokensFull(_ => Absent)
+            assert(h.name == "textDocument/semanticTokens/full")
+            assert(h.kind == LspHandler.Kind.SemanticTokensFull)
+            succeed
+        }
+
+        "semanticTokensFullDelta factory" in {
+            val h = LspHandler.TextDocument.semanticTokensFullDelta(_ => Absent)
+            assert(h.name == "textDocument/semanticTokens/full/delta")
+            assert(h.kind == LspHandler.Kind.SemanticTokensFullDelta)
+            succeed
+        }
+
+        "semanticTokensRange factory" in {
+            val h = LspHandler.TextDocument.semanticTokensRange(_ => Absent)
+            assert(h.name == "textDocument/semanticTokens/range")
+            assert(h.kind == LspHandler.Kind.SemanticTokensRange)
+            succeed
+        }
+
+        "moniker factory" in {
+            val h = LspHandler.TextDocument.moniker(_ => Chunk.empty)
+            assert(h.name == "textDocument/moniker")
+            assert(h.kind == LspHandler.Kind.Moniker)
+            succeed
+        }
+
+        "inlayHint factory" in {
+            val h = LspHandler.TextDocument.inlayHint(_ => Chunk.empty)
+            assert(h.name == "textDocument/inlayHint")
+            assert(h.kind == LspHandler.Kind.InlayHint)
+            succeed
+        }
+
+        "inlayHintResolve factory" in {
+            val h = LspHandler.TextDocument.inlayHintResolve(ih => ih)
+            assert(h.name == "inlayHint/resolve")
+            assert(h.kind == LspHandler.Kind.InlayHintResolve)
+            succeed
+        }
+
+        "inlineValue factory" in {
+            val h = LspHandler.TextDocument.inlineValue(_ => Chunk.empty)
+            assert(h.name == "textDocument/inlineValue")
+            assert(h.kind == LspHandler.Kind.InlineValue)
+            succeed
+        }
+
+        "diagnostic factory" in {
+            val h = LspHandler.TextDocument.diagnostic(_ =>
+                LspHandler.DocumentDiagnosticReport.Full(items = Chunk.empty)
+            )
+            assert(h.name == "textDocument/diagnostic")
+            assert(h.kind == LspHandler.Kind.DocumentDiagnostic)
+            succeed
+        }
+
+        "willSaveWaitUntil factory" in {
+            val h = LspHandler.TextDocument.willSaveWaitUntil(_ => Chunk.empty)
+            assert(h.name == "textDocument/willSaveWaitUntil")
+            assert(h.kind == LspHandler.Kind.TextDocumentWillSaveWaitUntil)
+            succeed
+        }
+
+        "didOpen factory is NotificationHandler" in {
+            val h = LspHandler.TextDocument.didOpen(_ => ())
+            assert(h.name == "textDocument/didOpen")
+            assert(h.kind == LspHandler.Kind.TextDocumentDidOpen)
+            assert(h.direction == LspHandler.Direction.ServerHandled)
+            succeed
+        }
+
+        "didChange factory" in {
+            val h = LspHandler.TextDocument.didChange(_ => ())
+            assert(h.name == "textDocument/didChange")
+            assert(h.kind == LspHandler.Kind.TextDocumentDidChange)
+            succeed
+        }
+
+        "didSave factory" in {
+            val h = LspHandler.TextDocument.didSave(_ => ())
+            assert(h.name == "textDocument/didSave")
+            assert(h.kind == LspHandler.Kind.TextDocumentDidSave)
+            succeed
+        }
+
+        "didClose factory" in {
+            val h = LspHandler.TextDocument.didClose(_ => ())
+            assert(h.name == "textDocument/didClose")
+            assert(h.kind == LspHandler.Kind.TextDocumentDidClose)
+            succeed
+        }
+
+        "willSave factory" in {
+            val h = LspHandler.TextDocument.willSave(_ => ())
+            assert(h.name == "textDocument/willSave")
+            assert(h.kind == LspHandler.Kind.TextDocumentWillSave)
+            succeed
+        }
+    }
+
+    // MARK: -- workspace namespace factory tests
+
+    "workspace namespace factories produce valid handlers" - {
+        "symbol factory" in {
+            val h = LspHandler.Workspace.symbol(_ => Chunk.empty)
+            assert(h.name == "workspace/symbol")
+            assert(h.kind == LspHandler.Kind.WorkspaceSymbol)
+            succeed
+        }
+
+        "symbolResolve factory" in {
+            val h = LspHandler.Workspace.symbolResolve(ws => ws)
+            assert(h.name == "workspaceSymbol/resolve")
+            assert(h.kind == LspHandler.Kind.WorkspaceSymbolResolve)
+            succeed
+        }
+
+        "executeCommand factory" in {
+            val h = LspHandler.Workspace.executeCommand[String](_ => Absent)
+            assert(h.name == "workspace/executeCommand")
+            assert(h.kind == LspHandler.Kind.ExecuteCommand)
+            succeed
+        }
+
+        "didChangeConfiguration factory" in {
+            val h = LspHandler.Workspace.didChangeConfiguration[String](_ => ())
+            assert(h.name == "workspace/didChangeConfiguration")
+            assert(h.kind == LspHandler.Kind.DidChangeConfiguration)
+            succeed
+        }
+
+        "didChangeWatchedFiles factory" in {
+            val h = LspHandler.Workspace.didChangeWatchedFiles(_ => ())
+            assert(h.name == "workspace/didChangeWatchedFiles")
+            assert(h.kind == LspHandler.Kind.DidChangeWatchedFiles)
+            succeed
+        }
+
+        "didChangeWorkspaceFolders factory" in {
+            val h = LspHandler.Workspace.didChangeWorkspaceFolders(_ => ())
+            assert(h.name == "workspace/didChangeWorkspaceFolders")
+            assert(h.kind == LspHandler.Kind.DidChangeWorkspaceFolders)
+            succeed
+        }
+
+        "willCreateFiles factory" in {
+            val h = LspHandler.Workspace.willCreateFiles(_ => Absent)
+            assert(h.name == "workspace/willCreateFiles")
+            assert(h.kind == LspHandler.Kind.WillCreateFiles)
+            succeed
+        }
+
+        "didCreateFiles factory" in {
+            val h = LspHandler.Workspace.didCreateFiles(_ => ())
+            assert(h.name == "workspace/didCreateFiles")
+            assert(h.kind == LspHandler.Kind.DidCreateFiles)
+            succeed
+        }
+
+        "willRenameFiles factory" in {
+            val h = LspHandler.Workspace.willRenameFiles(_ => Absent)
+            assert(h.name == "workspace/willRenameFiles")
+            assert(h.kind == LspHandler.Kind.WillRenameFiles)
+            succeed
+        }
+
+        "didRenameFiles factory" in {
+            val h = LspHandler.Workspace.didRenameFiles(_ => ())
+            assert(h.name == "workspace/didRenameFiles")
+            assert(h.kind == LspHandler.Kind.DidRenameFiles)
+            succeed
+        }
+
+        "willDeleteFiles factory" in {
+            val h = LspHandler.Workspace.willDeleteFiles(_ => Absent)
+            assert(h.name == "workspace/willDeleteFiles")
+            assert(h.kind == LspHandler.Kind.WillDeleteFiles)
+            succeed
+        }
+
+        "didDeleteFiles factory" in {
+            val h = LspHandler.Workspace.didDeleteFiles(_ => ())
+            assert(h.name == "workspace/didDeleteFiles")
+            assert(h.kind == LspHandler.Kind.DidDeleteFiles)
+            succeed
+        }
+
+        "diagnostic factory" in {
+            val h = LspHandler.Workspace.diagnostic(_ => LspHandler.WorkspaceDiagnosticReport(Chunk.empty))
+            assert(h.name == "workspace/diagnostic")
+            assert(h.kind == LspHandler.Kind.WorkspaceDiagnostic)
+            succeed
+        }
+
+        "applyEdit factory is ClientHandled" in {
+            val h = LspHandler.Workspace.applyEdit(_ => LspHandler.ApplyWorkspaceEditResult(applied = true))
+            assert(h.name == "workspace/applyEdit")
+            assert(h.kind == LspHandler.Kind.ApplyEdit)
+            assert(h.direction == LspHandler.Direction.ClientHandled)
+            succeed
+        }
+
+        "configuration factory" in {
+            val h = LspHandler.Workspace.configuration[String](_ => Chunk.empty)
+            assert(h.name == "workspace/configuration")
+            assert(h.kind == LspHandler.Kind.Configuration)
+            succeed
+        }
+
+        "workspaceFolders factory" in {
+            val h = LspHandler.Workspace.workspaceFolders(_ => Absent)
+            assert(h.name == "workspace/workspaceFolders")
+            assert(h.kind == LspHandler.Kind.WorkspaceFolders)
+            succeed
+        }
+
+        "refreshSemanticTokens factory" in {
+            val h = LspHandler.Workspace.refreshSemanticTokens
+            assert(h.name == "workspace/semanticTokens/refresh")
+            assert(h.kind == LspHandler.Kind.RefreshSemanticTokens)
+            assert(h.direction == LspHandler.Direction.ClientHandled)
+            succeed
+        }
+
+        "refreshInlineValue factory" in {
+            val h = LspHandler.Workspace.refreshInlineValue
+            assert(h.name == "workspace/inlineValue/refresh")
+            assert(h.kind == LspHandler.Kind.RefreshInlineValue)
+            succeed
+        }
+
+        "refreshInlayHint factory" in {
+            val h = LspHandler.Workspace.refreshInlayHint
+            assert(h.name == "workspace/inlayHint/refresh")
+            assert(h.kind == LspHandler.Kind.RefreshInlayHint)
+            succeed
+        }
+
+        "refreshDiagnostic factory" in {
+            val h = LspHandler.Workspace.refreshDiagnostic
+            assert(h.name == "workspace/diagnostic/refresh")
+            assert(h.kind == LspHandler.Kind.RefreshDiagnostic)
+            succeed
+        }
+
+        "refreshCodeLens factory" in {
+            val h = LspHandler.Workspace.refreshCodeLens
+            assert(h.name == "workspace/codeLens/refresh")
+            assert(h.kind == LspHandler.Kind.RefreshCodeLens)
+            succeed
+        }
+    }
+
+    // MARK: -- notebookDocument namespace factory tests
+
+    "notebookDocument namespace factories produce valid handlers" - {
+        "didOpen factory" in {
+            val h = LspHandler.NotebookDocument.didOpen(_ => ())
+            assert(h.name == "notebookDocument/didOpen")
+            assert(h.kind == LspHandler.Kind.NotebookDidOpen)
+            succeed
+        }
+
+        "didChange factory" in {
+            val h = LspHandler.NotebookDocument.didChange(_ => ())
+            assert(h.name == "notebookDocument/didChange")
+            assert(h.kind == LspHandler.Kind.NotebookDidChange)
+            succeed
+        }
+
+        "didSave factory" in {
+            val h = LspHandler.NotebookDocument.didSave(_ => ())
+            assert(h.name == "notebookDocument/didSave")
+            assert(h.kind == LspHandler.Kind.NotebookDidSave)
+            succeed
+        }
+
+        "didClose factory" in {
+            val h = LspHandler.NotebookDocument.didClose(_ => ())
+            assert(h.name == "notebookDocument/didClose")
+            assert(h.kind == LspHandler.Kind.NotebookDidClose)
+            succeed
+        }
+    }
+
+    // MARK: -- window namespace factory tests
+
+    "window namespace factories produce valid handlers" - {
+        "showMessage factory is ClientHandled" in {
+            val h = LspHandler.Window.showMessage(_ => ())
+            assert(h.name == "window/showMessage")
+            assert(h.kind == LspHandler.Kind.ShowMessage)
+            assert(h.direction == LspHandler.Direction.ClientHandled)
+            succeed
+        }
+
+        "showMessageRequest factory" in {
+            val h = LspHandler.Window.showMessageRequest(_ => Absent)
+            assert(h.name == "window/showMessageRequest")
+            assert(h.kind == LspHandler.Kind.ShowMessageRequest)
+            succeed
+        }
+
+        "showDocument factory" in {
+            val h = LspHandler.Window.showDocument(_ => LspHandler.ShowDocumentResult(success = true))
+            assert(h.name == "window/showDocument")
+            assert(h.kind == LspHandler.Kind.ShowDocument)
+            succeed
+        }
+
+        "logMessage factory" in {
+            val h = LspHandler.Window.logMessage(_ => ())
+            assert(h.name == "window/logMessage")
+            assert(h.kind == LspHandler.Kind.LogMessage)
+            succeed
+        }
+
+        "createWorkDoneProgress factory" in {
+            val h = LspHandler.Window.createWorkDoneProgress(_ => ())
+            assert(h.name == "window/workDoneProgress/create")
+            assert(h.kind == LspHandler.Kind.WorkDoneProgressCreate)
+            succeed
+        }
+
+        "workDoneProgressCancel factory" in {
+            val h = LspHandler.Window.workDoneProgressCancel(_ => ())
+            assert(h.name == "window/workDoneProgress/cancel")
+            assert(h.kind == LspHandler.Kind.WorkDoneProgressCancel)
+            succeed
+        }
+
+        "telemetry factory" in {
+            val h = LspHandler.Window.telemetry[String](_ => ())
+            assert(h.name == "telemetry/event")
+            assert(h.kind == LspHandler.Kind.Telemetry)
+            succeed
+        }
+    }
+
+    // MARK: -- client namespace factory tests
+
+    "client namespace factories produce valid handlers" - {
+        "registerCapability factory is ClientHandled" in {
+            val h = LspHandler.Client.registerCapability(_ => ())
+            assert(h.name == "client/registerCapability")
+            assert(h.kind == LspHandler.Kind.RegisterCapability)
+            assert(h.direction == LspHandler.Direction.ClientHandled)
+            succeed
+        }
+
+        "unregisterCapability factory" in {
+            val h = LspHandler.Client.unregisterCapability(_ => ())
+            assert(h.name == "client/unregisterCapability")
+            assert(h.kind == LspHandler.Kind.UnregisterCapability)
+            succeed
+        }
+    }
+
+    // MARK: -- custom escape hatch tests
+
+    "custom escape hatch factories" - {
+        "custom creates ServerHandled handler with given method" in {
+            val h = LspHandler.custom[String]("vendor/myMethod")(s => s)
+            assert(h.name == "vendor/myMethod")
+            assert(h.kind == LspHandler.Kind.Custom)
+            assert(h.direction == LspHandler.Direction.ServerHandled)
+            succeed
+        }
+
+        "customClient creates ClientHandled handler" in {
+            val h = LspHandler.customClient[String]("vendor/clientMethod")(s => s)
+            assert(h.name == "vendor/clientMethod")
+            assert(h.kind == LspHandler.Kind.Custom)
+            assert(h.direction == LspHandler.Direction.ClientHandled)
+            succeed
+        }
+    }
+
+    // MARK: -- .error[E2] extension tests
+
+    "error extension method" - {
+        "adds error mapping to RequestHandler" in {
+            case class MyError(msg: String) derives Schema, CanEqual
+            val h0 = LspHandler.TextDocument.hover(_ => Absent)
+            assert(h0.errorMappings.isEmpty)
+
+            val h1 = h0.error[MyError](code = -32001, message = "my error")
+            assert(h1.errorMappings.size == 1)
+            assert(h1.errorMappings(0).code == -32001)
+            assert(h1.errorMappings(0).message == "my error")
+            assert(h1.name == "textDocument/hover")
+            assert(h1.kind == LspHandler.Kind.Hover)
+            succeed
+        }
+
+        "adds error mapping to NotificationHandler" in {
+            case class NotifError(code: Int) derives Schema, CanEqual
+            val h0 = LspHandler.TextDocument.didOpen(_ => ())
+            assert(h0.errorMappings.isEmpty)
+
+            val h1 = h0.error[NotifError](code = -32002, message = "notif error")
+            assert(h1.errorMappings.size == 1)
+            assert(h1.errorMappings(0).code == -32002)
+            succeed
+        }
+
+        "chains multiple error mappings" in {
+            case class Err1(a: String) derives Schema, CanEqual
+            case class Err2(b: Int) derives Schema, CanEqual
+            val h0 = LspHandler.TextDocument.completion(_ => LspHandler.CompletionResult.Items(Chunk.empty))
+            val h1 = h0.error[Err1](code = 1, message = "err1")
+            val h2 = h1.error[Err2](code = 2, message = "err2")
+            assert(h2.errorMappings.size == 2)
+            assert(h2.errorMappings(0).code == 1)
+            assert(h2.errorMappings(1).code == 2)
+            succeed
+        }
+
+        "adds error mapping to CustomHandler" in {
+            case class CustomErr(reason: String) derives Schema, CanEqual
+            val h0 = LspHandler.custom[String]("vendor/x")(s => s)
+            val h1 = h0.error[CustomErr](code = -32003, message = "custom err")
+            assert(h1.errorMappings.size == 1)
+            assert(h1.errorMappings(0).code == -32003)
+            succeed
+        }
+    }
+
+    // MARK: -- Schema decode round-trip tests
+
+    "CommandOrCodeAction schema decode fixes" - {
+        "decodes a Command with string command field" in {
+            val cmd: LspHandler.CommandOrCodeAction = LspHandler.CommandOrCodeAction.Cmd(
+                LspHandler.Command("Run Tests", "test.run", Chunk("arg1", "arg2"))
+            )
+            val json    = Json.encode(cmd)
+            val decoded = Json.decode[LspHandler.CommandOrCodeAction](json)
+            decoded match
+                case Result.Success(LspHandler.CommandOrCodeAction.Cmd(LspHandler.Command(title, command, args))) =>
+                    assert(title == "Run Tests")
+                    assert(command == "test.run")
+                    // arguments contain string elements (string args round-trip)
+                    assert(args == Chunk("arg1", "arg2"))
+                case other =>
+                    fail(s"Expected Cmd, got: $other (json=$json)")
+            end match
+            succeed
+        }
+
+        "decodes a CodeAction with nested command object" in {
+            val cmd                                     = LspHandler.Command("Apply Fix", "fix.apply", Chunk.empty)
+            val ca                                      = LspHandler.CodeAction(title = "Fix all", command = Present(cmd))
+            val cmdOrCa: LspHandler.CommandOrCodeAction = LspHandler.CommandOrCodeAction.Action(ca)
+            val json                                    = Json.encode(cmdOrCa)
+            val decoded                                 = Json.decode[LspHandler.CommandOrCodeAction](json)
+            decoded match
+                case Result.Success(LspHandler.CommandOrCodeAction.Action(action)) =>
+                    assert(action.title == "Fix all")
+                    action.command match
+                        case Present(c) => assert(c.command == "fix.apply")
+                        case Absent     => fail("Expected command to be present")
+                case other =>
+                    fail(s"Expected Action with nested command, got: $other")
+            end match
+            succeed
+        }
+
+        "decodes a CodeAction with edit field (not confused with Command)" in {
+            val edit                                    = LspHandler.WorkspaceEdit()
+            val ca                                      = LspHandler.CodeAction(title = "Rename", edit = Present(edit))
+            val cmdOrCa: LspHandler.CommandOrCodeAction = LspHandler.CommandOrCodeAction.Action(ca)
+            val json                                    = Json.encode(cmdOrCa)
+            val decoded                                 = Json.decode[LspHandler.CommandOrCodeAction](json)
+            decoded match
+                case Result.Success(LspHandler.CommandOrCodeAction.Action(action)) =>
+                    assert(action.title == "Rename")
+                    assert(action.edit.isDefined)
+                case other =>
+                    fail(s"Expected Action, got: $other")
+            end match
+            succeed
+        }
+    }
+
+    "WorkspaceEditDocumentChange schema includes options for file operations" - {
+        "decodes CreateFile with options" in {
+            val create: LspHandler.WorkspaceEditDocumentChange = LspHandler.WorkspaceEditDocumentChange.Create(
+                LspHandler.CreateFile(
+                    uri = LspHandler.LspDocument.Uri.fromWire("file:///new.txt"),
+                    options = Present(LspHandler.CreateFileOptions(overwrite = Present(true), ignoreIfExists = Present(false)))
+                )
+            )
+            val json    = Json.encode(create)
+            val decoded = Json.decode[LspHandler.WorkspaceEditDocumentChange](json)
+            decoded match
+                case Result.Success(LspHandler.WorkspaceEditDocumentChange.Create(cf)) =>
+                    assert(cf.uri.asString == "file:///new.txt")
+                    cf.options match
+                        case Present(opts) =>
+                            assert(opts.overwrite == Present(true))
+                            assert(opts.ignoreIfExists == Present(false))
+                        case Absent => fail("Expected options to be present")
+                    end match
+                case other =>
+                    fail(s"Expected Create with options, got: $other")
+            end match
+            succeed
+        }
+
+        "decodes RenameFile with options" in {
+            val rename: LspHandler.WorkspaceEditDocumentChange = LspHandler.WorkspaceEditDocumentChange.Rename(
+                LspHandler.RenameFile(
+                    oldUri = LspHandler.LspDocument.Uri.fromWire("file:///old.txt"),
+                    newUri = LspHandler.LspDocument.Uri.fromWire("file:///new.txt"),
+                    options = Present(LspHandler.RenameFileOptions(overwrite = Present(false), ignoreIfExists = Absent))
+                )
+            )
+            val json    = Json.encode(rename)
+            val decoded = Json.decode[LspHandler.WorkspaceEditDocumentChange](json)
+            decoded match
+                case Result.Success(LspHandler.WorkspaceEditDocumentChange.Rename(rf)) =>
+                    assert(rf.oldUri.asString == "file:///old.txt")
+                    assert(rf.newUri.asString == "file:///new.txt")
+                    rf.options match
+                        case Present(opts) => assert(opts.overwrite == Present(false))
+                        case Absent        => fail("Expected options to be present")
+                case other =>
+                    fail(s"Expected Rename with options, got: $other")
+            end match
+            succeed
+        }
+
+        "decodes DeleteFile with options" in {
+            val delete: LspHandler.WorkspaceEditDocumentChange = LspHandler.WorkspaceEditDocumentChange.Delete(
+                LspHandler.DeleteFile(
+                    uri = LspHandler.LspDocument.Uri.fromWire("file:///old.txt"),
+                    options = Present(LspHandler.DeleteFileOptions(recursive = Present(true), ignoreIfNotExists = Present(false)))
+                )
+            )
+            val json    = Json.encode(delete)
+            val decoded = Json.decode[LspHandler.WorkspaceEditDocumentChange](json)
+            decoded match
+                case Result.Success(LspHandler.WorkspaceEditDocumentChange.Delete(df)) =>
+                    assert(df.uri.asString == "file:///old.txt")
+                    df.options match
+                        case Present(opts) =>
+                            assert(opts.recursive == Present(true))
+                            assert(opts.ignoreIfNotExists == Present(false))
+                        case Absent => fail("Expected options to be present")
+                    end match
+                case other =>
+                    fail(s"Expected Delete with options, got: $other")
+            end match
+            succeed
+        }
+    }
+
+    "TypeHierarchy params capitalization" - {
+        "TypeHierarchySupertypesParams round-trips" in {
+            val item = LspHandler.TypeHierarchyItem(
+                "MyClass",
+                LspHandler.SymbolKind.Class,
+                Chunk.empty,
+                Absent,
+                LspHandler.LspDocument.Uri.fromWire("file:///test.scala"),
+                LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(10, 0)),
+                LspHandler.Range(LspHandler.Position(0, 6), LspHandler.Position(0, 13))
+            )
+            val params  = LspHandler.TypeHierarchySupertypesParams(item = item)
+            val json    = Json.encode(params)
+            val decoded = Json.decode[LspHandler.TypeHierarchySupertypesParams](json)
+            decoded match
+                case Result.Success(p) =>
+                    assert(p.item.name == "MyClass")
+                case other =>
+                    fail(s"Expected success, got: $other")
+            end match
+            succeed
+        }
+
+        "TypeHierarchySubtypesParams round-trips" in {
+            val item = LspHandler.TypeHierarchyItem(
+                "SubClass",
+                LspHandler.SymbolKind.Class,
+                Chunk.empty,
+                Absent,
+                LspHandler.LspDocument.Uri.fromWire("file:///sub.scala"),
+                LspHandler.Range(LspHandler.Position(0, 0), LspHandler.Position(5, 0)),
+                LspHandler.Range(LspHandler.Position(0, 6), LspHandler.Position(0, 14))
+            )
+            val params  = LspHandler.TypeHierarchySubtypesParams(item = item)
+            val json    = Json.encode(params)
+            val decoded = Json.decode[LspHandler.TypeHierarchySubtypesParams](json)
+            decoded match
+                case Result.Success(p) =>
+                    assert(p.item.name == "SubClass")
+                case other =>
+                    fail(s"Expected success, got: $other")
+            end match
+            succeed
+        }
+    }
+
+    // MARK: -- general namespace factory tests
+
+    "general namespace factories produce valid handlers" - {
+        "cancelRequest factory has correct name, kind, and direction" in {
+            val h = LspHandler.General.cancelRequest(_ => ())
+            assert(h.name == "$/cancelRequest")
+            assert(h.kind == LspHandler.Kind.CancelRequest)
+            assert(h.direction == LspHandler.Direction.Either)
+            succeed
+        }
+
+        "progress factory has correct name, kind, and direction" in {
+            val h = LspHandler.General.progress[String](_ => ())
+            assert(h.name == "$/progress")
+            assert(h.kind == LspHandler.Kind.Progress)
+            assert(h.direction == LspHandler.Direction.Either)
+            succeed
+        }
+
+        "setTrace factory has correct name, kind, and direction" in {
+            val h = LspHandler.General.setTrace(_ => ())
+            assert(h.name == "$/setTrace")
+            assert(h.kind == LspHandler.Kind.SetTrace)
+            assert(h.direction == LspHandler.Direction.ServerHandled)
+            succeed
+        }
+
+        "logTrace factory has correct name, kind, and direction" in {
+            val h = LspHandler.General.logTrace(_ => ())
+            assert(h.name == "$/logTrace")
+            assert(h.kind == LspHandler.Kind.LogTrace)
+            assert(h.direction == LspHandler.Direction.ClientHandled)
+            succeed
+        }
+    }
+
+    "completion factory returns CompletionResult directly" - {
+        "completion handler type is CompletionResult not Maybe[CompletionResult]" in {
+            // The factory signature should compile with a non-Maybe handler
+            val h = LspHandler.TextDocument.completion(_ =>
+                LspHandler.CompletionResult.Items(Chunk(LspHandler.CompletionItem(label = "foo")))
+            )
+            assert(h.name == "textDocument/completion")
+            assert(h.kind == LspHandler.Kind.Completion)
+            succeed
+        }
+
+        "documentSymbol handler type is DocumentSymbolResult not Maybe[DocumentSymbolResult]" in {
+            val h = LspHandler.TextDocument.documentSymbol(_ =>
+                LspHandler.DocumentSymbolResult.Symbols(Chunk.empty)
+            )
+            assert(h.name == "textDocument/documentSymbol")
+            assert(h.kind == LspHandler.Kind.DocumentSymbol)
+            succeed
+        }
+    }
+
+end LspHandlerFactoryTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspHandlerLiftTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspHandlerLiftTest.scala
@@ -1,0 +1,57 @@
+package kyo.internal
+
+import kyo.*
+import kyo.internal.lsp.*
+
+class LspHandlerLiftTest extends Test:
+
+    "LspHandlerLiftTest" - {
+
+        "error mappings are applied to the lifted route" in {
+            case class MyError(msg: String) derives Schema
+            val handler = LspHandler.TextDocument.completion { _ =>
+                Abort.fail(MyError("test"))
+            }.error[MyError](-32099, "my error")
+
+            // The handler should have one error mapping
+            assert(handler.errorMappings.size == 1)
+            assert(handler.errorMappings(0).code == -32099)
+        }
+
+        "RequestHandler carries inSchema and outSchema" in {
+            val h = LspHandler.TextDocument.completion { _ =>
+                LspHandler.CompletionResult.Items(Chunk.empty)
+            }
+            h match
+                case rh: LspHandler.RequestHandler[?, ?, ?] =>
+                    assert(rh.inSchema != null)
+                    assert(rh.outSchema != null)
+                case _ =>
+                    fail("Expected RequestHandler")
+            end match
+        }
+
+        "NotificationHandler carries inSchema" in {
+            val h = LspHandler.TextDocument.didOpen { _ => () }
+            h match
+                case nh: LspHandler.NotificationHandler[?, ?] =>
+                    assert(nh.inSchema != null)
+                case _ =>
+                    fail("Expected NotificationHandler")
+            end match
+        }
+
+        "CustomHandler carries inSchema and outSchema" in {
+            val h = LspHandler.custom[String]("vendor/test")(_ => 42)
+            h match
+                case ch: LspHandler.CustomHandler[?, ?, ?] =>
+                    assert(ch.inSchema != null)
+                    assert(ch.outSchema != null)
+                case _ =>
+                    fail("Expected CustomHandler")
+            end match
+        }
+
+    }
+
+end LspHandlerLiftTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspLocalTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspLocalTest.scala
@@ -1,0 +1,12 @@
+package kyo
+
+/** Verifies Lsp.local reads as Absent outside a handler invocation. */
+class LspLocalTest extends Test:
+
+    "Lsp.local is Absent outside handler" in {
+        Lsp.local.use { value =>
+            assert(value == Absent)
+        }
+    }
+
+end LspLocalTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspProgressPolicyTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspProgressPolicyTest.scala
@@ -1,0 +1,87 @@
+package kyo.internal
+
+import kyo.*
+import kyo.internal.lsp.*
+
+class LspProgressPolicyTest extends Test:
+
+    "LspProgressPolicyTest" - {
+
+        "progressMethod is $/progress" in {
+            assert(LspProgressPolicy.default.progressMethod == "$/progress")
+        }
+
+        "extractInboundToken reads params.token" in {
+            val sv = Structure.Value.Record(Chunk(
+                "token" -> Structure.Value.Str("my-token"),
+                "value" -> Structure.Value.Record(Chunk.empty)
+            ))
+            LspProgressPolicy.default.extractInboundToken(sv).map { tok =>
+                assert(tok == Present(Structure.Value.Str("my-token")))
+            }
+        }
+
+        "extractRequestToken reads workDoneToken first" in {
+            val sv = Structure.Value.Record(Chunk(
+                "textDocument"       -> Structure.Value.Record(Chunk.empty),
+                "workDoneToken"      -> Structure.Value.Str("wdt-1"),
+                "partialResultToken" -> Structure.Value.Str("prt-1")
+            ))
+            LspProgressPolicy.default.extractRequestToken(sv).map { tok =>
+                assert(tok == Present(Structure.Value.Str("wdt-1")))
+            }
+        }
+
+        "extractRequestToken falls back to partialResultToken" in {
+            val sv = Structure.Value.Record(Chunk(
+                "textDocument"       -> Structure.Value.Record(Chunk.empty),
+                "partialResultToken" -> Structure.Value.Str("prt-1")
+            ))
+            LspProgressPolicy.default.extractRequestToken(sv).map { tok =>
+                assert(tok == Present(Structure.Value.Str("prt-1")))
+            }
+        }
+
+        "extractRequestToken returns Absent when neither token present" in {
+            val sv = Structure.Value.Record(Chunk(
+                "textDocument" -> Structure.Value.Record(Chunk.empty)
+            ))
+            LspProgressPolicy.default.extractRequestToken(sv).map { tok =>
+                assert(tok == Absent)
+            }
+        }
+
+        "encodeProgressParams builds { token, ...fields }" in {
+            val token = Structure.Value.Str("tok-1")
+            val value = Structure.Value.Record(Chunk("kind" -> Structure.Value.Str("begin")))
+            LspProgressPolicy.default.encodeProgressParams(token, value).map { encoded =>
+                encoded match
+                    case Structure.Value.Record(fields) =>
+                        val m = fields.toMap
+                        assert(m.get("token").contains(token))
+                        assert(m.get("kind").contains(Structure.Value.Str("begin")))
+                    case _ => fail("Expected Record")
+            }
+        }
+
+        "extractProgressValue strips token field" in {
+            val sv = Structure.Value.Record(Chunk(
+                "token" -> Structure.Value.Str("tok-1"),
+                "kind"  -> Structure.Value.Str("report")
+            ))
+            LspProgressPolicy.default.extractProgressValue(sv).map { v =>
+                v match
+                    case Present(Structure.Value.Record(fields)) =>
+                        assert(!fields.exists(_._1 == "token"))
+                        assert(fields.exists(_._1 == "kind"))
+                    case _ => fail("Expected Present(Record)")
+            }
+        }
+
+        "enforceMonotonic is false" in {
+            assert(!LspProgressPolicy.default.enforceMonotonic)
+        }
+
+    }
+
+end LspProgressPolicyTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspResultShapesTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspResultShapesTest.scala
@@ -1,0 +1,523 @@
+package kyo.internal
+
+import kyo.*
+
+/** Round-trip tests for every sealed result type.
+  *
+  * Each test encodes a representative value to JSON and decodes it back, asserting
+  * structural equality. Uses fromStructureValue path (Json.decode) which is the primary
+  * decode path for sealed unions.
+  */
+class LspResultShapesTest extends Test:
+
+    private def encode[A: Schema](value: A): String = Json.encode[A](value)
+    private def decode[A: Schema](json: String): A  = Json.decode[A](json).getOrThrow
+    private def roundtrip[A: Schema](value: A): A   = decode[A](encode[A](value))
+
+    given CanEqual[Any, Any] = CanEqual.canEqualAny
+
+    val pos0   = LspHandler.Position(0, 0)
+    val range0 = LspHandler.Range(pos0, pos0)
+    val loc0   = LspHandler.Location(LspHandler.LspDocument.Uri.fromWire("file:///test.scala"), range0)
+    val link0 = LspHandler.LocationLink(
+        originSelectionRange = Absent,
+        targetUri = LspHandler.LspDocument.Uri.fromWire("file:///test.scala"),
+        targetRange = range0,
+        targetSelectionRange = range0
+    )
+
+    // ---- TextDocumentContentChangeEvent ----
+
+    "TextDocumentContentChangeEvent.Full round-trips" in {
+        val v: LspHandler.TextDocumentContentChangeEvent = LspHandler.TextDocumentContentChangeEvent.Full("hello world")
+        assert(roundtrip(v) == v)
+    }
+
+    "TextDocumentContentChangeEvent.Incremental round-trips" in {
+        val v: LspHandler.TextDocumentContentChangeEvent =
+            LspHandler.TextDocumentContentChangeEvent.Incremental(range0, "updated text")
+        assert(roundtrip(v) == v)
+    }
+
+    "TextDocumentContentChangeEvent.Incremental encodes with range field" in {
+        val v    = LspHandler.TextDocumentContentChangeEvent.Incremental(range0, "x")
+        val json = encode(v)
+        assert(json.contains("range"))
+        assert(json.contains("text"))
+    }
+
+    "TextDocumentContentChangeEvent.Full encodes without range field" in {
+        val v    = LspHandler.TextDocumentContentChangeEvent.Full("x")
+        val json = encode(v)
+        assert(!json.contains("range"))
+        assert(json.contains("text"))
+    }
+
+    // ---- ProgressToken ----
+
+    "ProgressToken.IntToken round-trips" in {
+        val v: LspHandler.ProgressToken = LspHandler.ProgressToken.IntToken(42)
+        assert(roundtrip(v) == v)
+    }
+
+    "ProgressToken.StringToken round-trips" in {
+        val v: LspHandler.ProgressToken = LspHandler.ProgressToken.StringToken("mytoken")
+        assert(roundtrip(v) == v)
+    }
+
+    "ProgressToken.IntToken encodes as integer" in {
+        val v: LspHandler.ProgressToken = LspHandler.ProgressToken.IntToken(7)
+        assert(encode(v) == "7")
+    }
+
+    "ProgressToken.StringToken encodes as string" in {
+        val v: LspHandler.ProgressToken = LspHandler.ProgressToken.StringToken("abc")
+        assert(encode(v) == "\"abc\"")
+    }
+
+    // ---- WorkDoneProgressValue ----
+
+    "WorkDoneProgressValue.Begin round-trips with all fields" in {
+        val v: LspHandler.WorkDoneProgressValue = LspHandler.WorkDoneProgressValue.Begin(
+            title = "Processing",
+            cancellable = Present(true),
+            message = Present("0%"),
+            percentage = Present(0)
+        )
+        assert(roundtrip(v) == v)
+    }
+
+    "WorkDoneProgressValue.Report round-trips" in {
+        val v: LspHandler.WorkDoneProgressValue = LspHandler.WorkDoneProgressValue.Report(
+            message = Present("50%"),
+            percentage = Present(50)
+        )
+        assert(roundtrip(v) == v)
+    }
+
+    "WorkDoneProgressValue.End round-trips" in {
+        val v: LspHandler.WorkDoneProgressValue = LspHandler.WorkDoneProgressValue.End(Present("Done"))
+        assert(roundtrip(v) == v)
+    }
+
+    "WorkDoneProgressValue.Begin encodes with kind=begin" in {
+        val v: LspHandler.WorkDoneProgressValue = LspHandler.WorkDoneProgressValue.Begin("title")
+        val json                                = encode(v)
+        assert(json.contains("\"kind\":\"begin\""))
+    }
+
+    // ---- MarkedString ----
+
+    "MarkedString.Plain round-trips" in {
+        val v: LspHandler.MarkedString = LspHandler.MarkedString.Plain("hello")
+        assert(roundtrip(v) == v)
+    }
+
+    "MarkedString.Code round-trips" in {
+        val v: LspHandler.MarkedString = LspHandler.MarkedString.Code("scala", "val x = 1")
+        assert(roundtrip(v) == v)
+    }
+
+    "MarkedString.Plain encodes as JSON string" in {
+        val v: LspHandler.MarkedString = LspHandler.MarkedString.Plain("hello")
+        assert(encode(v) == "\"hello\"")
+    }
+
+    // ---- HoverContents ----
+
+    "HoverContents.Markup round-trips" in {
+        val markup                      = LspHandler.MarkupContent(LspHandler.MarkupKind.Markdown, "**bold**")
+        val v: LspHandler.HoverContents = LspHandler.HoverContents.Markup(markup)
+        assert(roundtrip(v) == v)
+    }
+
+    "HoverContents.Strings round-trips with single plain string" in {
+        val v: LspHandler.HoverContents = LspHandler.HoverContents.Strings(
+            Chunk(LspHandler.MarkedString.Plain("info"))
+        )
+        assert(roundtrip(v) == v)
+    }
+
+    "HoverContents.Markup encodes as object with kind field" in {
+        val markup                      = LspHandler.MarkupContent(LspHandler.MarkupKind.PlainText, "info")
+        val v: LspHandler.HoverContents = LspHandler.HoverContents.Markup(markup)
+        val json                        = encode(v)
+        assert(json.contains("kind"))
+    }
+
+    // ---- DocumentDiagnosticReport ----
+
+    "DocumentDiagnosticReport.Full round-trips" in {
+        val diag = LspHandler.Diagnostic(
+            range = range0,
+            severity = Present(LspHandler.DiagnosticSeverity.Error),
+            message = "error message"
+        )
+        val v: LspHandler.DocumentDiagnosticReport = LspHandler.DocumentDiagnosticReport.Full(
+            items = Chunk(diag)
+        )
+        assert(roundtrip(v) == v)
+    }
+
+    "DocumentDiagnosticReport.Unchanged round-trips" in {
+        val v: LspHandler.DocumentDiagnosticReport = LspHandler.DocumentDiagnosticReport.Unchanged(
+            resultId = "result-1"
+        )
+        assert(roundtrip(v) == v)
+    }
+
+    "DocumentDiagnosticReport.Full encodes with kind=full" in {
+        val v: LspHandler.DocumentDiagnosticReport = LspHandler.DocumentDiagnosticReport.Full(items = Chunk.empty)
+        val json                                   = encode(v)
+        assert(json.contains("\"kind\":\"full\""))
+    }
+
+    // ---- WorkspaceDocumentDiagnosticReport ----
+
+    "WorkspaceDocumentDiagnosticReport.Full round-trips" in {
+        val uri = LspHandler.LspDocument.Uri.fromWire("file:///test.scala")
+        val v: LspHandler.WorkspaceDocumentDiagnosticReport = LspHandler.WorkspaceDocumentDiagnosticReport.Full(
+            uri = uri,
+            items = Chunk.empty
+        )
+        assert(roundtrip(v) == v)
+    }
+
+    "WorkspaceDocumentDiagnosticReport.Unchanged round-trips" in {
+        val uri = LspHandler.LspDocument.Uri.fromWire("file:///test.scala")
+        val v: LspHandler.WorkspaceDocumentDiagnosticReport = LspHandler.WorkspaceDocumentDiagnosticReport.Unchanged(
+            uri = uri,
+            resultId = "r1"
+        )
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- DocumentSymbolResult ----
+
+    "DocumentSymbolResult.Symbols round-trips empty" in {
+        val v: LspHandler.DocumentSymbolResult = LspHandler.DocumentSymbolResult.Symbols(Chunk.empty)
+        assert(roundtrip(v) == v)
+    }
+
+    "DocumentSymbolResult.Symbols round-trips with one entry" in {
+        val ds = LspHandler.DocumentSymbol(
+            name = "myClass",
+            kind = LspHandler.SymbolKind.Class,
+            range = range0,
+            selectionRange = range0
+        )
+        val v: LspHandler.DocumentSymbolResult = LspHandler.DocumentSymbolResult.Symbols(Chunk(ds))
+        assert(roundtrip(v) == v)
+    }
+
+    "DocumentSymbolResult.Information round-trips" in {
+        val si = LspHandler.SymbolInformation(
+            name = "myVar",
+            kind = LspHandler.SymbolKind.Variable,
+            location = loc0
+        )
+        val v: LspHandler.DocumentSymbolResult = LspHandler.DocumentSymbolResult.Information(Chunk(si))
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- WorkspaceSymbolLocation ----
+
+    "WorkspaceSymbolLocation.WithRange round-trips" in {
+        val uri                                   = LspHandler.LspDocument.Uri.fromWire("file:///test.scala")
+        val v: LspHandler.WorkspaceSymbolLocation = LspHandler.WorkspaceSymbolLocation.WithRange(uri, range0)
+        assert(roundtrip(v) == v)
+    }
+
+    "WorkspaceSymbolLocation.UriOnly round-trips" in {
+        val uri                                   = LspHandler.LspDocument.Uri.fromWire("file:///test.scala")
+        val v: LspHandler.WorkspaceSymbolLocation = LspHandler.WorkspaceSymbolLocation.UriOnly(uri)
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- CompletionResult ----
+
+    "CompletionResult.Items round-trips empty" in {
+        val v: LspHandler.CompletionResult = LspHandler.CompletionResult.Items(Chunk.empty)
+        assert(roundtrip(v) == v)
+    }
+
+    "CompletionResult.Items round-trips with one item" in {
+        val item                           = LspHandler.CompletionItem(label = "myMethod")
+        val v: LspHandler.CompletionResult = LspHandler.CompletionResult.Items(Chunk(item))
+        assert(roundtrip(v) == v)
+    }
+
+    "CompletionResult.List round-trips" in {
+        val list = LspHandler.CompletionList(
+            isIncomplete = false,
+            items = Chunk(LspHandler.CompletionItem(label = "foo"))
+        )
+        val v: LspHandler.CompletionResult = LspHandler.CompletionResult.List(list)
+        assert(roundtrip(v) == v)
+    }
+
+    "CompletionResult.Items encodes as JSON array" in {
+        val v: LspHandler.CompletionResult = LspHandler.CompletionResult.Items(Chunk.empty)
+        val json                           = encode(v)
+        assert(json == "[]")
+    }
+
+    // ---- ParameterLabel ----
+
+    "ParameterLabel.StringLabel round-trips" in {
+        val v: LspHandler.ParameterLabel = LspHandler.ParameterLabel.StringLabel("param")
+        assert(roundtrip(v) == v)
+    }
+
+    "ParameterLabel.RangeLabel round-trips" in {
+        val v: LspHandler.ParameterLabel = LspHandler.ParameterLabel.RangeLabel(0, 5)
+        assert(roundtrip(v) == v)
+    }
+
+    "ParameterLabel.StringLabel encodes as string" in {
+        val v: LspHandler.ParameterLabel = LspHandler.ParameterLabel.StringLabel("p")
+        assert(encode(v) == "\"p\"")
+    }
+
+    "ParameterLabel.RangeLabel encodes as array" in {
+        val v: LspHandler.ParameterLabel = LspHandler.ParameterLabel.RangeLabel(2, 7)
+        assert(encode(v) == "[2,7]")
+    }
+
+    // ---- CommandOrCodeAction ----
+
+    "CommandOrCodeAction.Cmd round-trips" in {
+        val cmd                               = LspHandler.Command(title = "Run", command = "run.action")
+        val v: LspHandler.CommandOrCodeAction = LspHandler.CommandOrCodeAction.Cmd(cmd)
+        assert(roundtrip(v) == v)
+    }
+
+    "CommandOrCodeAction.Action round-trips" in {
+        val action = LspHandler.CodeAction(
+            title = "Fix",
+            isPreferred = Present(true)
+        )
+        val v: LspHandler.CommandOrCodeAction = LspHandler.CommandOrCodeAction.Action(action)
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- WorkspaceEditDocumentChange ----
+
+    "WorkspaceEditDocumentChange.Create round-trips" in {
+        val create = LspHandler.CreateFile(uri = LspHandler.LspDocument.Uri.fromWire("file:///new.scala"))
+        val v: LspHandler.WorkspaceEditDocumentChange = LspHandler.WorkspaceEditDocumentChange.Create(create)
+        assert(roundtrip(v) == v)
+    }
+
+    "WorkspaceEditDocumentChange.Delete round-trips" in {
+        val delete = LspHandler.DeleteFile(uri = LspHandler.LspDocument.Uri.fromWire("file:///old.scala"))
+        val v: LspHandler.WorkspaceEditDocumentChange = LspHandler.WorkspaceEditDocumentChange.Delete(delete)
+        assert(roundtrip(v) == v)
+    }
+
+    "WorkspaceEditDocumentChange.Create encodes with kind=create" in {
+        val create = LspHandler.CreateFile(uri = LspHandler.LspDocument.Uri.fromWire("file:///new.scala"))
+        val v: LspHandler.WorkspaceEditDocumentChange = LspHandler.WorkspaceEditDocumentChange.Create(create)
+        val json                                      = encode(v)
+        assert(json.contains("\"kind\":\"create\""))
+    }
+
+    // ---- PrepareRenameResult ----
+
+    "PrepareRenameResult.JustRange round-trips" in {
+        val v: LspHandler.PrepareRenameResult = LspHandler.PrepareRenameResult.JustRange(range0)
+        assert(roundtrip(v) == v)
+    }
+
+    "PrepareRenameResult.RangeWithPlaceholder round-trips" in {
+        val v: LspHandler.PrepareRenameResult = LspHandler.PrepareRenameResult.RangeWithPlaceholder(range0, "oldName")
+        assert(roundtrip(v) == v)
+    }
+
+    "PrepareRenameResult.DefaultBehavior round-trips" in {
+        val v: LspHandler.PrepareRenameResult = LspHandler.PrepareRenameResult.DefaultBehavior(true)
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- DefinitionResult ----
+
+    "DefinitionResult.One round-trips" in {
+        val v: LspHandler.DefinitionResult = LspHandler.DefinitionResult.One(loc0)
+        assert(roundtrip(v) == v)
+    }
+
+    "DefinitionResult.Many round-trips empty" in {
+        val v: LspHandler.DefinitionResult = LspHandler.DefinitionResult.Many(Chunk.empty)
+        assert(roundtrip(v) == v)
+    }
+
+    "DefinitionResult.Many round-trips with items" in {
+        val v: LspHandler.DefinitionResult = LspHandler.DefinitionResult.Many(Chunk(loc0))
+        assert(roundtrip(v) == v)
+    }
+
+    "DefinitionResult.Links round-trips" in {
+        val v: LspHandler.DefinitionResult = LspHandler.DefinitionResult.Links(Chunk(link0))
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- DeclarationResult ----
+
+    "DeclarationResult.One round-trips" in {
+        val v: LspHandler.DeclarationResult = LspHandler.DeclarationResult.One(loc0)
+        assert(roundtrip(v) == v)
+    }
+
+    "DeclarationResult.Many round-trips" in {
+        val v: LspHandler.DeclarationResult = LspHandler.DeclarationResult.Many(Chunk(loc0))
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- TypeDefinitionResult ----
+
+    "TypeDefinitionResult.One round-trips" in {
+        val v: LspHandler.TypeDefinitionResult = LspHandler.TypeDefinitionResult.One(loc0)
+        assert(roundtrip(v) == v)
+    }
+
+    "TypeDefinitionResult.Links round-trips" in {
+        val v: LspHandler.TypeDefinitionResult = LspHandler.TypeDefinitionResult.Links(Chunk(link0))
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- ImplementationResult ----
+
+    "ImplementationResult.One round-trips" in {
+        val v: LspHandler.ImplementationResult = LspHandler.ImplementationResult.One(loc0)
+        assert(roundtrip(v) == v)
+    }
+
+    "ImplementationResult.Many round-trips" in {
+        val v: LspHandler.ImplementationResult = LspHandler.ImplementationResult.Many(Chunk(loc0, loc0))
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- SemanticTokensResult ----
+
+    "SemanticTokensResult.Full round-trips" in {
+        val tokens                             = LspHandler.SemanticTokens(data = Chunk(1, 2, 3, 4, 5))
+        val v: LspHandler.SemanticTokensResult = LspHandler.SemanticTokensResult.Full(tokens)
+        assert(roundtrip(v) == v)
+    }
+
+    "SemanticTokensResult.Delta round-trips" in {
+        val edit                               = LspHandler.SemanticTokensEdit(start = 0, deleteCount = 2, data = Chunk(1, 2))
+        val delta                              = LspHandler.SemanticTokensDelta(edits = Chunk(edit))
+        val v: LspHandler.SemanticTokensResult = LspHandler.SemanticTokensResult.Delta(delta)
+        assert(roundtrip(v) == v)
+    }
+
+    "SemanticTokensResult.Full encodes with data field" in {
+        val tokens                             = LspHandler.SemanticTokens(data = Chunk(1))
+        val v: LspHandler.SemanticTokensResult = LspHandler.SemanticTokensResult.Full(tokens)
+        val json                               = encode(v)
+        assert(json.contains("data"))
+        assert(!json.contains("edits"))
+    }
+
+    "SemanticTokensResult.Delta encodes with edits field" in {
+        val delta                              = LspHandler.SemanticTokensDelta(edits = Chunk.empty)
+        val v: LspHandler.SemanticTokensResult = LspHandler.SemanticTokensResult.Delta(delta)
+        val json                               = encode(v)
+        assert(json.contains("edits"))
+    }
+
+    // ---- InlayHintLabelPart ----
+
+    "InlayHintLabelPart.StringPart round-trips" in {
+        val v: LspHandler.InlayHintLabelPart = LspHandler.InlayHintLabelPart.StringPart("label")
+        assert(roundtrip(v) == v)
+    }
+
+    "InlayHintLabelPart.StructuredPart round-trips" in {
+        val v: LspHandler.InlayHintLabelPart = LspHandler.InlayHintLabelPart.StructuredPart(value = "x")
+        assert(roundtrip(v) == v)
+    }
+
+    "InlayHintLabelPart.StringPart encodes as JSON string" in {
+        val v: LspHandler.InlayHintLabelPart = LspHandler.InlayHintLabelPart.StringPart("hi")
+        assert(encode(v) == "\"hi\"")
+    }
+
+    // ---- InlayHintLabel ----
+
+    "InlayHintLabel.PlainString round-trips" in {
+        val v: LspHandler.InlayHintLabel = LspHandler.InlayHintLabel.PlainString("label")
+        assert(roundtrip(v) == v)
+    }
+
+    "InlayHintLabel.Parts round-trips" in {
+        val v: LspHandler.InlayHintLabel = LspHandler.InlayHintLabel.Parts(
+            Chunk(LspHandler.InlayHintLabelPart.StringPart("a"))
+        )
+        assert(roundtrip(v) == v)
+    }
+
+    "InlayHintLabel.PlainString encodes as JSON string" in {
+        val v: LspHandler.InlayHintLabel = LspHandler.InlayHintLabel.PlainString("x")
+        assert(encode(v) == "\"x\"")
+    }
+
+    // ---- InlineValue ----
+
+    "InlineValue.Text round-trips" in {
+        val v: LspHandler.InlineValue = LspHandler.InlineValue.Text(range0, "hello")
+        assert(roundtrip(v) == v)
+    }
+
+    "InlineValue.VariableLookup round-trips" in {
+        val v: LspHandler.InlineValue = LspHandler.InlineValue.VariableLookup(
+            range0,
+            Present("myVar"),
+            caseSensitiveLookup = true
+        )
+        assert(roundtrip(v) == v)
+    }
+
+    "InlineValue.EvaluatableExpression round-trips" in {
+        val v: LspHandler.InlineValue = LspHandler.InlineValue.EvaluatableExpression(range0, Present("x + 1"))
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- NotebookDocumentFilter ----
+
+    "NotebookDocumentFilter.WithNotebookType round-trips" in {
+        val v: LspHandler.NotebookDocumentFilter = LspHandler.NotebookDocumentFilter.WithNotebookType("jupyter")
+        assert(roundtrip(v) == v)
+    }
+
+    "NotebookDocumentFilter.WithScheme round-trips" in {
+        val v: LspHandler.NotebookDocumentFilter = LspHandler.NotebookDocumentFilter.WithScheme(scheme = "file")
+        assert(roundtrip(v) == v)
+    }
+
+    "NotebookDocumentFilter.WithPattern round-trips" in {
+        val v: LspHandler.NotebookDocumentFilter = LspHandler.NotebookDocumentFilter.WithPattern(pattern = "**/*.ipynb")
+        assert(roundtrip(v) == v)
+    }
+
+    // ---- Registration ----
+
+    "Registration without options round-trips" in {
+        val v       = LspHandler.Registration("reg-1", "textDocument/completion")
+        val encoded = encode(v)
+        val back    = decode[LspHandler.Registration](encoded)
+        assert(back.id == "reg-1")
+        assert(back.method == "textDocument/completion")
+        assert(back._rawRegisterOptions.isEmpty)
+    }
+
+    "Registration with options round-trips id and method" in {
+        val v       = LspHandler.Registration("reg-2", "textDocument/hover", LspHandler.HoverOptions())
+        val encoded = encode(v)
+        val back    = decode[LspHandler.Registration](encoded)
+        assert(back.id == "reg-2")
+        assert(back.method == "textDocument/hover")
+    }
+
+end LspResultShapesTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspServerReverseMethodsTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspServerReverseMethodsTest.scala
@@ -1,0 +1,230 @@
+package kyo.internal
+
+import kyo.*
+
+/** Verifies that LspServer extension surface covers the ClientHandled Kind set.
+  *
+  * Reflects the method names on the LspServer opaque type's extension block and asserts
+  * the expected reverse-direction methods are present. A missing method fails this gate.
+  */
+class LspServerReverseMethodsTest extends Test:
+
+    private val clientInfo = LspInfo("rev-client", "0.0.0")
+    private val clientCaps = LspCapabilities.Client.empty
+
+    /** Starts a server and a client (carrying `clientHandlers` for the reverse-direction requests the
+      * server issues) over an in-memory pair, then runs `call(server)` so the server can drive a
+      * request back to the client and observe its handler's response. Scope-managed.
+      */
+    private def reverse[A](clientHandlers: LspHandler[?, ?, ?]*)(
+        call: LspServer => A < (Async & Abort[LspException])
+    )(using Frame): Result[LspException, A] < (Async & Scope) =
+        JsonRpcTransport.inMemory.flatMap { (ta, tb) =>
+            LspServer.init(ta).flatMap { server =>
+                Abort.run[LspException](
+                    LspClient.init(tb, clientInfo, clientCaps, clientHandlers*).andThen(call(server))
+                )
+            }
+        }
+
+    "showMessage is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                // Verify the method is callable with the correct param type.
+                val params = LspHandler.ShowMessageParams(LspHandler.MessageType.Info, "test")
+                val _: Unit < (Async & Abort[LspConnectionClosedException]) = server.showMessage(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "showMessageRequest round-trips: server asks, client handler answers" in {
+        val item    = LspHandler.MessageActionItem("Retry")
+        val clientH = LspHandler.Window.showMessageRequest { _ => Present(item) }
+        val params  = LspHandler.ShowMessageRequestParams(LspHandler.MessageType.Info, "pick one", Chunk(item))
+        Scope.run(reverse(clientH)(_.showMessageRequest(params))).map {
+            case Result.Success(result) => assert(result == Present(item))
+            case other                  => fail(s"showMessageRequest: $other")
+        }
+    }
+
+    "showDocument is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params = LspHandler.ShowDocumentParams(uri = "file:///Main.scala")
+                val _: LspHandler.ShowDocumentResult < (Async & Abort[LspRequestFailure]) = server.showDocument(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "logMessage is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params = LspHandler.LogMessageParams(LspHandler.MessageType.Log, "debug")
+                val _: Unit < (Async & Abort[LspConnectionClosedException]) = server.logMessage(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "createWorkDoneProgress is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val token                                        = LspHandler.ProgressToken.StringToken("test-token")
+                val params                                       = LspHandler.WorkDoneProgressCreateParams(token)
+                val _: Unit < (Async & Abort[LspRequestFailure]) = server.createWorkDoneProgress(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "telemetry is defined on LspServer" in {
+        case class TelemetryData(event: String) derives Schema
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Unit < (Async & Abort[LspConnectionClosedException]) = server.telemetry(TelemetryData("startup"))
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "applyEdit round-trips: server requests an edit, client handler reports the result" in {
+        val clientH = LspHandler.Workspace.applyEdit { _ =>
+            LspHandler.ApplyWorkspaceEditResult(applied = true)
+        }
+        val params = LspHandler.ApplyWorkspaceEditParams(edit = LspHandler.WorkspaceEdit())
+        Scope.run(reverse(clientH)(_.applyEdit(params))).map {
+            case Result.Success(result) => assert(result.applied)
+            case other                  => fail(s"applyEdit: $other")
+        }
+    }
+
+    "getConfiguration is defined on LspServer" in {
+        case class MyConfig(value: String) derives Schema
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val item                                                    = LspHandler.ConfigurationItem()
+                val params                                                  = LspHandler.ConfigurationParams(Chunk(item))
+                val _: Chunk[MyConfig] < (Async & Abort[LspRequestFailure]) = server.getConfiguration[MyConfig](params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "getWorkspaceFolders is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Maybe[Chunk[LspHandler.WorkspaceFolder]] < (Async & Abort[LspRequestFailure]) =
+                    server.getWorkspaceFolders
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "refreshSemanticTokens is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Unit < (Async & Abort[LspRequestFailure]) = server.refreshSemanticTokens
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "refreshInlineValue is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Unit < (Async & Abort[LspRequestFailure]) = server.refreshInlineValue
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "refreshInlayHint is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Unit < (Async & Abort[LspRequestFailure]) = server.refreshInlayHint
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "refreshDiagnostic is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Unit < (Async & Abort[LspRequestFailure]) = server.refreshDiagnostic
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "refreshCodeLens is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Unit < (Async & Abort[LspRequestFailure]) = server.refreshCodeLens
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "registerCapability is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params                                       = LspHandler.RegistrationParams(Chunk.empty)
+                val _: Unit < (Async & Abort[LspRequestFailure]) = server.registerCapability(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "unregisterCapability is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val params                                       = LspHandler.UnregistrationParams(Chunk.empty)
+                val _: Unit < (Async & Abort[LspRequestFailure]) = server.unregisterCapability(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "publishDiagnostics is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val uri                                                     = LspHandler.LspDocument.Uri.parse("file:///Main.scala").get
+                val params                                                  = LspHandler.PublishDiagnosticsParams(uri, Absent, Chunk.empty)
+                val _: Unit < (Async & Abort[LspConnectionClosedException]) = server.publishDiagnostics(params)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "logTrace is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Unit < (Async & Abort[LspConnectionClosedException]) = server.logTrace("trace msg")
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "workDoneProgress is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val token                                                   = LspHandler.ProgressToken.StringToken("wdp-token")
+                val value                                                   = LspHandler.WorkDoneProgressValue.Begin(title = "Working")
+                val _: Unit < (Async & Abort[LspConnectionClosedException]) = server.workDoneProgress(token, value)
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+    "cancel is defined on LspServer" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val _: Unit < (Async & Abort[LspConnectionClosedException]) = server.cancel(JsonRpcId(1L))
+                server.closeNow.andThen(succeed)
+            }
+        }
+    }
+
+end LspServerReverseMethodsTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/LspWireEnumSchemaTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/LspWireEnumSchemaTest.scala
@@ -1,0 +1,319 @@
+package kyo.internal
+
+import kyo.*
+
+/** Tests for all numeric-keyed and string-keyed LSP 3.17 enum schemas.
+  *
+  * Each enum encodes to its spec-mandated wire value (integer or string) and round-trips
+  * correctly. The "segments is empty" assertion confirms each schema uses transform (not
+  * derives Schema).
+  */
+class LspWireEnumSchemaTest extends Test:
+
+    private def encode[A: Schema](value: A): String = Json.encode[A](value)
+    private def decode[A: Schema](json: String): A  = Json.decode[A](json).getOrThrow
+    private def roundtrip[A: Schema](value: A): A   = decode[A](encode[A](value))
+
+    given CanEqual[Any, Any] = CanEqual.canEqualAny
+
+    // ---- DocumentHighlightKind ----
+
+    "DocumentHighlightKind.Text encodes to 1" in {
+        assert(encode[LspHandler.DocumentHighlightKind](LspHandler.DocumentHighlightKind.Text) == "1")
+    }
+    "DocumentHighlightKind.Read encodes to 2" in {
+        assert(encode[LspHandler.DocumentHighlightKind](LspHandler.DocumentHighlightKind.Read) == "2")
+    }
+    "DocumentHighlightKind.Write encodes to 3" in {
+        assert(encode[LspHandler.DocumentHighlightKind](LspHandler.DocumentHighlightKind.Write) == "3")
+    }
+    "DocumentHighlightKind round-trips all cases" in {
+        val cases = List(
+            LspHandler.DocumentHighlightKind.Text,
+            LspHandler.DocumentHighlightKind.Read,
+            LspHandler.DocumentHighlightKind.Write
+        )
+        assert(cases.forall(c => roundtrip(c) == c))
+    }
+    "DocumentHighlightKind schema uses transform" in {
+        assert(summon[Schema[LspHandler.DocumentHighlightKind]].segments.isEmpty)
+    }
+
+    // ---- TextDocumentSyncKind (None=0 is the special case) ----
+
+    "TextDocumentSyncKind.None encodes to 0" in {
+        assert(encode[LspHandler.TextDocumentSyncKind](LspHandler.TextDocumentSyncKind.None) == "0")
+    }
+    "TextDocumentSyncKind.Incremental encodes to 1" in {
+        assert(encode[LspHandler.TextDocumentSyncKind](LspHandler.TextDocumentSyncKind.Incremental) == "1")
+    }
+    "TextDocumentSyncKind.Full encodes to 2" in {
+        assert(encode[LspHandler.TextDocumentSyncKind](LspHandler.TextDocumentSyncKind.Full) == "2")
+    }
+    "TextDocumentSyncKind round-trips all cases" in {
+        val cases = List(
+            LspHandler.TextDocumentSyncKind.None,
+            LspHandler.TextDocumentSyncKind.Incremental,
+            LspHandler.TextDocumentSyncKind.Full
+        )
+        assert(cases.forall(c => roundtrip(c) == c))
+    }
+
+    // ---- TextDocumentSaveReason ----
+
+    "TextDocumentSaveReason.Manual encodes to 1" in {
+        assert(encode[LspHandler.TextDocumentSaveReason](LspHandler.TextDocumentSaveReason.Manual) == "1")
+    }
+    "TextDocumentSaveReason.AfterDelay encodes to 2" in {
+        assert(encode[LspHandler.TextDocumentSaveReason](LspHandler.TextDocumentSaveReason.AfterDelay) == "2")
+    }
+    "TextDocumentSaveReason.FocusOut encodes to 3" in {
+        assert(encode[LspHandler.TextDocumentSaveReason](LspHandler.TextDocumentSaveReason.FocusOut) == "3")
+    }
+    "TextDocumentSaveReason round-trips all cases" in {
+        val cases = List(
+            LspHandler.TextDocumentSaveReason.Manual,
+            LspHandler.TextDocumentSaveReason.AfterDelay,
+            LspHandler.TextDocumentSaveReason.FocusOut
+        )
+        assert(cases.forall(c => roundtrip(c) == c))
+    }
+
+    // ---- DiagnosticSeverity ----
+
+    "DiagnosticSeverity.Error encodes to 1" in {
+        assert(encode[LspHandler.DiagnosticSeverity](LspHandler.DiagnosticSeverity.Error) == "1")
+    }
+    "DiagnosticSeverity.Warning encodes to 2" in {
+        assert(encode[LspHandler.DiagnosticSeverity](LspHandler.DiagnosticSeverity.Warning) == "2")
+    }
+    "DiagnosticSeverity.Information encodes to 3" in {
+        assert(encode[LspHandler.DiagnosticSeverity](LspHandler.DiagnosticSeverity.Information) == "3")
+    }
+    "DiagnosticSeverity.Hint encodes to 4" in {
+        assert(encode[LspHandler.DiagnosticSeverity](LspHandler.DiagnosticSeverity.Hint) == "4")
+    }
+    "DiagnosticSeverity round-trips all 4 cases" in {
+        val cases = List(
+            LspHandler.DiagnosticSeverity.Error,
+            LspHandler.DiagnosticSeverity.Warning,
+            LspHandler.DiagnosticSeverity.Information,
+            LspHandler.DiagnosticSeverity.Hint
+        )
+        assert(cases.forall(c => roundtrip(c) == c))
+    }
+
+    // ---- DiagnosticTag ----
+
+    "DiagnosticTag.Unnecessary encodes to 1" in {
+        assert(encode[LspHandler.DiagnosticTag](LspHandler.DiagnosticTag.Unnecessary) == "1")
+    }
+    "DiagnosticTag.Deprecated encodes to 2" in {
+        assert(encode[LspHandler.DiagnosticTag](LspHandler.DiagnosticTag.Deprecated) == "2")
+    }
+
+    // ---- SymbolKind (File=1..TypeParameter=26) ----
+
+    "SymbolKind.File encodes to 1" in {
+        assert(encode[LspHandler.SymbolKind](LspHandler.SymbolKind.File) == "1")
+    }
+    "SymbolKind.TypeParameter encodes to 26" in {
+        assert(encode[LspHandler.SymbolKind](LspHandler.SymbolKind.TypeParameter) == "26")
+    }
+    "SymbolKind.Class encodes to 5" in {
+        assert(encode[LspHandler.SymbolKind](LspHandler.SymbolKind.Class) == "5")
+    }
+    "SymbolKind round-trips all 26 cases" in {
+        val cases = LspHandler.SymbolKind.values.toList
+        assert(cases.size == 26)
+        assert(cases.forall(c => roundtrip(c) == c))
+    }
+
+    // ---- CompletionItemKind (Text=1..TypeParameter=25) ----
+
+    "CompletionItemKind.Text encodes to 1" in {
+        assert(encode[LspHandler.CompletionItemKind](LspHandler.CompletionItemKind.Text) == "1")
+    }
+    "CompletionItemKind.TypeParameter encodes to 25" in {
+        assert(encode[LspHandler.CompletionItemKind](LspHandler.CompletionItemKind.TypeParameter) == "25")
+    }
+    "CompletionItemKind round-trips all 25 cases" in {
+        val cases = LspHandler.CompletionItemKind.values.toList
+        assert(cases.size == 25)
+        assert(cases.forall(c => roundtrip(c) == c))
+    }
+
+    // ---- InsertTextFormat ----
+
+    "InsertTextFormat.PlainText encodes to 1" in {
+        assert(encode[LspHandler.InsertTextFormat](LspHandler.InsertTextFormat.PlainText) == "1")
+    }
+    "InsertTextFormat.Snippet encodes to 2" in {
+        assert(encode[LspHandler.InsertTextFormat](LspHandler.InsertTextFormat.Snippet) == "2")
+    }
+
+    // ---- InsertTextMode ----
+
+    "InsertTextMode.AsIs encodes to 1" in {
+        assert(encode[LspHandler.InsertTextMode](LspHandler.InsertTextMode.AsIs) == "1")
+    }
+    "InsertTextMode.AdjustIndentation encodes to 2" in {
+        assert(encode[LspHandler.InsertTextMode](LspHandler.InsertTextMode.AdjustIndentation) == "2")
+    }
+
+    // ---- CompletionTriggerKind ----
+
+    "CompletionTriggerKind.Invoked encodes to 1" in {
+        assert(encode[LspHandler.CompletionTriggerKind](LspHandler.CompletionTriggerKind.Invoked) == "1")
+    }
+    "CompletionTriggerKind.TriggerForIncompleteCompletions encodes to 3" in {
+        assert(encode[LspHandler.CompletionTriggerKind](LspHandler.CompletionTriggerKind.TriggerForIncompleteCompletions) == "3")
+    }
+
+    // ---- SignatureHelpTriggerKind ----
+
+    "SignatureHelpTriggerKind.Invoked encodes to 1" in {
+        assert(encode[LspHandler.SignatureHelpTriggerKind](LspHandler.SignatureHelpTriggerKind.Invoked) == "1")
+    }
+    "SignatureHelpTriggerKind.ContentChange encodes to 3" in {
+        assert(encode[LspHandler.SignatureHelpTriggerKind](LspHandler.SignatureHelpTriggerKind.ContentChange) == "3")
+    }
+
+    // ---- CodeActionTriggerKind ----
+
+    "CodeActionTriggerKind.Invoked encodes to 1" in {
+        assert(encode[LspHandler.CodeActionTriggerKind](LspHandler.CodeActionTriggerKind.Invoked) == "1")
+    }
+    "CodeActionTriggerKind.Automatic encodes to 2" in {
+        assert(encode[LspHandler.CodeActionTriggerKind](LspHandler.CodeActionTriggerKind.Automatic) == "2")
+    }
+
+    // ---- InlayHintKind ----
+
+    "InlayHintKind.Type encodes to 1" in {
+        assert(encode[LspHandler.InlayHintKind](LspHandler.InlayHintKind.Type) == "1")
+    }
+    "InlayHintKind.Parameter encodes to 2" in {
+        assert(encode[LspHandler.InlayHintKind](LspHandler.InlayHintKind.Parameter) == "2")
+    }
+
+    // ---- NotebookCellKind ----
+
+    "NotebookCellKind.Markup encodes to 1" in {
+        assert(encode[LspHandler.NotebookCellKind](LspHandler.NotebookCellKind.Markup) == "1")
+    }
+    "NotebookCellKind.Code encodes to 2" in {
+        assert(encode[LspHandler.NotebookCellKind](LspHandler.NotebookCellKind.Code) == "2")
+    }
+
+    // ---- MessageType ----
+
+    "MessageType.Error encodes to 1" in {
+        assert(encode[LspHandler.MessageType](LspHandler.MessageType.Error) == "1")
+    }
+    "MessageType.Warning encodes to 2" in {
+        assert(encode[LspHandler.MessageType](LspHandler.MessageType.Warning) == "2")
+    }
+    "MessageType.Info encodes to 3" in {
+        assert(encode[LspHandler.MessageType](LspHandler.MessageType.Info) == "3")
+    }
+    "MessageType.Log encodes to 4" in {
+        assert(encode[LspHandler.MessageType](LspHandler.MessageType.Log) == "4")
+    }
+    "MessageType.Debug encodes to 5" in {
+        assert(encode[LspHandler.MessageType](LspHandler.MessageType.Debug) == "5")
+    }
+    "MessageType round-trips all 5 cases" in {
+        val cases = LspHandler.MessageType.values.toList
+        assert(cases.size == 5)
+        assert(cases.forall(c => roundtrip(c) == c))
+    }
+
+    // ---- FileChangeType ----
+
+    "FileChangeType.Created encodes to 1" in {
+        assert(encode[LspHandler.FileChangeType](LspHandler.FileChangeType.Created) == "1")
+    }
+    "FileChangeType.Changed encodes to 2" in {
+        assert(encode[LspHandler.FileChangeType](LspHandler.FileChangeType.Changed) == "2")
+    }
+    "FileChangeType.Deleted encodes to 3" in {
+        assert(encode[LspHandler.FileChangeType](LspHandler.FileChangeType.Deleted) == "3")
+    }
+
+    // ---- String-keyed enum schemas ----
+
+    "MarkupKind.PlainText encodes to \"plaintext\"" in {
+        assert(encode[LspHandler.MarkupKind](LspHandler.MarkupKind.PlainText) == "\"plaintext\"")
+    }
+    "MarkupKind.Markdown encodes to \"markdown\"" in {
+        assert(encode[LspHandler.MarkupKind](LspHandler.MarkupKind.Markdown) == "\"markdown\"")
+    }
+    "MarkupKind round-trips both cases" in {
+        assert(roundtrip[LspHandler.MarkupKind](LspHandler.MarkupKind.PlainText) == LspHandler.MarkupKind.PlainText)
+        assert(roundtrip[LspHandler.MarkupKind](LspHandler.MarkupKind.Markdown) == LspHandler.MarkupKind.Markdown)
+    }
+    "MarkupKind schema uses transform" in {
+        assert(summon[Schema[LspHandler.MarkupKind]].segments.isEmpty)
+    }
+
+    "ResourceOperationKind.Create encodes to \"create\"" in {
+        assert(encode[LspHandler.ResourceOperationKind](LspHandler.ResourceOperationKind.Create) == "\"create\"")
+    }
+    "ResourceOperationKind.Rename encodes to \"rename\"" in {
+        assert(encode[LspHandler.ResourceOperationKind](LspHandler.ResourceOperationKind.Rename) == "\"rename\"")
+    }
+    "ResourceOperationKind.Delete encodes to \"delete\"" in {
+        assert(encode[LspHandler.ResourceOperationKind](LspHandler.ResourceOperationKind.Delete) == "\"delete\"")
+    }
+    "ResourceOperationKind round-trips all 3 cases" in {
+        val cases = List(
+            LspHandler.ResourceOperationKind.Create,
+            LspHandler.ResourceOperationKind.Rename,
+            LspHandler.ResourceOperationKind.Delete
+        )
+        assert(cases.forall(c => roundtrip(c) == c))
+    }
+
+    "MonikerKind.Import encodes to \"import\"" in {
+        assert(encode[LspHandler.MonikerKind](LspHandler.MonikerKind.Import) == "\"import\"")
+    }
+    "MonikerKind.Export encodes to \"export\"" in {
+        assert(encode[LspHandler.MonikerKind](LspHandler.MonikerKind.Export) == "\"export\"")
+    }
+    "MonikerKind.Local encodes to \"local\"" in {
+        assert(encode[LspHandler.MonikerKind](LspHandler.MonikerKind.Local) == "\"local\"")
+    }
+
+    "UniquenessLevel.Document encodes to \"document\"" in {
+        assert(encode[LspHandler.UniquenessLevel](LspHandler.UniquenessLevel.Document) == "\"document\"")
+    }
+    "UniquenessLevel.Global encodes to \"global\"" in {
+        assert(encode[LspHandler.UniquenessLevel](LspHandler.UniquenessLevel.Global) == "\"global\"")
+    }
+    "UniquenessLevel round-trips all 5 cases" in {
+        val cases = List(
+            LspHandler.UniquenessLevel.Document,
+            LspHandler.UniquenessLevel.Project,
+            LspHandler.UniquenessLevel.Group,
+            LspHandler.UniquenessLevel.Scheme,
+            LspHandler.UniquenessLevel.Global
+        )
+        assert(cases.forall(c => roundtrip(c) == c))
+    }
+
+    "FileOperationPatternKind.File encodes to \"file\"" in {
+        assert(encode[LspHandler.FileOperationPatternKind](LspHandler.FileOperationPatternKind.File) == "\"file\"")
+    }
+    "FileOperationPatternKind.Folder encodes to \"folder\"" in {
+        assert(encode[LspHandler.FileOperationPatternKind](LspHandler.FileOperationPatternKind.Folder) == "\"folder\"")
+    }
+    "FileOperationPatternKind round-trips both cases" in {
+        val cases = List(LspHandler.FileOperationPatternKind.File, LspHandler.FileOperationPatternKind.Folder)
+        assert(cases.forall(c => roundtrip(c) == c))
+    }
+    "FileOperationPatternKind schema uses transform" in {
+        assert(summon[Schema[LspHandler.FileOperationPatternKind]].segments.isEmpty)
+    }
+
+end LspWireEnumSchemaTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/OpaqueIdentityTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/OpaqueIdentityTest.scala
@@ -1,0 +1,66 @@
+package kyo
+
+/** Opaque identity tests verifying runtime-level identity for all opaque String types.
+  *
+  * Note: Scala 3 opaque type `=:=` proofs are only available inside the defining companion scope.
+  * External code verifies identity by testing that values are accepted and round-trip as strings.
+  */
+class OpaqueIdentityTest extends Test:
+
+    "LspDocument.Uri round-trips as String" in {
+        val uri = LspHandler.LspDocument.Uri.parse("file:///Main.scala").get
+        assert(uri.asString == "file:///Main.scala")
+    }
+
+    "CodeActionKind round-trips as String" in {
+        val k = LspHandler.CodeActionKind.QuickFix
+        assert(k.asString == "quickfix")
+        val custom = LspHandler.CodeActionKind("custom.action")
+        assert(custom.asString == "custom.action")
+    }
+
+    "FoldingRangeKind round-trips as String" in {
+        val k = LspHandler.FoldingRangeKind.Comment
+        assert(k.asString == "comment")
+        val custom = LspHandler.FoldingRangeKind("custom.kind")
+        assert(custom.asString == "custom.kind")
+    }
+
+    "SemanticTokenTypes round-trips as String" in {
+        val t = LspHandler.SemanticTokenTypes.Class
+        assert(t.asString == "class")
+        val custom = LspHandler.SemanticTokenTypes("custom")
+        assert(custom.asString == "custom")
+    }
+
+    "SemanticTokenModifiers round-trips as String" in {
+        val m = LspHandler.SemanticTokenModifiers.Readonly
+        assert(m.asString == "readonly")
+        val custom = LspHandler.SemanticTokenModifiers("custom")
+        assert(custom.asString == "custom")
+    }
+
+    "PositionEncodingKind round-trips as String" in {
+        val k = LspHandler.PositionEncodingKind.UTF16
+        assert(k.asString == "utf-16")
+    }
+
+    "TraceValue round-trips as String" in {
+        val v = LspHandler.TraceValue.Off
+        assert(v.asString == "off")
+    }
+
+    "LspServer round-trips through safe/unsafe bridge" in {
+        JsonRpcTransport.inMemory.map { (ta, _) =>
+            LspServer.initUnscoped(ta).flatMap { server =>
+                val back = server.unsafe.safe
+                server.closeNow.andThen {
+                    // The opaque alias `LspServer = LspServer.Unsafe`; safe returns `this`.
+                    // Both values are the same underlying object; verify via a stable property.
+                    assert(back.specVersion == "3.17")
+                }
+            }
+        }
+    }
+
+end OpaqueIdentityTest

--- a/kyo-lsp/shared/src/test/scala/kyo/internal/SchemaSingletonTest.scala
+++ b/kyo-lsp/shared/src/test/scala/kyo/internal/SchemaSingletonTest.scala
@@ -1,0 +1,154 @@
+package kyo.internal
+
+import kyo.*
+
+/** Tests that sealed-union Schemas are reference-stable singletons.
+  *
+  * Each `summon[Schema[T]]` call must return the same object reference as the
+  * val in `LspContentSchemas`. This is the singleton guarantee: not just equal,
+  * but the same reference.
+  */
+class SchemaSingletonTest extends Test:
+
+    given CanEqual[Any, Any] = CanEqual.canEqualAny
+
+    "TextDocumentContentChangeEvent schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.TextDocumentContentChangeEvent]]
+        val s2 = summon[Schema[LspHandler.TextDocumentContentChangeEvent]]
+        assert(s1 eq s2)
+    }
+
+    "ProgressToken schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.ProgressToken]]
+        val s2 = summon[Schema[LspHandler.ProgressToken]]
+        assert(s1 eq s2)
+    }
+
+    "MarkedString schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.MarkedString]]
+        val s2 = summon[Schema[LspHandler.MarkedString]]
+        assert(s1 eq s2)
+    }
+
+    "HoverContents schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.HoverContents]]
+        val s2 = summon[Schema[LspHandler.HoverContents]]
+        assert(s1 eq s2)
+    }
+
+    "DocumentSymbolResult schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.DocumentSymbolResult]]
+        val s2 = summon[Schema[LspHandler.DocumentSymbolResult]]
+        assert(s1 eq s2)
+    }
+
+    "WorkspaceSymbolLocation schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.WorkspaceSymbolLocation]]
+        val s2 = summon[Schema[LspHandler.WorkspaceSymbolLocation]]
+        assert(s1 eq s2)
+    }
+
+    "CompletionResult schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.CompletionResult]]
+        val s2 = summon[Schema[LspHandler.CompletionResult]]
+        assert(s1 eq s2)
+    }
+
+    "ParameterLabel schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.ParameterLabel]]
+        val s2 = summon[Schema[LspHandler.ParameterLabel]]
+        assert(s1 eq s2)
+    }
+
+    "CommandOrCodeAction schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.CommandOrCodeAction]]
+        val s2 = summon[Schema[LspHandler.CommandOrCodeAction]]
+        assert(s1 eq s2)
+    }
+
+    "WorkspaceEditDocumentChange schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.WorkspaceEditDocumentChange]]
+        val s2 = summon[Schema[LspHandler.WorkspaceEditDocumentChange]]
+        assert(s1 eq s2)
+    }
+
+    "PrepareRenameResult schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.PrepareRenameResult]]
+        val s2 = summon[Schema[LspHandler.PrepareRenameResult]]
+        assert(s1 eq s2)
+    }
+
+    "DefinitionResult schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.DefinitionResult]]
+        val s2 = summon[Schema[LspHandler.DefinitionResult]]
+        assert(s1 eq s2)
+    }
+
+    "DeclarationResult schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.DeclarationResult]]
+        val s2 = summon[Schema[LspHandler.DeclarationResult]]
+        assert(s1 eq s2)
+    }
+
+    "TypeDefinitionResult schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.TypeDefinitionResult]]
+        val s2 = summon[Schema[LspHandler.TypeDefinitionResult]]
+        assert(s1 eq s2)
+    }
+
+    "ImplementationResult schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.ImplementationResult]]
+        val s2 = summon[Schema[LspHandler.ImplementationResult]]
+        assert(s1 eq s2)
+    }
+
+    "SemanticTokensResult schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.SemanticTokensResult]]
+        val s2 = summon[Schema[LspHandler.SemanticTokensResult]]
+        assert(s1 eq s2)
+    }
+
+    "InlayHintLabelPart schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.InlayHintLabelPart]]
+        val s2 = summon[Schema[LspHandler.InlayHintLabelPart]]
+        assert(s1 eq s2)
+    }
+
+    "InlayHintLabel schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.InlayHintLabel]]
+        val s2 = summon[Schema[LspHandler.InlayHintLabel]]
+        assert(s1 eq s2)
+    }
+
+    "InlineValue schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.InlineValue]]
+        val s2 = summon[Schema[LspHandler.InlineValue]]
+        assert(s1 eq s2)
+    }
+
+    "NotebookDocumentFilter schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.NotebookDocumentFilter]]
+        val s2 = summon[Schema[LspHandler.NotebookDocumentFilter]]
+        assert(s1 eq s2)
+    }
+
+    "Registration schema is a singleton" in {
+        val s1 = summon[Schema[LspHandler.Registration]]
+        val s2 = summon[Schema[LspHandler.Registration]]
+        assert(s1 eq s2)
+    }
+
+    // BooleanOr / StringOr are NOT singletons (they are parameterized givens)
+    // but they should resolve to non-stub instances
+
+    "BooleanOr schema is non-null and non-throwing" in {
+        val s = summon[Schema[LspHandler.BooleanOr[LspHandler.SaveOptions]]]
+        assert(s != null)
+    }
+
+    "StringOr schema is non-null and non-throwing" in {
+        val s = summon[Schema[LspHandler.StringOr[LspHandler.SaveOptions]]]
+        assert(s != null)
+    }
+
+end SchemaSingletonTest


### PR DESCRIPTION
### Problem

kyo-jsonrpc provides JSON-RPC transports and a request/notification handler, but nothing above it understands the Language Server Protocol. Building an LSP server or client on raw JSON-RPC means hand-writing the initialize / initialized / shutdown / exit lifecycle, the LSP 3.17 message schemas, document synchronization, position-encoding negotiation, and capability gating in every project.

### Solution

kyo-lsp, a typed LSP server and client built on kyo-jsonrpc and a sibling of kyo-mcp.

- LspServer and LspClient, each with a scoped init quartet (init / initWith / initUnscoped / initUnscopedWith) over a JsonRpcTransport.
- LspHandler factories covering the LSP 3.17 surface, grouped by namespace (TextDocument, Workspace, Window, NotebookDocument, Client, General), with typed params and results, smart constructors for the common result shapes, and a typed .error[E2] mapping that surfaces domain failures as JSON-RPC errors.
- An engine that derives the server's advertised capabilities from the registered handlers, runs the initialize / initialized / shutdown / exit lifecycle through composable gates (handshake, shutdown, capability), negotiates the position encoding, and maintains a document registry the textDocument and notebookDocument sync routes feed before invoking user handlers.
- Reverse-direction (server-initiated) methods: applyEdit, configuration, showMessage / showMessageRequest, showDocument, work-done progress, and the refresh notifications.
- Wire-correct schemas for the LSP 3.17 union types the spec encodes untagged or shape-discriminated.

All engine state is created and read through the safe kyo effect API: refs and gate flags are allocated with AtomicRef.init / AtomicBoolean.init inside Sync, session state is read with ref.get, and the only Sync.Unsafe is the safe-tier API bridging to the unsafe handler via Sync.Unsafe.defer. The request and reverse-request data paths are exercised end to end by round-trip tests (client to server and server to client) and route-level tests.

### Notes

- Depends on kyo-jsonrpc only. One shared source tree; the only per-platform restriction is the JVM-only Unix-domain-socket transport inherited from kyo-jsonrpc.
- The hand-rolled union schemas in internal/lsp/LspContentSchemas mirror LSP's untagged / shape-discriminated wire forms, which kyo-schema cannot yet derive; they migrate to derived .untagged schemas once kyo-schema#1695 lands.
- Validated on JVM (test plus README doctest), JS, and Native.
