### PR TITLE
[kyo-ui] add client commands, style props, and axis-title sizing

### DIFF
--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -50,15 +50,29 @@ private[kyo] object DomBackend:
             events <- Channel.init[Unit < Async](256)
             // runPartial captures only the Closed failure (the channel closed on page teardown -> stop draining); a
             // Panic propagates rather than being silently swallowed as a clean drain end.
-            _ <- Fiber.init(Loop.foreach(Abort.runPartial[Closed](events.take).map {
-                case Result.Success(eff) => eff.andThen(Loop.continue)
-                case Result.Failure(_)   => Loop.done
-            }))
+            // The drain carries the session's scroll sink: a handler calling UI.scrollIntoView scrolls the
+            // local document, the browser-mount counterpart of the server session's WebSocket op.
+            _ <- Fiber.init(UICommands.scrollSink.let(Present(scrollLocal)) {
+                Loop.foreach(Abort.runPartial[Closed](events.take).map {
+                    case Result.Success(eff) => eff.andThen(Loop.continue)
+                    case Result.Failure(_)   => Loop.done
+                })
+            })
             _ <- setupEventDelegation(dispatch.handle, events)
             _ <- Async.never
         yield ()
         end for
     end mountInto
+
+    // The local-document scroll sink installed on the mount's event-drain fiber; mirrors the embedded
+    // client's ScrollIntoView handling exactly (missing id = no-op, smooth scroll to the block start),
+    // so the same command behaves the same under either runner.
+    private def scrollLocal(id: String)(using Frame): Unit < Async =
+        Sync.defer {
+            val el = document.getElementById(id)
+            if el != null then
+                discard(el.asInstanceOf[js.Dynamic].scrollIntoView(js.Dynamic.literal(behavior = "smooth", block = "start")))
+        }
 
     /** Exchange that renders UI to HTML and applies directly to the DOM. */
     private class LocalExchange(root: ReactiveUI) extends UIExchange:

--- a/kyo-ui/shared/src/main/scala/kyo/Chart.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/Chart.scala
@@ -608,7 +608,8 @@ object Chart:
         axisColor: Maybe[Style.Color] = Absent,
         gridColor: Maybe[Style.Color] = Absent,
         fontFamily: Maybe[String] = Absent,
-        fontSize: Maybe[Double] = Absent
+        fontSize: Maybe[Double] = Absent,
+        titleFontSize: Maybe[Double] = Absent
     ) derives CanEqual:
         def light: Theme = copy(isDark = false)
         def dark: Theme  = copy(isDark = true)
@@ -625,8 +626,16 @@ object Chart:
         /** Sets the font family for axis and tick labels. */
         def font(family: String): Theme = copy(fontFamily = Present(family))
 
-        /** Sets the font size (in pixels) for axis and tick labels. */
+        /** Sets the font size (in pixels) for tick labels and legend text, and the fallback for axis
+          * titles when `titleFontSize` is not set.
+          */
         def fontSize(px: Double): Theme = copy(fontSize = Present(px))
+
+        /** Sets the font size (in pixels) for axis titles, independent of the tick-label size. Dense
+          * dashboards read best with small tick labels and slightly larger axis titles; a single shared
+          * size forces one of the two to be wrong. Falls back to `fontSize` when unset.
+          */
+        def titleFontSize(px: Double): Theme = copy(titleFontSize = Present(px))
 
         /** Sets the categorical palette from a named [[Palette]]. */
         def palette(p: Palette): Theme = copy(palette = Present(Palette.colors(p)))

--- a/kyo-ui/shared/src/main/scala/kyo/Style.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/Style.scala
@@ -146,6 +146,14 @@ final case class Style private[kyo] (props: Chunk[Style.Prop]) derives CanEqual:
     def color(c: Color): Style               = appendProp(Prop.TextColor(c))
     def color(f: Color.type => Color): Style = color(f(Color))
 
+    // Accent color (form controls)
+
+    /** Maps to the CSS `accent-color` property: tints the native check/track of checkbox, radio, range, and progress controls to match this
+      * color, without needing to rebuild the control's chrome from scratch.
+      */
+    def accentColor(c: Color): Style               = appendProp(Prop.AccentColorProp(c))
+    def accentColor(f: Color.type => Color): Style = accentColor(f(Color))
+
     // Padding: px, pct, or em (no auto)
 
     /** Sets padding. The 1-arg form applies to all four sides, the 2-arg form to vertical/horizontal, the 4-arg form to top/right/bottom/left.
@@ -282,6 +290,13 @@ final case class Style private[kyo] (props: Chunk[Style.Prop]) derives CanEqual:
 
     def textWrap(v: TextWrap): Style                  = appendProp(Prop.TextWrapProp(v))
     def textWrap(f: TextWrap.type => TextWrap): Style = textWrap(f(TextWrap))
+
+    /** Maps to the CSS `white-space` property: controls whether whitespace runs collapse and whether newlines are preserved, independent of
+      * [[textWrap]] (which controls word-breaking/balancing, not whitespace preservation). `preWrap` is the common case for rendering
+      * preformatted text (e.g. a log line) that must still wrap inside a constrained box rather than overflow.
+      */
+    def whiteSpace(v: WhiteSpace): Style                    = appendProp(Prop.WhiteSpaceProp(v))
+    def whiteSpace(f: WhiteSpace.type => WhiteSpace): Style = whiteSpace(f(WhiteSpace))
 
     // Borders: width is px only
 
@@ -626,6 +641,8 @@ object Style:
     def backgroundClip(f: BackgroundClip.type => BackgroundClip): Style = empty.backgroundClip(f)
     def color(c: Color): Style                                          = empty.color(c)
     def color(f: Color.type => Color): Style                            = empty.color(f)
+    def accentColor(c: Color): Style                                    = empty.accentColor(c)
+    def accentColor(f: Color.type => Color): Style                      = empty.accentColor(f)
     def padding(all: Length.Px | Length.Pct | Length.Em): Style         = empty.padding(all)
     def padding(vertical: Length.Px | Length.Pct | Length.Em, horizontal: Length.Px | Length.Pct | Length.Em): Style =
         empty.padding(vertical, horizontal)
@@ -692,6 +709,8 @@ object Style:
     def textOverflow(f: TextOverflow.type => TextOverflow): Style                   = empty.textOverflow(f)
     def textWrap(v: TextWrap): Style                                                = empty.textWrap(v)
     def textWrap(f: TextWrap.type => TextWrap): Style                               = empty.textWrap(f)
+    def whiteSpace(v: WhiteSpace): Style                                            = empty.whiteSpace(v)
+    def whiteSpace(f: WhiteSpace.type => WhiteSpace): Style                         = empty.whiteSpace(f)
     def border(width: Length.Px, style: BorderStyle, c: Color): Style               = empty.border(width, style, c)
     def border(width: Length.Px, style: BorderStyle, f: Color.type => Color): Style = empty.border(width, style, f)
     def border(width: Length.Px, c: Color): Style                                   = empty.border(width, c)
@@ -961,6 +980,19 @@ object Style:
     enum TextWrap derives CanEqual:
         case wrap, noWrap, ellipsis, balance, pretty
 
+    /** Maps to the CSS `white-space` property: controls whitespace collapsing and newline preservation, independent of [[TextWrap]] (which
+      * governs word-breaking/balancing within a line, not whether whitespace and newlines survive at all).
+      *
+      *   - `normal`: collapses whitespace runs and wraps lines normally (the CSS default).
+      *   - `noWrap`: collapses whitespace runs but never wraps; the text stays on one line.
+      *   - `pre`: preserves whitespace and newlines verbatim and never wraps, like HTML `<pre>`.
+      *   - `preWrap`: preserves whitespace and newlines verbatim but still wraps long lines, the common choice for pre-formatted text (e.g. a
+      *     log line) that must fit a constrained box.
+      *   - `preLine`: collapses whitespace runs but preserves newlines, wrapping long lines.
+      */
+    enum WhiteSpace derives CanEqual:
+        case normal, noWrap, pre, preWrap, preLine
+
     /** Maps to the CSS `font-family` property; `Custom` carries an arbitrary family name. */
     enum FontFamily derives CanEqual:
         case SansSerif, Serif, Monospace, Cursive, Fantasy, SystemUi
@@ -1090,6 +1122,7 @@ object Style:
         // Background
         case BgColor(color: Color)
         case TextColor(color: Color)
+        case AccentColorProp(color: Color)
         // Layout
         case Padding(top: Length, right: Length, bottom: Length, left: Length)
         case Margin(top: Length, right: Length, bottom: Length, left: Length)
@@ -1125,6 +1158,7 @@ object Style:
         case TextTransformProp(value: TextTransform)
         case TextOverflowProp(value: TextOverflow)
         case TextWrapProp(value: TextWrap)
+        case WhiteSpaceProp(value: WhiteSpace)
         // Borders
         case BorderColorProp(top: Color, right: Color, bottom: Color, left: Color)
         case BorderWidthProp(top: Length, right: Length, bottom: Length, left: Length)

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -2,6 +2,7 @@ package kyo
 
 import kyo.internal.HtmlRenderer
 import kyo.internal.ReactiveUI
+import kyo.internal.UICommands
 import kyo.internal.UIExchange
 import kyo.internal.UIServer
 import scala.language.implicitConversions
@@ -247,6 +248,22 @@ object UI:
       */
     def runHandlers(basePath: String)(ui: => UI < Async)(using Frame): Seq[HttpHandler[?, ?, ?]] < Sync =
         UIServer.handlers(basePath)(ui)
+
+    /** Scrolls the element with `id` into the client viewport, from inside an event handler.
+      *
+      * The command rides the session the handler runs in: under [[runHandlers]] it travels the same
+      * WebSocket as the reactive updates and the connected browser scrolls the element; under a
+      * browser mount (`UI.runMount`) it scrolls the local document directly. Outside any session
+      * (plain SSR, [[runRender]], render-only tests) there is no client to scroll and the call is a
+      * no-op.
+      *
+      * Fire-and-forget: an `id` with no matching element on the client is silently ignored, with no
+      * round trip or retry. The target must therefore already exist on the client when the command
+      * arrives; a scroll aimed at an element that only appears in a later re-render is dropped, since
+      * the command does not wait for pending updates beyond the frame it lands in.
+      */
+    def scrollIntoView(id: String)(using Frame): Unit < Async =
+        UICommands.scrollIntoView(id)
 
     /** Read-only stream of the full rendered HTML. Emits whenever any signal changes. First emission is the initial render. Useful for
       * testing, SSR, export, or custom transports.

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ChartAxes.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ChartAxes.scala
@@ -325,7 +325,7 @@ private[kyo] object ChartAxes:
                 val labelElem: Svg.SvgElement =
                     if isRight then
                         val cx = layout.svgW - AxisLabelInset
-                        withFont(
+                        withTitleFont(
                             theme,
                             Svg.text
                                 .x(cx)
@@ -337,7 +337,7 @@ private[kyo] object ChartAxes:
                         ).apply(lbl)
                     else
                         val cx = AxisLabelInset
-                        withFont(
+                        withTitleFont(
                             theme,
                             Svg.text
                                 .x(cx)
@@ -373,6 +373,16 @@ private[kyo] object ChartAxes:
     private[kyo] def withFont(theme: Theme, t: Svg.Text): Svg.Text =
         val t1 = theme.fontFamily.fold(t)(f => t.fontFamily(f))
         theme.fontSize.fold(t1)(px => t1.fontSize(Svg.SvgLength.Px(px)))
+
+    /** Apply theme font family and the axis-title font size to an Svg.Text element.
+      *
+      * Axis titles size from `theme.titleFontSize`, falling back to `theme.fontSize`, so a dense
+      * dashboard can pair small tick labels with readable titles. A no-op (element unchanged) when
+      * the theme sets no font field, matching `withFont`.
+      */
+    private[kyo] def withTitleFont(theme: Theme, t: Svg.Text): Svg.Text =
+        val t1 = theme.fontFamily.fold(t)(f => t.fontFamily(f))
+        theme.titleFontSize.orElse(theme.fontSize).fold(t1)(px => t1.fontSize(Svg.SvgLength.Px(px)))
 
     /** Apply theme font, configured anchor, and configured rotation to a tick-label text element.
       *
@@ -474,7 +484,7 @@ private[kyo] object ChartAxes:
         cfg.axisLabel match
             case Present(lbl) =>
                 val labelElem: Svg.SvgElement =
-                    withFont(
+                    withTitleFont(
                         theme,
                         Svg.text
                             .x(layout.plotX + layout.plotW / 2.0)

--- a/kyo-ui/shared/src/main/scala/kyo/internal/CssStyleRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/CssStyleRenderer.scala
@@ -49,6 +49,44 @@ private[kyo] object CssStyleRenderer:
         sb.toString
     end render
 
+    /** Derives a stable class name and CSS rule text for a [[kyo.Style]] that carries a pseudo-state
+      * (hover/focus/active/disabled), for renderers that have no inline-style channel for
+      * pseudo-states: an inline `style="..."` attribute cannot express `:hover` etc., so the
+      * server-push runtime (see `kyo.internal.HtmlRenderer`/`kyo.internal.UIServer`) carries them as a
+      * real stylesheet rule instead. The class name is a content hash of the rendered CSS, so two
+      * elements with identical styles collapse onto the same class and rule.
+      *
+      * The BASE (non-pseudo-state) props are folded into the class's own plain rule (`.cls { ... }`)
+      * rather than left for an inline `style="..."` attribute: an inline style always wins the
+      * cascade over any selector-based rule (including `.cls:hover`), so a base prop set inline would
+      * permanently shadow the pseudo-state's override of that same property and the pseudo-state
+      * would never visibly apply. Keeping base and pseudo-state declarations in the same class keeps
+      * them in the same cascade tier, so the later-declared `:hover`/`:focus`/`:active`/`:disabled`
+      * rule wins as CSS source order intends. Mirrors `DomStyleSheet`'s client-side class generation.
+      *
+      * Returns `Absent` when `style` carries no pseudo-state prop, or every pseudo-state prop AND the
+      * base props all render to no declarations.
+      */
+    private[kyo] def pseudoStateClass(style: Style): Maybe[(String, String)] =
+        val hoverCss    = style.find[HoverProp].map(p => render(p.style)).getOrElse("")
+        val focusCss    = style.find[FocusProp].map(p => render(p.style)).getOrElse("")
+        val activeCss   = style.find[ActiveProp].map(p => render(p.style)).getOrElse("")
+        val disabledCss = style.find[DisabledProp].map(p => render(p.style)).getOrElse("")
+        if hoverCss.isEmpty && focusCss.isEmpty && activeCss.isEmpty && disabledCss.isEmpty then Absent
+        else
+            val baseCss = render(style)
+            val key     = s"b{$baseCss}h{$hoverCss}f{$focusCss}a{$activeCss}d{$disabledCss}"
+            val cls     = s"kyo-s-${Integer.toHexString(key.##)}"
+            val sb      = new StringBuilder
+            if baseCss.nonEmpty then sb.append(s".$cls { $baseCss }\n")
+            if hoverCss.nonEmpty then sb.append(s".$cls:hover { $hoverCss }\n")
+            if focusCss.nonEmpty then sb.append(s".$cls:focus { $focusCss }\n")
+            if activeCss.nonEmpty then sb.append(s".$cls:active { $activeCss }\n")
+            if disabledCss.nonEmpty then sb.append(s".$cls:disabled { $disabledCss }\n")
+            Present((cls, sb.toString))
+        end if
+    end pseudoStateClass
+
     /** Present(fragment) for a CSS filter prop, Absent for any non-filter prop. */
     private def renderFilterFragment(prop: Prop): Maybe[String] = prop match
         case BrightnessProp(v) => Present(s"brightness(${fmt(v)})")
@@ -139,6 +177,13 @@ private[kyo] object CssStyleRenderer:
         case TextOverflow.clip     => "clip"
         case TextOverflow.ellipsis => "ellipsis"
 
+    private def whiteSpaceCss(v: WhiteSpace): String = v match
+        case WhiteSpace.normal  => "normal"
+        case WhiteSpace.noWrap  => "nowrap"
+        case WhiteSpace.pre     => "pre"
+        case WhiteSpace.preWrap => "pre-wrap"
+        case WhiteSpace.preLine => "pre-line"
+
     private def borderStyle(v: BorderStyle): String = v match
         case BorderStyle.none   => "none"
         case BorderStyle.solid  => "solid"
@@ -176,6 +221,7 @@ private[kyo] object CssStyleRenderer:
     private def renderProp(prop: Prop): String = prop match
         case BgColor(c)          => s"background-color: ${color(c)};"
         case TextColor(c)        => s"color: ${color(c)};"
+        case AccentColorProp(c)  => s"accent-color: ${color(c)};"
         case Padding(t, r, b, l) => s"padding: ${size(t)} ${size(r)} ${size(b)} ${size(l)};"
         case Margin(t, r, b, l)  => s"margin: ${size(t)} ${size(r)} ${size(b)} ${size(l)};"
         case Gap(v)              => s"gap: ${size(v)};"
@@ -225,6 +271,7 @@ private[kyo] object CssStyleRenderer:
                 case TextWrap.ellipsis => "overflow-wrap: normal; text-overflow: ellipsis;"
                 case TextWrap.balance  => "text-wrap: balance;"
                 case TextWrap.pretty   => "text-wrap: pretty;"
+        case WhiteSpaceProp(v)                => s"white-space: ${whiteSpaceCss(v)};"
         case BorderColorProp(t, r, b, l)      => s"border-color: ${color(t)} ${color(r)} ${color(b)} ${color(l)};"
         case BorderWidthProp(t, r, b, l)      => s"border-width: ${size(t)} ${size(r)} ${size(b)} ${size(l)};"
         case BorderStyleProp(v)               => s"border-style: ${borderStyle(v)};"

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlOp.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlOp.scala
@@ -9,4 +9,5 @@ private[kyo] object HtmlOp:
     case class Replace(path: Seq[String], html: String) extends HtmlOp derives Schema
     case class Remove(path: Seq[String])                extends HtmlOp derives Schema
     case class InjectCss(css: String)                   extends HtmlOp derives Schema
+    case class ScrollIntoView(id: String)               extends HtmlOp derives Schema
 end HtmlOp

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -7,10 +7,32 @@ import kyo.UI.Ast.*
 
 private[kyo] object HtmlRenderer:
 
+    // className -> rule CSS text, accumulated during a renderWithCss traversal. Threaded through
+    // renderTo/renderCommonAttrs/renderDropdown* the same way `sb` carries the HTML, so collection
+    // costs nothing on the render(...) path (cssRules stays Absent there).
+    private type CssCollector = scala.collection.mutable.LinkedHashMap[String, String]
+
     /** Render a UI tree to HTML with data-kyo-path attributes. */
     def render(ui: UI, path: Seq[String])(using Frame): String < Sync =
         val sb = new StringBuilder
         renderTo(sb, ui, path).andThen(sb.toString)
+
+    /** Render a UI tree to HTML, additionally collecting the CSS rule(s) for every pseudo-state
+      * (hover/focus/active/disabled) [[kyo.Style]] encountered along the way.
+      *
+      * Used by the server-push runtime (`kyo.internal.UIServer`), which has no inline-style channel
+      * for pseudo-states: an inline `style="..."` attribute cannot express `:hover` etc., so the
+      * collected rules must be carried in a real stylesheet alongside the HTML instead. Each entry is
+      * `(stableClass, ruleCss)`; an element whose pseudo-state style produces the SAME rule text as one
+      * already collected shares its class rather than generating a new one (see
+      * [[kyo.internal.CssStyleRenderer.pseudoStateClass]]), so the result has one entry per distinct
+      * rule, in first-encountered order.
+      */
+    private[kyo] def renderWithCss(ui: UI, path: Seq[String])(using Frame): (String, Chunk[(String, String)]) < Sync =
+        val sb  = new StringBuilder
+        val css = new CssCollector
+        renderTo(sb, ui, path, cssRules = Present(css)).andThen((sb.toString, Chunk.from(css)))
+    end renderWithCss
 
     /** Wrap a reactive region's inner HTML in the appropriate placeholder tag.
       *
@@ -98,15 +120,17 @@ private[kyo] object HtmlRenderer:
 
     // ---- Core rendering ----
 
-    private def renderTo(sb: StringBuilder, ui: UI, path: Seq[String], svg: Boolean = false)(using Frame): Unit < Sync =
+    private def renderTo(sb: StringBuilder, ui: UI, path: Seq[String], svg: Boolean = false, cssRules: Maybe[CssCollector] = Absent)(using
+        Frame
+    ): Unit < Sync =
         ui match
             case dd: Dropdown =>
-                renderDropdown(sb, dd, path)
+                renderDropdown(sb, dd, path, cssRules)
             case elem: Element =>
                 val tag  = tagName(elem)
                 val void = elem.isInstanceOf[Void]
                 w(sb, s"""<$tag data-kyo-path="${pathAttr(path)}"""")
-                renderCommonAttrs(sb, elem.attrs)
+                renderCommonAttrs(sb, elem.attrs, cssRules)
                 renderEventAttr(sb, elem)
                 for _ <- renderElementAttrs(sb, elem)
                 yield
@@ -137,7 +161,7 @@ private[kyo] object HtmlRenderer:
                             case _            => Kyo.unit
                         textChild.andThen(
                             Kyo.foreachDiscard(elem.children.toSeq.zipWithIndex) { (child, i) =>
-                                renderTo(sb, child, path :+ i.toString, childSvg)
+                                renderTo(sb, child, path :+ i.toString, childSvg, cssRules)
                             }.andThen(w(sb, s"</$tag>"))
                         )
                     end if
@@ -156,11 +180,11 @@ private[kyo] object HtmlRenderer:
                     val childPath = child match
                         case kc: KeyedChild[?] => path :+ kc.key
                         case _                 => path :+ i.toString
-                    renderTo(sb, child, childPath, svg)
+                    renderTo(sb, child, childPath, svg, cssRules)
                 }
 
             case KeyedChild(_, child) =>
-                renderTo(sb, child, path, svg)
+                renderTo(sb, child, path, svg, cssRules)
 
             case r: Reactive[?] =>
                 // In SVG context emit a <g> placeholder (a <span> is invalid inside <svg>); the
@@ -168,7 +192,7 @@ private[kyo] object HtmlRenderer:
                 val tag = if svg then "g" else "span"
                 w(sb, s"""<$tag data-kyo-path="${pathAttr(path)}" data-kyo-reactive>""")
                 for current <- r.signal.current(using r.frame)
-                yield renderTo(sb, current, path, svg).andThen(w(sb, s"</$tag>"))
+                yield renderTo(sb, current, path, svg, cssRules).andThen(w(sb, s"</$tag>"))
 
             case fe: Foreach[?, ?] @unchecked =>
                 val tag = if svg then "g" else "span"
@@ -181,7 +205,7 @@ private[kyo] object HtmlRenderer:
                                 val key = keyFn match
                                     case Present(f) => f(item)
                                     case Absent     => i.toString
-                                renderTo(sb, renderFn(i, item), path :+ key, svg)
+                                renderTo(sb, renderFn(i, item), path :+ key, svg, cssRules)
                             }.andThen(w(sb, s"</$tag>"))
                             end for
                 }
@@ -197,35 +221,53 @@ private[kyo] object HtmlRenderer:
 
     // ---- Dropdown (custom div-based overlay) ----
 
-    private def renderDropdown(sb: StringBuilder, dd: Dropdown, path: Seq[String])(using Frame): Unit < Sync =
+    private def renderDropdown(sb: StringBuilder, dd: Dropdown, path: Seq[String], cssRules: Maybe[CssCollector])(using
+        Frame
+    ): Unit < Sync =
         val baseId = dd.attrs.identifier.getOrElse("")
         // Read current selected value for initial highlight
         val currentValueEffect: Unit < Sync = dd.value match
             case Present(Bound.Ref(ref)) =>
                 ref.get.map { currentVal =>
-                    renderDropdownWithValue(sb, dd, path, baseId, currentVal)
+                    renderDropdownWithValue(sb, dd, path, baseId, currentVal, cssRules)
                 }
             case Present(Bound.Const(s)) =>
-                renderDropdownWithValue(sb, dd, path, baseId, s)
+                renderDropdownWithValue(sb, dd, path, baseId, s, cssRules)
             case _ =>
-                renderDropdownWithValue(sb, dd, path, baseId, "")
+                renderDropdownWithValue(sb, dd, path, baseId, "", cssRules)
         currentValueEffect
     end renderDropdown
 
-    private def renderDropdownWithValue(sb: StringBuilder, dd: Dropdown, path: Seq[String], baseId: String, currentVal: String)(using
+    private def renderDropdownWithValue(
+        sb: StringBuilder,
+        dd: Dropdown,
+        path: Seq[String],
+        baseId: String,
+        currentVal: String,
+        cssRules: Maybe[CssCollector]
+    )(using
         Frame
     ): Unit =
-        val pathStr   = pathAttr(path)
-        val idAttr    = if baseId.nonEmpty then s""" id="${esc(baseId)}"""" else ""
-        val ddAttr    = if baseId.nonEmpty then s""" data-kyo-dropdown="${esc(baseId)}"""" else " data-kyo-dropdown"
-        val disAttr   = if dd.disabled.getOrElse(false) then " data-kyo-disabled" else ""
-        val hidAttr   = if dd.attrs.hidden.getOrElse(false) then " hidden" else ""
-        val tabAttr   = dd.attrs.tabIndex.map(n => s""" tabindex="$n"""").getOrElse("")
-        val styleAttr = CssStyleRenderer.render(dd.attrs.uiStyle)
-        val styleStr  = if styleAttr.nonEmpty then s""" style="${esc(styleAttr)}"""" else ""
+        val pathStr     = pathAttr(path)
+        val idAttr      = if baseId.nonEmpty then s""" id="${esc(baseId)}"""" else ""
+        val ddAttr      = if baseId.nonEmpty then s""" data-kyo-dropdown="${esc(baseId)}"""" else " data-kyo-dropdown"
+        val disAttr     = if dd.disabled.getOrElse(false) then " data-kyo-disabled" else ""
+        val hidAttr     = if dd.attrs.hidden.getOrElse(false) then " hidden" else ""
+        val tabAttr     = dd.attrs.tabIndex.map(n => s""" tabindex="$n"""").getOrElse("")
+        val pseudoClass = registerPseudoClass(cssRules, dd.attrs.uiStyle)
+        // A generated pseudoClass already carries the base props in its own rule (see
+        // registerPseudoClass); rendering them inline too would shadow the pseudo-state override.
+        val styleStr = if pseudoClass.nonEmpty then ""
+        else
+            val styleAttr = CssStyleRenderer.render(dd.attrs.uiStyle)
+            if styleAttr.nonEmpty then s""" style="${esc(styleAttr)}"""" else ""
         // The dropdown wrapper carries its cssClasses (the same `.cssClass(...)` hook every other
-        // element honors) so callers can style the trigger container via a class selector.
-        val clsStr = if dd.attrs.cssClasses.nonEmpty then s""" class="${esc(dd.attrs.cssClasses.mkString(" "))}"""" else ""
+        // element honors), plus the generated pseudoClass when present, so callers can style the
+        // trigger container via a class selector.
+        val classes = pseudoClass match
+            case Present(cls) => dd.attrs.cssClasses :+ cls
+            case Absent       => dd.attrs.cssClasses
+        val clsStr = if classes.nonEmpty then s""" class="${esc(classes.mkString(" "))}"""" else ""
         // Determine initial trigger label
         val firstLabel    = dd.options.headMaybe.map(_._1).getOrElse("")
         val currentLabel  = Maybe.fromOption(dd.options.toSeq.find(_._2 == currentVal)).map(_._1).getOrElse(firstLabel)
@@ -315,15 +357,42 @@ private[kyo] object HtmlRenderer:
 
     // ---- Common attributes ----
 
-    private def renderCommonAttrs(sb: StringBuilder, attrs: Attrs): Unit =
+    /** Registers `style`'s pseudo-state rule (if any) into `cssRules` and returns its generated class,
+      * for an element whose render call is collecting CSS (the server-push path). Returns `Absent`
+      * when `cssRules` is `Absent` (the plain `render(...)` path, which keeps today's inline-style
+      * behavior unchanged) or `style` carries no pseudo-state prop. Deduped by class: an identical
+      * pseudo-state style anywhere else in the tree reuses the same entry rather than appending a
+      * duplicate rule.
+      *
+      * When this returns `Present`, the rule already carries the element's BASE props too (see
+      * [[kyo.internal.CssStyleRenderer.pseudoStateClass]]), so the caller must render NO inline style
+      * for `style` in that case, or the inline declaration would out-specificity the class rule and
+      * the pseudo-state would never visibly apply.
+      */
+    private def registerPseudoClass(cssRules: Maybe[CssCollector], style: Style): Maybe[String] =
+        cssRules.flatMap { rules =>
+            CssStyleRenderer.pseudoStateClass(style).map { case (cls, rule) =>
+                if !rules.contains(cls) then rules(cls) = rule
+                cls
+            }
+        }
+
+    private def renderCommonAttrs(sb: StringBuilder, attrs: Attrs, cssRules: Maybe[CssCollector] = Absent): Unit =
         attrs.identifier.foreach(id => w(sb, s""" id="${esc(id)}""""))
-        if attrs.cssClasses.nonEmpty then w(sb, s""" class="${esc(attrs.cssClasses.mkString(" "))}"""")
+        val pseudoClass = registerPseudoClass(cssRules, attrs.uiStyle)
+        val classes = pseudoClass match
+            case Present(cls) => attrs.cssClasses :+ cls
+            case Absent       => attrs.cssClasses
+        if classes.nonEmpty then w(sb, s""" class="${esc(classes.mkString(" "))}"""")
         attrs.hidden.foreach(v => if v then w(sb, " hidden"))
         attrs.tabIndex.foreach(n => w(sb, s""" tabindex="$n""""))
         attrs.focusTrap.foreach(v => if v then w(sb, """ data-kyo-focus-trap="1""""))
         attrs.focusGroup.foreach(id => w(sb, s""" data-kyo-focus-group="${esc(id)}""""))
-        val css = CssStyleRenderer.render(attrs.uiStyle)
-        if css.nonEmpty then w(sb, s""" style="${esc(css)}"""")
+        // A generated pseudoClass already carries the base props in its own rule (see
+        // registerPseudoClass); rendering them inline too would shadow the pseudo-state override.
+        if pseudoClass.isEmpty then
+            val css = CssStyleRenderer.render(attrs.uiStyle)
+            if css.nonEmpty then w(sb, s""" style="${esc(css)}"""")
         attrs.ariaAttrs.toSeq.sortBy(_._1).foreach { case (name, value) =>
             w(sb, s""" aria-$name="${esc(value)}"""")
         }
@@ -714,6 +783,13 @@ private[kyo] object HtmlRenderer:
            |    var s=document.createElement("style");
            |    s.textContent=op.InjectCss.css;
            |    document.head.appendChild(s);
+           |  }else if(op.ScrollIntoView){
+           |    // The scroll may arrive in the same batch as the Replace that introduces its target, so
+           |    // resolve the id after this frame's DOM writes have applied.
+           |    requestAnimationFrame(function(){
+           |      var el=document.getElementById(op.ScrollIntoView.id);
+           |      if(el)el.scrollIntoView({behavior:"smooth",block:"start"});
+           |    });
            |  }
            |};
            |function fp(el){

--- a/kyo-ui/shared/src/main/scala/kyo/internal/UICommands.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/UICommands.scala
@@ -1,0 +1,24 @@
+package kyo.internal
+
+import kyo.*
+
+/** Session-scoped client commands, the imperative complement of the reactive diff channel.
+  *
+  * A reactive update flows signal -> re-render -> HtmlOp; a command like scroll-into-view has no
+  * signal to ride, so each runner installs a sink for the session it owns: UIServer wires the
+  * WebSocket (the command becomes an [[HtmlOp]] the embedded client applies) and DomBackend wires
+  * the local document. Handlers reach the sink through a [[Local]], so the same handler code works
+  * under either runner; outside any session (plain SSR, render-only tests) the sink is absent and
+  * the command is a no-op.
+  */
+private[kyo] object UICommands:
+
+    private[kyo] val scrollSink: Local[Maybe[String => Unit < Async]] = Local.init(Absent)
+
+    def scrollIntoView(id: String)(using Frame): Unit < Async =
+        scrollSink.use {
+            case Present(sink) => sink(id)
+            case Absent        => ()
+        }
+
+end UICommands

--- a/kyo-ui/shared/src/main/scala/kyo/internal/UIServer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/UIServer.scala
@@ -18,9 +18,14 @@ private[kyo] object UIServer:
     private def getPage(base: String, pagePath: String, ui: => UI < Async)(using Frame): HttpHandler[?, ?, ?] =
         HttpRoute.getText(pagePath).handler { _ =>
             for
-                uiTree <- ui
-                html   <- HtmlRenderer.render(uiTree, Seq.empty)
-                page = HtmlRenderer.renderPage("kyo-ui", html, "", base)
+                uiTree        <- ui
+                (html, rules) <- HtmlRenderer.renderWithCss(uiTree, Seq.empty)
+                // Pseudo-state Style (hover/focus/active/disabled) has no inline-style channel (an
+                // inline `style="..."` attribute cannot express `:hover`), so its rules are carried
+                // here in a real stylesheet instead, after the base reset (renderPage already orders
+                // baseCss before css).
+                css  = rules.map(_._2).mkString
+                page = HtmlRenderer.renderPage("kyo-ui", html, css, base)
             yield HttpResponse.ok(page)
                 .addHeader("Content-Type", "text/html; charset=utf-8")
         }
@@ -30,12 +35,24 @@ private[kyo] object UIServer:
             for
                 uiTree <- ui
                 root   <- ReactiveUI.normalize(uiTree, Seq.empty)
-                exchange = wsExchange(root, ws)
+                // Pre-seed the connection's sent-class tracking with every pseudo-state class the
+                // initial SSR page already carries (rendered once more here, discarding the HTML), so
+                // the first reactive update touching an unchanged pseudo-styled element does not
+                // redundantly re-inject a rule the page's initial <style> block already has.
+                (_, initialRules) <- HtmlRenderer.renderWithCss(uiTree, Seq.empty)
+                exchange = wsExchange(root, ws, initialRules.map(_._1).toSet)
                 sub <- ReactiveUI.subscribe(root, exchange)
-                _ <- Async.race(
-                    ws.stream.foreach(payload => dispatchEvent(sub.handle, payload)),
-                    ws.onPeerClose
-                )
+                // Session command sink: an event handler calling UI.scrollIntoView sends the op over this
+                // connection's socket, riding the same channel as the reactive updates. runPartial drops
+                // only a Closed (the socket closed, so the command is moot); a Panic propagates.
+                scrollSink = (id: String) =>
+                    Abort.runPartial[Closed](ws.put(HttpWebSocket.Payload.Text(Json.encode[HtmlOp](HtmlOp.ScrollIntoView(id))))).unit
+                _ <- UICommands.scrollSink.let(Present(scrollSink)) {
+                    Async.race(
+                        ws.stream.foreach(payload => dispatchEvent(sub.handle, payload)),
+                        ws.onPeerClose
+                    )
+                }
             yield ()
         }
 
@@ -44,18 +61,36 @@ private[kyo] object UIServer:
             serveSession(ws, ui)
         }
 
-    private def wsExchange(root: ReactiveUI, ws: HttpWebSocket)(using Frame): UIExchange =
+    private def wsExchange(root: ReactiveUI, ws: HttpWebSocket, seenClasses: Set[String])(using Frame): UIExchange =
         new UIExchange:
             private def svgContextAt(path: Seq[String]): Boolean =
                 ReactiveUI.findNode(root, path).map(_.svgContext).getOrElse(false)
 
+            // Pseudo-state CSS classes already carried by this connection's <style> (seeded from the
+            // initial SSR page, then grown by every InjectCss this exchange sends), so a later
+            // re-render reusing one of these classes never re-sends its rule. Connection-scoped: each
+            // WS session gets its own set, matching the session-scoped subscription tree this exchange
+            // already belongs to.
+            private val sentClasses = scala.collection.mutable.Set.from(seenClasses)
+
             def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async =
-                HtmlRenderer.render(ui, path).map { html =>
+                HtmlRenderer.renderWithCss(ui, path).map { (html, rules) =>
+                    val newRules  = rules.filterNot(r => sentClasses.contains(r._1))
                     val finalHtml = HtmlRenderer.wrapReactiveRegion(path, svgContextAt(path), html)
-                    val op        = HtmlOp.Replace(path, finalHtml)
+                    val replaceOp = HtmlOp.Replace(path, finalHtml)
                     // runPartial drops only a Closed (the socket closed mid-render -> the op is moot); a Panic
                     // propagates to the region fiber rather than being swallowed by the discard.
-                    Abort.runPartial[Closed](ws.put(HttpWebSocket.Payload.Text(Json.encode[HtmlOp](op)))).unit
+                    val sendReplace =
+                        Abort.runPartial[Closed](ws.put(HttpWebSocket.Payload.Text(Json.encode[HtmlOp](replaceOp)))).unit
+                    if newRules.isEmpty then sendReplace
+                    else
+                        newRules.foreach(r => sentClasses += r._1)
+                        val injectOp = HtmlOp.InjectCss(newRules.map(_._2).mkString)
+                        // Send the new pseudo-state rule(s) before the replace that introduces the class
+                        // referencing them, so the element never paints unstyled between the two frames.
+                        Abort.runPartial[Closed](ws.put(HttpWebSocket.Payload.Text(Json.encode[HtmlOp](injectOp)))).unit
+                            .andThen(sendReplace)
+                    end if
                 }
             end onChange
 

--- a/kyo-ui/shared/src/test/scala/kyo/ChartAxisTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/ChartAxisTest.scala
@@ -1431,6 +1431,68 @@ class ChartAxisTest extends kyo.test.Test[Any]:
         }
     }
 
+    "titleFontSize sizes axis titles independently of tick labels and legend text" in {
+        val rows = Chunk(
+            Sale("Jan", Usd(1000), Region.NA),
+            Sale("Feb", Usd(2000), Region.EU)
+        )
+        val spec = Chart(rows)(
+            bar(x = _.month, y = _.revenue, color = _.region)
+        )
+            .yAxis(_.label("Revenue"))
+            .theme(_.fontSize(9).titleFontSize(12))
+            .legend(_.colorScale[Region](Region.NA -> Style.Color.blue, Region.EU -> Style.Color.green))
+        (spec).lower.map { root =>
+            val yTick = frameTextsIn(root)
+                .find(t =>
+                    t.svgAttrs.dominantBaseline.contains(Svg.DominantBaseline.Middle) &&
+                        t.svgAttrs.textAnchor.contains(Svg.TextAnchor.End)
+                )
+                .getOrElse(fail("Expected a left Y tick label with DominantBaseline.Middle + TextAnchor.End"))
+            assert(
+                yTick.svgAttrs.fontSize.exists(_.toString.contains("9")),
+                s"Y tick label must keep font-size=9px but got ${yTick.svgAttrs.fontSize}"
+            )
+
+            val yTitle = frameTextsIn(root)
+                .find(t => t.svgAttrs.transform.toSeq.exists { case _: Svg.Transform.Rotate => true; case _ => false })
+                .getOrElse(fail("Expected a rotated axis-title text"))
+            assert(
+                yTitle.svgAttrs.fontSize.exists(_.toString.contains("12")),
+                s"Y axis title must carry titleFontSize=12px but got ${yTitle.svgAttrs.fontSize}"
+            )
+
+            val legendLabel = frameTextsIn(root)
+                .find(t =>
+                    t.svgAttrs.dominantBaseline.contains(Svg.DominantBaseline.Middle) &&
+                        !t.svgAttrs.textAnchor.contains(Svg.TextAnchor.End) &&
+                        !t.svgAttrs.textAnchor.contains(Svg.TextAnchor.Start) &&
+                        t.svgAttrs.transform.isEmpty
+                )
+                .getOrElse(fail("Expected a legend label text without End/Start anchor and without Rotate"))
+            assert(
+                legendLabel.svgAttrs.fontSize.exists(_.toString.contains("9")),
+                s"Legend label must keep font-size=9px but got ${legendLabel.svgAttrs.fontSize}"
+            )
+        }
+    }
+
+    "axis titles fall back to fontSize when titleFontSize is unset" in {
+        val rows = Chunk(Sale("Jan", Usd(1000)), Sale("Feb", Usd(2000)))
+        val spec = Chart(rows)(bar(x = _.month, y = _.revenue))
+            .yAxis(_.label("Revenue"))
+            .theme(_.fontSize(14))
+        (spec).lower.map { root =>
+            val yTitle = frameTextsIn(root)
+                .find(t => t.svgAttrs.transform.toSeq.exists { case _: Svg.Transform.Rotate => true; case _ => false })
+                .getOrElse(fail("Expected a rotated axis-title text"))
+            assert(
+                yTitle.svgAttrs.fontSize.exists(_.toString.contains("14")),
+                s"Y axis title must fall back to fontSize=14px but got ${yTitle.svgAttrs.fontSize}"
+            )
+        }
+    }
+
     // ---- x tick-label chrome resolved through the shared helper ----
 
     "x tick rotateTicks/anchor/font are applied through the shared helper" in {

--- a/kyo-ui/shared/src/test/scala/kyo/UIServerWsTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIServerWsTest.scala
@@ -120,4 +120,55 @@ class UIServerWsTest extends kyo.test.Test[Any]:
         assert(decoded == Result.Success(event))
     }
 
+    // ==================== Leaf 5: scrollIntoView command over WS ====================
+
+    // notNative: WS-behavior leaf; see class scaladoc for RI-001 rationale.
+    "scrollIntoView: a click handler's command reaches the client as a ScrollIntoView op".notNative in {
+        for
+            // captured holds the frame received after the click (the command the handler sent).
+            captured <- AtomicRef.init(Absent: Maybe[String])
+            ref      <- Signal.initRef("static")
+            // The reactive region produces the initial render frame the client awaits before clicking;
+            // the handler never touches it, so the click's only response frame is the scroll command.
+            app = UI.div(
+                UI.button("Jump").id("btn").onClick(UI.scrollIntoView("card-7")),
+                ref.map(v => UI.span(v))
+            )
+            _ <- Scope.run {
+                HttpWebSocket.connect(
+                    (serverWs: HttpWebSocket) => UIServer.serveSession(serverWs, app),
+                    (clientWs: HttpWebSocket) =>
+                        for
+                            // Await the initial render frame to confirm the subscription is live.
+                            _ <- clientWs.take()
+                            clickEvent = UIEvent.Click(Seq("0"), MouseEventData(UI.Modifiers.none, Absent))
+                            _     <- clientWs.put(HttpWebSocket.Payload.Text(Json.encode[UIEvent](clickEvent)))
+                            frame <- clientWs.take()
+                            text = frame match
+                                case HttpWebSocket.Payload.Text(data) => Present(data)
+                                case _                                => Absent
+                            _ <- captured.set(text)
+                        yield ()
+                )
+            }
+            capturedData <- captured.get
+        yield capturedData match
+            case Present(data) =>
+                assert(Json.decode[HtmlOp](data) == Result.Success(HtmlOp.ScrollIntoView("card-7")))
+            case Absent => fail("client did not receive a frame after the click")
+        end for
+    }
+
+    "scrollIntoView outside any session is a no-op" in {
+        // No runner installed a sink (plain test context): the command completes without effect.
+        UI.scrollIntoView("nowhere").andThen(succeed)
+    }
+
+    "ScrollIntoView JSON round-trips through the wire codec" in {
+        val op      = HtmlOp.ScrollIntoView("card-7")
+        val encoded = Json.encode[HtmlOp](op)
+        assert(encoded.contains("ScrollIntoView"), s"the client dispatches on the op name; got $encoded")
+        assert(Json.decode[HtmlOp](encoded) == Result.Success(op))
+    }
+
 end UIServerWsTest


### PR DESCRIPTION
## Problem

kyo-ui drove the client only through the reactive diff channel: the server describes the UI as a value and the framework diffs and patches it. But some client actions are imperative, not declarative. Scrolling an element into view is a one-shot command, not a state a diff can express, and there was no way to issue one. Separately, the style surface had no `white-space` or `accent-color`, pseudo-state styling (hover, active, and the like) was not rendered server-side, and a chart's axis titles could only take the same font size as its tick labels.

## Solution

Add a session-scoped client-command channel, the imperative complement of the diff channel, with `UI.scrollIntoView(id)` as its first command: the server tells the client to scroll an element into view. Add `Style.whiteSpace` and `Style.accentColor`, render pseudo-state styles server-side, and give a chart theme a separate `titleFontSize` for axis titles that falls back to the tick-label `fontSize` when unset.
