### PR TITLE
[kyo-core] fix HalfOpen channel/queue close semantics

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Channel.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Channel.scala
@@ -224,7 +224,7 @@ object Channel:
           * closed.
           *
           * @return
-          *   true if the channel was successfully closed and emptied, false if it was already closed
+          *   true if the channel was successfully closed and emptied, false if it was already closed or a hard `close()` aborted the drain
           */
         def closeAwaitEmpty(using Frame): Boolean < Async = Sync.Unsafe.defer(self.closeAwaitEmpty().safe.get)
 
@@ -802,12 +802,26 @@ object Channel:
                     takes.poll().foreach { promise =>
                         queue.poll() match
                             case Result.Success(Present(value)) =>
-                                if !promise.complete(Result.succeed(value)) && !queue.offer(value).contains(true) then
-                                    // If completing the take fails and the queue
-                                    // cannot accept the value back, enqueue a
-                                    // placeholder put operation
-                                    val placeholder = Promise.Unsafe.init[Unit, Abort[Closed]]()
-                                    discard(puts.offer(Put.Value(value, placeholder)))
+                                if !promise.complete(Result.succeed(value)) then
+                                    // The take was interrupted before receiving the value. Put it back if the queue still accepts writes.
+                                    queue.offer(value) match
+                                        case r if r.contains(true) => ()
+                                        case Result.Success(false) =>
+                                            // Full but open: hold as a placeholder put for a later transfer.
+                                            val placeholder = Promise.Unsafe.init[Unit, Abort[Closed]]()
+                                            discard(puts.offer(Put.Value(value, placeholder)))
+                                        case _ =>
+                                            // HalfOpen/closed (a closeAwaitEmpty drain): the offer can never succeed, and a placeholder put would
+                                            // just be failed by the transfer arm, dropping the value. Retry delivery against the remaining takers.
+                                            // If none are waiting, the value's only consumer interrupted and the closing queue will not re-buffer
+                                            // it, so it is forfeited (the drain settles one element short).
+                                            @tailrec
+                                            def retryTransfer(): Unit =
+                                                takes.poll() match
+                                                    case Present(next) => if !next.complete(Result.succeed(value)) then retryTransfer()
+                                                    case Absent        => ()
+                                            retryTransfer()
+                                    end match
                             case _ =>
                                 // Queue became empty, enqueue the take again
                                 discard(takes.offer(promise))
@@ -827,21 +841,29 @@ object Channel:
                                     if i >= size then
                                         // All items offered, complete put
                                         promise.completeUnitDiscard()
-                                    else if !queue.offer(chunk(i)).contains(true) then
-                                        // Queue became full, add pending put for the rest of the batch
-                                        discard(priorityPuts.offer(Put.Batch(chunk.dropLeft(i), promise)))
-                                    else loop(i + 1)
+                                    else
+                                        queue.offer(chunk(i)) match
+                                            case Result.Success(true)  => loop(i + 1)
+                                            case Result.Success(false) =>
+                                                // Queue became full, add pending put for the rest of the batch
+                                                discard(priorityPuts.offer(Put.Batch(chunk.dropLeft(i), promise)))
+                                            case error =>
+                                                // Closing or closed: the offer can never succeed again; re-enqueueing would livelock this flush. Fail like the closed drain.
+                                                promise.completeDiscard(error.map(_ => ()))
+                                        end match
 
                                 loop(0)
 
                             case put @ Put.Value(value, promise) =>
-                                if queue.offer(value).contains(true) then
-                                    // Queue accepted the value, complete the put
-                                    promise.completeUnitDiscard()
-                                else
-                                    // Queue became full, enqueue the put again
-                                    discard(puts.offer(put))
-                                end if
+                                queue.offer(value) match
+                                    case Result.Success(true) =>
+                                        promise.completeUnitDiscard()
+                                    case Result.Success(false) =>
+                                        discard(puts.offer(put))
+                                    case error =>
+                                        // closing/closed: fail rather than re-enqueue (see the batch arm above)
+                                        promise.completeDiscard(error.map(_ => ()))
+                                end match
                         }
                         batchInProgress.set(false)
                         flush()

--- a/kyo-core/shared/src/main/scala/kyo/Queue.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Queue.scala
@@ -114,7 +114,8 @@ object Queue:
           */
         def drainUpTo(max: Int)(using Frame): Chunk[A] < (Sync & Abort[Closed]) = Sync.Unsafe.defer(Abort.get(self.drainUpTo(max)))
 
-        /** Closes the queue and returns any remaining elements.
+        /** Closes the queue and returns any remaining elements. On a queue with a pending `closeAwaitEmpty`, this aborts the drain: the awaiter
+          * completes `false` and this returns the undrained backlog.
           *
           * @return
           *   a sequence of remaining elements
@@ -128,8 +129,8 @@ object Queue:
           * closed.
           *
           * @return
-          *   true if the queue was successfully closed and emptied, false if it was already closed or another closeAwaitEmpty is already
-          *   running.
+          *   true if the queue was successfully closed and emptied, false if it was already closed, another closeAwaitEmpty is already
+          *   running, or a hard `close()` aborted the drain.
           */
         def closeAwaitEmpty(using Frame): Boolean < Async = Sync.Unsafe.defer(self.closeAwaitEmpty().safe.get)
 
@@ -554,7 +555,23 @@ object Queue:
 
             final def close()(using frame: Frame, allow: AllowUnsafe) =
                 val fail = Result.Failure(Closed("Queue", initFrame))
-                Maybe.when(state.compareAndSet(State.Open, State.FullyClosed(fail))) {
+                // A hard close on a HalfOpen queue aborts the await-empty: complete its promise false (the queue did not drain before this
+                // close) so a parked closeAwaitEmpty caller does not hang.
+                @tailrec
+                def escalate(): Boolean =
+                    state.get() match
+                        case State.Open =>
+                            if state.compareAndSet(State.Open, State.FullyClosed(fail)) then true
+                            else escalate()
+                        case s @ State.HalfOpen(p, _) =>
+                            if state.compareAndSet(s, State.FullyClosed(fail)) then
+                                p.completeDiscard(Result.succeed(false))
+                                true
+                            else escalate()
+                        case _: State.FullyClosed => false
+                    end match
+                end escalate
+                Maybe.when(escalate()) {
                     // Race: an in-flight offer that read state=Open before our CAS may still
                     // commit and run race-repair, which can re-insert via q.offer (when the
                     // polled item is not its own). If that re-insert lands AFTER _drain() exits,

--- a/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/ChannelTest.scala
@@ -1632,6 +1632,93 @@ class ChannelTest extends kyo.test.Test[Any]:
             yield assert(result && !closed1 && !closed2 && closed3)
         }
 
+        "with a parked put: a consumer poll does not livelock and the parked put fails Closed".timeout(15.seconds) in {
+            import AllowUnsafe.embrace.danger
+            Sync.defer {
+                val c = Channel.Unsafe.init[Int](2)
+                discard(c.offer(1))
+                discard(c.offer(2))
+                val p3    = c.putFiber(3)       // parks: channel full
+                val drain = c.closeAwaitEmpty() // HalfOpen: queue non-empty, further offers now fail Closed
+                // pre-fix: the put-transfer branch re-enqueued the parked put after a Closed offer and looped forever
+                val v1  = c.poll()
+                val p3r = p3.poll()    // the parked put must be settled here, with a Closed failure
+                val v2  = c.poll()
+                val v3  = c.poll()
+                val dr  = drain.poll() // closeAwaitEmpty settles true once the buffered elements have drained
+                assert(v1.contains(Maybe.Present(1)), s"v1=$v1")
+                assert(p3r.exists { case Result.Failure(_: Closed) => true; case _ => false }, s"parked put settled=$p3r")
+                assert(v2.contains(Maybe.Present(2)), s"v2=$v2")
+                assert(v3.isFailure, s"v3=$v3") // fully closed once drained
+                assert(dr.exists { case Result.Success(b) => b.eval; case _ => false }, s"closeAwaitEmpty drain=$dr")
+                succeed
+            }
+        }
+
+        "close() escalates a HalfOpen channel and fails a parked put instead of hanging it" in {
+            import AllowUnsafe.embrace.danger
+            Sync.defer {
+                val c = Channel.Unsafe.init[Int](2)
+                discard(c.offer(1))
+                discard(c.offer(2))
+                val p3    = c.putFiber(3)       // parks: channel full
+                val drain = c.closeAwaitEmpty() // HalfOpen: queue non-empty, put parked
+                // pre-fix: close() only transitioned from Open, so it no-oped on a HalfOpen queue and both promises hung forever
+                val backlog = c.close()
+                val p3r     = p3.poll()    // the parked put must be settled Closed, not left hanging
+                val dr      = drain.poll() // the await-empty must settle (aborted), not left pending
+                assert(backlog.contains(Seq(1, 2)), s"the closer must receive the undrained backlog=$backlog")
+                assert(p3r.exists { case Result.Failure(_: Closed) => true; case _ => false }, s"parked put settled=$p3r")
+                assert(dr.exists { case Result.Success(b) => !b.eval; case _ => false }, s"await-empty settled=$dr")
+                assert(c.closed(), "channel fully closed after the hard close")
+                succeed
+            }
+        }
+
+        "with a parked batch put: a consumer poll does not livelock and the parked batch fails Closed".timeout(15.seconds) in {
+            import AllowUnsafe.embrace.danger
+            Sync.defer {
+                val c = Channel.Unsafe.init[Int](2)
+                discard(c.offer(1))
+                discard(c.offer(2))
+                val pb    = c.putBatchFiber(Chunk(3, 4)) // parks: channel full, batch queued
+                val drain = c.closeAwaitEmpty()          // HalfOpen: queue non-empty, offers now fail Closed
+                // pre-fix: the batch transfer arm re-enqueued the parked batch after a Closed offer and looped forever
+                val v1  = c.poll()
+                val pbr = pb.poll()    // the parked batch must be settled Closed
+                val v2  = c.poll()
+                val v3  = c.poll()
+                val dr  = drain.poll() // closeAwaitEmpty settles true once the buffered elements have drained
+                assert(v1.contains(Maybe.Present(1)), s"v1=$v1")
+                assert(pbr.exists { case Result.Failure(_: Closed) => true; case _ => false }, s"parked batch settled=$pbr")
+                assert(v2.contains(Maybe.Present(2)), s"v2=$v2")
+                assert(v3.isFailure, s"v3=$v3") // fully closed once drained
+                assert(dr.exists { case Result.Success(b) => b.eval; case _ => false }, s"closeAwaitEmpty drain=$dr")
+                succeed
+            }
+        }
+
+        "close() racing the final drain settles the closeAwaitEmpty exactly once and never hangs".timeout(30.seconds) in {
+            Kyo.foreach(1 to 200) { _ =>
+                for
+                    c <- Channel.init[Int](2)
+                    _ <- c.put(1)
+                    // Park a closeAwaitEmpty (queue non-empty -> HalfOpen), then race the final drain (a poll empties the queue, so
+                    // handleHalfOpen settles the await true) against a hard close (escalates HalfOpen -> FullyClosed, settles it false).
+                    // Both CAS the same HalfOpen instance: exactly one wins, the await settles once, and neither side hangs.
+                    awaitF <- Fiber.initUnscoped(c.closeAwaitEmpty)
+                    pollF  <- Fiber.initUnscoped(Abort.run(c.poll))
+                    closeF <- Fiber.initUnscoped(c.close)
+                    _      <- awaitF.get
+                    _      <- pollF.get
+                    _      <- closeF.get
+                yield ()
+            }.map { results =>
+                assert(results.size == 200, s"every race iteration must settle without hanging; got ${results.size}")
+                succeed
+            }
+        }
+
         "returns false if channel is already closed" in {
             for
                 c      <- Channel.init[Int](10)

--- a/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/QueueTest.scala
@@ -345,6 +345,18 @@ class QueueTest extends kyo.test.Test[Any]:
             assert(closed == Maybe(Seq(5)))
             assert(testUnsafe.close().isEmpty)
         }
+
+        "a hard close aborts a pending closeAwaitEmpty and returns the backlog" in withQueue { testUnsafe =>
+            discard(testUnsafe.offer(1))
+            discard(testUnsafe.offer(2))
+            val await   = testUnsafe.closeAwaitEmpty() // HalfOpen: queue non-empty, so the await parks
+            val backlog = testUnsafe.close()           // escalate HalfOpen -> FullyClosed: abort the await, return the backlog
+            val ar      = await.poll()
+            assert(backlog.contains(Seq(1, 2)), s"close must return the undrained backlog=$backlog")
+            assert(ar.exists { case Result.Success(b) => !b.eval; case _ => false }, s"the aborted await must settle false=$ar")
+            assert(testUnsafe.offer(3).isFailure, "offers fail Closed after the hard close")
+            assert(testUnsafe.poll().isFailure, "polls fail Closed after the hard close")
+        }
     }
 
     "concurrency" - {


### PR DESCRIPTION
## Problem

Two related bugs on the `closeAwaitEmpty` (HalfOpen) path.

1. `Channel.flush` livelock. When `closeAwaitEmpty` leaves the backing queue `HalfOpen` with a parked put, a consumer that makes space drives the put-transfer branch into an infinite loop: `queue.offer` fails `Closed` for a `HalfOpen` queue, but the branch only checked `.contains(true)` and re-enqueued the parked put unchanged, so the tailrec `flush` re-evaluated the identical state forever. On single-threaded JS this freezes the event loop (dead timers, one pegged core, no allocation, no output); on the JVM it burns a carrier thread.

2. `Queue.close()` no-op on HalfOpen. `close()` only transitioned from `Open`, so a hard `close()` on a queue with a pending `closeAwaitEmpty` (for example `WritePump.teardown` closing a channel whose producer parked on a full outbound) did nothing: the await-empty promise never settled and the parked put hung forever.

## Solution

1. Match the `queue.offer` result three ways in both flush put-transfer arms. `Success(true)` completes the put, `Success(false)` re-enqueues (a genuine full queue), and a `Closed` failure fails the parked put, the same outcome the `FullyClosed` drain already delivers, at the right time. The take-transfer branch gets the same treatment: when a take is interrupted during a `HalfOpen` drain, its value is retried against the remaining takers rather than dropped through a placeholder put that the transfer arm would then fail.

2. `Queue.close()` now escalates from `HalfOpen` as well as `Open`: it CASes to `FullyClosed` and completes the pending await-empty promise with `false` (the queue did not drain to empty before this hard close), then drains the backlog, failing any parked puts and takes.

## Notes

`close()` on a queue with a pending `closeAwaitEmpty` is now a hard close, an externally visible change: `Scope`-managed channels and queues that sit in `HalfOpen` at scope exit (for example the stream extensions) now fully close and settle the await `false` instead of no-oping. Scope exit means the stream is done, so the new behavior is correct at each reviewed site.

Coverage: Channel-level regression tests for the flush livelock (single and batch put) and the hard-close escalation, a `QueueTest` for the `close()`-aborts-`closeAwaitEmpty` contract (backlog returned, await settles `false`, later ops fail `Closed`), and a looped close-vs-drain race test for the `handleHalfOpen`/escalate CAS.
