### PR TITLE
[kyo-test] add the leaked fiber's kyo trace to the fiber-leak report

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
+++ b/kyo-core/shared/src/main/scala/kyo/scheduler/IOTask.scala
@@ -41,6 +41,17 @@ sealed private[kyo] class IOTask[Ctx, E, A] private (
     final override def needsInterrupt(): Boolean =
         !isPending()
 
+    final override def fiberTrace(): String =
+        val snapshot = trace
+        if snapshot eq null then ""
+        else
+            try Trace.render(snapshot)
+            // Contain ANY throw (not just NonFatal): a diagnostic cross-thread read of a mutable trace
+            // buffer must never escape to the leak-probe thread; any failure falls back to the JVM stack.
+            catch case _: Throwable => ""
+        end if
+    end fiberTrace
+
     // Bumps the interrupt epoch and wakes the BlockingMonitor AFTER the promise CAS, so the
     // worker rebuild and monitor scan it triggers already see needsInterrupt() and the runtime
     // reset. The pre-CAS preInterrupt hook would let a worker spend its one gated rebuild

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -723,23 +723,30 @@ class FiberTest extends kyo.test.Test[Any]:
                 }
 
                 "Trace.saved captures frames from a running computation" in {
-                    // Spawning from inside run{} means the Safepoint has accumulated frames.
-                    // When trace.index > 0, the exception thrown by the carrier is enriched
-                    // with Kyo frame elements (format: "snippet @ className" in the class-name field).
-                    val carrier = Fiber.Unsafe.init { throw new RuntimeException("trace-test") }: Fiber.Unsafe[Int, Any]
-                    Abort.run[Any](carrier.safe.get).map {
-                        case Result.Panic(ex) =>
-                            val frames = ex.getStackTrace
-                            assert(frames.nonEmpty)
-                            // Kyo frames use the format "snippet @ className" in the declaring-class field
-                            // (from Trace.Owner.enrich); their presence proves Trace.saved() captured frames.
-                            val hasKyoFrame = frames.exists(_.getClassName.contains("@"))
-                            assert(
-                                hasKyoFrame,
-                                s"Expected enriched Kyo frames in stack trace but found: ${frames.take(3).mkString(", ")}"
-                            )
-                        case other =>
-                            fail(s"expected Panic, got $other")
+                    // Spawning from inside a running effect chain means the Safepoint has accumulated the
+                    // chain's own user frames. Trace.saved() snapshots them, and the exception thrown by
+                    // the carrier is enriched with those Kyo frame elements (format "snippet @ className"
+                    // in the class-name field). The spawn must follow at least one user-framed effect step,
+                    // since only those steps push frames; a spawn at the very start of the body would see an
+                    // empty trace (the internal placeholder frame is never pushed).
+                    Sync.defer(1).map(_ => 2).map { _ =>
+                        Fiber.Unsafe.init { throw new RuntimeException("trace-test") }: Fiber.Unsafe[Int, Any]
+                    }.map { carrier =>
+                        Abort.run[Any](carrier.safe.get).map {
+                            case Result.Panic(ex) =>
+                                val frames = ex.getStackTrace
+                                assert(frames.nonEmpty)
+                                // Kyo frames use the format "snippet @ className" in the declaring-class field
+                                // (from Trace.Owner.enrich); their presence proves Trace.saved() captured the
+                                // running chain's frames.
+                                val hasKyoFrame = frames.exists(_.getClassName.contains("@"))
+                                assert(
+                                    hasKyoFrame,
+                                    s"Expected enriched Kyo frames in stack trace but found: ${frames.take(3).mkString(", ")}"
+                                )
+                            case other =>
+                                fail(s"expected Panic, got $other")
+                        }
                     }
                 }
 

--- a/kyo-core/shared/src/test/scala/kyo/scheduler/IOTaskTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/scheduler/IOTaskTest.scala
@@ -1,0 +1,112 @@
+package kyo.scheduler
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import kyo.*
+import kyo.kernel.internal.*
+
+class IOTaskTest extends kyo.test.Test[Any]:
+
+    "fiberTrace" - {
+
+        "fiberTrace renders the live user frames of a blocked effectful fiber" in {
+            val blocker                      = new IOPromise[Nothing, Unit]()
+            def userStep(x: Int): Int < Sync = Sync.defer(x + 1)
+            def work: Unit < Async =
+                Sync.defer(1).map(userStep).map(_ => Async.use(blocker)(_ => ())).map(_ => ())
+            val iotask = IOTask(work, Trace.saved(), Context.empty)
+            for
+                // Deterministic readiness witness: poll the actual property (the live trace surfacing a
+                // user frame), not a sleep. The trace is published at the suspend boundary's writeback, so
+                // a populated trace also proves the fiber is blocked on `blocker` and its trace is stable.
+                _ <- assertEventually(Sync.defer(iotask.fiberTrace().contains("IOTaskTest.scala:")))
+                rendered = iotask.fiberTrace()
+                _ <- Sync.defer(blocker.completeDiscard(Result.succeed(())))
+                _ <- Async.use(iotask.asInstanceOf[IOPromise[Nothing, Unit]])(_ => ())
+            yield
+                assert(rendered.nonEmpty)
+                assert(rendered.startsWith("at "))
+                // A real user file:line from this test's effect chain, proving the live (not fork-time)
+                // frames are readable cross-thread off a still-blocked fiber.
+                assert(rendered.contains("IOTaskTest.scala:"))
+                assert(!rendered.contains("<internal>"))
+            end for
+        }
+
+        "fiberTrace excludes internal frames" in {
+            val blocker                      = new IOPromise[Nothing, Unit]()
+            def userStep(x: Int): Int < Sync = Sync.defer(x + 1)
+            def work: Unit < Async =
+                Sync.defer(1).map(userStep).map(_ => Async.use(blocker)(_ => ())).map(_ => ())
+            val iotask = IOTask(work, Trace.saved(), Context.empty)
+            for
+                _ <- assertEventually(Sync.defer(iotask.fiberTrace().contains("IOTaskTest.scala:")))
+                rendered = iotask.fiberTrace()
+                _ <- Sync.defer(blocker.completeDiscard(Result.succeed(())))
+                _ <- Async.use(iotask.asInstanceOf[IOPromise[Nothing, Unit]])(_ => ())
+            yield
+                // The trace carries real user frames (non-empty) yet never the shared internal placeholder:
+                // pushFrame drops Frame.internal by reference, so no <internal> line can enter the ring.
+                assert(rendered.nonEmpty)
+                assert(!rendered.contains("<internal>"))
+            end for
+        }
+
+        "fiberTrace is empty for a pure Sync.defer spin loop" in {
+            val stop                      = new AtomicBoolean(false)
+            val iterations                = new AtomicLong(0L)
+            def loop(i: Int): Unit < Sync = Sync.defer { discard(iterations.incrementAndGet()); if stop.get() then () else loop(i + 1) }
+            for
+                fiber <- Fiber.initUnscoped(loop(0))
+                // Deterministic witness that the loop is genuinely spinning (many bare defers executed)
+                // before reading its trace, so the empty-trace assertion is about an active fiber.
+                _ <- assertEventually(Sync.defer(iterations.get() > 100L))
+                // fiberTrace lives on IOTask; reach the concrete task for the diagnostic read.
+                rendered = fiber.asInstanceOf[IOTask[?, ?, ?]].fiberTrace()
+                _ <- Sync.defer(stop.set(true))
+                _ <- fiber.interrupt
+                _ <- fiber.getResult
+            yield
+                // A pure Sync.defer chain pushes no frames (defers carry no user frame; the IOTask's own
+                // call-site frame is Frame.internal and is skipped), so the live trace stays empty.
+                assert(!rendered.contains("IOTaskTest.scala:"))
+                assert(rendered.isEmpty)
+            end for
+        }
+
+        "fiberTrace never throws under concurrent trace mutation" in {
+            val blocker                      = new IOPromise[Nothing, Unit]()
+            def userStep(x: Int): Int < Sync = Sync.defer(x + 1)
+            def work: Unit < Async =
+                Sync.defer(1).map(userStep).map(_ => Async.use(blocker)(_ => ())).map(_ => ())
+            val iotask = IOTask(work, Trace.saved(), Context.empty)
+            for
+                // A forked reader hammers fiberTrace() while the worker mutates the trace: the fiber is
+                // blocked (populated trace), then resumes (writeback), then completes (run() nulls trace).
+                // Every cross-thread read must stay safe; the diagnostic read never escapes a throw.
+                reader <- Fiber.initUnscoped(Sync.defer((0 until 2000).map(_ => iotask.fiberTrace()).toVector))
+                _      <- Sync.defer(blocker.completeDiscard(Result.succeed(())))
+                reads  <- reader.get
+                _      <- Async.use(iotask.asInstanceOf[IOPromise[Nothing, Unit]])(_ => ())
+                // After the task is definitely complete its trace is nulled, so every later read is "".
+                afterComplete = (0 until 1000).map(_ => iotask.fiberTrace()).toVector
+            yield
+                assert(reads.size == 2000)
+                assert(reads.forall(s => (s ne null) && (s == "" || s.startsWith("at "))))
+                assert(afterComplete.forall(_ == ""))
+            end for
+        }
+
+        "fiberTrace has no effect row and is a plain String" in {
+            val iotask = IOTask(Sync.defer(()), Trace.init, Context.empty)
+            // Compile-shaped assertion: fiberTrace() is a bare String, with no pending effect row and no
+            // AllowUnsafe capability. If it returned `String < Sync` or required AllowUnsafe this would not
+            // typecheck.
+            val s: String = iotask.fiberTrace()
+            for _ <- Async.use(iotask.asInstanceOf[IOPromise[Nothing, Unit]])(_ => ())
+            yield assert(s == "" || s.startsWith("at "))
+        }
+
+    }
+
+end IOTaskTest

--- a/kyo-data/shared/src/main/scala/kyo/Frame.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Frame.scala
@@ -121,9 +121,18 @@ object Frame:
         end render
     end extension
 
-    implicit inline def derive: Frame = ${ frameImpl(false) }
+    implicit inline def derive: Frame = ${ frameImpl() }
 
-    private[kyo] inline def internal: Frame = ${ frameImpl(true) }
+    // A single shared placeholder Frame for synthesized-frame boundaries where no user frame exists
+    // (kernel-internal suspensions, generated bridges). Every `Frame.internal` reference is this one
+    // instance, so an identity/equality `eq`/`ne` check against the shared placeholder identifies an
+    // internal frame, and the trace ring can skip it without an allocation. (On the JS target `ne` on
+    // a String is a value comparison, not a reference one, but the placeholder content is globally
+    // unique, so the check still identifies exactly this frame.) The string is a valid version-'1'
+    // Frame parseable by every accessor: file/caller/callee/class/snippet are all "<internal>", line
+    // and column are 0, so it renders as "<internal>:0:0" and identifies as internal via its
+    // "<internal>" snippet.
+    private[kyo] val internal: Frame = "1<internal>:0:0|<internal>|<internal>|<internal>|<internal>"
 
     private val allowKyoFileSuffixes = Set("Test.scala", "Spec.scala", "Bench.scala")
 
@@ -149,13 +158,13 @@ object Frame:
                 (content, lines)
     end contentAndLines
 
-    private def frameImpl(internal: Boolean)(using Quotes): Expr[String] =
+    private def frameImpl()(using Quotes): Expr[String] =
         import quotes.reflect.*
 
         val pos      = quotes.reflect.Position.ofMacroExpansion
         val fileName = pos.sourceFile.name
 
-        if !internal && FindEnclosing.isInternal then
+        if FindEnclosing.isInternal then
             report.errorAndAbort(
                 s"""Frame cannot be derived within the kyo package.
                     |
@@ -169,18 +178,16 @@ object Frame:
         end if
 
         val cls    = FindEnclosing(_.isClassDef).map(_.fullName).getOrElse("?")
-        val caller = if internal then "?" else FindEnclosing(_.isDefDef).map(_.name).getOrElse("?")
+        val caller = FindEnclosing(_.isDefDef).map(_.name).getOrElse("?")
 
-        // For a non-internal frame, resolve the file's normalized content and line split from
-        // the per-file memo. On a hit (same source-file object) the content is reused without
-        // re-reading it; on a miss the content is read once, normalized, split, and stored.
+        // Resolve the file's normalized content and line split from the per-file memo. On a hit
+        // (same source-file object) the content is reused without re-reading it; on a miss the
+        // content is read once, normalized, split, and stored.
         val (rawContent, lines) =
-            if internal then ("", Array.empty[String])
-            else
-                contentAndLines(
-                    pos.sourceFile.asInstanceOf[AnyRef],
-                    pos.sourceFile.content.getOrElse(report.errorAndAbort("Can't locate source code"))
-                )
+            contentAndLines(
+                pos.sourceFile.asInstanceOf[AnyRef],
+                pos.sourceFile.content.getOrElse(report.errorAndAbort("Can't locate source code"))
+            )
 
         // Callee = syntactic name of the function whose `(using Frame)` parameter the macro is filling.
         // The macro splice always lands at the end of a call expression: either right after the function
@@ -193,40 +200,39 @@ object Frame:
         // unusual whitespace. Operator-named methods (return the operator string like "+", "==",
         // "::") and backticked identifiers (return the content without backticks) are both
         // handled.
-        val callee = if internal then "?" else extractCalleeName(rawContent, pos.end)
+        val callee = extractCalleeName(rawContent, pos.end)
 
         val snippet =
-            if internal then "<internal>"
-            else
-                // Build the marker-inserted snippet from the [startLine-1, endLine+2) line
-                // window of the memoized per-file line array, inserting the marker at the
-                // (endLine, endColumn) point. pos.end always lies within the retained window,
-                // so the marker insertion is exact: the filtered, dedented, newline-joined
-                // window is the snippet.
-                //
-                // pos.endColumn is the 0-based column on pos.endLine where the marker is inserted.
-                // This line/column placement corresponds to the position offset `pos.end` maps to
-                // in the normalized (LF) content: for LF source it produces the same marker
-                // placement as a direct offset-based insertion, and it is also CRLF-correct
-                // because a raw-offset insertion into CRLF source would drift the marker right by
-                // the count of preceding CRs, while the line/column split sidesteps that drift.
-                val markerCol = pos.endColumn
-                val from      = pos.startLine - 1
-                val until     = math.min(pos.endLine + 2, lines.length)
-                val windowBuf = scala.collection.mutable.ArrayBuffer.empty[String]
-                var i         = math.max(0, from)
-                while i < until do
-                    val line =
-                        if i == pos.endLine then
-                            val col = math.min(math.max(0, markerCol), line0Length(lines, i))
-                            lines(i).substring(0, col) + "📍" + lines(i).substring(col)
-                        else lines(i)
-                    if line.exists(_ != ' ') then windowBuf += line
-                    i += 1
-                end while
-                val selected = windowBuf.toSeq
-                val toDrop   = selected.map(_.takeWhile(_ == ' ').length).min
-                selected.map(_.drop(toDrop)).mkString("\n")
+            // Build the marker-inserted snippet from the [startLine-1, endLine+2) line
+            // window of the memoized per-file line array, inserting the marker at the
+            // (endLine, endColumn) point. pos.end always lies within the retained window,
+            // so the marker insertion is exact: the filtered, dedented, newline-joined
+            // window is the snippet.
+            //
+            // pos.endColumn is the 0-based column on pos.endLine where the marker is inserted.
+            // This line/column placement corresponds to the position offset `pos.end` maps to
+            // in the normalized (LF) content: for LF source it produces the same marker
+            // placement as a direct offset-based insertion, and it is also CRLF-correct
+            // because a raw-offset insertion into CRLF source would drift the marker right by
+            // the count of preceding CRs, while the line/column split sidesteps that drift.
+            val markerCol = pos.endColumn
+            val from      = pos.startLine - 1
+            val until     = math.min(pos.endLine + 2, lines.length)
+            val windowBuf = scala.collection.mutable.ArrayBuffer.empty[String]
+            var i         = math.max(0, from)
+            while i < until do
+                val line =
+                    if i == pos.endLine then
+                        val col = math.min(math.max(0, markerCol), line0Length(lines, i))
+                        lines(i).substring(0, col) + "📍" + lines(i).substring(col)
+                    else lines(i)
+                if line.exists(_ != ' ') then windowBuf += line
+                i += 1
+            end while
+            val selected = windowBuf.toSeq
+            val toDrop   = selected.map(_.takeWhile(_ == ' ').length).min
+            selected.map(_.drop(toDrop)).mkString("\n")
+        end snippet
 
         Expr(s"$version$fileName:${pos.startLine + 1}:${pos.startColumn + 1}|$cls|$caller|$callee|$snippet")
     end frameImpl

--- a/kyo-data/shared/src/test/scala/kyo/FrameTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/FrameTest.scala
@@ -83,13 +83,19 @@ class FrameTest extends kyo.test.Test[Any]:
     }
 
     "internal" in {
-        assert(internal.className == "kyo.FrameTest")
-        assert(internal.callerName == "?")
-        assert(internal.position.fileName == "FrameTest.scala")
-        assert(internal.position.lineNumber == 14)
-        assert(internal.position.columnNumber == 20)
+        // Frame.internal is a single shared placeholder, not a per-call-site macro, so every
+        // accessor returns the uniform "<internal>" sentinel rather than this call site's class
+        // or position. Two references to Frame.internal are the same instance.
+        assert(internal.className == "<internal>")
+        assert(internal.callerName == "<internal>")
+        assert(internal.calleeName == "<internal>")
+        assert(internal.position.fileName == "<internal>")
+        assert(internal.position.lineNumber == 0)
+        assert(internal.position.columnNumber == 0)
+        assert(internal.position.show == "<internal>:0:0")
         assert(internal.snippet == "<internal>")
         assert(internal.snippetShort == "<internal>")
+        assert(internal eq Frame.internal)
     }
 
     "calleeName" - {

--- a/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Trace.scala
+++ b/kyo-kernel/shared/src/main/scala/kyo/kernel/internal/Trace.scala
@@ -33,12 +33,86 @@ private[kyo] object Trace:
       */
     private[kyo] def saved()(using safepoint: Safepoint): Trace = safepoint.saveTrace()
 
+    /** Walks the ring newest-first, dropping nulls and collapsing consecutive identical frames into a
+      * single run. Returns each surviving frame paired with the count of consecutive occurrences it
+      * represents, plus the snippet padding width. A caller that uses the count can annotate a repeated
+      * run; a caller that ignores it sees each distinct frame once. Returns `(Nil, 0)` for an empty trace.
+      */
+    private def orderedRuns(frames: Array[Frame], index: Int): (List[(Frame, Int)], Int) =
+        val size = if index < maxTraceFrames then index else maxTraceFrames
+        if size <= 0 then (Nil, 0)
+        else
+            val start =
+                if index < maxTraceFrames then 0
+                else index & (maxTraceFrames - 1)
+
+            val ordered = new Array[Frame](size)
+            @tailrec def parse(idx: Int, maxSnippetSize: Int): Int =
+                if idx < size then
+                    val curr = frames((start + idx) & (maxTraceFrames - 1))
+                    ordered(idx) = curr
+                    if curr ne null then
+                        val snippetSize = curr.snippetShort.size
+                        parse(idx + 1, if snippetSize > maxSnippetSize then snippetSize else maxSnippetSize)
+                    else
+                        parse(idx + 1, maxSnippetSize)
+                    end if
+                else
+                    maxSnippetSize + 1
+            val toPad = parse(0, 0)
+
+            // Fold oldest-first, prepending so the result is newest-first. A non-null frame equal to the
+            // current head extends that run (bumps its count); a different non-null frame opens a new run.
+            val runs = ordered.foldLeft(List.empty[(Frame, Int)]) {
+                case (acc, curr) =>
+                    if curr eq null then acc
+                    else
+                        acc match
+                            case (`curr`, count) :: tail => (curr, count + 1) :: tail
+                            case _                       => (curr, 1) :: acc
+            }
+            (runs, toPad)
+        end if
+    end orderedRuns
+
+    private def toElement(frame: Frame, toPad: Int): StackTraceElement =
+        StackTraceElement(
+            frame.snippetShort.reverse.padTo(toPad, ' ').reverse + " @ " + frame.className,
+            frame.callerName,
+            frame.position.fileName,
+            frame.position.lineNumber
+        )
+
+    private def orderedElements(frames: Array[Frame], index: Int): List[StackTraceElement] =
+        val (runs, toPad) = orderedRuns(frames, index)
+        runs.map((frame, _) => toElement(frame, toPad))
+    end orderedElements
+
+    /** Renders a Trace snapshot to the same readable frame lines kyo splices into an enriched exception
+      * stack trace, newest-first (innermost / most-recent frame first). Each line is `at ` followed by a
+      * StackTraceElement's toString, i.e. `at <paddedSnippet> @ <className>.<callerName>(<fileName>:<lineNumber>)`.
+      * A run of consecutive identical frames (a tight loop pushing the same frame) is shown once with a
+      * ` (xN)` suffix carrying the repeat count; a single occurrence carries no suffix. Reuses the same
+      * ordering as enrich, so a rendered trace and an enriched exception name the same frames the same way.
+      * Returns "" for an empty trace.
+      */
+    private[kyo] def render(trace: Trace): String =
+        val (runs, toPad) = orderedRuns(trace.frames, trace.index)
+        runs.map { (frame, count) =>
+            val line = s"at ${toElement(frame, toPad)}"
+            if count > 1 then s"$line (x$count)" else line
+        }.mkString("\n")
+    end render
+
     abstract private[kernel] class Owner extends TracePool.Local:
         final private var frames = new Array[Frame](maxTraceFrames)
         final private var index  = 0
 
         private[kernel] inline def pushFrame(frame: Frame): Unit =
-            if frame ne null then
+            // Skip the shared internal placeholder: it carries no per-site position, only crowds the
+            // 16-slot ring, and renders as a uniform framework line. A single identity/equality check
+            // against the shared placeholder keeps the hot path allocation-free.
+            if (frame ne null) && (frame ne Frame.internal) then
                 val idx = this.index
                 frames(idx & (maxTraceFrames - 1)) = frame
                 this.index = idx + 1
@@ -83,6 +157,22 @@ private[kyo] object Trace:
                     enrich(ex)
                     throw ex
             finally
+                // Save the advanced index back into the trace so the trace reflects the frames pushed
+                // during this run, not just the position captured when it was created. A cross-thread
+                // reader (the end-of-run leak probe inspecting a still-busy fiber) then sees the fiber's
+                // live execution frames rather than a stale fork-time snapshot. The frames themselves are
+                // already in `trace.frames` (aliased above); only the index needs to advance with them.
+                //
+                // Fold the index into the canonical range [0, 2*maxTraceFrames) before storing it. The
+                // index counts every frame pushed over the trace's whole life, so a long-lived fiber would
+                // otherwise climb toward Int.MaxValue and overflow to a negative index, handing saveTrace
+                // and TracePool.clear a negative arraycopy length and emptying every render. maxTraceFrames
+                // is a power of two, so the fold preserves both the ring-full predicate (index <
+                // maxTraceFrames) and the slot mask (index & (maxTraceFrames - 1)) every consumer reads,
+                // leaving saved and rendered traces identical to the unfolded index.
+                trace.index =
+                    if index < maxTraceFrames then index
+                    else maxTraceFrames + (index & (maxTraceFrames - 1))
                 frames = prevFrames
                 index = prevIdx
             end try
@@ -98,47 +188,15 @@ private[kyo] object Trace:
         end withNewTrace
 
         final private[kernel] def enrich(ex: Throwable): Unit =
-            val size = if index < maxTraceFrames then index else maxTraceFrames
-            if size > 0 && !ex.isInstanceOf[NoStackTrace] then
-
-                val start =
-                    if index < maxTraceFrames then 0
-                    else index & (maxTraceFrames - 1)
-
-                val ordered = new Array[Frame](size)
-                @tailrec def parse(idx: Int, maxSnippetSize: Int): Int =
-                    if idx < size then
-                        val curr = frames((start + idx) & (maxTraceFrames - 1))
-                        ordered(idx) = curr
-                        if curr ne null then
-                            val snippetSize = curr.snippetShort.size
-                            parse(idx + 1, if snippetSize > maxSnippetSize then snippetSize else maxSnippetSize)
-                        else
-                            parse(idx + 1, maxSnippetSize)
-                        end if
-                    else
-                        maxSnippetSize + 1
-                val toPad = parse(0, 0)
-
-                val elements =
-                    ordered.foldLeft(List.empty[Frame]) {
-                        case (acc, curr) =>
-                            acc match
-                                case `curr` :: tail => acc
-                                case _              => if curr ne null then curr :: acc else acc
-                    }.map { frame =>
-                        StackTraceElement(
-                            frame.snippetShort.reverse.padTo(toPad, ' ').reverse + " @ " + frame.className,
-                            frame.callerName,
-                            frame.position.fileName,
-                            frame.position.lineNumber
-                        )
-                    }
-                val prefix = ex.getStackTrace.takeWhile(e =>
-                    e.getFileName() != elements(0).getFileName() || e.getLineNumber != elements(0).getLineNumber()
-                )
-                val suffix = (new Exception).getStackTrace().drop(2)
-                ex.setStackTrace(prefix ++ elements ++ suffix)
+            if !ex.isInstanceOf[NoStackTrace] then
+                val elements = Trace.orderedElements(frames, index).toArray
+                if elements.nonEmpty then
+                    val prefix = ex.getStackTrace.takeWhile(e =>
+                        e.getFileName() != elements(0).getFileName() || e.getLineNumber != elements(0).getLineNumber()
+                    )
+                    val suffix = (new Exception).getStackTrace().drop(2)
+                    ex.setStackTrace(prefix ++ elements ++ suffix)
+                end if
             end if
         end enrich
     end Owner

--- a/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/TraceTest.scala
+++ b/kyo-kernel/shared/src/test/scala/kyo/kernel/internal/TraceTest.scala
@@ -148,6 +148,167 @@ class TraceTest extends kyo.test.Test[Any]:
         succeed("runs without error: enrich with null frame does not throw (regression for #1172)")
     }
 
+    "Trace.render emits orderedElements toString newest-first for a golden snapshot" in {
+        val safepoint = Safepoint.get
+        val frame     = summon[Frame]
+        safepoint.pushFrame(frame)
+        val snapshot = safepoint.saveTrace()
+        val rendered = Trace.render(snapshot)
+        assert(rendered.nonEmpty)
+        assert(rendered.startsWith("at "))
+        assert(rendered.contains(" @ kyo.kernel.internal.TraceTest."))
+        val lines = rendered.linesIterator.toList
+        assert(lines.forall(_.startsWith("at ")))
+        val emptySnapshot = Trace.init
+        assert(Trace.render(emptySnapshot) == "")
+    }
+
+    "Trace.render collapses consecutive identical frames into one line with a (xN) count" in {
+        // Build a Trace directly from a known frame array, so the run length is deterministic and not
+        // perturbed by the shared safepoint ring. Three consecutive identical frames must collapse into
+        // a single line annotated with the repeat count, as a tight loop pushing the same frame would.
+        val frame    = summon[Frame]
+        val frames   = Array(frame, frame, frame)
+        val snapshot = new Trace(frames, 3)
+        val rendered = Trace.render(snapshot)
+        val lines    = rendered.linesIterator.toList
+        assert(lines.size == 1)
+        assert(lines.head.startsWith("at "))
+        assert(lines.head.endsWith(" (x3)"))
+        assert(lines.head.contains(" @ kyo.kernel.internal.TraceTest."))
+    }
+
+    "Trace.render omits the count suffix for a single occurrence" in {
+        val frame    = summon[Frame]
+        val snapshot = new Trace(Array(frame), 1)
+        val rendered = Trace.render(snapshot)
+        val lines    = rendered.linesIterator.toList
+        assert(lines.size == 1)
+        assert(!lines.head.contains("(x"))
+    }
+
+    "Trace.render counts only consecutive repeats, not all occurrences" in {
+        // A B A is two distinct runs of A (count 1 each), never one run of 2: only adjacent repeats fold.
+        val a = summon[Frame]
+        val b = summon[Frame]
+        assert(a != b)
+        val snapshot = new Trace(Array(a, b, a), 3)
+        val rendered = Trace.render(snapshot)
+        val lines    = rendered.linesIterator.toList
+        assert(lines.size == 3)
+        assert(lines.forall(!_.contains("(x")))
+    }
+
+    "pushFrame skips the shared internal placeholder frame" in {
+        // Frame.internal is the shared placeholder; pushFrame drops it via a reference check, so it
+        // never enters the ring and never reaches a render. The user frame is the only one that lands.
+        val safepoint = Safepoint.get
+        val frame     = summon[Frame]
+        safepoint.pushFrame(Frame.internal)
+        safepoint.pushFrame(frame)
+        safepoint.pushFrame(Frame.internal)
+        val snapshot = safepoint.saveTrace()
+        val rendered = Trace.render(snapshot)
+        // The internal placeholder is the only frame whose className is "<internal>"; if pushFrame had
+        // admitted it, a render line would carry that token. It must not, regardless of ring history.
+        assert(!rendered.contains("<internal>"))
+        assert(rendered.contains(" @ kyo.kernel.internal.TraceTest."))
+    }
+
+    "withTrace writes the advanced index back into the trace so frames pushed during the run survive" in {
+        // withTrace aliases the owner's ring to the passed Trace, runs the body, then in its finally copies
+        // the advanced index back into that Trace. Without the writeback the frames land in trace.frames but
+        // trace.index stays at the entry value, so a later render reads nothing. Drive withTrace over a fresh,
+        // initially-empty Trace, push frames inside, and confirm the index advanced (render non-empty) after.
+        val safepoint = Safepoint.get
+        val trace     = Trace.init
+        assert(trace.index == 0)
+        assert(Trace.render(trace) == "")
+        safepoint.withTrace(trace) {
+            safepoint.pushFrame(summon[Frame])
+            safepoint.pushFrame(summon[Frame])
+        }
+        assert(trace.index > 0)
+        val rendered = Trace.render(trace)
+        assert(rendered.nonEmpty)
+        assert(rendered.startsWith("at "))
+        assert(rendered.contains(" @ kyo.kernel.internal.TraceTest."))
+    }
+
+    "withTrace folds the written-back index into [0, 2*maxTraceFrames) so a long-lived fiber cannot overflow" in {
+        // The write-back counts every frame pushed over the trace's whole life, so across many batches a
+        // raw count would climb without bound (toward Int.MaxValue, where it overflows to a negative index
+        // that crashes saveTrace/TracePool.clear and empties every render). Drive many withTrace batches
+        // over one long-lived Trace, each pushing frames well past the maxTraceFrames boundary, and confirm
+        // the stored index stays non-negative and bounded throughout, while render still surfaces frames.
+        val safepoint = Safepoint.get
+        val trace     = Trace.init
+        val frame     = summon[Frame]
+        @scala.annotation.tailrec
+        def batches(n: Int): Unit =
+            if n > 0 then
+                safepoint.withTrace(trace) {
+                    safepoint.pushFrame(frame)
+                    safepoint.pushFrame(frame)
+                }
+                // Without the fold the stored index would equal the cumulative push count (3 per batch),
+                // crossing 2*maxTraceFrames within ~11 batches; the fold keeps it in [0, 2*maxTraceFrames).
+                assert(trace.index >= 0)
+                assert(trace.index < 2 * maxTraceFrames)
+                batches(n - 1)
+        batches(500)
+        // After hundreds of batches the ring is long full, so the folded index has settled into the upper
+        // half of the canonical range, never the unbounded count a raw write-back would have stored.
+        assert(trace.index >= maxTraceFrames)
+        assert(trace.index < 2 * maxTraceFrames)
+        val rendered = Trace.render(trace)
+        assert(rendered.nonEmpty)
+        assert(rendered.startsWith("at "))
+        assert(rendered.contains(" @ kyo.kernel.internal.TraceTest."))
+    }
+
+    "the folded canonical index is output-preserving against render and always in range" in {
+        // The fold maps a raw index to a canonical one in [0, 2*maxTraceFrames). It must be byte-identical
+        // to the raw index through every consumer (which read only the ring-full predicate `index <
+        // maxTraceFrames` and the slot mask `index & (maxTraceFrames - 1)`) and must never go negative or
+        // out of range, for any input including the values a long-lived fiber would reach.
+        def fold(rawIndex: Int): Int =
+            if rawIndex < maxTraceFrames then rawIndex
+            else maxTraceFrames + (rawIndex & (maxTraceFrames - 1))
+
+        // A full ring of distinct, non-repeating frames so the render order depends on the start slot
+        // (`index & (maxTraceFrames - 1)`): a fold that broke the mask would reorder and diverge here.
+        val a = summon[Frame]
+        val b = summon[Frame]
+        val c = summon[Frame]
+        assert(a != b && b != c && a != c)
+        val frames = Array.tabulate(maxTraceFrames) { i =>
+            (i % 3) match
+                case 0 => a
+                case 1 => b
+                case _ => c
+        }
+
+        val rawIndices = List(0, 1, 8, 15, 16, 17, 31, 32, 33, 47, 48, 100, 1000, Int.MaxValue)
+        rawIndices.foreach { raw =>
+            val folded = fold(raw)
+            // In range and non-negative for every input, including Int.MaxValue.
+            assert(folded >= 0, s"fold($raw) = $folded must be non-negative")
+            assert(folded < 2 * maxTraceFrames, s"fold($raw) = $folded must be < ${2 * maxTraceFrames}")
+            // The fold preserves the two quantities every consumer reads off the index.
+            assert((folded < maxTraceFrames) == (raw < maxTraceFrames))
+            assert((folded & (maxTraceFrames - 1)) == (raw & (maxTraceFrames - 1)))
+            // Byte-identical render for the raw and the folded index over the same frames.
+            val rawRender    = Trace.render(new Trace(frames, raw))
+            val foldedRender = Trace.render(new Trace(frames, folded))
+            assert(rawRender == foldedRender, s"render diverged for raw=$raw folded=$folded")
+        }
+
+        // The full-ring renders are non-trivial: a full distinct ring yields maxTraceFrames lines.
+        val full = Trace.render(new Trace(frames, fold(maxTraceFrames)))
+        assert(full.linesIterator.size == maxTraceFrames)
+    }
+
     def assertTrace[A](f: => A, expected: String)(using kyo.test.AssertScope) =
         try
             f

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/Scheduler.scala
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.LongAdder
 import java.util.concurrent.locks.LockSupport
 import kyo.scheduler.regulator.Admission
 import kyo.scheduler.regulator.Concurrency
+import kyo.scheduler.top.BusyWorker
 import kyo.scheduler.top.Reporter
 import kyo.scheduler.top.Status
 import kyo.scheduler.util.LoomSupport
@@ -499,6 +500,31 @@ final class Scheduler(
             admissionRegulator.status(),
             concurrencyRegulator.status()
         )
+    }
+
+    /** Per-busy-worker fiber attribution for the end-of-run leak probe: one [[kyo.scheduler.top.BusyWorker]] for every
+      * worker that holds work (`load > 0`) at call time, each carrying the worker's mount thread name and the rendered
+      * kyo Trace of the task it is running (or "" when that task carries no kyo trace).
+      *
+      * Covers EVERY busy worker, in worker-index order, not just the first. Total: it never throws, even while a worker
+      * thread concurrently completes its task or nulls a trace; a worker that goes idle between the load read and the
+      * task read contributes nothing. This is a leak-probe diagnostic, not a monitoring surface: it renders a kyo trace
+      * per busy worker, so it is called once at a leak finding, never on a hot path.
+      */
+    def busyFiberTraces(): Seq[BusyWorker] = {
+        val out = Seq.newBuilder[BusyWorker]
+        var i   = 0
+        while (i < allocatedWorkers) {
+            val w = workers(i)
+            if ((w ne null) && w.load() > 0) {
+                val t         = w.currentTask
+                val m         = w.mount
+                val mountName = if (m ne null) m.getName() else ""
+                out += BusyWorker(mountName, if (t ne null) t.fiberTrace() else "")
+            }
+            i += 1
+        }
+        out.result()
     }
 }
 

--- a/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/top/Status.scala
+++ b/kyo-scheduler/jvm-native/src/main/scala/kyo/scheduler/top/Status.scala
@@ -65,6 +65,18 @@ case class WorkerStatus(
         )
 }
 
+/** One scheduler worker that holds work (`load > 0`) at the end-of-run leak probe: its mount thread name and the
+  * rendered kyo Trace of the task it is running. `fiberTrace` is the multi-line, newest-first kyo frame render when
+  * the task carries a kyo trace (an IOTask-backed fiber), or "" when it does not (a plain `Task.apply` task, a
+  * scheduler-internal task), in which case the leak report shows only the JVM thread stack for this worker.
+  *
+  * @param mount
+  *   the worker's mount thread name (empty when the worker is momentarily unmounted)
+  * @param fiberTrace
+  *   the rendered kyo Trace, newest-first, or "" when the running task carries no kyo trace
+  */
+case class BusyWorker(mount: String, fiberTrace: String)
+
 case class TaskStatus(
     preempting: Boolean,
     runtime: Int

--- a/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/SchedulerTest.scala
+++ b/kyo-scheduler/jvm-native/src/test/scala/kyo/scheduler/SchedulerTest.scala
@@ -101,6 +101,48 @@ class SchedulerTest extends AnyFreeSpec with NonImplicitAssertions {
         }
     }
 
+    "busyFiberTraces" - {
+        "returns empty when the scheduler is idle" in withScheduler { scheduler =>
+            eventually(assert(scheduler.loadAvg() == 0))
+            assert(scheduler.busyFiberTraces().isEmpty)
+        }
+
+        "covers all busy workers, not first-only" in withScheduler { scheduler =>
+            val n   = 3
+            val cdl = new CountDownLatch(1)
+            val tasks = List.fill(n)(TestTask(_run = () => {
+                cdl.await()
+                Task.Done
+            }))
+            tasks.foreach(scheduler.schedule)
+            eventually(assert(scheduler.busyFiberTraces().size >= n))
+            val result = scheduler.busyFiberTraces()
+            assert(result.size >= n)
+            assert(result.forall(_.mount.nonEmpty))
+            assert(result.map(_.mount).distinct.size == result.size)
+            assert(result.forall(_.fiberTrace == ""))
+            cdl.countDown()
+            eventually(assert(scheduler.loadAvg() == 0))
+        }
+
+        "is total under concurrent worker mutation" in withScheduler { scheduler =>
+            val cdl = new CountDownLatch(1)
+            val task = TestTask(_run = () => {
+                cdl.await()
+                Task.Done
+            })
+            scheduler.schedule(task)
+            eventually(assert(scheduler.busyFiberTraces().nonEmpty))
+            // Release the latch so the worker completes and nulls currentTask concurrently with the probe loop below,
+            // exercising the busy -> idle transition the accessor must read without throwing.
+            cdl.countDown()
+            val results = (1 to 100).map(_ => scheduler.busyFiberTraces())
+            assert(results.forall(_ != null))
+            assert(results.forall(_.forall(_.mount != null)))
+            eventually(assert(scheduler.loadAvg() == 0))
+        }
+    }
+
     private def withScheduler[A](testCode: Scheduler => A): A = {
         val scheduler = new Scheduler(TestExecutors.cached, TestExecutors.scheduled)
         try testCode(scheduler)

--- a/kyo-scheduler/shared/src/main/scala/kyo/scheduler/Task.scala
+++ b/kyo-scheduler/shared/src/main/scala/kyo/scheduler/Task.scala
@@ -28,6 +28,15 @@ trait Task {
       */
     def needsInterrupt(): Boolean = false
 
+    /** The running fiber's logical trace as readable kyo frames, newest-first, or "" when this task carries no kyo trace.
+      *
+      * Read by the scheduler's diagnostic accessor to attribute a still-busy worker at the end-of-run leak probe. The
+      * default is "": a plain task (Task.apply, an admission probe) has no kyo trace, and "" signals the consumer to show
+      * only the JVM thread stack. IOTask overrides this to render its captured trace. The return is a plain String so the
+      * scheduler stays trace-agnostic (no kyo-kernel dependency); the read is best-effort and never throws.
+      */
+    private[scheduler] def fiberTrace(): String = ""
+
     private[scheduler] def runtime(): Int =
         state.runtime
 

--- a/kyo-scheduler/shared/src/test/scala/kyo/scheduler/TaskTest.scala
+++ b/kyo-scheduler/shared/src/test/scala/kyo/scheduler/TaskTest.scala
@@ -116,4 +116,11 @@ class TaskTest extends AnyFreeSpec with NonImplicitAssertions {
             assert(t.checkShouldPreempt())
         }
     }
+
+    "fiberTrace" - {
+        "Task.fiberTrace default returns empty string" in {
+            val task = Task.apply(() => ())
+            assert(task.fiberTrace() == "")
+        }
+    }
 }

--- a/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/internal/LeakCheck.scala
+++ b/kyo-test/runner/jvm/src/main/scala/kyo/test/runner/internal/LeakCheck.scala
@@ -132,34 +132,23 @@ private[runner] object LeakCheck:
         res
     end busyWorkerFrame
 
-    /** The full stack of a worker that currently holds work (`load > 0`), joined into one string, for allowlist matching. The scheduler's
-      * `WorkerStatus.frame` is only the top frame, and the top frame of a blocked fiber is an OS-specific syscall (`EPoll.wait` on Linux,
-      * `KQueue` on macOS); a allowlist needs a stable kyo frame deeper in the stack, so this reads the worker's mount thread's full stack via
-      * `Thread.getAllStackTraces` (keyed by the mount thread name in the status). `Absent` when no worker is busy.
+    /** The JVM stack of the thread named `name`, found via `Thread.getAllStackTraces`, joined into one string.
+      * Keyed by a `BusyWorker.mount` name so the leak dump can show the stack of every busy worker.
+      * `Absent` when no live thread has that name.
       */
-    def busyWorkerStack(): Maybe[String] =
-        val workers              = Scheduler.get.status().workers
-        var i                    = 0
-        var mount: Maybe[String] = Maybe.empty
-        while i < workers.length && mount.isEmpty do
-            val w = workers(i)
-            if (w ne null) && w.load > 0 && (w.mount ne null) && w.mount.nonEmpty then mount = Maybe(w.mount)
-            i += 1
-        end while
-        mount.flatMap { name =>
-            var res: Maybe[String] = Maybe.empty
-            Thread.getAllStackTraces.asScala.foreach { case (t, st) =>
-                if res.isEmpty && t.getName == name then res = Maybe(st.mkString("\n"))
-            }
-            res
+    def stackOfThread(name: String): Maybe[String] =
+        var res: Maybe[String] = Maybe.empty
+        Thread.getAllStackTraces.asScala.foreach { case (t, st) =>
+            if res.isEmpty && t.getName == name then res = Maybe(st.mkString("\n"))
         }
-    end busyWorkerStack
+        res
+    end stackOfThread
 
     /** A thread dump of every thread that is actually doing something at probe time, for an actionable fiber-leak report: each thread whose
-      * state is `RUNNABLE` or whose stack runs kyo code, with its name, state, and stack. Unlike [[busyWorkerStack]] (which sees only scheduler
-      * workers) this also captures NON-worker threads, e.g. a caller stuck mid-`offer` that holds a queue's race-repair counter while a worker
-      * spins in `close()` waiting for it. Idle pool/parked threads with no kyo frame are filtered out to keep the report focused. The leak
-      * check's own thread is excluded.
+      * state is `RUNNABLE` or whose stack runs kyo code, with its name, state, and stack. Unlike the per-busy-worker dump (which is keyed to
+      * the busy scheduler workers' mount threads via [[stackOfThread]]) this also captures NON-worker threads, e.g. a caller stuck mid-`offer`
+      * that holds a queue's race-repair counter while a worker spins in `close()` waiting for it. Idle pool/parked threads with no kyo frame are
+      * filtered out to keep the report focused. The leak check's own thread is excluded.
       */
     def runningThreadsDump(): String =
         val self = Thread.currentThread()
@@ -319,9 +308,10 @@ private[runner] object LeakCheck:
       *
       * Order: the scheduler/fiber probe first (it owns the settle window), then a `System.gc()` plus settle so Cleaner-closed abandoned
       * channels and finished threads drop out before the descriptor and thread diffs (a genuine leak stays referenced and survives the gc, so
-      * this trims false positives without hiding real leaks). The fiber probe matches the allowlist against the busy worker's full stack so an
-      * OS-independent kyo frame can excuse an expected event loop; the descriptor probe enumerates `/proc/self/fd` and reports the exact
-      * leaked targets with no count tolerance.
+      * this trims false positives without hiding real leaks). The fiber probe builds a per-busy-worker dump (each worker's rendered kyo trace,
+      * when its task carries one, plus its JVM thread stack) and matches the allowlist against EITHER the kyo trace or the JVM stack of any busy
+      * worker, so an OS-independent kyo frame or a stable JVM-stack frame can excuse an expected event loop; the descriptor probe enumerates
+      * `/proc/self/fd` and reports the exact leaked targets with no count tolerance.
       */
     def detect(
         baseline: Baseline,
@@ -343,11 +333,21 @@ private[runner] object LeakCheck:
             case IdleResult.Idle => ()
             case IdleResult.Busy(la, frame) =>
                 if checkFibers then
-                    val stack       = busyWorkerStack().getOrElse(frame.getOrElse(""))
-                    val allowlisted = effectiveAllowlist.exists(stack.contains)
+                    val busy = Scheduler.get.busyFiberTraces()
+                    val perWorker =
+                        busy.map { w =>
+                            val header     = s"  worker thread ${w.mount}:"
+                            val kyoSection = if w.fiberTrace.nonEmpty then s"\n    kyo trace:\n${w.fiberTrace}" else ""
+                            val stack = stackOfThread(w.mount).map { st =>
+                                st.linesIterator.take(30).map(f => s"        at $f").mkString("\n")
+                            }.getOrElse("        <stack unavailable>")
+                            s"$header$kyoSection\n    thread stack:\n$stack"
+                        }.mkString("\n")
+                    val matchText   = busy.map(w => w.fiberTrace + "\n" + stackOfThread(w.mount).getOrElse("")).mkString("\n")
+                    val allowlisted = effectiveAllowlist.exists(matchText.contains)
                     if !allowlisted then
                         findings += s"fiber leak: scheduler still busy (loadAvg=$la) after settle; running at ${frame.getOrElse("<unknown frame>")}" +
-                            s"\n    busy worker stack:\n$stack" +
+                            s"\n  per-busy-worker fiber dump:\n$perWorker" +
                             s"\n  all running threads (worker and non-worker) at probe time:${runningThreadsDump()}"
                     end if
         end match

--- a/kyo-test/runner/jvm/src/test/scala/kyo/test/runner/LeakCheckTest.scala
+++ b/kyo-test/runner/jvm/src/test/scala/kyo/test/runner/LeakCheckTest.scala
@@ -4,6 +4,7 @@ import java.nio.channels.FileChannel
 import java.nio.file.StandardOpenOption
 import java.util.concurrent.atomic.AtomicBoolean
 import kyo.*
+import kyo.scheduler.Scheduler
 import kyo.test.runner.internal.LeakCheck
 import org.scalatest.NonImplicitAssertions
 import org.scalatest.funsuite.AnyFunSuite
@@ -38,6 +39,24 @@ class LeakCheckTest extends AnyFunSuite with NonImplicitAssertions:
             ok = cond
         ok
     end awaitTrue
+
+    /** Runs the fiber probe of [[LeakCheck.detect]] (the `IdleResult.Busy` branch) with all other categories off, returning the
+      * leak report. Short idle budget so it returns a `Busy` verdict promptly while a deliberately busy worker is running; the dump it
+      * assembles iterates `Scheduler.get.busyFiberTraces()`.
+      */
+    private def detectFiberReport(allowlist: Chunk[String]): Maybe[String] =
+        LeakCheck.detect(
+            LeakCheck.baseline(),
+            allowlist,
+            checkFibers = true,
+            checkThreads = false,
+            checkFileDescriptors = false,
+            checkSockets = false,
+            idleBudgetNanos = 200_000_000L,
+            settleNanos = 20_000_000L,
+            pollNanos = 5_000_000L
+        )
+    end detectFiberReport
 
     test("benignFd excludes classpath/library/JVM-internal targets, keeps sockets/pipes/files") {
         assert(LeakCheck.benignFd("/home/u/.ivy2/cache/io.getkyo/kyo-core.jar"))
@@ -174,6 +193,140 @@ class LeakCheckTest extends AnyFunSuite with NonImplicitAssertions:
         assert(
             !LeakCheck.leakedNonDaemonThreads(baseline, Chunk.empty).exists(_.contains("leak-probe-thread")),
             "after the thread joined it must no longer be reported as leaked"
+        )
+    }
+
+    test("leak report contains a kyo Trace frame for a busy IOTask fiber") {
+        import kyo.AllowUnsafe.embrace.danger
+        val stop = new AtomicBoolean(false)
+        // An effectful busy loop: each iteration runs an allocation-free CPU burst (pegging one worker) then a `.map`
+        // whose `(using Frame)` stamps this test file's file:line into the fiber's live Trace, so the fiber stays
+        // runnable (busy) AND its fiberTrace is non-empty. The burst bounds the allocation rate (one continuation set
+        // per burst) so a fast .map recursion never exhausts the fork heap; the recursion threads `x` so it stays live.
+        // Not a pure Sync.defer loop, which by kernel design pushes no user frames and renders an empty trace.
+        def kyoBusyLoop(n: Long): Unit < Sync =
+            Sync.defer {
+                var x = n
+                var i = 0
+                while i < 1_000_000 && !stop.get() do
+                    x += 1
+                    i += 1
+                x
+            }.map(m => if stop.get() then () else kyoBusyLoop(m))
+        val fiber    = Sync.Unsafe.evalOrThrow(Fiber.initUnscoped(kyoBusyLoop(0L)))
+        val observed = awaitTrue(2000)(Scheduler.get.busyFiberTraces().exists(_.fiberTrace.nonEmpty))
+        val report   = detectFiberReport(Chunk.empty)
+        // Tear the loop down BEFORE asserting so a failed assertion never leaves the fiber pegging a worker.
+        stop.set(true)
+        val _       = Sync.Unsafe.evalOrThrow(fiber.interrupt)
+        val drained = awaitTrue(2000)(Scheduler.get.busyFiberTraces().isEmpty)
+
+        assert(observed, "an effectful busy IOTask fiber should surface a non-empty fiberTrace within 2s")
+        val text = report.getOrElse("")
+        assert(text.contains("kyo trace:"), s"the per-busy-worker dump should carry a 'kyo trace:' label; got:\n$text")
+        assert(text.contains("LeakCheckTest.scala:"), s"the dump should name this test's fiber-body file:line; got:\n$text")
+        assert(drained, "after teardown the scheduler should report no busy workers (no leaked fiber)")
+    }
+
+    test("busy non-IOTask worker produces a dump with no kyo trace subsection") {
+        val stop = new AtomicBoolean(false)
+        // A plain spinning Runnable scheduled through asExecutor becomes a non-IOTask Task whose fiberTrace() is "",
+        // so the dump shows only the JVM thread stack for that worker (the graceful empty-trace fallback). The
+        // `if x < 0 then throw` keeps the otherwise-dead accumulator live so the spin is not eliminated.
+        val spinner: Runnable =
+            () =>
+                var x = 0L
+                while !stop.get() do x += 1
+                if x < 0 then throw new AssertionError()
+        Scheduler.get.asExecutor.execute(spinner)
+        val observed = awaitTrue(2000)(Scheduler.get.busyFiberTraces().exists(_.fiberTrace.isEmpty))
+        val report   = detectFiberReport(Chunk.empty)
+        stop.set(true)
+        val drained = awaitTrue(2000)(Scheduler.get.busyFiberTraces().isEmpty)
+
+        assert(observed, "a busy non-IOTask worker should surface a BusyWorker with an empty fiberTrace within 2s")
+        val text = report.getOrElse("")
+        assert(text.contains("thread stack:"), s"every busy worker must show a 'thread stack:' subsection; got:\n$text")
+        assert(!text.contains("kyo trace:"), s"a non-IOTask worker (empty fiberTrace) must NOT show a 'kyo trace:' subsection; got:\n$text")
+        assert(drained, "after stop the scheduler should report no busy workers")
+    }
+
+    test("allowlist match covers a kyo-trace-only frame") {
+        import kyo.AllowUnsafe.embrace.danger
+        val stop = new AtomicBoolean(false)
+        def kyoBusyLoop(n: Long): Unit < Sync =
+            Sync.defer {
+                var x = n
+                var i = 0
+                while i < 1_000_000 && !stop.get() do
+                    x += 1
+                    i += 1
+                x
+            }.map(m => if stop.get() then () else kyoBusyLoop(m))
+        val fiber = Sync.Unsafe.evalOrThrow(Fiber.initUnscoped(kyoBusyLoop(0L)))
+        // Wait for the PERSISTENT recursion frame (the `.map` call site, `LeakCheckTest.kyoBusyLoop(...)`), not merely any
+        // non-empty trace: a transient startup frame is the newest line early on but does not survive once the 16-slot
+        // ring fills with the steady-state recursion frame, so a token taken from it would not match a later detect render.
+        val observed = awaitTrue(2000)(Scheduler.get.busyFiberTraces().exists(_.fiberTrace.contains("LeakCheckTest.kyoBusyLoop(")))
+        // Reproduce the Busy branch's allowlist match text against the REAL busy fiber: per worker, its rendered kyo
+        // trace joined with its JVM stack. The token is the ` @ <class>.<caller>(File:line)` fragment of the recursion
+        // frame: a JVM StackTraceElement carries no ` @ ` separator, so the token appears ONLY in the kyo trace, never in
+        // the JVM stack. The padded snippet (before ` @ `) and the trailing ` (xN)` repeat-count suffix are dropped (the
+        // count grows as the ring fills, so a count-bearing token would not match a later render).
+        val busy       = Scheduler.get.busyFiberTraces()
+        val jvmStacks  = busy.map(w => LeakCheck.stackOfThread(w.mount).getOrElse("")).mkString("\n")
+        val matchText  = busy.map(w => w.fiberTrace + "\n" + LeakCheck.stackOfThread(w.mount).getOrElse("")).mkString("\n")
+        val steadyLine = busy.iterator.flatMap(_.fiberTrace.linesIterator).find(_.contains("LeakCheckTest.kyoBusyLoop(")).getOrElse("")
+        val atIdx      = steadyLine.indexOf(" @ ")
+        val afterAt    = if atIdx >= 0 then steadyLine.substring(atIdx) else steadyLine
+        val xIdx       = afterAt.indexOf(" (x")
+        val kyoOnly    = if xIdx >= 0 then afterAt.substring(0, xIdx) else afterAt
+        // End-to-end: ONE detect with the kyo-trace token suppresses the finding (a single Busy probe, as reliable as
+        // the kyo-trace-frame arm above; a second back-to-back probe races the first probe's System.gc() and is avoided).
+        val suppressed = detectFiberReport(Chunk(kyoOnly))
+        // Tear the loop down BEFORE asserting so a failed assertion never leaves the fiber pegging a worker.
+        stop.set(true)
+        val _       = Sync.Unsafe.evalOrThrow(fiber.interrupt)
+        val drained = awaitTrue(2000)(Scheduler.get.busyFiberTraces().isEmpty)
+
+        assert(observed, "an effectful busy IOTask fiber should surface a non-empty fiberTrace within 2s")
+        assert(kyoOnly.nonEmpty && kyoOnly.contains(" @ "), s"the token should be a kyo-trace frame fragment; got '$kyoOnly'")
+        assert(!jvmStacks.contains(kyoOnly), s"the chosen token must be kyo-trace-only (absent from the JVM stacks); token '$kyoOnly'")
+        // Deterministic widening proof against the exact Busy-branch match expression on the real fiber's match text:
+        // absent the token no default pattern matches (so the finding would fire), and adding the kyo-trace token makes
+        // the match succeed (so the finding is suppressed) via the kyo trace, not the JVM stack.
+        assert(
+            !LeakCheck.defaultAllowlist.exists(matchText.contains),
+            "absent the token, no default pattern matches the busy fiber, so the finding would fire"
+        )
+        assert(
+            (LeakCheck.defaultAllowlist ++ Chunk(kyoOnly)).exists(matchText.contains),
+            s"the kyo-trace-only token must match via the Busy-branch match expression; token '$kyoOnly'"
+        )
+        assert(
+            !suppressed.getOrElse("").contains("fiber leak:"),
+            s"the kyo-trace-only allowlist token must suppress the detect fiber-leak finding; token=[$kyoOnly]"
+        )
+        assert(drained, "after teardown the scheduler should report no busy workers")
+    }
+
+    test("allowlist match excuses a default JVM-stack pattern") {
+        // The match text per busy worker is `fiberTrace + "\n" + jvmStack`. A default allowlist pattern that
+        // appears only in the JVM-stack portion suppresses the finding; a pattern in the kyo-trace portion
+        // suppresses it too. Driven via the pure match logic because constructing a real NioIoDriver-backed
+        // busy worker in a unit test is heavyweight.
+        val jvmStackPortion =
+            "    at kyo.net.internal.ProcessSharedTransport$$anon$1.pollLoop(ProcessSharedTransport.scala:42)\n" +
+                "    at kyo.http.NioIoDriver.run(NioIoDriver.scala:99)"
+        val matchTextJvmOnly = "" + "\n" + jvmStackPortion
+        assert(
+            LeakCheck.defaultAllowlist.exists(matchTextJvmOnly.contains),
+            s"a default pattern in the JVM-stack portion must suppress; match text was:\n$matchTextJvmOnly"
+        )
+        val matchTextKyoOnly = "at processSharedTransport @ kyo.Foo.bar(Foo.scala:1)" + "\n" + ""
+        assert(
+            LeakCheck.defaultAllowlist.exists(matchTextKyoOnly.contains),
+            s"a default pattern in the kyo-trace portion must suppress; match text was:\n$matchTextKyoOnly"
         )
     }
 

--- a/kyo-ui/shared/src/main/scala/kyo/Svg.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/Svg.scala
@@ -562,12 +562,10 @@ object Svg:
     type StopChild = Stop | Reactive[? <: Stop] | Foreach[?, ? <: Stop] | Fragment[? <: Stop]
     // There is no HtmlChild alias: HTML containment is expressed through the AsHtmlChild typeclass.
 
-    private[kyo] def liftSvg(cs: Seq[?]): Chunk[UI] =
+    private[kyo] def liftSvg(cs: Seq[?])(using Frame): Chunk[UI] =
         Chunk.from(cs.map {
-            case s: String => UI.Ast.Text(s)(using
-                    Frame.internal
-                ) // internal frame for the framework's string-to-text lift; no user-visible Frame site
-            case u: UI => u
+            case s: String => UI.Ast.Text(s)
+            case u: UI     => u
         })
 
     // ---- Element case classes: structure ----


### PR DESCRIPTION
### Problem

When the end-of-run leak check finds a still-busy (leaked) fiber, the report showed only the worker's JVM thread stack, with mangled `$$anon$NN` frames and no kyo-level context, so it was hard to see which computation leaked.

### Solution

The fiber-leak report now renders, per busy worker, the running fiber's kyo Trace alongside its JVM thread stack. The thread stack is always present; the kyo trace is added when the fiber carries one, giving readable user frames (file:line plus the source snippet) instead of only the raw JVM frame.

Making that trace high-quality and readable required supporting changes to the trace machinery:

- Frame.internal becomes a single shared placeholder. It was a per-call-site macro, but an internal frame's position only ever rendered as a fixed framework line, so it carried no useful information. As one shared value it is identified cheaply and skipped in Trace.pushFrame, so internal frames never enter the 16-slot ring. This reserves the ring for user frames and de-noises both fiber traces and exception enrichment.

- Trace.render collapses a run of consecutive identical frames into one line with an `(xN)` count, so a tight loop reads cleanly.

- Trace.withTrace writes the advanced index back into the trace, so a fiber's trace reflects the frames it pushes while running rather than only the position captured when it was created. The written-back index is folded into a bounded range so a long-lived fiber cannot overflow it.

- Task.fiberTrace and IOTask.fiberTrace render the trace; Scheduler.busyFiberTraces exposes, per busy worker, its mount thread name and rendered trace; the leak check consumes that.

- kyo-ui Svg.liftSvg now threads the element's real Frame into lifted text nodes instead of using Frame.internal, since the frame was already in scope.

### Notes
- Public surface added: `Scheduler.busyFiberTraces(): Seq[BusyWorker]` and `kyo.scheduler.top.BusyWorker(mount, fiberTrace)`.
- Behavior change: an internal frame now renders as a uniform `<internal>` placeholder rather than a framework file:line, and internal frames no longer appear in exception traces. The per-site positions were framework-internal and not asserted anywhere.
- A pure `Sync.defer` spin loop carries no logical trace (defers do not push frames), so for such a fiber the report shows the thread stack only.
