### PR TITLE
[kyo-http] harden HTTP/1.1 against the mature-server advisory record

### DIFF
--- a/kyo-http/shared/src/main/scala/kyo/HttpException.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpException.scala
@@ -280,6 +280,14 @@ object HttpUrlParseException:
         new HttpUrlParseException(HttpException.stripQuery(url), cause.getMessage, cause)
 end HttpUrlParseException
 
+/** A message body could not be decoded because its transfer framing is malformed: a chunk-size line with an embedded
+  * CR or LF, a bare-LF line ending, an invalid chunk size, or a missing CRLF after chunk data. Accepting such framing
+  * lets a recipient disagree with an upstream about where the body ends, a request-smuggling desync (RFC 9112 section
+  * 7.1.1; CVE-2025-22871, CVE-2026-2332, CVE-2026-33870).
+  */
+case class HttpMalformedBodyException private[kyo] (detail: String)(using Frame)
+    extends HttpDecodeException(s"Malformed chunked body framing: $detail.")
+
 /** Failed to decode a path capture, query parameter, header, or cookie field. */
 case class HttpFieldDecodeException private (
     fieldName: String,

--- a/kyo-http/shared/src/main/scala/kyo/HttpHeaders.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpHeaders.scala
@@ -423,11 +423,21 @@ object HttpHeaders:
             loop(0)
         end responseCookie
 
-        /** Adds a Set-Cookie header for a response cookie. */
+        /** Adds a Set-Cookie header for a response cookie.
+          *
+          * Raises an `IllegalArgumentException` when the name, the encoded value, or the Domain or Path attribute violates the RFC 6265
+          * section 4.1.1 grammar, since a value carrying a ';' would write cookie ATTRIBUTES rather than data and the grammar offers no
+          * escape to encode it as data instead. A caller holding content that may not qualify (anything user-derived) tests it first with
+          * [[HttpHeaders.isValidCookieName]], [[HttpHeaders.isValidCookieValue]] and [[HttpHeaders.isValidCookieAttribute]], or encodes it
+          * into an opaque token, base64 being the usual choice.
+          */
         def addCookie[A](name: String, cookie: HttpCookie[A]): HttpHeaders =
             self.add("Set-Cookie", HttpHeaders.serializeCookie(name, cookie))
 
-        /** Adds a Set-Cookie header with a simple string value. */
+        /** Adds a Set-Cookie header with a simple string value.
+          *
+          * Raises on a name or value outside the RFC 6265 section 4.1.1 grammar; see the overload above.
+          */
         def addCookie(name: String, value: String)(using HttpCodec[String]): HttpHeaders =
             addCookie(name, HttpCookie(value))
 
@@ -519,7 +529,7 @@ object HttpHeaders:
     end parseCookieHeader
 
     /** RFC 6265 cookie-name: token characters (RFC 2616 Section 2.2) */
-    private def isValidCookieName(name: String): Boolean =
+    def isValidCookieName(name: String): Boolean =
         @tailrec def loop(i: Int): Boolean =
             if i >= name.length then true
             else
@@ -531,7 +541,7 @@ object HttpHeaders:
 
     /** RFC 6265 cookie-value: *cookie-octet / ( DQUOTE *cookie-octet DQUOTE ) cookie-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
       */
-    private def isValidCookieValue(value: String): Boolean =
+    def isValidCookieValue(value: String): Boolean =
         val len = value.length
         // Value may optionally be wrapped in DQUOTE
         val (start, end) =
@@ -546,18 +556,61 @@ object HttpHeaders:
         loop(start)
     end isValidCookieValue
 
+    /** Whether `value` may be used as a Set-Cookie attribute value such as `Domain` or `Path`.
+      *
+      * RFC 6265 section 4.1.1 defines both as any CHAR except CTLs and ';'. The ';' is what matters: it is the delimiter BETWEEN attributes,
+      * so a value carrying one does not extend an attribute, it starts another.
+      */
+    def isValidCookieAttribute(value: String): Boolean =
+        @tailrec def loop(i: Int): Boolean =
+            if i >= value.length then true
+            else
+                val c = value.charAt(i)
+                if c < 0x20 || c == 0x7f || c == ';' then false
+                else loop(i + 1)
+        loop(0)
+    end isValidCookieAttribute
+
+    /** Renders a cookie as a Set-Cookie field value, refusing any part that would change the header's structure.
+      *
+      * Every part is checked against its RFC 6265 section 4.1.1 grammar and a violation raises, because there is no correct alternative:
+      * the grammar defines no escape mechanism, so a ';' in a value cannot be represented as data. Encoding one anyway would invent a
+      * convention no client undoes, trading an injection for silent corruption of the value. Rejecting is the same answer, for the same
+      * reason, that `GrowableByteBuffer.writeAscii` gives to a char it cannot encode.
+      *
+      * A raise rather than a typed failure because reaching it is a defect in the calling code, not a bad message from a peer: a cookie
+      * value is an opaque token the application chooses. An application that needs to carry arbitrary text (a display name, anything
+      * user-supplied) encodes it deliberately, base64 being the usual choice, so that both ends agree on how to read it back. Callers
+      * holding content that may not qualify can test it first with [[isValidCookieName]], [[isValidCookieValue]] and
+      * [[isValidCookieAttribute]] and take their own path.
+      */
     private[kyo] def serializeCookie[A](name: String, cookie: HttpCookie[A]): String =
+        require(
+            isValidCookieName(name),
+            s"cookie name must be a token per RFC 6265 section 4.1.1 (no controls, whitespace, or separators); got: $name"
+        )
+        val encoded = cookie.codec.encode(cookie.value)
+        require(
+            isValidCookieValue(encoded),
+            s"cookie value must be cookie-octets per RFC 6265 section 4.1.1 (no controls, whitespace, ';', ',', '\"' or '\\\\'); got: $encoded"
+        )
         val sb = new StringBuilder(name.size + 80)
-        discard(sb.append(name).append('=').append(cookie.codec.encode(cookie.value)))
+        discard(sb.append(name).append('=').append(encoded))
         cookie.maxAge match
             case Present(d) => discard(sb.append("; Max-Age=").append(d.toSeconds))
             case Absent     =>
         cookie.domain match
-            case Present(d) => discard(sb.append("; Domain=").append(d))
-            case Absent     =>
+            case Present(d) =>
+                require(isValidCookieAttribute(d), s"cookie Domain must not carry a control character or ';'; got: $d")
+                discard(sb.append("; Domain=").append(d))
+            case Absent =>
+        end match
         cookie.path match
-            case Present(p) => discard(sb.append("; Path=").append(p))
-            case Absent     =>
+            case Present(p) =>
+                require(isValidCookieAttribute(p), s"cookie Path must not carry a control character or ';'; got: $p")
+                discard(sb.append("; Path=").append(p))
+            case Absent =>
+        end match
         if cookie.secure then discard(sb.append("; Secure"))
         if cookie.httpOnly then discard(sb.append("; HttpOnly"))
         cookie.sameSite match

--- a/kyo-http/shared/src/main/scala/kyo/HttpResponse.scala
+++ b/kyo-http/shared/src/main/scala/kyo/HttpResponse.scala
@@ -51,7 +51,13 @@ case class HttpResponse[Fields](
 
     def contentDisposition(filename: String, isInline: Boolean = false): HttpResponse[Fields] =
         val disposition = if isInline then "inline" else "attachment"
-        setHeader("Content-Disposition", s"""$disposition; filename="$filename"""")
+        // Escape the quoted-string metacharacters so a filename cannot break out of the quotes and inject a second
+        // disposition parameter (RFC 6266). A raw '"' would close the quoted-string and a filename like
+        // `x"; filename="evil` would smuggle a second filename an intermediary or browser may honour (CVE-2026-59921).
+        // Backslash is escaped first so an existing '\' is not conflated with the escapes added for '"'.
+        val escaped = filename.replace("\\", "\\\\").replace("\"", "\\\"")
+        setHeader("Content-Disposition", s"""$disposition; filename="$escaped"""")
+    end contentDisposition
 
 end HttpResponse
 

--- a/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/client/HttpClientBackend.scala
@@ -162,7 +162,7 @@ final private[kyo] class HttpClientBackend private (
                                         readBufferedBody(conn, parsed, request.method, resultPromise, route, request, maxResponseLength)
                                     else
                                         val lastBodySpan = conn.http1.lastBodySpan
-                                        val bodyStream   = buildBodyStream(conn, parsed, lastBodySpan)
+                                        val bodyStream   = buildBodyStream(conn, parsed, lastBodySpan, maxResponseLength)
                                         RouteUtil.decodeStreamingResponse(
                                             route,
                                             HttpStatus(parsed.statusCode),
@@ -435,7 +435,8 @@ final private[kyo] class HttpClientBackend private (
                         case Result.Panic(t) =>
                             resultPromise.completeDiscard(Result.panic(t))
                     },
-                    size => resultPromise.completeDiscard(Result.fail(HttpPayloadTooLargeException(size, maxResponseLength)))
+                    size => resultPromise.completeDiscard(Result.fail(HttpPayloadTooLargeException(size, maxResponseLength))),
+                    malformed => resultPromise.completeDiscard(Result.fail(malformed))
                 )
             else if parsed.contentLength > 0 then
                 if parsed.contentLength > maxResponseLength then
@@ -567,7 +568,7 @@ final private[kyo] class HttpClientBackend private (
     // -- Streaming response path --
 
     /** Build a raw body stream from the parsed response metadata. */
-    private def buildBodyStream(conn: HttpConnection, parsed: ParsedResponse, lastBodySpan: Span[Byte])(using
+    private def buildBodyStream(conn: HttpConnection, parsed: ParsedResponse, lastBodySpan: Span[Byte], maxControlBytes: Int)(using
         AllowUnsafe,
         Frame
     ): Stream[Span[Byte], Async] =
@@ -578,10 +579,14 @@ final private[kyo] class HttpClientBackend private (
             val decodedCh = Channel.Unsafe.init[Span[Byte]](4)
             // Start the chunked decoder in a background fiber
             discard(kyo.scheduler.IOTask(
-                Abort.run[Closed](ChunkedBodyDecoder.readStreaming(
+                // Malformed framing (HttpMalformedBodyException) and an over-limit control plane
+                // (HttpPayloadTooLargeException) are caught here alongside Closed: the decoded channel is closed,
+                // ending the consumer's stream at the fault rather than propagating an uncaught abort.
+                Abort.run[Closed | HttpMalformedBodyException | HttpPayloadTooLargeException](ChunkedBodyDecoder.readStreaming(
                     conn.http1.bodyChannel,
                     lastBodySpan,
                     decodedCh,
+                    maxControlBytes,
                     conn.http1.chunkedDecoderState
                 ))
                     .unit
@@ -1075,12 +1080,31 @@ final private[kyo] class HttpClientBackend private (
                                         nonAsciiRedirect(resolved) match
                                             case Present(field) => Abort.fail(HttpNonAsciiException(field))
                                             case Absent         =>
+                                                // A redirect target is named by the ORIGIN, not by the caller, so the Location value is
+                                                // attacker-chosen whenever the origin is malicious, compromised, or merely open. Carrying
+                                                // the caller's credentials to whatever authority it names hands them to a third party, and
+                                                // an https to http Location additionally puts them on the wire in cleartext. Credentials
+                                                // are therefore scoped to the origin that received them (RFC 6454 section 4: the scheme,
+                                                // host and port triple) and dropped whenever a hop leaves it.
+                                                val crossOrigin = !HttpClientBackend.sameOrigin(req.url, resolved)
+                                                val nextHeaders =
+                                                    if crossOrigin then HttpClientBackend.stripCredentials(req.headers)
+                                                    else req.headers
                                                 // RFC 9110 section 15.4.4: 303 See Other requires changing method to GET
                                                 val nextReq =
                                                     if res.status == HttpStatus.SeeOther then
-                                                        req.copy(url = resolved, method = HttpMethod.GET)
-                                                    else req.copy(url = resolved)
-                                                loop(nextReq, count + 1, chain.append(location))
+                                                        req.copy(url = resolved, method = HttpMethod.GET, headers = nextHeaders)
+                                                    else req.copy(url = resolved, headers = nextHeaders)
+                                                // Debug rather than warn: a service redirecting an authenticated request to a CDN or a
+                                                // sibling port is ordinary traffic, so this is not on its own a fault. It is logged
+                                                // because the visible consequence, a 401 from the target, is otherwise hard to explain.
+                                                val announce =
+                                                    if crossOrigin && nextHeaders.size != req.headers.size then
+                                                        Log.debug(
+                                                            s"dropping credential headers on redirect leaving origin ${req.url.baseUrl} for ${resolved.baseUrl}"
+                                                        )
+                                                    else Kyo.unit
+                                                announce.andThen(loop(nextReq, count + 1, chain.append(location)))
                                         end match
                                     case Result.Failure(err) =>
                                         Abort.fail(err)
@@ -1217,6 +1241,34 @@ final private[kyo] class HttpClientBackend private (
 end HttpClientBackend
 
 private[kyo] object HttpClientBackend:
+
+    /** Header fields carrying a caller's credentials, dropped when a redirect leaves the origin they were sent to.
+      *
+      * `Cookie` belongs here with the two authorization fields: a cookie is bound to the origin that set it, and forwarding one to a
+      * different authority is the same disclosure as forwarding an `Authorization` value.
+      */
+    private val CredentialHeaders = List("Authorization", "Proxy-Authorization", "Cookie")
+
+    /** Drops every credential-bearing field from `headers`. */
+    private[client] def stripCredentials(headers: HttpHeaders): HttpHeaders =
+        CredentialHeaders.foldLeft(headers)((acc, name) => acc.remove(name))
+
+    /** Whether two URLs share an origin: the same scheme, host and port (RFC 6454 section 4).
+      *
+      * Host is compared case-insensitively because a DNS name is case-insensitive. Port needs no default-filling here because `HttpUrl.parse`
+      * already resolves an absent port to the scheme's default, so `https://h` and `https://h:443` arrive equal.
+      */
+    private[client] def sameOrigin(a: HttpUrl, b: HttpUrl): Boolean =
+        // Scheme and host are both compared case-insensitively (RFC 3986 sections 3.1 and 3.2.2 make both case-insensitive, and `HttpUrl`
+        // stores the scheme as written rather than normalized). Comparing the scheme exactly would read "HTTPS://host" redirecting to
+        // "https://host" as a change of origin and silently strip credentials from a hop that never left it.
+        val schemeMatches =
+            (a.scheme, b.scheme) match
+                case (Present(x), Present(y)) => x.equalsIgnoreCase(y)
+                case (Absent, Absent)         => true
+                case _                        => false
+        schemeMatches && a.host.equalsIgnoreCase(b.host) && a.port == b.port
+    end sameOrigin
 
     /** Create a fully pooled backend for production use.
       *

--- a/kyo-http/shared/src/main/scala/kyo/internal/codec/ParsedRequest.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/codec/ParsedRequest.scala
@@ -32,6 +32,47 @@ private[kyo] object ParsedRequest:
     /** Empty sentinel used as initial value before a request is parsed. */
     val empty: ParsedRequest = Span.empty[Byte]
 
+    /** Decodes percent-escapes in a path segment, total and never throwing.
+      *
+      * Path rules, not query rules: '+' is an ordinary character here (RFC 3986 section 3.3), and a malformed escape is passed through
+      * literally rather than raised, since this sits on a dispatch path with no exception handler. Decoding is byte-wise and the result is
+      * read back as UTF-8, so a multi-byte character split across several escapes reassembles correctly.
+      */
+    private[codec] def decodePathEscapes(raw: String): String =
+        val src = raw.getBytes(StandardCharsets.UTF_8)
+        val out = new Array[Byte](src.length)
+        @tailrec def loop(i: Int, j: Int): Int =
+            if i >= src.length then j
+            else
+                val b = src(i) & 0xff
+                if b == '%' && i + 2 < src.length then
+                    val hi = hexDigit(src(i + 1))
+                    val lo = hexDigit(src(i + 2))
+                    if hi >= 0 && lo >= 0 then
+                        out(j) = ((hi << 4) | lo).toByte
+                        loop(i + 3, j + 1)
+                    else
+                        out(j) = b.toByte
+                        loop(i + 1, j + 1)
+                    end if
+                else
+                    out(j) = b.toByte
+                    loop(i + 1, j + 1)
+                end if
+        val len = loop(0, 0)
+        new String(out, 0, len, StandardCharsets.UTF_8)
+    end decodePathEscapes
+
+    /** Numeric value of a hex digit byte, or -1 when it is not one. */
+    private def hexDigit(b: Byte): Int =
+        val c = b & 0xff
+        if c >= '0' && c <= '9' then c - '0'
+        else if c >= 'a' && c <= 'f' then c - 'a' + 10
+        else if c >= 'A' && c <= 'F' then c - 'A' + 10
+        else -1
+        end if
+    end hexDigit
+
     /** Pre-encoded route segment for zero-alloc matching. */
     opaque type Segment = Array[Byte]
 
@@ -188,14 +229,32 @@ private[kyo] object ParsedRequest:
             end if
         end pathSegmentAsString
 
-        /** Returns path segment `i` as a URL-decoded String. */
+        /** Returns path segment `i` with its percent-escapes decoded.
+          *
+          * Decoding is done here rather than by `java.net.URLDecoder` for three reasons, each of which has bitten this path: URLDecoder
+          * throws on a malformed escape, and this runs inside request dispatch where nothing catches it; it decodes '+' to a space, which is
+          * the query rule (RFC 3986 section 3.4) and not the path rule, where '+' is an ordinary character; and applying it only when a '%'
+          * is present, as this did, made even that inconsistent, so "a+b" and "a+b%20c" disagreed about what '+' meant.
+          *
+          * A malformed escape is emitted literally rather than raised. That is a fallback, not the contract: `Http1Parser` refuses such a
+          * request before routing, so a segment reaching this method has already been validated. It matters only for a segment built
+          * directly, where producing an odd string beats throwing from a total accessor.
+          */
         def pathSegmentAsStringDecoded(i: Int): String =
             val raw = pathSegmentAsString(i)
             if raw.indexOf('%') < 0 then raw
-            else java.net.URLDecoder.decode(raw, "UTF-8")
+            else ParsedRequest.decodePathEscapes(raw)
         end pathSegmentAsStringDecoded
 
-        /** Returns all remaining path segments from index `fromSegment` onward, joined with '/' and URL-decoded. Used for rest captures. */
+        /** Returns all remaining path segments from `fromSegment` onward, decoded and joined with '/'. Used for rest captures.
+          *
+          * The result is a faithful decode: what the client addressed, with escapes resolved. It is NOT a sanitized path. A capture value
+          * may contain a path separator, by design and on both capture kinds: the client percent-encodes a named capture (so a value of
+          * "hello/world" round-trips through "%2F") and appends a rest capture raw. A handler that resolves a capture against a directory
+          * must therefore validate it first, exactly as it would any other request-supplied string.
+          *
+          * Dot segments are already resolved by the parser, so no "." or ".." segment reaches here.
+          */
         def restPathAsString(fromSegment: Int): String =
             val segCount = readShort(self, 14)
             if fromSegment < 0 || fromSegment >= segCount then ""

--- a/kyo-http/shared/src/main/scala/kyo/internal/codec/ParsedRequestBuilder.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/codec/ParsedRequestBuilder.scala
@@ -100,6 +100,59 @@ final private[kyo] class ParsedRequestBuilder(using AllowUnsafe):
         segmentCount += 1
     end addPathSegment
 
+    /** Rewrites the stored path as "/" plus the surviving segments joined by "/".
+      *
+      * Called only when parsing actually resolved a dot segment, which is rare, so the ordinary request pays nothing: the path is stored
+      * once from the raw bytes and left alone. When resolution DID change the path, storing the raw form would leave the request routed on
+      * one path while reporting another: `pathAsString` reaches handlers and filters as `req.url.path`, so `/public/../admin/secret` would
+      * route to `admin/secret` while every log line and every filter decision read `/public/../admin/secret`. A recipient acting on one
+      * view while another recipient acts on the other is the same disagreement this parser refuses in message framing, so the two are kept
+      * in agreement here rather than left to whoever reads them.
+      *
+      * The segments are already stored in `rawBytes`; this appends a fresh joined copy and repoints the path at it, since the buffer is
+      * append-only and the segment offsets must stay valid.
+      */
+    def setPathFromSegments(): Unit =
+        val newOff = rawBytes.size
+        if segmentCount == 0 then rawBytes.writeByte('/'.toByte)
+        else
+            var i = 0
+            while i < segmentCount do
+                rawBytes.writeByte('/'.toByte)
+                val segOff = segOffsets(i * 2)
+                val segLen = segOffsets(i * 2 + 1)
+                rawBytes.writeBytes(rawBytes.array, segOff, segLen)
+                i += 1
+            end while
+        end if
+        pathOff = newOff
+        pathLen = rawBytes.size - newOff
+        pathSet = true
+    end setPathFromSegments
+
+    /** Drops the most recently added path segment, or does nothing when there is none.
+      *
+      * This is how a ".." segment is applied while the path is being parsed (RFC 3986 section 5.2.4 removes dot segments), so the router and
+      * every capture see the resolved path rather than one still carrying traversal. The segment's bytes stay in the raw buffer and are simply
+      * no longer addressed, which costs a few unreferenced bytes and keeps the append-only buffer append-only.
+      *
+      * A ".." with nothing left to drop is a no-op, per the same section: a path cannot be walked above its root.
+      */
+
+    def removeLastPathSegment(): Unit =
+        if segmentCount > 0 then
+            segOffsetCount -= 2
+            segmentCount -= 1
+
+    /** Whether the accumulated bytes have outgrown the 16-bit offsets the packed layout addresses them with.
+      *
+      * `build()` writes every path, segment and header offset as a two-byte field, so once the raw buffer passes 65535 bytes an offset
+      * wraps and a later read lands somewhere else entirely: a header name or value resolves to an arbitrary window of the buffer, which
+      * is request-supplied data at a request-influenced offset. The parser asks this before building and refuses the request instead,
+      * because a wrapped offset is not a degraded answer, it is a confidently wrong one.
+      */
+    def offsetsOverflowed: Boolean = rawBytes.size > 0xffff
+
     def addHeader(
         nameSrc: Array[Byte],
         nameOff: Int,

--- a/kyo-http/shared/src/main/scala/kyo/internal/http1/ChunkedBodyDecoder.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/http1/ChunkedBodyDecoder.scala
@@ -32,12 +32,13 @@ private[kyo] object ChunkedBodyDecoder:
         state: DecoderState = new DecoderState
     )(
         onResult: Result[Closed, Span[Byte]] => Unit,
-        onTooLarge: Int => Unit
+        onTooLarge: Int => Unit,
+        onInvalid: HttpMalformedBodyException => Unit
     )(using AllowUnsafe, Frame): Unit =
         val accumulator = new GrowableByteBuffer
         if !initialBytes.isEmpty then
             state.feedBytes(initialBytes)
-        bufferedLoopUnsafe(inbound, accumulator, state, maxBytes, onResult, onTooLarge)
+        bufferedLoopUnsafe(inbound, accumulator, state, maxBytes, onResult, onTooLarge, onInvalid)
     end readBufferedUnsafe
 
     /** Main unsafe buffered decode loop. Processes buffer, accumulates data, reads more via callbacks. Caps the accumulated body at
@@ -51,9 +52,11 @@ private[kyo] object ChunkedBodyDecoder:
         state: DecoderState,
         maxBytes: Int,
         onResult: Result[Closed, Span[Byte]] => Unit,
-        onTooLarge: Int => Unit
+        onTooLarge: Int => Unit,
+        onInvalid: HttpMalformedBodyException => Unit
     )(using AllowUnsafe, Frame): Unit =
-        if accumulator.size > maxBytes then onTooLarge(accumulator.size)
+        val pending = accumulator.size + state.pendingSize
+        if pending > maxBytes then onTooLarge(pending)
         else
             state.drain(accumulator) match
                 case DrainResult.Done =>
@@ -67,7 +70,7 @@ private[kyo] object ChunkedBodyDecoder:
                             result match
                                 case Result.Success(span) =>
                                     state.feedBytes(span)
-                                    bufferedLoopUnsafe(inbound, accumulator, state, maxBytes, onResult, onTooLarge)
+                                    bufferedLoopUnsafe(inbound, accumulator, state, maxBytes, onResult, onTooLarge, onInvalid)
                                 case Result.Failure(closed) =>
                                     onResult(Result.fail(closed))
                                 case Result.Panic(t) =>
@@ -75,61 +78,87 @@ private[kyo] object ChunkedBodyDecoder:
                         }
                 case DrainResult.ChunkReady =>
                     // In buffered mode, data is already in accumulator. Continue draining.
-                    bufferedLoopUnsafe(inbound, accumulator, state, maxBytes, onResult, onTooLarge)
+                    bufferedLoopUnsafe(inbound, accumulator, state, maxBytes, onResult, onTooLarge, onInvalid)
+                case DrainResult.Invalid(reason) =>
+                    onInvalid(HttpMalformedBodyException(reason))
         end if
     end bufferedLoopUnsafe
 
-    /** Buffered mode: accumulates all decoded chunks into one Span[Byte]. */
+    /** Buffered mode: accumulates all decoded chunks into one Span[Byte], bounded by `maxBytes`.
+      *
+      * A chunked body has no declared length, so decoding it into memory must be capped or it grows without limit
+      * (CWE-400). When the accumulated decoded bytes exceed `maxBytes` the decode aborts `HttpPayloadTooLargeException`
+      * so the caller can answer 413 rather than buffer an unbounded body.
+      */
     def readBuffered(
         inbound: Channel.Unsafe[Span[Byte]],
         initialBytes: Span[Byte],
+        maxBytes: Int,
         state: DecoderState = new DecoderState
-    )(using Frame): Span[Byte] < (Async & Abort[Closed]) =
+    )(using Frame): Span[Byte] < (Async & Abort[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException]) =
         val accumulator = new GrowableByteBuffer
         if !initialBytes.isEmpty then
             state.feedBytes(initialBytes)
-        bufferedLoop(inbound, accumulator, state)
+        bufferedLoop(inbound, accumulator, state, maxBytes)
     end readBuffered
 
-    /** Streaming mode: delivers each decoded chunk to output, then closes output. */
+    /** Streaming mode: delivers each decoded chunk to output, then closes output.
+      *
+      * The delivered body is unbounded by design (streaming trades unbounded total for bounded memory), but the control
+      * plane is not: a chunk extension or trailer that never completes a line would buffer without limit (CWE-400).
+      * `maxControlBytes` bounds the buffered-but-undelivered bytes (the size line and trailer, plus at most one read of
+      * chunk data), aborting HttpPayloadTooLargeException when exceeded; the delivered stream itself stays uncapped.
+      */
     def readStreaming(
         inbound: Channel.Unsafe[Span[Byte]],
         initialBytes: Span[Byte],
         output: Channel.Unsafe[Span[Byte]],
+        maxControlBytes: Int,
         state: DecoderState = new DecoderState
-    )(using Frame): Unit < (Async & Abort[Closed]) =
+    )(using Frame): Unit < (Async & Abort[Closed | HttpMalformedBodyException | HttpPayloadTooLargeException]) =
         if !initialBytes.isEmpty then
             state.feedBytes(initialBytes)
-        streamingLoop(inbound, output, state)
+        streamingLoop(inbound, output, state, maxControlBytes)
     end readStreaming
 
-    /** Main buffered decode loop. Processes buffer, accumulates data, reads more if needed. */
+    /** Main buffered decode loop. Processes buffer, accumulates data, reads more if needed. Caps the accumulated body
+      * at `maxBytes` (aborting HttpPayloadTooLargeException), for the same CWE-400 reason as bufferedLoopUnsafe.
+      */
     private def bufferedLoop(
         inbound: Channel.Unsafe[Span[Byte]],
         accumulator: GrowableByteBuffer,
-        state: DecoderState
-    )(using Frame): Span[Byte] < (Async & Abort[Closed]) =
-        state.drain(accumulator) match
-            case DrainResult.Done =>
-                Span.fromUnsafe(accumulator.toByteArray)
-            case DrainResult.NeedMore =>
-                inbound.safe.take.map { span =>
-                    state.feedBytes(span)
-                    bufferedLoop(inbound, accumulator, state)
-                }
-            case DrainResult.ChunkReady =>
-                // In buffered mode, data is already in accumulator. Continue draining.
-                bufferedLoop(inbound, accumulator, state)
+        state: DecoderState,
+        maxBytes: Int
+    )(using Frame): Span[Byte] < (Async & Abort[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException]) =
+        val pending = accumulator.size + state.pendingSize
+        if pending > maxBytes then
+            Abort.fail(HttpPayloadTooLargeException(pending, maxBytes))
+        else
+            state.drain(accumulator) match
+                case DrainResult.Done =>
+                    Span.fromUnsafe(accumulator.toByteArray)
+                case DrainResult.NeedMore =>
+                    inbound.safe.take.map { span =>
+                        state.feedBytes(span)
+                        bufferedLoop(inbound, accumulator, state, maxBytes)
+                    }
+                case DrainResult.ChunkReady =>
+                    // In buffered mode, data is already in accumulator. Continue draining.
+                    bufferedLoop(inbound, accumulator, state, maxBytes)
+                case DrainResult.Invalid(reason) =>
+                    Abort.fail(HttpMalformedBodyException(reason))
+        end if
     end bufferedLoop
 
     /** Main streaming decode loop. Processes buffer, delivers complete chunks to output. */
     private def streamingLoop(
         inbound: Channel.Unsafe[Span[Byte]],
         output: Channel.Unsafe[Span[Byte]],
-        state: DecoderState
-    )(using Frame): Unit < (Async & Abort[Closed]) =
+        state: DecoderState,
+        maxControlBytes: Int
+    )(using Frame): Unit < (Async & Abort[Closed | HttpMalformedBodyException | HttpPayloadTooLargeException]) =
         val chunkBuf = new GrowableByteBuffer
-        streamingDrainAndDeliver(inbound, output, state, chunkBuf)
+        streamingDrainAndDeliver(inbound, output, state, chunkBuf, maxControlBytes)
     end streamingLoop
 
     /** Drains the state buffer, delivering complete chunks via the safe channel API. */
@@ -137,43 +166,54 @@ private[kyo] object ChunkedBodyDecoder:
         inbound: Channel.Unsafe[Span[Byte]],
         output: Channel.Unsafe[Span[Byte]],
         state: DecoderState,
-        chunkBuf: GrowableByteBuffer
-    )(using Frame): Unit < (Async & Abort[Closed]) =
+        chunkBuf: GrowableByteBuffer,
+        maxControlBytes: Int
+    )(using Frame): Unit < (Async & Abort[Closed | HttpMalformedBodyException | HttpPayloadTooLargeException]) =
         state.drain(chunkBuf) match
             case DrainResult.Done =>
                 // Don't close the channel here, the caller (UnsafeServerDispatch) manages lifecycle.
                 // Channel.close drops buffered items, which would lose chunks the consumer hasn't read yet.
                 ()
+            case DrainResult.Invalid(reason) =>
+                // Malformed framing mid-stream: fail rather than silently ending the delivered stream truncated.
+                Abort.fail(HttpMalformedBodyException(reason))
             case DrainResult.ChunkReady =>
                 // A complete chunk has been decoded, deliver it
                 val decoded = Span.fromUnsafe(chunkBuf.toByteArray)
                 chunkBuf.reset()
                 output.safe.put(decoded).andThen(
-                    streamingDrainAndDeliver(inbound, output, state, chunkBuf)
+                    streamingDrainAndDeliver(inbound, output, state, chunkBuf, maxControlBytes)
                 )
             case DrainResult.NeedMore =>
-                // Deliver any partial data accumulated so far for this chunk
-                if chunkBuf.size > 0 then
-                    val decoded = Span.fromUnsafe(chunkBuf.toByteArray)
-                    chunkBuf.reset()
-                    output.safe.put(decoded).andThen(
+                // Deliver any partial data accumulated so far for this chunk, then, before blocking for more input,
+                // bound the undelivered control plane. At NeedMore the decoder has consumed all it can, so buf holds
+                // only an incomplete size line or trailer (chunk data has already been drained into chunkBuf), and
+                // state.pendingSize is that control plane alone. A control line that never completes would grow it
+                // without limit across reads (CWE-400); the delivered body is not counted, so a large legitimate body
+                // still streams.
+                val flush =
+                    if chunkBuf.size > 0 then
+                        val decoded = Span.fromUnsafe(chunkBuf.toByteArray)
+                        chunkBuf.reset()
+                        output.safe.put(decoded)
+                    else Kyo.unit
+                flush.andThen {
+                    if state.pendingSize > maxControlBytes then
+                        Abort.fail(HttpPayloadTooLargeException(state.pendingSize, maxControlBytes))
+                    else
                         inbound.safe.take.map { span =>
                             state.feedBytes(span)
-                            streamingDrainAndDeliver(inbound, output, state, chunkBuf)
+                            streamingDrainAndDeliver(inbound, output, state, chunkBuf, maxControlBytes)
                         }
-                    )
-                else
-                    inbound.safe.take.map { span =>
-                        state.feedBytes(span)
-                        streamingDrainAndDeliver(inbound, output, state, chunkBuf)
-                    }
+                }
     end streamingDrainAndDeliver
 
     /** Result of a drain operation. */
     private[http1] enum DrainResult derives CanEqual:
-        case Done       // Terminal chunk processed
-        case NeedMore   // Need more bytes from inbound
-        case ChunkReady // A complete chunk's data has been written to the accumulator
+        case Done                    // Terminal chunk processed
+        case NeedMore                // Need more bytes from inbound
+        case ChunkReady              // A complete chunk's data has been written to the accumulator
+        case Invalid(reason: String) // Malformed framing: the decode must fail, not truncate silently
     end DrainResult
 
     /** Mutable state machine for chunked decoding.
@@ -203,6 +243,9 @@ private[kyo] object ChunkedBodyDecoder:
         // Tracks whether we're mid-CRLF (saw CR, waiting for LF)
         private var sawCr: Boolean = false
 
+        // Set alongside PhaseInvalid: why the framing was rejected, surfaced as HttpMalformedBodyException by the loops.
+        private var invalidReason: String = ""
+
         /** Reset all parse state for reuse on a new chunked response. The internal byte buffer is retained to avoid reallocation. */
         def reset(): Unit =
             readPos = 0
@@ -212,7 +255,22 @@ private[kyo] object ChunkedBodyDecoder:
             dataRead = 0
             sizeLine.reset()
             sawCr = false
+            invalidReason = ""
         end reset
+
+        /** Transition to the terminal invalid phase with a reason; returns true so the drain loop re-checks the phase. */
+        private def fail(reason: String): Boolean =
+            phase = PhaseInvalid
+            invalidReason = reason
+            true
+        end fail
+
+        /** Bytes buffered but not yet turned into output: the raw buf tail plus the in-progress size line. A chunk
+          * extension or a trailer section with no terminating line accumulates here without ever producing output, so
+          * it must be counted against the cap or it grows unbounded (CWE-400). The decoded accumulator is counted
+          * separately by the caller.
+          */
+        def pendingSize: Int = (writePos - readPos) + sizeLine.size
 
         /** Feed new bytes into the internal buffer. */
         def feedBytes(span: Span[Byte]): Unit =
@@ -232,6 +290,7 @@ private[kyo] object ChunkedBodyDecoder:
         def drain(accumulator: GrowableByteBuffer): DrainResult =
             @tailrec def loop(): DrainResult =
                 if phase == PhaseDone then DrainResult.Done
+                else if phase == PhaseInvalid then DrainResult.Invalid(invalidReason)
                 else
                     val available = writePos - readPos
                     if available <= 0 then
@@ -292,24 +351,42 @@ private[kyo] object ChunkedBodyDecoder:
                 sizeLine.reset()
                 val lineLen = lineArr.length
                 if lineLen == 0 || lineArr(lineLen - 1) != CR then
-                    // Bare LF without CR -- reject (CVE-2025-22871)
-                    phase = PhaseDone
-                    true
+                    // Bare LF line ending (no preceding CR): RFC 9112 section 2.2 forbids it; CVE-2025-22871.
+                    fail("chunk size line ended with a bare LF")
+                else if hasEmbeddedCr(lineArr, lineLen - 1) then
+                    // A CR before the terminating CR. The chunk-ext is token / quoted-string (RFC 9112 section 7.1.1),
+                    // neither of which admits a CR, so a quoted-string-aware upstream reads the line end at a different
+                    // byte and the two disagree on where the chunk data begins (Jetty CVE-2026-2332 / Netty
+                    // CVE-2026-33870 smuggling desync). findHexEnd stops at ';', so only a full-line scan catches a CR
+                    // inside the extension.
+                    fail("embedded CR in chunk size line")
                 else
                     chunkSize = parseChunkSizeLine(lineArr)
                     dataRead = 0
 
                     if chunkSize == -1 then
-                        phase = PhaseDone // invalid chunk size
+                        fail("invalid chunk size")
                     else if chunkSize == 0 then
                         phase = PhaseReadTrailer
+                        true
                     else
                         phase = PhaseReadData
+                        true
                     end if
-                    true
                 end if
             end if
         end processReadSize
+
+        /** True if a CR appears anywhere in lineArr strictly before `crPos` (the terminating CR's index). The line was
+          * split on the first LF, so it holds no LF; only a bare CR can be embedded.
+          */
+        private def hasEmbeddedCr(lineArr: Array[Byte], crPos: Int): Boolean =
+            @tailrec def scan(i: Int): Boolean =
+                if i >= crPos then false
+                else if lineArr(i) == CR then true
+                else scan(i + 1)
+            scan(0)
+        end hasEmbeddedCr
 
         /** Process chunk data. Returns true if all data for this chunk has been consumed. */
         private def processReadData(accumulator: GrowableByteBuffer): Boolean =
@@ -342,8 +419,7 @@ private[kyo] object ChunkedBodyDecoder:
                     true
                 else
                     // CR not followed by LF -- framing error
-                    phase = PhaseDone
-                    true
+                    fail("CR not followed by LF after chunk data")
                 end if
             else if buf(readPos) == CR then
                 readPos += 1
@@ -357,13 +433,11 @@ private[kyo] object ChunkedBodyDecoder:
                     false
                 else
                     // CR followed by something other than LF -- framing error
-                    phase = PhaseDone
-                    true
+                    fail("CR not followed by LF after chunk data")
                 end if
             else
                 // Neither CR nor LF -- framing error (missing CRLF after chunk data)
-                phase = PhaseDone
-                true
+                fail("missing CRLF after chunk data")
             end if
         end processReadDataCrlf
 
@@ -426,6 +500,7 @@ private[kyo] object ChunkedBodyDecoder:
     private val PhaseReadDataCrlf: Int = 2
     private val PhaseReadTrailer: Int  = 3
     private val PhaseDone: Int         = 4
+    private val PhaseInvalid: Int      = 5
 
     /** Parse a chunk size line (may contain extensions after ';'). Strips trailing CR. */
     private def parseChunkSizeLine(lineBytes: Array[Byte]): Int =

--- a/kyo-http/shared/src/main/scala/kyo/internal/http1/HeaderTokens.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/http1/HeaderTokens.scala
@@ -1,0 +1,137 @@
+package kyo.internal.http1
+
+import scala.annotation.tailrec
+
+/** Whole-token matching for HTTP field values, shared by the request and response parsers.
+  *
+  * A field value is a list of DELIMITED tokens (RFC 9110 section 5.6.2), so a comparison that stops after the target's bytes is a PREFIX
+  * test rather than an equality test: it matches `chunkedfoo` against `chunked`, and a substring scan additionally matches `no-upgrade`
+  * against `upgrade`. Framing and connection decisions are made from these comparisons, and when two HTTP participants frame a message
+  * differently the bytes one of them counts as body the other reads as the start of the next request. That disagreement is the
+  * request-smuggling primitive, so every comparison here takes a length and compares it.
+  *
+  * Values arrive with leading whitespace already skipped but not trailing, since the parsers measure a value to the end of its line, so
+  * each entry point trims trailing OWS itself. Comparison is case-insensitive per RFC 9110 section 5.6.2.
+  */
+private[kyo] object HeaderTokens:
+
+    private val Chunked = "chunked"
+
+    /** Whether the field NAME in `src[off, off + len)` is exactly `target`, ignoring case.
+      *
+      * No OWS trimming: a field name is a token and cannot carry surrounding whitespace (a name with whitespace is rejected outright as a
+      * non-token before reaching here), so trimming would accept something the grammar does not. Comparing the length first also keeps this
+      * to an int compare for the common miss, which matters because every header walks the whole chain of these.
+      */
+    def nameEquals(src: Array[Byte], off: Int, len: Int, target: String): Boolean =
+        len == target.length && rangeEqualsIgnoreCase(src, off, target)
+
+    /** Whether the comma-separated list in `src[off, off + len)` contains `target` as a whole element.
+      *
+      * The list test, for fields defined as a list (`Connection` being the case that matters here). It matches an element exactly, so
+      * `no-upgrade` does not contain the element `upgrade` while `keep-alive, Upgrade` does.
+      */
+    def listContainsToken(src: Array[Byte], off: Int, len: Int, target: String): Boolean =
+        val end = off + len
+        @tailrec def loop(elemStart: Int): Boolean =
+            if elemStart > end then false
+            else
+                val comma   = indexOfComma(src, elemStart, end)
+                val elemEnd = if comma < 0 then end else comma
+                if elementEquals(src, elemStart, elemEnd, target) then true
+                else if comma < 0 then false
+                else loop(comma + 1)
+        loop(off)
+    end listContainsToken
+
+    /** Whether the value is the single transfer coding `chunked`, carrying no other coding.
+      *
+      * The REQUEST-side test. RFC 9112 section 6.3 item 6 gives a request whose final coding is not chunked no determinable body length,
+      * and chunked is the only coding decoded here, so a list naming anything else is refused rather than framed and handed to a handler
+      * still encoded.
+      */
+    def isSoleChunkedCoding(src: Array[Byte], off: Int, len: Int): Boolean =
+        // RFC 9110 section 5.6.1 permits empty list elements, so "chunked," and ", chunked" name exactly one coding and must be accepted.
+        // What must not be accepted is a second NON-empty coding, which is what makes the length undeterminable.
+        val end = off + len
+        @tailrec def loop(elemStart: Int, sawChunked: Boolean): Boolean =
+            if elemStart > end then sawChunked
+            else
+                val comma   = indexOfComma(src, elemStart, end)
+                val elemEnd = if comma < 0 then end else comma
+                val empty   = isBlank(src, elemStart, elemEnd)
+                val chunked = !empty && elementEquals(src, elemStart, elemEnd, Chunked)
+                if !empty && !chunked then false
+                else if comma < 0 then sawChunked || chunked
+                else loop(comma + 1, sawChunked || chunked)
+        loop(off, false)
+    end isSoleChunkedCoding
+
+    /** Whether `src[from, until)` is empty or entirely OWS. */
+    @tailrec private def isBlank(src: Array[Byte], from: Int, until: Int): Boolean =
+        if from >= until then true
+        else if isOws(src(from)) then isBlank(src, from + 1, until)
+        else false
+
+    /** Whether the value's final comma-separated transfer coding is `chunked`.
+      *
+      * The RESPONSE-side test. RFC 9112 section 6.1 requires chunked to be the final coding of any message that uses it, so the last list
+      * element decides chunk framing. `gzip, chunked` answers true; `chunked, gzip` and `chunkedfoo` answer false. Unlike the request side
+      * this only frames and never rejects, because a response carrying no chunked coding and no Content-Length is read until close, which
+      * RFC 9112 section 6.3 item 8 makes a legal response length.
+      */
+    def finalCodingIsChunked(src: Array[Byte], off: Int, len: Int): Boolean =
+        val end = off + len
+        @tailrec def lastComma(i: Int, found: Int): Int =
+            if i >= end then found
+            else lastComma(i + 1, if src(i) == ','.toByte then i else found)
+        val start = lastComma(off, -1) match
+            case -1 => off
+            case c  => c + 1
+        elementEquals(src, start, end, Chunked)
+    end finalCodingIsChunked
+
+    /** Index of the first comma in `src[from, until)`, or -1. */
+    @tailrec private def indexOfComma(src: Array[Byte], from: Int, until: Int): Int =
+        if from >= until then -1
+        else if src(from) == ','.toByte then from
+        else indexOfComma(src, from + 1, until)
+
+    /** Case-insensitive compare of `src[from, until)` against `target` with OWS trimmed from both ends.
+      *
+      * The length is compared for equality, which is what makes this a whole-element test rather than a prefix test.
+      */
+    private def elementEquals(src: Array[Byte], from: Int, until: Int, target: String): Boolean =
+        @tailrec def skipLeading(i: Int): Int =
+            if i < until && isOws(src(i)) then skipLeading(i + 1) else i
+        @tailrec def skipTrailing(i: Int): Int =
+            if i > from && isOws(src(i - 1)) then skipTrailing(i - 1) else i
+        val start = skipLeading(from)
+        val end   = skipTrailing(until)
+        if end - start != target.length then false
+        else
+            @tailrec def loop(i: Int): Boolean =
+                if i >= target.length then true
+                else
+                    val a = (src(start + i) & 0xff).toChar.toLower
+                    if a != target.charAt(i).toLower then false
+                    else loop(i + 1)
+            loop(0)
+        end if
+    end elementEquals
+
+    /** Case-insensitive compare of `target.length` bytes at `src[off]` against `target`, with no length or bounds check of its own. */
+    private def rangeEqualsIgnoreCase(src: Array[Byte], off: Int, target: String): Boolean =
+        @tailrec def loop(i: Int): Boolean =
+            if i >= target.length then true
+            else
+                val a = (src(off + i) & 0xff).toChar.toLower
+                if a != target.charAt(i).toLower then false
+                else loop(i + 1)
+        loop(0)
+    end rangeEqualsIgnoreCase
+
+    /** RFC 9110 section 5.6.3: OWS = *( SP / HTAB ). */
+    private def isOws(b: Byte): Boolean = b == ' '.toByte || b == '\t'.toByte
+
+end HeaderTokens

--- a/kyo-http/shared/src/main/scala/kyo/internal/http1/Http1Parser.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/http1/Http1Parser.scala
@@ -25,7 +25,11 @@ final private[kyo] class Http1Parser(
     // Configurable via HttpTransportConfig.maxHeaderSize when that type is introduced.
     maxHeaderSize: Int = 65536,
     onRequestParsed: (ParsedRequest, Span[Byte]) => Unit = (_, _) => (),
-    onClosed: () => Unit = () => ()
+    onClosed: () => Unit = () => (),
+    // Distinct from onClosed: the peer is still there and is owed an answer. RFC 9112 section 6.3 requires a 400 for a
+    // message whose framing cannot be determined, and closing without one leaves the peer waiting out its own timeout
+    // for a verdict already reached here. Defaults to onClosed so a caller that only reads keeps the old behavior.
+    onInvalidRequest: () => Unit = () => ()
 )(using allow: AllowUnsafe, frame: Frame):
 
     private val buf                  = new Array[Byte](maxHeaderSize)
@@ -98,8 +102,11 @@ final private[kyo] class Http1Parser(
             if remaining > 0 then
                 java.lang.System.arraycopy(buf, headerEnd + 4, buf, 0, remaining)
             pos = remaining
-            // Reject invalid requests before processing body
+            // Reject invalid requests before processing body. The peer is answered rather than merely disconnected: the
+            // framing is undeterminable, so nothing further can be read from this connection, but a 400 tells the peer
+            // that now instead of leaving it to infer a verdict from silence.
             if invalid then
+                onInvalidRequest()
                 onClosed()
             else
                 // Extract body bytes available in the parser buffer.
@@ -209,6 +216,7 @@ final private[kyo] class Http1Parser(
 
         if requestLineEnd == -1 then
             // Malformed: no request line found — return minimal request
+            if builder.offsetsOverflowed then invalid = true
             builder.build()
         else
             // Scan for bare CR (CR not followed by LF) in entire header region
@@ -230,6 +238,7 @@ final private[kyo] class Http1Parser(
             // Set HttpWebSocket upgrade flag when both Upgrade: websocket and Connection: upgrade are present
             if hasUpgradeWebSocket && hasConnectionUpgrade then
                 builder.setUpgrade(true)
+            if builder.offsetsOverflowed then invalid = true
             builder.build()
         end if
     end packRequest
@@ -237,12 +246,19 @@ final private[kyo] class Http1Parser(
     /** Parses "METHOD /path?query HTTP/1.1" from rawBuf[start..end). Structured as nested if/else to avoid `return` keywords.
       */
     private def parseRequestLine(rawBuf: Array[Byte], start: Int, end: Int): Unit =
+        // Every failure branch here marks the request invalid rather than falling through. Falling through left the
+        // builder at its defaults: method ordinal 0, which is GET, and no path, which routes to the root. That served a
+        // request no conforming server would accept, AS a different request than the one sent, which is a desync a front
+        // end's access-control rule cannot see. A request line that does not parse is refused (RFC 9112 section 3).
         // Find first space (after method)
         val sp1 = indexOfByte(rawBuf, start, end, ' ')
-        if sp1 != -1 then
-            // Parse method via byte-level comparison (zero-alloc)
+        if sp1 == -1 then invalid = true
+        else
+            // Parse method via byte-level comparison (zero-alloc). matchMethod is case-sensitive, which RFC 9110
+            // section 9.1 requires: "get" is not the method "GET".
             val ordinal = matchMethod(rawBuf, start, sp1 - start)
-            if ordinal != -1 then
+            if ordinal == -1 then invalid = true
+            else
                 builder.setMethod(ordinal)
 
                 // RFC 7230: exactly one SP between tokens. Reject multiple spaces.
@@ -251,56 +267,199 @@ final private[kyo] class Http1Parser(
 
                 // Find second space (before HTTP version)
                 val sp2 = indexOfByte(rawBuf, sp1 + 1, end, ' ')
-                if sp2 != -1 then
+                if sp2 == -1 then invalid = true
+                else
                     // Reject if there's a space immediately after sp2 (triple+ space)
                     if sp2 + 1 < end && rawBuf(sp2 + 1) == ' ' then
                         invalid = true
                     // The URI is between sp1+1 and sp2
                     val uriStart = sp1 + 1
                     val uriEnd   = sp2
+                    // An empty target is not a request-target (RFC 9112 section 3.2). Two adjacent spaces produce it.
+                    if uriEnd <= uriStart then
+                        invalid = true
 
-                    // Check HTTP version for keep-alive default
-                    // HTTP/1.1 defaults to keep-alive, HTTP/1.0 defaults to close
+                    // The version token must be HTTP/1.0 or HTTP/1.1. Anything else is not a request line this server
+                    // parses, and accepting it silently (as "default to 1.1") is how an HTTP/0.9 line or a bogus
+                    // version was served rather than refused. keep-alive defaults on for 1.1, off for 1.0.
                     val versionStart = sp2 + 1
-                    val isHttp11 =
-                        if end - versionStart >= 8 then
-                            rawBuf(versionStart + 5) == '1' && rawBuf(versionStart + 7) == '1'
-                        else
-                            true // default to 1.1
-                    builder.setKeepAlive(isHttp11)
-
-                    // Split URI into path and query
-                    val qMark = indexOfByte(rawBuf, uriStart, uriEnd, '?')
-                    if qMark == -1 then
-                        // No query string
-                        builder.setPath(rawBuf, uriStart, uriEnd - uriStart)
-                        parsePathSegments(rawBuf, uriStart, uriEnd)
+                    val versionLen   = end - versionStart
+                    if versionLen != 8 || !startsWith(
+                            rawBuf,
+                            versionStart,
+                            "HTTP/1."
+                        ) || rawBuf(versionStart + 7) != '0' && rawBuf(versionStart + 7) != '1'
+                    then
+                        invalid = true
                     else
-                        builder.setPath(rawBuf, uriStart, qMark - uriStart)
-                        parsePathSegments(rawBuf, uriStart, qMark)
-                        if qMark + 1 < uriEnd then
-                            builder.setQuery(rawBuf, qMark + 1, uriEnd - qMark - 1)
+                        builder.setKeepAlive(rawBuf(versionStart + 7) == '1')
+                    end if
+
+                    // Split a path range into path and query and store them. Segments first, then the path stored ONCE:
+                    // either rebuilt from the resolved segments or copied from the request line. Storing it up front and
+                    // rewriting it afterwards left a third copy of the path in the raw buffer, and the packed layout
+                    // addresses that buffer with 16-bit offsets, so a long enough path pushed the header offsets past
+                    // what they can represent.
+                    def storePathAndQuery(pStart: Int, pEnd: Int): Unit =
+                        val qMark = indexOfByte(rawBuf, pStart, pEnd, '?')
+                        if qMark == -1 then
+                            if parsePathSegments(rawBuf, pStart, pEnd) then builder.setPathFromSegments()
+                            else builder.setPath(rawBuf, pStart, pEnd - pStart)
+                        else
+                            if parsePathSegments(rawBuf, pStart, qMark) then builder.setPathFromSegments()
+                            else builder.setPath(rawBuf, pStart, qMark - pStart)
+                            if qMark + 1 < pEnd then
+                                builder.setQuery(rawBuf, qMark + 1, pEnd - qMark - 1)
+                        end if
+                    end storePathAndQuery
+
+                    // The request target is usually origin-form ("/path"), taken on a single byte compare. Absolute-form
+                    // ("scheme://authority/path", RFC 9112 section 3.2.2) and asterisk-form ("*") take the slower
+                    // branches. Feeding an absolute-form target to the path splitter mangled it to "/scheme:/authority/
+                    // path", so a front end applying an ACL to the real path and this server routed on different paths
+                    // (Jetty authority/host family, Netty CVE-2026-59900).
+                    if rawBuf(uriStart) == '/' then
+                        storePathAndQuery(uriStart, uriEnd)
+                    else if uriEnd - uriStart == 1 && rawBuf(uriStart) == '*' then
+                        // Asterisk-form (OPTIONS *): an empty path, not fed to the path splitter which would mangle it.
+                        builder.setPath(rawBuf, uriStart, 0)
+                    else
+                        // Not origin- or asterisk-form. If the target carries a scheme ("://") it is absolute-form:
+                        // skip the authority to the first '/' or '?'. The authority (with any userinfo, port, or IPv6
+                        // host) is skipped, not parsed, so it cannot disturb the path; kyo continues to route on Host.
+                        // A target with no "://" is not absolute-form; it is stored as a path unchanged, preserving the
+                        // prior lenient handling of a target without a leading slash.
+                        @tailrec def findSchemeSep(i: Int): Int =
+                            if i > uriEnd - 3 then -1
+                            else if rawBuf(i) == ':' && rawBuf(i + 1) == '/' && rawBuf(i + 2) == '/' then i
+                            else findSchemeSep(i + 1)
+                        val schemeSep = findSchemeSep(uriStart)
+                        if schemeSep == -1 then storePathAndQuery(uriStart, uriEnd)
+                        else
+                            @tailrec def findPathStart(i: Int): Int =
+                                if i >= uriEnd then uriEnd
+                                else if rawBuf(i) == '/' || rawBuf(i) == '?' then i
+                                else findPathStart(i + 1)
+                            val pathStart = findPathStart(schemeSep + 3)
+                            if pathStart < uriEnd && rawBuf(pathStart) == '/' then
+                                storePathAndQuery(pathStart, uriEnd)
+                            else
+                                // No path segment (bare authority "http://host", or a query with an empty path
+                                // "http://host?q"). The effective path is "/"; reuse the '/' from "://" as its source.
+                                builder.setPath(rawBuf, schemeSep + 1, 1)
+                                if pathStart < uriEnd && rawBuf(pathStart) == '?' && pathStart + 1 < uriEnd then
+                                    builder.setQuery(rawBuf, pathStart + 1, uriEnd - pathStart - 1)
+                            end if
+                        end if
                     end if
                 end if
             end if
         end if
     end parseRequestLine
 
-    /** Parses path segments from /seg1/seg2/seg3. */
-    private def parsePathSegments(rawBuf: Array[Byte], start: Int, end: Int): Unit =
+    /** Whether `rawBuf` at `off` begins with the ASCII bytes of `prefix`, without reading past `off + prefix.length`. */
+    private def startsWith(rawBuf: Array[Byte], off: Int, prefix: String): Boolean =
+        @tailrec def loop(i: Int): Boolean =
+            if i >= prefix.length then true
+            else if rawBuf(off + i) != prefix.charAt(i).toByte then false
+            else loop(i + 1)
+        loop(0)
+    end startsWith
+
+    /** Parses path segments from /seg1/seg2/seg3, validating each and resolving dot segments as it goes.
+      *
+      * Splitting happens on the literal byte '/', so an ENCODED separator does not split. That is the whole of the traversal problem: a
+      * consumer that decodes a segment afterwards turns "%2F" back into a separator and recovers structure the splitter never agreed to,
+      * which is how "..%2F..%2Fetc%2Fpasswd" arrives as one segment and leaves as four. So a segment is classified here, on the raw bytes
+      * and before routing, and a segment whose decoded form would carry a separator is refused rather than decoded later.
+      *
+      * Dot segments are resolved here too (RFC 3986 section 5.2.4) rather than left for a handler, because a handler cannot undo them: by
+      * the time it holds a capture the structure is already lost. Resolving before routing also means the route that matches is the route
+      * for the path that was actually addressed.
+      */
+    private def parsePathSegments(rawBuf: Array[Byte], start: Int, end: Int): Boolean =
         val initialI = if start < end && rawBuf(start) == '/' then start + 1 else start
+        // Whether the segment list no longer reproduces the raw path, which is what tells the caller the stored path
+        // has to be rewritten. That is broader than "a dot segment was resolved": an EMPTY segment is dropped too, so
+        // "/a//b" routes on [a, b] and "//" routes to the root, and RFC 3986 makes those different paths from what was
+        // sent. Reporting only dot resolution left exactly that spelling routing on one path and reporting another.
+        // Kept local to this call rather than made parser state: it describes one path, and a field would survive into
+        // the next request on a keep-alive connection.
+        var resolved = false
         @tailrec def loop(i: Int, segStart: Int): Unit =
             if i <= end then
                 if i == end || rawBuf(i) == '/' then
+                    // An empty segment contributes nothing but does mean the stored path and the segments differ.
+                    if i == segStart && i < end then resolved = true
                     if i > segStart then
-                        builder.addPathSegment(rawBuf, segStart, i - segStart)
+                        classifyPathSegment(rawBuf, segStart, i - segStart) match
+                            case Http1Parser.SegInvalid => invalid = true
+                            // "." addresses the segment it sits in, so it contributes nothing.
+                            case Http1Parser.SegDot => resolved = true
+                            case Http1Parser.SegDotDot =>
+                                resolved = true
+                                builder.removeLastPathSegment()
+                            case _ => builder.addPathSegment(rawBuf, segStart, i - segStart)
+                    end if
                     loop(i + 1, i + 1)
                 else
                     loop(i + 1, segStart)
             end if
         end loop
         loop(initialI, initialI)
+        resolved
     end parsePathSegments
+
+    /** Classifies one raw path segment, decoding percent-escapes as it scans without allocating.
+      *
+      * Answers [[Http1Parser.SegInvalid]] for a segment that must not be accepted at all: a malformed escape (RFC 3986 section 2.1 requires
+      * two hex digits, and leaving it to a decoder later means an exception from a code path with no handler), an escape decoding to '/'
+      * (forged structure), or a NUL byte in either form (it truncates a path in any C-facing consumer). Otherwise it reports whether the
+      * segment's DECODED form is "." or "..", so that "%2e%2e" is resolved exactly like "..".
+      */
+    private def classifyPathSegment(buf: Array[Byte], start: Int, len: Int): Int =
+        val end = start + len
+        // `dots` counts decoded '.' bytes and `decoded` counts all decoded bytes, so the two are equal only when the whole segment is dots.
+        @tailrec def loop(i: Int, decoded: Int, dots: Int): Int =
+            if i >= end then
+                if decoded == 1 && dots == 1 then Http1Parser.SegDot
+                else if decoded == 2 && dots == 2 then Http1Parser.SegDotDot
+                else Http1Parser.SegNormal
+            else
+                val b = buf(i) & 0xff
+                if b == '%' then
+                    if i + 2 >= end then Http1Parser.SegInvalid
+                    else
+                        val hi = hexVal(buf(i + 1))
+                        val lo = hexVal(buf(i + 2))
+                        if hi < 0 || lo < 0 then Http1Parser.SegInvalid
+                        else
+                            // An encoded separator is NOT refused here. Inside a single segment it is the legitimate way to say
+                            // "a slash that belongs to this value rather than dividing it", which is how a capture carries a
+                            // value like "hello/world", and the client encodes a named capture exactly that way.
+                            //
+                            // It therefore SURVIVES into the capture, on both capture kinds, decoded. Nothing downstream strips
+                            // or re-encodes it: a capture is request-supplied data, not a safe path fragment, and a handler
+                            // resolving one against a directory must validate it as it would any other untrusted string.
+                            val d = (hi << 4) | lo
+                            if d == 0 then Http1Parser.SegInvalid
+                            else loop(i + 3, decoded + 1, if d == '.' then dots + 1 else dots)
+                        end if
+                else if b == 0 then Http1Parser.SegInvalid
+                else loop(i + 1, decoded + 1, if b == '.' then dots + 1 else dots)
+                end if
+        loop(start, 0, 0)
+    end classifyPathSegment
+
+    /** Numeric value of a hex digit byte, or -1 when it is not one. */
+    private def hexVal(b: Byte): Int =
+        val c = b & 0xff
+        if c >= '0' && c <= '9' then c - '0'
+        else if c >= 'a' && c <= 'f' then c - 'a' + 10
+        else if c >= 'A' && c <= 'F' then c - 'A' + 10
+        else -1
+        end if
+    end hexVal
 
     /** Parses headers from rawBuf[start..end). Each header is "Name: Value\r\n". */
     private def parseHeaders(rawBuf: Array[Byte], start: Int, end: Int): Unit =
@@ -370,7 +529,7 @@ final private[kyo] class Http1Parser(
         valOff: Int,
         valLen: Int
     ): Unit =
-        if nameLen == 14 && asciiEqualsIgnoreCase(nameSrc, nameOff, "Content-Length") then
+        if HeaderTokens.nameEquals(nameSrc, nameOff, nameLen, "Content-Length") then
             if hasContentLength then
                 invalid = true
             else
@@ -381,30 +540,47 @@ final private[kyo] class Http1Parser(
                 if cl < 0 then
                     invalid = true
                 builder.setContentLength(cl)
-        else if nameLen == 17 && asciiEqualsIgnoreCase(nameSrc, nameOff, "Transfer-Encoding") then
+        else if HeaderTokens.nameEquals(nameSrc, nameOff, nameLen, "Transfer-Encoding") then
+            // RFC 9110 section 5.3 lets a recipient combine repeated field lines into one comma-separated list, so a
+            // second Transfer-Encoding line means the first line's coding was not the final one, which RFC 9112
+            // section 6.1 forbids (chunked must be final and must not be applied twice). Honoring whichever line came
+            // first would frame the message differently from any intermediary that combined them. Duplicate
+            // Content-Length is already refused above; this is the same rule for the same reason.
+            if hasTransferEncoding then
+                invalid = true
             hasTransferEncoding = true
             if hasContentLength then
                 invalid = true
-            if valLen >= 7 && asciiEqualsIgnoreCase(valSrc, valOff, "chunked") then
+            // RFC 9112 section 6.3 item 6: a request whose final transfer coding is not chunked has no determinable
+            // body length and must be rejected. Treating it as bodyless instead leaves the body in the buffer, where
+            // the next parse reads attacker-controlled bytes as a request line.
+            if HeaderTokens.isSoleChunkedCoding(valSrc, valOff, valLen) then
                 builder.setChunked(true)
-        else if nameLen == 10 && asciiEqualsIgnoreCase(nameSrc, nameOff, "Connection") then
-            if valLen >= 5 && asciiEqualsIgnoreCase(valSrc, valOff, "close") then
+            else
+                invalid = true
+            end if
+        else if HeaderTokens.nameEquals(nameSrc, nameOff, nameLen, "Connection") then
+            // Connection is a list (RFC 9110 section 7.6.1), so each token is matched as a whole list element: a value
+            // of "no-upgrade" names the token "no-upgrade" and must not be read as carrying "upgrade".
+            if HeaderTokens.listContainsToken(valSrc, valOff, valLen, "close") then
                 builder.setKeepAlive(false)
-            else if valLen >= 10 && asciiEqualsIgnoreCase(valSrc, valOff, "keep-alive") then
+            else if HeaderTokens.listContainsToken(valSrc, valOff, valLen, "keep-alive") then
                 builder.setKeepAlive(true)
             end if
-            // Also check for "upgrade" token in Connection header (may be sole value or comma-separated)
-            if valLen >= 7 && asciiContainsIgnoreCase(valSrc, valOff, valLen, "upgrade") then
+            if HeaderTokens.listContainsToken(valSrc, valOff, valLen, "upgrade") then
                 hasConnectionUpgrade = true
-        else if nameLen == 6 && asciiEqualsIgnoreCase(nameSrc, nameOff, "Expect") then
-            if valLen >= 12 && asciiEqualsIgnoreCase(valSrc, valOff, "100-continue") then
+        else if HeaderTokens.nameEquals(nameSrc, nameOff, nameLen, "Expect") then
+            // Expect is a list (RFC 9110 section 10.1.1), so "100-continue, foo" still asks for the interim response.
+            if HeaderTokens.listContainsToken(valSrc, valOff, valLen, "100-continue") then
                 builder.setExpectContinue(true)
-        else if nameLen == 4 && asciiEqualsIgnoreCase(nameSrc, nameOff, "Host") then
+        else if HeaderTokens.nameEquals(nameSrc, nameOff, nameLen, "Host") then
             hostCount += 1
             if valLen == 0 then
                 builder.setEmptyHost(true)
-        else if nameLen == 7 && asciiEqualsIgnoreCase(nameSrc, nameOff, "Upgrade") then
-            if valLen >= 9 && asciiEqualsIgnoreCase(valSrc, valOff, "websocket") then
+        else if HeaderTokens.nameEquals(nameSrc, nameOff, nameLen, "Upgrade") then
+            // Upgrade is a list of protocols in preference order (RFC 9110 section 7.8), so "websocket, h2c" offers
+            // websocket. Matching the whole value would refuse every client that names a fallback.
+            if HeaderTokens.listContainsToken(valSrc, valOff, valLen, "websocket") then
                 hasUpgradeWebSocket = true
         end if
     end detectSpecialHeader
@@ -429,30 +605,10 @@ final private[kyo] class Http1Parser(
             loop(0, 0)
     end parseContentLength
 
-    /** Case-insensitive comparison of raw bytes against an ASCII string. */
-    private def asciiEqualsIgnoreCase(src: Array[Byte], off: Int, target: String): Boolean =
-        @tailrec def loop(i: Int): Boolean =
-            if i >= target.length then true
-            else
-                val a = (src(off + i) & 0xff).toChar.toLower
-                val b = target.charAt(i).toLower
-                if a != b then false
-                else loop(i + 1)
-        loop(0)
-    end asciiEqualsIgnoreCase
-
-    /** Checks if target appears anywhere in src[off..off+len) using case-insensitive comparison. */
-    private def asciiContainsIgnoreCase(src: Array[Byte], off: Int, len: Int, target: String): Boolean =
-        val targetLen = target.length
-        if len < targetLen then false
-        else
-            @tailrec def scan(i: Int): Boolean =
-                if i + targetLen > len then false
-                else if asciiEqualsIgnoreCase(src, off + i, target) then true
-                else scan(i + 1)
-            scan(0)
-        end if
-    end asciiContainsIgnoreCase
+    // Field name and value comparison lives in HeaderTokens, which takes a length and compares it. The local helpers
+    // that used to sit here took no length and so compared a prefix, which is how "chunkedfoo" matched "chunked"; they
+    // are deliberately not kept alongside the correct ones, since a prefix comparison reachable by accident at a
+    // framing decision is the defect itself.
 
     /** Scans buf[i..end) for any CR byte not immediately followed by LF. */
     @tailrec private def containsBareCr(buf: Array[Byte], i: Int, end: Int): Boolean =
@@ -564,4 +720,10 @@ end Http1Parser
 private[kyo] object Http1Parser:
     val CRLF_CRLF: Array[Byte]   = "\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
     val CRLF_SINGLE: Array[Byte] = "\r\n".getBytes(StandardCharsets.US_ASCII)
+
+    /** Outcomes of classifying a raw path segment; see `Http1Parser.classifyPathSegment`. */
+    private[http1] val SegInvalid = -1
+    private[http1] val SegNormal  = 0
+    private[http1] val SegDot     = 1
+    private[http1] val SegDotDot  = 2
 end Http1Parser

--- a/kyo-http/shared/src/main/scala/kyo/internal/http1/Http1ResponseParser.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/http1/Http1ResponseParser.scala
@@ -34,6 +34,8 @@ final private[kyo] class Http1ResponseParser(
     private var hdrOffsets     = new Array[Int](128)
     private var hdrOffsetCount = 0
     private var invalid        = false
+    // Whether a Content-Length header has been seen at all, which a running value of -1 cannot express.
+    private var seenContentLength = false
 
     /** Reusable take promise — same pattern as Http1Parser.
       *
@@ -157,6 +159,7 @@ final private[kyo] class Http1ResponseParser(
         headerCount = 0
         hdrOffsetCount = 0
         invalid = false
+        seenContentLength = false
     end reset
 
     /** Parses the status line and headers from raw bytes into a ParsedResponse. */
@@ -165,6 +168,7 @@ final private[kyo] class Http1ResponseParser(
         headerCount = 0
         hdrOffsetCount = 0
         invalid = false
+        seenContentLength = false
 
         // A response header is stored as the raw octets it was parsed from and is written back out verbatim, so a peer
         // that smuggles a line break past this parser has it re-emitted unchanged by any proxy that echoes the header.
@@ -197,15 +201,36 @@ final private[kyo] class Http1ResponseParser(
                 val valOff  = hdrOffsets(i + 2)
                 val valLen  = hdrOffsets(i + 3)
                 val (nextCl, nextChunked, nextKa) =
-                    if nameLen == 14 && asciiEqualsIgnoreCase(rawBytes.array, nameOff, "Content-Length") then
-                        (parseContentLength(rawBytes.array, valOff, valLen), isChunked, isKeepAlive)
-                    else if nameLen == 17 && asciiEqualsIgnoreCase(rawBytes.array, nameOff, "Transfer-Encoding") then
-                        val chunked = if valLen >= 7 && asciiEqualsIgnoreCase(rawBytes.array, valOff, "chunked") then true else isChunked
+                    if HeaderTokens.nameEquals(rawBytes.array, nameOff, nameLen, "Content-Length") then
+                        // A second Content-Length is refused rather than allowed to overwrite the first. RFC 9112 section 6.3
+                        // item 5 makes conflicting values unrecoverable, and letting the last one win is the response-side
+                        // half of the smuggling primitive: a proxy honouring the first and this client the last disagree
+                        // about where the body ends, so the tail of one response becomes the head of the next. The request
+                        // side already refuses this; the asymmetry was the gap.
+                        val parsed = parseContentLength(rawBytes.array, valOff, valLen)
+                        // RFC 9112 section 6.3 item 4: an invalid Content-Length makes the framing unrecoverable. Treating it
+                        // as absent instead reads the response to connection close, which a proxy that DID parse a number
+                        // frames differently, so the tail of one response becomes the head of the next.
+                        if parsed < 0 then
+                            invalid = true
+                        // A second value is refused rather than allowed to overwrite the first (section 6.3 item 5). The
+                        // comparison is against seenContentLength, not the running value, because a malformed first header
+                        // leaves -1 behind and a >= 0 test could never fire against it: "abc" then "5" would be accepted.
+                        if seenContentLength && parsed != contentLengthVal then
+                            invalid = true
+                        seenContentLength = true
+                        (parsed, isChunked, isKeepAlive)
+                    else if HeaderTokens.nameEquals(rawBytes.array, nameOff, nameLen, "Transfer-Encoding") then
+                        // The final coding decides chunk framing (RFC 9112 section 6.1), matched as a whole token so a
+                        // server cannot steer this client's view of where one response ends by sending "chunkedfoo".
+                        // Unlike the request side this only frames and never rejects: a response with no chunked coding
+                        // and no Content-Length is read until close, a legal response length (section 6.3 item 8).
+                        val chunked = isChunked || HeaderTokens.finalCodingIsChunked(rawBytes.array, valOff, valLen)
                         (contentLengthVal, chunked, isKeepAlive)
-                    else if nameLen == 10 && asciiEqualsIgnoreCase(rawBytes.array, nameOff, "Connection") then
+                    else if HeaderTokens.nameEquals(rawBytes.array, nameOff, nameLen, "Connection") then
                         val ka =
-                            if valLen >= 5 && asciiEqualsIgnoreCase(rawBytes.array, valOff, "close") then false
-                            else if valLen >= 10 && asciiEqualsIgnoreCase(rawBytes.array, valOff, "keep-alive") then true
+                            if HeaderTokens.listContainsToken(rawBytes.array, valOff, valLen, "close") then false
+                            else if HeaderTokens.listContainsToken(rawBytes.array, valOff, valLen, "keep-alive") then true
                             else isKeepAlive
                         (contentLengthVal, isChunked, ka)
                     else
@@ -213,7 +238,13 @@ final private[kyo] class Http1ResponseParser(
                     end if
                 end val
                 scanHeaders(i + 4, nextCl, nextChunked, nextKa)
-        val (contentLengthVal, isChunked, isKeepAliveHdr) = scanHeaders(0, -1, false, isKeepAliveInit)
+        val (scannedCl, isChunked, isKeepAliveHdr) = scanHeaders(0, -1, false, isKeepAliveInit)
+
+        // RFC 9112 section 6.3 item 3: with both present, Transfer-Encoding determines the length and Content-Length is
+        // discarded outright. Keeping it would leave two framings in play, and a recipient that later consulted the
+        // wrong one would read the wrong number of bytes. The client already prefers chunked when deciding how to read
+        // the body, so this makes the value it would have fallen back to unavailable rather than merely unpreferred.
+        val contentLengthVal = if isChunked then -1 else scannedCl
 
         // Per RFC 7230 §3.3.3 item 7: a response without Content-Length and without
         // Transfer-Encoding: chunked is terminated by connection close. Such a
@@ -265,6 +296,14 @@ final private[kyo] class Http1ResponseParser(
                 val actualLineEnd = if lineEnd == -1 then end else lineEnd
 
                 if actualLineEnd > lineStart then
+                    // A header line beginning with SP or HTAB is obs-fold (a continuation of the previous value). RFC
+                    // 9112 section 5.2 has a user agent UNFOLD it (replace the fold with SP); kyo instead fails closed,
+                    // a deliberate hardening deviation matching its request-side obs-fold reject and its bare CR/LF
+                    // handling. Silently dropping the colon-less fold line (the prior behaviour) truncated the value.
+                    val firstByte = rawBuf(lineStart)
+                    if firstByte == ' ' || firstByte == '\t' then
+                        invalid = true
+
                     val colonIdx = indexOfByte(rawBuf, lineStart, actualLineEnd, ':')
                     if colonIdx != -1 then
                         val nameStart = lineStart
@@ -358,7 +397,14 @@ final private[kyo] class Http1ResponseParser(
                 else
                     val b = src(off + i)
                     if b < '0' || b > '9' then -1
-                    else loop(i + 1, acc * 10 + (b - '0'))
+                    else
+                        val digit = b - '0'
+                        // Overflow guard (mirrors the request parser): Int.MaxValue = 2147483647. Without it a value past
+                        // Int range wraps to a small number, so this client frames the body at a length a server that
+                        // parsed the true value never sent, the response-side overflow desync (RFC 9112 section 6.3).
+                        if acc > 214748364 || (acc == 214748364 && digit > 7) then -1
+                        else loop(i + 1, acc * 10 + digit)
+                    end if
             loop(0, 0)
     end parseContentLength
 
@@ -393,17 +439,8 @@ final private[kyo] class Http1ResponseParser(
         len > 0 && loop(0)
     end isToken
 
-    /** Case-insensitive comparison of raw bytes against an ASCII string. */
-    private def asciiEqualsIgnoreCase(src: Array[Byte], off: Int, target: String): Boolean =
-        @tailrec def loop(i: Int): Boolean =
-            if i >= target.length then true
-            else
-                val a = (src(off + i) & 0xff).toChar.toLower
-                val b = target.charAt(i).toLower
-                if a != b then false
-                else loop(i + 1)
-        loop(0)
-    end asciiEqualsIgnoreCase
+    // Field name and value comparison lives in HeaderTokens; see the note in Http1Parser for why no prefix-comparing
+    // variant is kept beside it.
 
     @tailrec private def skipSpaces(rawBuf: Array[Byte], from: Int, limit: Int): Int =
         if from < limit && rawBuf(from) == ' ' then skipSpaces(rawBuf, from + 1, limit)

--- a/kyo-http/shared/src/main/scala/kyo/internal/http1/Http1StreamContext.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/http1/Http1StreamContext.scala
@@ -26,18 +26,29 @@ final private[kyo] class Http1StreamContext(
     headerBuf: GrowableByteBuffer
 )(using allow: AllowUnsafe, frame: Frame) extends StreamContext:
 
-    private var _request: ParsedRequest = ParsedRequest.empty
-    private var _bodySpan: Span[Byte]   = Span.empty[Byte]
-    private var _leftover: Span[Byte]   = Span.empty[Byte]
+    private var _request: ParsedRequest       = ParsedRequest.empty
+    private var _bodySpan: Span[Byte]         = Span.empty[Byte]
+    private var _leftover: Span[Byte]         = Span.empty[Byte]
+    private var _mustCloseConnection: Boolean = false
 
     /** Called by parser when request is ready. */
     def setRequest(req: ParsedRequest, body: Span[Byte]): Unit =
         _request = req
         _bodySpan = body
         _leftover = Span.empty[Byte]
+        _mustCloseConnection = false
     end setRequest
 
     def request: ParsedRequest = _request
+
+    /** Marks the connection for closure after the in-flight handler settles. Set by a handler-path rejection (e.g. a chunked body over
+      * maxContentLength answered 413) whose declared body is not consumed, so the keep-alive restart must be suppressed and the connection
+      * closed instead (RFC 9112 section 9.3). Read by the dispatch's fiber onComplete.
+      */
+    def requestConnectionClose(): Unit =
+        _mustCloseConnection = true
+
+    def mustCloseConnection: Boolean = _mustCloseConnection
 
     /** Returns the initial body bytes passed by the parser (e.g., chunk framing data for chunked requests, or partial body for
       * Content-Length requests). Consumes the span — subsequent calls return empty.

--- a/kyo-http/shared/src/main/scala/kyo/internal/server/HttpRouter.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/server/HttpRouter.scala
@@ -27,26 +27,7 @@ final private[kyo] class HttpRouter private (
 ):
     import HttpRouter.*
 
-    /** Find an endpoint matching the given method and path.
-      *
-      * Per RFC 9110 §9.3.2, HEAD is implicitly supported wherever GET is registered.
-      */
-    def find(method: HttpMethod, path: String): Result[FindError, RouteMatch] =
-        val methodIdx = HttpRouter.methodIndex(method)
-        if maxCaptures == 0 then
-            val nodeIdx = findNodeIndexNoCaptures(path)
-            resolveEndpoint(nodeIdx, methodIdx, emptyCaptures, 0)
-        else
-            val captureValues = new Array[String](maxCaptures)
-            val nodeAndCount  = findNodeIndex(path, captureValues)
-            val nodeIdx       = nodeAndCount >> 16
-            val captureCount  = nodeAndCount & 0xffff
-            resolveEndpoint(nodeIdx, methodIdx, captureValues, captureCount)
-        end if
-    end find
-
-    /** Find endpoint using ParsedRequest byte-level matching. Populates the reusable RouteLookup instead of allocating RouteMatch. Result
-      * is stored in the lookup object.
+    /** Find endpoint using ParsedRequest byte-level matching. Populates the reusable RouteLookup rather than allocating a match object; the result is stored in the lookup.
       */
     def findParsed(method: HttpMethod, request: ParsedRequest, lookup: RouteLookup): Result[FindError, Unit] =
         val methodIdx = HttpRouter.methodIndex(method)
@@ -117,28 +98,6 @@ final private[kyo] class HttpRouter private (
         end if
     end resolveParsedEndpoint
 
-    private def resolveEndpoint(
-        nodeIdx: Int,
-        methodIdx: Int,
-        captureValues: Array[String],
-        captureCount: Int
-    ): Result[FindError, RouteMatch] =
-        if nodeIdx < 0 then NotFoundResult
-        else
-            val node       = nodes(nodeIdx)
-            val handlerIdx = node.endpointIndices(methodIdx)
-            if handlerIdx >= 0 then Result.succeed(buildMatch(handlerIdx, captureValues, captureCount))
-            else if methodIdx == HeadMethodIdx then
-                val getIdx = node.endpointIndices(GetMethodIdx)
-                if getIdx >= 0 then Result.succeed(buildMatch(getIdx, captureValues, captureCount))
-                else methodNotAllowedResult(node)
-            else if methodIdx == OptionsMethodIdx && node.allowedMethods.nonEmpty then
-                Result.fail(FindError.Options(buildOptionsHeaders(node.allowedMethods)))
-            else methodNotAllowedResult(node)
-            end if
-        end if
-    end resolveEndpoint
-
     private def findFirstEndpoint(node: Node): Int =
         @tailrec def loop(i: Int): Int =
             if i >= MethodCount then -1
@@ -175,82 +134,6 @@ final private[kyo] class HttpRouter private (
         loop(0, 0)
     end maxCaptures
 
-    private val emptyCaptures: Array[String] = Array.empty[String]
-
-    private def buildMatch(endpointIdx: Int, captureValues: Array[String], captureCount: Int): RouteMatch =
-        val wireNames = captureWireNames(endpointIdx)
-        val captures =
-            if captureCount == 0 then Dict.empty[String, String]
-            else
-                val builder = DictBuilder.init[String, String]
-                @tailrec def loop(i: Int): Unit =
-                    if i < captureCount && i < wireNames.size then
-                        discard(builder.add(wireNames(i), captureValues(i)))
-                        loop(i + 1)
-                loop(0)
-                builder.result()
-        RouteMatch(
-            endpoints(endpointIdx),
-            captures,
-            streamingReqFlags(endpointIdx),
-            streamingRespFlags(endpointIdx)
-        )
-    end buildMatch
-
-    /** Trie walk with capture extraction. Returns packed (nodeIdx << 16 | captureCount). nodeIdx is -1 on miss. */
-    private def findNodeIndex(path: String, captureValues: Array[String]): Int =
-        val len = path.length
-
-        @tailrec def loop(nodeIdx: Int, pos: Int, captureCount: Int): Int =
-            val start = skipSlashes(path, pos, len)
-            if start >= len then (nodeIdx << 16) | captureCount
-            else
-                val segEnd = findSegmentEnd(path, start, len)
-                val node   = nodes(nodeIdx)
-
-                val literalIdx = binarySearchSegment(node.literalSegments, path, start, segEnd)
-                if literalIdx >= 0 then loop(node.literalIndices(literalIdx), segEnd, captureCount)
-                else if node.captureChild >= 0 then
-                    if captureCount < captureValues.length then
-                        captureValues(captureCount) = urlDecodeSegment(path, start, segEnd)
-                    end if
-                    loop(node.captureChild, segEnd, captureCount + 1)
-                else if node.restChild >= 0 then
-                    if captureCount < captureValues.length then
-                        captureValues(captureCount) = path.substring(start)
-                    end if
-                    (node.restChild << 16) | (captureCount + 1)
-                else -1 << 16
-                end if
-            end if
-        end loop
-
-        loop(0, 0, 0)
-    end findNodeIndex
-
-    /** Trie walk without capture extraction — avoids array allocation entirely. */
-    private def findNodeIndexNoCaptures(path: String): Int =
-        val len = path.length
-
-        @tailrec def loop(nodeIdx: Int, pos: Int): Int =
-            val start = skipSlashes(path, pos, len)
-            if start >= len then nodeIdx
-            else
-                val segEnd = findSegmentEnd(path, start, len)
-                val node   = nodes(nodeIdx)
-
-                val literalIdx = binarySearchSegment(node.literalSegments, path, start, segEnd)
-                if literalIdx >= 0 then loop(node.literalIndices(literalIdx), segEnd)
-                else if node.captureChild >= 0 then loop(node.captureChild, segEnd)
-                else if node.restChild >= 0 then node.restChild
-                else -1
-                end if
-            end if
-        end loop
-
-        loop(0, 0)
-    end findNodeIndexNoCaptures
-
     private def binarySearchSegment(
         segments: Span[String],
         path: String,
@@ -271,13 +154,6 @@ final private[kyo] class HttpRouter private (
 end HttpRouter
 
 private[kyo] object HttpRouter:
-
-    case class RouteMatch(
-        endpoint: HttpHandler[?, ?, ?],
-        pathCaptures: Dict[String, String],
-        isStreamingRequest: Boolean,
-        isStreamingResponse: Boolean
-    )
 
     enum FindError derives CanEqual:
         case MethodNotAllowed(allowedMethods: Set[HttpMethod])
@@ -546,10 +422,6 @@ private[kyo] object HttpRouter:
         if pos < len && path.charAt(pos) == '/' then skipSlashes(path, pos + 1, len)
         else pos
 
-    @tailrec private def findSegmentEnd(path: String, pos: Int, len: Int): Int =
-        if pos >= len || path.charAt(pos) == '/' then pos
-        else findSegmentEnd(path, pos + 1, len)
-
     private def compareSegment(segment: String, path: String, start: Int, end: Int): Int =
         val segLen  = segment.length
         val pathLen = end - start
@@ -564,17 +436,5 @@ private[kyo] object HttpRouter:
                 else loop(i + 1)
         loop(0)
     end compareSegment
-
-    /** URL-decode a path segment, avoiding allocation when no encoding is present. */
-    private def urlDecodeSegment(path: String, start: Int, end: Int): String =
-        // Fast check: if no '%' in the segment, substring is sufficient
-        @tailrec def hasPercent(i: Int): Boolean =
-            if i >= end then false
-            else if path.charAt(i) == '%' then true
-            else hasPercent(i + 1)
-        val raw = path.substring(start, end)
-        if hasPercent(start) then java.net.URLDecoder.decode(raw, "UTF-8")
-        else raw
-    end urlDecodeSegment
 
 end HttpRouter

--- a/kyo-http/shared/src/main/scala/kyo/internal/server/RouteUtil.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/server/RouteUtil.scala
@@ -470,6 +470,20 @@ private[kyo] object RouteUtil:
                                     discard(headerBuilder += encoded)
                                     cookieBuilder
                                 case HttpRoute.Field.Param.Location.Cookie =>
+                                    // The request-side mirror of Set-Cookie serialization, and the same grammar applies: RFC 6265
+                                    // section 4.2.1 makes "; " the separator BETWEEN cookie-pairs, so a value carrying one does not
+                                    // extend a cookie, it appends another. Concatenating unchecked would let a caller-supplied value
+                                    // add or overwrite cookies the caller never named, and a CR or LF would end the header outright.
+                                    // Refused rather than escaped for the reason the response side gives: the grammar defines no
+                                    // escape, so there is nothing to encode to that a server would decode back.
+                                    require(
+                                        HttpHeaders.isValidCookieName(wireName),
+                                        s"cookie name must be a token per RFC 6265 section 4.1.1; got: $wireName"
+                                    )
+                                    require(
+                                        HttpHeaders.isValidCookieValue(encoded),
+                                        s"cookie value must be cookie-octets per RFC 6265 section 4.1.1 (no controls, whitespace, ';', ',', '\"' or '\\\\'); got: $encoded"
+                                    )
                                     val cb = cookieBuilder.getOrElse(new StringBuilder)
                                     if cookieBuilder.nonEmpty then discard(cb.append("; "))
                                     discard(cb.append(wireName).append('=').append(encoded))

--- a/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/server/UnsafeServerDispatch.scala
@@ -125,6 +125,21 @@ private[kyo] object UnsafeServerDispatch:
             }
         }
 
+        /** Tears the connection down now: flushes whatever is queued, completes onClosing so an in-flight handler is interrupted, and
+          * reclaims the fd. Used by every path that answers a request and then ends the connection, since none of them can rely on the
+          * idle timer, which is either cancelled by then or was never armed.
+          */
+        def closeConnectionNow(): Unit =
+            closeConnection match
+                case Present(closeFn) => closeFn()
+                case Absent           =>
+                    // Inbound only. These paths have just WRITTEN a response, and closing outbound here would discard it
+                    // before anything could read it: the peer would be refused with no explanation, which is the failure
+                    // this close was added to prevent. Closing inbound already ends the connection logically by stopping
+                    // any further read. The connection-backed branch above has no such tension because closeFn flushes
+                    // the queued tail through closeAwaitEmpty before reclaiming the fd.
+                    discard(inbound.close())
+
         def cancelIdleTimer(): Unit =
             idleTimerFiber match
                 case Present(fiber) =>
@@ -166,6 +181,25 @@ private[kyo] object UnsafeServerDispatch:
         // so this val is safe to allocate once and reuse across all requests on the connection.
         lazy val restartParserFn: () => Unit = () => restartParserKeepAlive(parser)
 
+        /** Answers a rejected request and then either keeps the connection alive or tears it down.
+          *
+          * A request answered with an error still has its declared body (Content-Length or chunked) on the wire, and
+          * the dispatch is not going to consume it. Reusing the connection would let those unconsumed bytes be parsed
+          * as the next request (RFC 9112 section 9.3, the unconsumed-body smuggling class, e.g. Undertow
+          * CVE-2020-10719). Keep-alive is preserved only when the request is keep-alive AND carries no body to strand;
+          * otherwise the answer carries `Connection: close` (RFC 9112 section 9.6) and the connection is closed. The
+          * `write` callback receives the connectionClose flag so it announces the close on the answer it writes.
+          */
+        def answerAndContinue(request: ParsedRequest, write: Boolean => Unit): Unit =
+            if request.isKeepAlive && !hasUnconsumedBody(request) then
+                write(false)
+                restartParserKeepAlive(parser)
+            else
+                write(true)
+                closeConnectionNow()
+            end if
+        end answerAndContinue
+
         // Note on re-entrancy: onRequestParsed fires inside parse(), which may call
         // parser.start() -> needMoreBytes(). This is correct (tail position) but worth
         // documenting for future maintainers.
@@ -183,10 +217,10 @@ private[kyo] object UnsafeServerDispatch:
                 // - Multiple Host headers -> 400
                 val hostInvalid = !request.hasHost || request.hasMultipleHost || request.hasEmptyHost
                 if hostInvalid then
-                    writeBadRequest(streamCtx)
-                    if request.isKeepAlive then
-                        restartParserKeepAlive(parser)
-                    end if
+                    // Answer 400 and continue per the shared rule: keep-alive only when there is no body to strand,
+                    // otherwise Connection: close and tear the connection down. A request with no headers is the
+                    // no-body, non-keep-alive case that used to leak the fd by answering without closing or rearming.
+                    answerAndContinue(request, close => writeBadRequest(streamCtx, connectionClose = close))
                 else
                     val cl  = request.contentLength
                     val max = config.maxContentLength
@@ -195,14 +229,15 @@ private[kyo] object UnsafeServerDispatch:
                     // Per RFC 9110 section 8.6, when both Content-Length and Transfer-Encoding
                     // are present, Transfer-Encoding wins and Content-Length is ignored.
                     if cl > max && !request.isChunked then
-                        if request.expectContinue then
-                            writeExpectationFailed(streamCtx)
-                        else
-                            writePayloadTooLarge(streamCtx)
-                        end if
-                        if request.isKeepAlive then
-                            restartParserKeepAlive(parser)
-                        end if
+                        // The over-limit body is never consumed (417 withholds it, 413 declined it), so the connection
+                        // cannot be reused: answerAndContinue closes it (RFC 9112 section 9.3). The 417-vs-413
+                        // selection on expectContinue is preserved.
+                        answerAndContinue(
+                            request,
+                            close =>
+                                if request.expectContinue then writeExpectationFailed(streamCtx, connectionClose = close)
+                                else writePayloadTooLarge(streamCtx, connectionClose = close)
+                        )
                     else
                         val method = request.method
                         router.findParsed(method, request, lookup) match
@@ -220,26 +255,40 @@ private[kyo] object UnsafeServerDispatch:
                                     parser,
                                     lookup,
                                     restartParserFn,
+                                    () => closeConnectionNow(),
                                     inflightHandler,
                                     onClosing
                                 )
                             case Result.Failure(error) =>
-                                writeErrorResponse(streamCtx, error)
-                                if request.isKeepAlive then
-                                    restartParserKeepAlive(parser)
-                                end if
+                                answerAndContinue(request, close => writeErrorResponse(streamCtx, error, connectionClose = close))
                             case Result.Panic(t) =>
                                 Log.live.unsafe.error("UnsafeServerDispatch: router panic", t)
-                                writeInternalError(streamCtx)
-                                if request.isKeepAlive then
-                                    restartParserKeepAlive(parser)
-                                end if
+                                answerAndContinue(request, close => writeInternalError(streamCtx, connectionClose = close))
                         end match
                     end if
                 end if
             ,
             onClosed = () =>
-                cancelIdleTimer()
+                cancelIdleTimer(),
+            // A request the parser refused (RFC 9112 section 6.3 framing it cannot determine, a malformed escape, a
+            // field that is not a token) is answered 400 before the connection goes away. The connection is not
+            // restarted for keep-alive afterwards, unlike the Host-header 400 above: there the message was framed and
+            // only its content was wrong, so the next request's boundary is known, whereas here the framing itself is
+            // in doubt and any remaining bytes cannot be trusted to start a request.
+            onInvalidRequest = () =>
+                // Answering is only half of it. Not restarting keep-alive is not the same as closing, and answering
+                // without closing is worse than staying silent: the peer sees a complete, well-framed 400, keeps a
+                // connection it believes is healthy, and sends its next request into a socket nothing is reading. So the
+                // answer carries Connection: close (RFC 9112 section 9.6) and the connection is actually torn down.
+                // Closing through closeFn also flushes the queued 400 rather than dropping it, and reclaims the fd,
+                // which the idle timer can no longer do for us because onClosed has just cancelled it.
+                writeBadRequest(streamCtx, connectionClose = true)
+                closeConnection match
+                    case Present(closeFn) => closeFn()
+                    case Absent =>
+                        discard(inbound.close())
+                        discard(outbound.close())
+                end match
         )
 
         // Inject any pre-read bytes into the parser
@@ -279,6 +328,7 @@ private[kyo] object UnsafeServerDispatch:
         parser: Http1Parser,
         routeLookup: RouteLookup,
         restartParser: () => Unit,
+        closeNow: () => Unit,
         inflightHandler: AtomicRef.Unsafe[Maybe[Fiber.Unsafe[Unit, Any]]],
         onClosing: Maybe[Fiber.Unsafe[Unit, Any]]
     )(using AllowUnsafe, Frame): Unit =
@@ -323,9 +373,16 @@ private[kyo] object UnsafeServerDispatch:
                 // for both, and interrupting an already-completed fiber is a harmless no-op.
                 if request.isKeepAlive then
                     fiber.onComplete { _ =>
-                        val leftover = streamCtx.takeLeftover()
-                        parser.injectLeftover(leftover)
-                        restartParser()
+                        if streamCtx.mustCloseConnection then
+                            // A handler-path rejection (e.g. a chunked body over maxContentLength answered 413) left
+                            // the declared body unconsumed; reusing the connection would reparse it (RFC 9112 section
+                            // 9.3), so close instead of restarting keep-alive.
+                            closeNow()
+                        else
+                            val leftover = streamCtx.takeLeftover()
+                            parser.injectLeftover(leftover)
+                            restartParser()
+                        end if
                     }
                 end if
         end match
@@ -513,12 +570,24 @@ private[kyo] object UnsafeServerDispatch:
             val initialBytes = streamCtx.takeBodySpan()
             Channel.initUnscopedWith[Span[Byte]](16) { decodedChan =>
                 Fiber.initUnscoped {
-                    Abort.run[Closed](
-                        ChunkedBodyDecoder.readStreaming(streamCtx.bodyChannel, initialBytes, decodedChan.unsafe)
+                    Abort.run[Closed | HttpMalformedBodyException | HttpPayloadTooLargeException](
+                        ChunkedBodyDecoder.readStreaming(
+                            streamCtx.bodyChannel,
+                            initialBytes,
+                            decodedChan.unsafe,
+                            maxControlBytes = config.maxContentLength
+                        )
                     ).map { result =>
                         result match
                             case Result.Panic(t) =>
                                 Log.error("UnsafeServerDispatch: chunked decoder panic", t)
+                            case Result.Failure(malformed: HttpMalformedBodyException) =>
+                                // Malformed chunk framing mid-stream: the delivered body is truncated at the fault.
+                                // Closing the decoded channel ends the handler's stream; the framing is undeterminable.
+                                Log.warn(s"UnsafeServerDispatch: malformed chunked request body: ${malformed.getMessage}")
+                            case Result.Failure(tooLarge: HttpPayloadTooLargeException) =>
+                                // The chunk control plane (an unterminated size line or trailer) exceeded the bound.
+                                Log.warn(s"UnsafeServerDispatch: chunked control bytes over limit: ${tooLarge.getMessage}")
                             case Result.Failure(_: Closed) =>
                                 Log.warn("UnsafeServerDispatch: chunked decoder channel closed")
                             case Result.Success(_) => Kyo.unit
@@ -544,10 +613,30 @@ private[kyo] object UnsafeServerDispatch:
                 }
             }
         else
-            // Body bytes (for buffered requests).
-            // readBody accumulates from the inbound channel if Content-Length > initial body span.
-            // Uses channel.safe.take which suspends the Kyo fiber without blocking OS threads.
-            Abort.run[Closed](streamCtx.readBody()).map {
+            // Body bytes (for buffered requests). A chunked request body carries no Content-Length, so it is
+            // dechunked here bounded by maxContentLength (RFC 9112 section 6.1); a Content-Length body is read by
+            // readBody, which accumulates from the inbound channel. Both suspend the Kyo fiber (channel.safe.take)
+            // without blocking OS threads. readBuffered aborts HttpPayloadTooLargeException when the decoded body
+            // exceeds the limit.
+            val readBodyEffect: Span[Byte] < (Async & Abort[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException]) =
+                if request.isChunked then
+                    ChunkedBodyDecoder.readBuffered(streamCtx.bodyChannel, streamCtx.takeBodySpan(), config.maxContentLength)
+                else
+                    streamCtx.readBody()
+            Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](readBodyEffect).map {
+                case Result.Failure(_: HttpPayloadTooLargeException) =>
+                    // The chunked body exceeded maxContentLength. Answer 413 and close: the unread body tail cannot be
+                    // left on a reused connection (RFC 9112 section 9.3), so mark the connection for closure.
+                    Sync.Unsafe.defer {
+                        writePayloadTooLarge(streamCtx, connectionClose = true)
+                        streamCtx.requestConnectionClose()
+                    }
+                case Result.Failure(malformed: HttpMalformedBodyException) =>
+                    // The chunked framing is malformed (embedded CR, bare LF, invalid size, missing CRLF). Answer 400
+                    // and close: the body boundary is undeterminable, so the connection cannot be safely reused.
+                    writeDecodeError(streamCtx, HttpStatus(400), malformed).andThen(
+                        Sync.Unsafe.defer(streamCtx.requestConnectionClose())
+                    )
                 case Result.Failure(_: Closed) =>
                     // Channel closed before full body arrived -- connection lost, nothing to respond to
                     Log.error("UnsafeServerDispatch: inbound channel closed before body was fully read")
@@ -598,48 +687,54 @@ private[kyo] object UnsafeServerDispatch:
                 endpoint.encodeResponseUnchecked(response)(
                     onEmpty = (status, hdrs) =>
                         Sync.Unsafe.defer {
-                            val writer = streamCtx.respond(status, hdrs.add("Content-Length", "0"))
-                            writer.finish()
+                            // The Content-Length: 0 head fully frames the response: no body, and no chunked last-chunk
+                            // terminator (which belongs only to a chunked response and would desync the next response).
+                            discard(streamCtx.respond(status, hdrs.add("Content-Length", "0")))
                         },
                     onBuffered = (status, hdrs, responseBody) =>
                         Sync.Unsafe.defer {
                             val withLen = hdrs.add("Content-Length", responseBody.size)
-                            if isHead then
-                                val writer = streamCtx.respond(status, withLen)
-                                writer.finish()
-                            else
-                                val writer = streamCtx.respond(status, withLen)
-                                writer.writeBody(responseBody)
-                            end if
+                            val writer  = streamCtx.respond(status, withLen)
+                            // A HEAD response is bodyless (RFC 9112 section 6.3); the Content-Length head frames it, so
+                            // write the body only for a non-HEAD request and never a chunked terminator.
+                            if !isHead then writer.writeBody(responseBody)
                         },
                     onStreaming = (status, hdrs, responseStream) =>
-                        Sync.Unsafe.defer {
-                            val writer = streamCtx.respond(status, hdrs.add("Transfer-Encoding", "chunked"))
-                            Abort.run[Any](
-                                responseStream.foreach { chunk =>
-                                    // Use safe.put for backpressure instead of offer() which silently drops data when full.
-                                    // Closed is NOT swallowed here: it must propagate so a disconnected client aborts the
-                                    // foreach instead of the handler stream being pulled forever into a dead outbound.
-                                    val formatted = Http1StreamContext.formatChunkSpan(chunk)
-                                    streamCtx.outbound.safe.put(formatted)
-                                }
-                            ).map { result =>
-                                result match
-                                    case Result.Panic(t) =>
-                                        Log.error("UnsafeServerDispatch: streaming response error", t).andThen(
-                                            Sync.Unsafe.defer(writer.finish())
-                                        )
-                                    case Result.Failure(_: Closed) =>
-                                        // Routine peer disconnect mid-stream: not an error, so no log noise.
-                                        Sync.Unsafe.defer(writer.finish())
-                                    case Result.Failure(e) =>
-                                        Log.error(s"UnsafeServerDispatch: streaming response aborted: $e").andThen(
-                                            Sync.Unsafe.defer(writer.finish())
-                                        )
-                                    case Result.Success(_) =>
-                                        Sync.Unsafe.defer(writer.finish())
+                        if isHead then
+                            Sync.Unsafe.defer {
+                                // HEAD mirrors GET's chunked framing header but writes no body and no last-chunk
+                                // terminator; a HEAD response is terminated by the blank line after the head (RFC 9112
+                                // section 6.3, RFC 9110 section 9.3.2).
+                                discard(streamCtx.respond(status, hdrs.add("Transfer-Encoding", "chunked")))
                             }
-                        }
+                        else
+                            Sync.Unsafe.defer {
+                                val writer = streamCtx.respond(status, hdrs.add("Transfer-Encoding", "chunked"))
+                                Abort.run[Any](
+                                    responseStream.foreach { chunk =>
+                                        // Use safe.put for backpressure instead of offer() which silently drops data when full.
+                                        // Closed is NOT swallowed here: it must propagate so a disconnected client aborts the
+                                        // foreach instead of the handler stream being pulled forever into a dead outbound.
+                                        val formatted = Http1StreamContext.formatChunkSpan(chunk)
+                                        streamCtx.outbound.safe.put(formatted)
+                                    }
+                                ).map { result =>
+                                    result match
+                                        case Result.Panic(t) =>
+                                            Log.error("UnsafeServerDispatch: streaming response error", t).andThen(
+                                                Sync.Unsafe.defer(writer.finish())
+                                            )
+                                        case Result.Failure(_: Closed) =>
+                                            // Routine peer disconnect mid-stream: not an error, so no log noise.
+                                            Sync.Unsafe.defer(writer.finish())
+                                        case Result.Failure(e) =>
+                                            Log.error(s"UnsafeServerDispatch: streaming response aborted: $e").andThen(
+                                                Sync.Unsafe.defer(writer.finish())
+                                            )
+                                        case Result.Success(_) =>
+                                            Sync.Unsafe.defer(writer.finish())
+                                }
+                            }
                 )
             case Result.Failure(error) =>
                 error match
@@ -648,8 +743,9 @@ private[kyo] object UnsafeServerDispatch:
                             RouteUtil.encodeHalt(halt) { (status, hdrs, haltBody) =>
                                 val withLen = hdrs.add("Content-Length", haltBody.size)
                                 val writer  = streamCtx.respond(status, withLen)
+                                // Content-Length framed; write the body only for a non-HEAD response that has content.
+                                // An empty or HEAD response is framed by its head, with no chunked terminator.
                                 if !isHead && haltBody.size > 0 then writer.writeBody(haltBody)
-                                else writer.finish()
                             }
                         }
                     case other =>
@@ -659,7 +755,6 @@ private[kyo] object UnsafeServerDispatch:
                                     val withLen = hdrs.add("Content-Length", errorBody.size)
                                     val writer  = streamCtx.respond(status, withLen)
                                     if !isHead && errorBody.size > 0 then writer.writeBody(errorBody)
-                                    else writer.finish()
                                 }
                             case Absent =>
                                 Log.error(s"UnsafeServerDispatch: unhandled handler error: $other").andThen(
@@ -673,18 +768,31 @@ private[kyo] object UnsafeServerDispatch:
     end dispatchHandler
 
     /** Write a router-level error response (404, 405, OPTIONS). */
+    /** True when the request declared a body (Content-Length > 0 or Transfer-Encoding: chunked) that a rejecting
+      * dispatch is not going to consume, so the connection cannot be safely reused (RFC 9112 section 9.3).
+      */
+    private def hasUnconsumedBody(request: ParsedRequest): Boolean =
+        request.isChunked || request.contentLength > 0
+
     private def writeErrorResponse(
         streamCtx: Http1StreamContext,
-        error: HttpRouter.FindError
+        error: HttpRouter.FindError,
+        connectionClose: Boolean = false
     )(using AllowUnsafe, Frame): Unit =
+        // Announce a pending connection close (RFC 9112 section 9.6) so the peer can tell this error, after which the
+        // connection is gone, from an ordinary one after which it may reuse the connection.
+        def withClose(headers: HttpHeaders): HttpHeaders =
+            if connectionClose then headers.add("Connection", "close") else headers
         error match
             case HttpRouter.FindError.NotFound =>
                 val bodyBytes = RouteUtil.encodeErrorBody(HttpStatus(404))
                 val writer = streamCtx.respond(
                     HttpStatus(404),
-                    HttpHeaders.empty
-                        .add("Content-Type", "application/json")
-                        .add("Content-Length", bodyBytes.size)
+                    withClose(
+                        HttpHeaders.empty
+                            .add("Content-Type", "application/json")
+                            .add("Content-Length", bodyBytes.size)
+                    )
                 )
                 writer.writeBody(bodyBytes)
             case HttpRouter.FindError.MethodNotAllowed(methods) =>
@@ -697,15 +805,18 @@ private[kyo] object UnsafeServerDispatch:
                 val bodyBytes = RouteUtil.encodeErrorBody(HttpStatus(405))
                 val writer = streamCtx.respond(
                     HttpStatus(405),
-                    HttpHeaders.empty
-                        .add("Allow", allow)
-                        .add("Content-Type", "application/json")
-                        .add("Content-Length", bodyBytes.size)
+                    withClose(
+                        HttpHeaders.empty
+                            .add("Allow", allow)
+                            .add("Content-Type", "application/json")
+                            .add("Content-Length", bodyBytes.size)
+                    )
                 )
                 writer.writeBody(bodyBytes)
             case HttpRouter.FindError.Options(headers) =>
-                val writer = streamCtx.respond(HttpStatus(204), headers)
-                writer.finish()
+                // 204 head fully frames the response: no body and no chunked last-chunk terminator.
+                discard(streamCtx.respond(HttpStatus(204), withClose(headers)))
+        end match
     end writeErrorResponse
 
     /** Write a 404 Not Found response. */
@@ -722,30 +833,39 @@ private[kyo] object UnsafeServerDispatch:
         writer.writeBody(bodyBytes)
     end writeNotFound
 
-    /** Write a 400 Bad Request response (e.g. missing or invalid Host header per RFC 9110 section 7.2). */
+    /** Write a 400 Bad Request response (e.g. missing or invalid Host header per RFC 9110 section 7.2).
+      *
+      * `connectionClose` adds the `Connection: close` header, and must be set whenever the caller is about to tear the connection down.
+      * RFC 9112 section 9.6 requires a sender to announce it, and without it the peer has no way to tell this 400 (after which the
+      * connection is gone) from an ordinary one (after which it may reuse the connection).
+      */
     private def writeBadRequest(
-        streamCtx: Http1StreamContext
+        streamCtx: Http1StreamContext,
+        connectionClose: Boolean = false
     )(using AllowUnsafe, Frame): Unit =
         val bodyBytes = RouteUtil.encodeErrorBody(HttpStatus(400))
+        val baseHeaders = HttpHeaders.empty
+            .add("Content-Type", "application/json")
+            .add("Content-Length", bodyBytes.size)
         val writer = streamCtx.respond(
             HttpStatus(400),
-            HttpHeaders.empty
-                .add("Content-Type", "application/json")
-                .add("Content-Length", bodyBytes.size)
+            if connectionClose then baseHeaders.add("Connection", "close") else baseHeaders
         )
         writer.writeBody(bodyBytes)
     end writeBadRequest
 
     /** Write a 500 Internal Server Error. */
     private def writeInternalError(
-        streamCtx: Http1StreamContext
+        streamCtx: Http1StreamContext,
+        connectionClose: Boolean = false
     )(using AllowUnsafe, Frame): Unit =
         val bodyBytes = RouteUtil.encodeErrorBody(HttpStatus(500))
+        val baseHeaders = HttpHeaders.empty
+            .add("Content-Type", "application/json")
+            .add("Content-Length", bodyBytes.size)
         val writer = streamCtx.respond(
             HttpStatus(500),
-            HttpHeaders.empty
-                .add("Content-Type", "application/json")
-                .add("Content-Length", bodyBytes.size)
+            if connectionClose then baseHeaders.add("Connection", "close") else baseHeaders
         )
         writer.writeBody(bodyBytes)
     end writeInternalError
@@ -774,28 +894,32 @@ private[kyo] object UnsafeServerDispatch:
 
     /** Write a 413 Payload Too Large response. */
     private def writePayloadTooLarge(
-        streamCtx: Http1StreamContext
+        streamCtx: Http1StreamContext,
+        connectionClose: Boolean = false
     )(using AllowUnsafe, Frame): Unit =
         val bodyBytes = RouteUtil.encodeErrorBody(HttpStatus(413))
+        val baseHeaders = HttpHeaders.empty
+            .add("Content-Type", "application/json")
+            .add("Content-Length", bodyBytes.size)
         val writer = streamCtx.respond(
             HttpStatus(413),
-            HttpHeaders.empty
-                .add("Content-Type", "application/json")
-                .add("Content-Length", bodyBytes.size)
+            if connectionClose then baseHeaders.add("Connection", "close") else baseHeaders
         )
         writer.writeBody(bodyBytes)
     end writePayloadTooLarge
 
     /** Write a 417 Expectation Failed response. */
     private def writeExpectationFailed(
-        streamCtx: Http1StreamContext
+        streamCtx: Http1StreamContext,
+        connectionClose: Boolean = false
     )(using AllowUnsafe, Frame): Unit =
         val bodyBytes = RouteUtil.encodeErrorBody(HttpStatus(417))
+        val baseHeaders = HttpHeaders.empty
+            .add("Content-Type", "application/json")
+            .add("Content-Length", bodyBytes.size)
         val writer = streamCtx.respond(
             HttpStatus(417),
-            HttpHeaders.empty
-                .add("Content-Type", "application/json")
-                .add("Content-Length", bodyBytes.size)
+            if connectionClose then baseHeaders.add("Connection", "close") else baseHeaders
         )
         writer.writeBody(bodyBytes)
     end writeExpectationFailed
@@ -816,7 +940,7 @@ private[kyo] object UnsafeServerDispatch:
     /** Build path captures Dict from RouteLookup indices + ParsedRequest segments. URL-decodes capture values and reconstructs the full
       * remaining path for rest captures.
       */
-    private def buildCaptures(
+    private[internal] def buildCaptures(
         request: ParsedRequest,
         lookup: RouteLookup,
         captureNames: Span[String]

--- a/kyo-http/shared/src/main/scala/kyo/internal/websocket/WebSocketCodec.scala
+++ b/kyo-http/shared/src/main/scala/kyo/internal/websocket/WebSocketCodec.scala
@@ -60,7 +60,7 @@ private[kyo] object WebSocketCodec:
         f: (HttpWebSocket.Payload, Stream[Span[Byte], Async]) => A < S
     )(using Frame): A < (S & Async & Abort[Closed]) =
         Abort.recover[HttpException](_ => Abort.fail(new Closed("HttpWebSocket", summon[Frame]))) {
-            readRawFrameWith(src, maxFrameSize) { (opcode, payload, remaining) =>
+            readRawFrameWith(src, maxFrameSize, expectMasked = !mask) { (opcode, payload, remaining) =>
                 opcode match
                     case OpText   => f(HttpWebSocket.Payload.Text(new String(payload.toArrayUnsafe, Utf8)), remaining)
                     case OpBinary => f(HttpWebSocket.Payload.Binary(payload), remaining)
@@ -336,15 +336,27 @@ private[kyo] object WebSocketCodec:
     // ── Internal I/O ────────────────────────────────────────────
 
     /** Read a single raw frame (handles extended length + masking). */
-    private inline def readRawFrameWith[A, S2](src: Stream[Span[Byte], Async], maxFrameSize: Int)(
+    private inline def readRawFrameWith[A, S2](src: Stream[Span[Byte], Async], maxFrameSize: Int, expectMasked: Boolean)(
         inline f: (Int, Span[Byte], Stream[Span[Byte], Async]) => A < S2
     )(using inline frame: Frame): A < (S2 & Async & Abort[HttpException]) =
         ByteStream.readExactWith(src, 2) { (header, rem1) =>
             val fh          = parseFrameHeader(header(0), header(1))
             val payloadLen  = fh.payloadLen
             val extLenBytes = if payloadLen == 126 then 2 else if payloadLen == 127 then 8 else 0
+            val isControl   = fh.opcode >= OpClose
 
-            if extLenBytes == 0 then
+            if fh.masked != expectMasked then
+                // A server MUST receive masked frames and a client MUST receive unmasked ones (RFC 6455 section 5.1);
+                // the wrong masking direction is a protocol violation and (server side) a smuggling lever.
+                Abort.fail(HttpProtocolException("HttpWebSocket frame masking violates role (RFC 6455 section 5.1)"))
+            else if isControl && payloadLen > 125 then
+                // A control frame's payload MUST be <= 125 bytes, so its length is never the 126/127 extended form
+                // (RFC 6455 section 5.5).
+                Abort.fail(HttpProtocolException("HttpWebSocket control frame payload exceeds 125 bytes (RFC 6455 section 5.5)"))
+            else if isControl && !fh.fin then
+                // A control frame MUST NOT be fragmented (RFC 6455 section 5.5).
+                Abort.fail(HttpProtocolException("HttpWebSocket control frame is fragmented (RFC 6455 section 5.5)"))
+            else if extLenBytes == 0 then
                 val actualLen = payloadLen.toLong
                 if actualLen > maxFrameSize.toLong then
                     Abort.fail(HttpProtocolException("HttpWebSocket frame exceeds max frame size"))

--- a/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpClientTest.scala
@@ -1020,6 +1020,165 @@ class HttpClientTest extends BaseHttpTest:
                 }.andThen(assert(called))
             }
         }
+
+        // RFC 9110 section 15.4.4: a 303 changes the method to GET, and a GET carries no body. The follow-up request is
+        // built by copying the original, whose body still sits in its fields, so the guarantee rests on the encoder
+        // filtering the body by method rather than on the redirect logic dropping it. There was no 303 coverage at all,
+        // which left that filtering unpinned: a change to it would send the POST body to the redirect target as a GET.
+        "303 See Other becomes a GET and sends no body (RFC 9110 section 15.4.4)" - {
+            val startRoute = HttpRoute.postRaw("start").request(_.bodyText).response(_.bodyText)
+            val seenRoute  = HttpRoute.getRaw("seen").response(_.bodyText)
+            val seenEp = seenRoute.handler { req =>
+                val method = req.method.name
+                val len    = req.headers.get("Content-Length").getOrElse("absent")
+                HttpResponse.ok(s"method=$method contentLength=$len")
+            }
+            val redirectEp = startRoute.handler { _ =>
+                HttpResponse.halt(HttpResponse(HttpStatus.SeeOther).setHeader("Location", "/seen"))
+            }
+            runServer(seenEp, redirectEp) { url =>
+                HttpClient.withConfig(noTimeout) {
+                    withClient { client =>
+                        val request = HttpRequest
+                            .postRaw(HttpUrl(url.scheme, url.host, url.port, "/start", Absent))
+                            .addField("body", "this body must not be forwarded")
+                        client.sendWith(startRoute, request) { resp =>
+                            // Either spelling of "no body" is correct: an absent Content-Length, or an explicit zero,
+                            // which RFC 9110 section 8.6 makes a valid way to say the same thing. What must not appear
+                            // is the original body, whose length is nowhere near zero.
+                            val body = resp.fields.body
+                            assert(body.startsWith("method=GET"), s"a 303 must arrive as a GET, got: $body")
+                            assert(
+                                body.endsWith("contentLength=0") || body.endsWith("contentLength=absent"),
+                                s"the original request body must not be forwarded, got: $body"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Credential forwarding across a redirect. A redirect target is chosen by the ORIGIN, not by the caller, so the
+        // Location value is attacker-controlled the moment the origin is malicious, compromised, or merely open. Carrying
+        // the caller's Authorization to whatever authority that value names hands the credential to a third party, so the
+        // decision to forward has to be conditioned on the target, not made unconditionally.
+        //
+        // The collector below reports what the SECOND server actually received, which is what makes the leak observable
+        // rather than inferred: the client returns the second server's body as the final response.
+
+        // The positive control for the two leaves below, and the reason they cannot be satisfied by stripping
+        // unconditionally. A relative Location stays on the origin the caller chose, so the credential is going
+        // exactly where it was already sent and must survive: dropping it here would break every authenticated
+        // redirect. None of the other redirect leaves carry credentials, so without this nothing pins that.
+        "forwards Authorization across a same-origin redirect (GHSA-2rgg-r783-mrx4 control)" - {
+            val startRoute  = HttpRoute.getRaw("start").response(_.bodyText)
+            val targetRoute = HttpRoute.getRaw("target").response(_.bodyText)
+            val targetEp = targetRoute.handler { req =>
+                HttpResponse.ok(s"auth=${req.headers.get("Authorization").getOrElse("none")}")
+            }
+            val redirectEp = startRoute.handler(_ => HttpResponse.redirect("/target").addField("body", "redirect"))
+            runServer(targetEp, redirectEp) { url =>
+                HttpClient.withConfig(noTimeout) {
+                    withClient { client =>
+                        val request = HttpRequest
+                            .getRaw(HttpUrl(url.scheme, url.host, url.port, "/start", Absent))
+                            .setHeader("Authorization", "Bearer super-secret")
+                        client.sendWith(targetRoute, request) { resp =>
+                            assert(
+                                resp.fields.body == "auth=Bearer super-secret",
+                                s"a same-origin redirect must keep the caller's credential, got: ${resp.fields.body}"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        "does not forward Authorization across an origin change (GHSA-2rgg-r783-mrx4)" - {
+            val startRoute   = HttpRoute.getRaw("start").response(_.bodyText)
+            val collectRoute = HttpRoute.getRaw("collect").response(_.bodyText)
+            // Both credential-bearing fields are reported, so a fix that drops only Authorization while Cookie still
+            // crosses cannot satisfy this leaf. A cookie is bound to the origin that set it just as an Authorization
+            // value is bound to the origin it was issued for.
+            val collectEp = collectRoute.handler { req =>
+                val auth   = req.headers.get("Authorization").getOrElse("none")
+                val cookie = req.headers.get("Cookie").getOrElse("none")
+                HttpResponse.ok(s"auth=$auth cookie=$cookie")
+            }
+            // The collector runs on its own server, so it is a different port and therefore a different origin
+            // (RFC 6454 section 4 makes origin the scheme/host/port triple, so a port change alone crosses it).
+            "plain" in {
+                initTrustAllClient().map { httpClient =>
+                    HttpServer.init(0, "localhost")(collectEp).map { collector =>
+                        val redirectEp = startRoute.handler { _ =>
+                            HttpResponse.halt(
+                                HttpResponse(HttpStatus.Found)
+                                    .setHeader("Location", s"http://localhost:${collector.port}/collect")
+                            )
+                        }
+                        HttpServer.init(0, "localhost")(redirectEp).map { origin =>
+                            HttpClient.let(httpClient) {
+                                HttpClient.withConfig(noTimeout) {
+                                    val request = HttpRequest
+                                        .getRaw(HttpUrl.parse(s"http://localhost:${origin.port}/start").getOrThrow)
+                                        .setHeader("Authorization", "Bearer super-secret")
+                                        .setHeader("Cookie", "session=super-secret")
+                                    HttpClient.use(_.sendWith(collectRoute, request) { resp =>
+                                        assert(
+                                            resp.fields.body == "auth=none cookie=none",
+                                            s"the redirect target received the caller's credentials: ${resp.fields.body}"
+                                        )
+                                    })
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // The scheme half of the same decision, and the more damaging one: here the credential does not merely reach an
+        // unintended party, it reaches the network in cleartext. A caller that chose https did so to keep the header off
+        // the wire, and a Location naming http silently undoes that choice.
+        "does not forward Authorization across an https to http downgrade (GHSA-2rgg-r783-mrx4)" in {
+            val startRoute   = HttpRoute.getRaw("start").response(_.bodyText)
+            val collectRoute = HttpRoute.getRaw("collect").response(_.bodyText)
+            val collectEp = collectRoute.handler { req =>
+                val auth   = req.headers.get("Authorization").getOrElse("none")
+                val cookie = req.headers.get("Cookie").getOrElse("none")
+                HttpResponse.ok(s"auth=$auth cookie=$cookie")
+            }
+            initTrustAllClient().map { httpClient =>
+                // Hop 2 is plaintext; hop 1 below is TLS, so following the Location downgrades the scheme.
+                HttpServer.init(0, "localhost")(collectEp).map { collector =>
+                    val redirectEp = startRoute.handler { _ =>
+                        HttpResponse.halt(
+                            HttpResponse(HttpStatus.Found)
+                                .setHeader("Location", s"http://localhost:${collector.port}/collect")
+                        )
+                    }
+                    HttpServer.init(
+                        HttpServerConfig.default.port(0).host("localhost")
+                            .tls(internal.HttpTestPlatformBackend.serverTlsConfig)
+                    )(redirectEp).map { origin =>
+                        HttpClient.let(httpClient) {
+                            HttpClient.withConfig(noTimeout) {
+                                val request = HttpRequest
+                                    .getRaw(HttpUrl.parse(s"https://localhost:${origin.port}/start").getOrThrow)
+                                    .setHeader("Authorization", "Bearer super-secret")
+                                    .setHeader("Cookie", "session=super-secret")
+                                HttpClient.use(_.sendWith(collectRoute, request) { resp =>
+                                    assert(
+                                        resp.fields.body == "auth=none cookie=none",
+                                        s"an https origin redirected to http and the credentials followed in cleartext: ${resp.fields.body}"
+                                    )
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     "retry" - {

--- a/kyo-http/shared/src/test/scala/kyo/HttpResponseTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpResponseTest.scala
@@ -20,6 +20,22 @@ class HttpResponseTest extends BaseHttpTest:
             assert(res.headers.get("X-Test") == Present("1"))
             assert(res.fields.key == "val")
         }
+
+        // Content-Disposition wraps the filename in a quoted-string, so a '"' in the filename closes it and everything
+        // after is read as additional disposition parameters. Netty CVE-2026-59921 built this header by concatenating
+        // the filename verbatim; a filename like `x"; filename="evil` injects a second filename an intermediary or
+        // browser may honor. The filename must be escaped or refused, not interpolated raw.
+        "contentDisposition does not let a filename inject a disposition parameter (CVE-2026-59921)" in {
+            val res = HttpResponse.ok("body").contentDisposition("report\"; filename=\"evil.exe")
+            res.headers.get("Content-Disposition") match
+                case Present(v) =>
+                    assert(
+                        !v.contains("filename=\"evil.exe"),
+                        s"a '\"' in the filename injected a second filename parameter: $v"
+                    )
+                case Absent => succeed("refusing the filename is acceptable")
+            end match
+        }
     }
 
     "factory methods" - {

--- a/kyo-http/shared/src/test/scala/kyo/HttpSecurityServerTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpSecurityServerTest.scala
@@ -8,12 +8,56 @@ class HttpSecurityServerTest extends BaseHttpTest:
     val echoRoute   = HttpRoute.postRaw("echo").response(_.bodyText)
     val echoHandler = echoRoute.handler(_ => HttpResponse.ok("ok"))
 
+    // A buffered route that reads and echoes the request body, used to observe what body the handler actually received.
+    val bodyRoute   = HttpRoute.postRaw("body").request(_.bodyText).response(_.bodyText)
+    val bodyHandler = bodyRoute.handler(req => HttpResponse.ok(s"[${req.fields.body}]"))
+
+    // A GET route whose response body is a recognizable marker, used as the target a smuggled request would reach.
+    val markerRoute   = HttpRoute.getRaw("marker").response(_.bodyText)
+    val markerHandler = markerRoute.handler(_ => HttpResponse.ok("SMUGGLED-MARKER"))
+
+    // A streaming-response route, used to observe whether a HEAD response carries a body.
+    val streamRoute = HttpRoute.getRaw("stream").response(_.bodyStream)
+    val streamHandler = streamRoute.handler(_ =>
+        HttpResponse.ok.addField("body", Stream.init(Seq(Span.fromUnsafe("STREAM-BODY".getBytes("UTF-8")))))
+    )
+
+    // A route whose response carries no body, used to observe the empty-response (onEmpty) framing.
+    val emptyRoute   = HttpRoute.getRaw("empty").response(_.header[String]("X-Empty"))
+    val emptyHandler = emptyRoute.handler(_ => HttpResponse.ok.addField("X-Empty", "yes"))
+
     /** Start a plain HTTP server and run a test against it. */
     def withEchoServer(
         test: (String, Int) => Unit < (Async & Abort[Any] & Scope)
     )(using Frame): Unit < (Scope & Async & Abort[Any]) =
-        HttpServer.init(0, "localhost")(echoHandler).map { s =>
+        HttpServer.init(0, "localhost")(echoHandler, bodyHandler, markerHandler, streamHandler, emptyHandler).map { s =>
             test("localhost", s.port)
+        }
+
+    /** Opens a connection, writes each of `writes` with a pause between them, then reads everything the server sends
+      * back within the budget. Returns the concatenated response bytes as a string. The staged writes let a test place
+      * bytes on the wire AFTER the server has already answered an earlier part, which is how a split-read desync is
+      * exercised.
+      */
+    def sendStaged(host: String, port: Int, writes: Seq[String])(using Frame): String < (Async & Abort[Any]) =
+        Sync.Unsafe.defer {
+            kyo.net.NetPlatform.transport.connect(host, port).safe.get.map { conn =>
+                def writeAll(rem: Seq[String]): Unit < (Async & Abort[Any]) =
+                    rem match
+                        case Seq() => Kyo.unit
+                        case w +: tail =>
+                            Abort.run[Closed](conn.outbound.safe.put(Span.fromUnsafe(w.getBytes("ISO-8859-1")))).andThen {
+                                Async.sleep(300.millis).andThen(writeAll(tail))
+                            }
+                def drain(acc: String, n: Int): String < (Async & Abort[Any]) =
+                    if n > 8 then acc
+                    else
+                        Abort.run[Any](Async.timeout(500.millis)(Abort.run[Closed](conn.inbound.safe.take))).map {
+                            case Result.Success(Result.Success(d)) => drain(acc + new String(d.toArray, "ISO-8859-1"), n + 1)
+                            case _                                 => acc
+                        }
+                writeAll(writes).andThen(drain("", 0)).map(all => Sync.Unsafe.defer(conn.close()).andThen(all))
+            }
         }
 
     /** Send raw bytes over TCP to host:port and read the response as a string.
@@ -53,16 +97,24 @@ class HttpSecurityServerTest extends BaseHttpTest:
             }
         }
 
-    /** Check that a response indicates rejection: either 400 status or connection closed. */
+    /** Checks that the server answered a malformed request with 400.
+      *
+      * An empty read is NOT accepted as a rejection. `sendRawBytes` returns "" for a closed connection, a timeout AND a
+      * failed connect alike, so treating silence as success would mean these tests could not fail for any infrastructure
+      * reason: a server that never started would pass every one of them. Requiring the status also pins the behavior that
+      * makes silence unnecessary, since a peer that is refused is told so (RFC 9112 section 6.3) rather than left to infer
+      * it from a disconnect after its own timeout expires.
+      */
     def assertRejected(response: String, description: String)(using kyo.test.AssertScope): Unit =
         if response.isEmpty then
-            // Connection closed -- server rejected the request
-            succeed("expected: server rejected by closing connection")
-        else if response.contains("400") then
-            assert(response.contains("400"), s"$description: server returned 400 Bad Request for malformed input")
-        else
             fail(
-                s"$description: Expected 400 Bad Request or connection close, but got:\n${response.take(200)}"
+                s"$description: expected a 400 Bad Request, but the connection produced nothing. " +
+                    "An empty read here is a closed, timed-out or never-established connection, none of which prove the request was refused."
+            )
+        else
+            assert(
+                response.contains("400"),
+                s"$description: expected 400 Bad Request, but got:\n${response.take(200)}"
             )
 
     "request smuggling defenses" - {
@@ -113,6 +165,346 @@ class HttpSecurityServerTest extends BaseHttpTest:
 
                 sendRawBytes(host, port, raw).map { response =>
                     assertRejected(response, "Content-Length integer overflow")
+                }
+            }
+        }
+    }
+
+    // Transfer-Encoding framing, RFC 9112 section 6.1 and 6.3. These cover the TE.TE smuggling family: the danger is not a
+    // malformed header on its own but a DISAGREEMENT between an upstream intermediary and this server about whether a body is
+    // chunked. Whichever way the disagreement falls, the bytes one party treats as a body the other treats as a new request.
+    // Rejecting is always a safe resolution, so each leaf asserts rejection rather than a particular framing interpretation.
+    "Transfer-Encoding smuggling defenses (GHSA-jrpm-956j-96jg)" - {
+
+        // A chunked request body to a BUFFERED route must reach the handler decoded, not be silently discarded. The
+        // server only decodes chunked for streaming-request routes; an ordinary buffered route reads the body by
+        // Content-Length, which is -1 for a chunked request, so the handler receives an empty body. That is both data
+        // loss and a framing gap: the chunk bytes are neither decoded nor consumed, and the maxContentLength check is
+        // skipped for chunked requests, so on a split read the chunk tail can be reparsed as the next request. This
+        // asserts the handler receives the body and therefore FAILS until buffered routes decode chunked (or reject it).
+        //
+        // Origin: the unconsumed-body-reinterpreted class, Go GO-2023-1495 / Node CVE-2022-32213.
+        "a chunked body to a buffered route reaches the handler" in {
+            withEchoServer { (host, port) =>
+                val raw =
+                    ("POST /body HTTP/1.1\r\n" +
+                        "Host: localhost\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "\r\n" +
+                        "5\r\n" +
+                        "hello\r\n" +
+                        "0\r\n" +
+                        "\r\n").getBytes("UTF-8")
+                sendRawBytes(host, port, raw).map { response =>
+                    assert(
+                        response.contains("[hello]"),
+                        s"the handler must receive the decoded chunked body, but got:\n${response.take(200)}"
+                    )
+                }
+            }
+        }
+
+        // RFC 9112 section 6.1: chunked must be the FINAL encoding. Here it is final, so the message IS chunked, but the gzip
+        // coding is one this server does not implement (section 6.1: respond 501 for a transfer coding it does not understand).
+        // A front end that decodes gzip and forwards would frame a body this server must not silently treat as absent.
+        "Transfer-Encoding: gzip, chunked (unsupported coding before chunked)" in {
+            withEchoServer { (host, port) =>
+                val raw =
+                    ("POST /echo HTTP/1.1\r\n" +
+                        "Host: localhost\r\n" +
+                        "Transfer-Encoding: gzip, chunked\r\n" +
+                        "\r\n" +
+                        "5\r\n" +
+                        "hello\r\n" +
+                        "0\r\n" +
+                        "\r\n").getBytes("UTF-8")
+                sendRawBytes(host, port, raw).map { response =>
+                    assertRejected(response, "Transfer-Encoding: gzip, chunked")
+                }
+            }
+        }
+
+        // RFC 9112 section 6.3: Transfer-Encoding present whose final coding is NOT chunked means the message length is
+        // undeterminable, and a server must respond 400. Accepting it as a bodyless request leaves any body bytes in the
+        // buffer to be read as the next request.
+        "Transfer-Encoding: identity (no chunked, length undeterminable)" in {
+            withEchoServer { (host, port) =>
+                val raw =
+                    ("POST /echo HTTP/1.1\r\n" +
+                        "Host: localhost\r\n" +
+                        "Transfer-Encoding: identity\r\n" +
+                        "\r\n" +
+                        "hello").getBytes("UTF-8")
+                sendRawBytes(host, port, raw).map { response =>
+                    assertRejected(response, "Transfer-Encoding: identity")
+                }
+            }
+        }
+
+        // "chunkedfoo" is not the token "chunked"; RFC 9110 section 5.6.2 tokens are delimited, not prefixes. A parser that
+        // matches a prefix accepts this as chunked while a strict intermediary rejects it, which is the desync.
+        "Transfer-Encoding: chunkedfoo (token must not match by prefix)" in {
+            withEchoServer { (host, port) =>
+                val raw =
+                    ("POST /echo HTTP/1.1\r\n" +
+                        "Host: localhost\r\n" +
+                        "Transfer-Encoding: chunkedfoo\r\n" +
+                        "\r\n" +
+                        "5\r\n" +
+                        "hello\r\n" +
+                        "0\r\n" +
+                        "\r\n").getBytes("UTF-8")
+                sendRawBytes(host, port, raw).map { response =>
+                    assertRejected(response, "Transfer-Encoding: chunkedfoo")
+                }
+            }
+        }
+
+        // Two Transfer-Encoding header lines. Intermediaries differ on whether to combine them into a list or honor one, so a
+        // server that silently picks one desyncs against a front end that picked the other.
+        "duplicate Transfer-Encoding headers" in {
+            withEchoServer { (host, port) =>
+                val raw =
+                    ("POST /echo HTTP/1.1\r\n" +
+                        "Host: localhost\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "Transfer-Encoding: identity\r\n" +
+                        "\r\n" +
+                        "5\r\n" +
+                        "hello\r\n" +
+                        "0\r\n" +
+                        "\r\n").getBytes("UTF-8")
+                sendRawBytes(host, port, raw).map { response =>
+                    assertRejected(response, "duplicate Transfer-Encoding")
+                }
+            }
+        }
+
+    }
+
+    // Connection reclamation on a refused request. A server that answers and then holds the socket open is a slow
+    // resource leak an unauthenticated peer controls: every refused request costs a file descriptor that nothing
+    // reclaims, since the idle timer is either cancelled by then or was never armed. The peer needs no valid request
+    // and no open connection of its own to spend one.
+    "refused requests release the connection (RFC 9112 section 9.6)" - {
+
+        /** Sends `raw`, then reports whether the server ended the connection within the deadline. */
+        def reapedAfter(host: String, port: Int, raw: String)(using Frame): Boolean < (Async & Abort[Any]) =
+            Sync.Unsafe.defer {
+                kyo.net.NetPlatform.transport.connect(host, port).safe.get.map { conn =>
+                    Abort.run[Closed](conn.outbound.safe.put(Span.fromUnsafe(raw.getBytes("UTF-8")))).map { _ =>
+                        // Read until the peer closes (an empty span or a Closed failure) or the budget runs out. A
+                        // response arriving first is expected and not the thing under test, so keep reading past it.
+                        def drain(n: Int): Boolean < (Async & Abort[Any]) =
+                            if n > 20 then false
+                            else
+                                Abort.run[Any](Async.timeout(10.seconds)(Abort.run[Closed](conn.inbound.safe.take))).map {
+                                    case Result.Success(Result.Success(span)) => if span.isEmpty then true else drain(n + 1)
+                                    case Result.Success(Result.Failure(_))    => true
+                                    case _                                    => false
+                                }
+                        drain(0).map { reaped =>
+                            Sync.Unsafe.defer(conn.close()).andThen(reaped)
+                        }
+                    }
+                }
+            }
+
+        // A LONG idle timeout, deliberately: with a short one every leaf below would pass on the timer expiring rather
+        // than on the connection being closed, which is a different mechanism and not the one under test. At 30 seconds
+        // against a 10 second read budget, only an explicit close can produce EOF.
+        def assertReaped(raw: String, description: String)(using Frame, kyo.test.AssertScope): Unit < (Async & Abort[Any] & Scope) =
+            val cfg = HttpServerConfig.default.port(0).host("localhost").idleTimeout(30.seconds)
+            HttpServer.init(cfg)(echoHandler).map { server =>
+                reapedAfter("localhost", server.port, raw).map { reaped =>
+                    assert(reaped, s"$description: the server answered but never released the connection")
+                }
+            }
+        end assertReaped
+
+        // A request with no headers at all is the case that leaked: keep-alive is carried by a header, so a bare
+        // request line is not keep-alive, and the branch that handled that answered without closing or rearming
+        // anything. This and the leaf below are the two that actually exercise the close.
+        "a request with a missing Host header" in {
+            assertReaped("GET /echo HTTP/1.1\r\n\r\n", "missing Host")
+        }
+
+        // The parser-level refusal, which reaches a different branch than the Host checks.
+        "a request the parser refused" in {
+            assertReaped("POST /echo HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: identity\r\n\r\nhello", "unframable request")
+        }
+
+        "a request whose Host header is missing and that asked to close" in {
+            assertReaped("GET /echo HTTP/1.1\r\nConnection: close\r\n\r\n", "missing Host with Connection: close")
+        }
+
+        // An invalid Host on a KEEP-ALIVE request is deliberately NOT closed, and this pins that rather than leaving it
+        // to look like an oversight. The message was framed correctly and only its content was wrong, so the next
+        // request's boundary is known and the connection stays usable; RFC 9110 section 7.2 asks for the 400, not for a
+        // teardown. The connection is then reclaimed by the ordinary idle timer like any other idle connection.
+        //
+        // Earlier versions of these leaves used a one second idle timeout, which made this case indistinguishable from
+        // the closing ones: all four went to EOF and three of them were passing on the timer.
+        "an invalid Host on a keep-alive request is answered without closing" in {
+            val cfg = HttpServerConfig.default.port(0).host("localhost").idleTimeout(30.seconds)
+            HttpServer.init(cfg)(echoHandler).map { server =>
+                reapedAfter("localhost", server.port, "GET /echo HTTP/1.1\r\nHost: a\r\nHost: b\r\n\r\n").map { reaped =>
+                    assert(!reaped, "a keep-alive request with a bad Host must be answered, not disconnected")
+                }
+            }
+        }
+    }
+
+    // Connection integrity across a request boundary. Both leaves here concern what a recipient reads AFTER a
+    // response, on a connection it will keep using.
+    "connection integrity defenses" - {
+
+        // A request that is answered but whose declared body is not consumed must not leave that body to be parsed as
+        // the next request. Here a POST to a nonexistent path carries a Content-Length body that is itself a valid
+        // GET /marker request. The server answers 404, restarts the parser for keep-alive, and then reads the body
+        // bytes, which arrive in a SEPARATE segment after the 404, as a fresh request, serving /marker. A front end
+        // that allowed the POST but would have blocked GET /marker is bypassed. RFC 9112 section 9.3 requires a
+        // recipient that does not consume the body to close the connection instead of reusing it. This asserts the
+        // marker is never served and therefore FAILS until the rejected request's body is drained or the connection
+        // closed.
+        //
+        // Origin: the unconsumed-body-reinterpreted smuggling class (Undertow CVE-2020-10719, RFC 9112 section 9.3).
+        "a rejected request's unconsumed body is not parsed as the next request" in {
+            withEchoServer { (host, port) =>
+                val smuggled = "GET /marker HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                val headers  = s"POST /missing HTTP/1.1\r\nHost: localhost\r\nContent-Length: ${smuggled.length}\r\n\r\n"
+                // Two staged writes: headers first (the server answers 404), then the body in a later segment.
+                sendStaged(host, port, Seq(headers, smuggled)).map { response =>
+                    assert(
+                        !response.contains("SMUGGLED-MARKER"),
+                        s"the unconsumed body was reparsed and /marker was served:\n${response.take(300)}"
+                    )
+                }
+            }
+        }
+
+        // The same unconsumed-body class on the 413 path: an over-limit Content-Length is answered 413 WITHOUT
+        // reading the body, so reusing the connection would reparse that body. The server must close instead.
+        //
+        // Origin: the unconsumed-body-reinterpreted smuggling class on a rejected-by-size request (RFC 9112 section 9.3).
+        "a 413-rejected request's unconsumed body is not parsed as the next request" in {
+            val cfg = HttpServerConfig.default.port(0).host("localhost").maxContentLength(10)
+            HttpServer.init(cfg)(echoHandler, bodyHandler, markerHandler, streamHandler).map { server =>
+                val smuggled = "GET /marker HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                // Content-Length is the smuggled request length, well over the 10-byte limit, so the POST is 413'd.
+                val headers = s"POST /echo HTTP/1.1\r\nHost: localhost\r\nContent-Length: ${smuggled.length}\r\n\r\n"
+                sendStaged("localhost", server.port, Seq(headers, smuggled)).map { response =>
+                    assert(response.contains("413"), s"expected a 413, got:\n${response.take(300)}")
+                    assert(
+                        !response.contains("SMUGGLED-MARKER"),
+                        s"the unconsumed body after a 413 was reparsed and /marker was served:\n${response.take(300)}"
+                    )
+                }
+            }
+        }
+
+        // The same class on the invalid-Host path: multiple Host headers are answered 400 WITHOUT reading the
+        // declared body, so reusing the connection would reparse that body. The server must close instead.
+        //
+        // Origin: the unconsumed-body-reinterpreted smuggling class on a rejected-by-Host request (RFC 9112 section 9.3).
+        "an invalid-Host request's unconsumed body is not parsed as the next request" in {
+            withEchoServer { (host, port) =>
+                val smuggled = "GET /marker HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                val headers  = s"POST /echo HTTP/1.1\r\nHost: a\r\nHost: b\r\nContent-Length: ${smuggled.length}\r\n\r\n"
+                sendStaged(host, port, Seq(headers, smuggled)).map { response =>
+                    assert(response.contains("400"), s"expected a 400, got:\n${response.take(300)}")
+                    assert(
+                        !response.contains("SMUGGLED-MARKER"),
+                        s"the unconsumed body after a 400 was reparsed and /marker was served:\n${response.take(300)}"
+                    )
+                }
+            }
+        }
+
+        // No per-request state may cross a keep-alive connection boundary. Jetty CVE-2026-10051 (trailers not reset),
+        // CVE-2020-27218 / CVE-2024-13009 (body buffer not recycled), and CVE-2015-2080 (a prior request's parse
+        // buffer echoed) are all the same failure: a field left set from request A is read by request B on the same
+        // connection, so B is served with A's body, trailers, or bytes. Two pipelined POSTs with distinct bodies must
+        // each be answered with their OWN body.
+        "does not leak a request body into the next pipelined request (CVE-2026-10051, CVE-2020-27218)" in {
+            withEchoServer { (host, port) =>
+                val a = "POST /body HTTP/1.1\r\nHost: localhost\r\nContent-Length: 3\r\n\r\nAAA"
+                val b = "POST /body HTTP/1.1\r\nHost: localhost\r\nContent-Length: 3\r\n\r\nBBB"
+                // Both requests in one write, back to back on the same connection.
+                sendStaged(host, port, Seq(a + b)).map { response =>
+                    assert(response.contains("[AAA]"), s"the first body must be served, got:\n${response.take(300)}")
+                    assert(response.contains("[BBB]"), s"the second body must be served, got:\n${response.take(300)}")
+                    assert(
+                        !response.contains("[AAABBB]") && !response.contains("[AAABBB") && !response.contains("[BBBAAA"),
+                        s"a body leaked across the pipelined boundary:\n${response.take(300)}"
+                    )
+                }
+            }
+        }
+
+        // RFC 9112 section 9.4 / RFC 9110 section 9.3.2: a response to a HEAD request must not carry a message body.
+        // The streaming-response encoder writes Transfer-Encoding: chunked and the chunk data regardless of method,
+        // and the router maps HEAD to the GET handler, so a HEAD to a streaming route emits a body. A client that
+        // correctly treats HEAD as bodyless then reads those body bytes as the next response on a pooled connection.
+        // This asserts the HEAD response carries no body and therefore FAILS until the streaming encoder honors HEAD.
+        //
+        // Origin: the HEAD-with-body response-desync class (RFC 9112 section 9.4).
+        "a HEAD to a streaming route carries no body" in {
+            withEchoServer { (host, port) =>
+                sendStaged(host, port, Seq("HEAD /stream HTTP/1.1\r\nHost: localhost\r\n\r\n")).map { response =>
+                    assert(
+                        !response.contains("STREAM-BODY"),
+                        s"a HEAD response must carry no body, but the stream body was written:\n${response.take(300)}"
+                    )
+                }
+            }
+        }
+
+        // A HEAD to a BUFFERED route is Content-Length framed and carries no body. The encoder terminated it with the
+        // chunked last-chunk marker (0\r\n\r\n), which belongs only to a chunked response; those 5 bytes then read as
+        // the head of the next response on a pooled connection. The HEAD head plus its Content-Length fully frames the
+        // response, so no chunk terminator may appear. This asserts the pipelined GET after the HEAD is cleanly served.
+        //
+        // Origin: the HEAD-with-body response-desync class (RFC 9112 section 6.3 / 9.4).
+        "a HEAD to a buffered route writes no chunk terminator and leaves the connection framed" in {
+            withEchoServer { (host, port) =>
+                val head = "HEAD /marker HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                val get  = "GET /marker HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                sendStaged(host, port, Seq(head + get)).map { response =>
+                    // A spurious chunk terminator appears as a lone "0\r\n\r\n" after the head's blank line. (A plain
+                    // "0\r\n\r\n" substring also occurs inside "Content-Length: 0\r\n\r\n", so match the blank line too.)
+                    assert(
+                        !response.contains("\r\n\r\n0\r\n\r\n"),
+                        s"a HEAD response wrote a spurious chunk terminator:\n${response.take(300)}"
+                    )
+                    assert(
+                        response.contains("SMUGGLED-MARKER"),
+                        s"the pipelined GET after a HEAD must be served:\n${response.take(300)}"
+                    )
+                }
+            }
+        }
+
+        // An empty (no-body) response is Content-Length: 0 framed. The encoder terminated it with the chunked
+        // last-chunk marker (0\r\n\r\n), which desyncs the pipelined follow-up exactly as the HEAD case does. The
+        // Content-Length: 0 head fully frames the response, so no chunk terminator may appear.
+        //
+        // Origin: the empty-response chunk-terminator desync class (RFC 9112 section 6.3).
+        "an empty response writes no chunk terminator and leaves the connection framed" in {
+            withEchoServer { (host, port) =>
+                val empty = "GET /empty HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                val get   = "GET /marker HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                sendStaged(host, port, Seq(empty + get)).map { response =>
+                    // A spurious chunk terminator appears as a lone "0\r\n\r\n" after the head's blank line. (A plain
+                    // "0\r\n\r\n" substring also occurs inside "Content-Length: 0\r\n\r\n", so match the blank line too.)
+                    assert(
+                        !response.contains("\r\n\r\n0\r\n\r\n"),
+                        s"an empty response wrote a spurious chunk terminator:\n${response.take(300)}"
+                    )
+                    assert(
+                        response.contains("SMUGGLED-MARKER"),
+                        s"the pipelined GET after an empty response must be served:\n${response.take(300)}"
+                    )
                 }
             }
         }

--- a/kyo-http/shared/src/test/scala/kyo/HttpSecurityServerTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/HttpSecurityServerTest.scala
@@ -60,10 +60,12 @@ class HttpSecurityServerTest extends BaseHttpTest:
             }
         }
 
-    /** Send raw bytes over TCP to host:port and read the response as a string.
+    /** Send raw bytes over TCP to host:port and read the WHOLE response as a string, draining spans until the peer closes or a read
+      * finds no more data within the idle budget. The status line, headers and body can arrive in separate reads, so a single take
+      * would capture only the leading span.
       *
-      * Returns the response string, or empty string if the connection was closed or timed out (both indicate server rejection of the
-      * malformed request).
+      * Returns the concatenated response, or the empty string when the server answered nothing (a close or timeout with no bytes). An
+      * empty result is not by itself proof of rejection; `assertRejected` treats it as a failure, not a pass.
       */
     def sendRawBytes(host: String, port: Int, raw: Array[Byte])(using Frame): String < (Async & Abort[Any]) =
         Sync.Unsafe.defer {
@@ -74,23 +76,30 @@ class HttpSecurityServerTest extends BaseHttpTest:
                     val payload = Span.fromUnsafe(raw)
                     // Write the malicious request
                     Abort.run[Closed](conn.outbound.safe.put(payload)).map { _ =>
-                        // Give the server time to process and respond
-                        Async.sleep(500.millis).andThen {
-                            // Try to read the response; catch both Closed and Timeout
-                            Abort.run[Any](
-                                Async.timeout(2.seconds)(
-                                    Abort.run[Closed](conn.inbound.safe.take)
-                                )
-                            ).map { outerResult =>
-                                val response = outerResult match
+                        // Read the WHOLE response, not just the first span. The status line, headers and body can arrive in
+                        // separate reads (they reliably split on a loaded CI runner, coalesce locally), so a single take would
+                        // capture only the leading span and miss a body a later span carries. Drain spans until the peer closes
+                        // or a read finds no more data within the idle budget; the first read's longer budget covers the server's
+                        // processing latency, so no upfront fixed sleep is needed.
+                        def drain(acc: String, n: Int): String < (Async & Abort[Any]) =
+                            if n >= 64 then acc
+                            else
+                                // A generous first-read budget covers server latency; a shorter per-span idle budget bounds the tail
+                                // wait once bytes are flowing (only a keep-alive response with no close pays it). ISO-8859-1 is
+                                // byte-preserving, so concatenating per-span decodes can never corrupt a boundary the way a split
+                                // multibyte UTF-8 sequence would (matches sendStaged).
+                                val budget = if n == 0 then 2.seconds else 1.second
+                                Abort.run[Any](Async.timeout(budget)(Abort.run[Closed](conn.inbound.safe.take))).map {
                                     case Result.Success(Result.Success(data)) =>
-                                        new String(data.toArray, "UTF-8")
+                                        drain(acc + new String(data.toArray, "ISO-8859-1"), n + 1)
                                     case _ =>
-                                        // Closed, timed out, or other error — server rejected
-                                        ""
-                                Sync.Unsafe.defer(conn.close())
-                                    .andThen(response)
-                            }
+                                        // Peer close, idle timeout, or error: the response is complete. Empty acc means the
+                                        // server answered nothing (a close or timeout with no bytes), which assertRejected
+                                        // rejects as no proof of refusal.
+                                        acc
+                                }
+                        drain("", 0).map { response =>
+                            Sync.Unsafe.defer(conn.close()).andThen(response)
                         }
                     }
                 case _ => "" // connection failed
@@ -104,6 +113,12 @@ class HttpSecurityServerTest extends BaseHttpTest:
       * reason: a server that never started would pass every one of them. Requiring the status also pins the behavior that
       * makes silence unnecessary, since a peer that is refused is told so (RFC 9112 section 6.3) rather than left to infer
       * it from a disconnect after its own timeout expires.
+      *
+      * The check anchors on the FIRST status line (`startsWith`), not a substring `contains("400")`. `sendRawBytes` now drains
+      * the whole response, so a `contains` would pass on a later 400 too: exactly the smuggling failure these leaves guard, where
+      * a server that treats the malformed framing as bodyless answers 200 to the request and 400 to the reparsed leftover. Only a
+      * refusal answered as the FIRST response proves the request itself was rejected. This also closes the pre-existing hole where
+      * a `Content-Length: 400` (or any incidental "400") satisfied the substring.
       */
     def assertRejected(response: String, description: String)(using kyo.test.AssertScope): Unit =
         if response.isEmpty then
@@ -113,8 +128,8 @@ class HttpSecurityServerTest extends BaseHttpTest:
             )
         else
             assert(
-                response.contains("400"),
-                s"$description: expected 400 Bad Request, but got:\n${response.take(200)}"
+                response.startsWith("HTTP/1.1 400"),
+                s"$description: expected the first response to be 400 Bad Request, but got:\n${response.take(200)}"
             )
 
     "request smuggling defenses" - {

--- a/kyo-http/shared/src/test/scala/kyo/Rfc3986Test.scala
+++ b/kyo-http/shared/src/test/scala/kyo/Rfc3986Test.scala
@@ -50,6 +50,20 @@ class Rfc3986Test extends BaseHttpTest:
         assert(url.host == "host.com", s"Host should be 'host.com' after stripping userinfo, got: ${url.host}")
     }
 
+    // An ambiguous authority must not resolve to a host different from what a browser would connect to. Jetty
+    // CVE-2024-6763 parsed a host from a malformed authority that disagreed with the client's, defeating an allow/deny
+    // list keyed on the URL. Whatever host kyo picks (for a client connection), it must not be the attacker's suffix
+    // "evil.example": either the leading authority, or a rejection. This is the SSRF / wrong-host property.
+    "Section 3.2.2 - an ambiguous authority does not resolve to an attacker suffix (CVE-2024-6763)" in {
+        HttpUrl.parse("http://browser.check#@evil.example/") match
+            case Result.Success(url) =>
+                assert(
+                    url.host != "evil.example",
+                    s"the host must not be the attacker suffix after a '#', got: ${url.host}"
+                )
+            case _ => succeed("rejecting the ambiguous authority is acceptable")
+    }
+
     "Section 3.2.2 - Host case normalization" in {
         // RFC 3986 §3.2.2: "the host subcomponent is case-insensitive"
         val url = HttpUrl.parse("http://EXAMPLE.COM/path").getOrThrow

--- a/kyo-http/shared/src/test/scala/kyo/Rfc6265Test.scala
+++ b/kyo-http/shared/src/test/scala/kyo/Rfc6265Test.scala
@@ -66,6 +66,19 @@ class Rfc6265Test extends BaseHttpTest:
         assert(value.nonEmpty, s"DQUOTE-wrapped value should be parseable, got: $value")
     }
 
+    // A ';' inside a DQUOTE-wrapped cookie value must still delimit cookie-pairs. Jetty CVE-2023-26049 and Undertow
+    // CVE-2023-4639 read a value beginning with '"' to the closing quote and swallowed every ';' in between, so a
+    // later "JSESSIONID=..." pair was captured INSIDE the first value; an intermediary splitting on ';' and the
+    // server disagreed on the cookie boundaries, which exfiltrates an HttpOnly session cookie into a readable one.
+    "Section 4.2 - a quoted value does not swallow following cookies (CVE-2023-26049, CVE-2023-4639)" in {
+        val headers = HttpHeaders.empty.set("Cookie", "DISPLAY=\"a; JSESSIONID=secret; b=c\"")
+        val session = headers.cookie("JSESSIONID")
+        assert(
+            session == Present("secret"),
+            s"';' inside a quoted value must still delimit, so JSESSIONID must parse separately, got: $session"
+        )
+    }
+
     // ==================== Response Cookie Parsing (Set-Cookie) ====================
 
     "Section 4.1 - Response cookie with Max-Age attribute" in {
@@ -266,6 +279,129 @@ class Rfc6265Test extends BaseHttpTest:
                 val setCookies = resp.headers.getAll("Set-Cookie")
                 assert(setCookies.size >= 2, s"Should have at least 2 Set-Cookie headers, got: ${setCookies.size}")
             }
+        }
+    }
+
+    // ==================== Set-Cookie Attribute Injection ====================
+
+    // RFC 6265 section 4.1.1 makes ';' the delimiter BETWEEN attributes of a set-cookie-string, and excludes it (with ',',
+    // DQUOTE, backslash, whitespace and controls) from cookie-value. A serializer that concatenates a value in without
+    // enforcing that grammar lets whoever supplies the value write the ATTRIBUTES too, and cookie attributes are security
+    // decisions: Domain widens who receives the cookie, Path widens where it is sent, and a re-stated Secure or HttpOnly
+    // cannot be undone by the caller who believed it set them. Cookie values are routinely user-derived, which is what makes
+    // this an injection rather than a formatting quirk.
+    //
+    // The grammar defines no escape, so there is nothing to escape TO: rejection is the only representation-preserving
+    // answer, and these leaves assert a raise rather than a transformed string. Asserting on a rendered string would instead
+    // presuppose that some encoding exists, which is the assumption that produces silent corruption.
+
+    "Section 4.1.1 - cookie value carrying an attribute delimiter is rejected (GHSA-7qh7-rghh-698h)" in {
+        val ex = intercept[IllegalArgumentException] {
+            discard(HttpHeaders.serializeCookie("session", HttpCookie("x; Domain=evil.example")))
+        }
+        assert(ex.getMessage.contains("cookie value"), s"expected a cookie-value grammar failure, got: ${ex.getMessage}")
+    }
+
+    "Section 4.1.1 - cookie value carrying a flag attribute is rejected (GHSA-7qh7-rghh-698h)" in {
+        // The reverse direction of the same defect: injecting an attribute the caller deliberately left off.
+        val ex = intercept[IllegalArgumentException] {
+            discard(HttpHeaders.serializeCookie("session", HttpCookie("x; HttpOnly")))
+        }
+        assert(ex.getMessage.contains("cookie value"), s"expected a cookie-value grammar failure, got: ${ex.getMessage}")
+    }
+
+    "Section 4.1.1 - cookie value carrying CR or LF is rejected (GHSA-7qh7-rghh-698h)" in {
+        // CR/LF is header injection rather than attribute injection: it ends the field and starts another. RFC 9110
+        // section 5.5 forbids it in a field value outright. Caught here at the grammar rather than downstream, so one bad
+        // cookie is a failure at the call that built it instead of a torn response.
+        val ex = intercept[IllegalArgumentException] {
+            discard(HttpHeaders.serializeCookie("session", HttpCookie("x\r\nX-Injected: 1")))
+        }
+        assert(ex.getMessage.contains("cookie value"), s"expected a cookie-value grammar failure, got: ${ex.getMessage}")
+    }
+
+    "Section 4.1.1 - cookie name carrying an attribute delimiter is rejected (GHSA-7qh7-rghh-698h)" in {
+        // The name reaches the same buffer by the same path and is just as often caller-supplied.
+        val ex = intercept[IllegalArgumentException] {
+            discard(HttpHeaders.serializeCookie("session; Domain=evil.example", HttpCookie("v")))
+        }
+        assert(ex.getMessage.contains("cookie name"), s"expected a cookie-name grammar failure, got: ${ex.getMessage}")
+    }
+
+    "Section 4.1.1 - Domain attribute carrying a delimiter is rejected (GHSA-7qh7-rghh-698h)" in {
+        val ex = intercept[IllegalArgumentException] {
+            discard(HttpHeaders.serializeCookie("session", HttpCookie("v").domain("example.com; Path=/admin")))
+        }
+        assert(ex.getMessage.contains("Domain"), s"expected a Domain grammar failure, got: ${ex.getMessage}")
+    }
+
+    // Path is appended exactly as rawly as Domain, so a fix validating only Domain would leave this open.
+    "Section 4.1.1 - Path attribute carrying a delimiter is rejected (GHSA-7qh7-rghh-698h)" in {
+        val ex = intercept[IllegalArgumentException] {
+            discard(HttpHeaders.serializeCookie("session", HttpCookie("v").path("/app; Domain=evil.example")))
+        }
+        assert(ex.getMessage.contains("Path"), s"expected a Path grammar failure, got: ${ex.getMessage}")
+    }
+
+    // The over-strictness guard. Every leaf above asserts a refusal, so without this the grammar could be satisfied by
+    // refusing everything; an ordinary cookie with every attribute set must still render.
+    "Section 4.1.1 - an ordinary cookie with all attributes still renders" in {
+        val cookie = HttpCookie("abc123")
+            .maxAge(3600.seconds)
+            .domain("example.com")
+            .path("/app")
+            .secure(true)
+            .httpOnly(true)
+            .sameSite(HttpCookie.SameSite.Strict)
+        val s = HttpHeaders.serializeCookie("session", cookie)
+        assert(s == "session=abc123; Max-Age=3600; Domain=example.com; Path=/app; Secure; HttpOnly; SameSite=Strict", s"got: $s")
+    }
+
+    // The predicates the raise is paired with, so a caller holding content that may not qualify can test it and take
+    // its own path rather than relying on the exception. This is the isAscii/writeAscii pairing from GrowableByteBuffer.
+    //
+    // The leaf checks AGREEMENT rather than the predicates in isolation: a predicate that answered correctly but
+    // disagreed with what serialization actually accepts would be worse than none, since a caller would clear the check
+    // and then be raised on anyway. So each value is run through both.
+    "Section 4.1.1 - the cookie grammar predicates agree with what serialization accepts" in {
+        def serializes(value: String): Boolean =
+            try
+                discard(HttpHeaders.serializeCookie("session", HttpCookie(value)))
+                true
+            catch case _: IllegalArgumentException => false
+
+        val values = List("abc123", "x; HttpOnly", "x; Domain=evil.example", "", "a=b", "x\r\ny", "plain")
+        values.foreach { v =>
+            assert(
+                HttpHeaders.isValidCookieValue(v) == serializes(v),
+                s"predicate and serializer disagree on \"${v.replace("\r", "\\r").replace("\n", "\\n")}\""
+            )
+        }
+
+        def serializesName(name: String): Boolean =
+            try
+                discard(HttpHeaders.serializeCookie(name, HttpCookie("v")))
+                true
+            catch case _: IllegalArgumentException => false
+
+        List("session", "sess ion", "a;b", "", "x-y_z").foreach { n =>
+            assert(
+                HttpHeaders.isValidCookieName(n) == serializesName(n),
+                s"name predicate and serializer disagree on \"$n\""
+            )
+        }
+
+        def serializesPath(path: String): Boolean =
+            try
+                discard(HttpHeaders.serializeCookie("session", HttpCookie("v").path(path)))
+                true
+            catch case _: IllegalArgumentException => false
+
+        List("/app", "/app; Secure", "/", "/a\u0001b").foreach { a =>
+            assert(
+                HttpHeaders.isValidCookieAttribute(a) == serializesPath(a),
+                s"attribute predicate and serializer disagree on \"$a\""
+            )
         }
     }
 

--- a/kyo-http/shared/src/test/scala/kyo/internal/ChunkedBodyDecoderTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/ChunkedBodyDecoderTest.scala
@@ -27,7 +27,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
             "single chunk complete in one read" in {
                 val inbound = Channel.Unsafe.init[Span[Byte]](16)
                 val initial = spanOf("5\r\nhello\r\n0\r\n\r\n")
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(spanToString(body) == "hello")
                 }
@@ -36,7 +40,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
             "multiple chunks" in {
                 val inbound = Channel.Unsafe.init[Span[Byte]](16)
                 val initial = spanOf("3\r\nabc\r\n2\r\nde\r\n0\r\n\r\n")
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(spanToString(body) == "abcde")
                 }
@@ -47,7 +55,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
                 // First read contains only "5" (partial hex line), second completes it
                 val initial = spanOf("5")
                 discard(inbound.offer(spanOf("\r\nhello\r\n0\r\n\r\n")))
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(spanToString(body) == "hello")
                 }
@@ -57,7 +69,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
                 val inbound = Channel.Unsafe.init[Span[Byte]](16)
                 val initial = spanOf("5\r\nhel")
                 discard(inbound.offer(spanOf("lo\r\n0\r\n\r\n")))
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(spanToString(body) == "hello")
                 }
@@ -67,7 +83,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
                 val inbound = Channel.Unsafe.init[Span[Byte]](16)
                 val initial = spanOf("5\r\n")
                 discard(inbound.offer(spanOf("hello\r\n0\r\n\r\n")))
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(spanToString(body) == "hello")
                 }
@@ -76,7 +96,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
             "zero-length chunk terminates" in {
                 val inbound = Channel.Unsafe.init[Span[Byte]](16)
                 val initial = spanOf("0\r\n\r\n")
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(body.isEmpty)
                 }
@@ -85,16 +109,45 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
             "chunk extensions ignored" in {
                 val inbound = Channel.Unsafe.init[Span[Byte]](16)
                 val initial = spanOf("5;ext=val\r\nhello\r\n0\r\n\r\n")
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(spanToString(body) == "hello")
+                }
+            }
+
+            // RFC 9112 section 7.1.1: a chunk extension is token / quoted-string, and neither admits a bare CR or LF.
+            // Jetty CVE-2026-2332 and Netty CVE-2026-33870 both terminated the chunk-size line at the first CRLF
+            // without rejecting a CR embedded in the extension, so a quoted-string-aware front end read the line end
+            // at a different byte and the two disagreed on where the chunk data began, a smuggling desync. A decoder
+            // must refuse a chunk-size line whose extension carries a bare CR rather than frame the chunk from it.
+            "rejects a bare CR inside a chunk extension (CVE-2026-2332, CVE-2026-33870)" in {
+                val inbound = Channel.Unsafe.init[Span[Byte]](16)
+                // "5;a=" then a bare CR, then "b", then the real CRLF. The extension "a=<CR>b" is invalid.
+                val initial = spanOfBytes("5;a=\rb\r\nhello\r\n0\r\n\r\n".getBytes(StandardCharsets.ISO_8859_1))
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
+                    assert(
+                        result.isFailure,
+                        s"a chunk extension carrying a bare CR must be refused, but decoded: ${result.map(spanToString)}"
+                    )
                 }
             }
 
             "trailer headers after final chunk" in {
                 val inbound = Channel.Unsafe.init[Span[Byte]](16)
                 val initial = spanOf("5\r\nhello\r\n0\r\nTrailer: value\r\n\r\n")
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(spanToString(body) == "hello")
                 }
@@ -105,7 +158,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
                 val initial = spanOf("3\r\nabc\r\n")
                 discard(inbound.offer(spanOf("4\r\ndefg\r\n")))
                 discard(inbound.offer(spanOf("2\r\nhi\r\n0\r\n\r\n")))
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(spanToString(body) == "abcdefghi")
                 }
@@ -136,7 +193,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
                 java.lang.System.arraycopy(trailerBytes, 0, secondChunk, size - half, trailerBytes.length)
                 discard(inbound.offer(spanOfBytes(secondChunk)))
 
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(body.size == size)
                     // Verify all bytes are 'A'
@@ -148,7 +209,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
             "empty body (immediate terminal chunk)" in {
                 val inbound = Channel.Unsafe.init[Span[Byte]](16)
                 val initial = spanOf("0\r\n\r\n")
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(body.isEmpty)
                 }
@@ -158,7 +223,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
                 val inbound = Channel.Unsafe.init[Span[Byte]](16)
                 val initial = spanOf("5\r\nhel") // Partial chunk data
                 discard(inbound.close()) // Close the channel — next take will fail
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     assert(result.isFailure)
                 }
             }
@@ -166,13 +235,21 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
             "decoder reset between requests" in {
                 val inbound1 = Channel.Unsafe.init[Span[Byte]](16)
                 val initial1 = spanOf("5\r\nhello\r\n0\r\n\r\n")
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound1, initial1)).map { result1 =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound1,
+                    initial1,
+                    maxBytes = Int.MaxValue
+                )).map { result1 =>
                     assert(spanToString(result1.getOrThrow) == "hello")
 
                     // Second request with new state (readBuffered creates a fresh DecoderState)
                     val inbound2 = Channel.Unsafe.init[Span[Byte]](16)
                     val initial2 = spanOf("5\r\nworld\r\n0\r\n\r\n")
-                    Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound2, initial2)).map { result2 =>
+                    Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                        inbound2,
+                        initial2,
+                        maxBytes = Int.MaxValue
+                    )).map { result2 =>
                         assert(spanToString(result2.getOrThrow) == "world")
                     }
                 }
@@ -195,7 +272,11 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
                 val initial = spanOfBytes(java.util.Arrays.copyOfRange(bytes, 0, mid))
                 discard(inbound.offer(spanOfBytes(java.util.Arrays.copyOfRange(bytes, mid, mid * 2))))
                 discard(inbound.offer(spanOfBytes(java.util.Arrays.copyOfRange(bytes, mid * 2, bytes.length))))
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = spanToString(result.getOrThrow)
                     assert(body == data1 + data100 + data10k)
                 }
@@ -206,9 +287,29 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
                 // Split the CRLF after chunk data: \r at end of one read, \n at start of next
                 val initial = spanOf("5\r\nhello\r")
                 discard(inbound.offer(spanOf("\n0\r\n\r\n")))
-                Abort.run[Closed](ChunkedBodyDecoder.readBuffered(inbound, initial)).map { result =>
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = Int.MaxValue
+                )).map { result =>
                     val body = result.getOrThrow
                     assert(spanToString(body) == "hello")
+                }
+            }
+
+            // A chunked body has no declared length, so decoding into memory must be bounded (CWE-400). The buffered
+            // decoder aborts HttpPayloadTooLargeException once the accumulated decoded bytes exceed maxBytes.
+            "aborts HttpPayloadTooLargeException when the decoded body exceeds maxBytes (CWE-400)" in {
+                val inbound = Channel.Unsafe.init[Span[Byte]](16)
+                // Two 5-byte chunks decode to 10 bytes, over the 8-byte cap.
+                val initial = spanOf("5\r\nhello\r\n5\r\nworld\r\n0\r\n\r\n")
+                Abort.run[Closed | HttpPayloadTooLargeException | HttpMalformedBodyException](ChunkedBodyDecoder.readBuffered(
+                    inbound,
+                    initial,
+                    maxBytes = 8
+                )).map {
+                    case Result.Failure(_: HttpPayloadTooLargeException) => succeed
+                    case other => fail(s"expected HttpPayloadTooLargeException for a 10-byte body under an 8-byte cap, got $other")
                 }
             }
         }
@@ -220,7 +321,7 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
                 val output  = Channel.Unsafe.init[Span[Byte]](16)
                 val initial = spanOf("3\r\nabc\r\n2\r\nde\r\n0\r\n\r\n")
                 // Run decoder — it puts decoded chunks to output, then returns
-                ChunkedBodyDecoder.readStreaming(inbound, initial, output).map { _ =>
+                ChunkedBodyDecoder.readStreaming(inbound, initial, output, maxControlBytes = Int.MaxValue).map { _ =>
                     // Decoder completed — chunks should be in the output channel
                     val r1 = output.poll().getOrThrow // Result[Closed, Maybe[Span[Byte]]]
                     assert(r1.isDefined, "Expected chunk1")
@@ -231,6 +332,95 @@ class ChunkedBodyDecoderTest extends kyo.BaseHttpTest:
                     val r3 = output.poll().getOrThrow
                     assert(r3.isEmpty, "Expected no more chunks")
                 }
+            }
+
+            // The streaming control plane must be bounded even though the delivered body is not: a chunk-size line
+            // with an unterminated extension grows the decoder's internal buffer across reads without ever delivering
+            // a chunk (CWE-400). maxControlBytes bounds that undelivered control plane.
+            "rejects an oversized chunk control plane in streaming mode (CWE-400)" in {
+                val inbound = Channel.Unsafe.init[Span[Byte]](16)
+                val output  = Channel.Unsafe.init[Span[Byte]](16)
+                // "5;" then a 200000-byte extension and no terminating LF: the size line never completes.
+                val initial = spanOf("5;" + ("a" * 200000))
+                Abort.run[Closed | HttpMalformedBodyException | HttpPayloadTooLargeException](
+                    ChunkedBodyDecoder.readStreaming(inbound, initial, output, maxControlBytes = 64)
+                ).map {
+                    case Result.Failure(_: HttpPayloadTooLargeException) => succeed
+                    case other => fail(s"expected HttpPayloadTooLargeException for an oversized control plane, got $other")
+                }
+            }
+
+            // The delivered body is NOT capped by maxControlBytes: a body whose total decoded size far exceeds the
+            // control-plane bound, but whose per-chunk control bytes are tiny, must stream to completion. This guards
+            // against capping cumulative delivered bytes (which would reject a legitimately large streaming body).
+            "streams a body larger than maxControlBytes (delivered bytes are not capped)" in {
+                val inbound = Channel.Unsafe.init[Span[Byte]](16)
+                val output  = Channel.Unsafe.init[Span[Byte]](32)
+                // Ten 10-byte chunks decode to 100 bytes, far over the 16-byte control cap, but each size line is tiny.
+                val body    = (1 to 10).map(_ => "a\r\n0123456789\r\n").mkString + "0\r\n\r\n"
+                val initial = spanOf(body)
+                Abort.run[Closed | HttpMalformedBodyException | HttpPayloadTooLargeException](
+                    ChunkedBodyDecoder.readStreaming(inbound, initial, output, maxControlBytes = 16)
+                ).map {
+                    case Result.Success(_) =>
+                        var total = 0
+                        var done  = false
+                        while !done do
+                            output.poll().getOrThrow match
+                                case Present(span) => total += span.size
+                                case Absent        => done = true
+                        end while
+                        assert(total == 100, s"all 100 delivered bytes must stream despite the 16-byte control cap, got $total")
+                    case other => fail(s"a large streaming body under the per-chunk control cap must stream, got $other")
+                }
+            }
+        }
+
+        // Resource bounds on the chunk CONTROL bytes, not just the decoded body. The maxBytes cap in the buffered
+        // loop is checked against the decoded accumulator, but the chunk-size line (including its extension) and the
+        // trailer section are accumulated in separate internal buffers that maxBytes never sees. An attacker who
+        // streams control bytes that never complete a data chunk grows those buffers without bound while the
+        // accumulator stays at zero, so onTooLarge never fires. These leaves assert the secure behavior (the cap must
+        // fire) and therefore FAIL until the control-plane buffers are bounded.
+        //
+        // Origin: Node CVE-2024-22019 (unbounded chunk extension), Go CVE-2023-39326 (chunk non-data overhead),
+        // Tomcat CVE-2012-3544 / CVE-2023-46589 (unbounded chunk extension / trailer).
+        "resource bounds" - {
+
+            "rejects a chunk-size line whose extension exceeds maxBytes" in {
+                // "5;" then a 200000-byte extension and no terminating LF. No data chunk completes, so the decoded
+                // accumulator stays empty and the accumulator-based cap cannot fire; the extension is buffered whole.
+                val inbound  = Channel.Unsafe.init[Span[Byte]](16)
+                val initial  = spanOf("5;" + ("a" * 200000))
+                var tooLarge = false
+                var resulted = false
+                ChunkedBodyDecoder.readBufferedUnsafe(inbound, initial, maxBytes = 64)(
+                    onResult = _ => resulted = true,
+                    onTooLarge = _ => tooLarge = true,
+                    onInvalid = _ => ()
+                )
+                assert(
+                    tooLarge,
+                    s"a ${200002}-byte chunk-size line under a 64-byte cap must be refused, but onTooLarge did not fire (resulted=$resulted)"
+                )
+            }
+
+            "rejects a trailer section that exceeds maxBytes" in {
+                // After the terminal "0\r\n", an endless trailer run with no closing empty line. The body is complete
+                // and empty, so the accumulator stays at zero and the cap cannot fire; the trailer is buffered whole.
+                val inbound  = Channel.Unsafe.init[Span[Byte]](16)
+                val initial  = spanOf("0\r\nX-Pad: " + ("a" * 200000))
+                var tooLarge = false
+                var resulted = false
+                ChunkedBodyDecoder.readBufferedUnsafe(inbound, initial, maxBytes = 64)(
+                    onResult = _ => resulted = true,
+                    onTooLarge = _ => tooLarge = true,
+                    onInvalid = _ => ()
+                )
+                assert(
+                    tooLarge,
+                    s"a ${200007}-byte trailer section under a 64-byte cap must be refused, but onTooLarge did not fire (resulted=$resulted)"
+                )
             }
         }
     }

--- a/kyo-http/shared/src/test/scala/kyo/internal/HeaderTokensTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/HeaderTokensTest.scala
@@ -1,0 +1,111 @@
+package kyo.internal
+
+import java.nio.charset.StandardCharsets
+import kyo.*
+import kyo.internal.http1.*
+
+/** Unit coverage for the field-value matching the parsers route every framing and connection decision through.
+  *
+  * These matter out of proportion to their size: a comparison that is one byte too generous turns "chunkedfoo" into chunked framing, and
+  * one that is one byte too strict refuses conformant traffic. Both directions are pinned here, on the helper itself, so a defect is
+  * located at the comparison rather than inferred from a parser leaf three layers up.
+  *
+  * Origin: GHSA-jrpm-956j-96jg.
+  */
+class HeaderTokensTest extends kyo.BaseHttpTest:
+
+    private def b(s: String): Array[Byte] = s.getBytes(StandardCharsets.US_ASCII)
+
+    /** Runs `f` against `s` embedded in a larger buffer, so any off-by-one reads a neighbouring byte rather than running off the end. */
+    private def embedded(s: String)(f: (Array[Byte], Int, Int) => Boolean): Boolean =
+        val padded = b("####" + s + "####")
+        f(padded, 4, s.length)
+
+    "nameEquals" - {
+        "matches a whole name" in {
+            assert(embedded("Content-Length")(HeaderTokens.nameEquals(_, _, _, "Content-Length")))
+        }
+        "is case-insensitive" in {
+            assert(embedded("cOnTeNt-LeNgTh")(HeaderTokens.nameEquals(_, _, _, "Content-Length")))
+        }
+        // The defect this whole helper exists for: a comparison that stops at the target's length.
+        "does not match a longer name by prefix" in {
+            assert(!embedded("Content-Lengthx")(HeaderTokens.nameEquals(_, _, _, "Content-Length")))
+        }
+        "does not match a shorter name" in {
+            assert(!embedded("Content-Lengt")(HeaderTokens.nameEquals(_, _, _, "Content-Length")))
+        }
+        // A name is a token and cannot carry OWS, so trimming here would accept what the grammar rejects.
+        "does not trim whitespace" in {
+            assert(!embedded("Content-Length ")(HeaderTokens.nameEquals(_, _, _, "Content-Length")))
+        }
+        "does not match an empty name" in {
+            assert(!embedded("")(HeaderTokens.nameEquals(_, _, _, "Content-Length")))
+        }
+    }
+
+    "listContainsToken" - {
+        "finds a sole element" in {
+            assert(embedded("upgrade")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+        }
+        "finds an element in any position" in {
+            assert(embedded("keep-alive, Upgrade")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+            assert(embedded("Upgrade, keep-alive")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+            assert(embedded("a, upgrade, b")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+        }
+        // The substring defect: "no-upgrade" is a token whose meaning is the refusal, and it CONTAINS "upgrade".
+        "does not match a token that merely contains the target" in {
+            assert(!embedded("no-upgrade")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+            assert(!embedded("upgraded")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+        }
+        "tolerates empty elements" in {
+            assert(embedded("upgrade,")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+            assert(embedded(",upgrade")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+            assert(embedded("a,,upgrade")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+        }
+        "does not match an empty list" in {
+            assert(!embedded("")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+            assert(!embedded(",,")(HeaderTokens.listContainsToken(_, _, _, "upgrade")))
+        }
+    }
+
+    "isSoleChunkedCoding" - {
+        "accepts the sole token" in {
+            assert(embedded("chunked")(HeaderTokens.isSoleChunkedCoding(_, _, _)))
+        }
+        // RFC 9110 section 5.6.1 permits empty list elements, so these still name exactly one coding.
+        "accepts empty list elements around it" in {
+            assert(embedded("chunked,")(HeaderTokens.isSoleChunkedCoding(_, _, _)))
+            assert(embedded(", chunked")(HeaderTokens.isSoleChunkedCoding(_, _, _)))
+        }
+        // A second real coding is what makes the body length undeterminable, whichever side of chunked it sits on.
+        "rejects any second coding" in {
+            assert(!embedded("chunked, gzip")(HeaderTokens.isSoleChunkedCoding(_, _, _)))
+            assert(!embedded("gzip, chunked")(HeaderTokens.isSoleChunkedCoding(_, _, _)))
+        }
+        "rejects a prefix of the token" in {
+            assert(!embedded("chunkedfoo")(HeaderTokens.isSoleChunkedCoding(_, _, _)))
+        }
+        "rejects an empty value" in {
+            assert(!embedded("")(HeaderTokens.isSoleChunkedCoding(_, _, _)))
+        }
+    }
+
+    "finalCodingIsChunked" - {
+        // RFC 9112 section 6.1 makes the FINAL coding the one that decides chunk framing on a response.
+        "accepts chunked as the final coding" in {
+            assert(embedded("chunked")(HeaderTokens.finalCodingIsChunked(_, _, _)))
+            assert(embedded("gzip, chunked")(HeaderTokens.finalCodingIsChunked(_, _, _)))
+        }
+        "rejects chunked in a non-final position" in {
+            assert(!embedded("chunked, gzip")(HeaderTokens.finalCodingIsChunked(_, _, _)))
+        }
+        "rejects a prefix of the token" in {
+            assert(!embedded("chunkedfoo")(HeaderTokens.finalCodingIsChunked(_, _, _)))
+        }
+        "rejects an empty value" in {
+            assert(!embedded("")(HeaderTokens.finalCodingIsChunked(_, _, _)))
+        }
+    }
+
+end HeaderTokensTest

--- a/kyo-http/shared/src/test/scala/kyo/internal/Http1ParserTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/Http1ParserTest.scala
@@ -68,6 +68,17 @@ class Http1ParserTest extends kyo.BaseHttpTest:
             assert(req.isKeepAlive)
         }
 
+        // RFC 9110 section 8.6: Content-Length is 1*DIGIT. A leading '+' is not a digit, so "Content-Length: +13"
+        // is invalid and must be refused. Jetty CVE-2023-40167 accepted it, which a peer that rejects it disagrees
+        // with about whether the message even has a determinable length.
+        "rejects a Content-Length with a leading plus (CVE-2023-40167)" in {
+            val req = parseRequest("POST /submit HTTP/1.1\r\nHost: example.com\r\nContent-Length: +13\r\n\r\n")
+            assert(
+                req == null || req.contentLength < 0,
+                s"a non-digit Content-Length must be refused, got contentLength=${if req == null then "n/a" else req.contentLength}"
+            )
+        }
+
         "parse chunked request" in {
             val req = parseRequest(
                 "POST /upload HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n"
@@ -236,12 +247,11 @@ class Http1ParserTest extends kyo.BaseHttpTest:
         }
 
         "case sensitive method - non-standard lowercase" in {
-            // HTTP methods are case-sensitive per RFC 9110
-            // "get" is not a standard method, so it maps to GET ordinal 0 as fallback
+            // HTTP methods are case-sensitive (RFC 9110 section 9.1), so "get" is not the method "GET". This used to be
+            // accepted and coerced to GET via an ordinal-0 fallback, which served the request as a method the client did
+            // not send. It is now refused; see the request-line validation leaves below.
             val req = parseRequest("get / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-            assert(req != null)
-            // ordinalFromName returns 0 (GET) as default for unknown methods
-            assert(req.method == HttpMethod.GET)
+            assert(req == null, "a lowercase method token is not a known method and must be refused, not coerced to GET")
         }
 
         "parse PUT method" in {
@@ -422,6 +432,503 @@ class Http1ParserTest extends kyo.BaseHttpTest:
             assert(req.headerCount == 2)
             assert(req.headerName(1) == name)
             assert(req.headerValue(1) == "ok")
+        }
+
+        // Path traversal. The splitter divides on the literal byte '/', so an ENCODED separator does not split, and a
+        // consumer that decodes a segment afterwards recovers structure the splitter never agreed to. These leaves are
+        // at the parser because that is where the request is turned into segments: a check further down cannot restore
+        // a distinction the segmentation already destroyed.
+        //
+        // The stakes are a handler joining a capture onto a base directory, which is what Capture.Rest is documented
+        // for. Two spellings both reach it, and one needs no encoding at all.
+
+        // An encoded separator inside a segment is legitimate on BOTH capture kinds, and that is a contract, not an
+        // oversight: the client percent-encodes a named capture (RouteUtil appends URLEncoder.encode), so a value of
+        // "hello/world" travels as "hello%2Fworld" and must come back intact, and it appends a rest capture raw. So a
+        // capture value may contain a path separator, and the parser does not refuse one.
+        //
+        // The consequence is stated plainly because it decides where the defense can live: a capture is request-supplied
+        // DATA, not a safe path fragment, and a handler resolving one against a directory must validate it exactly as it
+        // would any other untrusted string. No parser rule can substitute for that while "hello/world" remains a legal
+        // capture value.
+        "keeps an encoded separator inside a single segment (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /items/hello%2Fworld HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null, "an encoded separator is valid inside a segment")
+            assert(req.pathSegmentCount == 2, s"it must not split the segment, got ${req.pathSegmentCount}")
+            assert(req.pathSegmentAsStringDecoded(1) == "hello/world", s"got \"${req.pathSegmentAsStringDecoded(1)}\"")
+        }
+
+        // Both capture kinds must answer the same way for the same bytes. An earlier attempt re-encoded separators in
+        // the rest join only, which forked the contract by route shape: the same segment decoded one way for a named
+        // capture and another for a rest capture, so a rule proven on one said nothing about the other.
+        "resolves a segment identically for a named capture and a rest capture (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /files/a%2Fb HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null)
+            assert(
+                req.pathSegmentAsStringDecoded(1) == req.restPathAsString(1),
+                s"named gave \"${req.pathSegmentAsStringDecoded(1)}\", rest gave \"${req.restPathAsString(1)}\""
+            )
+        }
+
+        // Decoding must be injective: two different request lines must not collapse to one capture value. The
+        // re-encoding attempt above broke exactly this, mapping both "a%252Fb" and "a%2Fb" onto "a%2Fb", so a handler
+        // could no longer tell a literal "%2F" in a value from an encoded slash.
+        "decodes distinct escapes to distinct values (GHSA-crq5-92j2-j7wv)" in {
+            val once  = parseRequest("GET /files/a%2Fb HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            val twice = parseRequest("GET /files/a%252Fb HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(once != null && twice != null)
+            assert(
+                once.restPathAsString(1) != twice.restPathAsString(1),
+                s"\"a%2Fb\" and \"a%252Fb\" both decoded to \"${once.restPathAsString(1)}\""
+            )
+            assert(twice.restPathAsString(1) == "a%2Fb", s"got \"${twice.restPathAsString(1)}\"")
+        }
+
+        // Routing and reporting must not disagree. Dot segments are resolved before routing, so the stored path is
+        // rewritten to match: otherwise the request routes on "admin/secret" while req.url.path, every filter and every
+        // log line read "/public/../admin/secret". Two recipients acting on different views of one message is the same
+        // disagreement this parser refuses in framing.
+        "reports the same path it routed on after resolving dot segments (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /public/../admin/secret HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null)
+            assert(req.restPathAsString(0) == "admin/secret", s"routed on \"${req.restPathAsString(0)}\"")
+            assert(req.pathAsString == "/admin/secret", s"but reported \"${req.pathAsString}\"")
+        }
+
+        // The empty-segment spelling of the same disagreement. An empty segment is dropped from the segment list just as
+        // a dot segment is, so "/a//b" routes on [a, b]; reporting the raw path would again name a different resource
+        // than the one served. RFC 3986 makes "//" and "/" different paths, so this is not a cosmetic difference.
+        "reports the same path it routed on after dropping empty segments (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /a//b HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null)
+            assert(req.pathSegmentCount == 2, s"expected 2 segments, got ${req.pathSegmentCount}")
+            assert(req.pathAsString == "/a/b", s"routed on a/b but reported \"${req.pathAsString}\"")
+        }
+
+        // The degenerate case: "//" is all empty segments, so it routes to the root and must say so.
+        "reports the root after a path of only separators (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET // HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null)
+            assert(req.pathSegmentCount == 0, s"expected 0 segments, got ${req.pathSegmentCount}")
+            assert(req.pathAsString == "/", s"routed to the root but reported \"${req.pathAsString}\"")
+        }
+
+        // The over-strictness control for the rewrite: a path with no dot segments must be reported byte-for-byte as
+        // sent, since rewriting it would be both wasteful and a change nobody asked for.
+        "leaves an ordinary path untouched (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /a/b/c HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null)
+            assert(req.pathAsString == "/a/b/c", s"got \"${req.pathAsString}\"")
+        }
+
+        // The unencoded spelling. It needs no cleverness, it is the plain form of the same attack, and resolving it
+        // (RFC 3986 section 5.2.4) is what a URI reference means: "/files/../../etc/passwd" addresses "/etc/passwd".
+        // Resolution happens before routing so the route that matches is the route for the path actually addressed,
+        // and a ".." with nothing left to pop cannot walk above the root.
+        "resolves unencoded dot-dot segments rather than passing them on (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /files/../../etc/passwd HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null, "a path carrying dot segments is resolvable, not malformed")
+            assert(req.pathSegmentCount == 2, s"expected the traversal to resolve to 2 segments, got ${req.pathSegmentCount}")
+            assert(req.restPathAsString(0) == "etc/passwd", s"expected \"etc/passwd\", got \"${req.restPathAsString(0)}\"")
+        }
+
+        // A path parameter next to a dot segment must not open a traversal. Jetty CVE-2026-8384 left a real ".."
+        // beside a ";" UNRESOLVED (a downstream then traversed), and Undertow CVE-2024-1459 STRIPPED the ";" to
+        // collapse "/..;/" into "/.." and traversed. The safe position between the two: resolve a genuine ".."
+        // segment, and treat "..;" (which RFC 3986 section 3.3 makes an ordinary pchar segment, NOT a dot segment)
+        // as the literal directory name it is, so neither spelling escapes.
+        "a path parameter beside a dot segment does not open a traversal (CVE-2026-8384, CVE-2024-1459)" in {
+            // A real ".." segment, with a ";" on the PRECEDING segment: split on "/", so ".." is its own segment and
+            // must resolve, popping "public;".
+            val a = parseRequest("GET /public;/../admin/secret HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(a != null, "the request is well-formed")
+            assert(a.restPathAsString(0) == "admin/secret", s"the '..' beside a path parameter must resolve, got: ${a.restPathAsString(0)}")
+
+            // "..;" is one segment and is not the dot segment "..", so it is kept literal, not stripped to "..".
+            val b = parseRequest("GET /files/..;/etc HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(b != null)
+            assert(
+                b.pathSegmentAsString(1) == "..;",
+                s"\"..;\" must stay a literal segment, not be stripped to a traversal, got: ${b.pathSegmentAsString(1)}"
+            )
+        }
+
+        // A ';' is an ordinary path character (RFC 3986 section 3.3 pchar), so a segment carrying one is neither split
+        // nor stripped: "/a;b/c" is the two segments "a;b" and "c". Stripping the ';' (matrix-parameter handling) is
+        // what let Undertow CVE-2020-1757 route differently from what the security layer matched.
+        "keeps a path parameter as part of its segment (CVE-2020-1757)" in {
+            val req = parseRequest("GET /a;b/c HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null)
+            assert(req.pathSegmentCount == 2, s"expected 2 segments, got ${req.pathSegmentCount}")
+            assert(req.pathSegmentAsString(0) == "a;b", s"the ';' must stay part of the segment, got \"${req.pathSegmentAsString(0)}\"")
+        }
+
+        // RFC 9112 section 2.2 permits skipping at most one empty line before the request line; it does not permit
+        // skipping control bytes. Netty CVE-2026-50020 accepted leading NUL/control bytes before the request line
+        // (SKIP_CONTROL_CHARS over all 256 values), so "\x00\x00GET /..." was served as a request a strict front end
+        // would frame differently, a smuggling desync.
+        "rejects control bytes before the request line (CVE-2026-50020)" in {
+            val req = parseRequest("  GET /admin HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req == null, "leading control bytes before the request line must be refused, not skipped")
+        }
+
+        // RFC 9112 section 2.2: the only line terminator is CRLF. Undertow CVE-2026-28367 accepted three bare CRs as
+        // the end-of-headers terminator where a strict front end requires CRLF CRLF, splitting the message. kyo
+        // rejects any bare CR in the header block; this pins that the triple-CR terminator does not slip through.
+        "rejects a bare-CR run as a header terminator (CVE-2026-28367)" in {
+            val req = parseRequest("GET / HTTP/1.1\r\nHost: localhost\r\r\r\n\r\n")
+            assert(req == null, "a bare CR is not a line terminator and must be refused")
+        }
+
+        // The same resolution must apply to the ENCODED spelling of the dots, or "%2e%2e" becomes a way to smuggle a
+        // dot segment past a check that only looked at the raw bytes.
+        "resolves encoded dot-dot segments identically (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /files/%2e%2e/data HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null, "encoded dots are still dot segments, not malformed input")
+            assert(req.pathSegmentCount == 1, s"expected the traversal to resolve to 1 segment, got ${req.pathSegmentCount}")
+            assert(req.restPathAsString(0) == "data", s"expected \"data\", got \"${req.restPathAsString(0)}\"")
+        }
+
+        // A single dot addresses the segment it sits in, so it contributes nothing.
+        "drops single-dot segments (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /a/./b HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null)
+            assert(req.restPathAsString(0) == "a/b", s"expected \"a/b\", got \"${req.restPathAsString(0)}\"")
+        }
+
+        // A NUL truncates a path in any consumer that hands it to a C API, so the bytes after it stop being part of
+        // the name being checked while remaining part of the name being used.
+        "rejects an encoded NUL in a path segment (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /files/a%00b HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req == null, "a NUL byte in a path segment must be rejected")
+        }
+
+        // RFC 3986 section 2.1 requires two hex digits after '%'. Beyond being malformed, this is the case that used
+        // to raise from request dispatch, where nothing catches it.
+        "rejects a malformed percent-escape in a path (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /files/%zz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req == null, "an escape without two hex digits is malformed and must be rejected, not raised later")
+        }
+
+        "rejects a truncated percent-escape at the end of a path (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /files/abc% HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req == null, "a '%' with no hex digits after it is malformed")
+        }
+
+        // The over-strictness guard: ordinary percent-encoding must still decode. Without this the rules above could
+        // be satisfied by refusing every escape, which would break any path carrying a space or a non-ASCII character.
+        "still decodes ordinary percent-escapes in a path segment (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /files/John%20Doe HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null, "a well-formed escape must parse")
+            assert(req.pathSegmentAsStringDecoded(1) == "John Doe", s"got \"${req.pathSegmentAsStringDecoded(1)}\"")
+        }
+
+        // '+' is a space in a QUERY (RFC 3986 section 3.4) and an ordinary character in a PATH. Decoding it as a space
+        // here would rename the resource being addressed.
+        "does not decode '+' as a space in a path segment (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /files/a+b HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null)
+            assert(req.pathSegmentAsStringDecoded(1) == "a+b", s"'+' is literal in a path, got \"${req.pathSegmentAsStringDecoded(1)}\"")
+        }
+
+        // The same value with an escape elsewhere in it. This pins that the '+' rule does not depend on whether the
+        // segment happens to contain a '%', which is how the previous decoder disagreed with itself.
+        "treats '+' the same whether or not the segment carries an escape (GHSA-crq5-92j2-j7wv)" in {
+            val req = parseRequest("GET /files/a+b%20c HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req != null)
+            assert(req.pathSegmentAsStringDecoded(1) == "a+b c", s"got \"${req.pathSegmentAsStringDecoded(1)}\"")
+        }
+
+        // Upgrade and Expect are LISTS (RFC 9110 sections 7.8 and 10.1.1), so a client naming a fallback still names
+        // the first protocol. Tightening the old prefix match to a whole-VALUE match traded a too-loose test for a
+        // too-strict one and silently refused every such client; these pin the middle.
+        "Upgrade offers websocket even when other protocols follow (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket, h2c\r\n\r\n")
+            assert(req != null)
+            assert(req.isUpgrade, "\"websocket, h2c\" names websocket as a list element and must signal an upgrade")
+        }
+
+        "Expect asks for 100-continue even when other expectations follow (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("POST /u HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nExpect: 100-continue, foo\r\n\r\n")
+            assert(req != null)
+            assert(req.expectContinue, "\"100-continue, foo\" names 100-continue as a list element")
+        }
+
+        // RFC 9110 section 5.6.1 permits empty list elements, so a trailing comma names exactly one coding. Refusing it
+        // would reject a conformant request in the name of a smuggling defense that does not apply to it.
+        "Transfer-Encoding: chunked with a trailing comma is still sole chunked (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("POST /u HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked,\r\n\r\n")
+            assert(req != null, "an empty list element is legal and must not make the request invalid")
+            assert(req.isChunked, "the sole non-empty coding is chunked")
+        }
+
+        // The packed layout addresses the raw buffer with 16-bit offsets, so once that buffer passes 65535 bytes an
+        // offset wraps and a header name or value resolves to some other window of the buffer entirely: request-supplied
+        // bytes, at a request-influenced offset, presented as a header the client never sent, while the headers that
+        // were sent silently vanish. That is header smuggling with no malformed byte anywhere in the request.
+        //
+        // Resolving a dot segment used to make this reachable at the DEFAULT header size, because the resolved path was
+        // appended as a third copy on top of the raw path and the segments. The path is now stored once, and the
+        // overflow itself is refused rather than wrapped.
+        "refuses a request whose offsets cannot be represented" in {
+            val long = "b" * 22000
+            val req  = parseRequest(s"GET /$long/junk/../x HTTP/1.1\r\nHost: localhost\r\nX-Probe: sentinel\r\n\r\n")
+            if req != null then
+                assert(req.headerCount == 2, s"expected the two headers sent, got ${req.headerCount}")
+                assert(req.headerName(0) == "Host", s"header 0 resolved to \"${req.headerName(0)}\"")
+                assert(req.headerValue(0) == "localhost", s"Host resolved to \"${req.headerValue(0)}\"")
+                assert(req.headerName(1) == "X-Probe", s"header 1 resolved to \"${req.headerName(1)}\"")
+                assert(req.headerValue(1) == "sentinel", s"X-Probe resolved to \"${req.headerValue(1)}\"")
+            else succeed("refusing the request outright is the other acceptable answer")
+            end if
+        }
+
+        // The same length WITHOUT a dot segment, which stores one fewer copy and so must still parse cleanly. This is
+        // the control that stops the guard above from being satisfied by refusing every long path.
+        "still parses a long path that needs no resolution" in {
+            val long = "b" * 22000
+            val req  = parseRequest(s"GET /$long/junk/x HTTP/1.1\r\nHost: localhost\r\nX-Probe: sentinel\r\n\r\n")
+            assert(req != null, "a long but representable request must parse")
+            assert(req.headerValue(0) == "localhost", s"Host resolved to \"${req.headerValue(0)}\"")
+            assert(req.headerValue(1) == "sentinel", s"X-Probe resolved to \"${req.headerValue(1)}\"")
+        }
+
+        // Request-line validation. A request line that does not parse must be REFUSED, not repaired. Every failure
+        // branch below used to fall through silently, leaving the builder at its defaults: method ordinal 0, which is
+        // GET, and no path at all, which routes to the root. So a request no conforming server would accept was served,
+        // as a DIFFERENT request than the one sent.
+        //
+        // That is a desync with an access-control edge: a front end applying a rule to "BREW /admin" or to "/admin"
+        // forwards something this server then serves as "GET /". One request, two recipients, two different resources.
+
+        // RFC 9110 section 9.1: the method token is case-SENSITIVE. "get" is not "GET", and coercing it to GET means
+        // the request served is not the request sent.
+        "rejects a lowercase method" in {
+            val req = parseRequest("get /admin HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req == null, "a method token is case-sensitive, so \"get\" is not a known method")
+        }
+
+        // An unrecognized method must be refused rather than silently become GET, which is what the ordinal fallback
+        // did. This is the leaf with the clearest access-control consequence.
+        "rejects an unknown method" in {
+            val req = parseRequest("BREW /admin HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req == null, "an unknown method must not be coerced into GET")
+        }
+
+        // RFC 9112 section 3: request-line = method SP request-target SP HTTP-version. A tab is not SP.
+        "rejects tabs in place of the request-line spaces" in {
+            val req = parseRequest("GET\t/admin\tHTTP/1.1\r\nHost: localhost\r\n\r\n")
+            assert(req == null, "only SP separates the request-line tokens")
+        }
+
+        // RFC 9112 section 2.3: a server should not accept the HTTP/0.9 request line, and accepting it here dropped
+        // the target entirely rather than honoring it.
+        "rejects a request line with no HTTP version" in {
+            val req = parseRequest("GET /admin\r\nHost: localhost\r\n\r\n")
+            assert(req == null, "a request line without a version is not a valid HTTP/1.x request line")
+        }
+
+        "rejects an empty request line" in {
+            val req = parseRequest("\r\nHost: localhost\r\n\r\n")
+            assert(req == null, "an empty request line has no method, target or version")
+        }
+
+        "rejects a request line carrying only a method" in {
+            val req = parseRequest("GET\r\nHost: localhost\r\n\r\n")
+            assert(req == null, "a request line needs a target and a version")
+        }
+
+        // The over-strictness control: the ordinary request line must still parse, with its target intact. Without
+        // this, every leaf above could be satisfied by refusing everything.
+        "still parses an ordinary request line" in {
+            val req = parseRequest("POST /admin/x?q=1 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n")
+            assert(req != null, "a well-formed request line must parse")
+            assert(req.method == HttpMethod.POST, s"method was ${req.method.name}")
+            assert(req.pathAsString == "/admin/x", s"path was \"${req.pathAsString}\"")
+            assert(req.hasQuery, "the query must survive")
+        }
+
+        // Absolute-form request target (RFC 9112 section 3.2.2): a server MUST accept "GET http://host/path HTTP/1.1"
+        // and route on its PATH, with the authority taken from the request target (which takes precedence over Host).
+        // The scheme "http://authority" prefix is fed straight to the path splitter, which splits on '/', so the
+        // authority becomes path segments and the effective path is mangled to "/http:/evil.example/admin". The routed
+        // path is then neither "/admin" (what the target names) nor a rejection, so a front end applying an ACL to the
+        // real path and kyo route on different paths. A recipient must either parse the authority out and route on
+        // "/admin", or reject absolute-form; mangling it is neither.
+        "handles an absolute-form request target (RFC 9112 section 3.2.2, CVE-2026-59900)" in {
+            val req = parseRequest("GET http://evil.example/admin HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            if req == null then succeed("rejecting absolute-form is an acceptable resolution")
+            else
+                assert(
+                    req.pathAsString == "/admin",
+                    s"absolute-form must route on its path, not a mangled authority-in-path, got: ${req.pathAsString}"
+                )
+            end if
+        }
+
+        // An absolute-form target with a query: the authority is skipped and the path/query split still applies, so the
+        // path is "/search" and the query survives (RFC 9112 section 3.2.2).
+        "handles an absolute-form request target with a query" in {
+            val req = parseRequest("GET http://evil.example/search?q=1 HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            if req == null then succeed("rejecting absolute-form is an acceptable resolution")
+            else
+                assert(req.pathAsString == "/search", s"path must be /search, got: ${req.pathAsString}")
+                assert(req.hasQuery, "the query must survive absolute-form parsing")
+            end if
+        }
+
+        // An absolute-form target with a bare authority and no path component: the effective path is "/" (RFC 9112
+        // section 3.2.2), not a mangled authority.
+        "handles an absolute-form request target with no path" in {
+            val req = parseRequest("GET http://evil.example HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            if req == null then succeed("rejecting absolute-form is an acceptable resolution")
+            else
+                assert(req.pathAsString == "/", s"a bare authority must yield path /, got: ${req.pathAsString}")
+            end if
+        }
+
+        // Asterisk-form ("OPTIONS * HTTP/1.1", RFC 9112 section 3.2.4): the target is a single "*" and must not be run
+        // through the path splitter (which would treat it as a path segment).
+        "handles asterisk-form for OPTIONS" in {
+            val req = parseRequest("OPTIONS * HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            if req == null then succeed("rejecting asterisk-form is an acceptable resolution")
+            else
+                assert(
+                    req.pathAsString == "" || req.pathAsString == "*",
+                    s"asterisk-form must not be mangled into a path segment, got: ${req.pathAsString}"
+                )
+            end if
+        }
+
+        // The Content-Length vs Transfer-Encoding conflict must be refused regardless of HTTP version. Netty
+        // CVE-2026-42581 and Tomcat CVE-2021-33037 gated that resolution on HTTP/1.1, so an HTTP/1.0 request carrying
+        // both kept its Content-Length while still being framed by chunked, and a Content-Length-first proxy split the
+        // body at a different boundary. kyo's rejection is not version-gated; this pins that on the HTTP/1.0 spelling.
+        "refuses Content-Length with Transfer-Encoding on HTTP/1.0 (CVE-2021-33037, CVE-2026-42581)" in {
+            val req = parseRequest(
+                "POST /u HTTP/1.0\r\nHost: localhost\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n"
+            )
+            assert(req == null, "both length signals present must be refused whatever the version")
+        }
+
+        // Transfer-Encoding framing. Every leaf here is a request-smuggling vector: what matters is not that a value
+        // is odd on its own but that this parser and an upstream intermediary can reach DIFFERENT conclusions about
+        // where the body ends. The bytes one of them counts as body the other reads as the start of a new request,
+        // which is how an attacker prepends a request to another client's connection.
+
+        // The positive control for the leaves below: a plain "chunked" must still frame as chunked, or a stricter
+        // token check would have been bought by breaking ordinary chunked requests.
+        "Transfer-Encoding: chunked frames as chunked (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("POST /u HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n")
+            assert(req != null, "a well-formed chunked request must parse")
+            assert(req.isChunked, "\"chunked\" must set the chunked framing")
+        }
+
+        // "chunkedfoo" is a single token and it is not "chunked"; RFC 9110 section 5.6.2 tokens are delimited, not
+        // prefixes. A value-comparison that stops after the 7 bytes of "chunked" reports a match here, so this
+        // parser frames the message as chunked while a conforming intermediary does not: the desync.
+        //
+        // Rejection, not merely "not chunked", is the requirement: this value's final coding is not chunked, which is
+        // the same RFC 9112 section 6.3 item 6 condition the identity leaf below rejects. Accepting it as a bodyless
+        // request is the UNSAFE reading, since the body then sits in the buffer as the next request. The body is
+        // present here so that a parser taking the unsafe path has smuggled bytes to strand.
+        "Transfer-Encoding value is matched as a whole token, not by prefix (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("POST /u HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunkedfoo\r\n\r\n5\r\nhello\r\n0\r\n\r\n")
+            assert(
+                req == null,
+                "\"chunkedfoo\" is not the token \"chunked\", so the final coding is not chunked and the request must be rejected"
+            )
+        }
+
+        // RFC 9112 section 6.3 item 6: in a REQUEST whose Transfer-Encoding's final coding is not chunked, the body
+        // length cannot be determined, and the server MUST respond 400 and close. Treating it as a bodyless request
+        // instead leaves "hello" in the buffer to be parsed as the next request line.
+        "rejects Transfer-Encoding whose final coding is not chunked (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("POST /u HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: identity\r\n\r\nhello")
+            assert(req == null, "a request whose final transfer coding is not chunked has no determinable length and must be rejected")
+        }
+
+        // Here chunked IS the final coding, so RFC 9112 section 6.1 makes the message chunked and the gzip coding is
+        // one this server does not implement (section 6.1: SHOULD respond 501). Framing as chunked and rejecting are
+        // both conformant; treating the message as having no body at all is the third answer and the only unsafe one,
+        // since it strands the chunked body in the buffer as attacker-controlled bytes at a request boundary.
+        //
+        // Of the two conformant answers this asserts REJECTION, deliberately. kyo decodes no coding but chunked, so
+        // framing "gzip, chunked" as chunked would hand the handler gzip bytes while telling it nothing about the gzip
+        // layer. Asserting the disjunction instead would let a fix pick either, and the server-level leaf covering this
+        // same input already requires rejection; two leaves admitting different answers for one input is how a suite
+        // stops pinning anything.
+        "rejects a message carrying a transfer coding it cannot decode (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("POST /u HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: gzip, chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n")
+            assert(
+                req == null,
+                "gzip is not a coding this server decodes, so the request must be rejected rather than framed or treated as bodyless"
+            )
+        }
+
+        // Trailing OWS. RFC 9110 section 5.6.3 permits it after a field value, so "chunked " IS the token "chunked"
+        // and must still frame. This is the over-strictness guard on the whole-token check: a length comparison that
+        // does not trim would reject ordinary conformant traffic, trading a smuggling bug for an interop bug.
+        "Transfer-Encoding: chunked with trailing whitespace still frames as chunked (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("POST /u HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked \r\n\r\n")
+            assert(req != null, "a trailing space is permitted OWS and must not make the request invalid")
+            assert(req.isChunked, "\"chunked \" is the token \"chunked\" followed by OWS and must frame as chunked")
+        }
+
+        // The same prefix defect reached through Connection rather than Transfer-Encoding. "closefoo" is one token and
+        // is not "close"; honoring it tears down a connection the peer expects to keep, and the mirror case below
+        // keeps one alive that the peer expects closed, which is where a response can be attributed to the wrong
+        // request.
+        "Connection value is matched as a whole token, not by prefix (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: closefoo\r\n\r\n")
+            assert(req != null, "the request should still parse")
+            assert(req.isKeepAlive, "\"closefoo\" is not the token \"close\" and must not disable keep-alive")
+        }
+
+        // Connection is a list (RFC 9110 section 7.6.1), so its tokens must be matched as list ELEMENTS. A substring
+        // scan reports that "no-upgrade" contains "upgrade", which is the opposite of what the value says: it is a
+        // token whose meaning is the refusal. Paired with an Upgrade header this flips a plain request into an
+        // upgrade handshake the client never asked for.
+        "Connection: no-upgrade does not signal an upgrade (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: no-upgrade\r\nUpgrade: websocket\r\n\r\n")
+            assert(req != null, "the request should still parse")
+            assert(!req.isUpgrade, "\"no-upgrade\" names a token that is not \"upgrade\" and must not signal an upgrade")
+        }
+
+        // The over-strictness guard for the list matching: a real comma-separated Connection value must still be
+        // honored, or the fix above would have been bought by breaking every genuine upgrade handshake.
+        "Connection: keep-alive, Upgrade signals an upgrade (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive, Upgrade\r\nUpgrade: websocket\r\n\r\n")
+            assert(req != null, "the request should still parse")
+            assert(req.isUpgrade, "\"upgrade\" appearing as a list element must signal an upgrade")
+        }
+
+        // The remaining two value sites that were matched by prefix, kept as one leaf each so a regression names the
+        // header it broke. A spurious 100-continue makes the server send an interim response to a client not waiting
+        // for one; a spurious websocket upgrade hands a plain connection to the frame codec.
+        "Expect value is matched as a whole token, not by prefix (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("POST /u HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nExpect: 100-continuefoo\r\n\r\n")
+            assert(req != null, "the request should still parse")
+            assert(!req.expectContinue, "\"100-continuefoo\" is not the token \"100-continue\"")
+        }
+
+        "Upgrade value is matched as a whole token, not by prefix (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocketfoo\r\n\r\n")
+            assert(req != null, "the request should still parse")
+            assert(!req.isUpgrade, "\"websocketfoo\" is not the token \"websocket\"")
+        }
+
+        // RFC 9110 section 5.3 lets a recipient combine repeated field lines into one comma-separated list, making
+        // this "chunked, identity", whose final coding is identity and which section 6.3 therefore rejects. A parser
+        // that honors whichever line it saw first disagrees with any intermediary that combined them.
+        "rejects duplicate Transfer-Encoding header lines (GHSA-jrpm-956j-96jg)" in {
+            val req = parseRequest(
+                "POST /u HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: identity\r\n\r\n5\r\nhello\r\n0\r\n\r\n"
+            )
+            assert(
+                req == null,
+                "repeated Transfer-Encoding lines combine to a list whose final coding is not chunked, and must be rejected"
+            )
         }
     }
 

--- a/kyo-http/shared/src/test/scala/kyo/internal/Http1ResponseParserTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/Http1ResponseParserTest.scala
@@ -82,6 +82,85 @@ class Http1ResponseParserTest extends kyo.BaseHttpTest:
             assert(resp.statusCode == 200)
         }
 
+        // A response naming chunked as its FINAL coding is chunked, whatever precedes it (RFC 9112 section 6.1). The old
+        // comparison stopped after seven bytes and so failed on "gzip, chunked", framing the response by Content-Length
+        // or by close instead. Unpinned until now.
+        "frames a response whose final coding is chunked (GHSA-jrpm-956j-96jg)" in {
+            val (resp, _) = parseResponse("HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip, chunked\r\n\r\n")
+            assert(resp != null, "the response should parse")
+            assert(resp.isChunked, "chunked is the final coding, so the response is chunk-framed")
+        }
+
+        // RFC 9112 section 6.3 item 5: conflicting Content-Length values are unrecoverable. Letting the last one win is
+        // the response-side smuggling primitive, since a proxy honouring the first and this client the last disagree
+        // about where the body ends. The request side already refused this; the asymmetry was the gap.
+        "rejects a response with conflicting Content-Length values (GHSA-p83c-4wj9-p6w9)" in {
+            val (resp, _) = parseResponse("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Length: 100\r\n\r\nhello")
+            assert(resp == null, "two different Content-Length values leave the body length undeterminable")
+        }
+
+        // The over-strictness control: a repeated but IDENTICAL value is not a conflict and must still parse.
+        "accepts a repeated identical Content-Length (GHSA-p83c-4wj9-p6w9)" in {
+            val (resp, _) = parseResponse("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Length: 5\r\n\r\nhello")
+            assert(resp != null, "the two values agree, so the length is determinable")
+            assert(resp.contentLength == 5)
+        }
+
+        // RFC 9112 section 6.3 item 3: with both present, Transfer-Encoding determines the length and Content-Length is
+        // discarded. Leaving it readable keeps two framings in play for anything that later consults the wrong one.
+        "discards Content-Length when Transfer-Encoding is present (GHSA-p83c-4wj9-p6w9)" in {
+            val (resp, _) = parseResponse("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n")
+            assert(resp != null, "this is resolvable, not malformed: chunked wins")
+            assert(resp.isChunked, "the response is chunk-framed")
+            assert(resp.contentLength == -1, s"Content-Length must be discarded, got ${resp.contentLength}")
+        }
+
+        // The response parser must reject an obs-fold (a header line beginning with SP or HTAB), as the request parser
+        // does. RFC 9112 section 5.2 makes rejecting or unfolding a recipient MUST, because a folded value read one way
+        // by this client and another by an intermediary is a header-interpretation disagreement. Here the fold line is
+        // silently dropped, so the value is truncated ("one two" becomes "one") rather than rejected. This asserts the
+        // secure behavior (rejection) and therefore FAILS until the response parser refuses obs-fold.
+        //
+        // Origin: RFC 9112 section 5.2; the response-side analog of the request-parser obs-fold reject.
+        "rejects an obs-folded response header (RFC 9112 section 5.2)" in {
+            val (resp, _) = parseResponse("HTTP/1.1 200 OK\r\nX-A: one\r\n two\r\nContent-Length: 0\r\n\r\n")
+            assert(
+                resp == null,
+                s"an obs-folded header must be refused, but the response parsed with X-A=${
+                        if resp == null then "n/a" else resp.headers.get("X-A")
+                    }"
+            )
+        }
+
+        // A Content-Length that overflows the Int accumulator must be refused, not wrapped. The request parser guards
+        // this (Http1Parser.parseContentLength rejects above 214748364); the response parser does not, so
+        // "4294967301" (2^32 + 5) wraps to 5. The client then frames the body at 5 bytes, keeps the pooled keep-alive
+        // connection, and reads the attacker's trailing bytes as the next response on that connection. This asserts
+        // the secure behavior (refusal) and therefore FAILS until the response side carries the same overflow guard.
+        //
+        // Origin: hyper RUSTSEC-2021-0078 (lenient Content-Length), the response-side analog of the request-side guard.
+        "rejects a response Content-Length that overflows Int" in {
+            val (resp, _) = parseResponse("HTTP/1.1 200 OK\r\nContent-Length: 4294967301\r\nConnection: keep-alive\r\n\r\nHELLO")
+            assert(
+                resp == null || resp.contentLength < 0,
+                s"an overflowing Content-Length must be refused, but it wrapped to ${if resp == null then "n/a" else resp.contentLength}"
+            )
+        }
+
+        // The response-side half of the Transfer-Encoding token check. "chunkedfoo" is a single token and is not
+        // "chunked" (RFC 9110 section 5.6.2 tokens are delimited, not prefixes), so a value comparison that stops
+        // after the 7 bytes of "chunked" matches it here. On this side the reader is the CLIENT, so the party that
+        // chooses the value is the SERVER: a malicious or compromised origin picks a value a conforming proxy frames
+        // one way and this client frames the other, and the disagreement lets it steer where this client believes
+        // one response ends and the next begins.
+        "Transfer-Encoding value is matched as a whole token, not by prefix (GHSA-jrpm-956j-96jg)" in {
+            val (resp, _) = parseResponse(
+                "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunkedfoo\r\n\r\n"
+            )
+            assert(resp != null, "the response should still parse")
+            assert(!resp.isChunked, "\"chunkedfoo\" is not the token \"chunked\" and must not frame the response as chunked")
+        }
+
         // Test 3
         "parse response with explicit Connection: close" in {
             val (resp, _) = parseResponse(
@@ -170,13 +249,25 @@ class Http1ResponseParserTest extends kyo.BaseHttpTest:
         }
 
         // Test 10
+        // The leaf is named for rejection and used to assert the opposite: the response parsed and the bad length was
+        // reported as absent. RFC 9112 section 6.3 item 4 makes an invalid Content-Length unrecoverable, and treating it
+        // as absent reads the response to connection close, which a proxy that DID parse a number out of "1a2b" frames
+        // differently, so the tail of one response becomes the head of the next. The name was right and the assertion
+        // was wrong.
         "reject Content-Length with non-digit characters" in {
             val (resp, _) = parseResponse(
                 "HTTP/1.1 200 OK\r\nContent-Length: 1a2b\r\n\r\n"
             )
-            assert(resp != null, "Response should have been parsed")
-            // parseContentLength returns -1 on non-digit characters
-            assert(resp.contentLength == -1, "Content-Length with non-digits should be -1")
+            assert(resp == null, "an invalid Content-Length leaves the framing undeterminable and must be refused")
+        }
+
+        // The spelling the duplicate check could not catch while a malformed value was tolerated: the first header
+        // leaves -1 behind, so a test against the running value never fires and the second value is silently adopted.
+        "rejects a malformed Content-Length followed by a valid one (GHSA-p83c-4wj9-p6w9)" in {
+            val (resp, _) = parseResponse(
+                "HTTP/1.1 200 OK\r\nContent-Length: abc\r\nContent-Length: 5\r\n\r\nhello"
+            )
+            assert(resp == null, "the first value is not recoverable, so the message is not framed by the second")
         }
 
         // Test 11

--- a/kyo-http/shared/src/test/scala/kyo/internal/HttpRouterTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/HttpRouterTest.scala
@@ -1,6 +1,8 @@
 package kyo.internal
 
 import kyo.*
+import kyo.internal.codec.*
+import kyo.internal.http1.*
 import kyo.internal.server.*
 
 class HttpRouterTest extends kyo.BaseHttpTest:
@@ -9,19 +11,69 @@ class HttpRouterTest extends kyo.BaseHttpTest:
 
     given CanEqual[Any, Any] = CanEqual.derived
 
+    import AllowUnsafe.embrace.danger
+
     case class User(name: String, age: Int) derives Schema
 
     def mkEndpoint(route: HttpRoute[?, ?, ?]): HttpHandler[?, ?, ?] =
         HttpHandler.init(route.asInstanceOf[HttpRoute[Any, Any, Any]])(req => HttpResponse.ok)
+
+    /** Why a request did not reach a route: the parser refused it, or it parsed and matched nothing.
+      *
+      * Kept distinct because the helper below cannot otherwise tell them apart, and a leaf asserting "not found" would
+      * silently accept a request that never parsed, which is a different statement about the server.
+      */
+    enum NotRouted derives CanEqual:
+        case Unparseable
+        case Routing(error: HttpRouter.FindError)
+
+    /** What routing yields a handler: the capture values and the endpoint's streaming shape. */
+    final case class Routed(
+        pathCaptures: Dict[String, String],
+        endpoint: HttpHandler[?, ?, ?],
+        isStreamingRequest: Boolean,
+        isStreamingResponse: Boolean
+    )
+
+    /** Routes a request exactly as the server does: a real parse, `findParsed`, and the server's OWN capture assembly.
+      *
+      * The capture values come from `UnsafeServerDispatch.buildCaptures`, the production function, deliberately rather than from a copy of
+      * it here. A test that re-implemented capture assembly would pass or fail on the copy, so it would say nothing about what a handler
+      * actually receives, which is the only thing these assertions are about.
+      *
+      * Going through `Http1Parser` also means these tests see segmentation, dot-segment resolution and escape validation as a served
+      * request does, none of which the router applies on its own.
+      */
+    def findVia(router: HttpRouter, method: HttpMethod, path: String): Result[NotRouted, Routed] =
+        val channel = Channel.Unsafe.init[Span[Byte]](16)
+        val raw     = s"${method.name} $path HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        discard(channel.offer(Span.fromUnsafe(raw.getBytes(java.nio.charset.StandardCharsets.US_ASCII))))
+        val builder                = new ParsedRequestBuilder
+        var request: ParsedRequest = null.asInstanceOf[ParsedRequest]
+        val parser                 = new Http1Parser(channel, builder, onRequestParsed = (req, _) => request = req)
+        parser.start()
+        if request.asInstanceOf[AnyRef] eq null then Result.fail(NotRouted.Unparseable)
+        else
+            val lookup = new RouteLookup(router.maxCaptures)
+            router.findParsed(method, request, lookup).mapFailure(NotRouted.Routing(_)).map { _ =>
+                Routed(
+                    UnsafeServerDispatch.buildCaptures(request, lookup, router.captureNames(lookup)),
+                    router.endpoint(lookup),
+                    lookup.isStreamingRequest,
+                    lookup.isStreamingResponse
+                )
+            }
+        end if
+    end findVia
 
     // ==================== Empty router ====================
 
     "empty router" - {
         "returns NotFound for any path" in {
             val router = HttpRouter(Seq.empty, Absent)
-            router.find(HttpMethod.GET, "/anything") match
-                case Result.Failure(HttpRouter.FindError.NotFound) => succeed("expected: empty router returns NotFound")
-                case other                                         => fail(s"expected NotFound, got $other")
+            findVia(router, HttpMethod.GET, "/anything") match
+                case Result.Failure(NotRouted.Routing(HttpRouter.FindError.NotFound)) => succeed("expected: empty router returns NotFound")
+                case other                                                            => fail(s"expected NotFound, got $other")
         }
     }
 
@@ -31,7 +83,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "matches exact path" in {
             val route  = HttpRoute.getRaw("users")
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/users") match
+            findVia(router, HttpMethod.GET, "/users") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures.isEmpty)
                     assert(!m.isStreamingRequest)
@@ -43,7 +95,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "matches without leading slash" in {
             val route  = HttpRoute.getRaw("users")
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "users") match
+            findVia(router, HttpMethod.GET, "users") match
                 case Result.Success(m) => assert(m.pathCaptures.isEmpty) // path matched without leading slash
                 case other             => fail(s"expected match, got $other")
         }
@@ -51,7 +103,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "matches with trailing slash" in {
             val route  = HttpRoute.getRaw("users")
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/users/") match
+            findVia(router, HttpMethod.GET, "/users/") match
                 case Result.Success(m) => assert(!m.isStreamingRequest) // path matched with trailing slash
                 case other             => fail(s"expected match, got $other")
         }
@@ -59,7 +111,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "matches with multiple slashes" in {
             val route  = HttpRoute.getRaw("users")
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "///users///") match
+            findVia(router, HttpMethod.GET, "///users///") match
                 case Result.Success(m) => assert(!m.isStreamingRequest) // path matched with multiple slashes
                 case other             => fail(s"expected match, got $other")
         }
@@ -67,16 +119,16 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "returns NotFound for wrong path" in {
             val route  = HttpRoute.getRaw("users")
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/posts") match
-                case Result.Failure(HttpRouter.FindError.NotFound) => succeed("expected: wrong path returns NotFound")
-                case other                                         => fail(s"expected NotFound, got $other")
+            findVia(router, HttpMethod.GET, "/posts") match
+                case Result.Failure(NotRouted.Routing(HttpRouter.FindError.NotFound)) => succeed("expected: wrong path returns NotFound")
+                case other                                                            => fail(s"expected NotFound, got $other")
         }
 
         "returns MethodNotAllowed for wrong method" in {
             val route  = HttpRoute.getRaw("users")
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.POST, "/users") match
-                case Result.Failure(HttpRouter.FindError.MethodNotAllowed(methods)) =>
+            findVia(router, HttpMethod.POST, "/users") match
+                case Result.Failure(NotRouted.Routing(HttpRouter.FindError.MethodNotAllowed(methods))) =>
                     assert(methods.contains(HttpMethod.GET))
                 case other => fail(s"expected MethodNotAllowed, got $other")
             end match
@@ -85,7 +137,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "HEAD matches GET route" in {
             val route  = HttpRoute.getRaw("users")
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.HEAD, "/users") match
+            findVia(router, HttpMethod.HEAD, "/users") match
                 case Result.Success(m) => assert(m.endpoint.route.method == HttpMethod.GET) // HEAD resolves to GET route
                 case other             => fail(s"expected match, got $other")
         }
@@ -97,7 +149,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "matches nested path" in {
             val route  = HttpRoute.getRaw("api" / HttpPath.Literal("v1") / HttpPath.Literal("users"))
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/api/v1/users") match
+            findVia(router, HttpMethod.GET, "/api/v1/users") match
                 case Result.Success(m) => assert(m.pathCaptures.isEmpty) // multi-segment path matched
                 case other             => fail(s"expected match, got $other")
         }
@@ -105,17 +157,17 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "NotFound for partial match" in {
             val route  = HttpRoute.getRaw("api" / HttpPath.Literal("v1") / HttpPath.Literal("users"))
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/api/v1") match
-                case Result.Failure(HttpRouter.FindError.NotFound) => succeed("expected: partial path returns NotFound")
-                case other                                         => fail(s"expected NotFound, got $other")
+            findVia(router, HttpMethod.GET, "/api/v1") match
+                case Result.Failure(NotRouted.Routing(HttpRouter.FindError.NotFound)) => succeed("expected: partial path returns NotFound")
+                case other                                                            => fail(s"expected NotFound, got $other")
         }
 
         "NotFound for too-deep path" in {
             val route  = HttpRoute.getRaw("api")
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/api/v1/users") match
-                case Result.Failure(HttpRouter.FindError.NotFound) => succeed("expected: too-deep path returns NotFound")
-                case other                                         => fail(s"expected NotFound, got $other")
+            findVia(router, HttpMethod.GET, "/api/v1/users") match
+                case Result.Failure(NotRouted.Routing(HttpRouter.FindError.NotFound)) => succeed("expected: too-deep path returns NotFound")
+                case other                                                            => fail(s"expected NotFound, got $other")
         }
     }
 
@@ -125,7 +177,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "extracts single capture" in {
             val route  = HttpRoute.getRaw("users" / HttpPath.Capture[Int]("userId"))
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/users/42") match
+            findVia(router, HttpMethod.GET, "/users/42") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures.is(Dict("userId" -> "42")))
                 case other => fail(s"expected match, got $other")
@@ -135,7 +187,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "extracts multiple captures" in {
             val route  = HttpRoute.getRaw("users" / HttpPath.Capture[Int]("userId") / "posts" / HttpPath.Capture[Int]("postId"))
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/users/42/posts/7") match
+            findVia(router, HttpMethod.GET, "/users/42/posts/7") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures.is(Dict("userId" -> "42", "postId" -> "7")))
                 case other => fail(s"expected match, got $other")
@@ -145,7 +197,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "URL-decodes capture values" in {
             val route  = HttpRoute.getRaw("users" / HttpPath.Capture[String]("name"))
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/users/John%20Doe") match
+            findVia(router, HttpMethod.GET, "/users/John%20Doe") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures.is(Dict("name" -> "John Doe")))
                 case other => fail(s"expected match, got $other")
@@ -155,7 +207,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "uses wireName when set" in {
             val route  = HttpRoute.getRaw("users" / HttpPath.Capture[String]("userId", wireName = "user_id"))
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/users/42") match
+            findVia(router, HttpMethod.GET, "/users/42") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures.is(Dict("user_id" -> "42")))
                 case other => fail(s"expected match, got $other")
@@ -165,7 +217,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "capture matches any segment" in {
             val route  = HttpRoute.getRaw("users" / HttpPath.Capture[String]("userId"))
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/users/anything-goes-here") match
+            findVia(router, HttpMethod.GET, "/users/anything-goes-here") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures("userId") == "anything-goes-here")
                 case other => fail(s"expected match, got $other")
@@ -179,7 +231,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "captures remaining path" in {
             val route  = HttpRoute.getRaw("files" / Capture.Rest("path"))
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/files/a/b/c.txt") match
+            findVia(router, HttpMethod.GET, "/files/a/b/c.txt") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures.is(Dict("path" -> "a/b/c.txt")))
                 case other => fail(s"expected match, got $other")
@@ -189,7 +241,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "captures single segment" in {
             val route  = HttpRoute.getRaw("files" / Capture.Rest("path"))
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/files/readme.md") match
+            findVia(router, HttpMethod.GET, "/files/readme.md") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures("path") == "readme.md")
                 case other => fail(s"expected match, got $other")
@@ -206,7 +258,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "allows Rest as the only segment" in {
             val route  = HttpRoute.getRaw(Capture.Rest("path"))
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/anything/here") match
+            findVia(router, HttpMethod.GET, "/anything/here") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures("path") == "anything/here")
                 case other => fail(s"expected match, got $other")
@@ -221,12 +273,12 @@ class HttpRouterTest extends kyo.BaseHttpTest:
             val usersRoute = HttpRoute.getRaw("users")
             val postsRoute = HttpRoute.getRaw("posts")
             val router     = HttpRouter(Seq(mkEndpoint(usersRoute), mkEndpoint(postsRoute)), Absent)
-            router.find(HttpMethod.GET, "/users") match
+            findVia(router, HttpMethod.GET, "/users") match
                 case Result.Success(m) =>
                     assert(m.endpoint.route.request.path == usersRoute.request.path)
                 case other => fail(s"expected match, got $other")
             end match
-            router.find(HttpMethod.GET, "/posts") match
+            findVia(router, HttpMethod.GET, "/posts") match
                 case Result.Success(m) =>
                     assert(m.endpoint.route.request.path == postsRoute.request.path)
                 case other => fail(s"expected match, got $other")
@@ -237,12 +289,12 @@ class HttpRouterTest extends kyo.BaseHttpTest:
             val getRoute  = HttpRoute.getRaw("users")
             val postRoute = HttpRoute.postRaw("users").request(_.bodyJson[User])
             val router    = HttpRouter(Seq(mkEndpoint(getRoute), mkEndpoint(postRoute)), Absent)
-            router.find(HttpMethod.GET, "/users") match
+            findVia(router, HttpMethod.GET, "/users") match
                 case Result.Success(m) =>
                     assert(m.endpoint.route.method == HttpMethod.GET)
                 case other => fail(s"expected match, got $other")
             end match
-            router.find(HttpMethod.POST, "/users") match
+            findVia(router, HttpMethod.POST, "/users") match
                 case Result.Success(m) =>
                     assert(m.endpoint.route.method == HttpMethod.POST)
                 case other => fail(s"expected match, got $other")
@@ -254,8 +306,8 @@ class HttpRouterTest extends kyo.BaseHttpTest:
             val postRoute   = HttpRoute.postRaw("users").request(_.bodyJson[User])
             val deleteRoute = HttpRoute.deleteRaw("users")
             val router      = HttpRouter(Seq(mkEndpoint(getRoute), mkEndpoint(postRoute), mkEndpoint(deleteRoute)), Absent)
-            router.find(HttpMethod.PUT, "/users") match
-                case Result.Failure(HttpRouter.FindError.MethodNotAllowed(methods)) =>
+            findVia(router, HttpMethod.PUT, "/users") match
+                case Result.Failure(NotRouted.Routing(HttpRouter.FindError.MethodNotAllowed(methods))) =>
                     assert(methods.contains(HttpMethod.GET))
                     assert(methods.contains(HttpMethod.POST))
                     assert(methods.contains(HttpMethod.DELETE))
@@ -268,13 +320,13 @@ class HttpRouterTest extends kyo.BaseHttpTest:
             val captureRoute = HttpRoute.getRaw("users" / HttpPath.Capture[String]("userId"))
             val router       = HttpRouter(Seq(mkEndpoint(literalRoute), mkEndpoint(captureRoute)), Absent)
             // "me" should match literal
-            router.find(HttpMethod.GET, "/users/me") match
+            findVia(router, HttpMethod.GET, "/users/me") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures.isEmpty)
                 case other => fail(s"expected literal match, got $other")
             end match
             // other segments should match capture
-            router.find(HttpMethod.GET, "/users/42") match
+            findVia(router, HttpMethod.GET, "/users/42") match
                 case Result.Success(m) =>
                     assert(m.pathCaptures.is(Dict("userId" -> "42")))
                 case other => fail(s"expected capture match, got $other")
@@ -288,7 +340,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "non-streaming route" in {
             val route  = HttpRoute.getRaw("users").response(_.bodyJson[User])
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/users") match
+            findVia(router, HttpMethod.GET, "/users") match
                 case Result.Success(m) =>
                     assert(!m.isStreamingRequest)
                     assert(!m.isStreamingResponse)
@@ -299,7 +351,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "streaming request" in {
             val route  = HttpRoute.postRaw("upload").request(_.bodyStream)
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.POST, "/upload") match
+            findVia(router, HttpMethod.POST, "/upload") match
                 case Result.Success(m) =>
                     assert(m.isStreamingRequest)
                     assert(!m.isStreamingResponse)
@@ -310,7 +362,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "streaming response" in {
             val route  = HttpRoute.getRaw("events").response(_.bodySseJson[User])
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/events") match
+            findVia(router, HttpMethod.GET, "/events") match
                 case Result.Success(m) =>
                     assert(!m.isStreamingRequest)
                     assert(m.isStreamingResponse)
@@ -321,7 +373,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "both streaming" in {
             val route  = HttpRoute.postRaw("pipe").request(_.bodyStream).response(_.bodyStream)
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.POST, "/pipe") match
+            findVia(router, HttpMethod.POST, "/pipe") match
                 case Result.Success(m) =>
                     assert(m.isStreamingRequest)
                     assert(m.isStreamingResponse)
@@ -336,17 +388,24 @@ class HttpRouterTest extends kyo.BaseHttpTest:
         "matches empty path" in {
             val route  = HttpRoute.getRaw("")
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "/") match
+            findVia(router, HttpMethod.GET, "/") match
                 case Result.Success(m) => assert(m.pathCaptures.isEmpty) // root path matches "/"
                 case other             => fail(s"expected match, got $other")
         }
 
-        "matches empty string" in {
+        // This used to assert that a root route matches the empty STRING, which was a property of the router's
+        // String-based lookup rather than of any request: RFC 9112 section 3.2.1 gives origin-form a minimum of "/", so
+        // a request target is never empty on the wire. With routing driven by a real request the equivalent question is
+        // what happens to a request line that omits the target, and the answer must be refusal rather than a match on
+        // the root, since treating an absent target as "/" would serve the root to a malformed request.
+        "does not route a request whose target is missing" in {
             val route  = HttpRoute.getRaw("")
             val router = HttpRouter(Seq(mkEndpoint(route)), Absent)
-            router.find(HttpMethod.GET, "") match
-                case Result.Success(m) => assert(m.pathCaptures.isEmpty) // root path matches empty string
-                case other             => fail(s"expected match, got $other")
+            findVia(router, HttpMethod.GET, "") match
+                case Result.Failure(NotRouted.Unparseable) =>
+                    succeed("expected: a request line with no target is refused before routing")
+                case other => fail(s"an empty request target must be refused as unparseable, got $other")
+            end match
         }
     }
 
@@ -357,19 +416,21 @@ class HttpRouterTest extends kyo.BaseHttpTest:
             val routes = (0 until 20).map(i => HttpRoute.getRaw(f"route$i%02d"))
             val router = HttpRouter(routes.map(mkEndpoint), Absent)
             // Check first, last, and middle
-            router.find(HttpMethod.GET, "/route00") match
+            findVia(router, HttpMethod.GET, "/route00") match
                 case Result.Success(m) => assert(m.pathCaptures.isEmpty) // first route matched by binary search
                 case other             => fail(s"expected match for route00, got $other")
-            router.find(HttpMethod.GET, "/route10") match
+            findVia(router, HttpMethod.GET, "/route10") match
                 case Result.Success(m) => assert(m.pathCaptures.isEmpty) // middle route matched by binary search
                 case other             => fail(s"expected match for route10, got $other")
-            router.find(HttpMethod.GET, "/route19") match
+            findVia(router, HttpMethod.GET, "/route19") match
                 case Result.Success(m) => assert(m.pathCaptures.isEmpty) // last route matched by binary search
                 case other             => fail(s"expected match for route19, got $other")
             // Non-existent
-            router.find(HttpMethod.GET, "/route20") match
-                case Result.Failure(HttpRouter.FindError.NotFound) => succeed("expected: out-of-range route returns NotFound")
-                case other                                         => fail(s"expected NotFound for route20, got $other")
+            findVia(router, HttpMethod.GET, "/route20") match
+                case Result.Failure(NotRouted.Routing(HttpRouter.FindError.NotFound)) =>
+                    succeed("expected: out-of-range route returns NotFound")
+                case other => fail(s"expected NotFound for route20, got $other")
+            end match
         }
     }
 
@@ -394,7 +455,7 @@ class HttpRouterTest extends kyo.BaseHttpTest:
             val router = HttpRouter(routes, Absent)
             // All methods should match (HEAD via GET)
             val failures = methods.flatMap { m =>
-                router.find(m, "/test") match
+                findVia(router, m, "/test") match
                     case Result.Success(rm) =>
                         if m == HttpMethod.HEAD then
                             if rm.endpoint.route.method != HttpMethod.GET then Some(s"HEAD did not resolve to GET")

--- a/kyo-http/shared/src/test/scala/kyo/internal/HttpSecurityTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/HttpSecurityTest.scala
@@ -10,6 +10,10 @@ import kyo.internal.util.*
   *
   * Tests that FAIL expose real vulnerabilities -- that is the desired outcome. These tests must NOT be weakened to pass.
   */
+/** Which upstream advisory sources have already been swept against kyo-http, and what each yielded, is recorded in
+  * kyo-http/security-sources.md. Read it before starting a new sweep: it records the sources that came back CLEAN as
+  * well as the ones that produced fixes, so the same list is not read twice.
+  */
 class HttpSecurityTest extends kyo.BaseHttpTest:
 
     given CanEqual[Any, Any] = CanEqual.derived
@@ -76,6 +80,7 @@ class HttpSecurityTest extends kyo.BaseHttpTest:
                 case Result.Panic(_) =>
                     failed = true
             },
+            _ => failed = true,
             _ => failed = true
         )
 
@@ -97,7 +102,8 @@ class HttpSecurityTest extends kyo.BaseHttpTest:
                 case Result.Failure(_) => ()
                 case Result.Panic(_)   => ()
             },
-            _ => tooLarge = true
+            _ => tooLarge = true,
+            _ => ()
         )
         (completed, tooLarge)
     end decodeChunkedCapped

--- a/kyo-http/shared/src/test/scala/kyo/internal/UnsafeServerDispatchTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/UnsafeServerDispatchTest.scala
@@ -636,7 +636,11 @@ class UnsafeServerDispatchTest extends kyo.BaseHttpTest:
             }
         }
 
-        "413 response preserves keep-alive" in {
+        // A 413 declines an over-limit body it never reads. Reusing the connection would let those unconsumed body
+        // bytes be parsed as the next request (the unconsumed-body smuggling class, Undertow CVE-2020-10719, RFC 9112
+        // section 9.3), so the server answers Connection: close and tears the connection down rather than serve a
+        // pipelined follow-up. request2's bytes must NOT be served.
+        "413 response closes the connection instead of reusing it (RFC 9112 section 9.3)" in {
             val handler = HttpHandler.getText("hello")(_ => "world")
             val router  = HttpRouter(Seq(handler), Absent)
 
@@ -646,8 +650,8 @@ class UnsafeServerDispatchTest extends kyo.BaseHttpTest:
 
             // First request: Content-Length exceeds limit (keep-alive is default in HTTP/1.1)
             val request1 = "POST /hello HTTP/1.1\r\nHost: localhost\r\nContent-Length: 100\r\n\r\n"
-            // Second request: valid GET (with Connection: close)
-            val request2 = "GET /hello HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+            // A pipelined GET that must NOT be served, because the connection is torn down after the 413.
+            val request2 = "GET /hello HTTP/1.1\r\nHost: localhost\r\n\r\n"
             discard(inbound.offer(Span.fromUnsafe(request1.getBytes(StandardCharsets.US_ASCII))))
             discard(inbound.offer(Span.fromUnsafe(request2.getBytes(StandardCharsets.US_ASCII))))
 
@@ -655,10 +659,12 @@ class UnsafeServerDispatchTest extends kyo.BaseHttpTest:
 
             collectResponseAsync(outbound).map { response1 =>
                 assert(response1.contains("HTTP/1.1 413 Payload Too Large"), s"First response expected 413, got: $response1")
-                collectResponseAsync(outbound).map { response2 =>
-                    assert(response2.contains("HTTP/1.1 200 OK"), s"Second response expected 200, got: $response2")
-                    assert(response2.contains("world"), s"Second response expected 'world', got: $response2")
-                }
+                assert(response1.contains("Connection: close"), s"413 must announce Connection: close, got: $response1")
+                // Nothing more is written: the pipelined request2 was not served.
+                val servedFollowUp = outbound.poll() match
+                    case Result.Success(Present(_)) => true
+                    case _                          => false
+                assert(!servedFollowUp, "the pipelined request after a 413 must not be served")
             }
         }
 
@@ -782,9 +788,8 @@ class UnsafeServerDispatchTest extends kyo.BaseHttpTest:
         }
 
         "chunked body exceeding max returns 413" in {
-            // TODO: This test verifies that chunked bodies that accumulate beyond maxContentLength
-            // are rejected with 413. This requires chunked body accumulation checks which may not
-            // be implemented yet. The test documents the expected behavior.
+            // A chunked body on a buffered route is dechunked bounded by maxContentLength; a body decoding to more
+            // than the limit is answered 413, not buffered without limit (CWE-400, RFC 9112 section 6.1).
             val route = HttpRoute.postRaw("echo").request(_.bodyText).response(_.bodyText)
             val handler = route.handler { req =>
                 HttpResponse.ok(req.fields.body)
@@ -795,7 +800,7 @@ class UnsafeServerDispatchTest extends kyo.BaseHttpTest:
             val inbound  = Channel.Unsafe.init[Span[Byte]](16)
             val outbound = Channel.Unsafe.init[Span[Byte]](16)
 
-            // Send a chunked request with body exceeding maxContentLength
+            // Send a chunked request whose decoded body (15 bytes) exceeds maxContentLength (10).
             // Chunk format: hex-size\r\ndata\r\n ... 0\r\n\r\n
             val chunk1 = "a\r\n0123456789\r\n" // 10 bytes (at limit)
             val chunk2 = "5\r\nABCDE\r\n"      // 5 more bytes (over limit)
@@ -806,15 +811,10 @@ class UnsafeServerDispatchTest extends kyo.BaseHttpTest:
 
             UnsafeServerDispatch.serve(router, inbound, outbound, config)
 
-            // For now, the server may not enforce chunked body limits yet.
-            // This test documents the expectation that eventually it should return 413.
-            // Accept either 413 or 200 (if not yet implemented) — the test is informational.
             collectResponseAsync(outbound).map { response =>
-                // If chunked accumulation check is implemented, expect 413
-                // If not yet, 200 is acceptable (test documents future behavior)
                 assert(
-                    response.contains("413") || response.contains("200"),
-                    s"Expected either 413 (ideal) or 200 (acceptable), got: $response"
+                    response.contains("HTTP/1.1 413 Payload Too Large"),
+                    s"an over-limit chunked body on a buffered route must be 413'd, got: $response"
                 )
             }
         }

--- a/kyo-http/shared/src/test/scala/kyo/internal/WebSocketCodecTest.scala
+++ b/kyo-http/shared/src/test/scala/kyo/internal/WebSocketCodecTest.scala
@@ -68,6 +68,41 @@ class WebSocketCodecTest extends kyo.BaseHttpTest:
         header ++ payload
     end makeFrame
 
+    /** Build a masked WebSocket frame (client-to-server direction) with a fixed mask key, the framing a server-role
+      * reader requires (RFC 6455 section 5.1). Handles 7-bit, 16-bit, and 64-bit length encodings.
+      */
+    private def makeMaskedFrame(opcode: Int, fin: Boolean, payload: Array[Byte]): Array[Byte] =
+        val finBit  = if fin then 0x80 else 0
+        val b0      = ((finBit | opcode) & 0xff).toByte
+        val len     = payload.length
+        val maskKey = Array[Byte](0x12, 0x34, 0x56, 0x78)
+        val lenHeader =
+            if len < 126 then
+                Array[Byte](b0, (0x80 | len).toByte)
+            else if len < 65536 then
+                Array[Byte](b0, (0x80 | 126).toByte, ((len >> 8) & 0xff).toByte, (len & 0xff).toByte)
+            else
+                val ll = len.toLong
+                Array[Byte](
+                    b0,
+                    (0x80 | 127).toByte,
+                    ((ll >> 56) & 0xff).toByte,
+                    ((ll >> 48) & 0xff).toByte,
+                    ((ll >> 40) & 0xff).toByte,
+                    ((ll >> 32) & 0xff).toByte,
+                    ((ll >> 24) & 0xff).toByte,
+                    ((ll >> 16) & 0xff).toByte,
+                    ((ll >> 8) & 0xff).toByte,
+                    (ll & 0xff).toByte
+                )
+        val maskedPayload = new Array[Byte](len)
+        var i             = 0
+        while i < len do
+            maskedPayload(i) = (payload(i) ^ maskKey(i % 4)).toByte
+            i += 1
+        lenHeader ++ maskKey ++ maskedPayload
+    end makeMaskedFrame
+
     // ── Accept key ──────────────────────────────────────────────
 
     "computeAcceptKey" - {
@@ -242,7 +277,14 @@ class WebSocketCodecTest extends kyo.BaseHttpTest:
             val writeConn = new MockConn(Array.empty[Byte])
             WebSocketCodec.writeFrame(writeConn, HttpWebSocket.Payload.Text("hello"), mask = false).andThen {
                 val readConn = new MockConn(writeConn.written)
-                Abort.run[Closed](WebSocketCodec.readFrameWith(readConn.read, readConn)((frame, _) => frame)).map { result =>
+                // The written frame is unmasked (a server-to-client frame), so it is read in the client role (mask =
+                // true), which expects unmasked incoming frames per RFC 6455 section 5.1.
+                Abort.run[Closed](WebSocketCodec.readFrameWith(readConn.read, readConn, Int.MaxValue, _ => Kyo.unit, mask = true)(
+                    (
+                        frame,
+                        _
+                    ) => frame
+                )).map { result =>
                     result match
                         case Result.Success(HttpWebSocket.Payload.Text(text)) =>
                             assert(text == "hello")
@@ -278,19 +320,88 @@ class WebSocketCodecTest extends kyo.BaseHttpTest:
         }
 
         "rejects frame larger than maxFrameSize" in {
-            val payload = "hello".getBytes(Utf8)
-            val frame = Array[Byte](
-                (0x80 | 0x01).toByte,
-                payload.length.toByte
-            ) ++ payload
-            val conn = new MockConn(frame)
-            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn, 4, _ => Kyo.unit, mask = false)((frame, _) => frame)).map {
+            // A 5-byte unmasked (server) frame read in the client role (mask = true, so the masking check passes) under
+            // a 4-byte cap, so the SIZE check is what fires.
+            val frame = makeFrame(0x1, fin = true, "hello".getBytes(Utf8))
+            val conn  = new MockConn(frame)
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn, 4, _ => Kyo.unit, mask = true)((frame, _) => frame)).map {
                 result =>
                     assert(result.isFailure)
             }
         }
 
+        // RFC 6455 section 5.1: a server MUST close the connection on receiving a frame that is not masked. Masking is
+        // what stops an intermediary from being tricked into caching or misrouting attacker-chosen bytes, so a server
+        // that accepts an unmasked client frame loses that protection. The server-role reader (mask = false) applies no
+        // such check: it unmasks only when the mask bit is set and otherwise reads the frame as-is, whatever the role.
+        // This asserts the secure behavior and therefore FAILS until the server rejects an unmasked client frame.
+        //
+        // Origin: RFC 6455 section 5.1; Tomcat Bug 69844 (the mirror, a client accepting a masked server frame).
+        "rejects an unmasked client frame in the server role" in {
+            // A well-formed text frame with the mask bit CLEAR (a legal server-to-client frame, illegal client-to-server).
+            val unmasked = Array[Byte]((0x80 | 0x01).toByte, 0x05.toByte) ++ "hello".getBytes(Utf8)
+            val conn     = new MockConn(unmasked)
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn)((frame, _) => frame)).map { result =>
+                assert(result.isFailure, s"a server must reject an unmasked client frame, but it was accepted: $result")
+            }
+        }
+
+        // RFC 6455 section 5.5: all control frames (Close 0x8, Ping 0x9, Pong 0xA) MUST have a payload of 125 bytes or
+        // fewer. A decoder that reads a 126/127 extended length for a control frame lets a peer drive a large
+        // allocation from a frame that can carry none, the Tomcat CVE-2020-13935 class.
+        //
+        // A Ping is used, not a Close, so the assertion is discriminating: a Close would abort the reader regardless of
+        // length (a vacuous pass), whereas a Ping is auto-Ponged and the reader continues to the next frame. The stream
+        // is an oversized Ping followed by a valid text frame, so a decoder that ACCEPTS the bad Ping delivers "abc"
+        // (success), and one that REJECTS it fails. Refusal is the secure outcome.
+        "rejects a control frame with an extended payload length (CVE-2020-13935)" in {
+            // A MASKED Ping (so the masking check passes and the SIZE check is what fires) whose 200-byte payload forces
+            // the 126 extended-length form, which a control frame must never use. The following masked text frame would
+            // be delivered as "abc" if the bad Ping were wrongly accepted, keeping the assertion discriminating.
+            val ping = makeMaskedFrame(0x9, fin = true, new Array[Byte](200))
+            val text = makeMaskedFrame(0x1, fin = true, "abc".getBytes(Utf8))
+            val conn = new MockConn(ping ++ text)
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn)((_, _) => "abc")).map { result =>
+                assert(
+                    result.isFailure,
+                    s"a control frame over 125 bytes must be refused, but the reader accepted it and continued: $result"
+                )
+            }
+        }
+
+        // RFC 6455 section 5.5: a control frame MUST NOT be fragmented (FIN must be 1). A Ping with FIN=0 is malformed
+        // and must be refused, not auto-Ponged as if complete. Same discriminating shape: fragmented Ping then a valid
+        // text frame; accepting the bad Ping delivers "abc".
+        "rejects a fragmented control frame (RFC 6455 section 5.5)" in {
+            // A MASKED Ping with FIN CLEAR (so the masking check passes and the FIN check is what fires), zero payload.
+            // The following masked text frame would be delivered as "abc" if the bad Ping were wrongly accepted.
+            val ping = makeMaskedFrame(0x9, fin = false, Array.empty[Byte])
+            val text = makeMaskedFrame(0x1, fin = true, "abc".getBytes(Utf8))
+            val conn = new MockConn(ping ++ text)
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn)((_, _) => "abc")).map { result =>
+                assert(result.isFailure, s"a fragmented control frame must be refused, but the reader accepted it and continued: $result")
+            }
+        }
+
+        // The client-role mirror of the server masking check: a client MUST reject a MASKED frame, because a server
+        // must never mask (RFC 6455 section 5.1). Tomcat Bug 69844 is exactly this direction. The client-role reader is
+        // mask = true, so expectMasked is false.
+        "rejects a masked server frame in the client role (Tomcat Bug 69844)" in {
+            val masked = makeMaskedFrame(0x1, fin = true, "hello".getBytes(Utf8))
+            val conn   = new MockConn(masked)
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn, Int.MaxValue, _ => Kyo.unit, mask = true)(
+                (
+                    frame,
+                    _
+                ) => frame
+            )).map { result =>
+                assert(result.isFailure, s"a client must reject a masked server frame, but it was accepted: $result")
+            }
+        }
+
         "rejects 64-bit frame lengths before integer overflow" in {
+            // An unmasked (server) attack frame read in the client role (mask = true), so the masking check passes and
+            // the 64-bit length check is what fires.
             val frame = Array[Byte](
                 (0x80 | 0x01).toByte,
                 127.toByte,
@@ -304,8 +415,90 @@ class WebSocketCodecTest extends kyo.BaseHttpTest:
                 0x00.toByte
             )
             val conn = new MockConn(frame)
-            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn)((frame, _) => frame)).map { result =>
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn, Int.MaxValue, _ => Kyo.unit, mask = true)((frame, _) =>
+                frame
+            )).map { result =>
                 assert(result.isFailure)
+            }
+        }
+
+        // The 64-bit extended length is read into a Long, so every bit set reads as -1. A decoder that carries that
+        // straight to a read length asks for a negative count, which a bounds-tolerant reader answers with zero bytes:
+        // the frame then "succeeds" as empty, having consumed only the header, and every subsequent frame on the
+        // connection is read from the wrong offset. The pin is the SUCCESS side, not just any failure -- an unguarded
+        // decoder returns Text("") here rather than erroring, so a test asserting only "something went wrong" would
+        // pass either way.
+        "rejects a 64-bit frame length whose bits are all set (GHSA-3j86-pj9g-jchr)" in {
+            val frame = Array[Byte](
+                (0x80 | 0x01).toByte,
+                127.toByte,
+                0xff.toByte,
+                0xff.toByte,
+                0xff.toByte,
+                0xff.toByte,
+                0xff.toByte,
+                0xff.toByte,
+                0xff.toByte,
+                0xff.toByte
+            )
+            val conn = new MockConn(frame)
+            // Client role (mask = true) so the unmasked attack frame passes the masking check and the length check fires.
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn, Int.MaxValue, _ => Kyo.unit, mask = true)((frame, _) =>
+                frame
+            )).map {
+                case Result.Failure(_: Closed) => succeed("a negative declared length was rejected")
+                case other                     => fail(s"a negative declared length was accepted, got $other")
+            }
+        }
+
+        // A length that is positive as a Long but truncates to a small positive Int: 2^32 + 100 becomes exactly 100.
+        // An unguarded decoder returns a well-formed 100-byte frame while the peer believes it declared 4 GiB, so the
+        // two ends disagree about where the next frame starts. Same desync as the case above, reached from the other
+        // direction, and again the failure mode is a plausible SUCCESS rather than an error.
+        "rejects a 64-bit frame length that truncates to a valid Int (GHSA-3j86-pj9g-jchr)" in {
+            val payload = new Array[Byte](100)
+            val frame = Array[Byte](
+                (0x80 | 0x01).toByte,
+                127.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x01.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x64.toByte
+            ) ++ payload
+            val conn = new MockConn(frame)
+            // Client role (mask = true) so the unmasked attack frame passes the masking check and the length check fires.
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn, Int.MaxValue, _ => Kyo.unit, mask = true)((frame, _) =>
+                frame
+            )).map {
+                case Result.Failure(_: Closed) => succeed("a length exceeding Int range was rejected")
+                case other                     => fail(s"a 2^32+100 length was truncated to 100 and accepted, got $other")
+            }
+        }
+
+        // The configured cap on the EXTENDED-length path. The existing cap test above drives the 7-bit path only, where
+        // the declared length cannot exceed 125 and the cap is never the thing under test.
+        "enforces maxFrameSize on the 64-bit length path (GHSA-3j86-pj9g-jchr)" in {
+            val frame = Array[Byte](
+                (0x80 | 0x01).toByte,
+                127.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x00.toByte,
+                0x01.toByte,
+                0x00.toByte,
+                0x00.toByte
+            )
+            val conn = new MockConn(frame)
+            // Client role (mask = true) so the unmasked attack frame passes the masking check and the cap is what fires.
+            Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn, 4, _ => Kyo.unit, mask = true)((frame, _) => frame)).map {
+                case Result.Failure(_: Closed) => succeed("a 65536-byte frame was rejected against a 4-byte cap")
+                case other                     => fail(s"a 65536-byte frame passed a 4-byte cap, got $other")
             }
         }
     }
@@ -450,17 +643,9 @@ class WebSocketCodecTest extends kyo.BaseHttpTest:
         val textPayload = "after-ping".getBytes(Utf8)
         val pingPayload = "pingdata".getBytes(Utf8)
 
-        // Ping frame: FIN=1, opcode=9, no mask
-        val pingFrame = Array[Byte](
-            (0x80 | 0x09).toByte, // FIN + Ping
-            pingPayload.length.toByte
-        ) ++ pingPayload
-
-        // Text frame: FIN=1, opcode=1, no mask
-        val textFrame = Array[Byte](
-            (0x80 | 0x01).toByte, // FIN + Text
-            textPayload.length.toByte
-        ) ++ textPayload
+        // Masked Ping and Text: a server-role reader requires client frames to be masked (RFC 6455 section 5.1).
+        val pingFrame = makeMaskedFrame(0x9, fin = true, pingPayload)
+        val textFrame = makeMaskedFrame(0x1, fin = true, textPayload)
 
         val conn = new MockConn(pingFrame ++ textFrame)
         // Default (server) mode: the auto-Pong is UNMASKED per RFC 6455 §5.1 (servers must not mask).
@@ -509,15 +694,9 @@ class WebSocketCodecTest extends kyo.BaseHttpTest:
         val textPayload = "afterpong".getBytes(Utf8)
         val pongPayload = "pongdata".getBytes(Utf8)
 
-        val pongFrame = Array[Byte](
-            (0x80 | 0x0a).toByte, // FIN + Pong
-            pongPayload.length.toByte
-        ) ++ pongPayload
-
-        val textFrame = Array[Byte](
-            (0x80 | 0x01).toByte, // FIN + Text
-            textPayload.length.toByte
-        ) ++ textPayload
+        // Masked Pong and Text: a server-role reader requires client frames to be masked (RFC 6455 section 5.1).
+        val pongFrame = makeMaskedFrame(0xa, fin = true, pongPayload)
+        val textFrame = makeMaskedFrame(0x1, fin = true, textPayload)
 
         val conn = new MockConn(pongFrame ++ textFrame)
         Abort.run[Closed](WebSocketCodec.readFrameWith(conn.read, conn)((frame, _) => frame)).map {


### PR DESCRIPTION
## Problem

kyo-http implements HTTP/1.1 from scratch. Every framing and parsing invariant the mainstream servers enforce, most of them the settled aftermath of a disclosed vulnerability, is one kyo-http has to arrive at on its own. A hand-written stack is exactly where the classic HTTP attacks resurface, because each one turns on a wire-level framing decision that is easy to get subtly wrong and stays invisible until an adversary disagrees with it.

## Solution

Audit kyo-http against the record of the servers that have already met these attacks in production, rather than against a reviewer's imagination. The published security advisories of Netty, Tomcat, Jetty, Undertow, Go's net/http, Node's llhttp, and hyper were mined by defect class; each CVE and GHSA that could apply to an HTTP/1.1 server was read for the exact behavior it exploited and reproduced against kyo-http as a test that puts those precise bytes on the connection.

The discipline was reproduce before fix. A test counted only once it failed against the current code for the reason the advisory names and no other, and only once a control, a legitimate message shaped like the attack, still passed, so that no fix could be a blanket tightening that rejected real traffic along with the exploit. Advisories kyo-http already withstood stayed in as regression guards; the rest drove the corrections.

## Notes

Every test names the advisory behind it, so each defense traces to a real incident and the audit re-runs itself as new disclosures land. The durable deliverable is that standing adversarial suite as much as the individual fixes. Scoped to kyo-http.
