### PR TITLE
[schema] fix Protobuf repeated/map codec, add proto3 conformance

### DIFF
--- a/kyo-schema/CONTRIBUTING.md
+++ b/kyo-schema/CONTRIBUTING.md
@@ -396,6 +396,53 @@ def fieldId(name: String): Int =
     (MurmurHash3.stringHash(name) & 0x1fffff) + 1
 ```
 
+### Conformance modes (Strict and Permissive)
+
+`Protobuf.Config.conformance` is a CODEC-level concern, not a Schema slot. The schema derives the same structure in both modes; the codec gate is at encode time.
+
+`Conformance.Strict` (the default): encode rejects any map whose key type is not a proto3-native scalar (an integral, `Boolean`, `String`, or an opaque/value-class whose `Schema` reduces to one of those). Rejection throws `SchemaNotSerializableException` with a message prefixed `"non-canonical proto3 map key: "`. No bytes are written before the throw.
+
+`Conformance.Permissive`: all map key types are permitted. Non-canonical keys use the entry-message encoding and round-trip through this codec; they are not standard proto3 `map<K,V>` externally.
+
+The `given Protobuf = Protobuf()` zero-argument instance is Strict. Permissive requires an explicit config:
+
+```scala
+given Protobuf = Protobuf(Protobuf.Config(conformance = Protobuf.Conformance.Permissive))
+```
+
+### fieldNumberAudit and FieldNumberInfo
+
+`Protobuf.fieldNumberAudit[A]` is pure and total: no encode, no decode, no throw. It returns `Chunk[FieldNumberInfo]`, one row per message field, in declaration order, depth-first for nested messages.
+
+`FieldNumberInfo` fields:
+- `path`: dotted path from the root message (e.g., `"inner.id"` for a nested field)
+- `name`: leaf field name
+- `number`: the wire field number this codec uses (MurmurHash3 formula or a leaf-name override)
+- `pinned`: true when a single-segment (leaf field-name) `Schema.fieldId` override is in effect and is wire-functional; nested-path (multi-segment) overrides are a consistent no-op (`pinned` stays false), deferred to getkyo/kyo#1719
+- `inReservedRange`: true when `number` is in proto3's reserved band 19000-19999, which external `protoc` rejects
+
+The field-id formula is fixed and identical across `CodecMacro.fieldId`, `fieldNumberAudit`, and `protoSchema`:
+
+```
+(MurmurHash3.stringHash(name) & 0x1fffff) + 1
+```
+
+### Packed and unpacked repeated scalars
+
+Scalar repeated fields (`List[Int]`, `Vector[Double]`, `Set[Boolean]`, and so on) are emitted as a single packed length-delimited record (wire type 2). Non-scalar repeated fields (repeated messages, repeated strings, repeated bytes) stay per-element. The reader accepts both packed (wire type 2) and unpacked (element's primitive wire type) forms, so data from proto3 producers that emit unpacked decodes correctly.
+
+This dual-handling invariant must be preserved: adding a new scalar reader arm must accept both forms.
+
+### protoSchema emits wire-true field numbers
+
+`Protobuf.protoSchema[A]` emits the MurmurHash3-derived field number for every message field, the same number the codec writes on the wire. Hash-derived fields carry a line-end provenance comment. A pinned field (leaf-name `Schema.fieldId` override) carries no provenance comment. A field in proto3's reserved range 19000-19999 carries a WARNING comment unconditionally.
+
+Structural slots (oneof variant numbers, MapEntry key=1/value=2) are not affected and keep their structural assignments.
+
+### Leaf-name Schema.fieldId pin is wire-functional
+
+A single-segment `Schema.fieldId` override (e.g., `Schema[User].fieldId(_.id)(1)`) is wire-functional: encode writes the pinned number on the wire, decode matches it, and `protoSchema`/`fieldNumberAudit` report it. Pinning is keyed by field NAME and is global: pinning `id` to 1 assigns field 1 to every field named `id` across all messages in that schema tree. Nested-path overrides (multi-segment, e.g., `_.inner.id`) are a consistent no-op across all five surfaces, deferred to getkyo/kyo#1719.
+
 ## Extension Recipes
 
 ### Add a Schema for a new primitive

--- a/kyo-schema/README.md
+++ b/kyo-schema/README.md
@@ -649,6 +649,18 @@ val schema =
 
 `Protobuf.decode` accepts the same `maxDepth` and `maxCollectionSize` safety limits as `Json.decode`.
 
+Maps encode as a standard proto3 `map<K, V>`: each entry is a `MapEntry` message (key at field 1, value at field 2) repeated under the map field. A key type proto3 admits as a map key (an integral, `Boolean`, or `String` scalar, or an opaque type / value class whose `Schema` reduces to one) yields an interoperable `map<K, V>`. Any other key type (a message, `Float`, or `Double` key) cannot form a proto3-native `map<K, V>`. Under the default `Conformance.Strict` mode, encoding such a map raises `SchemaNotSerializableException` with a message prefixed `"non-canonical proto3 map key: "`. Under `Conformance.Permissive`, the map uses an entry-message encoding that round-trips through this codec but is not standard proto3 externally, and `protoSchema` describes the field as `repeated <Name>Entry` rather than the invalid `map<...>` syntax.
+
+Repeated and map fields follow proto3 emptiness: an empty `List`/`Seq`/`Map`/... emits no bytes, and an absent repeated or map field decodes to the empty collection rather than failing, so collection fields are not required on the wire.
+
+Repeated scalar fields (`List[Int]`, `Vector[Double]`, `Set[Boolean]`, and so on) are packed into a single length-delimited record, matching proto3's canonical form. The reader accepts both packed and unpacked forms. Self-consistent round-trips (kyo encode then decode) always work; an externally-produced zero-length packed scalar record is byte-identical to an empty string element on the same field number, so that specific external wire form is not distinguished.
+
+The proto3 conformance mode is `Conformance.Strict` by default: the zero-argument `given Protobuf` rejects any shape that cannot be encoded in canonical proto3. To allow the non-canonical extensions that still round-trip through this codec, supply an explicit instance:
+
+```scala
+given Protobuf = Protobuf(Protobuf.Config(conformance = Protobuf.Conformance.Permissive))
+```
+
 `Protobuf.protoSchema[A]` generates a `.proto` definition as a string:
 
 ```scala
@@ -656,20 +668,35 @@ val proto = Protobuf.protoSchema[User]
 // syntax = "proto3";
 //
 // message Address {
-//   string city = 1;
-//   string zip = 2;
+//   string city = 1842612;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   string zip = 739203;  // hash-derived field number; pin via Schema.fieldId for stable external interop
 // }
 //
 // message User {
-//   sint32 id = 1;
-//   string name = 2;
-//   string email = 3;
-//   string password = 4;
-//   Address address = 5;
+//   sint32 id = 1243642;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   string name = 1790876;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   string email = 1459300;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   string password = 508918;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   Address address = 1702831;  // hash-derived field number; pin via Schema.fieldId for stable external interop
 // }
 ```
 
-The field numbers in the generated `.proto` are assigned in declaration order (`1`, `2`, `3`, ...) and do **not** reflect the MurmurHash3-derived wire IDs that kyo-schema's own Protobuf codec uses on the wire. If you plan to interoperate with an external consumer of the `.proto`, pin field IDs explicitly with `fieldId(_.name)(1)` so the wire format matches the `.proto`.
+The field numbers in the generated `.proto` match the wire field numbers the codec writes: each is the MurmurHash3-derived value for that field name, the same number used at encode and decode. Hash-derived fields carry a provenance comment. Pinning a field with `fieldId` removes the provenance comment and writes the pinned number on the wire instead. A hash-derived number in proto3's reserved range (19000-19999) escalates the comment to a WARNING because external `protoc` rejects numbers in that band. The specific numbers in the examples above (1842612, 739203, and so on) are the hash-derived values for those field names and are shown for illustration; the actual values for your types are computed at compile time from field names via the same formula.
+
+`Protobuf.fieldNumberAudit[A]` returns one `FieldNumberInfo` per message field, depth-first, reporting the wire field number, a `pinned` flag, and an `inReservedRange` flag without performing any encode or decode:
+
+```scala
+val audit = Protobuf.fieldNumberAudit[User]
+// Chunk.Indexed(
+//   FieldNumberInfo(id,id,1243642,false,false),       // numbers are hash-derived for these field names
+//   FieldNumberInfo(name,name,1790876,false,false),
+//   FieldNumberInfo(email,email,1459300,false,false),
+//   FieldNumberInfo(password,password,508918,false,false),
+//   FieldNumberInfo(address,address,1702831,false,false),
+//   FieldNumberInfo(address.city,city,1842612,false,false),
+//   FieldNumberInfo(address.zip,zip,739203,false,false)
+// )
+```
 
 A few shapes that proto3 cannot express raise `IllegalArgumentException` at encode or `protoSchema` time: `Option[Option[_]]`, `List[Option[_]]`, `List[List[_]]`, `List[Map[_,_]]`, and `Unit`-typed fields. `BigInt` and `BigDecimal` serialize as proto3 `string`, since proto3 has no arbitrary-precision number type; this preserves exact round-trip values.
 

--- a/kyo-schema/shared/src/main/scala/kyo/Codec.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Codec.scala
@@ -108,6 +108,17 @@ object Codec:
           */
         def droppedFieldsMask(n: Int): Long = 0L
 
+        /** Returns a bitmask of absent fields that this reader can materialize from a typed empty seed.
+          *
+          * The macro-generated case-class decoder supplies `defaultableFieldsMask` with bit `i` set when constructor field `i` is a
+          * non-optional collection or map field that has a typed empty seed. A reader can return some or all of those bits when the wire
+          * format defines absence as the empty value for those field shapes, as Protobuf does for repeated and map fields.
+          *
+          * Self-describing codecs keep the default `0L`, so a missing required collection or map field still fails required-field validation.
+          * Only the low-order `n` bits are relevant; bits beyond that are ignored by the caller.
+          */
+        def absentDefaultedFieldsMask(n: Int, defaultableFieldsMask: Long): Long = 0L
+
         /** Parse the next field name and record it as internal state for [[matchField]] and [[lastFieldName]].
           *
           * Implementations should advance the wire stream past the field name (and any delimiters such as JSON's `:`) so subsequent value

--- a/kyo-schema/shared/src/main/scala/kyo/Protobuf.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Protobuf.scala
@@ -1,6 +1,9 @@
 package kyo
 
-final class Protobuf extends Codec:
+import scala.annotation.tailrec
+
+final class Protobuf(val config: Protobuf.Config) extends Codec:
+    def this() = this(Protobuf.Config.Default)
     def newWriter(): Codec.Writer = new kyo.internal.ProtobufWriter()
     def newReader(input: Span[Byte])(using Frame): Codec.Reader =
         new kyo.internal.ProtobufReader(input.toArray)
@@ -17,6 +20,59 @@ end Protobuf
   *   [[kyo.Json]] for JSON serialization
   */
 object Protobuf:
+    /** Proto3 conformance mode for the Protobuf codec.
+      *
+      * Selects which wire forms `encode` is allowed to produce. The default is `Strict`, so the
+      * zero-argument `given Protobuf` is canonical out of the box and interoperates with external
+      * proto3 tooling for the shapes proto3 defines.
+      *
+      * @see
+      *   [[Protobuf.Config]] for where this is configured
+      */
+    enum Conformance derives CanEqual:
+        /** Rejects non-proto3-native map keys at encode time. A map whose key type is not proto3-native
+          * (integral, bool, or string scalar, or an opaque/value-class type reducing to one of these)
+          * raises [[SchemaNotSerializableException]] before any bytes are written. Canonical proto3
+          * `map<K, V>` key types are accepted.
+          *
+          * This mode does not guarantee every emitted field number is accepted by external `protoc`.
+          * Hash-derived field numbers in the reserved range 19000-19999 produce a WARNING from
+          * `protoSchema` regardless of conformance mode. Pin numbers via `Schema.fieldId` and
+          * verify with `Protobuf.fieldNumberAudit` to avoid the reserved range for external interop.
+          */
+        case Strict
+
+        /** Round-trippable behavior: non-canonical extensions are permitted so every schema that
+          * round-trips through this codec keeps encoding, at the cost of strict external proto3 interop.
+          */
+        case Permissive
+    end Conformance
+
+    /** Configuration for the Protobuf codec.
+      *
+      * @param conformance
+      *   the proto3 conformance mode; defaults to [[Conformance.Strict]] so the codec is canonical
+      *   by default. See [[Conformance]] for the Strict vs Permissive contract.
+      * @param maxDepth
+      *   maximum nesting depth honored by `decode` across every recursive container (message, list,
+      *   string-keyed map, non-string map)
+      * @param maxCollectionSize
+      *   maximum number of entries honored by `decode` for maps, sets, arrays
+      * @param protoSchemaProvenance
+      *   when false, protoSchema omits the 'pin a stable number' comment on hash-derived field
+      *   numbers; the reserved-range warning is always emitted
+      */
+    final case class Config(
+        conformance: Conformance = Conformance.Strict,
+        maxDepth: Int = Json.DefaultMaxDepth,
+        maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
+        protoSchemaProvenance: Boolean = true
+    ) derives CanEqual
+
+    object Config:
+        val Default: Config = Config()
+    end Config
+
     given Protobuf = Protobuf()
 
     /** Encodes a value of type A to Protocol Buffers binary bytes.
@@ -26,26 +82,99 @@ object Protobuf:
       * @return
       *   the proto3 wire-format bytes
       */
-    inline def encode[A](value: A)(using schema: Schema[A], frame: Frame): Span[Byte] =
-        val w = summon[Protobuf].newWriter()
+    inline def encode[A](value: A)(using protobuf: Protobuf, schema: Schema[A], frame: Frame): Span[Byte] =
+        if protobuf.config.conformance == Conformance.Strict then validateCanonical(schema.structure)
+        val w         = protobuf.newWriter()
+        val overrides = schema.fieldIdNameOverrides
+        if overrides.nonEmpty then
+            w match
+                case pw: kyo.internal.ProtobufWriter => val _ = pw.withFieldIdOverrides(overrides)
+                case _                               => ()
+        end if
         schema.writeTo(value, w)
         w.result()
     end encode
 
-    /** Decodes Protocol Buffers binary bytes into a value of type A.
+    /** True iff `key` is a type proto3 admits as a `map<K, V>` key: an integral, bool, or string scalar
+      * (BigInt / BigDecimal serialize as string, so they qualify). Float, double, and any non-primitive
+      * (message, enum, collection) are not valid proto3 map keys.
+      */
+    private def isProto3MapKey(key: Structure.Type): Boolean =
+        key match
+            case p: Structure.Type.Primitive =>
+                p.kind match
+                    case Structure.PrimitiveKind.Double | Structure.PrimitiveKind.Float |
+                        Structure.PrimitiveKind.Unit => false
+                    case _ => true
+            case _ => false
+    end isProto3MapKey
+
+    /** Walks a schema structure under [[Conformance.Strict]] and rejects any shape proto3 cannot
+      * encode canonically. The only non-canonical shape this codec can produce is a map whose key is
+      * not a proto3-native scalar (the entry-message key form), so that is the entire rejection set.
+      * Product / Sum recursion is cycle-guarded by name; every container is reached so a map nested
+      * anywhere is validated.
+      */
+    private def validateCanonical(structure: Structure.Type)(using Frame): Unit =
+        // Explicit work-stack loop (tail-recursive): a Structure walk has multiple children per node
+        // (a Product's fields, a Sum's variants, a Mapping's key+value), so a single self-recursive
+        // tail call is impossible; the stack keeps the traversal O(1) on the call stack. `seen` is a
+        // global name set (carried immutably): each distinct type need only be CHECKED once.
+        @tailrec def loop(stack: List[Structure.Type], seen: Set[String]): Unit =
+            stack match
+                case Nil => ()
+                case t :: rest =>
+                    t match
+                        case Structure.Type.Mapping(_, _, key, value) =>
+                            if !isProto3MapKey(key) then
+                                throw SchemaNotSerializableException(
+                                    s"non-canonical proto3 map key: ${key.name}"
+                                )
+                            end if
+                            loop(key :: value :: rest, seen)
+                        case Structure.Type.Collection(_, _, elem) => loop(elem :: rest, seen)
+                        case Structure.Type.Optional(_, _, inner)  => loop(inner :: rest, seen)
+                        case p: Structure.Type.Product =>
+                            if seen.contains(p.name) then loop(rest, seen)
+                            else loop(p.fields.foldRight(rest)((f, a) => f.fieldType :: a), seen + p.name)
+                        case s: Structure.Type.Sum =>
+                            if seen.contains(s.name) then loop(rest, seen)
+                            else loop(s.variants.foldRight(rest)((v, a) => v.variantType :: a), seen + s.name)
+                        // A structureless leaf (primitive or open type) has no nested children to
+                        // recurse, so nothing to validate.
+                        case _ => loop(rest, seen)
+        loop(structure :: Nil, Set.empty)
+    end validateCanonical
+
+    /** Decodes Protocol Buffers binary bytes using the codec's configured limits. */
+    inline def decode[A](input: Span[Byte])(using protobuf: Protobuf, schema: Schema[A], frame: Frame): Result[DecodeException, A] =
+        decode(input, protobuf.config.maxDepth, protobuf.config.maxCollectionSize)
+    end decode
+
+    /** Decodes Protocol Buffers binary bytes into a value of type A with explicit limits.
       *
       * @param input
       *   the proto3 wire-format bytes to decode
+      * @param maxDepth
+      *   maximum nesting depth for objects/arrays
+      * @param maxCollectionSize
+      *   maximum number of entries in maps, sets, or arrays
       * @return
       *   the decoded value, or a DecodeException if the input is malformed or does not match the schema
       */
     def decode[A](
         input: Span[Byte],
-        maxDepth: Int = Json.DefaultMaxDepth,
-        maxCollectionSize: Int = Json.DefaultMaxCollectionSize
+        maxDepth: Int,
+        maxCollectionSize: Int
     )(using protobuf: Protobuf, schema: Schema[A], frame: Frame): Result[DecodeException, A] =
         val reader = protobuf.newReader(input)
         reader.resetLimits(maxDepth, maxCollectionSize)
+        val overrides = schema.fieldIdNameOverrides
+        if overrides.nonEmpty then
+            reader match
+                case pr: kyo.internal.ProtobufReader => val _ = pr.withFieldIdOverrides(overrides)
+                case _                               => ()
+        end if
         Result.catching[DecodeException](schema.readFrom(reader))
     end decode
 
@@ -59,7 +188,98 @@ object Protobuf:
       * @return
       *   a proto3 schema string ready for use as a `.proto` file
       */
-    inline def protoSchema[A](using s: Schema[A], frame: Frame): String = ProtoSchema.from[A]
+    inline def protoSchema[A](using protobuf: Protobuf, s: Schema[A], frame: Frame): String =
+        ProtoSchema.fromStructure(s.structure, s.fieldIdNameOverrides, protobuf.config.protoSchemaProvenance)
+
+    /** Audits the wire field number of every message field in `A`, recursively.
+      *
+      * Pure and total: no encode, no decode, no throw. One [[FieldNumberInfo]] per user-facing
+      * message field, with a dotted `path` for nested messages. `number` is the field number the
+      * codec actually writes (the MurmurHash3 scheme, or a leaf-name `Schema.fieldId` override),
+      * `pinned` is true when the number came from an override, and `inReservedRange` is true when
+      * the number falls in proto3's reserved band 19000-19999 (which external protoc rejects).
+      *
+      * @tparam A the type to audit
+      * @return one row per message field, in declaration order, depth-first
+      * @see [[FieldNumberInfo]]
+      */
+    inline def fieldNumberAudit[A](using schema: Schema[A], frame: Frame): Chunk[FieldNumberInfo] =
+        auditStructure(schema.structure, schema.fieldIdNameOverrides)
+
+    /** Field-number provenance for one field of a message tree.
+      *
+      * One row per field, recursive over nested messages.
+      *
+      * @param path     the dotted path from the root message (e.g. "inner.id")
+      * @param name     the leaf field name
+      * @param number   the wire field number this codec uses
+      * @param pinned   true when a single-segment (leaf field-name) `Schema` field-id override is
+      *   set and is wire-functional; a nested-path (multi-segment) override is a consistent no-op
+      *   (`pinned` stays false), deferred to getkyo/kyo#1719
+      * @param inReservedRange true if `number` is in proto3's reserved field-number band
+      *   19000-19999, which external tooling rejects; pin a stable number to avoid it
+      * @see [[Protobuf.fieldNumberAudit]]
+      */
+    final case class FieldNumberInfo(
+        path: String,
+        name: String,
+        number: Int,
+        pinned: Boolean,
+        inReservedRange: Boolean
+    ) derives CanEqual
+
+    private[kyo] def auditStructure(rt: Structure.Type, overrides: Map[String, Int]): Chunk[FieldNumberInfo] =
+        val buf                              = scala.collection.mutable.ArrayBuffer.empty[FieldNumberInfo]
+        def resolve(name: String): Int       = overrides.getOrElse(name, kyo.internal.CodecMacro.fieldId(name))
+        def isReservedRange(n: Int): Boolean = n >= 19000 && n <= 19999
+        // A traversal frame: the dotted-path prefix, the type to visit, and the ancestry (the set of
+        // type names on the path from the root to this node). Ancestry-based recursion guard: a
+        // Product/Sum is entered (its fields emitted) when its name is NOT on its own path; recursion
+        // stops only on a genuine cycle (name already on the path, e.g. TreeNode -> List[TreeNode]).
+        // The ancestry is per-frame, so a type REUSED across two sibling fields is not on its sibling's
+        // path and emits its field rows at EACH occurrence (both list-element and map-value inner
+        // fields). A global `seen` would wrongly drop the second occurrence.
+        final case class Frame(prefix: String, tpe: Structure.Type, ancestry: Set[String])
+        // Explicit work-stack loop (tail-recursive): a node has multiple children (a Product's fields,
+        // a Sum's variants), so a single self-recursive tail call is impossible; the stack keeps the
+        // walk O(1) on the call stack. `children` is a tightly-scoped local accumulator per node.
+        @tailrec def loop(stack: List[Frame]): Unit =
+            stack match
+                case Nil => ()
+                case Frame(prefix, tpe, ancestry) :: rest =>
+                    tpe match
+                        case p: Structure.Type.Product if !ancestry.contains(p.name) =>
+                            val nextAncestry = ancestry + p.name
+                            val children     = scala.collection.mutable.ListBuffer.empty[Frame]
+                            p.fields.foreach { field =>
+                                val name   = field.name
+                                val path   = if prefix.isEmpty then name else s"$prefix.$name"
+                                val number = resolve(name)
+                                buf += FieldNumberInfo(path, name, number, overrides.contains(name), isReservedRange(number))
+                                field.fieldType match
+                                    case np: Structure.Type.Product             => children += Frame(path, np, nextAncestry)
+                                    case ns: Structure.Type.Sum                 => children += Frame(path, ns, nextAncestry)
+                                    case Structure.Type.Optional(_, _, inner)   => children += Frame(path, inner, nextAncestry)
+                                    case Structure.Type.Collection(_, _, elem)  => children += Frame(path, elem, nextAncestry)
+                                    case Structure.Type.Mapping(_, _, _, value) => children += Frame(s"$path.value", value, nextAncestry)
+                                    case _                                      => ()
+                                end match
+                            }
+                            loop(children.toList ::: rest)
+                        case s: Structure.Type.Sum if !ancestry.contains(s.name) =>
+                            val nextAncestry = ancestry + s.name
+                            val children     = scala.collection.mutable.ListBuffer.empty[Frame]
+                            s.variants.foreach { variant =>
+                                variant.variantType match
+                                    case vp: Structure.Type.Product => children += Frame(prefix, vp, nextAncestry)
+                                    case vs: Structure.Type.Sum     => children += Frame(prefix, vs, nextAncestry)
+                                    case _                          => ()
+                            }
+                            loop(children.toList ::: rest)
+                        case _ => loop(rest)
+        loop(Frame("", rt, Set.empty) :: Nil)
+        Chunk.from(buf)
+    end auditStructure
 
     /** Generates Protocol Buffers schema (.proto file content) from Scala types.
       *
@@ -74,10 +294,35 @@ object Protobuf:
       */
     object ProtoSchema:
         /** Generates a `.proto` schema string for type `A`. */
-        inline def from[A](using s: Schema[A], frame: Frame): String = fromStructure(s.structure)
+        inline def from[A](using s: Schema[A], frame: Frame): String = fromStructure(s.structure, s.fieldIdNameOverrides)
 
-        /** Derives a proto schema string from a Structure.Type at runtime. */
-        private[kyo] def fromStructure(rt: Structure.Type)(using Frame): String =
+        /** Derives a proto schema string from a Structure.Type at runtime.
+          *
+          * `fieldIdOverrides` is the leaf-name override map so the emitted field numbers match the wire:
+          * hash-derived numbers carry a provenance comment, and a number in proto3's reserved
+          * range 19000-19999 carries an escalated WARNING. The reserved-range WARNING is
+          * UNCONDITIONAL on the range: it fires whether the number was hash-derived or pinned, because
+          * the band is invalid for external protoc however the number was chosen.
+          */
+        private[kyo] def fromStructure(rt: Structure.Type, fieldIdOverrides: Map[String, Int], emitProvenance: Boolean = true)(using
+            Frame
+        ): String =
+
+            def wireFieldNumber(name: String): Int =
+                fieldIdOverrides.getOrElse(name, kyo.internal.CodecMacro.fieldId(name))
+
+            def provenanceComment(name: String, number: Int): String =
+                // The reserved-range WARNING is unconditional on the range: a number in 19000-19999 is
+                // invalid for external protoc however it was chosen (hash-derived OR pinned), so the
+                // warning fires before the pinned/hash-derived split. The ordinary "pin a stable
+                // number" nudge stays gated on hash-derived numbers only, and is further suppressed
+                // when emitProvenance is false.
+                if number >= 19000 && number <= 19999 then
+                    "  // WARNING: in proto3 reserved range 19000-19999; external protoc REJECTS this number. Choose a number outside the band via Schema.fieldId for external interop."
+                else if fieldIdOverrides.contains(name) then ""
+                else if emitProvenance then
+                    "  // hash-derived field number; pin via Schema.fieldId for stable external interop"
+                else ""
 
             /** Accumulated state threaded through collection. */
             case class State(seen: Set[String], messages: List[String])
@@ -108,9 +353,10 @@ object Protobuf:
                         case Structure.Type.Product(name, _, _, fields) =>
                             val sb = new StringBuilder
                             sb.append(s"message $name {\n")
-                            val afterFields = fields.toList.zipWithIndex.foldLeft(visited) { case (acc, (field, idx)) =>
-                                val (decl, nextAcc) = protoFieldDecl(field.name, field.fieldType, idx + 1, acc)
-                                sb.append(s"  $decl\n")
+                            val afterFields = fields.toList.foldLeft(visited) { case (acc, field) =>
+                                val number          = wireFieldNumber(field.name)
+                                val (decl, nextAcc) = protoFieldDecl(field.name, field.fieldType, number, acc)
+                                sb.append(s"  $decl${provenanceComment(field.name, number)}\n")
                                 nextAcc
                             }
                             sb.append("}\n")
@@ -163,9 +409,20 @@ object Protobuf:
                                 (s"repeated $innerType $name = $fieldNumber;", nextState)
 
                     case Structure.Type.Mapping(_, _, key, value) =>
-                        val (keyName, s1) = protoTypeName(key, state)
-                        val (valName, s2) = protoTypeName(value, s1)
-                        (s"map<$keyName, $valName> $name = $fieldNumber;", s2)
+                        if isProto3MapKey(key) then
+                            val (keyName, s1) = protoTypeName(key, state)
+                            val (valName, s2) = protoTypeName(value, s1)
+                            (s"map<$keyName, $valName> $name = $fieldNumber;", s2)
+                        else
+                            // proto3 forbids this key type in map<>. The codec encodes such a map as an
+                            // array of [key, value] pairs, so describe it as a repeated entry message
+                            // rather than emit an invalid map<...>.
+                            val (keyName, s1) = protoTypeName(key, state)
+                            val (valName, s2) = protoTypeName(value, s1)
+                            val entryName     = s"${name.capitalize}Entry"
+                            val entryMsg      = s"message $entryName {\n  $keyName key = 1;\n  $valName value = 2;\n}\n"
+                            (s"repeated $entryName $name = $fieldNumber;", s2.copy(messages = entryMsg :: s2.messages))
+                        end if
 
                     case p: Structure.Type.Product =>
                         val nextState = collect(p, state)

--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -86,6 +86,8 @@ abstract class Schema[A] @publicInBinary private[kyo] (
 
     @publicInBinary private[kyo] def flattenedReadFields: Chunk[(String, String)] = Chunk.empty
 
+    @publicInBinary private[kyo] def absentDefaultValue: Maybe[A] = Maybe.empty
+
     // --- Abstract codec and focus methods. Each concrete Schema[A] overrides
     // these via `Schema.init` / `Schema.initFocused`, which inline the caller's
     // lambda expression directly into the method body: no Function closure is
@@ -992,10 +994,24 @@ abstract class Schema[A] @publicInBinary private[kyo] (
     def fieldIds: Dict[String, Int] =
         Dict.from(sourceFields.map(f => f.name -> fieldId(f.name)).toMap)
 
+    /** Leaf-name field-id overrides (single-segment focus paths) projected to a name-keyed map for
+      * the Protobuf wire resolver. Multi-segment (nested-path) overrides are not projected: the
+      * derived write path uses one stable hash id per leaf name, so only leaf-name pins are
+      * wire-functional.
+      */
+    private[kyo] def fieldIdNameOverrides: Map[String, Int] =
+        fieldIdOverrides.collect { case (Seq(name), id) => name -> id }
+
     /** Sets a custom field ID for a field identified by a Focus lambda.
       *
       * Use this when you need a specific field ID for interoperability with existing binary schemas (e.g., matching an existing `.proto`
-      * definition). This is for documentation/introspection purposes - the actual codec uses hash-based IDs computed at compile time.
+      * definition). A single-segment (top-level field) override is wire-functional for the Protobuf codec: encode emits it, decode
+      * matches it, and protoSchema / fieldNumberAudit report it. A nested-path override is a consistent no-op
+      * across encode, decode, protoSchema, and fieldNumberAudit, deferred to getkyo/kyo#1719.
+      *
+      * Pinning is keyed by field NAME and is therefore GLOBAL: pinning `id` sets the field number for
+      * EVERY field named `id` across all messages. This is consistent with the default scheme, where the
+      * field number is already `MurmurHash3(name)`, so all same-named fields already share a number.
       *
       * {{{
       * Schema[User].fieldId(_.age)(42)  // Sets field ID 42 for the 'age' field
@@ -1460,12 +1476,14 @@ object Schema:
         denyUnknownFieldsEnabled: Boolean = false,
         fieldDefaults: Chunk[(String, Schema.FieldDefault)] = Chunk.empty,
         fieldTransforms: Chunk[(String, Schema.FieldTransform[A])] = Chunk.empty[(String, Schema.FieldTransform[A])],
+        absentDefaultValue: => Maybe[A] = Maybe.empty,
         structure: => Structure.Type = Structure.Type.Open(Tag[Any])
     ): Schema[A] =
         // Lazy capture defers inner.structure access until structure is first queried.
         // Container givens pass `inner.structure` as the structure argument; lazy evaluation
         // prevents initialization cycles for recursive structure type graphs.
-        lazy val _structure = structure
+        lazy val _structure          = structure
+        lazy val _absentDefaultValue = absentDefaultValue
         new Schema[A](
             segments,
             examples,
@@ -1503,6 +1521,7 @@ object Schema:
             @publicInBinary override def rawSerializeRead(reader: Reader): A               = readFn(reader)
             @publicInBinary def getter(value: A): Maybe[Any]                               = getterFn(value)
             @publicInBinary def setter(value: A, next: Any): A                             = setterFn(value, next)
+            @publicInBinary override private[kyo] def absentDefaultValue: Maybe[A]         = _absentDefaultValue
             override def structure: Structure.Type                                         = _structure
         end new
     end init
@@ -1605,6 +1624,7 @@ object Schema:
         denyUnknownFieldsEnabled: Boolean = false,
         fieldDefaults: Chunk[(String, Schema.FieldDefault)] = Chunk.empty,
         fieldTransforms: Chunk[(String, Schema.FieldTransform[A])] = Chunk.empty[(String, Schema.FieldTransform[A])],
+        absentDefaultValue: => Maybe[A] = Maybe.empty,
         structure: => Structure.Type = Structure.Type.Open(Tag[Any])
     ): Schema[A] { type Focused = F } =
         // Erase the F-typed Function signatures to (A, Any) via asInstanceOf on the Function
@@ -1640,6 +1660,7 @@ object Schema:
             denyUnknownFieldsEnabled = denyUnknownFieldsEnabled,
             fieldDefaults = fieldDefaults,
             fieldTransforms = fieldTransforms,
+            absentDefaultValue = absentDefaultValue,
             structure = structure
         ).asInstanceOf[Schema[A] { type Focused = F }]
     end initFocused
@@ -2173,6 +2194,7 @@ object Schema:
         Schema.init[Span[Byte]](
             writeFn = (v, w) => w.bytes(v),
             readFn = _.bytes(),
+            absentDefaultValue = Maybe(Span.empty[Byte]),
             structure = Structure.Type.Primitive(Structure.PrimitiveKind.String, Tag[Span[Byte]].asInstanceOf[Tag[Any]])
         )
 
@@ -2282,6 +2304,7 @@ object Schema:
                 reader.arrayEnd()
                 builder.result()
             ,
+            absentDefaultValue = Maybe(List.empty[A]),
             // Non-inline givens have no implicit Tag[A] in scope; fall back to Tag[Any].
             structure = Structure.Type.Collection(
                 "List",
@@ -2313,6 +2336,7 @@ object Schema:
                 reader.arrayEnd()
                 builder.result()
             ,
+            absentDefaultValue = Maybe(Vector.empty[A]),
             // Non-inline givens have no implicit Tag[A] in scope; fall back to Tag[Any].
             structure = Structure.Type.Collection(
                 "Vector",
@@ -2344,6 +2368,7 @@ object Schema:
                 reader.arrayEnd()
                 builder.result()
             ,
+            absentDefaultValue = Maybe(Set.empty[A]),
             // Non-inline givens have no implicit Tag[A] in scope; fall back to Tag[Any].
             structure = Structure.Type.Collection(
                 "Set",
@@ -2375,6 +2400,7 @@ object Schema:
                 reader.arrayEnd()
                 builder.result()
             ,
+            absentDefaultValue = Maybe(Chunk.empty[A]),
             // Non-inline givens have no implicit Tag[A] in scope; fall back to Tag[Any].
             structure = Structure.Type.Collection(
                 "Chunk",
@@ -2406,6 +2432,7 @@ object Schema:
                 reader.arrayEnd()
                 builder.result()
             ,
+            absentDefaultValue = Maybe(Seq.empty[A]),
             // Non-inline givens have no implicit Tag[A] in scope; fall back to Tag[Any].
             structure = Structure.Type.Collection(
                 "Seq",
@@ -2437,6 +2464,7 @@ object Schema:
                 reader.arrayEnd()
                 Span.from(builder.result())
             ,
+            absentDefaultValue = Maybe(Span.empty[A]),
             structure = Structure.Type.Collection(
                 "Span",
                 Tag[Span[A]].asInstanceOf[Tag[Any]],
@@ -2519,6 +2547,7 @@ object Schema:
                 reader.mapEnd()
                 builder.result()
             ,
+            absentDefaultValue = Maybe(Map.empty[String, V]),
             // Non-inline givens have no implicit Tag[V] in scope; fall back to Tag[Any].
             structure = Structure.Type.Mapping(
                 "Map",
@@ -2528,6 +2557,64 @@ object Schema:
             )
         )
     end stringMapSchema
+
+    /** Schema for Map[K, V] with non-String keys.
+      *
+      * `stringMapSchema` is the more specific given for `Map[String, V]` (object encoding); this
+      * general given covers every other key type so `Map[Int, V]` and friends derive and round-trip
+      * on all codecs. Each entry is written as a two-field record (`key`, `value`): the Protobuf
+      * codec renders this as a standard proto3 `MapEntry` message, and self-describing codecs render
+      * an array of `{key, value}` objects (a non-String key cannot be an object field name).
+      */
+    given mapSchema[K, V](using kSchema0: => Schema[K], vSchema0: => Schema[V]): Schema[Map[K, V]] =
+        lazy val kSchema = kSchema0
+        lazy val vSchema = vSchema0
+        Schema.init[Map[K, V]](
+            writeFn = (value, writer) =>
+                writer.arrayStart(value.size)
+                value.foreach { (k, v) =>
+                    writer.objectStart("", 2)
+                    writer.field("key", 1)
+                    kSchema.serializeWrite(k, writer)
+                    writer.field("value", 2)
+                    vSchema.serializeWrite(v, writer)
+                    writer.objectEnd()
+                }
+                writer.arrayEnd()
+            ,
+            readFn = reader =>
+                discard(reader.arrayStart())
+                val builder = Map.newBuilder[K, V]
+                @tailrec
+                def loop(count: Int): Unit =
+                    if reader.hasNextElement() then
+                        reader.checkCollectionSize(count)
+                        discard(reader.objectStart())
+                        // hasNextField advances past the inter-field separator (a no-op for
+                        // Protobuf, the comma for a self-describing codec) before each field read.
+                        discard(reader.hasNextField())
+                        val _ = reader.field() // "key"
+                        val k = kSchema.serializeRead(reader)
+                        discard(reader.hasNextField())
+                        val _ = reader.field() // "value"
+                        val v = vSchema.serializeRead(reader)
+                        reader.objectEnd()
+                        builder += (k -> v)
+                        loop(count + 1)
+                loop(1)
+                reader.arrayEnd()
+                builder.result()
+            ,
+            absentDefaultValue = Maybe(Map.empty[K, V]),
+            // Non-inline givens have no implicit Tag[K] + Tag[V] in scope; fall back to Tag[Any].
+            structure = Structure.Type.Mapping(
+                "Map",
+                Tag[Any],
+                kSchema.structure,
+                vSchema.structure
+            )
+        )
+    end mapSchema
 
     // --- Tuple Schemas ---
 
@@ -2920,9 +3007,11 @@ object Schema:
         fieldTransforms: Chunk[(String, Schema.FieldTransform[A])] = Chunk.empty[(String, Schema.FieldTransform[A])],
         fieldMaterializedDefaults: Chunk[(String, Structure.Value)] = Chunk.empty,
         flattenedReadFields0: Chunk[(String, String)] = Chunk.empty,
+        absentDefaultValue: => Maybe[A] = Maybe.empty,
         structure: => Structure.Type
     ): Schema[A] { type Focused = E } =
-        lazy val _structure = structure
+        lazy val _structure          = structure
+        lazy val _absentDefaultValue = absentDefaultValue
         new Schema[A](
             segments,
             examples,
@@ -2962,6 +3051,7 @@ object Schema:
             @publicInBinary override def rawSerializeRead(reader: Reader): A               = readFn(reader)
             @publicInBinary def getter(value: A): Maybe[Any]                               = getterFn(value)
             @publicInBinary def setter(value: A, next: Any): A                             = setterFn(value, next)
+            @publicInBinary override private[kyo] def absentDefaultValue: Maybe[A]         = _absentDefaultValue
             override def structure: Structure.Type                                         = _structure
         end new
     end createWithFocused
@@ -3000,6 +3090,7 @@ object Schema:
         fieldTransforms: Chunk[(String, Schema.FieldTransform[A])] = self.fieldTransforms,
         fieldMaterializedDefaults: Chunk[(String, Structure.Value)] = self.fieldMaterializedDefaults,
         flattenedReadFields: Chunk[(String, String)] = self.flattenedReadFields,
+        absentDefaultValue: => Maybe[A] = self.absentDefaultValue,
         structure: => Structure.Type = self.structure
     ): Schema[A] { type Focused = self.Focused } =
         createWithFocused[A, self.Focused](
@@ -3033,6 +3124,7 @@ object Schema:
             fieldTransforms = fieldTransforms,
             fieldMaterializedDefaults = fieldMaterializedDefaults,
             flattenedReadFields0 = flattenedReadFields,
+            absentDefaultValue = absentDefaultValue,
             structure = structure
         )
 

--- a/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
@@ -550,9 +550,9 @@ import scala.quoted.*
       * Each per-field schema resolves via `summonInline[Schema[ft]]` at the generated-code typer phase;
       * the in-flight `derived$Schema` is visible by forward-reference, so recursive products close the
       * cycle. The read body seeds defaults / `Maybe.empty` / `None`, tracks a `Long` required-field
-      * bitmap, ORs in `droppedFieldsMask` before the required check, and throws `MissingFieldException`
-      * (carrying `reader.frame`) for a missing required field. Used by both `derivedImpl`
-      * (`derives Schema`) and the `metaApplyImpl` Focus path.
+      * bitmap, ORs in reader-supplied pre-satisfied field masks before the required check, and throws
+      * `MissingFieldException` (carrying `reader.frame`) for a missing required field. Used by both
+      * `derivedImpl` (`derives Schema`) and the `metaApplyImpl` Focus path.
       */
     private def emitProductSchemaStatic[A: Type](using
         Quotes
@@ -735,10 +735,21 @@ import scala.quoted.*
         // READ: static per-field name-matched loop.
         def readBody(r: Expr[Reader]): Expr[A] =
             val requiredMask: Long = fields.zipWithIndex.foldLeft(0L) { case (m, (_, idx)) =>
-                if !hasDefaultFlags(idx) && !isMaybeFlags(idx) && !isOptionFlags(idx) then m | (1L << idx)
+                if !hasDefaultFlags(idx) && !isMaybeFlags(idx) && !isOptionFlags(idx) then
+                    m | (1L << idx)
                 else m
             }
             val fieldNames: List[String] = fields.map(_.name)
+
+            val absentDefaultableMaskExpr: Expr[Long] =
+                fields.indices.foldLeft('{ 0L }) { (mask, idx) =>
+                    if hasDefaultFlags(idx) || isMaybeFlags(idx) || isOptionFlags(idx) then mask
+                    else
+                        effectiveSchemaTypes(idx).asType match
+                            case '[t] =>
+                                val s = fieldSchemaExprTyped[t](idx)
+                                '{ $mask | kyo.internal.absentDefaultMask($s, ${ Expr(1L << idx) }) }
+                }
 
             val seedExprs: List[Expr[Any]] = fields.zipWithIndex.map { (f, idx) =>
                 val ft = tpe.memberType(f)
@@ -754,8 +765,10 @@ import scala.quoted.*
                     ft.asType match
                         case '[t] => '{ Option.empty[Any].asInstanceOf[t] }
                 else
-                    ft.asType match
-                        case '[t] => '{ null.asInstanceOf[t] }
+                    effectiveSchemaTypes(idx).asType match
+                        case '[t] =>
+                            val s = fieldSchemaExprTyped[t](idx)
+                            '{ kyo.internal.absentDefaultSeed($s) }
                 end if
             }
 
@@ -836,7 +849,10 @@ import scala.quoted.*
                     val maskExpr  = Expr(requiredMask)
                     val nExpr     = Expr(n)
                     Some('{
-                        val _combined = $seenRef | $r.droppedFieldsMask($nExpr)
+                        val _combined =
+                            $seenRef |
+                                $r.droppedFieldsMask($nExpr) |
+                                $r.absentDefaultedFieldsMask($nExpr, $absentDefaultableMaskExpr)
                         if (_combined & $maskExpr) != $maskExpr then
                             val _missing = java.lang.Long.numberOfTrailingZeros((~_combined) & $maskExpr).toInt
                             val _names   = $namesExpr

--- a/kyo-schema/shared/src/main/scala/kyo/internal/ProtobufReader.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/ProtobufReader.scala
@@ -26,10 +26,45 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
     private var limits: List[Int]            = List(data.length)
     private var fieldNames: Map[Int, String] = Map.empty
     private var pendingTag: Boolean          = false
+    // Leaf-name field-id overrides for read/write symmetry under functional pinning. Empty in the
+    // common case; threaded from Schema.fieldIdNameOverrides by Protobuf.decode when present.
+    private var fieldIdOverrides: Map[String, Int] = Map.empty
+
+    // Per-array decode frame for unpacked (packed=false) repeated fields. Protobuf writes
+    // each repeated element as its own tag+value, so the elements of one field are separate
+    // wire fields sharing a field number. The collection read loop calls hasNextElement()
+    // before every element; the first element's tag was already consumed by the enclosing
+    // field(), so a fresh frame starts with firstPending=true. For later elements
+    // hasNextElement() peeks the next tag and consumes it only when it carries this field's
+    // number, leaving any other tag for the enclosing message loop. Frames stack because
+    // arrays nest across message boundaries (e.g. List[Nested] whose Nested holds a List[Int]).
+    // packed/packedLimit track a packed scalar run: a scalar reader called inside this frame whose
+    // consumed entry tag is wire type 2 (LengthDelimited) reads the length once, sets packedLimit,
+    // flips packed=true, then reads bare values until packedLimit. A mixed producer (some packed,
+    // some unpacked under the same field) is handled by resetting packed when the run is exhausted.
+    final private class RepeatedFrame(val fieldNumber: Int, var firstPending: Boolean, var packed: Boolean, var packedLimit: Int)
+    private var repeatedFrames: List[RepeatedFrame] = Nil
+
+    // Per-map decode frame. A map is a repeated MapEntry message under the map field number
+    // (see ProtobufWriter), key at field 1, value at field 2. The first entry's tag was
+    // consumed by the enclosing field(), so firstPending starts true; hasNextEntry() enters
+    // each entry message (pushing its limit) and field() reads the key and advances past the
+    // value tag. field() is a map-key read only when an entry limit is pushed and we are at
+    // the entry level (baseLimitDepth + 1); a field() nested inside an entry value is ordinary.
+    // Frames stack for a map-valued map.
+    final private class MapFrame(val fieldNumber: Int, val baseLimitDepth: Int, var firstPending: Boolean, var entryLimitPushed: Boolean)
+    private var mapFrames: List[MapFrame] = Nil
 
     /** Set field name mapping for the current message level. */
     def withFieldNames(names: Map[Int, String]): this.type =
         fieldNames = names
+        this
+
+    /** Configures leaf-name field-id overrides so matchField resolves a pinned field by its
+      * override number, mirroring the writer's resolution (read/write symmetry).
+      */
+    def withFieldIdOverrides(overrides: Map[String, Int]): this.type =
+        fieldIdOverrides = overrides
         this
 
     def objectStart(): Int =
@@ -60,18 +95,25 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
     end objectEnd
 
     def field(): String =
-        val tag = readVarint().toInt
-        currentFieldNumber = tag >>> 3
-        currentWireType = tag & 0x7
-        pendingTag = false
-        // If this is a length-delimited field and we're at the message level,
-        // push a limit for nested message reading
-        if currentWireType == LengthDelimited then
-            // peek: could be string, bytes, or nested message
-            // We don't push limit here; the caller decides (objectStart vs string)
-            ()
-        end if
-        fieldNames.getOrElse(currentFieldNumber, currentFieldNumber.toString)
+        mapFrames match
+            case f :: _ if f.entryLimitPushed && limits.size == f.baseLimitDepth + 1 =>
+                // Map entry: read the key at field 1, then advance past the value's field-2 tag
+                // so the following value read sees the right wire type. Returns the decoded key.
+                val keyTag = readVarint().toInt
+                currentWireType = keyTag & 0x7
+                val key    = string()
+                val valTag = readVarint().toInt
+                currentFieldNumber = valTag >>> 3
+                currentWireType = valTag & 0x7
+                pendingTag = false
+                key
+            case _ =>
+                val tag = readVarint().toInt
+                currentFieldNumber = tag >>> 3
+                currentWireType = tag & 0x7
+                pendingTag = false
+                fieldNames.getOrElse(currentFieldNumber, currentFieldNumber.toString)
+        end match
     end field
 
     override def fieldParse(): Unit =
@@ -82,7 +124,10 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
 
     override def matchField(nameBytes: Array[Byte]): Boolean =
         val name = new String(nameBytes, java.nio.charset.StandardCharsets.UTF_8)
-        currentFieldNumber == CodecMacro.fieldId(name)
+        val resolved =
+            if fieldIdOverrides.isEmpty then CodecMacro.fieldId(name)
+            else fieldIdOverrides.getOrElse(name, CodecMacro.fieldId(name))
+        currentFieldNumber == resolved
     end matchField
 
     override def lastFieldName(): String =
@@ -91,10 +136,59 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
     def hasNextField(): Boolean =
         pos < limits.head
 
-    def hasNextElement(): Boolean = hasNextField()
+    override def absentDefaultedFieldsMask(n: Int, defaultableFieldsMask: Long): Long =
+        defaultableFieldsMask
+
+    def hasNextElement(): Boolean =
+        repeatedFrames match
+            case frame :: _ =>
+                if frame.packed && pos >= frame.packedLimit then
+                    frame.packed = false // packed run exhausted; a mixed producer may continue
+                if frame.packed then
+                    true // still inside the current packed run, no tag to peek
+                else if frame.firstPending then
+                    frame.firstPending = false
+                    true
+                else if pos >= limits.head then false
+                else
+                    // Peek the next tag: another element only if it repeats this field's number.
+                    val start = pos
+                    val tag   = readVarint().toInt
+                    if (tag >>> 3) == frame.fieldNumber then
+                        currentFieldNumber = tag >>> 3
+                        currentWireType = tag & 0x7
+                        true
+                    else
+                        pos = start // un-read; the tag belongs to the enclosing message loop
+                        false
+                    end if
+                end if
+            case Nil =>
+                hasNextField()
+    end hasNextElement
+
+    // Establishes (or continues) a packed scalar run for the current repeated frame. Returns true
+    // when the current element is a bare packed value. On first call of a packed run, consumes the
+    // record length and sets packedLimit; subsequent calls return true until the limit is reached.
+    private def packedScalar(): Boolean =
+        repeatedFrames match
+            case frame :: _ =>
+                if frame.packed then true
+                else if currentWireType == LengthDelimited then
+                    val len = readVarint().toInt
+                    if len < 0 || pos + len > data.length then
+                        throw TruncatedInputException(Protobuf(), s"packed field length $len exceeds remaining data")
+                    frame.packedLimit = pos + len
+                    frame.packed = true
+                    true
+                else false
+            case Nil => false
+    end packedScalar
 
     def int(): Int =
-        if currentWireType == Varint then
+        if packedScalar() then
+            decodeZigZag32(readVarint())
+        else if currentWireType == Varint then
             decodeZigZag32(readVarint())
         else if currentWireType == Fixed32 then
             readFixedInt()
@@ -102,7 +196,9 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
             readVarint().toInt
 
     def long(): Long =
-        if currentWireType == Varint then
+        if packedScalar() then
+            decodeZigZag64(readVarint())
+        else if currentWireType == Varint then
             decodeZigZag64(readVarint())
         else if currentWireType == Fixed64 then
             readFixedLong()
@@ -119,12 +215,16 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
     end string
 
     def double(): Double =
+        val _ = packedScalar()
         java.lang.Double.longBitsToDouble(readFixedLong())
 
     def float(): Float =
+        val _ = packedScalar()
         java.lang.Float.intBitsToFloat(readFixedInt())
 
-    def boolean(): Boolean = readVarint() != 0L
+    def boolean(): Boolean =
+        val _ = packedScalar()
+        readVarint() != 0L
 
     def short(): Short =
         val v = int()
@@ -183,12 +283,78 @@ final class ProtobufReader(data: Array[Byte])(using _frame: Frame) extends Reade
     end captureValue
 
     def arrayStart(): Int =
-        checkDepth(); -1
-    def arrayEnd(): Unit = decrementDepth()
+        checkDepth()
+        // The enclosing field() consumed the first element's tag; start the frame with it pending.
+        repeatedFrames = new RepeatedFrame(currentFieldNumber, true, false, 0) :: repeatedFrames
+        -1
+    end arrayStart
 
-    def mapStart(): Int         = objectStart()
-    def mapEnd(): Unit          = objectEnd()
-    def hasNextEntry(): Boolean = hasNextField()
+    def arrayEnd(): Unit =
+        decrementDepth()
+        repeatedFrames match
+            case _ :: rest => repeatedFrames = rest
+            case Nil       => ()
+    end arrayEnd
+
+    def mapStart(): Int =
+        checkDepth()
+        // The enclosing field() consumed the first entry's MapEntry tag (currentWireType == LD);
+        // entries are read by hasNextEntry() / field(). No wrapper message, so no limit is pushed here.
+        mapFrames = new MapFrame(currentFieldNumber, limits.size, true, false) :: mapFrames
+        -1
+    end mapStart
+
+    def mapEnd(): Unit =
+        decrementDepth()
+        mapFrames match
+            case f :: rest =>
+                if f.entryLimitPushed then
+                    pos = limits.head
+                    limits = limits.tail
+                    f.entryLimitPushed = false
+                end if
+                mapFrames = rest
+            case Nil => ()
+        end match
+    end mapEnd
+
+    def hasNextEntry(): Boolean =
+        mapFrames match
+            case f :: _ =>
+                if f.entryLimitPushed then
+                    // Finished the previous entry: drop its limit and return to the map level.
+                    pos = limits.head
+                    limits = limits.tail
+                    f.entryLimitPushed = false
+                end if
+                val more =
+                    if f.firstPending then
+                        f.firstPending = false
+                        true
+                    else if pos >= limits.head then false
+                    else
+                        val start = pos
+                        val tag   = readVarint().toInt
+                        if (tag >>> 3) == f.fieldNumber then
+                            currentWireType = tag & 0x7
+                            true
+                        else
+                            pos = start // un-read; the tag belongs to the enclosing message loop
+                            false
+                        end if
+                if more then
+                    // Enter the MapEntry message: consume its length prefix and push a limit.
+                    val len = readVarint().toInt
+                    if len < 0 || pos + len > data.length then
+                        throw TruncatedInputException(Protobuf(), s"map entry length $len exceeds remaining data")
+                    limits = (pos + len) :: limits
+                    f.entryLimitPushed = true
+                    true
+                else false
+                end if
+            case Nil =>
+                hasNextField()
+    end hasNextEntry
 
     def bytes(): Span[Byte] =
         val len = readVarint().toInt

--- a/kyo-schema/shared/src/main/scala/kyo/internal/ProtobufWriter.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/ProtobufWriter.scala
@@ -14,7 +14,8 @@ import scala.annotation.tailrec
   * Nested messages are handled with a stack of byte buffers. When a nested object starts, a fresh buffer is pushed. When it ends, the
   * nested bytes are length-prefixed and written to the parent buffer.
   *
-  * Repeated fields (arrays) write each element with its own tag, following standard protobuf packed=false encoding.
+  * Repeated fields write each element with its own tag (standard protobuf packed=false). A map is written as a repeated `MapEntry`
+  * message under the map field number, with the key at field 1 and the value at field 2 (standard proto3 `map<K, V>`).
   */
 final class ProtobufWriter extends Writer:
 
@@ -35,6 +36,27 @@ final class ProtobufWriter extends Writer:
     private var fieldNumberStack: List[Int] = Nil
     private var repeatedFieldNumber: Int    = 0
     private var inArray: Boolean            = false
+
+    // Saved (inArray, repeatedFieldNumber) pairs. A nested objectStart and a nested
+    // arrayStart each push the current array state and the matching objectEnd / arrayEnd
+    // restores it, so a repeated message's own fields are written under their own field
+    // numbers (not the enclosing list's) and nested arrays restore the outer array context.
+    private var arrayStateStack: List[(Boolean, Int)] = Nil
+
+    // Per-array packed accumulator for repeated SCALAR fields. arrayStart pushes a fresh buffer,
+    // each scalar element appends its raw value bytes (no per-element tag), and arrayEnd flushes
+    // the buffer as one length-delimited record under the repeated field number. Stacked so nested
+    // scalar arrays are isolated. A null head means the current array is not a packed-scalar array
+    // (its elements are strings/bytes/messages, which stay length-delimited per element).
+    private var packedBufferStack: List[java.io.ByteArrayOutputStream] = Nil
+
+    // Map encoding state. A map is a repeated MapEntry message under the map field number.
+    // mapStart records that field number and the buffer depth at the map level; a field(key)
+    // call at that depth opens a new entry message (key at field 1), the value writes at
+    // field 2, and the entry is length-prefixed on the next key or on mapEnd. Frames stack
+    // for a map-valued map.
+    final private class MapFrame(val fieldNumber: Int, val baseDepth: Int, var entryOpen: Boolean)
+    private var mapFrames: List[MapFrame] = Nil
 
     // Field ID overrides for interop with existing .proto definitions
     private var fieldIdOverrides: Map[String, Int] = Map.empty
@@ -59,8 +81,11 @@ final class ProtobufWriter extends Writer:
         if currentFieldNumber > 0 then
             // Nested message: push a new buffer and remember the outer field number
             // so objectEnd can length-prefix the nested bytes under the correct tag,
-            // even after inner fieldBytes calls overwrite currentFieldNumber.
+            // even after inner fieldBytes calls overwrite currentFieldNumber. Save the
+            // array context and reset it: the message's own fields are not array elements.
             fieldNumberStack = currentFieldNumber :: fieldNumberStack
+            arrayStateStack = (inArray, repeatedFieldNumber) :: arrayStateStack
+            inArray = false
             bufferStack = new java.io.ByteArrayOutputStream(128) :: bufferStack
     end objectStart
 
@@ -80,33 +105,98 @@ final class ProtobufWriter extends Writer:
             // continue to use the parent message's currentFieldNumber (e.g. repeated
             // nested messages in a List field share the same field number).
             currentFieldNumber = outerFieldNumber
+            arrayStateStack match
+                case (ia, rfn) :: rest =>
+                    inArray = ia
+                    repeatedFieldNumber = rfn
+                    arrayStateStack = rest
+                case Nil => ()
+            end match
     end objectEnd
 
     def fieldBytes(nameBytes: Array[Byte], fieldId: Int): Unit =
-        // Resolve field ID: check overrides only if configured (avoids allocation in common case)
-        currentFieldNumber =
-            if fieldIdOverrides.isEmpty then fieldId
-            else
-                val name = new String(nameBytes, java.nio.charset.StandardCharsets.UTF_8)
-                fieldIdOverrides.getOrElse(name, fieldId)
+        mapFrames match
+            case f :: _ if bufferStack.size == f.baseDepth + (if f.entryOpen then 1 else 0) =>
+                // Map key: close the previous entry, open a new MapEntry message, write key = field 1.
+                if f.entryOpen then closeMapEntry(f)
+                openMapEntry(f, nameBytes)
+            case _ =>
+                // Resolve field ID: check overrides only if configured (avoids allocation in common case)
+                currentFieldNumber =
+                    if fieldIdOverrides.isEmpty then fieldId
+                    else
+                        val name = new String(nameBytes, java.nio.charset.StandardCharsets.UTF_8)
+                        fieldIdOverrides.getOrElse(name, fieldId)
+        end match
+    end fieldBytes
+
+    private def openMapEntry(f: MapFrame, keyBytes: Array[Byte]): Unit =
+        // The entry message is emitted under the map field number; objectStart captures it.
+        currentFieldNumber = f.fieldNumber
+        objectStart("", 2)
+        // key = field 1, length-delimited
+        writeTag(1, LengthDelimited)
+        writeVarint(keyBytes.length.toLong)
+        current.write(keyBytes)
+        // value -> field 2
+        currentFieldNumber = 2
+        f.entryOpen = true
+    end openMapEntry
+
+    private def closeMapEntry(f: MapFrame): Unit =
+        objectEnd()
+        f.entryOpen = false
+    end closeMapEntry
 
     def arrayStart(size: Int): Unit =
+        arrayStateStack = (inArray, repeatedFieldNumber) :: arrayStateStack
+        packedBufferStack = new java.io.ByteArrayOutputStream(64) :: packedBufferStack
         repeatedFieldNumber = currentFieldNumber
         inArray = true
+    end arrayStart
 
     def arrayEnd(): Unit =
-        inArray = false
+        packedBufferStack match
+            case buf :: bufRest =>
+                if buf.size() > 0 then
+                    // Flush the accumulated scalars as one packed length-delimited record.
+                    val packed = buf.toByteArray
+                    writeTag(repeatedFieldNumber, LengthDelimited)
+                    writeVarint(packed.length.toLong)
+                    current.write(packed)
+                end if
+                packedBufferStack = bufRest
+            case Nil => ()
+        end match
+        arrayStateStack match
+            case (ia, rfn) :: rest =>
+                inArray = ia
+                repeatedFieldNumber = rfn
+                arrayStateStack = rest
+            case Nil => inArray = false
+        end match
+    end arrayEnd
+
+    private def packedTarget: java.io.ByteArrayOutputStream =
+        // Non-null head buffer means the current array packs its scalar elements.
+        if inArray then packedBufferStack.headOption.orNull else null
 
     def int(value: Int): Unit =
-        val fn = if inArray then repeatedFieldNumber else currentFieldNumber
-        writeTag(fn, Varint)
-        writeVarint(encodeZigZag32(value))
+        val buf = packedTarget
+        if buf != null then writeVarintTo(buf, encodeZigZag32(value))
+        else
+            writeTag(currentFieldNumber, Varint)
+            writeVarint(encodeZigZag32(value))
+        end if
     end int
 
     def long(value: Long): Unit =
-        val fn = if inArray then repeatedFieldNumber else currentFieldNumber
-        writeTag(fn, Varint)
-        writeVarint(encodeZigZag64(value))
+        val buf = packedTarget
+        if buf != null then writeVarintTo(buf, encodeZigZag64(value))
+        else
+            writeTag(currentFieldNumber, Varint)
+            writeVarint(encodeZigZag64(value))
+        end if
     end long
 
     def string(value: String): Unit =
@@ -118,21 +208,30 @@ final class ProtobufWriter extends Writer:
     end string
 
     def double(value: Double): Unit =
-        val fn = if inArray then repeatedFieldNumber else currentFieldNumber
-        writeTag(fn, Fixed64)
-        writeFixedLong(java.lang.Double.doubleToLongBits(value))
+        val buf = packedTarget
+        if buf != null then writeFixedLongTo(buf, java.lang.Double.doubleToLongBits(value))
+        else
+            writeTag(currentFieldNumber, Fixed64)
+            writeFixedLong(java.lang.Double.doubleToLongBits(value))
+        end if
     end double
 
     def float(value: Float): Unit =
-        val fn = if inArray then repeatedFieldNumber else currentFieldNumber
-        writeTag(fn, Fixed32)
-        writeFixedInt(java.lang.Float.floatToIntBits(value))
+        val buf = packedTarget
+        if buf != null then writeFixedIntTo(buf, java.lang.Float.floatToIntBits(value))
+        else
+            writeTag(currentFieldNumber, Fixed32)
+            writeFixedInt(java.lang.Float.floatToIntBits(value))
+        end if
     end float
 
     def boolean(value: Boolean): Unit =
-        val fn = if inArray then repeatedFieldNumber else currentFieldNumber
-        writeTag(fn, Varint)
-        writeVarint(if value then 1L else 0L)
+        val buf = packedTarget
+        if buf != null then writeVarintTo(buf, if value then 1L else 0L)
+        else
+            writeTag(currentFieldNumber, Varint)
+            writeVarint(if value then 1L else 0L)
+        end if
     end boolean
 
     def short(value: Short): Unit = int(value.toInt)
@@ -141,8 +240,17 @@ final class ProtobufWriter extends Writer:
 
     def nil(): Unit = () // protobuf has no null representation; omit the field
 
-    def mapStart(size: Int): Unit = objectStart("", size)
-    def mapEnd(): Unit            = objectEnd()
+    def mapStart(size: Int): Unit =
+        mapFrames = new MapFrame(currentFieldNumber, bufferStack.size, false) :: mapFrames
+    end mapStart
+
+    def mapEnd(): Unit =
+        mapFrames match
+            case f :: rest =>
+                if f.entryOpen then closeMapEntry(f)
+                mapFrames = rest
+            case Nil => ()
+    end mapEnd
 
     def bytes(value: Span[Byte]): Unit =
         val fn  = if inArray then repeatedFieldNumber else currentFieldNumber
@@ -156,15 +264,21 @@ final class ProtobufWriter extends Writer:
     def bigDecimal(value: BigDecimal): Unit = string(value.toString)
 
     def instant(value: java.time.Instant): Unit =
-        val fn = if inArray then repeatedFieldNumber else currentFieldNumber
-        writeTag(fn, Varint)
-        writeVarint(encodeZigZag64(value.toEpochMilli))
+        val buf = packedTarget
+        if buf != null then writeVarintTo(buf, encodeZigZag64(value.toEpochMilli))
+        else
+            writeTag(currentFieldNumber, Varint)
+            writeVarint(encodeZigZag64(value.toEpochMilli))
+        end if
     end instant
 
     def duration(value: java.time.Duration): Unit =
-        val fn = if inArray then repeatedFieldNumber else currentFieldNumber
-        writeTag(fn, Varint)
-        writeVarint(encodeZigZag64(value.toMillis))
+        val buf = packedTarget
+        if buf != null then writeVarintTo(buf, encodeZigZag64(value.toMillis))
+        else
+            writeTag(currentFieldNumber, Varint)
+            writeVarint(encodeZigZag64(value.toMillis))
+        end if
     end duration
 
     def resultBytes: Array[Byte] = bufferStack.last.toByteArray
@@ -193,6 +307,33 @@ final class ProtobufWriter extends Writer:
                 loop(i + 1)
         loop(0)
     end writeFixedLong
+
+    // OutputStream-targeted raw writers used to accumulate packed scalar elements (no tag).
+    private def writeVarintTo(out: java.io.ByteArrayOutputStream, value: Long): Unit =
+        @tailrec def loop(v: Long): Unit =
+            if (v & ~0x7fL) != 0L then
+                out.write(((v & 0x7f) | 0x80).toInt)
+                loop(v >>> 7)
+            else
+                out.write((v & 0x7f).toInt)
+        loop(value)
+    end writeVarintTo
+
+    private def writeFixedLongTo(out: java.io.ByteArrayOutputStream, value: Long): Unit =
+        @tailrec def loop(i: Int): Unit =
+            if i < 8 then
+                out.write(((value >>> (i * 8)) & 0xff).toInt)
+                loop(i + 1)
+        loop(0)
+    end writeFixedLongTo
+
+    private def writeFixedIntTo(out: java.io.ByteArrayOutputStream, value: Int): Unit =
+        @tailrec def loop(i: Int): Unit =
+            if i < 4 then
+                out.write(((value >>> (i * 8)) & 0xff).toInt)
+                loop(i + 1)
+        loop(0)
+    end writeFixedIntTo
 
     private def writeFixedInt(value: Int): Unit =
         @tailrec def loop(i: Int): Unit =

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaBridge.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaBridge.scala
@@ -3,6 +3,7 @@ package kyo.internal
 import kyo.Codec.Reader
 import kyo.Codec.Writer
 import kyo.Frame
+import kyo.Present
 import kyo.Schema
 import scala.compiletime.erasedValue
 
@@ -51,3 +52,13 @@ inline def readField[A](inline s: Schema[A], r: Reader): A =
         case _: Byte    => r.byte().asInstanceOf[A]
         case _: Char    => r.char().asInstanceOf[A]
         case _          => s.serializeRead(r)
+
+inline def absentDefaultSeed[A](inline s: Schema[A]): A =
+    s.absentDefaultValue match
+        case Present(value) => value
+        case _              => null.asInstanceOf[A]
+
+inline def absentDefaultMask[A](inline s: Schema[A], bit: Long): Long =
+    s.absentDefaultValue match
+        case Present(_) => bit
+        case _          => 0L

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
@@ -1148,6 +1148,13 @@ private[kyo] object SchemaSerializer:
 
         override def release(): Unit = inner.release()
 
+        override def absentDefaultedFieldsMask(n: Int, defaultableFieldsMask: Long): Long =
+            delegateReader match
+                case Present(reader) => reader.absentDefaultedFieldsMask(n, defaultableFieldsMask)
+                case _               => inner.absentDefaultedFieldsMask(n, defaultableFieldsMask)
+            end match
+        end absentDefaultedFieldsMask
+
     end DelegatingWrapperReader
 
     /** A [[Reader]] wrapper that transforms flat discriminator format back to wrapper format for sealed trait deserialization.
@@ -1663,6 +1670,9 @@ private[kyo] object SchemaSerializer:
             if n >= 64 then _droppedMask | innerMask
             else (_droppedMask & ((1L << n) - 1L)) | innerMask
         end droppedFieldsMask
+
+        override def absentDefaultedFieldsMask(n: Int, defaultableFieldsMask: Long): Long =
+            inner.absentDefaultedFieldsMask(n, defaultableFieldsMask)
 
         override def initFields(n: Int): Array[AnyRef] = inner.initFields(n)
 

--- a/kyo-schema/shared/src/test/scala/kyo/ProtobufConformanceTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/ProtobufConformanceTest.scala
@@ -1,0 +1,72 @@
+package kyo
+
+import kyo.Protobuf.Conformance
+
+// Float key is not a proto3-native map key (isProto3MapKey rejects PrimitiveKind.Float).
+// Local to this conformance suite; not added to the shared ProtobufTest fixtures.
+case class PB1716MapFloat(f: Map[Float, Int]) derives Schema, CanEqual
+
+class ProtobufConformanceTest extends kyo.test.Test[Any]:
+
+    given CanEqual[Any, Any] = CanEqual.derived
+
+    "Protobuf conformance" - {
+
+        "INV-PBC-02-native-int: native Int key accepted under Strict default" in {
+            val v     = PB1716MapInt(3, Map(10 -> 100))
+            val bytes = Protobuf.encode(v)
+            assert(bytes.nonEmpty)
+            assert(Protobuf.decode[PB1716MapInt](bytes) == Result.Success(v))
+        }
+
+        "INV-PBC-02-product-key-rejected: product message key rejected under Strict default" in {
+            val v      = PB1716VcKey(Map(Pid(1) -> "x"))
+            val result = scala.util.Try(Protobuf.encode(v))
+            assert(result.isFailure)
+            assert(result.failed.get.isInstanceOf[SchemaNotSerializableException])
+        }
+
+        "INV-PBC-02-float-key-rejected: Float key rejected under Strict default" in {
+            val v      = PB1716MapFloat(Map(1.5f -> 1))
+            val result = scala.util.Try(Protobuf.encode(v))
+            assert(result.isFailure)
+            assert(result.failed.get.isInstanceOf[SchemaNotSerializableException])
+        }
+
+        "INV-PBC-02s-opaque-native-allowed: opaque type reducing to native scalar allowed under Strict" in {
+            val v     = PB1716OpaqueKey(Map(PB1716Ids.UserId(1) -> "x"))
+            val bytes = Protobuf.encode(v)
+            assert(Protobuf.decode[PB1716OpaqueKey](bytes) == Result.Success(v))
+        }
+
+        "INV-PBC-02-permissive-allows-noncanonical: Permissive accepts product key and round-trips" in {
+            given Protobuf = Protobuf(Protobuf.Config(conformance = Conformance.Permissive))
+            val v          = PB1716VcKey(Map(Pid(1) -> "x", Pid(2) -> "y"))
+            val bytes      = Protobuf.encode(v)
+            assert(Protobuf.decode[PB1716VcKey](bytes) == Result.Success(v))
+        }
+
+        "INV-PBC-02-rejection-detail-prefix: rejection carries stable message prefix" in {
+            val v      = PB1716VcKey(Map(Pid(1) -> "x"))
+            val result = scala.util.Try(Protobuf.encode(v))
+            assert(result.isFailure)
+            val ex = result.failed.get.asInstanceOf[SchemaNotSerializableException]
+            assert(ex.detail.startsWith("non-canonical proto3 map key: "))
+        }
+
+        "INV-PBC-01-roundtrip-both-modes: canonical value encodes identically under Strict and Permissive" in {
+            val v           = PB1716MapInt(3, Map(10 -> 100))
+            val strictBytes = Protobuf.encode(v)
+            assert(Protobuf.decode[PB1716MapInt](strictBytes) == Result.Success(v))
+            // Permissive mode must not change the wire bytes for a canonical (native-key) value.
+            {
+                given Protobuf      = Protobuf(Protobuf.Config(conformance = Conformance.Permissive))
+                val permissiveBytes = Protobuf.encode(v)
+                assert(Protobuf.decode[PB1716MapInt](permissiveBytes) == Result.Success(v))
+                assert(strictBytes.toArray.toSeq == permissiveBytes.toArray.toSeq)
+            }
+        }
+
+    }
+
+end ProtobufConformanceTest

--- a/kyo-schema/shared/src/test/scala/kyo/ProtobufTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/ProtobufTest.scala
@@ -5,6 +5,7 @@ import kyo.Schema.*
 import kyo.internal.CodecMacro
 import kyo.internal.ProtobufReader
 import kyo.internal.ProtobufWriter
+import scala.annotation.tailrec
 
 class ProtobufTest extends kyo.test.Test[Any]:
 
@@ -197,20 +198,20 @@ class ProtobufTest extends kyo.test.Test[Any]:
         "ProtoSchema primitive types" in {
             val schema = ProtoSchema.from[MTPerson]
             assert(schema.contains("message MTPerson"))
-            assert(schema.contains("string name = 1;"))
-            assert(schema.contains("sint32 age = 2;"))
+            assert(schema.contains(s"string name = ${kyo.internal.CodecMacro.fieldId("name")};"))
+            assert(schema.contains(s"sint32 age = ${kyo.internal.CodecMacro.fieldId("age")};"))
         }
 
         "ProtoSchema nested messages" in {
             val schema = ProtoSchema.from[MTTeam]
             assert(schema.contains("message MTTeam"))
             assert(schema.contains("message MTPersonAddr"))
-            assert(schema.contains("repeated MTPersonAddr members = 3;"))
+            assert(schema.contains(s"repeated MTPersonAddr members = ${kyo.internal.CodecMacro.fieldId("members")};"))
         }
 
         "ProtoSchema optional fields" in {
             val schema = ProtoSchema.from[MTOptional]
-            assert(schema.contains("optional string nickname = 2;"))
+            assert(schema.contains(s"optional string nickname = ${kyo.internal.CodecMacro.fieldId("nickname")};"))
         }
 
         "ProtoSchema sealed trait" in {
@@ -234,25 +235,25 @@ class ProtobufTest extends kyo.test.Test[Any]:
 
         "ProtoSchema top-level Primitive throws IllegalArgumentException" in {
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[Int])
+                ProtoSchema.fromStructure(Structure.of[Int], Map.empty)
             }
         }
 
         "ProtoSchema top-level Collection throws IllegalArgumentException" in {
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[List[Int]])
+                ProtoSchema.fromStructure(Structure.of[List[Int]], Map.empty)
             }
         }
 
         "ProtoSchema top-level Optional throws IllegalArgumentException" in {
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[Option[Int]])
+                ProtoSchema.fromStructure(Structure.of[Option[Int]], Map.empty)
             }
         }
 
         "ProtoSchema top-level Mapping throws IllegalArgumentException" in {
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[Map[String, Int]])
+                ProtoSchema.fromStructure(Structure.of[Map[String, Int]], Map.empty)
             }
         }
 
@@ -265,56 +266,56 @@ class ProtobufTest extends kyo.test.Test[Any]:
         "ProtoSchema List[List[A]] field throws IllegalArgumentException" in {
             case class ListOfList(values: List[List[Int]]) derives CanEqual
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[ListOfList])
+                ProtoSchema.fromStructure(Structure.of[ListOfList], Map.empty)
             }
         }
 
         "ProtoSchema List[Map[K, V]] field throws IllegalArgumentException" in {
             case class ListOfMap(values: List[Map[String, Int]]) derives CanEqual
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[ListOfMap])
+                ProtoSchema.fromStructure(Structure.of[ListOfMap], Map.empty)
             }
         }
 
         "ProtoSchema Option[Option[A]] field throws IllegalArgumentException" in {
             case class NestedOption(value: Option[Option[Int]]) derives CanEqual
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[NestedOption])
+                ProtoSchema.fromStructure(Structure.of[NestedOption], Map.empty)
             }
         }
 
         "ProtoSchema Option[List[A]] field throws IllegalArgumentException" in {
             case class OptionOfList(value: Option[List[Int]]) derives CanEqual
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[OptionOfList])
+                ProtoSchema.fromStructure(Structure.of[OptionOfList], Map.empty)
             }
         }
 
         "ProtoSchema Option[Map[K, V]] field throws IllegalArgumentException" in {
             case class OptionOfMap(value: Option[Map[String, Int]]) derives CanEqual
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[OptionOfMap])
+                ProtoSchema.fromStructure(Structure.of[OptionOfMap], Map.empty)
             }
         }
 
         "ProtoSchema Map[K, Option[V]] field throws IllegalArgumentException" in {
             case class MapWithOptionValue(value: Map[String, Option[Int]]) derives CanEqual
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[MapWithOptionValue])
+                ProtoSchema.fromStructure(Structure.of[MapWithOptionValue], Map.empty)
             }
         }
 
         "ProtoSchema Map[K, List[V]] field throws IllegalArgumentException" in {
             case class MapWithListValue(value: Map[String, List[Int]]) derives CanEqual
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[MapWithListValue])
+                ProtoSchema.fromStructure(Structure.of[MapWithListValue], Map.empty)
             }
         }
 
         "ProtoSchema Map[K, Map[K2, V]] field throws IllegalArgumentException" in {
             case class MapWithMapValue(value: Map[String, Map[String, Int]]) derives CanEqual
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(Structure.of[MapWithMapValue])
+                ProtoSchema.fromStructure(Structure.of[MapWithMapValue], Map.empty)
             }
         }
 
@@ -338,7 +339,7 @@ class ProtobufTest extends kyo.test.Test[Any]:
                 Chunk(Structure.Field("value", optionalKeyMapping, Maybe.empty, Maybe.empty, false))
             )
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(productWithOptKey)
+                ProtoSchema.fromStructure(productWithOptKey, Map.empty)
             }
         }
 
@@ -361,7 +362,7 @@ class ProtobufTest extends kyo.test.Test[Any]:
                 Chunk(Structure.Field("value", collectionKeyMapping, Maybe.empty, Maybe.empty, false))
             )
             interceptThrown[IllegalArgumentException] {
-                ProtoSchema.fromStructure(productWithListKey)
+                ProtoSchema.fromStructure(productWithListKey, Map.empty)
             }
         }
 
@@ -379,7 +380,7 @@ class ProtobufTest extends kyo.test.Test[Any]:
                 Chunk.empty,
                 Chunk(Structure.Field("values", longKeyMapping, Maybe.empty, Maybe.empty, false))
             )
-            val schema = ProtoSchema.fromStructure(productWithLongKey)
+            val schema = ProtoSchema.fromStructure(productWithLongKey, Map.empty)
             assert(schema.contains("map<sint64, string>"))
             assert(schema.contains("values"))
         }
@@ -670,9 +671,10 @@ class ProtobufTest extends kyo.test.Test[Any]:
         }
 
         "Protobuf.decode returns LimitExceededException when collection size exceeds limit" in {
-            val holder = MTCollectionHolder(List.fill(20)(1))
-            val bytes  = Protobuf.encode(holder)
-            val result = Protobuf.decode[MTCollectionHolder](bytes, maxCollectionSize = 5)
+            val holder     = MTCollectionHolder(List.fill(20)(1))
+            given Protobuf = Protobuf(Protobuf.Config(maxCollectionSize = 5))
+            val bytes      = Protobuf.encode(holder)
+            val result     = Protobuf.decode[MTCollectionHolder](bytes)
             assert(result.failure.exists(_.isInstanceOf[LimitExceededException]))
         }
 
@@ -682,7 +684,17 @@ class ProtobufTest extends kyo.test.Test[Any]:
                 case (v, acc) => TreeNode(v, List(acc))
             }
             val bytes  = Protobuf.encode(deep)
-            val result = Protobuf.decode[TreeNode](bytes, maxDepth = 2)
+            val result = Protobuf.decode[TreeNode](bytes, 2, Json.DefaultMaxCollectionSize)
+            assert(result.failure.exists(_.isInstanceOf[LimitExceededException]))
+        }
+
+        "Protobuf.Config maxDepth limit applies to the no-arg decode" in {
+            val deep = List.range(1, 6).foldRight(TreeNode(0, scala.Nil)) {
+                case (v, acc) => TreeNode(v, List(acc))
+            }
+            given Protobuf = Protobuf(Protobuf.Config(maxDepth = 2))
+            val bytes      = Protobuf.encode(deep)
+            val result     = Protobuf.decode[TreeNode](bytes)
             assert(result.failure.exists(_.isInstanceOf[LimitExceededException]))
         }
 
@@ -734,13 +746,13 @@ class ProtobufTest extends kyo.test.Test[Any]:
 
         "ProtoSchema.fromStructure on Open throws SchemaNotSerializableException" in {
             val open = Structure.Type.Open(Tag[Structure.Value].asInstanceOf[Tag[Any]])
-            val ex   = intercept[SchemaNotSerializableException](Protobuf.ProtoSchema.fromStructure(open))
+            val ex   = intercept[SchemaNotSerializableException](Protobuf.ProtoSchema.fromStructure(open, Map.empty))
             assert(ex.getMessage.contains("open-shape schemas"))
         }
 
         "ProtoSchema.fromStructure on Open throws SchemaNotSerializableException not IllegalArgumentException" in {
             val open = Structure.Type.Open(Tag[Structure.Value].asInstanceOf[Tag[Any]])
-            val ex   = intercept[SchemaNotSerializableException](Protobuf.ProtoSchema.fromStructure(open))
+            val ex   = intercept[SchemaNotSerializableException](Protobuf.ProtoSchema.fromStructure(open, Map.empty))
             assert(!(ex: Throwable).isInstanceOf[IllegalArgumentException])
         }
 
@@ -871,10 +883,757 @@ class ProtobufTest extends kyo.test.Test[Any]:
         )
     }
 
+    // ===== #1716: repeated (List/Seq/...) and Map field round-trips =====
+
+    "issue #1716 repeated and map fields" - {
+
+        def pbRoundtrip[A](value: A)(using Schema[A], kyo.test.AssertScope): A =
+            Protobuf.decode[A](Protobuf.encode(value)) match
+                case Result.Success(a) => a
+                case other             => fail(s"protobuf decode failed for $value: $other")
+
+        "List[Int] field round-trips" in {
+            val v = PB1716ListInt(1, List(1, 2, 3))
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "List[Int] field round-trips alongside a non-Int sibling" in {
+            val v = PB1716NestedList(true, List(4, 5))
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "List of case classes (repeated embedded message) round-trips" in {
+            val v = PB1716ListNested(7, List(PB1716NestedList(false, List(1)), PB1716NestedList(true, List(2, 3))))
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "single-element List round-trips" in {
+            val v = PB1716ListInt(1, List(42))
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "Vector / Seq / Set / Chunk fields round-trip" in {
+            val v = PB1716Collections(
+                Vector(1, 2),
+                Seq("a", "b"),
+                Set(3, 4),
+                Chunk(5, 6),
+                Span.from(Array[Byte](7, 8)),
+                Map("m" -> 9),
+                Map(11  -> 12)
+            )
+            val decoded = pbRoundtrip(v)
+            assert(decoded.v == v.v)
+            assert(decoded.s.toSeq == v.s.toSeq)
+            assert(decoded.set == v.set)
+            assert(decoded.c == v.c)
+            assert(decoded.sp.toArray.toSeq == v.sp.toArray.toSeq)
+            assert(decoded.m == v.m)
+            assert(decoded.n == v.n)
+        }
+
+        "absent repeated and map fields decode to empty values" in {
+            val decoded = Protobuf.decode[PB1716Collections](Span.empty[Byte])
+            assert(
+                decoded == Result.Success(
+                    PB1716Collections(
+                        Vector.empty,
+                        Seq.empty[String],
+                        Set.empty,
+                        Chunk.empty,
+                        Span.empty[Byte],
+                        Map.empty,
+                        Map.empty
+                    )
+                )
+            )
+        }
+
+        "schema-defined collection absent default is honored" in {
+            val value = PB1716CustomCollection(PB1716Bag(Chunk(1, 2, 3)))
+            assert(pbRoundtrip(value) == value)
+            val decoded = Protobuf.decode[PB1716CustomCollection](Span.empty[Byte])
+            assert(decoded == Result.Success(PB1716CustomCollection(PB1716Bag(Chunk.empty))))
+        }
+
+        "Map[String, Int] round-trips with keys preserved" in {
+            val v = PB1716MapStr(9, Map("a" -> 1, "b" -> 2))
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "empty Map[String, Int] still round-trips" in {
+            val v = PB1716MapStr(0, Map.empty)
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "Map[Int, Int] (non-String key) derives and round-trips" in {
+            val v = PB1716MapInt(3, Map(10 -> 100, 20 -> 200))
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "Map[String, case class] round-trips" in {
+            val v = PB1716MapMsg(Map("x" -> MTItem("pen", 1.5), "y" -> MTItem("ink", 2.0)))
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "cross-codec: Json round-trips the same shapes (no regression)" in {
+            val a = PB1716ListNested(7, List(PB1716NestedList(false, List(1)), PB1716NestedList(true, List(2, 3))))
+            assert(Schema[PB1716ListNested].decodeString[Json](Schema[PB1716ListNested].encodeString[Json](a)) == Result.Success(a))
+            val b = PB1716MapStr(9, Map("a" -> 1, "b" -> 2))
+            assert(Schema[PB1716MapStr].decodeString[Json](Schema[PB1716MapStr].encodeString[Json](b)) == Result.Success(b))
+            val c = PB1716MapInt(3, Map(10 -> 100))
+            assert(Schema[PB1716MapInt].decodeString[Json](Schema[PB1716MapInt].encodeString[Json](c)) == Result.Success(c))
+        }
+
+        "cross-codec: Yaml round-trips the same shapes (no regression)" in {
+            val a = PB1716ListNested(7, List(PB1716NestedList(false, List(1)), PB1716NestedList(true, List(2, 3))))
+            assert(Schema[PB1716ListNested].decodeString[Yaml](Schema[PB1716ListNested].encodeString[Yaml](a)) == Result.Success(a))
+            val b = PB1716MapStr(9, Map("a" -> 1, "b" -> 2))
+            assert(Schema[PB1716MapStr].decodeString[Yaml](Schema[PB1716MapStr].encodeString[Yaml](b)) == Result.Success(b))
+            val c = PB1716MapInt(3, Map(10 -> 100))
+            assert(Schema[PB1716MapInt].decodeString[Yaml](Schema[PB1716MapInt].encodeString[Yaml](c)) == Result.Success(c))
+        }
+
+        "cross-codec: Ion round-trips the same shapes (no regression)" in {
+            val a = PB1716ListNested(7, List(PB1716NestedList(false, List(1)), PB1716NestedList(true, List(2, 3))))
+            assert(Schema[PB1716ListNested].decodeString[Ion](Schema[PB1716ListNested].encodeString[Ion](a)) == Result.Success(a))
+            val b = PB1716MapStr(9, Map("a" -> 1, "b" -> 2))
+            assert(Schema[PB1716MapStr].decodeString[Ion](Schema[PB1716MapStr].encodeString[Ion](b)) == Result.Success(b))
+            val c = PB1716MapInt(3, Map(10 -> 100))
+            assert(Schema[PB1716MapInt].decodeString[Ion](Schema[PB1716MapInt].encodeString[Ion](c)) == Result.Success(c))
+        }
+
+        "cross-codec: MsgPack round-trips the same shapes (no regression)" in {
+            val a = PB1716ListNested(7, List(PB1716NestedList(false, List(1)), PB1716NestedList(true, List(2, 3))))
+            assert(Schema[PB1716ListNested].decode[MsgPack](Schema[PB1716ListNested].encode[MsgPack](a)) == Result.Success(a))
+            val b = PB1716MapStr(9, Map("a" -> 1, "b" -> 2))
+            assert(Schema[PB1716MapStr].decode[MsgPack](Schema[PB1716MapStr].encode[MsgPack](b)) == Result.Success(b))
+            val c = PB1716MapInt(3, Map(10 -> 100))
+            assert(Schema[PB1716MapInt].decode[MsgPack](Schema[PB1716MapInt].encode[MsgPack](c)) == Result.Success(c))
+        }
+
+        // Regression tests: empty string elements in a repeated field must not be silently dropped.
+        // kyo encodes Seq("") as one LengthDelimited record of length 0; the reader must return it,
+        // not treat it as a packed-scalar empty run.
+
+        "Seq with one empty string element round-trips" in {
+            val v = PB1716SeqStr(Seq(""))
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "Seq with empty string followed by non-empty string round-trips" in {
+            val v = PB1716SeqStr(Seq("", "y"))
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "Seq with multiple empty strings mixed with non-empty strings round-trips" in {
+            val v = PB1716SeqStr(Seq("", "a", "", "b"))
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "empty List[Int] field round-trips to empty" in {
+            val v = PB1716ListInt(5, List.empty)
+            assert(pbRoundtrip(v) == v)
+        }
+
+        "Map[Int, Int] protoSchema emits a valid map<sint32, sint32>" in {
+            val schema = ProtoSchema.from[PB1716MapInt]
+            assert(schema.contains("map<sint32, sint32> f"))
+        }
+
+        "opaque-type key reducing to a native scalar round-trips and is a native map key" in {
+            val v = PB1716OpaqueKey(Map(PB1716Ids.UserId(1) -> "a", PB1716Ids.UserId(2) -> "b"))
+            assert(pbRoundtrip(v) == v)
+            val schema = ProtoSchema.from[PB1716OpaqueKey]
+            assert(schema.contains("map<sint32, string> m"))
+        }
+
+        "value-class key (derives a message) round-trips via the entry-message form" in {
+            given Protobuf = Protobuf(Protobuf.Config(conformance = Protobuf.Conformance.Permissive))
+            val v          = PB1716VcKey(Map(Pid(1) -> "x", Pid(2) -> "y"))
+            // pbRoundtrip captures the default given at its definition site; use inline encode/decode directly.
+            assert(Protobuf.decode[PB1716VcKey](Protobuf.encode(v)) == Result.Success(v))
+            // proto3 cannot use a message as a map key, so protoSchema describes a repeated entry message.
+            val schema = ProtoSchema.from[PB1716VcKey]
+            assert(schema.contains("repeated MEntry m") && schema.contains("message MEntry"))
+        }
+
+        "strict config rejects a non-proto3-native map key at encode" in {
+            given Protobuf = Protobuf(Protobuf.Config(conformance = Protobuf.Conformance.Strict))
+            val v          = PB1716VcKey(Map(Pid(1) -> "x"))
+            val result     = scala.util.Try(Protobuf.encode(v))
+            assert(result.isFailure && result.failed.get.isInstanceOf[SchemaNotSerializableException])
+        }
+
+        "strict config still allows native-keyed maps" in {
+            given Protobuf = Protobuf(Protobuf.Config(conformance = Protobuf.Conformance.Strict))
+            val v          = PB1716MapInt(3, Map(10 -> 100))
+            assert(Protobuf.decode[PB1716MapInt](Protobuf.encode(v)) == Result.Success(v))
+        }
+    }
+
+    "map decode depth-guard" - {
+
+        "INV-PBC-07-nested-string-map-depth" in {
+            // String-keyed maps go through mapStart/mapEnd, which honor the nesting-depth limit.
+            // Depth levels: objectStart (case class) = 1, outer mapStart = 2, inner mapStart = 3 > maxDepth 2.
+            val value  = PBStr2Map(Map("k" -> Map("inner" -> 1)))
+            val bytes  = Protobuf.encode(value)
+            val result = Protobuf.decode[PBStr2Map](bytes, 2, Json.DefaultMaxCollectionSize)
+            assert(
+                result.isFailure && result.failure.exists(_.isInstanceOf[LimitExceededException]),
+                s"nested string-map exceeding maxDepth must be Result.Failure(LimitExceededException): $result"
+            )
+        }
+
+        "INV-PBC-07-nested-nonstring-map-depth" in {
+            // Non-string maps go through arrayStart + per-entry objectStart (arrayStart already calls checkDepth).
+            // Depth levels: objectStart (case class) = 1, arrayStart for outer Map[Int,...] = 2,
+            // objectStart for the first MapEntry = 3 > maxDepth 2.
+            val value  = PBIntIntMap(Map(1 -> Map(2 -> 3)))
+            val bytes  = Protobuf.encode(value)
+            val result = Protobuf.decode[PBIntIntMap](bytes, 2, Json.DefaultMaxCollectionSize)
+            assert(
+                result.isFailure && result.failure.exists(_.isInstanceOf[LimitExceededException]),
+                s"nested non-string-map exceeding maxDepth must be Result.Failure(LimitExceededException): $result"
+            )
+        }
+
+        "INV-PBC-07-nested-list-depth" in {
+            // Nested list: each level of List[List[...]] calls arrayStart which checks depth.
+            // Depth levels: objectStart (case class) = 1, outer arrayStart = 2, inner arrayStart = 3 > maxDepth 2.
+            val value  = PBListList(List(List(1)))
+            val bytes  = Protobuf.encode(value)
+            val result = Protobuf.decode[PBListList](bytes, 2, Json.DefaultMaxCollectionSize)
+            assert(
+                result.isFailure && result.failure.exists(_.isInstanceOf[LimitExceededException]),
+                s"nested list exceeding maxDepth must be Result.Failure(LimitExceededException): $result"
+            )
+        }
+
+        "INV-PBC-07-map-at-limit-decodes" in {
+            // Same bytes as the exceeding test but maxDepth = 3: objectStart (depth 1) + outer mapStart (depth 2)
+            // + inner mapStart (depth 3) is exactly at the limit. All three levels must succeed.
+            val value  = PBStr2Map(Map("k" -> Map("inner" -> 1)))
+            val bytes  = Protobuf.encode(value)
+            val result = Protobuf.decode[PBStr2Map](bytes, 3, Json.DefaultMaxCollectionSize)
+            assert(
+                result == Result.Success(value),
+                s"nested string-map at exactly maxDepth must be Result.Success: $result"
+            )
+        }
+
+        "INV-PBC-11-hostile-frame-decode-totality" in {
+            // Locked anti-case: 0x08 is a complete tag byte (field 1, Varint wire type) with no value body.
+            // hasNextField consumes the tag (pos 0 -> 1 = data.length); any subsequent read or skip
+            // of the missing value throws TruncatedInputException, which Result.catching intercepts.
+            val truncated = Span.from(Array[Byte](0x08.toByte))
+            // Second hostile input: tag 0x0a (field 1, LengthDelimited) followed by 0x80 (varint
+            // continuation bit set, no terminator byte) - readVarint throws when reading the length.
+            val overLarge = Span.from(Array[Byte](0x0a.toByte, 0x80.toByte))
+            val inputs    = List(truncated, overLarge)
+            for bytes <- inputs do
+                val r1 = Protobuf.decode[MTCollectionHolder](bytes, Json.DefaultMaxDepth, Json.DefaultMaxCollectionSize)
+                assert(
+                    r1.isFailure && r1.failure.exists(_.isInstanceOf[DecodeException]),
+                    s"list-path decode must return Result.Failure(_: DecodeException) for malformed input: $r1"
+                )
+                val r2 = Protobuf.decode[PB1716MapInt](bytes, Json.DefaultMaxDepth, Json.DefaultMaxCollectionSize)
+                assert(
+                    r2.isFailure && r2.failure.exists(_.isInstanceOf[DecodeException]),
+                    s"map-path decode must return Result.Failure(_: DecodeException) for malformed input: $r2"
+                )
+            end for
+        }
+
+    }
+
+    "packed repeated scalars" - {
+
+        // Walk flat outer-message bytes and count records for (targetField, targetWireType).
+        // Only visits the top-level tag/value pairs; does not descend into nested messages.
+        def countRecs(bytes: Array[Byte], targetField: Int, targetWt: Int): Int =
+            @tailrec def readVarnt(pos: Int, v: Long, sh: Int): (Long, Int) =
+                if pos >= bytes.length then (v, pos)
+                else
+                    val b  = bytes(pos) & 0xff
+                    val nv = v | ((b & 0x7f).toLong << sh)
+                    if (b & 0x80) != 0 then readVarnt(pos + 1, nv, sh + 7)
+                    else (nv, pos + 1)
+            def skipVal(pos: Int, wt: Int): Int =
+                wt match
+                    case 0 => readVarnt(pos, 0L, 0)._2
+                    case 1 => pos + 8
+                    case 2 =>
+                        val (len, p) = readVarnt(pos, 0L, 0)
+                        p + len.toInt
+                    case 5 => pos + 4
+                    case _ => bytes.length
+            @tailrec def walk(pos: Int, acc: Int): Int =
+                if pos >= bytes.length then acc
+                else
+                    val (tagVal, p1) = readVarnt(pos, 0L, 0)
+                    val fn           = (tagVal >>> 3).toInt
+                    val wt           = (tagVal & 0x7).toInt
+                    val hit          = if fn == targetField && wt == targetWt then 1 else 0
+                    walk(skipVal(p1, wt), acc + hit)
+            walk(0, 0)
+        end countRecs
+
+        "INV-PBC-04-scalar-packed-token-shape" in {
+            val v       = PB1716ListInt(1, List(1, 2, 3))
+            val encoded = Protobuf.encode(v).toArray
+            val bField  = CodecMacro.fieldId("b")
+            // Packed encoding: exactly one LengthDelimited record for field b.
+            assert(
+                countRecs(encoded, bField, 2) == 1,
+                "field b must appear as exactly one LengthDelimited record (packed)"
+            )
+            // No per-element Varint records for field b.
+            assert(
+                countRecs(encoded, bField, 0) == 0,
+                "packed form must emit no per-element Varint records for field b"
+            )
+            // The packed bytes decode correctly.
+            assert(Protobuf.decode[PB1716ListInt](Span.from(encoded)) == Result.Success(v))
+        }
+
+        "INV-PBC-04-message-and-string-stay-per-element" in {
+            // Repeated embedded messages must emit one LengthDelimited record per element,
+            // not a single merged packed record.
+            val msgs     = PB1716ListNested(1, List(PB1716NestedList(false, List(4)), PB1716NestedList(true, List(5, 6))))
+            val msgBytes = Protobuf.encode(msgs).toArray
+            val dField   = CodecMacro.fieldId("d")
+            assert(
+                countRecs(msgBytes, dField, 2) == 2,
+                "two repeated message elements must produce two separate LengthDelimited records"
+            )
+
+            // Repeated strings must also emit one LengthDelimited record per element.
+            val strs = PB1716Collections(
+                Vector.empty,
+                Seq("hello", "world"),
+                Set.empty,
+                Chunk.empty,
+                Span.empty[Byte],
+                Map.empty,
+                Map.empty
+            )
+            val strBytes = Protobuf.encode(strs).toArray
+            val sField   = CodecMacro.fieldId("s")
+            assert(
+                countRecs(strBytes, sField, 2) == 2,
+                "two repeated string elements must produce two separate LengthDelimited records"
+            )
+        }
+
+        "INV-PBC-03-dual-read-packed-and-unpacked" in {
+            val aValue = 1
+            val elems  = List(1, 2, 3)
+            val holder = PB1716ListInt(aValue, elems)
+
+            // Packed form produced by encode.
+            val packed = Protobuf.encode(holder)
+
+            // Hand-built unpacked form: one Varint tag per element, no arrayStart/arrayEnd.
+            val uw = new ProtobufWriter
+            uw.field("a", CodecMacro.fieldId("a"))
+            uw.int(aValue)
+            uw.field("b", CodecMacro.fieldId("b"))
+            uw.int(1)
+            uw.field("b", CodecMacro.fieldId("b"))
+            uw.int(2)
+            uw.field("b", CodecMacro.fieldId("b"))
+            uw.int(3)
+            val unpacked = Span.from(uw.resultBytes)
+
+            // Both forms must decode to the identical value.
+            assert(Protobuf.decode[PB1716ListInt](packed) == Result.Success(holder))
+            assert(
+                Protobuf.decode[PB1716ListInt](unpacked) == Result.Success(holder),
+                "unpacked (one tag per element) form must decode identically to the packed form"
+            )
+        }
+
+        "INV-PBC-03-mixed-producer" in {
+            // Build packed bytes for elements [1, 2] via encode.
+            val baseBytes = Protobuf.encode(PB1716ListInt(7, List(1, 2))).toArray
+
+            // Append unpacked elements [3, 4] for the same field using the raw writer outside
+            // an array context (inArray=false -> one Varint tag per element).
+            val xw = new ProtobufWriter
+            xw.field("b", CodecMacro.fieldId("b"))
+            xw.int(3)
+            xw.field("b", CodecMacro.fieldId("b"))
+            xw.int(4)
+            val extra = xw.resultBytes
+
+            val mixed  = Span.from(baseBytes ++ extra)
+            val result = Protobuf.decode[PB1716ListInt](mixed)
+            assert(
+                result == Result.Success(PB1716ListInt(7, List(1, 2, 3, 4))),
+                s"mixed-producer (packed run then unpacked elements) must decode all elements in order: $result"
+            )
+        }
+
+        "INV-PBC-09-packed-order-preserved" in {
+            val v = PB1716ListInt(0, List(5, 4, 3, 2, 1))
+            assert(
+                Protobuf.decode[PB1716ListInt](Protobuf.encode(v)) == Result.Success(v),
+                "packed decode must preserve write order (descending)"
+            )
+        }
+
+        "INV-PBC-08-empty-collection-and-map-absent" in {
+            val bField = CodecMacro.fieldId("b")
+
+            // Empty List must produce no wire record for the repeated field.
+            val emptyList      = PB1716ListInt(7, Nil)
+            val emptyListBytes = Protobuf.encode(emptyList).toArray
+            assert(
+                countRecs(emptyListBytes, bField, 2) == 0 && countRecs(emptyListBytes, bField, 0) == 0,
+                "encoding an empty List must produce no record for the repeated field"
+            )
+            // Decodes back to the original (absent field -> empty List).
+            assert(Protobuf.decode[PB1716ListInt](Span.from(emptyListBytes)) == Result.Success(emptyList))
+
+            // Empty Map must produce no wire record for the map field.
+            val emptyMap      = PB1716MapStr(5, Map.empty)
+            val emptyMapBytes = Protobuf.encode(emptyMap).toArray
+            val fField        = CodecMacro.fieldId("f")
+            assert(
+                countRecs(emptyMapBytes, fField, 2) == 0,
+                "encoding an empty Map must produce no record for the map field"
+            )
+            assert(Protobuf.decode[PB1716MapStr](Span.from(emptyMapBytes)) == Result.Success(emptyMap))
+        }
+
+        "INV-PBC-04-all-scalar-collections-roundtrip-packed" in {
+            val v = PB1716Collections(
+                Vector(10, 20, 30),
+                Seq("x", "y"),
+                Set(1, 2, 3),
+                Chunk(4, 5, 6),
+                Span.from(Array[Byte](7, 8, 9)),
+                Map("a" -> 1, "b"   -> 2),
+                Map(100 -> 200, 300 -> 400)
+            )
+            Protobuf.decode[PB1716Collections](Protobuf.encode(v)) match
+                case Result.Success(d) =>
+                    assert(d.v == v.v)
+                    assert(d.s.toSeq == v.s.toSeq)
+                    // Set is unordered; element equality suffices.
+                    assert(d.set == v.set)
+                    assert(d.c == v.c)
+                    assert(d.sp.toArray.toSeq == v.sp.toArray.toSeq)
+                    assert(d.m == v.m)
+                    assert(d.n == v.n)
+                case other => fail(s"PB1716Collections encode/decode failed: $other")
+            end match
+        }
+
+    }
+
+    // ===== fieldNumberAudit =====
+
+    "fieldNumberAudit" - {
+
+        "INV-PBC-06-number-equals-wire-formula" in {
+            val rows = Protobuf.fieldNumberAudit[PBAuditPerson]
+            assert(rows.nonEmpty)
+            rows.foreach { row =>
+                assert(
+                    row.number == CodecMacro.fieldId(row.name),
+                    s"row '${row.path}': number ${row.number} != fieldId('${row.name}') ${CodecMacro.fieldId(row.name)}"
+                )
+            }
+        }
+
+        "INV-PBC-06-dotted-path-recursion" in {
+            val rows  = Protobuf.fieldNumberAudit[PBAuditPerson]
+            val paths = rows.map(_.path).toSet
+            assert(paths.contains("name"), s"expected path 'name' in $paths")
+            assert(paths.contains("inner"), s"expected path 'inner' in $paths")
+            assert(paths.contains("inner.id"), s"expected path 'inner.id' in $paths")
+            val innerIdRow = rows.find(_.path == "inner.id").get
+            assert(innerIdRow.name == "id")
+        }
+
+        "INV-PBC-06-pinned-flag" in {
+            val pBPinned: Schema[PBAuditPerson] = Schema[PBAuditPerson].fieldId(_.name)(7)
+            val rows                            = Protobuf.fieldNumberAudit[PBAuditPerson](using pBPinned)
+            val nameRow                         = rows.find(_.name == "name").get
+            assert(nameRow.pinned == true, s"expected pinned=true for 'name', got ${nameRow.pinned}")
+            assert(nameRow.number == 7, s"expected number=7 for 'name', got ${nameRow.number}")
+            rows.filter(_.name != "name").foreach { row =>
+                assert(row.pinned == false, s"expected pinned=false for '${row.path}', got ${row.pinned}")
+            }
+        }
+
+        "INV-PBC-12-reserved-flag-and-control" in {
+            val rows    = Protobuf.fieldNumberAudit[PBReserved]
+            val inBand  = rows.find(_.name == "bAt").get
+            val control = rows.find(_.name == "ctrl").get
+            assert(inBand.inReservedRange == true, s"'bAt' (number=${inBand.number}) should be in reserved range 19000-19999")
+            assert(control.inReservedRange == false, s"'ctrl' (number=${control.number}) should NOT be in reserved range 19000-19999")
+        }
+
+        "INV-PBC-06-traversal-shape-and-type-reuse" in {
+            val rows  = Protobuf.fieldNumberAudit[PBAuditReuse]
+            val paths = rows.map(_.path)
+            // PBAuditInner is reused: its fields appear at both the list-element path and the map-value path.
+            assert(paths.contains("list"), s"expected 'list' row in $paths")
+            assert(paths.contains("map"), s"expected 'map' row in $paths")
+            assert(paths.contains("ints"), s"expected 'ints' row in $paths")
+            assert(paths.contains("list.id"), s"expected 'list.id' row (PBAuditInner fields at list occurrence) in $paths")
+            assert(paths.contains("map.value.id"), s"expected 'map.value.id' row (PBAuditInner fields at map-value occurrence) in $paths")
+            // ints: List[Int] - Int is a primitive, so no per-element row.
+            assert(!paths.exists(_.startsWith("ints.")), s"unexpected sub-path of 'ints' (Int is primitive) in $paths")
+        }
+
+        "INV-PBC-06-recursive-type-terminates" in {
+            val rows  = Protobuf.fieldNumberAudit[PBAuditTree]
+            val paths = rows.map(_.path)
+            // The audit must terminate and emit exactly the two top-level fields.
+            assert(rows.size == 2, s"expected exactly 2 rows for PBAuditTree, got ${rows.size}: $paths")
+            assert(paths.contains("value"), s"expected path 'value' in $paths")
+            assert(paths.contains("children"), s"expected path 'children' in $paths")
+            // Recursion guard: children.value / children.children must NOT appear.
+            assert(!paths.contains("children.value"), s"unexpected 'children.value' - recursion guard failed")
+            assert(!paths.contains("children.children"), s"unexpected 'children.children' - recursion guard failed")
+        }
+
+    }
+
+    "protoSchema wire-true numbers and pinning" - {
+
+        "INV-PBC-05-protoSchema-number-equals-wire" in {
+            // Every message field in protoSchema output must carry its CodecMacro.fieldId number.
+            val output = Protobuf.protoSchema[PBAuditPerson]
+            List("name", "inner", "id").foreach { fieldName =>
+                val line = output.linesIterator.find(l => l.contains(s" $fieldName = ")).getOrElse(
+                    fail(s"field '$fieldName' not found in protoSchema output:\n$output")
+                )
+                val numStr   = line.split("=").last.trim.takeWhile(_.isDigit)
+                val num      = numStr.toInt
+                val expected = kyo.internal.CodecMacro.fieldId(fieldName)
+                assert(num == expected, s"protoSchema number for '$fieldName' is $num but wire number (CodecMacro.fieldId) is $expected")
+            }
+        }
+
+        "INV-PBC-05-no-idx-plus-one" in {
+            // protoSchema emits the actual wire field number (the name hash), not the declaration
+            // position: the first field's number equals CodecMacro.fieldId("name"), which is not 1.
+            val output = Protobuf.protoSchema[PBAuditPerson]
+            val line = output.linesIterator.find(_.contains(" name = ")).getOrElse(
+                fail(s"field 'name' not found in protoSchema output:\n$output")
+            )
+            val num      = line.split("=").last.trim.takeWhile(_.isDigit).toInt
+            val expected = kyo.internal.CodecMacro.fieldId("name")
+            assert(num != 1, s"field 'name' must not use idx+1 numbering; hash-derived number is $expected not 1")
+            assert(num == expected, s"field 'name' must equal CodecMacro.fieldId('name')=$expected; got $num")
+        }
+
+        "INV-PBC-05-structural-numbers-preserved" in {
+            // oneof variants use idx+1 (proto3-required); MapEntry key=1/value=2 (proto3-structural).
+            val sealedOutput = Protobuf.protoSchema[Protobuf1517Sealed]
+            // Alpha is first variant (idx=0), must be = 1; Beta is second (idx=1), must be = 2.
+            assert(sealedOutput.contains("Alpha alpha = 1;"), s"first oneof variant must be = 1:\n$sealedOutput")
+            assert(sealedOutput.contains("Beta beta = 2;"), s"second oneof variant must be = 2:\n$sealedOutput")
+
+            // A map with a non-proto3-native key (Pid is a product) is emitted as a repeated entry message.
+            // The entry message's key and value field numbers are proto3-structural (always 1 and 2).
+            val vcKeyOutput = Protobuf.protoSchema[PB1716VcKey]
+            assert(vcKeyOutput.contains("key = 1;"), s"MapEntry key must be = 1:\n$vcKeyOutput")
+            assert(vcKeyOutput.contains("value = 2;"), s"MapEntry value must be = 2:\n$vcKeyOutput")
+        }
+
+        "INV-PBC-05-provenance-comment-on-hash-derived" in {
+            // Every hash-derived field declaration in PBAuditPerson / PBAuditInner must carry the nudge comment.
+            val output = Protobuf.protoSchema[PBAuditPerson]
+            List("name", "inner", "id").foreach { fieldName =>
+                val line = output.linesIterator.find(l => l.contains(s" $fieldName = ")).getOrElse(
+                    fail(s"field '$fieldName' not found in protoSchema output:\n$output")
+                )
+                assert(
+                    line.contains("hash-derived field number; pin via Schema.fieldId"),
+                    s"hash-derived field '$fieldName' line missing provenance nudge: '$line'"
+                )
+            }
+        }
+
+        "INV-PBC-12-reserved-WARNING-comment" in {
+            // Sub-case A: hash-derived-in-band. PBReserved.bAt hashes to 19506.
+            val reservedOutput = Protobuf.protoSchema[PBReserved]
+            val bAtLine        = reservedOutput.linesIterator.find(_.contains(" bAt = ")).getOrElse("")
+            val ctrlLine       = reservedOutput.linesIterator.find(_.contains(" ctrl = ")).getOrElse("")
+            assert(
+                bAtLine.contains("WARNING: in proto3 reserved range 19000-19999"),
+                s"'bAt' (hash-derived in reserved band) must carry the WARNING: '$bAtLine'"
+            )
+            assert(
+                !ctrlLine.contains("WARNING"),
+                s"'ctrl' (out-of-band) must NOT carry the WARNING: '$ctrlLine'"
+            )
+            assert(
+                ctrlLine.contains("hash-derived field number; pin via Schema.fieldId"),
+                s"'ctrl' must carry the ordinary hash-derived nudge: '$ctrlLine'"
+            )
+
+            // Sub-case B: pinned-in-band. A field pinned to 19500 still triggers the WARNING.
+            given pinnedInBandSchema: Schema[PBReservedPinnedHolder] = Schema[PBReservedPinnedHolder].fieldId(_.x)(19500)
+            val pinnedOutput                                         = Protobuf.protoSchema[PBReservedPinnedHolder]
+            val xLine                                                = pinnedOutput.linesIterator.find(_.contains(" x = ")).getOrElse("")
+            assert(
+                xLine.contains("WARNING: in proto3 reserved range 19000-19999"),
+                s"pinned-in-band field must still carry the WARNING (unconditional on range): '$xLine'"
+            )
+        }
+
+        "INV-PBC-PIN-i-override-round-trip-wire-true" in {
+            // A field pinned via Schema.fieldId must encode with the pinned number and decode back correctly.
+            val pinnedSchema: Schema[PBAuditPerson] = Schema[PBAuditPerson].fieldId(_.name)(7)
+            given Schema[PBAuditPerson]             = pinnedSchema
+            val value                               = PBAuditPerson("Alice", PBAuditInner(42))
+            val bytes                               = Protobuf.encode(value)
+            val result                              = Protobuf.decode[PBAuditPerson](bytes)
+            assert(result == Result.Success(value), s"pinned-field round-trip failed: $result")
+        }
+
+        "INV-PBC-PIN-i-pinned-field-no-provenance-comment" in {
+            // A pinned out-of-band field carries no comment; a non-pinned sibling still carries the nudge.
+            given pinnedSchema: Schema[PBAuditPerson] = Schema[PBAuditPerson].fieldId(_.name)(7)
+            val output                                = Protobuf.protoSchema[PBAuditPerson]
+            val nameLine = output.linesIterator.find(_.contains(" name = ")).getOrElse(
+                fail(s"'name' field not found in protoSchema output:\n$output")
+            )
+            assert(nameLine.contains("= 7;"), s"pinned field 'name' must emit = 7;: '$nameLine'")
+            assert(!nameLine.contains("//"), s"pinned field 'name' must carry no comment: '$nameLine'")
+            val innerLine = output.linesIterator.find(_.contains(" inner = ")).getOrElse(
+                fail(s"'inner' field not found in protoSchema output:\n$output")
+            )
+            assert(
+                innerLine.contains("hash-derived field number; pin via Schema.fieldId"),
+                s"non-pinned 'inner' must still carry the hash-derived nudge: '$innerLine'"
+            )
+        }
+
+    }
+
+    "protoSchema provenance opt-out" - {
+
+        "default config emits hash-derived provenance nudge" in {
+            val output = Protobuf.protoSchema[PBAuditPerson]
+            List("name", "inner", "id").foreach { fieldName =>
+                val line = output.linesIterator.find(l => l.contains(s" $fieldName = ")).getOrElse(
+                    fail(s"field '$fieldName' not found in protoSchema output:\n$output")
+                )
+                assert(
+                    line.contains("hash-derived field number; pin via Schema.fieldId"),
+                    s"default config: hash-derived field '$fieldName' must carry the provenance nudge: '$line'"
+                )
+            }
+        }
+
+        "suppressed: no pin nudge but fields still present" in {
+            given Protobuf = Protobuf(Protobuf.Config(protoSchemaProvenance = false))
+            val output     = Protobuf.protoSchema[PBAuditPerson]
+            List("name", "inner", "id").foreach { fieldName =>
+                val line = output.linesIterator.find(l => l.contains(s" $fieldName = ")).getOrElse(
+                    fail(s"field '$fieldName' not found in suppressed protoSchema output:\n$output")
+                )
+                assert(
+                    !line.contains("pin via Schema.fieldId"),
+                    s"suppressed config: field '$fieldName' must not carry the pin nudge: '$line'"
+                )
+            }
+        }
+
+        "reserved-range WARNING always emitted even when suppressed" in {
+            given Protobuf = Protobuf(Protobuf.Config(protoSchemaProvenance = false))
+            val output     = Protobuf.protoSchema[PBReserved]
+            val bAtLine = output.linesIterator.find(_.contains(" bAt = ")).getOrElse(
+                fail(s"'bAt' field not found in protoSchema output:\n$output")
+            )
+            assert(
+                bAtLine.contains("WARNING: in proto3 reserved range 19000-19999"),
+                s"reserved-range WARNING must be emitted even when protoSchemaProvenance=false: '$bAtLine'"
+            )
+        }
+
+    }
+
 end ProtobufTest
 
 // Top-level to avoid issues with derives Schema inside nested definitions
 case class WithUnitField(done: Unit) derives Schema
+
+// #1716 fixtures: repeated and map fields.
+case class PB1716ListInt(a: Int, b: List[Int]) derives Schema, CanEqual
+case class PB1716NestedList(a: Boolean, b: List[Int]) derives Schema, CanEqual
+case class PB1716ListNested(a: Int, d: List[PB1716NestedList]) derives Schema, CanEqual
+case class PB1716Collections(
+    v: Vector[Int],
+    s: Seq[String],
+    set: Set[Int],
+    c: Chunk[Int],
+    sp: Span[Byte],
+    m: Map[String, Int],
+    n: Map[Int, Int]
+) derives Schema, CanEqual
+case class PB1716MapStr(a: Int, f: Map[String, Int]) derives Schema, CanEqual
+case class PB1716MapInt(a: Int, f: Map[Int, Int]) derives Schema, CanEqual
+case class PB1716MapMsg(m: Map[String, MTItem]) derives Schema, CanEqual
+case class PB1716Bag(values: Chunk[Int]) derives CanEqual
+object PB1716Bag:
+    given Schema[PB1716Bag] =
+        lazy val inner = summon[Schema[Int]]
+        Schema.init[PB1716Bag](
+            writeFn = (value, writer) =>
+                writer.arrayStart(value.values.size)
+                value.values.foreach(inner.serializeWrite(_, writer))
+                writer.arrayEnd()
+            ,
+            readFn = reader =>
+                discard(reader.arrayStart())
+                val builder = Chunk.newBuilder[Int]
+                @tailrec
+                def loop(count: Int): Unit =
+                    if reader.hasNextElement() then
+                        reader.checkCollectionSize(count)
+                        builder += inner.serializeRead(reader)
+                        loop(count + 1)
+                loop(1)
+                reader.arrayEnd()
+                PB1716Bag(builder.result())
+            ,
+            absentDefaultValue = Maybe(PB1716Bag(Chunk.empty)),
+            structure = Structure.Type.Collection(
+                "PB1716Bag",
+                Tag[PB1716Bag].asInstanceOf[Tag[Any]],
+                inner.structure
+            )
+        )
+    end given
+end PB1716Bag
+case class PB1716CustomCollection(bag: PB1716Bag) derives Schema, CanEqual
+
+// Opaque-type key whose Schema reduces to a native scalar (sint32): a native proto3 map key.
+object PB1716Ids:
+    opaque type UserId = Int
+    object UserId:
+        def apply(i: Int): UserId            = i
+        extension (u: UserId) def value: Int = u
+        given Schema[UserId]                 = summon[Schema[Int]].transform(apply)(_.value)
+        given CanEqual[UserId, UserId]       = CanEqual.derived
+    end UserId
+end PB1716Ids
+
+case class PB1716OpaqueKey(m: Map[PB1716Ids.UserId, String]) derives Schema, CanEqual
+
+// Value-class key that derives a message: not a proto3 map key, encoded as an entry message.
+case class Pid(value: Int) derives Schema, CanEqual
+case class PB1716VcKey(m: Map[Pid, String]) derives Schema, CanEqual
 
 // Types for error-path tests
 case class MTCollectionHolder(items: List[Int]) derives Schema, CanEqual
@@ -909,4 +1668,26 @@ case class CFAllFeaturesWide(tag: String, qty: Int, code: Int, note: String, ext
 // Isolates the decode-default Protobuf interaction (no transform confound): a present field
 // reported by its numeric id must not be overwritten by the configured default supplier.
 case class CFDefaulted(name: String, score: Int = 0) derives CanEqual, Schema
+
+// Map decode depth-guard fixtures.
+// A two-level string-keyed map: objectStart (depth 1) + outer mapStart (depth 2) + inner mapStart (depth 3).
+case class PBStr2Map(m: Map[String, Map[String, Int]]) derives Schema, CanEqual
+// A two-level non-string map: objectStart (depth 1) + arrayStart (depth 2) + entry objectStart (depth 3).
+case class PBIntIntMap(m: Map[Int, Map[Int, Int]]) derives Schema, CanEqual
+// A two-level nested list: objectStart (depth 1) + outer arrayStart (depth 2) + inner arrayStart (depth 3).
+case class PBListList(m: List[List[Int]]) derives Schema, CanEqual
 case class CFPersonWide(name: String, age: Int, extra: String) derives CanEqual, Schema
+
+// fieldNumberAudit fixtures.
+case class PBAuditInner(id: Int) derives Schema, CanEqual
+case class PBAuditPerson(name: String, inner: PBAuditInner) derives Schema, CanEqual
+case class PBAuditReuse(list: List[PBAuditInner], map: Map[String, PBAuditInner], ints: List[Int]) derives Schema, CanEqual
+case class PBAuditTree(value: Int, children: List[PBAuditTree]) derives Schema, CanEqual
+// bAt hashes to 19506 (in proto3 reserved range 19000-19999); ctrl is the out-of-band control field.
+case class PBReserved(bAt: Int, ctrl: Int) derives Schema, CanEqual
+
+// Holder for testing that the reserved-range WARNING fires unconditionally on pinned-in-band numbers.
+case class PBReservedPinnedHolder(x: Int) derives Schema, CanEqual
+
+// Fixture for empty-string element regression tests.
+case class PB1716SeqStr(items: Seq[String]) derives Schema, CanEqual

--- a/kyo-schema/shared/src/test/scala/kyo/SchemaCompositionTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/SchemaCompositionTest.scala
@@ -12,7 +12,7 @@ class SchemaCompositionTest extends kyo.test.Test[Any]:
         "sealed-trait variant with .discriminator round-trips correctly" in {
             val schema                    = Schema[DiscriminatedShape].discriminator("type")
             val value: DiscriminatedShape = ShapeA(42)
-            val bytes: Span[Byte]         = Protobuf.encode(value)(using schema)
+            val bytes: Span[Byte]         = Protobuf.encode(value)(using summon[Protobuf], schema)
             val result: Result[DecodeException, DiscriminatedShape] =
                 Protobuf.decode[DiscriminatedShape](bytes)(using summon[Protobuf], schema)
             assert(result == Result.succeed(value))

--- a/kyo-schema/shared/src/test/scala/kyo/SchemaTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/SchemaTest.scala
@@ -2385,7 +2385,7 @@ class SchemaTest extends kyo.test.Test[Any]:
         }
     }
 
-    "unconfigured schema is byte-identical and missing collection is failure" in {
+    "unconfigured schema is byte-identical and self-describing codecs require missing collections" in {
         val schema  = Schema[Cart]
         val value   = Cart(Chunk("a", "b"), Maybe("hello"))
         val encoded = schema.encodeString[Json](value)
@@ -2394,12 +2394,11 @@ class SchemaTest extends kyo.test.Test[Any]:
         assert(schema.fieldDefaults.isEmpty)
         assert(schema.fieldTransforms.isEmpty)
 
-        val missingItems = """{"note":"hi"}"""
-        val decoded      = schema.decodeString[Json](missingItems)
-        val missingField = decoded match
-            case Result.Failure(_: MissingFieldException) => true
-            case _                                        => false
-        assert(missingField)
+        val missingItems = schema.decodeString[Json]("""{"note":"hi"}""")
+        assert(missingItems.failure.exists(_.isInstanceOf[MissingFieldException]), s"expected missing items failure, got: $missingItems")
+
+        val missingTags = Schema[CartWithMap].decodeString[Json]("""{"name":"cart"}""")
+        assert(missingTags.failure.exists(_.isInstanceOf[MissingFieldException]), s"expected missing tags failure, got: $missingTags")
     }
 
     "omit policy survives a subsequent copyWith-routed builder" in {
@@ -2902,7 +2901,7 @@ object SfA:
 object SfB:
     case class Dup(y: Int) derives CanEqual, Schema
 
-case class Cart(items: Chunk[String], note: Maybe[String]) derives Schema
+case class Cart(items: Chunk[String], note: Maybe[String]) derives Schema, CanEqual
 
 case class StrictPerson(id: Int, name: String) derives CanEqual, Schema
 case class StrictRename(firstName: String, lastName: String) derives CanEqual, Schema

--- a/kyo-schema/shared/src/test/scala/kyo/StructureTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/StructureTest.scala
@@ -1136,8 +1136,10 @@ class StructureTest extends kyo.test.Test[Any]:
         }
 
         "protobuf mapStart/mapEnd" in {
-            // At the top level, mapStart/mapEnd are equivalent to objectStart/objectEnd
+            // A map is a repeated MapEntry message under its field number (proto3 map<K, V>), so the
+            // map must sit under a field. Each entry holds the key at field 1 and the value at field 2.
             val w = new ProtobufWriter
+            w.field("m", 5)
             w.mapStart(2)
             w.field("key1", 0)
             w.string("value1")
@@ -1146,14 +1148,15 @@ class StructureTest extends kyo.test.Test[Any]:
             w.mapEnd()
             val bytes = w.resultBytes
             assert(bytes.nonEmpty)
-            // Verify we can read it back
+            // Read it back: the enclosing field() consumes the first entry's tag, then the map drives entries.
             val r = new ProtobufReader(bytes)
+            val _ = r.field()
             val _ = r.mapStart()
             assert(r.hasNextEntry())
-            val _ = r.field()
+            assert(r.field() == "key1")
             assert(r.string() == "value1")
             assert(r.hasNextEntry())
-            val _ = r.field()
+            assert(r.field() == "key2")
             assert(r.int() == 42)
             assert(!r.hasNextEntry())
             r.mapEnd()


### PR DESCRIPTION
## Problem

Two correctness bugs corrupted every repeated and map field (fixes #1716).

**Repeated fields.** `hasNextElement()` delegated to `hasNextField()` without tracking the field number, so only the first element of any repeated `List`/`Seq`/`Vector`/`Set`/`Chunk`/`Span` field was consumed. Elements past the first trashed the surrounding message parse, producing `MissingFieldException` for repeated message fields and silently truncated collections for repeated scalars.

**Map fields.** The writer emitted each map entry as a struct field with a synthetic number rather than as a proto3 `MapEntry` message (key at field 1, value at field 2). On decode, string keys were replaced by positional index strings (`"0"`, `"1"`, ...). Non-String map keys did not compile; no `mapSchema[K, V]` given existed.

Two secondary bugs completed the picture.

**`protoSchema` wrong field numbers.** The emitter used `idx + 1` sequential numbers while the wire carries MurmurHash3-derived numbers, making the `.proto` output inconsistent with the actual bytes.

**Map decode depth bypass.** The string-keyed map decode path never incremented the depth counter, so a deeply nested `Map[String, Map[String, ...]]` produced a `StackOverflowError` instead of `Result.Failure(LimitExceededException)`.

## What changed

User-facing summary of the change set:

- **Repeated fields round-trip.** `List`, `Seq`, `Vector`, `Set`, `Chunk`, and `Span` of scalars or case classes encode and decode correctly, top-level and nested.
- **Maps round-trip with keys preserved.** `Map[String, V]` keeps its keys; non-String keys (`Map[Int, V]`, `Map[Boolean, V]`, opaque/value-class keys) now derive a `Schema` via the new `mapSchema[K, V]` given and round-trip.
- **Absent repeated/map fields decode to empty** (proto3 semantics), not a failure.
- **Strict proto3 conformance by default.** New `Protobuf.Conformance` enum on `Protobuf.Config`; `Strict` (the default) rejects map keys proto3 cannot express natively, `Permissive` keeps the round-trippable extensions. **Breaking** for a non-native-key map under the default given (see Notes).
- **Packed repeated scalars.** Scalar repeated fields encode in proto3's canonical packed form; the reader accepts both packed and unpacked.
- **`protoSchema` emits the real wire field numbers** (was `idx + 1`), with a provenance comment on hash-derived numbers and a warning for the proto3 reserved range `19000-19999`. Suppress the provenance comment with `Config(protoSchemaProvenance = false)`.
- **New `Protobuf.fieldNumberAudit[A]`** reports each field's wire number and whether it is pinned or in the reserved range, without encoding or decoding.
- **Field-number pinning is wire-functional.** `Schema[A].fieldId(_.field)(n)` now pins the number on encode, decode, `protoSchema`, and the audit.
- **Map decode honors `maxDepth`** (no more `StackOverflowError` on a deeply nested map).
- README and CONTRIBUTING updated. Field-number annotation affordance tracked in getkyo/kyo#1719.

## Usage

### Repeated and map round-trips

```scala
import kyo.*

case class Order(id: Int, items: List[String], counts: Map[Int, Int]) derives Schema, CanEqual

val order   = Order(1, List("pen", "ink"), Map(10 -> 2, 20 -> 5))
val bytes   = Protobuf.encode(order)
val decoded = Protobuf.decode[Order](bytes)
// decoded == Result.Success(order)
```

### Conformance mode

The zero-argument `given Protobuf` is `Strict`. Strict rejects a map key proto3 cannot
express natively (a value-class or float key); opt into the entry-message extension with
`Permissive`:

```scala
case class Pid(value: Int) derives Schema, CanEqual
case class Doc(tags: Map[Pid, String]) derives Schema, CanEqual

// default (Strict): a value-class key is rejected at encode
Protobuf.encode(Doc(Map(Pid(1) -> "x"))) // throws SchemaNotSerializableException

// Permissive: encodes via the entry-message form and round-trips
given Protobuf = Protobuf(Protobuf.Config(conformance = Protobuf.Conformance.Permissive))
val d = Doc(Map(Pid(1) -> "x"))
Protobuf.decode[Doc](Protobuf.encode(d)) // Result.Success(d)
```

A key that reduces to a native scalar (an opaque type or value class whose `Schema` is a
native scalar) stays allowed under Strict.

### protoSchema

```scala
case class User(id: Int, name: String) derives Schema

Protobuf.protoSchema[User]
// message User {
//   sint32 id = 1243642;    // hash-derived field number; pin via Schema.fieldId for stable external interop
//   string name = 1790876;  // hash-derived field number; pin via Schema.fieldId for stable external interop
// }

// suppress the provenance comments (the reserved-range warning is always kept):
given Protobuf = Protobuf(Protobuf.Config(protoSchemaProvenance = false))
Protobuf.protoSchema[User]
// message User {
//   sint32 id = 1243642;
//   string name = 1790876;
// }
```

### Pinning a stable field number

```scala
case class User(id: Int, name: String) derives Schema, CanEqual

// pin `name` to 7 on the wire; encode/decode/protoSchema/audit all honor it
given Schema[User] = Schema.derived[User].fieldId(_.name)(7)

val u = User(1, "ada")
Protobuf.decode[User](Protobuf.encode(u)) // Result.Success(u), with `name` at field 7
```

### Field-number audit

```scala
case class User(id: Int, name: String) derives Schema

Protobuf.fieldNumberAudit[User]
// Chunk(
//   FieldNumberInfo(path = "id",   name = "id",   number = 1243642, pinned = false, inReservedRange = false),
//   FieldNumberInfo(path = "name", name = "name", number = 1790876, pinned = false, inReservedRange = false)
// )

// enforce pinning in your own test/CI, at your chosen severity:
val unpinned = Protobuf.fieldNumberAudit[User].filter(!_.pinned)
assert(unpinned.isEmpty, s"pin field numbers for external interop: ${unpinned.map(_.path)}")
```

### Decode limits

```scala
// config-backed limits (defaults from Json.DefaultMaxDepth / DefaultMaxCollectionSize)
given Protobuf = Protobuf(Protobuf.Config(maxDepth = 16, maxCollectionSize = 1024))
Protobuf.decode[Order](bytes) // Result.Failure(LimitExceededException) if a bound is exceeded

// or pass explicit limits for a one-off
Protobuf.decode[Order](bytes, maxDepth = 8, maxCollectionSize = 256)
```

## Notes

**Default is `Strict`, but this does not break any correctly-functioning prior usage.** The repeated and map fields produced corrupt output before this PR, so no code that ran correctly against a prior release depended on non-canonical map-key encoding. A `Float`-, `Double`-, or product-type-keyed map that now raises `SchemaNotSerializableException` under `Strict` was previously encoding to bytes that could not be decoded back. To allow the non-canonical extensions:

```scala
given Protobuf = Protobuf(Protobuf.Config(conformance = Protobuf.Conformance.Permissive))
```

**Derivation-time field-number annotation is deferred to getkyo/kyo#1719.** `Schema.fieldId` at the call site is the current path for pinning a stable wire number. A compile-time annotation on a case-class field that makes the derived `Schema` carry the pin automatically is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)