### PR TITLE
[kyo-ai] add command-backed completion harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,11 +283,12 @@ The vertical an application developer assembles: HTTP services and clients, deri
 
 | Module                                       | JVM | JS  | Native | WASM | Identity                                                                                                   |
 | -------------------------------------------- | --- | --- | ------ | ---- | ---------------------------------------------------------------------------------------------------------- |
-| [kyo-http](kyo-http/README.md)               | ✅  | ✅  | ✅     | ✅   | HTTP/1.1 client and server  with shared API across JVM/JS/Native/WASM, bidirectional OpenAPI               |
+| [kyo-http](kyo-http/README.md)               | ✅  | ✅  | ✅     | ✅   | HTTP/1.1 client and server with shared API across JVM/JS/Native/WASM, bidirectional OpenAPI                |
 | [kyo-schema](kyo-schema/README.md)           | ✅  | ✅  | ✅     | ✅   | One `derives Schema` powers JSON, Protobuf, validation, lenses, diffs, builders, and structural conversion |
 | [kyo-config](kyo-config/README.md)           | ✅  | ✅  | ✅     | ✅   | Type-safe config + feature flags with a percentage-rollout DSL, optional kyo-http admin and live sync      |
 | [kyo-flow](kyo-flow/README.md)               | ✅  | ✅  | ✅     | ✅   | Durable workflow engine (Temporal/Cadence/ZIO-Flow space); value-replay execution, auto-generated REST     |
-| [kyo-ui](kyo-ui/README.md)                   | ✅  | ✅  | ✅     | ✅   | Web UIs as pure values: Scala.js DOM app, server HTML-over-SSE or SSR stream with irst-class reactivity.   |
+| [kyo-ui](kyo-ui/README.md)                   | ✅  | ✅  | ✅     | ✅   | Web UIs as pure values: Scala.js DOM app, server HTML-over-SSE or SSR stream with first-class reactivity   |
+| [kyo-ai](kyo-ai/README.md)                   | ✅  | ✅  | ✅     | ✅   | Typed LLM programs: prompts, tools, thoughts, agents, streaming, provider backends                         |
 | [kyo-caliban](kyo-caliban/README.md)         | ✅  |     |        |      | Caliban GraphQL mounted on kyo-http: typed Kyo effects in resolvers, WebSocket subscriptions               |
 
 ### Writing style
@@ -328,6 +329,10 @@ Domain-shaped modules: parsing, durable workflows, container management, low-lat
 | [kyo-pod](kyo-pod/README.md)            | ✅  | ✅  | ✅     | ✅   | Docker and Podman client cross-compiled to JVM/JS/Native/WASM, streaming logs/stats, scope-managed cleanup |
 | [kyo-slack](kyo-slack/README.md)        | ✅  | ✅  | ✅     | ✅   | Slack Socket Mode bot client: structural acking, Web API, typed Block Kit + `dsl`, lossless reconnect      |
 | [kyo-browser](kyo-browser/README.md)    | ✅  | ✅  | ✅     | ✅   | Browser automation over Chrome DevTools Protocol; settlement-aware actions, `readableContent` as Markdown  |
+| [kyo-jsonrpc](kyo-jsonrpc/README.md)    | ✅  | ✅  | ✅     | ✅   | JSON-RPC 2.0 peers over pluggable transports with typed routes, calls, notifications, progress, and cancel |
+| [kyo-mcp](kyo-mcp/README.md)            | ✅  | ✅  | ✅     | ✅   | Model Context Protocol client and server built on kyo-jsonrpc with typed tools, prompts, and resources     |
+| [kyo-lsp](kyo-lsp/README.md)            | ✅  | ✅  | ✅     | ✅   | Language Server Protocol 3.17 servers and clients with typed handlers, documents, progress, and cancel     |
+| [kyo-compiler](kyo-compiler/README.md)  | ✅  |     |        |      | Scala 3 presentation compiler pool for diagnostics, completions, hover, signatures, and symbols            |
 | [kyo-aeron](kyo-aeron/README.md)        | ✅  |     |        |      | Typed pub/sub on Aeron: shared-memory IPC, UDP unicast, UDP multicast through one `Topic` API              |
 | [kyo-ffi](kyo-ffi/README.md)            | ✅  | ✅  | ✅     |      | Bind a C library once with typed Scala signatures; safe calls from JVM (Panama), JS (koffi), and Native    |
 | [kyo-tasty](kyo-tasty/README.md)        | ✅  | ✅  | ✅     | ✅   | Cross-platform TASTy reflection over a pure sealed model; Scala 3 reflection without a live JVM             |

--- a/build.sbt
+++ b/build.sbt
@@ -1223,7 +1223,7 @@ lazy val `kyo-ai` =
     crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
         .crossType(CrossType.Full)
         .in(file("kyo-ai"))
-        .dependsOn(`kyo-core`, `kyo-schema`, `kyo-http`, `kyo-actor`)
+        .dependsOn(`kyo-core`, `kyo-schema`, `kyo-http`, `kyo-actor`, `kyo-jsonrpc`, `kyo-jsonrpc-http`, `kyo-mcp`)
         .withKyoTest
         .settings(`kyo-settings`)
         .jvmSettings(mimaCheck(false))

--- a/kyo-ai/CONTRIBUTING.md
+++ b/kyo-ai/CONTRIBUTING.md
@@ -101,7 +101,7 @@ final case class State private[kyo] (
 
 ### The stream loop
 
-`AI.stream[A]` / `ai.stream[A]` suspend `Op.Stream`, whose handler runs `streamAgainst` ([`LLM.scala:259-263`], [`LLM.scala:133-141`]). `streamAgainst` posts an SSE request with the result tool in every request, parses each delta through `config.provider.completion.parseDeltaArguments`, accumulates the tool-call argument fragments, and emits each successfully decoded prefix as a `Chunk[A]` (the terminal element is the full `A`) ([`LLM.scala:147-225`]). The returned `Stream` carries its failures typed in its element row as `Abort[AIStreamException]`: a malformed delta is `AIStreamDeltaException`, an end without a decodable value `AIStreamIncompleteException`, a transport error `AITransportException` ([`LLM.scala:181-216`]). A missing API key is the one failure raised eagerly (before the `Stream` value), as `AIMissingApiKeyException` on the run boundary ([`LLM.scala:164-167`]).
+`AI.stream[A]` / `ai.stream[A]` suspend `Op.Stream`, whose handler runs `streamAgainst` ([`LLM.scala:259-263`], [`LLM.scala:133-141`]). `streamAgainst` asks `config.provider.completion.streamFragments` for raw JSON fragments of the `{ resultValue: ... }` envelope and accumulates the fragments. For `String`, it emits decoded text chunks whose concatenation is the final text. For other result types, it emits each complete decoded element from the result array exactly once ([`LLM.scala:147-225`]). HTTP providers implement fragments with SSE result-tool deltas; command harnesses use their native event or stream-json output. The returned `Stream` carries its failures typed in its element row as `Abort[AIStreamException]`: a malformed delta is `AIStreamDeltaException`, an end without a decodable value `AIStreamIncompleteException`, a transport error `AITransportException` ([`LLM.scala:181-216`]). A missing API key is the one failure raised eagerly (before the `Stream` value), as `AIMissingApiKeyException` on the run boundary ([`LLM.scala:164-167`]).
 
 ### The `LLM.isolate` given
 
@@ -182,9 +182,9 @@ Actor.run(Abort.run[AIGenException](llmRun).map(_.getOrThrow))
 
 - **Temperature is opt-in.** `temperature` is `Maybe[Double] = Absent`; it is OMITTED from the request when unset (the model uses its own default) and clamped to `[0, 2]` when set (`temperature.max(0).min(2)`) ([`Config.scala:24`], [`Config.scala:35`], [`Config.scala:6-10`]). There is no `forcedTemperature` / `effectiveTemperature` and no `gpt-5` heuristic.
 - **Optional builders.** `maxTokens(Int)` and `seed(Int)` are also `Maybe`; an internal `seed(Maybe[Int])` exists for cross-run seed derivation ([`Config.scala:25-26`], [`Config.scala:36-44`]).
-- **Default selection.** `Config.default` probes each provider's API key (system properties first, then env vars) via `kyo.System`, never raw `sys.props` / `sys.env`, and falls back to Anthropic ([`Config.scala:64-70`]).
+- **Default selection.** `Config.default` probes provider markers and API keys (system properties first, then env vars) via `kyo.System`, never raw `sys.props` / `sys.env`, and falls back to Anthropic ([`Config.scala:64-70`]).
 
-There are **seven** providers in `Provider.all`: `Anthropic`, `OpenAI`, `DeepSeek`, `Gemini`, `Groq`, `Baseten`, `OpenRouter` ([`Config.scala:96-98`]). Each exposes its model catalog as named pure `Config` constants (key absent, filled at use), and `default` points at the recommended entry ([`Config.scala:100-205`]). `DeepSeek`, `Gemini`, `Groq`, `Baseten`, and `OpenRouter` all carry `Completion.openAI` as their wire backend; only `Anthropic` carries `Completion.anthropic` ([`Config.scala:102-205`]). The model catalog is current (Anthropic `claude-opus-4-8` / `claude-sonnet-4-6`, OpenAI `gpt-5.x`, etc.); update the literals here, not in the wire layer.
+There are **nine** providers in `Provider.all`: `Anthropic`, `OpenAI`, `DeepSeek`, `Gemini`, `Groq`, `Baseten`, `OpenRouter`, `ClaudeCode`, `Codex` ([`Config.scala:96-98`]). `Config.default` checks the provider marker/key names in default-candidate order, preferring `CLAUDE_CODE`, then `CODEX`, then HTTP/API provider keys. Each provider exposes its model catalog as named pure `Config` constants (key absent, filled at use), and `default` points at the recommended entry ([`Config.scala:100-228`]). `DeepSeek`, `Gemini`, `Groq`, `Baseten`, and `OpenRouter` all carry `Completion.openAI` as their wire backend; `Anthropic` carries `Completion.anthropic`; `ClaudeCode` and `Codex` carry command-backed harness completions ([`Config.scala:102-228`]). The model catalog is current (Anthropic `claude-opus-4-8` / `claude-sonnet-4-6`, OpenAI `gpt-5.x`, etc.); update the literals here, not in the wire layer.
 
 ## `Context` and `Message`
 
@@ -192,20 +192,49 @@ There are **seven** providers in `Provider.all`: `Anthropic`, `OpenAI`, `DeepSee
 
 ## Wire layer: `Completion`
 
-`Completion` is the provider-backend contract ([`Completion.scala:23-53`]):
+`Completion` is the provider-backend contract ([`Completion.scala:23-44`]):
 
 ```scala
-def apply(config: Config, context: Context, tools: Chunk[Tool.internal.Info[?, ?, LLM]], resultSchema: Maybe[JsonSchema] = Absent)(using Frame): AssistantMessage < (LLM & Async & Abort[HttpException | AIGenException])
+def apply(config: Config, context: Context, tools: Chunk[Tool.internal.Info[?, ?, LLM]], resultSchema: Maybe[JsonSchema] = Absent)(using Frame): Chunk[Message] < (LLM & Async & Abort[HttpException | AIGenException])
 ```
 
-plus `streamRequest` (assembles the provider-specific endpoint URL + headers + body for the result tool) and `parseDeltaArguments` (parses one SSE data line into an incremental result-tool argument fragment) ([`Completion.scala:38-51`]). Transport failures surface as `Abort[HttpException]`, never `Abort[Throwable]`; a missing key or undecodable reply as the typed `Abort[AIGenException]` leaves ([`Completion.scala:9-21`]).
+plus `streamFragments`, which emits raw JSON fragments for the `{ resultValue: ... }` envelope consumed by `LLM.stream` ([`Completion.scala:33-44`]). HTTP providers implement it by posting their native SSE request and projecting result-tool argument deltas through `Completion.sseFragments`; command harnesses implement it through their native event or stream-json output. Returning `Chunk[Message]` lets command harnesses append the transcript delta they produced, while the HTTP providers still return a singleton assistant message. Transport failures surface as `Abort[HttpException]`, never `Abort[Throwable]`; a missing key or undecodable reply as the typed `Abort[AIGenException]` leaves ([`Completion.scala:9-21`]).
 
-Two implementations, both `private[completion] object`s reached through `Config.Provider.completion`, never constructed by users ([`Completion.scala:55-68`]):
+Three implementation families, reached through `Config.Provider.completion`, never constructed by users ([`Completion.scala:55-74`]):
 
 - `OpenAICompletion`: `POST {apiUrl}/chat/completions` with `content-type: application/json` and `Authorization: Bearer <key>` (plus `OpenAI-Organization` when present); covers OpenAI and the five compatible providers ([`OpenAICompletion.scala:27`], [`OpenAICompletion.scala:51-61`]). The SSE stream terminates on a `[DONE]` line ([`OpenAICompletion.scala:70-92`]).
 - `AnthropicCompletion`: `POST {apiUrl}/messages` with `x-api-key: <key>` and `anthropic-version: 2023-06-01` ([`AnthropicCompletion.scala:27`], [`AnthropicCompletion.scala:57-64`], [`AnthropicCompletion.scala:76-79`]).
+- `ClaudeCodeCompletion` and `CodexCompletion`: command-backed harness adapters sharing the `HarnessCompletion` base class. Claude Code receives SDK `stream-json` input and emits `stream-json` output. Enabled Kyo tools are exposed to Claude Code through a private localhost MCP bridge that calls back into Kyo tool handlers, with ambient MCP, plugins, shell tools, browser tools, and user config disabled. Codex uses `codex app-server`, injects prior context with `thread/inject_items`, starts turns with `turn/start`, and reads turn events until `turn/completed`. Completed Kyo tool-call history is replayed inertly in Claude Code so the CLI does not re-execute old calls; new tool calls are carried by the private bridge and the returned transcript is converted back to Kyo messages.
 
 The result tool has the reserved name `Completion.resultToolName` (`"result_tool"`); when `resultSchema` is `Present`, the backend substitutes it for the tool's opaque `Structure.Value` input schema so the wire parameter schema exposes the real thought-aware properties ([`Completion.scala:65-68`], [`Completion.scala:9-21`]).
+
+### kyo-ai Completion Backends
+
+`kyo-ai` completion backends are an internal implementation detail behind `AI.Config.Provider`. A backend must be transparent to the public API: `AI.gen`, `AI.stream[String]`, `AI.stream[A]`, typed results, images, prompts, thoughts, modes, retained `AI` history, and Kyo tools must behave the same from the caller's perspective across HTTP providers and command harness providers.
+
+Backend implementation rules:
+
+- Implement the full `Completion` contract. Do not add placeholder streaming methods, silent tool rejection, or partial support paths.
+- Kyo remains the tool runner for every backend. If a provider agent loop needs synchronous tool execution, use a private bridge that calls back into Kyo tool handlers and return the produced transcript as Kyo `Context.Message` values. Do not expose ambient user MCP servers, provider shell tools, plugins, or unrelated host tools through a completion backend.
+- Preserve structured context as far as the provider protocol allows. Use native message, image, function-call, and tool-result protocol items when they exist. If a provider has no supported native injection path for a piece of history, keep the workaround explicit in code and tests, and verify the public behavior it affects.
+- Command harnesses must live in `shared/src/main`, unless behavior is genuinely platform-specific. `Command`, `Path`, and the Kyo effects are cross-platform APIs.
+- Isolate provider config without losing auth. For command harnesses this means a temporary working directory and an isolated config home that copies only required auth material. Disable user plugins, shell tools, browser/computer tools, and other external provider tools unless they are the explicit backend under test.
+- Surface provider unavailability as typed failures, for example auth, quota, rate limit, and network failures should become provider-unavailable exceptions rather than string matching in tests.
+- Log backend dispatch through `kyo.Log`, not raw printing. The `LLM` boundary should name the provider, model, message count, tool count, and streaming mode without dumping prompts, API keys, auth files, or full transcripts.
+
+Backend tests must cover the same behavior a user can observe:
+
+- Unit tests for request and response conversion: context messages, images, assistant tool calls, tool results, result tool envelopes, malformed provider output, and streaming fragments.
+- Shared live integration tests for command harnesses in `shared/src/test`. Use `assume` when the CLI, auth, quota, account, or network provider is unavailable, and fail on behavioral regressions after the provider is available.
+- Live tests must assert that the intended provider and completion backend are actually selected.
+- Live tests must exercise `ai.gen`, retained history via `AI.snapshot` and `AI.recover`, image input, Kyo tool calling, `ai.stream[String]`, and object streaming via `ai.stream[A]`.
+- Use `KYO_AI_PROVIDER=<provider>` for forked sbt demos; a `-Dkyo.ai.provider=...` argument before the sbt task configures the sbt JVM and may not reach the forked demo process. If a manual program needs visible backend selection, wrap it with `Log.withConsoleLogger(..., Log.Level.debug)` or another debug-enabled logger.
+
+Self-contained demo command shape:
+
+```sh
+JAVA_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8" JVM_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8" KYO_AI_PROVIDER=codex sbt -Dsbt.server=false 'kyo-aiJVM/Test/runMain demo.HarnessCompletionDemo'
+```
 
 ## The exception hierarchy
 
@@ -298,6 +327,6 @@ In addition to the root checklist:
 4. **Config override.** Is an instance config a `Maybe[Config]` (`Absent` = inherit, `Present` = override)? Does `genLoop`'s merge keep `Present` winning over the scope and over a scope `withConfig`, while a mode `withConfig` still layers on top? [`LLM.scala:318-326`, `LLMTest.scala:325-374`]
 5. **New `Mode`.** Is `apply`'s `gen` row exactly `Maybe[A] < (LLM & Async & Abort[AIGenException])`? Does the mode receive `ai` and read/write that instance only? [`Mode.scala:21-23`]
 6. **New `Agent` overload.** Does it delegate to `runImpl`, minting ONE stable instance via `AI.initWith(behavior)`, discharging with `LLM.run`, re-throwing `Abort[AIGenException]` via `getOrThrow`, and handing to `Actor.run`? [`Agent.scala:217-240`]
-7. **New completion backend.** Does it match the result tool by `Completion.resultToolName` and substitute `resultSchema` when `Present`? Does it surface transport failures as `Abort[HttpException]`, never `Abort[Throwable]`? Is it reached through a new `Config.Provider` in `Provider.all`? [`Completion.scala:65-68`, `Config.scala:96-98`]
+7. **New completion backend.** Does it match the result tool by `Completion.resultToolName` and substitute `resultSchema` when `Present`? Does it surface transport failures as `Abort[HttpException]`, never `Abort[Throwable]`? If it is command-backed, does it use the harness's native input/output shape and map process or decode failures to `AIDecodeException`? Is it reached through a new `Config.Provider` in `Provider.all`? [`Completion.scala:65-74`, `Config.scala:96-98`]
 8. **New failure.** Is there a leaf in `AIException.scala` under the right operation trait(s), with its message on the leaf, mapped from any raw `HttpException` at the eval/stream boundary? Is a misuse/impossible-state panic kept off both rows? [`AIException.scala`, `LLM.scala:331`]
 9. **New test.** Does it extend `kyo.test.Test[Any]`, use `TestCompletionServer` (not a live endpoint), assert concrete values, place each `enqueueBody`/`enqueueStream` before the consuming client call, and live in `shared/src/test`? [`TestCompletionServer.scala`, `LLMTest.scala`]

--- a/kyo-ai/README.md
+++ b/kyo-ai/README.md
@@ -5,7 +5,6 @@
 <!-- doctest:setup
 ```scala
 import kyo.*
-import kyo.schema.doc
 ```
 -->
 
@@ -309,7 +308,7 @@ end boundedAgent
 
 `AI.stream[A]` (or `ai.stream[A]`) projects a generation as a `Stream`, in one of two forms inferred from `A`. The result tool rides every streaming request, so the model always has a tool to call.
 
-For a `String`, the stream is incremental text: each element is a longer prefix of the answer, the terminal one the full text. This is the chat-UI, token-by-token case.
+For a `String`, the stream is incremental text chunks whose concatenation is the final answer. This is the chat-UI, token-by-token case.
 
 ```scala
 def streamedText: Chunk[String] < (Async & Abort[AIStreamException | AIGenException] & Scope) =
@@ -385,14 +384,14 @@ val openAiConfig =
         .temperature(0.2)
 ```
 
-The module ships seven providers: Anthropic, OpenAI, DeepSeek, Gemini, Groq, Baseten, OpenRouter, each available as `AI.Config.Anthropic`, `AI.Config.OpenAI`, and so on, and as `AI.Config.Provider.all`. Each exposes a pure catalog `.default` you refine with builders. `AI.Config.init` builds a config for a provider while reading its API key and org from system properties then the environment.
+The module ships nine providers: Anthropic, OpenAI, DeepSeek, Gemini, Groq, Baseten, OpenRouter, Claude Code, and Codex, each available as `AI.Config.Anthropic`, `AI.Config.OpenAI`, and so on, and as `AI.Config.Provider.all`. `AI.Config.default` first honors the provider override flag `kyo.ai.provider` (environment variable `KYO_AI_PROVIDER`), then probes provider markers and keys in order, preferring `CLAUDE_CODE`, then `CODEX`, then API provider keys such as `ANTHROPIC_API_KEY` and `OPENAI_API_KEY`. Supported override values are `claude-code`, `codex`, `anthropic`, `openai`, `deepseek`, `gemini`, `groq`, `baseten`, and `openrouter`. Each provider exposes a pure catalog `.default` you refine with builders. `AI.Config.init` builds a config for an API-key provider while reading its API key and org from system properties then the environment.
 
 ```scala
 def initConfig: AI.Config < Sync =
     AI.Config.init(AI.Config.Anthropic, "claude-sonnet-4-5-20250929", 200000)
 ```
 
-The no-argument `LLM.run` resolves its config with `AI.Config.default`, which probes each provider's API key (system properties first, then environment variables) and selects the first present, falling back to Anthropic. Retries and timeouts are wired into the eval loop, configured here: the completion call is wrapped meter, then retry, then timeout.
+The no-argument `LLM.run` resolves its config with `AI.Config.default`, which probes provider markers and API keys (system properties first, then environment variables) and selects the first present, falling back to Anthropic. Retries and timeouts are wired into the eval loop, configured here: the completion call is wrapped meter, then retry, then timeout.
 
 ```scala
 def reliable(q: Question): Answer < (Async & Abort[AIGenException]) =
@@ -402,6 +401,14 @@ def reliable(q: Question): Answer < (Async & Abort[AIGenException]) =
 ```
 
 > **Caution:** `AI.Config.default` is effectful, typed `AI.Config < Sync`, because it probes system properties and environment variables. It is not a pure `val` and must be `.map`ped. The per-provider `.default` values (such as `AI.Config.OpenAI.default`) are pure and safe to use directly.
+
+When running forked sbt demos, prefer the `KYO_AI_PROVIDER` environment variable on the command itself. A `-Dkyo.ai.provider=...` argument passed before the sbt task configures the sbt JVM, not necessarily the forked demo JVM. The `LLM` boundary emits debug logs through `kyo.Log`; enable a debug logger around your program to see the backend that actually ran:
+
+```text
+kyo-ai gen backend=Claude Code model=sonnet messages=3 tools=1 thoughts=0 forceResult=false
+```
+
+The runnable demos at the end of this README print the resolved provider and model so a forked run can be checked directly.
 
 The error model is principled and typed. A generation's failures ride `run`'s residual as `Abort[AIGenException]`, a sealed hierarchy whose leaves name the specific failure: a transport error is an `AITransportException` (wrapping the kyo-http `HttpException`), eval-loop exhaustion an `AIEvalExhaustedException`, an invalid thought name an `AIInvalidThoughtException`, an undecodable reply an `AIDecodeException`, a missing API key an `AIMissingApiKeyException`. Streaming failures are typed in the stream's own row as `Abort[AIStreamException]`: a malformed delta is an `AIStreamDeltaException`, a stream that ends without a decodable value an `AIStreamIncompleteException`. The super-types track operations, the leaves track failures, and a failure shared by both operations (a missing key, a transport error) belongs to both. Misuse stays off the rows: using an `AI` outside the `LLM.run` that created it panics with `AICrossRunException`.
 
@@ -470,7 +477,7 @@ for event in stream:
             pass
 ```
 
-In kyo-ai that is a `Stream` of decoded prefix snapshots:
+In kyo-ai that is a `Stream` of decoded values:
 
 ```scala
 val answerStream =
@@ -481,4 +488,29 @@ The categories removed wholesale: JSON-schema authoring and the parse-and-valida
 
 ## How it works
 
-`LLM` is a custom `ArrowEffect` whose operations carry data: a program typed `A < LLM` is a tree of virtual operations with no `Async` in its row, reading and appending to per-instance conversation histories held in one threaded `State`. The single operation that reaches the world is `Gen`, whose handler runs the eval loop; that is where `Async` and `Abort[AIGenException]` enter, riding out on `run`'s residual. The completion call is wrapped meter, then retry, then timeout, and two wire backends (an OpenAI-compatible one shared by six providers, and an Anthropic one) sit behind `AI.Config.Provider`. For the operation GADT, the state-threading handler, and the asymmetric `Isolate` that backs parallel branches, see `kyo-ai/shared/src/main/scala/kyo/LLM.scala` and CONTRIBUTING.md.
+`LLM` is a custom `ArrowEffect` whose operations carry data: a program typed `A < LLM` is a tree of virtual operations with no `Async` in its row, reading and appending to per-instance conversation histories held in one threaded `State`. The single operation that reaches the world is `Gen`, whose handler runs the eval loop; that is where `Async` and `Abort[AIGenException]` enter, riding out on `run`'s residual. The completion call is wrapped meter, then retry, then timeout, and four backend adapters sit behind `AI.Config.Provider`: an OpenAI-compatible HTTP adapter shared by six providers, an Anthropic HTTP adapter, plus Claude Code and Codex command harness adapters. The eval boundary emits debug logs through `kyo.Log` naming the selected backend, model, message count, tool count, and streaming mode. For the operation GADT, the state-threading handler, and the asymmetric `Isolate` that backs parallel branches, see `kyo-ai/shared/src/main/scala/kyo/LLM.scala` and CONTRIBUTING.md.
+
+## Demos
+
+Runnable end-to-end demos live in [`shared/src/test/scala/demo`](shared/src/test/scala/demo). Run any with `sbt 'kyo-aiJVM/Test/runMain demo.<Name>'`.
+
+- [**TypedGenerationDemo**](shared/src/test/scala/demo/TypedGenerationDemo.scala): schema-derived typed generation into a case class.
+- [**ConversationDemo**](shared/src/test/scala/demo/ConversationDemo.scala): one persistent `AI` instance carrying multi-turn history.
+- [**ToolCallDemo**](shared/src/test/scala/demo/ToolCallDemo.scala): Kyo tool registration, model tool calls, tool execution, and final typed answer.
+- [**StreamingDemo**](shared/src/test/scala/demo/StreamingDemo.scala): text-chunk streaming and object-by-object streaming.
+- [**HarnessCompletionDemo**](shared/src/test/scala/demo/HarnessCompletionDemo.scala): command-backed harness providers with image input and retained history. It prints the resolved provider and model before running.
+- [**AgentDemo**](shared/src/test/scala/demo/AgentDemo.scala): a small typed `Agent` retaining its own conversation.
+- [**SamplingDemo**](shared/src/test/scala/demo/SamplingDemo.scala): parallel sampling and synthesis.
+- [**ThoughtsDemo**](shared/src/test/scala/demo/ThoughtsDemo.scala): thought extraction alongside a final answer.
+- [**WikiResearchDemo**](shared/src/test/scala/demo/WikiResearchDemo.scala): a richer tool-backed research flow.
+
+Self-contained commands for the harness smoke demo, assuming API keys and command harness auth are already available in the environment:
+
+```sh
+JAVA_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8" JVM_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8" KYO_AI_PROVIDER=claude-code sbt -Dsbt.server=false 'kyo-aiJVM/Test/runMain demo.HarnessCompletionDemo'
+JAVA_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8" JVM_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8" KYO_AI_PROVIDER=codex sbt -Dsbt.server=false 'kyo-aiJVM/Test/runMain demo.HarnessCompletionDemo'
+JAVA_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8" JVM_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8" KYO_AI_PROVIDER=anthropic sbt -Dsbt.server=false 'kyo-aiJVM/Test/runMain demo.HarnessCompletionDemo'
+JAVA_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8" JVM_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8" KYO_AI_PROVIDER=openai sbt -Dsbt.server=false 'kyo-aiJVM/Test/runMain demo.HarnessCompletionDemo'
+```
+
+Use the same command shape with `demo.ToolCallDemo` for tool calling and `demo.StreamingDemo` for both streaming modes.

--- a/kyo-ai/README.md
+++ b/kyo-ai/README.md
@@ -205,6 +205,8 @@ The problem it solves: reasoning before answering (chain of thought) improves qu
 A model fills the fields in order, top to bottom, so an **opening** thought's field is generated *before* the answer: the model writes its reasoning first, and that reasoning conditions the answer it then commits to. A **closing** thought's field is generated *after* the answer, acting as a self-check. You give the reasoning a shape with a plain type, and its `@doc` annotations become the instructions the model sees for that field:
 
 ```scala
+import kyo.schema.doc
+
 case class Reasoning(@doc("step-by-step working") steps: String) derives Schema
 val reasonFirst = Thought.opening[Reasoning]
 

--- a/kyo-ai/shared/src/main/scala/kyo/AI.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/AI.scala
@@ -93,10 +93,10 @@ object AI:
         gen[A]((input1, input2, input3, input4))
 
     /** Projects a generation as a `Stream`, in one of two forms inferred from `A`. For a `String` the stream
-      * is incremental text: each element is a longer prefix of the answer, the terminal one the full text (the
-      * chat-UI, token-by-token case). For any other type the stream is object by object: the model produces a
-      * sequence of `A` and each element is emitted once it is complete, never a half-filled value (the iterable
-      * case, for extracting or generating multiple records). Mints a fresh ephemeral instance to stream against.
+      * is incremental text chunks whose concatenation is the final answer (the chat-UI, token-by-token case).
+      * For any other type the stream is object by object: the model produces a sequence of `A` and each element
+      * is emitted once it is complete, never a half-filled value (the iterable case, for extracting or generating
+      * multiple records). Mints a fresh ephemeral instance to stream against.
       */
     def stream[A: Schema](using Frame, Tag[Emit[Chunk[A]]]): Stream[A, Async & Scope & Abort[AIStreamException]] < LLM =
         init.map(ai => ai.stream[A])

--- a/kyo-ai/shared/src/main/scala/kyo/AIException.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/AIException.scala
@@ -51,6 +51,12 @@ case class AIInvalidThoughtException(name: String)(using Frame)
 case class AIDecodeException(detail: String)(using Frame)
     extends AIException(detail) with AIGenException
 
+/** A command-backed provider could not be reached because its local account, quota, or network transport is
+  * unavailable.
+  */
+case class AIProviderUnavailableException(provider: String, detail: String)(using Frame)
+    extends AIException(s"$provider provider is unavailable: $detail") with AIGenException with AIStreamException
+
 /** A streaming SSE delta was not a parseable event for the provider. */
 case class AIStreamDeltaException(detail: String)(using Frame)
     extends AIException(s"malformed SSE delta: $detail") with AIStreamException

--- a/kyo-ai/shared/src/main/scala/kyo/LLM.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/LLM.scala
@@ -145,10 +145,11 @@ object LLM:
     end runWith
 
     /** Projects the conversation as a streaming completion: posts the SSE request, parses each delta as an
-      * OpenAI streaming chunk, accumulates the tool-call argument fragments, and emits each successfully
-      * decoded prefix as a `Chunk[A]` snapshot (the terminal element is the full A). The result_tool rides
-      * every request so the model has a tool to call. Config and the result-tool/context assembly are read
-      * on the `LLM` row; the returned `Stream` value carries the I/O effects in its element row, with the
+      * OpenAI streaming chunk, accumulates the tool-call argument fragments, and emits decoded values. For
+      * `String`, emitted chunks concatenate to the final text. For every other type, emitted values are complete
+      * array elements. The result_tool rides every request so the model has a tool to call. Config and the
+      * result-tool/context assembly are read on the `LLM` row; the returned `Stream` value carries the I/O
+      * effects in its element row, with the
       * SSE connection scoped so it closes on stream termination or error. The returned `Stream` carries its
       * failures typed in its row (`Abort[AIStreamException]`): a malformed delta is an
       * `AIStreamDeltaException`, a stream that ends without a decodable value an `AIStreamIncompleteException`,
@@ -190,54 +191,41 @@ object LLM:
     ): Stream[A, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
         given Schema[A] = schema
         AI.config.map { config =>
-            config.apiKey match
-                case Absent =>
-                    Abort.fail[AIGenException](AIMissingApiKeyException(config.modelName))
-                case Present(_) =>
-                    // assemble the streaming request with the result_tool in every request:
-                    // resultToolInfo supplies the tool definition; enrichedContext includes its prompt and
-                    // the tool definition in the request body.
-                    val toolInfos = Tool.internal.resultToolInfo.infos
-                    // Two streaming modes, inferred from A. A String result streams incrementally: each emitted
-                    // element is a growing text prefix, the terminal one the full answer. Any other type streams
-                    // object by object: the model returns an array of A and each element is emitted once it is
-                    // complete (never a half-filled A). A bare partial scalar has no meaning, so only String takes
-                    // the prefix path; everything else, scalars included, takes the complete-element path.
-                    val stringMode = schema.structure match
-                        case Structure.Type.Primitive(Structure.PrimitiveKind.String, _) => true
-                        case _                                                           => false
-                    context(target).map { targetContext =>
-                        Prompt.internal.enrichedContext(targetContext, toolInfos).map { context =>
-                            // Wrap in the {resultValue: A} object envelope (an array of A in element mode); a bare
-                            // non-object schema is rejected by the providers, which require an object tool schema. The
-                            // array schema is derived through kyo-schema's chunk Schema, not hand-built.
-                            val resultValueSchema =
-                                if stringMode then Json.jsonSchema[A] else Json.jsonSchema(using Schema.chunkSchema(using schema))
-                            val resultSchema = Thought.internal.resultJson(Chunk.empty, resultValueSchema)
-                            // The streaming request (url + headers + body) is fully provider-dispatched; the SSE
-                            // projection below is generic, feeding each data line through parseDeltaArguments.
-                            val req = config.provider.completion.streamRequest(config, context, resultSchema, toolInfos)
-                            given sseTag: Tag[Emit[Chunk[HttpSseEvent[String]]]] = Tag[Emit[Chunk[HttpSseEvent[String]]]]
-                            val route      = HttpRoute.postRaw("").request(_.bodyText).response(_.bodySseText)
-                            val completion = config.provider.completion
+            if config.provider.usesApiKey && config.apiKey.isEmpty then
+                Abort.fail[AIGenException](AIMissingApiKeyException(config.modelName))
+            else
+                // assemble the streaming request with the result_tool in every request:
+                // resultToolInfo supplies the tool definition; enrichedContext includes its prompt and
+                // the tool definition in the request body.
+                val toolInfos = Tool.internal.resultToolInfo.infos
+                // Two streaming modes, inferred from A. A String result streams incrementally: each emitted
+                // element is the next decoded text chunk. Any other type streams object by object: the model
+                // returns an array of A and each element is emitted once it is complete (never a half-filled A).
+                // A bare partial scalar has no meaning, so only String takes the incremental text path;
+                // everything else, scalars included, takes the complete-element path.
+                val stringMode = schema.structure match
+                    case Structure.Type.Primitive(Structure.PrimitiveKind.String, _) => true
+                    case _                                                           => false
+                context(target).map { targetContext =>
+                    Prompt.internal.enrichedContext(targetContext, toolInfos).map { context =>
+                        // Wrap in the {resultValue: A} object envelope (an array of A in element mode); a bare
+                        // non-object schema is rejected by the providers, which require an object tool schema. The
+                        // array schema is derived through kyo-schema's chunk Schema, not hand-built.
+                        val resultValueSchema =
+                            if stringMode then Json.jsonSchema[A] else Json.jsonSchema(using Schema.chunkSchema(using schema))
+                        val resultSchema = Thought.internal.resultJson(Chunk.empty, resultValueSchema)
+                        val completion   = config.provider.completion
+                        Log.debug(
+                            s"kyo-ai stream backend=${config.provider.name} model=${config.modelName} " +
+                                s"mode=${if stringMode then "prefix" else "elements"} messages=${context.messages.size} tools=${toolInfos.size}"
+                        ).andThen(completion.streamFragments(config, context, resultSchema, toolInfos)).map { fragments =>
                             Stream[A, Async & Scope & Abort[AIStreamException]] {
-                                Abort.recover[HttpException](e => Abort.fail(AITransportException(e))) {
-                                    Abort.get(HttpRequest.postRaw(req.url)).map { baseReq =>
-                                        val request = req.headers.foldLeft(baseReq)((r, kv) => r.addHeader(kv._1, kv._2))
-                                            .addField("body", req.body)
-                                        HttpClient.withConfig(_.timeout(config.timeout)) {
-                                            HttpClient.use { client =>
-                                                client.sendWith(route, request)(_.fields.body)
-                                            }.map { sseStream =>
-                                                if stringMode then consumePrefixStream(sseStream, completion, schema)
-                                                else consumeElementStream(sseStream, completion, schema)
-                                            }
-                                        }
-                                    }
-                                }
+                                if stringMode then consumePrefixFragments(fragments, schema)
+                                else consumeElementFragments(fragments, schema)
                             }
                         }
                     }
+                }
         }
     end streamAgainst
 
@@ -299,56 +287,65 @@ object LLM:
         loop(0, false, false, 0, -1, -1, Chunk.empty)
     end completeElements
 
-    // Prefix mode (String): emit each growing decode of resultValue, skipping a repeat of the last one emitted,
-    // so the text streams token by token. Fails if the stream ends with buffered args that never decoded.
-    private def consumePrefixStream[A](
-        sseStream: Stream[HttpSseEvent[String], Async & Scope & Abort[AIStreamException]],
-        completion: Completion,
+    // Text mode (String): the provider exposes growing decodable prefixes of resultValue. Emit only the newly
+    // decoded suffix so callers receive normal text chunks and can concatenate them into the final answer.
+    // Fails if the stream ends with buffered args that never decoded.
+    private[kyo] def consumePrefixFragments[A](
+        fragments: Stream[String, Async & Scope & Abort[AIStreamException]],
         schema: Schema[A]
     )(using
         Frame,
         Tag[Emit[Chunk[A]]],
-        Tag[Emit[Chunk[HttpSseEvent[String]]]]
+        Tag[Emit[Chunk[String]]]
     ): Unit < (Emit[Chunk[A]] & Async & Scope & Abort[AIStreamException]) =
         given Schema[A] = schema
-        sseStream.fold(("", Maybe.empty[String])) { (state, event) =>
-            val (argsBuf, lastJson) = state
-            completion.parseDeltaArguments(event.data) match
-                case Result.Failure(err)    => Abort.fail(AIStreamDeltaException(err))
-                case Result.Success(Absent) => Kyo.lift(state)
-                case Result.Success(Present(fragment)) =>
-                    val newBuf = argsBuf + fragment
-                    resultValueOf(newBuf) match
-                        case Present(sub) =>
-                            Structure.decode(sub)(using schema, summon) match
-                                case Result.Success(a) =>
-                                    val encoded = Json.encode(a)(using schema, summon)
-                                    if lastJson.exists(_ == encoded) then Kyo.lift((newBuf, lastJson))
-                                    else Emit.value(Chunk(a)).andThen((newBuf, Present(encoded)))
-                                case _ => Kyo.lift((newBuf, lastJson))
-                        case Absent => Kyo.lift((newBuf, lastJson))
-                    end match
+        def emitText(delta: String): Unit < (Emit[Chunk[A]] & Abort[AIStreamException]) =
+            Structure.decode[A](Structure.Value.Str(delta)) match
+                case Result.Success(a) => Emit.value(Chunk(a))
+                case Result.Failure(err) =>
+                    Abort.fail(AIStreamDeltaException(s"stream[String] decoded text chunk failed schema validation: $err"))
+                case Result.Panic(ex) =>
+                    Abort.panic(ex)
+        fragments.fold(("", Maybe.empty[String])) { (state, fragment) =>
+            val (argsBuf, lastText) = state
+            val newBuf              = argsBuf + fragment
+            resultValueOf(newBuf) match
+                case Present(Structure.Value.Str(text)) =>
+                    lastText match
+                        case Present(prev) if text == prev =>
+                            Kyo.lift((newBuf, lastText))
+                        case Present(prev) if text.startsWith(prev) =>
+                            emitText(text.drop(prev.length)).andThen((newBuf, Present(text)))
+                        case Present(prev) =>
+                            Abort.fail(AIStreamDeltaException(
+                                s"stream[String] decoded a non-monotonic text prefix. Previous: $prev, next: $text"
+                            ))
+                        case Absent =>
+                            emitText(text).andThen((newBuf, Present(text)))
+                case Present(other) =>
+                    Abort.fail(AIStreamDeltaException(s"stream[String] expected a JSON string resultValue, got: ${Json.encode(other)}"))
+                case Absent =>
+                    Kyo.lift((newBuf, lastText))
             end match
-        }.map { case (argsBuf, lastJson) =>
+        }.map { case (argsBuf, lastText) =>
             // No provider terminator is required: if the SSE stream ends having buffered argument JSON but
             // never emitted a decodable A, the generation failed.
-            if lastJson.isEmpty && argsBuf.nonEmpty then Abort.fail(AIStreamIncompleteException(argsBuf))
+            if lastText.isEmpty && argsBuf.nonEmpty then Abort.fail(AIStreamIncompleteException(argsBuf))
             else Kyo.lift(())
         }
-    end consumePrefixStream
+    end consumePrefixFragments
 
     // Element mode (object by object): resultValue is an array of A. After each delta, emit every newly-complete
     // element (one whose JSON closed and is followed by a delimiter); an in-progress final element waits. Each A
     // is emitted exactly once, fully formed; a truncated tail is dropped and a complete element before a trailing
     // comma is kept.
-    private def consumeElementStream[A](
-        sseStream: Stream[HttpSseEvent[String], Async & Scope & Abort[AIStreamException]],
-        completion: Completion,
+    private[kyo] def consumeElementFragments[A](
+        fragments: Stream[String, Async & Scope & Abort[AIStreamException]],
         schema: Schema[A]
     )(using
         Frame,
         Tag[Emit[Chunk[A]]],
-        Tag[Emit[Chunk[HttpSseEvent[String]]]]
+        Tag[Emit[Chunk[String]]]
     ): Unit < (Emit[Chunk[A]] & Async & Scope & Abort[AIStreamException]) =
         given Schema[A] = schema
         def decodeElement(raw: String): A < Abort[AIStreamException] =
@@ -358,17 +355,12 @@ object LLM:
                         case Result.Success(a) => a
                         case _                 => Abort.fail(AIStreamIncompleteException(raw))
                 case _ => Abort.fail(AIStreamIncompleteException(raw))
-        sseStream.fold(("", 0)) { (state, event) =>
+        fragments.fold(("", 0)) { (state, fragment) =>
             val (argsBuf, emitted) = state
-            completion.parseDeltaArguments(event.data) match
-                case Result.Failure(err)    => Abort.fail(AIStreamDeltaException(err))
-                case Result.Success(Absent) => Kyo.lift(state)
-                case Result.Success(Present(fragment)) =>
-                    val newBuf = argsBuf + fragment
-                    val ready  = completeElements(newBuf)
-                    if ready.size <= emitted then Kyo.lift((newBuf, emitted))
-                    else Kyo.foreach(ready.drop(emitted))(decodeElement).map(as => Emit.value(as).andThen((newBuf, ready.size)))
-            end match
+            val newBuf             = argsBuf + fragment
+            val ready              = completeElements(newBuf)
+            if ready.size <= emitted then Kyo.lift((newBuf, emitted))
+            else Kyo.foreach(ready.drop(emitted))(decodeElement).map(as => Emit.value(as).andThen((newBuf, ready.size)))
         }.map { case (argsBuf, emitted) =>
             // Everything complete was emitted during the fold. An empty or in-progress-only array yields an empty
             // stream; only a buffer that never produced a resultValue array at all is incomplete.
@@ -376,7 +368,7 @@ object LLM:
                 Abort.fail(AIStreamIncompleteException(argsBuf))
             else Kyo.unit
         }
-    end consumeElementStream
+    end consumeElementFragments
 
     /** Discharges `LLM`, threading a fresh `State`. */
     def run[A, S](v: A < (LLM & S))(using Frame): A < (S & Async & Abort[AIGenException]) =
@@ -516,7 +508,11 @@ object LLM:
             resultSchema = Thought.internal.resultJson(thoughts, Json.jsonSchema[A])
             ctx     <- ai.context
             context <- Prompt.internal.enrichedContext(ctx, allTools)
-            message <-
+            _ <- Log.debug(
+                s"kyo-ai gen backend=${config.provider.name} model=${config.modelName} " +
+                    s"messages=${context.messages.size} tools=${allTools.size} thoughts=${thoughts.size} forceResult=$forceResult"
+            )
+            messages <-
                 HttpClient.withConfig(_.timeout(config.timeout)) {
                     Abort.run[Closed] {
                         config.provider
@@ -526,15 +522,21 @@ object LLM:
                                 Retry[HttpException](config.retrySchedule)(_)
                             )
                     }.map {
-                        case Result.Success(msg) => msg
-                        case Result.Failure(_)   => Abort.panic(AIMeterClosedException())
-                        case Result.Panic(ex)    => Abort.panic(ex)
+                        case Result.Success(msgs) => msgs
+                        case Result.Failure(_)    => Abort.panic(AIMeterClosedException())
+                        case Result.Panic(ex)     => Abort.panic(ex)
                     }
                 }
-            _ <- ai.updateContext(_.add(message))
-            _ <- Tool.internal.handle(ai, allTools, message.calls)
+            _ <- Log.debug(
+                s"kyo-ai gen backend=${config.provider.name} returned messages=${messages.size} " +
+                    s"toolCalls=${messages.collect { case msg: AssistantMessage => msg.calls.size }.sum}"
+            )
+            _ <- ai.updateContext(ctx => messages.foldLeft(ctx)(_.add(_)))
+            calls            = messages.collect { case msg: AssistantMessage => msg.calls }.flatten
+            completedCallIds = messages.collect { case ToolMessage(callId, _) => callId }
+            _ <- Tool.internal.handle(ai, allTools, calls.filterNot(call => completedCallIds.contains(call.id)))
             // Extract the model's structured result directly from its result_tool call (no capturing run).
-            raw = message.calls.filter(_.function == Completion.resultToolName).headMaybe
+            raw = calls.filter(_.function == Completion.resultToolName).headMaybe
                 .flatMap(call => Json.decode[Structure.Value](call.arguments).toMaybe)
             r <- raw match
                 case Present(record) =>

--- a/kyo-ai/shared/src/main/scala/kyo/Thought.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/Thought.scala
@@ -141,7 +141,7 @@ object Thought:
                     case Present(sv) =>
                         Abort.run[DecodeException](Abort.get(Structure.decode(sv)(using resultSchema, summon))).map {
                             case Result.Success(a) => a
-                            case Result.Failure(e) => Abort.fail(AIDecodeException(e.getMessage))
+                            case Result.Failure(e) => Abort.fail(AIDecodeException(s"${e.getMessage}: ${Json.encode(sv)}"))
                             case p: Result.Panic   => Abort.panic(p.exception)
                         }
                     case Absent => Abort.fail(AIDecodeException("result envelope has no resultValue"))

--- a/kyo-ai/shared/src/main/scala/kyo/ai/Config.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/Config.scala
@@ -9,9 +9,9 @@ import kyo.ai.completion.*
   * provider (which carries the wire backend), the model and its token cap, and the runtime knobs
   * (temperature, seed, timeout, retry schedule, meter, iteration cap). `temperature` is optional: it is
   * omitted from the request when unset (the model uses its own default) and clamped to `[0, 2]` when set.
-  * `default` auto-selects the first provider whose API key is present (system properties
-  * before environment variables, read via `kyo.System`, never raw `sys.props`/`sys.env`), falling back
-  * to Anthropic. The active config is carried in `LLM.State.env.config`, read via `AI.config`
+  * `default` auto-selects the first provider marker or API key present (system properties before
+  * environment variables, read via `kyo.System`, never raw `sys.props`/`sys.env`), falling back to
+  * Anthropic. The active config is carried in `LLM.State.env.config`, read via `AI.config`
   * and scoped via `AI.withConfig`.
   */
 final case class Config private (
@@ -53,6 +53,8 @@ final case class Config private (
 
 end Config
 
+private[kyo] object provider extends StaticFlag[String]("")
+
 object Config:
 
     private[kyo] def read(key: String)(using Frame): Maybe[String] < Sync =
@@ -61,19 +63,33 @@ object Config:
             env  <- if prop.isDefined then (prop: Maybe[String] < Sync) else System.env[String](key)
         yield env
 
-    /** Resolves the default config by probing each provider's key (sys props first, then env), via
-      * `kyo.System`. Evaluated once under `Sync` since key probing is effectful; falls back to Anthropic.
+    /** Resolves the default config by probing provider flags and API keys (sys props first, then env), via
+      * `kyo.System`. The static `kyo.ai.provider` flag can force a provider by name. Without an explicit
+      * provider, command harnesses are selected only when their marker variables are present, then API
+      * providers are selected by key presence.
       */
     def default(using Frame): Config < Sync =
-        Kyo.foreach(Provider.all)(p => read(p.keyName).map(_.isDefined -> p)).map { probes =>
-            probes.collectFirst { case (true, p) => p }.getOrElse(Anthropic)
-        }.map(p => init(p, p.default.modelName, p.default.modelMaxTokens))
+        val selected = provider().trim
+        providerByName(selected.toLowerCase) match
+            case Present(p) =>
+                init(p, p.default.modelName, p.default.modelMaxTokens)
+            case Absent if selected.nonEmpty =>
+                throw IllegalArgumentException(s"Unsupported kyo.ai provider '$selected'.")
+            case Absent =>
+                Kyo.foreach(Provider.defaultCandidates)(p => read(p.keyName).map(_.isDefined -> p)).map { probes =>
+                    probes.collectFirst { case (true, p) => p }.getOrElse(Anthropic)
+                }.map(p => init(p, p.default.modelName, p.default.modelMaxTokens))
+        end match
+    end default
 
     def init(provider: Provider, modelName: String, modelMaxTokens: Int)(using Frame): Config < Sync =
-        for
-            key <- read(provider.keyName)
-            org <- read(provider.orgKey)
-        yield Config(provider.baseUrl, key, org, provider, modelName, modelMaxTokens)
+        if provider.usesApiKey then
+            for
+                key <- read(provider.keyName)
+                org <- read(provider.orgKey)
+            yield Config(provider.baseUrl, key, org, provider, modelName, modelMaxTokens)
+        else
+            Config(provider.baseUrl, Absent, Absent, provider, modelName, modelMaxTokens)
 
     /** A purely-constructed config for a provider's catalog entry (key/org left absent; filled at use via
       * the provider default path). The catalog values use this so a model literal is pure.
@@ -81,21 +97,41 @@ object Config:
     private[kyo] def catalog(provider: Provider, modelName: String, modelMaxTokens: Int): Config =
         Config(provider.baseUrl, Absent, Absent, provider, modelName, modelMaxTokens)
 
-    /** A provider: its display name, base URL, the key env-var name, and the wire completion backend. */
+    /** A provider: its display name, base URL, credential behavior, and completion backend. */
     abstract class Provider(
         val name: String,
         val baseUrl: String,
         val keyName: String,
-        val completion: Completion
+        val completion: Completion,
+        val usesApiKey: Boolean = true
     ):
         val orgKey: String = keyName + "_ORG"
         def default: Config
     end Provider
 
     object Provider:
-        val all: Chunk[Provider] =
-            Chunk(Anthropic, OpenAI, DeepSeek, Gemini, Groq, Baseten, OpenRouter)
+        def all: Chunk[Provider] =
+            Chunk(Anthropic, OpenAI, DeepSeek, Gemini, Groq, Baseten, OpenRouter, ClaudeCode, Codex)
+        def apiKeyProviders: Chunk[Provider] =
+            all.filter(_.usesApiKey)
+        def defaultCandidates: Chunk[Provider] =
+            Chunk(ClaudeCode, Codex, Anthropic, OpenAI, DeepSeek, Gemini, Groq, Baseten, OpenRouter)
     end Provider
+
+    private def providerByName(name: String): Maybe[Provider] =
+        name match
+            case ""                                       => Absent
+            case "claude-code" | "claude_code" | "claude" => Present(ClaudeCode)
+            case "codex"                                  => Present(Codex)
+            case "anthropic"                              => Present(Anthropic)
+            case "openai"                                 => Present(OpenAI)
+            case "deepseek"                               => Present(DeepSeek)
+            case "gemini"                                 => Present(Gemini)
+            case "groq"                                   => Present(Groq)
+            case "baseten"                                => Present(Baseten)
+            case "openrouter"                             => Present(OpenRouter)
+            case _                                        => Absent
+    end providerByName
 
     // Each provider exposes its catalog as named pure `Config` constants (key absent, filled at use), so
     // `Config.<Provider>.<model>` is a model literal; `default` points at the recommended entry.
@@ -203,5 +239,33 @@ object Config:
         val gpt_5_mini: Config                = catalog(this, "openai/gpt-5-mini", 400000)
         def default: Config                   = grok_4_fast
     end OpenRouter
+
+    case object ClaudeCode extends Provider(
+            "Claude Code",
+            "",
+            "CLAUDE_CODE",
+            Completion.claudeCode,
+            usesApiKey = false
+        ):
+        val opus: Config    = catalog(this, "opus", 1000000)
+        val sonnet: Config  = catalog(this, "sonnet", 1000000)
+        val haiku: Config   = catalog(this, "haiku", 200000)
+        def default: Config = sonnet
+    end ClaudeCode
+
+    case object Codex extends Provider(
+            "Codex",
+            "",
+            "CODEX",
+            Completion.codex,
+            usesApiKey = false
+        ):
+        val auto: Config       = catalog(this, "", 400000)
+        val gpt_5_5: Config    = catalog(this, "gpt-5.5", 1050000)
+        val gpt_5_4: Config    = catalog(this, "gpt-5.4", 1050000)
+        val gpt_5: Config      = catalog(this, "gpt-5", 400000)
+        val gpt_5_mini: Config = catalog(this, "gpt-5-mini", 400000)
+        def default: Config    = auto
+    end Codex
 
 end Config

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
@@ -7,7 +7,7 @@ import kyo.Schema
 import kyo.Structure
 import kyo.Tool
 import kyo.ai.*
-import kyo.ai.Context.*
+import kyo.ai.Context.{Message as ContextMessage, *}
 
 /** The Anthropic completion backend (the `/messages` API).
   *
@@ -33,10 +33,10 @@ private[completion] object AnthropicCompletion extends Completion:
         context: Context,
         tools: Chunk[Tool.internal.Info[?, ?, LLM]],
         resultSchema: Maybe[JsonSchema] = Absent
-    )(using Frame): AssistantMessage < (LLM & Async & Abort[HttpException | AIGenException]) =
+    )(using Frame): Chunk[ContextMessage] < (LLM & Async & Abort[HttpException | AIGenException]) =
         fetch(config, Request(context, config, tools, resultSchema)).map(read)
 
-    private def read(response: Response)(using Frame): AssistantMessage < LLM =
+    private def read(response: Response)(using Frame): Chunk[ContextMessage] < LLM =
         val text = response.content.collect {
             case c if c.`type` == "text" => c.text.getOrElse("")
         }.mkString("")
@@ -48,7 +48,7 @@ private[completion] object AnthropicCompletion extends Completion:
                     Json.encode(c.input.getOrElse(Structure.Value.Record(Chunk.empty)))
                 )
         }.to(Chunk)
-        AssistantMessage(text, toolCalls)
+        Chunk(AssistantMessage(text, toolCalls))
     end read
 
     private def fetch(config: Config, req: Request)(using Frame): Response < (LLM & Async & Abort[HttpException | AIGenException]) =
@@ -62,15 +62,28 @@ private[completion] object AnthropicCompletion extends Completion:
                     "anthropic-version" -> "2023-06-01"
                 )
                 val url = s"${config.apiUrl}/messages"
-                HttpClient.postText(url, Json.encode(req), headers)
-                    .map(body => Abort.get(Json.decode[Response](body).mapFailure(e => HttpJsonDecodeException(e.getMessage, "POST", url))))
+                HttpClient.withConfig(_.timeout(config.timeout)) {
+                    HttpClient.postText(url, Json.encode(req), headers)
+                        .map(body =>
+                            Abort.get(Json.decode[Response](body).mapFailure(e => HttpJsonDecodeException(e.getMessage, "POST", url)))
+                        )
+                }
 
-    override def streamRequest(
+    def streamFragments(
         config: Config,
         context: Context,
         resultSchema: JsonSchema,
         resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
-    )(using Frame): Completion.StreamRequest =
+    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
+        Completion.sseFragments(config, streamRequest(config, context, resultSchema, resultTool), parseDeltaArguments)
+    end streamFragments
+
+    private[kyo] def streamRequest(
+        config: Config,
+        context: Context,
+        resultSchema: JsonSchema,
+        resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
+    )(using Frame): Completion.StreamRequest < Abort[AIStreamException] =
         import internal.*
         val headers =
             Seq("content-type" -> "application/json", "anthropic-version" -> "2023-06-01") ++
@@ -87,7 +100,7 @@ private[completion] object AnthropicCompletion extends Completion:
       * (`message_start`, `content_block_start`, `text_delta`, `message_delta`, `message_stop`, `ping`) carries
       * no tool-argument fragment. There is no `[DONE]` terminator; the stream ends at `message_stop`.
       */
-    override def parseDeltaArguments(line: String)(using Frame): Result[String, Maybe[String]] =
+    private[kyo] def parseDeltaArguments(line: String)(using Frame): Result[String, Maybe[String]] =
         import internal.*
         Json.decode[StreamEvent](line) match
             case Result.Success(event) =>
@@ -114,6 +127,7 @@ private[completion] object AnthropicCompletion extends Completion:
         case class Source(`type`: String, media_type: String, data: String) derives Schema
         case class Message(role: String, content: List[Content]) derives Schema
         case class ToolDefinition(name: String, description: Maybe[String], input_schema: JsonSchema) derives Schema
+        case class ToolChoice(`type`: String, name: Maybe[String] = Absent) derives Schema
         case class Request(
             model: String,
             messages: List[Message],
@@ -121,6 +135,7 @@ private[completion] object AnthropicCompletion extends Completion:
             max_tokens: Int,
             temperature: Maybe[Double],
             tools: Maybe[List[ToolDefinition]] = Absent,
+            tool_choice: Maybe[ToolChoice] = Absent,
             stream: Maybe[Boolean] = Absent
         ) derives Schema
         case class Usage(input_tokens: Int, output_tokens: Int) derives Schema
@@ -203,7 +218,15 @@ private[completion] object AnthropicCompletion extends Completion:
                                 else Json.jsonSchema(using t.inputSchema)
                             ToolDefinition(t.name, Maybe.when(t.description.nonEmpty)(t.description), schema)
                         }.toList)
-                Request(config.modelName, messages, system, config.maxTokens.getOrElse(8192), config.temperature, toolDefs)
+                val toolChoice =
+                    tools.headMaybe match
+                        case Present(tool) if tools.size == 1 && tool.name == Completion.resultToolName =>
+                            Present(ToolChoice("tool", Present(Completion.resultToolName)))
+                        case Present(_) =>
+                            Present(ToolChoice("any"))
+                        case Absent =>
+                            Absent
+                Request(config.modelName, messages, system, config.maxTokens.getOrElse(8192), config.temperature, toolDefs, toolChoice)
             end apply
         end Request
 

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
@@ -1,0 +1,728 @@
+package kyo.ai.completion
+
+import kyo.*
+import kyo.Json
+import kyo.Json.JsonSchema
+import kyo.Schema
+import kyo.Tool
+import kyo.ai.*
+import kyo.ai.Context.*
+
+/** Claude Code command-backed completion adapter.
+  *
+  * Claude Code is driven through `claude -p` with SDK `stream-json` input and output. System messages are
+  * passed as the CLI system prompt, and every non-system Kyo message is encoded as one stream-json event
+  * using Claude's native content blocks: text, image, tool_use, and tool_result. Kyo tools are exposed to
+  * Claude Code as an ephemeral in-process MCP server, so the CLI can use native tool execution while the
+  * adapter folds the resulting transcript back into ordinary Kyo messages.
+  */
+private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claude Code"):
+
+    private case class InputSource(`type`: String, media_type: String, data: String) derives Schema
+    private case class InputContent(
+        `type`: String,
+        text: Maybe[String] = Absent,
+        id: Maybe[String] = Absent,
+        name: Maybe[String] = Absent,
+        input: Maybe[Structure.Value] = Absent,
+        tool_use_id: Maybe[String] = Absent,
+        content: Maybe[String] = Absent,
+        source: Maybe[InputSource] = Absent,
+        is_error: Maybe[Boolean] = Absent
+    ) derives Schema
+    private case class InputMessage(role: String, content: List[InputContent]) derives Schema
+    private case class InputEvent(`type`: String, message: InputMessage) derives Schema
+
+    private case class MessageContent(
+        `type`: String,
+        id: Maybe[String] = Absent,
+        text: Maybe[String] = Absent,
+        name: Maybe[String] = Absent,
+        input: Maybe[Structure.Value] = Absent,
+        tool_use_id: Maybe[String] = Absent,
+        content: Maybe[String] = Absent,
+        is_error: Maybe[Boolean] = Absent
+    ) derives Schema
+    private case class OutputMessage(role: String, content: List[MessageContent]) derives Schema
+    private case class OutputEvent(
+        `type`: String,
+        message: Maybe[OutputMessage] = Absent,
+        result: Maybe[String] = Absent,
+        subtype: Maybe[String] = Absent
+    ) derives Schema
+
+    private case class McpServerConfig(`type`: String, url: String, timeout: Int, alwaysLoad: Boolean) derives Schema
+    private case class McpConfig(mcpServers: Map[String, McpServerConfig]) derives Schema
+    private case class McpBridge(config: String, allowedTools: Chunk[String], executedTools: AtomicRef[Chunk[ExecutedTool]])
+    private case class ExecutedTool(name: String, arguments: Structure.Value, output: String)
+
+    private val apiKeyEnvVars =
+        Set("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL", "CLAUDE_API_KEY")
+    private val mcpServerName = "kyo"
+    private val mcpToolPrefix = s"mcp__${mcpServerName}__"
+
+    private enum CliResult derives CanEqual:
+        case Completed(out: Chunk[Byte], err: Chunk[Byte], code: Process.ExitCode)
+        case TimedOut
+
+    override def streamFragments(
+        config: Config,
+        context: Context,
+        resultSchema: JsonSchema,
+        resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
+    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
+        turnInput(context).map { case (input, prompt) =>
+            Stream[String, Async & Scope & Abort[AIStreamException]] {
+                Abort.run[CommandException] {
+                    claudeCommand(streamCommandArgs(config, context, resultSchema, prompt))
+                        .stdin(input + "\n")
+                        .spawn
+                }.map {
+                    case Result.Success(proc) => emitProcessFragments(proc)
+                    case Result.Failure(ex)   => Abort.fail(streamFailure(ex.getMessage))
+                    case Result.Panic(ex)     => Abort.panic(ex)
+                }
+            }
+        }
+    end streamFragments
+
+    protected def run(
+        config: Config,
+        context: Context,
+        tools: Chunk[Tool.internal.Info[?, ?, LLM]],
+        resultSchema: JsonSchema
+    )(using Frame): Chunk[Message] < (LLM & Async & Abort[AIGenException]) =
+        Scope.run {
+            val userTools = tools.filterNot(_.name == Completion.resultToolName)
+            withMcpBridge(config, userTools) { bridge =>
+                for
+                    (input, prompt) <- turnInput(context)
+                    schema = Structure.encode(resultSchema)
+                    _ <- Log.debug(
+                        s"kyo-ai Claude Code mode=result messages=${context.messages.size} tools=${tools.map(_.name).mkString(",")}"
+                    )
+                    raw      <- runCli(config, context, schema, input, prompt, bridge)
+                    executed <- bridge.map(_.executedTools.get).getOrElse(Kyo.lift(Chunk.empty))
+                    messages <- readMessages(raw, executed)
+                yield messages
+            }
+        }
+    end run
+
+    private def runCli(
+        config: Config,
+        context: Context,
+        schema: Structure.Value,
+        input: String,
+        prompt: Maybe[String],
+        bridge: Maybe[McpBridge]
+    )(using Frame): String < (Async & Abort[AIGenException]) =
+        runClaudeCommand(claudeCommand(commandArgs(config, context, schema, prompt, bridge)).stdin(input + "\n"), config.timeout)
+    end runCli
+
+    private def claudeCommand(args: Chunk[String]): Command =
+        Command(args*).envRemove(apiKeyEnvVars).envAppend(Map("ENABLE_TOOL_SEARCH" -> "false"))
+
+    private def runClaudeCommand(command: Command, timeout: Duration)(using Frame): String < (Async & Abort[AIGenException]) =
+        Abort.run[CommandException] {
+            Scope.run {
+                for
+                    proc      <- command.spawn
+                    outputFib <- Fiber.init(Scope.run(proc.collectOutput))
+                    code      <- proc.waitFor(timeout)
+                    result <- code match
+                        case Present(code) =>
+                            outputFib.get.map { case (out, err) => CliResult.Completed(out, err, code) }
+                        case Absent =>
+                            proc.destroyForcibly.andThen(proc.waitFor(5.seconds)).andThen(Kyo.lift(CliResult.TimedOut))
+                yield result
+            }
+        }.map {
+            case Result.Success(CliResult.Completed(outBytes, _, code)) if code.isSuccess =>
+                String(outBytes.toArray)
+            case Result.Success(CliResult.Completed(outBytes, errBytes, code)) =>
+                val out = String(outBytes.toArray)
+                val err = String(errBytes.toArray)
+                Abort.fail(commandFailure(s"exited with ${code.toInt}: $out$err"))
+            case Result.Success(CliResult.TimedOut) =>
+                Abort.fail(AIProviderUnavailableException("Claude Code", "turn timed out waiting for CLI completion"))
+            case Result.Failure(ex) =>
+                Abort.fail(commandFailure(ex.getMessage))
+            case Result.Panic(ex) =>
+                Abort.panic(ex)
+        }
+    end runClaudeCommand
+
+    private def withMcpBridge[A, S](
+        config: Config,
+        tools: Chunk[Tool.internal.Info[?, ?, LLM]]
+    )(body: Maybe[McpBridge] => A < S)(using Frame): A < (S & LLM & Async & Scope & Abort[AIGenException]) =
+        if tools.isEmpty then body(Absent)
+        else
+            for
+                state    <- LLM.state
+                stateRef <- AtomicRef.init(state)
+                executed <- AtomicRef.init(Chunk.empty[ExecutedTool])
+                meter    <- Meter.initMutex
+                handlers = tools.map(tool => mcpToolHandler(stateRef, executed, meter, tool))
+                server <- HttpServer.init(0, "127.0.0.1")(
+                    HttpHandler.webSocket("mcp") { (_, ws) =>
+                        Scope.run {
+                            JsonRpcHttpTransport.webSocket(ws).map { transport =>
+                                McpServer.initWith(transport, handlers.toSeq*) { _ =>
+                                    ws.onPeerClose
+                                }
+                            }
+                        }
+                    }
+                )
+                url     = s"ws://127.0.0.1:${server.port}/mcp"
+                timeout = math.min(Int.MaxValue.toLong, math.max(1000L, config.timeout.toMillis)).toInt
+                bridge = McpBridge(
+                    Json.encode(McpConfig(Map(mcpServerName -> McpServerConfig("ws", url, timeout, alwaysLoad = true)))),
+                    tools.map(tool => s"$mcpToolPrefix${tool.name}"),
+                    executed
+                )
+                result <- body(Present(bridge))
+                next   <- stateRef.get
+                _      <- LLM.setState(next)
+            yield result
+        end if
+    end withMcpBridge
+
+    private def mcpToolHandler(
+        stateRef: AtomicRef[LLM.State],
+        executedTools: AtomicRef[Chunk[ExecutedTool]],
+        meter: Meter,
+        tool: Tool.internal.Info[?, ?, LLM]
+    )(using Frame): McpHandler[?, ?, ?] =
+        given Schema[Any] = tool.inputSchema.asInstanceOf[Schema[Any]]
+        McpHandler.toolRaw[Any](tool.name, tool.description) { input =>
+            Abort.run[Closed] {
+                meter.run {
+                    stateRef.get.map { state =>
+                        Abort.run[Throwable] {
+                            val run = tool.run.asInstanceOf[Any => Any < LLM](input)
+                            LLM.runWith(state)(run) { (next, out) =>
+                                (next, out)
+                            }
+                        }.map {
+                            case Result.Success((next, out)) =>
+                                val outputSchema = tool.outputSchema.asInstanceOf[Schema[Any]]
+                                val text         = Json.encode[Any](out)(using outputSchema, summon[Frame])
+                                val structured   = Structure.encode[Any](out)(using outputSchema)
+                                val arguments    = Structure.encode[Any](input)(using tool.inputSchema.asInstanceOf[Schema[Any]])
+                                stateRef.set(next).andThen(executedTools.getAndUpdate(_.append(ExecutedTool(
+                                    tool.name,
+                                    arguments,
+                                    text
+                                ))).unit).andThen(
+                                    McpHandler.ToolOutcome.okWith(
+                                        content = Chunk(McpContent.text(text)),
+                                        structuredContent = Present(structured)
+                                    )
+                                )
+                            case Result.Failure(ex) =>
+                                val text      = toolError(tool.name, ex.toString)
+                                val arguments = Structure.encode[Any](input)(using tool.inputSchema.asInstanceOf[Schema[Any]])
+                                executedTools.getAndUpdate(_.append(ExecutedTool(tool.name, arguments, text))).unit.andThen(
+                                    McpHandler.ToolOutcome.error(text)
+                                )
+                            case Result.Panic(ex) =>
+                                val text      = toolError(tool.name, ex.toString)
+                                val arguments = Structure.encode[Any](input)(using tool.inputSchema.asInstanceOf[Schema[Any]])
+                                executedTools.getAndUpdate(_.append(ExecutedTool(tool.name, arguments, text))).unit.andThen(
+                                    McpHandler.ToolOutcome.error(text)
+                                )
+                        }
+                    }
+                }
+            }.map {
+                case Result.Success(outcome) => outcome
+                case Result.Failure(ex)      => McpHandler.ToolOutcome.error(toolError(tool.name, ex.toString))
+                case Result.Panic(ex)        => McpHandler.ToolOutcome.error(toolError(tool.name, ex.toString))
+            }
+        }
+    end mcpToolHandler
+
+    private def toolError(name: String, detail: String): String =
+        p"""
+            Tool '$name' failed:
+            $detail
+        """
+    end toolError
+
+    private def commandArgs(
+        config: Config,
+        context: Context,
+        schema: Structure.Value,
+        prompt: Maybe[String],
+        bridge: Maybe[McpBridge]
+    )(using Frame): Chunk[String] =
+        val base =
+            Chunk(
+                "claude",
+                "-p",
+                "--input-format",
+                "stream-json",
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--no-session-persistence",
+                "--tools",
+                "",
+                "--disable-slash-commands",
+                "--strict-mcp-config",
+                "--mcp-config",
+                bridge.map(_.config).getOrElse("""{"mcpServers":{}}"""),
+                "--disallowedTools",
+                "ToolSearch",
+                "--setting-sources",
+                "",
+                "--permission-mode",
+                "dontAsk",
+                "--model",
+                config.modelName,
+                "--json-schema",
+                Json.encode(schema)
+            )
+        val withAllowed =
+            bridge match
+                case Present(value) if value.allowedTools.nonEmpty =>
+                    base.append("--allowedTools").append(value.allowedTools.mkString(","))
+                case _ =>
+                    base
+        val system     = outputInstructions(context, schema, bridge.nonEmpty)
+        val withSystem = if system.isEmpty then withAllowed else withAllowed.append("--system-prompt").append(system)
+        prompt match
+            case Present(value) => withSystem.append(value)
+            case Absent         => withSystem
+    end commandArgs
+
+    private def streamCommandArgs(config: Config, context: Context, resultSchema: JsonSchema, prompt: Maybe[String])(using
+        Frame
+    ): Chunk[String] =
+        val base =
+            Chunk(
+                "claude",
+                "-p",
+                "--input-format",
+                "stream-json",
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--no-session-persistence",
+                "--tools",
+                "",
+                "--disable-slash-commands",
+                "--strict-mcp-config",
+                "--mcp-config",
+                """{"mcpServers":{}}""",
+                "--disallowedTools",
+                "ToolSearch",
+                "--setting-sources",
+                "",
+                "--permission-mode",
+                "dontAsk",
+                "--model",
+                config.modelName,
+                "--json-schema",
+                Json.encode(resultSchema)
+            )
+        val system     = streamInstructions(context, resultSchema)
+        val withSystem = if system.isEmpty then base else base.append("--system-prompt").append(system)
+        prompt match
+            case Present(value) => withSystem.append(value)
+            case Absent         => withSystem
+    end streamCommandArgs
+
+    private def turnInput(context: Context)(using Frame): (String, Maybe[String]) < Abort[AIGenException] =
+        val messages = context.messages.filterNot(_.role == Role.System)
+        val input =
+            messages.lastMaybe match
+                case Present(_: UserMessage) => messages
+                case Present(_)              => messages.append(UserMessage("Continue.", Absent))
+                case Absent                  => Chunk(UserMessage("Continue.", Absent))
+        inputJsonLines(input).map(_ -> Absent)
+    end turnInput
+
+    private def streamInstructions(context: Context, resultSchema: JsonSchema)(using Frame): String =
+        val instruction =
+            p"""
+                Answer only the final user message. Earlier user messages are conversation history, not active requests.
+                Never replay, concatenate, summarize, or include earlier assistant outputs in the new result.
+                The result value must contain only the answer requested by the final user message.
+                For streaming string results, output exactly the string requested by the final user message and no prior history text.
+                Return only JSON matching this result envelope schema:
+                ${Json.encode(resultSchema)}
+            """
+        (context.messages.collect { case SystemMessage(content) => content } :+ instruction).mkString("\n\n")
+    end streamInstructions
+
+    private def outputInstructions(context: Context, schema: Structure.Value, hasTools: Boolean)(using Frame): String =
+        val instruction =
+            if hasTools then
+                p"""
+                    Answer only the final user message. Earlier user messages are conversation history, not active requests.
+                    Never replay, concatenate, summarize, or include earlier assistant outputs in the new result.
+                    Return only JSON matching this output schema:
+                    ${Json.encode(schema)}
+                    Use the available MCP tools when they are needed to answer the user.
+                """
+            else
+                p"""
+                    Answer only the final user message. Earlier user messages are conversation history, not active requests.
+                    Never replay, concatenate, summarize, or include earlier assistant outputs in the new result.
+                    Return only JSON matching this result envelope schema:
+                    ${Json.encode(schema)}
+                """
+        (context.messages.collect { case SystemMessage(content) => content } :+ instruction).mkString("\n\n")
+    end outputInstructions
+
+    private[kyo] def inputJsonLines(messages: Chunk[Message])(using Frame): String < Abort[AIGenException] =
+        inputEvents(messages).map(_.map(Json.encode(_)).mkString("\n"))
+    end inputJsonLines
+
+    private def inputEvents(messages: Chunk[Message])(using Frame): Chunk[InputEvent] < Abort[AIGenException] =
+        Kyo.foreach(messages)(inputEventsForMessage).map(_.flattenChunk)
+    end inputEvents
+
+    private def inputEventsForMessage(message: Message)(using Frame): Chunk[InputEvent] < Abort[AIGenException] =
+        message match
+            case AssistantMessage(_, calls) if calls.exists(_.function == Completion.resultToolName) =>
+                Kyo.foreach(calls.filter(_.function == Completion.resultToolName)) { call =>
+                    InputEvent(
+                        "assistant",
+                        InputMessage(
+                            Role.Assistant.name,
+                            List(InputContent(
+                                "text",
+                                text = Present(
+                                    renderResultHistory(call.arguments)
+                                )
+                            ))
+                        )
+                    )
+                }.map { resultEvents =>
+                    val nonResult = AssistantMessage(
+                        "",
+                        calls.filterNot(_.function == Completion.resultToolName)
+                    )
+                    if nonResult.calls.isEmpty then resultEvents
+                    else inputEvent(nonResult).map(event => resultEvents.prepended(event))
+                }
+            case ToolMessage(callId, _) if callId.id == "harness-result" =>
+                Chunk.empty[InputEvent]
+            case _ =>
+                inputEvent(message).map(Chunk(_))
+    end inputEventsForMessage
+
+    private def inputEvent(message: Message)(using Frame): InputEvent < Abort[AIGenException] =
+        message match
+            case SystemMessage(content) =>
+                Abort.fail(AIDecodeException(s"Claude Code system message was not routed to system prompt: $content"))
+            case UserMessage(content, Present(image)) =>
+                InputEvent(
+                    "user",
+                    InputMessage(
+                        Role.User.name,
+                        List(
+                            InputContent("text", text = Present(content)),
+                            InputContent("image", source = Present(InputSource("base64", "image/jpeg", image.base64)))
+                        )
+                    )
+                )
+            case UserMessage(content, _) =>
+                InputEvent("user", InputMessage(Role.User.name, List(InputContent("text", text = Present(content)))))
+            case AssistantMessage(content, calls) =>
+                Kyo.foreach(calls)(inputToolCall).map { callBlocks =>
+                    val contentBlocks =
+                        (if content.nonEmpty then List(InputContent("text", text = Present(content))) else Nil) ++ callBlocks.toList
+                    InputEvent("assistant", InputMessage(Role.Assistant.name, contentBlocks))
+                }
+            case ToolMessage(callId, content) =>
+                InputEvent(
+                    "user",
+                    InputMessage(
+                        Role.User.name,
+                        List(
+                            InputContent(
+                                "tool_result",
+                                tool_use_id = Present(callId.id),
+                                content = Present(content),
+                                is_error = Present(isToolError(content))
+                            )
+                        )
+                    )
+                )
+    end inputEvent
+
+    private def inputToolCall(call: Call)(using Frame): InputContent < Abort[AIGenException] =
+        Json.decode[Structure.Value](call.arguments) match
+            case Result.Success(arguments) =>
+                InputContent(
+                    "tool_use",
+                    id = Present(call.id.id),
+                    name = Present(inputToolName(call.function)),
+                    input = Present(arguments)
+                )
+            case Result.Failure(err) =>
+                Abort.fail(AIDecodeException(s"Claude Code received invalid tool-call arguments: $err\n${call.arguments}"))
+            case Result.Panic(ex) =>
+                Abort.panic(ex)
+    end inputToolCall
+
+    private def isToolError(content: String): Boolean =
+        content.contains("Tool '") && content.contains("failed:")
+
+    private def inputToolName(name: String): String =
+        if name == Completion.resultToolName || name.startsWith(mcpToolPrefix) then name
+        else s"$mcpToolPrefix$name"
+    end inputToolName
+
+    private def renderResultArguments(arguments: String)(using Frame): String =
+        Json.decode[Structure.Value](arguments) match
+            case Result.Success(Structure.Value.Record(fields)) if fields.exists(_._1 == "resultValue") =>
+                fields.collectFirst {
+                    case ("resultValue", Structure.Value.Str(raw)) =>
+                        Json.decode[Structure.Value](raw) match
+                            case Result.Success(decoded) => Json.encode(decoded)
+                            case _                       => Json.encode(Structure.Value.Str(raw))
+                    case ("resultValue", value) =>
+                        Json.encode(value)
+                }.getOrElse(arguments)
+            case Result.Success(value) =>
+                Json.encode(value)
+            case _ =>
+                arguments
+    end renderResultArguments
+
+    private def renderResultHistory(arguments: String)(using Frame): String =
+        val rendered = renderResultArguments(arguments)
+        Json.decode[Structure.Value](rendered) match
+            case Result.Success(Structure.Value.Record(fields)) =>
+                val assignments = fields.map { (name, value) =>
+                    s"$name = ${renderScalar(value)}"
+                }.mkString("\n")
+                p"""
+                    Kyo history record for one previous assistant result. Use it only when the current user asks for prior values.
+                    Do not replay this record. Do not include this record in a future answer unless the current user asks for these exact fields.
+                    Exact JSON:
+                    $rendered
+                    Exact fields:
+                    $assignments
+                """
+            case _ =>
+                p"""
+                    Kyo history record for one previous assistant result. Use it only when the current user asks for prior values.
+                    Do not replay this record. Do not include this record in a future answer unless the current user asks for this exact value.
+                    Exact JSON:
+                    $rendered
+                """
+        end match
+    end renderResultHistory
+
+    private def renderScalar(value: Structure.Value)(using Frame): String =
+        value match
+            case Structure.Value.Str(value)     => value
+            case Structure.Value.Bool(value)    => value.toString
+            case Structure.Value.Integer(value) => value.toString
+            case Structure.Value.Decimal(value) => value.toString
+            case other                          => Json.encode(other)
+    end renderScalar
+
+    private def emitProcessFragments(proc: Process)(using Frame): Unit < (Emit[Chunk[String]] & Async & Scope & Abort[AIStreamException]) =
+        stdoutLines(proc).fold((Absent: Maybe[String], Chunk.empty[String])) { case ((fragment, output), line) =>
+            outputFragment(line) match
+                case Result.Success(Present(next)) =>
+                    Kyo.lift((Present(next), output.append(line)))
+                case Result.Success(Absent) =>
+                    Kyo.lift((fragment, output.append(line)))
+                case Result.Failure(err) =>
+                    Abort.fail(AIStreamDeltaException(err))
+                case Result.Panic(ex) =>
+                    Abort.panic(ex)
+        }.map { case (fragment, output) =>
+            proc.waitFor.map { code =>
+                if !code.isSuccess then
+                    Abort.fail(streamFailure(s"exited with ${code.toInt}: ${output.mkString("\n")}"))
+                else
+                    fragment match
+                        case Present(value) => Emit.value(Chunk(value))
+                        case Absent         => Abort.fail(AIStreamIncompleteException(output.mkString("\n")))
+            }
+        }
+    end emitProcessFragments
+
+    private def stdoutLines(proc: Process)(using Frame): Stream[String, Sync & Scope] =
+        Stream[String, Sync & Scope] {
+            proc.stdout
+                .mapChunkPure(bytes => Chunk(String(bytes.toArray)))
+                .fold("") { (buffer, text) =>
+                    val next  = buffer + text
+                    val parts = next.split("\n", -1).toIndexedSeq
+                    val ready = Chunk.from(parts.dropRight(1).map(_.trim).filter(_.nonEmpty))
+                    val rest  = parts.lastOption.getOrElse("")
+                    if ready.isEmpty then rest
+                    else Emit.value(ready).andThen(rest)
+                }.map { rest =>
+                    val trimmed = rest.trim
+                    if trimmed.nonEmpty then Emit.value(Chunk(trimmed))
+                    else Kyo.unit
+                }
+        }
+    end stdoutLines
+
+    private def outputFragment(line: String)(using Frame): Result[String, Maybe[String]] =
+        Json.decode[OutputEvent](line) match
+            case Result.Success(event) =>
+                Result.Success(event.result.map(resultFragment))
+            case Result.Failure(err) =>
+                Result.Failure(s"Claude Code emitted malformed stream-json: $err\n$line")
+            case Result.Panic(ex) =>
+                Result.Panic(ex)
+    end outputFragment
+
+    private def resultFragment(raw: String)(using Frame): String =
+        Json.decode[Structure.Value](raw) match
+            case Result.Success(_) => raw
+            case _ =>
+                Json.encode(Structure.Value.Record(Chunk("resultValue" -> Structure.Value.Str(raw))))
+    end resultFragment
+
+    private[kyo] def readMessages(output: String)(using Frame): Chunk[Message] < Abort[AIGenException] =
+        readMessages(output, Chunk.empty)
+
+    private def readMessages(output: String, executedTools: Chunk[ExecutedTool])(using Frame): Chunk[Message] < Abort[AIGenException] =
+        readEvents(output).map { parsed =>
+            val structuredOutput = parsed.reverse.flatMap(_.message.toList).flatMap(_.content).collectFirst {
+                case MessageContent("tool_use", _, _, Present("StructuredOutput"), Present(input), _, _, _) => Json.encode(input)
+            }
+            val transcript = transcriptMessages(parsed, executedTools)
+            parsed.reverse.collectFirst { case e if e.result.nonEmpty => e.result.get } match
+                case Some(result) =>
+                    resultOutput(result).map(transcript.concat)
+                case None if structuredOutput.nonEmpty =>
+                    resultOutput(structuredOutput.get).map(transcript.concat)
+                case None =>
+                    parsed.reverse.flatMap(_.message.toList).headOption match
+                        case Some(message) =>
+                            val text = message.content.collect { case MessageContent("text", _, Present(text), _, _, _, _, _) =>
+                                text
+                            }.mkString
+                            val calls = message.content.collect {
+                                case MessageContent("tool_use", Present(id), _, Present(name), Present(input), _, _, _)
+                                    if name != "StructuredOutput" =>
+                                    val toolName = kyoToolName(name)
+                                    val arguments =
+                                        if toolName == Completion.resultToolName then resultEnvelope(input)
+                                        else input
+                                    Call(CallId(id), toolName, Json.encode(arguments))
+                            }
+                            if calls.nonEmpty then
+                                transcriptMessages(Chunk(OutputEvent("assistant", message = Present(message))), executedTools)
+                            else if text.nonEmpty then resultOutput(text)
+                            else Abort.fail(AIDecodeException(s"Claude Code emitted no result message: $output"))
+                            end if
+                        case None =>
+                            Abort.fail(AIDecodeException(s"Claude Code emitted no result message: $output"))
+            end match
+        }
+    end readMessages
+
+    private def transcriptMessages(events: Chunk[OutputEvent], executedTools: Chunk[ExecutedTool])(using Frame): Chunk[Message] =
+        val (unmatched, messages) = events.foldLeft((executedTools, Chunk.empty[Message])) { case ((executed, out), event) =>
+            event.message match
+                case Present(message) if message.role == Role.Assistant.name =>
+                    val text = message.content.collect { case MessageContent("text", _, Present(text), _, _, _, _, _) => text }.mkString
+                    val (remaining, calls, toolMessages) =
+                        message.content.foldLeft((executed, Chunk.empty[Call], Chunk.empty[ToolMessage])) {
+                            case (
+                                    (remaining, calls, tools),
+                                    MessageContent("tool_use", Present(id), _, Present(name), Present(input), _, _, _)
+                                )
+                                if name != "StructuredOutput" =>
+                                val toolName = kyoToolName(name)
+                                val arguments =
+                                    if toolName == Completion.resultToolName then resultEnvelope(input)
+                                    else input
+                                val call = Call(CallId(id), toolName, Json.encode(arguments))
+                                if toolName == Completion.resultToolName then
+                                    (remaining, calls.append(call), tools)
+                                else
+                                    matchExecutedTool(toolName, input, remaining) match
+                                        case Present((executedTool, nextRemaining)) =>
+                                            (nextRemaining, calls.append(call), tools.append(ToolMessage(call.id, executedTool.output)))
+                                        case Absent =>
+                                            (remaining, calls.append(call), tools)
+                                    end match
+                                end if
+                            case (state, _) =>
+                                state
+                        }
+                    val next =
+                        if calls.nonEmpty then out.append(AssistantMessage(text, calls)).concat(toolMessages)
+                        else out
+                    (remaining, next)
+                case Present(message) if message.role == Role.User.name =>
+                    val toolMessages = Chunk.from(message.content.collect {
+                        case MessageContent("tool_result", _, _, _, _, Present(callId), Present(content), _) =>
+                            ToolMessage(CallId(callId), content)
+                    })
+                    (executed, out.concat(toolMessages))
+                case _ =>
+                    (executed, out)
+        }
+        messages.concat(syntheticToolMessages(unmatched))
+    end transcriptMessages
+
+    private def syntheticToolMessages(executedTools: Chunk[ExecutedTool])(using Frame): Chunk[Message] =
+        executedTools.zipWithIndex.flatMap { case (tool, index) =>
+            val call = Call(CallId(s"mcp-${tool.name}-$index"), tool.name, Json.encode(tool.arguments))
+            Chunk(
+                AssistantMessage("", Chunk(call)),
+                ToolMessage(call.id, tool.output)
+            )
+        }
+    end syntheticToolMessages
+
+    private def matchExecutedTool(
+        name: String,
+        arguments: Structure.Value,
+        executedTools: Chunk[ExecutedTool]
+    ): Maybe[(ExecutedTool, Chunk[ExecutedTool])] =
+        Maybe.fromOption(executedTools.zipWithIndex.collectFirst {
+            case (tool, index) if tool.name == name && tool.arguments == arguments =>
+                tool -> executedTools.take(index).concat(executedTools.drop(index + 1))
+        })
+    end matchExecutedTool
+
+    private def kyoToolName(name: String): String =
+        if name.startsWith(mcpToolPrefix) then name.drop(mcpToolPrefix.length) else name
+
+    private def resultEnvelope(value: Structure.Value)(using Frame): Structure.Value =
+        value match
+            case Structure.Value.Record(fields) if fields.exists(_._1 == "resultValue") =>
+                Structure.Value.Record(fields.map {
+                    case ("resultValue", Structure.Value.Str(raw)) =>
+                        Json.decode[Structure.Value](raw) match
+                            case Result.Success(decoded) => "resultValue" -> decoded
+                            case _                       => "resultValue" -> Structure.Value.Str(raw)
+                    case field => field
+                })
+            case Structure.Value.Record(Chunk(("Valueresult", value))) =>
+                Structure.Value.Record(Chunk("resultValue" -> value))
+            case _ => Structure.Value.Record(Chunk("resultValue" -> value))
+    end resultEnvelope
+
+    private def readEvents(output: String)(using Frame): Chunk[OutputEvent] < Abort[AIGenException] =
+        val lines = Chunk.from(output.linesIterator.toList.filter(_.trim.nonEmpty))
+        Kyo.foreach(lines) { line =>
+            Json.decode[OutputEvent](line) match
+                case Result.Success(event) => event
+                case Result.Failure(err)   => Abort.fail(AIDecodeException(s"Claude Code emitted malformed stream-json: $err\n$line"))
+                case Result.Panic(ex)      => Abort.panic(ex)
+        }
+    end readEvents
+
+end ClaudeCodeCompletion

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexCompletion.scala
@@ -1,0 +1,978 @@
+package kyo.ai.completion
+
+import java.nio.charset.StandardCharsets
+import kyo.*
+import kyo.Json
+import kyo.Json.JsonSchema
+import kyo.Schema
+import kyo.Tool
+import kyo.ai.*
+import kyo.ai.Context.*
+
+/** Codex app-server completion adapter.
+  *
+  * Codex is driven through the app-server protocol so the CLI account transport is used while Kyo supplies
+  * model-visible history with native Responses API items. The adapter
+  * starts an ephemeral thread in an isolated temp cwd, injects prior non-system messages with
+  * `thread/inject_items`, starts a turn with `turn/start`, then consumes the `item/completed` turn events
+  * until `turn/completed`.
+  */
+private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
+
+    private case class RpcEvent(method: String, params: Structure.Value)
+    private enum OutputText:
+        case Delta(text: String)
+        case Completed(text: String)
+
+    private enum TurnResult:
+        case Output(text: String)
+        case ToolCall(call: Call)
+
+    private val stderrTailMax = 8192
+
+    private case class OutputMode(
+        schema: Structure.Value,
+        read: String => Chunk[Message] < Abort[AIGenException]
+    )
+
+    private case class ClientInfo(name: String, version: String) derives Schema
+    private case class ClientCapabilities(experimentalApi: Boolean) derives Schema
+    private case class InitializeParams(clientInfo: ClientInfo, capabilities: ClientCapabilities) derives Schema
+
+    private case class CodexFeatures(plugins: Boolean, apps: Boolean, shell_tool: Boolean) derives Schema
+    private case class CodexServerConfig(
+        features: CodexFeatures,
+        plugins: Map[String, Boolean],
+        skills: Map[String, Boolean],
+        marketplaces: Map[String, Boolean],
+        web_search: String
+    ) derives Schema
+    private case class ThreadStartParams(
+        model: Maybe[String],
+        cwd: Maybe[String],
+        ephemeral: Boolean,
+        experimentalRawEvents: Boolean,
+        baseInstructions: String,
+        developerInstructions: String,
+        approvalPolicy: String,
+        sandbox: String,
+        config: CodexServerConfig
+    ) derives Schema
+    private case class ThreadId(id: String) derives Schema
+    private case class ThreadStartResponse(thread: ThreadId) derives Schema
+    private case class ThreadInjectItemsParams(threadId: String, items: List[Structure.Value]) derives Schema
+    private case class TurnInput(`type`: String, text: Maybe[String] = Absent, url: Maybe[String] = Absent) derives Schema
+    private case class TurnStartParams(
+        threadId: String,
+        input: List[TurnInput],
+        outputSchema: Structure.Value,
+        model: Maybe[String],
+        cwd: Maybe[String],
+        approvalPolicy: String
+    ) derives Schema
+    private case class TurnId(id: String) derives Schema
+    private case class TurnStartResponse(turn: TurnId) derives Schema
+    private case class ThreadStatus(`type`: String) derives Schema
+    private case class ThreadStatusChangedNotification(threadId: String, status: ThreadStatus) derives Schema
+    private case class AgentMessageDeltaNotification(threadId: String, turnId: String, delta: String) derives Schema
+    private case class HarnessTool(name: String, description: String, inputSchema: Structure.Value) derives Schema
+    private case class HarnessCall(id: String, function: String, arguments: Structure.Value) derives Schema
+    private case class HarnessAssistantMessage(content: String, calls: List[HarnessCall]) derives Schema
+    private case class HarnessOutput(messages: List[HarnessAssistantMessage]) derives Schema
+
+    private case class ContentItem(
+        `type`: String,
+        text: Maybe[String] = Absent,
+        image_url: Maybe[String] = Absent
+    ) derives Schema
+    private case class ResponseHistoryItem(
+        `type`: String,
+        role: Maybe[String] = Absent,
+        content: Maybe[List[ContentItem]] = Absent,
+        call_id: Maybe[String] = Absent,
+        name: Maybe[String] = Absent,
+        arguments: Maybe[String] = Absent,
+        output: Maybe[String] = Absent
+    ) derives Schema
+    private case class ThreadItem(
+        `type`: String,
+        text: Maybe[String] = Absent,
+        id: Maybe[String] = Absent,
+        namespace: Maybe[String] = Absent,
+        tool: Maybe[String] = Absent,
+        arguments: Maybe[Structure.Value] = Absent
+    ) derives Schema
+    private case class ItemCompletedNotification(threadId: String, turnId: String, item: ThreadItem) derives Schema
+    private case class ResponseItem(`type`: String, role: Maybe[String] = Absent, content: Maybe[List[ContentItem]] = Absent)
+        derives Schema
+    private case class RawResponseItemCompletedNotification(threadId: String, turnId: String, item: ResponseItem) derives Schema
+
+    private val disabledFeatures =
+        Chunk(
+            "plugins",
+            "apps",
+            "shell_tool",
+            "browser_use",
+            "computer_use",
+            "unified_exec",
+            "workspace_dependencies",
+            "tool_suggest",
+            "multi_agent",
+            "hooks"
+        )
+
+    override def streamFragments(
+        config: Config,
+        context: Context,
+        resultSchema: JsonSchema,
+        resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
+    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
+        Kyo.lift(Stream[String, Async & Scope & Abort[AIStreamException]] {
+            Abort.run[
+                CommandException | FileFsException | FileReadException | FileWriteException | JsonRpcError | AIGenException | Closed
+            ] {
+                withSession { (workDir, handler, events, stderrTail) =>
+                    for
+                        thread <- requestAs[ThreadStartResponse, ThreadStartParams](
+                            handler,
+                            "thread/start",
+                            threadStartParams(config, context, resultTool, workDir, appServerSchema(resultSchema))
+                        )
+                        items <- historyItems(historyMessages(context))
+                        _ <-
+                            if items.isEmpty then Kyo.unit
+                            else
+                                requestAs[Structure.Value, ThreadInjectItemsParams](
+                                    handler,
+                                    "thread/inject_items",
+                                    ThreadInjectItemsParams(thread.thread.id, items.toList)
+                                ).unit
+                        turn <- requestAs[TurnStartResponse, TurnStartParams](
+                            handler,
+                            "turn/start",
+                            turnStartParams(config, thread.thread.id, workDir, appServerSchema(resultSchema), turnInput(context))
+                        )
+                        _ <- emitTurnFragments(events, thread.thread.id, turn.turn.id, stderrTail)
+                    yield ()
+                }
+            }.map {
+                case Result.Success(_)                     => Kyo.unit
+                case Result.Failure(ex: AIStreamException) => Abort.fail(ex)
+                case Result.Failure(ex: AIGenException)    => Abort.fail(streamFailure(ex.getMessage))
+                case Result.Failure(_: Closed) => Abort.fail(AIStreamDeltaException("Codex app-server closed before completing the turn"))
+                case Result.Failure(ex: JsonRpcError) => Abort.fail(streamFailure(s"${ex.code}: ${ex.message}"))
+                case Result.Failure(ex)               => Abort.fail(streamFailure(ex.getMessage))
+                case Result.Panic(ex)                 => Abort.panic(ex)
+            }
+        })
+    end streamFragments
+
+    protected def run(
+        config: Config,
+        context: Context,
+        tools: Chunk[Tool.internal.Info[?, ?, LLM]],
+        resultSchema: JsonSchema
+    )(using
+        Frame
+    ): Chunk[Message] < (LLM & Async & Abort[AIGenException]) =
+        Scope.run(Abort.run[
+            CommandException | FileFsException | FileReadException | FileWriteException | JsonRpcError | AIGenException | Closed
+        ] {
+            withSession { (workDir, handler, events, stderrTail) =>
+                for
+                    outputMode = outputModeFor(tools, resultSchema)
+                    thread <- requestAs[ThreadStartResponse, ThreadStartParams](
+                        handler,
+                        "thread/start",
+                        threadStartParams(config, context, tools, workDir, outputMode.schema)
+                    )
+                    items <- historyItems(historyMessages(context))
+                    _ <-
+                        if items.isEmpty then Kyo.unit
+                        else
+                            requestAs[Structure.Value, ThreadInjectItemsParams](
+                                handler,
+                                "thread/inject_items",
+                                ThreadInjectItemsParams(thread.thread.id, items.toList)
+                            ).unit
+                    turn <- requestAs[TurnStartResponse, TurnStartParams](
+                        handler,
+                        "turn/start",
+                        turnStartParams(
+                            config,
+                            thread.thread.id,
+                            workDir,
+                            outputMode.schema,
+                            turnInput(context)
+                        )
+                    )
+                    result <- Async.timeoutWithError[AIGenException | Closed, TurnResult, Any](
+                        config.timeout,
+                        Result.Failure(AIProviderUnavailableException("Codex", "turn timed out waiting for app-server completion"))
+                    )(collectTurnResult(events, thread.thread.id, turn.turn.id, stderrTail))
+                    out <- result match
+                        case TurnResult.Output(raw)    => outputMode.read(raw)
+                        case TurnResult.ToolCall(call) => Kyo.lift(Chunk(AssistantMessage("", Chunk(call))))
+                yield out
+            }
+        }).map {
+            case Result.Success(messages)           => messages
+            case Result.Failure(ex: AIGenException) => Abort.fail(ex)
+            case Result.Failure(_: Closed)          => Abort.fail(AIDecodeException("Codex app-server closed before completing the turn"))
+            case Result.Failure(ex: JsonRpcError)   => Abort.fail(commandFailure(s"${ex.code}: ${ex.message}"))
+            case Result.Failure(ex)                 => Abort.fail(commandFailure(ex.getMessage))
+            case Result.Panic(ex)                   => Abort.panic(ex)
+        }
+    end run
+
+    private def withSession[A, S](
+        f: (Path, JsonRpcHandler, Channel[RpcEvent], AtomicRef[String]) => A < S
+    )(using
+        Frame
+    ): A < (S & Async & Scope & Abort[
+        CommandException | FileFsException | FileReadException | FileWriteException | JsonRpcError | Closed
+    ]) =
+        for
+            rawWorkDir <- Path.tempDir("kyo-ai-codex-cwd")
+            workDir    <- Scope.acquireRelease(rawWorkDir)(path => Abort.run[FileFsException](path.removeAll).unit)
+            codexHome  <- isolatedCodexHome
+            proc       <- appServerCommand(workDir, codexHome).spawn
+            stderrTail <- AtomicRef.init("")
+            _          <- Fiber.init(Scope.run(captureStderr(proc, stderrTail)))
+            events     <- Channel.init[RpcEvent](1024)
+            transport  <- JsonRpcTransport.fromWire(processWire(proc), JsonRpcFramer.lineDelimited)
+            handler    <- JsonRpcHandler.init(transport, eventRoutes(events))
+            _ <- requestAs[Structure.Value, InitializeParams](
+                handler,
+                "initialize",
+                InitializeParams(ClientInfo("kyo-ai", "0"), ClientCapabilities(experimentalApi = true))
+            )
+            _      <- handler.notify("initialized", Structure.Value.Record(Chunk.empty))
+            result <- f(workDir, handler, events, stderrTail)
+        yield result
+    end withSession
+
+    private def captureStderr(proc: Process, tail: AtomicRef[String])(using Frame): Unit < (Sync & Scope) =
+        proc.stderr.foreachChunk { bytes =>
+            val text = new String(bytes.toArray, StandardCharsets.UTF_8)
+            tail.updateAndGet(previous => truncateStderr(previous + text)).unit
+        }
+    end captureStderr
+
+    private def truncateStderr(text: String): String =
+        if text.length <= stderrTailMax then text
+        else text.takeRight(stderrTailMax)
+    end truncateStderr
+
+    private def appServerCommand(workDir: Path, codexHome: Path): Command =
+        Command((Chunk("codex", "app-server", "--stdio", "--strict-config") ++ disabledFeatures.flatMap(f => Chunk("--disable", f)))*)
+            .cwd(workDir)
+            .envAppend(Map("CODEX_HOME" -> codexHome.toString))
+            .pipeStdin
+    end appServerCommand
+
+    private def isolatedCodexHome(using
+        Frame
+    ): Path < (Sync & Scope & Abort[FileFsException | FileReadException | FileWriteException]) =
+        for
+            rawIsolated <- Path.tempDir("kyo-ai-codex-home")
+            isolated    <- Scope.acquireRelease(rawIsolated)(path => Abort.run[FileFsException](path.removeAll).unit)
+            real        <- realCodexHome
+            auth   = real / "auth.json"
+            config = real / "config.toml"
+            hasAuth   <- auth.exists
+            hasConfig <- config.exists
+            _         <- if hasAuth then auth.copy(isolated / "auth.json") else Kyo.unit
+            _         <- if hasConfig then config.copy(isolated / "config.toml") else Kyo.unit
+        yield isolated
+    end isolatedCodexHome
+
+    private def realCodexHome(using Frame): Path < Sync =
+        for
+            env         <- System.env[String]("CODEX_HOME")
+            property    <- System.property[String]("user.home")
+            home        <- System.env[String]("HOME")
+            userProfile <- System.env[String]("USERPROFILE")
+        yield env match
+            case Present(path) => Path(path)
+            case Absent =>
+                val path = property.orElse(home).orElse(userProfile).getOrElse("")
+                if path.isEmpty then Path(".codex")
+                else Path(path) / ".codex"
+    end realCodexHome
+
+    private def threadStartParams(
+        config: Config,
+        context: Context,
+        tools: Chunk[Tool.internal.Info[?, ?, LLM]],
+        workDir: Path,
+        schema: Structure.Value
+    )(using Frame): ThreadStartParams =
+        ThreadStartParams(
+            model = modelOverride(config),
+            cwd = Present(workDir.toString),
+            ephemeral = true,
+            experimentalRawEvents = true,
+            baseInstructions = outputInstructions(context, tools, schema),
+            developerInstructions = "Use only the injected conversation history and return only the requested structured output.",
+            approvalPolicy = "never",
+            sandbox = "read-only",
+            config = CodexServerConfig(
+                features = CodexFeatures(plugins = false, apps = false, shell_tool = false),
+                plugins = Map.empty,
+                skills = Map.empty,
+                marketplaces = Map.empty,
+                web_search = "disabled"
+            )
+        )
+    end threadStartParams
+
+    private def turnStartParams(
+        config: Config,
+        threadId: String,
+        workDir: Path,
+        schema: Structure.Value,
+        input: Chunk[TurnInput]
+    )(using Frame): TurnStartParams =
+        TurnStartParams(
+            threadId = threadId,
+            input = input.toList,
+            outputSchema = schema,
+            model = modelOverride(config),
+            cwd = Present(workDir.toString),
+            approvalPolicy = "never"
+        )
+
+    private[kyo] def closedSchema(schema: JsonSchema)(using Frame): Structure.Value =
+        closeObjects(Structure.encode(schema))
+
+    private[kyo] def appServerSchema(schema: JsonSchema)(using Frame): Structure.Value =
+        appServerCompatible(closedSchema(schema))
+
+    private def appServerCompatible(value: Structure.Value): Structure.Value =
+        value match
+            case Structure.Value.Record(fields) =>
+                val nullable = fields.collectFirst {
+                    case ("oneOf", Structure.Value.Sequence(values)) =>
+                        val nonNull = values.filterNot(isNullSchema)
+                        if nonNull.size == 1 then Present(appServerCompatible(nonNull.head))
+                        else Absent
+                }
+                nullable match
+                    case Some(Present(value)) => value
+                    case _ =>
+                        val mapped = fields.map((name, value) => name -> appServerCompatible(value))
+                        if isOpenMapObject(mapped) then
+                            Structure.Value.Record(mapped.map {
+                                case ("additionalProperties", _) => "additionalProperties" -> Structure.Value.Bool(true)
+                                case field                       => field
+                            })
+                        else Structure.Value.Record(mapped)
+                        end if
+                end match
+            case Structure.Value.Sequence(values) =>
+                Structure.Value.Sequence(values.map(appServerCompatible))
+            case Structure.Value.MapEntries(entries) =>
+                Structure.Value.MapEntries(entries.map((k, v) => appServerCompatible(k) -> appServerCompatible(v)))
+            case other =>
+                other
+        end match
+    end appServerCompatible
+
+    private def isNullSchema(value: Structure.Value): Boolean =
+        value match
+            case Structure.Value.Record(fields) =>
+                fields.exists {
+                    case ("type", Structure.Value.Str("null")) => true
+                    case _                                     => false
+                }
+            case _ => false
+        end match
+    end isNullSchema
+
+    private def isOpenMapObject(fields: Chunk[(String, Structure.Value)]): Boolean =
+        val byName = fields.iterator.toMap
+        byName.get("type").contains(Structure.Value.Str("object")) &&
+        byName.get("properties").contains(Structure.Value.Record(Chunk.empty)) &&
+        byName.get("additionalProperties").exists(_ != Structure.Value.Bool(false))
+    end isOpenMapObject
+
+    private def closeObjects(value: Structure.Value): Structure.Value =
+        value match
+            case Structure.Value.Record(fields) =>
+                val closedFields =
+                    if fields.exists(_._1 == "type") && fields.exists {
+                            case ("type", Structure.Value.Str("object")) => true
+                            case _                                       => false
+                        }
+                    then
+                        if fields.exists(_._1 == "additionalProperties") then fields
+                        else fields.append("additionalProperties" -> Structure.Value.Bool(false))
+                    else fields
+                Structure.Value.Record(closedFields.map((name, value) => name -> closeObjects(value)))
+            case Structure.Value.Sequence(values) =>
+                Structure.Value.Sequence(values.map(closeObjects))
+            case Structure.Value.MapEntries(entries) =>
+                Structure.Value.MapEntries(entries.map((k, v) => closeObjects(k) -> closeObjects(v)))
+            case other =>
+                other
+        end match
+    end closeObjects
+
+    private def outputModeFor(
+        tools: Chunk[Tool.internal.Info[?, ?, LLM]],
+        resultSchema: JsonSchema
+    )(using Frame): OutputMode =
+        val userTools = tools.filterNot(_.name == Completion.resultToolName)
+        if userTools.nonEmpty then
+            OutputMode(toolCallOutputSchema(tools, resultSchema), raw => readStructuredOutput(raw))
+        else
+            OutputMode(stringifiedResultSchema(closedSchema(resultSchema)), raw => resultOutput(raw))
+        end if
+    end outputModeFor
+
+    private def toolCallOutputSchema(tools: Chunk[Tool.internal.Info[?, ?, LLM]], resultSchema: JsonSchema)(using
+        Frame
+    ): Structure.Value =
+        val callSchema = anyOfSchema(tools.map { tool =>
+            callObjectSchema(
+                enumSchema(tool.name),
+                if tool.name == Completion.resultToolName then
+                    val schema = closedSchema(resultSchema)
+                    if hasDynamicMap(schema) then stringifiedResultSchema(schema)
+                    else appServerCompatible(schema)
+                else
+                    val schema = appServerSchema(Json.jsonSchema(using tool.inputSchema.asInstanceOf[Schema[Any]]))
+                    if hasDynamicMap(schema) then stringifiedJsonSchema(schema)
+                    else schema
+            )
+        })
+        objectSchema(
+            Chunk(
+                "messages" -> arraySchema(objectSchema(
+                    Chunk(
+                        "content" -> stringSchema,
+                        "calls"   -> arraySchema(callSchema)
+                    ),
+                    Chunk("content", "calls")
+                ))
+            ),
+            Chunk("messages")
+        )
+    end toolCallOutputSchema
+
+    private def callObjectSchema(functionSchema: Structure.Value, argumentsSchema: Structure.Value): Structure.Value =
+        objectSchema(
+            Chunk(
+                "id"        -> stringSchema,
+                "function"  -> functionSchema,
+                "arguments" -> argumentsSchema
+            ),
+            Chunk("id", "function", "arguments")
+        )
+
+    private def stringSchema: Structure.Value =
+        Structure.Value.Record(Chunk("type" -> Structure.Value.Str("string")))
+
+    private def enumSchema(value: String): Structure.Value =
+        Structure.Value.Record(Chunk(
+            "type" -> Structure.Value.Str("string"),
+            "enum" -> Structure.Value.Sequence(Chunk(Structure.Value.Str(value)))
+        ))
+
+    private def anyOfSchema(values: Chunk[Structure.Value]): Structure.Value =
+        Structure.Value.Record(Chunk("anyOf" -> Structure.Value.Sequence(values)))
+
+    private def arraySchema(items: Structure.Value): Structure.Value =
+        Structure.Value.Record(Chunk(
+            "type"  -> Structure.Value.Str("array"),
+            "items" -> items
+        ))
+
+    private def objectSchema(properties: Chunk[(String, Structure.Value)], required: Chunk[String]): Structure.Value =
+        Structure.Value.Record(Chunk(
+            "type"                 -> Structure.Value.Str("object"),
+            "properties"           -> Structure.Value.Record(properties),
+            "required"             -> Structure.Value.Sequence(required.map(Structure.Value.Str(_))),
+            "additionalProperties" -> Structure.Value.Bool(false)
+        ))
+
+    private def stringifiedResultSchema(realSchema: Structure.Value)(using Frame): Structure.Value =
+        objectSchema(
+            Chunk(
+                "resultValue" -> stringifiedJsonSchema(realSchema)
+            ),
+            Chunk("resultValue")
+        )
+    end stringifiedResultSchema
+
+    private def stringifiedJsonSchema(realSchema: Structure.Value)(using Frame): Structure.Value =
+        Structure.Value.Record(Chunk(
+            "type" -> Structure.Value.Str("string"),
+            "description" -> Structure.Value.Str(
+                s"JSON string whose parsed value matches this schema: ${Json.encode(realSchema)}"
+            )
+        ))
+    end stringifiedJsonSchema
+
+    private def hasDynamicMap(value: Structure.Value): Boolean =
+        value match
+            case Structure.Value.Record(fields) =>
+                isOpenMapObject(fields) || fields.exists((_, value) => hasDynamicMap(value))
+            case Structure.Value.Sequence(values) =>
+                values.exists(hasDynamicMap)
+            case Structure.Value.MapEntries(entries) =>
+                entries.exists((k, v) => hasDynamicMap(k) || hasDynamicMap(v))
+            case _ =>
+                false
+        end match
+    end hasDynamicMap
+
+    private def outputInstructions(
+        context: Context,
+        tools: Chunk[Tool.internal.Info[?, ?, LLM]],
+        schema: Structure.Value
+    )(using Frame): String =
+        val userTools = tools.filterNot(_.name == Completion.resultToolName)
+        val finishingToolResult = conversationMessages(context).lastMaybe.exists {
+            case ToolMessage(_, content) => isSuccessfulToolResult(content)
+            case _                       => false
+        }
+        val toolSpecs = userTools.map { tool =>
+            HarnessTool(
+                tool.name,
+                tool.description,
+                appServerSchema(Json.jsonSchema(using tool.inputSchema.asInstanceOf[Schema[Any]]))
+            )
+        }
+        val instruction =
+            if userTools.nonEmpty && finishingToolResult then
+                p"""
+                    Return only JSON matching this output schema:
+                    ${Json.encode(schema)}
+                    The JSON contains assistant messages in order.
+                    The latest conversation item is a successful Kyo tool result for the current request.
+                    Use that tool result to answer. Do not call any Kyo tool except '${Completion.resultToolName}'.
+                    Call '${Completion.resultToolName}' with the final result arguments.
+                """
+            else if userTools.nonEmpty then
+                p"""
+                    Return only JSON matching this output schema:
+                    ${Json.encode(schema)}
+                    The JSON contains assistant messages in order.
+                    Each assistant message may contain text content and tool calls.
+                    If an available Kyo tool is needed, return that tool call and wait for Kyo to execute it.
+                    Kyo executes the tool and sends the result back in a later turn.
+                    If conversation history already contains a function_call_output for the current request, use that output and do not call the same tool again.
+                    If no Kyo tool is needed, call '${Completion.resultToolName}' with the final result arguments.
+                    Available Kyo tools:
+                    ${Json.encode(toolSpecs.toList)}
+                """
+            else
+                p"""
+                    Return only JSON matching this output schema:
+                    ${Json.encode(schema)}
+                    Include every required property using the exact property name from the schema.
+                    When the schema contains a top-level property named 'resultValue', the response object must contain that exact property name.
+                    Put a valid JSON string inside 'resultValue'. The parsed string must match the schema described by the 'resultValue' property.
+                    Never create property names from words in the user's request or answer.
+                    Do not rename, abbreviate, split, merge, or omit schema properties.
+                    Use the native injected conversation history and current turn input.
+                """
+        (context.messages.collect { case SystemMessage(content) => content } :+ instruction).mkString("\n\n")
+    end outputInstructions
+
+    private def isSuccessfulToolResult(content: String): Boolean =
+        !content.contains("Tool '") || !content.contains("failed:")
+    end isSuccessfulToolResult
+
+    private def historyMessages(context: Context): Chunk[Message] =
+        val messages = conversationMessages(context)
+        messages.lastMaybe match
+            case Present(_: UserMessage) => messages.dropRight(1)
+            case _                       => messages
+    end historyMessages
+
+    private def turnInput(context: Context): Chunk[TurnInput] =
+        conversationMessages(context).lastMaybe match
+            case Present(UserMessage(content, image)) =>
+                Chunk(TurnInput("text", text = Present(content))).concat(
+                    image.map(img => Chunk(TurnInput("image", url = Present(s"data:image/jpeg;base64,${img.base64}")))).getOrElse(
+                        Chunk.empty
+                    )
+                )
+            case _ =>
+                Chunk(TurnInput("text", text = Present("Continue.")))
+        end match
+    end turnInput
+
+    private def conversationMessages(context: Context): Chunk[Message] =
+        context.messages.filterNot(_.role == Role.System)
+
+    private def modelOverride(config: Config): Maybe[String] =
+        if config.modelName.isEmpty then Absent else Present(config.modelName)
+
+    private[kyo] def historyItems(messages: Chunk[Message])(using Frame): Chunk[Structure.Value] < Abort[AIGenException] =
+        Kyo.foreach(messages.filterNot(_.role == Role.System)) {
+            case UserMessage(content, image) =>
+                val blocks =
+                    List(ContentItem("input_text", text = Present(content))) ++
+                        image.toList.map(img => ContentItem("input_image", image_url = Present(s"data:image/jpeg;base64,${img.base64}")))
+                Chunk(Structure.encode(ResponseHistoryItem("message", role = Present("user"), content = Present(blocks))))
+            case AssistantMessage(content, calls) =>
+                Kyo.foreach(calls) { call =>
+                    Json.decode[Structure.Value](call.arguments) match
+                        case Result.Success(_) =>
+                            Structure.encode(ResponseHistoryItem(
+                                "function_call",
+                                call_id = Present(call.id.id),
+                                name = Present(call.function),
+                                arguments = Present(call.arguments)
+                            ))
+                        case Result.Failure(err) =>
+                            Abort.fail(AIDecodeException(s"Codex received invalid tool-call arguments: $err\n${call.arguments}"))
+                        case Result.Panic(ex) =>
+                            Abort.panic(ex)
+                }.map { callItems =>
+                    val textItem =
+                        if content.nonEmpty then
+                            Chunk(Structure.encode(ResponseHistoryItem(
+                                "message",
+                                role = Present("assistant"),
+                                content = Present(List(ContentItem("output_text", text = Present(content))))
+                            )))
+                        else Chunk.empty
+                    textItem.concat(callItems)
+                }
+            case ToolMessage(callId, content) =>
+                Chunk(Structure.encode(ResponseHistoryItem(
+                    "function_call_output",
+                    call_id = Present(callId.id),
+                    output = Present(content)
+                )))
+            case SystemMessage(_) =>
+                Chunk.empty[Structure.Value]
+        }.map(_.flattenChunk)
+    end historyItems
+
+    private def requestAs[A: Schema, P: Schema](handler: JsonRpcHandler, method: String, params: P)(using
+        Frame
+    ): A < (Async & Abort[JsonRpcError | Closed]) =
+        handler.call[P, A](method, params)
+    end requestAs
+
+    private def eventRoutes(events: Channel[RpcEvent])(using Frame): Seq[JsonRpcRoute[?, ?, ?]] =
+        Seq(
+            eventRoute(events, "item/completed"),
+            eventRoute(events, "raw_response_item/completed"),
+            eventRoute(events, "rawResponseItem/completed"),
+            eventRoute(events, "item/agentMessage/delta"),
+            eventRoute(events, "turn/completed"),
+            eventRoute(events, "thread/status/changed"),
+            eventRoute(events, "error")
+        )
+    end eventRoutes
+
+    private def eventRoute(events: Channel[RpcEvent], method: String)(using
+        Frame
+    ): JsonRpcRoute[Structure.Value, Unit, Nothing] =
+        JsonRpcRoute.notification[Structure.Value](method) { (params, _) =>
+            Abort.run[Closed](events.put(RpcEvent(method, params))).unit
+        }
+    end eventRoute
+
+    private def processWire(proc: Process)(using Frame): JsonRpcWireTransport =
+        new JsonRpcWireTransport:
+            def send(bytes: Chunk[Byte])(using Frame): Unit < (Async & Abort[Closed]) =
+                Abort.run[Throwable] {
+                    Sync.Unsafe.defer {
+                        // Unsafe: JsonRpcWireTransport needs direct access to the child process stdin.
+                        proc.unsafe.stdinJava.write(bytes.toArray)
+                        proc.unsafe.stdinJava.flush()
+                    }
+                }.map {
+                    case Result.Success(_)  => ()
+                    case Result.Failure(ex) => Abort.fail(Closed("Codex app-server", summon[Frame], ex.getMessage))
+                    case Result.Panic(ex)   => Abort.panic(ex)
+                }
+            end send
+
+            def incoming(using Frame): Stream[Chunk[Byte], Async & Abort[Closed]] =
+                proc.stdout.map(Chunk(_)).handle(Scope.run)
+
+            def close(using Frame): Unit < Async =
+                Sync.Unsafe.defer {
+                    // Unsafe: closing the process stdin is the transport shutdown boundary.
+                    proc.unsafe.stdinJava.close()
+                }.unit
+            end close
+        end new
+    end processWire
+
+    private def collectTurnResult(
+        events: Channel[RpcEvent],
+        threadId: String,
+        turnId: String,
+        stderrTail: AtomicRef[String]
+    )(using Frame): TurnResult < (Async & Abort[AIGenException | Closed]) =
+        Loop((Absent: Maybe[String], "", false, Chunk.empty[String])) { case (completed, delta, turnCompleted, recent) =>
+            if turnCompleted && completed.isDefined then
+                Loop.done(TurnResult.Output(completed.get))
+            else if turnCompleted && delta.nonEmpty then
+                Loop.done(TurnResult.Output(delta))
+            else
+                val nextEvent =
+                    if turnCompleted then
+                        Async.timeoutWithError[AIGenException | Closed, RpcEvent, Any](
+                            1.second,
+                            Result.Failure(AIDecodeException(
+                                s"Codex app-server completed without an assistant message. Recent events: ${recent.mkString(", ")}"
+                            ))
+                        )(events.take)
+                    else events.take
+                nextEvent.map { event =>
+                    val nextRecent = recent.append(eventSummary(event)).takeRight(12)
+                    if isTurnCompleted(event, threadId, turnId) then
+                        completed match
+                            case Present(text) => Loop.done(TurnResult.Output(text))
+                            case Absent if delta.nonEmpty =>
+                                Loop.done(TurnResult.Output(delta))
+                            case Absent =>
+                                Loop.continue((completed, delta, true, nextRecent))
+                    else
+                        eventResult(event, threadId, turnId).map {
+                            case Present(TurnResult.ToolCall(call)) =>
+                                Loop.done(TurnResult.ToolCall(call))
+                            case Absent =>
+                                eventText(event, threadId, turnId, stderrTail).map {
+                                    case Present(OutputText.Completed(text)) =>
+                                        Loop.continue((Present(text), delta, turnCompleted, nextRecent))
+                                    case Present(OutputText.Delta(text)) =>
+                                        Loop.continue((completed, delta + text, turnCompleted, nextRecent))
+                                    case _ =>
+                                        Loop.continue((completed, delta, turnCompleted, nextRecent))
+                                }
+                        }
+                    end if
+                }
+            end if
+        }
+    end collectTurnResult
+
+    private def emitTurnFragments(
+        events: Channel[RpcEvent],
+        threadId: String,
+        turnId: String,
+        stderrTail: AtomicRef[String]
+    )(using Frame): Unit < (Emit[Chunk[String]] & Async & Abort[AIStreamException | Closed]) =
+        Abort.recover[AIGenException](ex => Abort.fail(streamFailure(ex.getMessage))) {
+            collectTurnResult(events, threadId, turnId, stderrTail).map {
+                case TurnResult.Output(text) if text.nonEmpty =>
+                    Emit.value(Chunk(text))
+                case TurnResult.Output(_) =>
+                    Abort.fail(AIStreamIncompleteException("Codex app-server completed without a stream fragment"))
+                case TurnResult.ToolCall(call) =>
+                    Abort.fail(
+                        AIStreamDeltaException(s"Codex app-server emitted an unexpected tool call while streaming: ${call.function}")
+                    )
+            }
+        }
+    end emitTurnFragments
+
+    private def isTurnCompleted(event: RpcEvent, threadId: String, turnId: String)(using Frame): Boolean =
+        if event.method != "turn/completed" then false
+        else
+            event.params match
+                case Structure.Value.Record(fields) =>
+                    fields.iterator.toMap.get("threadId").contains(Structure.Value.Str(threadId)) &&
+                    fields.iterator.toMap.get("turn").exists {
+                        case Structure.Value.Record(turnFields) =>
+                            turnFields.iterator.toMap.get("id").contains(Structure.Value.Str(turnId))
+                        case _ => false
+                    }
+                case _ => false
+        end if
+    end isTurnCompleted
+
+    private def eventSummary(event: RpcEvent)(using Frame): String =
+        val params = Json.encode(event.params)
+        val preview =
+            if params.length <= 500 then params
+            else params.take(500) + "..."
+        s"${event.method}: $preview"
+    end eventSummary
+
+    private def eventText(
+        event: RpcEvent,
+        threadId: String,
+        turnId: String,
+        stderrTail: AtomicRef[String]
+    )(using Frame): Maybe[OutputText] < (Sync & Abort[AIGenException]) =
+        event.method match
+            case "item/completed" =>
+                decodeEvent[ItemCompletedNotification](event).map { notification =>
+                    if notification.threadId == threadId && notification.turnId == turnId && notification.item.`type` == "agentMessage" then
+                        notification.item.text.map(OutputText.Completed(_))
+                    else Absent
+                }
+            case "raw_response_item/completed" | "rawResponseItem/completed" =>
+                decodeEvent[RawResponseItemCompletedNotification](event).map { notification =>
+                    if notification.threadId == threadId && notification.turnId == turnId then
+                        val text = notification.item.content
+                            .getOrElse(Nil)
+                            .collect { case ContentItem("output_text", Present(text), _) => text }
+                            .mkString
+                        if text.nonEmpty then Present(OutputText.Completed(text)) else Absent
+                    else Absent
+                }
+            case "item/agentMessage/delta" =>
+                decodeEvent[AgentMessageDeltaNotification](event).map { notification =>
+                    if notification.threadId == threadId && notification.turnId == turnId && notification.delta.nonEmpty then
+                        Present(OutputText.Delta(notification.delta))
+                    else Absent
+                }
+            case "error" =>
+                if isRetryingError(event.params) then Absent
+                else failWithStderr(Json.encode(event.params), stderrTail)
+            case "thread/status/changed" =>
+                decodeEvent[ThreadStatusChangedNotification](event).map { notification =>
+                    if notification.threadId == threadId && notification.status.`type` == "systemError" then
+                        failWithStderr(Json.encode(event.params), stderrTail)
+                    else Absent
+                }
+            case _ =>
+                Absent
+    end eventText
+
+    private def failWithStderr(detail: String, stderrTail: AtomicRef[String])(using Frame): Nothing < (Sync & Abort[AIGenException]) =
+        stderrTail.get.map { stderr =>
+            val suffix =
+                if stderr.trim.isEmpty then ""
+                else s"\nCodex app-server stderr tail:\n${stderr.trim}"
+            Abort.fail(commandFailure(detail + suffix))
+        }
+    end failWithStderr
+
+    private def isRetryingError(params: Structure.Value): Boolean =
+        params match
+            case Structure.Value.Record(fields) =>
+                fields.iterator.toMap.get("willRetry").contains(Structure.Value.Bool(true))
+            case _ =>
+                false
+        end match
+    end isRetryingError
+
+    private def eventResult(event: RpcEvent, threadId: String, turnId: String)(using Frame): Maybe[TurnResult] < Abort[AIGenException] =
+        event.method match
+            case "item/completed" =>
+                decodeEvent[ItemCompletedNotification](event).map { notification =>
+                    val item = notification.item
+                    if notification.threadId == threadId && notification.turnId == turnId && item.`type` == "dynamicToolCall" then
+                        for
+                            id        <- item.id
+                            tool      <- item.tool
+                            arguments <- item.arguments
+                        yield TurnResult.ToolCall(Call(CallId(id), toolName(item.namespace, tool), Json.encode(arguments)))
+                    else Absent
+                    end if
+                }
+            case _ =>
+                Absent
+    end eventResult
+
+    private def toolName(namespace: Maybe[String], tool: String): String =
+        namespace match
+            case Present(ns) => s"$ns.$tool"
+            case Absent      => tool
+    end toolName
+
+    private[kyo] def readStructuredOutput(raw: String)(using Frame): Chunk[Message] < Abort[AIGenException] =
+        decodeHarnessMessages(raw) match
+            case Result.Success(messages) =>
+                if messages.isEmpty then
+                    Abort.fail(AIDecodeException(s"Codex harness output contained no messages: $raw"))
+                else
+                    Chunk.from(messages.map { message =>
+                        val calls = Chunk.from(message.calls.map { call =>
+                            Call(CallId(call.id), call.function, Json.encode(callArguments(call)))
+                        })
+                        AssistantMessage(message.content, calls)
+                    })
+            case Result.Failure(_) =>
+                resultOutput(raw)
+            case Result.Panic(ex) =>
+                Abort.panic(ex)
+    end readStructuredOutput
+
+    private def decodeHarnessMessages(raw: String)(using Frame): Result[String, List[HarnessAssistantMessage]] =
+        decodeHarnessOutput(raw) match
+            case Result.Success(output) =>
+                Result.Success(output.messages)
+            case Result.Failure(err) =>
+                val trimmed = raw.trim
+                if trimmed.startsWith("[") then
+                    decodeHarnessOutput(s"""{"messages":$trimmed}""") match
+                        case Result.Success(output) => Result.Success(output.messages)
+                        case Result.Failure(_)      => Result.Failure(err)
+                        case Result.Panic(ex)       => Result.Panic(ex)
+                else Result.Failure(err)
+                end if
+            case Result.Panic(ex) =>
+                Result.Panic(ex)
+    end decodeHarnessMessages
+
+    private def decodeHarnessOutput(raw: String)(using Frame): Result[String, HarnessOutput] =
+        Json.decode[HarnessOutput](raw) match
+            case Result.Success(output) => Result.Success(output)
+            case Result.Failure(err)    => Result.Failure(err.getMessage)
+            case Result.Panic(ex)       => Result.Panic(ex)
+    end decodeHarnessOutput
+
+    private def callArguments(call: HarnessCall)(using Frame): Structure.Value =
+        if call.function == Completion.resultToolName then resultEnvelope(call.arguments)
+        else
+            call.arguments match
+                case Structure.Value.Str(raw) =>
+                    Json.decode[Structure.Value](raw) match
+                        case Result.Success(value) => value
+                        case _                     => call.arguments
+                case _ => call.arguments
+    end callArguments
+
+    private def resultEnvelope(value: Structure.Value)(using Frame): Structure.Value =
+        value match
+            case Structure.Value.Record(fields) if fields.exists(_._1 == "resultValue") =>
+                fields.collectFirst { case ("resultValue", Structure.Value.Str(raw)) => raw } match
+                    case Some(raw) =>
+                        decodeStringifiedResult(raw) match
+                            case Result.Success(decoded @ Structure.Value.Record(decodedFields))
+                                if decodedFields.exists(_._1 == "resultValue") =>
+                                decoded
+                            case Result.Success(decoded) =>
+                                Structure.Value.Record(fields.map {
+                                    case ("resultValue", _) => "resultValue" -> decoded
+                                    case field              => field
+                                })
+                            case _ =>
+                                value
+                    case None =>
+                        value
+            case Structure.Value.Record(Chunk(("Valueresult", value))) =>
+                Structure.Value.Record(Chunk("resultValue" -> value))
+            case _ => Structure.Value.Record(Chunk("resultValue" -> value))
+    end resultEnvelope
+
+    private def decodeStringifiedResult(raw: String)(using Frame): Result[Throwable, Structure.Value] =
+        Json.decode[Structure.Value](raw) match
+            case success @ Result.Success(_) => success
+            case Result.Failure(_)           => Json.decode[Structure.Value](LLM.completePartialJson(raw))
+            case Result.Panic(ex)            => Result.Panic(ex)
+    end decodeStringifiedResult
+
+    private def decodeEvent[A: Schema](event: RpcEvent)(using Frame): A < Abort[AIGenException] =
+        Structure.decode[A](event.params) match
+            case Result.Success(value) => value
+            case Result.Failure(err)   => Abort.fail(AIDecodeException(s"Codex event '${event.method}' is invalid: $err"))
+            case Result.Panic(ex)      => Abort.panic(ex)
+
+end CodexCompletion

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/Completion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/Completion.scala
@@ -6,19 +6,18 @@ import kyo.Tool
 import kyo.ai.*
 import kyo.ai.Context.*
 
-/** The provider completion-backend contract: turn a config + conversation + tool set into one assistant reply.
+/** The provider completion-backend contract: turn a config + conversation + tool set into transcript messages.
   *
   * A `Completion` is the wire layer for one provider family. `apply` serializes the conversation and the
-  * tool definitions to the provider's request DTO, posts it over kyo-http, and decodes the reply into an
-  * `AssistantMessage` (text plus any tool calls). Transport failures surface as `Abort[HttpException]` (the
+  * tool definitions to the provider's request DTO, posts it over kyo-http, and decodes the reply into one or
+  * more `Message` values. Transport failures surface as `Abort[HttpException]` (the
   * typed kyo-http error hierarchy), never `Abort[Throwable]`; a missing API key or an undecodable reply
   * surface as the typed `Abort[AIGenException]` leaves (`AIMissingApiKeyException`, `AIDecodeException`),
   * mapped to `AITransportException` at the eval boundary. The `resultSchema` override, when
   * present, supplies the parameter schema for the dynamic `result_tool` (whose own `inputSchema` is the
   * opaque `Structure.Value` shape): the thought-aware result envelope is assembled by the eval loop and
-  * carried here so the request's result-tool definition exposes the real properties. Two implementations
-  * exist: `OpenAICompletion` (OpenAI and 5 compatible providers) and `AnthropicCompletion`. Backends are
-  * reached through `Config.Provider`, not constructed by users.
+  * carried here so the request's result-tool definition exposes the real properties. Backends are reached
+  * through `Config.Provider`, not constructed by users.
   */
 trait Completion:
 
@@ -27,28 +26,19 @@ trait Completion:
         context: Context,
         tools: Chunk[Tool.internal.Info[?, ?, LLM]],
         resultSchema: Maybe[JsonSchema] = Absent
-    )(using Frame): AssistantMessage < (LLM & Async & Abort[HttpException | AIGenException])
+    )(using Frame): Chunk[Message] < (LLM & Async & Abort[HttpException | AIGenException])
 
-    /** Assembles the provider-specific streaming request (endpoint URL, headers, and body) for the result
-      * tool over the assembled `resultSchema`, with the provider's stream flag set. The `streamAgainst`
-      * projection posts it and feeds each SSE data line back through `parseDeltaArguments`. The URL and
-      * headers differ by provider (`/chat/completions` + bearer auth for OpenAI, `/messages` + `x-api-key`
-      * for Anthropic), so the whole request is dispatched here, not just the body.
+    /** Provides raw JSON fragments for the `{ resultValue: ... }` envelope consumed by `LLM.stream`.
+      *
+      * HTTP providers implement this by posting their native SSE request and projecting tool-call argument
+      * deltas. Harness providers implement it through their native event or stream-json output.
       */
-    def streamRequest(
+    def streamFragments(
         config: Config,
         context: Context,
         resultSchema: JsonSchema,
         resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
-    )(using Frame): Completion.StreamRequest
-
-    /** Parses one SSE data line into the incremental result-tool argument fragment, if it carries one.
-      *
-      * `Result.Success(Present(fragment))` is an argument-JSON delta to append; `Result.Success(Absent)` is
-      * a line with no argument fragment (a non-delta event, a keep-alive, or the provider's terminator);
-      * `Result.Failure` is a line that is not a parseable streaming event for this provider.
-      */
-    def parseDeltaArguments(line: String)(using Frame): Result[String, Maybe[String]]
+    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException])
 
 end Completion
 
@@ -62,6 +52,12 @@ object Completion:
     /** The Anthropic Messages backend. */
     val anthropic: Completion = AnthropicCompletion
 
+    /** The Claude Code CLI harness backend. */
+    val claudeCode: Completion = ClaudeCodeCompletion
+
+    /** The Codex CLI harness backend. */
+    val codex: Completion = CodexCompletion
+
     /** The reserved name of the result tool. A backend matches a tool by this name to substitute the
       * thought-aware result envelope schema for the tool's opaque `Structure.Value` input schema.
       */
@@ -69,5 +65,36 @@ object Completion:
 
     /** The provider-specific pieces of a streaming completion request: endpoint URL, headers, and body. */
     case class StreamRequest(url: String, headers: Seq[(String, String)], body: String)
+
+    private[completion] def sseFragments(
+        config: Config,
+        request: StreamRequest < Abort[AIStreamException],
+        parseDeltaArguments: String => Result[String, Maybe[String]]
+    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < Async =
+        given sseTag: Tag[Emit[Chunk[HttpSseEvent[String]]]] = Tag[Emit[Chunk[HttpSseEvent[String]]]]
+        val route                                            = HttpRoute.postRaw("").request(_.bodyText).response(_.bodySseText)
+        Stream.unwrap {
+            for
+                req <- request
+                sseStream <- Abort.recover[HttpException](e => Abort.fail(AITransportException(e))) {
+                    for
+                        baseReq <- Abort.get(HttpRequest.postRaw(req.url))
+                        httpRequest = req.headers.foldLeft(baseReq)((r, kv) => r.addHeader(kv._1, kv._2))
+                            .addField("body", req.body)
+                        sseStream <- HttpClient.withConfig(_.timeout(config.timeout)) {
+                            HttpClient.use { client =>
+                                client.sendWith(route, httpRequest)(_.fields.body)
+                            }
+                        }
+                    yield sseStream
+                }
+            yield sseStream.map { event =>
+                parseDeltaArguments(event.data) match
+                    case Result.Success(Present(fragment)) => fragment
+                    case Result.Success(Absent)            => ""
+                    case Result.Failure(err)               => Abort.fail(AIStreamDeltaException(err))
+            }.filterPure(_.nonEmpty)
+        }
+    end sseFragments
 
 end Completion

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/HarnessCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/HarnessCompletion.scala
@@ -1,0 +1,141 @@
+package kyo.ai.completion
+
+import kyo.*
+import kyo.Json
+import kyo.Json.JsonSchema
+import kyo.Tool
+import kyo.ai.*
+import kyo.ai.Context.*
+
+abstract private[completion] class HarnessCompletion(providerName: String) extends Completion:
+
+    final def apply(
+        config: Config,
+        context: Context,
+        tools: Chunk[Tool.internal.Info[?, ?, LLM]],
+        resultSchema: Maybe[JsonSchema] = Absent
+    )(using Frame): Chunk[Message] < (LLM & Async & Abort[HttpException | AIGenException]) =
+        resultSchema match
+            case Absent          => Abort.fail(AIDecodeException(s"$providerName completion requires a result schema"))
+            case Present(schema) => run(config, context, tools, schema)
+
+    protected def run(
+        config: Config,
+        context: Context,
+        tools: Chunk[Tool.internal.Info[?, ?, LLM]],
+        resultSchema: JsonSchema
+    )(using Frame): Chunk[Message] < (LLM & Async & Abort[AIGenException])
+
+    final protected def resultInstructions(context: Context)(using Frame): String =
+        HarnessCompletion.resultInstructions(context)
+
+    final protected def resultOutput(raw: String)(using Frame): Chunk[Message] < Abort[AIGenException] =
+        HarnessCompletion.resultOutput(providerName, raw)
+
+    final protected def commandFailure(detail: String)(using Frame): AIGenException =
+        HarnessCompletion.commandFailure(providerName, detail)
+
+    final protected def streamFailure(detail: String)(using Frame): AIStreamException =
+        HarnessCompletion.streamFailure(providerName, detail)
+
+end HarnessCompletion
+
+private[completion] object HarnessCompletion:
+
+    private[kyo] def resultInstructions(context: Context)(using Frame): String =
+        context.messages.collect { case SystemMessage(content) => content }.mkString("\n\n")
+    end resultInstructions
+
+    private[kyo] def resultOutput(provider: String, raw: String)(using Frame): Chunk[Message] < Abort[AIGenException] =
+        decodeResult(raw) match
+            case Result.Success(value) =>
+                Chunk(AssistantMessage(
+                    "",
+                    Chunk(Call(
+                        CallId("harness-result"),
+                        Completion.resultToolName,
+                        Json.encode(resultArguments(value))
+                    ))
+                ))
+            case Result.Failure(err) =>
+                Abort.fail(AIDecodeException(s"$provider harness result is not valid JSON: $err\n$raw"))
+            case Result.Panic(ex) =>
+                Abort.panic(ex)
+    end resultOutput
+
+    private def decodeResult(raw: String)(using Frame): Result[Throwable, Structure.Value] =
+        Json.decode[Structure.Value](raw) match
+            case Result.Success(value) => Result.Success(value)
+            case Result.Failure(_) =>
+                val trimmed = raw.trim
+                val index   = trimmed.indexOf('{')
+                if index > 0 then Json.decode[Structure.Value](trimmed.drop(index))
+                else Json.decode[Structure.Value](trimmed)
+            case Result.Panic(ex) =>
+                Result.Panic(ex)
+    end decodeResult
+
+    private def resultArguments(value: Structure.Value)(using Frame): Structure.Value =
+        value match
+            case Structure.Value.Record(fields) if fields.exists(_._1 == "resultValue") =>
+                fields.collectFirst { case ("resultValue", Structure.Value.Str(raw)) => raw } match
+                    case Some(raw) =>
+                        decodeStringifiedResult(raw) match
+                            case Result.Success(decoded @ Structure.Value.Record(decodedFields))
+                                if decodedFields.exists(_._1 == "resultValue") =>
+                                decoded
+                            case Result.Success(decoded) =>
+                                Structure.Value.Record(fields.map {
+                                    case ("resultValue", _) => "resultValue" -> decoded
+                                    case field              => field
+                                })
+                            case _ =>
+                                value
+                    case None =>
+                        value
+            case Structure.Value.Record(Chunk(("Valueresult", value))) =>
+                Structure.Value.Record(Chunk("resultValue" -> value))
+            case Structure.Value.Record(Chunk(("", value))) =>
+                Structure.Value.Record(Chunk("resultValue" -> value))
+            case _ => Structure.Value.Record(Chunk("resultValue" -> value))
+    end resultArguments
+
+    private def decodeStringifiedResult(raw: String)(using Frame): Result[Throwable, Structure.Value] =
+        Json.decode[Structure.Value](raw) match
+            case success @ Result.Success(_) => success
+            case Result.Failure(_)           => Json.decode[Structure.Value](LLM.completePartialJson(raw))
+            case Result.Panic(ex)            => Result.Panic(ex)
+    end decodeStringifiedResult
+
+    private[kyo] def commandFailure(provider: String, detail: String)(using Frame): AIGenException =
+        val lower = detail.toLowerCase
+        if lower.contains("not authenticated") ||
+            lower.contains("login") ||
+            lower.contains("quota") ||
+            lower.contains("rate limit") ||
+            lower.contains("credit balance") ||
+            lower.contains("billing") ||
+            lower.contains("429") ||
+            lower.contains("529") ||
+            lower.contains("401") ||
+            lower.contains("403") ||
+            lower.contains("overloaded") ||
+            lower.contains("service unavailable") ||
+            lower.contains("temporarily unavailable") ||
+            lower.contains("network") ||
+            lower.contains("could not resolve") ||
+            lower.contains("connection") ||
+            lower.contains("timeout") ||
+            lower.contains("timed out")
+        then AIProviderUnavailableException(provider, detail)
+        else AIDecodeException(s"$provider harness failed: $detail")
+        end if
+    end commandFailure
+
+    private[kyo] def streamFailure(provider: String, detail: String)(using Frame): AIStreamException =
+        commandFailure(provider, detail) match
+            case ex: AIProviderUnavailableException => ex
+            case ex                                 => AIStreamDeltaException(ex.getMessage)
+    end streamFailure
+
+end HarnessCompletion

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/OpenAICompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/OpenAICompletion.scala
@@ -32,20 +32,20 @@ private[completion] object OpenAICompletion extends Completion:
         context: Context,
         tools: Chunk[Tool.internal.Info[?, ?, LLM]],
         resultSchema: Maybe[JsonSchema] = Absent
-    )(using Frame): AssistantMessage < (LLM & Async & Abort[HttpException | AIGenException]) =
+    )(using Frame): Chunk[Message] < (LLM & Async & Abort[HttpException | AIGenException]) =
         fetch(config, Request(context, config, tools, resultSchema)).map(read)
 
-    private def read(response: Response)(using Frame): AssistantMessage < (LLM & Sync & Abort[AIGenException]) =
+    private def read(response: Response)(using Frame): Chunk[Message] < (LLM & Sync & Abort[AIGenException]) =
         Maybe.fromOption(response.choices.headOption) match
             case Absent =>
                 Abort.fail(AIDecodeException("LLM response has no choices: " + Json.encode(response)))
             case Present(v) =>
-                AssistantMessage(
+                Chunk(AssistantMessage(
                     v.message.content.getOrElse(""),
                     Chunk.from(v.message.tool_calls.getOrElse(Nil).map(c =>
                         Call(CallId(c.id), c.function.name, c.function.arguments)
                     ))
-                )
+                ))
 
     private def fetch(config: Config, req: Request)(using Frame): Response < (LLM & Async & Abort[HttpException | AIGenException]) =
         config.apiKey match
@@ -56,8 +56,12 @@ private[completion] object OpenAICompletion extends Completion:
                     Seq("content-type" -> "application/json", "Authorization" -> s"Bearer $key") ++
                         config.apiOrg.map("OpenAI-Organization" -> _).toList
                 val url = s"${config.apiUrl}/chat/completions"
-                HttpClient.postText(url, Json.encode(req), headers)
-                    .map(body => Abort.get(Json.decode[Response](body).mapFailure(e => HttpJsonDecodeException(e.getMessage, "POST", url))))
+                HttpClient.withConfig(_.timeout(config.timeout)) {
+                    HttpClient.postText(url, Json.encode(req), headers)
+                        .map(body =>
+                            Abort.get(Json.decode[Response](body).mapFailure(e => HttpJsonDecodeException(e.getMessage, "POST", url)))
+                        )
+                }
 
     /** Parses one SSE data line as an OpenAI streaming chunk and extracts the tool-call argument fragment.
       *
@@ -66,7 +70,16 @@ private[completion] object OpenAICompletion extends Completion:
       * argument fragment: a content-only or empty delta, or the `[DONE]` terminator. Returns
       * `Result.Failure` when the line is not a parseable OpenAI streaming chunk.
       */
-    override def parseDeltaArguments(line: String)(using Frame): Result[String, Maybe[String]] =
+    def streamFragments(
+        config: Config,
+        context: Context,
+        resultSchema: JsonSchema,
+        resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
+    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
+        Completion.sseFragments(config, streamRequest(config, context, resultSchema, resultTool), parseDeltaArguments)
+    end streamFragments
+
+    private[kyo] def parseDeltaArguments(line: String)(using Frame): Result[String, Maybe[String]] =
         import internal.*
         // The chat-completions stream terminates with a `[DONE]` sentinel line; treat it (and any content-only
         // or empty delta) as carrying no argument fragment, so the generic projection ignores it.
@@ -90,12 +103,12 @@ private[completion] object OpenAICompletion extends Completion:
         end if
     end parseDeltaArguments
 
-    override def streamRequest(
+    private[kyo] def streamRequest(
         config: Config,
         context: Context,
         resultSchema: JsonSchema,
         resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
-    )(using Frame): Completion.StreamRequest =
+    )(using Frame): Completion.StreamRequest < Abort[AIStreamException] =
         import internal.*
         val headers =
             Seq("content-type" -> "application/json") ++

--- a/kyo-ai/shared/src/test/scala/demo/HarnessCompletionDemo.scala
+++ b/kyo-ai/shared/src/test/scala/demo/HarnessCompletionDemo.scala
@@ -1,0 +1,64 @@
+package demo
+
+import kyo.*
+
+/** Harness completion: exercises the command-backed providers with one persistent `AI` instance.
+  *
+  * This demo keeps message history in a named instance, sends a system message, sends an image-bearing user
+  * message, performs a typed generation, then performs a second typed generation whose prompt only makes
+  * sense if the previous assistant result is still in the instance history.
+  *
+  * Demonstrates: Config.Codex or Config.ClaudeCode selection, AI.initWith, system messages, image messages,
+  * typed schema output, and multi-turn history.
+  */
+object HarnessCompletionDemo extends KyoApp:
+
+    case class FirstTurn(marker: String, imageObserved: Boolean, description: String) derives Schema
+    case class SecondTurn(marker: String, rememberedDescription: String, historyUsed: Boolean) derives Schema
+
+    private val marker = "kyo-harness-demo-red-pixel"
+
+    private val redPixelJpeg =
+        "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcp" +
+            "LDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIy" +
+            "MjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAA" +
+            "AgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6" +
+            "Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXG" +
+            "x8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREA" +
+            "AgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5" +
+            "OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPE" +
+            "xcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDi6KKK+ZP3E//Z"
+
+    run {
+        LLM.run {
+            AI.initWith { ai =>
+                for
+                    config <- AI.config
+                    _      <- Console.printLine(s"backend:             ${config.provider.name}")
+                    _      <- Console.printLine(s"model:               ${config.modelName}")
+                    _ <- ai.systemMessage(
+                        "You are validating a harness completion adapter. Return compact factual values. " +
+                            s"Preserve the marker '$marker' exactly when asked."
+                    )
+                    _ <- ai.userMessage(
+                        s"Look at the attached image and remember this marker: $marker. " +
+                            "Describe the image in five words or fewer.",
+                        AI.Image.fromBase64(redPixelJpeg)
+                    )
+                    first <- ai.gen[FirstTurn]
+                    _ <- ai.userMessage(
+                        "Using only the conversation so far, return the same marker and the remembered image description. " +
+                            "Set historyUsed to true only if the prior assistant result was used."
+                    )
+                    second <- ai.gen[SecondTurn]
+                    _      <- Console.printLine(s"first marker:        ${first.marker}")
+                    _      <- Console.printLine(s"image observed:      ${first.imageObserved}")
+                    _      <- Console.printLine(s"description:         ${first.description}")
+                    _      <- Console.printLine(s"second marker:       ${second.marker}")
+                    _      <- Console.printLine(s"remembered:          ${second.rememberedDescription}")
+                    _      <- Console.printLine(s"history used:        ${second.historyUsed}")
+                yield ()
+            }
+        }
+    }
+end HarnessCompletionDemo

--- a/kyo-ai/shared/src/test/scala/demo/StreamingDemo.scala
+++ b/kyo-ai/shared/src/test/scala/demo/StreamingDemo.scala
@@ -4,10 +4,11 @@ import kyo.*
 
 /** Streaming, in its two forms, inferred from the result type.
   *
-  * `ai.stream[A]` projects a generation as a `Stream`. For a `String` it streams the text incrementally,
-  * each element a longer prefix (the chat-UI token-by-token case). For any other type it streams object by
-  * object: the model produces a sequence of `A` and each element is emitted once it is complete, never a
-  * half-filled value. The first run below streams text; the second streams whole `Destination` records.
+  * `ai.stream[A]` projects a generation as a `Stream`. For a `String` it streams incremental text chunks
+  * whose concatenation is the final answer (the chat-UI token-by-token case). For any other type it streams
+  * object by object: the model produces a sequence of `A` and each element is emitted once it is complete,
+  * never a half-filled value. The first run below streams text; the second streams whole `Destination`
+  * records.
   *
   * Demonstrates: ai.stream[String] (incremental text), ai.stream[A] (object by object), Stream.foreach
   * Run on OpenAI:    OPENAI_API_KEY=...    sbt "kyo-aiJVM/Test/runMain demo.StreamingDemo"
@@ -24,7 +25,7 @@ object StreamingDemo extends KyoApp:
                     _     <- Console.printLine("-- text streaming --")
                     _     <- ai.userMessage("In two or three sentences, explain why the sky is blue.")
                     text  <- ai.stream[String]
-                    _     <- text.foreach(prefix => Console.printLine(s"[${prefix.length} chars] $prefix"))
+                    _     <- text.foreach(chunk => Console.printLine(s"[${chunk.length} chars] $chunk"))
                     _     <- Console.printLine("-- object streaming --")
                     _     <- ai.userMessage("Recommend four great hiking destinations worldwide, each with its name and country.")
                     dests <- ai.stream[Destination]

--- a/kyo-ai/shared/src/test/scala/kyo/LLMStreamTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/LLMStreamTest.scala
@@ -64,10 +64,10 @@ class LLMStreamTest extends kyo.test.Test[Any]:
         assert(LLM.completePartialJson("{\"resultValue\":123}") == "{\"resultValue\":123}")
     }
 
-    "stream[String] emits growing text prefixes as the answer arrives" in {
-        // A String result streams in prefix mode: the resultValue text arrives split mid-word and the completer
-        // closes each prefix, so the stream emits "The", "The sky", "The sky is blue" incrementally. This is the
-        // chat-UI token-by-token case; the terminal element is the full answer.
+    "stream[String] emits text chunks as the answer arrives" in {
+        // A String result streams in text mode: the resultValue text arrives split mid-word and the completer
+        // closes each prefix internally, but the public stream emits only the newly decoded suffix. Concatenating
+        // the elements yields the full answer.
         TestCompletionServer.runStreaming { server =>
             val config = serverConfig(server.baseUrl)
             server.enqueueStream(Chunk(
@@ -77,10 +77,8 @@ class LLMStreamTest extends kyo.test.Test[Any]:
             )).andThen {
                 LLM.run(config) {
                     AI.stream[String].map(_.run.map { collected =>
-                        assert(
-                            collected == Chunk("The", "The sky", "The sky is blue"),
-                            s"expected growing String prefixes, got: $collected"
-                        )
+                        assert(collected == Chunk("The", " sky", " is blue"), s"expected String chunks, got: $collected")
+                        assert(collected.mkString == "The sky is blue", s"chunks should concatenate to the final text: $collected")
                     })
                 }
             }
@@ -375,16 +373,16 @@ class LLMStreamTest extends kyo.test.Test[Any]:
         }
     }
 
-    // --- prefix mode (String) ---
+    // --- text mode (String) ---
 
-    "stream[String] does not re-emit an unchanged prefix when the closing delta arrives" in {
+    "stream[String] does not re-emit unchanged text when the closing delta arrives" in {
         // After the text decodes to "hi", the closing `"}` delta yields the same "hi"; it must be deduped, so the
         // stream emits "hi" exactly once, not twice.
         TestCompletionServer.runStreaming { server =>
             val config = serverConfig(server.baseUrl)
             server.enqueueStream(Chunk(argDelta("{\"resultValue\":\"hi"), argDelta("\"}"))).andThen {
                 LLM.run(config)(AI.stream[String].map(_.run.map { collected =>
-                    assert(collected == Chunk("hi"), s"the unchanged prefix must be deduped, got: $collected")
+                    assert(collected == Chunk("hi"), s"unchanged text must be deduped, got: $collected")
                 }))
             }
         }
@@ -395,20 +393,20 @@ class LLMStreamTest extends kyo.test.Test[Any]:
             val config = serverConfig(server.baseUrl)
             server.enqueueStream(Chunk(argDelta(prefixArgs("")))).andThen {
                 LLM.run(config)(AI.stream[String].map(_.run.map { collected =>
-                    assert(collected == Chunk(""), s"an empty text result must yield one empty prefix, got: $collected")
+                    assert(collected == Chunk(""), s"an empty text result must yield one empty chunk, got: $collected")
                 }))
             }
         }
     }
 
     "stream[String] decodes escaped characters in the text" in {
-        // The text carries embedded quotes, a backslash, and a newline; the completed prefix must decode them.
+        // The text carries embedded quotes, a backslash, and a newline; the emitted chunk must decode them.
         val text = "she said \"hi\"\\\n done"
         TestCompletionServer.runStreaming { server =>
             val config = serverConfig(server.baseUrl)
             server.enqueueStream(Chunk(argDelta(prefixArgs(text)))).andThen {
                 LLM.run(config)(AI.stream[String].map(_.run.map { collected =>
-                    assert(collected.last == text, s"escaped characters must decode, got: ${collected.last}")
+                    assert(collected.mkString == text, s"escaped characters must decode, got: $collected")
                 }))
             }
         }
@@ -425,13 +423,13 @@ class LLMStreamTest extends kyo.test.Test[Any]:
         }
     }
 
-    "stream[String] yields the partial prefix when the stream is cut off mid-text" in {
-        // A String prefix is always valid, so a truncated text stream yields the shorter prefix, not a failure.
+    "stream[String] yields the partial text when the stream is cut off mid-text" in {
+        // A decodable String prefix is valid, so a truncated text stream yields the shorter text, not a failure.
         TestCompletionServer.runStreaming { server =>
             val config = serverConfig(server.baseUrl)
             server.enqueueStream(Chunk(argDelta("{\"resultValue\":\"hel"))).andThen {
                 LLM.run(config)(AI.stream[String].map(_.run.map { collected =>
-                    assert(collected == Chunk("hel"), s"a truncated text stream must yield the partial prefix, got: $collected")
+                    assert(collected == Chunk("hel"), s"a truncated text stream must yield the partial text, got: $collected")
                 }))
             }
         }
@@ -612,7 +610,7 @@ class LLMStreamTest extends kyo.test.Test[Any]:
 
     // --- request shape: the result schema reflects the mode ---
 
-    "the streaming result schema is an array in element mode and a bare value in prefix mode" in {
+    "the streaming result schema is an array in element mode and a bare value in text mode" in {
         TestCompletionServer.runStreaming { server =>
             val config = serverConfig(server.baseUrl)
             server.enqueueStream(Chunk(argDelta(elementArgs(List(Answer("a")))))).andThen {
@@ -628,14 +626,14 @@ class LLMStreamTest extends kyo.test.Test[Any]:
         }
     }
 
-    "the streaming result schema carries no array items in prefix mode" in {
+    "the streaming result schema carries no array items in text mode" in {
         TestCompletionServer.runStreaming { server =>
             val config = serverConfig(server.baseUrl)
             server.enqueueStream(Chunk(argDelta(prefixArgs("hi")))).andThen {
                 LLM.run(config)(AI.stream[String].map(_.run))
             }.andThen {
                 server.captured.map { caps =>
-                    assert(!caps.head.body.contains("\"items\""), s"prefix-mode request must carry a bare value schema: ${caps.head.body}")
+                    assert(!caps.head.body.contains("\"items\""), s"text-mode request must carry a bare value schema: ${caps.head.body}")
                 }
             }
         }
@@ -643,7 +641,7 @@ class LLMStreamTest extends kyo.test.Test[Any]:
 
     // --- provider parity ---
 
-    "stream[String] streams growing text against the Anthropic backend" in {
+    "stream[String] streams text chunks against the Anthropic backend" in {
         TestCompletionServer.runStreaming { server =>
             val config = anthropicServerConfig(server.baseUrl)
             server.enqueueStream(Chunk(
@@ -651,8 +649,8 @@ class LLMStreamTest extends kyo.test.Test[Any]:
                 anthropicArgDelta(" sky\"}")
             )).andThen {
                 LLM.run(config)(AI.stream[String].map(_.run.map { collected =>
-                    assert(collected.last == "The sky", s"the Anthropic prefix stream must terminate in the full text, got: $collected")
-                    assert(collected == Chunk("The", "The sky"), s"got: $collected")
+                    assert(collected.mkString == "The sky", s"the Anthropic text stream must concatenate to the full text, got: $collected")
+                    assert(collected == Chunk("The", " sky"), s"got: $collected")
                 }))
             }
         }
@@ -678,7 +676,7 @@ class LLMStreamTest extends kyo.test.Test[Any]:
         }
     }
 
-    "prefix streaming terminates in the full text regardless of delta boundaries (randomized)" in {
+    "text streaming concatenates to the full text regardless of delta boundaries (randomized)" in {
         val text = "The quick brown fox jumps over the lazy dog."
         val full = prefixArgs(text)
         val rng  = new scala.util.Random(7L)
@@ -688,18 +686,10 @@ class LLMStreamTest extends kyo.test.Test[Any]:
                 val frags = randomSplit(full, rng)
                 server.enqueueStream(frags.map(argDelta)).andThen {
                     LLM.run(config)(AI.stream[String].map(_.run.map { collected =>
-                        assert(collected.nonEmpty, s"iteration $i must emit at least one prefix")
+                        assert(collected.nonEmpty, s"iteration $i must emit at least one text chunk")
                         assert(
-                            collected.last == text,
-                            s"iteration $i split=${frags.toList} must terminate in the full text, got: ${collected.last}"
-                        )
-                        assert(
-                            collected.forall(text.startsWith),
-                            s"iteration $i every element must be a prefix of the text, got: $collected"
-                        )
-                        assert(
-                            collected.map(_.length) == collected.map(_.length).sorted,
-                            s"iteration $i prefixes must grow monotonically, got: $collected"
+                            collected.mkString == text,
+                            s"iteration $i split=${frags.toList} must concatenate to the full text, got: $collected"
                         )
                     }))
                 }
@@ -718,9 +708,8 @@ class LLMStreamTest extends kyo.test.Test[Any]:
             val config = serverConfig(server.baseUrl)
             server.enqueueStream(chars(prefixArgs(text)).map(argDelta)).andThen {
                 LLM.run(config)(AI.stream[String].map(_.run.map { collected =>
-                    assert(collected.nonEmpty, "the stream must emit at least one prefix")
-                    assert(collected.last == text, s"the terminal prefix must be the full text, got: ${collected.last}")
-                    assert(collected.forall(text.startsWith), s"every emitted prefix must be a prefix of the text, got: $collected")
+                    assert(collected.nonEmpty, "the stream must emit at least one text chunk")
+                    assert(collected.mkString == text, s"text chunks must concatenate to the full text, got: $collected")
                 }))
             }
         }

--- a/kyo-ai/shared/src/test/scala/kyo/ToolTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ToolTest.scala
@@ -137,7 +137,9 @@ class ToolTest extends kyo.test.Test[Any]:
                 tableNode match
                     case Some(JsonSchema.Obj(innerProps, _, additionalProps, _, _, _)) =>
                         assert(innerProps.isEmpty)
-                        assert(additionalProps == Present(JsonSchema.Integer()))
+                        additionalProps match
+                            case Present(JsonSchema.Integer(_, _, _, _, _)) => succeed
+                            case other                                      => fail(s"expected Integer additionalProperties, got $other")
                     case _ =>
                         assert(false, s"expected Obj with additionalProperties for table, got $tableNode")
                 end match

--- a/kyo-ai/shared/src/test/scala/kyo/ai/ConfigTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/ConfigTest.scala
@@ -27,11 +27,27 @@ class ConfigTest extends kyo.test.Test[Any]:
         assert(cfg.temperature.isEmpty)
     }
 
-    "Provider.all carries exactly the 7 providers in order, each with a valid Completion backend" in {
+    "provider override flags use the documented names" in {
+        assert(provider.name == "kyo.ai.provider")
+        assert(provider.envName == "KYO_AI_PROVIDER")
+    }
+
+    "Provider.all carries exactly the providers in order, each with a valid Completion backend" in {
         val names = Config.Provider.all.map(_.name)
-        assert(names == Chunk("Anthropic", "OpenAI", "DeepSeek", "Gemini", "Groq", "Baseten", "OpenRouter"))
+        assert(names == Chunk("Anthropic", "OpenAI", "DeepSeek", "Gemini", "Groq", "Baseten", "OpenRouter", "Claude Code", "Codex"))
+        assert(Config.Provider.apiKeyProviders.map(_.name) == Chunk(
+            "Anthropic",
+            "OpenAI",
+            "DeepSeek",
+            "Gemini",
+            "Groq",
+            "Baseten",
+            "OpenRouter"
+        ))
         assert(Config.Anthropic.completion eq Completion.anthropic)
         assert(Config.OpenAI.completion eq Completion.openAI)
+        assert(Config.ClaudeCode.completion eq Completion.claudeCode)
+        assert(Config.Codex.completion eq Completion.codex)
     }
 
     "default auto-selects the keyed provider via kyo.System and fills its key" in {
@@ -45,6 +61,31 @@ class ConfigTest extends kyo.test.Test[Any]:
     "default falls back to Anthropic when no key is set" in {
         val customSystem = System(new TestUnsafeSystem())
         System.let(customSystem)(Config.default).map(cfg => assert(cfg.provider.name == "Anthropic"))
+    }
+
+    "default prefers command harness markers before API provider keys" in {
+        val customSystem = System(new TestUnsafeSystem(properties = Map("CODEX" -> "1", "CLAUDE_CODE" -> "1")))
+        System.let(customSystem)(Config.default).map(cfg => assert(cfg.provider.name == "Claude Code"))
+    }
+
+    "default selects Codex when its marker is present and Claude Code is absent" in {
+        val customSystem = System(new TestUnsafeSystem(properties = Map("CODEX" -> "1", "ANTHROPIC_API_KEY" -> "key")))
+        System.let(customSystem)(Config.default).map(cfg => assert(cfg.provider.name == "Codex"))
+    }
+
+    "init for command harness providers does not read API key or org settings" in {
+        val customSystem = System(new TestUnsafeSystem(properties =
+            Map(
+                "CODEX"     -> "not-an-api-key",
+                "CODEX_ORG" -> "not-an-org"
+            )
+        ))
+        System.let(customSystem)(Config.init(Config.Codex, Config.Codex.default.modelName, Config.Codex.default.modelMaxTokens)).map {
+            cfg =>
+                assert(cfg.provider eq Config.Codex)
+                assert(cfg.apiKey.isEmpty)
+                assert(cfg.apiOrg.isEmpty)
+        }
     }
 
     "named catalog entries are pure Config literals (key absent) with the right model and token cap" in {
@@ -89,10 +130,9 @@ class ConfigTest extends kyo.test.Test[Any]:
         assert(cfg.modelName == "claude-x" && cfg.modelMaxTokens == 1000 && cfg.provider.name == "Anthropic")
     }
 
-    "every provider default is a pure catalog entry: non-empty model, positive cap, absent key, matching provider" in {
+    "every provider default is a pure catalog entry with positive cap, absent key, matching provider" in {
         Config.Provider.all.foreach { p =>
             val d = p.default
-            assert(d.modelName.nonEmpty, s"${p.name} default modelName is empty")
             assert(d.modelMaxTokens > 0, s"${p.name} default token cap not positive: ${d.modelMaxTokens}")
             assert(d.apiKey.isEmpty, s"${p.name} default must leave the key absent (filled at use)")
             assert(d.provider eq p, s"${p.name} default provider mismatch: ${d.provider.name}")
@@ -108,6 +148,8 @@ class ConfigTest extends kyo.test.Test[Any]:
         assert(Config.Groq.default.modelName == "openai/gpt-oss-120b")
         assert(Config.Baseten.default.modelName == "deepseek-ai/DeepSeek-V4-Pro")
         assert(Config.OpenRouter.default.modelName == "x-ai/grok-4-fast:nitro")
+        assert(Config.ClaudeCode.default.modelName == "sonnet")
+        assert(Config.Codex.default.modelName == "")
     }
 
     private class TestUnsafeSystem(

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/AnthropicCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/AnthropicCompletionTest.scala
@@ -157,7 +157,7 @@ class AnthropicCompletionTest extends kyo.test.Test[Any]:
                     }
                 }.map { result =>
                     result match
-                        case Result.Success(Result.Success(msg)) =>
+                        case Result.Success(Result.Success(Chunk(msg: AssistantMessage))) =>
                             assert(msg.calls.size == 1, s"expected 1 call, got ${msg.calls.size}")
                             val call = msg.calls.head
                             assert(call.id == CallId("tu-1"), s"expected call id 'tu-1', got ${call.id}")
@@ -214,16 +214,22 @@ class AnthropicCompletionTest extends kyo.test.Test[Any]:
     }
 
     "streaming: streamRequest targets /messages with x-api-key auth and a stream-flagged body" in {
-        val req = AnthropicCompletion.streamRequest(
-            keyedConfig("https://anthropic.test/v1"),
-            Context.empty.userMessage("hi"),
-            Json.jsonSchema[String],
-            Chunk.empty
-        )
-        assert(req.url == "https://anthropic.test/v1/messages", s"url: ${req.url}")
-        assert(req.headers.exists { case (k, v) => k == "x-api-key" && v == "test-key" }, s"headers: ${req.headers}")
-        assert(req.headers.exists(_._1 == "anthropic-version"), s"headers: ${req.headers}")
-        assert(req.body.contains("\"stream\":true"), s"stream flag in body: ${req.body}")
+        Abort.run[AIStreamException](
+            AnthropicCompletion.streamRequest(
+                keyedConfig("https://anthropic.test/v1"),
+                Context.empty.userMessage("hi"),
+                Json.jsonSchema[String],
+                Chunk.empty
+            )
+        ).map {
+            case Result.Success(req) =>
+                assert(req.url == "https://anthropic.test/v1/messages", s"url: ${req.url}")
+                assert(req.headers.exists { case (k, v) => k == "x-api-key" && v == "test-key" }, s"headers: ${req.headers}")
+                assert(req.headers.exists(_._1 == "anthropic-version"), s"headers: ${req.headers}")
+                assert(req.body.contains("\"stream\":true"), s"stream flag in body: ${req.body}")
+            case other =>
+                fail(s"expected success, got: $other")
+        }
     }
 
     "a gen runs end-to-end against the Anthropic backend, extracting the result" in {

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/CompletionIntegrationTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/CompletionIntegrationTest.scala
@@ -1,0 +1,964 @@
+package kyo.ai.completion
+
+import java.util.UUID
+import kyo.*
+import kyo.ai.Config
+
+private[kyo] object provider extends StaticFlag[String]("")
+
+class CompletionIntegrationTest extends kyo.test.Test[Any]:
+
+    case class Backend(label: String, provider: Config.Provider, cli: Maybe[String])
+    case class FirstTurn(marker: String, dominantColor: String, imageKind: String, hasReadableText: Boolean, description: String)
+        derives Schema,
+          CanEqual
+    case class SecondTurn(
+        marker: String,
+        rememberedColor: String,
+        rememberedImageKind: String,
+        rememberedHasReadableText: Boolean,
+        description: String,
+        historyUsed: Boolean
+    ) derives Schema, CanEqual
+    case class OrderQuery(orderId: Int) derives Schema, CanEqual
+    case class OrderInfo(status: String, etaDays: Int) derives Schema, CanEqual
+    case class CustomerQuery(customerId: Int) derives Schema, CanEqual
+    case class CustomerInfo(tier: String, region: String) derives Schema, CanEqual
+    case class ToolTurn(marker: String, status: String, etaDays: Int, toolUsed: Boolean) derives Schema, CanEqual
+    case class RepairQuery(code: String) derives Schema, CanEqual
+    case class RepairInfo(value: String, attempt: Int) derives Schema, CanEqual
+    case class RepairTurn(marker: String, value: String, attempt: Int, recovered: Boolean) derives Schema, CanEqual
+    case class MultiToolTurn(
+        marker: String,
+        orderStatus: String,
+        etaDays: Int,
+        customerTier: String,
+        customerRegion: String,
+        orderToolUsed: Boolean,
+        customerToolUsed: Boolean
+    ) derives Schema, CanEqual
+    case class MultiTurnOrder(marker: String, orderStatus: String, etaDays: Int, orderToolUsed: Boolean) derives Schema, CanEqual
+    case class MultiTurnCustomer(
+        marker: String,
+        rememberedOrderStatus: String,
+        customerCode: String,
+        customerZone: String,
+        orderHistoryUsed: Boolean,
+        customerToolUsed: Boolean
+    ) derives Schema, CanEqual
+    case class MultiTurnFinal(
+        marker: String,
+        rememberedOrderStatus: String,
+        rememberedCustomerCode: String,
+        rememberedCustomerZone: String,
+        historyOnly: Boolean
+    ) derives Schema, CanEqual
+    case class StructuredAddress(city: String, postalCodes: Chunk[Int]) derives Schema, CanEqual
+    case class StructuredProfile(
+        marker: String,
+        address: StructuredAddress,
+        tags: Chunk[String],
+        scores: Map[String, Int],
+        note: Maybe[String]
+    ) derives Schema, CanEqual
+    case class StreamItem(marker: String, index: Int, text: String) derives Schema, CanEqual
+    case class StreamMemory(marker: String, token: String) derives Schema, CanEqual
+    case class Reasoning(summary: String, marker: String) derives Schema, CanEqual
+    case class ClosingCheck(marker: String, valid: Boolean) derives Schema, CanEqual
+    case class ThoughtAnswer(marker: String, answer: Int) derives Schema, CanEqual
+    case class IsolationAnswer(marker: String, label: String) derives Schema, CanEqual
+    case class PromptAnswer(marker: String, primaryLabel: String, reminderLabel: String) derives Schema, CanEqual
+    case class ToolPromptAnswer(marker: String, code: String, toolUsed: Boolean) derives Schema, CanEqual
+    case class ComplexToolInput(
+        marker: String,
+        address: StructuredAddress,
+        tags: Chunk[String],
+        scores: Map[String, Int],
+        note: Maybe[String]
+    ) derives Schema, CanEqual
+    case class ComplexToolOutput(marker: String, city: String, total: Int, tagsJoined: String, noteSeen: Boolean) derives Schema, CanEqual
+    case class ComplexToolAnswer(
+        marker: String,
+        city: String,
+        total: Int,
+        tagsJoined: String,
+        noteSeen: Boolean,
+        toolUsed: Boolean
+    ) derives Schema, CanEqual
+    case class TypedInput(marker: String, left: Int, right: Int, label: String) derives Schema, CanEqual
+    case class TypedInputAnswer(marker: String, sum: Int, label: String) derives Schema, CanEqual
+    case class ModeAnswer(marker: String, modeSecret: String) derives Schema, CanEqual
+    case class AgentQuestion(text: String) derives Schema, CanEqual
+    case class AgentReply(marker: String, answer: String, historyUsed: Boolean) derives Schema, CanEqual
+
+    private val allBackends: Chunk[Backend] =
+        Chunk(
+            Backend("OpenAI", Config.OpenAI, Absent),
+            Backend("Anthropic", Config.Anthropic, Absent),
+            Backend("Claude Code", Config.ClaudeCode, Present("claude")),
+            Backend("Codex", Config.Codex, Present("codex"))
+        )
+
+    private val backends: Chunk[Backend] =
+        Maybe(provider().trim.toLowerCase).filter(_.nonEmpty).fold(allBackends) { name =>
+            val selected = allBackends.filter(backend => providerMatches(name, backend))
+            if selected.isEmpty then
+                throw IllegalArgumentException(
+                    s"Unsupported kyo-ai completion integration provider '$name'. Use openai, anthropic, claude-code, or codex."
+                )
+            end if
+            selected
+        }
+    end backends
+
+    private var anthropicPreflight: Maybe[Result[HttpException, Unit]] = Absent
+
+    private def providerMatches(name: String, backend: Backend): Boolean =
+        val label = backend.label.toLowerCase
+        name == label ||
+        name == label.replace(" ", "-") ||
+        name == label.replace(" ", "_") ||
+        (name == "claude" && backend.provider.name == Config.ClaudeCode.name)
+    end providerMatches
+
+    override def timeout: Duration = 4.minutes
+
+    override def config =
+        super.config.sequential.heartbeatInterval(2.minutes)
+
+    private def runBackends(
+        v: Backend => kyo.test.AssertScope ?=> Unit < (LLM & Async & Abort[Any] & Scope)
+    )(using Frame): Unit =
+        backends.foreach { backend =>
+            s"[${backend.label}]" in {
+                for
+                    config <- requireBackend(backend)
+                    _      <- LLM.run(config)(v(backend))
+                yield ()
+            }
+        }
+    end runBackends
+
+    private def runBackendConfigs(
+        v: (Backend, Config) => kyo.test.AssertScope ?=> Unit < (Async & Abort[Any] & Scope)
+    )(using Frame): Unit =
+        backends.foreach { backend =>
+            s"[${backend.label}]" in {
+                for
+                    config <- requireBackend(backend)
+                    _      <- v(backend, config)
+                yield ()
+            }
+        }
+    end runBackendConfigs
+
+    private def requireBackend(backend: Backend)(using Frame, kyo.test.AssertScope): Config < Async =
+        for
+            config <- Config.init(backend.provider, backend.provider.default.modelName, backend.provider.default.modelMaxTokens)
+            _ <- backend.cli match
+                case Present(command) =>
+                    commandAvailable(command).map(available => assume(available, s"$command CLI is not available"))
+                case Absent =>
+                    Kyo.lift(assume(config.apiKey.isDefined, s"${backend.provider.keyName} is not available")).andThen(
+                        apiBackendAvailable(backend, config)
+                    )
+        yield config
+    end requireBackend
+
+    private def apiBackendAvailable(backend: Backend, config: Config)(using Frame, kyo.test.AssertScope): Unit < Async =
+        if backend.provider.name != Config.Anthropic.name then Kyo.unit
+        else
+            config.apiKey match
+                case Absent =>
+                    Kyo.unit
+                case Present(key) =>
+                    anthropicPreflight match
+                        case Present(result) =>
+                            handleApiPreflight(backend, result)
+                        case Absent =>
+                            val headers = Seq(
+                                "content-type"      -> "application/json",
+                                "x-api-key"         -> key,
+                                "anthropic-version" -> "2023-06-01"
+                            )
+                            val body =
+                                Json.encode(Structure.Value.Record(Chunk(
+                                    "model"      -> Structure.Value.Str(config.modelName),
+                                    "max_tokens" -> Structure.Value.Integer(1),
+                                    "messages" -> Structure.Value.Sequence(Chunk(Structure.Value.Record(Chunk(
+                                        "role"    -> Structure.Value.Str("user"),
+                                        "content" -> Structure.Value.Str("ping")
+                                    ))))
+                                )))
+                            Abort.run[HttpException] {
+                                HttpClient.postText(s"${config.apiUrl}/messages", body, headers).unit
+                            }.map { result =>
+                                anthropicPreflight = Present(result)
+                                handleApiPreflight(backend, result)
+                            }
+            end match
+        end if
+    end apiBackendAvailable
+
+    private def handleApiPreflight(backend: Backend, result: Result[HttpException, Unit])(using
+        Frame,
+        kyo.test.AssertScope
+    ): Unit =
+        result match
+            case Result.Success(_) =>
+                ()
+            case Result.Failure(ex) if unavailableCause(ex) =>
+                cancel(providerUnavailableMessage(backend, AITransportException(ex)))
+            case Result.Failure(ex) =>
+                fail(ex)
+            case Result.Panic(ex) =>
+                fail(ex)
+    end handleApiPreflight
+
+    private def unwrap[A](backend: Backend, result: Result[AIException, A])(using Frame, kyo.test.AssertScope): A < Sync =
+        result match
+            case Result.Success(value) => Kyo.lift(value)
+            case Result.Failure(ex) if providerUnavailable(ex) =>
+                Kyo.lift(cancel(providerUnavailableMessage(backend, ex)))
+            case Result.Failure(ex) =>
+                Kyo.lift(fail(ex))
+            case Result.Panic(ex) if providerUnavailable(ex) =>
+                Kyo.lift(cancel(providerUnavailableMessage(backend, ex)))
+            case Result.Panic(ex) =>
+                Kyo.lift(fail(ex))
+    end unwrap
+
+    private def commandAvailable(command: String)(using Frame): Boolean < Async =
+        Abort.run[CommandException] {
+            Command(command, "--version").textWithExitCode
+        }.map {
+            case Result.Success((_, code)) => code.isSuccess
+            case _                         => false
+        }
+    end commandAvailable
+
+    private def providerUnavailable(ex: Throwable): Boolean =
+        val renderedUnavailable = unavailableText(ex.getMessage) || unavailableText(ex.toString)
+        ex match
+            case _: AIMissingApiKeyException       => true
+            case _: AIProviderUnavailableException => true
+            case transport: AITransportException   => renderedUnavailable || unavailableCause(transport.cause)
+            case _: AIStreamException              => renderedUnavailable
+            case _: AIGenException                 => renderedUnavailable
+            case _                                 => renderedUnavailable
+        end match
+    end providerUnavailable
+
+    private def unavailableCause(ex: Throwable): Boolean =
+        unavailableText(ex.getMessage) ||
+            unavailableText(ex.toString) ||
+            unavailableProduct(ex) ||
+            (ex match
+                case status: HttpStatusException =>
+                    status.body.exists(unavailableText)
+                case _ =>
+                    false) ||
+            Maybe(ex.getCause).exists(unavailableCause)
+    end unavailableCause
+
+    private def unavailableProduct(value: Any): Boolean =
+        if value.asInstanceOf[AnyRef] eq null then false
+        else
+            value match
+                case message: String  => unavailableText(message)
+                case product: Product => product.productIterator.exists(unavailableProduct)
+                case other            => unavailableText(other.toString)
+    end unavailableProduct
+
+    private def providerUnavailableMessage(backend: Backend, ex: Throwable): String =
+        unavailableDetail(ex).map(detail => s"${backend.label} provider is unavailable: $detail").getOrElse(
+            s"${backend.label} provider is unavailable"
+        )
+    end providerUnavailableMessage
+
+    private def unavailableDetail(ex: Throwable): Maybe[String] =
+        ex match
+            case provider: AIProviderUnavailableException =>
+                Present(provider.detail)
+            case transport: AITransportException =>
+                unavailableDetail(transport.cause)
+            case status: HttpStatusException =>
+                status.body
+                    .flatMap(extractProviderErrorMessage)
+                    .orElse(Maybe(status.getMessage).filter(_.nonEmpty))
+            case _ =>
+                Maybe(ex.getMessage)
+                    .filter(message => message.nonEmpty && unavailableText(message))
+                    .orElse(Maybe(ex.getCause).flatMap(unavailableDetail))
+        end match
+    end unavailableDetail
+
+    private def extractProviderErrorMessage(body: String): Maybe[String] =
+        Json.decode[Structure.Value](body).toMaybe.flatMap {
+            case Structure.Value.Record(fields) =>
+                Maybe.fromOption(fields.collectFirst {
+                    case ("error", Structure.Value.Record(errorFields)) =>
+                        Maybe.fromOption(errorFields.collectFirst { case ("message", Structure.Value.Str(message)) => message })
+                    case ("message", Structure.Value.Str(message)) =>
+                        Present(message)
+                }).flatten
+            case _ =>
+                Absent
+        }.orElse(Maybe.when(body.nonEmpty)(body))
+    end extractProviderErrorMessage
+
+    private def unavailableText(message: String): Boolean =
+        if message == null then false
+        else
+            val text = message.toLowerCase
+            text.contains("not authenticated") ||
+            text.contains("login") ||
+            text.contains("quota") ||
+            text.contains("rate limit") ||
+            text.contains("rate_limit") ||
+            text.contains("session limit") ||
+            text.contains("credit balance") ||
+            text.contains("billing") ||
+            text.contains("429") ||
+            text.contains("529") ||
+            text.contains("401") ||
+            text.contains("403") ||
+            text.contains("overloaded") ||
+            text.contains("service unavailable") ||
+            text.contains("temporarily unavailable") ||
+            text.contains("network") ||
+            text.contains("could not resolve") ||
+            text.contains("connection")
+    end unavailableText
+
+    private val redPixelJpeg =
+        "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAIBAQEBAQIBAQECAgICAgQDAgICAgUEBAMEBgUGBgYFBgYGBwkIBgcJBwYG" +
+            "CAsICQoKCgoKBggLDAsKDAkKCgr/2wBDAQICAgICAgUDAwUKBwYHCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoK" +
+            "CgoKCgoKCgoKCgoKCgoKCgoKCgr/wAARCAAgACADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcI" +
+            "CQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRol" +
+            "JicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ip" +
+            "qrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAA" +
+            "AAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLR" +
+            "ChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaX" +
+            "mJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEA" +
+            "PwD4Hooor+az/bgKKKKACiiigAooooA//9k="
+
+    private def marker(using Frame): String < Sync =
+        Sync.Unsafe.defer("kyo" + UUID.randomUUID().getMostSignificantBits.abs.toString.take(8))
+
+    "Completion implementations preserve context and images" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                for
+                    ai <- AI.init
+                    _ <- ai.systemMessage(
+                        "You are validating a Kyo completion backend. Return compact factual values. " +
+                            s"Preserve marker '$marker' exactly."
+                    )
+                    _ <- ai.userMessage(
+                        s"Look at the attached image and remember marker: $marker. " +
+                            "Return dominantColor as the lowercase dominant color visible in the image. " +
+                            "Return imageKind as exactly solid-color if the image is a plain solid-color image. " +
+                            "Return hasReadableText true only if readable text is visible. Return description exactly solid red image.",
+                        AI.Image.fromBase64(redPixelJpeg)
+                    )
+                    first <- ai.gen[FirstTurn]
+                    _ <- ai.userMessage(
+                        "Using only the conversation so far, return the same marker, remembered dominant color, remembered image kind, " +
+                            "remembered readable-text flag, and remembered image description exactly solid red image. Set historyUsed to true only if the prior assistant " +
+                            "result was used."
+                    )
+                    second <- ai.gen[SecondTurn]
+                yield (first, second)
+            }
+            (first, second) <- unwrap(backend, result)
+            _ = assert(
+                first == FirstTurn(marker, "red", "solid-color", hasReadableText = false, "solid red image"),
+                s"first turn mismatch: $first"
+            )
+            _ = assert(
+                second == SecondTurn(
+                    marker,
+                    "red",
+                    "solid-color",
+                    rememberedHasReadableText = false,
+                    "solid red image",
+                    historyUsed = true
+                ),
+                s"second turn mismatch: $second"
+            )
+        yield ()
+    }
+
+    "Completion implementations apply prompts and reminders" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                val prompt = Prompt.init(
+                    "For this test, the primary prompt label is exactly primary31.",
+                    "For this test, the reminder prompt label is exactly reminder47."
+                )
+                AI.enable(prompt) {
+                    AI.initWith { ai =>
+                        for
+                            _ <- ai.userMessage(
+                                s"Return marker $marker, the primary prompt label, and the reminder prompt label."
+                            )
+                            answer <- ai.gen[PromptAnswer]
+                        yield answer
+                    }
+                }
+            }
+            answer <- unwrap(backend, result)
+            _ = assert(answer == PromptAnswer(marker, "primary31", "reminder47"), s"prompt answer mismatch: $answer")
+        yield ()
+    }
+
+    "Completion implementations execute Kyo tools" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                for
+                    calls <- AtomicInt.init(0)
+                    lookupOrder = Tool.init[OrderQuery](
+                        "lookup_order",
+                        "Look up an order by id. Use this tool whenever an order status or ETA is requested."
+                    ) { query =>
+                        calls.incrementAndGet.map(_ => OrderInfo(s"ready_for_launch_${query.orderId}", 17))
+                    }
+                    result <- AI.initWith { ai =>
+                        for
+                            _ <- ai.enable(lookupOrder)
+                            _ <- ai.userMessage(
+                                s"You must call lookup_order with orderId 733 before answering. " +
+                                    s"After the tool result arrives, copy the exact status and ETA days from it, and include marker $marker."
+                            )
+                            toolTurn <- ai.gen[ToolTurn]
+                            count    <- calls.get
+                        yield (toolTurn, count)
+                    }
+                yield result
+            }
+            (toolTurn, calls) <- unwrap(backend, result)
+            _ = assert(toolTurn == ToolTurn(marker, "ready_for_launch_733", 17, toolUsed = true), s"tool turn mismatch: $toolTurn")
+            _ = assert(calls == 1, s"lookup_order should have been called exactly once, got $calls")
+        yield ()
+    }
+
+    "Completion implementations apply tool prompts and reminders" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                for
+                    calls <- AtomicInt.init(0)
+                    prompt = Prompt.init(
+                        "When using prompted_lookup, the requested code must be exactly tool_prompt_secret_503.",
+                        "If a prompt asks for the prompted lookup secret, call prompted_lookup before answering."
+                    )
+                    promptedLookup = Tool.init[RepairQuery](
+                        "prompted_lookup",
+                        "Return the code supplied by the tool-specific prompt.",
+                        prompt
+                    ) { query =>
+                        calls.incrementAndGet.map(_ => RepairInfo(query.code, 1))
+                    }
+                    result <- AI.initWith { ai =>
+                        for
+                            _ <- ai.enable(promptedLookup)
+                            _ <- ai.userMessage(
+                                s"Use the prompted lookup secret from the enabled tool prompt. Return marker $marker, code exactly " +
+                                    "tool_prompt_secret_503, and toolUsed true."
+                            )
+                            answer <- ai.gen[ToolPromptAnswer]
+                            count  <- calls.get
+                        yield (answer, count)
+                    }
+                yield result
+            }
+            (answer, calls) <- unwrap(backend, result)
+            _ = assert(answer == ToolPromptAnswer(marker, "tool_prompt_secret_503", toolUsed = true), s"tool prompt mismatch: $answer")
+            _ = assert(calls == 1, s"prompted_lookup should have been called exactly once, got $calls")
+        yield ()
+    }
+
+    "Completion implementations decode complex Kyo tool schemas" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                for
+                    calls    <- AtomicInt.init(0)
+                    received <- AtomicRef.init(Maybe.empty[ComplexToolInput])
+                    complexLookup = Tool.init[ComplexToolInput](
+                        "complex_lookup",
+                        "Accepts a nested structured query and returns a computed structured response."
+                    ) { query =>
+                        received.set(Present(query)).andThen {
+                            calls.incrementAndGet.map { _ =>
+                                ComplexToolOutput(
+                                    query.marker,
+                                    query.address.city,
+                                    query.scores.values.sum,
+                                    query.tags.mkString("|"),
+                                    query.note.nonEmpty
+                                )
+                            }
+                        }
+                    }
+                    result <- AI.initWith { ai =>
+                        for
+                            _ <- ai.enable(complexLookup)
+                            _ <- ai.userMessage(
+                                s"Call complex_lookup once with marker $marker, address city Recife, postalCodes 50000 and 50010, " +
+                                    "tags alpha and beta, scores a 2 and b 5, and note tool-note. " +
+                                    "Then return the exact structured values from the tool and set toolUsed true."
+                            )
+                            answer <- ai.gen[ComplexToolAnswer]
+                            seen   <- received.get
+                            count  <- calls.get
+                        yield (answer, seen, count)
+                    }
+                yield result
+            }
+            (answer, received, calls) <- unwrap(backend, result)
+            expectedInput = ComplexToolInput(
+                marker,
+                StructuredAddress("Recife", Chunk(50000, 50010)),
+                Chunk("alpha", "beta"),
+                Map("a" -> 2, "b" -> 5),
+                Present("tool-note")
+            )
+            _ = assert(
+                answer == ComplexToolAnswer(marker, "Recife", 7, "alpha|beta", noteSeen = true, toolUsed = true),
+                s"complex tool mismatch: $answer"
+            )
+            _ = assert(received == Present(expectedInput), s"complex tool input mismatch: $received")
+            _ = assert(calls == 1, s"complex_lookup should have been called exactly once, got $calls")
+        yield ()
+    }
+
+    "Completion implementations repair after a tool run failure" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                for
+                    attempts <- AtomicInt.init(0)
+                    flakyLookup = Tool.init[RepairQuery](
+                        "flaky_lookup",
+                        "Look up a repair code. The first failure is temporary, so retry with the same code when it fails."
+                    ) { query =>
+                        attempts.incrementAndGet.map { attempt =>
+                            if attempt == 1 then
+                                throw new RuntimeException("temporary lookup failure; retry flaky_lookup with the same code")
+                            else
+                                RepairInfo(s"recovered_${query.code}", attempt)
+                        }
+                    }
+                    result <- AI.initWith { ai =>
+                        for
+                            _ <- ai.enable(flakyLookup)
+                            _ <- ai.userMessage(
+                                s"Call flaky_lookup with code repair_19. If the tool reports a temporary failure, call flaky_lookup again " +
+                                    s"with the same code before answering. Return marker $marker, value exactly recovered_repair_19, " +
+                                    "attempt exactly 2, and recovered true."
+                            )
+                            repairTurn <- ai.gen[RepairTurn]
+                            count      <- attempts.get
+                        yield (repairTurn, count)
+                    }
+                yield result
+            }
+            (repairTurn, attempts) <- unwrap(backend, result)
+            _ = assert(repairTurn == RepairTurn(marker, "recovered_repair_19", 2, recovered = true), s"repair turn mismatch: $repairTurn")
+            _ = assert(attempts == 2, s"flaky_lookup should have been called exactly twice, got $attempts")
+        yield ()
+    }
+
+    "Completion implementations decode typed AI.gen inputs" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                AI.initWith { ai =>
+                    ai.gen[TypedInputAnswer](TypedInput(marker, 5, 7, "typed-input-ok"))
+                }
+            }
+            answer <- unwrap(backend, result)
+            _ = assert(answer == TypedInputAnswer(marker, 12, "typed-input-ok"), s"typed input answer mismatch: $answer")
+        yield ()
+    }
+
+    "Completion implementations execute multiple Kyo tools in one request" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                for
+                    orderCalls    <- AtomicInt.init(0)
+                    customerCalls <- AtomicInt.init(0)
+                    lookupOrder = Tool.init[OrderQuery](
+                        "lookup_order",
+                        "Look up an order by id. Use this tool whenever an order status or ETA is requested."
+                    ) { query =>
+                        orderCalls.incrementAndGet.map(_ => OrderInfo(s"packed_${query.orderId}", 17))
+                    }
+                    lookupCustomer = Tool.init[CustomerQuery](
+                        "lookup_customer",
+                        "Look up customer tier and region by id. Use this tool whenever customer account details are requested."
+                    ) { query =>
+                        customerCalls.incrementAndGet.map(_ => CustomerInfo(s"platinum_${query.customerId}", "south"))
+                    }
+                    result <- AI.initWith { ai =>
+                        for
+                            _ <- ai.enable(lookupOrder, lookupCustomer)
+                            _ <- ai.userMessage(
+                                s"Before answering, call lookup_order with orderId 733 and lookup_customer with customerId 42. " +
+                                    s"Return marker $marker. Set orderStatus to exactly packed_733, etaDays to exactly 17, " +
+                                    "customerTier to exactly platinum_42, and customerRegion to exactly south. " +
+                                    "Do not put JSON objects or JSON strings in any response field. " +
+                                    "Set each toolUsed flag only if that specific tool result was used."
+                            )
+                            toolTurn      <- ai.gen[MultiToolTurn]
+                            orderCount    <- orderCalls.get
+                            customerCount <- customerCalls.get
+                        yield (toolTurn, orderCount, customerCount)
+                    }
+                yield result
+            }
+            (toolTurn, orderCalls, customerCalls) <- unwrap(backend, result)
+            _ = assert(
+                toolTurn == MultiToolTurn(marker, "packed_733", 17, "platinum_42", "south", orderToolUsed = true, customerToolUsed = true),
+                s"multi-tool turn mismatch: $toolTurn"
+            )
+            _ = assert(orderCalls == 1, s"lookup_order should have been called exactly once, got $orderCalls")
+            _ = assert(customerCalls == 1, s"lookup_customer should have been called exactly once, got $customerCalls")
+        yield ()
+    }
+
+    "Completion implementations run modes around real generations" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                val mode = Mode.init([A] =>
+                    (ai, gen) =>
+                        ai.systemMessage("A custom Kyo Mode added this instruction: modeSecret must be exactly mode_secret_29.")
+                            .andThen(gen))
+                AI.enable(mode) {
+                    AI.initWith { ai =>
+                        for
+                            _      <- ai.userMessage(s"Return marker $marker and the modeSecret provided by the enabled mode.")
+                            answer <- ai.gen[ModeAnswer]
+                        yield answer
+                    }
+                }
+            }
+            answer <- unwrap(backend, result)
+            _ = assert(answer == ModeAnswer(marker, "mode_secret_29"), s"mode answer mismatch: $answer")
+        yield ()
+    }
+
+    "Completion implementations preserve multi-turn tool history" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                for
+                    orderCalls    <- AtomicInt.init(0)
+                    customerCalls <- AtomicInt.init(0)
+                    lookupOrder = Tool.init[OrderQuery](
+                        "lookup_order",
+                        "Look up an order by id. Use this tool whenever an order status or ETA is requested."
+                    ) { query =>
+                        orderCalls.incrementAndGet.map(_ => OrderInfo(s"multi_turn_order_${query.orderId}", 23))
+                    }
+                    lookupCustomer = Tool.init[CustomerQuery](
+                        "lookup_customer",
+                        "Look up customer tier and region by id. Use this tool whenever customer account details are requested."
+                    ) { query =>
+                        customerCalls.incrementAndGet.map(_ => CustomerInfo(s"tier_token_${query.customerId}", "region_token_north"))
+                    }
+                    result <- AI.initWith { ai =>
+                        for
+                            _ <- ai.systemMessage(
+                                "This test validates multi-turn Kyo tool history. Preserve exact values from prior turns."
+                            )
+                            orderTurn <- AI.enable(lookupOrder) {
+                                for
+                                    _ <- ai.userMessage(
+                                        s"Turn 1. Call lookup_order exactly once with orderId 811. Do not call lookup_customer. " +
+                                            s"Return marker $marker, the exact order status and ETA from the tool, and set orderToolUsed true."
+                                    )
+                                    orderTurn <- ai.gen[MultiTurnOrder]
+                                yield orderTurn
+                            }
+                            orderAfterOrder    <- orderCalls.get
+                            customerAfterOrder <- customerCalls.get
+                            customerTurn <- AI.enable(lookupCustomer) {
+                                for
+                                    _ <- ai.userMessage(
+                                        s"Turn 2. Use the prior assistant JSON field named orderStatus for the order status. " +
+                                            "Call lookup_customer exactly once with customerId 51. " +
+                                            s"Return marker $marker, rememberedOrderStatus exactly multi_turn_order_811 with no ETA or extra text, " +
+                                            "customerCode exactly tier_token_51, customerZone exactly region_token_north, " +
+                                            "orderHistoryUsed true, and customerToolUsed true."
+                                    )
+                                    customerTurn <- ai.gen[MultiTurnCustomer]
+                                yield customerTurn
+                            }
+                            orderAfterCustomer    <- orderCalls.get
+                            customerAfterCustomer <- customerCalls.get
+                            _ <- ai.userMessage(
+                                s"Turn 3. Do not call any tool. Using conversation history only, return marker $marker. " +
+                                    "Copy rememberedOrderStatus from the first tool-backed assistant result. " +
+                                    "Copy customerCode and customerZone from the immediately previous assistant result. " +
+                                    "Set historyOnly true."
+                            )
+                            finalTurn     <- ai.gen[MultiTurnFinal]
+                            orderFinal    <- orderCalls.get
+                            customerFinal <- customerCalls.get
+                        yield (
+                            orderTurn,
+                            customerTurn,
+                            finalTurn,
+                            orderAfterOrder,
+                            customerAfterOrder,
+                            orderAfterCustomer,
+                            customerAfterCustomer,
+                            orderFinal,
+                            customerFinal
+                        )
+                    }
+                yield result
+            }
+            (
+                orderTurn,
+                customerTurn,
+                finalTurn,
+                orderAfterOrder,
+                customerAfterOrder,
+                orderAfterCustomer,
+                customerAfterCustomer,
+                orderFinal,
+                customerFinal
+            ) <- unwrap(backend, result)
+            _ = assert(
+                orderTurn == MultiTurnOrder(marker, "multi_turn_order_811", 23, orderToolUsed = true),
+                s"order turn mismatch: $orderTurn"
+            )
+            _ = assert(
+                customerTurn == MultiTurnCustomer(
+                    marker,
+                    "multi_turn_order_811",
+                    "tier_token_51",
+                    "region_token_north",
+                    orderHistoryUsed = true,
+                    customerToolUsed = true
+                ),
+                s"customer turn mismatch: $customerTurn"
+            )
+            _ = assert(
+                finalTurn == MultiTurnFinal(
+                    marker,
+                    "multi_turn_order_811",
+                    "tier_token_51",
+                    "region_token_north",
+                    historyOnly = true
+                ),
+                s"final turn mismatch: $finalTurn"
+            )
+            _ = assert(orderAfterOrder == 1, s"lookup_order should be called exactly once during turn 1, got $orderAfterOrder")
+            _ = assert(customerAfterOrder == 0, s"lookup_customer must not be called during turn 1, got $customerAfterOrder")
+            _ = assert(
+                orderAfterCustomer == orderAfterOrder,
+                s"lookup_order must not be called during turn 2, got $orderAfterOrder then $orderAfterCustomer"
+            )
+            _ = assert(
+                customerAfterCustomer == 1,
+                s"lookup_customer should be called exactly once during turn 2, got $customerAfterCustomer"
+            )
+            _ = assert(orderFinal == orderAfterCustomer, s"lookup_order must not be called during final turn, got $orderFinal")
+            _ = assert(customerFinal == customerAfterCustomer, s"lookup_customer must not be called during final turn, got $customerFinal")
+        yield ()
+    }
+
+    "Completion implementations preserve Agent conversation history" - runBackendConfigs { (backend, config) =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                Agent.run[AgentQuestion](config) { (self: AI, question: AgentQuestion) =>
+                    for
+                        _     <- self.userMessage(question.text)
+                        reply <- self.gen[AgentReply]
+                    yield reply
+                }.map { agent =>
+                    for
+                        first <- agentAsk(
+                            agent,
+                            AgentQuestion(
+                                s"Remember marker $marker and answer agent-first. Return historyUsed false."
+                            )
+                        )
+                        second <- agentAsk(
+                            agent,
+                            AgentQuestion(
+                                "Using only this agent conversation history, return the same marker and the prior answer agent-first. " +
+                                    "Set historyUsed true."
+                            )
+                        )
+                        closed <- agent.close
+                    yield (first, second, closed)
+                }
+            }
+            (first, second, closed) <- unwrap(backend, result)
+            _ = assert(first == AgentReply(marker, "agent-first", historyUsed = false), s"agent first reply mismatch: $first")
+            _ = assert(second == AgentReply(marker, "agent-first", historyUsed = true), s"agent second reply mismatch: $second")
+            _ = assert(closed == Present(Seq.empty), s"agent should close with explicit empty pending messages: $closed")
+        yield ()
+    }
+
+    "Completion implementations keep AI instance histories isolated" - runBackends { backend =>
+        for
+            markerA <- marker
+            markerB <- marker
+            result <- Abort.run[AIException] {
+                for
+                    aiA <- AI.init
+                    aiB <- AI.init
+                    _ <- aiA.systemMessage(
+                        s"This conversation's marker is '$markerA' and display label is alpha. Use only this conversation's marker."
+                    )
+                    _ <- aiB.systemMessage(
+                        s"This conversation's marker is '$markerB' and display label is beta. Use only this conversation's marker."
+                    )
+                    _  <- aiA.userMessage("Return this conversation's marker and display label.")
+                    a1 <- aiA.gen[IsolationAnswer]
+                    _  <- aiB.userMessage("Return this conversation's marker and display label.")
+                    b1 <- aiB.gen[IsolationAnswer]
+                    _ <- aiA.userMessage(
+                        "Using this conversation history only, return the same marker and display label again."
+                    )
+                    a2 <- aiA.gen[IsolationAnswer]
+                yield (a1, b1, a2)
+            }
+            (a1, b1, a2) <- unwrap(backend, result)
+            _ = assert(a1 == IsolationAnswer(markerA, "alpha"), s"first A answer mismatch: $a1")
+            _ = assert(b1 == IsolationAnswer(markerB, "beta"), s"B answer mismatch: $b1")
+            _ = assert(a2 == IsolationAnswer(markerA, "alpha"), s"second A answer mismatch: $a2")
+        yield ()
+    }
+
+    "Completion implementations decode nested structured outputs" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                AI.initWith { ai =>
+                    for
+                        _ <- ai.userMessage(
+                            s"Return exactly this structured value: marker $marker, address city Recife, postalCodes 50000 and 50010, " +
+                                "tags alpha, beta, gamma, scores first 1, second 2, third 3, and note nested-ok."
+                        )
+                        profile <- ai.gen[StructuredProfile]
+                    yield profile
+                }
+            }
+            profile <- unwrap(backend, result)
+            expected = StructuredProfile(
+                marker,
+                StructuredAddress("Recife", Chunk(50000, 50010)),
+                Chunk("alpha", "beta", "gamma"),
+                Map("first" -> 1, "second" -> 2, "third" -> 3),
+                Present("nested-ok")
+            )
+            _ = assert(profile == expected, s"structured output mismatch: $profile")
+        yield ()
+    }
+
+    "Completion implementations stream strings and complete objects" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                AI.initWith { ai =>
+                    for
+                        _ <- ai.systemMessage(s"Preserve marker '$marker' exactly.")
+                        expectedText = s"streaming works for $marker"
+                        _ <- ai.userMessage(
+                            s"Stream exactly this string and nothing else: $expectedText"
+                        )
+                        textChunks <- ai.stream[String].map(_.run)
+                        _ <- ai.userMessage(
+                            s"Stream exactly two objects. Use marker '$marker' exactly, indexes 1 and 2, " +
+                                "and text values 'first' and 'second'."
+                        )
+                        streamedItems <- ai.stream[StreamItem].map(_.run)
+                        _             <- ai.userMessage("Stream exactly these three integer values in order: 3, 5, 8.")
+                        streamedInts  <- ai.stream[Int].map(_.run)
+                        memoryToken = s"stream-history-$marker"
+                        _ <- ai.userMessage(
+                            s"Remember marker '$marker' and stream history token '$memoryToken'. Return both exactly."
+                        )
+                        memory <- ai.gen[StreamMemory]
+                        _ <- ai.userMessage(
+                            "Stream exactly this string using conversation history only: " +
+                                s"history stream uses $memoryToken"
+                        )
+                        historyChunks <- ai.stream[String].map(_.run)
+                    yield (textChunks, streamedItems, streamedInts, memory, historyChunks)
+                }
+            }
+            (textChunks, streamedItems, streamedInts, memory, historyChunks) <- unwrap(backend, result)
+            expectedText        = s"streaming works for $marker"
+            expectedHistoryText = s"history stream uses stream-history-$marker"
+            _ = assert(textChunks.mkString == expectedText, s"stream[String] chunks should concatenate to the final value: $textChunks")
+            _ = assert(
+                streamedItems == Chunk(StreamItem(marker, 1, "first"), StreamItem(marker, 2, "second")),
+                s"stream[StreamItem] should emit complete objects in order: $streamedItems"
+            )
+            _ = assert(streamedInts == Chunk(3, 5, 8), s"stream[Int] should emit complete scalar values: $streamedInts")
+            _ = assert(memory == StreamMemory(marker, s"stream-history-$marker"), s"stream memory write mismatch: $memory")
+            _ = assert(
+                historyChunks.mkString == expectedHistoryText,
+                s"stream should see prior history exactly: $historyChunks"
+            )
+        yield ()
+    }
+
+    "Completion implementations decode and process thoughts" - runBackends { backend =>
+        for
+            marker <- marker
+            result <- Abort.run[AIException] {
+                for
+                    openingRef <- AtomicRef.init(Maybe.empty[Reasoning])
+                    closingRef <- AtomicRef.init(Maybe.empty[ClosingCheck])
+                    opening = Thought.opening[Reasoning](reasoning => openingRef.set(Present(reasoning)))
+                    closing = Thought.closing[ClosingCheck](check => closingRef.set(Present(check)))
+                    ai <- AI.init
+                    _  <- ai.enable(opening, closing)
+                    _ <- ai.systemMessage(
+                        "You are validating Kyo thought extraction. Return only the requested values."
+                    )
+                    _ <- ai.userMessage(
+                        s"Use an opening Reasoning thought with marker '$marker' and summary exactly arithmetic-check. " +
+                            s"Then answer with marker '$marker' and answer 4. " +
+                            s"Use a closing ClosingCheck thought with marker '$marker' and valid true."
+                    )
+                    thoughtAnswer <- ai.gen[ThoughtAnswer]
+                    openingValue  <- openingRef.get
+                    closingValue  <- closingRef.get
+                yield (thoughtAnswer, openingValue, closingValue)
+            }
+            (thoughtAnswer, opening, closing) <- unwrap(backend, result)
+            _ = assert(thoughtAnswer.marker == marker, s"thought answer marker mismatch: $thoughtAnswer")
+            _ = assert(thoughtAnswer.answer == 4, s"thought answer mismatch: $thoughtAnswer")
+            _ = assert(opening == Present(Reasoning("arithmetic-check", marker)), s"opening thought hook mismatch: $opening")
+            _ = assert(closing == Present(ClosingCheck(marker, valid = true)), s"closing thought hook mismatch: $closing")
+        yield ()
+    }
+
+    private def agentAsk(agent: Agent[Nothing, AgentQuestion, AgentReply], question: AgentQuestion)(using
+        Frame
+    ): AgentReply < (Async & Abort[AIGenException]) =
+        Abort.run[Closed](agent.ask(question)).map {
+            case Result.Success(reply) => reply
+            case Result.Failure(ex)    => Abort.fail(AIDecodeException(s"agent closed before replying: ${ex.getMessage}"))
+            case Result.Panic(ex)      => Abort.panic(ex)
+        }
+    end agentAsk
+
+end CompletionIntegrationTest

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/HarnessCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/HarnessCompletionTest.scala
@@ -1,0 +1,254 @@
+package kyo.ai.completion
+
+import kyo.*
+import kyo.Json
+import kyo.ai.Config
+import kyo.ai.Context
+import kyo.ai.Context.*
+import kyo.ai.Image
+
+class HarnessCompletionTest extends kyo.test.Test[Any]:
+
+    case class CodexSchemaProbe(scores: Map[String, Int], note: Maybe[String]) derives Schema
+
+    "ClaudeCodeCompletion.inputJsonLines preserves roles, images, and native Kyo tool transcript records" in {
+        val image = Image.fromBytes(Span.from(Array[Byte](1, 2, 3)))
+        val ctx = Context.empty
+            .userMessage("look", Present(image))
+            .assistantMessage("calling", Chunk(Call(CallId("c1"), "lookup", """{"q":"kyo"}""")))
+            .toolMessage(CallId("c1"), """{"answer":"Kyo"}""")
+
+        Abort.run[AIGenException](ClaudeCodeCompletion.inputJsonLines(ctx.messages)).map {
+            case Result.Success(lines) =>
+                assert(lines.contains("\"role\":\"user\""), s"user role missing: $lines")
+                assert(lines.contains("\"role\":\"assistant\""), s"assistant role missing: $lines")
+                assert(lines.contains("\"type\":\"image\""), s"image block missing: $lines")
+                assert(lines.contains("\"media_type\":\"image/jpeg\""), s"image media type missing: $lines")
+                assert(lines.contains("\"data\":\"AQID\""), s"image data missing: $lines")
+                assert(lines.contains("\"type\":\"tool_use\""), s"tool_use block missing: $lines")
+                assert(lines.contains("\"id\":\"c1\""), s"tool call id missing: $lines")
+                assert(lines.contains("\"name\":\"mcp__kyo__lookup\""), s"MCP tool function missing: $lines")
+                assert(lines.contains("\"input\":{\"q\":\"kyo\"}"), s"tool arguments missing: $lines")
+                assert(lines.contains("\"type\":\"tool_result\""), s"tool_result block missing: $lines")
+                assert(lines.contains("\"tool_use_id\":\"c1\""), s"tool result id missing: $lines")
+                assert(lines.contains("answer") && lines.contains("Kyo"), s"tool output missing: $lines")
+                assert(lines.contains("\"is_error\":false"), s"successful tool result should not be marked as an error: $lines")
+            case other =>
+                fail(s"expected success, got: $other")
+        }
+    }
+
+    "ClaudeCodeCompletion.inputJsonLines marks failed Kyo tool results in structured transcript records" in {
+        val ctx = Context.empty
+            .assistantMessage("calling", Chunk(Call(CallId("c1"), "lookup", """{"q":"kyo"}""")))
+            .toolMessage(
+                CallId("c1"),
+                """Tool 'lookup' failed:
+                  |temporary lookup failure
+                  |Call ID: c1""".stripMargin
+            )
+
+        Abort.run[AIGenException](ClaudeCodeCompletion.inputJsonLines(ctx.messages)).map {
+            case Result.Success(lines) =>
+                assert(lines.contains("\"type\":\"tool_result\""), s"tool_result block missing: $lines")
+                assert(lines.contains("\"tool_use_id\":\"c1\""), s"tool result id missing: $lines")
+                assert(lines.contains("\"is_error\":true"), s"failed tool result should be marked as an error: $lines")
+            case other =>
+                fail(s"expected success, got: $other")
+        }
+    }
+
+    "ClaudeCodeCompletion.inputJsonLines replays result_tool as assistant history record" in {
+        val ctx = Context.empty
+            .assistantMessage(
+                "",
+                Chunk(Call(CallId("harness-result"), Completion.resultToolName, """{"resultValue":{"status":"ready","etaDays":3}}"""))
+            )
+            .toolMessage(CallId("harness-result"), "{}")
+
+        Abort.run[AIGenException](ClaudeCodeCompletion.inputJsonLines(ctx.messages)).map {
+            case Result.Success(lines) =>
+                assert(lines.contains("Kyo history record for one previous assistant result"), s"history record missing: $lines")
+                assert(lines.contains("status = ready"), s"status field missing: $lines")
+                assert(lines.contains("etaDays = 3"), s"etaDays field missing: $lines")
+                assert(!lines.contains("resultValue"), s"internal result envelope should not be model-visible: $lines")
+                assert(!lines.contains("Application data returned for request harness-result"), s"internal result output leaked: $lines")
+            case other =>
+                fail(s"expected success, got: $other")
+        }
+    }
+
+    "CodexCompletion.historyItems preserves raw Responses items, images, calls, and tool outputs" in {
+        val image = Image.fromBytes(Span.from(Array[Byte](1, 2, 3)))
+        val ctx = Context.empty
+            .systemMessage("system stays in base instructions")
+            .userMessage("look", Present(image))
+            .assistantMessage("calling", Chunk(Call(CallId("c1"), "lookup", """{"q":"kyo"}""")))
+            .toolMessage(CallId("c1"), """{"answer":"Kyo"}""")
+
+        Abort.run[AIGenException](CodexCompletion.historyItems(ctx.messages)).map {
+            case Result.Success(items) =>
+                val encoded = Json.encode(items.toList)
+                assert(encoded.contains("\"type\":\"message\""), s"message item missing: $encoded")
+                assert(encoded.contains("\"role\":\"user\""), s"user role missing: $encoded")
+                assert(encoded.contains("\"type\":\"input_text\""), s"input_text block missing: $encoded")
+                assert(encoded.contains("\"type\":\"input_image\""), s"input_image block missing: $encoded")
+                assert(encoded.contains("data:image/jpeg;base64,AQID"), s"image data URL missing: $encoded")
+                assert(encoded.contains("\"role\":\"assistant\""), s"assistant role missing: $encoded")
+                assert(encoded.contains("\"type\":\"output_text\""), s"output_text block missing: $encoded")
+                assert(encoded.contains("\"type\":\"function_call\""), s"function_call item missing: $encoded")
+                assert(encoded.contains("\"call_id\":\"c1\""), s"call id missing: $encoded")
+                assert(encoded.contains("\"name\":\"lookup\""), s"call name missing: $encoded")
+                assert(encoded.contains("\"arguments\":\"{\\\"q\\\":\\\"kyo\\\"}\""), s"call arguments missing: $encoded")
+                assert(encoded.contains("\"type\":\"function_call_output\""), s"function_call_output item missing: $encoded")
+                assert(
+                    !encoded.contains("system stays in base instructions"),
+                    s"system message should not be injected as raw item: $encoded"
+                )
+            case other =>
+                fail(s"expected success, got: $other")
+        }
+    }
+
+    "CodexCompletion.appServerSchema relaxes schema constructs rejected by the app-server" in {
+        val encoded = Json.encode(CodexCompletion.appServerSchema(Json.jsonSchema[CodexSchemaProbe]))
+        assert(!encoded.contains("\"oneOf\""), s"nullable fields should not be sent as oneOf to Codex app-server: $encoded")
+        assert(encoded.contains("\"additionalProperties\":true"), s"map fields should remain open objects: $encoded")
+        assert(encoded.contains("\"note\":{\"type\":\"string\""), s"present nullable values should keep their value schema: $encoded")
+    }
+
+    "CodexCompletion.readStructuredOutput accepts top-level assistant message arrays" in {
+        val raw = """[{"content":"","calls":[{"id":"call_1","function":"lookup_order","arguments":{"orderId":733}}]}]"""
+        Abort.run[AIGenException](CodexCompletion.readStructuredOutput(raw)).map {
+            case Result.Success(Chunk(msg: AssistantMessage)) =>
+                assert(msg.content == "")
+                assert(msg.calls.size == 1)
+                assert(msg.calls.head.id == CallId("call_1"))
+                assert(msg.calls.head.function == "lookup_order")
+                assert(msg.calls.head.arguments == """{"orderId":733}""")
+            case other =>
+                fail(s"expected assistant tool call message, got: $other")
+        }
+    }
+
+    "ClaudeCodeCompletion.readMessages returns native tool_use blocks as Kyo tool calls" in {
+        val output =
+            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"checking"},{"type":"tool_use","id":"toolu_1","name":"lookup","input":{"q":"kyo"}}]}}"""
+
+        Abort.run[AIGenException](ClaudeCodeCompletion.readMessages(output)).map {
+            case Result.Success(Chunk(msg: AssistantMessage)) =>
+                assert(msg.content == "checking")
+                assert(msg.calls.size == 1)
+                assert(msg.calls.head.id == CallId("toolu_1"))
+                assert(msg.calls.head.function == "lookup")
+                assert(msg.calls.head.arguments == """{"q":"kyo"}""")
+            case other =>
+                fail(s"expected assistant tool call message, got: $other")
+        }
+    }
+
+    "ClaudeCodeCompletion.readMessages wraps native result_tool calls in the result envelope" in {
+        val output =
+            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"r1","name":"result_tool","input":{"answer":"ok"}}]}}"""
+
+        Abort.run[AIGenException](ClaudeCodeCompletion.readMessages(output)).map {
+            case Result.Success(Chunk(msg: AssistantMessage)) =>
+                assert(msg.calls.head.function == Completion.resultToolName)
+                assert(msg.calls.head.arguments == """{"resultValue":{"answer":"ok"}}""")
+            case other =>
+                fail(s"expected native result_tool call, got: $other")
+        }
+    }
+
+    "ClaudeCodeCompletion.readMessages decodes stringified resultValue objects" in {
+        val output =
+            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"r1","name":"result_tool","input":{"resultValue":"{\"answer\":\"ok\"}"}}]}}"""
+
+        Abort.run[AIGenException](ClaudeCodeCompletion.readMessages(output)).map {
+            case Result.Success(Chunk(msg: AssistantMessage)) =>
+                assert(msg.calls.head.function == Completion.resultToolName)
+                assert(msg.calls.head.arguments == """{"resultValue":{"answer":"ok"}}""")
+            case other =>
+                fail(s"expected decoded stringified resultValue, got: $other")
+        }
+    }
+
+    "ClaudeCodeCompletion.readMessages decodes StructuredOutput direct results" in {
+        val output =
+            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_result","name":"StructuredOutput","input":{"answer":"ok"}}]}}"""
+
+        Abort.run[AIGenException](ClaudeCodeCompletion.readMessages(output)).map {
+            case Result.Success(Chunk(msg: AssistantMessage)) =>
+                assert(msg.content == "")
+                assert(msg.calls.size == 1)
+                assert(msg.calls.head.id == CallId("harness-result"))
+                assert(msg.calls.head.function == Completion.resultToolName)
+                assert(msg.calls.head.arguments == """{"resultValue":{"answer":"ok"}}""")
+            case other =>
+                fail(s"expected structured output message, got: $other")
+        }
+    }
+
+    "ClaudeCodeCompletion.readMessages preserves native tool transcript before final result" in {
+        val output =
+            """{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"checking"},{"type":"tool_use","id":"toolu_1","name":"lookup","input":{"q":"kyo"}}]}}
+              |{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"{\"answer\":\"ok\"}"}]}}
+              |{"type":"result","subtype":"success","result":"{\"answer\":\"ok\"}"}""".stripMargin
+
+        Abort.run[AIGenException](ClaudeCodeCompletion.readMessages(output)).map {
+            case Result.Success(Chunk(callMsg: AssistantMessage, toolMsg: ToolMessage, resultMsg: AssistantMessage)) =>
+                assert(callMsg.content == "checking")
+                assert(callMsg.calls.head.id == CallId("toolu_1"))
+                assert(callMsg.calls.head.function == "lookup")
+                assert(callMsg.calls.head.arguments == """{"q":"kyo"}""")
+                assert(toolMsg.callId == CallId("toolu_1"))
+                assert(toolMsg.content == """{"answer":"ok"}""")
+                assert(resultMsg.calls.head.function == Completion.resultToolName)
+                assert(resultMsg.calls.head.arguments == """{"resultValue":{"answer":"ok"}}""")
+            case other =>
+                fail(s"expected MCP transcript and final result, got: $other")
+        }
+    }
+
+    "resultOutput converts a direct structured result to the result_tool call shape" in {
+        Abort.run[AIGenException](HarnessCompletion.resultOutput("test", """{"answer":"ok"}""")).map {
+            case Result.Success(Chunk(msg: AssistantMessage)) =>
+                assert(msg.calls.head.function == Completion.resultToolName)
+                assert(msg.calls.head.arguments == """{"resultValue":{"answer":"ok"}}""")
+            case other =>
+                fail(s"expected one assistant result_tool message, got: $other")
+        }
+    }
+
+    "resultOutput decodes stringified resultValue objects" in {
+        Abort.run[AIGenException](HarnessCompletion.resultOutput("test", """{"resultValue":"{\"answer\":\"ok\"}"}""")).map {
+            case Result.Success(Chunk(msg: AssistantMessage)) =>
+                assert(msg.calls.head.function == Completion.resultToolName)
+                assert(msg.calls.head.arguments == """{"resultValue":{"answer":"ok"}}""")
+            case other =>
+                fail(s"expected decoded direct result output, got: $other")
+        }
+    }
+
+    "resultOutput unwraps stringified resultValue envelopes" in {
+        Abort.run[AIGenException](HarnessCompletion.resultOutput("test", """{"resultValue":"{\"resultValue\":{\"answer\":\"ok\"}}"}"""))
+            .map {
+                case Result.Success(Chunk(msg: AssistantMessage)) =>
+                    assert(msg.calls.head.function == Completion.resultToolName)
+                    assert(msg.calls.head.arguments == """{"resultValue":{"answer":"ok"}}""")
+                case other =>
+                    fail(s"expected decoded direct result output, got: $other")
+            }
+    }
+
+    "resultOutput normalizes Codex prefixed empty-key direct results" in {
+        Abort.run[AIGenException](HarnessCompletion.resultOutput("test", """resultValue{"":{"answer":"ok"}}""")).map {
+            case Result.Success(Chunk(msg: AssistantMessage)) =>
+                assert(msg.calls.head.function == Completion.resultToolName)
+                assert(msg.calls.head.arguments == """{"resultValue":{"answer":"ok"}}""")
+            case other =>
+                fail(s"expected normalized direct result output, got: $other")
+        }
+    }
+
+end HarnessCompletionTest

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/OpenAICompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/OpenAICompletionTest.scala
@@ -85,7 +85,7 @@ class OpenAICompletionTest extends kyo.test.Test[Any]:
                     }
                 }.map { result =>
                     result match
-                        case Result.Success(Result.Success(msg)) =>
+                        case Result.Success(Result.Success(Chunk(msg: AssistantMessage))) =>
                             assert(msg.content == "", s"expected empty content, got: ${msg.content}")
                             assert(msg.calls == Chunk.empty, s"expected no calls, got: ${msg.calls}")
                         case other =>
@@ -133,7 +133,7 @@ class OpenAICompletionTest extends kyo.test.Test[Any]:
                     }
                 }.map { result =>
                     result match
-                        case Result.Success(Result.Success(msg)) =>
+                        case Result.Success(Result.Success(Chunk(msg: AssistantMessage))) =>
                             assert(msg.calls.size == 1, s"expected 1 call, got ${msg.calls.size}")
                             val call = msg.calls.head
                             assert(call.id == CallId("tid-1"), s"expected call id 'tid-1', got ${call.id}")

--- a/kyo-config/js-wasm/src/main/scala/kyo/FlagPlatform.scala
+++ b/kyo-config/js-wasm/src/main/scala/kyo/FlagPlatform.scala
@@ -1,0 +1,30 @@
+package kyo
+
+import scala.jdk.CollectionConverters.*
+import scala.scalajs.js
+
+private[kyo] object FlagPlatform:
+
+    def property(name: String): String =
+        java.lang.System.getProperty(name)
+
+    def properties: Iterable[String] =
+        java.lang.System.getProperties.propertyNames().asScala.map(_.toString).toList
+
+    def env(name: String): String =
+        val proc = js.Dynamic.global.process
+        if js.typeOf(proc) == "undefined" || js.typeOf(proc.env) == "undefined" then null
+        else
+            val value = proc.env.selectDynamic(name)
+            if js.isUndefined(value) || value == null then null
+            else value.asInstanceOf[String]
+        end if
+    end env
+
+    def envNames: Iterable[String] =
+        val proc = js.Dynamic.global.process
+        if js.typeOf(proc) == "undefined" || js.typeOf(proc.env) == "undefined" then Iterable.empty
+        else js.Object.keys(proc.env.asInstanceOf[js.Object]).toSeq
+    end envNames
+
+end FlagPlatform

--- a/kyo-config/js-wasm/src/main/scala/kyo/FlagPlatform.scala
+++ b/kyo-config/js-wasm/src/main/scala/kyo/FlagPlatform.scala
@@ -3,7 +3,7 @@ package kyo
 import scala.jdk.CollectionConverters.*
 import scala.scalajs.js
 
-private[kyo] object FlagPlatform:
+private[kyo] object FlagPlatform {
 
     def property(name: String): String =
         java.lang.System.getProperty(name)
@@ -11,20 +11,20 @@ private[kyo] object FlagPlatform:
     def properties: Iterable[String] =
         java.lang.System.getProperties.propertyNames().asScala.map(_.toString).toList
 
-    def env(name: String): String =
+    def env(name: String): String = {
         val proc = js.Dynamic.global.process
-        if js.typeOf(proc) == "undefined" || js.typeOf(proc.env) == "undefined" then null
-        else
+        if (js.typeOf(proc) == "undefined" || js.typeOf(proc.env) == "undefined") null
+        else {
             val value = proc.env.selectDynamic(name)
-            if js.isUndefined(value) || value == null then null
+            if (js.isUndefined(value) || value == null) null
             else value.asInstanceOf[String]
-        end if
-    end env
+        }
+    }
 
-    def envNames: Iterable[String] =
+    def envNames: Iterable[String] = {
         val proc = js.Dynamic.global.process
-        if js.typeOf(proc) == "undefined" || js.typeOf(proc.env) == "undefined" then Iterable.empty
+        if (js.typeOf(proc) == "undefined" || js.typeOf(proc.env) == "undefined") Iterable.empty
         else js.Object.keys(proc.env.asInstanceOf[js.Object]).toSeq
-    end envNames
+    }
 
-end FlagPlatform
+}

--- a/kyo-config/jvm-native/src/main/scala/kyo/FlagPlatform.scala
+++ b/kyo-config/jvm-native/src/main/scala/kyo/FlagPlatform.scala
@@ -1,0 +1,19 @@
+package kyo
+
+import scala.jdk.CollectionConverters.*
+
+private[kyo] object FlagPlatform:
+
+    def property(name: String): String =
+        java.lang.System.getProperty(name)
+
+    def properties: Iterable[String] =
+        java.lang.System.getProperties.propertyNames().asScala.map(_.toString).toList
+
+    def env(name: String): String =
+        java.lang.System.getenv(name)
+
+    def envNames: Iterable[String] =
+        java.lang.System.getenv().keySet().asScala.toList
+
+end FlagPlatform

--- a/kyo-config/jvm-native/src/main/scala/kyo/FlagPlatform.scala
+++ b/kyo-config/jvm-native/src/main/scala/kyo/FlagPlatform.scala
@@ -2,7 +2,7 @@ package kyo
 
 import scala.jdk.CollectionConverters.*
 
-private[kyo] object FlagPlatform:
+private[kyo] object FlagPlatform {
 
     def property(name: String): String =
         java.lang.System.getProperty(name)
@@ -16,4 +16,4 @@ private[kyo] object FlagPlatform:
     def envNames: Iterable[String] =
         java.lang.System.getenv().keySet().asScala.toList
 
-end FlagPlatform
+}

--- a/kyo-config/shared/src/main/scala/kyo/DynamicFlag.scala
+++ b/kyo-config/shared/src/main/scala/kyo/DynamicFlag.scala
@@ -101,9 +101,9 @@ abstract class DynamicFlag[A](default: A, validate: A => Either[Throwable, A] = 
     def reload()(implicit allow: AllowUnsafe): Flag.ReloadResult = {
         val expr: Option[String] = source match {
             case Flag.Source.SystemProperty =>
-                Option(java.lang.System.getProperty(name))
+                Option(FlagPlatform.property(name))
             case Flag.Source.EnvironmentVariable =>
-                Option(java.lang.System.getenv(envName))
+                Option(FlagPlatform.env(envName))
             case Flag.Source.Default =>
                 None
         }

--- a/kyo-config/shared/src/main/scala/kyo/Flag.scala
+++ b/kyo-config/shared/src/main/scala/kyo/Flag.scala
@@ -1,7 +1,6 @@
 package kyo
 
 import scala.annotation.implicitNotFound
-import scala.jdk.CollectionConverters.*
 
 /** Shared foundation for type-safe configuration flags backed by system properties and environment variables.
   *
@@ -60,10 +59,10 @@ abstract class Flag[A] private[kyo] (final val default: A, final val validate: A
     // --- Internal ---
 
     private val (resolvedSource: Flag.Source, resolvedExpression: String) = {
-        val prop = java.lang.System.getProperty(name)
+        val prop = FlagPlatform.property(name)
         if (prop ne null) (Flag.Source.SystemProperty, prop)
         else {
-            val env = java.lang.System.getenv(envName)
+            val env = FlagPlatform.env(envName)
             if (env ne null) (Flag.Source.EnvironmentVariable, env)
             else (Flag.Source.Default, "")
         }
@@ -224,11 +223,11 @@ object Flag {
       * dots → underscores) → default. No rollout evaluation.
       */
     def apply[A](name: String, default: A)(implicit reader: Reader[A]): A = {
-        val prop = java.lang.System.getProperty(name)
+        val prop = FlagPlatform.property(name)
         if (prop ne null) reader.parse(name, prop)
         else {
             val envName = name.replace('.', '_').toUpperCase
-            val env     = java.lang.System.getenv(envName)
+            val env     = FlagPlatform.env(envName)
             if (env ne null) reader.parse(name, env)
             else default
         }
@@ -304,9 +303,7 @@ object Flag {
             val envNameLower  = flag.envName.toLowerCase
 
             try {
-                val props = java.lang.System.getProperties
-                scala.jdk.CollectionConverters.EnumerationHasAsScala(props.propertyNames()).asScala.foreach { elem =>
-                    val propName = elem.toString
+                FlagPlatform.properties.foreach { propName =>
                     if (propName.toLowerCase == flagNameLower && propName != flag.name) {
                         java.lang.System.err.println(
                             s"[kyo-config] Warning: Flag '${flag.name}' resolved to default \u2014 did you mean system property '$propName'?"
@@ -318,8 +315,7 @@ object Flag {
             }
             // Also check env vars for near-miss
             try {
-                val envMap = java.lang.System.getenv()
-                envMap.keySet().asScala.foreach { envKey =>
+                FlagPlatform.envNames.foreach { envKey =>
                     if (envKey.toLowerCase == envNameLower && envKey != flag.envName) {
                         java.lang.System.err.println(
                             s"[kyo-config] Warning: Flag '${flag.name}' resolved to default \u2014 did you mean environment variable '$envKey'?"

--- a/kyo-config/shared/src/main/scala/kyo/Rollout.scala
+++ b/kyo-config/shared/src/main/scala/kyo/Rollout.scala
@@ -689,11 +689,11 @@ object Rollout {
 
     /** Reads a system property or environment variable, returning empty string if neither is set. */
     private def readProperty(sysProp: String, envVar: String): String = {
-        val prop = java.lang.System.getProperty(sysProp)
+        val prop = FlagPlatform.property(sysProp)
         if (prop != null) prop
         else {
             val env =
-                try java.lang.System.getenv(envVar)
+                try FlagPlatform.env(envVar)
                 catch { case _: SecurityException => null }
             if (env != null) env
             else ""
@@ -741,7 +741,7 @@ object Rollout {
 
     private def env(name: String): String = {
         val v =
-            try java.lang.System.getenv(name)
+            try FlagPlatform.env(name)
             catch { case _: SecurityException => null }
         if (v eq null) "" else v
     }

--- a/kyo-core/js-wasm/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
+++ b/kyo-core/js-wasm/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
@@ -314,11 +314,31 @@ final private[kyo] class NodeCommandUnsafe(
     def withCwd(path: kyo.Path): NodeCommandUnsafe = copy(workDir = Present(path))
     def withEnvAppend(vars: Map[String, String]): NodeCommandUnsafe =
         val newMode = envMode match
-            case EnvMode.Clear                 => EnvMode.ClearThenAppend(vars)
-            case EnvMode.ClearThenAppend(prev) => EnvMode.ClearThenAppend(prev ++ vars)
-            case _                             => EnvMode.Append(vars)
+            case EnvMode.Clear                         => EnvMode.ClearThenAppend(vars)
+            case EnvMode.ClearThenAppend(prev)         => EnvMode.ClearThenAppend(prev ++ vars)
+            case EnvMode.Remove(names)                 => EnvMode.AppendThenRemove(vars -- names, names)
+            case EnvMode.AppendThenRemove(prev, names) => EnvMode.AppendThenRemove((prev ++ vars) -- names, names)
+            case _                                     => EnvMode.Append(vars)
         copy(envMode = newMode)
     end withEnvAppend
+    def withEnvRemove(names: Set[String]): NodeCommandUnsafe =
+        val newMode = envMode match
+            case EnvMode.Inherit =>
+                EnvMode.Remove(names)
+            case EnvMode.Append(vars) =>
+                EnvMode.AppendThenRemove(vars -- names, names)
+            case EnvMode.Remove(prev) =>
+                EnvMode.Remove(prev ++ names)
+            case EnvMode.AppendThenRemove(vars, prev) =>
+                EnvMode.AppendThenRemove(vars -- names, prev ++ names)
+            case EnvMode.Replace(vars) =>
+                EnvMode.Replace(vars -- names)
+            case EnvMode.Clear =>
+                EnvMode.Clear
+            case EnvMode.ClearThenAppend(vars) =>
+                EnvMode.ClearThenAppend(vars -- names)
+        copy(envMode = newMode)
+    end withEnvRemove
     def withEnvReplace(vars: Map[String, String]): NodeCommandUnsafe = copy(envMode = EnvMode.Replace(vars))
     def withEnvClear: NodeCommandUnsafe                              = copy(envMode = EnvMode.Clear)
 
@@ -369,6 +389,21 @@ final private[kyo] class NodeCommandUnsafe(
                     js.Dynamic.global.process.env
                 )
                 vars.foreach { (k, v) => env.updateDynamic(k)(v) }
+                opts.env = env
+            case EnvMode.Remove(names) =>
+                val env = js.Dynamic.global.Object.assign(
+                    js.Dynamic.literal(),
+                    js.Dynamic.global.process.env
+                )
+                names.foreach(name => discard(js.Dynamic.global.Reflect.deleteProperty(env, name)))
+                opts.env = env
+            case EnvMode.AppendThenRemove(vars, names) =>
+                val env = js.Dynamic.global.Object.assign(
+                    js.Dynamic.literal(),
+                    js.Dynamic.global.process.env
+                )
+                vars.foreach { (k, v) => env.updateDynamic(k)(v) }
+                names.foreach(name => discard(js.Dynamic.global.Reflect.deleteProperty(env, name)))
                 opts.env = env
             case EnvMode.Replace(vars) =>
                 val env = js.Dynamic.literal()
@@ -600,6 +635,21 @@ final private[kyo] class NodeCommandUnsafe(
                                                     js.Dynamic.global.process.env
                                                 )
                                                 vars.foreach { (k, v) => env.updateDynamic(k)(v) }
+                                                opts.env = env
+                                            case EnvMode.Remove(names) =>
+                                                val env = js.Dynamic.global.Object.assign(
+                                                    js.Dynamic.literal(),
+                                                    js.Dynamic.global.process.env
+                                                )
+                                                names.foreach(name => discard(js.Dynamic.global.Reflect.deleteProperty(env, name)))
+                                                opts.env = env
+                                            case EnvMode.AppendThenRemove(vars, names) =>
+                                                val env = js.Dynamic.global.Object.assign(
+                                                    js.Dynamic.literal(),
+                                                    js.Dynamic.global.process.env
+                                                )
+                                                vars.foreach { (k, v) => env.updateDynamic(k)(v) }
+                                                names.foreach(name => discard(js.Dynamic.global.Reflect.deleteProperty(env, name)))
                                                 opts.env = env
                                             case EnvMode.Replace(vars) =>
                                                 val env = js.Dynamic.literal()

--- a/kyo-core/js-wasm/src/main/scala/kyo/internal/SystemPlatformSpecific.scala
+++ b/kyo-core/js-wasm/src/main/scala/kyo/internal/SystemPlatformSpecific.scala
@@ -10,6 +10,19 @@ import scala.scalajs.js
   * `"Mac OS X"`, `"Linux"`) so downstream `String.contains("mac")` checks just work.
   */
 private[kyo] object SystemPlatformSpecific:
+    def env(name: String)(using AllowUnsafe): String =
+        val proc = js.Dynamic.global.process
+        if js.typeOf(proc) == "undefined" || js.typeOf(proc.env) == "undefined" then null
+        else
+            val value = proc.env.selectDynamic(name)
+            if js.isUndefined(value) || value == null then null
+            else value.asInstanceOf[String]
+        end if
+    end env
+
+    def property(name: String)(using AllowUnsafe): String =
+        java.lang.System.getProperty(name)
+
     def osName()(using AllowUnsafe): String =
         val javaProp = java.lang.System.getProperty("os.name", "")
         if javaProp.nonEmpty then javaProp

--- a/kyo-core/jvm-native/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/internal/ProcessPlatformSpecific.scala
@@ -84,11 +84,32 @@ final private[kyo] class JvmCommandUnsafe(
 
     def withEnvAppend(vars: Map[String, String]): JvmCommandUnsafe =
         val newMode = envMode match
-            case EnvMode.Clear                 => EnvMode.ClearThenAppend(vars)
-            case EnvMode.ClearThenAppend(prev) => EnvMode.ClearThenAppend(prev ++ vars)
-            case _                             => EnvMode.Append(vars)
+            case EnvMode.Clear                         => EnvMode.ClearThenAppend(vars)
+            case EnvMode.ClearThenAppend(prev)         => EnvMode.ClearThenAppend(prev ++ vars)
+            case EnvMode.Remove(names)                 => EnvMode.AppendThenRemove(vars -- names, names)
+            case EnvMode.AppendThenRemove(prev, names) => EnvMode.AppendThenRemove((prev ++ vars) -- names, names)
+            case _                                     => EnvMode.Append(vars)
         copy(envMode = newMode)
     end withEnvAppend
+
+    def withEnvRemove(names: Set[String]): JvmCommandUnsafe =
+        val newMode = envMode match
+            case EnvMode.Inherit =>
+                EnvMode.Remove(names)
+            case EnvMode.Append(vars) =>
+                EnvMode.AppendThenRemove(vars -- names, names)
+            case EnvMode.Remove(prev) =>
+                EnvMode.Remove(prev ++ names)
+            case EnvMode.AppendThenRemove(vars, prev) =>
+                EnvMode.AppendThenRemove(vars -- names, prev ++ names)
+            case EnvMode.Replace(vars) =>
+                EnvMode.Replace(vars -- names)
+            case EnvMode.Clear =>
+                EnvMode.Clear
+            case EnvMode.ClearThenAppend(vars) =>
+                EnvMode.ClearThenAppend(vars -- names)
+        copy(envMode = newMode)
+    end withEnvRemove
 
     def withEnvReplace(vars: Map[String, String]): JvmCommandUnsafe =
         copy(envMode = EnvMode.Replace(vars))
@@ -170,6 +191,11 @@ final private[kyo] class JvmCommandUnsafe(
                     case EnvMode.Inherit => () // default: inherit parent env
                     case EnvMode.Append(vars) =>
                         pb.environment().putAll(vars.asJava)
+                    case EnvMode.Remove(names) =>
+                        names.foreach(pb.environment().remove)
+                    case EnvMode.AppendThenRemove(vars, names) =>
+                        pb.environment().putAll(vars.asJava)
+                        names.foreach(pb.environment().remove)
                     case EnvMode.Replace(vars) =>
                         pb.environment().clear()
                         pb.environment().putAll(vars.asJava)
@@ -370,6 +396,11 @@ final private[kyo] class JvmCommandUnsafe(
                         case EnvMode.Inherit => ()
                         case EnvMode.Append(vars) =>
                             vars.foreach { (k, v) => discard(pb.environment().put(k, v)) }
+                        case EnvMode.Remove(names) =>
+                            names.foreach(pb.environment().remove)
+                        case EnvMode.AppendThenRemove(vars, names) =>
+                            vars.foreach { (k, v) => discard(pb.environment().put(k, v)) }
+                            names.foreach(pb.environment().remove)
                         case EnvMode.Replace(vars) =>
                             pb.environment().clear()
                             vars.foreach { (k, v) => discard(pb.environment().put(k, v)) }

--- a/kyo-core/jvm-native/src/main/scala/kyo/internal/SystemPlatformSpecific.scala
+++ b/kyo-core/jvm-native/src/main/scala/kyo/internal/SystemPlatformSpecific.scala
@@ -6,6 +6,8 @@ import kyo.AllowUnsafe
   * `os.name`, `user.name`, and `line.separator` via `java.lang.System` — simply delegate.
   */
 private[kyo] object SystemPlatformSpecific:
-    def osName()(using AllowUnsafe): String = java.lang.System.getProperty("os.name", "")
-    def osArch()(using AllowUnsafe): String = java.lang.System.getProperty("os.arch", "")
+    def env(name: String)(using AllowUnsafe): String      = java.lang.System.getenv(name)
+    def property(name: String)(using AllowUnsafe): String = java.lang.System.getProperty(name)
+    def osName()(using AllowUnsafe): String               = java.lang.System.getProperty("os.name", "")
+    def osArch()(using AllowUnsafe): String               = java.lang.System.getProperty("os.arch", "")
 end SystemPlatformSpecific

--- a/kyo-core/shared/src/main/scala/kyo/Command.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Command.scala
@@ -155,6 +155,9 @@ object Command:
         /** Appends the given environment variables (merged on top of the inherited environment). */
         def envAppend(vars: Map[String, String]): Command = self.unsafe.withEnvAppend(vars).safe
 
+        /** Removes the given variables from the inherited or configured process environment. */
+        def envRemove(names: Iterable[String]): Command = self.unsafe.withEnvRemove(names.toSet).safe
+
         /** Replaces the entire environment with the given variables. */
         def envReplace(vars: Map[String, String]): Command = self.unsafe.withEnvReplace(vars).safe
 
@@ -221,6 +224,8 @@ object Command:
     private[kyo] enum EnvMode derives CanEqual:
         case Inherit
         case Append(vars: Map[String, String])
+        case Remove(names: Set[String])
+        case AppendThenRemove(vars: Map[String, String], names: Set[String])
         case Replace(vars: Map[String, String])
         case Clear
         case ClearThenAppend(vars: Map[String, String])
@@ -256,16 +261,19 @@ object Command:
 
         /** Returns the environment variables that will be appended/replaced, or empty if inheriting/cleared. */
         final def env: Map[String, String] = envMode match
-            case EnvMode.Inherit               => Map.empty
-            case EnvMode.Append(vars)          => vars
-            case EnvMode.Replace(vars)         => vars
-            case EnvMode.Clear                 => Map.empty
-            case EnvMode.ClearThenAppend(vars) => vars
+            case EnvMode.Inherit                   => Map.empty
+            case EnvMode.Append(vars)              => vars
+            case EnvMode.Remove(_)                 => Map.empty
+            case EnvMode.AppendThenRemove(vars, _) => vars
+            case EnvMode.Replace(vars)             => vars
+            case EnvMode.Clear                     => Map.empty
+            case EnvMode.ClearThenAppend(vars)     => vars
 
         // --- Pure builder methods (return new Unsafe instances) ---
 
         def withCwd(path: kyo.Path): Unsafe
         def withEnvAppend(vars: Map[String, String]): Unsafe
+        def withEnvRemove(names: Set[String]): Unsafe
         def withEnvReplace(vars: Map[String, String]): Unsafe
         def withEnvClear: Unsafe
         def withStdin(input: Process.Input): Unsafe

--- a/kyo-core/shared/src/main/scala/kyo/System.scala
+++ b/kyo-core/shared/src/main/scala/kyo/System.scala
@@ -100,9 +100,9 @@ object System:
         System(
             new Unsafe:
                 def env(name: String)(using AllowUnsafe): Maybe[String] =
-                    Maybe(JSystem.getenv(name))
+                    Maybe(SystemPlatformSpecific.env(name))
                 def property(name: String)(using AllowUnsafe): Maybe[String] =
-                    Maybe(JSystem.getProperty(name))
+                    Maybe(SystemPlatformSpecific.property(name))
                 def lineSeparator()(using AllowUnsafe): String = JSystem.lineSeparator()
                 def userName()(using AllowUnsafe): String      = JSystem.getProperty("user.name")
                 def operatingSystem()(using AllowUnsafe): OS =

--- a/kyo-core/shared/src/test/scala/kyo/ExitCodeTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ExitCodeTest.scala
@@ -216,6 +216,28 @@ class ExitCodeTest extends kyo.test.Test[Any]:
             }
     }
 
+    "envRemove removes inherited environment variables" in {
+        assume(!kyo.internal.Platform.isWindows, "env command is Unix-only")
+        {
+            Command("env")
+                .envRemove(Set("PATH"))
+                .text
+                .map { result =>
+                    assert(!result.linesIterator.exists(_.startsWith("PATH=")), s"PATH should be removed from child env: $result")
+                }
+        }
+    }
+
+    "envRemove removes appended environment variables" in {
+        Command("sh", "-c", "echo ${KYO_REMOVE_ME:-missing}:${KYO_KEEP_ME:-missing}")
+            .envAppend(Map("KYO_REMOVE_ME" -> "bad", "KYO_KEEP_ME" -> "good"))
+            .envRemove(Set("KYO_REMOVE_ME"))
+            .text
+            .map { result =>
+                assert(result.trim == "missing:good")
+            }
+    }
+
     "envReplace runs process with only specified environment" in {
         Command("sh", "-c", "echo ${KYO_ONLY_VAR:-only}")
             .envReplace(Map("KYO_ONLY_VAR" -> "only"))

--- a/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
@@ -795,7 +795,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
                                 // to react to peer close compose ws.onPeerClose into their sender/receiver race.
                                 readFiber.getResult.map { result =>
                                     val log = result match
-                                        case Result.Failure(e) => Log.warn(s"HttpWebSocket client reader failed: $e")
+                                        case Result.Failure(_) => Kyo.unit
                                         case Result.Panic(t)   => Log.warn("HttpWebSocket client reader panicked", t)
                                         case Result.Success(_) => Kyo.unit
                                     log.andThen(inbound.close.unit).andThen(peerClosedPromise.completeUnit.unit)

--- a/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
@@ -334,7 +334,7 @@ private[kyo] object UnsafeServerDispatch:
                                 // their own race (see HttpWebSocket.onPeerClose docs).
                                 readFiber.getResult.map { result =>
                                     val log = result match
-                                        case Result.Failure(e) => Log.warn(s"HttpWebSocket server reader failed: $e")
+                                        case Result.Failure(_) => Kyo.unit
                                         case Result.Panic(t)   => Log.warn("HttpWebSocket server reader panicked", t)
                                         case Result.Success(_) => Kyo.unit
                                     log.andThen(inbound.close.unit).andThen(peerClosedPromise.completeUnit.unit)

--- a/kyo-jsonrpc-http/src/main/scala/kyo/JsonRpcHttpTransport.scala
+++ b/kyo-jsonrpc-http/src/main/scala/kyo/JsonRpcHttpTransport.scala
@@ -13,6 +13,52 @@ package kyo
   */
 object JsonRpcHttpTransport:
 
+    /** Adapts an accepted `HttpWebSocket` as a [[JsonRpcTransport]].
+      *
+      * This is the server-side counterpart to [[webSocket]]: each JSON-RPC envelope is carried as
+      * one WebSocket text frame. Binary frames surface as malformed JSON-RPC messages so the peer
+      * gets a protocol-level failure instead of a silent drop.
+      */
+    def webSocket(
+        ws: HttpWebSocket,
+        codec: Schema[JsonRpcEnvelope]
+    )(using Frame): JsonRpcTransport < Sync =
+        Sync.defer {
+            new JsonRpcTransport:
+                def send(env: JsonRpcEnvelope)(using Frame): Unit < (Async & Abort[Closed]) =
+                    Abort.run[JsonRpcError](Structure.encode[JsonRpcEnvelope](env)(using codec)).map {
+                        case Result.Success(structure) =>
+                            ws.put(HttpWebSocket.Payload.Text(Json.encode(structure)))
+                        case Result.Failure(err) =>
+                            Log.warn(s"kyo-jsonrpc-http: encode failed ${err.message}")
+                        case Result.Panic(t) =>
+                            Log.warn(s"kyo-jsonrpc-http: encode panic ${t.getMessage}")
+                    }
+
+                def incoming(using Frame): Stream[JsonRpcEnvelope, Async & Abort[Closed]] =
+                    ws.stream.map {
+                        case HttpWebSocket.Payload.Text(text) =>
+                            Json.decode[Structure.Value](text) match
+                                case Result.Success(sv) =>
+                                    Structure.decode[JsonRpcEnvelope](sv)(using codec)
+                                        .getOrElse(JsonRpcMalformedMessage(Absent, "decode failed", sv))
+                                case Result.Failure(e) =>
+                                    JsonRpcMalformedMessage(Absent, s"json parse: ${e.getMessage}", Structure.Value.Str(text))
+                                case Result.Panic(t) =>
+                                    JsonRpcMalformedMessage(Absent, s"json parse panic: ${t.getMessage}", Structure.Value.Str(text))
+                        case HttpWebSocket.Payload.Binary(data) =>
+                            JsonRpcMalformedMessage(Absent, "binary WebSocket frame", Structure.Value.Str(s"${data.size} bytes"))
+                    }
+
+                def close(using Frame): Unit < Async =
+                    ws.close()
+            end new
+        }
+    end webSocket
+
+    def webSocket(ws: HttpWebSocket)(using Frame): JsonRpcTransport < Sync =
+        webSocket(ws, summon[Schema[JsonRpcEnvelope]])
+
     /** Opens a WebSocket to `url` and adapts it as a [[JsonRpcTransport]].
       *
       * @param url
@@ -40,9 +86,9 @@ object JsonRpcHttpTransport:
             val transport: JsonRpcTransport = new JsonRpcTransport:
                 def send(env: JsonRpcEnvelope)(using Frame): Unit < (Async & Abort[Closed]) =
                     // Structure.encode is pure but throws a JsonRpcError for the unencodable cases (a Malformed
-                    // message, or a lenient reserved-extras key); Abort.catching reifies that so the
+                    // message, or a lenient reserved-extras key); Abort.run reifies that so the
                     // Success/Failure/Panic logging is preserved.
-                    Abort.run[JsonRpcError](Abort.catching[JsonRpcError](Structure.encode[JsonRpcEnvelope](env)(using codec))).map {
+                    Abort.run[JsonRpcError](Structure.encode[JsonRpcEnvelope](env)(using codec)).map {
                         case Result.Success(structure) =>
                             // Json.encode[Structure.Value] emits standard JSON-RPC wire text via the identity
                             // wire shape (Record to object, Str to string, Integer/Decimal to number), so the
@@ -112,6 +158,10 @@ object JsonRpcHttpTransport:
             }.map(_ => transport)
 
     extension (self: JsonRpcTransport.type)
+        def webSocket(ws: HttpWebSocket)(using Frame): JsonRpcTransport < Sync =
+            JsonRpcHttpTransport.webSocket(ws)
+        def webSocket(ws: HttpWebSocket, codec: Schema[JsonRpcEnvelope])(using Frame): JsonRpcTransport < Sync =
+            JsonRpcHttpTransport.webSocket(ws, codec)
         def webSocket(url: HttpUrl)(using Frame): JsonRpcTransport < (Async & Scope & Abort[HttpException]) =
             JsonRpcHttpTransport.webSocket(url)
         def webSocket(url: HttpUrl, headers: HttpHeaders)(using Frame): JsonRpcTransport < (Async & Scope & Abort[HttpException]) =

--- a/kyo-jsonrpc/shared/src/main/scala/kyo/internal/engine/JsonRpcEndpointImpl.scala
+++ b/kyo-jsonrpc/shared/src/main/scala/kyo/internal/engine/JsonRpcEndpointImpl.scala
@@ -280,12 +280,10 @@ object JsonRpcEndpointImpl:
                                     req.idSignal.completeDiscard(Result.succeed(id))(using AllowUnsafe.embrace.danger)
                                 }.andThen {
                                     // Build envelope and encode to JSON. Structure.encode is pure but throws a
-                                    // JsonRpcError for the unencodable cases; Abort.catching reifies that so the
+                                    // JsonRpcError for the unencodable cases; Abort.run reifies that so the
                                     // Success/non-Success branch shape is preserved.
                                     val env = JsonRpcRequest(id, req.method, req.encodedParams, extrasVal)
-                                    Abort.run[JsonRpcError](
-                                        Abort.catching[JsonRpcError](Structure.encode[JsonRpcEnvelope](env)(using config.codec, frame))
-                                    ).map {
+                                    Abort.run[JsonRpcError](Structure.encode[JsonRpcEnvelope](env)(using config.codec, frame)).map {
                                         case Result.Success(sv) => Json.encode[Structure.Value](sv)
                                         case _                  => ""
                                     }

--- a/kyo-jsonrpc/shared/src/main/scala/kyo/internal/transport/WireTransportAdapter.scala
+++ b/kyo-jsonrpc/shared/src/main/scala/kyo/internal/transport/WireTransportAdapter.scala
@@ -10,9 +10,9 @@ final private[kyo] class WireTransportAdapter(
 
     def send(env: JsonRpcEnvelope)(using Frame): Unit < (Async & Abort[Closed]) =
         // Structure.encode is pure but throws a JsonRpcError for the unencodable cases (a Malformed
-        // message, or a Lenient reserved-extras key); Abort.catching reifies that into a Result so the
+        // message, or a Lenient reserved-extras key); Abort.run reifies that into a Result so the
         // Success/Failure/Panic logging below is preserved.
-        Abort.run[JsonRpcError](Abort.catching[JsonRpcError](Structure.encode[JsonRpcEnvelope](env)(using codec))).map {
+        Abort.run[JsonRpcError](Structure.encode[JsonRpcEnvelope](env)(using codec)).map {
             case Result.Success(structure) =>
                 // Json.encode[Structure.Value] emits standard JSON-RPC wire bytes via the identity wire
                 // shape (Record to object, Str to string, Integer/Decimal to number), so the universal


### PR DESCRIPTION
## Problem

kyo-ai completion backends only covered direct API transports, so users could not run the same Prompt, Tool, Thought, Agent, ai.gen, and ai.stream workflows through Claude Code or Codex. Default backend selection also only probed API keys, which made command-backed providers awkward to select in demos and integration tests.

## Solution

Adds Claude Code and Codex completion backends behind the existing kyo-ai public API. Codex uses the app-server JSON-RPC protocol with native Responses history items and turn events. Claude Code uses the CLI stream-json protocol with structured transcript records and MCP-backed Kyo tool execution. Both backends return normal Kyo assistant and tool-call messages so the outer LLM loop keeps handling tools, results, thoughts, multi-turn history, and streaming consistently with the API providers.

Adds provider selection through StaticFlag-backed configuration, cross-platform command/process support needed by the harnesses, and comprehensive completion integration coverage across API and harness backends. The docs and demos now show how to run the command-backed and API providers explicitly.

## Notes

The harness implementations keep command tools, plugins, and project instructions out of the provider sessions. Kyo tool support remains routed through the kyo-ai tool loop rather than exposed as provider shell execution.

Supporting module changes are included in the same PR: kyo-config adds platform StaticFlag env/property resolution, kyo-core extends cross-platform Command, Process, and System support used by the harnesses, kyo-jsonrpc-http adds the WebSocket transport used by Codex app-server integration, kyo-jsonrpc removes redundant Abort.catching wrappers around envelope encoding, and kyo-http keeps the small WebSocket dispatch adjustments needed by that transport.