### PR TITLE
[kyo-data] restore constant-time Tag hashing on the dispatch path

### DIFF
--- a/kyo-config/README.md
+++ b/kyo-config/README.md
@@ -343,7 +343,7 @@ Increasing the percentage adds entities without removing existing ones. A typica
 | 4 | `true@75%;false` | 75% of users (buckets 0-74) |
 | 5 | `true` | 100% of users (terminal) |
 
-Bucketing is deterministic per key (via XXH32), so a user who was included at 5% stays included at 25%. The bucket range grows from the same starting point, making progressive rollouts additive.
+Bucketing is deterministic per key (via a stable string hash), so a user who was included at 5% stays included at 25%. The bucket range grows from the same starting point, making progressive rollouts additive.
 
 However, **decreasing** a percentage can remove entities: going from 75% back to 50% drops buckets 50-74, removing 25% of previously included users.
 

--- a/kyo-config/shared/src/main/scala/kyo/internal/XXHash.scala
+++ b/kyo-config/shared/src/main/scala/kyo/internal/XXHash.scala
@@ -5,6 +5,10 @@ package kyo.internal
   * This is a Scala port of the official Java XXH32 and XXH64 implementations from xxHash 0.8.x. The port keeps the same constants, round
   * functions, tail processing, and avalanche steps, while replacing platform-specific memory access with explicit little-endian array reads.
   *
+  * The `String` overload is not a UTF-8 content hash: it applies XXH32 to the memoized JLS `String.hashCode` so that hashing a reused
+  * string is constant-time and allocation-free (see `hash32(String)`). To hash a composite key (for example a case class), prefer
+  * `hashInt(key.hashCode)` over rendering the key to a string.
+  *
   * Return values preserve the exact xxHash bit pattern in signed Scala `Int` and `Long` values. Callers that need unsigned formatting should
   * format the returned bits explicitly.
   */
@@ -67,48 +71,15 @@ private[kyo] object XXHash {
         avalanche32(processTail32(h, bytes, i, end))
     }
 
-    /** Hashes a string as UTF-8 bytes with XXH32 and seed `0`.
+    /** Hashes a string as XXH32 of the four little-endian bytes of its `hashCode`.
+      *
+      * This deliberately builds on the JLS-specified, platform-stable `String.hashCode` rather than streaming the string's UTF-8 content:
+      * the JVM memoizes `String.hashCode` per instance, so hashing a reused string is constant-time and allocation-free. This method may
+      * sit on hot paths, so that property is load-bearing; do not replace it with a per-call content hash. The XXH32 finalizer restores
+      * avalanche quality over the weakly-mixed JLS hash, while collision pairs remain exactly those of `String.hashCode`.
       */
     def hash32(input: String): Int =
-        hash32(input, 0)
-
-    /** Hashes a string as UTF-8 bytes with XXH32 and the supplied seed.
-      *
-      * The implementation streams UTF-8 bytes into the XXH32 state instead of first allocating a byte array. Valid surrogate pairs are encoded
-      * as their Unicode code point. Unpaired surrogates are encoded as `?`, matching Java's default UTF-8 replacement behavior.
-      */
-    def hash32(input: String, seed: Int): Int = {
-        val state = new Utf8State32(seed)
-        var i     = 0
-        while (i < input.length) {
-            val c = input.charAt(i)
-            if (c < 0x80) {
-                state.add(c)
-            } else if (c < 0x800) {
-                state.add(0xc0 | (c >>> 6))
-                state.add(0x80 | (c & 0x3f))
-            } else if (Character.isHighSurrogate(c)) {
-                if (i + 1 < input.length && Character.isLowSurrogate(input.charAt(i + 1))) {
-                    val codePoint = Character.toCodePoint(c, input.charAt(i + 1))
-                    state.add(0xf0 | (codePoint >>> 18))
-                    state.add(0x80 | ((codePoint >>> 12) & 0x3f))
-                    state.add(0x80 | ((codePoint >>> 6) & 0x3f))
-                    state.add(0x80 | (codePoint & 0x3f))
-                    i += 1
-                } else {
-                    state.add(0x3f)
-                }
-            } else if (Character.isLowSurrogate(c)) {
-                state.add(0x3f)
-            } else {
-                state.add(0xe0 | (c >>> 12))
-                state.add(0x80 | ((c >>> 6) & 0x3f))
-                state.add(0x80 | (c & 0x3f))
-            }
-            i += 1
-        }
-        state.digest()
-    }
+        hashInt(input.hashCode)
 
     /** Hashes an integer as its four little-endian bytes with XXH32 and seed `0`.
       */
@@ -165,73 +136,6 @@ private[kyo] object XXHash {
         }
         h += length.toLong
         avalanche64(processTail64(h, bytes, i, end))
-    }
-
-    final private class Utf8State32(seed: Int) {
-
-        private var total     = 0
-        private var buffered  = 0
-        private var processed = false
-        private var m0        = 0
-        private var m1        = 0
-        private var m2        = 0
-        private var m3        = 0
-        private var v1        = seed + Prime32_1 + Prime32_2
-        private var v2        = seed + Prime32_2
-        private var v3        = seed
-        private var v4        = seed - Prime32_1
-
-        def add(byte: Int): Unit = {
-            val b     = byte & 0xff
-            val shift = (buffered & 3) << 3
-            (buffered >> 2) match {
-                case 0 => m0 |= b << shift
-                case 1 => m1 |= b << shift
-                case 2 => m2 |= b << shift
-                case _ => m3 |= b << shift
-            }
-            buffered += 1
-            total += 1
-            if (buffered == 16) {
-                v1 = round32(v1, m0)
-                v2 = round32(v2, m1)
-                v3 = round32(v3, m2)
-                v4 = round32(v4, m3)
-                m0 = 0
-                m1 = 0
-                m2 = 0
-                m3 = 0
-                buffered = 0
-                processed = true
-            }
-        }
-
-        def digest(): Int = {
-            var h =
-                if (processed) rotateLeft(v1, 1) + rotateLeft(v2, 7) + rotateLeft(v3, 12) + rotateLeft(v4, 18)
-                else seed + Prime32_5
-            h += total
-            h = processWord(h, m0, buffered, 0)
-            h = processWord(h, m1, buffered, 4)
-            h = processWord(h, m2, buffered, 8)
-            h = processWord(h, m3, buffered, 12)
-            avalanche32(h)
-        }
-
-        private def processWord(hash: Int, word: Int, size: Int, base: Int): Int = {
-            var h         = hash
-            val available = size - base
-            if (available >= 4) {
-                h = rotateLeft(h + word * Prime32_3, 17) * Prime32_4
-            } else if (available > 0) {
-                var i = 0
-                while (i < available) {
-                    h = rotateLeft(h + ((word >>> (i << 3)) & 0xff) * Prime32_5, 11) * Prime32_1
-                    i += 1
-                }
-            }
-            h
-        }
     }
 
     private def processTail32(hash: Int, bytes: Array[Byte], offset: Int, end: Int): Int = {

--- a/kyo-config/shared/src/test/scala/kyo/XXHashTest.scala
+++ b/kyo-config/shared/src/test/scala/kyo/XXHashTest.scala
@@ -1,6 +1,5 @@
 package kyo
 
-import java.nio.charset.StandardCharsets
 import kyo.internal.XXHash
 import org.scalatest.freespec.AnyFreeSpec
 
@@ -33,13 +32,19 @@ class XXHashTest extends AnyFreeSpec {
             assert(sliced == XXHash.hash32(whole, 0, whole.length, Seed32))
         }
 
-        "hashes strings as UTF-8 bytes" in {
+        "hashes strings as XXH32 of the JLS string hash" in {
             val values = Seq("", "ascii", "caf\u00e9", "\u6f22\u5b57", "emoji \ud83d\ude80", "\ud800", "\udc00")
             values.foreach { value =>
-                val bytes = value.getBytes(StandardCharsets.UTF_8)
-                assert(XXHash.hash32(value) == XXHash.hash32(bytes))
-                assert(XXHash.hash32(value, Seed32) == XXHash.hash32(bytes, Seed32))
+                assert(XXHash.hash32(value) == XXHash.hashInt(value.hashCode))
             }
+        }
+
+        "string hashes are pinned cross-platform constants" in {
+            assert(XXHash.hash32("") == 148298089)
+            assert(XXHash.hash32("ascii") == 1274324121)
+            assert(XXHash.hash32("caf\u00e9") == 310371487)
+            assert(XXHash.hash32("\u6f22\u5b57") == -1761639557)
+            assert(XXHash.hash32("emoji \ud83d\ude80") == 687346460)
         }
     }
 

--- a/kyo-data/shared/src/main/scala/kyo/Tag.scala
+++ b/kyo-data/shared/src/main/scala/kyo/Tag.scala
@@ -166,6 +166,9 @@ object Tag:
           * Since the set of statically derived tags is bounded and fixed at compile time, hash code collisions between different types are
           * extremely unlikely. This method checks for these common cases before falling back to the more expensive full type-based checking
           * if any of the tags are dynamic.
+          *
+          * This method runs on the kernel's per-operation dispatch path, so it relies on the memoized `String.hashCode` and must not
+          * recompute a content hash per call. Content-stable cross-process hashing is `hash`'s job, not this method's.
           */
         private def fastPathEqual[B](that: Tag[B]): Boolean =
             (self eq that) || {
@@ -173,7 +176,7 @@ object Tag:
                     case self: String =>
                         that match
                             case that: String =>
-                                XXHash.hash32(self) == XXHash.hash32(that)
+                                self.hashCode == that.hashCode
                             case _ =>
                                 false
                     case _ =>
@@ -375,7 +378,9 @@ object Tag:
           *   true if a is a subtype of b, false otherwise
           */
         def checkTypes[A, B](a: Tag[A], b: Tag[B], mode: Mode): Boolean =
-            var hash = (a.hash.toLong << 32) | (b.hash & 0xffffffffL)
+            // Cache key from memoized hashCodes: this is a per-call in-process key, so it must not
+            // recompute a content hash (the memoization constraint on fastPathEqual applies here too).
+            var hash = (a.hashCode.toLong << 32) | (b.hashCode & 0xffffffffL)
             hash += mode.factor
             hash ^= (hash >>> 30)
             hash *= 0xbf58476d1ce4e5b9L

--- a/kyo-data/shared/src/test/scala/kyo/TagTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/TagTest.scala
@@ -1200,11 +1200,12 @@ class TagTest extends kyo.test.Test[Any]:
 
         // kyo-aeron derives aeron stream ids from `Tag.hash`, so a publish and a subscribe of the same
         // type in separate JVM processes must hash identically. Pinning to constants is the in-JVM proxy:
-        // the hash is the content-stable XXH32 hash of the encoded tag, so it reproduces these
-        // values on any JVM. An identity-derived hash would vary across processes and break that.
+        // the hash is content-derived (XXH32 applied to the encoded tag's JLS string hash), so it
+        // reproduces these values on any JVM. An identity-derived hash would vary across processes
+        // and break that.
         "is pinned to its content-derived constant (process-independent determinism)" in {
-            assert(Tag[Int].hash == 1027356392, s"Tag[Int].hash = ${Tag[Int].hash}")
-            assert(Tag[String].hash == -8622366, s"Tag[String].hash = ${Tag[String].hash}")
+            assert(Tag[Int].hash == -1492440803, s"Tag[Int].hash = ${Tag[Int].hash}")
+            assert(Tag[String].hash == -59591402, s"Tag[String].hash = ${Tag[String].hash}")
         }
     }
 

--- a/kyo-scheduler/README.md
+++ b/kyo-scheduler/README.md
@@ -171,7 +171,7 @@ When more work arrives than the scheduler can run on time, queuing delay rises a
 There are three rejection variants. They differ only in how they pick the sampling input that the admission percentage is compared against:
 
 - `reject(): Boolean` draws a fresh random integer per call.
-- `reject(key: String): Boolean` uses XXH32 of `key`.
+- `reject(key: String): Boolean` uses a stable hash of `key`.
 - `reject(key: Int): Boolean` uses `key` directly.
 
 ### Random rejection
@@ -219,7 +219,7 @@ end if
 
 Both forms read the same admission percentage. Use `reject()` for traffic without a natural key, or when you specifically want each call to be an independent draw. Use `reject(key)` when related work should share a fate (a user's retries, a session's RPC calls, a batch job's sub-tasks) and when fairness across keys matters more than per-call randomness. The integer variant exists for cases where you have already computed a numeric key and want to skip the hash.
 
-> **Caution:** The integer-keyed hash is `(key * 2147483647 * windowId).abs % 100`. If your key set is small or correlated with a multiple of 100, distribution can be uneven. Prefer the `String` variant (XXH32) for arbitrary inputs.
+> **Caution:** The integer-keyed hash is `(key * 2147483647 * windowId).abs % 100`. If your key set is small or correlated with a multiple of 100, distribution can be uneven. Prefer the `String` variant (stable string hash) for arbitrary inputs.
 
 ### Reading the current admission percentage
 

--- a/kyo-schema/CONTRIBUTING.md
+++ b/kyo-schema/CONTRIBUTING.md
@@ -473,7 +473,7 @@ The hand-rolled reader uses the canonical `Codec.Reader` contract: `hasNextField
 
 ### Stable Protobuf field IDs
 
-`CodecMacro.fieldId(name)` is a 21-bit `XXH32` over field names used as the stable Protobuf field number, so adding / removing fields does not collide on the wire [kyo-schema/shared/src/main/scala/kyo/internal/CodecMacro.scala:6-19]:
+`CodecMacro.fieldId(name)` is a 21-bit hash of the field name used as the stable Protobuf field number, so adding / removing fields does not collide on the wire. Note that `XXHash.hash32(name)` for a `String` is XXH32 applied to the four little-endian bytes of the name's JLS `String.hashCode`, not XXH32 of the name's UTF-8 bytes; an external implementation must reproduce that exact derivation [kyo-schema/shared/src/main/scala/kyo/internal/CodecMacro.scala:6-19]:
 
 ```
 def fieldId(name: String): Int =

--- a/kyo-schema/README.md
+++ b/kyo-schema/README.md
@@ -704,33 +704,33 @@ val proto = Protobuf.protoSchema[User]
 // syntax = "proto3";
 //
 // message Address {
-//   string city = 1771380;  // hash-derived field number; pin via Schema.fieldId for stable external interop
-//   string zip = 366489;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   string city = 1521334;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   string zip = 176885;  // hash-derived field number; pin via Schema.fieldId for stable external interop
 // }
 //
 // message User {
-//   sint32 id = 671968;  // hash-derived field number; pin via Schema.fieldId for stable external interop
-//   string name = 770848;  // hash-derived field number; pin via Schema.fieldId for stable external interop
-//   string email = 2042990;  // hash-derived field number; pin via Schema.fieldId for stable external interop
-//   string password = 814318;  // hash-derived field number; pin via Schema.fieldId for stable external interop
-//   Address address = 2084274;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   sint32 id = 198960;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   string name = 1684051;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   string email = 1928090;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   string password = 48118;  // hash-derived field number; pin via Schema.fieldId for stable external interop
+//   Address address = 209473;  // hash-derived field number; pin via Schema.fieldId for stable external interop
 // }
 ```
 
-The field numbers in the generated `.proto` match the wire field numbers the codec writes: each is the XXH32-derived value for that field name, the same number used at encode and decode. Hash-derived fields carry a provenance comment. Pinning a field with `fieldId` removes the provenance comment and writes the pinned number on the wire instead. A hash-derived number in proto3's reserved range (19000-19999) escalates the comment to a WARNING because external `protoc` rejects numbers in that band. The specific numbers in the examples above (1771380, 366489, and so on) are the hash-derived values for those field names and are shown for illustration; the actual values for your types are computed at compile time from field names via the same formula.
+The field numbers in the generated `.proto` match the wire field numbers the codec writes: each is derived from the field name (XXH32 applied to the name's JLS string hash), the same number used at encode and decode. Hash-derived fields carry a provenance comment. Pinning a field with `fieldId` removes the provenance comment and writes the pinned number on the wire instead. A hash-derived number in proto3's reserved range (19000-19999) escalates the comment to a WARNING because external `protoc` rejects numbers in that band. The specific numbers in the examples above (1521334, 176885, and so on) are the hash-derived values for those field names and are shown for illustration; the actual values for your types are computed at compile time from field names via the same formula.
 
 `Protobuf.fieldNumberAudit[A]` returns one `FieldNumberInfo` per message field, depth-first, reporting the wire field number, a `pinned` flag, and an `inReservedRange` flag without performing any encode or decode:
 
 ```scala
 val audit = Protobuf.fieldNumberAudit[User]
 // Chunk.Indexed(
-//   FieldNumberInfo(id,id,671968,false,false),       // numbers are hash-derived for these field names
-//   FieldNumberInfo(name,name,770848,false,false),
-//   FieldNumberInfo(email,email,2042990,false,false),
-//   FieldNumberInfo(password,password,814318,false,false),
-//   FieldNumberInfo(address,address,2084274,false,false),
-//   FieldNumberInfo(address.city,city,1771380,false,false),
-//   FieldNumberInfo(address.zip,zip,366489,false,false)
+//   FieldNumberInfo(id,id,198960,false,false),       // numbers are hash-derived for these field names
+//   FieldNumberInfo(name,name,1684051,false,false),
+//   FieldNumberInfo(email,email,1928090,false,false),
+//   FieldNumberInfo(password,password,48118,false,false),
+//   FieldNumberInfo(address,address,209473,false,false),
+//   FieldNumberInfo(address.city,city,1521334,false,false),
+//   FieldNumberInfo(address.zip,zip,176885,false,false)
 // )
 ```
 

--- a/kyo-schema/shared/src/main/scala/kyo/Protobuf.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Protobuf.scala
@@ -15,7 +15,8 @@ end Protobuf
 /** Entry point for Protocol Buffers binary serialization and schema generation.
   *
   * All methods are inline and require a `Schema[A]` instance in scope. Encoding produces proto3 wire-format bytes. Field numbers are
-  * derived from stable XXH32 hashes of field names, enabling schema evolution without breaking existing encoded data.
+  * derived from stable hashes of field names (XXH32 applied to the name's JLS string hash), enabling schema evolution without breaking
+  * existing encoded data.
   *
   * @see
   *   [[kyo.Schema]] for the type-driven serialization model

--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -993,7 +993,7 @@ abstract class Schema[A] @publicInBinary private[kyo] (
 
     /** Returns the stable field ID for a given field name.
       *
-      * Field IDs are computed using XXH32 of the field name, producing stable 21-bit positive integers. These IDs are used by binary
+      * Field IDs are computed by applying XXH32 to the field name's JLS string hash, producing stable 21-bit positive integers. These IDs are used by binary
       * formats like Protocol Buffers and MessagePack for schema evolution compatibility.
       *
       * The ID remains stable across:

--- a/kyo-schema/shared/src/main/scala/kyo/internal/ProtobufWriter.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/ProtobufWriter.scala
@@ -6,7 +6,7 @@ import scala.annotation.tailrec
 
 /** Writes values in Protocol Buffers wire format.
   *
-  * Field numbers are stable hash-based IDs computed from field names using XXH32. This provides schema evolution compatibility -
+  * Field numbers are stable hash-based IDs computed from field names (XXH32 applied to the name's JLS string hash). This provides schema evolution compatibility -
   * adding or removing fields doesn't affect existing field numbers.
   *
   * Field ID overrides can be configured via `withFieldIdOverrides` for interoperability with existing `.proto` definitions.

--- a/kyo-schema/shared/src/test/scala/kyo/ProtobufTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/ProtobufTest.scala
@@ -1427,9 +1427,9 @@ class ProtobufTest extends kyo.test.Test[Any]:
 
         "INV-PBC-12-reserved-flag-and-control" in {
             val rows    = Protobuf.fieldNumberAudit[PBReserved]
-            val inBand  = rows.find(_.name == "r1641").get
+            val inBand  = rows.find(_.name == "r1635").get
             val control = rows.find(_.name == "ctrl").get
-            assert(inBand.inReservedRange == true, s"'r1641' (number=${inBand.number}) should be in reserved range 19000-19999")
+            assert(inBand.inReservedRange == true, s"'r1635' (number=${inBand.number}) should be in reserved range 19000-19999")
             assert(control.inReservedRange == false, s"'ctrl' (number=${control.number}) should NOT be in reserved range 19000-19999")
         }
 
@@ -1518,13 +1518,13 @@ class ProtobufTest extends kyo.test.Test[Any]:
         }
 
         "INV-PBC-12-reserved-WARNING-comment" in {
-            // Sub-case A: hash-derived-in-band. PBReserved.r1641 hashes to 19603.
+            // Sub-case A: hash-derived-in-band. PBReserved.r1635 hashes to 19700.
             val reservedOutput = Protobuf.protoSchema[PBReserved]
-            val r1641Line      = reservedOutput.linesIterator.find(_.contains(" r1641 = ")).getOrElse("")
+            val r1635Line      = reservedOutput.linesIterator.find(_.contains(" r1635 = ")).getOrElse("")
             val ctrlLine       = reservedOutput.linesIterator.find(_.contains(" ctrl = ")).getOrElse("")
             assert(
-                r1641Line.contains("WARNING: in proto3 reserved range 19000-19999"),
-                s"'r1641' (hash-derived in reserved band) must carry the WARNING: '$r1641Line'"
+                r1635Line.contains("WARNING: in proto3 reserved range 19000-19999"),
+                s"'r1635' (hash-derived in reserved band) must carry the WARNING: '$r1635Line'"
             )
             assert(
                 !ctrlLine.contains("WARNING"),
@@ -1607,12 +1607,12 @@ class ProtobufTest extends kyo.test.Test[Any]:
         "reserved-range WARNING always emitted even when suppressed" in {
             given Protobuf = Protobuf(Protobuf.Config(protoSchemaProvenance = false))
             val output     = Protobuf.protoSchema[PBReserved]
-            val r1641Line = output.linesIterator.find(_.contains(" r1641 = ")).getOrElse(
-                fail(s"'r1641' field not found in protoSchema output:\n$output")
+            val r1635Line = output.linesIterator.find(_.contains(" r1635 = ")).getOrElse(
+                fail(s"'r1635' field not found in protoSchema output:\n$output")
             )
             assert(
-                r1641Line.contains("WARNING: in proto3 reserved range 19000-19999"),
-                s"reserved-range WARNING must be emitted even when protoSchemaProvenance=false: '$r1641Line'"
+                r1635Line.contains("WARNING: in proto3 reserved range 19000-19999"),
+                s"reserved-range WARNING must be emitted even when protoSchemaProvenance=false: '$r1635Line'"
             )
         }
 
@@ -1768,8 +1768,8 @@ case class PBAuditInner(id: Int) derives Schema, CanEqual
 case class PBAuditPerson(name: String, inner: PBAuditInner) derives Schema, CanEqual
 case class PBAuditReuse(list: List[PBAuditInner], map: Map[String, PBAuditInner], ints: List[Int]) derives Schema, CanEqual
 case class PBAuditTree(value: Int, children: List[PBAuditTree]) derives Schema, CanEqual
-// r1641 hashes to 19603 (in proto3 reserved range 19000-19999); ctrl is the out-of-band control field.
-case class PBReserved(r1641: Int, ctrl: Int) derives Schema, CanEqual
+// r1635 hashes to 19700 (in proto3 reserved range 19000-19999); ctrl is the out-of-band control field.
+case class PBReserved(r1635: Int, ctrl: Int) derives Schema, CanEqual
 
 // Holder for testing that the reserved-range WARNING fires unconditionally on pinned-in-band numbers.
 case class PBReservedPinnedHolder(x: Int) derives Schema, CanEqual


### PR DESCRIPTION
## Problem

`Tag.fastPathEqual` and `Tag.checkTypes` compared tags by streaming their encoded strings through XXH32 on every call instead of comparing the memoized `String.hashCode`. Both methods sit on the kernel's per-operation tag-comparison path, so every non-identical tag comparison re-streamed both encoded strings, up to four times per comparison. This slowed effect dispatch roughly 10x on CI (`STMTest` went from 3s to 30s on linux-arm64) and starved the STM stress tests' bounded-retry writers into `FailedTransaction`, keeping `main` red on linux-arm64 since July 2.

`XXHash.hash32(String)` had the same per-call cost baked into the primitive itself, streaming UTF-8 bytes through a dedicated state machine (`Utf8State32`) on every invocation rather than reusing anything cheap and already available on the `String`.

## Solution

`Tag.fastPathEqual` and `Tag.checkTypes` compare memoized `hashCode`s directly instead of routing through `XXHash.hash32`.

`XXHash.hash32(String)` now delegates to `hashInt(input.hashCode)`: XXH32 applied to the four little-endian bytes of the JLS `String.hashCode`. This is constant-time and allocation-free for a reused string, deterministic across platforms, and still avalanche-mixed by the XXH32 finalizer, with collision pairs identical to plain `String.hashCode`. The now-dead `Utf8State32` streaming state machine and the seeded `String` overload are removed.

Because `Tag.hash`, the Protobuf/MessagePack field IDs (`Schema.fieldId`, `Protobuf`), and the config/scheduler key-based bucketing all derive from `hash32(String)`, every one of those call sites becomes constant-time for reused strings, not just the two kernel methods above.

## Notes

String-derived constants are regenerated to match the new derivation: `Tag.hash` pins for `Tag[Int]`/`Tag[String]` in `TagTest`, the Protobuf field-number examples in `kyo-schema/README.md`, and the reserved-range test fixture in `ProtobufTest` (`PBReserved.r1641` renamed to `r1635` to land back in the proto3 reserved range under the new derivation). No release contains the old values, so this constant churn is compat-free.

Interop docs (`kyo-schema/CONTRIBUTING.md`, `kyo-schema/README.md`) now spell out the exact derivation, XXH32 over the JLS `hashCode` bytes, not over UTF-8 content, so an external implementation reproducing Protobuf field numbers can match it precisely.

`kyo-config/README.md` and `kyo-scheduler/README.md` drop "XXH32" in favor of "stable string hash" when describing the string-keyed bucketing and rejection helpers, since the underlying primitive is no longer a direct content hash.

Validated: kyo-config, kyo-data, kyo-schema, and kyo-flow JVM suites green; `STMTest` back to 3.3s locally; `STMStressTest` green across 5 consecutive runs.