### PR TITLE
[core] make the process-shared unsafe logger non-blocking

### DIFF
--- a/kyo-core/jvm-native/src/main/scala/kyo/internal/LogPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/internal/LogPlatformSpecific.scala
@@ -151,14 +151,29 @@ private[kyo] object LogDaemon:
             case _ => ()
     end drainFlushWaiters
 
-    // Off-daemon failure report: route through Log.live's console backend (a fixed sink, never the
-    // failing event.sink) and inline (never back through the daemon channel), so a failing sink
-    // cannot recurse into the logging system. Contain ANY throw: the reporter runs inside a catch
-    // handler whose escape would kill the drain fiber, and Log.live.unsafe.error can itself throw
-    // (a broken stderr, a Throwable whose printStackTrace throws), so the whole call is wrapped and
-    // any throw absorbed. event.message is the already-forced message string, so reading it is safe.
+    // Off-daemon failure report: write INLINE to Log.live's console sink via emit (the terminal writeLine
+    // path) -- a fixed sink, never the failing event.sink, and never the async dispatcher. reportDrainFailure
+    // runs ON the drain fiber, so routing through Log.live.unsafe.error (async by default since the unsafe
+    // tier now dispatches) would re-enqueue the failure into the drain's own channel; emit() writes
+    // synchronously and cannot recurse. Contain ANY throw: the reporter runs inside a catch handler whose
+    // escape would kill the drain fiber, and emit/the clock read can themselves throw (a broken stderr, a
+    // Throwable whose printStackTrace throws), so the whole call is wrapped and any throw absorbed.
+    // event.message is the already-forced message string, so reading it is safe.
     private def reportDrainFailure(event: Log.Event, error: Throwable)(using Frame, AllowUnsafe): Unit =
-        try Log.live.unsafe.error("Log drain failed for '" + event.message + "'", error)
+        try
+            // Reuse the failing event's own timestamp rather than reading the clock: this is an error-path
+            // report tied to that event, so a fresh clock read (and the Sync.Unsafe.evalOrThrow bridge it
+            // would need here) is not warranted.
+            Log.live.unsafe.emit(
+                Log.Event(
+                    Log.Level.error,
+                    Log.live.unsafe,
+                    "Log drain failed for '" + event.message + "'",
+                    Present(error),
+                    summon[Frame],
+                    event.timestamp
+                )
+            )
         catch case _: Throwable => ()
 
 end LogDaemon

--- a/kyo-core/shared/src/main/scala/kyo/Log.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Log.scala
@@ -112,7 +112,7 @@ object Log extends kyo.internal.LogPlatformSpecific:
         case silent extends Level(60)
     end Level
 
-    val live: Log = Log(Unsafe.ConsoleLogger("kyo.logs", Level.warn))
+    val live: Log = Log(Unsafe.AsyncUnsafe(Unsafe.ConsoleLogger("kyo.logs", Level.warn)))
 
     private val local = Local.init(live)
 
@@ -274,6 +274,8 @@ object Log extends kyo.internal.LogPlatformSpecific:
             // The direct unsafe tier (Log.live.unsafe.trace, ...) bypasses emitAt, so it gates here
             // and stamps with the ambient clock's now: a synchronous direct call's emission time is
             // the current instant, and reading the ambient clock keeps Clock time-control in reach.
+            // ConsoleLogger is the terminal synchronous sink: it writes inline here and in emit. The
+            // async front for the process-shared logger is AsyncUnsafe below, which wraps a ConsoleLogger.
             inline def trace(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
                 if Level.trace.enabled(level) then writeLine(Level.trace, frame, msg, Absent, stamp)
             inline def trace(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
@@ -309,6 +311,53 @@ object Log extends kyo.internal.LogPlatformSpecific:
                 t.foreach(_.printStackTrace(stream))
             end writeLine
         end ConsoleLogger
+
+        /** Async front for the process-shared unsafe logger (Log.live.unsafe). Its direct tier hands each event
+          * to the async dispatcher (Log.emit) instead of writing inline, so the unsafe API is non-blocking and
+          * does not perturb timing in unsafe code (the println happens on the drain). The wrapped `underlying`
+          * stays the terminal synchronous sink: emit delegates to underlying.emit and never re-dispatches, so
+          * when this is itself an event's sink (the safe path's emitAt sets sink = this) the drain writes
+          * exactly once with no recursion. Stamping reads the ambient clock so timestamps honor Clock
+          * time-control, the same motivated evalOrThrow ConsoleLogger.stamp uses. Raw ConsoleLogger stays
+          * synchronous; only the process-shared logger is wrapped, so the direct ConsoleLogger format/routing
+          * tests remain synchronous.
+          */
+        final case class AsyncUnsafe(underlying: Log.Unsafe) extends Log.Unsafe:
+            def level: Level                       = underlying.level
+            def name: String                       = underlying.name
+            def withName(name: String): Log.Unsafe = AsyncUnsafe(underlying.withName(name))
+
+            // Terminal sink role: delegate to the synchronous underlying and NEVER re-dispatch (no recursion).
+            override def emit(event: Log.Event)(using AllowUnsafe): Unit = underlying.emit(event)
+
+            inline def trace(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
+                if Level.trace.enabled(level) then Log.emit(Log.Event(Level.trace, this, msg, Absent, frame, stamp))
+            inline def trace(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
+                if Level.trace.enabled(level) then Log.emit(Log.Event(Level.trace, this, msg, Present(t), frame, stamp))
+
+            inline def debug(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
+                if Level.debug.enabled(level) then Log.emit(Log.Event(Level.debug, this, msg, Absent, frame, stamp))
+            inline def debug(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
+                if Level.debug.enabled(level) then Log.emit(Log.Event(Level.debug, this, msg, Present(t), frame, stamp))
+
+            inline def info(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
+                if Level.info.enabled(level) then Log.emit(Log.Event(Level.info, this, msg, Absent, frame, stamp))
+            inline def info(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
+                if Level.info.enabled(level) then Log.emit(Log.Event(Level.info, this, msg, Present(t), frame, stamp))
+
+            inline def warn(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
+                if Level.warn.enabled(level) then Log.emit(Log.Event(Level.warn, this, msg, Absent, frame, stamp))
+            inline def warn(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
+                if Level.warn.enabled(level) then Log.emit(Log.Event(Level.warn, this, msg, Present(t), frame, stamp))
+
+            inline def error(msg: => String)(using frame: Frame, allow: AllowUnsafe): Unit =
+                if Level.error.enabled(level) then Log.emit(Log.Event(Level.error, this, msg, Absent, frame, stamp))
+            inline def error(msg: => String, t: => Throwable)(using frame: Frame, allow: AllowUnsafe): Unit =
+                if Level.error.enabled(level) then Log.emit(Log.Event(Level.error, this, msg, Present(t), frame, stamp))
+
+            private def stamp(using Frame, AllowUnsafe): Instant =
+                Sync.Unsafe.evalOrThrow(Clock.nowWith(now => now))
+        end AsyncUnsafe
     end Unsafe
 
     private inline def enqueue(


### PR DESCRIPTION
## Problem

`Log.live` is the process-shared default logger. Its direct unsafe tier (`Log.live.unsafe.info` / `.warn` / `.error` / ...) wrote each line INLINE: a synchronous `println` on the calling thread. In hot or timing-sensitive unsafe code (schedulers, I/O drivers, the unsafe bridging boundary) that blocks the caller on console I/O and perturbs the very timing such code runs under. The safe `Log` API already dispatches through an async drain fiber; only the direct unsafe tier stayed synchronous.

## Solution

Wrap `Log.live`'s logger in a new `Log.Unsafe.AsyncUnsafe` decorator whose direct tier hands each event to the async dispatcher (`Log.emit`, the drain fiber) instead of writing inline, so `Log.live.unsafe.*` is non-blocking and timing-neutral.

- `AsyncUnsafe(underlying)` is a terminal-aware decorator: its `emit` delegates straight to the synchronous `underlying` and never re-dispatches, so when `AsyncUnsafe` is itself an event's sink (the safe path sets `sink = this`) the drain writes exactly once, with no recursion.
- Only the process-shared `Log.live` is wrapped; a raw `ConsoleLogger` stays synchronous, so direct-logger format and routing tests are unchanged.
- Stamping reads the ambient clock (the same motivated `Sync.Unsafe.evalOrThrow` bridge `ConsoleLogger` already uses), so timestamps still honor `Clock` time-control.

## Notes

- The drain's own off-fiber failure reporter (`LogDaemon.reportDrainFailure`) now writes INLINE through `Log.live.unsafe.emit` (the terminal sink) rather than `Log.live.unsafe.error`: the reporter runs ON the drain fiber, and `.error` is now async, so routing through it would re-enqueue the failure into the drain's own channel and recurse. `emit` writes synchronously and cannot. It reuses the failing event's own timestamp instead of reading the clock, since the report is tied to that event.
- Public surface: `Log.Unsafe` gains the `AsyncUnsafe` case class. The safe `Log` API and raw `ConsoleLogger` behavior are unchanged.

<!--
PRs require an approval from any of the core contributors, other than the PR author.

Include this header if applicable:
Fixes #issue1, #issue2, ...
-->
