### PR TITLE
[kyo-schema] fix Yaml.decode Panic on discriminated field in List

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,13 +71,19 @@ jobs:
       # still runs the four targets on separate runners, so this costs no wall-clock on the JVM pole.
       SBT_TASK_LIMIT: 1
       # G1 is the JDK 24 default; pin it explicitly so the collector is fixed across JDK vendor/version.
-      # -Xmx12G is the driver ceiling, needed by the compile/link phase (Scala plus Scala.js/Wasm link
-      # run in the driver heap). There is deliberately no -Xms floor: tests run in forked JVMs (sized via
+      # -Xmx12G is the driver ceiling for the JVM, JS, and Wasm targets, whose compile and link phases run
+      # in the driver heap. There is deliberately no -Xms floor: tests run in forked JVMs (sized via
       # build.sbt Test/javaOptions), and SBT_TASK_LIMIT=1 keeps compile and test from overlapping, so a low
       # floor lets G1 release the driver's compile heap back to the box during the test phase, leaving room
-      # for the forks. Re-add a per-os ceiling override here if a memory-constrained arch is re-enabled.
-      JAVA_OPTS: '-Xmx12G -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
-      JVM_OPTS:  '-Xmx12G -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
+      # for the forks.
+      # The Native target is capped lower (8G). Its optimizer runs in the driver heap, but the native
+      # compile and link phase forks the LLVM toolchain (clang/ld) that runs ALONGSIDE the still-large
+      # driver heap within the one sbt task, so SBT_TASK_LIMIT=1 cannot serialize the two. A 12G driver
+      # heap plus the forked toolchain overcommits the 16GB runner and the kernel OOM-kills the driver
+      # (exit 143). 8G leaves physical headroom for the forked LLVM toolchain while still fitting the
+      # in-heap optimizer.
+      JAVA_OPTS: "-Xmx${{ matrix.target == 'Native' && '8G' || '12G' }} -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
+      JVM_OPTS:  "-Xmx${{ matrix.target == 'Native' && '8G' || '12G' }} -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
 
     steps:
       - uses: actions/checkout@v7.0.0

--- a/kyo-schema/shared/src/main/scala/kyo/internal/yaml/YamlReader.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/yaml/YamlReader.scala
@@ -466,8 +466,12 @@ final private[kyo] class YamlReader private (
                 delegate = Absent
                 reader
             case _ =>
+                // Only pull a new source-sequence element when no delegate holds the current one.
+                // A present delegate is the sequence element currently being decoded (its fields drained
+                // by a wrapper reader), so the capture forwards into it; pulling a new element here would
+                // re-enter the enclosing sequence frame after it is exhausted and read past end of buffer.
                 sourceFrames match
-                    case (f: SourceSequenceFrame) :: _ if allowSourcePull && !prepared =>
+                    case (f: SourceSequenceFrame) :: _ if allowSourcePull && !prepared && delegate.isEmpty =>
                         sourceCaptureSequenceElement(f)
                         delegate match
                             case Present(reader) =>
@@ -475,7 +479,7 @@ final private[kyo] class YamlReader private (
                                 reader
                             case Absent => error("Expected captured YAML value")
                         end match
-                    case (f: SourceFlowSequenceFrame) :: _ if allowSourcePull && !prepared =>
+                    case (f: SourceFlowSequenceFrame) :: _ if allowSourcePull && !prepared && delegate.isEmpty =>
                         sourceCaptureSequenceElement(f)
                         delegate match
                             case Present(reader) =>
@@ -1012,7 +1016,13 @@ final private[kyo] class YamlReader private (
                 anchor.foreach(a => registerSourceAnchor(a.value, value, valueLine))
                 SourceValue(value, valueLine)
             else if tailEnd > tailStart then
-                SourceValue(trimmed + "\n" + normalizeBlock(tailStart, tailEnd, frame.indent), lineNumber)
+                // Exclude a tail that is entirely blank lines: those are trailing
+                // document blanks, not continuation content for a plain scalar.
+                // Block scalar indicators (| >) and multi-line plain scalar
+                // continuations always produce non-blank tail text, so they pass through.
+                val normalizedTail = normalizeBlock(tailStart, tailEnd, frame.indent)
+                if normalizedTail.isBlank then SourceValue(trimmed + "\n", lineNumber)
+                else SourceValue(trimmed + "\n" + normalizedTail, lineNumber)
             else SourceValue(trimmed + "\n", lineNumber)
             end if
         else
@@ -1572,6 +1582,7 @@ final private[kyo] class YamlReader private (
 
     private def readSourceRestOfLineFrom(start: Int): String =
         sourcePos = YamlSource.lineEnd(source, sourcePos)
+        if start > sourcePos then sourceError("Invalid YAML source capture position")
         val out = source.substring(start, sourcePos)
         if sourcePos < source.length && source.charAt(sourcePos) == '\n' then sourcePos += 1
         out

--- a/kyo-schema/shared/src/test/scala/kyo/YamlTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/YamlTest.scala
@@ -35,6 +35,20 @@ final case class YamlMultiDocumentConfig(
     unit: SealedNoArgVariants
 ) derives CanEqual
 
+sealed trait YamlDiscSource derives CanEqual
+case class YamlRabbit(host: String, queue: Maybe[String]) extends YamlDiscSource derives CanEqual, Schema
+case class YamlKafka(broker: String)                      extends YamlDiscSource derives CanEqual, Schema
+given Schema[YamlDiscSource] = Schema.derived[YamlDiscSource].discriminator("type")
+case class YamlDiscTable(name: String, source: YamlDiscSource) derives CanEqual, Schema
+case class YamlDiscRoot(tables: List[YamlDiscTable]) derives CanEqual, Schema
+case class YamlDiscGroup(name: String, tables: List[YamlDiscTable]) derives CanEqual, Schema
+case class YamlDiscDeep(groups: List[YamlDiscGroup]) derives CanEqual, Schema
+
+sealed trait YamlAdjSource derives CanEqual
+case class YamlAdjRabbit(host: String) extends YamlAdjSource derives CanEqual, Schema
+given Schema[YamlAdjSource] = Schema.derived[YamlAdjSource].adjacent("type", "content")
+case class YamlAdjRoot(sources: List[YamlAdjSource]) derives CanEqual, Schema
+
 class YamlTest extends kyo.test.Test[Any]:
 
     given CanEqual[Any, Any] = CanEqual.derived
@@ -1166,6 +1180,194 @@ class YamlTest extends kyo.test.Test[Any]:
                         Result.succeed(context + 1)
 
             assert(Yaml.Events.visit("x: &a 1\ny: *a\n", 0)(countingMappings) == Result.succeed(1))
+        }
+
+        "discriminated source in single-element list decodes to Success" in {
+            val yaml =
+                """tables:
+                  |  - name: t1
+                  |    source:
+                  |      type: YamlRabbit
+                  |      host: localhost
+                  |""".stripMargin
+            val result = Yaml.decode[YamlDiscRoot](yaml)
+            assert(result == Result.succeed(YamlDiscRoot(List(YamlDiscTable("t1", YamlRabbit("localhost", Absent))))))
+        }
+
+        // guards StringIndexOutOfBoundsException regression
+        "discriminated source decode in single-element list is not a Panic" in {
+            val yaml =
+                """tables:
+                  |  - name: t1
+                  |    source:
+                  |      type: YamlRabbit
+                  |      host: localhost
+                  |""".stripMargin
+            val result = Yaml.decode[YamlDiscRoot](yaml)
+            assert(!result.isPanic)
+            assert(result == Result.succeed(YamlDiscRoot(List(YamlDiscTable("t1", YamlRabbit("localhost", Absent))))))
+        }
+
+        "unknown discriminator variant in list element is typed failure not panic" in {
+            val yaml =
+                """tables:
+                  |  - name: t1
+                  |    source:
+                  |      type: Unknown
+                  |      host: localhost
+                  |""".stripMargin
+            val result = Yaml.decode[YamlDiscRoot](yaml)
+            assert(result.isFailure)
+            assert(!result.isPanic)
+        }
+
+        "multi-element list with discriminated source decodes all elements correctly" in {
+            val yaml =
+                """tables:
+                  |  - name: t1
+                  |    source:
+                  |      type: YamlRabbit
+                  |      host: h1
+                  |  - name: t2
+                  |    source:
+                  |      type: YamlKafka
+                  |      broker: b2
+                  |""".stripMargin
+            val result = Yaml.decode[YamlDiscRoot](yaml)
+            assert(result == Result.succeed(YamlDiscRoot(List(
+                YamlDiscTable("t1", YamlRabbit("h1", Absent)),
+                YamlDiscTable("t2", YamlKafka("b2"))
+            ))))
+        }
+
+        "depth: nested list with discriminated source, inner list exhausted at EOF" in {
+            val yaml =
+                """groups:
+                  |  - name: g1
+                  |    tables:
+                  |      - name: t1
+                  |        source:
+                  |          type: YamlRabbit
+                  |          host: h1
+                  |""".stripMargin
+            val result = Yaml.decode[YamlDiscDeep](yaml)
+            assert(result == Result.succeed(YamlDiscDeep(List(
+                YamlDiscGroup("g1", List(YamlDiscTable("t1", YamlRabbit("h1", Absent))))
+            ))))
+        }
+
+        "depth: nested list with outer sibling group after inner exhausted list" in {
+            val yaml =
+                """groups:
+                  |  - name: g1
+                  |    tables:
+                  |      - name: t1
+                  |        source:
+                  |          type: YamlRabbit
+                  |          host: h1
+                  |  - name: g2
+                  |    tables:
+                  |      - name: t2
+                  |        source:
+                  |          type: YamlKafka
+                  |          broker: b2
+                  |""".stripMargin
+            val result = Yaml.decode[YamlDiscDeep](yaml)
+            assert(result == Result.succeed(YamlDiscDeep(List(
+                YamlDiscGroup("g1", List(YamlDiscTable("t1", YamlRabbit("h1", Absent)))),
+                YamlDiscGroup("g2", List(YamlDiscTable("t2", YamlKafka("b2"))))
+            ))))
+        }
+
+        "flow-sequence: inline flow list and nested-flow decode to Success" in {
+            val yaml1    = "tables: [{name: t1, source: {type: YamlRabbit, host: localhost}}]"
+            val yaml2    = "{tables: [{name: t1, source: {type: YamlRabbit, host: localhost}}]}"
+            val expected = Result.succeed(YamlDiscRoot(List(YamlDiscTable("t1", YamlRabbit("localhost", Absent)))))
+            assert(Yaml.decode[YamlDiscRoot](yaml1) == expected)
+            assert(Yaml.decode[YamlDiscRoot](yaml2) == expected)
+        }
+
+        "EOF-adjacent: trailing blank lines and no trailing newline both decode to the same value" in {
+            val yamlNoTrail = "tables:\n  - name: t1\n    source:\n      type: YamlRabbit\n      host: localhost"
+            val yamlTrail =
+                """tables:
+                  |  - name: t1
+                  |    source:
+                  |      type: YamlRabbit
+                  |      host: localhost
+                  |
+                  |
+                  |""".stripMargin
+            val expected = Result.succeed(YamlDiscRoot(List(YamlDiscTable("t1", YamlRabbit("localhost", Absent)))))
+            assert(Yaml.decode[YamlDiscRoot](yamlNoTrail) == expected)
+            assert(Yaml.decode[YamlDiscRoot](yamlTrail) == expected)
+        }
+
+        "direct decode and list-nested decode of a discriminated source agree" in {
+            val directYaml =
+                """type: YamlRabbit
+                  |host: localhost
+                  |
+                  |""".stripMargin
+            val listYaml =
+                """tables:
+                  |  - name: t1
+                  |    source:
+                  |      type: YamlRabbit
+                  |      host: localhost
+                  |
+                  |""".stripMargin
+            val directResult = Yaml.decode[YamlDiscSource](directYaml)
+            val listResult   = Yaml.decode[YamlDiscRoot](listYaml).map(_.tables.head.source)
+            assert(directResult == listResult)
+            assert(directResult == Result.succeed(YamlRabbit("localhost", Absent)))
+        }
+
+        "sibling-key-after-block and comment-in-block both decode to Success" in {
+            val yamlSibling =
+                """tables:
+                  |  - name: t1
+                  |    source:
+                  |      type: YamlRabbit
+                  |      host: localhost
+                  |    extra: ignored
+                  |""".stripMargin
+            val yamlComment =
+                """tables:
+                  |  - name: t1
+                  |    source:
+                  |      # note
+                  |      type: YamlRabbit
+                  |      host: localhost
+                  |""".stripMargin
+            val expected = Result.succeed(YamlDiscRoot(List(YamlDiscTable("t1", YamlRabbit("localhost", Absent)))))
+            assert(Yaml.decode[YamlDiscRoot](yamlSibling) == expected)
+            assert(Yaml.decode[YamlDiscRoot](yamlComment) == expected)
+        }
+
+        "adjacent-tagged union in list element decodes correctly" in {
+            val yaml =
+                """sources:
+                  |  - type: YamlAdjRabbit
+                  |    content:
+                  |      host: localhost
+                  |""".stripMargin
+            val result = Yaml.decode[YamlAdjRoot](yaml)
+            assert(result == Result.succeed(YamlAdjRoot(List(YamlAdjRabbit("localhost")))))
+        }
+
+        "non-regression: direct YAML decode and JSON list decode still succeed" in {
+            val yamlDirect =
+                """type: YamlRabbit
+                  |host: localhost
+                  |queue: q1
+                  |""".stripMargin
+            val jsonList = """{"tables":[{"name":"t1","source":{"type":"YamlRabbit","host":"localhost"}}]}"""
+            assert(Yaml.decode[YamlDiscSource](yamlDirect) == Result.succeed(YamlRabbit("localhost", Present("q1"))))
+            assert(Json.decode[YamlDiscRoot](jsonList) == Result.succeed(YamlDiscRoot(List(YamlDiscTable(
+                "t1",
+                YamlRabbit("localhost", Absent)
+            )))))
         }
 
     }


### PR DESCRIPTION
Fixes #1734

## Problem

`Yaml.decode` is a total decoder: its contract is `Result[DecodeException, A]`, so every failure on structurally valid input must surface as a typed `Result.Failure`, never a raw JVM throwable. Decoding a case class whose field is a `.discriminator("type")` sealed trait broke that contract whenever the enclosing case class was an element of a `List`.

The reporter's minimal case:

```scala
sealed trait TableSource
case class RabbitMQ(topic: String = "OK", routingKey: String = "OK", format: String) extends TableSource
given Schema[TableSource] = Schema[TableSource].discriminator("type")

case class Table(name: String, target: String, source: TableSource, hardDelete: Boolean = false) derives Schema
case class Root(tables: List[Table]) derives Schema

val yaml =
  """tables:
    |  - name: sample
    |    target: sample
    |    hardDelete: true
    |    source:
    |      type: RabbitMQ
    |      format: maxwell
    |""".stripMargin

Yaml.decode[Root](yaml) // Result.Panic(StringIndexOutOfBoundsException: Range [1041, 1040) ...)
```

Decoding the same `Table` on its own (not inside a `List`) worked, and JSON decode of the equivalent structure worked. Only YAML + a discriminated field + a `List`-nested enclosing class crashed.

### Root cause

In `YamlReader.captureValue`. A wrapper reader (here `DiscriminatorReader`) drains the non-discriminator fields of the current element by calling `inner.captureValue()` in a loop. That call forwards down the delegate chain until it reaches the reader holding the enclosing `List`'s `SourceSequenceFrame`. At that point the frame is exhausted **and** a delegate is present (the list element being decoded), but the sequence arms were guarded only on `allowSourcePull && !prepared`, not on whether a delegate was live. So they fired anyway, pulled a nonexistent next element, advanced `sourcePos` past end of buffer, and handed `start = len + 1` to `readSourceRestOfLineFrom`, which called `source.substring(len + 1, len)`.

The defect was shared by all four wrapper readers (`DiscriminatorReader`, `AdjacentReader`, `TupleReader`, `TupleFlatReader`) since they all drain through the same `captureValue` path.

A second, related gap: plain scalars captured in source mode absorbed trailing blank document lines as continuation content, so direct decode and list-nested decode of the same field produced different captured strings (e.g. `"localhost"` vs `"localhost\n\n"`).

## Fix

**1. Guard the source-sequence arms on `delegate.isEmpty`** so a reader pulls a new element only when it does not already hold the current one. Per-reader and depth-independent.

```scala
// before
case (f: SourceSequenceFrame) :: _ if allowSourcePull && !prepared =>
case (f: SourceFlowSequenceFrame) :: _ if allowSourcePull && !prepared =>

// after
case (f: SourceSequenceFrame) :: _ if allowSourcePull && !prepared && delegate.isEmpty =>
case (f: SourceFlowSequenceFrame) :: _ if allowSourcePull && !prepared && delegate.isEmpty =>
```

When a delegate is present, both arms are skipped and control falls to the existing general arm, which forwards the capture into the current element. When no delegate is present, the arms fire exactly as before.

**2. Typed bounds backstop** in `readSourceRestOfLineFrom`, so any future re-introduction of a `start > sourcePos` inversion surfaces as a diagnosable `ParseException` rather than a raw `StringIndexOutOfBoundsException`:

```scala
private def readSourceRestOfLineFrom(start: Int): String =
    sourcePos = YamlSource.lineEnd(source, sourcePos)
    if start > sourcePos then sourceError("Invalid YAML source capture position")
    ...
```

**3. Trailing-blank scalar parity.** A plain-scalar tail that is entirely blank lines is trailing document whitespace, not continuation content, and is now excluded so direct and list-nested decode agree:

```scala
val normalizedTail = normalizeBlock(tailStart, tailEnd, frame.indent)
if normalizedTail.isBlank then SourceValue(trimmed + "\n", lineNumber)
else SourceValue(trimmed + "\n" + normalizedTail, lineNumber)
```

Block scalar indicators (`|`, `>`) and multi-line plain-scalar continuations always produce non-blank tail text, so they pass through unchanged.

## What now works

The reporter's repro decodes to `Result.Success`. Verified by twelve regression tests added to `YamlTest.scala`:

- the exact single-element repro
- a `!result.isPanic` assertion naming the `StringIndexOutOfBoundsException` regression
- unknown discriminator variant yielding a typed `Failure` (not a Panic)
- multi-element list with every element decoded correctly
- depth with an outer sibling group following an exhausted inner list
- inline flow sequence
- EOF-adjacent (no trailing newline, and trailing blank lines)
- direct vs list-nested decode parity
- sibling-key and in-block-comment variants
- an adjacent-tagged union in a list element (covers the shared wrapper-reader path)
- non-regression for direct YAML and JSON decodes

Green on JVM, JS, and Native (`YamlTest` 87/87 on each); the full `kyo-schema` suite passes on all three platforms with no other behavioral change.

## Notes

The bounds check in `readSourceRestOfLineFrom` is not reachable by any current test (the guard removes the only inverting route). It is kept as a boundary invariant so this bug class cannot silently recur as a `Panic` under a future change to the source-capture path.