### PR TITLE
[kyo-test] add golden snapshot testing over generated samples

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2914,6 +2914,7 @@ lazy val `kyo-test-snapshot` =
         .crossType(CrossType.Full)
         .dependsOn(`kyo-test-api`)
         .dependsOn(`kyo-data`)
+        .dependsOn(`kyo-schema`)
         .dependsOn(`kyo-test-runner` % Test)
         .in(file("kyo-test/snapshot"))
         .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -2915,6 +2915,7 @@ lazy val `kyo-test-snapshot` =
         .dependsOn(`kyo-test-api`)
         .dependsOn(`kyo-data`)
         .dependsOn(`kyo-schema`)
+        .dependsOn(`kyo-test-prop`)
         .dependsOn(`kyo-test-runner` % Test)
         .in(file("kyo-test/snapshot"))
         .settings(

--- a/kyo-test/README.md
+++ b/kyo-test/README.md
@@ -458,7 +458,7 @@ val doubleShrinks: Chunk[Double] = Shrink.double(2.7) // 2.0 (integral neighbor)
 
 ## Write meaningful tests: no-assertion enforcement
 
-A leaf that runs to completion having evaluated zero assertions is itself a bug: it proves nothing. kyo-test enforces this at run time. After a leaf body joins, the runner counts how many assertions it evaluated; a leaf that would otherwise pass with a count of zero is flipped to `Failed` with the message `leaf passed without evaluating any assertion`. The whole assert family counts: `assert`, `fail`, `intercept`, `assertEventually`, `typeCheck`, `assertSnapshot`, and a property `forAll`. `cancel` and `assume` do not count, because they steer the outcome rather than make a claim.
+A leaf that runs to completion having evaluated zero assertions is itself a bug: it proves nothing. kyo-test enforces this at run time. After a leaf body joins, the runner counts how many assertions it evaluated; a leaf that would otherwise pass with a count of zero is flipped to `Failed` with the message `leaf passed without evaluating any assertion`. The whole assert family counts: `assert`, `fail`, `intercept`, `assertEventually`, `typeCheck`, `assertSnapshot`, `assertSchemaSnapshot`, and a property `forAll`. `cancel` and `assume` do not count, because they steer the outcome rather than make a claim.
 
 This is a run-level setting, `failOnNoAssertion`, on by default. ScalaTest forced this at compile time through its `Assertion` return type; kyo-test cannot, because a leaf body is an effectful `Unit < (S & Async & Abort[Any] & Scope)`, so the check runs after the body completes.
 
@@ -508,6 +508,31 @@ end StatementSnapshotTest
 ```
 
 > **Caution:** the first run of `assertSnapshot` writes the proposed snapshot file and FAILS with `SnapshotNotFound`; the test passes only on a later run once you have reviewed the written file. To accept new or changed snapshots, run with `KYO_TEST_SNAPSHOT=update` in the environment (or override `snapshotUpdateMode` per suite). Snapshot names may not contain path separators, spaces, `.`, or `..`.
+
+### `assertSchemaSnapshot`: schema-based snapshots
+
+When a `Schema[A]` instance is in scope, reach for `assertSchemaSnapshot(actual, name)` instead. It renders `actual` through its `Schema[A]` using a `SnapshotCodec` (default `SnapshotCodec.Yaml`, a readable field-named format) and stores the result under `${snapshotDir}/${suite}/${name}.snap.yaml`, a distinct extension from `assertSnapshot`'s plain `.snap` so the two never collide on the same name.
+
+```scala
+import kyo.*
+import kyo.test.*
+import kyo.test.snapshot.*
+
+case class Statement(id: Int, balanceCents: Long, generatedAt: Long) derives Schema
+
+class SchemaStatementSnapshotTest extends SnapshotTest[Any]:
+    "monthly statement" in {
+        val statement = Statement(1, balanceCents = 12_300L, generatedAt = java.lang.System.currentTimeMillis())
+        assertSchemaSnapshot(statement, "monthly-schema", _.normalize(_.set(_.generatedAt)(0L)))
+    }
+end SchemaStatementSnapshotTest
+```
+
+The third argument builds a `SnapshotConfig[A]`, the single per-call customization point: `.normalize` scrubs non-deterministic fields (timestamps, ids) before both encoding and comparison, so a repeated run with a fresh timestamp still matches the stored snapshot. A suite that needs a different serialization format overrides the per-suite `snapshotCodec` hook (default `SnapshotCodec.Yaml`); the text presets are `Yaml`, `Json`, and `Ion`, the binary presets (stored as raw wire bytes) are `Protobuf`, `Bson`, `MsgPack`, and `IonBinary`, and `SnapshotCodec.Text`/`Binary` wrap any other kyo-schema `Codec`.
+
+> **Note:** the comparison is structural and format-tolerant: a hand-reformatted stored snapshot that still decodes to an equal value passes. A mismatch reports the changed field paths (dotted for a nested field, e.g. `b.y`) plus a unified text diff for text codecs. A stored snapshot that fails to decode at all (a genuine schema evolution) fails with `SnapshotSchemaEvolution` instead, distinct from a value mismatch.
+
+Reach for `assertSnapshot` when a `Render` instance is all you need (a quick, flat text snapshot); reach for `assertSchemaSnapshot` when you have a `Schema[A]` and want readable field-named output, field normalization, format-tolerant comparison, or schema-evolution detection.
 
 ## Running and selecting tests
 

--- a/kyo-test/README.md
+++ b/kyo-test/README.md
@@ -458,7 +458,7 @@ val doubleShrinks: Chunk[Double] = Shrink.double(2.7) // 2.0 (integral neighbor)
 
 ## Write meaningful tests: no-assertion enforcement
 
-A leaf that runs to completion having evaluated zero assertions is itself a bug: it proves nothing. kyo-test enforces this at run time. After a leaf body joins, the runner counts how many assertions it evaluated; a leaf that would otherwise pass with a count of zero is flipped to `Failed` with the message `leaf passed without evaluating any assertion`. The whole assert family counts: `assert`, `fail`, `intercept`, `assertEventually`, `typeCheck`, `assertSnapshot`, `assertSchemaSnapshot`, and a property `forAll`. `cancel` and `assume` do not count, because they steer the outcome rather than make a claim.
+A leaf that runs to completion having evaluated zero assertions is itself a bug: it proves nothing. kyo-test enforces this at run time. After a leaf body joins, the runner counts how many assertions it evaluated; a leaf that would otherwise pass with a count of zero is flipped to `Failed` with the message `leaf passed without evaluating any assertion`. The whole assert family counts: `assert`, `fail`, `intercept`, `assertEventually`, `typeCheck`, `assertSnapshot`, `assertSchemaSnapshot`, `assertGoldenSnapshot`, and a property `forAll`. `cancel` and `assume` do not count, because they steer the outcome rather than make a claim.
 
 This is a run-level setting, `failOnNoAssertion`, on by default. ScalaTest forced this at compile time through its `Assertion` return type; kyo-test cannot, because a leaf body is an effectful `Unit < (S & Async & Abort[Any] & Scope)`, so the check runs after the body completes.
 
@@ -532,7 +532,32 @@ The third argument builds a `SnapshotConfig[A]`, the single per-call customizati
 
 > **Note:** the comparison is structural and format-tolerant: a hand-reformatted stored snapshot that still decodes to an equal value passes. A mismatch reports the changed field paths (dotted for a nested field, e.g. `b.y`) plus a unified text diff for text codecs. A stored snapshot that fails to decode at all (a genuine schema evolution) fails with `SnapshotSchemaEvolution` instead, distinct from a value mismatch.
 
-Reach for `assertSnapshot` when a `Render` instance is all you need (a quick, flat text snapshot); reach for `assertSchemaSnapshot` when you have a `Schema[A]` and want readable field-named output, field normalization, format-tolerant comparison, or schema-evolution detection.
+### `assertGoldenSnapshot`: golden snapshots over a generated spread
+
+When both a `Gen[A]` and a `Schema[A]` are in scope, reach for `assertGoldenSnapshot[A](name)` instead. Where `assertSchemaSnapshot` locks one hand-picked value, golden draws a deterministic spread of `sampleCount` values (default 20) from the generator, normalizes each, and stores the whole spread as ONE document under `${snapshotDir}/${suite}/${name}.golden.${bare}` (for example `event.golden.yaml`), wrapped as a `samples`-keyed object.
+
+```scala
+import kyo.*
+import kyo.test.*
+import kyo.test.prop.*
+import kyo.test.snapshot.*
+
+case class Event(id: Int, kind: String) derives Schema
+
+given Gen[Event] = Gen.derive[Event]
+
+class EventGoldenTest extends SnapshotTest[Any]:
+    "event wire format" in {
+        assertGoldenSnapshot[Event]("event", _.sampleCount(50))
+    }
+end EventGoldenTest
+```
+
+A later run regenerates the same spread and compares it per sample, so a wire-format change to any field the spread exercises is caught and reported as `sample[N].field`, including a field a single hand-written value would never have covered. The optional second argument builds a `GoldenConfig[A]`, the per-call customization point: `.sampleCount`, `.seed`, and `.size` tune the generated spread, and `.normalize` scrubs non-deterministic fields before both encoding and comparison (the same field scrub `assertSchemaSnapshot` uses). Its `golden.*` extension never collides with `assertSnapshot`'s `.snap` or `assertSchemaSnapshot`'s `.snap.*`.
+
+> **Note:** golden shares the first-run write-then-fail and `KYO_TEST_SNAPSHOT=update` bless of the other two assertions: the first run writes the proposed spread and fails with `SnapshotNotFound`, and only a later run against the reviewed, blessed file passes.
+
+Reach for `assertSnapshot` when a `Render` instance is all you need (a quick, flat text snapshot); reach for `assertSchemaSnapshot` when you have a `Schema[A]` and want readable field-named output, field normalization, format-tolerant comparison, or schema-evolution detection on a single value; reach for `assertGoldenSnapshot` when you want to lock a type's wire format across the whole range of values it can hold, so the test survives schema changes without rewriting fixtures.
 
 ## Running and selecting tests
 
@@ -580,7 +605,7 @@ val config: RunConfig =
 
 `TestFilter` selects leaves: `pathInclude`/`pathExclude` are globs against the dot-joined leaf path, `tagsInclude`/`tagsExclude` are exact tag names. Includes act as allow-lists; excludes apply after. `TestFilter.empty` runs everything. `Verbosity` is `Quiet` / `Normal` / `Verbose`. Two `RunConfig` flags toggle discovery-only modes: `countOnly` reports the leaf count without running bodies, and `listOnly` additionally prints every leaf path (implying count-only). `strictStructure` turns on strict leaf-name-path validation, rejecting duplicate or structurally invalid paths at registration time.
 
-> **Note:** `parallelism = 1` means within-suite sequential (the suite's leaves run one at a time); `0` (the default) and any `N > 1` mean parallel: leaves are pushed to the process-global pool and the pool's `globalK` bound sets the real degree of concurrency; `N > 1` is no longer a per-suite cap. On Scala Native `globalK = 1`, so all leaves run sequentially regardless of the requested value.
+> **Note:** `parallelism = 1` means within-suite sequential (the suite's leaves run one at a time); `0` (the default) and any `N > 1` mean parallel: leaves are pushed to the process-global pool and the pool's `globalK` bound sets the real degree of concurrency; `N > 1` requests parallel leaves bounded by the pool's `globalK`, not a per-suite cap. On Scala Native `globalK = 1`, so all leaves run sequentially regardless of the requested value.
 
 ### Outcomes and counters
 

--- a/kyo-test/api/shared/src/main/scala/kyo/test/AssertScope.scala
+++ b/kyo-test/api/shared/src/main/scala/kyo/test/AssertScope.scala
@@ -109,7 +109,7 @@ object AssertScope:
     private[kyo] val noAssertionDiagram: String =
         "leaf passed without evaluating any assertion\n\n" +
             "The leaf body ran to completion and produced no failures, but no assert, intercept, fail,\n" +
-            "assertEventually, typeCheck, assertSnapshot, or forAll call was reached on this run.\n\n" +
+            "assertEventually, typeCheck, assertSnapshot, assertSchemaSnapshot, or forAll call was reached on this run.\n\n" +
             "Fix: add a concrete assertion on the result (preferred), or if the intent is genuinely\n" +
             "'verify it runs without error', write `succeed` (or `succeed(\"why\")`) in the leaf body.\n\n" +
             "To disable this check run-wide: RunConfig.default.failOnNoAssertion(false).\n" +

--- a/kyo-test/api/shared/src/main/scala/kyo/test/AssertScope.scala
+++ b/kyo-test/api/shared/src/main/scala/kyo/test/AssertScope.scala
@@ -109,7 +109,7 @@ object AssertScope:
     private[kyo] val noAssertionDiagram: String =
         "leaf passed without evaluating any assertion\n\n" +
             "The leaf body ran to completion and produced no failures, but no assert, intercept, fail,\n" +
-            "assertEventually, typeCheck, assertSnapshot, assertSchemaSnapshot, or forAll call was reached on this run.\n\n" +
+            "assertEventually, typeCheck, assertSnapshot, assertSchemaSnapshot, assertGoldenSnapshot, or forAll call was reached on this run.\n\n" +
             "Fix: add a concrete assertion on the result (preferred), or if the intent is genuinely\n" +
             "'verify it runs without error', write `succeed` (or `succeed(\"why\")`) in the leaf body.\n\n" +
             "To disable this check run-wide: RunConfig.default.failOnNoAssertion(false).\n" +

--- a/kyo-test/prop/CONTRIBUTING.md
+++ b/kyo-test/prop/CONTRIBUTING.md
@@ -1,0 +1,136 @@
+# Contributing to kyo-test-prop
+
+This guide complements the root [CONTRIBUTING.md](../../CONTRIBUTING.md), which covers every global Kyo convention (naming, `Maybe` / `Result` / `Chunk` / `Span`, `using`-clause ordering, Frame/Tag, inline guidelines, scaladoc, visibility tiers, cross-platform source placement, `AllowUnsafe`). Defer to the root guide for those; this file covers only what is specific to the property-testing module (`kyo-test/prop`, sbt project `kyo-test-prop`).
+
+**The headline invariant:** every generator is a pure function of a splittable seed, and shrinking is integrated, not bolted on. A `Gen[A]` samples a rose `Tree[A]` (the value plus the full lazy tree of its shrink candidates) from a pure `Seed` and a size hint, so `map` / `flatMap` / `filter` propagate shrinking structurally through the `Tree` combinators instead of dropping it (`shared/src/main/scala/kyo/test/prop/Gen.scala:9-38`, `internal/Tree.scala:3-16`). Determinism follows from purity: a fixed `(seed, size)` pair always produces the same `Tree` (`PropertyTest.scala:137`). Keep both properties intact: a generator that reaches for a mutable RNG, or a combinator that discards the source tree's shrink structure, breaks the model.
+
+Like [kyo-test-snapshot](../snapshot/CONTRIBUTING.md), this module is an inheritance-based DSL. A suite gains `forAll` by extending `PropertyTest[S]` (or the marker-free `PropertyTestBase[S]`), and the DSL methods are `protected`: "The DSL methods in this class use `protected` visibility because the framework contract is inheritance-based; this is a deliberate exception to the `No protected` convention (CONTRIBUTING P5)" (`PropertyTest.scala:37-38`). Keep a new DSL method `protected` on the base, never a package function.
+
+## Architecture overview
+
+Every public type lives in `shared/src/main/scala/kyo/test/prop/`; the shrinking primitives are internal, under `internal/`.
+
+| Type | File | Purpose |
+|------|------|---------|
+| `Gen[A]` | `Gen.scala:26` | The generator: `sample(seed, size): Tree[A]`, plus `map`/`flatMap`/`filter` and the companion's built-ins and combinators |
+| `PropertyTestBase[S]` | `PropertyTest.scala:51` | Marker-free base carrying the `forAll` DSL; extended by non-discoverable internal fixtures |
+| `PropertyTest[S]` | `PropertyTest.scala:320` | Public discoverable base: `PropertyTestBase[S] with SuiteFingerprintMarker` |
+| `Shrink` | `Shrink.scala:17` | Primitive shrink algorithms exposed for custom generators (`int`/`long`/`double`/`string`/`list`) |
+| `PropertyFailedException` | `PropertyFailedException.scala:30` | Carries the original and the shrunk counterexample plus the run seed for replay |
+| `Seed` | `internal/Seed.scala:15` | Pure splittable SplitMix64 seed (opaque over `Long`) |
+| `Tree[A]` | `internal/Tree.scala:16` | Rose tree of a value and its lazy shrink candidates; the integrated-shrinking core |
+| `GenDerive` | `internal/GenDerive.scala:16` | Macro deriving `Gen[A]` from a `scala.deriving.Mirror` |
+
+`PropertyTest[S]` adds only the discovery marker; all `forAll` machinery lives on `PropertyTestBase[S]` (`PropertyTest.scala:309-311`). The base is split off precisely so the deliberately-failing fixture suites in this module's own tests can extend it and stay out of test discovery on every platform, including Scala Native's reflective discovery, which "matches the marker on the actual class hierarchy via `@EnableReflectiveInstantiation`" and previously surfaced a `PropertyTest[Any]` fixture as a standalone suite (`PropertyTest.scala:19-27`).
+
+## Purity and the SplitMix64 seed
+
+`Seed` is an `opaque type Seed = Long` implementing SplitMix64 (`internal/Seed.scala:15`). Two operations carry the contract: `next` advances the stream deterministically, and `split` derives two statistically independent streams so an outer and an inner generator never share draws (`internal/Seed.scala:42-56`).
+
+The purity is not a stylistic choice, it is required by integrated shrinking: "`flatMap` expansion re-runs the bind function and re-samples the inner generator while the lazy tree is traversed, so a mutable RNG (whose state would be consumed unpredictably during traversal) cannot be used. A pure splittable seed solves this" (`internal/Seed.scala:5-8`). `kyo.Random` exposes only the stateful `Sync` effect and no pure splittable PRNG, so SplitMix64 lives here as the right pure primitive; the top-level seed is drawn once at the boundary from the configured run seed and threaded purely through sampling (`internal/Seed.scala:10-11`). The property RNG is therefore unrelated to `kyo.Random`; a scenario that needs `kyo.Random` discharges it through the suite's effect row `S` via `.handle(Random.withSeed(...))`, a scenario concern the framework has zero awareness of (`PropertyTest.scala:137-139`).
+
+Threading rule for a new combinator: to draw two independent values, `split` the seed (never reuse one stream for both); to draw a sequence, thread the advanced seed forward. The built-ins are the reference: `flatMap` splits into outer/inner streams (`Gen.scala:56-60`), `samples` splits per draw so successive draws are independent (`Gen.scala:120-133`), and the derivation macro splits per field and per subtype (`internal/GenDerive.scala:72-80`, `:118-137`).
+
+## Integrated shrinking
+
+`Tree[A]` is a rose tree carrying a value together with a lazily-computed sequence of strictly-smaller subtrees, "the core of integrated (Hedgehog-style) shrinking: a generated value and the full lazy tree of its shrink candidates travel together" (`internal/Tree.scala:3-16`). The combinators preserve the shrink structure: `map` transforms values while keeping the tree shape, `flatMap` is the monadic rose-tree bind, `filter` prunes candidates while splicing in satisfying descendants so no valid shrink path is lost, and `zipWith` is the applicative product that interleaves two subtrees so BOTH components minimize independently (`internal/Tree.scala:21-59`).
+
+The consequence a contributor must respect: applicative composition minimizes better than monadic. `flatMap` shrinking is NOT guaranteed minimal, because the inner generator is re-sampled per outer shrink and the dependency blocks component-wise minimization; when the components are independent, prefer `zipWith` / `zip`, whose applicative shrinking minimizes each component independently, and reach for `flatMap` only when the inner generator genuinely depends on the outer value (`Gen.scala:51-54`).
+
+`Shrink` exposes the canonical primitive shrink algorithms as static methods (`int`/`long`/`double`/`string`/`list`), used by the built-in `Gen` instances and available directly for custom generators (`Shrink.scala:5-46`). Each documents its exact strategy (halving toward zero for `int`/`long`, toward `0.0` and integral values for `double`, character removal for `string`, drop-then-shrink-elements for `list`); a new primitive generator's shrink belongs here so it is reusable and covered by `ShrinkTest`.
+
+## Derivation: Mirror-based, with boundaries
+
+`Gen.derive[A]` is an inline macro delegating to `GenDerive.deriveImpl` (`Gen.scala:460`, `internal/GenDerive.scala:16-40`). It derives from a `scala.deriving.Mirror`:
+
+- **Case classes** (`Mirror.ProductOf[A]`): summon `Gen[FieldType]` for each field (recursively deriving when no given is in scope), sample each field tree from an independent seed split, then assemble via `Mirror.fromProduct` and zip the field trees into a product tree (`internal/GenDerive.scala:44-90`).
+- **Sealed traits** (`Mirror.SumOf[A]`): pick a subtype uniformly at random and delegate to that subtype's `Gen`; earlier (lower-index) subtypes are prepended as additional shrink candidates so the shrink walk tends toward the simplest, index-0 subtype (`internal/GenDerive.scala:94-141`).
+
+Boundaries, all enforced at macro time:
+
+- Only case classes and sealed traits are supported. A type with no `Mirror` aborts with "no Mirror found for .... Only case classes and sealed traits are supported" (`internal/GenDerive.scala:35-38`); an unsupported `Mirror` shape aborts too (`:31-34`). Function-typed generators (e.g. `Gen[Int => Int]`) are not supported (`Gen.scala:15`).
+- Recursion is size-bounded: the size parameter is decremented by 1 at each recursive level, and at `size == 0` a Sum mirror always chooses the index-0 subtype to produce a base case and avoid infinite recursion on recursive ADTs (`internal/GenDerive.scala:13-15`, `:117-123`).
+
+### The primitive-givens block convention
+
+For `Gen.derive[A]` to resolve a field, a `Gen[FieldType]` must be summonable. The companion therefore carries a givens block for the built-in field types, each with a rationale comment naming why it exists:
+
+```scala
+// Given instances for the primitive built-ins, so `Gen.derive[A]` can resolve a field of these types ...
+given Gen[Int]     = int
+given Gen[Long]    = long
+given Gen[Double]  = double
+given Gen[String]  = string
+given Gen[Boolean] = boolean
+```
+
+(`Gen.scala:269-276`.) The same convention extends to commonly-derived container fields: `optionGen` ("So `Gen.derive[A]` resolves a field of type `Option[B]`": draws `None` 1:4 against `Some`, covering both branches) and `chunkGen` ("So `Gen.derive[A]` resolves a field of type `Chunk[B]`") are givens carrying the identical comment form (`Gen.scala:278-283`). `byteGen` extends the primitive set itself: `Gen[Byte]` narrows `Gen.int` via `toByte` so `Gen.derive[A]` resolves a `Byte` field (and, through `chunkGen`, a `Chunk[Byte]` field) without a hand-supplied given (`Gen.scala:285-288`). When you add a generator for a type that commonly appears as a case-class field, add it here as a `given` with the `so Gen.derive can resolve` comment, so derivation keeps working without a user hand-writing the instance.
+
+## The `forAll` DSL
+
+`forAll` (arities 1 to 4) and `forAllSeeded` are `protected inline` methods on `PropertyTestBase` (`PropertyTest.scala:177-301`). A call runs `numSamples` iterations (default 100) over a size schedule that grows from 1 to 100 as `size = 1 + i * 100 / numSamples` (`PropertyTest.scala:54`, `:148-152`); on the first failure the shrink loop minimizes the counterexample, up to `maxShrinks` iterations (default 100), before reporting (`PropertyTest.scala:57`, `:159-161`).
+
+The run seed is `rngSeed`: `randomSeed` (inherited from `TestBase`) when `randomize` is true, else `nonRandomSeed` (default 42L, a `protected def` override hook) (`PropertyTest.scala:59-64`). On failure, `PropertyFailedException` carries the original sample, the shrunk counterexample, the cause, and the seed; copy that seed into `forAllSeeded(seed, gen) { ... }` to replay a failure deterministically (`PropertyFailedException.scala:16-18`, `:30-44`). The leaf body registered by `forAll` has type `Unit < (S & Async & Abort[Throwable] & Scope)`, matching the `TestBase[S]` baseline; a thrown `AssertionFailed` is caught at the `Abort.run[Throwable]` boundary and surfaced as a `Result.Failure` (`PropertyTest.scala:33-34`, `:68-83`).
+
+## The samples API (consumed by kyo-test-snapshot)
+
+`Gen` exposes two pure introspection helpers that run a generator WITHOUT a property test:
+
+- `samples(seed: Long, size: Int, count: Int): Chunk[A]` draws `count` root values, each from an independently split seed; "the same `(seed, size, count)` triple always produces the same `Chunk`", and `count <= 0` returns `Chunk.empty` (`Gen.scala:105-134`).
+- `classify(seed, size, count)(label): Map[String, Int]` tallies draws into labelled buckets whose counts sum to `count` (`Gen.scala:136-156`).
+
+Both take a plain `Long` seed; the internal `Seed` type never appears in a public signature. `samples` is the contract the `kyo-test-snapshot` golden flavor depends on (`assertGoldenSnapshot` calls `gen.samples(seed, size, count)` to draw its deterministic spread), which is why this module carries a `dependsOn(kyo-test-prop)` build edge from snapshot (`build.sbt:2896`). Preserve `samples`'s determinism and its seed-split topology: the golden's cross-platform byte-identity rests on it.
+
+## Cross-platform
+
+This is a four-platform module (JVM, JS, Native, Wasm), a `crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)` with `CrossType.Full` (`build.sbt:2834-2836`). All source is cross-platform under `shared/`; only the test `TestExecutionContext` is platform-split. The module depends on `kyo-test-api` and `kyo-data`, with `kyo-test-runner` and ScalaTest as `Test`-only dependencies (`build.sbt:2837-2844`).
+
+## Test conventions
+
+### The self-hosting boundary: ScalaTest, not kyo-test
+
+This module's own tests use ScalaTest directly (`AsyncFreeSpec` / `AnyFunSuite` with `NonImplicitAssertions`), never the `PropertyTest` DSL under test. The reason is stated in each test file: "kyo-test-prop has no KyoTestPlugin (would be circular); only ScalaTest is available here" (`shared/src/test/scala/kyo/test/prop/GenTest.scala:11`) and "this file tests PropertyTest DSL itself; cannot self-host using the framework-under-test" (`PropertyTestSelfTest.scala:65-68`). This is the deliberate local exception to the root rule that tests use the module's own `Test` base.
+
+The recurring pattern for exercising the DSL is a fixture suite extending the marker-free `PropertyTestBase[Any]` (not `PropertyTest[Any]`), driven through the real runner via `TestRunner.runToFuture`. Fixtures that fail by design MUST extend the marker-free base so platform discovery does not pick them up (`PropertyTestSelfTest.scala:18-49`, `PropTest.scala:27-56`); this matters on Scala Native, whose reflective discovery would otherwise surface them as standalone suites (`PropertyTest.scala:24-27`).
+
+### Test file naming
+
+The 1:1 source-to-test rule holds, with aspect splits where one source needs more than one file:
+
+| Source | Test file(s) |
+|--------|--------------|
+| `Gen.scala` | `GenTest.scala`, `GenEdgeBiasTest.scala`, `GenFilterBudgetTest.scala`, `GenIntrospectionTest.scala`, `GenSeedIndependenceTest.scala`, `GenZipTest.scala`, `GenChoiceShrinkTest.scala`, `GenShrinkChunkTest.scala`, `IntegratedShrinkTest.scala` |
+| `PropertyTest.scala` | `PropTest.scala`, `PropertyTestSelfTest.scala`, `PropertyMaybeTest.scala`, `ForAllSeededTest.scala` |
+| `Shrink.scala` | `ShrinkTest.scala` |
+| `internal/Tree.scala` | `internal/TreeZipWithTest.scala` |
+
+Scratch and reproduction files must be folded into the matching `*Test.scala` by source prefix and deleted before a change is complete.
+
+## Building and testing
+
+```sh
+export JAVA_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8"
+export JVM_OPTS="$JAVA_OPTS"
+
+# All tests on JVM
+sbt 'kyo-test-propJVM/test'
+
+# A single test class
+sbt 'kyo-test-propJVM/testOnly kyo.test.prop.GenTest'
+```
+
+Tests run cross-platform (JVM, JS, Native, Wasm) from the shared test tree; never move a shared test into a single-platform tree to dodge platform cost. Building runs scalafmt automatically, so re-read any file you edit after building.
+
+See the root [CONTRIBUTING.md](../../CONTRIBUTING.md) for full conventions on naming, scaladoc, inline guidelines, `using`-clause ordering, and the pre-submission checklist.
+
+## Decision checklist: before adding a new X
+
+1. **New generator or combinator.** Is it a pure function of the `Seed`? Does it `split` for independent draws and thread the advanced seed for sequences? Does it preserve the source `Tree`'s shrink structure (via the `Tree` combinators), rather than dropping shrinking?
+
+2. **New primitive shrink.** Is the algorithm added to `Shrink` (and delegated to from the built-in `Gen`), so it is reusable and covered by `ShrinkTest`?
+
+3. **New commonly-derived field type.** Is its `Gen` added as a `given` in the companion's givens block with the `so Gen.derive can resolve` rationale comment, so derivation resolves the field without a hand-written instance?
+
+4. **New DSL method.** Is it `protected inline` on `PropertyTestBase`, not a package function? Does its leaf body stay `Unit < (S & Async & Abort[Throwable] & Scope)`?
+
+5. **New test.** Does it use ScalaTest directly (the self-hosting boundary), fold into the matching `*Test.scala` by source prefix, and assert on a concrete value? For a fail-by-design or runner-driven fixture, does it extend the marker-free `PropertyTestBase`?

--- a/kyo-test/prop/shared/src/main/scala/kyo/test/prop/Gen.scala
+++ b/kyo-test/prop/shared/src/main/scala/kyo/test/prop/Gen.scala
@@ -275,6 +275,18 @@ object Gen:
     given Gen[String]  = string
     given Gen[Boolean] = boolean
 
+    /** So `Gen.derive[A]` resolves a field of type `Option[B]`: draws `None` 1:4 against `Some(inner)`, covering both branches. */
+    given optionGen[A](using inner: Gen[A]): Gen[Option[A]] =
+        Gen.frequency(1 -> Gen.const(None: Option[A]), 4 -> inner.map(Some(_): Option[A]))
+
+    /** So `Gen.derive[A]` resolves a field of type `Chunk[B]`: `Gen.list` already yields a `Gen[Chunk[B]]`. */
+    given chunkGen[A](using inner: Gen[A]): Gen[Chunk[A]] = Gen.list(inner)
+
+    /** So `Gen.derive[A]` resolves a field of type `Byte`: narrows `Gen.int` via `toByte`, so every value in the full `Byte` range remains
+      * reachable through truncation.
+      */
+    given byteGen: Gen[Byte] = Gen.int.map(_.toByte)
+
     /** Generates chunks of varying length in [0, clampedSize] where clampedSize = max(0, size), with elements from g, biased occasionally
       * toward the empty and singleton collections (both in-band: length stays within [0, clampedSize]).
       */

--- a/kyo-test/prop/shared/src/test/scala/kyo/test/prop/GenTest.scala
+++ b/kyo-test/prop/shared/src/test/scala/kyo/test/prop/GenTest.scala
@@ -237,4 +237,47 @@ class GenTest extends AsyncFreeSpec with NonImplicitAssertions:
         Future.successful(succeed)
     }
 
+    "derive resolves chunkGen for a Chunk-field case class (non-degenerate)" in {
+        case class Event(id: Int, kind: String, payload: Chunk[Byte]) derives CanEqual
+        val g       = Gen.derive[Event]
+        val samples = (0 until 100).map(i => g.sample(seed(i), size).value)
+        assert(samples.size == 100)
+        assert(samples.exists(_.payload.nonEmpty), "expected at least one non-empty payload Chunk across 100 draws")
+        Future.successful(succeed)
+    }
+
+    "byteGen samples a deterministic value and reaches the full Byte range via toByte truncation" in {
+        // A size at least Byte.MaxValue+1 puts the underlying Gen.int's producible range [-size, size] at or beyond
+        // the Byte bounds, so toByte truncation reaches both Byte.MinValue and Byte.MaxValue without relying on wraparound.
+        val byteSize = 200
+        val g        = Gen.byteGen
+        assert(
+            g.sample(seed(0), byteSize).value == g.sample(seed(0), byteSize).value,
+            "expected the same seed to draw the same value"
+        )
+        val samples = (0 until 3000).map(i => g.sample(seed(i), byteSize).value)
+        assert(samples.exists(_ == Byte.MinValue), "expected Byte.MinValue reachable across 3000 draws")
+        assert(samples.exists(_ == Byte.MaxValue), "expected Byte.MaxValue reachable across 3000 draws")
+        Future.successful(succeed)
+    }
+
+    "derive resolves optionGen for an Option-field case class covering Some and None" in {
+        case class Box(v: Option[Int]) derives CanEqual
+        val g       = Gen.derive[Box]
+        val samples = (0 until 100).map(i => g.sample(seed(i), size).value)
+        assert(samples.exists(_.v.isDefined), "expected at least one Some(_) across 100 draws")
+        assert(samples.exists(_.v.isEmpty), "expected at least one None across 100 draws")
+        Future.successful(succeed)
+    }
+
+    "optionGen draws are not all-Some and not all-None (coverage non-vacuity)" in {
+        case class Box(v: Option[Int]) derives CanEqual
+        val g         = Gen.derive[Box]
+        val samples   = (0 until 100).map(i => g.sample(seed(i), size).value)
+        val someCount = samples.count(_.v.isDefined)
+        val noneCount = samples.count(_.v.isEmpty)
+        assert(someCount > 0 && noneCount > 0, s"expected both Some and None; got someCount=$someCount noneCount=$noneCount")
+        Future.successful(succeed)
+    }
+
 end GenTest

--- a/kyo-test/snapshot/CONTRIBUTING.md
+++ b/kyo-test/snapshot/CONTRIBUTING.md
@@ -1,0 +1,217 @@
+# Contributing to kyo-test-snapshot
+
+This guide complements the root [CONTRIBUTING.md](../../CONTRIBUTING.md), which covers every global Kyo convention (naming, `Maybe` / `Result` / `Chunk` / `Span`, `using`-clause ordering, Frame/Tag, inline guidelines, scaladoc, file organisation, visibility tiers, the test framework, cross-platform source placement, `AllowUnsafe`). Defer to the root guide for those; this file covers only what is specific to the snapshot module (`kyo-test/snapshot`, sbt project `kyo-test-snapshot`).
+
+**The headline invariant:** snapshot assertions are an inheritance-based DSL, not free functions. A suite gains `assertSnapshot` and `assertSchemaSnapshot` by extending `SnapshotTest[S]` (or the marker-free `SnapshotTestBase[S]`), and those DSL methods are `protected`. This is the module's single, documented exception to the root guide's no-`protected` convention: the framework contract is inheritance-based, so the methods are visible to subclass bodies and to nothing else. Both classes carry this exception verbatim in their scaladoc, "The DSL methods in this class use `protected` visibility because the framework contract is inheritance-based; this is a deliberate exception to the `No protected` convention (CONTRIBUTING P5)" (`shared/src/main/scala/kyo/test/snapshot/SnapshotTest.scala:33-34`, `:248-249`). Before adding a new assertion, keep it `protected` on the base and do not promote it to a package-level function.
+
+## Architecture overview
+
+Every public type lives in `shared/src/main/scala/kyo/test/snapshot/`; the file I/O leaf is split by platform under `jvm-native/` and `js-wasm/`.
+
+| Type | File | Purpose |
+|------|------|---------|
+| `SnapshotTestBase[S]` | `SnapshotTest.scala:49` | Marker-free base carrying the DSL; extended by non-discoverable internal fixtures |
+| `SnapshotTest[S]` | `SnapshotTest.scala:264` | Public discoverable base: `SnapshotTestBase[S] with SuiteFingerprintMarker` |
+| `SnapshotConfig[A]` | `SnapshotConfig.scala:31` | The per-call customization builder for `assertSchemaSnapshot` |
+| `SnapshotCodec` | `SnapshotCodec.scala:24` | The `Text` / `Binary` format wrapper (2-case enum, 7 presets) |
+| `SnapshotSchemaEvolution` | `SnapshotSchemaEvolution.scala:24` | Distinct failure factory for a stored snapshot that no longer decodes |
+| `SnapshotNotFound` | `SnapshotNotFound.scala:26` | First-run failure factory (proposed file written, then fail) |
+| `SnapshotStore` | `internal/SnapshotStore.scala:11` | Shared facade over the per-platform file I/O |
+| `SnapshotDiff` | `internal/SnapshotDiff.scala:8` | Unified-diff renderer, delegates to `kyo.test.internal.Diff.stringDiff` |
+
+`SnapshotTest[S]` adds only the discovery marker; all assertion machinery lives on `SnapshotTestBase[S]` (`SnapshotTest.scala:244-246`). The base is split off precisely so the deliberately-failing fixture suites in this module's own tests can extend it and stay out of sbt/Native discovery: "The public `SnapshotTest` subclass adds the marker so real user snapshot suites are discovered; the fixtures must not be, because they fail by design" (`SnapshotTest.scala:28-31`).
+
+---
+
+## The two snapshot flavors
+
+The module offers two assertions with different serialization models. Choosing between them is the first decision a contributor or user makes.
+
+### `assertSnapshot` (Render-based)
+
+```
+protected inline def assertSnapshot[A](inline actual: A, inline name: String)
+    (using inline r: Render[A], inline frame: Frame, inline as: kyo.test.AssertScope)
+    : Unit < (S & Async & Abort[Throwable] & Scope)
+```
+
+(`SnapshotTest.scala:82-85`.) It renders `actual` through `Render[A]` to a single flat string, stores it at `${snapshotDir}/${this.name}/${name}.snap`, and compares after trailing-whitespace normalization: "If snapshot exists and matches (after trailing-whitespace normalization): pass" (`SnapshotTest.scala:72`, impl `stored.stripTrailing() != rendered.stripTrailing()` at `:96`). Use it for any type that has a `Render` instance when a flat textual form is all you need.
+
+### `assertSchemaSnapshot` (schema-based)
+
+```
+protected inline def assertSchemaSnapshot[A](inline actual: A, inline name: String,
+    inline config: SnapshotConfig[A] => SnapshotConfig[A] = identity[SnapshotConfig[A]])
+    (using inline schema: Schema[A], inline frame: Frame, inline as: kyo.test.AssertScope)
+    : Unit < (S & Async & Abort[Throwable] & Scope)
+```
+
+(`SnapshotTest.scala:135-139`.) It requires a `Schema[A]` and serializes through a `SnapshotCodec`. This buys three things the Render path cannot give: a field-named encoding (Yaml/Json/etc.), format-tolerant structural comparison, and a per-call normalization pass. The default Yaml output is field-named, not a positional `toString`: the test "default Yaml output is field-named, not a positional flat toString" asserts the stored text contains `x:` and `y:` keys and is not `Point(1,2)` (`shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaTest.scala:101-116`).
+
+**When to use which.** Reach for `assertSchemaSnapshot` when the value has a `Schema`, when you need to scrub non-deterministic fields (timestamps, ids), or when you want the comparison to survive a hand-reformatted snapshot file. Reach for `assertSnapshot` when the value only has a `Render` instance, or when a flat rendered string is the artifact you actually want to review.
+
+The two share the name-validation and first-run contracts exactly. `SnapshotSchemaTest` verifies that "`assertSnapshot` rejects a path separator, empty, dot, dot-dot, and an embedded space, same as `assertSchemaSnapshot`" (`SnapshotSchemaTest.scala:303-313`) and that both fail first-run with `SnapshotNotFound` (`:249-269`, `:293-301`).
+
+---
+
+## Customization surfaces: `SnapshotConfig` and `snapshotCodec`
+
+These are two complementary hooks at different scopes. Do not conflate them.
+
+### `snapshotCodec` (per-suite format)
+
+```
+protected def snapshotCodec: SnapshotCodec = SnapshotCodec.Yaml
+```
+
+(`SnapshotTest.scala:112`.) Override it in a suite to change the serialization format for every `assertSchemaSnapshot` call in that suite. The default is `SnapshotCodec.Yaml`, "the readable field-named text format" (`SnapshotTest.scala:112`, `SnapshotCodec.scala:37`).
+
+### `SnapshotConfig` (per-call customization)
+
+`SnapshotConfig[A]` is "The single per-call customization point for `assertSchemaSnapshot`" (`SnapshotConfig.scala:5`). It is passed as a `SnapshotConfig[A] => SnapshotConfig[A]` lambda (default `identity`). It exists so the assertion can grow new knobs "without changing its signature or breaking existing call sites: each new knob is an additive method here, never a new parameter on `assertSchemaSnapshot`" (`SnapshotConfig.scala:8-9`).
+
+Today it carries exactly one capability, `normalize`, which "Adds a field-normalization pass, scrubbing non-deterministic fields before encode and before compare" (`SnapshotConfig.scala:33`). Normalization accumulates: `.normalize(f1).normalize(f2)` composes `f1` then `f2` (`SnapshotConfig.scala:34-35`, proven by `SnapshotConfigTest.scala:23-27`). It builds on `kyo.Modify`, the field-transform DSL, so a typical scrub reads `_.normalize(_.set(_.ts)(0L))` (`SnapshotSchemaTest.scala:123`).
+
+**Contract for a contributor adding a capability.** Add it as a new method plus a new internal field whose default preserves current behavior, so existing `.normalize(...)` call sites keep compiling (`SnapshotConfig.scala:15-17`). The example the scaladoc names is a custom comparison strategy. Never add a parameter to `assertSchemaSnapshot` for it; that is the whole reason `SnapshotConfig` exists. The format choice stays out of this builder: "The serialization format is chosen separately, per suite, by the `snapshotCodec` override hook, not through this builder" (`SnapshotConfig.scala:10-13`).
+
+---
+
+## The storage contract
+
+### Path scheme
+
+Both assertions compute `${snapshotDir}/${this.name}/${name}.${ext}`. `snapshotDir` defaults to `"test-snapshots"` and is a `protected def` override hook (`SnapshotTest.scala:51-55`); `this.name` is the suite name, so a suite's snapshots live in a subdirectory named after the suite. The Render path fixes the extension to `snap` (`SnapshotTest.scala:89`); the schema path uses `codec.ext` (`SnapshotTest.scala:144`).
+
+`name` must be a bare file name. `validateSnapshotName` rejects a path separator (`/` or `\`), the empty string, `.`, `..`, and any embedded space (`SnapshotTest.scala:211-229`). Add a new restriction there, not at each call site.
+
+### Text codecs versus binary codecs
+
+`SnapshotCodec` wraps a kyo-schema `Codec` "with the text-versus-binary distinction the codec itself does not carry" (`SnapshotCodec.scala:5-6`). The KIND decides two things a raw `Codec` cannot express: whether the stored file holds a UTF-8 string or raw wire bytes, and whether a mismatch report can carry a textual diff (`SnapshotCodec.scala:8-11`).
+
+- A `Text` codec encodes to a UTF-8 string via `schema.encodeString` and stores it through the `String` store path (`SnapshotTest.scala:146-147`). `SnapshotStore.write` appends a single trailing newline if absent (`internal/SnapshotStore.scala:21-23`).
+- A `Binary` codec encodes to raw wire bytes via `schema.encode` and stores them through the bytes store path (`SnapshotTest.scala:175-176`). `writeBytes` writes "content exactly as given, with no base64 encoding and no trailing-newline append, so a stored binary snapshot is the real codec wire artifact" (`internal/SnapshotStore.scala:33-39`).
+
+The Protobuf round-trip test pins this: stored bytes are byte-identical to a fresh `schema.encode`, and the stored length is asserted not equal to the base64-encoded length (`SnapshotSchemaTest.scala:271-291`). The raw-bytes store path has its own byte-fidelity coverage including `0x00`, `0xFF`, and a newline byte (`SnapshotStoreBytesTest.scala:25-39`).
+
+### Extensions are pairwise-distinct and distinct from `snap`
+
+The seven presets are `Yaml` (`snap.yaml`), `Json` (`snap.json`), `Ion` (`snap.ion`), `Protobuf` (`snap.pb`), `Bson` (`snap.bson`), `MsgPack` (`snap.msgpack`), `IonBinary` (`snap.ionb`) (`SnapshotCodec.scala:36-55`). The schema default is `snap.yaml`, deliberately distinct from the Render path's plain `snap`. Extensions are "kept pairwise-distinct across presets so a text and a binary snapshot of the same name never collide, and distinct from the plain `snap` extension of the `Render`-based `assertSnapshot` so a suite mixing both assertions on the same name never cross-writes one file" (`SnapshotCodec.scala:16-18`). `SnapshotCodecTest.scala:57-70` enforces all seven distinct and none equal to `snap`. When adding a preset, choose a fresh extension and add it to that distinctness assertion.
+
+`Text` and `Binary` stay the open extension point for any custom `Codec` (`SnapshotCodec.scala:11`, `SnapshotCodecTest.scala:73-91`).
+
+---
+
+## The compare contract
+
+On a subsequent run with an existing snapshot, `assertSchemaSnapshot` decodes the stored bytes via `Schema[A]` and branches three ways (`SnapshotTest.scala:156-172` for Text, `:185-202` for Binary):
+
+1. **Decode failure (`Result.Failure`)** routes to `SnapshotSchemaEvolution`, "a stored snapshot whose bytes no longer decode via the current `Schema[A]`" (`SnapshotSchemaEvolution.scala:7`). This is kept distinct from a value mismatch so "schema drift is reported with its own message and never conflated with an ordinary value mismatch" (`SnapshotSchemaEvolution.scala:9-10`). Its diagram is prefixed `SnapshotSchemaEvolution:` and is never the `Snapshot mismatch` prefix (`SnapshotSchemaEvolutionTest.scala:12-20`; distinctness proven end-to-end for both Text and Binary at `SnapshotSchemaTest.scala:206-218`, `:315-329`).
+
+2. **Decode panic (`Result.Panic`)** propagates the underlying throwable unwrapped: `case Result.Panic(err) => throw err` (`SnapshotTest.scala:162-163`, `:188-189`). An unexpected codec defect is not rewrapped as `SnapshotSchemaEvolution`. Both the Binary and Text decode arms are pinned by `SnapshotSchemaTest.scala:347-379`.
+
+3. **Decode success** compares structurally through `Changeset[A](storedValue, norm).operations`; a mismatch fails with the changed field paths (`SnapshotTest.scala:164-172`, `:190-202`). The gate follows schema-structural `Changeset.operations`, not value `.equals`: the `Ver` fixture whose `.equals` ignores field `b` still fails the assertion on a `b` change (`SnapshotSchemaTest.scala:331-345`).
+
+The comparison is **format-tolerant**: a hand-reformatted stored snapshot that still decodes to an equal value passes (`SnapshotSchemaTest.scala:186-204`), because the compare is on decoded values, not on the stored text. The mismatch report shape differs by codec kind: a `Text` codec carries the changed field path plus a unified textual diff, a `Binary` codec carries the changed field path but no textual diff (`SnapshotSchemaTest.scala:142-170`). Nested field changes report the full dotted path (`b.y`), produced by the recursive `snapshotChangedPaths` helper (`SnapshotTest.scala:231-235`, test `:172-184`).
+
+`SnapshotDiff.render(stored, actual)` fixes the diff direction convention: `stored` is the on-disk baseline, `actual` is the newly rendered value (`internal/SnapshotDiff.scala:5-6`).
+
+---
+
+## The update-mode workflow
+
+```
+protected def snapshotUpdateMode: Boolean =
+    java.lang.System.getenv("KYO_TEST_SNAPSHOT") == "update"
+```
+
+(`SnapshotTest.scala:62-63`.) When update mode is active, both assertions write the proposed value and pass without reading a prior file (`SnapshotTest.scala:91-92`, `:148-149`, `:177-178`). The default reads the `KYO_TEST_SNAPSHOT` environment variable, but the hook is a plain `protected def` so a suite can force it on or off "without mutating the process environment" (`SnapshotTest.scala:57-61`). Tests exercise this by overriding it directly and by reading a JVM system property (`SnapshotUpdateModeTest.scala:38-60`, `:98-113`).
+
+On the first run with no stored file, both assertions write the proposed snapshot and then fail with `SnapshotNotFound` so the run is red until the reviewer confirms the proposed file (`SnapshotTest.scala:101-103`, `:152-154`; `SnapshotNotFound.scala:7-13`).
+
+---
+
+## Cross-platform
+
+This is a four-platform module (JVM, JS, Native, Wasm; `build.sbt:2556-2558`). Source is placed in three tiers:
+
+- `shared/src/main/scala/` holds all types except the file I/O leaf.
+- `jvm-native/` holds the `java.nio.file`-backed `SnapshotStorePlatform`. "Scala Native ships a compatible implementation of `java.nio.file` so the same source compiles and runs on both platforms without modification" (`jvm-native/.../SnapshotStorePlatform.scala:9-13`); the source set is wired for both JVM and Native in `build.sbt:2578-2581` and `:2593-2596`.
+- `js-wasm/` holds the Node.js `fs` facade `SnapshotStorePlatform`, shared by JS and Wasm (auto-wired by the custom `CrossType.Full`; see `project/WasmPlatform.scala:18`).
+
+`SnapshotStore` (`internal/SnapshotStore.scala`) is the shared facade; each platform provides an `object SnapshotStorePlatform` with the same four-method surface (`read`, `write`, `readBytes`, `writeBytes`).
+
+### Plain-sync platform I/O (no Sync/AllowUnsafe ceremony)
+
+The store methods are plain synchronous functions returning `Maybe[String]` / `Maybe[Span[Byte]]` / `Unit`, not Kyo effects. Snapshot I/O runs on the synchronous assertion path, so it does not wrap file access in `Sync` or reach for `AllowUnsafe` at the store boundary. The only `// Unsafe:` comments in the module are the two `Path.getParent` null-guards in the JVM/Native writer (`jvm-native/.../SnapshotStorePlatform.scala:25`, `:46`), each annotated with the reason. Preserve this: a new store operation stays a plain function and is added to all three source sets in lockstep, mirroring the existing four-method shape. The JS/Wasm facade re-throws a browser-environment `js.JavaScriptException` as `UnsupportedOperationException` with a clear message (`js-wasm/.../SnapshotStorePlatform.scala:39-43`); keep that translation on any new JS store method.
+
+### Foreign-package inline access
+
+`assertSchemaSnapshot` is `inline`, and a user extends `SnapshotTestBase` from their own package. `SnapshotConfig.modify` is `private[snapshot]` (`SnapshotConfig.scala:31`), so the inline body must resolve `normalizeWith` (`SnapshotTest.scala:208-209`) through a compiler-generated accessor rather than a direct cross-package field read. `SnapshotForeignPackageTest` is the standing proof: a `SnapshotTest[Any]` subclass in the sibling package `kyo.test.snapshotforeign` "compiles and runs `assertSchemaSnapshot` with the config lambda" where `private[snapshot]` is genuinely inaccessible (`shared/src/test/scala/kyo/test/snapshotforeign/SnapshotForeignPackageTest.scala:15-22`, `:45-60`). Any change to the inline assertion body or to `SnapshotConfig`'s visibility must keep that test compiling; do not widen `private[snapshot]` to make the inline resolve.
+
+---
+
+## Conventions
+
+### The `protected` exception
+
+The root guide bans `protected` in favour of `private[kyo]`. This module is the documented exception for its abstract DSL base classes only (`SnapshotTest.scala:33-34`, `:248-249`). The exception covers the inheritance-facing DSL surface: `snapshotDir`, `snapshotUpdateMode`, `snapshotCodec`, `assertSnapshot`, `assertSchemaSnapshot`. Internal helpers stay `private` (`normalizeWith`, `validateSnapshotName`, `snapshotChangedPaths` at `SnapshotTest.scala:208-235`) and the platform I/O objects stay `private[snapshot]`. Do not extend the `protected` exception to anything that is not a subclass override hook.
+
+### Kyo types
+
+Follow the root guide. In this module: `Maybe` for optional store results (`internal/SnapshotStore.scala:14`, `:30`), `Result` for decode outcomes (`SnapshotTest.scala:156-164`), `Span[Byte]` for raw bytes (`internal/SnapshotStore.scala:30`), `Chunk` for changed-path accumulation (`SnapshotTest.scala:231`).
+
+### Test framework
+
+Because this module IS a test framework, its own tests cannot self-host: they use ScalaTest directly. Each test file states the reason, for example "ScalaTest bootstrap: this file tests SnapshotTest DSL itself; cannot self-host using the framework-under-test" (`jvm-native/.../SnapshotSelfTest.scala:88`). This is the deliberate local exception to the root rule that tests use the module's own `Test` base. Two ScalaTest styles are in use: `AnyFunSuite` for synchronous value/IO checks and `AsyncFreeSpec` for tests that drive the runner.
+
+The recurring pattern for exercising the DSL is a minimal `private class ... extends SnapshotTest[Any]` fixture that overrides `snapshotDir`/`snapshotUpdateMode`/`snapshotCodec` via constructor parameters and re-exposes the `protected` assertions as package-accessible methods (`SnapshotSchemaTest.scala:82-97`, `SnapshotUpdateModeTest.scala:38-47`, `SnapshotSelfTest.scala:21-28`). Fixtures that must fail by design extend the marker-free `SnapshotTestBase` so platform discovery does not pick them up (`SnapshotReparamTest.scala:25-28`, `:40-43`), and drive them via `TestRunner.runToFuture` (`SnapshotReparamTest.scala:100-117`).
+
+### Test file naming
+
+The 1:1 source-to-test rule holds, with aspect splits where one source needs more than one file:
+
+| Source | Test file(s) |
+|--------|--------------|
+| `SnapshotTest.scala` | `SnapshotTestTest.scala`, `SnapshotSchemaTest.scala`, `SnapshotUpdateModeTest.scala`, `SnapshotReparamTest.scala`, `SnapshotSelfTest.scala` |
+| `SnapshotConfig.scala` | `SnapshotConfigTest.scala` |
+| `SnapshotCodec.scala` | `SnapshotCodecTest.scala` |
+| `SnapshotSchemaEvolution.scala` | `SnapshotSchemaEvolutionTest.scala` |
+| `internal/SnapshotStore.scala` | `SnapshotStoreBytesTest.scala`, `SnapshotStoreTest` (in `SnapshotSelfTest.scala`) |
+| `internal/SnapshotDiff.scala` | `SnapshotDiffTest.scala` |
+
+`SnapshotForeignPackageTest.scala` is a deliberate cross-package proof and lives under `kyo.test.snapshotforeign`, a sibling of `kyo.test.snapshot`; it shares no source-file prefix because its subject is package accessibility itself, not a single source. Scratch and reproduction files must be folded into the matching `*Test.scala` and deleted before a change is complete.
+
+---
+
+## Building and testing
+
+```sh
+export JAVA_OPTS="-Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8"
+export JVM_OPTS="$JAVA_OPTS"
+
+# All tests on JVM
+sbt 'kyo-test-snapshotJVM/test'
+
+# A single test class
+sbt 'kyo-test-snapshotJVM/testOnly kyo.test.snapshot.SnapshotSchemaTest'
+```
+
+Tests run cross-platform (JVM, JS, Native, Wasm) from the shared and partially-shared test trees; never move a shared test into a single-platform tree to dodge platform cost. Building runs scalafmt automatically, so re-read any file you edit after building.
+
+See the root [CONTRIBUTING.md](../../CONTRIBUTING.md) for full conventions on naming, scaladoc, inline guidelines, `using`-clause ordering, and the pre-submission checklist.
+
+---
+
+## Decision checklist: before adding a new X
+
+1. **New assertion.** Is it `protected` on `SnapshotTestBase`, not a package function? Does it validate `name` through `validateSnapshotName`? Does it honour `snapshotUpdateMode` (write-and-pass) and first-run (`SnapshotNotFound`)? Does its effect row stay `S & Async & Abort[Throwable] & Scope`?
+
+2. **New `SnapshotConfig` capability.** Is it an additive method plus an internal field whose default preserves current behavior, leaving `assertSchemaSnapshot`'s signature untouched? Does it stay out of format selection (that is `snapshotCodec`)?
+
+3. **New codec preset.** Is it `Text` or `Binary`? Does its extension collide with no existing preset and differ from plain `snap`? Is it added to the distinctness assertion in `SnapshotCodecTest`?
+
+4. **New store operation.** Is it a plain synchronous function added to all three source sets (`shared` facade, `jvm-native`, `js-wasm`) in lockstep? Does the binary path stay verbatim (no base64, no newline munge)? Is every `AllowUnsafe`/null-guard marked with `// Unsafe:`?
+
+5. **Change to the inline body or `private[snapshot]` visibility.** Does `SnapshotForeignPackageTest` still compile from the foreign package?
+
+6. **New test.** Does it fold into the matching `*Test.scala` by source prefix? Does it assert on a concrete value? For a fail-by-design fixture, does it extend the marker-free `SnapshotTestBase`?

--- a/kyo-test/snapshot/CONTRIBUTING.md
+++ b/kyo-test/snapshot/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This guide complements the root [CONTRIBUTING.md](../../CONTRIBUTING.md), which covers every global Kyo convention (naming, `Maybe` / `Result` / `Chunk` / `Span`, `using`-clause ordering, Frame/Tag, inline guidelines, scaladoc, file organisation, visibility tiers, the test framework, cross-platform source placement, `AllowUnsafe`). Defer to the root guide for those; this file covers only what is specific to the snapshot module (`kyo-test/snapshot`, sbt project `kyo-test-snapshot`).
 
-**The headline invariant:** snapshot assertions are an inheritance-based DSL, not free functions. A suite gains `assertSnapshot` and `assertSchemaSnapshot` by extending `SnapshotTest[S]` (or the marker-free `SnapshotTestBase[S]`), and those DSL methods are `protected`. This is the module's single, documented exception to the root guide's no-`protected` convention: the framework contract is inheritance-based, so the methods are visible to subclass bodies and to nothing else. Both classes carry this exception verbatim in their scaladoc, "The DSL methods in this class use `protected` visibility because the framework contract is inheritance-based; this is a deliberate exception to the `No protected` convention (CONTRIBUTING P5)" (`shared/src/main/scala/kyo/test/snapshot/SnapshotTest.scala:33-34`, `:248-249`). Before adding a new assertion, keep it `protected` on the base and do not promote it to a package-level function.
+**The headline invariant:** snapshot assertions are an inheritance-based DSL, not free functions. A suite gains `assertSnapshot`, `assertSchemaSnapshot`, and `assertGoldenSnapshot` by extending `SnapshotTest[S]` (or the marker-free `SnapshotTestBase[S]`), and those DSL methods are `protected`. This is the module's single, documented exception to the root guide's no-`protected` convention: the framework contract is inheritance-based, so the methods are visible to subclass bodies and to nothing else. Both classes carry this exception verbatim in their scaladoc, "The DSL methods in this class use `protected` visibility because the framework contract is inheritance-based; this is a deliberate exception to the `No protected` convention (CONTRIBUTING P5)" (`shared/src/main/scala/kyo/test/snapshot/SnapshotTest.scala:35-36`, `:357-358`). Before adding a new assertion, keep it `protected` on the base and do not promote it to a package-level function.
 
 ## Architecture overview
 
@@ -10,22 +10,24 @@ Every public type lives in `shared/src/main/scala/kyo/test/snapshot/`; the file 
 
 | Type | File | Purpose |
 |------|------|---------|
-| `SnapshotTestBase[S]` | `SnapshotTest.scala:49` | Marker-free base carrying the DSL; extended by non-discoverable internal fixtures |
-| `SnapshotTest[S]` | `SnapshotTest.scala:264` | Public discoverable base: `SnapshotTestBase[S] with SuiteFingerprintMarker` |
+| `SnapshotTestBase[S]` | `SnapshotTest.scala:51` | Marker-free base carrying the DSL; extended by non-discoverable internal fixtures |
+| `SnapshotTest[S]` | `SnapshotTest.scala:373` | Public discoverable base: `SnapshotTestBase[S] with SuiteFingerprintMarker` |
 | `SnapshotConfig[A]` | `SnapshotConfig.scala:31` | The per-call customization builder for `assertSchemaSnapshot` |
+| `GoldenConfig[A]` | `GoldenConfig.scala:27` | The per-call customization builder for `assertGoldenSnapshot` |
+| `GoldenSamples[A]` | `GoldenSamples.scala:9` | Internal storage envelope wrapping a golden's normalized sample spread as one document |
 | `SnapshotCodec` | `SnapshotCodec.scala:24` | The `Text` / `Binary` format wrapper (2-case enum, 7 presets) |
 | `SnapshotSchemaEvolution` | `SnapshotSchemaEvolution.scala:24` | Distinct failure factory for a stored snapshot that no longer decodes |
 | `SnapshotNotFound` | `SnapshotNotFound.scala:26` | First-run failure factory (proposed file written, then fail) |
 | `SnapshotStore` | `internal/SnapshotStore.scala:11` | Shared facade over the per-platform file I/O |
 | `SnapshotDiff` | `internal/SnapshotDiff.scala:8` | Unified-diff renderer, delegates to `kyo.test.internal.Diff.stringDiff` |
 
-`SnapshotTest[S]` adds only the discovery marker; all assertion machinery lives on `SnapshotTestBase[S]` (`SnapshotTest.scala:244-246`). The base is split off precisely so the deliberately-failing fixture suites in this module's own tests can extend it and stay out of sbt/Native discovery: "The public `SnapshotTest` subclass adds the marker so real user snapshot suites are discovered; the fixtures must not be, because they fail by design" (`SnapshotTest.scala:28-31`).
+`SnapshotTest[S]` adds only the discovery marker; all assertion machinery lives on `SnapshotTestBase[S]` (`SnapshotTest.scala:353-355`). The base is split off precisely so the deliberately-failing fixture suites in this module's own tests can extend it and stay out of sbt/Native discovery: "The public `SnapshotTest` subclass adds the marker so real user snapshot suites are discovered; the fixtures must not be, because they fail by design" (`SnapshotTest.scala:28-29`).
 
 ---
 
-## The two snapshot flavors
+## The three snapshot flavors
 
-The module offers two assertions with different serialization models. Choosing between them is the first decision a contributor or user makes.
+The module offers three assertions with different serialization models. Choosing between them is the first decision a contributor or user makes.
 
 ### `assertSnapshot` (Render-based)
 
@@ -35,7 +37,7 @@ protected inline def assertSnapshot[A](inline actual: A, inline name: String)
     : Unit < (S & Async & Abort[Throwable] & Scope)
 ```
 
-(`SnapshotTest.scala:82-85`.) It renders `actual` through `Render[A]` to a single flat string, stores it at `${snapshotDir}/${this.name}/${name}.snap`, and compares after trailing-whitespace normalization: "If snapshot exists and matches (after trailing-whitespace normalization): pass" (`SnapshotTest.scala:72`, impl `stored.stripTrailing() != rendered.stripTrailing()` at `:96`). Use it for any type that has a `Render` instance when a flat textual form is all you need.
+(`SnapshotTest.scala:84-87`.) It renders `actual` through `Render[A]` to a single flat string, stores it at `${snapshotDir}/${this.name}/${name}.snap`, and compares after trailing-whitespace normalization: "If snapshot exists and matches (after trailing-whitespace normalization): pass" (`SnapshotTest.scala:74`, impl `stored.stripTrailing() != rendered.stripTrailing()` at `:98`). Use it for any type that has a `Render` instance when a flat textual form is all you need.
 
 ### `assertSchemaSnapshot` (schema-based)
 
@@ -46,17 +48,21 @@ protected inline def assertSchemaSnapshot[A](inline actual: A, inline name: Stri
     : Unit < (S & Async & Abort[Throwable] & Scope)
 ```
 
-(`SnapshotTest.scala:135-139`.) It requires a `Schema[A]` and serializes through a `SnapshotCodec`. This buys three things the Render path cannot give: a field-named encoding (Yaml/Json/etc.), format-tolerant structural comparison, and a per-call normalization pass. The default Yaml output is field-named, not a positional `toString`: the test "default Yaml output is field-named, not a positional flat toString" asserts the stored text contains `x:` and `y:` keys and is not `Point(1,2)` (`shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaTest.scala:101-116`).
+(`SnapshotTest.scala:137-141`.) It requires a `Schema[A]` and serializes through a `SnapshotCodec`. This buys three things the Render path cannot give: a field-named encoding (Yaml/Json/etc.), format-tolerant structural comparison, and a per-call normalization pass. The default Yaml output is field-named, not a positional `toString`: the test "default Yaml output is field-named, not a positional flat toString" asserts the stored text contains `x:` and `y:` keys and is not `Point(1,2)` (`shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaTest.scala:101-116`).
 
-**When to use which.** Reach for `assertSchemaSnapshot` when the value has a `Schema`, when you need to scrub non-deterministic fields (timestamps, ids), or when you want the comparison to survive a hand-reformatted snapshot file. Reach for `assertSnapshot` when the value only has a `Render` instance, or when a flat rendered string is the artifact you actually want to review.
+### `assertGoldenSnapshot` (golden over a generated spread)
 
-The two share the name-validation and first-run contracts exactly. `SnapshotSchemaTest` verifies that "`assertSnapshot` rejects a path separator, empty, dot, dot-dot, and an embedded space, same as `assertSchemaSnapshot`" (`SnapshotSchemaTest.scala:303-313`) and that both fail first-run with `SnapshotNotFound` (`:249-269`, `:293-301`).
+`assertGoldenSnapshot[A](name, config)` requires both a `Gen[A]` and a `Schema[A]`. It draws `config.sampleCount` values (default 20) via `gen.samples(seed, size, count)`, normalizes each through the accumulated `Modify[A]`, and stores the whole spread as ONE document wrapped in the internal `private[snapshot] GoldenSamples[A](samples: Chunk[A])` envelope (its `Schema` obtained via `Schema.derived`), at `${snapshotDir}/${this.name}/${name}.golden.${bare}` where `bare = snapshotCodec.ext.stripPrefix("snap.")`. On a later run it decodes the stored document and compares per sample through the same three-way decode branch as `assertSchemaSnapshot` (`Result.Failure` routes to `SnapshotSchemaEvolution`, `Result.Panic` is rethrown unwrapped, `Result.Success` runs a structural `Changeset` compare), reporting a field change as the index-prefixed token `sample[N].field`; a decoded spread whose length differs from the regenerated spread fails first, naming the count delta. It shares `validateSnapshotName`, the first-run `SnapshotNotFound` write-then-fail, and the `snapshotUpdateMode` bless with the two siblings, and its per-call knobs ride the `GoldenConfig[A]` builder (`.sampleCount`, `.seed`, `.size`, `.normalize`), mirroring `SnapshotConfig`. Its inline signature is `protected inline def assertGoldenSnapshot[A](inline name: String, inline config: GoldenConfig[A] => GoldenConfig[A] = identity[GoldenConfig[A]])(using inline gen: Gen[A], inline schema: Schema[A], inline frame: Frame, inline as: kyo.test.AssertScope): Unit < (S & Async & Abort[Throwable] & Scope)` (`SnapshotTest.scala`). The `kyo-test-snapshot` module gains a `dependsOn(kyo-test-prop)` build edge to bring `Gen[A]` into scope.
+
+**When to use which.** Reach for `assertSchemaSnapshot` when the value has a `Schema`, when you need to scrub non-deterministic fields (timestamps, ids), or when you want the comparison to survive a hand-reformatted snapshot file. Reach for `assertGoldenSnapshot` when a single hand-picked value is not enough and you want to detect a wire-format change across the whole range of values a type can hold, drawn deterministically from its `Gen`. Reach for `assertSnapshot` when the value only has a `Render` instance, or when a flat rendered string is the artifact you actually want to review.
+
+All three share the name-validation and first-run contracts exactly. `SnapshotSchemaTest` verifies that "`assertSnapshot` rejects a path separator, empty, dot, dot-dot, and an embedded space, same as `assertSchemaSnapshot`" (`SnapshotSchemaTest.scala:303-313`) and that both fail first-run with `SnapshotNotFound` (`:249-269`, `:293-301`); `assertGoldenSnapshot` shares both by construction, calling the same `validateSnapshotName` (`SnapshotTest.scala:260`) and the same first-run `SnapshotNotFound` write-then-fail path (`SnapshotTest.scala:224`, `:246`).
 
 ---
 
-## Customization surfaces: `SnapshotConfig` and `snapshotCodec`
+## Customization surfaces: `SnapshotConfig`, `GoldenConfig`, and `snapshotCodec`
 
-These are two complementary hooks at different scopes. Do not conflate them.
+These are complementary hooks at different scopes. Do not conflate them: `SnapshotConfig` and `GoldenConfig` are per-call builders (one per schema-backed flavor), `snapshotCodec` is the per-suite format.
 
 ### `snapshotCodec` (per-suite format)
 
@@ -64,7 +70,7 @@ These are two complementary hooks at different scopes. Do not conflate them.
 protected def snapshotCodec: SnapshotCodec = SnapshotCodec.Yaml
 ```
 
-(`SnapshotTest.scala:112`.) Override it in a suite to change the serialization format for every `assertSchemaSnapshot` call in that suite. The default is `SnapshotCodec.Yaml`, "the readable field-named text format" (`SnapshotTest.scala:112`, `SnapshotCodec.scala:37`).
+(`SnapshotTest.scala:114`.) Override it in a suite to change the serialization format for every `assertSchemaSnapshot` call in that suite. The default is `SnapshotCodec.Yaml`, "the readable field-named text format" (`SnapshotTest.scala:114`, `SnapshotCodec.scala:37`).
 
 ### `SnapshotConfig` (per-call customization)
 
@@ -74,22 +80,34 @@ Today it carries exactly one capability, `normalize`, which "Adds a field-normal
 
 **Contract for a contributor adding a capability.** Add it as a new method plus a new internal field whose default preserves current behavior, so existing `.normalize(...)` call sites keep compiling (`SnapshotConfig.scala:15-17`). The example the scaladoc names is a custom comparison strategy. Never add a parameter to `assertSchemaSnapshot` for it; that is the whole reason `SnapshotConfig` exists. The format choice stays out of this builder: "The serialization format is chosen separately, per suite, by the `snapshotCodec` override hook, not through this builder" (`SnapshotConfig.scala:10-13`).
 
+### `GoldenConfig` (per-call customization for the golden flavor)
+
+`GoldenConfig[A]` is the golden twin of `SnapshotConfig`, "The per-call customization point for `assertGoldenSnapshot`" (`GoldenConfig.scala:5`), passed the same way as a `GoldenConfig[A] => GoldenConfig[A]` lambda (default `identity`). It is an immutable builder started from the companion `GoldenConfig[A]` (the empty config: 20 samples, seed 0, size 10, identity normalization; `GoldenConfig.scala:57-58`) and carries four knobs: `sampleCount` (how many values the spread covers, default 20), `seed` and `size` (threaded into `gen.samples`, defaults 0 and 10), and `normalize` (the accumulating `Modify[A]` scrub, composing `f1` then `f2`; `GoldenConfig.scala:34-52`). A `sampleCount` below 1 is rejected at the assertion boundary, naming the invalid count (`SnapshotTest.scala:288-289`, test `SnapshotGoldenTest.scala:316-325`); it is checked in `goldenSamples` before any draw, so no golden file is written when the guard throws (`SnapshotGoldenTest.scala:327-339`).
+
+The same extensibility contract as `SnapshotConfig` binds: a new capability is an additive method plus an internal field whose default preserves current behavior, never a new parameter on `assertGoldenSnapshot` (`GoldenConfig.scala:8-9`). Format selection stays out of this builder; it is the per-suite `snapshotCodec` override (`GoldenConfig.scala:11-13`).
+
 ---
 
 ## The storage contract
 
 ### Path scheme
 
-Both assertions compute `${snapshotDir}/${this.name}/${name}.${ext}`. `snapshotDir` defaults to `"test-snapshots"` and is a `protected def` override hook (`SnapshotTest.scala:51-55`); `this.name` is the suite name, so a suite's snapshots live in a subdirectory named after the suite. The Render path fixes the extension to `snap` (`SnapshotTest.scala:89`); the schema path uses `codec.ext` (`SnapshotTest.scala:144`).
+All three assertions compute `${snapshotDir}/${this.name}/${name}.${ext}`. `snapshotDir` defaults to `"test-snapshots"` and is a `protected def` override hook (`SnapshotTest.scala:53-57`); `this.name` is the suite name, so a suite's snapshots live in a subdirectory named after the suite. The Render path fixes the extension to `snap` (`SnapshotTest.scala:91`); the schema path uses `codec.ext` (`SnapshotTest.scala:146`); the golden path uses `golden.${bare}` where `bare = codec.ext.stripPrefix("snap.")` (`SnapshotTest.scala:296-297`, `:304`).
 
-`name` must be a bare file name. `validateSnapshotName` rejects a path separator (`/` or `\`), the empty string, `.`, `..`, and any embedded space (`SnapshotTest.scala:211-229`). Add a new restriction there, not at each call site.
+`name` must be a bare file name. `validateSnapshotName` rejects a path separator (`/` or `\`), the empty string, `.`, `..`, and any embedded space (`SnapshotTest.scala:260-278`). Add a new restriction there, not at each call site.
+
+### The golden storage envelope and its determinism contract
+
+A golden stores an entire spread as ONE document. The normalized `Chunk[A]` is wrapped in the internal `private[snapshot] case class GoldenSamples[A](samples: Chunk[A])` (`GoldenSamples.scala:9`), whose `Schema` is `Schema.derived` (`GoldenSamples.scala:11-12`). The envelope exists so the whole spread round-trips as a single `samples`-keyed document through both a text and a binary codec, not as a bare sequence: the stored Yaml begins with a top-level `samples:` mapping and holds every sample in one file (`SnapshotGoldenTest.scala:389-405`). The compare unwraps `storedDoc.samples` and pairs it positionally against the regenerated spread (`SnapshotTest.scala:308-309`, `compareSamples` at `:339-344`); a length delta fails first, naming both counts before any per-index compare (`compareGolden` at `:318-327`, test `:341-354`). Keep a golden a single enveloped document: do not switch it to a bare top-level sequence, which would lose the shared text/binary round-trip.
+
+The spread is deterministic and platform-independent, and this is a contract the golden path must preserve. `gen.samples(seed, size, count)` is pure and reproducible: the same `(seed, size, count)` triple always draws the same `Chunk[A]` (`kyo-test/prop/shared/src/main/scala/kyo/test/prop/Gen.scala:105-134`), so a blessed golden regenerates identically on every run. The stored bytes are furthermore byte-identical across JVM, JS, Native, and Wasm: a pinned Yaml encoding of a fixed spread is asserted equal on all four platforms (`SnapshotGoldenTest.scala:407-412`, pinned literal `:456-467`). A change that makes the spread seed-dependent in a new way, or that lets one platform diverge in the stored bytes, breaks the golden contract and the pinned-determinism test is the guard.
 
 ### Text codecs versus binary codecs
 
 `SnapshotCodec` wraps a kyo-schema `Codec` "with the text-versus-binary distinction the codec itself does not carry" (`SnapshotCodec.scala:5-6`). The KIND decides two things a raw `Codec` cannot express: whether the stored file holds a UTF-8 string or raw wire bytes, and whether a mismatch report can carry a textual diff (`SnapshotCodec.scala:8-11`).
 
-- A `Text` codec encodes to a UTF-8 string via `schema.encodeString` and stores it through the `String` store path (`SnapshotTest.scala:146-147`). `SnapshotStore.write` appends a single trailing newline if absent (`internal/SnapshotStore.scala:21-23`).
-- A `Binary` codec encodes to raw wire bytes via `schema.encode` and stores them through the bytes store path (`SnapshotTest.scala:175-176`). `writeBytes` writes "content exactly as given, with no base64 encoding and no trailing-newline append, so a stored binary snapshot is the real codec wire artifact" (`internal/SnapshotStore.scala:33-39`).
+- A `Text` codec encodes to a UTF-8 string via `schema.encodeString` and stores it through the `String` store path (`SnapshotTest.scala:217-219`). `SnapshotStore.write` appends a single trailing newline if absent (`internal/SnapshotStore.scala:21-23`).
+- A `Binary` codec encodes to raw wire bytes via `schema.encode` and stores them through the bytes store path (`SnapshotTest.scala:239-241`). `writeBytes` writes "content exactly as given, with no base64 encoding and no trailing-newline append, so a stored binary snapshot is the real codec wire artifact" (`internal/SnapshotStore.scala:33-39`).
 
 The Protobuf round-trip test pins this: stored bytes are byte-identical to a fresh `schema.encode`, and the stored length is asserted not equal to the base64-encoded length (`SnapshotSchemaTest.scala:271-291`). The raw-bytes store path has its own byte-fidelity coverage including `0x00`, `0xFF`, and a newline byte (`SnapshotStoreBytesTest.scala:25-39`).
 
@@ -103,15 +121,15 @@ The seven presets are `Yaml` (`snap.yaml`), `Json` (`snap.json`), `Ion` (`snap.i
 
 ## The compare contract
 
-On a subsequent run with an existing snapshot, `assertSchemaSnapshot` decodes the stored bytes via `Schema[A]` and branches three ways (`SnapshotTest.scala:156-172` for Text, `:185-202` for Binary):
+On a subsequent run with an existing snapshot, the stored bytes are decoded via `Schema[D]` and branched three ways through the single shared private helper `storeAndCompare[D]` (`SnapshotTest.scala:210-258`; the decode arms are `:226-236` for Text, `:248-255` for Binary). This one helper owns the codec `Text`/`Binary` dispatch, the update-mode write, the first-run absent-write-then-`SnapshotNotFound` path, and the three-way decode branch for every flavor that stores through a `Schema[D]`: `assertSchemaSnapshot` routes its value through it as `storeAndCompare[A]` (`SnapshotTest.scala:147`), and `assertGoldenSnapshot` routes the whole spread through it as `storeAndCompare[GoldenSamples[A]]` (`SnapshotTest.scala:308`). There is one decode branch in the module, not one per assertion; a new schema-backed flavor reuses `storeAndCompare` rather than re-implementing the branch. The three branches:
 
 1. **Decode failure (`Result.Failure`)** routes to `SnapshotSchemaEvolution`, "a stored snapshot whose bytes no longer decode via the current `Schema[A]`" (`SnapshotSchemaEvolution.scala:7`). This is kept distinct from a value mismatch so "schema drift is reported with its own message and never conflated with an ordinary value mismatch" (`SnapshotSchemaEvolution.scala:9-10`). Its diagram is prefixed `SnapshotSchemaEvolution:` and is never the `Snapshot mismatch` prefix (`SnapshotSchemaEvolutionTest.scala:12-20`; distinctness proven end-to-end for both Text and Binary at `SnapshotSchemaTest.scala:206-218`, `:315-329`).
 
-2. **Decode panic (`Result.Panic`)** propagates the underlying throwable unwrapped: `case Result.Panic(err) => throw err` (`SnapshotTest.scala:162-163`, `:188-189`). An unexpected codec defect is not rewrapped as `SnapshotSchemaEvolution`. Both the Binary and Text decode arms are pinned by `SnapshotSchemaTest.scala:347-379`.
+2. **Decode panic (`Result.Panic`)** propagates the underlying throwable unwrapped: `case Result.Panic(err) => throw err` (`SnapshotTest.scala:232-233`, `:251-252`). An unexpected codec defect is not rewrapped as `SnapshotSchemaEvolution`. Both the Binary and Text decode arms are pinned by `SnapshotSchemaTest.scala:347-379`.
 
-3. **Decode success** compares structurally through `Changeset[A](storedValue, norm).operations`; a mismatch fails with the changed field paths (`SnapshotTest.scala:164-172`, `:190-202`). The gate follows schema-structural `Changeset.operations`, not value `.equals`: the `Ver` fixture whose `.equals` ignores field `b` still fails the assertion on a `b` change (`SnapshotSchemaTest.scala:331-345`).
+3. **Decode success** invokes the caller's `onCompare`, which compares structurally through `Changeset[A](storedValue, norm).operations`; a mismatch fails with the changed field paths (`SnapshotTest.scala:148-157`). The gate follows schema-structural `Changeset.operations`, not value `.equals`: the `Ver` fixture whose `.equals` ignores field `b` still fails the assertion on a `b` change (`SnapshotSchemaTest.scala:331-345`).
 
-The comparison is **format-tolerant**: a hand-reformatted stored snapshot that still decodes to an equal value passes (`SnapshotSchemaTest.scala:186-204`), because the compare is on decoded values, not on the stored text. The mismatch report shape differs by codec kind: a `Text` codec carries the changed field path plus a unified textual diff, a `Binary` codec carries the changed field path but no textual diff (`SnapshotSchemaTest.scala:142-170`). Nested field changes report the full dotted path (`b.y`), produced by the recursive `snapshotChangedPaths` helper (`SnapshotTest.scala:231-235`, test `:172-184`).
+The comparison is **format-tolerant**: a hand-reformatted stored snapshot that still decodes to an equal value passes (`SnapshotSchemaTest.scala:186-204`), because the compare is on decoded values, not on the stored text. The mismatch report shape differs by codec kind: a `Text` codec carries the changed field path plus a unified textual diff, a `Binary` codec carries the changed field path but no textual diff (`SnapshotSchemaTest.scala:142-170`). Nested field changes report the full dotted path (`b.y`), produced by the recursive `snapshotChangedPaths` helper (`SnapshotTest.scala:280-284`, test `:172-184`).
 
 `SnapshotDiff.render(stored, actual)` fixes the diff direction convention: `stored` is the on-disk baseline, `actual` is the newly rendered value (`internal/SnapshotDiff.scala:5-6`).
 
@@ -124,9 +142,9 @@ protected def snapshotUpdateMode: Boolean =
     java.lang.System.getenv("KYO_TEST_SNAPSHOT") == "update"
 ```
 
-(`SnapshotTest.scala:62-63`.) When update mode is active, both assertions write the proposed value and pass without reading a prior file (`SnapshotTest.scala:91-92`, `:148-149`, `:177-178`). The default reads the `KYO_TEST_SNAPSHOT` environment variable, but the hook is a plain `protected def` so a suite can force it on or off "without mutating the process environment" (`SnapshotTest.scala:57-61`). Tests exercise this by overriding it directly and by reading a JVM system property (`SnapshotUpdateModeTest.scala:38-60`, `:98-113`).
+(`SnapshotTest.scala:64-65`.) When update mode is active, all three assertions write the proposed value and pass without reading a prior file (`SnapshotTest.scala:93-94` for the Render path; the schema and golden paths share the `storeAndCompare` Text and Binary write sites at `:218-219` and `:240-241`). The default reads the `KYO_TEST_SNAPSHOT` environment variable, but the hook is a plain `protected def` so a suite can force it on or off "without mutating the process environment" (`SnapshotTest.scala:59-63`). Tests exercise this by overriding it directly and by reading a JVM system property (`SnapshotUpdateModeTest.scala:38-60`, `:98-113`).
 
-On the first run with no stored file, both assertions write the proposed snapshot and then fail with `SnapshotNotFound` so the run is red until the reviewer confirms the proposed file (`SnapshotTest.scala:101-103`, `:152-154`; `SnapshotNotFound.scala:7-13`).
+On the first run with no stored file, all three assertions write the proposed snapshot and then fail with `SnapshotNotFound` so the run is red until the reviewer confirms the proposed file (`SnapshotTest.scala:103-105` for the Render path; the schema and golden paths share the `storeAndCompare` Text and Binary absent-write sites at `:222-224` and `:244-246`; `SnapshotNotFound.scala:7-13`).
 
 ---
 
@@ -146,7 +164,7 @@ The store methods are plain synchronous functions returning `Maybe[String]` / `M
 
 ### Foreign-package inline access
 
-`assertSchemaSnapshot` is `inline`, and a user extends `SnapshotTestBase` from their own package. `SnapshotConfig.modify` is `private[snapshot]` (`SnapshotConfig.scala:31`), so the inline body must resolve `normalizeWith` (`SnapshotTest.scala:208-209`) through a compiler-generated accessor rather than a direct cross-package field read. `SnapshotForeignPackageTest` is the standing proof: a `SnapshotTest[Any]` subclass in the sibling package `kyo.test.snapshotforeign` "compiles and runs `assertSchemaSnapshot` with the config lambda" where `private[snapshot]` is genuinely inaccessible (`shared/src/test/scala/kyo/test/snapshotforeign/SnapshotForeignPackageTest.scala:15-22`, `:45-60`). Any change to the inline assertion body or to `SnapshotConfig`'s visibility must keep that test compiling; do not widen `private[snapshot]` to make the inline resolve.
+`assertSchemaSnapshot` is `inline`, and a user extends `SnapshotTestBase` from their own package. `SnapshotConfig.modify` is `private[snapshot]` (`SnapshotConfig.scala:31`), so the inline body must resolve `normalizeWith` (`SnapshotTest.scala:199-200`) through a compiler-generated accessor rather than a direct cross-package field read. `SnapshotForeignPackageTest` is the standing proof: a `SnapshotTest[Any]` subclass in the sibling package `kyo.test.snapshotforeign` "compiles and runs `assertSchemaSnapshot` with the config lambda" where `private[snapshot]` is genuinely inaccessible (`shared/src/test/scala/kyo/test/snapshotforeign/SnapshotForeignPackageTest.scala:15-22`, `:45-60`). Any change to the inline assertion body or to `SnapshotConfig`'s visibility must keep that test compiling; do not widen `private[snapshot]` to make the inline resolve.
 
 ---
 
@@ -154,11 +172,11 @@ The store methods are plain synchronous functions returning `Maybe[String]` / `M
 
 ### The `protected` exception
 
-The root guide bans `protected` in favour of `private[kyo]`. This module is the documented exception for its abstract DSL base classes only (`SnapshotTest.scala:33-34`, `:248-249`). The exception covers the inheritance-facing DSL surface: `snapshotDir`, `snapshotUpdateMode`, `snapshotCodec`, `assertSnapshot`, `assertSchemaSnapshot`. Internal helpers stay `private` (`normalizeWith`, `validateSnapshotName`, `snapshotChangedPaths` at `SnapshotTest.scala:208-235`) and the platform I/O objects stay `private[snapshot]`. Do not extend the `protected` exception to anything that is not a subclass override hook.
+The root guide bans `protected` in favour of `private[kyo]`. This module is the documented exception for its abstract DSL base classes only (`SnapshotTest.scala:35-36`, `:357-358`). The exception covers the inheritance-facing DSL surface: `snapshotDir`, `snapshotUpdateMode`, `snapshotCodec`, `assertSnapshot`, `assertSchemaSnapshot`, `assertGoldenSnapshot`. Internal helpers stay `private` (`normalizeWith`, `storeAndCompare`, `validateSnapshotName`, `snapshotChangedPaths` at `SnapshotTest.scala:199-284`) and the platform I/O objects stay `private[snapshot]`. Do not extend the `protected` exception to anything that is not a subclass override hook.
 
 ### Kyo types
 
-Follow the root guide. In this module: `Maybe` for optional store results (`internal/SnapshotStore.scala:14`, `:30`), `Result` for decode outcomes (`SnapshotTest.scala:156-164`), `Span[Byte]` for raw bytes (`internal/SnapshotStore.scala:30`), `Chunk` for changed-path accumulation (`SnapshotTest.scala:231`).
+Follow the root guide. In this module: `Maybe` for optional store results (`internal/SnapshotStore.scala:14`, `:30`), `Result` for decode outcomes (`SnapshotTest.scala:226-235`), `Span[Byte]` for raw bytes (`internal/SnapshotStore.scala:30`), `Chunk` for changed-path accumulation (`SnapshotTest.scala:280`).
 
 ### Test framework
 
@@ -172,8 +190,9 @@ The 1:1 source-to-test rule holds, with aspect splits where one source needs mor
 
 | Source | Test file(s) |
 |--------|--------------|
-| `SnapshotTest.scala` | `SnapshotTestTest.scala`, `SnapshotSchemaTest.scala`, `SnapshotUpdateModeTest.scala`, `SnapshotReparamTest.scala`, `SnapshotSelfTest.scala` |
+| `SnapshotTest.scala` | `SnapshotTestTest.scala`, `SnapshotSchemaTest.scala`, `SnapshotUpdateModeTest.scala`, `SnapshotReparamTest.scala`, `SnapshotSelfTest.scala`, `SnapshotGoldenTest.scala` |
 | `SnapshotConfig.scala` | `SnapshotConfigTest.scala` |
+| `GoldenConfig.scala` | `GoldenConfigTest.scala` |
 | `SnapshotCodec.scala` | `SnapshotCodecTest.scala` |
 | `SnapshotSchemaEvolution.scala` | `SnapshotSchemaEvolutionTest.scala` |
 | `internal/SnapshotStore.scala` | `SnapshotStoreBytesTest.scala`, `SnapshotStoreTest` (in `SnapshotSelfTest.scala`) |
@@ -206,7 +225,7 @@ See the root [CONTRIBUTING.md](../../CONTRIBUTING.md) for full conventions on na
 
 1. **New assertion.** Is it `protected` on `SnapshotTestBase`, not a package function? Does it validate `name` through `validateSnapshotName`? Does it honour `snapshotUpdateMode` (write-and-pass) and first-run (`SnapshotNotFound`)? Does its effect row stay `S & Async & Abort[Throwable] & Scope`?
 
-2. **New `SnapshotConfig` capability.** Is it an additive method plus an internal field whose default preserves current behavior, leaving `assertSchemaSnapshot`'s signature untouched? Does it stay out of format selection (that is `snapshotCodec`)?
+2. **New `SnapshotConfig` or `GoldenConfig` capability.** Is it an additive method plus an internal field whose default preserves current behavior, leaving `assertSchemaSnapshot`'s / `assertGoldenSnapshot`'s signature untouched? Does it stay out of format selection (that is `snapshotCodec`)?
 
 3. **New codec preset.** Is it `Text` or `Binary`? Does its extension collide with no existing preset and differ from plain `snap`? Is it added to the distinctness assertion in `SnapshotCodecTest`?
 

--- a/kyo-test/snapshot/js-wasm/src/main/scala/kyo/test/snapshot/internal/SnapshotStorePlatform.scala
+++ b/kyo-test/snapshot/js-wasm/src/main/scala/kyo/test/snapshot/internal/SnapshotStorePlatform.scala
@@ -1,6 +1,7 @@
 package kyo.test.snapshot.internal
 
 import kyo.Maybe
+import kyo.Span
 import scala.scalajs.js
 import scala.scalajs.js.annotation.*
 
@@ -9,7 +10,9 @@ import scala.scalajs.js.annotation.*
 private object NodeFsSnap extends js.Object:
     def existsSync(path: String): Boolean                                 = js.native
     def readFileSync(path: String, encoding: String): String              = js.native
+    def readFileSync(path: String): js.typedarray.Uint8Array              = js.native
     def writeFileSync(path: String, data: String, opts: js.Dynamic): Unit = js.native
+    def writeFileSync(path: String, data: js.typedarray.Uint8Array): Unit = js.native
     def mkdirSync(path: String, opts: js.Dynamic): Unit                   = js.native
 end NodeFsSnap
 
@@ -45,6 +48,34 @@ private[snapshot] object SnapshotStorePlatform:
             if parent.nonEmpty && parent != path then
                 NodeFsSnap.mkdirSync(parent, js.Dynamic.literal(recursive = true))
             NodeFsSnap.writeFileSync(path, content, js.Dynamic.literal(encoding = "utf8"))
+        catch
+            case _: js.JavaScriptException =>
+                throw new UnsupportedOperationException(
+                    "Snapshot file I/O is not available in browser environments; use Node.js for snapshot tests"
+                )
+
+    def readBytes(path: String): Maybe[Span[Byte]] =
+        try
+            if NodeFsSnap.existsSync(path) then
+                val u8 = NodeFsSnap.readFileSync(path)
+                val i8 = new js.typedarray.Int8Array(u8.buffer, u8.byteOffset, u8.length)
+                Maybe.Present(Span.fromUnsafe(js.typedarray.int8Array2ByteArray(i8)))
+            else
+                Maybe.Absent
+        catch
+            case _: js.JavaScriptException =>
+                throw new UnsupportedOperationException(
+                    "Snapshot file I/O is not available in browser environments; use Node.js for snapshot tests"
+                )
+
+    def writeBytes(path: String, content: Span[Byte]): Unit =
+        try
+            val parent = NodePathSnap.dirname(path)
+            if parent.nonEmpty && parent != path then
+                NodeFsSnap.mkdirSync(parent, js.Dynamic.literal(recursive = true))
+            val i8 = js.typedarray.byteArray2Int8Array(content.toArrayUnsafe)
+            val u8 = new js.typedarray.Uint8Array(i8.buffer, i8.byteOffset, i8.length)
+            NodeFsSnap.writeFileSync(path, u8)
         catch
             case _: js.JavaScriptException =>
                 throw new UnsupportedOperationException(

--- a/kyo-test/snapshot/jvm-native/src/main/scala/kyo/test/snapshot/internal/SnapshotStorePlatform.scala
+++ b/kyo-test/snapshot/jvm-native/src/main/scala/kyo/test/snapshot/internal/SnapshotStorePlatform.scala
@@ -4,6 +4,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 import kyo.Maybe
+import kyo.Span
 
 /** JVM and Native snapshot file I/O backed by `java.nio.file`.
   *
@@ -21,7 +22,7 @@ private[snapshot] object SnapshotStorePlatform:
     def write(path: String, content: String): Unit =
         val p      = Paths.get(path)
         val parent = p.getParent
-        // Unsafe: java.io.File.getParent returns null for top-level paths; skip directory creation in that case
+        // Unsafe: java.nio.file.Path.getParent returns null for top-level paths; skip directory creation in that case
         if parent != null then
             val _ = Files.createDirectories(parent)
         val _ = Files.writeString(
@@ -32,5 +33,26 @@ private[snapshot] object SnapshotStorePlatform:
             StandardOpenOption.WRITE
         )
     end write
+
+    def readBytes(path: String): Maybe[Span[Byte]] =
+        val p = Paths.get(path)
+        if Files.exists(p) then Maybe.Present(Span.fromUnsafe(Files.readAllBytes(p)))
+        else Maybe.Absent
+    end readBytes
+
+    def writeBytes(path: String, content: Span[Byte]): Unit =
+        val p      = Paths.get(path)
+        val parent = p.getParent
+        // Unsafe: java.nio.file.Path.getParent returns null for top-level paths; skip directory creation in that case
+        if parent != null then
+            val _ = Files.createDirectories(parent)
+        val _ = Files.write(
+            p,
+            content.toArrayUnsafe,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING,
+            StandardOpenOption.WRITE
+        )
+    end writeBytes
 
 end SnapshotStorePlatform

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/GoldenConfig.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/GoldenConfig.scala
@@ -1,0 +1,58 @@
+package kyo.test.snapshot
+
+import kyo.Modify
+
+/** The per-call customization point for [[SnapshotTestBase.assertGoldenSnapshot]].
+  *
+  * An immutable builder passed to `assertGoldenSnapshot` as a `GoldenConfig[A] => GoldenConfig[A]` lambda. It carries the four golden
+  * knobs (`sampleCount`, `seed`, `size`, `normalize`) so the assertion can gain new per-call capabilities over time without changing its
+  * signature: each new knob is an additive method here, never a new parameter on `assertGoldenSnapshot`.
+  *
+  * This configures a single `assertGoldenSnapshot` invocation. The serialization format is chosen separately, per suite, by the
+  * [[SnapshotTestBase.snapshotCodec]] override hook, not through this builder; the two are complementary customization surfaces at
+  * different scopes (per-call here, per-suite there).
+  *
+  * Start from the empty config via the companion `GoldenConfig[A]` (20 samples, seed 0, size 10, identity normalization) and compose
+  * builder methods, for example `_.sampleCount(50).seed(7L).normalize(_.set(_.at)(0L))` inside the `assertGoldenSnapshot` config lambda.
+  *
+  * @tparam A
+  *   the type being sampled; a `Gen[A]` and a `Schema[A]` are required by `assertGoldenSnapshot`
+  * @see
+  *   [[SnapshotTestBase.assertGoldenSnapshot]] the assertion this configures
+  * @see
+  *   [[SnapshotConfig]] the sibling per-call builder for `assertSchemaSnapshot`
+  * @see
+  *   [[kyo.Modify]] the field-transform DSL that `normalize` builds on
+  */
+final class GoldenConfig[A] private[snapshot] (
+    private[snapshot] val modify: Modify[A],
+    private[snapshot] val sampleCount: Int,
+    private[snapshot] val seed: Long,
+    private[snapshot] val size: Int
+):
+
+    /** Adds a field-normalization pass, scrubbing non-deterministic fields before encode and before compare.
+      *
+      * Accumulates: the supplied transform is applied to the config's current `Modify[A]`, so `.normalize(f1).normalize(f2)` composes
+      * `f1` then `f2`.
+      */
+    def normalize(f: Modify[A] => Modify[A]): GoldenConfig[A] =
+        new GoldenConfig[A](f(modify), sampleCount, seed, size)
+
+    /** Sets how many generated values the spread covers (default 20). A value below 1 is rejected at the assertion boundary. */
+    def sampleCount(n: Int): GoldenConfig[A] =
+        new GoldenConfig[A](modify, n, seed, size)
+
+    /** Sets the deterministic sampling seed threaded into `gen.samples` (default 0). */
+    def seed(s: Long): GoldenConfig[A] =
+        new GoldenConfig[A](modify, sampleCount, s, size)
+
+    /** Sets the generator size hint threaded into `gen.samples` (default 10). */
+    def size(sz: Int): GoldenConfig[A] =
+        new GoldenConfig[A](modify, sampleCount, seed, sz)
+
+end GoldenConfig
+
+object GoldenConfig:
+    /** The empty config for `A`: 20 samples, seed 0, size 10, identity normalization. */
+    def apply[A]: GoldenConfig[A] = new GoldenConfig[A](Modify.apply[A], 20, 0L, 10)

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/GoldenSamples.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/GoldenSamples.scala
@@ -1,0 +1,12 @@
+package kyo.test.snapshot
+
+import kyo.Chunk
+import kyo.Schema
+
+/** Internal storage envelope for a golden: the normalized sample spread as a `samples`-keyed document, so a golden file round-trips as one
+  * document through both text and binary codecs.
+  */
+final private[snapshot] case class GoldenSamples[A](samples: Chunk[A])
+
+private[snapshot] object GoldenSamples:
+    given goldenSamplesSchema[A](using Schema[A]): Schema[GoldenSamples[A]] = Schema.derived

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotCodec.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotCodec.scala
@@ -1,0 +1,57 @@
+package kyo.test.snapshot
+
+import kyo.Codec
+
+/** Serialization format for a schema-driven snapshot, wrapping a kyo-schema [[kyo.Codec]] with the text-versus-binary distinction
+  * the codec itself does not carry.
+  *
+  * A snapshot codec is either [[Text]] or [[Binary]]. The KIND (which of the two cases) decides two things a raw `Codec` cannot
+  * express: whether the stored file holds a UTF-8 string or raw wire bytes, and whether a mismatch report can carry a unified
+  * textual diff (only `Text` can). The seven companion presets cover every codec kyo-schema ships (`Yaml`, `Json`, `Ion`,
+  * `Protobuf`, `Bson`, `MsgPack`, `IonBinary`); `Text` and `Binary` remain the open extension point for any custom `Codec`.
+  *
+  * @param codec
+  *   the underlying kyo-schema codec that encodes and decodes the snapshotted value
+  * @param ext
+  *   the file extension for stored snapshots, kept pairwise-distinct across presets so a text and a binary snapshot of the same
+  *   name never collide, and distinct from the plain `snap` extension of the `Render`-based `assertSnapshot` so a suite mixing
+  *   both assertions on the same name never cross-writes one file
+  * @see
+  *   [[kyo.test.snapshot.SnapshotTestBase.snapshotCodec]] the per-suite hook selecting a codec
+  * @see
+  *   [[kyo.test.snapshot.SnapshotTestBase.assertSchemaSnapshot]] the assertion that reads it
+  */
+enum SnapshotCodec(val codec: Codec, val ext: String):
+
+    /** A text codec: the snapshot stores a UTF-8 string and a mismatch reports a textual diff. */
+    case Text(override val codec: Codec, override val ext: String) extends SnapshotCodec(codec, ext)
+
+    /** A binary codec: the snapshot stores raw wire bytes and a mismatch reports no textual diff. */
+    case Binary(override val codec: Codec, override val ext: String) extends SnapshotCodec(codec, ext)
+
+end SnapshotCodec
+
+object SnapshotCodec:
+
+    /** YAML, the default readable field-named text format. */
+    val Yaml: SnapshotCodec = Text(kyo.Yaml(), "snap.yaml")
+
+    /** JSON text format. */
+    val Json: SnapshotCodec = Text(kyo.Json(), "snap.json")
+
+    /** Amazon Ion text format. */
+    val Ion: SnapshotCodec = Text(kyo.Ion(), "snap.ion")
+
+    /** Protocol Buffers binary format. */
+    val Protobuf: SnapshotCodec = Binary(kyo.Protobuf(), "snap.pb")
+
+    /** BSON binary format. */
+    val Bson: SnapshotCodec = Binary(kyo.Bson(), "snap.bson")
+
+    /** MessagePack binary format. */
+    val MsgPack: SnapshotCodec = Binary(kyo.MsgPack(), "snap.msgpack")
+
+    /** Amazon Ion Binary format. */
+    val IonBinary: SnapshotCodec = Binary(kyo.IonBinary(), "snap.ionb")
+
+end SnapshotCodec

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotConfig.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotConfig.scala
@@ -1,0 +1,45 @@
+package kyo.test.snapshot
+
+import kyo.Modify
+
+/** The single per-call customization point for [[SnapshotTestBase.assertSchemaSnapshot]].
+  *
+  * An immutable builder passed to `assertSchemaSnapshot` as a `SnapshotConfig[A] => SnapshotConfig[A]` lambda. It exists so the
+  * assertion can gain new per-call customization capabilities over time without changing its signature or breaking existing call
+  * sites: each new knob is an additive method here, never a new parameter on `assertSchemaSnapshot`.
+  *
+  * This configures a single `assertSchemaSnapshot` invocation. The serialization format is chosen separately, per suite, by the
+  * [[SnapshotTestBase.snapshotCodec]] override hook, not through this builder; the two are complementary customization surfaces at
+  * different scopes (per-call here, per-suite there).
+  *
+  * Today it carries exactly one capability, [[normalize]]. A future capability (for example a custom comparison strategy) is added
+  * as a new method plus a new internal field whose default preserves the current behavior, so existing `.normalize(...)` call sites
+  * keep compiling unchanged.
+  *
+  * Start from the empty config via the companion `SnapshotConfig[A]` (identity normalization) and compose builder methods, for
+  * example `_.normalize(_.set(_.startedAt)(Instant.EPOCH))` inside the `assertSchemaSnapshot` config lambda.
+  *
+  * @tparam A
+  *   the type being snapshotted; a `Schema[A]` is required by `assertSchemaSnapshot`
+  * @see
+  *   [[SnapshotTestBase.assertSchemaSnapshot]] the assertion this configures
+  * @see
+  *   [[SnapshotTestBase.snapshotCodec]] the separate per-suite format-selection hook
+  * @see
+  *   [[kyo.Modify]] the field-transform DSL that `normalize` builds on
+  */
+final class SnapshotConfig[A] private[snapshot] (private[snapshot] val modify: Modify[A]):
+
+    /** Adds a field-normalization pass, scrubbing non-deterministic fields before encode and before compare.
+      *
+      * Accumulates: the supplied transform is applied to the config's current `Modify[A]`, so `.normalize(f1).normalize(f2)`
+      * composes `f1` then `f2`.
+      */
+    def normalize(f: Modify[A] => Modify[A]): SnapshotConfig[A] =
+        new SnapshotConfig[A](f(modify))
+
+end SnapshotConfig
+
+object SnapshotConfig:
+    /** The empty config for `A`: identity normalization, built from the empty `Modify[A]`. */
+    def apply[A]: SnapshotConfig[A] = new SnapshotConfig[A](Modify.apply[A])

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotSchemaEvolution.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotSchemaEvolution.scala
@@ -1,0 +1,33 @@
+package kyo.test.snapshot
+
+import kyo.Frame
+import kyo.Maybe
+import kyo.test.AssertionFailed
+
+/** Distinct failure for schema-evolution drift: a stored snapshot whose bytes no longer decode via the current `Schema[A]`.
+  *
+  * Constructed (never thrown) by [[SnapshotTestBase.assertSchemaSnapshot]] on the decode-failure branch, so schema drift is
+  * reported with its own message and never conflated with an ordinary value mismatch. Mirrors the sibling [[SnapshotNotFound]]
+  * factory: a named single-purpose factory whose diagram is self-describing, with `msg` and `cause` both absent.
+  *
+  * @param path
+  *   the path to the stored snapshot file that failed to decode
+  * @param detail
+  *   the decode-failure explanation (for Text codecs the caller prepends a unified diff)
+  * @param frame
+  *   the source location of the failing assertSchemaSnapshot call
+  * @see
+  *   [[kyo.test.snapshot.SnapshotNotFound]] the first-run sibling failure factory
+  * @see
+  *   [[kyo.test.AssertionFailed]] the failure type this factory constructs
+  */
+object SnapshotSchemaEvolution:
+    /** Constructs the `AssertionFailed` for a stored snapshot that failed to decode. */
+    def apply(path: String, detail: String)(using frame: Frame): AssertionFailed =
+        new AssertionFailed(
+            s"SnapshotSchemaEvolution: stored snapshot at $path could not be decoded: $detail",
+            frame,
+            Maybe.Absent,
+            Maybe.Absent
+        )
+end SnapshotSchemaEvolution

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotTest.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotTest.scala
@@ -3,14 +3,20 @@ package kyo.test.snapshot
 import kyo.<
 import kyo.Abort
 import kyo.Async
+import kyo.Changeset
+import kyo.Chunk
 import kyo.Frame
 import kyo.Maybe
 import kyo.Render
+import kyo.Result
+import kyo.Schema
 import kyo.Scope
 import kyo.test.AssertionFailed
 import kyo.test.SuiteFingerprintMarker
 import kyo.test.internal.TestBase
+import kyo.test.snapshot.SnapshotCodec
 import kyo.test.snapshot.SnapshotNotFound
+import kyo.test.snapshot.SnapshotSchemaEvolution
 import kyo.test.snapshot.internal.SnapshotDiff
 import kyo.test.snapshot.internal.SnapshotStore
 
@@ -79,23 +85,7 @@ abstract class SnapshotTestBase[S] extends TestBase[S]:
     )(using inline r: Render[A], inline frame: Frame, inline as: kyo.test.AssertScope): Unit < (S & Async & Abort[Throwable] & Scope) =
         as.recordEvaluated()
         val rendered = r.asString(actual)
-        if name.contains('/') || name.contains('\\') then
-            throw new IllegalArgumentException(
-                s"Snapshot name must not contain path separators: $name"
-            )
-        end if
-        if name.isEmpty then
-            throw new IllegalArgumentException("snapshot name must not be empty")
-        end if
-        if name == "." then
-            throw new IllegalArgumentException("snapshot name must not be '.'")
-        end if
-        if name == ".." then
-            throw new IllegalArgumentException("snapshot name must not be '..'")
-        end if
-        if name.contains(' ') then
-            throw new IllegalArgumentException("snapshot name must not contain a space")
-        end if
+        validateSnapshotName(name)
         val path       = s"${snapshotDir}/${this.name}/${name}.snap"
         val updateMode = snapshotUpdateMode
         if updateMode then
@@ -113,6 +103,136 @@ abstract class SnapshotTestBase[S] extends TestBase[S]:
                     throw SnapshotNotFound(path)(using frame)
         end if
     end assertSnapshot
+
+    /** Snapshot serialization format used by [[assertSchemaSnapshot]].
+      *
+      * Override in a suite to change the format (e.g. `SnapshotCodec.Protobuf` for a binary round trip). Defaults to
+      * `SnapshotCodec.Yaml`, the readable field-named text format.
+      */
+    protected def snapshotCodec: SnapshotCodec = SnapshotCodec.Yaml
+
+    /** Assert that `actual`, normalized then encoded through [[snapshotCodec]], matches the stored schema snapshot named `name`.
+      *
+      * Algorithm:
+      *   1. Normalize: `norm = config(SnapshotConfig.apply[A]).modify.applyTo(actual)`, applied before encode AND before compare.
+      *   2. Encode `norm` by codec kind: a Text codec produces a UTF-8 string, a Binary codec produces raw wire bytes.
+      *   3. Compute the storage path `${snapshotDir}/${this.name}/${name}.${snapshotCodec.ext}`.
+      *   4. If update mode: write the proposed value and pass.
+      *   5. If no snapshot exists yet: write the proposed value and fail with `SnapshotNotFound`.
+      *   6. If a snapshot exists: decode it via `Schema[A]`; a decode failure fails with `SnapshotSchemaEvolution`, a decode
+      *      success compares structurally and passes when equal, else fails with the changed field paths (plus a textual diff
+      *      for Text codecs).
+      *
+      * @param actual
+      *   the value to snapshot; a `Schema[A]` instance must be in scope
+      * @param name
+      *   the snapshot identifier; must not contain path separators, be empty, be `.` or `..`, or contain a space
+      * @param config
+      *   customizes the assertion through the `SnapshotConfig[A]` builder (today `.normalize`); defaults to `identity`
+      * @tparam A
+      *   the type of the value; a `Schema[A]` instance must be in scope
+      */
+    protected inline def assertSchemaSnapshot[A](
+        inline actual: A,
+        inline name: String,
+        inline config: SnapshotConfig[A] => SnapshotConfig[A] = identity[SnapshotConfig[A]]
+    )(using inline schema: Schema[A], inline frame: Frame, inline as: kyo.test.AssertScope): Unit < (S & Async & Abort[Throwable] & Scope) =
+        as.recordEvaluated()
+        validateSnapshotName(name)
+        val codec = snapshotCodec
+        val norm  = normalizeWith(config, actual)
+        val path  = s"${snapshotDir}/${this.name}/${name}.${codec.ext}"
+        codec match
+            case SnapshotCodec.Text(c, _) =>
+                val proposed = schema.encodeString(norm)(using c, frame)
+                if snapshotUpdateMode then
+                    SnapshotStore.write(path, proposed)
+                else
+                    SnapshotStore.read(path) match
+                        case Maybe.Absent =>
+                            SnapshotStore.write(path, proposed)
+                            throw SnapshotNotFound(path)(using frame)
+                        case Maybe.Present(stored) =>
+                            schema.decodeString(stored)(using c, frame) match
+                                case Result.Failure(err) =>
+                                    throw SnapshotSchemaEvolution(
+                                        path,
+                                        s"${err.getMessage}\n\n${SnapshotDiff.render(stored, proposed)}"
+                                    )(using frame)
+                                case Result.Panic(err) =>
+                                    throw err
+                                case Result.Success(storedValue) =>
+                                    val ops = Changeset[A](storedValue, norm)(using schema, frame).operations
+                                    if ops.nonEmpty then
+                                        val paths   = snapshotChangedPaths(ops)
+                                        val diagram = s"changed fields: ${paths.mkString(", ")}\n\n${SnapshotDiff.render(stored, proposed)}"
+                                        val failure = new AssertionFailed(diagram, frame, Maybe.Present("Snapshot mismatch"), Maybe.Absent)
+                                        as.record(failure)
+                                        throw failure
+                                    end if
+                    end match
+                end if
+            case SnapshotCodec.Binary(c, _) =>
+                val proposed = schema.encode(norm)(using c, frame)
+                if snapshotUpdateMode then
+                    SnapshotStore.writeBytes(path, proposed)
+                else
+                    SnapshotStore.readBytes(path) match
+                        case Maybe.Absent =>
+                            SnapshotStore.writeBytes(path, proposed)
+                            throw SnapshotNotFound(path)(using frame)
+                        case Maybe.Present(stored) =>
+                            schema.decode(stored)(using c, frame) match
+                                case Result.Failure(err) =>
+                                    throw SnapshotSchemaEvolution(path, err.getMessage)(using frame)
+                                case Result.Panic(err) =>
+                                    throw err
+                                case Result.Success(storedValue) =>
+                                    val ops = Changeset[A](storedValue, norm)(using schema, frame).operations
+                                    if ops.nonEmpty then
+                                        val paths = snapshotChangedPaths(ops)
+                                        val failure = new AssertionFailed(
+                                            s"changed fields: ${paths.mkString(", ")}",
+                                            frame,
+                                            Maybe.Present("Snapshot mismatch"),
+                                            Maybe.Absent
+                                        )
+                                        as.record(failure)
+                                        throw failure
+                                    end if
+                    end match
+                end if
+        end match
+    end assertSchemaSnapshot
+
+    private def normalizeWith[A](config: SnapshotConfig[A] => SnapshotConfig[A], value: A): A =
+        config(SnapshotConfig.apply[A]).modify.applyTo(value)
+
+    private def validateSnapshotName(name: String): Unit =
+        if name.contains('/') || name.contains('\\') then
+            throw new IllegalArgumentException(
+                s"Snapshot name must not contain path separators: $name"
+            )
+        end if
+        if name.isEmpty then
+            throw new IllegalArgumentException("snapshot name must not be empty")
+        end if
+        if name == "." then
+            throw new IllegalArgumentException("snapshot name must not be '.'")
+        end if
+        if name == ".." then
+            throw new IllegalArgumentException("snapshot name must not be '..'")
+        end if
+        if name.contains(' ') then
+            throw new IllegalArgumentException("snapshot name must not contain a space")
+        end if
+    end validateSnapshotName
+
+    private def snapshotChangedPaths(ops: Chunk[Changeset.Patch], prefix: Chunk[String] = Chunk.empty): Chunk[String] =
+        ops.flatMap {
+            case Changeset.Patch.Nested(fp, nested) => snapshotChangedPaths(nested, prefix ++ fp)
+            case patch                              => Chunk((prefix ++ patch.fieldPath).mkString("."))
+        }
 
 end SnapshotTestBase
 

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotTest.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/SnapshotTest.scala
@@ -14,6 +14,7 @@ import kyo.Scope
 import kyo.test.AssertionFailed
 import kyo.test.SuiteFingerprintMarker
 import kyo.test.internal.TestBase
+import kyo.test.prop.Gen
 import kyo.test.snapshot.SnapshotCodec
 import kyo.test.snapshot.SnapshotNotFound
 import kyo.test.snapshot.SnapshotSchemaEvolution
@@ -27,8 +28,9 @@ import kyo.test.snapshot.internal.SnapshotStore
   * standalone) can extend it directly and stay out of sbt test discovery. The public [[SnapshotTest]] subclass adds the marker so real user
   * snapshot suites are discovered; the fixtures must not be, because they fail by design. JVM discovery (Zinc's `xsbt.api.Discovery`) does
   * not surface a `SnapshotTest[Any]` fixture as a standalone suite, but Scala Native's reflective discovery does (it matches the marker on
-  * the actual class hierarchy via `@EnableReflectiveInstantiation`), which previously failed the Native task. Extending this marker-free
-  * base keeps the fixtures instantiable by `runToFuture` while invisible to discovery on every platform.
+  * the actual class hierarchy via `@EnableReflectiveInstantiation`), so a marker-carrying fixture would otherwise be discovered as a
+  * standalone suite on Native. Extending this marker-free base keeps the fixtures instantiable by `runToFuture` while invisible to
+  * discovery on every platform.
   *
   * The DSL methods in this class use `protected` visibility because the framework contract is inheritance-based; this is a deliberate
   * exception to the `No protected` convention (CONTRIBUTING P5), documented here as permitted for abstract DSL base classes.
@@ -142,9 +144,77 @@ abstract class SnapshotTestBase[S] extends TestBase[S]:
         val codec = snapshotCodec
         val norm  = normalizeWith(config, actual)
         val path  = s"${snapshotDir}/${this.name}/${name}.${codec.ext}"
+        storeAndCompare[A](codec, path, norm) { (storedValue, textDiff) =>
+            val ops = Changeset[A](storedValue, norm)(using schema, frame).operations
+            if ops.nonEmpty then
+                val paths = snapshotChangedPaths(ops)
+                val diagram = textDiff match
+                    case Maybe.Present(diff) => s"changed fields: ${paths.mkString(", ")}\n\n$diff"
+                    case Maybe.Absent        => s"changed fields: ${paths.mkString(", ")}"
+                val failure = new AssertionFailed(diagram, frame, Maybe.Present("Snapshot mismatch"), Maybe.Absent)
+                as.record(failure)
+                throw failure
+            end if
+        }
+    end assertSchemaSnapshot
+
+    /** Assert that a deterministic spread of `sampleCount` generated `A` values, normalized then encoded through [[snapshotCodec]] as one
+      * document, matches the stored golden identified by `name`.
+      *
+      * Draws `config.sampleCount` values from the required `Gen[A]` via `gen.samples(config.seed, config.size, config.sampleCount)`,
+      * normalizes each through the accumulated `Modify[A]`, and encodes the normalized spread as a single `samples`-keyed document. On a
+      * later run the stored document is decoded and compared per sample against the freshly-regenerated, identically-normalized spread; a
+      * field change is reported as the literal token `sample[N].field.path`.
+      *
+      * Algorithm:
+      *   1. Draw and normalize the spread, guarding `sampleCount >= 1`.
+      *   2. Compute the storage path `${snapshotDir}/${this.name}/${name}.golden.${bare}`, `bare = snapshotCodec.ext.stripPrefix("snap.")`.
+      *   3. If update mode: write the proposed golden and pass.
+      *   4. If no golden exists yet: write the proposed golden and fail with `SnapshotNotFound`.
+      *   5. If a golden exists: decode it; a decode failure fails with `SnapshotSchemaEvolution`, a length mismatch fails naming the count
+      *      delta, and a per-sample structural difference fails with the index-prefixed changed field paths.
+      *
+      * @param name
+      *   the golden identifier; must not contain path separators, be empty, be `.` or `..`, or contain a space
+      * @param config
+      *   customizes the assertion through the `GoldenConfig[A]` builder (`sampleCount`/`seed`/`size`/`normalize`); defaults to `identity`
+      * @tparam A
+      *   the type being sampled; a `Gen[A]` and a `Schema[A]` instance must be in scope
+      */
+    protected inline def assertGoldenSnapshot[A](
+        inline name: String,
+        inline config: GoldenConfig[A] => GoldenConfig[A] = identity[GoldenConfig[A]]
+    )(using
+        inline gen: Gen[A],
+        inline schema: Schema[A],
+        inline frame: Frame,
+        inline as: kyo.test.AssertScope
+    ): Unit < (S & Async & Abort[Throwable] & Scope) =
+        as.recordEvaluated()
+        validateSnapshotName(name)
+        val norm = goldenSamples(config, gen)
+        goldenStoreAndCompare(name, norm)(using schema, frame, as)
+    end assertGoldenSnapshot
+
+    private def normalizeWith[A](config: SnapshotConfig[A] => SnapshotConfig[A], value: A): A =
+        config(SnapshotConfig.apply[A]).modify.applyTo(value)
+
+    /** Stores or compares one encoded document `doc` at `path` through `codec`, owning the codec-Text/Binary dispatch, the
+      * update-mode write, the absent-write-then-`SnapshotNotFound` first-run path, and the three-way decode branch
+      * (`Result.Failure` routes to `SnapshotSchemaEvolution`, `Result.Panic` rethrows unwrapped, `Result.Success` invokes
+      * `onCompare`) shared by every snapshot flavor that stores through a `Schema[D]`.
+      *
+      * `onCompare` receives the decoded stored value plus, for a `Text` codec, the unified textual diff between the stored
+      * and proposed encodings (`Maybe.Absent` for a `Binary` codec, which carries no textual diff).
+      */
+    private def storeAndCompare[D](
+        codec: SnapshotCodec,
+        path: String,
+        doc: D
+    )(onCompare: (stored: D, textDiff: Maybe[String]) => Unit)(using schema: Schema[D], frame: Frame): Unit =
         codec match
             case SnapshotCodec.Text(c, _) =>
-                val proposed = schema.encodeString(norm)(using c, frame)
+                val proposed = schema.encodeString(doc)(using c, frame)
                 if snapshotUpdateMode then
                     SnapshotStore.write(path, proposed)
                 else
@@ -162,18 +232,11 @@ abstract class SnapshotTestBase[S] extends TestBase[S]:
                                 case Result.Panic(err) =>
                                     throw err
                                 case Result.Success(storedValue) =>
-                                    val ops = Changeset[A](storedValue, norm)(using schema, frame).operations
-                                    if ops.nonEmpty then
-                                        val paths   = snapshotChangedPaths(ops)
-                                        val diagram = s"changed fields: ${paths.mkString(", ")}\n\n${SnapshotDiff.render(stored, proposed)}"
-                                        val failure = new AssertionFailed(diagram, frame, Maybe.Present("Snapshot mismatch"), Maybe.Absent)
-                                        as.record(failure)
-                                        throw failure
-                                    end if
+                                    onCompare(storedValue, Maybe.Present(SnapshotDiff.render(stored, proposed)))
                     end match
                 end if
             case SnapshotCodec.Binary(c, _) =>
-                val proposed = schema.encode(norm)(using c, frame)
+                val proposed = schema.encode(doc)(using c, frame)
                 if snapshotUpdateMode then
                     SnapshotStore.writeBytes(path, proposed)
                 else
@@ -188,25 +251,11 @@ abstract class SnapshotTestBase[S] extends TestBase[S]:
                                 case Result.Panic(err) =>
                                     throw err
                                 case Result.Success(storedValue) =>
-                                    val ops = Changeset[A](storedValue, norm)(using schema, frame).operations
-                                    if ops.nonEmpty then
-                                        val paths = snapshotChangedPaths(ops)
-                                        val failure = new AssertionFailed(
-                                            s"changed fields: ${paths.mkString(", ")}",
-                                            frame,
-                                            Maybe.Present("Snapshot mismatch"),
-                                            Maybe.Absent
-                                        )
-                                        as.record(failure)
-                                        throw failure
-                                    end if
+                                    onCompare(storedValue, Maybe.Absent)
                     end match
                 end if
         end match
-    end assertSchemaSnapshot
-
-    private def normalizeWith[A](config: SnapshotConfig[A] => SnapshotConfig[A], value: A): A =
-        config(SnapshotConfig.apply[A]).modify.applyTo(value)
+    end storeAndCompare
 
     private def validateSnapshotName(name: String): Unit =
         if name.contains('/') || name.contains('\\') then
@@ -232,6 +281,66 @@ abstract class SnapshotTestBase[S] extends TestBase[S]:
         ops.flatMap {
             case Changeset.Patch.Nested(fp, nested) => snapshotChangedPaths(nested, prefix ++ fp)
             case patch                              => Chunk((prefix ++ patch.fieldPath).mkString("."))
+        }
+
+    private def goldenSamples[A](config: GoldenConfig[A] => GoldenConfig[A], gen: Gen[A]): Chunk[A] =
+        val resolvedConfig = config(GoldenConfig.apply[A])
+        if resolvedConfig.sampleCount < 1 then
+            throw new IllegalArgumentException(s"golden sampleCount must be >= 1, got ${resolvedConfig.sampleCount}")
+        end if
+        gen.samples(resolvedConfig.seed, resolvedConfig.size, resolvedConfig.sampleCount).map(sample =>
+            resolvedConfig.modify.applyTo(sample)
+        )
+    end goldenSamples
+
+    private def goldenPath(name: String, bare: String): String =
+        s"${snapshotDir}/${this.name}/${name}.golden.${bare}"
+
+    private def goldenStoreAndCompare[A](
+        name: String,
+        norm: Chunk[A]
+    )(using schema: Schema[A], frame: Frame, as: kyo.test.AssertScope): Unit =
+        val codec        = snapshotCodec
+        val bare         = codec.ext.stripPrefix("snap.")
+        val path         = goldenPath(name, bare)
+        val doc          = GoldenSamples(norm)
+        val goldenSchema = summon[Schema[GoldenSamples[A]]]
+        storeAndCompare[GoldenSamples[A]](codec, path, doc) { (storedDoc, textDiff) =>
+            compareGolden(storedDoc.samples, norm, textDiff)
+        }(using goldenSchema, frame)
+    end goldenStoreAndCompare
+
+    private def compareGolden[A](
+        stored: Chunk[A],
+        actual: Chunk[A],
+        textDiff: Maybe[String]
+    )(using schema: Schema[A], frame: Frame, as: kyo.test.AssertScope): Unit =
+        if stored.length != actual.length then
+            val failure = new AssertionFailed(
+                s"golden holds ${stored.length} samples, run produced ${actual.length}; re-bless if intended",
+                frame,
+                Maybe.Present("Golden sample count mismatch"),
+                Maybe.Absent
+            )
+            as.record(failure)
+            throw failure
+        end if
+        val paths = compareSamples(stored, actual)
+        if paths.nonEmpty then
+            val diagram = textDiff match
+                case Maybe.Present(diff) => s"changed fields: ${paths.mkString(", ")}\n\n$diff"
+                case Maybe.Absent        => s"changed fields: ${paths.mkString(", ")}"
+            val failure = new AssertionFailed(diagram, frame, Maybe.Present("Golden mismatch"), Maybe.Absent)
+            as.record(failure)
+            throw failure
+        end if
+    end compareGolden
+
+    private def compareSamples[A](stored: Chunk[A], actual: Chunk[A])(using schema: Schema[A], frame: Frame): Chunk[String] =
+        Chunk.from(0 until stored.length).flatMap { i =>
+            val ops = Changeset[A](stored(i), actual(i))(using schema, frame).operations
+            if ops.isEmpty then Chunk.empty[String]
+            else snapshotChangedPaths(ops, Chunk(s"sample[$i]"))
         }
 
 end SnapshotTestBase

--- a/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/internal/SnapshotStore.scala
+++ b/kyo-test/snapshot/shared/src/main/scala/kyo/test/snapshot/internal/SnapshotStore.scala
@@ -1,6 +1,7 @@
 package kyo.test.snapshot.internal
 
 import kyo.Maybe
+import kyo.Span
 
 /** Platform-specific file I/O for snapshot files.
   *
@@ -20,5 +21,21 @@ object SnapshotStore:
     def write(path: String, content: String): Unit =
         val normalized = if content.endsWith("\n") then content else content + "\n"
         SnapshotStorePlatform.write(path, normalized)
+
+    /** Returns the raw snapshot bytes, or Absent if the file does not exist.
+      *
+      * The bytes-path sibling of [[read]] for binary codecs. Unlike [[read]] and [[write]], no trailing-newline handling is
+      * applied: the bytes are returned exactly as stored.
+      */
+    def readBytes(path: String): Maybe[Span[Byte]] =
+        SnapshotStorePlatform.readBytes(path)
+
+    /** Writes raw bytes to path verbatim, creating parent directories as needed. Overwrites if already present.
+      *
+      * The bytes-path sibling of [[write]] for binary codecs: content is written exactly as given, with no base64 encoding and
+      * no trailing-newline append, so a stored binary snapshot is the real codec wire artifact.
+      */
+    def writeBytes(path: String, content: Span[Byte]): Unit =
+        SnapshotStorePlatform.writeBytes(path, content)
 
 end SnapshotStore

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/GoldenConfigTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/GoldenConfigTest.scala
@@ -1,0 +1,80 @@
+package kyo.test.snapshot
+
+import kyo.Schema
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for `GoldenConfig`: the builder's defaults, immutable accumulation, and normalize composition order.
+  *
+  * All assertions are synchronous plain-value checks (no file I/O, no Sync/Async boundary); uses ScalaTest directly, mirroring
+  * `SnapshotConfigTest`.
+  */
+class GoldenConfigTest extends AnyFunSuite with NonImplicitAssertions:
+
+    case class Point(x: Int, y: Int) derives CanEqual, Schema
+
+    test("the empty config from GoldenConfig.apply has defaults sampleCount 20, seed 0L, size 10, and identity normalization") {
+        val config = GoldenConfig.apply[Point]
+        assert(config.sampleCount == 20, s"Expected sampleCount 20, got ${config.sampleCount}")
+        assert(config.seed == 0L, s"Expected seed 0L, got ${config.seed}")
+        assert(config.size == 10, s"Expected size 10, got ${config.size}")
+        val result = config.modify.applyTo(Point(1, 2))
+        assert(result == Point(1, 2), s"Expected Point(1, 2) unchanged (identity normalization), got $result")
+    }
+
+    test("each setter returns a fresh instance, leaving the original unchanged (immutable additive)") {
+        val cfg1 = GoldenConfig.apply[Point].sampleCount(5)
+        val cfg2 = cfg1.seed(9L)
+        assert(cfg1.seed == 0L, s"Expected original cfg1.seed unchanged at 0L, got ${cfg1.seed}")
+        assert(cfg2.sampleCount == 5, s"Expected cfg2 to retain the accumulated sampleCount 5, got ${cfg2.sampleCount}")
+        assert(cfg2.seed == 9L, s"Expected cfg2.seed 9L, got ${cfg2.seed}")
+        assert(cfg1 ne cfg2, "Expected cfg1 and cfg2 to be distinct instances")
+    }
+
+    test("normalize composes in call order: f1 then f2, not reversed") {
+        val config = GoldenConfig.apply[Point].normalize(_.set(_.x)(1)).normalize(_.set(_.x)(2))
+        val result = config.modify.applyTo(Point(0, 0))
+        assert(result == Point(2, 0), s"Expected x==2 (f2 applied after f1, left-to-right accumulation), got $result")
+    }
+
+    test("each of the four setters threads the other three fields unchanged (field-preservation matrix)") {
+        val base = GoldenConfig.apply[Point].sampleCount(7).seed(3L).size(5).normalize(_.set(_.x)(9))
+
+        val viaSampleCount = base.sampleCount(50)
+        assert(viaSampleCount.sampleCount == 50, s"Expected sampleCount 50, got ${viaSampleCount.sampleCount}")
+        assert(viaSampleCount.seed == 3L, s"Expected seed unchanged at 3L, got ${viaSampleCount.seed}")
+        assert(viaSampleCount.size == 5, s"Expected size unchanged at 5, got ${viaSampleCount.size}")
+        assert(
+            viaSampleCount.modify.applyTo(Point(0, 0)) == Point(9, 0),
+            s"Expected normalize unchanged (x==9), got ${viaSampleCount.modify.applyTo(Point(0, 0))}"
+        )
+
+        val viaSeed = base.seed(50L)
+        assert(viaSeed.seed == 50L, s"Expected seed 50L, got ${viaSeed.seed}")
+        assert(viaSeed.sampleCount == 7, s"Expected sampleCount unchanged at 7, got ${viaSeed.sampleCount}")
+        assert(viaSeed.size == 5, s"Expected size unchanged at 5, got ${viaSeed.size}")
+        assert(
+            viaSeed.modify.applyTo(Point(0, 0)) == Point(9, 0),
+            s"Expected normalize unchanged (x==9), got ${viaSeed.modify.applyTo(Point(0, 0))}"
+        )
+
+        val viaSize = base.size(50)
+        assert(viaSize.size == 50, s"Expected size 50, got ${viaSize.size}")
+        assert(viaSize.sampleCount == 7, s"Expected sampleCount unchanged at 7, got ${viaSize.sampleCount}")
+        assert(viaSize.seed == 3L, s"Expected seed unchanged at 3L, got ${viaSize.seed}")
+        assert(
+            viaSize.modify.applyTo(Point(0, 0)) == Point(9, 0),
+            s"Expected normalize unchanged (x==9), got ${viaSize.modify.applyTo(Point(0, 0))}"
+        )
+
+        val viaNormalize = base.normalize(_.set(_.y)(4))
+        assert(viaNormalize.sampleCount == 7, s"Expected sampleCount unchanged at 7, got ${viaNormalize.sampleCount}")
+        assert(viaNormalize.seed == 3L, s"Expected seed unchanged at 3L, got ${viaNormalize.seed}")
+        assert(viaNormalize.size == 5, s"Expected size unchanged at 5, got ${viaNormalize.size}")
+        assert(
+            viaNormalize.modify.applyTo(Point(0, 0)) == Point(9, 4),
+            s"Expected both normalize passes composed (x==9 from base, y==4 from this call), got ${viaNormalize.modify.applyTo(Point(0, 0))}"
+        )
+    }
+
+end GoldenConfigTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotCodecTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotCodecTest.scala
@@ -68,6 +68,16 @@ class SnapshotCodecTest extends AnyFunSuite with NonImplicitAssertions:
             !allExts.contains("snap"),
             s"Expected no preset extension to equal the plain Render assertSnapshot extension 'snap', got $allExts"
         )
+        val goldenExts = allExts.map(ext => s"golden.${ext.stripPrefix("snap.")}")
+        val combined   = allExts ++ goldenExts
+        assert(
+            combined.distinct.size == combined.size,
+            s"Expected all fourteen extensions (seven snap.* plus seven golden.*) pairwise distinct, got $combined"
+        )
+        assert(
+            !combined.contains("snap"),
+            s"Expected no golden extension to equal the plain Render assertSnapshot extension 'snap', got $combined"
+        )
     }
 
     test("the open Text and Binary constructors expose the given codec and extension") {

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotCodecTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotCodecTest.scala
@@ -1,0 +1,93 @@
+package kyo.test.snapshot
+
+import kyo.Codec
+import kyo.Frame
+import kyo.Span
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for `SnapshotCodec`: the locked preset kind/extension data and the open Text/Binary constructors.
+  *
+  * All assertions are synchronous plain value/pattern-match checks (no file I/O, no Sync/Async boundary); uses ScalaTest directly,
+  * mirroring `SnapshotStoreBytesTest`.
+  *
+  * Covers:
+  *   1. The seven companion presets carry the locked kind (Text/Binary) and extension, all pairwise-distinct and none equal to the plain
+  *      `Render`-based `assertSnapshot`'s `"snap"` extension.
+  *   2. The open `Text`/`Binary` constructors expose the exact codec and extension passed to them.
+  */
+class SnapshotCodecTest extends AnyFunSuite with NonImplicitAssertions:
+
+    /** A minimal Codec double: only identity (never encode/decode) is exercised by this test. */
+    private def fakeCodec(): Codec =
+        new Codec:
+            def newWriter(): Codec.Writer = throw NotImplementedError("fakeCodec.newWriter is not exercised by this test")
+            def newReader(input: Span[Byte])(using Frame): Codec.Reader =
+                throw NotImplementedError("fakeCodec.newReader is not exercised by this test")
+
+    test("the seven presets carry the locked kind and extension") {
+        SnapshotCodec.Yaml match
+            case SnapshotCodec.Text(_, ext) => assert(ext == "snap.yaml", s"Expected ext 'snap.yaml', got '$ext'")
+            case other                      => fail(s"Expected SnapshotCodec.Text, got $other")
+
+        SnapshotCodec.Json match
+            case SnapshotCodec.Text(_, ext) => assert(ext == "snap.json", s"Expected ext 'snap.json', got '$ext'")
+            case other                      => fail(s"Expected SnapshotCodec.Text, got $other")
+
+        SnapshotCodec.Ion match
+            case SnapshotCodec.Text(_, ext) => assert(ext == "snap.ion", s"Expected ext 'snap.ion', got '$ext'")
+            case other                      => fail(s"Expected SnapshotCodec.Text, got $other")
+
+        SnapshotCodec.Protobuf match
+            case SnapshotCodec.Binary(_, ext) => assert(ext == "snap.pb", s"Expected ext 'snap.pb', got '$ext'")
+            case other                        => fail(s"Expected SnapshotCodec.Binary, got $other")
+
+        SnapshotCodec.Bson match
+            case SnapshotCodec.Binary(_, ext) => assert(ext == "snap.bson", s"Expected ext 'snap.bson', got '$ext'")
+            case other                        => fail(s"Expected SnapshotCodec.Binary, got $other")
+
+        SnapshotCodec.MsgPack match
+            case SnapshotCodec.Binary(_, ext) => assert(ext == "snap.msgpack", s"Expected ext 'snap.msgpack', got '$ext'")
+            case other                        => fail(s"Expected SnapshotCodec.Binary, got $other")
+
+        SnapshotCodec.IonBinary match
+            case SnapshotCodec.Binary(_, ext) => assert(ext == "snap.ionb", s"Expected ext 'snap.ionb', got '$ext'")
+            case other                        => fail(s"Expected SnapshotCodec.Binary, got $other")
+
+        val allExts = List(
+            SnapshotCodec.Yaml.ext,
+            SnapshotCodec.Json.ext,
+            SnapshotCodec.Ion.ext,
+            SnapshotCodec.Protobuf.ext,
+            SnapshotCodec.Bson.ext,
+            SnapshotCodec.MsgPack.ext,
+            SnapshotCodec.IonBinary.ext
+        )
+        assert(allExts.distinct.size == allExts.size, s"Expected all seven extensions pairwise distinct, got $allExts")
+        assert(
+            !allExts.contains("snap"),
+            s"Expected no preset extension to equal the plain Render assertSnapshot extension 'snap', got $allExts"
+        )
+    }
+
+    test("the open Text and Binary constructors expose the given codec and extension") {
+        val textCodec   = fakeCodec()
+        val binaryCodec = fakeCodec()
+
+        val text: SnapshotCodec   = SnapshotCodec.Text(textCodec, "snap.custom")
+        val binary: SnapshotCodec = SnapshotCodec.Binary(binaryCodec, "bin.custom")
+
+        assert(text.codec eq textCodec, "Expected Text.codec to be the exact codec instance passed in")
+        assert(text.ext == "snap.custom", s"Expected Text.ext 'snap.custom', got '${text.ext}'")
+        assert(binary.codec eq binaryCodec, "Expected Binary.codec to be the exact codec instance passed in")
+        assert(binary.ext == "bin.custom", s"Expected Binary.ext 'bin.custom', got '${binary.ext}'")
+
+        text match
+            case SnapshotCodec.Text(_, _) => succeed
+            case other                    => fail(s"Expected SnapshotCodec.Text, got $other")
+        binary match
+            case SnapshotCodec.Binary(_, _) => succeed
+            case other                      => fail(s"Expected SnapshotCodec.Binary, got $other")
+    }
+
+end SnapshotCodecTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotConfigTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotConfigTest.scala
@@ -1,0 +1,35 @@
+package kyo.test.snapshot
+
+import kyo.Schema
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for `SnapshotConfig`: the builder's identity, accumulate, and scrub semantics.
+  *
+  * All assertions are synchronous plain-value checks (no file I/O, no Sync/Async boundary); uses ScalaTest directly, mirroring
+  * `SnapshotCodecTest`.
+  */
+class SnapshotConfigTest extends AnyFunSuite with NonImplicitAssertions:
+
+    case class Point(x: Int, y: Int) derives CanEqual, Schema
+    case class Event(id: Int, ts: Long) derives CanEqual, Schema
+
+    test("the empty config from SnapshotConfig.apply is identity normalization") {
+        val config = SnapshotConfig.apply[Point]
+        val result = config.modify.applyTo(Point(1, 2))
+        assert(result == Point(1, 2), s"Expected Point(1, 2) unchanged, got $result")
+    }
+
+    test("normalize accumulates: .normalize(setX).normalize(setY) applies BOTH passes, not just the last") {
+        val config = SnapshotConfig.apply[Point].normalize(_.set(_.x)(7)).normalize(_.set(_.y)(9))
+        val result = config.modify.applyTo(Point(1, 2))
+        assert(result == Point(7, 9), s"Expected Point(7, 9) (both passes applied), got $result")
+    }
+
+    test("the built Modify scrubs a real field: normalize(_.set(_.ts)(0L)) zeroes the timestamp") {
+        val config = SnapshotConfig.apply[Event].normalize(_.set(_.ts)(0L))
+        val result = config.modify.applyTo(Event(1, 999L))
+        assert(result == Event(1, 0L), s"Expected Event(1, 0L) with ts scrubbed, got $result")
+    }
+
+end SnapshotConfigTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotGoldenTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotGoldenTest.scala
@@ -1,0 +1,465 @@
+package kyo.test.snapshot
+
+import kyo.Base64
+import kyo.Chunk
+import kyo.Codec
+import kyo.Maybe
+import kyo.Protobuf
+import kyo.Result
+import kyo.Schema
+import kyo.Span
+import kyo.Yaml
+import kyo.test.AssertionFailed
+import kyo.test.AssertScope
+import kyo.test.RunConfig
+import kyo.test.internal.TestContext
+import kyo.test.prop.Gen
+import kyo.test.runner.TestRunner
+import kyo.test.snapshot.internal.SnapshotStore
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.freespec.AsyncFreeSpec
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+/** All-primitive fixture type shared by every leaf in this file and by [[GoldenOnlyLeafSuite]], which must sit at file scope so
+  * `classOf[GoldenOnlyLeafSuite]` resolves for `TestRunner.runToFuture`.
+  */
+case class Event(id: Int, kind: String) derives CanEqual, Schema
+
+given Gen[Event] = Gen.derive[Event]
+
+/** Top-level (not nested) so `classOf[...]` resolves for `TestRunner.runToFuture`; extends the marker-free `SnapshotTestBase[Any]` (not
+  * `SnapshotTest[Any]`) so sbt/Native discovery does not ALSO pick this up as a separate real suite, mirroring `RunnerTest.scala`'s
+  * `RTFailPassSuite` convention.
+  */
+private class GoldenOnlyLeafSuite extends SnapshotTestBase[Any]:
+    override protected def snapshotDir: String         = s"target/snap-golden-runner-test-${java.lang.System.nanoTime()}"
+    override protected def snapshotUpdateMode: Boolean = true
+    "golden-only" in assertGoldenSnapshot[Event]("event")
+end GoldenOnlyLeafSuite
+
+/** End-to-end tests for `assertGoldenSnapshot`, mirroring `SnapshotSchemaTest`'s pattern: most leaves drive a private `SnapshotTest[Any]`
+  * fixture directly and assert synchronously; one leaf drives the dedicated top-level [[GoldenOnlyLeafSuite]] fixture through the real
+  * kyo-test runner to prove the no-assertion guard is satisfied by a golden-only leaf.
+  *
+  * Covers: first-run write-then-fail, update-mode write-and-pass, the no-assertion-guard interaction, format-tolerant structural compare,
+  * a genuine field-value mismatch, positional per-sample pairing, schema-evolution decode failures, a raw codec panic propagating
+  * unwrapped, the Protobuf raw-bytes round trip, golden/schema coexistence on one suite, the non-positive sampleCount guard, the
+  * sample-count length-mismatch short-circuit, normalize-before-encode-and-before-compare, the samples-keyed storage envelope, a pinned
+  * cross-platform byte-identical encoding, a Chunk-field type exercising the collection-field generator, and name validation.
+  */
+class SnapshotGoldenTest extends AsyncFreeSpec with NonImplicitAssertions:
+
+    implicit override val executionContext: ExecutionContext = ExecutionContext.global
+
+    // These tests drive `assertGoldenSnapshot` outside the runner, so they supply a standalone scope to
+    // satisfy the assert family's using-clause; the golden throws fire on the synchronous path.
+    private given AssertScope = new AssertScope(Chunk.empty)
+
+    private def tmpDir(): String =
+        s"target/snap-golden-test-${java.lang.System.nanoTime()}"
+
+    private def installContexts(): Unit =
+        TestContext.setForInstantiation(new TestContext(Chunk.empty))
+
+    case class Rec(id: Int, ts: Long) derives CanEqual, Schema
+
+    case class EventWithPayload(id: Int, kind: String, payload: Chunk[Byte]) derives CanEqual, Schema
+
+    given Gen[EventWithPayload] = Gen.derive[EventWithPayload]
+
+    /** A non-`DecodeException` runtime defect: a raw codec failure must propagate unwrapped, never rewrapped as `SnapshotSchemaEvolution`. */
+    class GoldenDecodePanic(message: String) extends RuntimeException(message)
+
+    /** A `Codec` whose writer delegates to `Yaml` (so encode succeeds and a golden file is produced) but whose reader unconditionally
+      * throws a [[GoldenDecodePanic]], deterministically producing a `Result.Panic` on decode.
+      */
+    private def panickingYamlCodec(): Codec =
+        new Codec:
+            def newWriter(): Codec.Writer = Yaml().newWriter()
+            def newReader(input: Span[Byte])(using kyo.Frame): Codec.Reader =
+                throw GoldenDecodePanic("golden decode panic")
+
+    /** Minimal `SnapshotTest[Any]` subclass; storage dir, update mode, and codec are all controlled by constructor parameters. */
+    private class GoldenFixture(dir: String, update: Boolean, codecOverride: SnapshotCodec = SnapshotCodec.Yaml) extends SnapshotTest[Any]:
+        override protected def snapshotDir: String          = dir
+        override protected def snapshotUpdateMode: Boolean  = update
+        override protected def snapshotCodec: SnapshotCodec = codecOverride
+
+        def golden[A](
+            name: String,
+            config: GoldenConfig[A] => GoldenConfig[A] = identity[GoldenConfig[A]]
+        )(using Gen[A], Schema[A], AssertScope): Unit =
+            assertGoldenSnapshot[A](name, config): Unit
+
+        def schemaSnapshot[A](actual: A, name: String)(using Schema[A], kyo.Frame, AssertScope): Unit =
+            assertSchemaSnapshot(actual, name): Unit
+
+    end GoldenFixture
+
+    private def storedEvents(path: String): Chunk[Event] =
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                Schema[GoldenSamples[Event]].decodeString[Yaml](stored) match
+                    case Result.Success(decoded) => decoded.samples
+                    case other                   => fail(s"Expected a decodable GoldenSamples[Event], got $other")
+            case Maybe.Absent => fail(s"expected a golden file at $path")
+
+    private def writeGoldenEvents(path: String, samples: Chunk[Event]): Unit =
+        val encoded = Schema[GoldenSamples[Event]].encodeString[Yaml](GoldenSamples(samples))
+        SnapshotStore.write(path, encoded)
+
+    private def mutateAt(samples: Chunk[Event], idx: Int)(f: Event => Event): Chunk[Event] =
+        Chunk.from(samples.zipWithIndex.map { case (e, i) => if i == idx then f(e) else e })
+
+    // ── tests ────────────────────────────────────────────────────────────────
+
+    "first run with no golden writes the proposed file then fails SnapshotNotFound" in {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new GoldenFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            fixture.golden[Event]("event")
+        }
+        assert(ex.diagram.contains("SnapshotNotFound"), s"Expected a SnapshotNotFound diagram, got: ${ex.diagram}")
+
+        val path     = s"$dir/GoldenFixture/event.golden.yaml"
+        val expected = summon[Gen[Event]].samples(0L, 10, 20)
+        assert(storedEvents(path) == expected, "Expected the stored spread to equal the proposed 20 samples")
+        Future.successful(succeed)
+    }
+
+    "update mode with no prior golden writes and passes without reading" in {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new GoldenFixture(dir, update = true)
+        fixture.golden[Event]("event")
+
+        val path     = s"$dir/GoldenFixture/event.golden.yaml"
+        val expected = summon[Gen[Event]].samples(0L, 10, 20)
+        assert(storedEvents(path) == expected, "Expected the stored spread to equal the freshly-generated 20 samples")
+        Future.successful(succeed)
+    }
+
+    "a golden-only leaf records an assertion and does not trip the no-assertion guard" in {
+        TestRunner.runToFuture(classOf[GoldenOnlyLeafSuite], RunConfig.default).map { report =>
+            assert(
+                report.passed == 1 && report.failed == 0,
+                s"expected the golden-only leaf to pass without tripping the no-assertion guard, got $report"
+            )
+        }
+    }
+
+    "format-tolerant compare passes on a whitespace-only re-encode" in {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new GoldenFixture(dir, update = true)
+        writer.golden[Event]("event")
+
+        val path = s"$dir/GoldenFixture/event.golden.yaml"
+        val original = SnapshotStore.read(path) match
+            case Maybe.Present(content) => content
+            case Maybe.Absent           => fail(s"expected the update-mode write to produce $path")
+        val reformatted = original.linesIterator.map(line => s"$line  ").mkString("\n") + "\n"
+        assert(reformatted.trim != original.trim, "expected the reformatted content to differ from the original encode")
+        SnapshotStore.write(path, reformatted)
+
+        installContexts()
+        val reader = new GoldenFixture(dir, update = false)
+        reader.golden[Event]("event")
+        Future.successful(succeed)
+    }
+
+    "a real field-value change (not formatting) in one sample FAILS (non-vacuous tolerance)" in {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new GoldenFixture(dir, update = true)
+        writer.golden[Event]("event")
+
+        val path    = s"$dir/GoldenFixture/event.golden.yaml"
+        val stored  = storedEvents(path)
+        val mutated = mutateAt(stored, 0)(e => e.copy(kind = e.kind + "-mutated"))
+        writeGoldenEvents(path, mutated)
+
+        installContexts()
+        val reader = new GoldenFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            reader.golden[Event]("event")
+        }
+        assert(ex.diagram.contains("changed fields:"), s"Expected 'changed fields:' in the diagram, got: ${ex.diagram}")
+        assert(ex.diagram.contains("sample["), s"Expected a 'sample[' token in the diagram, got: ${ex.diagram}")
+        Future.successful(succeed)
+    }
+
+    "a single-field change confined to sample index 4 reports EXACTLY sample[4] (positional pairing)" in {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new GoldenFixture(dir, update = true)
+        writer.golden[Event]("event")
+
+        val path    = s"$dir/GoldenFixture/event.golden.yaml"
+        val stored  = storedEvents(path)
+        val mutated = mutateAt(stored, 4)(e => e.copy(kind = e.kind + "-mutated"))
+        writeGoldenEvents(path, mutated)
+
+        installContexts()
+        val reader = new GoldenFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            reader.golden[Event]("event")
+        }
+        assert(ex.diagram.contains("sample[4]"), s"Expected the literal token 'sample[4]', got: ${ex.diagram}")
+        val otherIndices = (0 until stored.length).filterNot(_ == 4).map(i => s"sample[$i]")
+        assert(!otherIndices.exists(ex.diagram.contains), s"Expected no other sample[N] index, got: ${ex.diagram}")
+        Future.successful(succeed)
+    }
+
+    "a stored golden that no longer decodes fails SnapshotSchemaEvolution, distinct from a value mismatch" in {
+        val dir  = tmpDir()
+        val path = s"$dir/GoldenFixture/event.golden.yaml"
+        SnapshotStore.write(path, "not-a-decodable-golden-payload")
+
+        installContexts()
+        val fixture = new GoldenFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            fixture.golden[Event]("event")
+        }
+        assert(ex.diagram.contains("SnapshotSchemaEvolution:"), s"Expected the SnapshotSchemaEvolution prefix, got: ${ex.diagram}")
+        assert(!ex.diagram.contains("Golden mismatch"), s"Expected no Golden mismatch prefix, got: ${ex.diagram}")
+        Future.successful(succeed)
+    }
+
+    "a decode Panic is rethrown unwrapped, never rewrapped as SnapshotSchemaEvolution" in {
+        val dir        = tmpDir()
+        val panicCodec = SnapshotCodec.Text(panickingYamlCodec(), "snap.panicgld")
+        installContexts()
+        val writer = new GoldenFixture(dir, update = true, panicCodec)
+        writer.golden[Event]("event")
+
+        installContexts()
+        val reader = new GoldenFixture(dir, update = false, panicCodec)
+        val ex = intercept[GoldenDecodePanic] {
+            reader.golden[Event]("event")
+        }
+        assert(ex.getMessage == "golden decode panic", s"Expected message 'golden decode panic', got: ${ex.getMessage}")
+        Future.successful(succeed)
+    }
+
+    "Binary (Protobuf) golden round-trips byte-identically" in {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new GoldenFixture(dir, update = true, SnapshotCodec.Protobuf)
+        writer.golden[Event]("event")
+
+        val path     = s"$dir/GoldenFixture/event.golden.pb"
+        val expected = Schema[GoldenSamples[Event]].encode[Protobuf](GoldenSamples(summon[Gen[Event]].samples(0L, 10, 20)))
+        SnapshotStore.readBytes(path) match
+            case Maybe.Present(stored) =>
+                assert(stored.size == expected.size, s"Expected length ${expected.size}, got ${stored.size}")
+                assert(stored.is(expected), "Expected the stored bytes to be byte-identical to a fresh schema.encode")
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+
+        installContexts()
+        val reader = new GoldenFixture(dir, update = false, SnapshotCodec.Protobuf)
+        reader.golden[Event]("event")
+        Future.successful(succeed)
+    }
+
+    "Binary golden stores raw wire bytes, no base64 and no trailing-newline munge" in {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new GoldenFixture(dir, update = true, SnapshotCodec.Protobuf)
+        fixture.golden[Event]("event")
+
+        val path     = s"$dir/GoldenFixture/event.golden.pb"
+        val expected = Schema[GoldenSamples[Event]].encode[Protobuf](GoldenSamples(summon[Gen[Event]].samples(0L, 10, 20)))
+        SnapshotStore.readBytes(path) match
+            case Maybe.Present(stored) =>
+                assert(stored.size == expected.size, s"Expected stored length ${expected.size}, got ${stored.size}")
+                val base64Length = Base64.encode(expected).size
+                assert(
+                    stored.size != base64Length,
+                    s"Stored byte length (${stored.size}) must not equal the base64-encoded length ($base64Length)"
+                )
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+        Future.successful(succeed)
+    }
+
+    "golden and schema snapshots coexist on one suite writing distinct files, no cross-write" in {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new GoldenFixture(dir, update = true)
+        fixture.golden[Event]("event")
+        fixture.schemaSnapshot(Event(1, "x"), "event")
+
+        val goldenPath = s"$dir/GoldenFixture/event.golden.yaml"
+        val schemaPath = s"$dir/GoldenFixture/event.snap.yaml"
+        SnapshotStore.read(goldenPath) match
+            case Maybe.Present(_) => ()
+            case Maybe.Absent     => fail(s"expected $goldenPath to exist")
+        SnapshotStore.read(schemaPath) match
+            case Maybe.Present(stored) =>
+                Schema[Event].decodeString[Yaml](stored) match
+                    case Result.Success(decoded) =>
+                        assert(decoded == Event(1, "x"), s"Expected the schema snapshot unaffected by the golden write, got $decoded")
+                    case other => fail(s"Expected a decodable Event, got $other")
+            case Maybe.Absent => fail(s"expected $schemaPath to exist")
+        end match
+        Future.successful(succeed)
+    }
+
+    "a non-positive sampleCount raises IllegalArgumentException at the boundary" in {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new GoldenFixture(dir, update = false)
+        val ex = intercept[IllegalArgumentException] {
+            fixture.golden[Event]("event", _.sampleCount(0))
+        }
+        assert(ex.getMessage.contains("0"), s"Expected the message to name the invalid count, got: ${ex.getMessage}")
+        Future.successful(succeed)
+    }
+
+    "no golden file is written after the sampleCount guard throws" in {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new GoldenFixture(dir, update = false)
+        intercept[IllegalArgumentException] {
+            fixture.golden[Event]("event", _.sampleCount(0))
+        }
+        val path = s"$dir/GoldenFixture/event.golden.yaml"
+        val result = SnapshotStore.read(path) match
+            case Maybe.Absent     => succeed
+            case Maybe.Present(_) => fail(s"expected no golden file at $path after the sampleCount guard throws")
+        Future.successful(result)
+    }
+
+    "a sample-count length mismatch fails naming the count delta before any per-index compare" in {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new GoldenFixture(dir, update = true)
+        writer.golden[Event]("event", _.sampleCount(20))
+
+        installContexts()
+        val reader = new GoldenFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            reader.golden[Event]("event", _.sampleCount(25))
+        }
+        assert(ex.diagram.contains("20") && ex.diagram.contains("25"), s"Expected the message to name both counts, got: ${ex.diagram}")
+        Future.successful(succeed)
+    }
+
+    "the length-mismatch message carries no per-sample changed-path text (short-circuit)" in {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new GoldenFixture(dir, update = true)
+        writer.golden[Event]("event", _.sampleCount(20))
+
+        installContexts()
+        val reader = new GoldenFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            reader.golden[Event]("event", _.sampleCount(25))
+        }
+        assert(!ex.diagram.contains("sample["), s"Expected no per-sample changed-path token, got: ${ex.diagram}")
+        Future.successful(succeed)
+    }
+
+    "normalization scrubs a volatile field on BOTH the stored and the compared side" in {
+        val dir = tmpDir()
+        installContexts()
+        locally {
+            val writer     = new GoldenFixture(dir, update = true)
+            given Gen[Rec] = Gen.const(Rec(1, java.lang.System.nanoTime()))
+            writer.golden[Rec]("rec", _.sampleCount(1).normalize(_.set(_.ts)(0L)))
+        }
+
+        installContexts()
+        locally {
+            val reader     = new GoldenFixture(dir, update = false)
+            given Gen[Rec] = Gen.const(Rec(1, java.lang.System.nanoTime() + 1L))
+            reader.golden[Rec]("rec", _.sampleCount(1).normalize(_.set(_.ts)(0L)))
+        }
+        Future.successful(succeed)
+    }
+
+    "the stored document is one file with a top-level samples-keyed mapping wrapping the sequence" in {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new GoldenFixture(dir, update = true)
+        fixture.golden[Event]("event")
+
+        val path = s"$dir/GoldenFixture/event.golden.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                assert(stored.trim.startsWith("samples:"), s"Expected a top-level 'samples:' mapping key, got: $stored")
+                val decoded = storedEvents(path)
+                assert(decoded.length == 20, s"Expected all 20 samples in the single stored document, got ${decoded.length}")
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+        Future.successful(succeed)
+    }
+
+    "golden bytes are cross-platform byte-identical (pinned determinism)" in {
+        val samples = summon[Gen[Event]].samples(0L, 10, 3)
+        val encoded = Schema[GoldenSamples[Event]].encodeString[Yaml](GoldenSamples(samples))
+        assert(encoded == SnapshotGoldenTest.pinnedEventGoldenYaml, s"Expected the pinned golden encoding, got:\n$encoded")
+        Future.successful(succeed)
+    }
+
+    "a golden over a Chunk-field type compiles and round-trips end-to-end (chunkGen consumer)" in {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new GoldenFixture(dir, update = true)
+        writer.golden[EventWithPayload]("event")
+
+        val path = s"$dir/GoldenFixture/event.golden.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(_) => ()
+            case Maybe.Absent     => fail(s"expected the update-mode write to produce $path")
+
+        installContexts()
+        val reader = new GoldenFixture(dir, update = false)
+        reader.golden[EventWithPayload]("event")
+        Future.successful(succeed)
+    }
+
+    "assertGoldenSnapshot rejects each of the five invalid names (path-sep, empty, dot, dot-dot, space)" in {
+        val invalidNames = List("a/b", "", ".", "..", "a b")
+        invalidNames.foreach { invalidName =>
+            val dir = tmpDir()
+            installContexts()
+            val fixture = new GoldenFixture(dir, update = true)
+            intercept[IllegalArgumentException] {
+                fixture.golden[Event](invalidName)
+            }
+            if !invalidName.contains('/') then
+                val path = s"$dir/GoldenFixture/$invalidName.golden.yaml"
+                SnapshotStore.read(path) match
+                    case Maybe.Absent     => ()
+                    case Maybe.Present(_) => fail(s"expected no golden file written for invalid name '$invalidName'")
+            end if
+        }
+        Future.successful(succeed)
+    }
+
+end SnapshotGoldenTest
+
+object SnapshotGoldenTest:
+    /** Pinned encoding of `GoldenSamples(Gen[Event].samples(seed = 0L, size = 10, count = 3))` through the Yaml codec, obtained by
+      * running the encode once; this same literal must match on JVM, JS, Native, and Wasm.
+      */
+    private val pinnedEventGoldenYaml: String =
+        "samples:\n" +
+            "  -\n" +
+            "    id: 1\n" +
+            "    kind: qv7\n" +
+            "  -\n" +
+            "    id: 9\n" +
+            "    kind: jG\n" +
+            "  -\n" +
+            "    id: -6\n" +
+            "    kind: clv2C5uc\n"
+end SnapshotGoldenTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaEvolutionTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaEvolutionTest.scala
@@ -1,0 +1,22 @@
+package kyo.test.snapshot
+
+import kyo.test.AssertionFailed
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for `SnapshotSchemaEvolution`: the distinct decode-failure factory. All assertions are synchronous plain value checks (no file
+  * I/O); uses ScalaTest directly, mirroring `SnapshotDiffTest`.
+  */
+class SnapshotSchemaEvolutionTest extends AnyFunSuite with NonImplicitAssertions:
+
+    test("the factory message is distinctly prefixed and never the mismatch prefix") {
+        val failure: AssertionFailed = SnapshotSchemaEvolution("dir/name.snap.yaml", "boom")
+
+        assert(
+            failure.diagram == "SnapshotSchemaEvolution: stored snapshot at dir/name.snap.yaml could not be decoded: boom",
+            s"Expected the distinct decode-failure diagram, got: ${failure.diagram}"
+        )
+        assert(!failure.getMessage.contains("Snapshot mismatch"), s"Expected no 'Snapshot mismatch' prefix, got: ${failure.getMessage}")
+    }
+
+end SnapshotSchemaEvolutionTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotSchemaTest.scala
@@ -1,0 +1,381 @@
+package kyo.test.snapshot
+
+import kyo.Base64
+import kyo.Chunk
+import kyo.Codec
+import kyo.Maybe
+import kyo.Modify
+import kyo.Protobuf
+import kyo.Render
+import kyo.Result
+import kyo.Schema
+import kyo.Span
+import kyo.Yaml
+import kyo.test.AssertionFailed
+import kyo.test.AssertScope
+import kyo.test.internal.TestContext
+import kyo.test.snapshot.internal.SnapshotStore
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** End-to-end tests for `assertSchemaSnapshot`, driven outside the kyo-test runner via a private `SnapshotTest[Any]` fixture, mirroring
+  * `SnapshotUpdateModeTest`'s pattern. All assertions are synchronous (file I/O + try/catch); uses ScalaTest directly.
+  *
+  * Covers: field-named Text encoding, normalize-before-encode-and-compare, the Text/Binary mismatch report shapes, the recursive nested
+  * changed-path report, format-tolerant structural compare, schema-evolution decode failures, name validation, update mode, first-run
+  * behavior, the Protobuf raw-bytes round trip, a raw codec defect propagating unwrapped from both the Binary and Text decode arms,
+  * and the Render-based `assertSnapshot` path, whose name validation and first-run behavior match `assertSchemaSnapshot` exactly.
+  */
+class SnapshotSchemaTest extends AnyFunSuite with NonImplicitAssertions:
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    // These tests drive `assertSchemaSnapshot` outside the runner, so they supply a standalone scope to
+    // satisfy the assert family's using-clause; the snapshot throws fire on the synchronous path.
+    private given AssertScope = new AssertScope(Chunk.empty)
+
+    private def tmpDir(): String =
+        s"target/snap-schema-test-${java.lang.System.nanoTime()}"
+
+    private def installContexts(): Unit =
+        TestContext.setForInstantiation(new TestContext(Chunk.empty))
+
+    case class Point(x: Int, y: Int) derives CanEqual, Schema
+    case class Line(a: Point, b: Point) derives CanEqual, Schema
+    case class Event(id: Int, ts: Long) derives CanEqual, Schema
+
+    /** A fixture whose `equals`/`hashCode` ignore field `b`, so value-equality and schema-structural equality diverge:
+      * the schema still encodes `b`, so a `Changeset` diff detects the difference even though `.equals` does not.
+      */
+    case class Ver(a: Int, b: Int) derives Schema:
+        override def equals(other: Any): Boolean = other match
+            case that: Ver => this.a == that.a
+            case _         => false
+        override def hashCode(): Int = a.hashCode()
+    end Ver
+
+    /** A non-`DecodeException` runtime defect: a raw codec failure must propagate unwrapped, never rewrapped as
+      * `SnapshotSchemaEvolution`.
+      */
+    class RawCodecDefect(message: String) extends RuntimeException(message)
+
+    /** A `Codec` whose writer delegates to `Protobuf` (so encode succeeds and a snapshot file is produced) but whose
+      * reader unconditionally throws a [[RawCodecDefect]], deterministically producing a `Result.Panic` on decode
+      * (`Result.catching[DecodeException]` maps a non-matching throwable to `Panic`).
+      */
+    private def throwingCodec(): Codec =
+        new Codec:
+            def newWriter(): Codec.Writer = Protobuf().newWriter()
+            def newReader(input: Span[Byte])(using kyo.Frame): Codec.Reader =
+                throw RawCodecDefect("raw codec defect")
+
+    /** A `Codec` whose writer delegates to `Yaml` (so encode succeeds and a snapshot file is produced) but whose reader
+      * unconditionally throws a [[RawCodecDefect]], deterministically producing a `Result.Panic` on decode, mirroring
+      * `throwingCodec` for the Text decode arm rather than the Binary one.
+      */
+    private def throwingTextCodec(): Codec =
+        new Codec:
+            def newWriter(): Codec.Writer = Yaml().newWriter()
+            def newReader(input: Span[Byte])(using kyo.Frame): Codec.Reader =
+                throw RawCodecDefect("raw text codec defect")
+
+    /** Minimal `SnapshotTest[Any]` subclass; storage dir, update mode, and codec are all controlled by constructor parameters. */
+    private class SchemaFixture(dir: String, update: Boolean, codecOverride: SnapshotCodec = SnapshotCodec.Yaml) extends SnapshotTest[Any]:
+        override protected def snapshotDir: String          = dir
+        override protected def snapshotUpdateMode: Boolean  = update
+        override protected def snapshotCodec: SnapshotCodec = codecOverride
+
+        def assertSchema[A](actual: A, name: String)(using Schema[A], kyo.Frame, AssertScope): Unit =
+            assertSchemaSnapshot(actual, name): Unit
+
+        def assertSchema[A](actual: A, name: String, normalize: Modify[A] => Modify[A])(using Schema[A], kyo.Frame, AssertScope): Unit =
+            assertSchemaSnapshot(actual, name, _.normalize(normalize)): Unit
+
+        def assertRendered[A](actual: A, name: String)(using Render[A], kyo.Frame, AssertScope): Unit =
+            assertSnapshot(actual, name): Unit
+
+    end SchemaFixture
+
+    // ── tests ────────────────────────────────────────────────────────────────
+
+    test("default Yaml output is field-named, not a positional flat toString") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = true)
+        fixture.assertSchema(Point(1, 2), "point")
+
+        val path = s"$dir/SchemaFixture/point.snap.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                assert(stored.contains("x:"), s"Expected a field-named 'x:' key, got: $stored")
+                assert(stored.contains("y:"), s"Expected a field-named 'y:' key, got: $stored")
+                assert(stored.stripTrailing() != "Point(1,2)", s"Expected a Yaml mapping, not the positional Render form, got: $stored")
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+    }
+
+    test("normalize scrubs a non-deterministic timestamp before encode and before compare so repeated runs pass") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true)
+        val ts1    = java.lang.System.nanoTime()
+        writer.assertSchema(Event(1, ts1), "event", _.set(_.ts)(0L))
+
+        val path = s"$dir/SchemaFixture/event.snap.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                Schema[Event].decodeString[Yaml](stored) match
+                    case Result.Success(decoded) => assert(decoded.ts == 0L, s"Expected the stored ts scrubbed to 0, got: $decoded")
+                    case other                   => fail(s"Expected a decodable Event, got $other")
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false)
+        val ts2    = ts1 + 1L
+        reader.assertSchema(Event(1, ts2), "event", _.set(_.ts)(0L))
+        succeed
+    }
+
+    test("Text (Yaml) mismatch report carries a unified textual diff and the changed field path") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true)
+        writer.assertSchema(Point(1, 2), "point")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            reader.assertSchema(Point(1, 3), "point")
+        }
+        assert(ex.diagram.contains("changed fields: y"), s"Expected the changed field 'y', got: ${ex.diagram}")
+        assert(ex.diagram.contains("actual vs expected"), s"Expected a unified textual diff block, got: ${ex.diagram}")
+    }
+
+    test("Binary (Protobuf) mismatch report carries the changed field path but no textual diff") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true, SnapshotCodec.Protobuf)
+        writer.assertSchema(Point(1, 2), "point")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false, SnapshotCodec.Protobuf)
+        val ex = intercept[AssertionFailed] {
+            reader.assertSchema(Point(1, 3), "point")
+        }
+        assert(ex.diagram.contains("changed fields: y"), s"Expected the changed field 'y', got: ${ex.diagram}")
+        assert(!ex.diagram.contains("actual vs expected"), s"Expected no textual diff block for a Binary codec, got: ${ex.diagram}")
+    }
+
+    test("mismatch on a nested field reports the full dotted nested path") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true)
+        writer.assertSchema(Line(Point(1, 2), Point(3, 4)), "line")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            reader.assertSchema(Line(Point(1, 2), Point(3, 9)), "line")
+        }
+        assert(ex.diagram.contains("changed fields: b.y"), s"Expected the dotted nested path 'b.y', got: ${ex.diagram}")
+    }
+
+    test("format-tolerant compare: a hand-reformatted stored snapshot that decodes equal still passes") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true)
+        writer.assertSchema(Point(1, 2), "point")
+
+        val path = s"$dir/SchemaFixture/point.snap.yaml"
+        val original = SnapshotStore.read(path) match
+            case Maybe.Present(content) => content
+            case Maybe.Absent           => fail(s"expected the update-mode write to produce $path")
+        val reformatted = original.linesIterator.toList.reverse.map(line => s"$line   ").mkString("\n") + "\n"
+        assert(reformatted.trim != original.trim, "expected the hand-reformatted content to differ from the original encode")
+        SnapshotStore.write(path, reformatted)
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false)
+        reader.assertSchema(Point(1, 2), "point")
+        succeed
+    }
+
+    test("a stored snapshot that fails to decode routes to SnapshotSchemaEvolution, distinct from a value mismatch") {
+        val dir  = tmpDir()
+        val path = s"$dir/SchemaFixture/point.snap.yaml"
+        SnapshotStore.write(path, "not-a-decodable-point-payload")
+
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            fixture.assertSchema(Point(1, 2), "point")
+        }
+        assert(ex.diagram.contains("SnapshotSchemaEvolution:"), s"Expected the SnapshotSchemaEvolution prefix, got: ${ex.diagram}")
+        assert(!ex.diagram.contains("Snapshot mismatch"), s"Expected no Snapshot mismatch prefix, got: ${ex.diagram}")
+    }
+
+    test("name validation rejects a path separator, empty, dot, dot-dot, and an embedded space") {
+        val invalidNames = List("a/b", "", ".", "..", "a b")
+        invalidNames.foreach { invalidName =>
+            val dir = tmpDir()
+            installContexts()
+            val fixture = new SchemaFixture(dir, update = true)
+            intercept[IllegalArgumentException] {
+                fixture.assertSchema(Point(1, 2), invalidName)
+            }
+        }
+    }
+
+    test("update mode writes the encoded value and passes without reading a prior file") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = true)
+        fixture.assertSchema(Point(5, 6), "fresh")
+
+        val path = s"$dir/SchemaFixture/fresh.snap.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                Schema[Point].decodeString[Yaml](stored) match
+                    case Result.Success(decoded) => assert(decoded == Point(5, 6), s"Expected Point(5, 6), got $decoded")
+                    case other                   => fail(s"Expected a decodable Point(5, 6), got $other")
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+    }
+
+    test("first run with no stored file writes the proposed value then fails with SnapshotNotFound") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            fixture.assertSchema(Point(7, 8), "first-run")
+        }
+        assert(!ex.diagram.contains("SnapshotSchemaEvolution:"), s"Expected no SnapshotSchemaEvolution prefix, got: ${ex.diagram}")
+        assert(!ex.diagram.contains("Snapshot mismatch"), s"Expected no Snapshot mismatch prefix, got: ${ex.diagram}")
+        assert(ex.diagram.contains("SnapshotNotFound"), s"Expected a SnapshotNotFound diagram, got: ${ex.diagram}")
+
+        val path = s"$dir/SchemaFixture/first-run.snap.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                Schema[Point].decodeString[Yaml](stored) match
+                    case Result.Success(decoded) => assert(decoded == Point(7, 8), s"Expected Point(7, 8), got $decoded")
+                    case other                   => fail(s"Expected a decodable Point(7, 8), got $other")
+            case Maybe.Absent =>
+                fail(s"expected the first-run write to produce $path")
+        end match
+    }
+
+    test("Protobuf round-trip stores raw wire bytes byte-identical to schema.encode on every platform") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = true, SnapshotCodec.Protobuf)
+        fixture.assertSchema(Point(1, 2), "protobuf-point")
+
+        val path     = s"$dir/SchemaFixture/protobuf-point.snap.pb"
+        val expected = Schema[Point].encode[Protobuf](Point(1, 2))
+        SnapshotStore.readBytes(path) match
+            case Maybe.Present(stored) =>
+                assert(stored.size == expected.size, s"Expected length ${expected.size}, got ${stored.size}")
+                assert(stored.is(expected), "Expected the stored bytes to be byte-identical to a fresh schema.encode")
+                val encodedLength = Base64.encode(expected).size
+                assert(
+                    stored.size != encodedLength,
+                    s"Stored byte length (${stored.size}) must not equal the base64-encoded length ($encodedLength)"
+                )
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+    }
+
+    test("assertSnapshot still fails first-run with SnapshotNotFound for a type with only a Render instance") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            fixture.assertRendered(42, "render-only")
+        }
+        assert(ex.diagram.contains("SnapshotNotFound"), s"Expected a SnapshotNotFound diagram, got: ${ex.diagram}")
+    }
+
+    test("assertSnapshot rejects a path separator, empty, dot, dot-dot, and an embedded space, same as assertSchemaSnapshot") {
+        val invalidNames = List("a/b", "", ".", "..", "a b")
+        invalidNames.foreach { invalidName =>
+            val dir = tmpDir()
+            installContexts()
+            val fixture = new SchemaFixture(dir, update = true)
+            intercept[IllegalArgumentException] {
+                fixture.assertRendered(42, invalidName)
+            }
+        }
+    }
+
+    test("a Binary (Protobuf) stored snapshot that fails to decode routes to SnapshotSchemaEvolution, distinct from a value mismatch") {
+        val dir       = tmpDir()
+        val path      = s"$dir/SchemaFixture/point.snap.pb"
+        val encoded   = Schema[Point].encode[Protobuf](Point(1, 2))
+        val truncated = encoded.dropRight(1)
+        SnapshotStore.writeBytes(path, truncated)
+
+        installContexts()
+        val fixture = new SchemaFixture(dir, update = false, SnapshotCodec.Protobuf)
+        val ex = intercept[AssertionFailed] {
+            fixture.assertSchema(Point(1, 2), "point")
+        }
+        assert(ex.diagram.contains("SnapshotSchemaEvolution:"), s"Expected the SnapshotSchemaEvolution prefix, got: ${ex.diagram}")
+        assert(!ex.diagram.contains("Snapshot mismatch"), s"Expected no Snapshot mismatch prefix, got: ${ex.diagram}")
+    }
+
+    test("the pass/fail gate follows schema-structural Changeset.operations, not value .equals") {
+        val dir = tmpDir()
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true)
+        writer.assertSchema(Ver(1, 2), "ver")
+
+        assert(Ver(1, 2).equals(Ver(1, 9)), "expected the fixture's custom equals to ignore field b")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false)
+        val ex = intercept[AssertionFailed] {
+            reader.assertSchema(Ver(1, 9), "ver")
+        }
+        assert(ex.diagram.contains("changed fields: b"), s"Expected the changed field 'b', got: ${ex.diagram}")
+    }
+
+    test(
+        "a raw (non-DecodeException) Binary codec defect yields Result.Panic and propagates unwrapped, never rewrapped as SnapshotSchemaEvolution"
+    ) {
+        val dir        = tmpDir()
+        val panicCodec = SnapshotCodec.Binary(throwingCodec(), "snap.panicbin")
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true, panicCodec)
+        writer.assertSchema(Point(1, 2), "panic-point")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false, panicCodec)
+        val ex = intercept[RawCodecDefect] {
+            reader.assertSchema(Point(1, 2), "panic-point")
+        }
+        assert(ex.getMessage == "raw codec defect", s"Expected message 'raw codec defect', got: ${ex.getMessage}")
+    }
+
+    test(
+        "a raw (non-DecodeException) Text codec defect yields Result.Panic and propagates unwrapped, never rewrapped as SnapshotSchemaEvolution"
+    ) {
+        val dir        = tmpDir()
+        val panicCodec = SnapshotCodec.Text(throwingTextCodec(), "snap.panictxt")
+        installContexts()
+        val writer = new SchemaFixture(dir, update = true, panicCodec)
+        writer.assertSchema(Point(1, 2), "panic-point")
+
+        installContexts()
+        val reader = new SchemaFixture(dir, update = false, panicCodec)
+        val ex = intercept[RawCodecDefect] {
+            reader.assertSchema(Point(1, 2), "panic-point")
+        }
+        assert(ex.getMessage == "raw text codec defect", s"Expected message 'raw text codec defect', got: ${ex.getMessage}")
+    }
+
+end SnapshotSchemaTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotStoreBytesTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshot/SnapshotStoreBytesTest.scala
@@ -1,0 +1,72 @@
+package kyo.test.snapshot
+
+import kyo.Base64
+import kyo.Maybe
+import kyo.Span
+import kyo.test.snapshot.internal.SnapshotStore
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Tests for the raw-bytes store path (`SnapshotStore.readBytes`/`writeBytes`).
+  *
+  * All assertions are synchronous (plain file I/O, no Sync/Async boundary); uses ScalaTest directly, mirroring
+  * `SnapshotDiffTest`/`SnapshotUpdateModeTest`.
+  *
+  * Covers:
+  *   1. Byte-fidelity round-trip, including 0x00, 0xFF, and a newline byte.
+  *   2. No trailing-newline append and no base64 encoding of the stored content.
+  *   3. Absent-file returns Maybe.Absent.
+  */
+class SnapshotStoreBytesTest extends AnyFunSuite with NonImplicitAssertions:
+
+    private def tmpDir(): String =
+        s"target/snap-bytes-test-${java.lang.System.nanoTime()}"
+
+    test("raw-bytes round-trip is byte-identical including 0x00, 0xFF, and a newline byte") {
+        val path     = s"${tmpDir()}/round-trip.bin"
+        val original = Span[Byte](0x00.toByte, 0x01.toByte, 0xff.toByte, '\n'.toByte, 0x7f.toByte)
+
+        SnapshotStore.writeBytes(path, original)
+        val result = SnapshotStore.readBytes(path)
+
+        result match
+            case Maybe.Present(stored) =>
+                assert(stored.size == original.size, s"Expected length ${original.size}, got ${stored.size}")
+                assert(stored.is(original), s"Expected byte-identical content, got ${stored.toArrayUnsafe.toList}")
+            case Maybe.Absent =>
+                fail(s"Expected Maybe.Present, got Maybe.Absent for $path")
+        end match
+    }
+
+    test("stored bytes are verbatim: no trailing newline appended and not base64-encoded") {
+        val path    = s"${tmpDir()}/verbatim.bin"
+        val content = Span[Byte](0x10.toByte, 0x20.toByte, 0x30.toByte, 0x40.toByte, 0x50.toByte)
+
+        SnapshotStore.writeBytes(path, content)
+        val result = SnapshotStore.readBytes(path)
+
+        result match
+            case Maybe.Present(stored) =>
+                assert(stored.size == content.size, s"Expected no appended newline byte: length ${stored.size} != ${content.size}")
+                assert(stored.is(content), s"Expected verbatim byte content, got ${stored.toArrayUnsafe.toList}")
+                val encodedLength = Base64.encode(content).size
+                assert(
+                    stored.size != encodedLength,
+                    s"Stored byte length (${stored.size}) must not equal the base64-encoded string length ($encodedLength)"
+                )
+            case Maybe.Absent =>
+                fail(s"Expected Maybe.Present, got Maybe.Absent for $path")
+        end match
+    }
+
+    test("readBytes on a missing file returns Absent") {
+        val path   = s"${tmpDir()}/missing.bin"
+        val result = SnapshotStore.readBytes(path)
+
+        result match
+            case Maybe.Absent     => succeed
+            case Maybe.Present(_) => fail(s"Expected Maybe.Absent for a file never written: $path")
+        end match
+    }
+
+end SnapshotStoreBytesTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshotforeign/SnapshotForeignPackageTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshotforeign/SnapshotForeignPackageTest.scala
@@ -1,0 +1,62 @@
+package kyo.test.snapshotforeign
+
+import kyo.Chunk
+import kyo.Maybe
+import kyo.Result
+import kyo.Schema
+import kyo.Yaml
+import kyo.test.AssertScope
+import kyo.test.internal.TestContext
+import kyo.test.snapshot.SnapshotTest
+import kyo.test.snapshot.internal.SnapshotStore
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Compile-and-run proof that `assertSchemaSnapshot`'s config-lambda form resolves from a package where `SnapshotConfig`'s
+  * `private[snapshot] modify` accessor is genuinely inaccessible.
+  *
+  * Package `kyo.test.snapshotforeign` is a sibling of `kyo.test.snapshot`. The suite still sits under `kyo.test`, so the
+  * test-internal `AssertScope` and `TestContext` constructors stay reachable here; the isolated axis under test is
+  * `private[snapshot]` accessibility, proving the inline `assertSchemaSnapshot` body resolves its `normalizeWith` call
+  * through a compiler-generated accessor rather than a direct cross-package field read.
+  */
+class SnapshotForeignPackageTest extends AnyFunSuite with NonImplicitAssertions:
+
+    private given AssertScope = new AssertScope(Chunk.empty)
+
+    private def tmpDir(): String =
+        s"target/snap-foreign-test-${java.lang.System.nanoTime()}"
+
+    private def installContexts(): Unit =
+        TestContext.setForInstantiation(new TestContext(Chunk.empty))
+
+    case class Rec(id: Int, ts: Long) derives Schema
+
+    /** Minimal `SnapshotTest[Any]` subclass; the config-lambda call site lives here, in package `kyo.test.snapshotforeign`. */
+    private class ForeignFixture(dir: String) extends SnapshotTest[Any]:
+        override protected def snapshotDir: String         = dir
+        override protected def snapshotUpdateMode: Boolean = true
+
+        def storeRec(actual: Rec, name: String)(using AssertScope): Unit =
+            assertSchemaSnapshot(actual, name, _.normalize(_.set(_.ts)(0L))): Unit
+
+    end ForeignFixture
+
+    test("a suite in a sibling package (outside kyo.test.snapshot) compiles and runs assertSchemaSnapshot with the config lambda") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new ForeignFixture(dir)
+        fixture.storeRec(Rec(1, 999L), "rec")
+
+        val path = s"$dir/ForeignFixture/rec.snap.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(stored) =>
+                Schema[Rec].decodeString[Yaml](stored) match
+                    case Result.Success(decoded) => assert(decoded.ts == 0L, s"Expected the stored ts scrubbed to 0, got: $decoded")
+                    case other                   => fail(s"Expected a decodable Rec, got $other")
+            case Maybe.Absent =>
+                fail(s"expected the update-mode write to produce $path")
+        end match
+    }
+
+end SnapshotForeignPackageTest

--- a/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshotforeign/SnapshotForeignPackageTest.scala
+++ b/kyo-test/snapshot/shared/src/test/scala/kyo/test/snapshotforeign/SnapshotForeignPackageTest.scala
@@ -7,6 +7,7 @@ import kyo.Schema
 import kyo.Yaml
 import kyo.test.AssertScope
 import kyo.test.internal.TestContext
+import kyo.test.prop.Gen
 import kyo.test.snapshot.SnapshotTest
 import kyo.test.snapshot.internal.SnapshotStore
 import org.scalatest.NonImplicitAssertions
@@ -32,6 +33,8 @@ class SnapshotForeignPackageTest extends AnyFunSuite with NonImplicitAssertions:
 
     case class Rec(id: Int, ts: Long) derives Schema
 
+    given Gen[Rec] = Gen.derive[Rec]
+
     /** Minimal `SnapshotTest[Any]` subclass; the config-lambda call site lives here, in package `kyo.test.snapshotforeign`. */
     private class ForeignFixture(dir: String) extends SnapshotTest[Any]:
         override protected def snapshotDir: String         = dir
@@ -39,6 +42,9 @@ class SnapshotForeignPackageTest extends AnyFunSuite with NonImplicitAssertions:
 
         def storeRec(actual: Rec, name: String)(using AssertScope): Unit =
             assertSchemaSnapshot(actual, name, _.normalize(_.set(_.ts)(0L))): Unit
+
+        def storeGolden(name: String)(using AssertScope): Unit =
+            assertGoldenSnapshot[Rec](name, _.sampleCount(5).normalize(_.set(_.ts)(0L))): Unit
 
     end ForeignFixture
 
@@ -57,6 +63,18 @@ class SnapshotForeignPackageTest extends AnyFunSuite with NonImplicitAssertions:
             case Maybe.Absent =>
                 fail(s"expected the update-mode write to produce $path")
         end match
+    }
+
+    test("a foreign-package inline assertGoldenSnapshot resolves GoldenConfig's private[snapshot] fields via the compiler accessor") {
+        val dir = tmpDir()
+        installContexts()
+        val fixture = new ForeignFixture(dir)
+        fixture.storeGolden("rec-golden")
+
+        val path = s"$dir/ForeignFixture/rec-golden.golden.yaml"
+        SnapshotStore.read(path) match
+            case Maybe.Present(_) => succeed
+            case Maybe.Absent     => fail(s"expected the update-mode write to produce $path")
     }
 
 end SnapshotForeignPackageTest


### PR DESCRIPTION
# Golden snapshot testing over generated samples

> **Stacked on #1763.** This branch is based on the `assertSchemaSnapshot` PR's branch, so until #1763 merges the diff below shows both changes combined. The golden-specific change is the single commit `1a179c71d` (14 files, +1048/-60). Closes #1767.

## Problem

#1763 adds `assertSchemaSnapshot`, which answers "did the value my code produced change?" for one hand-written value per assertion. It cannot answer the question that motivated #1767: "did the wire format of this type change, across the range of values it can hold?" A single hand-picked sample passes even after a format-breaking change to a field the sample never exercises, so a type's encoding can drift undetected until a downstream consumer breaks.

`kyo-test-prop` already ships a pure, deterministic sample source (`gen.samples(seed, size, count)`, SplitMix64 seed splitting, plain `Long` arithmetic on every platform), and the snapshot module already ships codec selection, text/bytes storage, first-run/update blessing, structural comparison, and schema-evolution classification. Golden testing is the thin composition of the two.

## Solution

A third assertion on `SnapshotTestBase[S]`, a structural sibling of `assertSchemaSnapshot`:

```scala
protected inline def assertGoldenSnapshot[A](
    inline name: String,
    inline config: GoldenConfig[A] => GoldenConfig[A] = identity[GoldenConfig[A]]
)(using
    inline gen: Gen[A],
    inline schema: Schema[A],
    inline frame: Frame,
    inline as: kyo.test.AssertScope
): Unit < (S & Async & Abort[Throwable] & Scope)
```

It draws a deterministic spread of `sampleCount` values (default 20) from the implicit `Gen[A]`, normalizes each, encodes the whole spread as ONE document through the suite's `snapshotCodec`, and on a later run detects any wire-format change across that spread with a per-sample structural compare. The test is a one-liner per type and survives schema changes without rewriting fixtures; an intentional wire change is accepted by re-blessing the baseline.

### Usage

```scala
import kyo.*
import kyo.test.*
import kyo.test.prop.Gen
import kyo.test.snapshot.*

case class Event(id: Int, kind: String) derives Schema
given Gen[Event] = Gen.derive[Event]

class EventGoldenTest extends SnapshotTest[Any]:
    "event wire format" in {
        assertGoldenSnapshot[Event]("event", _.sampleCount(50))
    }
end EventGoldenTest
```

Stored at `test-snapshots/EventGoldenTest/event.golden.yaml` (the `golden.${bare}` extension scheme keeps golden, schema, and Render snapshots pairwise non-colliding). The stored document wraps the spread under a `samples` key, matching the zio-json-golden envelope for maximum compatibility:

```yaml
samples:
  - id: 0
    kind: ""
  - id: -3
    kind: "wq"
  # ... sampleCount entries
```

### `GoldenConfig[A]`: the per-call builder

The single extensible customization point, twin of #1763's `SnapshotConfig`: knobs are additive methods, never new positional parameters.

```scala
final class GoldenConfig[A] private[snapshot] (...):
    def normalize(f: Modify[A] => Modify[A]): GoldenConfig[A]  // scrub non-deterministic fields per sample
    def sampleCount(n: Int): GoldenConfig[A]                   // default 20
    def seed(s: Long): GoldenConfig[A]                         // default 0
    def size(sz: Int): GoldenConfig[A]                         // generator magnitude, default 10
```

Format selection stays the per-suite `snapshotCodec` hook (all seven presets work; binary codecs store raw wire bytes).

### Semantics

1. First run writes the proposed golden and fails with `SnapshotNotFound`; `KYO_TEST_SNAPSHOT=update` blesses new or changed baselines. Goldens are git-tracked, so a re-bless is reviewed via `git diff`.
2. A stored golden is decoded via `Schema[A]` and compared structurally per sample, so hand-reformatting never fails a test; a genuine difference reports the literal path `sample[N].field` (plus a unified text diff for text codecs).
3. A sample count change is a value mismatch (re-bless), never misclassified as evolution.
4. A stored golden that no longer decodes fails with `SnapshotSchemaEvolution`, distinct from a value mismatch; a decode `Result.Panic` propagates unwrapped.
5. Byte-identical golden files across JVM, JS, Native, and Wasm: every draw path for common field types is pure integer arithmetic, and a pinned-literal test asserts the exact encoded bytes on all four platforms.

### `Gen` derivation gap closed

`Gen.derive` previously hard-errored on `Option`/`Chunk`/`Byte` fields (only five primitive givens existed). Three companion givens close it, so the example above and `Chunk[Byte]` payload types derive with nothing hand-supplied:

```scala
given optionGen[A](using inner: Gen[A]): Gen[Option[A]] =
    Gen.frequency(1 -> Gen.const(None: Option[A]), 4 -> inner.map(Some(_): Option[A]))

given chunkGen[A](using inner: Gen[A]): Gen[Chunk[A]] = Gen.list(inner)

given byteGen: Gen[Byte] = Gen.int.map(_.toByte)
```

A user-local given still wins by normal lexical scoping.

## Changelog

**Added**
- `assertGoldenSnapshot[A]` on `SnapshotTestBase[S]` / `SnapshotTest[S]`.
- `GoldenConfig[A]` per-call builder (`normalize`, `sampleCount`, `seed`, `size`).
- `private[snapshot] GoldenSamples[A]` storage envelope (the `samples`-keyed document; not public surface).
- `given optionGen`, `given chunkGen`, `given byteGen` in the `kyo-test-prop` `Gen` companion, plus regression tests (determinism, both `Option` branches, full `Byte` range reachability).
- `SnapshotGoldenTest` (20 leaves: first-run, bless, format tolerance, per-sample mismatch paths, length change, evolution, panic propagation, Protobuf raw-bytes round trip, cross-platform pinned bytes, name validation) plus golden coverage in `SnapshotCodecTest` and the foreign-package compile proof.
- `kyo-test/prop/CONTRIBUTING.md` (new, source-cited) and golden coverage in `kyo-test/snapshot/CONTRIBUTING.md`; `kyo-test` README section with a doctest-compiled example.

**Changed**
- `build.sbt`: `kyo-test-snapshot` now depends on `kyo-test-prop`.
- `SnapshotTest.scala`: the codec-dispatch / store / three-way-decode scaffold is extracted into one shared private `storeAndCompare[D]` helper used by both `assertSchemaSnapshot` and the golden path (behavior-preserving; the documented decode contract now exists in exactly one place).
- `AssertScope.noAssertionDiagram` names the new assertion.

**Unchanged**
- `assertSnapshot` and `assertSchemaSnapshot` behavior, their extensions, and their failure surfaces.
- kyo-schema public API (consumed as-is).

## Verification

Both modules green on all four platforms (JVM/JS/Native/Wasm; 142 prop tests and 61-73 snapshot tests per platform), README doctest `failures=0 warnings=0`, scalafmt clean. Held-out maintainer code review, api-design audit, and hygiene sweeps all pass on the final tree.