### PR TITLE
[kyo-test] add schema-based snapshot testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2914,6 +2914,7 @@ lazy val `kyo-test-snapshot` =
         .crossType(CrossType.Full)
         .dependsOn(`kyo-test-api`)
         .dependsOn(`kyo-data`)
+        .dependsOn(`kyo-schema`)
         .dependsOn(`kyo-test-runner` % Test)
         .in(file("kyo-test/snapshot"))
         .settings(

--- a/kyo-test/README.md
+++ b/kyo-test/README.md
@@ -458,7 +458,7 @@ val doubleShrinks: Chunk[Double] = Shrink.double(2.7) // 2.0 (integral neighbor)
 
 ## Write meaningful tests: no-assertion enforcement
 
-A leaf that runs to completion having evaluated zero assertions is itself a bug: it proves nothing. kyo-test enforces this at run time. After a leaf body joins, the runner counts how many assertions it evaluated; a leaf that would otherwise pass with a count of zero is flipped to `Failed` with the message `leaf passed without evaluating any assertion`. The whole assert family counts: `assert`, `fail`, `intercept`, `assertEventually`, `typeCheck`, `assertSnapshot`, and a property `forAll`. `cancel` and `assume` do not count, because they steer the outcome rather than make a claim.
+A leaf that runs to completion having evaluated zero assertions is itself a bug: it proves nothing. kyo-test enforces this at run time. After a leaf body joins, the runner counts how many assertions it evaluated; a leaf that would otherwise pass with a count of zero is flipped to `Failed` with the message `leaf passed without evaluating any assertion`. The whole assert family counts: `assert`, `fail`, `intercept`, `assertEventually`, `typeCheck`, `assertSnapshot`, `assertSchemaSnapshot`, and a property `forAll`. `cancel` and `assume` do not count, because they steer the outcome rather than make a claim.
 
 This is a run-level setting, `failOnNoAssertion`, on by default. ScalaTest forced this at compile time through its `Assertion` return type; kyo-test cannot, because a leaf body is an effectful `Unit < (S & Async & Abort[Any] & Scope)`, so the check runs after the body completes.
 
@@ -508,6 +508,31 @@ end StatementSnapshotTest
 ```
 
 > **Caution:** the first run of `assertSnapshot` writes the proposed snapshot file and FAILS with `SnapshotNotFound`; the test passes only on a later run once you have reviewed the written file. To accept new or changed snapshots, run with `KYO_TEST_SNAPSHOT=update` in the environment (or override `snapshotUpdateMode` per suite). Snapshot names may not contain path separators, spaces, `.`, or `..`.
+
+### `assertSchemaSnapshot`: schema-based snapshots
+
+When a `Schema[A]` instance is in scope, reach for `assertSchemaSnapshot(actual, name)` instead. It renders `actual` through its `Schema[A]` using a `SnapshotCodec` (default `SnapshotCodec.Yaml`, a readable field-named format) and stores the result under `${snapshotDir}/${suite}/${name}.snap.yaml`, a distinct extension from `assertSnapshot`'s plain `.snap` so the two never collide on the same name.
+
+```scala
+import kyo.*
+import kyo.test.*
+import kyo.test.snapshot.*
+
+case class Statement(id: Int, balanceCents: Long, generatedAt: Long) derives Schema
+
+class SchemaStatementSnapshotTest extends SnapshotTest[Any]:
+    "monthly statement" in {
+        val statement = Statement(1, balanceCents = 12_300L, generatedAt = java.lang.System.currentTimeMillis())
+        assertSchemaSnapshot(statement, "monthly-schema", _.normalize(_.set(_.generatedAt)(0L)))
+    }
+end SchemaStatementSnapshotTest
+```
+
+The third argument builds a `SnapshotConfig[A]`, the single per-call customization point: `.normalize` scrubs non-deterministic fields (timestamps, ids) before both encoding and comparison, so a repeated run with a fresh timestamp still matches the stored snapshot. A suite that needs a different serialization format overrides the per-suite `snapshotCodec` hook (default `SnapshotCodec.Yaml`); the text presets are `Yaml`, `Json`, and `Ion`, the binary presets (stored as raw wire bytes) are `Protobuf`, `Bson`, `MsgPack`, and `IonBinary`, and `SnapshotCodec.Text`/`Binary` wrap any other kyo-schema `Codec`.
+
+> **Note:** the comparison is structural and format-tolerant: a hand-reformatted stored snapshot that still decodes to an equal value passes. A mismatch reports the changed field paths (dotted for a nested field, e.g. `b.y`) plus a unified text diff for text codecs. A stored snapshot that fails to decode at all (a genuine schema evolution) fails with `SnapshotSchemaEvolution` instead, distinct from a value mismatch.
+
+Reach for `assertSnapshot` when a `Render` instance is all you need (a quick, flat text snapshot); reach for `assertSchemaSnapshot` when you have a `Schema[A]` and want readable field-named output, field normalization, format-tolerant comparison, or schema-evolution detection.
 
 ## Running and selecting tests
 

--- a/kyo-test/api/shared/src/main/scala/kyo/test/AssertScope.scala
+++ b/kyo-test/api/shared/src/main/scala/kyo/test/AssertScope.scala
@@ -109,7 +109,7 @@ object AssertScope:
     private[kyo] val noAssertionDiagram: String =
         "leaf passed without evaluating any assertion\n\n" +
             "The leaf body ran to completion and produced no failures, but no assert, intercept, fail,\n" +
-            "assertEventually, typeCheck, assertSnapshot, or forAll call was reached on this run.\n\n" +
+            "assertEventually, typeCheck, assertSnapshot, assertSchemaSnapshot, or forAll call was reached on this run.\n\n" +
             "Fix: add a concrete assertion on the result (preferred), or if the intent is genuinely\n" +
             "'verify it runs without error', write `succeed` (or `succeed(\"why\")`) in the leaf body.\n\n" +
             "To disable this check run-wide: RunConfig.default.failOnNoAssertion(false).\n" +

--- a/kyo-test/snapshot/CONTRIBUTING.md
+++ b/kyo-test/snapshot/CONTRIBUTING.md
@@ -1,0 +1,217 @@
+# Contributing to kyo-test-snapshot
+
+This guide complements the root [CONTRIBUTING.md](../../CONTRIBUTING.md), which covers every global Kyo convention (naming, `Maybe` / `Result` / `Chunk` / `Span`, `using`-clause ordering, Frame/Tag, inline guidelines, scaladoc, file organisation, visibility tiers, the test framework, cross-platform source placement, `AllowUnsafe`). Defer to the root guide for those; this file covers only what is specific to the snapshot module (`kyo-test/snapshot`, sbt project `kyo-test-snapshot`).
+
+**The headline invariant:** snapshot assertions are an inheritance-based DSL, not free functions. A suite gains `assertSnapshot` and `assertSchemaSnapshot` by extending `SnapshotTest[S]` (or the marker-free `SnapshotTestBase[S]`), and those DSL methods are `protected`. This is the module's single, documented exception to the root guide's no-`protected` convention: the framework contract is inheritance-based, so the methods are visible to subclass bodies and to nothing else. Both classes carry this exception verbatim in their scaladoc, "The DSL methods in this class use `protected` visibility because the framework contract is inheritance-based; this is a deliberate exception to the `No protected` convention (CONTRIBUTING P5)" (`shared/src/main/scala/kyo/test/snapshot/SnapshotTest.scala:33-34`, `:248-249`). Before adding a new assertion, keep it `protected` on the base and do not promote it to a package-level function.
+
+## Architecture overview
+
+Every public type lives in `shared/src/main/scala/kyo/test/snapshot/`; the file I/O leaf is split by platform under `jvm-native/` and `js-wasm/`.
+
+| Type | File | Purpose |
+|------|------|---------|
+| `SnapshotTestBase[S]` | `SnapshotTest.scala:49` | Marker-free base carrying the DSL; extended by non-discoverable internal fixtures |
+| `SnapshotTest[S]` | `SnapshotTest.scala:264` | Public discoverable base: `SnapshotTestBase[S] with SuiteFingerprintMarker` |
+| `SnapshotConfig[A]` | `SnapshotConfig.scala:31` | The per-call customization builder for `assertSchemaSnapshot` |
+| `SnapshotCodec` | `SnapshotCodec.scala:24` | The `Text` / `Binary` format wrapper (2-case enum, 7 presets) |
+| `SnapshotSchemaEvolution` | `SnapshotSchemaEvolution.scala:24` | Distinct failure factory for a stored snapshot that no longer decodes |
+| `SnapshotNotFound` | `SnapshotNotFound.scala:26` | First-run failure factory (proposed file written, then fail) |
+| `SnapshotStore` | `internal/SnapshotStore.scala:11` | Shared facade over the per-platform file I/O |
+| `SnapshotDiff` | `internal/SnapshotDiff.scala:8` | Unified-diff renderer, delegates to `kyo.test.internal.Diff.stringDiff` |
+
+`SnapshotTest[S]` adds only the discovery marker; all assertion machinery lives on `SnapshotTestBase[S]` (`SnapshotTest.scala:244-246`). The base is split off precisely so the deliberately-failing fixture suites in this module's own tests can extend it and stay out of sbt/Native discovery: "The public `SnapshotTest` subclass adds the marker so real user snapshot suites are discovered; the fixtures must not be, because they fail by design" (`SnapshotTest.scala:28-31`).
+
+---
+
+## The two snapshot flavors
+
+The module offers two assertions with different serialization models. Choosing between them is the first decision a contributor or user makes.
+
+### `assertSnapshot` (Render-based)
+
+```
+protected inline def assertSnapshot[A](inline actual: A, inline name: String)
+    (using inline r: Render[A], inline frame: Frame, inline as: kyo.test.AssertScope)
+    : Unit < (S & Async & Abort[Throwable] & Scope)
+```
+
+(`SnapshotTest.scala:82-85`.) It renders `actual` through `Render[A]` to a single flat string, stores it at `${snapshotDir}/${this.name}/${name}.snap`, and compares after trailing-whitespace normalization: "If snapshot exists and matches (after trailing-whitespace normalization): pass" (`SnapshotTest.scala:72`, impl `stored.stripTrailing() != rendered.stripTrailing()` at `:96`). Use it for any type that has a `Render` instance when a flat textual form is all you need.
+
+### `assertSchemaSnapshot` (schema-based)
+
+```
+protected inline def assertSchemaSnapshot[A](inline actual: A, inline name: String,
+    inline config: SnapshotConfig[A] => SnapshotConfig[A] = identity[SnapshotConfig[A]])
+    (using inline schema: Schema[A], inline frame: Frame, inline as: kyo.test.AssertScope)
+    : Unit < (S & Async & Abort[Throwable] & Scope)
+```
+
+(`SnapshotTest.scala:135-139`.) It requires a `Schema[A]` and serializes through a `SnapshotCodec`. This buys three things the Render path cannot give: a field-named encoding (Yaml/Json/etc.), format-tolerant structural comparison, and a per-call normalization pass. The default Yaml output is field-named, not a positional `toString`: the test "default Yaml output is field-named, not a positional flat toString" asserts the stored text contains `x:` and `y:` keys and is not `Point(1,2)` (`shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaTest.scala:101-116`).
+
+**When to use which.** Reach for `assertSchemaSnapshot` when the value has a `Schema`, when you need to scrub non-deterministic fields (timestamps, ids), or when you want the comparison to survive a hand-reformatted snapshot file. Reach for `assertSnapshot` when the value only has a `Render` instance, or when a flat rendered string is the artifact you actually want to review.
+
+The two share the name-validation and first-run contracts exactly. `SnapshotSchemaTest` verifies that "`assertSnapshot` rejects a path separator, empty, dot, dot-dot, and an embedded space, same as `assertSchemaSnapshot`" (`SnapshotSchemaTest.scala:303-313`) and that both fail first-run with `SnapshotNotFound` (`:249-269`, `:293-301`).
+
+---
+
+## Customization surfaces: `SnapshotConfig` and `snapshotCodec`
+
+These are two complementary hooks at different scopes. Do not conflate them.
+
+### `snapshotCodec` (per-suite format)
+
+```
+protected def snapshotCodec: SnapshotCodec = SnapshotCodec.Yaml
+```
+
+(`SnapshotTest.scala:112`.) Override it in a suite to change the serialization format for every `assertSchemaSnapshot` call in that suite. The default is `SnapshotCodec.Yaml`, "the readable field-named text format" (`SnapshotTest.scala:112`, `SnapshotCodec.scala:37`).
+
+### `SnapshotConfig` (per-call customization)
+
+`SnapshotConfig[A]` is "The single per-call customization point for `assertSchemaSnapshot`" (`SnapshotConfig.scala:5`). It is passed as a `SnapshotConfig[A] => SnapshotConfig[A]` lambda (default `identity`). It exists so the assertion can grow new knobs "without changing its signature or breaking existing call sites: each new knob is an additive method here, never a new parameter on `assertSchemaSnapshot`" (`SnapshotConfig.scala:8-9`).
+
+Today it carries exactly one capability, `normalize`, which "Adds a field-normalization pass, scrubbing non-deterministic fields before encode and before compare" (`SnapshotConfig.scala:33`). Normalization accumulates: `.normalize(f1).normalize(f2)` composes `f1` then `f2` (`SnapshotConfig.scala:34-35`, proven by `SnapshotConfigTest.scala:23-27`). It builds on `kyo.Modify`, the field-transform DSL, so a typical scrub reads `_.normalize(_.set(_.ts)(0L))` (`SnapshotSchemaTest.scala:123`).
+
+**Contract for a contributor adding a capability.** Add it as a new method plus a new internal field whose default preserves current behavior, so existing `.normalize(...)` call sites keep compiling (`SnapshotConfig.scala:15-17`). The example the scaladoc names is a custom comparison strategy. Never add a parameter to `assertSchemaSnapshot` for it; that is the whole reason `SnapshotConfig` exists. The format choice stays out of this builder: "The serialization format is chosen separately, per suite, by the `snapshotCodec` override hook, not through this builder" (`SnapshotConfig.scala:10-13`).
+
+---
+
+## The storage contract
+
+### Path scheme
+
+Both assertions compute `${snapshotDir}/${this.name}/${name}.${ext}`. `snapshotDir` defaults to `"test-snapshots"` and is a `protected def` override hook (`SnapshotTest.scala:51-55`); `this.name` is the suite name, so a suite's snapshots live in a subdirectory named after the suite. The Render path fixes the extension to `snap` (`SnapshotTest.scala:89`); the schema path uses `codec.ext` (`SnapshotTest.scala:144`).
+
+`name` must be a bare file name. `validateSnapshotName` rejects a path separator (`/` or `\`), the empty string, `.`, `..`, and any embedded space (`SnapshotTest.scala:211-229`). Add a new restriction there, not at each call site.
+
+### Text codecs versus binary codecs
+
+`SnapshotCodec` wraps a kyo-schema `Codec` "with the text-versus-binary distinction the codec itself does not carry" (`SnapshotCodec.scala:5-6`). The KIND decides two things a raw `Codec` cannot express: whether the stored file holds a UTF-8 string or raw wire bytes, and whether a mismatch report can carry a textual diff (`SnapshotCodec.scala:8-11`).
+
+- A `Text` codec encodes to a UTF-8 string via `schema.encodeString` and stores it through the `String` store path (`SnapshotTest.scala:146-147`). `SnapshotStore.write` appends a single trailing newline if absent (`internal/SnapshotStore.scala:21-23`).
+- A `Binary` codec encodes to raw wire bytes via `schema.encode` and stores them through the bytes store path (`SnapshotTest.scala:175-176`). `writeBytes` writes "content exactly as given, with no base64 encoding and no trailing-newline append, so a stored binary snapshot is the real codec wire artifact" (`internal/SnapshotStore.scala:33-39`).
+
+The Protobuf round-trip test pins this: stored bytes are byte-identical to a fresh `schema.encode`, and the stored length is asserted not equal to the base64-encoded length (`SnapshotSchemaTest.scala:271-291`). The raw-bytes store path has its own byte-fidelity coverage including `0x00`, `0xFF`, and a newline byte (`SnapshotStoreBytesTest.scala:25-39`).
+
+### Extensions are pairwise-distinct and distinct from `snap`
+
+The seven presets are `Yaml` (`snap.yaml`), `Json` (`snap.json`), `Ion` (`snap.ion`), `Protobuf` (`snap.pb`), `Bson` (`snap.bson`), `MsgPack` (`snap.msgpack`), `IonBinary` (`snap.ionb`) (`SnapshotCodec.scala:36-55`). The schema default is `snap.yaml`, deliberately distinct from the Render path's plain `snap`. Extensions are "kept pairwise-distinct across presets so a text and a binary snapshot of the same name never collide, and distinct from the plain `snap` extension of the `Render`-based `assertSnapshot` so a suite mixing both assertions on the same name never cross-writes one file" (`SnapshotCodec.scala:16-18`). `SnapshotCodecTest.scala:57-70` enforces all seven distinct and none equal to `snap`. When adding a preset, choose a fresh extension and add it to that distinctness assertion.
+
+`Text` and `Binary` stay the open extension point for any custom `Codec` (`SnapshotCodec.scala:11`, `SnapshotCodecTest.scala:73-91`).
+
+---
+
+## The compare contract
+
+On a subsequent run with an existing snapshot, `assertSchemaSnapshot` decodes the stored bytes via `Schema[A]` and branches three ways (`SnapshotTest.scala:156-172` for Text, `:185-202` for Binary):
+
+1. **Decode failure (`Result.Failure`)** routes to `SnapshotSchemaEvolution`, "a stored snapshot whose bytes no longer decode via the current `Schema[A]`" (`SnapshotSchemaEvolution.scala:7`). This is kept distinct from a value mismatch so "schema drift is reported with its own message and never conflated with an ordinary value mismatch" (`SnapshotSchemaEvolution.scala:9-10`). Its diagram is prefixed `SnapshotSchemaEvolution:` and is never the `Snapshot mismatch` prefix (`SnapshotSchemaEvolutionTest.scala:12-20`; distinctness proven end-to-end for both Text and Binary at `SnapshotSchemaTest.scala:206-218`, `:315-329`).
+
+2. **Decode panic (`Result.Panic`)** propagates the underlying throwable unwrapped: `case Result.Panic(err) => throw err` (`SnapshotTest.scala:162-163`, `:188-189`). An unexpected codec defect is not rewrapped as `SnapshotSchemaEvolution`. Both the Binary and Text decode arms are pinned by `SnapshotSchemaTest.scala:347-379`.
+
+3. **Decode success** compares structurally through `Changeset[A](storedValue, norm).operations`; a mismatch fails with the changed field paths (`SnapshotTest.scala:164-172`, `:190-202`). The gate follows schema-structural `Changeset.operations`, not value `.equals`: the `Ver` fixture whose `.equals` ignores field `b` still fails the assertion on a `b` change (`SnapshotSchemaTest.scala:331-345`).
+
+The comparison is **format-tolerant**: a hand-reformatted stored snapshot that still decodes to an equal value passes (`SnapshotSchemaTest.scala:186-204`), because the compare is on decoded values, not on the stored text. The mismatch report shape differs by codec kind: a `Text` codec carries the changed field path plus a unified textual diff, a `Binary` codec carries the changed field path but no textual diff (`SnapshotSchemaTest.scala:142-170`). Nested field changes report the full dotted path (`b.y`), produced by the recursive `snapshotChangedPaths` helper (`SnapshotTest.scala:231-235`, test `:172-184`).
+
+`SnapshotDiff.render(stored, actual)` fixes the diff direction convention: `stored` is the on-disk baseline, `actual` is the newly rendered value (`internal/SnapshotDiff.scala:5-6`).
+
+---
+
+## The update-mode workflow
+
+```
+protected def snapshotUpdateMode: Boolean =
+    java.lang.System.getenv("KYO_TEST_SNAPSHOT") == "update"
+```
+
+(`SnapshotTest.scala:62-63`.) When update mode is active, both assertions write the proposed value and pass without reading a prior file (`SnapshotTest.scala:91-92`, `:148-149`, `:177-178`). The default reads the `KYO_TEST_SNAPSHOT` environment variable, but the hook is a plain `protected def` so a suite can force it on or off "without mutating the process environment" (`SnapshotTest.scala:57-61`). Tests exercise this by overriding it directly and by reading a JVM system property (`SnapshotUpdateModeTest.scala:38-60`, `:98-113`).
+
+On the first run with no stored file, both assertions write the proposed snapshot and then fail with `SnapshotNotFound` so the run is red until the reviewer confirms the proposed file (`SnapshotTest.scala:101-103`, `:152-154`; `SnapshotNotFound.scala:7-13`).
+
+---
+
+## Cross-platform
+
+This is a four-platform module (JVM, JS, Native, Wasm; `build.sbt:2556-2558`). Source is placed in three tiers:
+
+- `shared/src/main/scala/` holds all types except the file I/O leaf.
+- `jvm-native/` holds the `java.nio.file`-backed `SnapshotStorePlatform`. "Scala Native ships a compatible implementation of `java.nio.file` so the same source compiles and runs on both platforms without modification" (`jvm-native/.../SnapshotStorePlatform.scala:9-13`); the source set is wired for both JVM and Native in `build.sbt:2578-2581` and `:2593-2596`.
+- `js-wasm/` holds the Node.js `fs` facade `SnapshotStorePlatform`, shared by JS and Wasm (auto-wired by the custom `CrossType.Full`; see `project/WasmPlatform.scala:18`).
+
+`SnapshotStore` (`internal/SnapshotStore.scala`) is the shared facade; each platform provides an `object SnapshotStorePlatform` with the same four-method surface (`read`, `write`, `readBytes`, `writeBytes`).
+
+### Plain-sync platform I/O (no Sync/AllowUnsafe ceremony)
+
+The store methods are plain synchronous functions returning `Maybe[String]` / `Maybe[Span[Byte]]` / `Unit`, not Kyo effects. Snapshot I/O runs on the synchronous assertion path, so it does not wrap file access in `Sync` or reach for `AllowUnsafe` at the store boundary. The only `// Unsafe:` comments in the module are the two `Path.getParent` null-guards in the JVM/Native writer (`jvm-native/.../SnapshotStorePlatform.scala:25`, `:46`), each annotated with the reason. Preserve this: a new store operation stays a plain function and is added to all three source sets in lockstep, mirroring the existing four-method shape. The JS/Wasm facade re-throws a browser-environment `js.JavaScriptException` as `UnsupportedOperationException` with a clear message (`js-wasm/.../SnapshotStorePlatform.scala:39-43`); keep that translation on any new JS store method.
+
+### Foreign-package inline access
+
+`assertSchemaSnapshot` is `inline`, and a user extends `SnapshotTestBase` from their own package. `SnapshotConfig.modify` is `private[snapshot]` (`SnapshotConfig.scala:31`), so the inline body must resolve `normalizeWith` (`SnapshotTest.scala:208-209`) through a compiler-generated accessor rather than a direct cross-package field read. `SnapshotForeignPackageTest` is the standing proof: a `SnapshotTest[Any]` subclass in the sibling package `kyo.test.snapshotforeign` "compiles and runs `assertSchemaSnapshot` with the config lambda" where `private[snapshot]` is genuinely inaccessible (`shared/src/test/scala/kyo/test/snapshotforeign/SnapshotForeignPackageTest.scala:15-22`, `:45-60`). Any change to the inline assertion body or to `SnapshotConfig`'s visibility must keep that test compiling; do not widen `private[snapshot]` to make the inline resolve.
+
+---
+
+## Conventions
+
+### The `protected` exception
+
+The root guide bans `protected` in favour of `private[kyo]`. This module is the documented exception for its abstract DSL base classes only (`SnapshotTest.scala:33-34`, `:248-249`). The exception covers the inheritance-facing DSL surface: `snapshotDir`, `snapshotUpdateMode`, `snapshotCodec`, `assertSnapshot`, `assertSchemaSnapshot`. Internal helpers stay `private` (`normalizeWith`, `validateSnapshotName`, `snapshotChangedPaths` at `SnapshotTest.scala:208-235`) and the platform I/O objects stay `private[snapshot]`. Do not extend the `protected` exception to anything that is not a subclass override hook.
+
+### Kyo types
+
+Follow the root guide. In this module: `Maybe` for optional store results (`internal/SnapshotStore.scala:14`, `:30`), `Result` for decode outcomes (`SnapshotTest.scala:156-164`), `Span[Byte]` for raw bytes (`internal/SnapshotStore.scala:30`), `Chunk` for changed-path accumulation (`SnapshotTest.scala:231`).
+
+### Test framework
+
+Because this module IS a test framework, its own tests cannot self-host: they use ScalaTest directly. Each test file states the reason, for example "ScalaTest bootstrap: this file tests SnapshotTest DSL itself; cannot self-host using the framework-under-test" (`jvm-native/.../SnapshotSelfTest.scala:88`). This is the deliberate local exception to the root rule that tests use the module's own `Test` base. Two ScalaTest styles are in use: `AnyFunSuite` for synchronous value/IO checks and `AsyncFreeSpec` for tests that drive the runner.
+
+The recurring pattern for exercising the DSL is a minimal `private class ... extends SnapshotTest[Any]` fixture that overrides `snapshotDir`/`snapshotUpdateMode`/`snapshotCodec` via constructor parameters and re-exposes the `protected` assertions as package-accessible methods (`SnapshotSchemaTest.scala:82-97`, `SnapshotUpdateModeTest.scala:38-47`, `SnapshotSelfTest.scala:21-28`). Fixtures that must fail by design extend the marker-free `SnapshotTestBase` so platform discovery does not pick them up (`SnapshotReparamTest.scala:25-28`, `:40-43`), and drive them via `TestRunner.runToFuture` (`SnapshotReparamTest.scala:100-117`).
+
+### Test file naming
+
+The 1:1 source-to-test rule holds, with aspect splits where one source needs more than one file:
+
+| Source | Test file(s) |
+|--------|--------------|
+| `SnapshotTest.scala` | `SnapshotTestTest.scala`, `SnapshotSchemaTest.scala`, `SnapshotUpdateModeTest.scala`, `SnapshotReparamTest.scala`, `SnapshotSelfTest.scala` |
+| `SnapshotConfig.scala` | `SnapshotConfigTest.scala` |
+| `SnapshotCodec.scala` | `SnapshotCodecTest.scala` |
+| `SnapshotSchemaEvolution.scala` | `SnapshotSchemaEvolutionTest.scala` |
+| `internal/SnapshotStore.scala` | `SnapshotStoreBytesTest.scala`, `SnapshotStoreTest` (in `SnapshotSelfTest.scala`) |
+| `internal/SnapshotDiff.scala` | `SnapshotDiffTest.scala` |
+
+`SnapshotForeignPackageTest.scala` is a deliberate cross-package proof and lives under `kyo.test.snapshotforeign`, a sibling of `kyo.test.snapshot`; it shares no source-file prefix because its subject is package accessibility itself, not a single source. Scratch and reproduction files must be folded into the matching `*Test.scala` and deleted before a change is complete.
+
+---
+
+## Building and testing
+
+```sh
+export JAVA_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8"
+export JVM_OPTS="$JAVA_OPTS"
+
+# All tests on JVM
+sbt 'kyo-test-snapshotJVM/test'
+
+# A single test class
+sbt 'kyo-test-snapshotJVM/testOnly kyo.test.snapshot.SnapshotSchemaTest'
+```
+
+Tests run cross-platform (JVM, JS, Native, Wasm) from the shared and partially-shared test trees; never move a shared test into a single-platform tree to dodge platform cost. Building runs scalafmt automatically, so re-read any file you edit after building.
+
+See the root [CONTRIBUTING.md](../../CONTRIBUTING.md) for full conventions on naming, scaladoc, inline guidelines, `using`-clause ordering, and the pre-submission checklist.
+
+---
+
+## Decision checklist: before adding a new X
+
+1. **New assertion.** Is it `protected` on `SnapshotTestBase`, not a package function? Does it validate `name` through `validateSnapshotName`? Does it honour `snapshotUpdateMode` (write-and-pass) and first-run (`SnapshotNotFound`)? Does its effect row stay `S & Async & Abort[Throwable] & Scope`?
+
+2. **New `SnapshotConfig` capability.** Is it an additive method plus an internal field whose default preserves current behavior, leaving `assertSchemaSnapshot`'s signature untouched? Does it stay out of format selection (that is `snapshotCodec`)?
+
+3. **New codec preset.** Is it `Text` or `Binary`? Does its extension collide with no existing preset and differ from plain `snap`? Is it added to the distinctness assertion in `SnapshotCodecTest`?
+
+4. **New store operation.** Is it a plain synchronous function added to all three source sets (`shared` facade, `jvm-native`, `js-wasm`) in lockstep? Does the binary path stay verbatim (no base64, no newline munge)? Is every `AllowUnsafe`/null-guard marked with `// Unsafe:`?
+
+5. **Change to the inline body or `private[snapshot]` visibility.** Does `SnapshotForeignPackageTest` still compile from the foreign package?
+
+6. **New test.** Does it fold into the matching `*Test.scala` by source prefix? Does it assert on a concrete value? For a fail-by-design fixture, does it extend the marker-free `SnapshotTestBase`?

--- a/kyo-test/snapshot/js-wasm/src/main/scala/kyo/test/snapshot/internal/SnapshotStorePlatform.scala
+++ b/kyo-test/snapshot/js-wasm/src/main/scala/kyo/test/snapshot/internal/SnapshotStorePlatform.scala
@@ -1,6 +1,7 @@
 package kyo.test.snapshot.internal
 
 import kyo.Maybe
+import kyo.Span
 import scala.scalajs.js
 import scala.scalajs.js.annotation.*
 
@@ -9,7 +10,9 @@ import scala.scalajs.js.annotation.*
 private object NodeFsSnap extends js.Object:
     def existsSync(path: String): Boolean                                 = js.native
     def readFileSync(path: String, encoding: String): String              = js.native
+    def readFileSync(path: String): js.typedarray.Uint8Array              = js.native
     def writeFileSync(path: String, data: String, opts: js.Dynamic): Unit = js.native
+    def writeFileSync(path: String, data: js.typedarray.Uint8Array): Unit = js.native
     def mkdirSync(path: String, opts: js.Dynamic): Unit                   = js.native
 end NodeFsSnap
 
@@ -45,6 +48,34 @@ private[snapshot] object SnapshotStorePlatform:
             if parent.nonEmpty && parent != path then
                 NodeFsSnap.mkdirSync(parent, js.Dynamic.literal(recursive = true))
             NodeFsSnap.writeFileSync(path, content, js.Dynamic.literal(encoding = "utf8"))
+        catch
+            case _: js.JavaScriptException =>
+                throw new UnsupportedOperationException(
+                    "Snapshot file I/O is not available in browser environments; use Node.js for snapshot tests"
+                )
+
+    def readBytes(path: String): Maybe[Span[Byte]] =
+        try
+            if NodeFsSnap.existsSync(path) then
+                val u8 = NodeFsSnap.readFileSync(path)
+                val i8 = new js.typedarray.Int8Array(u8.buffer, u8.byteOffset, u8.length)
+                Maybe.Present(Span.fromUnsafe(js.typedarray.int8Array2ByteArray(i8)))
+            else
+                Maybe.Absent
+        catch
+            case _: js.JavaScriptException =>
+                throw new UnsupportedOperationException(
+                    "Snapshot file I/O is not available in browser environments; use Node.js for snapshot tests"
+                )
+
+    def writeBytes(path: String, content: Span[Byte]): Unit =
+        try
+            val parent = NodePathSnap.dirname(path)
+            if parent.nonEmpty && parent != path then
+                NodeFsSnap.mkdirSync(parent, js.Dynamic.literal(recursive = true))
+            val i8 = js.typedarray.byteArray2Int8Array(content.toArrayUnsafe)
+            val u8 = new js.typedarray.Uint8Array(i8.buffer, i8.byteOffset, i8.length)
+            NodeFsSnap.writeFileSync(path, u8)
         catch
             case _: js.JavaScriptException =>
                 throw new UnsupportedOperationException(

--- a/kyo-test/snapshot/jvm-native/src/main/scala/kyo/test/snapshot/internal/SnapshotStorePlatform.scala
+++ b/kyo-test/snapshot/jvm-native/src/main/scala/kyo/test/snapshot/internal/SnapshotStorePlatform.scala
@@ -4,6 +4,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 import kyo.Maybe
+import kyo.Span
 
 /** JVM and Native snapshot file I/O backed by `java.nio.file`.
   *
@@ -21,7 +22,7 @@ private[snapshot] object SnapshotStorePlatform:
     def write(path: String, content: String): Unit =
         val p      = Paths.get(path)
         val parent = p.getParent
-        // Unsafe: java.io.File.getParent returns null for top-level paths; skip directory creation in that case
+        // Unsafe: java.nio.file.Path.getParent returns null for top-level paths; skip directory creation in that case
         if parent != null then
             val _ = Files.createDirectories(parent)
         val _ = Files.writeString(
@@ -32,5 +33,26 @@ private[snapshot] object SnapshotStorePlatform:
             StandardOpenOption.WRITE
         )
     end write
+
+    def readBytes(path: String): Maybe[Span[Byte]] =
+        val p = Paths.get(path)
+        if Files.exists(p) then Maybe.Present(Span.fromUnsafe(Files.readAllBytes(p)))
+        else Maybe.Absent
+    end readBytes
+
+    def writeBytes(path: String, content: Span[Byte]): Unit =
+        val p      = Paths.get(path)
+        val parent = p.getParent
+        // Unsafe: java.nio.file.Path.getParent returns null for top-level paths; skip directory creation in that case
+        if parent != null then
+            val _ = Files.createDirectories(parent)
+        val _ = Files.write(
+            p,
+            content.toArrayUnsafe,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING,
+            StandardOpenOption.WRITE
+        )
+    end writeBytes
 
 end SnapshotStorePlatform

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotCodec.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotCodec.scala
@@ -1,0 +1,57 @@
+package kyo.test.snapshot
+
+import kyo.Codec
+
+/** Serialization format for a schema-driven snapshot, wrapping a kyo-schema [[kyo.Codec]] with the text-versus-binary distinction
+  * the codec itself does not carry.
+  *
+  * A snapshot codec is either [[Text]] or [[Binary]]. The KIND (which of the two cases) decides two things a raw `Codec` cannot
+  * express: whether the stored file holds a UTF-8 string or raw wire bytes, and whether a mismatch report can carry a unified
+  * textual diff (only `Text` can). The seven companion presets cover every codec kyo-schema ships (`Yaml`, `Json`, `Ion`,
+  * `Protobuf`, `Bson`, `MsgPack`, `IonBinary`); `Text` and `Binary` remain the open extension point for any custom `Codec`.
+  *
+  * @param codec
+  *   the underlying kyo-schema codec that encodes and decodes the snapshotted value
+  * @param ext
+  *   the file extension for stored snapshots, kept pairwise-distinct across presets so a text and a binary snapshot of the same
+  *   name never collide, and distinct from the plain `snap` extension of the `Render`-based `assertSnapshot` so a suite mixing
+  *   both assertions on the same name never cross-writes one file
+  * @see
+  *   [[kyo.test.snapshot.SnapshotTestBase.snapshotCodec]] the per-suite hook selecting a codec
+  * @see
+  *   [[kyo.test.snapshot.SnapshotTestBase.assertSchemaSnapshot]] the assertion that reads it
+  */
+enum SnapshotCodec(val codec: Codec, val ext: String):
+
+    /** A text codec: the snapshot stores a UTF-8 string and a mismatch reports a textual diff. */
+    case Text(override val codec: Codec, override val ext: String) extends SnapshotCodec(codec, ext)
+
+    /** A binary codec: the snapshot stores raw wire bytes and a mismatch reports no textual diff. */
+    case Binary(override val codec: Codec, override val ext: String) extends SnapshotCodec(codec, ext)
+
+end SnapshotCodec
+
+object SnapshotCodec:
+
+    /** YAML, the default readable field-named text format. */
+    val Yaml: SnapshotCodec = Text(kyo.Yaml(), "snap.yaml")
+
+    /** JSON text format. */
+    val Json: SnapshotCodec = Text(kyo.Json(), "snap.json")
+
+    /** Amazon Ion text format. */
+    val Ion: SnapshotCodec = Text(kyo.Ion(), "snap.ion")
+
+    /** Protocol Buffers binary format. */
+    val Protobuf: SnapshotCodec = Binary(kyo.Protobuf(), "snap.pb")
+
+    /** BSON binary format. */
+    val Bson: SnapshotCodec = Binary(kyo.Bson(), "snap.bson")
+
+    /** MessagePack binary format. */
+    val MsgPack: SnapshotCodec = Binary(kyo.MsgPack(), "snap.msgpack")
+
+    /** Amazon Ion Binary format. */
+    val IonBinary: SnapshotCodec = Binary(kyo.IonBinary(), "snap.ionb")
+
+end SnapshotCodec

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotConfig.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotConfig.scala
@@ -1,0 +1,45 @@
+package kyo.test.snapshot
+
+import kyo.Modify
+
+/** The single per-call customization point for [[SnapshotTestBase.assertSchemaSnapshot]].
+  *
+  * An immutable builder passed to `assertSchemaSnapshot` as a `SnapshotConfig[A] => SnapshotConfig[A]` lambda. It exists so the
+  * assertion can gain new per-call customization capabilities over time without changing its signature or breaking existing call
+  * sites: each new knob is an additive method here, never a new parameter on `assertSchemaSnapshot`.
+  *
+  * This configures a single `assertSchemaSnapshot` invocation. The serialization format is chosen separately, per suite, by the
+  * [[SnapshotTestBase.snapshotCodec]] override hook, not through this builder; the two are complementary customization surfaces at
+  * different scopes (per-call here, per-suite there).
+  *
+  * Today it carries exactly one capability, [[normalize]]. A future capability (for example a custom comparison strategy) is added
+  * as a new method plus a new internal field whose default preserves the current behavior, so existing `.normalize(...)` call sites
+  * keep compiling unchanged.
+  *
+  * Start from the empty config via the companion `SnapshotConfig[A]` (identity normalization) and compose builder methods, for
+  * example `_.normalize(_.set(_.startedAt)(Instant.EPOCH))` inside the `assertSchemaSnapshot` config lambda.
+  *
+  * @tparam A
+  *   the type being snapshotted; a `Schema[A]` is required by `assertSchemaSnapshot`
+  * @see
+  *   [[SnapshotTestBase.assertSchemaSnapshot]] the assertion this configures
+  * @see
+  *   [[SnapshotTestBase.snapshotCodec]] the separate per-suite format-selection hook
+  * @see
+  *   [[kyo.Modify]] the field-transform DSL that `normalize` builds on
+  */
+final class SnapshotConfig[A] private[snapshot] (private[snapshot] val modify: Modify[A]):
+
+    /** Adds a field-normalization pass, scrubbing non-deterministic fields before encode and before compare.
+      *
+      * Accumulates: the supplied transform is applied to the config's current `Modify[A]`, so `.normalize(f1).normalize(f2)`
+      * composes `f1` then `f2`.
+      */
+    def normalize(f: Modify[A] => Modify[A]): SnapshotConfig[A] =
+        new SnapshotConfig[A](f(modify))
+
+end SnapshotConfig
+
+object SnapshotConfig:
+    /** The empty config for `A`: identity normalization, built from the empty `Modify[A]`. */
+    def apply[A]: SnapshotConfig[A] = new SnapshotConfig[A](Modify.apply[A])

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotSchemaEvolution.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotSchemaEvolution.scala
@@ -1,0 +1,33 @@
+package kyo.test.snapshot
+
+import kyo.Frame
+import kyo.Maybe
+import kyo.test.AssertionFailed
+
+/** Distinct failure for schema-evolution drift: a stored snapshot whose bytes no longer decode via the current `Schema[A]`.
+  *
+  * Constructed (never thrown) by [[SnapshotTestBase.assertSchemaSnapshot]] on the decode-failure branch, so schema drift is
+  * reported with its own message and never conflated with an ordinary value mismatch. Mirrors the sibling [[SnapshotNotFound]]
+  * factory: a named single-purpose factory whose diagram is self-describing, with `msg` and `cause` both absent.
+  *
+  * @param path
+  *   the path to the stored snapshot file that failed to decode
+  * @param detail
+  *   the decode-failure explanation (for Text codecs the caller prepends a unified diff)
+  * @param frame
+  *   the source location of the failing assertSchemaSnapshot call
+  * @see
+  *   [[kyo.test.snapshot.SnapshotNotFound]] the first-run sibling failure factory
+  * @see
+  *   [[kyo.test.AssertionFailed]] the failure type this factory constructs
+  */
+object SnapshotSchemaEvolution:
+    /** Constructs the `AssertionFailed` for a stored snapshot that failed to decode. */
+    def apply(path: String, detail: String)(using frame: Frame): AssertionFailed =
+        new AssertionFailed(
+            s"SnapshotSchemaEvolution: stored snapshot at $path could not be decoded: $detail",
+            frame,
+            Maybe.Absent,
+            Maybe.Absent
+        )
+end SnapshotSchemaEvolution

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotTest.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotTest.scala
@@ -3,14 +3,20 @@ package kyo.test.snapshot
 import kyo.<
 import kyo.Abort
 import kyo.Async
+import kyo.Changeset
+import kyo.Chunk
 import kyo.Frame
 import kyo.Maybe
 import kyo.Render
+import kyo.Result
+import kyo.Schema
 import kyo.Scope
 import kyo.test.AssertionFailed
 import kyo.test.SuiteFingerprintMarker
 import kyo.test.internal.TestBase
+import kyo.test.snapshot.SnapshotCodec
 import kyo.test.snapshot.SnapshotNotFound
+import kyo.test.snapshot.SnapshotSchemaEvolution
 import kyo.test.snapshot.internal.SnapshotDiff
 import kyo.test.snapshot.internal.SnapshotStore
 
@@ -79,23 +85,7 @@ abstract class SnapshotTestBase[S] extends TestBase[S]:
     )(using inline r: Render[A], inline frame: Frame, inline as: kyo.test.AssertScope): Unit < (S & Async & Abort[Throwable] & Scope) =
         as.recordEvaluated()
         val rendered = r.asString(actual)
-        if name.contains('/') || name.contains('\\') then
-            throw new IllegalArgumentException(
-                s"Snapshot name must not contain path separators: $name"
-            )
-        end if
-        if name.isEmpty then
-            throw new IllegalArgumentException("snapshot name must not be empty")
-        end if
-        if name == "." then
-            throw new IllegalArgumentException("snapshot name must not be '.'")
-        end if
-        if name == ".." then
-            throw new IllegalArgumentException("snapshot name must not be '..'")
-        end if
-        if name.contains(' ') then
-            throw new IllegalArgumentException("snapshot name must not contain a space")
-        end if
+        validateSnapshotName(name)
         val path       = s"${snapshotDir}/${this.name}/${name}.snap"
         val updateMode = snapshotUpdateMode
         if updateMode then
@@ -113,6 +103,136 @@ abstract class SnapshotTestBase[S] extends TestBase[S]:
                     throw SnapshotNotFound(path)(using frame)
         end if
     end assertSnapshot
+
+    /** Snapshot serialization format used by [[assertSchemaSnapshot]].
+      *
+      * Override in a suite to change the format (e.g. `SnapshotCodec.Protobuf` for a binary round trip). Defaults to
+      * `SnapshotCodec.Yaml`, the readable field-named text format.
+      */
+    protected def snapshotCodec: SnapshotCodec = SnapshotCodec.Yaml
+
+    /** Assert that `actual`, normalized then encoded through [[snapshotCodec]], matches the stored schema snapshot named `name`.
+      *
+      * Algorithm:
+      *   1. Normalize: `norm = config(SnapshotConfig.apply[A]).modify.applyTo(actual)`, applied before encode AND before compare.
+      *   2. Encode `norm` by codec kind: a Text codec produces a UTF-8 string, a Binary codec produces raw wire bytes.
+      *   3. Compute the storage path `${snapshotDir}/${this.name}/${name}.${snapshotCodec.ext}`.
+      *   4. If update mode: write the proposed value and pass.
+      *   5. If no snapshot exists yet: write the proposed value and fail with `SnapshotNotFound`.
+      *   6. If a snapshot exists: decode it via `Schema[A]`; a decode failure fails with `SnapshotSchemaEvolution`, a decode
+      *      success compares structurally and passes when equal, else fails with the changed field paths (plus a textual diff
+      *      for Text codecs).
+      *
+      * @param actual
+      *   the value to snapshot; a `Schema[A]` instance must be in scope
+      * @param name
+      *   the snapshot identifier; must not contain path separators, be empty, be `.` or `..`, or contain a space
+      * @param config
+      *   customizes the assertion through the `SnapshotConfig[A]` builder (today `.normalize`); defaults to `identity`
+      * @tparam A
+      *   the type of the value; a `Schema[A]` instance must be in scope
+      */
+    protected inline def assertSchemaSnapshot[A](
+        inline actual: A,
+        inline name: String,
+        inline config: SnapshotConfig[A] => SnapshotConfig[A] = identity[SnapshotConfig[A]]
+    )(using inline schema: Schema[A], inline frame: Frame, inline as: kyo.test.AssertScope): Unit < (S & Async & Abort[Throwable] & Scope) =
+        as.recordEvaluated()
+        validateSnapshotName(name)
+        val codec = snapshotCodec
+        val norm  = normalizeWith(config, actual)
+        val path  = s"${snapshotDir}/${this.name}/${name}.${codec.ext}"
+        codec match
+            case SnapshotCodec.Text(c, _) =>
+                val proposed = schema.encodeString(norm)(using c, frame)
+                if snapshotUpdateMode then
+                    SnapshotStore.write(path, proposed)
+                else
+                    SnapshotStore.read(path) match
+                        case Maybe.Absent =>
+                            SnapshotStore.write(path, proposed)
+                            throw SnapshotNotFound(path)(using frame)
+                        case Maybe.Present(stored) =>
+                            schema.decodeString(stored)(using c, frame) match
+                                case Result.Failure(err) =>
+                                    throw SnapshotSchemaEvolution(
+                                        path,
+                                        s"${err.getMessage}\n\n${SnapshotDiff.render(stored, proposed)}"
+                                    )(using frame)
+                                case Result.Panic(err) =>
+                                    throw err
+                                case Result.Success(storedValue) =>
+                                    val ops = Changeset[A](storedValue, norm)(using schema, frame).operations
+                                    if ops.nonEmpty then
+                                        val paths   = snapshotChangedPaths(ops)
+                                        val diagram = s"changed fields: ${paths.mkString(", ")}\n\n${SnapshotDiff.render(stored, proposed)}"
+                                        val failure = new AssertionFailed(diagram, frame, Maybe.Present("Snapshot mismatch"), Maybe.Absent)
+                                        as.record(failure)
+                                        throw failure
+                                    end if
+                    end match
+                end if
+            case SnapshotCodec.Binary(c, _) =>
+                val proposed = schema.encode(norm)(using c, frame)
+                if snapshotUpdateMode then
+                    SnapshotStore.writeBytes(path, proposed)
+                else
+                    SnapshotStore.readBytes(path) match
+                        case Maybe.Absent =>
+                            SnapshotStore.writeBytes(path, proposed)
+                            throw SnapshotNotFound(path)(using frame)
+                        case Maybe.Present(stored) =>
+                            schema.decode(stored)(using c, frame) match
+                                case Result.Failure(err) =>
+                                    throw SnapshotSchemaEvolution(path, err.getMessage)(using frame)
+                                case Result.Panic(err) =>
+                                    throw err
+                                case Result.Success(storedValue) =>
+                                    val ops = Changeset[A](storedValue, norm)(using schema, frame).operations
+                                    if ops.nonEmpty then
+                                        val paths = snapshotChangedPaths(ops)
+                                        val failure = new AssertionFailed(
+                                            s"changed fields: ${paths.mkString(", ")}",
+                                            frame,
+                                            Maybe.Present("Snapshot mismatch"),
+                                            Maybe.Absent
+                                        )
+                                        as.record(failure)
+                                        throw failure
+                                    end if
+                    end match
+                end if
+        end match
+    end assertSchemaSnapshot
+
+    private def normalizeWith[A](config: SnapshotConfig[A] => SnapshotConfig[A], value: A): A =
+        config(SnapshotConfig.apply[A]).modify.applyTo(value)
+
+    private def validateSnapshotName(name: String): Unit =
+        if name.contains('/') || name.contains('\\') then
+            throw new IllegalArgumentException(
+                s"Snapshot name must not contain path separators: $name"
+            )
+        end if
+        if name.isEmpty then
+            throw new IllegalArgumentException("snapshot name must not be empty")
+        end if
+        if name == "." then
+            throw new IllegalArgumentException("snapshot name must not be '.'")
+        end if
+        if name == ".." then
+            throw new IllegalArgumentException("snapshot name must not be '..'")
+        end if
+        if name.contains(' ') then
+            throw new IllegalArgumentException("snapshot name must not contain a space")
+        end if
+    end validateSnapshotName
+
+    private def snapshotChangedPaths(ops: Chunk[Changeset.Patch], prefix: Chunk[String] = Chunk.empty): Chunk[String] =
+        ops.flatMap {
+            case Changeset.Patch.Nested(fp, nested) => snapshotChangedPaths(nested, prefix ++ fp)
+            case patch                              => Chunk((prefix ++ patch.fieldPath).mkString("."))
+        }
 
 end SnapshotTestBase
 

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/internal/SnapshotStore.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/internal/SnapshotStore.scala
@@ -1,6 +1,7 @@
 package kyo.test.snapshot.internal
 
 import kyo.Maybe
+import kyo.Span
 
 /** Platform-specific file I/O for snapshot files.
   *
@@ -20,5 +21,21 @@ object SnapshotStore:
     def write(path: String, content: String): Unit =
         val normalized = if content.endsWith("\n") then content else content + "\n"
         SnapshotStorePlatform.write(path, normalized)
+
+    /** Returns the raw snapshot bytes, or Absent if the file does not exist.
+      *
+      * The bytes-path sibling of [[read]] for binary codecs. Unlike [[read]] and [[write]], no trailing-newline handling is
+      * applied: the bytes are returned exactly as stored.
+      */
+    def readBytes(path: String): Maybe[Span[Byte]] =
+        SnapshotStorePlatform.readBytes(path)
+
+    /** Writes raw bytes to path verbatim, creating parent directories as needed. Overwrites if already present.
+      *
+      * The bytes-path sibling of [[write]] for binary codecs: content is written exactly as given, with no base64 encoding and
+      * no trailing-newline append, so a stored binary snapshot is the real codec wire artifact.
+      */
+    def writeBytes(path: String, content: Span[Byte]): Unit =
+        SnapshotStorePlatform.writeBytes(path, content)
 
 end SnapshotStore

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotCodecTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotCodecTest.scala
@@ -1,0 +1,93 @@
+package kyo.test.snapshot
+
+import kyo.Codec
+import kyo.Frame
+import kyo.Span
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for `SnapshotCodec`: the locked preset kind/extension data and the open Text/Binary constructors.
+  *
+  * All assertions are synchronous plain value/pattern-match checks (no file I/O, no Sync/Async boundary); uses ScalaTest directly,
+  * mirroring `SnapshotStoreBytesTest`.
+  *
+  * Covers:
+  *   1. The seven companion presets carry the locked kind (Text/Binary) and extension, all pairwise-distinct and none equal to the plain
+  *      `Render`-based `assertSnapshot`'s `"snap"` extension.
+  *   2. The open `Text`/`Binary` constructors expose the exact codec and extension passed to them.
+  */
+class SnapshotCodecTest extends AnyFunSuite with NonImplicitAssertions:
+
+    /** A minimal Codec double: only identity (never encode/decode) is exercised by this test. */
+    private def fakeCodec(): Codec =
+        new Codec:
+            def newWriter(): Codec.Writer = throw NotImplementedError("fakeCodec.newWriter is not exercised by this test")
+            def newReader(input: Span[Byte])(using Frame): Codec.Reader =
+                throw NotImplementedError("fakeCodec.newReader is not exercised by this test")
+
+    test("the seven presets carry the locked kind and extension") {
+        SnapshotCodec.Yaml match
+            case SnapshotCodec.Text(_, ext) => assert(ext == "snap.yaml", s"Expected ext 'snap.yaml', got '$ext'")
+            case other                      => fail(s"Expected SnapshotCodec.Text, got $other")
+
+        SnapshotCodec.Json match
+            case SnapshotCodec.Text(_, ext) => assert(ext == "snap.json", s"Expected ext 'snap.json', got '$ext'")
+            case other                      => fail(s"Expected SnapshotCodec.Text, got $other")
+
+        SnapshotCodec.Ion match
+            case SnapshotCodec.Text(_, ext) => assert(ext == "snap.ion", s"Expected ext 'snap.ion', got '$ext'")
+            case other                      => fail(s"Expected SnapshotCodec.Text, got $other")
+
+        SnapshotCodec.Protobuf match
+            case SnapshotCodec.Binary(_, ext) => assert(ext == "snap.pb", s"Expected ext 'snap.pb', got '$ext'")
+            case other                        => fail(s"Expected SnapshotCodec.Binary, got $other")
+
+        SnapshotCodec.Bson match
+            case SnapshotCodec.Binary(_, ext) => assert(ext == "snap.bson", s"Expected ext 'snap.bson', got '$ext'")
+            case other                        => fail(s"Expected SnapshotCodec.Binary, got $other")
+
+        SnapshotCodec.MsgPack match
+            case SnapshotCodec.Binary(_, ext) => assert(ext == "snap.msgpack", s"Expected ext 'snap.msgpack', got '$ext'")
+            case other                        => fail(s"Expected SnapshotCodec.Binary, got $other")
+
+        SnapshotCodec.IonBinary match
+            case SnapshotCodec.Binary(_, ext) => assert(ext == "snap.ionb", s"Expected ext 'snap.ionb', got '$ext'")
+            case other                        => fail(s"Expected SnapshotCodec.Binary, got $other")
+
+        val allExts = List(
+            SnapshotCodec.Yaml.ext,
+            SnapshotCodec.Json.ext,
+            SnapshotCodec.Ion.ext,
+            SnapshotCodec.Protobuf.ext,
+            SnapshotCodec.Bson.ext,
+            SnapshotCodec.MsgPack.ext,
+            SnapshotCodec.IonBinary.ext
+        )
+        assert(allExts.distinct.size == allExts.size, s"Expected all seven extensions pairwise distinct, got $allExts")
+        assert(
+            !allExts.contains("snap"),
+            s"Expected no preset extension to equal the plain Render assertSnapshot extension 'snap', got $allExts"
+        )
+    }
+
+    test("the open Text and Binary constructors expose the given codec and extension") {
+        val textCodec   = fakeCodec()
+        val binaryCodec = fakeCodec()
+
+        val text: SnapshotCodec   = SnapshotCodec.Text(textCodec, "snap.custom")
+        val binary: SnapshotCodec = SnapshotCodec.Binary(binaryCodec, "bin.custom")
+
+        assert(text.codec eq textCodec, "Expected Text.codec to be the exact codec instance passed in")
+        assert(text.ext == "snap.custom", s"Expected Text.ext 'snap.custom', got '${text.ext}'")
+        assert(binary.codec eq binaryCodec, "Expected Binary.codec to be the exact codec instance passed in")
+        assert(binary.ext == "bin.custom", s"Expected Binary.ext 'bin.custom', got '${binary.ext}'")
+
+        text match
+            case SnapshotCodec.Text(_, _) => succeed
+            case other                    => fail(s"Expected SnapshotCodec.Text, got $other")
+        binary match
+            case SnapshotCodec.Binary(_, _) => succeed
+            case other                      => fail(s"Expected SnapshotCodec.Binary, got $other")
+    }
+
+end SnapshotCodecTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotConfigTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotConfigTest.scala
@@ -1,0 +1,35 @@
+package kyo.test.snapshot
+
+import kyo.Schema
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for `SnapshotConfig`: the builder's identity, accumulate, and scrub semantics.
+  *
+  * All assertions are synchronous plain-value checks (no file I/O, no Sync/Async boundary); uses ScalaTest directly, mirroring
+  * `SnapshotCodecTest`.
+  */
+class SnapshotConfigTest extends AnyFunSuite with NonImplicitAssertions:
+
+    case class Point(x: Int, y: Int) derives CanEqual, Schema
+    case class Event(id: Int, ts: Long) derives CanEqual, Schema
+
+    test("the empty config from SnapshotConfig.apply is identity normalization") {
+        val config = SnapshotConfig.apply[Point]
+        val result = config.modify.applyTo(Point(1, 2))
+        assert(result == Point(1, 2), s"Expected Point(1, 2) unchanged, got $result")
+    }
+
+    test("normalize accumulates: .normalize(setX).normalize(setY) applies BOTH passes, not just the last") {
+        val config = SnapshotConfig.apply[Point].normalize(_.set(_.x)(7)).normalize(_.set(_.y)(9))
+        val result = config.modify.applyTo(Point(1, 2))
+        assert(result == Point(7, 9), s"Expected Point(7, 9) (both passes applied), got $result")
+    }
+
+    test("the built Modify scrubs a real field: normalize(_.set(_.ts)(0L)) zeroes the timestamp") {
+        val config = SnapshotConfig.apply[Event].normalize(_.set(_.ts)(0L))
+        val result = config.modify.applyTo(Event(1, 999L))
+        assert(result == Event(1, 0L), s"Expected Event(1, 0L) with ts scrubbed, got $result")
+    }
+
+end SnapshotConfigTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaEvolutionTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaEvolutionTest.scala
@@ -1,0 +1,22 @@
+package kyo.test.snapshot
+
+import kyo.test.AssertionFailed
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for `SnapshotSchemaEvolution`: the distinct decode-failure factory. All assertions are synchronous plain value checks (no file
+  * I/O); uses ScalaTest directly, mirroring `SnapshotDiffTest`.
+  */
+class SnapshotSchemaEvolutionTest extends AnyFunSuite with NonImplicitAssertions:
+
+    test("the factory message is distinctly prefixed and never the mismatch prefix") {
+        val failure: AssertionFailed = SnapshotSchemaEvolution("dir/name.snap.yaml", "boom")
+
+        assert(
+            failure.diagram == "SnapshotSchemaEvolution: stored snapshot at dir/name.snap.yaml could not be decoded: boom",
+            s"Expected the distinct decode-failure diagram, got: ${failure.diagram}"
+        )
+        assert(!failure.getMessage.contains("Snapshot mismatch"), s"Expected no 'Snapshot mismatch' prefix, got: ${failure.getMessage}")
+    }
+
+end SnapshotSchemaEvolutionTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaTest.scala
@@ -1,0 +1,381 @@
+package kyo.test.snapshot
+
+import kyo.Base64
+import kyo.Chunk
+import kyo.Codec
+import kyo.Maybe
+import kyo.Modify
+import kyo.Protobuf
+import kyo.Render
+import kyo.Result
+import kyo.Schema
+import kyo.Span
+import kyo.Yaml
+import kyo.test.AssertionFailed
+import kyo.test.AssertScope
+import kyo.test.internal.TestContext
+import kyo.test.snapshot.internal.SnapshotStore
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** End-to-end tests for `assertSchemaSnapshot`, driven outside the kyo-test runner via a private `SnapshotTest[Any]` fixture, mirroring
+  * `SnapshotUpdateModeTest`'s pattern. All assertions are synchronous (file I/O + try/catch); uses ScalaTest directly.
+  *
+  * Covers: field-named Text encoding, normalize-before-encode-and-compare, the Text/Binary mismatch report shapes, the recursive nested
+  * changed-path report, format-tolerant structural compare, schema-evolution decode failures, name validation, update mode, first-run
+  * behavior, the Protobuf raw-bytes round trip, a raw codec defect propagating unwrapped from both the Binary and Text decode arms,
+  * and the Render-based `assertSnapshot` path, whose name validation and first-run behavior match `assertSchemaSnapshot` exactly.
+  */
+class SnapshotSchemaTest extends AnyFunSuite with NonImplicitAssertions:
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    // These tests drive `assertSchemaSnapshot` outside the runner, so they supply a standalone scope to
+    // satisfy the assert family's using-clause; the snapshot throws fire on the synchronous path.
+    private given AssertScope = new AssertScope(Chunk.empty)
+
+    private def tmpDir(): String =
+        s"target/snap-schema-test-${java.lang.System.nanoTime()}"
+
+    private def installContexts(): Unit =
+        TestContext.setForInstantiation(new TestContext(Chunk.empty))
+
+    case class Point(x: Int, y: Int) derives CanEqual, Schema
+    case class Line(a: Point, b: Point) derives CanEqual, Schema
+    case class Event(id: Int, ts: Long) derives CanEqual, Schema
+
+    /** A fixture whose `equals`/`hashCode` ignore field `b`, so value-equality and schema-structural equality diverge:
+      * the schema still encodes `b`, so a `Changeset` diff detects the difference even though `.equals` does not.
+      */
+    case class Ver(a: Int, b: Int) derives Schema:
+        override def equals(other: Any): Boolean = other match
+            case that: Ver => this.a == that.a
+            case _         => false
+        override def hashCode(): Int = a.hashCode()
+    end Ver
+
+    /** A non-`DecodeException` runtime defect: a raw codec failure must propagate unwrapped, never rewrapped as
+      * `SnapshotSchemaEvolution`.
+      */
+    class RawCodecDefect(message: String) extends RuntimeException(message)
+
+    /** A `Codec` whose writer delegates to `Protobuf` (so encode succeeds and a snapshot file is produced) but whose
+      * reader unconditionally throws a [[RawCodecDefect]], deterministically producing a `Result.Panic` on decode
+      * (`Result.catching[DecodeException]` maps a non-matching throwable to `Panic`).
+      */
+    private def throwingCodec(): Codec =
+        new Codec:
+            def newWriter(): Codec.Writer = Protobuf().newWriter()
+            def newReader(input: Span[Byte])(using kyo.Frame): Codec.Reader =
+                throw RawCodecDefect("raw codec defect")
+
+    /** A `Codec` whose writer delegates to `Yaml` (so encode succeeds and a snapshot file is produced) but whose reader
+      * unconditionally throws a [[RawCodecDefect]], deterministically producing a `Result.Panic` on decode, mirroring
+      * `throwingCodec` for the Text decode arm rather than the Binary one.
+      */
+    private def throwingTextCodec(): Codec =
+        new Codec:
+            def newWriter(): Codec.Writer = Yaml().newWriter()
+            def newReader(input: Span[Byte])(using kyo.Frame): Codec.Reader =
+                throw RawCodecDefect("raw text codec defect")
+
+    /** Minimal `SnapshotTest[Any]` subclass; storage dir, update mode, and codec are all controlled by constructor parameters. */
+    private class SchemaFixture(dir: String, update: Boolean, codecOverride: SnapshotCodec = SnapshotCodec.Yaml) extends SnapshotTest[Any]:
+        override protected def snapshotDir: String          = dir
+        override protected def snapshotUpdateMode: Boolean  = update
+        override protected def snapshotCodec: SnapshotCodec = codecOverride
+
+        def assertSchema[A](actual: A, name: String)(using Schema[A], kyo.Frame, AssertScope): Unit =
+            assertSchemaSnapshot(actual, name): Unit
+
+        def assertSchema[A](actual: A, name: String, normalize: Modify[A] => Modify[A])(using Schema[A], kyo.Frame, AssertScope): Unit =
+            assertSchemaSnapshot(actual, name, _.normalize(normalize)): Unit
+
+        def assertRendered[A](actual: A, name: String)(using Render[A], kyo.Frame, AssertScope): Unit =
+            assertSnapshot(actual, name): Unit
+
+    end SchemaFixture
+
+    // ── tests ────────────────────────────────────────────────────────────────
+
+    test("default Yaml output is field-named, not a positional flat toString") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = true)
+        fixture.assertSchema(Point(1, 2), "point")
+
+        val path = s"$dir/SchemaFixture/point.snap.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                assert(stored.contains("x:"), s"Expected a field-named 'x:' key, got: $stored")
+                assert(stored.contains("y:"), s"Expected a field-named 'y:' key, got: $stored")
+                assert(stored.stripTrailing() != "Point(1,2)", s"Expected a Yaml mapping, not the positional Render form, got: $stored")
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+    }
+
+    test("normalize scrubs a non-deterministic timestamp before encode and before compare so repeated runs pass") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true)
+        val ts1    = java.lang.System.nanoTime()
+        writer.assertSchema(Event(1, ts1), "event", _.set(_.ts)(0L))
+
+        val path = s"$dir/SchemaFixture/event.snap.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                Schema[Event].decodeString[Yaml](stored) match
+                    case Result.Success(decoded) => assert(decoded.ts == 0L, s"Expected the stored ts scrubbed to 0, got: $decoded")
+                    case other                   => fail(s"Expected a decodable Event, got $other")
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false)
+        val ts2    = ts1 + 1L
+        reader.assertSchema(Event(1, ts2), "event", _.set(_.ts)(0L))
+        succeed
+    }
+
+    test("Text (Yaml) mismatch report carries a unified textual diff and the changed field path") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true)
+        writer.assertSchema(Point(1, 2), "point")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            reader.assertSchema(Point(1, 3), "point")
+        }
+        assert(ex.diagram.contains("changed fields: y"), s"Expected the changed field 'y', got: ${ex.diagram}")
+        assert(ex.diagram.contains("actual vs expected"), s"Expected a unified textual diff block, got: ${ex.diagram}")
+    }
+
+    test("Binary (Protobuf) mismatch report carries the changed field path but no textual diff") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true, SnapshotCodec.Protobuf)
+        writer.assertSchema(Point(1, 2), "point")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false, SnapshotCodec.Protobuf)
+        val ex = intercept[AssertionFailed] {
+            reader.assertSchema(Point(1, 3), "point")
+        }
+        assert(ex.diagram.contains("changed fields: y"), s"Expected the changed field 'y', got: ${ex.diagram}")
+        assert(!ex.diagram.contains("actual vs expected"), s"Expected no textual diff block for a Binary codec, got: ${ex.diagram}")
+    }
+
+    test("mismatch on a nested field reports the full dotted nested path") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true)
+        writer.assertSchema(Line(Point(1, 2), Point(3, 4)), "line")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            reader.assertSchema(Line(Point(1, 2), Point(3, 9)), "line")
+        }
+        assert(ex.diagram.contains("changed fields: b.y"), s"Expected the dotted nested path 'b.y', got: ${ex.diagram}")
+    }
+
+    test("format-tolerant compare: a hand-reformatted stored snapshot that decodes equal still passes") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true)
+        writer.assertSchema(Point(1, 2), "point")
+
+        val path = s"$dir/SchemaFixture/point.snap.yaml"
+        val original = SnapshotStore.read(path) match
+            case Maybe.Present(content) => content
+            case Maybe.Absent           => fail(s"expected the update-mode write to produce $path")
+        val reformatted = original.linesIterator.toList.reverse.map(line => s"$line   ").mkString("\n") + "\n"
+        assert(reformatted.trim != original.trim, "expected the hand-reformatted content to differ from the original encode")
+        SnapshotStore.write(path, reformatted)
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false)
+        reader.assertSchema(Point(1, 2), "point")
+        succeed
+    }
+
+    test("a stored snapshot that fails to decode routes to SnapshotSchemaEvolution, distinct from a value mismatch") {
+        val dir  = tmpDir()
+        val path = s"$dir/SchemaFixture/point.snap.yaml"
+        SnapshotStore.write(path, "not-a-decodable-point-payload")
+
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            fixture.assertSchema(Point(1, 2), "point")
+        }
+        assert(ex.diagram.contains("SnapshotSchemaEvolution:"), s"Expected the SnapshotSchemaEvolution prefix, got: ${ex.diagram}")
+        assert(!ex.diagram.contains("Snapshot mismatch"), s"Expected no Snapshot mismatch prefix, got: ${ex.diagram}")
+    }
+
+    test("name validation rejects a path separator, empty, dot, dot-dot, and an embedded space") {
+        val invalidNames = List("a/b", "", ".", "..", "a b")
+        invalidNames.foreach { invalidName =>
+            val dir = tmpDir()
+            installContexts()
+            val fixture = new SchemaFixture(dir, update = true)
+            intercept[IllegalArgumentException] {
+                fixture.assertSchema(Point(1, 2), invalidName)
+            }
+        }
+    }
+
+    test("update mode writes the encoded value and passes without reading a prior file") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = true)
+        fixture.assertSchema(Point(5, 6), "fresh")
+
+        val path = s"$dir/SchemaFixture/fresh.snap.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                Schema[Point].decodeString[Yaml](stored) match
+                    case Result.Success(decoded) => assert(decoded == Point(5, 6), s"Expected Point(5, 6), got $decoded")
+                    case other                   => fail(s"Expected a decodable Point(5, 6), got $other")
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+    }
+
+    test("first run with no stored file writes the proposed value then fails with SnapshotNotFound") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            fixture.assertSchema(Point(7, 8), "first-run")
+        }
+        assert(!ex.diagram.contains("SnapshotSchemaEvolution:"), s"Expected no SnapshotSchemaEvolution prefix, got: ${ex.diagram}")
+        assert(!ex.diagram.contains("Snapshot mismatch"), s"Expected no Snapshot mismatch prefix, got: ${ex.diagram}")
+        assert(ex.diagram.contains("SnapshotNotFound"), s"Expected a SnapshotNotFound diagram, got: ${ex.diagram}")
+
+        val path = s"$dir/SchemaFixture/first-run.snap.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                Schema[Point].decodeString[Yaml](stored) match
+                    case Result.Success(decoded) => assert(decoded == Point(7, 8), s"Expected Point(7, 8), got $decoded")
+                    case other                   => fail(s"Expected a decodable Point(7, 8), got $other")
+            case Maybe.Absent =>
+                fail(s"expected the first-run write to produce $path")
+        end match
+    }
+
+    test("Protobuf round-trip stores raw wire bytes byte-identical to schema.encode on every platform") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = true, SnapshotCodec.Protobuf)
+        fixture.assertSchema(Point(1, 2), "protobuf-point")
+
+        val path     = s"$dir/SchemaFixture/protobuf-point.snap.pb"
+        val expected = Schema[Point].encode[Protobuf](Point(1, 2))
+        SnapshotStore.readBytes(path) match
+            case Maybe.Present(stored) =>
+                assert(stored.size == expected.size, s"Expected length ${expected.size}, got ${stored.size}")
+                assert(stored.is(expected), "Expected the stored bytes to be byte-identical to a fresh schema.encode")
+                val encodedLength = Base64.encode(expected).size
+                assert(
+                    stored.size != encodedLength,
+                    s"Stored byte length (${stored.size}) must not equal the base64-encoded length ($encodedLength)"
+                )
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+    }
+
+    test("assertSnapshot still fails first-run with SnapshotNotFound for a type with only a Render instance") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            fixture.assertRendered(42, "render-only")
+        }
+        assert(ex.diagram.contains("SnapshotNotFound"), s"Expected a SnapshotNotFound diagram, got: ${ex.diagram}")
+    }
+
+    test("assertSnapshot rejects a path separator, empty, dot, dot-dot, and an embedded space, same as assertSchemaSnapshot") {
+        val invalidNames = List("a/b", "", ".", "..", "a b")
+        invalidNames.foreach { invalidName =>
+            val dir = tmpDir()
+            installContexts()
+            val fixture = new SchemaFixture(dir, update = true)
+            intercept[IllegalArgumentException] {
+                fixture.assertRendered(42, invalidName)
+            }
+        }
+    }
+
+    test("a Binary (Protobuf) stored snapshot that fails to decode routes to SnapshotSchemaEvolution, distinct from a value mismatch") {
+        val dir       = tmpDir()
+        val path      = s"$dir/SchemaFixture/point.snap.pb"
+        val encoded   = Schema[Point].encode[Protobuf](Point(1, 2))
+        val truncated = encoded.dropRight(1)
+        SnapshotStore.writeBytes(path, truncated)
+
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = false, SnapshotCodec.Protobuf)
+        val ex = intercept[AssertionFailed] {
+            fixture.assertSchema(Point(1, 2), "point")
+        }
+        assert(ex.diagram.contains("SnapshotSchemaEvolution:"), s"Expected the SnapshotSchemaEvolution prefix, got: ${ex.diagram}")
+        assert(!ex.diagram.contains("Snapshot mismatch"), s"Expected no Snapshot mismatch prefix, got: ${ex.diagram}")
+    }
+
+    test("the pass/fail gate follows schema-structural Changeset.operations, not value .equals") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true)
+        writer.assertSchema(Ver(1, 2), "ver")
+
+        assert(Ver(1, 2).equals(Ver(1, 9)), "expected the fixture's custom equals to ignore field b")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            reader.assertSchema(Ver(1, 9), "ver")
+        }
+        assert(ex.diagram.contains("changed fields: b"), s"Expected the changed field 'b', got: ${ex.diagram}")
+    }
+
+    test(
+        "a raw (non-DecodeException) Binary codec defect yields Result.Panic and propagates unwrapped, never rewrapped as SnapshotSchemaEvolution"
+    ) {
+        val dir        = tmpDir()
+        val panicCodec = SnapshotCodec.Binary(throwingCodec(), "snap.panicbin")
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true, panicCodec)
+        writer.assertSchema(Point(1, 2), "panic-point")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false, panicCodec)
+        val ex = intercept[RawCodecDefect] {
+            reader.assertSchema(Point(1, 2), "panic-point")
+        }
+        assert(ex.getMessage == "raw codec defect", s"Expected message 'raw codec defect', got: ${ex.getMessage}")
+    }
+
+    test(
+        "a raw (non-DecodeException) Text codec defect yields Result.Panic and propagates unwrapped, never rewrapped as SnapshotSchemaEvolution"
+    ) {
+        val dir        = tmpDir()
+        val panicCodec = SnapshotCodec.Text(throwingTextCodec(), "snap.panictxt")
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true, panicCodec)
+        writer.assertSchema(Point(1, 2), "panic-point")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false, panicCodec)
+        val ex = intercept[RawCodecDefect] {
+            reader.assertSchema(Point(1, 2), "panic-point")
+        }
+        assert(ex.getMessage == "raw text codec defect", s"Expected message 'raw text codec defect', got: ${ex.getMessage}")
+    }
+
+end SnapshotSchemaTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotStoreBytesTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotStoreBytesTest.scala
@@ -1,0 +1,72 @@
+package kyo.test.snapshot
+
+import kyo.Base64
+import kyo.Maybe
+import kyo.Span
+import kyo.test.snapshot.internal.SnapshotStore
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for the raw-bytes store path (`SnapshotStore.readBytes`/`writeBytes`).
+  *
+  * All assertions are synchronous (plain file I/O, no Sync/Async boundary); uses ScalaTest directly, mirroring
+  * `SnapshotDiffTest`/`SnapshotUpdateModeTest`.
+  *
+  * Covers:
+  *   1. Byte-fidelity round-trip, including 0x00, 0xFF, and a newline byte.
+  *   2. No trailing-newline append and no base64 encoding of the stored content.
+  *   3. Absent-file returns Maybe.Absent.
+  */
+class SnapshotStoreBytesTest extends AnyFunSuite with NonImplicitAssertions:
+
+    private def tmpDir(): String =
+        s"target/snap-bytes-test-${java.lang.System.nanoTime()}"
+
+    test("raw-bytes round-trip is byte-identical including 0x00, 0xFF, and a newline byte") {
+        val path     = s"${tmpDir()}/round-trip.bin"
+        val original = Span[Byte](0x00.toByte, 0x01.toByte, 0xff.toByte, '\n'.toByte, 0x7f.toByte)
+
+        SnapshotStore.writeBytes(path, original)
+        val result = SnapshotStore.readBytes(path)
+
+        result match
+            case Maybe.Present(stored) =>
+                assert(stored.size == original.size, s"Expected length ${original.size}, got ${stored.size}")
+                assert(stored.is(original), s"Expected byte-identical content, got ${stored.toArrayUnsafe.toList}")
+            case Maybe.Absent =>
+                fail(s"Expected Maybe.Present, got Maybe.Absent for $path")
+        end match
+    }
+
+    test("stored bytes are verbatim: no trailing newline appended and not base64-encoded") {
+        val path    = s"${tmpDir()}/verbatim.bin"
+        val content = Span[Byte](0x10.toByte, 0x20.toByte, 0x30.toByte, 0x40.toByte, 0x50.toByte)
+
+        SnapshotStore.writeBytes(path, content)
+        val result = SnapshotStore.readBytes(path)
+
+        result match
+            case Maybe.Present(stored) =>
+                assert(stored.size == content.size, s"Expected no appended newline byte: length ${stored.size} != ${content.size}")
+                assert(stored.is(content), s"Expected verbatim byte content, got ${stored.toArrayUnsafe.toList}")
+                val encodedLength = Base64.encode(content).size
+                assert(
+                    stored.size != encodedLength,
+                    s"Stored byte length (${stored.size}) must not equal the base64-encoded string length ($encodedLength)"
+                )
+            case Maybe.Absent =>
+                fail(s"Expected Maybe.Present, got Maybe.Absent for $path")
+        end match
+    }
+
+    test("readBytes on a missing file returns Absent") {
+        val path   = s"${tmpDir()}/missing.bin"
+        val result = SnapshotStore.readBytes(path)
+
+        result match
+            case Maybe.Absent     => succeed
+            case Maybe.Present(_) => fail(s"Expected Maybe.Absent for a file never written: $path")
+        end match
+    }
+
+end SnapshotStoreBytesTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshotforeign/SnapshotForeignPackageTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshotforeign/SnapshotForeignPackageTest.scala
@@ -1,0 +1,62 @@
+package kyo.test.snapshotforeign
+
+import kyo.Chunk
+import kyo.Maybe
+import kyo.Result
+import kyo.Schema
+import kyo.Yaml
+import kyo.test.AssertScope
+import kyo.test.internal.TestContext
+import kyo.test.snapshot.SnapshotTest
+import kyo.test.snapshot.internal.SnapshotStore
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Compile-and-run proof that `assertSchemaSnapshot`'s config-lambda form resolves from a package where `SnapshotConfig`'s
+  * `private[snapshot] modify` accessor is genuinely inaccessible.
+  *
+  * Package `kyo.test.snapshotforeign` is a sibling of `kyo.test.snapshot`. The suite still sits under `kyo.test`, so the
+  * test-internal `AssertScope` and `TestContext` constructors stay reachable here; the isolated axis under test is
+  * `private[snapshot]` accessibility, proving the inline `assertSchemaSnapshot` body resolves its `normalizeWith` call
+  * through a compiler-generated accessor rather than a direct cross-package field read.
+  */
+class SnapshotForeignPackageTest extends AnyFunSuite with NonImplicitAssertions:
+
+    private given AssertScope = new AssertScope(Chunk.empty)
+
+    private def tmpDir(): String =
+        s"target/snap-foreign-test-${java.lang.System.nanoTime()}"
+
+    private def installContexts(): Unit =
+        TestContext.setForInstantiation(new TestContext(Chunk.empty))
+
+    case class Rec(id: Int, ts: Long) derives Schema
+
+    /** Minimal `SnapshotTest[Any]` subclass; the config-lambda call site lives here, in package `kyo.test.snapshotforeign`. */
+    private class ForeignFixture(dir: String) extends SnapshotTest[Any]:
+        override protected def snapshotDir: String         = dir
+        override protected def snapshotUpdateMode: Boolean = true
+
+        def storeRec(actual: Rec, name: String)(using AssertScope): Unit =
+            assertSchemaSnapshot(actual, name, _.normalize(_.set(_.ts)(0L))): Unit
+
+    end ForeignFixture
+
+    test("a suite in a sibling package (outside kyo.test.snapshot) compiles and runs assertSchemaSnapshot with the config lambda") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new ForeignFixture(dir)
+        fixture.storeRec(Rec(1, 999L), "rec")
+
+        val path = s"$dir/ForeignFixture/rec.snap.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                Schema[Rec].decodeString[Yaml](stored) match
+                    case Result.Success(decoded) => assert(decoded.ts == 0L, s"Expected the stored ts scrubbed to 0, got: $decoded")
+                    case other                   => fail(s"Expected a decodable Rec, got $other")
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+    }
+
+end SnapshotForeignPackageTest


### PR DESCRIPTION
# Schema-based snapshot testing

## Problem

`kyo-test/snapshot` snapshots a value only through `Render[A].asString`, a flat `toString`-shaped string with no field names and one format. Three costs follow from that:

1. **Non-deterministic fields**: a timestamp, instant, or process id makes a snapshot perpetually unstable, because nothing can normalize the value before storage.
2. **Opaque mismatches**: a failure surfaces only as a raw line diff, never as "which field changed".
3. **Silent schema drift**: a type that gains or loses a field drifts with no schema-evolution signal.

`kyo-schema` already ships the machinery to close all three gaps (`Schema[A]` derivation with pluggable `Codec`, `Modify[A]` for typed field-level normalization, `Changeset` for structural comparison), but nothing in kyo-test wired it into the snapshot path.

## Solution

A new `assertSchemaSnapshot[A]` assertion on `SnapshotTestBase[S]` (inherited by the discoverable `SnapshotTest[S]`), alongside the existing `Render`-based `assertSnapshot`, which is unchanged in behavior and stays available for types without a `Schema`.

```scala
protected inline def assertSchemaSnapshot[A](
    inline actual: A,
    inline name: String,
    inline config: SnapshotConfig[A] => SnapshotConfig[A] = identity[SnapshotConfig[A]]
)(using inline schema: Schema[A], inline frame: Frame, inline as: kyo.test.AssertScope): Unit < (S & Async & Abort[Throwable] & Scope)
```

Given a `Schema[A]` in scope, it normalizes `actual` through the config's `Modify[A]`, encodes it via the suite's `SnapshotCodec` (default `SnapshotCodec.Yaml`, a readable field-named text format), and stores the result under `${snapshotDir}/${suite}/${name}.${ext}`. Each codec has its own extension (`snap.yaml`, `snap.json`, `snap.pb`, ...), all distinct from `assertSnapshot`'s plain `.snap`, so the two assertions never collide on the same name.

### `SnapshotCodec`: any codec, text vs binary

`kyo.Codec` carries no text-versus-binary flag, so the snapshot module wraps it in a two-case enum that decides both the storage format and whether a mismatch can carry a textual diff:

```scala
enum SnapshotCodec(val codec: Codec, val ext: String):
    case Text(override val codec: Codec, override val ext: String)   extends SnapshotCodec(codec, ext)
    case Binary(override val codec: Codec, override val ext: String) extends SnapshotCodec(codec, ext)
```

Seven presets cover every codec kyo-schema ships; `Text`/`Binary` remain the open extension point for any custom `Codec`:

| Preset | Kind | Extension | Stored as |
|---|---|---|---|
| `SnapshotCodec.Yaml` (default) | Text | `snap.yaml` | UTF-8 string |
| `SnapshotCodec.Json` | Text | `snap.json` | UTF-8 string |
| `SnapshotCodec.Ion` | Text | `snap.ion` | UTF-8 string |
| `SnapshotCodec.Protobuf` | Binary | `snap.pb` | raw wire bytes |
| `SnapshotCodec.Bson` | Binary | `snap.bson` | raw wire bytes |
| `SnapshotCodec.MsgPack` | Binary | `snap.msgpack` | raw wire bytes |
| `SnapshotCodec.IonBinary` | Binary | `snap.ionb` | raw wire bytes |

Binary snapshots are the real wire artifact: stored byte-identical to codec output (no base64, no trailing-newline munging), so a `.pb` file stays inspectable with format tooling. `SnapshotStore` gains a raw-bytes sibling path to support this:

```scala
def readBytes(path: String): Maybe[Span[Byte]]
def writeBytes(path: String, content: Span[Byte]): Unit
```

with platform implementations for JVM/Native (NIO) and JS/Wasm (Node `fs`).

The format is selected per suite by overriding a hook, mirroring the existing `snapshotDir`:

```scala
protected def snapshotCodec: SnapshotCodec = SnapshotCodec.Yaml
```

### `SnapshotConfig`: the single per-call customization point

Per-call customization goes through an immutable builder passed as a lambda, so future capabilities (for example a custom comparison strategy) become additive methods on the config, never new parameters on `assertSchemaSnapshot`, and existing call sites keep compiling unchanged:

```scala
final class SnapshotConfig[A] private[snapshot] (private[snapshot] val modify: Modify[A]):
    /** Adds a field-normalization pass, scrubbing non-deterministic fields before encode and before compare. */
    def normalize(f: Modify[A] => Modify[A]): SnapshotConfig[A]

object SnapshotConfig:
    def apply[A]: SnapshotConfig[A] = new SnapshotConfig[A](Modify.apply[A])
```

Today it carries exactly one capability, `.normalize`, which composes a `Modify[A]` transform applied before both encode and compare. Multiple `.normalize` calls accumulate in order. Format selection deliberately stays a per-suite `snapshotCodec` concern, not a `SnapshotConfig` knob: the two are complementary customization surfaces at different scopes.

### Comparison semantics

On a run with an existing stored snapshot:

1. The stored bytes are decoded via `Schema[A]`.
2. **Decode succeeds**: the stored value and the normalized actual are compared structurally through `Changeset`. Structural equality passes, so re-serialization noise (a hand-reformatted YAML file that still decodes to an equal value) never fails the assertion: the compare is format-tolerant.
3. **Values differ**: the failure reports the changed field paths (nested paths dotted, e.g. `b.y`), plus a unified text diff for text codecs.
4. **Decode fails**: the type's shape has drifted from the stored snapshot (field added, removed, retyped). This fails with the distinct `SnapshotSchemaEvolution` exception, never conflated with an ordinary value mismatch. A `Result.Panic` on decode (a raw codec defect, not a schema mismatch) propagates unwrapped.

First-run and update-mode behavior matches `assertSnapshot`: the first run writes the proposed snapshot and fails with `SnapshotNotFound`; `KYO_TEST_SNAPSHOT=update` (or the `snapshotUpdateMode` override) accepts new or changed snapshots.

## Usage

### Basic: readable YAML snapshot

```scala
import kyo.*
import kyo.test.*
import kyo.test.snapshot.*

case class Statement(id: Int, balanceCents: Long) derives Schema

class StatementSnapshotTest extends SnapshotTest[Any]:
    "monthly statement" in {
        assertSchemaSnapshot(Statement(1, balanceCents = 12_300L), "monthly")
    }
end StatementSnapshotTest
```

Stored at `test-snapshots/StatementSnapshotTest/monthly.snap.yaml` as field-named YAML.

### Normalizing non-deterministic fields

```scala
case class Statement(id: Int, balanceCents: Long, generatedAt: Long) derives Schema

class SchemaStatementSnapshotTest extends SnapshotTest[Any]:
    "monthly statement" in {
        val statement = Statement(1, balanceCents = 12_300L, generatedAt = java.lang.System.currentTimeMillis())
        assertSchemaSnapshot(statement, "monthly-schema", _.normalize(_.set(_.generatedAt)(0L)))
    }
end SchemaStatementSnapshotTest
```

The `generatedAt` field is scrubbed to `0L` before both encoding and comparison, so a repeated run with a fresh timestamp still matches the stored snapshot. `Modify[A]` supports `.set` and `.update` on nested fields, so `_.normalize(_.update(_.request.id)(_ => "<redacted>"))` works the same way.

### Per-suite format selection

```scala
class ProtoSnapshotTest extends SnapshotTest[Any]:
    override protected def snapshotCodec: SnapshotCodec = SnapshotCodec.Protobuf

    "wire format" in {
        assertSchemaSnapshot(Statement(1, 12_300L), "wire")
    }
end ProtoSnapshotTest
```

Stored at `test-snapshots/ProtoSnapshotTest/wire.snap.pb` as the exact Protobuf wire bytes.

### Failure output

A value mismatch names the changed fields and, for text codecs, includes a unified diff:

```
Snapshot mismatch
changed fields: balanceCents, account.owner

--- stored
+++ actual
 id: 1
-balanceCents: 12300
+balanceCents: 45600
```

A schema drift (stored snapshot no longer decodes) fails with `SnapshotSchemaEvolution` and the decode error, keeping "the type changed shape" distinct from "the value changed".

## Changelog

**Added**

- `assertSchemaSnapshot[A]` on `SnapshotTestBase[S]` / `SnapshotTest[S]`: schema-driven snapshot assertion with normalization, structural comparison, and schema-evolution detection.
- `SnapshotCodec`: `Text`/`Binary` enum wrapping any kyo-schema `Codec`, with seven presets (`Yaml` default, `Json`, `Ion`, `Protobuf`, `Bson`, `MsgPack`, `IonBinary`), each with a distinct snapshot extension.
- `SnapshotConfig[A]`: extensible per-call config builder, currently carrying `.normalize(Modify[A] => Modify[A])`.
- `SnapshotSchemaEvolution`: distinct failure for a stored snapshot that no longer decodes under the current schema.
- `snapshotCodec` per-suite override hook (default `SnapshotCodec.Yaml`), mirroring `snapshotDir`.
- `SnapshotStore.readBytes`/`writeBytes`: raw-bytes storage path for binary codecs, implemented for JVM/Native (NIO) and JS/Wasm (Node `fs`).
- Module `CONTRIBUTING.md` for `kyo-test/snapshot` and an `assertSchemaSnapshot` section in the `kyo-test` README.
- Tests: `SnapshotSchemaTest`, `SnapshotCodecTest`, `SnapshotConfigTest`, `SnapshotSchemaEvolutionTest`, `SnapshotStoreBytesTest`, plus a foreign-package compile proof (`SnapshotForeignPackageTest`), all cross-platform (JVM/JS/Native).

**Changed**

- `assertSnapshot`: behavior-preserving refactor only; its inline name validation now delegates to the shared `validateSnapshotName` helper used by both assertions.
- `build.sbt`: `kyo-test-snapshot` now depends on `kyo-schema`.
- `AssertScope.noAssertionDiagram`: mentions `assertSchemaSnapshot` alongside the existing assertions.

**Unchanged**

- The `Render`-based `assertSnapshot` path, its `.snap` extension, and its failure behavior.
- kyo-schema's public API (consumed as-is).

## Notes

- `SnapshotConfig.modify` is `private[snapshot]`; the inline `assertSchemaSnapshot` body resolves it through a non-inline in-package helper so a suite in a foreign package can still call it with a config lambda (covered by `SnapshotForeignPackageTest`).
- The config parameter defaults to `identity[SnapshotConfig[A]]` (an explicitly typed witness) rather than bare `identity`, avoiding a type-inference pitfall with defaulted function parameters on inline methods.
