### PR TITLE
[kyo-compat] add Scala Native support for the cats-effect binding

### DIFF
--- a/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatPlugin.scala
+++ b/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatPlugin.scala
@@ -57,7 +57,7 @@ object CompatPlugin extends AutoPlugin {
         val ZioLib: CompatBackendAxis =
             _root_.io.getkyo.compat.CompatBackendAxis("zio", "Zio", "-zio", Set("jvm", "js", "native"))
         val CeLib: CompatBackendAxis =
-            _root_.io.getkyo.compat.CompatBackendAxis("ce", "Ce", "-ce", Set("jvm", "js"))
+            _root_.io.getkyo.compat.CompatBackendAxis("ce", "Ce", "-ce", Set("jvm", "js", "native"))
         val OxLib: CompatBackendAxis =
             _root_.io.getkyo.compat.CompatBackendAxis("ox", "Ox", "-ox", Set("jvm"))
         val TwitterFutureLib: CompatBackendAxis =

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/cross-platform/build.sbt
@@ -1,8 +1,7 @@
 // Scripted test — all 5 backends, all 3 platforms.
 //
 // Per-backend supportedPlatforms intersection means:
-//   Kyo / Zio       : JVM + JS + Native
-//   Ce              : JVM + JS         (Native skipped)
+//   Kyo / Zio / Ce  : JVM + JS + Native
 //   Future / Ox     : JVM              (JS + Native skipped)
 
 ThisBuild / scalaVersion     := "3.3.4"
@@ -22,7 +21,7 @@ lazy val myLib = (projectMatrix in file("my-lib"))
 // --------------------------------------------------------------------
 
 val checkProjects                     = taskKey[Unit]("verify exact project set")
-val checkSkippedCells                 = taskKey[Unit]("verify Ce/Native, Ox/JS, Ox/Native are not generated")
+val checkSkippedCells                 = taskKey[Unit]("verify Future/JS, Future/Native, Ox/JS, Ox/Native are not generated")
 val checkDepsPerPlatform              = taskKey[Unit]("verify per-platform cross-version on the kyo-compat-X dep")
 val checkSharedSourcesAcrossPlatforms = taskKey[Unit]("verify every per-platform project sees the shared dir")
 
@@ -33,7 +32,7 @@ checkProjects := {
         "myLibFuture",
         "myLibKyo",    "myLibKyoJS",    "myLibKyoNative",
         "myLibZio",    "myLibZioJS",    "myLibZioNative",
-        "myLibCe",     "myLibCeJS",
+        "myLibCe",     "myLibCeJS",     "myLibCeNative",
         "myLibOx"
     )
     val actual  = ext.structure.allProjectRefs.map(_.project).toSet
@@ -46,14 +45,14 @@ checkProjects := {
 checkSkippedCells := {
     val s   = Keys.state.value
     val ext = sbt.Project.extract(s)
-    val mustNotExist = Set("myLibFutureJS", "myLibFutureNative", "myLibCeNative", "myLibOxJS", "myLibOxNative")
+    val mustNotExist = Set("myLibFutureJS", "myLibFutureNative", "myLibOxJS", "myLibOxNative")
     val actual       = ext.structure.allProjectRefs.map(_.project).toSet
     val leaked       = mustNotExist intersect actual
     if (leaked.nonEmpty)
         sys.error(
             s"Cells the backend cannot support leaked into the project graph: $leaked"
         )
-    println("checkSkippedCells OK; Future/JS, Future/Native, Ce/Native, Ox/JS, Ox/Native are absent.")
+    println("checkSkippedCells OK; Future/JS, Future/Native, Ox/JS, Ox/Native are absent.")
 }
 
 checkDepsPerPlatform := {
@@ -71,6 +70,7 @@ checkDepsPerPlatform := {
         Case(myLib.kyo.js,        "kyo-compat-kyo",    "sjs1"),
         Case(myLib.zio.native,    "kyo-compat-zio",    "native"),
         Case(myLib.ce.js,         "kyo-compat-ce",     "sjs1"),
+        Case(myLib.ce.native,     "kyo-compat-ce",     "native"),
         Case(myLib.ox.jvm,        "kyo-compat-ox",     "jvm")
     )
 
@@ -124,7 +124,7 @@ checkSharedSourcesAcrossPlatforms := {
         myLib.future.jvm,
         myLib.kyo.jvm,    myLib.kyo.js,    myLib.kyo.native,
         myLib.zio.jvm,    myLib.zio.js,    myLib.zio.native,
-        myLib.ce.jvm,     myLib.ce.js,
+        myLib.ce.jvm,     myLib.ce.js,     myLib.ce.native,
         myLib.ox.jvm
     )
 


### PR DESCRIPTION
### Problem

The cats-effect binding in `kyo-compat` only supports `jvm` and `js`, while the ZIO and Kyo bindings already support all three platforms (`jvm`, `js`, `native`). cats-effect 3.5+ ships with Scala Native support, so there is no technical reason for the CE binding to lag behind. Downstream libraries trying to target Scala Native with the cats-effect backend hit an "empty intersection" error from the plugin's platform check.

### Solution

- Add `"native"` to the cats-effect backend's supported platforms in `CompatPlugin.scala`
- Create `bindings/ce/native/src/main/scala/.gitkeep` (empty placeholder, same pattern as the ZIO and Kyo bindings)

The cats-effect binding's `shared/` code compiles on Native without modification. The JVM-only `FromCompletionStage` file correctly stays in `jvm/` and is excluded from the Native build.

### Notes

- No Native-specific source files are needed for the CE binding
- The existing `cross-platform` scripted test is updated to expect and verify the CE Native project is now generated, including the correct native cross-version marker on its dependency
- Tested with: `sbt 'kyo-compat-plugin/scripted kyo-compat/cross-platform'`