### PR TITLE
[schema] shrink Schema derivation codegen (shared bodies, hoisted name bytes)

### DIFF
--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -1566,10 +1566,10 @@ object Schema:
         ):
             @publicInBinary def serializeWrite(value: A, writer: Writer): Unit =
                 if hasTransforms then transformedWrite(value, writer)
-                else writeFn(value, writer)
+                else rawSerializeWrite(value, writer)
             @publicInBinary def serializeRead(reader: Reader): A =
                 if hasReadTransforms then transformedRead(reader)
-                else readFn(reader)
+                else rawSerializeRead(reader)
             @publicInBinary override def rawSerializeWrite(value: A, writer: Writer): Unit = writeFn(value, writer)
             @publicInBinary override def rawSerializeRead(reader: Reader): A               = readFn(reader)
             @publicInBinary def getter(value: A): Maybe[Any]                               = getterFn(value)
@@ -3096,10 +3096,10 @@ object Schema:
             @publicInBinary override private[kyo] val flattenedReadFields: Chunk[(String, String)] = flattenedReadFields0
             @publicInBinary def serializeWrite(value: A, writer: Writer): Unit =
                 if hasTransforms then transformedWrite(value, writer)
-                else writeFn(value, writer)
+                else rawSerializeWrite(value, writer)
             @publicInBinary def serializeRead(reader: Reader): A =
                 if hasReadTransforms then transformedRead(reader)
-                else readFn(reader)
+                else rawSerializeRead(reader)
             @publicInBinary override def rawSerializeWrite(value: A, writer: Writer): Unit = writeFn(value, writer)
             @publicInBinary override def rawSerializeRead(reader: Reader): A               = readFn(reader)
             @publicInBinary def getter(value: A): Maybe[Any]                               = getterFn(value)

--- a/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
@@ -333,7 +333,7 @@ import scala.quoted.*
             if isMarker || policyAdmits(policy, fqn) then reifyAnnotation(term)
             else None
         }
-        '{ kyo.Chunk.from[Any](Array[Any](${ Varargs(kept) }*)) }
+        if kept.isEmpty then '{ kyo.Chunk.empty[Any] } else '{ kyo.Chunk.from[Any](Array[Any](${ Varargs(kept) }*)) }
     end captureAnnotations
 
     /** Captures the policy-surviving annotation instances for a case-class field as an
@@ -367,7 +367,7 @@ import scala.quoted.*
             if isMarker || policyAdmits(policy, fqn) then reifyAnnotation(term)
             else None
         }
-        '{ kyo.Chunk.from[Any](Array[Any](${ Varargs(kept) }*)) }
+        if kept.isEmpty then '{ kyo.Chunk.empty[Any] } else '{ kyo.Chunk.from[Any](Array[Any](${ Varargs(kept) }*)) }
     end captureFieldAnnotations
 
     /** Summons the in-scope `AnnotationPolicy`, falling back to the companion `given default`.
@@ -1555,6 +1555,14 @@ import scala.quoted.*
                 s
             }
 
+        // Hoist each field's UTF-8 name bytes to one val shared by the write and read bodies and
+        // materialized once per Schema instance, instead of a `_wnb`/`_nb` pair recomputed on every
+        // serialize call. Mirrors the hoisted field-schema mechanism above; referenced from both
+        // bodies via Ref, the same cross-body sharing the hoisted schemas already use.
+        val nameByteSyms: List[Symbol] = fields.zipWithIndex.map { (_, idx) =>
+            Symbol.newVal(hoistOwner, s"_nb${idx}", TypeRepr.of[Array[Byte]], Flags.EmptyFlags, Symbol.noSymbol)
+        }
+
         val tagExpr = summonSchemaTag(tpe)
 
         // Per-field flag: is the effective inner type itself nullable (Maybe[T] / Option[T])?
@@ -1608,19 +1616,11 @@ import scala.quoted.*
 
         // WRITE: static per-field emission, no runtime field walk.
         def writeBody(v: Expr[A], w: Expr[Writer]): Expr[Unit] =
-            val owner = Symbol.spliceOwner
-            // Pre-encode each field's UTF-8 name bytes once per serialization, mirroring the read side's
-            // nameByteSyms and the sealed-variant write path. Schema field keys go through `fieldBytes`
-            // (the canonical schema-field key method: the JSON writer's ASCII fast path, the Protobuf
-            // field tag, and the MsgPack key-encoding switch). Dynamic `Map` keys and the hand-written
-            // sum discriminator keys stay on `field`, which carries the raw String for escaping.
-            val nameByteSyms: List[Symbol] = fields.zipWithIndex.map { (f, idx) =>
-                Symbol.newVal(owner, s"_wnb${idx}", TypeRepr.of[Array[Byte]], Flags.EmptyFlags, Symbol.noSymbol)
-            }
-            val nameByteDefs: List[Statement] = fields.zipWithIndex.map { (f, idx) =>
-                val nameExpr = Expr(f.name)
-                ValDef(nameByteSyms(idx), Some('{ $nameExpr.getBytes(java.nio.charset.StandardCharsets.UTF_8) }.asTerm))
-            }
+            // Field name bytes are hoisted to one per-instance val shared with the read body (see
+            // nameByteSyms above). Schema field keys go through `fieldBytes` (the canonical schema-field
+            // key method: the JSON writer's ASCII fast path, the Protobuf field tag, and the MsgPack
+            // key-encoding switch). Dynamic `Map` keys and the hand-written sum discriminator keys stay
+            // on `field`, which carries the raw String for escaping.
             val header: Term = '{ $w.objectStart(${ Expr(typeName) }, ${ Expr(n) }) }.asTerm
             val perField: List[Term] = fields.zipWithIndex.map { (f, idx) =>
                 // Field header tag MUST be the hash-based field ID (CodecMacro.fieldId), NOT the
@@ -1664,7 +1664,7 @@ import scala.quoted.*
                 end if
             }
             val trailer: Term = '{ $w.objectEnd() }.asTerm
-            Block(nameByteDefs ++ (header :: perField), trailer).asExprOf[Unit]
+            Block(header :: perField, trailer).asExprOf[Unit]
         end writeBody
 
         // READ: static per-field name-matched loop.
@@ -1747,15 +1747,7 @@ import scala.quoted.*
             // Dispatch via reader.matchField(nameBytes), NOT lastFieldName(). matchField is the
             // canonical name-bytes comparison that works on every wire format; lastFieldName() is a
             // human-readable surrogate only (a numeric field-ID under Protobuf, never the field name).
-            // Pre-encode each field's UTF-8 name bytes into a stable local; a `while j < n && matchedIdx < 0`
-            // chain then selects the matching field.
-            val nameByteSyms: List[Symbol] = fields.zipWithIndex.map { (f, idx) =>
-                Symbol.newVal(owner, s"_nb${idx}", TypeRepr.of[Array[Byte]], Flags.EmptyFlags, Symbol.noSymbol)
-            }
-            val nameByteDefs: List[Statement] = fields.zipWithIndex.map { (f, idx) =>
-                val nameExpr = Expr(f.name)
-                ValDef(nameByteSyms(idx), Some('{ $nameExpr.getBytes(java.nio.charset.StandardCharsets.UTF_8) }.asTerm))
-            }
+            // The name bytes come from the hoisted per-instance nameByteSyms shared with the write body.
 
             // Per-field arm: assign the typed read result + OR-in the seen bit.
             def fieldArm(idx: Int): Term =
@@ -1816,7 +1808,7 @@ import scala.quoted.*
                             '{ kyo.discard($r.objectStart()) }.asTerm,
                             '{ kyo.discard($r.initFields($nExpr)) }.asTerm,
                             seenDef
-                        ) ++ localDefs ++ nameByteDefs ++
+                        ) ++ localDefs ++
                             List(whileLoop) ++
                             requiredCheckOpt.toList ++
                             List(
@@ -1911,10 +1903,17 @@ import scala.quoted.*
                     structure = ${ structureExpr }
                 )
             }.asTerm
-        val hoistedValDefs: List[Statement] = hoistedSchemas.toList.map { (t, sym) =>
+        val hoistedSchemaValDefs: List[Statement] = hoistedSchemas.toList.map { (t, sym) =>
             t.asType match
                 case '[tt] => ValDef(sym, Some('{ summonInline[Schema[tt]] }.asTerm))
         }
+        // Name-byte vals: one per field, materialized once per instance and shared by write and read
+        // (they replaced the former per-body `_wnb`/`_nb` locals).
+        val hoistedNameByteDefs: List[Statement] = fields.zipWithIndex.map { (f, idx) =>
+            val nameExpr = Expr(f.name)
+            ValDef(nameByteSyms(idx), Some('{ $nameExpr.getBytes(java.nio.charset.StandardCharsets.UTF_8) }.asTerm))
+        }
+        val hoistedValDefs: List[Statement] = hoistedSchemaValDefs ++ hoistedNameByteDefs
         if hoistedValDefs.isEmpty then schemaInitTerm.asExprOf[Schema[A]]
         else Block(hoistedValDefs, schemaInitTerm).asExprOf[Schema[A]]
     end emitProductSchemaStatic


### PR DESCRIPTION
## Motivation

`Schema` derivation emits a fully static, per-field write/read/structure body per derived type (`FocusMacro.emitProductSchemaStatic`). That generated volume is paid twice: the Scala compiler expands it, and the Scala Native optimizer/linker processes it again. On a memory-constrained CI runner a module that derives many `Schema`s pushes the Native optimize/link phase into an out-of-memory kill. This change removes duplicated generated code without touching behavior, wire format, or the public surface.

No API change, no wire-format change. The full `kyo-schema` suite (Schema, Json, Yaml, Protobuf, MsgPack, Ion, composition) passes on JVM, JS, and Native.

## Changes

**1. Emit each write/read body once, not twice.** `Schema.init` is `inline`, so its `writeFn`/`readFn` were inline-expanded into both the transform-gated method and the raw method:

```scala
// before — writeFn expands in serializeWrite's else-branch AND rawSerializeWrite
def serializeWrite(value, writer) = if hasTransforms then transformedWrite(...) else writeFn(value, writer)
override def rawSerializeWrite(value, writer) = writeFn(value, writer)

// after — the transform-free path delegates, so writeFn expands once
def serializeWrite(value, writer) = if hasTransforms then transformedWrite(...) else rawSerializeWrite(value, writer)
override def rawSerializeWrite(value, writer) = writeFn(value, writer)
```

Same for `serializeRead`/`rawSerializeRead`. Both methods stay defined (the transform engine calls the `raw*` variants directly); only the duplicated body is removed. Applies to the two `Schema.init` construction sites and `initFocused`.

**2. Hoist field name bytes to one shared per-instance val.** The product emitter computed each field's UTF-8 name bytes twice — a `_wnb{idx}` local in the write body and a `_nb{idx}` local in the read body — both recomputed on every serialize call. They are now one hoisted val per field, materialized once per `Schema` instance and referenced by both bodies, using the same mechanism the sealed and union emitters already use for their name bytes.

**3. Short-circuit empty annotations.** `captureAnnotations` / `captureFieldAnnotations` emitted `Chunk.from(Array[Any]())` per field and per variant even when no annotation survived the policy filter; they now return `Chunk.empty[Any]` in that (common) case.

## Effect

Halves the two largest per-derivation bodies, removes the duplicate name-byte materialization from the hot serialize paths (moving it to once-per-instance construction), and drops the empty-annotation array wrapper per field/variant. The result is less static code per `derives Schema` for both the compiler and the Native toolchain to process, which is what relieves the Native optimize/link memory pressure.

## Verification

Clean `kyo-schemaJVM/test`, `kyo-schemaJS/test`, and `kyo-schemaNative/test` all green (SchemaTest 270, JsonTest 199, YamlTest 75, ProtobufTest 134, MsgPackTest 52, IonTest 22, SchemaCompositionTest 57, plus codec/composition suites), confirming every wire format round-trips unchanged.