### PR TITLE
[kyo-markdown] add a cross-platform Markdown-to-UI renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ The vertical an application developer assembles: HTTP services and clients, deri
 | [kyo-config](kyo-config/README.md)           | ✅  | ✅  | ✅     | ✅   | Type-safe config + feature flags with a percentage-rollout DSL, optional kyo-http admin and live sync      |
 | [kyo-flow](kyo-flow/README.md)               | ✅  | ✅  | ✅     | ✅   | Durable workflow engine (Temporal/Cadence/ZIO-Flow space); value-replay execution, auto-generated REST     |
 | [kyo-ui](kyo-ui/README.md)                   | ✅  | ✅  | ✅     | ✅   | Web UIs as pure values: Scala.js DOM app, server HTML-over-SSE or SSR stream with first-class reactivity   |
+| [kyo-markdown](kyo-markdown/README.md)       | ✅  | ✅  | ✅     | ✅   | Markdown to a kyo-ui article tree plus a heading outline; pure, total, no third-party Markdown dependency  |
 | [kyo-ai](kyo-ai/README.md)                   | ✅  | ✅  | ✅     | ✅   | Typed LLM programs: prompts, tools, thoughts, agents, streaming, provider backends                         |
 | [kyo-caliban](kyo-caliban/README.md)         | ✅  |     |        |      | Caliban GraphQL mounted on kyo-http: typed Kyo effects in resolvers, WebSocket subscriptions               |
 

--- a/build.sbt
+++ b/build.sbt
@@ -300,6 +300,7 @@ lazy val kyoJVM: Project = project
         `kyo-browser`.jvm,
         `kyo-slack`.jvm,
         `kyo-ui`.jvm,
+        `kyo-markdown`.jvm,
         `kyo-case-app`.jvm,
         `kyo-pod`.jvm,
         `kyo-examples`.jvm,
@@ -367,6 +368,7 @@ lazy val kyoJS = project
         `kyo-browser`.js,
         `kyo-slack`.js,
         `kyo-ui`.js,
+        `kyo-markdown`.js,
         `kyo-website`.js,
         `kyo-website-bundle`.js,
         `kyo-pod`.js,
@@ -425,6 +427,7 @@ lazy val kyoNative = project
         `kyo-browser`.native,
         `kyo-slack`.native,
         `kyo-ui`.native,
+        `kyo-markdown`.native,
         `kyo-pod`.native,
         `kyo-compat-future`.native,
         `kyo-compat-kyo`.native,
@@ -480,6 +483,7 @@ lazy val kyoWasm = project
         `kyo-browser`.wasm,
         `kyo-slack`.wasm,
         `kyo-ui`.wasm,
+        `kyo-markdown`.wasm,
         `kyo-test-api`.wasm,
         `kyo-test-runner`.wasm,
         `kyo-test-prop`.wasm,
@@ -2278,6 +2282,24 @@ lazy val `kyo-slack` =
         .nativeSettings(
             `native-settings`,
             `openssl-native-settings`
+        )
+        .wasmSettings(`wasm-settings`)
+
+lazy val `kyo-markdown` =
+    crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-markdown"))
+        .dependsOn(`kyo-ui`)
+        .dependsOn(`kyo-parse`)
+        .withKyoTest
+        .settings(`kyo-settings`)
+        .jvmSettings(mimaCheck(false))
+        .nativeSettings(`native-settings`)
+        .jsSettings(
+            `js-settings`,
+            // kyo-ui links as a CommonJS module (its js-wasm sources import scalajs-dom); a
+            // downstream test link must match its module kind.
+            scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
         )
         .wasmSettings(`wasm-settings`)
 

--- a/kyo-markdown/README.md
+++ b/kyo-markdown/README.md
@@ -1,0 +1,303 @@
+# kyo-markdown
+
+kyo-markdown turns a single Markdown source string into a kyo-ui `UI` article tree plus the document's heading outline, in one pure, total call. `Markdown.render(source)` returns a `Markdown.Rendered(article, headings)`. `article` is a real `UI` value you embed into a page and hand to any kyo-ui runner (`UI.runRender`); `headings` is the ordered outline you turn into a table of contents. The two stay in lockstep: every outline entry's `id` is byte-identical to the `id` attribute set on the corresponding in-page `<h1>..<h4>`, so a table of contents built from `headings` links straight to the anchors in `article`.
+
+Two facts complete the mental model. Rendering is total: the grammar is a bounded construct set (headings, paragraphs, ordered and unordered lists, GFM pipe tables, fenced code, blockquotes, inline emphasis, inline code, links, images, linked images, raw HTML, HTML comments), and anything it does not recognize degrades to plain text or a verbatim paragraph rather than aborting; an empty source yields `Rendered(UI.empty, Chunk.empty)`. Because the result is a plain value with no leftover effect, it is usable anywhere a `UI` subtree is built, including inside reactive regions that require pure producers. kyo-markdown also carries no third-party Markdown dependency and no syntax highlighter: it is built on kyo-parse `Parse[Char]` combinators, and fenced code renders as a plain `pre`/`code` pair exposing the info string's first token as a `language-<lang>` CSS class, leaving highlighting to the consumer. It runs unchanged on JVM, JS, Native, and Wasm.
+
+<!-- doctest:setup
+```scala
+import kyo.*
+
+final case class DocPage(slug: String, markdown: String)
+final case class TocEntry(level: Int, label: String, anchor: String)
+
+val docPage: DocPage =
+    DocPage(
+        "getting-started",
+        "# Getting Started\n\n" +
+            "Install and run in **one** step. See `Sync.defer` for suspension,\n" +
+            "or jump to [config](#configuration).\n\n" +
+            "## Configuration\n\n" +
+            "- host: the server host\n" +
+            "  - defaults to localhost\n" +
+            "- port: the listening port\n\n" +
+            "| Setting | Type |\n" +
+            "| ------- | ---- |\n" +
+            "| host    | String |\n" +
+            "| port    | Int  |\n\n" +
+            "```scala\n" +
+            "val config = load(\"etc\", \"app\")\n" +
+            "```\n\n" +
+            "## Configuration\n\n" +
+            "A duplicate heading, to show `-2` disambiguation.\n"
+    )
+```
+-->
+
+```scala
+import kyo.*
+
+val rendered = Markdown.render(
+    "# Getting Started\n\nRun in **one** step.\n\n## Configuration\n"
+)
+
+// rendered.article: a UI subtree ready to embed
+// rendered.headings: the ordered outline
+val toc = rendered.headings.map(h => (h.level, h.text, h.id))
+// Chunk((1, "Getting Started", "getting-started"), (2, "Configuration", "configuration"))
+```
+
+## Render a document
+
+You reach for kyo-markdown when you have Markdown text and want a `UI` subtree you can embed plus an outline you can navigate. One call produces both. `Markdown.render(source: String): Rendered` is the whole entry point, and `Rendered` is the pair it hands back:
+
+```scala
+import kyo.*
+
+val page: Markdown.Rendered = Markdown.render(docPage.markdown)
+
+val article  = page.article  // UI, embeddable in any page
+val headings = page.headings // Chunk[Markdown.Heading], the outline
+```
+
+When you want to display the document, embed `article`: it is a `UI` value, so you hand it to a kyo-ui runner exactly like any other subtree. When you want navigation (a sidebar, in-page anchors, a table of contents), read `headings`. Both describe the same document from the same `render` call.
+
+`render` itself performs no effect: it takes a `String` and returns a `Rendered` synchronously, so the outline path never touches `Async`. Turning the article into HTML is the step that runs, through kyo-ui:
+
+```scala
+import kyo.*
+
+val html: Stream[String, Async] =
+    UI.runRender(Markdown.render(docPage.markdown).article)
+```
+
+> **Note:** `render` is pure and total, so the `Rendered` value is safe to produce inside a reactive region, a `Signal.render` boundary, or any position that requires a pure producer. You do not wrap it in `Sync`, `Abort`, or any handler.
+
+## Build a table of contents
+
+Documentation pages need a sidebar or a set of in-page anchors, and the outline that `render` returns alongside the article is exactly that. A `Markdown.Heading(level, text, id)` is one entry: `level` is `1..4` (matching `#` through `####`), `text` is the plain-text label, and `id` is the URL-safe anchor.
+
+The `id` is derived from the heading text: lowercased, non-alphanumeric runs collapsed to a single `-`, leading and trailing `-` trimmed.
+
+```scala
+import kyo.*
+
+val head = Markdown.render("## Composing: map, flatMap\n").headings.head
+// head.level == 2
+// head.text  == "Composing: map, flatMap"
+// head.id    == "composing-map-flatmap"
+```
+
+Repeated heading text is disambiguated with a `-2` (then `-3`, and so on) suffix, on both the outline entry and the in-page element:
+
+```scala
+import kyo.*
+
+val dupIds = Markdown.render("## Configuration\n## Configuration\n").headings.map(_.id)
+// Chunk("configuration", "configuration-2")
+```
+
+> **Note:** Every outline `id` is the exact `id` attribute set on the matching in-page `<h1>..<h4>`, so a table of contents built from `headings` links straight into `article`. The duplicate counter is local to a single `render` call, so build the anchors and render the article from the same `Rendered` value; do not call `render` twice and mix the two.
+
+A heading is rendered twice on purpose, with intentionally different results. The in-page `<hN>` keeps rich inline markup, but the outline `text` is flat:
+
+```scala
+import kyo.*
+
+val h = Markdown.render("## Working with `Sync`\n").headings.head
+// h.text == "Working with Sync"   (backticks removed for the label)
+// h.id   == "working-with-sync"
+```
+
+> **Unlike** the in-page heading, which keeps real inline markup (a live `<code>`, bold, italic), the outline `text` is flattened: backticks and asterisks are removed and `[label](url)` collapses to `label`, so a table of contents shows clean labels.
+
+## Which Markdown you can write
+
+Before you feed a string to `render`, it helps to know exactly which constructs it understands. The grammar is a fixed set, taught here as two families (block structure and inline spans) plus a raw-HTML escape hatch. Anything outside the set degrades (see [Total by construction](#total-by-construction)).
+
+### Block structure
+
+Blocks are the document skeleton:
+
+- ATX headings `#` through `####`; a line with five or more hashes is not a heading, it degrades to a paragraph with no outline entry.
+- Paragraphs: consecutive non-blank lines coalesce into one `<p>` (joined with a space); a blank line starts a new one.
+- Unordered lists `- `, with two-space sub-indented items (`  - `) kept nested.
+- Ordered lists `N. `, with the marker stripped.
+- GFM pipe tables: a header row, a separator row, then body rows; `\|` escapes a literal pipe inside a cell.
+- Fenced code, delimited by three or more backticks.
+- Blockquotes `> `, which may themselves contain paragraphs and fenced code.
+
+A two-space sub-item stays nested inside its parent list item rather than flattening:
+
+```scala
+import kyo.*
+
+val nested = Markdown.render(
+    "- Exception\n" +
+        "  - FileException\n" +
+        "  - TimeoutException\n"
+)
+// FileException and TimeoutException render as a nested <ul> inside the Exception <li>.
+val hasHeadings = nested.headings.isEmpty // true; a list produces no outline entries
+```
+
+A GFM table needs its separator row; the header cells become `<th>`, the rest `<td>`:
+
+```scala
+import kyo.*
+
+val table = Markdown.render(
+    "| Setting | Type |\n" +
+        "| ------- | ---- |\n" +
+        "| host    | String |\n" +
+        "| port    | Int  |\n"
+)
+// table.article is a UI.table subtree.
+```
+
+Fenced code renders verbatim. The info string's first token labels the language:
+
+```scala
+import kyo.*
+
+val withCode = Markdown.render(
+    "```scala\n" +
+        "val config = load(\"etc\", \"app\")\n" +
+        "```\n"
+)
+// <pre><code class="language-scala">val config = load("etc", "app")</code></pre>
+```
+
+> **Note:** A fenced block renders as a plain `pre`/`code` pair. Only the info string's first whitespace-delimited token becomes a `language-<lang>` class (extra tokens are dropped), and there is no syntax highlighting; wiring one up is left to the consumer, see [Deliberate non-goals](#deliberate-non-goals).
+
+> **Note:** Fences are length-aware. A four-backtick fence wraps inner three-backtick blocks verbatim as one code block instead of closing on the first inner ```` ``` ````, matching CommonMark. A length-unaware parser would shatter the content.
+
+### Inline spans
+
+Inside a paragraph, list item, table cell, or heading, `render` recognizes a fixed set of inline spans, resolved in PEG ordered-choice precedence:
+
+- Bold `**text**` and italic `*text*`.
+- Inline code `` `text` `` (a `<code>` chip).
+- Links `[text](url)` and images `![alt](url)`.
+- Linked images `[![alt](img)](link)` (an anchor wrapping an image).
+
+```scala
+import kyo.*
+
+val prose = Markdown.render(
+    "Install in **one** step with `Sync.defer`, or read the [guide](../guide.md).\n"
+)
+// One paragraph: **one** -> a bold span, `Sync.defer` -> an inline <code> chip,
+// [guide](../guide.md) -> a relative-path link.
+val noHeadings = prose.headings.isEmpty // true
+```
+
+The same CommonMark delimiter-length rule governs both layers of code. When you write a block of code, use a fenced block, where a fence of four or more backticks wraps inner three-backtick fences verbatim. When you write code inside a sentence, use a backtick span, where an N-backtick span lets shorter runs appear inside it. It is one rule applied at two scopes.
+
+> **Note:** An unmatched opening backtick run in prose is kept as literal backticks and parsing resumes after it, so a bare ```` ```scala ```` written mid-sentence does not open a span that swallows the following text into a spurious `<code>`.
+
+A link target is classified by prefix, which is what makes cross-document and in-page links both work:
+
+```scala
+import kyo.*
+
+val links = Markdown.render(
+    "See [config](#configuration), the [guide](../guide.md), " +
+        "or [the site](https://getkyo.io).\n"
+)
+// #configuration  -> an in-page fragment link
+// ../guide.md     -> a relative path, preserved untouched
+// https://getkyo.io -> an external link, full URL preserved
+```
+
+> **Note:** `#id` becomes a fragment, `http://` and `https://` become external links, and everything else becomes a relative path kept exactly as written. A relative path is never rewritten.
+
+### Raw HTML and comments
+
+When a construct is outside the grammar but you still want it in the page, drop to raw HTML. A block-level `<img>` line, or a multi-line `<a>...<img>...</a>`, is coalesced and passed through verbatim inside a paragraph; an inline `<...>` snippet is the same escape hatch at inline scope.
+
+```scala
+import kyo.*
+
+val embed = Markdown.render(
+    "<img src=\"kyo.png\" width=\"200\" alt=\"Kyo\">\nSome text.\n"
+)
+// The <img> line passes through verbatim (wrapped in a <p>); "Some text." is normal prose.
+```
+
+> **Caution:** Raw HTML is emitted verbatim and is NOT escaped. An `<img>` or an `<a><img></a>` embed goes straight into the output, so only feed `render` Markdown you trust.
+
+HTML comments are dropped, but text that trails the closing `-->` is not lost:
+
+```scala
+import kyo.*
+
+val commented = Markdown.render(
+    "<!-- a comment\nspanning lines -->Kept text.\n# Title\n"
+)
+val titles = commented.headings.map(_.text) // Chunk("Title")
+// "Kept text." after the closing --> survives as a paragraph; the comment itself is gone.
+```
+
+> **Note:** A leading or interior HTML comment is skipped, but any text after the closing `-->` is preserved as a paragraph rather than silently dropped.
+
+## Total by construction
+
+You never wrap `render` in error handling, and that is deliberate. Every construct degrades instead of failing, which is exactly what lets the result be a plain value you can use in any position. An empty or whitespace-only source is the base case:
+
+```scala
+import kyo.*
+
+val empty = Markdown.render("")
+// empty == Markdown.Rendered(UI.empty, Chunk.empty)
+
+val blank = Markdown.render("   \n\n  ")
+// blank is also Rendered(UI.empty, Chunk.empty): whitespace-only counts as empty
+```
+
+Malformed and unknown input degrades rather than aborting. A table missing its separator row does not become a `<table>`, and an unsupported construct becomes a paragraph carrying its verbatim lines:
+
+```scala
+import kyo.*
+
+val malformed = Markdown.render("| A | B |\n")
+// No separator row, so this degrades to a paragraph, not a table.
+
+val unknown = Markdown.render("term\n:   definition\n")
+// Definition-list syntax is not in the grammar; it degrades to a paragraph.
+// Both calls return a value; neither aborts.
+```
+
+> **Note:** An unknown inline construct degrades to plain text and an unrecognized block degrades to a paragraph, both through kyo-parse `recoverWith`. There is no configuration that makes `render` throw or return an error channel; totality is the contract.
+
+## Deliberate non-goals
+
+A few things kyo-markdown intentionally leaves to you, so nothing about the output surprises you later.
+
+- No syntax highlighting. A fenced block is a plain `pre`/`code` pair with a `language-<lang>` class and nothing more; if you want highlighted tokens, wire a highlighter to that class on the consumer side.
+- No third-party Markdown engine and no JVM-only dependency. The grammar is expressed with kyo-parse `Parse[Char]` combinators, so the same renderer runs on JVM, JS, Native, and Wasm.
+- A fixed grammar. The construct set is bounded; input outside it degrades (see [Total by construction](#total-by-construction)) rather than being extended at runtime.
+
+## Putting it together
+
+Rendering a documentation page and deriving its sidebar exercises the whole surface in one thread: `render` the source, map the outline to your own navigation type, and hand the article to a runner. The running `docPage` carries a heading, bold and inline-code prose, a fragment link, a nested list, a GFM table, a Scala fence, and a duplicate heading:
+
+```scala
+import kyo.*
+
+val rendered = Markdown.render(docPage.markdown)
+
+val sidebar: Chunk[TocEntry] =
+    rendered.headings.map(h => TocEntry(h.level, h.text, h.id))
+// Chunk(
+//   TocEntry(1, "Getting Started", "getting-started"),
+//   TocEntry(2, "Configuration",   "configuration"),
+//   TocEntry(2, "Configuration",   "configuration-2")
+// )
+
+// Each TocEntry.anchor is an id attribute inside rendered.article, so a sidebar
+// link to "#configuration-2" jumps to the second Configuration heading.
+val page: Stream[String, Async] = UI.runRender(rendered.article)
+```
+
+The two `## Configuration` headings become anchors `configuration` and `configuration-2`; the bold, inline code, and link in the paragraph render inside `article` but never appear in the outline; and the article is a `Stream[String, Async]` of HTML once you run it, while the sidebar was built with no effect at all.

--- a/kyo-markdown/shared/src/main/scala/kyo/Markdown.scala
+++ b/kyo-markdown/shared/src/main/scala/kyo/Markdown.scala
@@ -1,0 +1,722 @@
+package kyo
+
+import kyo.UI.*
+import scala.collection.mutable
+import scala.language.implicitConversions
+
+/** Cross-platform Markdown-to-UI renderer.
+  *
+  * Converts a single Markdown source string into a [[Markdown.Rendered]] value: a `kyo-ui` `UI`
+  * article subtree (headings, paragraphs, ordered and unordered lists, GFM pipe tables, fenced
+  * code blocks, blockquotes, inline images and links) plus the document's heading outline. The
+  * article is a real `UI` tree ready to embed into a page and render with any `kyo-ui` runner.
+  *
+  * The grammar is bounded to a fixed construct set and is expressed with kyo-parse `Parse[Char]`
+  * combinators. A thin line-oriented splitter groups raw lines into block segments; the inline
+  * content of each block and the block-level recognizers (headings, list markers, table cells,
+  * fence info-strings, link and image tokens) are genuine kyo-parse parsers run via
+  * `Parse.runResult`.
+  *
+  * Rendering is total: malformed input degrades rather than aborting. An unknown inline construct
+  * becomes plain text, an unrecognized block becomes a paragraph carrying its verbatim line, and
+  * an empty source yields `Rendered(UI.empty, Chunk.empty)`. Fenced code renders as a plain
+  * `pre`/`code` pair with the info string's first token exposed as a `language-<lang>` CSS class;
+  * syntax highlighting is left to the consumer.
+  *
+  * @see
+  *   [[Markdown.render]] for the single entry point
+  * @see
+  *   [[Markdown.Rendered]] for the render output
+  */
+object Markdown:
+
+    /** The article subtree and heading outline produced by [[render]].
+      *
+      * `article` is a `UI` value ready to embed into a document. `headings` is the ordered outline;
+      * each entry carries the same `id` that was set as the `id` attribute on the corresponding
+      * `UI.h1`..`UI.h4` element, so `article` id attributes and `headings` ids are always
+      * consistent. Duplicate heading texts are disambiguated with a `-2` (then `-3`, etc.) suffix
+      * on both sides.
+      */
+    final case class Rendered(article: UI, headings: Chunk[Heading]) derives CanEqual
+
+    /** A single heading entry in the document outline produced by [[render]].
+      *
+      * `level` is 1..4 (matching `# ` through `#### `). `text` is the plain-text heading content
+      * with inline markup stripped, suitable for a table of contents. `id` is the URL-safe anchor
+      * derived from `text`: lowercased, non-alphanumeric characters replaced with `-`, runs of `-`
+      * collapsed, leading and trailing `-` removed, and duplicate ids disambiguated with a `-2`
+      * (then `-3`, etc.) suffix.
+      */
+    final case class Heading(level: Int, text: String, id: String) derives CanEqual
+
+    /** Render a single Markdown source to a [[Rendered]] value.
+      *
+      * Pure and total: the grammar is bounded and every construct degrades rather than failing
+      * (unknown inline constructs become plain `UI.text` via kyo-parse `recoverWith`, unknown
+      * block constructs become a `UI.p` carrying the verbatim line, and a blank source returns
+      * `Rendered(UI.empty, Chunk.empty)`), so the result is a plain value usable anywhere a UI
+      * subtree is built, including inside reactive regions, which take pure producers.
+      *
+      * @param source
+      *   The Markdown text to render. May be empty.
+      */
+    def render(source: String)(using Frame): Rendered =
+        if source.isBlank then Rendered(UI.empty, Chunk.empty)
+        else parseArticle(source)
+
+    private def html(cs: Seq[UI]): Seq[UI.Ast.HtmlChildVal] =
+        cs.map(n => UI.Ast.HtmlChildVal.lift(n))
+    private def html(cs: Chunk[UI]): Seq[UI.Ast.HtmlChildVal] =
+        cs.toSeq.map(n => UI.Ast.HtmlChildVal.lift(n))
+
+    /** Render a fenced code block to a `pre`/`code` pair. The info string's first whitespace-
+      * delimited token, when present, becomes a `language-<token>` CSS class on the `code` element
+      * (the CommonMark convention); the body is emitted verbatim as a single text leaf. Syntax
+      * highlighting is left to the consumer.
+      */
+    private def renderFence(info: String, body: String)(using Frame): UI =
+        val lang = info.takeWhile(c => !c.isWhitespace)
+        val code =
+            if lang.isEmpty then UI.code(Ast.Text(body))
+            else UI.code.cssClass("language-" + lang)(Ast.Text(body))
+        UI.pre(code)
+    end renderFence
+
+    // ---- block grouping (thin line splitter, the permitted structuring step) ----
+
+    /** A block segment grouped by the line splitter. Each segment carries the raw text that the
+      * corresponding kyo-parse block parser consumes; the splitter only groups lines, it does not
+      * interpret their inline content.
+      */
+    private enum Block:
+        case Heading(line: String)
+        case Fence(info: String, body: String)
+        case Quote(content: String)
+        case Table(lines: Chunk[String])
+        case Unordered(lines: Chunk[String])
+        case Ordered(lines: Chunk[String])
+        case RawEmbed(snippet: String)
+        case Paragraph(text: String)
+    end Block
+
+    private def isHeadingLine(t: String): Boolean =
+        t.startsWith("# ") || t.startsWith("## ") || t.startsWith("### ") || t.startsWith("#### ")
+
+    private def isOrderedItem(t: String): Boolean =
+        t.length > 2 && t.head.isDigit && t.drop(1).startsWith(". ")
+
+    // The number of leading backticks when `t` (already trimmed) opens a fenced code block (>= 3
+    // backticks), else 0. CommonMark allows a fence of N >= 3 backticks, and a fence LONGER than the
+    // minimum lets shorter fences appear verbatim in its body. Every fence pass must track this
+    // length, or a 4-backtick block closes on its first inner 3-backtick line.
+    private def fenceLen(t: String): Int =
+        val n = t.takeWhile(_ == '`').length
+        if n >= 3 then n else 0
+
+    // True when `t` (already trimmed) closes a fence opened with `open` backticks: at least `open`
+    // backticks and nothing but whitespace after them (the CommonMark closing-fence rule).
+    private def isFenceClose(t: String, open: Int): Boolean =
+        val n = t.takeWhile(_ == '`').length
+        n >= open && t.drop(n).trim.isEmpty
+
+    /** Group source lines into [[Block]] segments. Leading HTML comments are skipped. This is
+      * line-level structuring only; the content of each block is parsed by the kyo-parse
+      * block/inline parsers.
+      */
+    private def splitBlocks(cleaned: String): Chunk[Block] =
+        val lines  = cleaned.linesIterator.toArray
+        val blocks = new mutable.ArrayBuffer[Block]()
+        var i      = 0
+
+        // Advance past an HTML comment that starts at `lines(i)`, consuming every line through and
+        // including the one that closes the comment with `-->`. Returns the index of the first line
+        // after the comment. Any text after `-->` on the closing line is appended to `blocks` as a
+        // paragraph so it is not silently dropped.
+        def skipComment(): Int =
+            var j = i
+            while j < lines.length && !lines(j).contains("-->") do j += 1
+            if j < lines.length then
+                val closing = lines(j)
+                val after   = closing.substring(closing.indexOf("-->") + 3)
+                if after.trim.nonEmpty then blocks += Block.Paragraph(after.trim)
+                j + 1
+            else j
+            end if
+        end skipComment
+
+        // Skip leading HTML comments.
+        while i < lines.length && lines(i).trim.startsWith("<!--") do
+            i = skipComment()
+        end while
+
+        while i < lines.length do
+            val line    = lines(i)
+            val trimmed = line.trim
+
+            if trimmed.isEmpty then
+                i += 1
+            else if isHeadingLine(trimmed) then
+                blocks += Block.Heading(trimmed)
+                i += 1
+            else if fenceLen(trimmed) > 0 then
+                val open = fenceLen(trimmed)
+                val info = trimmed.drop(open).trim
+                i += 1
+                val codeLines = new mutable.ArrayBuffer[String]()
+                while i < lines.length && !isFenceClose(lines(i).trim, open) do
+                    codeLines += lines(i)
+                    i += 1
+                if i < lines.length then i += 1
+                blocks += Block.Fence(info, codeLines.mkString("\n"))
+            else if trimmed.startsWith("> ") || trimmed == ">" then
+                val bqLines = new mutable.ArrayBuffer[String]()
+                while i < lines.length && (lines(i).trim.startsWith("> ") || lines(i).trim == ">") do
+                    val l = lines(i).trim
+                    bqLines += (if l == ">" then "" else l.drop(2))
+                    i += 1
+                end while
+                blocks += Block.Quote(bqLines.mkString("\n"))
+            else if trimmed.startsWith("<!--") then
+                i = skipComment()
+            else if trimmed.startsWith("|") then
+                val tableLines = new mutable.ArrayBuffer[String]()
+                while i < lines.length && lines(i).trim.startsWith("|") do
+                    tableLines += lines(i).trim
+                    i += 1
+                blocks += Block.Table(Chunk.from(tableLines))
+            else if trimmed.startsWith("- ") || line.startsWith("  - ") then
+                val listLines = new mutable.ArrayBuffer[String]()
+                while i < lines.length &&
+                    (lines(i).trim.startsWith("- ") || lines(i).startsWith("  - "))
+                do
+                    listLines += lines(i)
+                    i += 1
+                end while
+                blocks += Block.Unordered(Chunk.from(listLines))
+            else if isOrderedItem(trimmed) then
+                val listLines = new mutable.ArrayBuffer[String]()
+                while i < lines.length && isOrderedItem(lines(i).trim) do
+                    listLines += lines(i).trim
+                    i += 1
+                blocks += Block.Ordered(Chunk.from(listLines))
+
+            // Block-level raw HTML embed: lines starting with <img or <a only. <img is single line.
+            // <a may wrap <img on subsequent lines; coalesce until the closing </a>. The embed is
+            // wrapped in UI.p so the article body stays a real UI node and the <a><img></a> nesting
+            // is preserved as one unit.
+            else if trimmed.startsWith("<img") || trimmed.startsWith("<a") then
+                if trimmed.startsWith("<img") then
+                    blocks += Block.RawEmbed(trimmed)
+                    i += 1
+                else
+                    val embedLines = new mutable.ArrayBuffer[String]()
+                    embedLines += trimmed
+                    i += 1
+                    while i < lines.length && !embedLines.last.trim.contains("</a>") do
+                        embedLines += lines(i).trim
+                        i += 1
+                    end while
+                    blocks += Block.RawEmbed(embedLines.mkString("\n"))
+                end if
+            else
+                val paraLines = new mutable.ArrayBuffer[String]()
+                while i < lines.length &&
+                    lines(i).trim.nonEmpty &&
+                    !isHeadingLine(lines(i).trim) &&
+                    !lines(i).trim.startsWith("```") &&
+                    !lines(i).trim.startsWith("> ") &&
+                    !lines(i).trim.startsWith("- ") &&
+                    !lines(i).startsWith("  - ") &&
+                    !lines(i).trim.startsWith("|") &&
+                    !lines(i).trim.startsWith("<!--") &&
+                    !isOrderedItem(lines(i).trim)
+                do
+                    paraLines += lines(i).trim
+                    i += 1
+                end while
+                blocks += Block.Paragraph(paraLines.mkString(" "))
+            end if
+        end while
+
+        Chunk.from(blocks)
+    end splitBlocks
+
+    // ---- article assembly ----
+
+    /** Parse the Markdown string into a [[Rendered]] value. Lines are grouped into [[Block]]
+      * segments by [[splitBlocks]]; each segment's content is then parsed by a kyo-parse
+      * `Parse[Char]` parser. Heading ids are tracked in a mutable map local to this call; duplicate
+      * ids receive `-2` (then `-3`, etc.) suffixes.
+      */
+    private def parseArticle(cleaned: String)(using Frame): Rendered =
+        val blocks     = splitBlocks(cleaned)
+        val uiBlocks   = new mutable.ArrayBuffer[UI]()
+        val headings   = new mutable.ArrayBuffer[Heading]()
+        val slugCounts = new mutable.HashMap[String, Int]()
+
+        def uniqueSlug(raw: String): String =
+            val count = slugCounts.getOrElse(raw, 0)
+            slugCounts(raw) = count + 1
+            if count == 0 then raw else s"$raw-${count + 1}"
+        end uniqueSlug
+
+        def makeSlug(text: String): String =
+            val base = text.toLowerCase
+                .map(c => if c.isLetterOrDigit then c else '-')
+                .mkString
+                .replaceAll("-+", "-")
+                .stripPrefix("-")
+                .stripSuffix("-")
+            uniqueSlug(base)
+        end makeSlug
+
+        blocks.foreach {
+            case Block.Heading(line) =>
+                val (level, text)  = parseHeading(line)
+                val slug           = makeSlug(text)
+                val inlineNodes    = parseInline(text)
+                val inlineChildren = html(inlineNodes)
+                val heading: UI = level match
+                    case 1 => UI.h1.id(slug)(inlineChildren*)
+                    case 2 => UI.h2.id(slug)(inlineChildren*)
+                    case 3 => UI.h3.id(slug)(inlineChildren*)
+                    case _ => UI.h4.id(slug)(inlineChildren*)
+                uiBlocks += heading
+                // The in-page heading keeps the rich inline render (real <code>, bold, italic); the
+                // outline entry stores the plain-text form so a table of contents shows clean labels
+                // without literal backticks/asterisks. The id is derived from the raw text so the
+                // heading `id` and the outline anchor stay byte-identical to the rendered HTML.
+                headings += Heading(level, stripInlineMarkdown(text), slug)
+
+            case Block.Fence(info, body) =>
+                uiBlocks += renderFence(info, body)
+
+            case Block.Quote(content) =>
+                uiBlocks += parseBlockquote(content)
+
+            case Block.Table(lines) =>
+                uiBlocks += parseTable(lines)
+
+            case Block.Unordered(lines) =>
+                uiBlocks += parseUnorderedList(lines)
+
+            case Block.Ordered(lines) =>
+                val items = lines.map(l => UI.li(html(parseInline(parseOrderedItem(l)))*))
+                uiBlocks += UI.ol(html(items)*)
+
+            case Block.RawEmbed(snippet) =>
+                uiBlocks += UI.p(UI.rawHtml(snippet))
+
+            case Block.Paragraph(text) =>
+                uiBlocks += UI.p(html(parseInline(text))*)
+        }
+
+        val article: UI =
+            if uiBlocks.isEmpty then UI.empty
+            else UI.fragment(uiBlocks.toSeq*)
+        Rendered(article, Chunk.from(headings.toSeq))
+    end parseArticle
+
+    // ---- block-level kyo-parse parsers ----
+
+    /** Strip inline Markdown markers from a heading's raw text for plain-text display in an
+      * outline. Removes inline-code backticks, bold/italic asterisks, and unwraps `[text](url)`
+      * links to their visible `text`. The in-page heading still renders the real inline markup;
+      * only the outline label is flattened. Idempotent and total.
+      */
+    private def stripInlineMarkdown(raw: String): String =
+        val sb  = new mutable.StringBuilder()
+        val s   = raw
+        var i   = 0
+        val len = s.length
+        while i < len do
+            val c = s.charAt(i)
+            if c == '`' then
+                // Skip the backtick; the inner text is kept verbatim.
+                i += 1
+            else if c == '*' then
+                // Skip one or two asterisks (italic or bold opener/closer).
+                if i + 1 < len && s.charAt(i + 1) == '*' then i += 2
+                else i += 1
+            else if c == '[' then
+                // `[text](url)` -> keep `text`, drop the bracket and the `(url)` target. If the
+                // construct is not a well-formed link, keep the `[` literally.
+                val closeBracket = s.indexOf(']', i + 1)
+                if closeBracket >= 0 && closeBracket + 1 < len && s.charAt(closeBracket + 1) == '(' then
+                    val closeParen = s.indexOf(')', closeBracket + 2)
+                    if closeParen >= 0 then
+                        sb.append(stripInlineMarkdown(s.substring(i + 1, closeBracket)))
+                        i = closeParen + 1
+                    else
+                        sb.append(c)
+                        i += 1
+                    end if
+                else
+                    sb.append(c)
+                    i += 1
+                end if
+            else
+                sb.append(c)
+                i += 1
+            end if
+        end while
+        sb.toString
+    end stripInlineMarkdown
+
+    /** Parse an ATX heading line via a `Parse[Char]` grammar: 1..4 `#`, a space, then the rest of
+      * the line as the heading text. Returns the level and the trimmed text.
+      */
+    private def parseHeading(line: String)(using Frame): (Int, String) =
+        val parser: (Int, String) < Parse[Char] =
+            for
+                hashes <- Parse.readWhile[Char](_ == '#')
+                _      <- Parse.literal(' ')
+                rest   <- Parse.readWhile[Char](_ => true)
+            yield (hashes.length, rest.mkString.trim)
+        runParser(line)(parser).getOrElse {
+            // Total fall-through: a leading `#` always matches one of the H1..H4 openers.
+            (1, line.dropWhile(_ == '#').trim)
+        }
+    end parseHeading
+
+    /** Strip the ordered-list marker (`N. `) from a line via a `Parse[Char]` grammar, returning the
+      * item text.
+      */
+    private def parseOrderedItem(line: String)(using Frame): String =
+        val parser: String < Parse[Char] =
+            for
+                _    <- Parse.readWhile[Char](_.isDigit)
+                _    <- Parse.literal('.')
+                _    <- Parse.literal(' ')
+                rest <- Parse.readWhile[Char](_ => true)
+            yield rest.mkString
+        runParser(line)(parser).getOrElse(line)
+    end parseOrderedItem
+
+    /** Parse a GFM pipe-table row into trimmed cell strings via a `Parse[Char]` grammar. A GFM row
+      * is `| c1 | c2 |`: a leading `|` followed by a run of `cell` then `|` pairs. A cell is a run
+      * of characters up to the next pipe, with a `\|` escape contributing a literal `|` to the cell.
+      */
+    private def parseRowCells(line: String)(using Frame): Chunk[String] =
+        val cellChar: String < Parse[Char] =
+            Parse.firstOf(
+                Parse.literal("\\|").andThen("|"),
+                Parse.anyIf[Char](c => c != '|')(c => s"Unexpected $c").map(_.toString)
+            )
+        val cell: String < Parse[Char] =
+            for
+                chars <- Parse.repeat(cellChar)
+                _     <- Parse.literal('|')
+            yield chars.mkString.trim
+        val row: Chunk[String] < Parse[Char] =
+            for
+                _     <- Parse.literal('|')
+                cells <- Parse.repeat(cell)
+            yield Chunk.from(cells)
+        runParser(line)(row).getOrElse {
+            // Total fall-through for a row that is not pipe-delimited.
+            Chunk(line.stripPrefix("|").stripSuffix("|").trim)
+        }
+    end parseRowCells
+
+    /** Parse a GFM pipe table. The first row is the header; the second is the separator; remaining
+      * rows are body rows. Cell content is re-parsed with [[parseInline]].
+      */
+    private def parseTable(tableLines: Chunk[String])(using Frame): UI =
+        if tableLines.length < 2 then
+            // Malformed table (missing separator): degrade to paragraph.
+            UI.p(Ast.Text(tableLines.headOption.getOrElse("")))
+        else
+            val headerCells = parseRowCells(tableLines.head)
+            val bodyRows    = if tableLines.length > 2 then tableLines.drop(2) else Chunk.empty[String]
+            val headerTr    = UI.tr(html(headerCells.map(cell => UI.th(html(parseInline(cell))*)))*)
+            val bodyTrs = bodyRows.map { row =>
+                val cells = parseRowCells(row)
+                UI.tr(html(cells.map(cell => UI.td(html(parseInline(cell))*)))*)
+            }
+            UI.table(html(headerTr +: bodyTrs)*)
+        end if
+    end parseTable
+
+    /** Parse an unordered list from its grouped lines, handling two-space sub-indented items. The
+      * `- ` / `  - ` markers are recognized with a `Parse[Char]` parser per line.
+      */
+    private def parseUnorderedList(lines: Chunk[String])(using Frame): UI =
+        val arr   = lines.toArray
+        val items = new mutable.ArrayBuffer[Ast.Li]()
+        var i     = 0
+        while i < arr.length do
+            val line = arr(i)
+            if line.startsWith("  - ") then
+                // Orphan sub-item with no preceding top-level item; treat as a top-level item.
+                items += UI.li(html(parseInline(parseListItem(line.trim)))*)
+                i += 1
+            else
+                val text = parseListItem(line.trim)
+                i += 1
+                val subItems = new mutable.ArrayBuffer[Ast.Li]()
+                while i < arr.length && arr(i).startsWith("  - ") do
+                    subItems += UI.li(html(parseInline(parseListItem(arr(i).trim)))*)
+                    i += 1
+                end while
+                if subItems.isEmpty then items += UI.li(html(parseInline(text))*)
+                else items += UI.li(html(parseInline(text) :+ UI.ul(html(subItems.toSeq)*))*)
+            end if
+        end while
+        UI.ul(html(items.toSeq)*)
+    end parseUnorderedList
+
+    /** Strip the `- ` marker from a (trimmed) unordered-list line via a `Parse[Char]` grammar. */
+    private def parseListItem(trimmed: String)(using Frame): String =
+        val parser: String < Parse[Char] =
+            for
+                _    <- Parse.literal("- ")
+                rest <- Parse.readWhile[Char](_ => true)
+            yield rest.mkString
+        runParser(trimmed)(parser).getOrElse(trimmed.stripPrefix("- "))
+    end parseListItem
+
+    /** Parse a blockquote run into a `blockquote` element. The leading `> ` is already stripped by
+      * the splitter. Nested paragraphs and fenced code blocks are recognized inside the quote.
+      */
+    private def parseBlockquote(content: String)(using Frame): UI =
+        UI.blockquote(html(parseBlockquoteContent(content))*)
+
+    private def parseBlockquoteContent(content: String)(using Frame): Chunk[UI] =
+        val lines  = content.linesIterator.toArray
+        val result = new mutable.ArrayBuffer[UI]()
+        var i      = 0
+        while i < lines.length do
+            val trimmed = lines(i).trim
+            if trimmed.isEmpty then
+                i += 1
+            else if fenceLen(trimmed) > 0 then
+                val open = fenceLen(trimmed)
+                val info = trimmed.drop(open).trim
+                i += 1
+                val codeLines = new mutable.ArrayBuffer[String]()
+                while i < lines.length && !isFenceClose(lines(i).trim, open) do
+                    codeLines += lines(i)
+                    i += 1
+                if i < lines.length then i += 1
+                result += renderFence(info, codeLines.mkString("\n"))
+            else
+                val paraLines = new mutable.ArrayBuffer[String]()
+                while i < lines.length && lines(i).trim.nonEmpty && !lines(i).trim.startsWith("```") do
+                    paraLines += lines(i).trim
+                    i += 1
+                result += UI.p(html(parseInline(paraLines.mkString(" ")))*)
+            end if
+        end while
+        Chunk.from(result)
+    end parseBlockquoteContent
+
+    // ---- inline kyo-parse grammar ----
+
+    /** Convert a raw URL string to a `Href`. Treats `#id` as Fragment, `http(s)://...` as
+      * External, and everything else as Path.
+      */
+    private def toHref(url: String): Href =
+        if url.startsWith("#") then Href.Fragment(url.drop(1))
+        else if url.startsWith("https://") then Href.External("https", url.drop(6))
+        else if url.startsWith("http://") then Href.External("http", url.drop(5))
+        else Href.Path(url)
+    end toHref
+
+    /** Parse inline Markdown to a sequence of UI nodes with a kyo-parse `Parse[Char]` grammar.
+      *
+      * Handles, in PEG ordered-choice precedence: linked images (`[![alt](img)](link)`), images
+      * (`![alt](url)`), links (`[text](url)`), bold (`**text**`), italic (`*text*`), inline code
+      * (`` `text` ``), inline raw HTML (`<...>`), and plain text runs. Any inline token that does
+      * not parse degrades to a single literal character via `recoverWith` + `RecoverStrategy`, so
+      * the row never aborts.
+      */
+    private def parseInline(text: String)(using Frame): Chunk[UI] =
+        if text.isEmpty then Chunk(Ast.Text(""))
+        else runParser(text)(inlineNodes).getOrElse(Chunk(Ast.Text(text)))
+
+    /** One result of the inline grammar: either a single literal character (a degrade unit,
+      * coalesced into `Ast.Text` runs) or a fully parsed inline `UI` node.
+      */
+    private enum Token:
+        case Lit(char: Char)
+        case Node(ui: UI)
+
+    /** The inline grammar: repeat a single inline token until end of input, then coalesce adjacent
+      * literal characters into `Ast.Text` runs.
+      */
+    private def inlineNodes(using Frame): Chunk[UI] < Parse[Char] =
+        Parse.repeat(inlineToken).map(tokens => coalesceText(Chunk.from(tokens)))
+
+    /** A single inline token, as a `Token`: `Lit(char)` is one literal character (a degrade unit);
+      * `Node(ui)` is a parsed inline node. Unknown markup degrades to one literal character via the
+      * `firstOf` last branch, and any fatal failure is recovered to one literal character via
+      * `recoverWith` + `RecoverStrategy`, so the inline row never aborts.
+      */
+    private def inlineToken(using Frame): Token < Parse[Char] =
+        def node(p: UI < Parse[Char]): Token < Parse[Char] = p.map(Token.Node(_))
+        val literalChar: Token < Parse[Char]               = Parse.any[Char].map(Token.Lit(_))
+        Parse.recoverWith(
+            Parse.firstOf(
+                node(linkedImage),
+                node(image),
+                node(link),
+                node(bold),
+                node(italic),
+                node(inlineCode),
+                node(inlineHtml),
+                literalChar
+            ),
+            RecoverStrategy.viaParser[Char, Token](Parse.any[Char].map(Token.Lit(_)))
+        )
+    end inlineToken
+
+    /** Coalesce a token stream of literal-char runs and parsed nodes into a UI sequence, merging
+      * adjacent literal characters into single `Ast.Text` leaves.
+      */
+    private def coalesceText(tokens: Chunk[Token])(using Frame): Chunk[UI] =
+        val out = new mutable.ArrayBuffer[UI]()
+        val buf = new mutable.StringBuilder()
+        def flush(): Unit =
+            if buf.nonEmpty then
+                out += Ast.Text(buf.toString)
+                buf.clear()
+        tokens.foreach {
+            case Token.Lit(c)   => buf.append(c)
+            case Token.Node(ui) => flush(); out += ui
+        }
+        flush()
+        Chunk.from(out)
+    end coalesceText
+
+    /** Read characters until (but not including) the next occurrence of `stop`, as a String. */
+    private def readUntilChar(stop: Char)(using Frame): String < Parse[Char] =
+        Parse.readWhile[Char](_ != stop).map(_.mkString)
+
+    /** Read characters until (but not including) the next occurrence of `stop`, as a String. */
+    private def readUntilString(stop: String)(using Frame): String < Parse[Char] =
+        // stop is one or two characters in the inline grammar; read char-by-char with a not-lookahead.
+        Parse.repeat(
+            for
+                _ <- Parse.not(Parse.literal(stop))
+                c <- Parse.any[Char]
+            yield c
+        ).map(_.mkString)
+
+    /** `[![alt](img)](link)` -> `UI.a.href(link)(UI.img(img, alt))`. */
+    private def linkedImage(using Frame): UI < Parse[Char] =
+        for
+            _   <- Parse.literal("[![")
+            alt <- readUntilChar(']')
+            _   <- Parse.literal("](")
+            img <- readUntilChar(')')
+            _   <- Parse.literal(")](")
+            lnk <- readUntilChar(')')
+            _   <- Parse.literal(')')
+        yield UI.a.href(toHref(lnk))(UI.img(ImgSrc.Path(img), alt))
+
+    /** `![alt](url)` -> `UI.img(url, alt)`. */
+    private def image(using Frame): UI < Parse[Char] =
+        for
+            _   <- Parse.literal("![")
+            alt <- readUntilChar(']')
+            _   <- Parse.literal("](")
+            url <- readUntilChar(')')
+            _   <- Parse.literal(')')
+        yield UI.img(ImgSrc.Path(url), alt)
+
+    /** `[text](url)` -> `UI.a.href(url)(parseInline(text)*)`. */
+    private def link(using Frame): UI < Parse[Char] =
+        for
+            _    <- Parse.literal('[')
+            body <- readUntilString("](")
+            _    <- Parse.literal("](")
+            url  <- readUntilChar(')')
+            _    <- Parse.literal(')')
+        yield UI.a.href(toHref(url))(html(parseInline(body))*)
+
+    /** `**text**` -> a bold `md-strong` span. */
+    private def bold(using Frame): UI < Parse[Char] =
+        for
+            _     <- Parse.literal("**")
+            inner <- nonEmptyUntilString("**")
+            _     <- Parse.literal("**")
+        yield UI.span.cssClass("md-strong")(Ast.Text(inner))
+
+    /** `*text*` -> an italic span. */
+    private def italic(using Frame): UI < Parse[Char] =
+        for
+            _     <- Parse.literal('*')
+            inner <- nonEmptyUntilChar('*')
+            _     <- Parse.literal('*')
+        yield UI.span.style(Style.italic)(Ast.Text(inner))
+
+    // A CommonMark inline code span: a run of N backticks, then content up to the next run of N
+    // backticks. The delimiter length matters: a span opened with N backticks lets runs of OTHER
+    // lengths appear verbatim inside it. A single backtick (N=1) is the common case.
+    //
+    // An UNMATCHED opening run (no closing run of the same length) is LITERAL text, consumed here so
+    // parsing resumes AFTER the run. This is the CommonMark rule: without it, a bare ```scala in
+    // prose would leave the failed branch to backtrack one char and re-enter on the next backtick,
+    // and the leftover single backtick would open a span that swallows the prose up to the next real
+    // inline-code backtick.
+    private def inlineCode(using Frame): UI < Parse[Char] =
+        for
+            ticks <- Parse.readWhile[Char](_ == '`').map(_.mkString).map { run =>
+                if run.isEmpty then Parse.fail[Char]("no opening backtick run") else run
+            }
+            node <- Parse.firstOf(
+                for
+                    inner <- readUntilString(ticks)
+                    _     <- Parse.literal(ticks)
+                yield UI.code(Ast.Text(stripInlineCodeSpan(inner))),
+                // No matching close: the opening run is literal backticks (already consumed above).
+                (Ast.Text(ticks): UI)
+            )
+        yield node
+
+    // CommonMark: when a code span's content has a non-space character and begins AND ends with a
+    // space, strip exactly one space from each end. Content that is all spaces, or padded on one
+    // side only, is left untouched.
+    private def stripInlineCodeSpan(s: String): String =
+        if s.length >= 2 && s.startsWith(" ") && s.endsWith(" ") && s.exists(_ != ' ') then s.substring(1, s.length - 1)
+        else s
+
+    /** `<...>` -> a verbatim `UI.rawHtml` leaf for inline HTML snippets. */
+    private def inlineHtml(using Frame): UI < Parse[Char] =
+        for
+            _     <- Parse.literal('<')
+            inner <- nonEmptyUntilChar('>')
+            _     <- Parse.literal('>')
+        yield UI.rawHtml("<" + inner + ">")
+
+    /** Read at least one character up to (not including) `stop`; drops the branch if the run is
+      * empty so an unmatched opener falls through to a literal character.
+      */
+    private def nonEmptyUntilChar(stop: Char)(using Frame): String < Parse[Char] =
+        Parse.readWhile[Char](_ != stop).map(_.mkString).map { run =>
+            if run.isEmpty then Parse.fail[Char]("empty span")
+            else run
+        }
+
+    /** Read at least one character up to (not including) the `stop` string; drops the branch on an
+      * empty run so an unmatched opener falls through to a literal character.
+      */
+    private def nonEmptyUntilString(stop: String)(using Frame): String < Parse[Char] =
+        readUntilString(stop).map { run =>
+            if run.isEmpty then Parse.fail[Char]("empty span")
+            else run
+        }
+
+    // ---- kyo-parse runner ----
+
+    /** Run a `Parse[Char]` parser over `input`, requiring it to consume the entire input, and
+      * return its result as a `Maybe`. A failed or incomplete parse yields `Absent`, which the
+      * callers turn into their total fall-through. The `Parse[Char]` effect is fully discharged here
+      * (effect row `Any`), so the pure result is evaluated synchronously.
+      */
+    private def runParser[A](input: String)(parser: A < Parse[Char])(using Frame): Maybe[A] =
+        Parse.runResult(input)(Parse.entireInput(parser)).map(_.out).eval
+
+end Markdown

--- a/kyo-markdown/shared/src/test/scala/kyo/MarkdownTest.scala
+++ b/kyo-markdown/shared/src/test/scala/kyo/MarkdownTest.scala
@@ -1,0 +1,458 @@
+package kyo
+
+import kyo.UI.*
+
+class MarkdownTest extends kyo.test.Test[Any]:
+
+    // Render a UI subtree to its first (static) HTML emission.
+    private def renderHtml(ui: UI)(using Frame): String < Async =
+        UI.runRender(ui).take(1).run.map(_.headMaybe.getOrElse(""))
+
+    // Render a Markdown source to HTML in one step.
+    private def renderMd(source: String)(using Frame): String < Async =
+        for
+            rendered <- Kyo.lift(Markdown.render(source))
+            html     <- renderHtml(rendered.article)
+        yield html
+
+    // ---- GFM pipe table ----
+
+    "GFM pipe table -> UI.table subtree" in {
+        val source =
+            "| Name | Type |\n" +
+                "| ---- | ---- |\n" +
+                "| Foo  | Int  |\n" +
+                "| Bar  | String |\n"
+        for html <- renderMd(source)
+        yield
+            assert(html.contains("<table"), s"Expected table: $html")
+            assert(html.contains("<th"), s"Expected th: $html")
+            assert(html.contains("<td"), s"Expected td: $html")
+            assert(html.contains("Name"), s"Expected Name: $html")
+            assert(html.contains("Foo"), s"Expected Foo: $html")
+        end for
+    }
+
+    // ---- Heading ids ----
+
+    "heading id attributes equal the outline ids" in {
+        val source =
+            "# Alpha\n" +
+                "## Beta\n" +
+                "### Gamma\n" +
+                "#### Delta\n" +
+                "## Beta\n"
+        for
+            rendered <- Kyo.lift(Markdown.render(source))
+            html     <- renderHtml(rendered.article)
+        yield
+            val ids = rendered.headings.map(_.id)
+            for id <- ids.toSeq do
+                assert(html.contains(s"""id="$id""""), s"Missing id=$id in HTML")
+            val betaIds = ids.filter(s => s == "beta" || s == "beta-2")
+            assert(betaIds.size == 2, s"Expected two beta ids, got: $betaIds")
+        end for
+    }
+
+    "id lowercases text and replaces non-alphanumeric runs with a single dash" in {
+        for rendered <- Kyo.lift(Markdown.render("## Composing: map, flatMap\n"))
+        yield
+            assert(rendered.headings.size == 1)
+            assert(rendered.headings.head.id == "composing-map-flatmap")
+        end for
+    }
+
+    "duplicate headings get a -2 suffix on both the id attribute and the outline" in {
+        val source = "## Note\n## Note\n"
+        for
+            rendered <- Kyo.lift(Markdown.render(source))
+            html     <- renderHtml(rendered.article)
+        yield
+            val ids = rendered.headings.map(_.id).toSeq
+            assert(ids == Seq("note", "note-2"), s"ids: $ids")
+            assert(html.contains("""id="note""""), s"Missing id=note: $html")
+            assert(html.contains("""id="note-2""""), s"Missing id=note-2: $html")
+        end for
+    }
+
+    "heading level maps to h1..h4" in {
+        for rendered <- Kyo.lift(Markdown.render("# A\n## B\n### C\n#### D\n"))
+        yield assert(
+            rendered.headings.map(_.level).toSeq == Seq(1, 2, 3, 4),
+            s"levels: ${rendered.headings}"
+        )
+    }
+
+    // ---- Lists ----
+
+    "two-space nested list stays nested rather than flattening" in {
+        val source = "- Exception\n  - FileException\n  - TimeoutException\n"
+        for html <- renderMd(source)
+        yield
+            assert(html.contains("<ul"), s"Expected ul: $html")
+            assert(html.contains("FileException"), s"Expected sub-item: $html")
+            // Two <ul> tags means the list is nested.
+            assert(html.indexOf("<ul") != html.lastIndexOf("<ul"), s"Expected nested ul: $html")
+        end for
+    }
+
+    "ordered list strips the N. marker and renders an ol" in {
+        val source = "1. first\n2. second\n3. third\n"
+        for html <- renderMd(source)
+        yield
+            assert(html.contains("<ol"), s"Expected ol: $html")
+            assert(html.contains("<li"), s"Expected li: $html")
+            assert(html.contains(">first</li>") || html.contains("first"), s"Expected first item text: $html")
+            assert(!html.contains("1. "), s"marker must be stripped: $html")
+        end for
+    }
+
+    // ---- Inline emphasis ----
+
+    "bold opener in a paragraph renders a md-strong span" in {
+        for html <- renderMd("**Note:** inline text here\n")
+        yield
+            assert(html.contains("<p"), s"Expected paragraph: $html")
+            assert(html.contains("md-strong"), s"Expected bold span: $html")
+            assert(html.contains("Note:"), s"Expected bold text: $html")
+        end for
+    }
+
+    // ---- Blockquotes ----
+
+    "a blockquote renders a blockquote element" in {
+        for html <- renderMd("> some quoted text\n")
+        yield
+            assert(html.contains("<blockquote"), s"Expected blockquote: $html")
+            assert(html.contains("some quoted text"), s"Expected quoted text: $html")
+        end for
+    }
+
+    "a blockquote-wrapped fenced code block is a real pre/code block inside the blockquote" in {
+        val source =
+            "> intro line\n" +
+                ">\n" +
+                "> ```scala\n" +
+                "> val x = 1\n" +
+                "> ```\n"
+        for html <- renderMd(source)
+        yield
+            assert(html.contains("<blockquote"), s"Expected blockquote wrapper: $html")
+            assert(html.contains("<pre"), s"Expected pre block: $html")
+            assert(html.contains("<code"), s"Expected code block: $html")
+            assert(html.contains("val x = 1"), s"Expected code body: $html")
+        end for
+    }
+
+    // ---- Fenced code (nesting + info string) ----
+
+    // A fence LONGER than the minimum lets shorter fences appear verbatim in its body. A fence-length
+    // unaware parser closes the outer block on its first inner ``` line and shatters the content.
+    "a 4-backtick fence wrapping 3-backtick blocks renders as one verbatim code block" in {
+        val source =
+            "### Wrapping example\n" +
+                "\n" +
+                "````markdown\n" +
+                "# A document\n" +
+                "\n" +
+                "```scala\n" +
+                "val x = 1\n" +
+                "```\n" +
+                "````\n" +
+                "\n" +
+                "After the block.\n"
+        for html <- renderMd(source)
+        yield
+            // One outer code block, not several fragments from an early close.
+            assert(html.split("<pre", -1).length - 1 == 1, s"the 4-backtick block must be ONE pre, not split: $html")
+            // The outer info string's first token becomes the language class.
+            assert(html.contains("language-markdown"), s"outer fence language class: $html")
+            // The inner literal ```scala fence survives (it is content, shown to the reader).
+            assert(html.contains("```scala"), s"the inner fence must render verbatim: $html")
+            assert(html.contains("val x = 1"), s"the inner body must survive: $html")
+            // The block is closed by the ```` line, so prose after it renders normally.
+            assert(html.contains("After the block."), s"content after the outer fence must render: $html")
+        end for
+    }
+
+    "a fenced code block exposes only the info string's first token as a language class" in {
+        val source = "```scala extra=modifier\nval x = 1\n```\n"
+        for html <- renderMd(source)
+        yield
+            assert(html.contains("language-scala"), s"Expected language-scala class: $html")
+            assert(!html.contains("extra=modifier"), s"info-string suffix must be dropped: $html")
+            assert(html.contains("val x = 1"), s"body must render verbatim: $html")
+        end for
+    }
+
+    "a scala fence renders plain monospace code with no highlight token spans" in {
+        val source = "```scala\nval x = 1\ndef foo: Int = x\n```\n"
+        for html <- renderMd(source)
+        yield
+            assert(html.contains("<pre") && html.contains("<code"), s"Expected pre/code: $html")
+            assert(html.contains("language-scala"), s"Expected language-scala class: $html")
+            assert(!html.contains("tok-"), s"there is no syntax highlighting in kyo-markdown: $html")
+            assert(html.contains("val x = 1"), s"body verbatim: $html")
+        end for
+    }
+
+    "a bare fence renders pre/code with no language class" in {
+        val source = "```\nsome plain text\n```\n"
+        for html <- renderMd(source)
+        yield
+            assert(html.contains("<pre") && html.contains("<code"), s"Expected pre/code: $html")
+            assert(!html.contains("language-"), s"bare fence must have no language class: $html")
+            assert(html.contains("some plain text"), s"body verbatim: $html")
+        end for
+    }
+
+    // ---- Inline code spans (CommonMark backtick-run rules) ----
+
+    "a plain single-backtick inline code span renders as one chip" in {
+        for html <- renderMd("Use `Sync.defer` to suspend.\n")
+        yield assert(html.contains(">Sync.defer</code>"), s"single-backtick code span must render as one chip: $html")
+    }
+
+    // A code span may be delimited by N backticks, letting a shorter run appear inside it.
+    "a multi-backtick inline code span renders the literal inner backticks as one chip" in {
+        val source = "A plain ```` ```scala ```` fenced block, or a `<details>` element.\n"
+        for html <- renderMd(source)
+        yield
+            // The 4-backtick span becomes ONE <code> chip whose text is the literal ```scala (one
+            // padding space stripped each side), not stray backticks leaking into the prose.
+            assert(html.contains(">```scala</code>"), s"the ```scala token must be one inline code chip: $html")
+            // The trailing single-backtick span still works alongside the multi-backtick one.
+            assert(html.contains(">&lt;details&gt;</code>"), s"the <details> token must be its own chip: $html")
+            // The prose around the chips is intact.
+            assert(html.contains("fenced block, or a"), s"prose around the chip must be clean: $html")
+            assert(!html.contains("```` "), s"no raw 4-backtick run may leak into the rendered prose: $html")
+        end for
+    }
+
+    // An unmatched backtick run in the MIDDLE of prose is literal and parsing resumes after it.
+    "an unmatched backtick run in prose is literal and does not swallow following inline code" in {
+        val source = "extracts every ```scala block, and opts out with `.disable` per project.\n"
+        for html <- renderMd(source)
+        yield
+            // The bare ```scala renders as literal backticks in the prose, not a code chip.
+            assert(html.contains("```scala block"), s"bare ```scala must render literally in prose: $html")
+            // The real single-backtick chip after it is its own clean chip.
+            assert(html.contains(">.disable</code>"), s"the later inline-code chip must render as one chip: $html")
+            // The word before that chip keeps its space.
+            assert(html.contains("opts out with "), s"the space before the chip must survive: $html")
+            // Exactly ONE code chip on the line (the bare run did not open a spurious span).
+            assert(html.split("<code", -1).length - 1 == 1, s"only the real chip is a <code>, not the bare run: $html")
+        end for
+    }
+
+    // ---- Links and images ----
+
+    "an external http(s) link keeps its full URL" in {
+        for html <- renderMd("Visit [site](https://example.com/page) now.\n")
+        yield
+            assert(html.contains("<a"), s"Expected anchor: $html")
+            assert(html.contains("https://example.com/page"), s"external URL must be preserved: $html")
+        end for
+    }
+
+    "a fragment link renders as #id" in {
+        for html <- renderMd("Jump to [section](#getting-started).\n")
+        yield assert(html.contains("#getting-started"), s"fragment link must render as #id: $html")
+    }
+
+    "a relative path link is left untouched" in {
+        for html <- renderMd("See [prelude](../kyo-prelude/) for details.\n")
+        yield assert(html.contains("../kyo-prelude/"), s"relative path must be preserved: $html")
+    }
+
+    "a linked image renders an anchor wrapping an img" in {
+        val source = "[![Version](https://img.shields.io/badge/v-1.0)](https://getkyo.io)\n"
+        for html <- renderMd(source)
+        yield
+            assert(html.contains("<a"), s"Expected anchor: $html")
+            assert(html.contains("<img"), s"Expected img: $html")
+            assert(html.contains("shields.io"), s"Expected image URL: $html")
+            assert(html.contains("getkyo.io"), s"Expected link URL: $html")
+        end for
+    }
+
+    "an inline image renders an img with the given src and alt" in {
+        for html <- renderMd("An image ![logo](kyo.png) inline.\n")
+        yield
+            assert(html.contains("<img"), s"Expected img: $html")
+            assert(html.contains("kyo.png"), s"Expected src: $html")
+            assert(html.contains("logo"), s"Expected alt text: $html")
+        end for
+    }
+
+    // ---- Heading inline-markdown stripping for the outline ----
+
+    "a heading with inline code yields plain outline text but renders a real code element" in {
+        val source = "## Working with `Sync`\n"
+        for
+            rendered <- Kyo.lift(Markdown.render(source))
+            html     <- renderHtml(rendered.article)
+        yield
+            assert(
+                rendered.headings.headMaybe.map(_.text) == Present("Working with Sync"),
+                s"outline text should be backtick-free: ${rendered.headings}"
+            )
+            assert(rendered.headings.headMaybe.map(_.id) == Present("working-with-sync"), s"id should be stable: ${rendered.headings}")
+            assert(html.contains("<code"), s"in-page heading should still render a real code element: $html")
+        end for
+    }
+
+    "a heading with bold, italic, and a link yields plain outline text" in {
+        val source = "### **Bold** and *italic* and [linked](x.md)\n"
+        for rendered <- Kyo.lift(Markdown.render(source))
+        yield assert(
+            rendered.headings.headMaybe.map(_.text) == Present("Bold and italic and linked"),
+            s"outline text should be markup-free: ${rendered.headings}"
+        )
+    }
+
+    // ---- Raw HTML passthrough ----
+
+    "an inline img on its own line becomes a verbatim rawHtml leaf inside a paragraph" in {
+        val snippet = """<img src="kyo.png" width="200" alt="Kyo">"""
+        val source  = snippet + "\nSome regular text here.\n"
+        for html <- renderMd(source)
+        yield
+            assert(html.contains("""<img src="kyo.png""""), s"Expected verbatim img: $html")
+            assert(html.contains("Some regular text here"), s"Expected text: $html")
+            assert(!html.contains("&lt;img"), s"img must not be escaped: $html")
+        end for
+    }
+
+    "a multi-line <a><img></a> embed is coalesced into one wrapped rawHtml node" in {
+        val source =
+            "<a href=\"http://www.youtube.com/watch?v=uA2_TWP5WF4\" title=\"Tour\">\n" +
+                "    <img src=\"https://img.youtube.com/vi/uA2_TWP5WF4/maxresdefault.jpg\" alt=\"Kyo\" width=\"500\" height=\"300\">\n" +
+                "</a>\n"
+        for html <- renderMd(source)
+        yield
+            assert(html.contains("<a href=\"http://www.youtube.com/watch?v=uA2_TWP5WF4\""), s"Expected verbatim <a: $html")
+            assert(html.contains("<img src=\"https://img.youtube.com/vi/uA2_TWP5WF4/maxresdefault.jpg\""), s"Expected verbatim <img: $html")
+            assert(html.contains("</a>"), s"Expected </a>: $html")
+            assert(!html.contains("&lt;a"), s"<a must not be escaped: $html")
+            assert(!html.contains("&lt;img"), s"<img must not be escaped: $html")
+            // The <img must appear BETWEEN the <a and the </a> (nesting preserved as one unit).
+            val aIdx     = html.indexOf("<a href")
+            val imgIdx   = html.indexOf("<img src=")
+            val closeIdx = html.indexOf("</a>")
+            assert(aIdx >= 0, s"<a not found: $html")
+            assert(imgIdx > aIdx, s"<img must follow <a: html=$html aIdx=$aIdx imgIdx=$imgIdx")
+            assert(imgIdx < closeIdx, s"<img must precede </a>: html=$html imgIdx=$imgIdx closeIdx=$closeIdx")
+            assert(html.contains("<p") && (html.contains("<p>") || html.contains("<p ")), s"Expected <p> wrapper: $html")
+        end for
+    }
+
+    // ---- HTML comments ----
+
+    "a leading HTML comment is skipped and the first heading is the H1" in {
+        val source = "<!-- This is a comment -->\n# kyo-core\nSome text.\n"
+        for rendered <- Kyo.lift(Markdown.render(source))
+        yield assert(rendered.headings.headMaybe.map(_.text) == Present("kyo-core"))
+    }
+
+    "a leading multi-line HTML comment keeps the text after the closing -->" in {
+        val source =
+            "<!-- a comment\n" +
+                "spanning lines -->Kept text.\n" +
+                "# Title\n"
+        for html <- renderMd(source)
+        yield
+            assert(!html.contains("-->"), s"--> must not leak: $html")
+            assert(html.contains("Kept text."), s"text after --> must be preserved: $html")
+        end for
+    }
+
+    // ---- Totality: degrade, do not fail ----
+
+    "empty source returns an empty article and no headings" in {
+        for rendered <- Kyo.lift(Markdown.render(""))
+        yield assert(rendered == Markdown.Rendered(UI.empty, Chunk.empty))
+    }
+
+    "blank (whitespace-only) source returns an empty article and no headings" in {
+        for rendered <- Kyo.lift(Markdown.render("   \n\n  \n"))
+        yield assert(rendered == Markdown.Rendered(UI.empty, Chunk.empty))
+    }
+
+    "an unknown construct degrades to a plain paragraph without aborting" in {
+        // A definition-list style is not supported; it must not abort and must produce output.
+        val source = "term\n:   definition\n"
+        for
+            rendered <- Kyo.lift(Markdown.render(source))
+            html     <- renderHtml(rendered.article)
+        yield
+            assert(rendered.headings.isEmpty, s"Expected no headings, got: ${rendered.headings}")
+            assert(html.contains("<p"), s"Expected paragraph element: $html")
+            assert(html.contains("term"), s"Expected literal 'term' in output: $html")
+            assert(html.contains("definition"), s"Expected literal 'definition' in output: $html")
+            assert(rendered.article != UI.empty, s"Expected non-empty article: $rendered")
+        end for
+    }
+
+    "a malformed table (no separator row) degrades without producing a table" in {
+        val source = "| A | B |\n"
+        for html <- renderMd(source)
+        yield assert(!html.contains("<table"), s"Malformed table should not produce <table: $html")
+    }
+
+    // ---- Paragraph flow ----
+
+    "consecutive non-blank lines coalesce into one paragraph; a blank line starts a new one" in {
+        val source = "line one\nline two\n\nsecond paragraph\n"
+        for
+            rendered <- Kyo.lift(Markdown.render(source))
+            html     <- renderHtml(rendered.article)
+        yield
+            // Two <p> elements: the first coalesces line one + line two, the second is separate.
+            assert(html.split("<p", -1).length - 1 == 2, s"expected exactly two paragraphs: $html")
+            assert(html.contains("line one line two"), s"lines must coalesce with a space: $html")
+            assert(html.contains("second paragraph"), s"second paragraph must be present: $html")
+        end for
+    }
+
+    // ---- Perf guard: a large document renders in bounded time ----
+
+    "a large synthetic document renders in bounded time" in {
+        val sb = new StringBuilder()
+        sb.append("# Large synthetic module\n\n")
+        var i = 0
+        while i < 220 do
+            sb.append(s"## Section $i\n\n")
+            sb.append("This is a paragraph with some `inline code` and a [link](https://example.com/page) ")
+            sb.append("and **bold** and *italic* spread across a moderately long line of ordinary prose. ")
+            sb.append("It repeats enough plain words to exercise the inline text-run path at scale.\n\n")
+            sb.append("```scala\n")
+            sb.append("val config = load(\"etc\", \"app\")\n")
+            sb.append("val xs = List(1, 2, 3).map(_ * 2)\n")
+            sb.append("```\n\n")
+            sb.append("| Name | Type | Note |\n")
+            sb.append("| ---- | ---- | ---- |\n")
+            sb.append(s"| Foo$i | Int | a b |\n")
+            sb.append(s"| Bar$i | String | x y |\n\n")
+            sb.append("- first item with `code`\n")
+            sb.append("- second item with a [ref](#section-0)\n")
+            sb.append("  - nested item\n\n")
+            i += 1
+        end while
+        val source = sb.toString
+        assert(source.length > 100000, s"fixture too small: ${source.length}")
+
+        val start = java.lang.System.nanoTime()
+        for
+            rendered <- Kyo.lift(Markdown.render(source))
+            html     <- renderHtml(rendered.article)
+        yield
+            val elapsed = (java.lang.System.nanoTime() - start) / 1000000L
+            assert(rendered.headings.nonEmpty, "expected headings")
+            assert(html.contains("Large synthetic module"), "expected title in output")
+            assert(html.contains("<table"), "expected a table in output")
+            assert(elapsed < 30000L, s"render took ${elapsed}ms (budget 30000ms): not linear")
+        end for
+    }
+
+end MarkdownTest


### PR DESCRIPTION
## Problem

kyo has no shared way to turn a Markdown string into renderable UI. A module that needs to show authored content (a docs page, a rendered message) has to reach for a third-party Markdown library, which pins it to one platform and pulls in a syntax highlighter that does not cross-compile.

## Solution

Add `kyo-markdown`, a cross-platform module whose single entry point, `Markdown.render(source)`, returns `Rendered(article, headings)`: a kyo-ui `UI` article tree ready to mount, plus a heading outline for a table of contents. Each `Heading` carries the same id the article's in-page anchor uses, so an outline link and its target stay in lockstep.

`render` is pure and total: a construct outside the supported grammar degrades to text rather than failing, so no call needs error handling. The grammar covers ATX headings, paragraphs, ordered and unordered lists, GFM pipe tables, fenced code, blockquotes, and an inline span set, parsed with kyo-parse combinators. There is no third-party Markdown dependency and no JVM-only highlighter, so the module builds on JVM, JS, Native, and Wasm, kyo-ui's full platform set.

## Notes

Raw HTML in the source passes through un-escaped, the trust model a CommonMark renderer applies by default; a caller rendering untrusted Markdown sanitizes the output itself.
