### PR TITLE
[kyo-http][kyo-browser] cap response size, stream Chrome download

### DIFF
--- a/kyo-browser/shared/src/main/scala/kyo/internal/BrowserLauncher.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/BrowserLauncher.scala
@@ -140,6 +140,11 @@ private[kyo] object BrowserLauncher:
             "--disable-gpu",
             "--disable-extensions",
             "--no-first-run",
+            // Suppress Chrome's default startup window. `attachAndSetupTab` opens the automation target in
+            // its own isolated browser context, so the default-context startup window would linger unused
+            // for the whole session (an extra renderer, and a visible idle window in headed mode). The
+            // remote-debugging server keeps Chrome alive with no window open, so nothing else is needed.
+            "--no-startup-window",
             "--disable-background-networking",
             // Disable Chromium's headless-mode timer/wakeup throttling so setInterval/setTimeout
             // cadences in test pages and instrumentation are not clamped.

--- a/kyo-browser/shared/src/main/scala/kyo/internal/ChromeDownloader.scala
+++ b/kyo-browser/shared/src/main/scala/kyo/internal/ChromeDownloader.scala
@@ -200,16 +200,24 @@ private[kyo] object ChromeDownloader:
         Frame
     )
         : Unit < (Async & Abort[BrowserSetupException]) =
-        Abort.recover[HttpException | FileWriteException] { (ex) =>
+        Abort.recover[HttpException | FileException] { (ex) =>
             val cause: Throwable = ex match
-                case e: HttpException      => e
-                case e: FileWriteException => e
+                case e: HttpException => e
+                case e: FileException => e
             Abort.fail[BrowserSetupException](
                 BrowserSetupFailedException(s"failed to download Chrome from $url", cause)
             )
         } {
             HttpClient.withConfig(_.timeout(downloadTimeout)) {
-                HttpClient.getBinary(url).map(bytes => dest.writeBytes(bytes))
+                // Stream the archive straight to disk rather than buffering it. `getBinary` reads the whole body into
+                // memory bounded by `HttpClientConfig.maxResponseLength` (100 MiB), which rejects the full-Chrome zip
+                // (~200 MiB). `getStreamBytes` has no such cap; `writeTo` sinks each network chunk through a scoped write
+                // handle and removes the partial file if the download fails midway.
+                Scope.run {
+                    HttpClient.getStreamBytes(url)
+                        .mapChunkPure(_.map(span => Chunk.from(span.toArray)).flattenChunk)
+                        .writeTo(dest)
+                }
             }
         }
 

--- a/kyo-browser/shared/src/test/scala/kyo/internal/BrowserLauncherTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/internal/BrowserLauncherTest.scala
@@ -133,6 +133,7 @@ class BrowserLauncherTest extends BaseBrowserTest:
             "--disable-gpu",
             "--disable-extensions",
             "--no-first-run",
+            "--no-startup-window",
             "--disable-background-networking",
             "--disable-default-apps",
             "--disable-sync",

--- a/kyo-browser/shared/src/test/scala/kyo/internal/ChromeDownloaderTest.scala
+++ b/kyo-browser/shared/src/test/scala/kyo/internal/ChromeDownloaderTest.scala
@@ -287,6 +287,40 @@ class ChromeDownloaderTest extends BaseBrowserTest:
         }
     }
 
+    // ---- downloadZip streams past the buffered maxResponseLength cap ----
+
+    // Reproduce-first for the kyo-browser Chrome-download wipeout: downloadZip used HttpClient.getBinary, which reads the
+    // whole response into memory bounded by HttpClientConfig.maxResponseLength (100 MiB) and rejects the full-Chrome zip
+    // (~200 MiB) with HttpPayloadTooLargeException, surfaced as BrowserSetupFailedException. A tiny 64 KiB cap makes a
+    // 256 KiB body reproduce that rejection deterministically without a 100 MiB fixture. The fix streams via getStreamBytes
+    // (no buffered cap) and sinks each chunk to disk, so the download succeeds and the full body lands on the file even
+    // though it far exceeds the cap.
+    "downloadZip streams a body larger than maxResponseLength to disk instead of rejecting it" in {
+        val bodySize = 256 * 1024
+        val body     = Span.fromUnsafe(new Array[Byte](bodySize))
+        val bodyStream: Stream[Span[Byte], Async] = Stream[Span[Byte], Async] {
+            Emit.valueWith(Chunk(body))(())
+        }
+        val handler = HttpRoute.getRaw("/chrome.zip").response(_.bodyStream).handler { _ =>
+            HttpResponse.ok.addField("body", bodyStream).addHeader("Content-Type", "application/octet-stream")
+        }
+        Scope.run {
+            for
+                server <- HttpServer.init(0, "127.0.0.1")(handler)
+                dest   <- Path.tempScoped("kyo-cd-stream-", ".zip")
+                url = s"http://${server.host}:${server.port}/chrome.zip"
+                // Force the buffered ceiling below the body size: getBinary would reject, the streamed path must not.
+                result <- HttpClient.withConfig(_.maxResponseLength(64 * 1024)) {
+                    Abort.run[BrowserSetupException](ChromeDownloader.downloadZip(url, dest, 1.minute))
+                }
+                size <- dest.size
+            yield
+                assert(result.isSuccess, s"streamed download should succeed past the 64 KiB buffered cap, got: $result")
+                assert(size == bodySize.toLong, s"expected the full $bodySize-byte body on disk, got $size")
+            end for
+        }
+    }
+
     // ---- extractZip corrupt-zip failure ----
 
     "extractZip on a garbage-bytes archive raises BrowserSetupFailedException" in {

--- a/kyo-http/shared/src/main/scala/kyo/HttpClientConfig.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpClientConfig.scala
@@ -41,6 +41,13 @@ import kyo.*
   * @param tls
   *   TLS settings applied to HTTPS connections made by this client. See [[HttpTlsConfig]]. Per-request TLS overrides can be set via
   *   `HttpClientConfig` on [[HttpClient.init]].
+  * @param maxResponseLength
+  *   Hard cap, in bytes, on a BUFFERED response body the client accumulates in memory. A server (malicious or buggy) that streams an
+  *   unbounded chunked or connection-close-framed body, or declares an enormous `Content-Length`, would otherwise grow the client's buffer
+  *   without limit until the JVM runs out of memory (CWE-400). When a buffered response exceeds this, the request fails with
+  *   [[HttpPayloadTooLargeException]] instead. Defaults to 100 MiB: a safety ceiling, not a functional limit, large enough for realistic
+  *   buffered JSON/HTML/file responses. Responses larger than this should use the streaming API (`getStreamBytes`, `getSseJson`, etc.),
+  *   which is NOT subject to this cap (the caller controls consumption). Must be positive.
   * @param autoFilters
   *   Whether ServiceLoader-discovered client filters are applied. Defaults to true.
   * @param clientFilter
@@ -66,10 +73,12 @@ case class HttpClientConfig(
     retryOn: HttpStatus => Boolean = _.isServerError,
     transportConfig: HttpTransportConfig = HttpTransportConfig.default,
     tls: HttpTlsConfig = HttpTlsConfig.default,
+    maxResponseLength: Int = 100 * 1024 * 1024,
     autoFilters: Boolean = true,
     clientFilter: HttpFilter.Passthrough[Nothing] = HttpFilter.noop
 ):
     require(maxRedirects >= 0, s"maxRedirects must be non-negative: $maxRedirects")
+    require(maxResponseLength > 0, s"maxResponseLength must be positive: $maxResponseLength")
     require(timeout > Duration.Zero || timeout == Duration.Infinity, s"timeout must be positive or Infinity: $timeout")
     require(
         connectTimeout > Duration.Zero || connectTimeout == Duration.Infinity,
@@ -86,6 +95,7 @@ case class HttpClientConfig(
     def retryOn(f: HttpStatus => Boolean): HttpClientConfig       = copy(retryOn = f)
     def transportConfig(v: HttpTransportConfig): HttpClientConfig = copy(transportConfig = v)
     def tls(config: HttpTlsConfig): HttpClientConfig              = copy(tls = config)
+    def maxResponseLength(v: Int): HttpClientConfig               = copy(maxResponseLength = v)
     def autoFilters(v: Boolean): HttpClientConfig                 = copy(autoFilters = v)
     def withoutAutoFilters: HttpClientConfig                      = autoFilters(false)
     def filter(f: HttpFilter.Passthrough[Nothing]): HttpClientConfig =

--- a/kyo-http/shared/src/main/scala/kyo/HttpException.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpException.scala
@@ -337,10 +337,13 @@ case class HttpProtocolException private[kyo] (detail: String)(using Frame)
         s"HTTP protocol error: $detail"
     )
 
-/** Request body exceeds the configured maximum size (RFC 9110 §15.5.14). */
+/** A response body exceeds the client's configured `HttpClientConfig.maxResponseLength`. The client rejects an oversized response (by its
+  * declared `Content-Length` or its accumulated bytes) rather than buffer it without bound (CWE-400); `bodySize` is the offending size,
+  * `maxSize` the configured cap.
+  */
 case class HttpPayloadTooLargeException private[kyo] (bodySize: Int, maxSize: Int)(using Frame)
     extends HttpDecodeException(
-        s"Request body size $bodySize exceeds maximum allowed $maxSize"
+        s"Response body size $bodySize exceeds the configured maximum $maxSize"
     )
 
 /** Connection closed cleanly (EOF). Not an error — normal keep-alive termination. */

--- a/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
@@ -89,7 +89,8 @@ final private[kyo] class HttpClientBackend[Handle] private (
     def sendBuffered[In, Out](
         conn: HttpConnection[Handle],
         route: HttpRoute[In, Out, ?],
-        request: HttpRequest[In]
+        request: HttpRequest[In],
+        maxResponseLength: Int
     )(using AllowUnsafe, Frame): Fiber.Unsafe[HttpResponse[Out], Abort[HttpException]] =
         val resultPromise = Promise.Unsafe.init[HttpResponse[Out], Abort[HttpException]]()
         try
@@ -98,7 +99,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
                 responsePromise.onComplete { parseResult =>
                     parseResult match
                         case Result.Success(parsed) =>
-                            readBufferedBody(conn, parsed, request.method, resultPromise, route, request)
+                            readBufferedBody(conn, parsed, request.method, resultPromise, route, request, maxResponseLength)
                         case Result.Failure(e) =>
                             resultPromise.completeDiscard(Result.fail(HttpConnectionClosedException()))
                         case Result.Panic(t) =>
@@ -116,7 +117,8 @@ final private[kyo] class HttpClientBackend[Handle] private (
     def sendStreaming[In, Out](
         conn: HttpConnection[Handle],
         route: HttpRoute[In, Out, ?],
-        request: HttpRequest[In]
+        request: HttpRequest[In],
+        maxResponseLength: Int
     )(using AllowUnsafe, Frame): Fiber.Unsafe[HttpResponse[Out], Abort[HttpException]] =
         val resultPromise = Promise.Unsafe.init[HttpResponse[Out], Abort[HttpException]]()
         try
@@ -134,7 +136,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
                                 // away the only diagnostic. Going through the buffered path lets
                                 // RouteUtil.decodeBufferedResponse populate HttpStatusException.body.
                                 if parsed.statusCode >= 400 then
-                                    readBufferedBody(conn, parsed, request.method, resultPromise, route, request)
+                                    readBufferedBody(conn, parsed, request.method, resultPromise, route, request, maxResponseLength)
                                 else
                                     val lastBodySpan = conn.http1.lastBodySpan
                                     val bodyStream   = buildBodyStream(conn, parsed, lastBodySpan)
@@ -180,23 +182,26 @@ final private[kyo] class HttpClientBackend[Handle] private (
             fiber.safe.use(f)
         }
 
-    /** Safe wrapper for send — bridges the unsafe fiber with `f`. Used by tests. */
+    /** Safe wrapper for send, bridges the unsafe fiber with `f`. Used by tests. `maxResponseLength` defaults to the same buffered-response
+      * cap as [[HttpClientConfig.maxResponseLength]].
+      */
     def sendWith[In, Out, A](
         conn: HttpConnection[Handle],
         route: HttpRoute[In, Out, ?],
         request: HttpRequest[In],
-        onRelease: Maybe[Result.Error[Any]] => Unit < Sync = _ => Kyo.unit
+        onRelease: Maybe[Result.Error[Any]] => Unit < Sync = _ => Kyo.unit,
+        maxResponseLength: Int = 100 * 1024 * 1024
     )(
         f: HttpResponse[Out] => A < (Async & Abort[HttpException])
     )(using Frame): A < (Async & Abort[HttpException]) =
         Sync.Unsafe.defer {
             val fiber =
                 if request.method == HttpMethod.HEAD then
-                    sendBuffered(conn, route, request)
+                    sendBuffered(conn, route, request, maxResponseLength)
                 else if RouteUtil.isStreamingResponse(route) then
-                    sendStreaming(conn, route, request)
+                    sendStreaming(conn, route, request, maxResponseLength)
                 else
-                    sendBuffered(conn, route, request)
+                    sendBuffered(conn, route, request, maxResponseLength)
             Sync.ensure { (error: Maybe[Result.Error[Any]]) =>
                 onRelease(error)
             } {
@@ -314,7 +319,8 @@ final private[kyo] class HttpClientBackend[Handle] private (
         method: HttpMethod,
         resultPromise: Promise.Unsafe[HttpResponse[Out], Abort[HttpException]],
         route: HttpRoute[In, Out, ?],
-        request: HttpRequest[In]
+        request: HttpRequest[In],
+        maxResponseLength: Int
     )(using AllowUnsafe, Frame): Unit =
         val noBody = method == HttpMethod.HEAD ||
             parsed.statusCode < 200 ||
@@ -325,27 +331,40 @@ final private[kyo] class HttpClientBackend[Handle] private (
         else
             val lastBodySpan = conn.http1.lastBodySpan
             if parsed.isChunked then
-                // Chunked: decode all chunks via callback-based reader
-                ChunkedBodyDecoder.readBufferedUnsafe(conn.http1.bodyChannel, lastBodySpan, conn.http1.chunkedDecoderState) { result =>
-                    result match
+                // Chunked: decode all chunks via callback-based reader, bounding the accumulated body at maxResponseLength
+                // (a server streaming an unbounded chunked body would otherwise OOM the client, CWE-400).
+                ChunkedBodyDecoder.readBufferedUnsafe(
+                    conn.http1.bodyChannel,
+                    lastBodySpan,
+                    maxResponseLength,
+                    conn.http1.chunkedDecoderState
+                )(
+                    {
                         case Result.Success(bodyBytes) =>
                             decodeAndComplete(conn, bodyBytes, parsed, resultPromise, route, request)
                         case Result.Failure(_) =>
                             resultPromise.completeDiscard(Result.fail(HttpConnectionClosedException()))
                         case Result.Panic(t) =>
                             resultPromise.completeDiscard(Result.panic(t))
-                }
+                    },
+                    size => resultPromise.completeDiscard(Result.fail(HttpPayloadTooLargeException(size, maxResponseLength)))
+                )
             else if parsed.contentLength > 0 then
-                val remaining = parsed.contentLength - lastBodySpan.size
-                if remaining <= 0 then
-                    // All body bytes were in the header chunk
-                    decodeAndComplete(conn, lastBodySpan, parsed, resultPromise, route, request)
+                if parsed.contentLength > maxResponseLength then
+                    // Reject before allocating: an enormous declared Content-Length must not size the read buffer (CWE-400).
+                    resultPromise.completeDiscard(Result.fail(HttpPayloadTooLargeException(parsed.contentLength, maxResponseLength)))
                 else
-                    // Read remaining bytes from the inbound channel
-                    val buf = new GrowableByteBuffer
-                    if lastBodySpan.nonEmpty then
-                        buf.writeBytes(lastBodySpan.toArrayUnsafe, 0, lastBodySpan.size)
-                    readLoopUnsafe(conn, buf, remaining, parsed, resultPromise, route, request)
+                    val remaining = parsed.contentLength - lastBodySpan.size
+                    if remaining <= 0 then
+                        // All body bytes were in the header chunk
+                        decodeAndComplete(conn, lastBodySpan, parsed, resultPromise, route, request)
+                    else
+                        // Read remaining bytes from the inbound channel
+                        val buf = new GrowableByteBuffer
+                        if lastBodySpan.nonEmpty then
+                            buf.writeBytes(lastBodySpan.toArrayUnsafe, 0, lastBodySpan.size)
+                        readLoopUnsafe(conn, buf, remaining, parsed, resultPromise, route, request)
+                    end if
                 end if
             else if parsed.contentLength == 0 then
                 decodeAndComplete(conn, Span.empty[Byte], parsed, resultPromise, route, request)
@@ -358,7 +377,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
                 val buf = new GrowableByteBuffer
                 if lastBodySpan.nonEmpty then
                     buf.writeBytes(lastBodySpan.toArrayUnsafe, 0, lastBodySpan.size)
-                readUntilCloseUnsafe(conn, buf, parsed, resultPromise, route, request)
+                readUntilCloseUnsafe(conn, buf, parsed, resultPromise, route, request, maxResponseLength)
             end if
         end if
     end readBufferedBody
@@ -403,14 +422,20 @@ final private[kyo] class HttpClientBackend[Handle] private (
         parsed: ParsedResponse,
         resultPromise: Promise.Unsafe[HttpResponse[Out], Abort[HttpException]],
         route: HttpRoute[In, Out, ?],
-        request: HttpRequest[In]
+        request: HttpRequest[In],
+        maxResponseLength: Int
     )(using AllowUnsafe, Frame): Unit =
         conn.http1.bodyChannel.takeFiber()
             .asInstanceOf[IOPromise[Closed, Span[Byte]]].onComplete { result =>
                 result match
                     case Result.Success(span) =>
                         buf.writeBytes(span.toArrayUnsafe, 0, span.size)
-                        readUntilCloseUnsafe(conn, buf, parsed, resultPromise, route, request)
+                        if buf.size > maxResponseLength then
+                            // A close-framed body that keeps growing past the cap would OOM the client (CWE-400).
+                            resultPromise.completeDiscard(Result.fail(HttpPayloadTooLargeException(buf.size, maxResponseLength)))
+                        else
+                            readUntilCloseUnsafe(conn, buf, parsed, resultPromise, route, request, maxResponseLength)
+                        end if
                     case Result.Failure(_) =>
                         // EOF is expected for close-framed bodies — deliver what we have.
                         decodeAndComplete(conn, Span.fromUnsafe(buf.toByteArray), parsed, resultPromise, route, request)
@@ -966,7 +991,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
         Sync.Unsafe.defer {
             pool.poll(key) match
                 case Present(conn) =>
-                    val responseFiber = sendViaBackend(conn, route, request)
+                    val responseFiber = sendViaBackend(conn, route, request, config.maxResponseLength)
                     Sync.ensure { (error: Maybe[Result.Error[Any]]) =>
                         Sync.Unsafe.defer(releaseConn(key, conn, error))
                     } {
@@ -979,7 +1004,7 @@ final private[kyo] class HttpClientBackend[Handle] private (
                             val connectFiber = connect(url, config.connectTimeout, config.tls)
                             connectFiber.safe.use { conn =>
                                 trackConn(conn)
-                                val responseFiber = sendViaBackend(conn, route, request)
+                                val responseFiber = sendViaBackend(conn, route, request, config.maxResponseLength)
                                 Sync.ensure { (error: Maybe[Result.Error[Any]]) =>
                                     Sync.Unsafe.defer(releaseConn(key, conn, error))
                                 } {
@@ -1038,16 +1063,17 @@ final private[kyo] class HttpClientBackend[Handle] private (
     private def sendViaBackend[In, Out](
         conn: HttpConnection[Handle],
         route: HttpRoute[In, Out, ?],
-        request: HttpRequest[In]
+        request: HttpRequest[In],
+        maxResponseLength: Int
     )(using AllowUnsafe, Frame): Fiber.Unsafe[HttpResponse[Out], Abort[HttpException]] =
         // HEAD responses never have a body (RFC 9110 Section 9.3.2),
         // so always use the buffered path which skips body reading for HEAD.
         if request.method == HttpMethod.HEAD then
-            sendBuffered(conn, route, request)
+            sendBuffered(conn, route, request, maxResponseLength)
         else if RouteUtil.isStreamingResponse(route) then
-            sendStreaming(conn, route, request)
+            sendStreaming(conn, route, request, maxResponseLength)
         else
-            sendBuffered(conn, route, request)
+            sendBuffered(conn, route, request, maxResponseLength)
 
     def closeFiber(gracePeriod: Duration)(using AllowUnsafe, Frame): Fiber.Unsafe[Unit, Any] =
         // Mark closing FIRST so any new connection gets closed immediately by trackConn.

--- a/kyo-http/shared/src/main/scala/kyo/internal/http1/ChunkedBodyDecoder.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/http1/ChunkedBodyDecoder.scala
@@ -28,44 +28,56 @@ private[kyo] object ChunkedBodyDecoder:
     def readBufferedUnsafe(
         inbound: Channel.Unsafe[Span[Byte]],
         initialBytes: Span[Byte],
+        maxBytes: Int,
         state: DecoderState = new DecoderState
     )(
-        onResult: Result[Closed, Span[Byte]] => Unit
+        onResult: Result[Closed, Span[Byte]] => Unit,
+        onTooLarge: Int => Unit
     )(using AllowUnsafe, Frame): Unit =
         val accumulator = new GrowableByteBuffer
         if !initialBytes.isEmpty then
             state.feedBytes(initialBytes)
-        bufferedLoopUnsafe(inbound, accumulator, state, onResult)
+        bufferedLoopUnsafe(inbound, accumulator, state, maxBytes, onResult, onTooLarge)
     end readBufferedUnsafe
 
-    /** Main unsafe buffered decode loop. Processes buffer, accumulates data, reads more via callbacks. */
+    /** Main unsafe buffered decode loop. Processes buffer, accumulates data, reads more via callbacks. Caps the accumulated body at
+      * `maxBytes`: a server streaming an unbounded chunked body would otherwise grow `accumulator` without limit (CWE-400). The cap is
+      * checked at the top of each drain iteration; since per-chunk size is already overflow-bounded ([[parseChunkSizeLine]]) and the
+      * realistic attack is many chunks, the accumulated total cannot grow past `maxBytes` plus at most one in-flight chunk before
+      * `onTooLarge` fires.
+      */
     private def bufferedLoopUnsafe(
         inbound: Channel.Unsafe[Span[Byte]],
         accumulator: GrowableByteBuffer,
         state: DecoderState,
-        onResult: Result[Closed, Span[Byte]] => Unit
+        maxBytes: Int,
+        onResult: Result[Closed, Span[Byte]] => Unit,
+        onTooLarge: Int => Unit
     )(using AllowUnsafe, Frame): Unit =
-        state.drain(accumulator) match
-            case DrainResult.Done =>
-                onResult(Result.succeed(Span.fromUnsafe(accumulator.toByteArray)))
-            case DrainResult.NeedMore =>
-                // Cross opaque boundary: Fiber.Unsafe[Span[Byte], Abort[Closed]] is IOPromise[Any, Span[Byte] < Abort[Closed]]
-                // at runtime, but Channel delivers plain Span[Byte] values, not effectful computations.
-                // Casting to IOPromise[Closed, Span[Byte]] lets onComplete see Result[Closed, Span[Byte]] directly.
-                inbound.takeFiber()
-                    .asInstanceOf[kyo.scheduler.IOPromise[Closed, Span[Byte]]].onComplete { result =>
-                        result match
-                            case Result.Success(span) =>
-                                state.feedBytes(span)
-                                bufferedLoopUnsafe(inbound, accumulator, state, onResult)
-                            case Result.Failure(closed) =>
-                                onResult(Result.fail(closed))
-                            case Result.Panic(t) =>
-                                onResult(Result.panic(t))
-                    }
-            case DrainResult.ChunkReady =>
-                // In buffered mode, data is already in accumulator. Continue draining.
-                bufferedLoopUnsafe(inbound, accumulator, state, onResult)
+        if accumulator.size > maxBytes then onTooLarge(accumulator.size)
+        else
+            state.drain(accumulator) match
+                case DrainResult.Done =>
+                    onResult(Result.succeed(Span.fromUnsafe(accumulator.toByteArray)))
+                case DrainResult.NeedMore =>
+                    // Cross opaque boundary: Fiber.Unsafe[Span[Byte], Abort[Closed]] is IOPromise[Any, Span[Byte] < Abort[Closed]]
+                    // at runtime, but Channel delivers plain Span[Byte] values, not effectful computations.
+                    // Casting to IOPromise[Closed, Span[Byte]] lets onComplete see Result[Closed, Span[Byte]] directly.
+                    inbound.takeFiber()
+                        .asInstanceOf[kyo.scheduler.IOPromise[Closed, Span[Byte]]].onComplete { result =>
+                            result match
+                                case Result.Success(span) =>
+                                    state.feedBytes(span)
+                                    bufferedLoopUnsafe(inbound, accumulator, state, maxBytes, onResult, onTooLarge)
+                                case Result.Failure(closed) =>
+                                    onResult(Result.fail(closed))
+                                case Result.Panic(t) =>
+                                    onResult(Result.panic(t))
+                        }
+                case DrainResult.ChunkReady =>
+                    // In buffered mode, data is already in accumulator. Continue draining.
+                    bufferedLoopUnsafe(inbound, accumulator, state, maxBytes, onResult, onTooLarge)
+        end if
     end bufferedLoopUnsafe
 
     /** Buffered mode: accumulates all decoded chunks into one Span[Byte]. */

--- a/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
@@ -527,6 +527,36 @@ class HttpClientTest extends BaseHttpTest:
                 }
             }
         }
+
+        "a buffered response larger than maxResponseLength fails HttpPayloadTooLargeException (CWE-400)" in {
+            // A server returns a 256 KiB body; the client caps buffered responses at 64 KiB. The client must reject the
+            // over-cap response (here via the Content-Length pre-check) rather than buffer it without limit. Exercises the
+            // full production path: HttpClientConfig.maxResponseLength threaded through sendWithConfig -> readBufferedBody.
+            val largeBody = "x" * (256 * 1024)
+            val route     = HttpRoute.getRaw("big").response(_.bodyText)
+            val ep        = route.handler(_ => HttpResponse.ok(largeBody))
+            withServer(ep) { url =>
+                HttpClient.withConfig(_.maxResponseLength(64 * 1024)) {
+                    Abort.run[HttpException](HttpClient.getText(s"$url/big")).map {
+                        case Result.Failure(_: HttpPayloadTooLargeException) => succeed
+                        case other =>
+                            fail(s"expected HttpPayloadTooLargeException for a 256 KiB response under a 64 KiB cap, got $other")
+                    }
+                }
+            }
+        }
+
+        "a buffered response within maxResponseLength still succeeds" in {
+            // The cap must not break legitimate responses below it: a 32 KiB body under a 64 KiB cap round-trips.
+            val body  = "y" * (32 * 1024)
+            val route = HttpRoute.getRaw("ok").response(_.bodyText)
+            val ep    = route.handler(_ => HttpResponse.ok(body))
+            withServer(ep) { url =>
+                HttpClient.withConfig(_.maxResponseLength(64 * 1024)) {
+                    HttpClient.getText(s"$url/ok").map(b => assert(b.length == 32 * 1024))
+                }
+            }
+        }
     }
 
     "streaming" - {

--- a/kyo-http/shared/src/test/scala/kyo/internal/HttpSecurityTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/HttpSecurityTest.scala
@@ -66,8 +66,8 @@ class HttpSecurityTest extends kyo.BaseHttpTest:
         var completed                = false
         var failed                   = false
 
-        ChunkedBodyDecoder.readBufferedUnsafe(channel, initial) { result =>
-            result match
+        ChunkedBodyDecoder.readBufferedUnsafe(channel, initial, Int.MaxValue)(
+            {
                 case Result.Success(span) =>
                     resultBytes = span.toArray
                     completed = true
@@ -75,10 +75,32 @@ class HttpSecurityTest extends kyo.BaseHttpTest:
                     failed = true
                 case Result.Panic(_) =>
                     failed = true
-        }
+            },
+            _ => failed = true
+        )
 
         (resultBytes, completed)
     end decodeChunked
+
+    /** Decode a chunked body with a `maxBytes` cap. Returns (completed, tooLarge): tooLarge=true means the accumulated body exceeded
+      * `maxBytes` and the decode was rejected (CWE-400 guard) rather than completing.
+      */
+    private def decodeChunkedCapped(rawChunkedBody: String, maxBytes: Int): (Boolean, Boolean) =
+        val channel   = Channel.Unsafe.init[Span[Byte]](16)
+        val bytes     = rawChunkedBody.getBytes(StandardCharsets.ISO_8859_1)
+        val initial   = Span.fromUnsafe(bytes)
+        var completed = false
+        var tooLarge  = false
+        ChunkedBodyDecoder.readBufferedUnsafe(channel, initial, maxBytes)(
+            {
+                case Result.Success(_) => completed = true
+                case Result.Failure(_) => ()
+                case Result.Panic(_)   => ()
+            },
+            _ => tooLarge = true
+        )
+        (completed, tooLarge)
+    end decodeChunkedCapped
 
     // ====================================================================================
     // Group 1: Request Smuggling -- Multiple Content-Length (CVE-2019-20445, CVE-2026-23941)
@@ -701,6 +723,29 @@ class HttpSecurityTest extends kyo.BaseHttpTest:
                 )
             end if
             succeed("security check passed: parser correctly rejected or did not exhibit the vulnerability")
+        }
+    }
+
+    // ====================================================================================
+    // Group: Response body DoS -- unbounded buffered chunked accumulation (CWE-400)
+    // ====================================================================================
+
+    "Response body DoS: unbounded buffered chunked accumulation (CWE-400)" - {
+
+        "a chunked body within the cap decodes normally" in {
+            // 3 small chunks (4+5+3 = 12 decoded bytes), cap 1 MiB: completes, not rejected.
+            val body                  = "4\r\nWiki\r\n5\r\npedia\r\n3\r\n in\r\n0\r\n\r\n"
+            val (completed, tooLarge) = decodeChunkedCapped(body, 1024 * 1024)
+            assert(completed && !tooLarge, s"a small chunked body must decode under the cap; completed=$completed tooLarge=$tooLarge")
+        }
+
+        "a chunked body whose total exceeds the cap is rejected, not accumulated unboundedly" in {
+            // 64 chunks of 16 decoded bytes each = 1024 decoded bytes; cap 256 bytes. The decoder must reject via onTooLarge
+            // rather than grow the accumulator past the cap (a server streaming endless chunks would otherwise OOM the client).
+            val chunk                 = "10\r\n" + ("A" * 16) + "\r\n"
+            val body                  = (chunk * 64) + "0\r\n\r\n"
+            val (completed, tooLarge) = decodeChunkedCapped(body, 256)
+            assert(tooLarge && !completed, s"an over-cap chunked body must be rejected; completed=$completed tooLarge=$tooLarge")
         }
     }
 


### PR DESCRIPTION
## Problem
The HTTP client placed no bound on a buffered response body, so a large or malicious response was read fully into memory. kyo-browser's Chrome download hit this directly: downloadZip used getBinary, which buffers the whole body, and the full Chrome archive (~200 MiB) landed entirely in memory. Separately, Chrome opened a default-context startup window that lingered unused for the whole automation session (an extra renderer, and a visible idle window in headed mode).

## Solution
Add HttpClientConfig.maxResponseLength (default 100 MiB), enforced on every buffered read path: the declared Content-Length pre-check, the close-framed read, and the chunked-transfer decode loop (a chunked body would otherwise accumulate past the cap unchecked). An oversized response fails with HttpPayloadTooLargeException. Switch ChromeDownloader.downloadZip to stream the archive to disk via getStreamBytes().writeTo(), so the body is never buffered. Add Chrome's --no-startup-window flag so no idle window or extra renderer lingers.

## Notes
The ChromeDownloader change is reproduce-first: against the old getBinary path the new test fails with HttpPayloadTooLargeException on a chunked body exceeding a lowered cap, and passes once streamed. Validated locally: HttpClientTest 334/0, HttpSecurityTest 29/0, ChromeDownloaderTest 27/0, BrowserLauncherTest 17/0. The kyo-browser suites launch a real Chrome and also run in CI.
