### PR TITLE
[kyo-ai] add Observe: turn observation and token usage tracking

### DIFF
--- a/kyo-ai/CONTRIBUTING.md
+++ b/kyo-ai/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Module-specific guide for kyo-ai. Read the repository-root [CONTRIBUTING.md](../CONTRIBUTING.md) first: it carries the conventions, naming rules, type vocabulary (`Maybe` / `Result` / `Chunk` / `Span`), `using`-clause ordering, Frame/Tag, inline guidelines, scaladoc, visibility tiers, the test framework, cross-platform placement, and the unsafe-tier boundary that apply across all of Kyo. This document records only what is specific to kyo-ai: the explicit-instance model, the `LLM` `ArrowEffect` and its threaded `State`, the per-run owner and cross-run guard, the unified enablement surface, the scope/instance env-merge rule, the eval and stream loops, the agent wiring, the provider wire layer, and the test conventions.
 
-**The headline invariant:** a program typed `A < LLM` is a pure value. `LLM` is a custom `ArrowEffect[LLM.internal.Op, Id]`, NOT a subtype of `Async` ([`LLM.scala:26`]). Its ops carry data and read/append per-instance conversation histories in one threaded `State`. The single op that reaches the world is `Gen` (and its sibling `Stream`): its handler interpretation runs the eval loop, and that is the ONLY place `Async & Abort[AIGenException]` enter, riding out on `LLM.run`'s residual ([`LLM.scala:125-141`], [`LLM.scala:228`]). A row `A < LLM` must never include `Async`; no change to the eval loop should push `Async` into the `LLM` row. `LLMTest` pins this with `summon[NotGiven[LLM <:< Async]]` ([`LLMTest.scala:409-417`]).
+**The headline invariant:** a program typed `A < LLM` is a pure value. `LLM` is a custom `ArrowEffect[LLM.internal.Op, Id]`, NOT a subtype of `Async` ([`LLM.scala:26`]). Its ops carry data and read/append per-instance conversation histories in one threaded `State`. The single op that reaches the world is `Gen` (and its sibling `Stream`): its handler interpretation runs the eval loop, and that is the ONLY place `Async & Abort[AIGenException]` enter, riding out on `LLM.run`'s residual ([`LLM.scala:119-132`], [`LLM.scala:473`]). A row `A < LLM` must never include `Async`; no change to the eval loop should push `Async` into the `LLM` row. `LLMTest` pins this with `summon[NotGiven[LLM <:< Async]]` ([`LLMTest.scala:409-417`]).
 
 ## What kyo-ai is
 
@@ -11,17 +11,17 @@ kyo-ai is a typed effect for first-class conversations with a language model. Th
 - `LLM`, the `ArrowEffect`, and its `run` (the discharge boundary).
 - `AI`, the first-class conversation instance (both the identity value `ai` and the namespace of operations).
 - `Agent`, an opaque alias over `kyo.Actor` that pairs the LLM surface with the actor model.
-- `Prompt`, `Tool`, `Thought`, `Mode`, the four composable enablement kinds (`AI.Enablement`).
+- `Prompt`, `Tool`, `Thought`, `Mode`, `Observe`, the five composable enablement kinds (`AI.Enablement`).
 - `AIEnv` and `AISession`, the generation environment and the per-instance state record.
 - the `AIException` hierarchy (`AIGenException`, `AIStreamException`, and their leaves).
 
-The settings/content value types `Config`, `Context`, `Image` live in package `kyo.ai`, but they are surfaced into `kyo` so `import kyo.*` reaches everything: the `AI` companion `export`s `kyo.ai.Config` / `Context` / `Image` ([`AI.scala:36-38`]), so a user writes `AI.Config`, `AI.Context`, `AI.Image`; `LLM` also `export`s `Config` ([`LLM.scala:31`]).
+The settings/content value types `Config`, `Context`, `Image` live in package `kyo.ai`, but they are surfaced into `kyo` so `import kyo.*` reaches everything: the `AI` companion `export`s `kyo.ai.Config` / `Context` / `Image` ([`AI.scala:36-38`]), so a user writes `AI.Config`, `AI.Context`, `AI.Image`; `LLM` also `export`s `Config` ([`LLM.scala:30`]).
 
 All code lives in `shared/src/main/scala` (`kyo/` for the effect surface, `kyo/ai/` for the value types, `kyo/ai/completion/` for the wire backends). All tests live in `shared/src/test/scala` and run cross-platform (JVM, Scala.js, Scala Native, Wasm). The `jvm/`, `js/`, `native/`, and `wasm/` trees carry no `.scala` source.
 
 ## The explicit-instance model
 
-There is no ambient "current" instance and no `AI.use`. A behavior receives its instance explicitly and calls `self.gen`; the eval loop threads the target `AI` explicitly (`reads ai.context, appends to ai`), so nothing is ambient ([`LLM.scala:317`]). Two surfaces exist:
+There is no ambient "current" instance and no `AI.use`. A behavior receives its instance explicitly and calls `self.gen`; the eval loop threads the target `AI` explicitly (`reads ai.context, appends to ai`), so nothing is ambient ([`LLM.scala:560-565`]). Two surfaces exist:
 
 - **One-shot.** `AI.gen[A]` mints a fresh ephemeral instance, generates against it, then discards its slot via `ai.reset` on success, so two one-shots never share state ([`AI.scala:80-84`]). `AITest` pins that a successful one-shot leaves `State.instances` empty (and stays empty under concurrent gens, and a transport abort fails the run so nothing leaks) ([`AITest.scala:274-300`]).
 - **Named instance.** `AI.init` mints a persistent slot whose conversation, enablements, and config override survive across turns within one `LLM.run`; `ai.gen[A]` runs against that slot ([`AI.scala:55-56`], [`AI.scala:166-167`]).
@@ -33,11 +33,11 @@ final class AI private[kyo] (private[kyo] val id: Long, private[kyo] val owner: 
     private[kyo] val ref: LLM.internal.AIRef = new LLM.internal.AIRef(this)
 ```
 
-([`AI.scala:16-17`]). The id is drawn from the run's threaded `State` counter (no process-global mutable state), so identity is scoped to one `LLM.run` and restarts per run; `LLMTest` pins that within a run successive `init` ids are `0, 1, ...` and a fresh run restarts at `0` ([`LLMTest.scala:500-513`]). Every method on `AI` is a thin value over the `LLM` effect surface: `AI` summons no `ArrowEffect` op directly, only `LLM`'s `private[kyo]` interface ([`AI.scala:19-26`], [`LLM.scala:243-275`]).
+([`AI.scala:16-17`]). The id is drawn from the run's threaded `State` counter (no process-global mutable state), so identity is scoped to one `LLM.run` and restarts per run; `LLMTest` pins that within a run successive `init` ids are `0, 1, ...` and a fresh run restarts at `0` ([`LLMTest.scala:500-513`]). Every method on `AI` is a thin value over the `LLM` effect surface: `AI` summons no `ArrowEffect` op directly, only `LLM`'s `private[kyo]` interface ([`AI.scala:19-26`], [`LLM.scala:490-519`]).
 
 ### Per-run owner and the cross-run guard
 
-Each instance remembers the run that created it (`owner`, a fresh `AnyRef` per run, object identity, no counter) ([`LLM.scala:56-59`], [`LLM.scala:106-107`]). Using an instance inside a different `LLM.run` is misuse: it cannot address that run's slots. `crossRunFailure` inspects every op that targets an instance and, when `ai.owner ne state.owner`, raises `AICrossRunException`; the panic is the handler arm's result, so it rides `runWith`'s residual `Abort` row (not the `LLM` continuation) and aborts the whole computation ([`LLM.scala:65-95`]). `AICrossRunException`'s message points the user at `ai.snapshot` / `AI.recover` ([`AIException.scala:62-70`]). `LLMTest` pins that the guard fires for EVERY targeting op (read, set, gen, stream, discard, session, setSession), not just one ([`LLMTest.scala:531-550`]).
+Each instance remembers the run that created it (`owner`, a fresh `AnyRef` per run, object identity, no counter) ([`LLM.scala:56-59`], [`LLM.scala:97-101`]). Using an instance inside a different `LLM.run` is misuse: it cannot address that run's slots. `crossRunFailure` inspects every op that targets an instance and, when `ai.owner ne state.owner`, raises `AICrossRunException`; the panic is the handler arm's result, so it rides `runWith`'s residual `Abort` row (not the `LLM` continuation) and aborts the whole computation ([`LLM.scala:63-95`]). `AICrossRunException`'s message points the user at `ai.snapshot` / `AI.recover` ([`AIException.scala:62-70`]). `LLMTest` pins that the guard fires for EVERY targeting op (read, set, gen, stream, discard, session, setSession), not just one ([`LLMTest.scala:531-550`]).
 
 To carry an instance across runs deliberately, capture it with `ai.snapshot` (returns its `AISession`) and restore it with `AI.recover(session)` in the new run ([`AI.scala:69-71`], [`AI.scala:230-231`]); `AITest` pins a round-trip of history + an enabled tool + a config override across two runs ([`AITest.scala:201-223`]).
 
@@ -45,7 +45,7 @@ To carry an instance across runs deliberately, capture it with `ai.snapshot` (re
 
 ### Effect definition and the op GADT
 
-`LLM` is `sealed trait LLM extends ArrowEffect[LLM.internal.Op, Id]` ([`LLM.scala:26`]). The op GADT `LLM.internal.Op[A]` indexes each op's reply by `A`, so the handler continuation needs no reply-side cast ([`LLM.scala:399`]). It has exactly **13** subclasses ([`LLM.scala:400-415`]); field-less ops are `case object`s, the rest carry data:
+`LLM` is `sealed trait LLM extends ArrowEffect[LLM.internal.Op, Id]` ([`LLM.scala:26`]). The op GADT `LLM.internal.Op[A]` indexes each op's reply by `A`, so the handler continuation needs no reply-side cast ([`LLM.scala:815`]). It has exactly **13** subclasses ([`LLM.scala:816-831`]); field-less ops are `case object`s, the rest carry data:
 
 | Op | Carries | Reply (`Op[A]`) |
 |----|---------|-----------------|
@@ -63,11 +63,11 @@ To carry an instance across runs deliberately, capture it with `ai.snapshot` (re
 | `GetSession(target: AI)` | target | `AISession` |
 | `SetSession(target: AI, session: AISession)` | target, session | `Unit` |
 
-There is **no `SetCurrent`** op and no ambient-current concept. `LLMTest` pins the data-bearing ops carry their fields ([`LLMTest.scala:472-484`]). `Gen` is the one op that reaches the world; its arm runs `genLoop` under a nested `runWith` against the live state, and `Async & Abort[AIGenException]` enter there ([`LLM.scala:125-132`]). `Stream`'s arm projects the SSE response and is read-only (no instance write-back), so the threaded state passes through unchanged ([`LLM.scala:133-141`]).
+There is **no `SetCurrent`** op and no ambient-current concept. `LLMTest` pins the data-bearing ops carry their fields ([`LLMTest.scala:472-484`]). `Gen` is the one op that reaches the world; its arm runs `genLoop` under a nested `runWith` against the live state, and `Async & Abort[AIGenException]` enter there ([`LLM.scala:119-125`]). `Stream`'s arm runs `streamAgainst` under a nested `runWith`: the stream's CREATION applies and restores the target's session env (the same merge `genLoop` performs), so the state threads through net-unchanged, and the recorded turn is written later, at consumption, through ordinary ops ([`LLM.scala:126-132`], [`LLM.scala:174-191`]).
 
 ### Threaded state: `LLM.State`
 
-`State` is the single record threaded through `ArrowEffect.handleLoop` ([`LLM.scala:40-44`], [`LLM.scala:83-86`]):
+`State` is the single record threaded through `ArrowEffect.handleLoop` ([`LLM.scala:39-53`], [`LLM.scala:81-137`]):
 
 ```scala
 final case class State private[kyo] (
@@ -78,48 +78,48 @@ final case class State private[kyo] (
 )
 ```
 
-- `instances` is keyed by `internal.AIRef`, a `WeakReference[AI]` whose equality/hash are by the AI's stable `id`, so a dropped `AI` becomes GC-reclaimable while its key still matches its slot ([`LLM.scala:417-428`]). `State.pruned` sweeps slots whose `AI` was collected, run when minting a new instance so an unbounded mint stream never accumulates dead slots ([`LLM.scala:51-53`], [`LLM.scala:102-107`]).
-- `nextId` is the monotonic id counter `Init` draws from; `SetState` never lowers it (`math.max`), so a `forget`/`fresh` rollback keeps the high-water id and a slot key is never reused ([`LLM.scala:116-120`]).
+- `instances` is keyed by `internal.AIRef`, a `WeakReference[AI]` whose equality/hash are by the AI's stable `id`, so a dropped `AI` becomes GC-reclaimable while its key still matches its slot ([`LLM.scala:837-845`]). `State.pruned` sweeps slots whose `AI` was collected, run when minting a new instance so an unbounded mint stream never accumulates dead slots ([`LLM.scala:50-52`], [`LLM.scala:97-101`]).
+- `nextId` is the monotonic id counter `Init` draws from; `SetState` never lowers it (`math.max`), so a `forget`/`fresh` rollback keeps the high-water id and a slot key is never reused ([`LLM.scala:110-113`]).
 - `owner` stamps every instance for the cross-run guard ([`LLM.scala:56-59`]).
-- `env` is the scope `AIEnv` (see below), read by `Op.Env` and replaced by `Op.SetEnv` ([`LLM.scala:108-111`]).
+- `env` is the scope `AIEnv` (see below), read by `Op.Env` and replaced by `Op.SetEnv` ([`LLM.scala:102-105`]).
 
-`State.empty(config)` seeds a `Present(config)` scope env and a fresh `owner` ([`LLM.scala:56-60`]).
+`State.empty(config)` seeds a `Present(config)` scope env and a fresh `owner` ([`LLM.scala:55-59`]).
 
 ### `run` and its residual
 
-`LLM.run[A, S](v: A < (LLM & S)): A < (S & Async & Abort[AIGenException])` threads a fresh `State.empty(config)` through `runWith` and discards the final state ([`LLM.scala:228-229`]). Three overloads (`run(v)`, `run(f: Config => Config)(v)`, `run(config)(v)`) all funnel through `runWith`; the first two resolve `Config.default` under `Sync` first ([`LLM.scala:228-237`]). `runTuple` keeps the final state with the value for tests and transcript access (`private[kyo]`) ([`LLM.scala:239-241`]). `runWith` is NOT inline ([`LLM.scala:82-83`]).
+`LLM.run[A, S](v: A < (LLM & S)): A < (S & Async & Abort[AIGenException])` threads a fresh `State.empty(config)` through `runWith` and discards the final state ([`LLM.scala:473-474`]). Three overloads (`run(v)`, `run(f: Config => Config)(v)`, `run(config)(v)`) all funnel through `runWith`; the first two resolve `Config.default` under `Sync` first ([`LLM.scala:473-483`]). `runTuple` keeps the final state with the value for tests and transcript access (`private[kyo]`) ([`LLM.scala:485-487`]). `runWith` is NOT inline ([`LLM.scala:79-81`]).
 
 ### The eval loop
 
-`genLoop(ai, schema)` is the `Gen` interpretation ([`LLM.scala:313-351`]). It:
+`genLoop(ai, schema)` is the `Gen` interpretation ([`LLM.scala:555-613`]). It:
 
-1. Merges the instance's own env onto the scope env for the duration of the eval, then restores it (so the effective surface is `scope ++ instance`): config is `session.env.config.orElse(scopeEnv.config)`, and the instance's prompt/tools/thoughts/modes are layered on ([`LLM.scala:318-326`]). This is the merge that makes a `Present` instance config override the scope config; an `Absent` instance config inherits the scope's.
-2. Enables `Prompt.internal.defaultGuidance` (generic structured-output guidance, not part of the empty prompt) ([`LLM.scala:327`], [`Prompt.scala:92-104`]).
-3. Loops: each iteration calls `eval[A](ai, forceResult = iterations >= config.maxIterations)`, wraps transport `HttpException` into `AITransportException`, passes the result through `Mode.internal.handle` (the mode pipeline), and on `Present(r)` yields, on `Absent` re-loops with the seed modulated (`c.seed.map(_ * 31)`) until `iterations >= config.maxIterations * 2`, where it aborts with `AIEvalExhaustedException` ([`LLM.scala:329-345`]).
+1. Merges the instance's own env onto the scope env for the duration of the eval, then restores it (so the effective surface is `scope ++ instance`): config is `session.env.config.orElse(scopeEnv.config)`, and the instance's prompt/tools/thoughts/modes are layered on ([`LLM.scala:561-565`]). This is the merge that makes a `Present` instance config override the scope config; an `Absent` instance config inherits the scope's.
+2. The default structured-output guidance rides the enriched context built per request (`Prompt.internal.enrichedContext`), not the empty prompt, so the merged env stays exactly `scope ++ instance` ([`AISession.scala:13-28`]).
+3. Loops: each iteration calls `eval[A](ai, forceResult = iterations >= config.maxIterations)`, wraps transport `HttpException` into `AITransportException`, passes the result through `Mode.internal.handle` (the mode pipeline), and on `Present(r)` yields, on `Absent` re-loops with the seed modulated (`c.seed.map(_ * 31)`) until `iterations >= config.maxIterations * 2`, where it aborts with `AIEvalExhaustedException` ([`LLM.scala:569-599`]).
 
-`eval` posts one completion request: it assembles the tools (plus the result tool), the thought-aware result schema, the enriched context, runs the provider completion under the config meter and a `Retry[HttpException](config.retrySchedule)`, appends the reply, dispatches any tool calls, and extracts the structured result directly from the `result_tool` call arguments ([`LLM.scala:353-392`]). A closed meter under an in-flight gen panics with `AIMeterClosedException` (an impossible-state, off both rows) ([`LLM.scala:374-377`], [`AIException.scala:72-76`]).
+`eval` posts one completion request: it assembles the tools (plus the result tool), the thought-aware result schema, the enriched context, runs the provider completion under the config meter and a `Retry[HttpException](config.retrySchedule)`, appends the reply, dispatches any tool calls, and extracts the structured result directly from the `result_tool` call arguments ([`LLM.scala:615-808`]). A closed meter under an in-flight gen panics with `AIMeterClosedException` (an impossible-state, off both rows) ([`LLM.scala:694-696`], [`AIException.scala:72-76`]).
 
 ### The stream loop
 
-`AI.stream[A]` / `ai.stream[A]` suspend `Op.Stream`, whose handler runs `streamAgainst` ([`LLM.scala:259-263`], [`LLM.scala:133-141`]). `streamAgainst` asks `config.provider.completion.streamFragments` for raw JSON fragments of the `{ resultValue: ... }` envelope and accumulates the fragments. For `String`, it emits decoded text chunks whose concatenation is the final text. For other result types, it emits each complete decoded element from the result array exactly once ([`LLM.scala:147-225`]). HTTP providers implement fragments with SSE result-tool deltas; command harnesses use their native event or stream-json output. The returned `Stream` carries its failures typed in its element row as `Abort[AIStreamException]`: a malformed delta is `AIStreamDeltaException`, an end without a decodable value `AIStreamIncompleteException`, a transport error `AITransportException` ([`LLM.scala:181-216`]). A missing API key is the one failure raised eagerly (before the `Stream` value), as `AIMissingApiKeyException` on the run boundary ([`LLM.scala:164-167`]).
+`AI.stream[A]` / `ai.stream[A]` suspend `Op.Stream`, whose handler runs `streamAgainst` ([`LLM.scala:503-507`], [`LLM.scala:126-132`]). `streamAgainst` asks `config.provider.completion.streamFragments` for raw JSON fragments of the `{ resultValue: ... }` envelope and accumulates the fragments. For `String`, it emits decoded text chunks whose concatenation is the final text. For other result types, it emits each complete decoded element from the result array exactly once ([`LLM.scala:368-470`]). HTTP providers implement fragments with SSE result-tool deltas; command harnesses use their native event or stream-json output. The returned `Stream` carries its failures typed in its element row as `Abort[AIStreamException]`: a malformed delta is `AIStreamDeltaException`, an end without a decodable value `AIStreamIncompleteException`, a transport error `AITransportException` ([`LLM.scala:368-470`], [`Completion.scala:119-139`]). A missing API key is the one failure raised eagerly (before the `Stream` value), as `AIMissingApiKeyException` on the run boundary ([`LLM.scala:199-201`]).
 
 ### The `LLM.isolate` given
 
-`given isolate: Isolate[LLM, Async, LLM]` lets `Async.fill`/`foreach`/`race` fork over a bare `LLM` row ([`LLM.scala:285-305`]). `Keep = Async` is exact: the in-tree parallel sites require `Isolate[LLM, Abort[E] & Async, LLM]`, and for the `E = Nothing` body (whose transport errors the eval loop already recovers) that reduces to `Isolate[LLM, Async, LLM]`, which a wider `Keep` (`Abort[Any] & Async`) cannot satisfy by `Keep` contravariance ([`LLM.scala:277-284`]). `capture` reads the live `State` via `Op.GetState`; `isolate` discharges `runWith`'s residual `Abort[AIGenException]` inside the fork with `getOrThrow`, so an unrecovered fork generation failure surfaces as a fiber panic; `restore` merges fork-born instance contexts back via `mergeInstance` (prefix-aware `Context.merge`, parent env kept), skipping GC'd slots ([`LLM.scala:289-311`]). `LLMTest` pins both the fork resolution ([`LLMTest.scala:443-455`]) and the unrecovered-fork panic ([`LLMTest.scala:457-470`]).
+`given isolate: Isolate[LLM, Async, LLM]` lets `Async.fill`/`foreach`/`race` fork over a bare `LLM` row ([`LLM.scala:528-547`]). `Keep = Async` is exact: the in-tree parallel sites require `Isolate[LLM, Abort[E] & Async, LLM]`, and for the `E = Nothing` body (whose transport errors the eval loop already recovers) that reduces to `Isolate[LLM, Async, LLM]`, which a wider `Keep` (`Abort[Any] & Async`) cannot satisfy by `Keep` contravariance ([`LLM.scala:521-527`]). `capture` reads the live `State` via `Op.GetState`; `isolate` discharges `runWith`'s residual `Abort[AIGenException]` inside the fork with `getOrThrow`, so an unrecovered fork generation failure surfaces as a fiber panic; `restore` merges fork-born instance contexts back via `mergeInstance` (prefix-aware `Context.merge`, parent env kept), skipping GC'd slots ([`LLM.scala:533-553`]). `LLMTest` pins both the fork resolution ([`LLMTest.scala:443-455`]) and the unrecovered-fork panic ([`LLMTest.scala:457-470`]).
 
 ## `AIEnv` and `AISession`: the env-merge rule
 
 `AIEnv` is the generation environment: a config plus the enablements layered for a scope or instance ([`AIEnv.scala:12-18`]):
 
 ```scala
-case class AIEnv(config: Maybe[Config], prompt: Prompt[Any], tools: Chunk[Tool[Any]], thoughts: Chunk[Thought[Any]], mode: Chunk[Mode[Any]])
+case class AIEnv(config: Maybe[Config], prompt: Prompt[Any], tools: Chunk[Tool[Any]], thoughts: Chunk[Thought[Any]], mode: Chunk[Mode[Any]], observe: Chunk[Observe[Any]])
 ```
 
 `config` is `Maybe[Config]`: the SCOPE env always holds `Present` (set at `LLM.run`), while an INSTANCE env holds `Absent` to inherit the scope config or `Present` to override it ([`AIEnv.scala:8-11`], [`AISession.scala:30-31`]). `AIEnv.empty` and `AISession.empty` both carry an `Absent` config ([`AIEnv.scala:46`], [`AISession.scala:31`]); `AIEnvTest`/`AISessionTest` pin that `config(cfg)` sets `Present`, `mapConfig` is a no-op while `Absent`, and the empty session has no override ([`AIEnvTest.scala:9-15`], [`AISessionTest.scala:8-20`]).
 
 `AISession(context: Context, env: AIEnv)` is one instance's full state: its conversation plus its env override and enablements ([`AISession.scala:12`]). It is both the value `State.instances` holds per instance and the snapshot `ai.snapshot` returns / `AI.recover` restores. It holds code (tool runners, effectful prompts, modes), so it is in-memory only and not serializable; only the `session.context` slice is serializable (`Context derives Schema`) ([`AISession.scala:6-11`]).
 
-**The override-merge rule** (`genLoop`, [`LLM.scala:318-326`]; pinned in `LLMTest`):
+**The override-merge rule** (`genLoop`, [`LLM.scala:561-565`]; pinned in `LLMTest`):
 
 - An instance `Present` config override beats the scope config in the request ([`LLMTest.scala:325-341`]).
 - A scope `AI.withConfig` wrapped around a gen is SHADOWED by the instance config override (the override wins) ([`LLMTest.scala:362-374`]).
@@ -127,14 +127,14 @@ case class AIEnv(config: Maybe[Config], prompt: Prompt[Any], tools: Chunk[Tool[A
 
 ## The enablement surface
 
-The four composable kinds, `Tool`, `Prompt`, `Thought`, `Mode`, all extend `AI.Enablement[-S]`, whose two `private[kyo]` methods say how the kind layers itself onto a scope env or an instance session ([`AI.scala:48-53`], [`Tool.scala:19-26`], [`Prompt.scala:19-43`], [`Thought.scala:21-28`], [`Mode.scala:15-28`]). `private[kyo]` so only the module's four kinds implement it; users compose, never extend. There are **no** per-type `enable` binders (no `Tool.enable`, `Thought.enable`, `Prompt.enable`, or `Mode.enable`). Enabling is unified:
+The five composable kinds, `Tool`, `Prompt`, `Thought`, `Mode`, `Observe`, all extend `AI.Enablement[-S]`, whose two `private[kyo]` methods say how the kind layers itself onto a scope env or an instance session ([`AI.scala:48-53`], [`Tool.scala:19-26`], [`Prompt.scala:19-43`], [`Thought.scala:21-28`], [`Mode.scala:15-28`], [`Observe.scala:25-32`]). `private[kyo]` so only the module's five kinds implement it; users compose, never extend. There are **no** per-type `enable` binders (no `Tool.enable`, `Thought.enable`, `Prompt.enable`, or `Mode.enable`). Enabling is unified:
 
 - **Scope.** `AI.enable[A, S](enablements: Enablement[S]*)(v): A < (S & LLM)` folds each enablement's `enableIn(AIEnv)` over the scope env via `LLM.updateEnv` (on top of the scope's current enablements); empty varargs is a no-op ([`AI.scala:114-126`]). The capability `S` rides the row, unified across the varargs to their intersection, until discharged at the run boundary.
 - **Instance.** `ai.enable[S](enablements: Enablement[S]*): AI < (S & LLM)` folds each `enableIn(AISession)` onto the named instance ([`AI.scala:217-227`]).
 
 Both take varargs or a `Seq` (a `DummyImplicit` differentiates the erased `Seq[T]` signatures) and accept a mix of kinds in one call ([`AI.scala:125`], [`AI.scala:225-227`]).
 
-Config is scoped by `AI.withConfig` (NOT `LLM.withConfig`), built on `LLM.updateEnv(_.mapConfig(f))` ([`AI.scala:107-112`], [`LLM.scala:268-273`]). `updateEnv` brackets a transform of the scope `AIEnv` over `v`: get, modify, set, run, restore, written once and reused by the `enable` methods and `withConfig`.
+Config is scoped by `AI.withConfig` (NOT `LLM.withConfig`), built on `LLM.updateEnv(_.mapConfig(f))` ([`AI.scala:114-119`], [`LLM.scala:512-517`]). `updateEnv` brackets a transform of the scope `AIEnv` over `v`: get, modify, set, run, restore, written once and reused by the `enable` methods and `withConfig`.
 
 ### Forget and fresh
 
@@ -142,7 +142,7 @@ Config is scoped by `AI.withConfig` (NOT `LLM.withConfig`), built on `LLM.update
 
 ### `Tool`
 
-`Tool.init[In][Out, S]` builds a tool from a name, optional description and prompt, and a run `In => Out < S` ([`Tool.scala:34-46`]). The `Isolate[S, LLM, S]` constraint lets the tool's effects be isolated for the mode-pipeline parallel paths. `aggregate` composes tools; `empty` is the no-tool aggregate ([`Tool.scala:48-54`]). The internal `resultToolInfo` is the dynamic `result_tool` the eval loop adds to every request: its run is a no-op, and the eval loop extracts the call's arguments directly (no capturing run, no ref) ([`Tool.scala:72-92`], [`LLM.scala:382-384`]). Tool-call dispatch contains ANY throw from user code as a tool message and never lets it escape the eval loop ([`Tool.scala:110-117`]).
+`Tool.init[In][Out, S]` builds a tool from a name, optional description and prompt, and a run `In => Out < S` ([`Tool.scala:34-46`]). The `Isolate[S, LLM, S]` constraint lets the tool's effects be isolated for the mode-pipeline parallel paths. `aggregate` composes tools; `empty` is the no-tool aggregate ([`Tool.scala:48-54`]). The internal `resultToolInfo` is the dynamic `result_tool` the eval loop adds to every request: its run is a no-op, and the eval loop extracts the call's arguments directly (no capturing run, no ref) ([`Tool.scala:72-92`], [`LLM.scala:698-707`]). Tool-call dispatch contains ANY throw from user code as a tool message and never lets it escape the eval loop ([`Tool.scala:110-117`]).
 
 ### `Thought`
 
@@ -161,6 +161,16 @@ def apply[A: Schema](ai: AI, gen: Maybe[A] < (LLM & Async & Abort[AIGenException
 ```
 
 ([`Mode.scala:21-23`]). The `gen` parameter carries its failures typed as `Abort[AIGenException]` and the mode receives the target `ai` (so it can read/write that instance's conversation around the gen). `Mode.init[S]` builds a mode from a polymorphic transform, the convenient alternative to `new Mode[S]` ([`Mode.scala:42-49`]).
+
+### `Observe`
+
+`Observe[-S]` is the wire-tier, notification-only counterpart of `Mode`: where a mode receives the generation as a value and may replace it, an observer receives each completed turn's `Completion.Reply` (messages, stop reason, usage) and returns `Unit`, so it cannot change control flow. Its method is:
+
+```scala
+def apply(ai: AI, reply: Completion.Reply)(using Frame): Unit < (LLM & Sync & S)
+```
+
+Observers fire once per completion call the eval loop resolved, on the fiber that ran the turn, on the generation path BEFORE the ceiling adjudication (a turn that aborts at the output ceiling still spent its tokens; a streamed ceiling stop fails the stream and reports nothing) and on both paths before the turn's messages join the instance context. The streaming path fires on full consumption with the recorded synthetic result pair as the reply; an abandoned stream fires nothing, matching the transcript rule. Firing at the source is load-bearing: a fork's turns fire on the fork's own fiber, so a losing `Async.race` branch and a rolled-back `AI.forget` block still count the turns they completed. `Observe.init` builds one from a callback; `Observe.withStats` (both forms) is the provided usage-collecting implementation and is deliberately just a user of the enablement machinery: it allocates its own `AtomicRef` (hence the `Sync` in its row), enables an internal observer over `v`, and reads the cell at scope end. No `LLM` op is involved; the targeted form probes each target through the existing session op so a foreign run's instance fails loud. An observer's `Sync` is honest (both fire sites run under `Async`); an `Abort[E]` in `S` is the guardrail contract: its failure fails the generation it fired in.
 
 ## `Agent`
 
@@ -214,7 +224,7 @@ The result tool has the reserved name `Completion.resultToolName` (`"result_tool
 
 Backend implementation rules:
 
-- **A backend returns messages and tool calls; it never processes tool-call payloads.** Map the provider reply to `Context.Message` values with every tool call's arguments passed through VERBATIM, exactly as `AnthropicCompletion.read` does (`Call(id, name, Json.encode(input))`) ([`AnthropicCompletion.scala:39-52`]). This includes the result tool: the backend identifies it by NAME (`Completion.resultToolName`, or a harness's native structured-output tool) or by structural position (a terminal result field), never by inspecting the payload, and forwards the arguments untouched. A backend must NOT decode, validate, reshape, envelope, or fail on a tool-call payload. The only decoding a backend does is the transport/wire format (the provider's response body or the harness's stream-json events) into typed `Message`/`Call` values. All result decoding, `resultValue`-envelope handling, thought extraction, and validation live in `LLM.eval` ([`LLM.scala:353-392`]); that is the ONLY place a result payload is decoded.
+- **A backend returns messages and tool calls; it never processes tool-call payloads.** Map the provider reply to `Context.Message` values with every tool call's arguments passed through VERBATIM, exactly as `AnthropicCompletion.read` does (`Call(id, name, Json.encode(input))`) ([`AnthropicCompletion.scala:39-52`]). This includes the result tool: the backend identifies it by NAME (`Completion.resultToolName`, or a harness's native structured-output tool) or by structural position (a terminal result field), never by inspecting the payload, and forwards the arguments untouched. A backend must NOT decode, validate, reshape, envelope, or fail on a tool-call payload. The only decoding a backend does is the transport/wire format (the provider's response body or the harness's stream-json events) into typed `Message`/`Call` values. All result decoding, `resultValue`-envelope handling, thought extraction, and validation live in `LLM.eval` ([`LLM.scala:615-808`]); that is the ONLY place a result payload is decoded.
 - **A missing or unusable result is not a backend failure; it is the eval loop's repair signal.** When the model produced no result (only text or non-result tool calls), return the transcript with no `result_tool` call. `eval` then sees no result and re-queries, and on the forced iteration it passes zero user tools so the next request exposes only the result tool and the model must call it ([`LLM.scala`] eval loop, `forceResult`). This repair loop is the harness's substitute for the HTTP `tool_choice` force (`AnthropicCompletion` sets `tool_choice` to the result tool when it is the only tool; `OpenAICompletion` uses `tool_choice:"required"`), which command harnesses like the Claude Code CLI have no equivalent for. A backend that decodes/validates the payload and aborts (e.g. `AIDecodeException` on non-JSON result text) DEFEATS this loop and must not do so. NOTE: `CodexCompletion` currently violates the payload-faithfulness rule (it reshapes through `HarnessCompletion.resultOutput`); this is a known deviation to be fixed, not a pattern to copy.
 - Implement the full `Completion` contract. Do not add placeholder streaming methods, silent tool rejection, or partial support paths.
 - Kyo remains the tool runner for every backend. If a provider agent loop needs synchronous tool execution, use a private bridge that calls back into Kyo tool handlers and return the produced transcript as Kyo `Context.Message` values. Do not expose ambient user MCP servers, provider shell tools, plugins, or unrelated host tools through a completion backend.
@@ -247,11 +257,11 @@ JAVA_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCache
 
 A leaf mixes in every operation it can occur in. `AIMissingApiKeyException` and `AITransportException` mix in BOTH (either operation reaches the provider) ([`AIException.scala:30-38`]). Gen-only leaves: `AIEvalExhaustedException`, `AIInvalidThoughtException`, `AIDecodeException` ([`AIException.scala:40-52`]). Stream-only leaves: `AIStreamDeltaException`, `AIStreamIncompleteException` ([`AIException.scala:54-60`]). `AICrossRunException` (misuse) and `AIMeterClosedException` (impossible-state) are `AIException`s but in NEITHER operation set: they panic rather than ride a row ([`AIException.scala:62-76`]). `AIExceptionTest` pins the full lattice with `summon[... <:< ...]` and asserts cross-run/meter-closed are not gen/stream failures ([`AIExceptionTest.scala:4-48`]).
 
-When adding a failure, add a leaf to `AIException.scala` under the right operation trait(s) and route to it; keep every message string on the leaf, and never let a non-module exception (a raw `HttpException`) ride a public row, map it to `AITransportException` at the eval/stream boundary ([`LLM.scala:331`], [`LLM.scala:182`]).
+When adding a failure, add a leaf to `AIException.scala` under the right operation trait(s) and route to it; keep every message string on the leaf, and never let a non-module exception (a raw `HttpException`) ride a public row, map it to `AITransportException` at the eval/stream boundary ([`LLM.scala:686-689`], [`Completion.scala:119-139`]).
 
 ## Unsafe boundary
 
-This module has no `AllowUnsafe` sites and no `import AllowUnsafe.embrace.danger` in its sources. The former process-global `AtomicLong` id counter is GONE: ids now come from the run's threaded `State.nextId` ([`LLM.scala:106-107`]), so there is no module-level mutable state to bridge. The only `java.lang.ref` use is `internal.AIRef extends WeakReference[AI]`, a GC-reclaimability mechanism for the `State.instances` keys, not an unsafe-tier API ([`LLM.scala:417-428`]). When threading new state, keep it in `State` and the `Op` GADT; do not introduce a process-global counter or an `AllowUnsafe` parameter.
+This module has no `AllowUnsafe` sites and no `import AllowUnsafe.embrace.danger` in its sources. The former process-global `AtomicLong` id counter is GONE: ids now come from the run's threaded `State.nextId` ([`LLM.scala:97-101`]), so there is no module-level mutable state to bridge. The only `java.lang.ref` use is `internal.AIRef extends WeakReference[AI]`, a GC-reclaimability mechanism for the `State.instances` keys, not an unsafe-tier API ([`LLM.scala:837-845`]). When threading new state, keep it in `State` and the `Op` GADT; do not introduce a process-global counter or an `AllowUnsafe` parameter.
 
 ## Test patterns
 
@@ -286,7 +296,7 @@ All source and tests live in `shared/`. The `jvm/`, `js/`, `native/`, `wasm/` tr
 
 ### Effect-row precision
 
-Never widen the effect row of a `< LLM` computation to include `Async`; `Async` belongs only on `LLM.run`'s residual (the `Gen`/`Stream` interpretation) ([`LLM.scala:125-141`]). A new op goes in `LLM.internal.Op`, gets a `runWith` arm that introduces no `Async` for any op but `Gen`/`Stream`, and is suspended via `ArrowEffect.suspend` ([`LLM.scala:245-275`]). A `Mode.apply`'s `gen` parameter row is exactly `Maybe[A] < (LLM & Async & Abort[AIGenException])`, not wider ([`Mode.scala:21-23`]).
+Never widen the effect row of a `< LLM` computation to include `Async`; `Async` belongs only on `LLM.run`'s residual (the `Gen`/`Stream` interpretation) ([`LLM.scala:119-132`]). A new op goes in `LLM.internal.Op`, gets a `runWith` arm that introduces no `Async` for any op but `Gen`/`Stream`, and is suspended via `ArrowEffect.suspend` ([`LLM.scala:490-519`]). A `Mode.apply`'s `gen` parameter row is exactly `Maybe[A] < (LLM & Async & Abort[AIGenException])`, not wider ([`Mode.scala:21-23`]).
 
 ### `private[kyo]` over `protected`
 
@@ -323,15 +333,16 @@ Building auto-formats; re-read any file you edit after building, formatting may 
 
 In addition to the root checklist:
 
-1. **New `Op`.** Is it a final `case class` (data) or `case object` (field-less)? Does its `runWith` arm thread `State` and introduce no `Async` (only `Gen`/`Stream` may)? Does the reply type in `Op[A]` match the `ArrowEffect.suspend` return? Does it appear in `crossRunFailure` if it targets an instance? [`LLM.scala:65-95`, `LLM.scala:400-415`]
+1. **New `Op`.** Is it a final `case class` (data) or `case object` (field-less)? Does its `runWith` arm thread `State` and introduce no `Async` (only `Gen`/`Stream` may)? Does the reply type in `Op[A]` match the `ArrowEffect.suspend` return? Does it appear in `crossRunFailure` if it targets an instance? [`LLM.scala:63-95`, `LLM.scala:816-831`]
 2. **Eval-loop change.** Does every non-`Gen` path stay `< LLM` (no `Async`)? Does the `Gen` residual stay `A < (LLM & Async & Abort[AIGenException])`? Does `summon[NotGiven[LLM <:< Async]]` still hold? [`LLMTest.scala:409-417`]
 3. **New enablement kind or call.** Does it implement `AI.Enablement[S]`'s two `enableIn` methods (`AIEnv` and `AISession`)? Is it reached only through `AI.enable` / `ai.enable` (never a per-type binder)? Does the row carry `S` until the run boundary? [`AI.scala:48-53`, `AI.scala:114-126`]
-4. **Config override.** Is an instance config a `Maybe[Config]` (`Absent` = inherit, `Present` = override)? Does `genLoop`'s merge keep `Present` winning over the scope and over a scope `withConfig`, while a mode `withConfig` still layers on top? [`LLM.scala:318-326`, `LLMTest.scala:325-374`]
+4. **Config override.** Is an instance config a `Maybe[Config]` (`Absent` = inherit, `Present` = override)? Does `genLoop`'s merge keep `Present` winning over the scope and over a scope `withConfig`, while a mode `withConfig` still layers on top? [`LLM.scala:561-565`, `LLMTest.scala:325-374`]
 5. **New `Mode`.** Is `apply`'s `gen` row exactly `Maybe[A] < (LLM & Async & Abort[AIGenException])`? Does the mode receive `ai` and read/write that instance only? [`Mode.scala:21-23`]
-6. **New `Agent` overload.** Does it delegate to `runImpl`, minting ONE stable instance via `AI.initWith(behavior)`, discharging with `LLM.run`, re-throwing `Abort[AIGenException]` via `getOrThrow`, and handing to `Actor.run`? [`Agent.scala:217-240`]
-7. **New completion backend.** Does it match the result tool by `Completion.resultToolName` and substitute `resultSchema` when `Present`? Does it surface transport failures as `Abort[HttpException]`, never `Abort[Throwable]`? If it is command-backed, does it use the harness's native input/output shape and map process or decode failures to `AIDecodeException`? Is it reached through a new `Config.Provider` in `Provider.all`? [`Completion.scala:65-74`, `Config.scala:96-98`]
-8. **New failure.** Is there a leaf in `AIException.scala` under the right operation trait(s), with its message on the leaf, mapped from any raw `HttpException` at the eval/stream boundary? Is a misuse/impossible-state panic kept off both rows? [`AIException.scala`, `LLM.scala:331`]
-9. **New test.** Does it extend `kyo.test.Test[Any]`, use `TestCompletionServer` (not a live endpoint), assert concrete values, place each `enqueueBody`/`enqueueStream` before the consuming client call, and live in `shared/src/test`? [`TestCompletionServer.scala`, `LLMTest.scala`]
+6. **New `Observe` fire site or `AIStats` field.** Does the site fire once per resolved completion call, before any adjudication that can abort the turn? Does a new `AIStats` field follow the subset convention (shared suffix, `Maybe` when a wire may not report it)? Do all four backends map their wire's fields, with a fixture test each? [`LLM.scala:709-715`, `AIStats.scala:15-27`]
+7. **New `Agent` overload.** Does it delegate to `runImpl`, minting ONE stable instance via `AI.initWith(behavior)`, discharging with `LLM.run`, re-throwing `Abort[AIGenException]` via `getOrThrow`, and handing to `Actor.run`? [`Agent.scala:217-240`]
+8. **New completion backend.** Does it match the result tool by `Completion.resultToolName` and substitute `resultSchema` when `Present`? Does it surface transport failures as `Abort[HttpException]`, never `Abort[Throwable]`? If it is command-backed, does it use the harness's native input/output shape and map process or decode failures to `AIDecodeException`? Is it reached through a new `Config.Provider` in `Provider.all`? [`Completion.scala:65-74`, `Config.scala:96-98`]
+9. **New failure.** Is there a leaf in `AIException.scala` under the right operation trait(s), with its message on the leaf, mapped from any raw `HttpException` at the eval/stream boundary? Is a misuse/impossible-state panic kept off both rows? [`AIException.scala`, `LLM.scala:331`]
+10. **New test.** Does it extend `kyo.test.Test[Any]`, use `TestCompletionServer` (not a live endpoint), assert concrete values, place each `enqueueBody`/`enqueueStream` before the consuming client call, and live in `shared/src/test`? [`TestCompletionServer.scala`, `LLMTest.scala`]
 
 ## Model facts are data, never inference
 

--- a/kyo-ai/README.md
+++ b/kyo-ai/README.md
@@ -345,6 +345,55 @@ def answerAll(questions: Chunk[Question]) =
 
 The given is the asymmetric `isolate`: on join it merges each shared instance's conversation prefix-aware (so the shared history is never duplicated) and adds fork-born instances as-is. You do not manage threads or per-conversation state isolation across branches; the isolate does both.
 
+## Tracking usage
+
+Every completed model turn reports what it spent. `Observe.withStats` collects it over a scope, alongside the result:
+
+```scala
+def measured(question: String): (AIStats, String) < (LLM & Sync) =
+    Observe.withStats(AI.gen[String](question))
+```
+
+`AIStats` carries `inputTokens`, `outputTokens`, and `turns`, plus two subsets the wire may break out: `cachedInputTokens` (part of `inputTokens` served from the provider's cache) and `reasoningOutputTokens` (part of `outputTokens` spent reasoning). The subsets are `Maybe`, so a wire that reports zero stays distinguishable from one that reports nothing; `add` aggregates any two.
+
+The varargs form breaks the count down by named instances. Every named instance appears, `AIStats.empty` if it completed no turn; spend by any other instance stays out of the breakdown (wrap in the untargeted form for the scope total):
+
+```scala
+def perAgent(researcher: AI, writer: AI): (Dict[AI, AIStats], String) < (LLM & Sync) =
+    Observe.withStats(researcher, writer) {
+        researcher.gen[String]("Gather the facts.").map(facts => writer.gen[String](facts))
+    }
+```
+
+Counting is a side effect at the source: each turn is recorded on the fiber that ran it, at the moment the wire reply is read. So a rolled-back `AI.forget` block, a losing `Async.race` branch, and an `AI.gen` one-shot all count the turns they completed, and nothing can un-spend them. A turn interrupted before its reply arrives is uncounted (no number ever reached this side of the wire), and an abandoned stream records nothing. One placement rule for streams: a scope-enabled observer covers a streamed turn only when the stream is consumed inside the enabling bracket, while an instance-enabled observer covers its instance's streams wherever they are consumed.
+
+Underneath sits the fifth enablement kind: `Observe`, a wire-tier counterpart of `Mode` that cannot change control flow. Where a mode receives the generation as a value and returns what the caller sees, an observer receives each completed turn's reply (its messages and usage) and returns `Unit`. Enable one on a scope or an instance like any other enablement:
+
+```scala
+def logged[A, S](v: A < (LLM & S)): A < (LLM & S) =
+    val log = Observe.init { (ai, reply) =>
+        AI.config.map(c => Log.info(s"${c.modelName}: ${reply.usage.totalTokens} tokens"))
+    }
+    AI.enable(log)(v)
+end logged
+```
+
+`AI.config` inside the callback is the config the turn ran under, instance overrides included, and `ai.context` is the conversation up to (not including) the turn. An observer whose capability row carries `Abort[E]` is a typed guardrail: its failure fails the generation it fired in, visible in the row at the enable site.
+
+```scala
+case class BudgetExceeded(spent: Long)
+
+def capped[A, S](limit: Long)(v: A < (LLM & S)): A < (LLM & S & Abort[BudgetExceeded] & Sync) =
+    AtomicRef.init(0L).map { spent =>
+        val guard = Observe.init { (_, reply) =>
+            spent.updateAndGet(_ + reply.usage.totalTokens).map { total =>
+                Abort.when(total > limit)(BudgetExceeded(total))
+            }
+        }
+        AI.enable(guard)(v)
+    }
+```
+
 ## Controlling conversation state
 
 Once a conversation has history, you sometimes need to run something against it without changing it, or run a clean turn that ignores it. `AI.forget` and `AI.fresh` isolate state for a block; each has a whole-scope form and a per-instance form.

--- a/kyo-ai/shared/src/main/scala/kyo/AI.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/AI.scala
@@ -36,7 +36,7 @@ object AI:
     export kyo.ai.Image
 
     /** A composable element of the generation surface that can be enabled on an `AI`: a [[kyo.Tool]], a
-      * [[kyo.Prompt]], a [[kyo.Thought]], or a [[kyo.Mode]].
+      * [[kyo.Prompt]], a [[kyo.Thought]], a [[kyo.Mode]], or an [[kyo.Observe]].
       *
       * `AI.enable` layers enablements over a scoped computation; `ai.enable` layers them onto a single
       * instance. Both take varargs or a `Seq` and accept a mix of kinds in one call. `S` is the capability an
@@ -45,7 +45,7 @@ object AI:
       */
     trait Enablement[-S]:
         // How this enablement layers itself onto the scope env (AI.enable) or one instance's session
-        // (ai.enable). private[kyo] so only the module's four kinds implement it; users compose, never extend.
+        // (ai.enable). private[kyo] so only the module's five kinds implement it; users compose, never extend.
         private[kyo] def enableIn(env: AIEnv)(using Frame): AIEnv
         private[kyo] def enableIn(session: AISession)(using Frame): AISession
     end Enablement
@@ -102,7 +102,7 @@ object AI:
     def stream[A: Schema](using Frame, Tag[Emit[Chunk[A]]]): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < LLM =
         init.map(ai => ai.stream[A])
 
-    /** Reads the current scope `AIEnv`: the active config plus the scope's enablements (prompt, tools, thoughts, modes). */
+    /** Reads the current scope `AIEnv`: the active config plus the scope's enablements (prompt, tools, thoughts, modes, observers). */
     def env(using Frame): AIEnv < LLM = LLM.env
 
     /** Reads the active config. The active env (the scope env, or the scope merged with an instance during a
@@ -118,7 +118,7 @@ object AI:
     def withConfig[A, S](config: Config)(v: A < (LLM & S))(using Frame): A < (LLM & S) =
         withConfig(_ => config)(v)
 
-    /** Layers enablements (tools, prompts, thoughts, modes, in any mix) over a scoped computation, on top of
+    /** Layers enablements (tools, prompts, thoughts, modes, observers, in any mix) over a scoped computation, on top of
       * the scope's current enablements. Each enablement's capability `S` rides the row, unified across the
       * varargs to their intersection, so the requirements stay visible until discharged at the run boundary.
       */
@@ -221,7 +221,7 @@ object AI:
         def updateContext(f: Context => Context)(using Frame): Unit < LLM =
             ai.context.map(c => ai.setContext(f(c)))
 
-        /** Layers enablements (tools, prompts, thoughts, modes, in any mix) onto this instance, on top of the
+        /** Layers enablements (tools, prompts, thoughts, modes, observers, in any mix) onto this instance, on top of the
           * scope's enablements. Each enablement's capability `S` rides the row, unified across the varargs to
           * their intersection, so a tool/prompt/thought/mode needing more than `LLM` keeps that requirement
           * visible at this instance's generations.

--- a/kyo-ai/shared/src/main/scala/kyo/AIEnv.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/AIEnv.scala
@@ -3,7 +3,7 @@ package kyo
 import kyo.ai.Config
 
 /** The generation environment: a config plus the enablements layered for a scope or instance (prompt, tools,
-  * thoughts, modes). The scope's active env is threaded in `LLM.State`, read via `AI.env` / `AI.config` and
+  * thoughts, modes, observers). The scope's active env is threaded in `LLM.State`, read via `AI.env` / `AI.config` and
   * scoped via `AI.withConfig` and the `enable` methods; each `AI.Session` carries one as its instance env.
   *
   * `config` is `Maybe[Config]`: the scope env always holds `Present` (set at `LLM.run`), while an instance env
@@ -14,7 +14,8 @@ case class AIEnv(
     prompt: Prompt[Any],
     tools: Chunk[Tool[Any]],
     thoughts: Chunk[Thought[Any]],
-    mode: Chunk[Mode[Any]]
+    mode: Chunk[Mode[Any]],
+    observe: Chunk[Observe[Any]]
 ):
     /** Sets the config (`Present`), overriding any inherited one. */
     def config(config: Config): AIEnv = copy(config = Present(config))
@@ -39,9 +40,15 @@ case class AIEnv(
 
     /** Appends modes to the pipeline. */
     def addModes(modes: Chunk[Mode[Any]]): AIEnv = copy(mode = mode ++ modes)
+
+    /** Appends an observer. */
+    def addObserve(observe: Observe[Any]): AIEnv = copy(observe = this.observe.append(observe))
+
+    /** Appends observers. */
+    def addObserves(observes: Chunk[Observe[Any]]): AIEnv = copy(observe = observe ++ observes)
 end AIEnv
 
 object AIEnv:
     /** The empty env: no config override, no enablements. */
-    val empty: AIEnv = AIEnv(Absent, Prompt.empty, Chunk.empty, Chunk.empty, Chunk.empty)
+    val empty: AIEnv = AIEnv(Absent, Prompt.empty, Chunk.empty, Chunk.empty, Chunk.empty, Chunk.empty)
 end AIEnv

--- a/kyo-ai/shared/src/main/scala/kyo/AIException.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/AIException.scala
@@ -161,7 +161,7 @@ case class AIOutputLimitException(
     // the number that picks the lever: a stop that spent nearly its whole allowance reasoning is not short
     // of ceiling, and raising the limit buys another expensive stop; one that barely reasoned is genuinely
     // short.
-    reasoningTokens: Maybe[Int] = Absent
+    reasoningTokens: Maybe[Long] = Absent
 )(using Frame)
     extends AIException(
         s"$provider stopped generating for model $model at the output-token ceiling" +

--- a/kyo-ai/shared/src/main/scala/kyo/AISession.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/AISession.scala
@@ -12,10 +12,10 @@ import kyo.ai.Context
 case class AISession(rawContext: Context, env: AIEnv):
 
     /** The env a generation for this session runs under: the ambient scope env with this session's
-      * enablements layered on top (instance config override wins; prompts, tools, thoughts, and modes
-      * append) and the default structured-output guidance last. The ONE construction shared by the eval loop
-      * and the faithful [[context]] enrichment, so transcript capture cannot drift from what generation
-      * assembles.
+      * enablements layered on top (instance config override wins; prompts, tools, thoughts, modes, and
+      * observers append) and the default structured-output guidance last. The ONE construction shared by the
+      * eval loop and the faithful [[context]] enrichment, so transcript capture cannot drift from what
+      * generation assembles.
       */
     private[kyo] def effectiveEnv(scope: AIEnv)(using Frame): AIEnv =
         scope
@@ -24,6 +24,7 @@ case class AISession(rawContext: Context, env: AIEnv):
             .addTools(env.tools)
             .addThoughts(env.thoughts)
             .addModes(env.mode)
+            .addObserves(env.observe)
 
     /** The conversation as the model actually receives it: `rawContext` enriched with the effective
       * generation env's prompt stack ([[effectiveEnv]]), instructions as system messages at the start,
@@ -57,6 +58,9 @@ case class AISession(rawContext: Context, env: AIEnv):
 
     /** Appends a mode onto this instance. */
     def addMode(mode: Mode[Any]): AISession = copy(env = env.addMode(mode))
+
+    /** Layers an observer onto this instance. */
+    def addObserve(observe: Observe[Any]): AISession = copy(env = env.addObserve(observe))
 end AISession
 
 object AISession:

--- a/kyo-ai/shared/src/main/scala/kyo/AIStats.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/AIStats.scala
@@ -1,0 +1,48 @@
+package kyo
+
+/** Token usage and turn counts for completed model turns, aggregated by addition.
+  *
+  * Field names follow the subset convention: a field sharing another's suffix counts a subset of it
+  * (`cachedInputTokens` is part of `inputTokens`; `reasoningOutputTokens` is part of `outputTokens`).
+  * A subset is `Maybe` because providers report it optionally: `Present` when the wire broke the
+  * subset out (possibly as zero), `Absent` when it did not, so "reported zero" and "not reported"
+  * stay distinguishable. A total a wire does not report is 0.
+  *
+  * One wire-decoded reply carries `turns = 1`; a synthetic reply that reached no model carries 0.
+  * Aggregation over any scope is then plain [[add]]. Produced per turn on `Completion.Reply` and
+  * collected over a scope by `Observe.withStats`.
+  */
+case class AIStats(
+    inputTokens: Long,
+    cachedInputTokens: Maybe[Long],
+    outputTokens: Long,
+    reasoningOutputTokens: Maybe[Long],
+    turns: Int
+) derives Schema, CanEqual:
+
+    /** Everything read plus everything produced. */
+    def totalTokens: Long = inputTokens + outputTokens
+
+    /** Field-wise sum. A subset sums when both sides report it and keeps the reporting side when only
+      * one does, so a mixed-wire aggregate is a stated lower bound rather than a lost number.
+      */
+    def add(that: AIStats): AIStats =
+        AIStats(
+            inputTokens + that.inputTokens,
+            AIStats.addSubset(cachedInputTokens, that.cachedInputTokens),
+            outputTokens + that.outputTokens,
+            AIStats.addSubset(reasoningOutputTokens, that.reasoningOutputTokens),
+            turns + that.turns
+        )
+end AIStats
+
+object AIStats:
+
+    /** No tokens, no turns, subsets unreported. The identity of [[AIStats.add]]. */
+    val empty: AIStats = AIStats(0L, Absent, 0L, Absent, 0)
+
+    private def addSubset(a: Maybe[Long], b: Maybe[Long]): Maybe[Long] =
+        a match
+            case Present(x) => Present(x + b.getOrElse(0L))
+            case Absent     => b
+end AIStats

--- a/kyo-ai/shared/src/main/scala/kyo/LLM.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/LLM.scala
@@ -20,7 +20,8 @@ import kyo.kernel.*
   * @see
   *   [[kyo.AIException]] for the module's failure hierarchy
   * @see
-  *   [[kyo.Tool]], [[kyo.Thought]], [[kyo.Prompt]], [[kyo.Mode]] for the composable generation surface
+  *   [[kyo.Tool]], [[kyo.Thought]], [[kyo.Prompt]], [[kyo.Mode]], [[kyo.Observe]] for the composable
+  *   generation surface
   */
 sealed trait LLM extends ArrowEffect[LLM.internal.Op, Id]
 
@@ -54,7 +55,7 @@ object LLM:
     private[kyo] object State:
         def empty(config: Config): State =
             // A fresh owner per run (object identity, no counter); every instance minted in this run carries it.
-            State(Dict.empty, 0L, new AnyRef, AIEnv(Present(config), Prompt.empty, Chunk.empty, Chunk.empty, Chunk.empty))
+            State(Dict.empty, 0L, new AnyRef, AIEnv(Present(config), Prompt.empty, Chunk.empty, Chunk.empty, Chunk.empty, Chunk.empty))
     end State
 
     // An op targeting an instance from a DIFFERENT run (owner differs) can't address this run's slots, so
@@ -174,6 +175,25 @@ object LLM:
         Frame,
         Tag[Emit[Chunk[A]]]
     ): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
+        // The instance's enablements are layered onto the scope env for the stream's CREATION (config,
+        // prompts, request assembly), then restored, exactly as genLoop does for a generation: without
+        // this an instance's config override and enablements were silently ignored on the streaming
+        // path. The failure path restores too, mirroring genLoop's recover.
+        LLM.session(target).map { session =>
+            LLM.env.map { scopeEnv =>
+                LLM.setEnv(session.effectiveEnv(scopeEnv)).map { prevEnv =>
+                    Abort.recover[AIGenException](e => LLM.setEnv(prevEnv).andThen(Abort.fail(e))) {
+                        streamUnder(target, schema)
+                    }.map(stream => LLM.setEnv(prevEnv).andThen(stream))
+                }
+            }
+        }
+    end streamAgainst
+
+    private def streamUnder[A](target: AI, schema: Schema[A])(using
+        Frame,
+        Tag[Emit[Chunk[A]]]
+    ): Stream[A, LLM & Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
         given Schema[A] = schema
         AI.config.map { config =>
             if config.provider.usesApiKey && config.apiKey.isEmpty then
@@ -213,7 +233,7 @@ object LLM:
                                 val consumed =
                                     if stringMode then consumePrefixFragments(fragments, schema)
                                     else consumeElementFragments(fragments, schema)
-                                consumed.map { produced =>
+                                consumed.map { (produced, usage) =>
                                     // Recorded HERE, after the fold completes, so the turn joins the
                                     // conversation exactly as a generated one and a later turn can read it; an
                                     // abandoned or part-way-failed stream records nothing rather than half a
@@ -221,16 +241,30 @@ object LLM:
                                     // fragments ARE its arguments), closed by a synthetic result: recording it
                                     // as prose instead teaches a weaker model to answer in text on a later turn
                                     // and pull away from the forced tool call a streamed result requires.
+                                    // Observers fire BEFORE the append, matching the generation path: an
+                                    // observer reading ai.context sees the conversation up to this turn, and a
+                                    // guardrail abort keeps the turn out of the transcript on both paths. An
+                                    // abandoned or failed stream fires nothing.
                                     Kyo.when(produced.nonEmpty) {
                                         val envelope =
                                             if stringMode then s"""{"resultValue":${Json.encode(produced)}}"""
                                             else s"""{"resultValue":$produced}"""
                                         // The context grows with the conversation, so its size is a per-turn
                                         // unique seed matching call to result.
-                                        val callId = CallId(s"stream-result-${context.messages.size}")
-                                        val call   = Call(callId, Completion.resultToolName, envelope)
-                                        LLM.append(target, AssistantMessage("", Chunk(call)))
-                                            .andThen(LLM.append(target, ToolMessage(callId, Json.encode("Result received."))))
+                                        val callId        = CallId(s"stream-result-${context.messages.size}")
+                                        val call          = Call(callId, Completion.resultToolName, envelope)
+                                        val callMessage   = AssistantMessage("", Chunk(call))
+                                        val resultMessage = ToolMessage(callId, Json.encode("Result received."))
+                                        // The turn count is structural on this path, as it already is on every
+                                        // non-streaming path: a fully consumed stream IS one turn, even when the
+                                        // wire emitted no usage element (a provider ignoring the usage request).
+                                        val turnUsage = if usage.turns == 0 then usage.copy(turns = 1) else usage
+                                        fireStreamObservers(
+                                            target,
+                                            Completion.Reply(Chunk(callMessage, resultMessage), Completion.StopReason.Completed, turnUsage)
+                                        )
+                                            .andThen(LLM.append(target, callMessage))
+                                            .andThen(LLM.append(target, resultMessage))
                                     }.unit
                                 }
                             }
@@ -238,7 +272,41 @@ object LLM:
                     }
                 }
         }
-    end streamAgainst
+    end streamUnder
+
+    /** Fires the target's effective observers for a fully consumed streamed turn. Runs at CONSUMPTION
+      * time, where the ambient env is the scope's, so the session env is merged here explicitly (and
+      * installed for the callbacks' duration, so `AI.config` inside one reads the turn's config),
+      * mirroring what genLoop provides on the generation path. The prior env is restored on EVERY
+      * exit: unlike the generation path's fire site (handler frame, where an abort can only surface
+      * past `LLM.run` and the env dies with the run), this site runs in the consumer's frames, where
+      * a guardrail abort can be recovered inside the run, so a skipped restore would leak the merged
+      * env into the rest of the run.
+      */
+    private def fireStreamObservers(target: AI, reply: Completion.Reply)(using Frame): Unit < (LLM & Sync) =
+        LLM.session(target).map { session =>
+            LLM.env.map { scopeEnv =>
+                val effective = session.effectiveEnv(scopeEnv)
+                // Deduped by identity: a stream consumed inside a generation of the SAME instance runs
+                // under genLoop's already-merged env, and re-merging the session here would fire that
+                // instance's observers twice for one turn.
+                val observers = effective.observe.distinct.asInstanceOf[Chunk[Observe[LLM]]]
+                Kyo.when(observers.nonEmpty) {
+                    LLM.setEnv(effective).map { prev =>
+                        // The observer cast above already erases each callback's failure types, so this
+                        // catch-all tells no additional lie: capture ANY outcome (typed guardrail
+                        // failures and panics included), restore the prior env, then re-raise. Abort
+                        // matches a failure by the VALUE's type (ConcreteTag.accepts), so the re-raised
+                        // guardrail error stays catchable as its concrete type; the Abort[Any] the
+                        // re-raise adds statically is hidden behind the same erasure boundary the
+                        // enablement machinery established.
+                        Abort.run[Any](Kyo.foreachDiscard(observers)(_(target, reply)))
+                            .map(outcome => LLM.setEnv(prev).andThen(Abort.get(outcome)))
+                            .asInstanceOf[Unit < (LLM & Sync)]
+                    }
+                }.unit
+            }
+        }
 
     // Decodes the {resultValue: ...} envelope from a partial SSE buffer, completing it so the parsed-so-far
     // prefix decodes, and returns the resultValue sub-value (Absent if the prefix does not decode yet).
@@ -301,13 +369,13 @@ object LLM:
     // decoded suffix so callers receive normal text chunks and can concatenate them into the final answer.
     // Fails if the stream ends with buffered args that never decoded.
     private[kyo] def consumePrefixFragments[A](
-        fragments: Stream[String, Async & Scope & Abort[AIStreamException]],
+        fragments: Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]],
         schema: Schema[A]
     )(using
         Frame,
         Tag[Emit[Chunk[A]]],
-        Tag[Emit[Chunk[String]]]
-    ): String < (Emit[Chunk[A]] & Async & Scope & Abort[AIStreamException]) =
+        Tag[Emit[Chunk[Completion.StreamElement]]]
+    ): (String, AIStats) < (Emit[Chunk[A]] & Async & Scope & Abort[AIStreamException]) =
         given Schema[A] = schema
         def emitText(delta: String): Unit < (Emit[Chunk[A]] & Abort[AIStreamException]) =
             Structure.decode[A](Structure.Value.Str(delta)) match
@@ -316,35 +384,44 @@ object LLM:
                     Abort.fail(AIStreamDeltaException(s"stream[String] decoded text chunk failed schema validation: $err"))
                 case Result.Panic(ex) =>
                     Abort.panic(ex)
-        fragments.fold(("", Maybe.empty[String])) { (state, fragment) =>
-            val (argsBuf, lastText) = state
-            val newBuf              = argsBuf + fragment
-            resultValueOf(newBuf) match
-                case Present(Structure.Value.Str(text)) =>
-                    lastText match
-                        case Present(prev) if text == prev =>
-                            Kyo.lift((newBuf, lastText))
-                        case Present(prev) if text.startsWith(prev) =>
-                            emitText(text.drop(prev.length)).andThen((newBuf, Present(text)))
-                        case Present(prev) =>
-                            Abort.fail(AIStreamDeltaException(
-                                s"stream[String] decoded a non-monotonic text prefix. Previous: $prev, next: $text"
-                            ))
+        fragments.fold(("", Maybe.empty[String], AIStats.empty)) { (state, element) =>
+            val (argsBuf, lastText, usage) = state
+            element match
+                case Completion.StreamElement.Usage(stats) =>
+                    // Wires emit disjoint partials (see Completion.StreamElement), so plain addition is
+                    // the whole accumulation.
+                    Kyo.lift((argsBuf, lastText, usage.add(stats)))
+                case Completion.StreamElement.Fragment(fragment) =>
+                    val newBuf = argsBuf + fragment
+                    resultValueOf(newBuf) match
+                        case Present(Structure.Value.Str(text)) =>
+                            lastText match
+                                case Present(prev) if text == prev =>
+                                    Kyo.lift((newBuf, lastText, usage))
+                                case Present(prev) if text.startsWith(prev) =>
+                                    emitText(text.drop(prev.length)).andThen((newBuf, Present(text), usage))
+                                case Present(prev) =>
+                                    Abort.fail(AIStreamDeltaException(
+                                        s"stream[String] decoded a non-monotonic text prefix. Previous: $prev, next: $text"
+                                    ))
+                                case Absent =>
+                                    emitText(text).andThen((newBuf, Present(text), usage))
+                        case Present(other) =>
+                            Abort.fail(
+                                AIStreamDeltaException(s"stream[String] expected a JSON string resultValue, got: ${Json.encode(other)}")
+                            )
                         case Absent =>
-                            emitText(text).andThen((newBuf, Present(text)))
-                case Present(other) =>
-                    Abort.fail(AIStreamDeltaException(s"stream[String] expected a JSON string resultValue, got: ${Json.encode(other)}"))
-                case Absent =>
-                    Kyo.lift((newBuf, lastText))
+                            Kyo.lift((newBuf, lastText, usage))
+                    end match
             end match
-        }.map { case (argsBuf, lastText) =>
+        }.map { case (argsBuf, lastText, usage) =>
             // A stream that ends without decoding a value failed, whether it buffered unusable bytes or
             // none. The empty case is reachable: a request the wire does not compel can be answered in
             // prose, producing no tool-call fragments, and reading that as success would return nothing to
             // a caller who asked for a value.
             if lastText.isEmpty then Abort.fail(AIStreamIncompleteException(argsBuf))
             // The text the model produced, handed back so the turn can be recorded from it.
-            else Kyo.lift(lastText.getOrElse(""))
+            else Kyo.lift((lastText.getOrElse(""), usage))
         }
     end consumePrefixFragments
 
@@ -353,13 +430,13 @@ object LLM:
     // is emitted exactly once, fully formed; a truncated tail is dropped and a complete element before a trailing
     // comma is kept.
     private[kyo] def consumeElementFragments[A](
-        fragments: Stream[String, Async & Scope & Abort[AIStreamException]],
+        fragments: Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]],
         schema: Schema[A]
     )(using
         Frame,
         Tag[Emit[Chunk[A]]],
-        Tag[Emit[Chunk[String]]]
-    ): String < (Emit[Chunk[A]] & Async & Scope & Abort[AIStreamException]) =
+        Tag[Emit[Chunk[Completion.StreamElement]]]
+    ): (String, AIStats) < (Emit[Chunk[A]] & Async & Scope & Abort[AIStreamException]) =
         given Schema[A] = schema
         def decodeElement(raw: String): A < Abort[AIStreamException] =
             Json.decode[Structure.Value](raw) match
@@ -368,20 +445,27 @@ object LLM:
                         case Result.Success(a) => a
                         case _                 => Abort.fail(AIStreamIncompleteException(raw))
                 case _ => Abort.fail(AIStreamIncompleteException(raw))
-        fragments.fold(("", 0)) { (state, fragment) =>
-            val (argsBuf, emitted) = state
-            val newBuf             = argsBuf + fragment
-            val ready              = completeElements(newBuf)
-            if ready.size <= emitted then Kyo.lift((newBuf, emitted))
-            else Kyo.foreach(ready.drop(emitted))(decodeElement).map(as => Emit.value(as).andThen((newBuf, ready.size)))
-        }.map { case (argsBuf, emitted) =>
+        fragments.fold(("", 0, AIStats.empty)) { (state, element) =>
+            val (argsBuf, emitted, usage) = state
+            element match
+                case Completion.StreamElement.Usage(stats) =>
+                    // Wires emit disjoint partials (see Completion.StreamElement), so plain addition is
+                    // the whole accumulation.
+                    Kyo.lift((argsBuf, emitted, usage.add(stats)))
+                case Completion.StreamElement.Fragment(fragment) =>
+                    val newBuf = argsBuf + fragment
+                    val ready  = completeElements(newBuf)
+                    if ready.size <= emitted then Kyo.lift((newBuf, emitted, usage))
+                    else Kyo.foreach(ready.drop(emitted))(decodeElement).map(as => Emit.value(as).andThen((newBuf, ready.size, usage)))
+            end match
+        }.map { case (argsBuf, emitted, usage) =>
             // Everything complete was emitted during the fold. An EMPTY array is a legitimate empty stream,
             // so the test is whether a resultValue arrived at all, not whether it held anything. A buffer
             // that never produced one is incomplete, including the empty buffer a prose-answered turn leaves.
             if emitted == 0 && resultValueOf(argsBuf).isEmpty then
                 Abort.fail(AIStreamIncompleteException(argsBuf))
             // The elements the model produced, as the resultValue they arrived in.
-            else Kyo.lift(resultValueOf(argsBuf).fold("")(Json.encode(_)))
+            else Kyo.lift((resultValueOf(argsBuf).fold("")(Json.encode(_)), usage))
         }
     end consumeElementFragments
 
@@ -635,6 +719,12 @@ object LLM:
                 }
             (reply, rejectionRepaired) = replyAndRepaired
             messages                   = reply.messages
+            // Observers fire on the raw wire reply, BEFORE the ceiling adjudication below: a turn that
+            // stops at the ceiling and aborts still spent its tokens, and firing after would lose exactly
+            // the expensive turns. The env here is the merged scope-plus-instance env genLoop installed,
+            // so instance observers cover this turn and `AI.config` inside a callback reads this turn's
+            // config. The erasure cast is the enablement pattern modes and tools use.
+            _ <- LLM.env.map(env => Kyo.foreachDiscard(env.observe.asInstanceOf[Chunk[Observe[LLM]]])(_(ai, reply)))
             // A ceiling stop is reported by the backend and adjudicated here, because neither layer alone
             // can tell a usable turn from a truncated one. A reply that stopped at the ceiling may still
             // carry a complete call worth running; what makes it unusable is having nothing to act on, or
@@ -665,7 +755,7 @@ object LLM:
                             config.modelName,
                             Present(config.effectiveMaxOutputTokens),
                             prior,
-                            reply.reasoningTokens
+                            reply.usage.reasoningOutputTokens
                         ))
                     }
                 }

--- a/kyo-ai/shared/src/main/scala/kyo/Observe.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/Observe.scala
@@ -1,0 +1,86 @@
+package kyo
+
+import kyo.ai.completion.Completion
+
+/** Turn-completion notification: react to each completed model turn without altering it.
+  *
+  * `Observe` is the wire-tier counterpart of [[Mode]]: where a mode receives the generation as a
+  * value and returns what the caller sees, an observer receives the completed turn's
+  * [[kyo.ai.completion.Completion.Reply]] and returns `Unit`, so nothing can be skipped, rerun, or
+  * replaced. Enabled observers fire in enablement order, once per completed model turn, on the fiber
+  * that ran the turn, at the moment the wire reply is read: on the generation path before the
+  * ceiling adjudication (a turn that stops at the output ceiling still spent its tokens; a streamed
+  * ceiling stop fails the stream and, like any failed stream, reports nothing) and on both paths
+  * before the turn's messages join the instance context, so `ai.context` is the conversation up to
+  * this turn and the reply carries the turn itself. `AI.config` inside the callback is the config
+  * the turn ran under, instance overrides included. A fork's turns fire on
+  * the fork's own fiber, so branches later discarded (a losing race, a rolled-back `AI.forget`) still
+  * report the turns they completed.
+  *
+  * `S` is the capability the callback requires, riding the row to the run boundary like every
+  * enablement's; an observer whose `S` carries `Abort[E]` is a typed guardrail whose failure fails
+  * the generation it fired in (on the generation path it surfaces past `LLM.run`; on the streaming
+  * path at the consumption site, where it can be recovered in-run). A scope-enabled observer covers
+  * a streamed turn only when the stream is consumed inside the enabling bracket, since the env is
+  * read at consumption; an instance-enabled observer rides the session and covers its instance's
+  * streams wherever they are consumed. Build one with [[Observe.init]]; [[Observe.withStats]] is
+  * the provided implementation collecting token usage over a scope.
+  */
+trait Observe[-S] extends AI.Enablement[S]:
+
+    def apply(ai: AI, reply: Completion.Reply)(using Frame): Unit < (LLM & Sync & S)
+
+    private[kyo] def enableIn(env: AIEnv)(using Frame): AIEnv =
+        env.addObserve(this.asInstanceOf[Observe[Any]])
+    private[kyo] def enableIn(session: AISession)(using Frame): AISession =
+        session.addObserve(this.asInstanceOf[Observe[Any]])
+end Observe
+
+object Observe:
+
+    /** Builds an observer from a callback, the convenient alternative to `new Observe[S]`. */
+    def init[S](f: (AI, Completion.Reply) => Unit < (LLM & Sync & S)): Observe[S] =
+        new Observe[S]:
+            def apply(ai: AI, reply: Completion.Reply)(using Frame): Unit < (LLM & Sync & S) =
+                f(ai, reply)
+
+    /** Runs `v` and reports what it spent, alongside its result.
+      *
+      * Covers every turn any instance completes within `v` on this fiber's path and its forks,
+      * `AI.gen` one-shots included, and the completed turns of branches later discarded (a losing
+      * race, a rolled-back `AI.forget`). A turn interrupted before its reply arrives is uncounted:
+      * no number ever reached this side of the wire. Nested brackets are independent; brackets on
+      * parallel fibers never see each other's spend. `Sync` in the row is the bracket's own cell:
+      * the count is an ordinary observer over an `AtomicRef` this method allocates and reads.
+      */
+    def withStats[A, S](v: A < (LLM & S))(using Frame): (AIStats, A) < (LLM & Sync & S) =
+        AtomicRef.init(AIStats.empty).map { cell =>
+            val track = new Observe[Any]:
+                def apply(ai: AI, reply: Completion.Reply)(using Frame): Unit < (LLM & Sync) =
+                    cell.getAndUpdate(_.add(reply.usage)).unit
+            AI.enable(track)(v).map(a => cell.get.map(stats => (stats, a)))
+        }
+
+    /** As `withStats`, broken down by the named instances.
+      *
+      * Every named instance appears, [[AIStats.empty]] for one that completed no turn; spend by any
+      * other instance (an `AI.gen` one-shot included) is not in the breakdown. Wrap in the
+      * untargeted form for the scope total.
+      */
+    def withStats[A, S](ais: AI*)(v: A < (LLM & S))(using Frame): (Dict[AI, AIStats], A) < (LLM & Sync & S) =
+        // Probing each target's session routes the targets through an existing targeted op, so naming a
+        // foreign run's instance fails loud (the cross-run guard) instead of silently reporting an
+        // empty entry.
+        Kyo.foreachDiscard(ais)(ai => LLM.session(ai).unit).andThen {
+            val seeded = ais.foldLeft(Dict.empty[AI, AIStats])((d, ai) => d.update(ai, AIStats.empty))
+            AtomicRef.init(seeded).map { cell =>
+                val track = new Observe[Any]:
+                    def apply(ai: AI, reply: Completion.Reply)(using Frame): Unit < (LLM & Sync) =
+                        // Only seeded keys accumulate: an unnamed instance's turn leaves the breakdown
+                        // untouched. The write happens on the firing fiber, which is what lets a
+                        // discarded branch's completed turns count.
+                        cell.getAndUpdate(d => d.get(ai).fold(d)(prev => d.update(ai, prev.add(reply.usage)))).unit
+                AI.enable(track)(v).map(a => cell.get.map(byInstance => (byInstance, a)))
+            }
+        }
+end Observe

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
@@ -60,8 +60,22 @@ private[completion] object AnthropicCompletion extends Completion:
                 case Completion.StopReason.Other(raw) =>
                     Log.debug(s"kyo-ai ${config.provider.name} unrecognized stop reason: $raw")
                 case _ => Kyo.unit
-        surfaced.andThen(Completion.Reply(Chunk(AssistantMessage(textOf(response), calls)), stop))
+        val usage = response.usage.fold(AIStats(0L, Absent, 0L, Absent, 1))(usageStats)
+        surfaced.andThen(Completion.Reply(Chunk(AssistantMessage(textOf(response), calls)), stop, usage))
     end read
+
+    /** This wire reports cache traffic BESIDE input_tokens, so the input total sums all three;
+      * creation counts as read (a fresh read that populates the cache), not as cached. Reasoning is
+      * never broken out of output_tokens on this wire, so the subset stays Absent.
+      */
+    private def usageStats(u: internal.Usage): AIStats =
+        AIStats(
+            inputTokens = u.input_tokens + u.cache_read_input_tokens.getOrElse(0L) + u.cache_creation_input_tokens.getOrElse(0L),
+            cachedInputTokens = u.cache_read_input_tokens,
+            outputTokens = u.output_tokens,
+            reasoningOutputTokens = Absent,
+            turns = 1
+        )
 
     private def textOf(response: Response): String =
         response.content.collect { case c if c.`type` == "text" => c.text.getOrElse("") }.mkString("")
@@ -98,7 +112,7 @@ private[completion] object AnthropicCompletion extends Completion:
         context: Context,
         resultSchema: JsonSchema,
         resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
-    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
+    )(using Frame): Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
         Completion.sseFragments(
             config,
             streamRequest(config, context, resultSchema, resultTool),
@@ -149,7 +163,26 @@ private[completion] object AnthropicCompletion extends Completion:
                         Completion.Delta.Fragment(d.partial_json.getOrElse(""))
                     case Present(d) if stopReason(d.stop_reason) == Completion.StopReason.MaxOutputTokens =>
                         Completion.Delta.OutputLimit
-                    case _ => Completion.Delta.Skip)
+                    case _ =>
+                        // Usage arrives split: message_start embeds the input side, message_delta the final
+                        // output count. Each side is emitted as a DISJOINT partial (the input partial zeroes
+                        // output and carries the turn count; the output partial carries output alone), so the
+                        // consumer's sum is exact regardless of what extra fields either event carries.
+                        event.message.flatMap(_.usage).fold(
+                            event.usage.flatMap(_.output_tokens).fold(Completion.Delta.Skip)(outputTokens =>
+                                Completion.Delta.Usage(AIStats(0L, Absent, outputTokens, Absent, 0))
+                            )
+                        )(u =>
+                            Completion.Delta.Usage(AIStats(
+                                inputTokens = u.input_tokens.getOrElse(0L) +
+                                    u.cache_read_input_tokens.getOrElse(0L) +
+                                    u.cache_creation_input_tokens.getOrElse(0L),
+                                cachedInputTokens = u.cache_read_input_tokens,
+                                outputTokens = 0L,
+                                reasoningOutputTokens = Absent,
+                                turns = 1
+                            ))
+                        ))
             case _ =>
                 Result.Failure(s"Not a parseable Anthropic streaming event: $line")
         end match
@@ -196,7 +229,12 @@ private[completion] object AnthropicCompletion extends Completion:
             thinking: Maybe[Thinking] = Absent,
             stream: Maybe[Boolean] = Absent
         ) derives Schema
-        case class Usage(input_tokens: Int, output_tokens: Int) derives Schema
+        case class Usage(
+            input_tokens: Long,
+            output_tokens: Long,
+            cache_read_input_tokens: Maybe[Long] = Absent,
+            cache_creation_input_tokens: Maybe[Long] = Absent
+        ) derives Schema
 
         // Streaming SSE event DTOs. Fields are Maybe to tolerate the non-tool event types (message_start,
         // content_block_start, text_delta, message_delta, message_stop, ping).
@@ -205,7 +243,21 @@ private[completion] object AnthropicCompletion extends Completion:
             partial_json: Maybe[String] = Absent,
             stop_reason: Maybe[String] = Absent
         ) derives Schema
-        case class StreamEvent(`type`: Maybe[String] = Absent, delta: Maybe[StreamDelta] = Absent) derives Schema
+        // message_start embeds the message object whose usage carries the input side; message_delta
+        // carries an event-level usage with the final output count. Both are decoded tolerantly.
+        case class StreamMessage(usage: Maybe[StreamUsage] = Absent) derives Schema
+        case class StreamUsage(
+            input_tokens: Maybe[Long] = Absent,
+            output_tokens: Maybe[Long] = Absent,
+            cache_read_input_tokens: Maybe[Long] = Absent,
+            cache_creation_input_tokens: Maybe[Long] = Absent
+        ) derives Schema
+        case class StreamEvent(
+            `type`: Maybe[String] = Absent,
+            delta: Maybe[StreamDelta] = Absent,
+            message: Maybe[StreamMessage] = Absent,
+            usage: Maybe[StreamUsage] = Absent
+        ) derives Schema
         case class Response(
             id: String,
             content: List[Content],

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeCompletion.scala
@@ -70,15 +70,15 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
         context: Context,
         resultSchema: JsonSchema,
         resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
-    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
+    )(using Frame): Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
         // Streaming rides the SAME MCP result tool and kill-on-call as the completion path. No user tools
         // here, so the bridge threads no LLM.State (withResultBridge, the result-only variant of
         // withMcpBridge), which is what lets it run inside the Stream's element row (no LLM). The captured
-        // envelope is emitted as the single fragment; a resultless turn ends the stream with
-        // AIStreamIncompleteException (no eval-loop repair on this path). The AIGenException->AIStreamException
-        // mapping is in the recover below.
+        // envelope is emitted as the single fragment, followed by the turn's usage read from the flushed
+        // transcript; a resultless turn ends the stream with AIStreamIncompleteException (no eval-loop
+        // repair on this path). The AIGenException->AIStreamException mapping is in the recover below.
         turnInput(context).map { input =>
-            Stream[String, Async & Scope & Abort[AIStreamException]] {
+            Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]] {
                 // Map bridge/runner AIGenException failures to AIStreamException. An AIStreamException (a
                 // resultless-turn AIStreamIncompleteException, or a classified provider leaf) is re-raised
                 // type-preserving; only a genuinely-unclassified AIGenException wraps as a harness malfunction
@@ -94,9 +94,17 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                                 .stdin(input + "\n"),
                             config.timeout,
                             bridge
-                        ).andThen(bridge.resultCapture.get).map {
-                            case Present(envelope) => Emit.value(Chunk(envelope))
-                            case Absent            => Abort.fail(AIStreamIncompleteException(""))
+                        ).map { raw =>
+                            bridge.resultCapture.get.map {
+                                case Present(envelope) =>
+                                    turnUsage(raw).map { usage =>
+                                        Emit.value(Chunk[Completion.StreamElement](
+                                            Completion.StreamElement.Fragment(envelope),
+                                            Completion.StreamElement.Usage(usage)
+                                        ))
+                                    }
+                                case Absent => Abort.fail(AIStreamIncompleteException(""))
+                            }
                         }
                     }
                 }
@@ -109,7 +117,7 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
         context: Context,
         tools: Chunk[Tool.internal.Info[?, ?, LLM]],
         resultSchema: JsonSchema
-    )(using Frame): Chunk[Message] < (LLM & Async & Abort[AIGenException]) =
+    )(using Frame): (Chunk[Message], AIStats) < (LLM & Async & Abort[AIGenException]) =
         Scope.run {
             withMcpBridge(config, tools, resultSchema) { bridge =>
                 for
@@ -131,7 +139,8 @@ private[completion] object ClaudeCodeCompletion extends HarnessCompletion("Claud
                     // carries duplicate tool_use ids across generations.
                     callIdSeed <- Random.nextStringAlphanumeric(12)
                     messages   <- readMessages(raw, executed, captured, callIdSeed)
-                yield messages
+                    usage      <- turnUsage(raw)
+                yield (messages, usage)
             }
         }
     end run

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeWire.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/ClaudeCodeWire.scala
@@ -36,7 +36,21 @@ private[completion] object ClaudeCodeWire:
         content: Maybe[String] = Absent,
         is_error: Maybe[Boolean] = Absent
     ) derives Schema
-    private case class OutputMessage(role: String, content: List[MessageContent]) derives Schema
+    // The API usage shape the CLI embeds on assistant events and the terminal result event
+    // (Anthropic-style fields; cache traffic reported beside input_tokens). Every field is Maybe:
+    // this decodes possibly-truncated output.
+    private[completion] case class Usage(
+        input_tokens: Maybe[Long] = Absent,
+        output_tokens: Maybe[Long] = Absent,
+        cache_read_input_tokens: Maybe[Long] = Absent,
+        cache_creation_input_tokens: Maybe[Long] = Absent
+    ) derives Schema
+    private case class OutputMessage(
+        role: String,
+        content: List[MessageContent],
+        id: Maybe[String] = Absent,
+        usage: Maybe[Usage] = Absent
+    ) derives Schema
     private case class OutputEvent(
         `type`: String,
         message: Maybe[OutputMessage] = Absent,
@@ -51,7 +65,9 @@ private[completion] object ClaudeCodeWire:
         api_error_status: Maybe[Int] = Absent,
         // Set when the CLI ends a turn for a structural reason of its own rather than an upstream
         // status, which is how stopping at the output ceiling is reported.
-        error: Maybe[String] = Absent
+        error: Maybe[String] = Absent,
+        // The terminal result event's aggregate usage across the invocation's internal iterations.
+        usage: Maybe[Usage] = Absent
     ) derives Schema
 
     /** True when the flattened stdout carries the CLI's own report that a turn stopped at the output ceiling.
@@ -412,5 +428,54 @@ private[completion] object ClaudeCodeWire:
             }
         }
     end failureStatus
+
+    /** The turn's token usage from the flattened stdout.
+      *
+      * The terminal `result` event's aggregate is authoritative and preferred: it sums the
+      * invocation's internal iterations (verified live). On the kill-on-capture path that event never
+      * arrives, so the fallback sums the assistant events' embedded usage, deduplicated by message id
+      * (the CLI re-emits an event per message): the input-side numbers are accurate there, while
+      * output tokens are the message-start count, a stated lower bound (verified live: 4 reported at
+      * message start against 38 on the aggregate). Parses leniently, since the kill can truncate the
+      * last line. Always reports `turns = 1`: the invocation is one kyo turn whether or not the CLI
+      * flushed its numbers.
+      */
+    def turnUsage(output: String)(using Frame): AIStats < Abort[AIGenException] =
+        readEvents(output, lenient = true).map { events =>
+            val resultUsage = events.foldLeft(Maybe.empty[Usage]) { (last, event) =>
+                if event.`type` == "result" then event.usage.orElse(last) else last
+            }
+            val base = resultUsage match
+                case Present(usage) => usageStats(usage)
+                case Absent         =>
+                    // Last event per message id wins (the CLI re-emits an event per message); an event
+                    // whose id was lost to truncation still counts once.
+                    val (byId, anonymous) =
+                        events.foldLeft((Dict.empty[String, Usage], Chunk.empty[Usage])) { case ((byId, anonymous), event) =>
+                            event.message match
+                                case Present(message) if message.role == Role.Assistant.name && message.usage.isDefined =>
+                                    val usage = message.usage.getOrElse(Usage())
+                                    message.id match
+                                        case Present(id) => (byId.update(id, usage), anonymous)
+                                        case Absent      => (byId, anonymous.append(usage))
+                                case _ => (byId, anonymous)
+                        }
+                    (Chunk.from(byId.toMap.values) ++ anonymous).foldLeft(AIStats.empty)((acc, u) => acc.add(usageStats(u)))
+            base.copy(turns = 1)
+        }
+    end turnUsage
+
+    // The Anthropic-wire mapping: cache traffic is reported beside input_tokens, so the input total
+    // sums all three; creation counts as read, not cached; reasoning is never broken out.
+    private def usageStats(usage: Usage): AIStats =
+        AIStats(
+            inputTokens = usage.input_tokens.getOrElse(0L) +
+                usage.cache_read_input_tokens.getOrElse(0L) +
+                usage.cache_creation_input_tokens.getOrElse(0L),
+            cachedInputTokens = usage.cache_read_input_tokens,
+            outputTokens = usage.output_tokens.getOrElse(0L),
+            reasoningOutputTokens = Absent,
+            turns = 0
+        )
 
 end ClaudeCodeWire

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexCompletion.scala
@@ -75,8 +75,8 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
         context: Context,
         resultSchema: JsonSchema,
         resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
-    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
-        Kyo.lift(Stream[String, Async & Scope & Abort[AIStreamException]] {
+    )(using Frame): Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
+        Kyo.lift(Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]] {
             AtomicRef.init("").map { stderrTail =>
                 Abort.run[
                     CommandException | FileFsException | FileReadException | FileWriteException | JsonRpcError | AIGenException |
@@ -94,14 +94,18 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
                                     workDir,
                                     dynamicToolSpecs(resultTool, resultSchema)
                                 )
-                                _ <- Async.timeoutWithError[AIGenException | Closed, Maybe[String], Any](
+                                (_, usage) <- Async.timeoutWithError[AIGenException | Closed, (Maybe[String], AIStats), Any](
                                     config.timeout,
                                     Result.Failure(AICompletionTimeoutException("Codex", config.timeout))
                                 )(collectTurn(handler, events, threadId, turnId, stderrTail, bridge))
                                 captured <- bridge.resultCapture.get
                                 _ <- captured match
-                                    case Present((_, arguments)) => Emit.value(Chunk(arguments))
-                                    case Absent                  => Abort.fail(AIStreamIncompleteException(""))
+                                    case Present((_, arguments)) =>
+                                        Emit.value(Chunk[Completion.StreamElement](
+                                            Completion.StreamElement.Fragment(arguments),
+                                            Completion.StreamElement.Usage(usage)
+                                        ))
+                                    case Absent => Abort.fail(AIStreamIncompleteException(""))
                             yield ()
                         }
                     yield ()
@@ -128,7 +132,7 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
         resultSchema: JsonSchema
     )(using
         Frame
-    ): Chunk[Message] < (LLM & Async & Abort[AIGenException]) =
+    ): (Chunk[Message], AIStats) < (LLM & Async & Abort[AIGenException]) =
         LLM.state.map { state =>
             Scope.run {
                 for
@@ -150,13 +154,13 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
                                         workDir,
                                         dynamicToolSpecs(tools, resultSchema)
                                     )
-                                    finalText <- Async.timeoutWithError[AIGenException | Closed, Maybe[String], Any](
+                                    (finalText, usage) <- Async.timeoutWithError[AIGenException | Closed, (Maybe[String], AIStats), Any](
                                         config.timeout,
                                         Result.Failure(AICompletionTimeoutException("Codex", config.timeout))
                                     )(collectTurn(handler, events, threadId, turnId, stderrTail, bridge))
                                     executed <- bridge.executed.get
                                     captured <- bridge.resultCapture.get
-                                yield resultMessages(executed, captured, finalText)
+                                yield (resultMessages(executed, captured, finalText), usage)
                         }
                     }
                     next <- stateRef.get
@@ -477,21 +481,32 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
         turnId: String,
         stderrTail: AtomicRef[String],
         bridge: ToolBridge
-    )(using Frame): Maybe[String] < (Async & Abort[AIGenException | Closed]) =
-        Loop((Absent: Maybe[String], "")) { (completed, delta) =>
+    )(using Frame): (Maybe[String], AIStats) < (Async & Abort[AIGenException | Closed]) =
+        Loop((Absent: Maybe[String], "", Maybe.empty[TokenCounts])) { (completed, delta, usage) =>
             events.take.map { event =>
                 trackFollowUp(bridge, event, threadId, turnId).andThen {
                     bridge.resultCapture.get.map { captured =>
                         bridge.deferred.get.map { deferred =>
                             if captured.isDefined || deferred then
-                                interruptTurn(handler, threadId, turnId).andThen(Loop.done(finalText(completed, delta)))
+                                interruptTurn(handler, threadId, turnId)
+                                    .andThen(Loop.done((finalText(completed, delta), turnStats(usage))))
                             else if isTurnCompleted(event, threadId, turnId) then
-                                Loop.done(finalText(completed, delta))
+                                Loop.done((finalText(completed, delta), turnStats(usage)))
+                            else if event.method == "thread/tokenUsage/updated" then
+                                // Keep the latest total: the ephemeral thread's aggregate IS this turn's
+                                // usage, already summed across the CLI turn's internal provider requests.
+                                // Tracked here rather than in eventText so the interrupt path (capture)
+                                // reports the totals that arrived before the kill.
+                                decodeEvent[TokenUsageNotification](event).map { notification =>
+                                    if notification.threadId == threadId && notification.turnId == turnId then
+                                        Loop.continue((completed, delta, notification.tokenUsage.total.orElse(usage)))
+                                    else Loop.continue((completed, delta, usage))
+                                }
                             else
                                 eventText(event, threadId, turnId, stderrTail).map {
-                                    case Present(OutputText.Completed(text)) => Loop.continue((Present(text), delta))
-                                    case Present(OutputText.Delta(text))     => Loop.continue((completed, delta + text))
-                                    case _                                   => Loop.continue((completed, delta))
+                                    case Present(OutputText.Completed(text)) => Loop.continue((Present(text), delta, usage))
+                                    case Present(OutputText.Delta(text))     => Loop.continue((completed, delta + text, usage))
+                                    case _                                   => Loop.continue((completed, delta, usage))
                                 }
                         }
                     }
@@ -499,6 +514,10 @@ private[completion] object CodexCompletion extends HarnessCompletion("Codex"):
             }
         }
     end collectTurn
+
+    // A turn that saw no usage notification still ran: one turn, no numbers.
+    private def turnStats(usage: Maybe[TokenCounts]): AIStats =
+        usage.fold(AIStats.empty.copy(turns = 1))(usageStats)
 
     private def finalText(completed: Maybe[String], delta: String): Maybe[String] =
         completed match

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexWire.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/CodexWire.scala
@@ -110,6 +110,18 @@ private[completion] object CodexWire:
     ) derives Schema
     // Carried by both item/started and item/completed: {threadId, turnId, item}.
     case class ItemNotification(threadId: String, turnId: String, item: ThreadItem) derives Schema
+    // The thread/tokenUsage/updated notification (verified live against codex app-server): `total`
+    // aggregates the thread, `last` is the most recent provider request. The thread is ephemeral per
+    // completion call, so its final `total` IS the kyo turn's usage, already summed across the
+    // several provider requests one CLI turn can make. camelCase is the app-server's own vocabulary.
+    case class TokenCounts(
+        inputTokens: Maybe[Long] = Absent,
+        cachedInputTokens: Maybe[Long] = Absent,
+        outputTokens: Maybe[Long] = Absent,
+        reasoningOutputTokens: Maybe[Long] = Absent
+    ) derives Schema
+    case class ThreadTokenUsage(total: Maybe[TokenCounts] = Absent, last: Maybe[TokenCounts] = Absent) derives Schema
+    case class TokenUsageNotification(threadId: String, turnId: String, tokenUsage: ThreadTokenUsage) derives Schema
     case class ResponseItem(`type`: String, role: Maybe[String] = Absent, content: Maybe[List[ContentItem]] = Absent)
         derives Schema
     case class RawResponseItemCompletedNotification(threadId: String, turnId: String, item: ResponseItem) derives Schema
@@ -363,6 +375,18 @@ private[completion] object CodexWire:
                 finalText.filter(_.nonEmpty).fold(pairs)(text => pairs.append(AssistantMessage(text)))
         end match
     end resultMessages
+
+    /** This wire's counts already use the module's field vocabulary; the subsets stay their reported
+      * values (`Present(0)` is a reported zero, not an absence).
+      */
+    def usageStats(counts: TokenCounts): AIStats =
+        AIStats(
+            inputTokens = counts.inputTokens.getOrElse(0L),
+            cachedInputTokens = counts.cachedInputTokens,
+            outputTokens = counts.outputTokens.getOrElse(0L),
+            reasoningOutputTokens = counts.reasoningOutputTokens,
+            turns = 1
+        )
 
     def decodeEvent[A: Schema](event: RpcEvent)(using Frame): A < Abort[AIGenException] =
         Structure.decode[A](event.params) match

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/Completion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/Completion.scala
@@ -35,7 +35,7 @@ trait Completion:
         context: Context,
         resultSchema: JsonSchema,
         resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
-    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException])
+    )(using Frame): Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException])
 
 end Completion
 
@@ -184,37 +184,52 @@ object Completion:
             exc
         }
 
-    /** What a turn produced, together with how the wire said it ended.
+    /** What a turn produced, together with how the wire said it ended and what it spent.
       *
       * The stop reason travels with the messages because deciding what a ceiling stop MEANS needs both
       * halves: a backend knows the wire said "stopped at the ceiling" but must not inspect a tool payload
       * (that belongs to the tool loop), and the loop cannot see the wire. Carrying the reason lets the policy
       * be decided once, with both facts in hand.
       *
-      * `reasoningTokens` travels for the same reason: at a ceiling stop, how much went to reasoning rather
-      * than the answer separates the two levers (a stop that spent most of its allowance reasoning needs less
-      * reasoning; one that barely reasoned needs a larger ceiling).
+      * `usage` travels for the same reason and is the record each enabled [[kyo.Observe]] receives: the
+      * wire is the only place the numbers exist, and at a ceiling stop the reasoning subset separates the
+      * two levers (a stop that spent most of its allowance reasoning needs less reasoning; one that barely
+      * reasoned needs a larger ceiling). A synthetic reply that reached no model carries [[AIStats.empty]].
+      * Fields may grow with the wire contract; consumers should read fields, not match exhaustively.
       */
-    case class Reply(messages: Chunk[Message], stopReason: StopReason, reasoningTokens: Maybe[Int] = Absent)
+    case class Reply(messages: Chunk[Message], stopReason: StopReason, usage: AIStats = AIStats.empty)
 
     /** Why a provider stopped a reply, decoded once at each wire boundary from that provider's own
       * vocabulary so no decision elsewhere reads a raw wire string.
       *
       * Only [[StopReason.MaxOutputTokens]] changes behavior. [[StopReason.Other]] keeps the
       * unrecognized value for diagnosis and behaves like [[StopReason.Completed]]: vocabulary a
-      * provider adds later must never fail a reply whose content is perfectly usable.
+      * provider adds later must never fail a reply whose content is perfectly usable, and any consumer
+      * (an [[kyo.Observe]] included) must treat it the same way.
       */
-    private[kyo] enum StopReason derives CanEqual:
+    enum StopReason derives CanEqual:
         case Completed
         case MaxOutputTokens
         case Other(raw: String)
     end StopReason
 
-    /** One parsed streaming event's contribution to the fragment stream: a fragment to emit, nothing
-      * to emit, or the provider reporting that it stopped at the output ceiling.
+    /** One element of a streaming completion: a fragment of the result envelope's argument JSON, or a
+      * usage report. Usage elements are PARTIAL and disjoint by construction (a wire may report the
+      * input and output sides in separate events); the consumers sum them, and the record site forces
+      * `turns = 1` on the sum, so a wire that emitted no usage element still reports the structural
+      * fact that a fully consumed stream is one turn.
+      */
+    enum StreamElement derives CanEqual:
+        case Fragment(value: String)
+        case Usage(stats: AIStats)
+    end StreamElement
+
+    /** One parsed streaming event's contribution to the element stream: a fragment to emit, a usage
+      * report, nothing to emit, or the provider reporting that it stopped at the output ceiling.
       */
     private[completion] enum Delta derives CanEqual:
         case Fragment(value: String)
+        case Usage(stats: AIStats)
         case Skip
         case OutputLimit
     end Delta
@@ -236,12 +251,12 @@ object Completion:
         request: StreamRequest < Abort[AIStreamException],
         parseDeltaArguments: String => Result[String, Delta],
         outputLimit: Maybe[Int]
-    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < Async =
+    )(using Frame): Stream[StreamElement, Async & Scope & Abort[AIStreamException]] < Async =
         given sseTag: Tag[Emit[Chunk[HttpSseEvent[String]]]] = Tag[Emit[Chunk[HttpSseEvent[String]]]]
         val route                                            = HttpRoute.postRaw("").request(_.bodyText).response(_.bodySseText)
         Stream.unwrap {
             for
-                channel <- Channel.init[Result[AIStreamException, Maybe[Chunk[String]]]](sseBufferSize)
+                channel <- Channel.init[Result[AIStreamException, Maybe[Chunk[StreamElement]]]](sseBufferSize)
                 // Releasing the consumer's scope interrupts the producer. The deadline's own inner fiber is
                 // unscoped, so an abandoned connection can linger until the remaining deadline elapses,
                 // bounded by config.timeout.
@@ -283,10 +298,10 @@ object Completion:
                                                 // forced tool choice, only reasoning/content deltas that leave
                                                 // the result buffer empty and fail the generation.
                                                 Log.trace(s"kyo-ai stream event ${config.provider.name} ${elideBody(event.data)}").andThen {
-                                                    // An empty event carries no chunk. A stream may hold the
+                                                    // An empty event carries no element. A stream may hold the
                                                     // connection open with a keepalive between fragments; handing
                                                     // that to a decoder expecting a chunk fails a healthy generation.
-                                                    if event.data.trim.isEmpty then ""
+                                                    if event.data.trim.isEmpty then Maybe.empty[StreamElement]
                                                     else
                                                         // A provider can end a 200 stream with an error event instead
                                                         // of an HTTP status; surface it typed rather than let the delta
@@ -299,8 +314,11 @@ object Completion:
                                                             case Present(exc) => Abort.fail(exc)
                                                             case Absent =>
                                                                 parseDeltaArguments(event.data) match
-                                                                    case Result.Success(Delta.Fragment(fragment)) => fragment
-                                                                    case Result.Success(Delta.Skip)               => ""
+                                                                    case Result.Success(Delta.Fragment(fragment)) =>
+                                                                        Present(StreamElement.Fragment(fragment))
+                                                                    case Result.Success(Delta.Usage(stats)) =>
+                                                                        Present(StreamElement.Usage(stats))
+                                                                    case Result.Success(Delta.Skip) => Maybe.empty[StreamElement]
                                                                     case Result.Success(Delta.OutputLimit) =>
                                                                         Abort.fail(AIOutputLimitException(
                                                                             config.provider.name,
@@ -310,7 +328,7 @@ object Completion:
                                                                     case Result.Failure(err) => Abort.fail(AIStreamDeltaException(err))
                                                         end match
                                                 }
-                                            }.filterPure(_.nonEmpty)
+                                            }.filterPure(_.nonEmpty).mapPure(_.get)
                                                 .foreachChunk(chunk => channel.put(Result.Success(Present(chunk))))
                                         }
                                     yield ()

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/HarnessCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/HarnessCompletion.scala
@@ -20,14 +20,17 @@ abstract private[completion] class HarnessCompletion(providerName: String) exten
             // A command harness has no reply-level stop vocabulary: one learns it stopped at a ceiling only
             // from a failed invocation (raised directly on that path), the other cannot learn it at all. A
             // normal reply is reported as completed: whatever these harnesses hand back, they hand back whole.
-            case Present(schema) => run(config, context, tools, schema).map(Completion.Reply(_, Completion.StopReason.Completed))
+            case Present(schema) =>
+                run(config, context, tools, schema).map((messages, usage) =>
+                    Completion.Reply(messages, Completion.StopReason.Completed, usage)
+                )
 
     protected def run(
         config: Config,
         context: Context,
         tools: Chunk[Tool.internal.Info[?, ?, LLM]],
         resultSchema: JsonSchema
-    )(using Frame): Chunk[Message] < (LLM & Async & Abort[AIGenException])
+    )(using Frame): (Chunk[Message], AIStats) < (LLM & Async & Abort[AIGenException])
 
     final protected def commandFailure(status: Maybe[Int], detail: String)(using Frame): AIGenException =
         HarnessCompletion.commandFailure(providerName, status, detail)

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/OpenAICompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/OpenAICompletion.scala
@@ -98,6 +98,18 @@ private[completion] object OpenAICompletion extends Completion:
         end if
     end warnUndeclaredReasoning
 
+    /** This wire nests the cache subset inside prompt_tokens, so the fields map straight across; the
+      * subsets stay Maybe because the details objects are themselves optional on the wire.
+      */
+    private def usageStats(usage: Maybe[internal.Usage]): AIStats =
+        AIStats(
+            inputTokens = usage.flatMap(_.prompt_tokens).getOrElse(0L),
+            cachedInputTokens = usage.flatMap(_.prompt_tokens_details).flatMap(_.cached_tokens),
+            outputTokens = usage.flatMap(_.completion_tokens).fold(0L)(_.toLong),
+            reasoningOutputTokens = usage.flatMap(_.completion_tokens_details).flatMap(_.reasoning_tokens).map(_.toLong),
+            turns = 1
+        )
+
     private def read(config: Config, response: Response)(using Frame): Completion.Reply < (LLM & Sync & Abort[AIGenException]) =
         Maybe.fromOption(response.choices.headOption) match
             case Absent =>
@@ -121,7 +133,7 @@ private[completion] object OpenAICompletion extends Completion:
                         Completion.Reply(
                             Chunk(AssistantMessage(v.message.content.getOrElse(""), calls)),
                             stop,
-                            response.usage.flatMap(_.completion_tokens_details).flatMap(_.reasoning_tokens)
+                            usageStats(response.usage)
                         )
                     )
                 }
@@ -161,7 +173,7 @@ private[completion] object OpenAICompletion extends Completion:
         context: Context,
         resultSchema: JsonSchema,
         resultTool: Chunk[Tool.internal.Info[?, ?, LLM]]
-    )(using Frame): Stream[String, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
+    )(using Frame): Stream[Completion.StreamElement, Async & Scope & Abort[AIStreamException]] < (LLM & Async & Abort[AIGenException]) =
         Completion.sseFragments(
             config,
             streamRequest(config, context, resultSchema, resultTool),
@@ -192,6 +204,10 @@ private[completion] object OpenAICompletion extends Completion:
                             case Absent =>
                                 if choice.exists(c => stopReason(c.finish_reason) == Completion.StopReason.MaxOutputTokens)
                                 then Completion.Delta.OutputLimit
+                                // The final usage chunk the request asked for via stream_options: empty
+                                // choices, usage only, arriving before the [DONE] terminator. One complete
+                                // report per stream, so the consumer's sum is exactly this turn's usage.
+                                else if chunk.usage.isDefined then Completion.Delta.Usage(usageStats(chunk.usage))
                                 else Completion.Delta.Skip
                     )
                 case _ =>
@@ -219,7 +235,10 @@ private[completion] object OpenAICompletion extends Completion:
                 Completion.StreamRequest(
                     s"${config.apiUrl.stripSuffix("/")}/chat/completions",
                     headers,
-                    Json.encode(Request(context, config, resultTool, Present(resultSchema)).copy(stream = Present(true)))
+                    Json.encode(
+                        Request(context, config, resultTool, Present(resultSchema))
+                            .copy(stream = Present(true), stream_options = Present(StreamOptions(include_usage = true)))
+                    )
                 )
         end match
     end streamRequest
@@ -273,8 +292,12 @@ private[completion] object OpenAICompletion extends Completion:
             reasoning_effort: Maybe[String] = Absent,
             // Exactly one of this and max_completion_tokens ever carries a value; which one is the
             // endpoint's declared fact. The unset one is omitted from the body entirely.
-            max_tokens: Maybe[Int] = Absent
+            max_tokens: Maybe[Int] = Absent,
+            // Streaming only: asks the endpoint to end the stream with a usage chunk. Without it the
+            // final usage report is never sent and a streamed turn cannot state what it spent.
+            stream_options: Maybe[StreamOptions] = Absent
         ) derives Schema
+        case class StreamOptions(include_usage: Boolean) derives Schema
         case class ResponseFunctionCall(arguments: String, name: String) derives Schema
         case class ResponseToolCall(
             id: String,
@@ -291,9 +314,12 @@ private[completion] object OpenAICompletion extends Completion:
         ) derives Schema
         case class Choice(message: ResponseMessage, finish_reason: Maybe[String] = Absent) derives Schema
         case class CompletionTokensDetails(reasoning_tokens: Maybe[Int] = Absent) derives Schema
+        case class PromptTokensDetails(cached_tokens: Maybe[Long] = Absent) derives Schema
         case class Usage(
             completion_tokens: Maybe[Int] = Absent,
-            completion_tokens_details: Maybe[CompletionTokensDetails] = Absent
+            completion_tokens_details: Maybe[CompletionTokensDetails] = Absent,
+            prompt_tokens: Maybe[Long] = Absent,
+            prompt_tokens_details: Maybe[PromptTokensDetails] = Absent
         ) derives Schema
         case class Response(choices: List[Choice], usage: Maybe[Usage] = Absent) derives Schema
 
@@ -304,7 +330,7 @@ private[completion] object OpenAICompletion extends Completion:
         case class StreamToolCallDelta(function: Maybe[StreamFunctionDelta] = Absent) derives Schema
         case class StreamDelta(tool_calls: Maybe[List[StreamToolCallDelta]] = Absent) derives Schema
         case class StreamChoice(delta: Maybe[StreamDelta] = Absent, finish_reason: Maybe[String] = Absent) derives Schema
-        case class StreamChunk(choices: Maybe[List[StreamChoice]] = Absent) derives Schema
+        case class StreamChunk(choices: Maybe[List[StreamChoice]] = Absent, usage: Maybe[Usage] = Absent) derives Schema
 
         private def toEntry(msg: Message)(using Frame): MessageEntry =
             def text(s: String): Structure.Value = Structure.Value.Str(s)

--- a/kyo-ai/shared/src/test/scala/kyo/AIEnvTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/AIEnvTest.scala
@@ -4,7 +4,7 @@ import kyo.ai.Config
 
 class AIEnvTest extends kyo.test.Test[Any]:
 
-    val base: AIEnv = AIEnv(Present(Config.OpenAI.default), Prompt.empty, Chunk.empty, Chunk.empty, Chunk.empty)
+    val base: AIEnv = AIEnv(Present(Config.OpenAI.default), Prompt.empty, Chunk.empty, Chunk.empty, Chunk.empty, Chunk.empty)
 
     "config replaces the config" in {
         val cfg = Config.Anthropic.default

--- a/kyo-ai/shared/src/test/scala/kyo/AIStatsTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/AIStatsTest.scala
@@ -1,0 +1,46 @@
+package kyo
+
+class AIStatsTest extends kyo.test.Test[Any]:
+
+    "empty is the identity of add" in {
+        val stats = AIStats(100L, Present(30L), 40L, Present(10L), 2)
+        assert(AIStats.empty.add(stats) == stats)
+        assert(stats.add(AIStats.empty) == stats)
+        assert(AIStats.empty == AIStats(0L, Absent, 0L, Absent, 0))
+    }
+
+    "add sums totals, turns, and reported subsets" in {
+        val a = AIStats(100L, Present(30L), 40L, Present(10L), 1)
+        val b = AIStats(50L, Present(20L), 15L, Present(5L), 1)
+        assert(a.add(b) == AIStats(150L, Present(50L), 55L, Present(15L), 2))
+    }
+
+    "add keeps the reporting side of a subset one wire broke out and the other did not" in {
+        // A mixed-wire aggregate: the sum is a stated lower bound, never a lost number.
+        val reporting = AIStats(100L, Present(30L), 40L, Present(10L), 1)
+        val silent    = AIStats(50L, Absent, 15L, Absent, 1)
+        assert(reporting.add(silent) == AIStats(150L, Present(30L), 55L, Present(10L), 2))
+        assert(silent.add(reporting) == AIStats(150L, Present(30L), 55L, Present(10L), 2))
+    }
+
+    "add keeps Absent when neither wire broke the subset out" in {
+        val a = AIStats(10L, Absent, 5L, Absent, 1)
+        val b = AIStats(20L, Absent, 5L, Absent, 1)
+        assert(a.add(b) == AIStats(30L, Absent, 10L, Absent, 2))
+    }
+
+    "a reported zero stays distinguishable from not reported" in {
+        val zero   = AIStats(10L, Present(0L), 5L, Present(0L), 1)
+        val silent = AIStats(10L, Absent, 5L, Absent, 1)
+        assert(zero.add(zero).cachedInputTokens == Present(0L))
+        assert(zero.add(zero).reasoningOutputTokens == Present(0L))
+        assert(silent.add(silent).cachedInputTokens == Absent)
+        assert(zero != silent)
+    }
+
+    "totalTokens sums input and output" in {
+        assert(AIStats(100L, Present(30L), 40L, Present(10L), 1).totalTokens == 140L)
+        assert(AIStats.empty.totalTokens == 0L)
+    }
+
+end AIStatsTest

--- a/kyo-ai/shared/src/test/scala/kyo/LLMIntegrationTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/LLMIntegrationTest.scala
@@ -235,9 +235,9 @@ class LLMIntegrationTest extends BaseAITest:
                     cfg.provider.completion(cfg, ask, resultTools, Present(resultSchema))
                 ))
             }
-        def reasoningOf(result: Result[AIException, Result[HttpException, Completion.Reply]]): Maybe[Int] =
+        def reasoningOf(result: Result[AIException, Result[HttpException, Completion.Reply]]): Maybe[Long] =
             result match
-                case Result.Success(Result.Success(reply)) => reply.reasoningTokens
+                case Result.Success(Result.Success(reply)) => reply.usage.reasoningOutputTokens
                 case _                                     => Absent
         val off = config.disableReasoning
         for

--- a/kyo-ai/shared/src/test/scala/kyo/LLMStreamTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/LLMStreamTest.scala
@@ -1045,6 +1045,132 @@ class LLMStreamTest extends kyo.test.Test[Any]:
         }
     }
 
+    "a streamed turn reports its usage" - {
+
+        // OpenAI ends the stream with one complete usage chunk (empty choices), sent because the
+        // request asks for it; the fold sums the elements into the turn's stats.
+        val openAIUsageChunk =
+            """{"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":20,"prompt_tokens_details":{"cached_tokens":7},"completion_tokens_details":{"reasoning_tokens":0}}}"""
+
+        "OpenAI: the final usage chunk lands on the observed reply" in {
+            TestCompletionServer.runStreaming { server =>
+                val config = serverConfig(server.baseUrl)
+                server.enqueueStream(Chunk(
+                    argDelta("{\"resultValue\":\"str"),
+                    argDelta("eamed\"}"),
+                    openAIUsageChunk
+                )).andThen {
+                    LLM.run(config) {
+                        Observe.withStats(AI.stream[String].map(_.fold("")(_ + _)))
+                    }.map { (stats, text) =>
+                        assert(text == "streamed")
+                        assert(stats == AIStats(100L, Present(7L), 20L, Present(0L), 1), s"stats: $stats")
+                    }
+                }
+            }
+        }
+
+        "OpenAI: the streaming request asks for the usage chunk" in {
+            TestCompletionServer.runStreaming { server =>
+                val config = serverConfig(server.baseUrl)
+                server.enqueueStream(Chunk(argDelta("{\"resultValue\":\"x\"}"), openAIUsageChunk)).andThen {
+                    LLM.run(config)(AI.stream[String].map(_.run)).andThen {
+                        server.captured.map { caps =>
+                            assert(caps.nonEmpty)
+                            assert(
+                                caps(0).body.contains("\"include_usage\":true"),
+                                s"the request must carry stream_options.include_usage, body: ${caps(0).body}"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        "Anthropic: the split input and output sides sum to the turn's usage" in {
+            TestCompletionServer.runStreaming { server =>
+                val config = anthropicServerConfig(server.baseUrl)
+                val messageStart =
+                    """{"type":"message_start","message":{"usage":{"input_tokens":50,"output_tokens":1,"cache_read_input_tokens":30,"cache_creation_input_tokens":5}}}"""
+                val messageDelta =
+                    """{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":38}}"""
+                server.enqueueStream(Chunk(
+                    messageStart,
+                    anthropicArgDelta("{\"resultValue\":[{\"text\":\"hi\"}]}"),
+                    messageDelta
+                )).andThen {
+                    LLM.run(config) {
+                        Observe.withStats(AI.stream[Answer].map(_.run))
+                    }.map { (stats, collected) =>
+                        assert(collected == Chunk(Answer("hi")))
+                        // input = 50 + 30 cache-read + 5 cache-creation; output = the final count, not the
+                        // message_start snapshot; one turn.
+                        assert(stats == AIStats(85L, Present(30L), 38L, Absent, 1), s"stats: $stats")
+                    }
+                }
+            }
+        }
+
+        "the observed reply is the recorded synthetic result pair" in {
+            TestCompletionServer.runStreaming { server =>
+                val config = serverConfig(server.baseUrl)
+                AtomicRef.init(Chunk.empty[kyo.ai.completion.Completion.Reply]).map { seen =>
+                    val record = Observe.init((_, reply) => seen.getAndUpdate(_.append(reply)).unit)
+                    server.enqueueStream(Chunk(argDelta("{\"resultValue\":\"ok\"}"), openAIUsageChunk)).andThen {
+                        LLM.run(config)(AI.enable(record)(AI.stream[String].map(_.run))).andThen {
+                            seen.get.map { replies =>
+                                assert(replies.size == 1, s"one streamed turn fires once, got ${replies.size}")
+                                val calls = replies(0).messages.collect { case m: AssistantMessage => m.calls }.flattenChunk
+                                assert(calls.map(_.function) == Chunk("result_tool"), s"calls: $calls")
+                                assert(replies(0).usage.totalTokens == 120L, s"usage: ${replies(0).usage}")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        "an abandoned stream fires no observer" in {
+            TestCompletionServer.runStreaming { server =>
+                val config = serverConfig(server.baseUrl)
+                AtomicRef.init(0).map { fired =>
+                    val count = Observe.init((_, _) => fired.getAndUpdate(_ + 1).unit)
+                    server.enqueueStream(Chunk(argDelta("{\"resultValue\":\"abandoned\"}"), openAIUsageChunk)).andThen {
+                        LLM.run(config) {
+                            AI.enable(count) {
+                                AI.stream[String].map(stream => Scope.run(stream.take(0).run))
+                            }
+                        }.andThen(fired.get.map(n => assert(n == 0, s"an abandoned stream must fire nothing, got $n")))
+                    }
+                }
+            }
+        }
+    }
+
+    "a named instance's config override applies to its stream" in {
+        // The regression guard for the streaming session-env fix: before it, ai.stream read the scope
+        // config and an instance's override was silently ignored (ai.gen honored it).
+        TestCompletionServer.runStreaming { server =>
+            val config = serverConfig(server.baseUrl)
+            server.enqueueStream(Chunk(argDelta("{\"resultValue\":\"routed\"}"))).andThen {
+                LLM.run(config) {
+                    AI.init(config.modelName("overridden-model")).map { ai =>
+                        ai.stream[String].map(_.fold("")(_ + _))
+                    }
+                }.map { text =>
+                    server.captured.map { caps =>
+                        assert(text == "routed")
+                        assert(caps.nonEmpty)
+                        assert(
+                            caps(0).body.contains("\"model\":\"overridden-model\""),
+                            s"the instance override must reach the wire, body: ${caps(0).body}"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     "a keepalive between fragments does not fail the stream" in {
         // A stream may hold the connection open with a payload-free event. It carries no chunk, and
         // reading it as a malformed one fails a generation that was proceeding normally.

--- a/kyo-ai/shared/src/test/scala/kyo/ObserveTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ObserveTest.scala
@@ -1,0 +1,411 @@
+package kyo
+
+import kyo.ai.Config
+import kyo.ai.Context.*
+import kyo.ai.completion.Completion
+
+class ObserveTest extends kyo.test.Test[Any]:
+
+    /** A config pointing the OpenAI backend at the test server, with a dummy key so the backend proceeds
+      * to the HTTP call instead of aborting on a missing key.
+      */
+    def serverConfig(baseUrl: String): Config =
+        Config.OpenAI.default
+            .apiKey("test")
+            .model(Config.OpenAI, "gpt-4o", 128000, Config.OutputMaximum.Verified(16384), Config.ReasoningEncoding.Unavailable, true, true)
+            .apiUrl(baseUrl)
+
+    /** An OpenAI result_tool completion body carrying usage, so a turn reports concrete numbers. */
+    def resultBodyWithUsage(value: String, promptTokens: Int, completionTokens: Int): String =
+        val escaped = Json.encode(s"""{"resultValue":"$value"}""")
+        s"""{"choices":[{"message":{"role":"assistant","content":null,"tool_calls":[{"id":"r1","type":"function","function":{"name":"result_tool","arguments":$escaped}}]}}],""" +
+            s""""usage":{"prompt_tokens":$promptTokens,"completion_tokens":$completionTokens,""" +
+            s""""prompt_tokens_details":{"cached_tokens":7},"completion_tokens_details":{"reasoning_tokens":0}}}"""
+    end resultBodyWithUsage
+
+    /** Wraps an argument JSON fragment in a real OpenAI streaming chunk envelope. */
+    def argDelta(fragment: String): String =
+        val escaped = fragment.replace("\\", "\\\\").replace("\"", "\\\"")
+        s"""{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"$escaped","name":""}}]}}]}"""
+
+    /** An OpenAI completion body with a plain assistant reply and no tool call (the eval loop iterates). */
+    def noResultBody: String =
+        """{"choices":[{"message":{"role":"assistant","content":"thinking","tool_calls":null}}]}"""
+
+    val usageOf100and20 = AIStats(100L, Present(7L), 20L, Present(0L), 1)
+
+    "an observer receives the wire reply: messages and usage" in {
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            AtomicRef.init(Chunk.empty[Completion.Reply]).map { seen =>
+                val record = Observe.init((_, reply) => seen.getAndUpdate(_.append(reply)).unit)
+                server.enqueueBody(resultBodyWithUsage("42", 100, 20)).andThen {
+                    LLM.run(config)(AI.enable(record)(AI.gen[String])).map { result =>
+                        seen.get.map { replies =>
+                            assert(result == "42")
+                            assert(replies.size == 1, s"one turn fires one observer, got ${replies.size}")
+                            val reply = replies(0)
+                            assert(reply.usage == usageOf100and20, s"usage: ${reply.usage}")
+                            assert(reply.stopReason == Completion.StopReason.Completed)
+                            val calls = reply.messages.collect { case m: AssistantMessage => m.calls }.flattenChunk
+                            assert(calls.map(_.function) == Chunk("result_tool"), s"calls: $calls")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "observers fire once per turn across a multi-turn generation" in {
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            AtomicRef.init(0).map { fired =>
+                val count = Observe.init((_, _) => fired.getAndUpdate(_ + 1).unit)
+                server.enqueueBody(noResultBody).andThen {
+                    server.enqueueBody(resultBodyWithUsage("done", 100, 20)).andThen {
+                        LLM.run(config)(AI.enable(count)(AI.gen[String])).map { result =>
+                            fired.get.map { turns =>
+                                assert(result == "done")
+                                assert(turns == 2, s"a resultless turn plus the result turn fire twice, got $turns")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "observers fire in enablement order" in {
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            AtomicRef.init(Chunk.empty[String]).map { recorded =>
+                val first  = Observe.init((_, _) => recorded.getAndUpdate(_.append("first")).unit)
+                val second = Observe.init((_, _) => recorded.getAndUpdate(_.append("second")).unit)
+                server.enqueueBody(resultBodyWithUsage("x", 10, 5)).andThen {
+                    LLM.run(config)(AI.enable(first, second)(AI.gen[String])).andThen {
+                        recorded.get.map(tags => assert(tags == Chunk("first", "second"), s"order: $tags"))
+                    }
+                }
+            }
+        }
+    }
+
+    "an instance observer fires for that instance's turns and stays silent for a sibling's" in {
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            AtomicRef.init(Chunk.empty[Long]).map { firedFor =>
+                LLM.run(config) {
+                    AI.initWith { watched =>
+                        AI.initWith { sibling =>
+                            val record = Observe.init((ai, _) => firedFor.getAndUpdate(_.append(ai.id)).unit)
+                            watched.enable(record).map { _ =>
+                                server.enqueueBody(resultBodyWithUsage("a", 10, 5)).andThen {
+                                    server.enqueueBody(resultBodyWithUsage("b", 10, 5)).andThen {
+                                        watched.gen[String].map(a => sibling.gen[String].map(b => (watched.id, a, b)))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }.map { (watchedId, a, b) =>
+                    firedFor.get.map { ids =>
+                        assert(a == "a" && b == "b")
+                        assert(ids == Chunk(watchedId), s"only the watched instance's turn fires, got ids: $ids")
+                    }
+                }
+            }
+        }
+    }
+
+    "an observer whose S aborts is a guardrail: its failure fails the generation, typed at the boundary" in {
+        case class BudgetExceeded(spent: Long)
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            val budget: Observe[Abort[BudgetExceeded]] =
+                new Observe[Abort[BudgetExceeded]]:
+                    def apply(ai: AI, reply: Completion.Reply)(using Frame): Unit < (LLM & Sync & Abort[BudgetExceeded]) =
+                        if reply.usage.totalTokens > 50 then Abort.fail(BudgetExceeded(reply.usage.totalTokens))
+                        else ()
+            server.enqueueBody(resultBodyWithUsage("expensive", 100, 20)).andThen {
+                Abort.run[BudgetExceeded] {
+                    Abort.run[AIException](LLM.run(config)(AI.enable(budget)(AI.gen[String])))
+                }.map { result =>
+                    assert(result == Result.Failure(BudgetExceeded(120L)), s"got: $result")
+                }
+            }
+        }
+    }
+
+    "a turn that aborts at the output ceiling still fires the observer" in {
+        TestCompletionServer.run { server =>
+            val config = Config.Anthropic.default.apiKey("test").apiUrl(server.baseUrl)
+            AtomicRef.init(Chunk.empty[AIStats]).map { seen =>
+                val record = Observe.init((_, reply) => seen.getAndUpdate(_.append(reply.usage)).unit)
+                server.enqueueBody(
+                    """{"id":"m","content":[],"model":"m","role":"assistant","stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":9,"output_tokens":4}}"""
+                ).andThen {
+                    Abort.run[AIException](LLM.run(config)(AI.enable(record)(AI.gen[String]))).map { result =>
+                        seen.get.map { usages =>
+                            val ceiling = result match
+                                case Result.Failure(_: AIOutputLimitException) => true
+                                case _                                         => false
+                            assert(ceiling, s"expected AIOutputLimitException, got: $result")
+                            assert(
+                                usages == Chunk(AIStats(9L, Absent, 4L, Absent, 1)),
+                                s"the aborted turn's spend must be observed, got: $usages"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "a rejected tool call fires with empty stats, the repair turn with real ones" in {
+        // Config.Groq declares InvalidToolCalls.Rejected("tool_use_failed"): the 400 never reaches the loop
+        // as a reply, so the observer sees the synthesized empty turn, then the repair turn's real usage.
+        TestCompletionServer.run { server =>
+            val config = Config.Groq.default.apiKey("test").apiUrl(server.baseUrl)
+            AtomicRef.init(Chunk.empty[AIStats]).map { seen =>
+                val record = Observe.init((_, reply) => seen.getAndUpdate(_.append(reply.usage)).unit)
+                server.enqueueStatus(400, """{"error":{"code":"tool_use_failed","message":"bad arguments"}}""").andThen {
+                    server.enqueueBody(resultBodyWithUsage("repaired", 100, 20)).andThen {
+                        LLM.run(config)(AI.enable(record)(AI.gen[String])).map { result =>
+                            seen.get.map { usages =>
+                                assert(result == "repaired")
+                                assert(
+                                    usages == Chunk(AIStats.empty, usageOf100and20),
+                                    s"expected the synthetic empty turn then the repair turn, got: $usages"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "withStats reports what the computation spent, alongside its result" in {
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            server.enqueueBody(resultBodyWithUsage("one", 100, 20)).andThen {
+                server.enqueueBody(resultBodyWithUsage("two", 100, 20)).andThen {
+                    LLM.run(config) {
+                        Observe.withStats(AI.gen[String].map(a => AI.gen[String].map(b => (a, b))))
+                    }.map { (stats, results) =>
+                        assert(results == ("one", "two"))
+                        assert(stats == usageOf100and20.add(usageOf100and20), s"stats: $stats")
+                        assert(stats.turns == 2)
+                    }
+                }
+            }
+        }
+    }
+
+    "withStats with no generation reports empty" in {
+        LLM.run(Observe.withStats(Kyo.lift(42))).map { (stats, result) =>
+            assert(result == 42)
+            assert(stats == AIStats.empty)
+        }
+    }
+
+    "targeted withStats breaks down interleaved instances and excludes the unnamed" in {
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            Kyo.foreachDiscard(0 until 3)(_ => server.enqueueBody(resultBodyWithUsage("r", 100, 20))).andThen {
+                LLM.run(config) {
+                    AI.initWith { a =>
+                        AI.initWith { b =>
+                            Observe.withStats {
+                                Observe.withStats(a, b) {
+                                    // Interleaved: a, then the unnamed one-shot, then b.
+                                    a.gen[String].map(_ => AI.gen[String].map(_ => b.gen[String])).map(_ => (a, b))
+                                }
+                            }
+                        }
+                    }
+                }.map { case (total, (byInstance, (a, b))) =>
+                    assert(byInstance.size == 2, s"both named instances appear, got: ${byInstance.size}")
+                    assert(byInstance.get(a) == Present(usageOf100and20), s"a: ${byInstance.get(a)}")
+                    assert(byInstance.get(b) == Present(usageOf100and20), s"b: ${byInstance.get(b)}")
+                    assert(total.turns == 3, s"the scope total counts the unnamed one-shot too, got: $total")
+                    assert(total.totalTokens == 360L, s"total: $total")
+                }
+            }
+        }
+    }
+
+    "a named instance that completed no turn appears as empty" in {
+        LLM.run {
+            AI.initWith { idle =>
+                Observe.withStats(idle)(Kyo.lift("nothing")).map { (byInstance, result) =>
+                    assert(result == "nothing")
+                    assert(byInstance.get(idle) == Present(AIStats.empty), s"got: ${byInstance.get(idle)}")
+                }
+            }
+        }
+    }
+
+    "nested brackets both see an inner turn" in {
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            server.enqueueBody(resultBodyWithUsage("inner", 100, 20)).andThen {
+                LLM.run(config) {
+                    Observe.withStats(Observe.withStats(AI.gen[String]))
+                }.map { case (outer, (inner, result)) =>
+                    assert(result == "inner")
+                    assert(inner == usageOf100and20, s"inner: $inner")
+                    assert(outer == usageOf100and20, s"outer: $outer")
+                }
+            }
+        }
+    }
+
+    "parallel brackets are disjoint" in {
+        // Both branches consume identical bodies, so whichever order the server pops them in, a bracket
+        // that leaked the sibling's spend would report 240 tokens; each must report exactly its own 120.
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            Kyo.foreachDiscard(0 until 2)(_ => server.enqueueBody(resultBodyWithUsage("r", 100, 20))).andThen {
+                LLM.run(config) {
+                    Async.zip(
+                        Observe.withStats(AI.gen[String]),
+                        Observe.withStats(AI.gen[String])
+                    )
+                }.map { case ((statsA, _), (statsB, _)) =>
+                    assert(statsA == usageOf100and20, s"a: $statsA")
+                    assert(statsB == usageOf100and20, s"b: $statsB")
+                }
+            }
+        }
+    }
+
+    "a losing race branch's completed turn is counted" in {
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            server.enqueueBody(resultBodyWithUsage("loser", 100, 20)).andThen {
+                Latch.init(1).map { genDone =>
+                    Latch.init(1).map { never =>
+                        // The loser completes a real generation, signals, then blocks forever; the winner
+                        // waits for the signal, so the loser's turn always completes before the race ends.
+                        val loser: String < (LLM & Async)  = AI.gen[String].map(r => genDone.release.andThen(never.await).andThen(r))
+                        val winner: String < (LLM & Async) = genDone.await.andThen(Kyo.lift("winner"))
+                        LLM.run(config) {
+                            Observe.withStats(Async.race(loser, winner))
+                        }.map { (stats, result) =>
+                            assert(result == "winner")
+                            assert(stats == usageOf100and20, s"the discarded loser's turn must be counted, got: $stats")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "withStats survives forget: a rolled-back branch cannot un-spend" in {
+        TestCompletionServer.run { server =>
+            val config = serverConfig(server.baseUrl)
+            server.enqueueBody(resultBodyWithUsage("rolled-back", 100, 20)).andThen {
+                LLM.run(config) {
+                    Observe.withStats(AI.forget(AI.gen[String]))
+                }.map { (stats, result) =>
+                    assert(result == "rolled-back")
+                    assert(stats == usageOf100and20, s"forget must not un-spend, got: $stats")
+                }
+            }
+        }
+    }
+
+    "a foreign run's instance named as a target panics with the cross-run error" in {
+        LLM.run(AI.init).map { escaped =>
+            Abort.run[AIException](LLM.run(Observe.withStats(escaped)(Kyo.lift(())))).map { result =>
+                assert(result.isPanic, s"cross-run target should panic, got: $result")
+            }
+        }
+    }
+
+    "a streaming observer sees the conversation up to, not including, the turn" in {
+        // The documented invariant, path-symmetric with generation: the fire precedes the context
+        // append, so ai.context inside the callback excludes the streamed turn the reply carries.
+        TestCompletionServer.runStreaming { server =>
+            val config = serverConfig(server.baseUrl)
+            AtomicRef.init(-1).map { seenSize =>
+                val record = Observe.init((ai, _) => ai.context.map(ctx => seenSize.set(ctx.messages.size)))
+                server.enqueueStream(Chunk(argDelta("{\"resultValue\":\"streamed\"}"))).andThen {
+                    LLM.run(config) {
+                        AI.initWith { ai =>
+                            ai.userMessage("before").andThen {
+                                AI.enable(record)(ai.stream[String].map(_.run)).andThen {
+                                    ai.context.map(after => (after.messages.size))
+                                }
+                            }
+                        }
+                    }.map { afterSize =>
+                        seenSize.get.map { seen =>
+                            assert(seen == 1, s"the observer must see only the pre-turn message, got $seen")
+                            assert(afterSize == 3, s"the turn joins the context after the fire, got $afterSize")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    "a fully consumed stream with no usage element still counts one turn" in {
+        // A provider that ignores the usage request reports nothing; the turn count is structural.
+        TestCompletionServer.runStreaming { server =>
+            val config = serverConfig(server.baseUrl)
+            server.enqueueStream(Chunk(argDelta("{\"resultValue\":\"quiet\"}"))).andThen {
+                LLM.run(config) {
+                    Observe.withStats(AI.stream[String].map(_.fold("")(_ + _)))
+                }.map { (stats, text) =>
+                    assert(text == "quiet")
+                    assert(stats == AIStats(0L, Absent, 0L, Absent, 1), s"one structural turn, no tokens known; got $stats")
+                }
+            }
+        }
+    }
+
+    "a recovered guardrail abort on a streamed turn leaves the scope env clean" in {
+        // The streaming fire site runs in the consumer's frames, so a guardrail abort CAN be recovered
+        // inside the run; the merged session env (config override and the guard itself) must not leak
+        // into the scope. Before the any-exit restore, the second request went out with the leaked
+        // "leaky-model" override and the leaked guard fired again.
+        case class Tripped()
+        TestCompletionServer.runStreaming { server =>
+            val config = serverConfig(server.baseUrl)
+            val guard: Observe[Abort[Tripped]] =
+                new Observe[Abort[Tripped]]:
+                    def apply(ai: AI, reply: Completion.Reply)(using Frame): Unit < (LLM & Sync & Abort[Tripped]) =
+                        Abort.fail(Tripped())
+            server.enqueueStream(Chunk(argDelta("{\"resultValue\":\"first\"}"))).andThen {
+                server.enqueueStream(Chunk(argDelta("{\"resultValue\":\"second\"}"))).andThen {
+                    LLM.run(config) {
+                        AI.init(config.modelName("leaky-model")).map { ai =>
+                            ai.enable(guard).map { _ =>
+                                Abort.run[Tripped](ai.stream[String].map(_.run)).map { tripped =>
+                                    AI.stream[String].map(_.fold("")(_ + _)).map(second => (tripped, second))
+                                }
+                            }
+                        }
+                    }.map { (tripped, second) =>
+                        server.captured.map { caps =>
+                            assert(tripped == Result.Failure(Tripped()), s"the guard must fire and be recoverable: $tripped")
+                            assert(second == "second", s"the run must continue cleanly, got: $second")
+                            assert(caps.size == 2, s"two requests expected, got ${caps.size}")
+                            assert(
+                                caps(0).body.contains("\"model\":\"leaky-model\""),
+                                s"the guarded instance's stream carries its override: ${caps(0).body}"
+                            )
+                            assert(
+                                caps(1).body.contains("\"model\":\"gpt-4o\"") && !caps(1).body.contains("leaky-model"),
+                                s"after recovery the scope config must be restored: ${caps(1).body}"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+end ObserveTest

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/AnthropicCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/AnthropicCompletionTest.scala
@@ -806,4 +806,22 @@ class AnthropicCompletionTest extends kyo.test.Test[Any]:
         }
     }
 
+    "usage sums the cache fields into the input total: creation counts as read, not cached" in {
+        // This wire reports cache traffic BESIDE input_tokens: the input total is all three summed,
+        // cachedInputTokens is the cache_read side alone, and reasoning is never broken out.
+        TestCompletionServer.run { server =>
+            val config = keyedConfig(server.baseUrl)
+            val body =
+                """{"id":"msg-1","content":[{"type":"text","text":"ok"}],"model":"m","role":"assistant","stop_reason":"end_turn","stop_sequence":null,""" +
+                    """"usage":{"input_tokens":50,"output_tokens":7,"cache_read_input_tokens":30,"cache_creation_input_tokens":5}}"""
+            server.enqueueBody(body).andThen {
+                LLM.run(config) {
+                    AnthropicCompletion(config, Context.empty.userMessage("hi"), Chunk.empty, Absent)
+                }.map { reply =>
+                    assert(reply.usage == AIStats(85L, Present(30L), 7L, Absent, 1), s"got ${reply.usage}")
+                }
+            }
+        }
+    }
+
 end AnthropicCompletionTest

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeWireTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/ClaudeCodeWireTest.scala
@@ -375,4 +375,40 @@ class ClaudeCodeWireTest extends kyo.test.Test[Any]:
         end for
     }
 
+    "turnUsage prefers the terminal result event's aggregate" in {
+        // The result event sums the invocation's internal iterations (verified live), so it wins over
+        // the per-message assistant events, whose output counts are message-start snapshots.
+        val output =
+            """{"type":"assistant","message":{"id":"msg_1","role":"assistant","content":[],"usage":{"input_tokens":10,"output_tokens":4,"cache_read_input_tokens":0,"cache_creation_input_tokens":29065}}}
+              |{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":10,"output_tokens":38,"cache_read_input_tokens":5,"cache_creation_input_tokens":29065}}""".stripMargin
+        Abort.run[AIGenException](ClaudeCodeWire.turnUsage(output)).map { result =>
+            assert(
+                result == Result.succeed(AIStats(29080L, Present(5L), 38L, Absent, 1)),
+                s"the aggregate must win: input 10+5+29065, cached 5, output 38, one turn; got $result"
+            )
+        }
+    }
+
+    "turnUsage falls back to assistant events deduplicated by message id" in {
+        // The kill-on-capture path never sees the result event, and the CLI re-emits an event per
+        // message (verified live): the same id must count once, distinct ids sum.
+        val output =
+            """{"type":"assistant","message":{"id":"msg_1","role":"assistant","content":[],"usage":{"input_tokens":10,"output_tokens":4,"cache_read_input_tokens":2,"cache_creation_input_tokens":100}}}
+              |{"type":"assistant","message":{"id":"msg_1","role":"assistant","content":[],"usage":{"input_tokens":10,"output_tokens":4,"cache_read_input_tokens":2,"cache_creation_input_tokens":100}}}
+              |{"type":"assistant","message":{"id":"msg_2","role":"assistant","content":[],"usage":{"input_tokens":50,"output_tokens":7,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}""".stripMargin
+        Abort.run[AIGenException](ClaudeCodeWire.turnUsage(output)).map { result =>
+            assert(
+                result == Result.succeed(AIStats(162L, Present(2L), 11L, Absent, 1)),
+                s"msg_1 counts once (112 in, 4 out) plus msg_2 (50 in, 7 out), one turn; got $result"
+            )
+        }
+    }
+
+    "turnUsage on output with no usage anywhere reports one turn of zeros" in {
+        val output = """{"type":"system","subtype":"init","session_id":"s"}"""
+        Abort.run[AIGenException](ClaudeCodeWire.turnUsage(output)).map { result =>
+            assert(result == Result.succeed(AIStats(0L, Absent, 0L, Absent, 1)), s"got $result")
+        }
+    }
+
 end ClaudeCodeWireTest

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/CodexWireTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/CodexWireTest.scala
@@ -287,4 +287,25 @@ class CodexWireTest extends kyo.test.Test[Any]:
         assert(empty.isEmpty, s"a resultless empty turn produces no messages: $empty")
     }
 
+    "thread/tokenUsage/updated decodes and maps the thread total onto AIStats" in {
+        // The fixture is the RAW wire JSON captured from a live app-server run, not a round-trip of the
+        // DTO, so a drift in the camelCase field names fails here. reasoningOutputTokens is reported
+        // even when zero, which must stay Present(0), not Absent.
+        val params = Json.decode[Structure.Value](
+            """{"threadId":"t1","turnId":"u1","tokenUsage":{
+              |"total":{"totalTokens":5963,"inputTokens":5958,"cachedInputTokens":2432,"outputTokens":5,"reasoningOutputTokens":0},
+              |"last":{"totalTokens":5963,"inputTokens":5958,"cachedInputTokens":2432,"outputTokens":5,"reasoningOutputTokens":0},
+              |"modelContextWindow":258400}}""".stripMargin.replace("\n", "")
+        ).getOrThrow
+        val event = CodexWire.RpcEvent("thread/tokenUsage/updated", params)
+        Abort.run[AIGenException](CodexWire.decodeEvent[CodexWire.TokenUsageNotification](event)).map { decoded =>
+            assert(decoded.isSuccess, s"the notification must decode: $decoded")
+            val stats = decoded.map(n => n.tokenUsage.total.map(CodexWire.usageStats))
+            assert(
+                stats == Result.succeed(Present(AIStats(5958L, Present(2432L), 5L, Present(0L), 1))),
+                s"got $stats"
+            )
+        }
+    }
+
 end CodexWireTest


### PR DESCRIPTION
Problem
-------
Every provider reports what a turn spent (tokens read, served from cache, produced, spent reasoning) and kyo-ai discarded nearly all of it: one backend kept a single subset field for one error message, the others decoded nothing. Callers had no way to answer what a computation cost, and no seam to react to turns at all: Mode intercepts at the result tier (it sees the decoded value, never the wire reply, and does not run on the streaming path), so passive concerns like usage metering, transcript capture, or a spend guardrail had nowhere to attach.

Solution
--------
Add Observe, the fifth enablement kind: the wire-tier, notification-only counterpart of Mode. Where a mode receives the generation as a value and may replace it, an observer receives each completed turn's Completion.Reply and returns Unit, so it cannot change control flow; an Abort in its capability row is a typed guardrail whose failure fails the generation it fired in. Observers fire once per turn on the fiber that ran it, at the moment the wire reply is read: before the ceiling adjudication (a turn that aborts at the ceiling still spent its tokens), on the generation and streaming paths alike, and inside forks, so a losing race branch and a rolled-back forget block still report the turns they completed.

All four backends decode their wire's usage into Reply.usage as AIStats: input, cached-input, output, and reasoning-output tokens plus turns, with the subsets kept Maybe so a reported zero stays distinct from a wire that never breaks the number out. Observe.withStats collects stats over a scope, alongside the result, with a per-instance breakdown variant; Observe.init builds custom observers. Streaming carries usage as stream elements the consumers sum, and a fully consumed stream fires observers with the recorded synthetic result pair.

Notes
-----
- ai.stream previously ignored an instance's config override and enablements while ai.gen honored them; streamAgainst now applies the session env the way genLoop does.
- StopReason becomes public as part of Reply being the observer payload.
- The Claude Code kill-on-capture path reports a stated lower bound for output tokens (the terminal result event never arrives, so assistant events are summed after dedup by message id); both harness usage shapes were verified against live runs.
