### PR TITLE
[build] reduce Maven Central publishing footprint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,19 +80,6 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-      - name: Stage Wasm (retriable)
-        uses: nick-fields/retry@v4
-        with:
-          max_attempts: 3
-          timeout_minutes: 120
-          command: sbt -Dplatform=Wasm "ci-release"
-        env:
-          CI_SONATYPE_RELEASE: ""
-          CI_CLEAN: ""
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       # Phase 2: upload and publish the whole staged bundle as ONE Central Portal deployment. Single
       # attempt: re-uploading would collide on the portal. It bundles target/sona-staging and does not
       # re-run doc. Tag pushes only; snapshots were already published by the stage steps above.

--- a/build.sbt
+++ b/build.sbt
@@ -319,7 +319,8 @@ lazy val kyoJS = project
     .in(file("js"))
     .settings(
         name := "kyoJS",
-        `kyo-settings`
+        `kyo-settings`,
+        publish / skip := true
     )
     .disablePlugins(MimaPlugin, KyoDoctestPlugin)
     .aggregate(
@@ -373,7 +374,8 @@ lazy val kyoNative = project
     .in(file("native"))
     .settings(
         name := "kyoNative",
-        `native-settings`
+        `native-settings`,
+        publish / skip := true
     )
     .disablePlugins(MimaPlugin, KyoDoctestPlugin)
     .aggregate(
@@ -426,7 +428,8 @@ lazy val kyoWasm = project
     .in(file("wasm"))
     .settings(
         name := "kyoWasm",
-        `kyo-settings`
+        `kyo-settings`,
+        publish / skip := true
     )
     .disablePlugins(MimaPlugin, KyoDoctestPlugin)
     .aggregate(
@@ -876,40 +879,15 @@ lazy val `kyo-ffi-plugin` =
             crossScalaVersions := Seq("2.12.20"),
             name               := "kyo-ffi-plugin",
             sbtPlugin          := true,
-            // Bundle the Scala 3 codegen JAR + its runtime deps as plugin resources so the
-            // 2.12 plugin can load them reflectively at task time.
+            // Bake this plugin's version into a resource so it can resolve the matching
+            // kyo-ffi-codegen (and its Scala 3 toolchain) from the user's resolvers at task time,
+            // instead of bundling the ~33 MB toolchain into the published plugin JAR.
             Compile / resourceGenerators += Def.task {
-                val codegenJar = (LocalProject("kyo-ffi-codegen") / Compile / packageBin).value
-                val codegenCp = (LocalProject("kyo-ffi-codegen") / Compile / fullClasspath).value
-                    .map(_.data)
                 val outDir = (Compile / resourceManaged).value / "kyo-ffi-plugin"
                 IO.createDirectory(outDir)
-                // Names of JARs we must bundle to make the codegen self-sufficient at runtime.
-                val names = Set(
-                    "scala3-tasty-inspector_3",
-                    "tasty-core_3",
-                    "scala3-compiler_3",
-                    "scala3-interfaces",
-                    "scala-asm",
-                    "compiler-interface",
-                    "util-interface",
-                    s"scala-library" // the REAL Scala 3 stdlib is published as `scala-library` at scala3 version
-                )
-                val bundledJars = codegenCp.filter { f =>
-                    val n = f.getName
-                    names.exists(prefix => n.startsWith(prefix + "-"))
-                }
-                val results = Seq(codegenJar -> "kyo-ffi-codegen.jar") ++
-                    bundledJars.map(j => j -> j.getName)
-                val copied = results.map { case (src, name) =>
-                    val dest = outDir / name
-                    IO.copyFile(src, dest)
-                    dest
-                }
-                // Write a manifest of bundled JAR names so the plugin can enumerate at runtime.
-                val manifest = outDir / "bundled.txt"
-                IO.write(manifest, results.map(_._2).mkString("\n"))
-                copied :+ manifest
+                val versionFile = outDir / "version.txt"
+                IO.write(versionFile, version.value)
+                Seq(versionFile)
             }.taskValue,
             scriptedLaunchOpts := {
                 scriptedLaunchOpts.value ++
@@ -952,6 +930,9 @@ lazy val `kyo-ffi-plugin` =
                 val c5 = (`kyo-scheduler`.js / publishLocal).value
                 val c6 = (`kyo-core`.js / publishLocal).value
                 val c7 = (`kyo-ffi`.js / publishLocal).value
+                // The plugin resolves kyo-ffi-codegen at task time, so publish it locally too:
+                // scripted tests resolve it from Ivy the way a downstream user resolves it from Central.
+                val d0 = (`kyo-ffi-codegen` / publishLocal).value
                 scriptedDependencies.value
             },
             publish   := {},
@@ -1072,7 +1053,10 @@ lazy val `kyo-tasty-fixtures-internal` =
         .crossType(CrossType.Full)
         .in(file("kyo-tasty/fixtures"))
         .withKyoTest
-        .settings(`kyo-settings`)
+        .settings(
+            `kyo-settings`,
+            publish / skip := true
+        )
         .jvmSettings(mimaCheck(false))
         .nativeSettings(`native-settings`)
         .jsSettings(`js-settings`)
@@ -1960,7 +1944,8 @@ lazy val `kyo-examples` =
                 "--add-opens=java.base/java.nio=ALL-UNNAMED",
                 "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED"
             ),
-            Compile / doc / sources := Seq.empty
+            Compile / doc / sources := Seq.empty,
+            publish / skip          := true
         )
 
 lazy val `kyo-bench` =
@@ -1980,6 +1965,7 @@ lazy val `kyo-bench` =
         .jvmConfigure(_.disablePlugins(KyoDoctestPlugin))
         .settings(
             `kyo-settings`,
+            publish / skip                          := true,
             libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestVersion % Test,
             Test / testForkedParallel               := true,
             // Forks each test suite individually

--- a/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/CodegenBridge.scala
+++ b/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/CodegenBridge.scala
@@ -1,7 +1,6 @@
 package kyo.ffi.sbt
 
 import java.io.File
-import java.io.FileOutputStream
 import java.net.URL
 import java.net.URLClassLoader
 import java.nio.file.Files
@@ -15,22 +14,20 @@ import sbt.util.Logger
   * Scala 3 library. We cannot statically `dependsOn` across major Scala versions.
   *
   * Strategy:
-  *   - The plugin JAR bundles `kyo-ffi-codegen.jar` as a resource under
-  *     `kyo-ffi-plugin/kyo-ffi-codegen.jar` (see `build.sbt`,  *     `Compile/resourceGenerators`).
-  *   - At runtime we extract that JAR to a temp file and build a URLClassLoader
-  *     whose URLs are: `[codegenJar, ...userDependencyClasspath]`. Parent is
-  *     the JVM bootstrap (no plugin-class-loader parent, so there's no 2.12
-  *     stdlib in scope to clash with 3.x).
-  *   - The user's `Compile / dependencyClasspath` is passed in from the plugin
-  *     and must contain scala3-library, scala3-tasty-inspector, and
-  *     scala3-compiler, which it does automatically because the user depends
-  *     on `kyo-ffi` (a Scala 3 library).
+  *   - The plugin resolves `kyo-ffi-codegen` (and its transitive Scala 3 toolchain:
+  *     scala3-tasty-inspector, scala3-compiler, tasty-core, ...) from the user's
+  *     resolvers via `ffiCodegenClasspath` (see `KyoFfiPlugin`). The in-repo
+  *     integration test overrides that task with the codegen project's own classpath.
+  *   - At runtime we build a URLClassLoader whose URLs are
+  *     `[...codegenClasspath, ...userDependencyClasspath]`. Parent is the JVM
+  *     bootstrap (no plugin-class-loader parent, so there's no 2.12 stdlib in scope
+  *     to clash with 3.x).
+  *   - The user's `Compile / dependencyClasspath` is passed in so kyo-ffi and its
+  *     runtime friends are also visible.
   */
 private[sbt] object CodegenBridge {
 
-    private val cachedLoader         = new AtomicReference[ClassLoader](null)
-    private val cachedOverrideLoader = new AtomicReference[ClassLoader](null)
-    private val cachedFingerprint    = new AtomicReference[String](null)
+    private val cachedCodegenLoader = new AtomicReference[ClassLoader](null)
 
     /** Outcome of a single `generate` invocation.
       *
@@ -162,35 +159,22 @@ private[sbt] object CodegenBridge {
     private def getCodegenClassLoader(
         userClasspath: Seq[String],
         log: Logger,
-        codegenClasspathOverride: Seq[String] = Nil
+        codegenClasspath: Seq[String]
     ): Option[ClassLoader] = {
-        if (codegenClasspathOverride.nonEmpty) {
-            val existing = cachedOverrideLoader.get
-            if (existing != null) return Some(existing)
-
-            val urls = new java.util.ArrayList[URL]()
-            codegenClasspathOverride.foreach(s => urls.add(new File(s).toURI.toURL))
-            userClasspath.foreach(s => urls.add(new File(s).toURI.toURL))
-
-            // Parent = bootstrap (via `null`) so there's no 2.12 stdlib clash.
-            val loader = new URLClassLoader(urls.toArray(new Array[URL](0)), null)
-            cachedOverrideLoader.set(loader)
-            return Some(loader)
+        if (codegenClasspath.isEmpty) {
+            log.warn("[kyo-ffi-plugin] codegen classpath is empty; ffiGenerate is a no-op.")
+            return None
         }
-
-        val existing = cachedLoader.get
+        val existing = cachedCodegenLoader.get
         if (existing != null) return Some(existing)
 
-        val bundled = extractBundledJars(log)
-        if (bundled.isEmpty) return None
-
         val urls = new java.util.ArrayList[URL]()
-        bundled.foreach(p => urls.add(p.toUri.toURL))
+        codegenClasspath.foreach(s => urls.add(new File(s).toURI.toURL))
         userClasspath.foreach(s => urls.add(new File(s).toURI.toURL))
 
         // Parent = bootstrap (via `null`) so there's no 2.12 stdlib clash.
         val loader = new URLClassLoader(urls.toArray(new Array[URL](0)), null)
-        cachedLoader.set(loader)
+        cachedCodegenLoader.set(loader)
         Some(loader)
     }
 
@@ -203,87 +187,36 @@ private[sbt] object CodegenBridge {
       * (#255). Cached: the bundle is fixed for the JVM session. Returns "unknown" when the bundle is
       * absent, the case where ffiGenerate is already a no-op.
       */
-    def codegenFingerprint(): String = codegenFingerprint(Nil)
-
-    /** SHA-256 fingerprint of the codegen, override-aware.
-      *
-      * When `codegenClasspathOverride` is non-empty the fingerprint is the SHA-256 over the bytes
-      * of those jar files (in sorted-path order for stability), so the in-repo bootstrap path stays
-      * incrementally correct when the codegen classpath changes. Directory entries on the override
-      * are folded in by path so a codegen rebuild still invalidates the cache. When it is empty the
-      * bundled-resource fingerprint is used (and cached for the JVM session), the default path.
+    /** SHA-256 fingerprint of the codegen classpath: the bytes of each jar (in sorted-path order for
+      * stability), so ffiGenerate's cache stays incrementally correct when the codegen changes. A
+      * codegen upgrade (a new `kyo-ffi-codegen` version resolving different jars) invalidates the
+      * cache. Returns "unknown" when the classpath is empty, the case where ffiGenerate is a no-op.
       */
-    def codegenFingerprint(codegenClasspathOverride: Seq[String]): String = {
-        if (codegenClasspathOverride.nonEmpty) {
-            val md = java.security.MessageDigest.getInstance("SHA-256")
-            codegenClasspathOverride.sorted.foreach { path =>
-                md.update(path.getBytes(java.nio.charset.StandardCharsets.UTF_8))
-                val f = new File(path)
-                if (f.isFile) {
-                    val in = new java.io.FileInputStream(f)
-                    try md.update(readAll(in))
-                    finally in.close()
-                }
+    def codegenFingerprint(codegenClasspath: Seq[String]): String = {
+        if (codegenClasspath.isEmpty) return "unknown"
+        val md = java.security.MessageDigest.getInstance("SHA-256")
+        codegenClasspath.sorted.foreach { path =>
+            md.update(path.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+            val f = new File(path)
+            if (f.isFile) {
+                val in = new java.io.FileInputStream(f)
+                try md.update(readAll(in))
+                finally in.close()
             }
-            return md.digest().map(b => "%02x".format(b)).mkString
         }
-        val existing = cachedFingerprint.get
-        if (existing != null) return existing
-        val manifestStream = getClass.getResourceAsStream("/kyo-ffi-plugin/bundled.txt")
-        val result =
-            if (manifestStream == null) "unknown"
-            else {
-                val manifest =
-                    try new String(readAll(manifestStream), java.nio.charset.StandardCharsets.UTF_8)
-                    finally manifestStream.close()
-                val md = java.security.MessageDigest.getInstance("SHA-256")
-                md.update(manifest.getBytes(java.nio.charset.StandardCharsets.UTF_8))
-                manifest.split("\n").toList.filter(_.nonEmpty).foreach { name =>
-                    val in = getClass.getResourceAsStream(s"/kyo-ffi-plugin/$name")
-                    if (in != null)
-                        try md.update(readAll(in))
-                        finally in.close()
-                }
-                md.digest().map(b => "%02x".format(b)).mkString
-            }
-        cachedFingerprint.set(result)
-        result
+        md.digest().map(b => "%02x".format(b)).mkString
     }
 
-    /** Extract every JAR listed in `/kyo-ffi-plugin/bundled.txt` to temp files. */
-    private def extractBundledJars(log: Logger): Seq[Path] = {
-        val manifestStream = getClass.getResourceAsStream("/kyo-ffi-plugin/bundled.txt")
-        if (manifestStream == null) {
-            log.warn("[kyo-ffi-plugin] bundled.txt not found in plugin JAR; codegen bundle missing.")
-            return Nil
-        }
-        val manifest =
-            try new String(readAll(manifestStream), java.nio.charset.StandardCharsets.UTF_8)
-            finally manifestStream.close()
-
-        manifest.split("\n").toList.filter(_.nonEmpty).flatMap { name =>
-            val resPath = s"/kyo-ffi-plugin/$name"
-            val in      = getClass.getResourceAsStream(resPath)
-            if (in == null) {
-                log.warn(s"[kyo-ffi-plugin] bundled resource $resPath missing from plugin JAR.")
-                None
-            } else {
-                try {
-                    val tmp = Files.createTempFile("kyo-ffi-bundle-", ".jar")
-                    tmp.toFile.deleteOnExit()
-                    val out = new FileOutputStream(tmp.toFile)
-                    try {
-                        val buf = new Array[Byte](8192)
-                        var n   = in.read(buf)
-                        while (n > 0) {
-                            out.write(buf, 0, n)
-                            n = in.read(buf)
-                        }
-                    } finally out.close()
-                    Some(tmp)
-                } finally in.close()
-            }
-        }
+    /** Version of this plugin, read from the `version.txt` resource baked into the plugin JAR at
+      * build time. Used to resolve the matching `kyo-ffi-codegen` release from the user's resolvers.
+      */
+    def pluginVersion: String = {
+        val in = getClass.getResourceAsStream("/kyo-ffi-plugin/version.txt")
+        if (in == null)
+            sys.error("[kyo-ffi-plugin] version.txt missing from plugin JAR; cannot resolve kyo-ffi-codegen.")
+        else
+            try new String(readAll(in), java.nio.charset.StandardCharsets.UTF_8).trim
+            finally in.close()
     }
 
     private def readAll(in: java.io.InputStream): Array[Byte] = {

--- a/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/KyoFfiPlugin.scala
+++ b/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/KyoFfiPlugin.scala
@@ -53,7 +53,7 @@ object KyoFfiPlugin extends AutoPlugin {
         )
         val ffiTargetPlatform = settingKey[String]("Target platform: 'JVM', 'Native', or 'JS'. Auto-detected.")
         val ffiCodegenClasspath = taskKey[Seq[File]](
-            "Explicit codegen classpath for in-repo bootstrap; when set, the plugin loads the codegen from here instead of the bundled plugin resource."
+            "Codegen classpath: kyo-ffi-codegen plus its Scala 3 toolchain. Defaults to resolving kyo-ffi-codegen from the project's resolvers; the in-repo integration test overrides it with the codegen project's classpath."
         )
 
         // Multi-library setting (DESIGN §3.4)
@@ -130,9 +130,36 @@ object KyoFfiPlugin extends AutoPlugin {
             "advapi32"
         ),
         ffiLibraries := Nil,
-        // Default empty: the plugin loads the codegen from its bundled resource. Set this to the
-        // codegen project's classpath for the in-repo bootstrap (no bundled resource, no reload).
-        ffiCodegenClasspath := Nil,
+        // Resolve kyo-ffi-codegen (and its transitive Scala 3 toolchain) from the project's
+        // resolvers, matched to this plugin's version. The in-repo integration test overrides this
+        // with the codegen project's own classpath (no resolution, no publishLocal round-trip).
+        ffiCodegenClasspath := {
+            val log     = streams.value.log
+            val depRes  = dependencyResolution.value
+            val version = CodegenBridge.pluginVersion
+            val codegen = "io.getkyo" % "kyo-ffi-codegen_3" % version
+            val descriptor = depRes.moduleDescriptor(
+                sbt.librarymanagement.ModuleDescriptorConfiguration(
+                    "io.getkyo" % "kyo-ffi-codegen-resolver" % version,
+                    sbt.librarymanagement.ModuleInfo("kyo-ffi-codegen-resolver")
+                ).withDependencies(Vector(codegen))
+                    .withConfigurations(Vector(sbt.librarymanagement.Configurations.Compile))
+                    .withScalaModuleInfo(None)
+            )
+            val files = depRes.update(
+                descriptor,
+                sbt.librarymanagement.UpdateConfiguration()
+                    .withLogging(sbt.librarymanagement.UpdateLogging.Quiet),
+                sbt.librarymanagement.UnresolvedWarningConfiguration(),
+                log
+            ) match {
+                case Right(report) => report.allFiles.distinct
+                case Left(warn)    => throw warn.resolveException
+            }
+            if (files.isEmpty)
+                sys.error(s"[kyo-ffi-plugin] resolved no artifacts for io.getkyo:kyo-ffi-codegen_3:$version")
+            files
+        },
         // Auto-detect: inspect the enabled auto-plugins. Scala Native (ScalaNativePlugin)
         // yields `Native`; Scala.js (ScalaJSPlugin) yields `JS`; otherwise JVM. The user
         // can still override explicitly.

--- a/project/WasmPlatform.scala
+++ b/project/WasmPlatform.scala
@@ -37,8 +37,9 @@ case object WasmPlatform extends Platform {
             // Give kyo's own wasm artifacts a distinct coordinate the way the ScalaJS and ScalaNative platforms do for theirs. External
             // `%%%` dependencies stay on `_sjs1`, since no upstream Scala.js library publishes a wasm build yet and the `_sjs1` artifacts
             // link to WasmGC unchanged.
-            crossVersion             := wasmCrossVersion,
-            platformDepsCrossVersion := ScalaJSCrossVersion.binary
+            crossVersion                     := wasmCrossVersion,
+            platformDepsCrossVersion         := ScalaJSCrossVersion.binary,
+            sbt.Keys.publish / sbt.Keys.skip := true
         )
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -34,47 +34,15 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.6.1")
 // `kyo-ffi-it` sub-project can call `enablePlugins(KyoFfiPlugin)` without
 // requiring a `publishLocal` round-trip.
 //
-// Approach: meta-build source-linking. The plugin's `CodegenBridge` extracts a
-// bundled `kyo-ffi-codegen.jar` (plus Scala 3 runtime deps) from the classpath
-// resource `/kyo-ffi-plugin/bundled.txt`. We replicate the resource generation
-// in the meta-build by delegating to the plugin sub-project's existing
-// `Compile / resourceManaged` output.
-//
-// Bootstrap order:
-//   1. `sbt kyo-ffi-plugin/compile`  (generates bundled resources)
-//   2. `sbt kyo-ffi-it/test`          (picks up the bundled resources via the resourceGenerator below)
-//
-// On CI, step 1 is equivalent to any other `compile` already in the matrix.
+// Approach: meta-build source-linking. The main build's `kyo-ffi-it` sets
+// `ffiCodegenClasspath` to the codegen project's own classpath, so the source-linked
+// plugin loads the codegen from there directly (no publishLocal round-trip, no reload).
 // ---------------------------------------------------------------------------
 
 Compile / unmanagedSourceDirectories ++= {
     val pluginRoot = baseDirectory.value.getParentFile / "kyo-ffi" / "plugin"
     Seq(pluginRoot / "src" / "main" / "scala")
 }
-
-// Bundle the plugin's codegen resources into the meta-build's classpath.
-// The plugin's own build.sbt writes these to
-// `kyo-ffi-plugin/target/scala-2.12/resource_managed/main/kyo-ffi-plugin/`.
-Compile / resourceGenerators += Def.task {
-    val log            = sLog.value
-    val outDir         = (Compile / resourceManaged).value / "kyo-ffi-plugin"
-    val pluginRoot     = baseDirectory.value.getParentFile / "kyo-ffi" / "plugin"
-    val resolvedResDir = pluginRoot / "target" / "scala-2.12" / "sbt-1.0" / "resource_managed" / "main" / "kyo-ffi-plugin"
-    if (!resolvedResDir.exists) {
-        log.info(
-            s"[kyo-ffi-it] bundled plugin resources not found at $resolvedResDir; " +
-                "run `sbt kyo-ffi-plugin/compile` once, then reload."
-        )
-        Seq.empty[File]
-    } else {
-        IO.createDirectory(outDir)
-        IO.listFiles(resolvedResDir).toList.map { src =>
-            val dest = outDir / src.getName
-            IO.copyFile(src, dest)
-            dest
-        }
-    }
-}.taskValue
 
 libraryDependencies ++= Seq(
     "org.typelevel" %% "scalac-options" % "0.1.11"


### PR DESCRIPTION
### Problem
Maven Central is introducing per-namespace monthly publishing limits (file count, release size, release count) enforced from August 2026. Each io.getkyo release publishes about 197 artifact coordinates at 24 files each, placing the namespace in the top publishing percentile on both file count and size. Part of that footprint never needed to be on Central: the test-only WebAssembly target, benchmarks, examples, internal test fixtures, and empty platform aggregators. Separately, kyo-ffi-plugin ships a ~33 MB jar because it bundles the whole Scala 3 toolchain as plugin resources.

### Solution
* WebAssembly becomes a test-only platform. WasmPlatform sets publish/skip on every wasm row and on the kyoWasm aggregator, and release.yml no longer stages Wasm. Wasm still builds and tests in the CI matrix.
* Stop publishing non-library artifacts: kyo-bench, kyo-examples, kyo-tasty-fixtures-internal (a Test-only dependency), and the empty kyoJS and kyoNative aggregators.
* kyo-ffi-plugin no longer bundles the Scala 3 toolchain. It resolves kyo-ffi-codegen and its transitive toolchain from the consumer's resolvers at task time, version matched through a baked version.txt, reusing the existing ffiCodegenClasspath seam. The published plugin jar drops from ~33 MB to ~94 KB.

### Notes
* Codegen resolution is automatic and cached in the consumer's coursier cache. The in-repo integration test still overrides ffiCodegenClasspath with the codegen project's own classpath, so there is no publishLocal round-trip.
* Javadoc jars remain a separate, larger size lever and are not addressed here.
