### PR TITLE
[test] make leaks and hangs diagnosable on first occurrence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -868,6 +868,23 @@ The string passed to `typeCheckFailure` is a substring match against the compile
 }
 ```
 
+### Debugging Hangs and Timeouts
+
+When a leaf stalls past the heartbeat interval or hits its timeout, the runner captures a full thread dump and every registered diagnostic snapshot alongside the failure. This makes a rare hang or deadlock root-causable from a single occurrence, rather than needing a second, instrumented reproduction.
+
+Runtime components publish their live internal state through the process-global registry `kyo.internal.Diagnostics`. Register a named dumper (typically at construction) and close the registration when the component shuts down so it does not accumulate across a long-lived process:
+
+```scala
+private val diag =
+    Diagnostics.register("ConnectionPool@" + java.lang.System.identityHashCode(this)) { () =>
+        s"active=${active.size} idle=[${idleKeys.mkString(" ")}]"
+    }
+// on shutdown:
+diag.close()
+```
+
+A dumper runs on the reporter's thread, concurrently with the component it inspects, so it must read state best-effort (a stale or partial snapshot is acceptable) and must never block. An I/O driver, for example, can register its pending-operation tables and poll/reap liveness counters this way.
+
 ### Exception and Failure Assertions
 
 `intercept[E](body)` asserts that `body` throws an exception of type `E` and returns the caught exception:

--- a/kyo-core/shared/src/main/scala/kyo/internal/Diagnostics.scala
+++ b/kyo-core/shared/src/main/scala/kyo/internal/Diagnostics.scala
@@ -1,0 +1,58 @@
+package kyo.internal
+
+/** Process-global registry of best-effort runtime state dumpers.
+  *
+  * A runtime component (a transport poller, a scheduler, a connection pool) registers a named thunk that renders a snapshot of its live
+  * internal state. A diagnostic consumer (the kyo-test runner when a leaf hangs, a signal handler, an admin endpoint) calls [[dumpAll]] to
+  * collect every registered snapshot at once.
+  *
+  * The point is to make a rare hang diagnosable on its FIRST occurrence: the state is captured at the moment the consumer asks, so a
+  * once-in-a-thousand-runs deadlock yields the poller's pending-fd map and liveness counters without needing a second, instrumented
+  * reproduction.
+  *
+  * This lives in kyo-core so production components can register without depending on the test framework; the test runner (which has kyo-core
+  * on its classpath) consumes it. The dumpers run on the consumer's thread, concurrently with the components they inspect, so each must read
+  * its state best-effort (a stale or partially-updated snapshot is acceptable, a throw is contained by [[dumpAll]]) and must never block.
+  *
+  * `synchronized` guards only the registry list (a no-op on single-threaded JS); the dumper thunks run outside the lock so a slow dumper
+  * cannot stall registration or other dumpers.
+  */
+private[kyo] object Diagnostics:
+
+    /** A live registration. Closing it removes the dumper, so a component that registered at construction unregisters at close and its state
+      * stops appearing in [[dumpAll]] (and cannot leak across a long-lived process).
+      */
+    final class Registration private[Diagnostics] (private val entry: AnyRef):
+        def close(): Unit = remove(entry)
+
+    final private case class Entry(name: String, dump: () => String)
+
+    private var entries: List[Entry] = Nil
+
+    /** Register a named state dumper. Returns a [[Registration]] whose `close()` removes it. */
+    def register(name: String)(dump: () => String): Registration =
+        val entry = Entry(name, dump)
+        synchronized { entries = entry :: entries }
+        new Registration(entry)
+    end register
+
+    private def remove(entry: AnyRef): Unit =
+        synchronized { entries = entries.filterNot(_ eq entry) }
+
+    /** Render every registered dumper's snapshot, each under its name. A dumper that throws is reported inline rather than aborting the rest,
+      * so one broken component never suppresses the others' state.
+      */
+    def dumpAll(): String =
+        val snapshot = synchronized { entries }
+        if snapshot.isEmpty then "Diagnostics: (no dumpers registered)"
+        else
+            snapshot.reverse.map { e =>
+                val body =
+                    try e.dump()
+                    catch case t: Throwable => "dump threw: " + t
+                "=== " + e.name + " ===\n" + body
+            }.mkString("\n")
+        end if
+    end dumpAll
+
+end Diagnostics

--- a/kyo-test/runner/js-wasm/src/main/scala/kyo/test/runner/internal/ThreadDump.scala
+++ b/kyo-test/runner/js-wasm/src/main/scala/kyo/test/runner/internal/ThreadDump.scala
@@ -1,0 +1,8 @@
+package kyo.test.runner.internal
+
+/** Hang-diagnostics thread dump. JS and Wasm are single-threaded with no thread enumeration, so this is a
+  * placeholder; the hang diagnostics still emit the cross-platform `kyo.internal.Diagnostics` snapshot.
+  */
+private[runner] object ThreadDump:
+    def render(): String = "\n(thread dump unavailable on JS)\n"
+end ThreadDump

--- a/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/internal/LeakCheck.scala
+++ b/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/internal/LeakCheck.scala
@@ -5,6 +5,7 @@ import java.nio.file.Paths
 import java.util.concurrent.locks.LockSupport
 import kyo.Chunk
 import kyo.Maybe
+import kyo.discard
 import kyo.scheduler.Scheduler
 import scala.jdk.CollectionConverters.*
 
@@ -25,15 +26,19 @@ import scala.jdk.CollectionConverters.*
 private[runner] object LeakCheck:
 
     /** Built-in allowlist patterns applied by [[detect]] in addition to each suite's `RunConfig.leakCheckAllowlist`, for process-lifetime infra
-      * that legitimately outlives every test in the fork.
+      * that legitimately outlives every test in the fork. Both entries name a process-shared I/O carrier that is never closed by design and so
+      * is a busy scheduler fiber at every net/http-using module's end-of-run check; the union covers both the current and the migrated network
+      * stack, so neither is reported as a leak.
       *
-      * `NioIoDriver` is allowlisted pending the network stack rewrite. kyo-http's process-wide IO transport (`HttpPlatformTransport.transport`)
-      * is a lazy singleton whose `NioIoDriver` runs a selector event loop on a scheduler fiber for the JVM's lifetime, and nothing ever closes
-      * the shared transport, so the fiber is parked in `select()` at every http-using module's end-of-run check. It is intentional infra, not a
-      * leak; excusing it here covers every http-touching test module in one place. The entry is removed once the network stack gives the driver
-      * a proper lifecycle (or moves its loop off the scheduler).
+      * `NioIoDriver` matches kyo-http's process-wide IO transport (`HttpPlatformTransport.transport`), a lazy singleton whose `NioIoDriver` runs
+      * a selector event loop on a scheduler fiber for the JVM's lifetime.
+      *
+      * `processSharedTransport` matches the I/O carrier of kyo-net's process-shared default transport (`kyo.net.NetPlatform.transport`): a lazy
+      * singleton shared across every client and server in the process and never closed by design. The kyo-net drivers route ONLY this singleton's
+      * carrier through a `processSharedTransport*` frame (see `kyo.net.internal.ProcessSharedTransport`); an owned, per-config transport keeps its
+      * plain `pollLoop`/`reapLoop` frame, so a genuinely leaked owned transport is still reported rather than masked by a broad driver-name match.
       */
-    val defaultAllowlist: Chunk[String] = Chunk("NioIoDriver")
+    val defaultAllowlist: Chunk[String] = Chunk("NioIoDriver", "processSharedTransport")
 
     /** The set of open file descriptors, each as its `/proc/self/fd` symlink target (`socket:[inode]`, `pipe:[inode]`, a file path, a `.jar`,
       * ...). `Absent` on a platform without `/proc/self/fd` (macOS, Windows), where the descriptor probe is a no-op. The descriptor that the
@@ -275,6 +280,30 @@ private[runner] object LeakCheck:
             scan("/proc/net/tcp").orElse(scan("/proc/net/tcp6")).getOrElse("")
     end describeSocket
 
+    /** Leak-debug attribution: descriptor target -> the leaf path that first left it open. Populated only in leak-debug mode (see
+      * [[LeakDebug]]), where leaves run serially and the runner's per-leaf probe records each leaf's surviving descriptors here; joined into the
+      * leak report by [[originOf]]. Empty (and never read) in a normal parallel run.
+      */
+    private val fdOrigins = new java.util.concurrent.ConcurrentHashMap[String, String]()
+
+    /** Record, against `leafPath`, every descriptor open after the leaf body that was not open before it (excluding benign descriptors). First
+      * writer wins, so the leaf that introduced a descriptor owns it. Called by the runner's per-leaf probe in leak-debug mode only.
+      */
+    def recordLeafOrigins(leafPath: String, before: Set[String], after: Set[String]): Unit =
+        after.foreach { target =>
+            if !before.contains(target) && !benignFd(target) then discard(fdOrigins.putIfAbsent(target, leafPath))
+        }
+    end recordLeafOrigins
+
+    /** The leak-debug attribution suffix for a leaked target: ` (opened by test: <leaf>)` when leak-debug mode recorded an origin, else "".
+      * A normal (non-debug) run records nothing, so this is always "" there and the report is unchanged.
+      */
+    def originOf(target: String): String =
+        fdOrigins.get(target) match
+            case null => ""
+            case leaf => s" (opened by test: $leaf)"
+    end originOf
+
     /** Process-global resource snapshot taken once at runner construction, before any suite runs, and diffed at `done()`. Captures the open
       * descriptor targets and the set of live non-daemon threads so the JVM's own startup infrastructure (the `main` thread, the ForkMain
       * reader and socket) is excluded from the diff.
@@ -348,7 +377,7 @@ private[runner] object LeakCheck:
                         val second     = leaksNow()
                         val persistent = first.filter(second.contains)
                         if persistent.nonEmpty then
-                            val described = persistent.map(t => t + describeSocket(t))
+                            val described = persistent.map(t => t + describeSocket(t) + originOf(t))
                             findings += s"file-descriptor leak (${persistent.size}): ${described.mkString("; ")}"
                     end if
                 case Maybe.Absent => () // /proc/self/fd unavailable: descriptor probe is a no-op on this platform.
@@ -366,8 +395,9 @@ private[runner] object LeakCheck:
     final class Detected(report: String)
         extends RuntimeException(
             s"kyo-test leak check failed:$report\n\nThese resources outlived the test run; a leaked fiber, thread, or descriptor means a " +
-                "test (or the code under test) did not release a resource. Disable for a suite with " +
-                "`override def config = super.config.leakCheck(false)`, or excuse one expected resource with " +
+                "test (or the code under test) did not release a resource. To attribute each leaked descriptor to the test that opened it, " +
+                "re-run with KYO_TEST_LEAK_DEBUG=1 (runs leaves serially and appends `opened by test: <leaf>` to each descriptor). Disable " +
+                "for a suite with `override def config = super.config.leakCheck(false)`, or excuse one expected resource with " +
                 "`super.config.leakCheckAllowlist(\"<stack-or-target-substring>\")`."
         )
 

--- a/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/internal/SbtRunner.scala
+++ b/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/internal/SbtRunner.scala
@@ -67,6 +67,16 @@ final private[runner] class SbtRunner(
     private val leakBaseline = if forked then LeakCheck.baseline() else LeakCheck.Baseline(kyo.Maybe.empty, Set.empty)
     private val leakCheckRan = new java.util.concurrent.atomic.AtomicBoolean(false)
 
+    // Leak-debug mode (KYO_TEST_LEAK_DEBUG=1): leaves are forced serial (LeafPool.globalK = 1), so install a per-leaf probe that snapshots the
+    // open descriptors around each leaf and records which descriptors the leaf left open. The end-of-run leak report then attributes each leaked
+    // descriptor to the test that opened it (see LeakCheck.originOf). Only in a forked JVM, where the descriptor probe is sound.
+    if forked && LeakDebug.enabled then
+        LeakDebug.leafProbe = kyo.Maybe((path: Chunk[String]) =>
+            val before = LeakCheck.openFdTargets().getOrElse(Set.empty)
+            () => LeakCheck.recordLeafOrigins(path.mkString(" > "), before, LeakCheck.openFdTargets().getOrElse(Set.empty))
+        )
+    end if
+
     // Populated on first tasks() invocation. SuiteDiscovery scans the META-INF/services file
     // and surfaces classloader / non-TestBase failures so they end up in Summary's warning line.
     private[runner] val discoveryErrors: AtomicReference[Chunk[String]] =

--- a/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/internal/ThreadDump.scala
+++ b/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/internal/ThreadDump.scala
@@ -1,0 +1,15 @@
+package kyo.test.runner.internal
+
+/** Hang-diagnostics thread dump. On the JVM this renders every live thread's name, state, and stack via
+  * `Thread.getAllStackTraces`, so a STUCK leaf's dump shows exactly where each thread is parked.
+  */
+private[runner] object ThreadDump:
+    def render(): String =
+        val sb = new StringBuilder
+        Thread.getAllStackTraces.forEach { (t, st) =>
+            sb.append("\n--- " + t.getName + " (" + t.getState + ") ---\n")
+            st.foreach(f => sb.append("  at " + f + "\n"))
+        }
+        sb.toString
+    end render
+end ThreadDump

--- a/kyo-test/runner/native/src/main/scala/kyo/test/runner/internal/ThreadDump.scala
+++ b/kyo-test/runner/native/src/main/scala/kyo/test/runner/internal/ThreadDump.scala
@@ -1,0 +1,8 @@
+package kyo.test.runner.internal
+
+/** Hang-diagnostics thread dump. Scala Native exposes no portable all-thread stack capture, so this is a
+  * placeholder; the hang diagnostics still emit the cross-platform `kyo.internal.Diagnostics` snapshot.
+  */
+private[runner] object ThreadDump:
+    def render(): String = "\n(thread dump unavailable on Scala Native)\n"
+end ThreadDump

--- a/kyo-test/runner/shared/src/main/scala/kyo/test/runner/ConsoleReporter.scala
+++ b/kyo-test/runner/shared/src/main/scala/kyo/test/runner/ConsoleReporter.scala
@@ -147,9 +147,20 @@ final class ConsoleReporter(
         end match
     end onLeafComplete
 
+    // Hang diagnostics: the first time any leaf is detected STUCK, capture a one-shot thread dump (real on JVM, a
+    // placeholder off-JVM where no portable all-thread capture exists) plus every registered
+    // `kyo.internal.Diagnostics` snapshot, so a rare hang is root-caused from a single occurrence. Once per run (a
+    // hang usually has one cause).
+    private val hangDumpEmitted = new java.util.concurrent.atomic.AtomicBoolean(false)
+
     override def onLeafHeartbeat(info: LeafInfo, elapsed: Duration): Unit =
+        if hangDumpEmitted.compareAndSet(false, true) then
+            val header = "kyo-test hang diagnostics on STUCK leaf: " + renderPath(info.path) + "\n"
+            out.println(header + kyo.test.runner.internal.ThreadDump.render() + "\n" + kyo.internal.Diagnostics.dumpAll() + "\n")
+        end if
         if verbosity != Verbosity.Quiet then
             out.println(color(s"${indent(info.path)}[STUCK] ${renderPath(info.path)}  ${durationSuffix(elapsed)}", _.yellow))
+    end onLeafHeartbeat
 
     override def onSuiteComplete(info: SuiteInfo, report: SuiteReport): Unit =
         val passedCount   = report.leafResults.count(_._2.isInstanceOf[TestResult.Passed])

--- a/kyo-test/runner/shared/src/main/scala/kyo/test/runner/TestRunner.scala
+++ b/kyo-test/runner/shared/src/main/scala/kyo/test/runner/TestRunner.scala
@@ -35,6 +35,7 @@ import kyo.test.runner.ConsoleReporter
 import kyo.test.runner.internal.Glob
 import kyo.test.runner.internal.Instantiate
 import kyo.test.runner.internal.LeafPool
+import kyo.test.runner.internal.LeakDebug
 import kyo.test.runner.internal.Randomize
 import scala.concurrent.Future
 
@@ -153,15 +154,23 @@ object TestRunner:
                                 case _ => rawBuilder
                         val leafInfo = LeafInfo(suiteInfo.name, path, builder.tags)
                         val cursor   = cursorMap.getOrElse(path, Chunk.empty)
-                        Sync.defer(reporter.onLeafStart(leafInfo)).andThen(
+                        Sync.defer {
+                            reporter.onLeafStart(leafInfo)
+                            // Leak-debug attribution: snapshot the open descriptors before the leaf body and get the after-leaf finalizer. A
+                            // no-op (single shared closure) unless leak-debug mode installed a probe, so the normal path is untouched.
+                            LeakDebug.beginLeaf(path)
+                        }.map { probeFinish =>
                             withHeartbeat(leafInfo, effectiveConfig.heartbeatInterval, reporter)(
                                 runLeaf(suite, cursor, path, builder, hasFocus, effectiveConfig.failOnNoAssertion)
-                            )
-                        ).map { entries =>
-                            entries.headMaybe match
-                                case Maybe.Present((_, result)) => reporter.onLeafComplete(leafInfo, result)
-                                case Maybe.Absent               => ()
-                            entries
+                            ).map { entries =>
+                                // Run after the leaf body (which includes the leaf's Scope.run, so the leaf's own finalizers have already run):
+                                // any descriptor still open here that the leaf opened is the leaf's leak, recorded against this leaf path.
+                                probeFinish()
+                                entries.headMaybe match
+                                    case Maybe.Present((_, result)) => reporter.onLeafComplete(leafInfo, result)
+                                    case Maybe.Absent               => ()
+                                entries
+                            }
                         }
                     end leafComp
 

--- a/kyo-test/runner/shared/src/main/scala/kyo/test/runner/internal/LeafPool.scala
+++ b/kyo-test/runner/shared/src/main/scala/kyo/test/runner/internal/LeafPool.scala
@@ -123,7 +123,7 @@ object LeafPool:
       * to the whole process. Native = 1 (single-threaded; concurrent unwinding crashes libunwind).
       */
     val globalK: Int =
-        if kyo.internal.Platform.isNative then 1
+        if kyo.internal.Platform.isNative || LeakDebug.enabled then 1
         else math.max(1, Async.defaultConcurrency)
 
     /** THE process-global pool: `globalK` workers, capacity 1024. Every suite routes its leaves through this one

--- a/kyo-test/runner/shared/src/main/scala/kyo/test/runner/internal/LeakDebug.scala
+++ b/kyo-test/runner/shared/src/main/scala/kyo/test/runner/internal/LeakDebug.scala
@@ -1,0 +1,41 @@
+package kyo.test.runner.internal
+
+import kyo.*
+
+/** Leak-debug mode: opt-in attribution of a leaked descriptor to the test that opened it.
+  *
+  * The end-of-run leak check (see [[LeakCheck]]) reports a leaked descriptor by its `socket:[inode]` target, which on its own does not say
+  * which test opened it. Snapshot diffing cannot recover that under parallel leaf execution: watching a descriptor "appear" between two
+  * snapshots only says WHEN, and concurrent leaves interleave, so the opener is ambiguous. The fix is to run serially and snapshot around
+  * each leaf, so a descriptor that survives a leaf is unambiguously that leaf's.
+  *
+  * Enabled by `KYO_TEST_LEAK_DEBUG=1` (or `-Dkyo.test.leakDebug=true`). When on it (1) forces [[LeafPool.globalK]] to 1 so leaves run one at
+  * a time across the whole process, and (2) lets the JVM runner register a [[leafProbe]] that snapshots open descriptors around each leaf and
+  * records `inode -> leaf` for the final report. Off by default, so a normal parallel run pays nothing.
+  */
+private[runner] object LeakDebug:
+
+    /** True when leak-debug mode is requested via the environment variable or system property. Read once at class init (the flag is set before
+      * the JVM starts), so it is a stable `val` usable from the process-global [[LeafPool.globalK]].
+      */
+    val enabled: Boolean =
+        sys.env.get("KYO_TEST_LEAK_DEBUG").orElse(sys.props.get("kyo.test.leakDebug"))
+            .exists(v => v == "1" || v.equalsIgnoreCase("true"))
+
+    /** Per-leaf attribution hook the JVM runner installs in leak-debug mode (Absent off-JVM, or when leak-debug is off, so the leaf path pays
+      * nothing). Given a leaf path it snapshots the open descriptors and returns a finalizer that, run after the leaf body, records which
+      * descriptors the leaf left open against that leaf.
+      */
+    @volatile var leafProbe: Maybe[Chunk[String] => (() => Unit)] = Absent
+
+    private val noOp: () => Unit = () => ()
+
+    /** Begin attribution for a leaf, returning the after-leaf finalizer. A no-op (and a single shared closure, no allocation) when no probe is
+      * installed, so the non-debug leaf path is untouched.
+      */
+    def beginLeaf(path: Chunk[String]): () => Unit =
+        leafProbe match
+            case Maybe.Present(f) => f(path)
+            case Maybe.Absent     => noOp
+
+end LeakDebug


### PR DESCRIPTION
## Problem

The end-of-run leak check fails the run when a test (or the code it exercises) leaves a file descriptor alive past the end of the run, reporting each leak by its `socket:[inode]` and TCP state. But it does not say *which test* opened it, and under parallel leaf execution that cannot be recovered after the fact: watching a descriptor appear between snapshots only tells you *when*, and concurrent leaves interleave, so the opener is ambiguous. Tracking a leak down meant guesswork or hand-rolled per-investigation instrumentation.

## Solution

An opt-in leak-debug mode (`KYO_TEST_LEAK_DEBUG=1`, or `-Dkyo.test.leakDebug=true`): re-run with the flag and the leak report names the test behind each leaked descriptor, e.g.

```
file-descriptor leak (2): socket:[...] [CLOSE_WAIT ...] (opened by test: <leaf path>); ...
```

It runs leaves serially and snapshots the open descriptors around each leaf, so a surviving descriptor is unambiguously that leaf's. The leak-check failure message points at the flag, so the next step is discoverable. Off by default; a normal parallel run is unchanged and pays nothing.

## Notes

- Wired as a per-leaf probe the runner installs only when the flag is set (a single shared no-op closure otherwise), plus forcing the leaf pool to run serially so each leaf's surviving descriptors are its own.
- The leak-check allowlist unions the names of the process-shared I/O carriers that are never closed by design (`NioIoDriver`, `processSharedTransport`), so it stays correct across the in-flight network-stack migration without either carrier showing up as a leak.
- Internal to the test runner (`LeakDebug` is `private[runner]`); compiles against kyo-test-runner alone, with no module dependency.
