### PR TITLE
[ci] cap native link parallelism and drop ineffective heap overrides

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -41,6 +41,28 @@ runs:
         key: kyo-browser-${{ inputs.os }}-${{ hashFiles('kyo-browser/shared/src/main/scala/kyo/Browser.scala', 'kyo-browser/shared/src/main/scala/kyo/internal/ChromeDownloader.scala') }}
         restore-keys: kyo-browser-${{ inputs.os }}-
 
+    - name: Add supplementary swap (Linux)
+      if: ${{ contains(inputs.os, 'linux') }}
+      shell: bash
+      run: |
+        # The Native link phase can overcommit the 16GB runner (a large sbt driver heap plus
+        # forked clang jobs), and the stock runner swap has been observed fully exhausted right
+        # before kernel OOM kills. Extra swap turns a marginal overcommit into slowdown instead
+        # of a SIGKILL. Best-effort: a runner that cannot host the file keeps its stock swap.
+        for dir in /mnt "${RUNNER_TEMP:-/tmp}"; do
+          swapfile="$dir/kyo-swapfile"
+          if sudo fallocate -l 8G "$swapfile" 2>/dev/null \
+             && sudo chmod 600 "$swapfile" \
+             && sudo mkswap "$swapfile" >/dev/null 2>&1 \
+             && sudo swapon "$swapfile" 2>/dev/null; then
+            echo "supplementary swap active at $swapfile"
+            free -m | awk 'NR==1 || /Swap/'
+            exit 0
+          fi
+          sudo rm -f "$swapfile" 2>/dev/null || true
+        done
+        echo "warning: could not add supplementary swap; continuing with stock swap only"
+
     - name: Install native dependencies (Linux)
       if: ${{ inputs.target == 'Native' && contains(inputs.os, 'linux') }}
       uses: nick-fields/retry@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,24 +70,22 @@ jobs:
       # (java.lang.OutOfMemoryError) or overcommit the box (kernel OOM-kill, exit 143). max-parallel:4
       # still runs the four targets on separate runners, so this costs no wall-clock on the JVM pole.
       SBT_TASK_LIMIT: 1
-      # G1 is the JDK 24 default; pin it explicitly so the collector is fixed across JDK vendor/version.
-      # -Xmx12G is the driver ceiling for the JVM, JS, and Wasm targets, whose compile and link phases run
-      # in the driver heap. There is deliberately no -Xms floor: tests run in forked JVMs (sized via
-      # build.sbt Test/javaOptions), and SBT_TASK_LIMIT=1 keeps compile and test from overlapping, so a low
-      # floor lets G1 release the driver's compile heap back to the box during the test phase, leaving room
-      # for the forks.
-      # The Native target is capped lower (8G). Its optimizer runs in the driver heap, but the native
-      # compile and link phase forks the LLVM toolchain (clang/ld) that runs ALONGSIDE the still-large
-      # driver heap within the one sbt task, so SBT_TASK_LIMIT=1 cannot serialize the two. A 12G driver
-      # heap plus the forked toolchain overcommits the 16GB runner and the kernel OOM-kills the driver
-      # (exit 143). 8G leaves physical headroom for the forked LLVM toolchain while still fitting the
-      # in-heap optimizer.
-      JAVA_OPTS: "-Xmx${{ matrix.target == 'Native' && '8G' || '12G' }} -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
-      JVM_OPTS:  "-Xmx${{ matrix.target == 'Native' && '8G' || '12G' }} -Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
+      # The sbt driver heap is governed by the checked-in .jvmopts (12G): the sbt runner appends
+      # .jvmopts after these env opts on the java command line, so an -Xmx set here would never
+      # take effect. The env therefore carries only the non-heap flags, which do reach the JVM
+      # because .jvmopts holds no conflicting duplicates for them.
+      JAVA_OPTS: "-Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
+      JVM_OPTS:  "-Xss10M -XX:+UseG1GC -XX:+UseCompactObjectHeaders -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8"
       # Link kyo-schema's native test binary in its own sbt driver before the aggregate link: its
-      # whole-program optimize peaks ~7.7G RSS, which OOM-killed the 8G-capped aggregate driver once
-      # ~10 prior modules had filled metaspace. ci-test.sh honors this only for the Native target.
+      # whole-program optimize runs against a fresh heap instead of a driver that has accumulated
+      # ~10 prior modules of heap and metaspace. ci-test.sh honors this only for the Native target.
       NATIVE_HEAVY: "${{ matrix.target == 'Native' && 'kyo-schema' || '' }}"
+      # Cap the Native link drivers to 2 CPUs (-XX:ActiveProcessorCount). The scala-native
+      # toolchain sizes its optimizer pool and its concurrent clang forks from
+      # availableProcessors, and the fork fleet stacked on the driver heap is what overcommits
+      # the 16GB runner (kernel OOM, exit 143). ci-test.sh applies this to the nativeLink
+      # invocations only; compile and the test run keep all 4 CPUs.
+      NATIVE_LINK_CPUS: "${{ matrix.target == 'Native' && '2' || '' }}"
 
     steps:
       - uses: actions/checkout@v7.0.0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -170,7 +170,11 @@ container_provision() {
         JS|Wasm|all) node_pkgs="nodejs npm" ;;
     esac
     case "$platform" in
-        Native|all) native_pkgs="libcurl4-openssl-dev libidn2-dev libh2o-evloop-dev=2.2.5+dfsg2-8.1ubuntu3" ;;
+        # clang, cc (build-essential), and libssl-dev are preinstalled on GitHub runners,
+        # so the CI setup action never lists them; a bare container needs them explicitly
+        # (scala-native drives clang, kyo-ffi-it's bundled lib builds with cc, and the
+        # openssl-linked modules need -lssl -lcrypto).
+        Native|all) native_pkgs="clang build-essential libssl-dev libcurl4-openssl-dev libidn2-dev libh2o-evloop-dev=2.2.5+dfsg2-8.1ubuntu3" ;;
     esac
     cat <<PROVISION
 export DEBIAN_FRONTEND=noninteractive
@@ -180,10 +184,15 @@ if command -v apt-get >/dev/null 2>&1; then
 fi
 export COURSIER_CACHE=/root/.cache/coursier
 if ! command -v cs >/dev/null 2>&1; then
-    arch=\$(uname -m); cs_arch=x86_64-pc-linux
-    [ "\$arch" = aarch64 ] && cs_arch=aarch64-pc-linux
-    curl -fsSL "https://github.com/coursier/coursier/releases/latest/download/cs-\$cs_arch.gz" \
-        | gzip -d > /usr/local/bin/cs && chmod +x /usr/local/bin/cs
+    # Linux aarch64 launchers are published by VirtusLab's coursier-m1 releases, not
+    # by coursier/coursier (whose latest release has no aarch64-pc-linux asset).
+    arch=\$(uname -m)
+    if [ "\$arch" = aarch64 ]; then
+        cs_url="https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz"
+    else
+        cs_url="https://github.com/coursier/coursier/releases/latest/download/cs-x86_64-pc-linux.gz"
+    fi
+    curl -fsSL "\$cs_url" | gzip -d > /usr/local/bin/cs && chmod +x /usr/local/bin/cs
 fi
 eval "\$(cs java --jvm corretto:25 --env)"
 command -v sbt >/dev/null 2>&1 || cs install sbt >/dev/null

--- a/scripts/ci-monitor.sh
+++ b/scripts/ci-monitor.sh
@@ -74,10 +74,31 @@ sched_snapshot() {
     { [ -n "$SCHED_FILE" ] && [ -r "$SCHED_FILE" ]; } && cat "$SCHED_FILE" 2>/dev/null
 }
 
-log "started interval=${INTERVAL}s src=$MON_SRC sched=${SCHED_FILE:-none}"
+# Per-process attribution: total RSS and process count aggregated by command name, top 3 by RSS,
+# e.g. "top=[java:11216M/2 clang:1834M/4 node:912M/1]". Host-level numbers alone cannot answer
+# "whose memory is it" when a link or test phase overcommits the box. Best-effort: skipped where
+# ps is unavailable (minimal containers).
+proc_top() {
+    command -v ps >/dev/null 2>&1 || return 0
+    local rows
+    rows=$(ps axo rss=,comm= 2>/dev/null | awk '
+        {
+            rss = $1; $1 = ""; cmd = substr($0, 2)
+            sub(/.*\//, "", cmd); gsub(/ /, "_", cmd)
+            if (cmd != "" && rss + 0 > 0) { r[cmd] += rss; n[cmd]++ }
+        }
+        END { for (c in r) printf "%d %s %d\n", r[c], c, n[c] }' \
+        | sort -rn | head -3 \
+        | awk '{ printf "%s%s:%dM/%d", sep, $2, $1 / 1024, $3; sep = " " }')
+    [ -n "$rows" ] && printf 'top=[%s]' "$rows"
+}
+
+ncpu=$( (command -v nproc >/dev/null 2>&1 && nproc) || sysctl -n hw.ncpu 2>/dev/null || echo '?')
+log "started interval=${INTERVAL}s src=$MON_SRC cores=$ncpu sched=${SCHED_FILE:-none}"
 while true; do
     os="$(os_headline)"
+    top="$(proc_top)"
     sc="$(sched_snapshot)"
-    echo "[ci-mon $(date -u +%H:%M:%S)]${os:+ $os}${sc:+ $sc}"
+    echo "[ci-mon $(date -u +%H:%M:%S)]${os:+ $os}${top:+ $top}${sc:+ $sc}"
     sleep "$INTERVAL"
 done

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -17,9 +17,12 @@ set -uo pipefail
 # and mid-RPC errno-104 resets. The strategy is derived from the platform; no
 # caller selects it.
 #
-# Reads CI, SBT_TASK_LIMIT, JAVA_OPTS, and JVM_OPTS from the environment; sets
-# none of them. The caller (a CI workflow, or build.sh --env podman-ci) owns the
-# environment, so this one runner is correct in every environment.
+# Reads CI, SBT_TASK_LIMIT, JAVA_OPTS, JVM_OPTS, NATIVE_HEAVY, and
+# NATIVE_LINK_CPUS from the environment; mutates none of them (the nativeLink
+# invocations append -XX:ActiveProcessorCount per invocation when
+# NATIVE_LINK_CPUS is set). The caller (a CI workflow, or build.sh --env
+# podman-ci) owns the environment, so this one runner is correct in every
+# environment.
 
 PLATFORMS="JVM JS Native Wasm"
 ACTIONS="test testDiff compile link"
@@ -44,8 +47,8 @@ contains_word() {
 # the RECORDED CALLS or the RECORDED HEAP, not just the exit code: the
 # JVM/JS/Wasm three-phase split (compile-main, compile-test, run) on full AND
 # diff; the Native single-process aggregate-link path with no --phase; the
-# platform-derived strategy; the exit-code mapping; and the JS-only 14G driver
-# heap bump against the shared 12G ceiling.
+# platform-derived strategy; the exit-code mapping; and the NATIVE_LINK_CPUS
+# cap reaching the nativeLink invocations but never the test run.
 if [ "${1:-}" = "--self-test" ]; then
     SELF="$0"
     PASS=0; FAIL=0; TOTAL=0
@@ -79,28 +82,13 @@ if [ "${1:-}" = "--self-test" ]; then
         CT_EXIT=$?
     }
 
-    # Same as run_runner but with the CI heap env the workflow exports (the
-    # shared 12G ceiling for JAVA_OPTS and JVM_OPTS), so the heap assertions
-    # observe the JS-only bump against the real inherited opts.
-    CI_OPTS='-Xmx12G -Xss10M -XX:+UseG1GC -XX:MaxMetaspaceSize=2G -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8'
-    run_runner_ci() {
-        local platform="$1" action="$2" body="$3"
-        : > "$CALLS"; : > "$HEAP"
-        make_fake_sbt "$body"
-        PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 \
-            JAVA_OPTS="$CI_OPTS" JVM_OPTS="$CI_OPTS" \
-            "$SELF" "$platform" "$action" >/dev/null 2>&1
-        CT_EXIT=$?
-    }
-
     # Assertion helpers, evaluated against CT_EXIT and CALLS.
     exit_is()      { [ "$CT_EXIT" = "$1" ]; }
     calls_count()  { [ "$(wc -l < "$CALLS" | tr -d ' ')" = "$1" ]; }
     call_nth_is()  { [ "$(sed -n "${1}p" "$CALLS")" = "$2" ]; }
     calls_have()   { grep -qF -- "$1" "$CALLS"; }
     calls_lack()   { ! grep -qF -- "$1" "$CALLS"; }
-    heap_saw()     { grep -qF -- "$1" "$HEAP"; }
-    heap_never()   { ! grep -qF -- "$1" "$HEAP"; }
+    heap_nth_has() { sed -n "${1}p" "$HEAP" | grep -qF -- "$2"; }
 
     # Register a case: name + an assertion expression already evaluated by
     # the caller into $? . PASS when the caller passed 'true'.
@@ -181,6 +169,16 @@ if [ "${1:-}" = "--self-test" ]; then
     then record ok "NATIVE_HEAVY pre-links heavy modules before the aggregate link"
     else record no "NATIVE_HEAVY pre-links heavy modules before the aggregate link"; fi
 
+    # 8a2. NATIVE_LINK_CPUS caps the two link invocations but never the test run.
+    : > "$CALLS"; : > "$HEAP"; make_fake_sbt 'echo "Tests: succeeded 100, failed 0"; exit 0'
+    PATH="$SELFDIR:$PATH" MAX_RETRIES=2 STALE_TIMEOUT=2 POLL_INTERVAL=1 CI_MON=0 \
+        NATIVE_HEAVY="kyo-schema" NATIVE_LINK_CPUS=2 "$SELF" Native test >/dev/null 2>&1
+    CT_EXIT=$?
+    if heap_nth_has 1 "-XX:ActiveProcessorCount=2" && heap_nth_has 2 "-XX:ActiveProcessorCount=2" \
+       && ! heap_nth_has 3 "-XX:ActiveProcessorCount=2" && exit_is 0
+    then record ok "NATIVE_LINK_CPUS caps link invocations, never the test run"
+    else record no "NATIVE_LINK_CPUS caps link invocations, never the test run"; fi
+
     # 8b. A heavy pre-link failure aborts before the aggregate link and before any tests.
     : > "$CALLS"; : > "$HEAP"
     make_fake_sbt 'if [ "$*" = "kyo-schemaNative/Test/nativeLink" ]; then exit 3; fi; echo "Tests: succeeded 100, failed 0"; exit 0'
@@ -229,18 +227,6 @@ echo "Exception in thread \"main\" java.lang.RuntimeException: oops"; exit 1'
     if exit_is 2 && calls_count 0; then record ok "unknown action exits 2 before any sbt"
     else record no "unknown action exits 2 before any sbt"; fi
 
-    # 23. JS bumps the inherited 12G driver heap to 14G for every sbt call.
-    run_runner_ci JS test 'exit 0'
-    if heap_saw "-Xmx14G" && heap_never "-Xmx12G" && exit_is 0
-    then record ok "JS bumps the inherited driver heap to 14G"
-    else record no "JS bumps the inherited driver heap to 14G"; fi
-
-    # 24. JVM leaves the inherited 12G driver heap unchanged.
-    run_runner_ci JVM test 'exit 0'
-    if heap_saw "-Xmx12G" && heap_never "-Xmx14G" && exit_is 0
-    then record ok "JVM leaves the inherited driver heap at 12G"
-    else record no "JVM leaves the inherited driver heap at 12G"; fi
-
     # Negative control: a deliberately wrong expectation MUST flip FAIL,
     # proving the harness is not vacuous. Not counted in the scenario total.
     run_runner JVM test 'exit 0'
@@ -248,7 +234,7 @@ echo "Exception in thread \"main\" java.lang.RuntimeException: oops"; exit 1'
 
     echo ""
     echo "Results: $PASS/$TOTAL passed, $FAIL failed"
-    [ "$FAIL" -eq 0 ] && [ "$TOTAL" -eq 26 ]
+    [ "$FAIL" -eq 0 ] && [ "$TOTAL" -eq 25 ]
     exit $?
 fi
 
@@ -265,20 +251,6 @@ if ! contains_word "$ACTION" "$ACTIONS"; then
     echo "ci-test.sh: unknown action '$ACTION'" >&2; usage; exit 2
 fi
 
-# The Scala.js link runs in the sbt driver heap, and the full JS test-class
-# compile OOMs at the shared 12G ceiling. Raise the driver to 14G for JS only:
-# each platform runs on its own runner, so JVM/Wasm stay at 12G (green there)
-# and Native stays at 12G because its forked LLVM/podman/chrome alongside a 14G
-# heap would overcommit the 16G box (exit 143). This mutates the inherited opts
-# rather than hardcoding a second string, so the only ceiling is the caller's
-# 12G. When JAVA_OPTS is unset/empty (direct mode without the CI env) the
-# substitution is a no-op and the launcher's .jvmopts governs, which is correct
-# for the unconstrained dev box.
-if [ "$PLATFORM" = "JS" ]; then
-    export JAVA_OPTS="${JAVA_OPTS:-}"; export JAVA_OPTS="${JAVA_OPTS//-Xmx12G/-Xmx14G}"
-    export JVM_OPTS="${JVM_OPTS:-}"; export JVM_OPTS="${JVM_OPTS//-Xmx12G/-Xmx14G}"
-fi
-
 MAX_RETRIES=${MAX_RETRIES:-3}
 STALE_TIMEOUT=${STALE_TIMEOUT:-600}
 POLL_INTERVAL=${POLL_INTERVAL:-10}
@@ -292,7 +264,26 @@ POLL_INTERVAL=${POLL_INTERVAL:-10}
 # linked here. Empty by default; the CI workflow sets it for the Native target.
 NATIVE_HEAVY="${NATIVE_HEAVY:-}"
 
+# When non-empty, the nativeLink sbt invocations run with -XX:ActiveProcessorCount=$NATIVE_LINK_CPUS.
+# The scala-native toolchain sizes its optimizer pool and its concurrent clang forks from
+# availableProcessors, and the fork fleet stacked on top of the driver heap is what overcommits the
+# 16GB CI runners. Scoped to the link invocations only; compile and the test run keep every CPU.
+NATIVE_LINK_CPUS="${NATIVE_LINK_CPUS:-}"
+
 log() { echo "=== [ci-test] $(date '+%H:%M:%S') $* ==="; }
+
+# sbt for a nativeLink invocation: applies the NATIVE_LINK_CPUS cap when set. The flag is added
+# via the invocation's environment; .jvmopts only overrides flags it duplicates, so a flag that
+# appears only here always reaches the JVM.
+link_sbt() {
+    if [ -n "$NATIVE_LINK_CPUS" ]; then
+        JAVA_OPTS="${JAVA_OPTS:-} -XX:ActiveProcessorCount=$NATIVE_LINK_CPUS" \
+        JVM_OPTS="${JVM_OPTS:-} -XX:ActiveProcessorCount=$NATIVE_LINK_CPUS" \
+            sbt "$@"
+    else
+        sbt "$@"
+    fi
+}
 
 # run-arg: full run sends --all, diff run sends nothing (testKyo diffs vs
 # origin/main). compile/link map to the dedicated phases below.
@@ -392,10 +383,10 @@ run_native() {
     # the on-disk nativeLink cache and skips what was linked here.
     for heavy in $NATIVE_HEAVY; do
         log "pre-linking heavy native module in an isolated driver: sbt ${heavy}Native/Test/nativeLink"
-        sbt "${heavy}Native/Test/nativeLink" || { log "native pre-link of $heavy failed"; return 1; }
+        link_sbt "${heavy}Native/Test/nativeLink" || { log "native pre-link of $heavy failed"; return 1; }
     done
     log "linking native test binaries: sbt kyoNative/Test/nativeLink"
-    sbt "kyoNative/Test/nativeLink"
+    link_sbt "kyoNative/Test/nativeLink"
     link_exit=$?
     if [ "$link_exit" -ne 0 ]; then
         log "native linking failed (exit $link_exit)"; return 1


### PR DESCRIPTION
Problem

The linux-x64 Native job was intermittently kernel-OOM-killed during the kyo-schema test-binary link: the aggregate sbt driver accumulates ~11GB RSS across the preceding module links, and the clang jobs the toolchain forks on top of it overcommit the 16GB runner. The per-target heap caps meant to prevent this (Native 8G, JS 14G) never took effect: the sbt runner appends .jvmopts (-Xmx12G) after the env opts on the java command line, and java takes the last -Xmx, so every driver has been running at 12G regardless of the workflow env. A CI-faithful local reproduction (podman, 16g/4cpu, 4G swap) measured ~17.7GB of demand against the 16GiB cap during that link, surviving only on swap.

Solution

Cap the Native link drivers with -XX:ActiveProcessorCount=2, wired as NATIVE_LINK_CPUS from build.yml and applied by ci-test.sh to the nativeLink invocations only. The scala-native toolchain sizes its optimizer pool and its concurrent clang forks from availableProcessors (one fixed pool in Build.await), so this halves the fork fleet at the pinch while compile and the test run keep all 4 CPUs. Flags that appear only in the env always reach the JVM since .jvmopts holds no duplicate for them.

Remove the dead heap overrides instead of repairing them: build.yml drops -Xmx from the job env (.jvmopts is the single source of truth) and ci-test.sh drops the JS 14G substitution, with self-tests updated (a new case pins the cap to the link invocations and off the test run).

Add an 8G supplementary swapfile in the setup action so a residual overcommit degrades into slowdown instead of a SIGKILL, and extend ci-monitor.sh with per-command RSS attribution (top=[java:...M/n ...]) plus a cores= field, so memory incidents are attributable from the job log instead of reconstructed from kernel kill lines.

Notes

build.sh gains the container-provisioning fixes the local reproduction surfaced: the Linux aarch64 coursier launcher comes from VirtusLab's coursier-m1 releases, and bare containers need clang, build-essential, and libssl-dev, which GitHub runners preinstall.
