### PR TITLE
[kyo-i18n] add a cross-platform internationalization module

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ The vertical an application developer assembles: HTTP services and clients, deri
 | [kyo-flow](kyo-flow/README.md)               | ✅  | ✅  | ✅     | ✅   | Durable workflow engine (Temporal/Cadence/ZIO-Flow space); value-replay execution, auto-generated REST     |
 | [kyo-ui](kyo-ui/README.md)                   | ✅  | ✅  | ✅     | ✅   | Web UIs as pure values: Scala.js DOM app, server HTML-over-SSE or SSR stream with first-class reactivity   |
 | [kyo-markdown](kyo-markdown/README.md)       | ✅  | ✅  | ✅     | ✅   | Markdown to a kyo-ui article tree plus a heading outline; pure, total, no third-party Markdown dependency  |
+| [kyo-i18n](kyo-i18n/README.md)               | ✅  | ✅  | ✅     | ✅   | Translate from `.ftl` bundles; active locale as a `Signal` drives reactive `t` leaves; pure Fluent subset  |
 | [kyo-ai](kyo-ai/README.md)                   | ✅  | ✅  | ✅     | ✅   | Typed LLM programs: prompts, tools, thoughts, agents, streaming, provider backends                         |
 | [kyo-caliban](kyo-caliban/README.md)         | ✅  |     |        |      | Caliban GraphQL mounted on kyo-http: typed Kyo effects in resolvers, WebSocket subscriptions               |
 

--- a/build.sbt
+++ b/build.sbt
@@ -375,6 +375,7 @@ lazy val kyoJVM: Project = project
         `kyo-slack`.jvm,
         `kyo-ui`.jvm,
         `kyo-markdown`.jvm,
+        `kyo-i18n`.jvm,
         `kyo-case-app`.jvm,
         `kyo-pod`.jvm,
         `kyo-examples`.jvm,
@@ -449,6 +450,7 @@ lazy val kyoJS = project
         `kyo-slack`.js,
         `kyo-ui`.js,
         `kyo-markdown`.js,
+        `kyo-i18n`.js,
         `kyo-website`.js,
         `kyo-website-bundle`.js,
         `kyo-pod`.js,
@@ -515,6 +517,7 @@ lazy val kyoNative = project
         `kyo-slack`.native,
         `kyo-ui`.native,
         `kyo-markdown`.native,
+        `kyo-i18n`.native,
         `kyo-pod`.native,
         `kyo-compat-future`.native,
         `kyo-compat-kyo`.native,
@@ -579,6 +582,7 @@ lazy val kyoWasm = project
         `kyo-slack`.wasm,
         `kyo-ui`.wasm,
         `kyo-markdown`.wasm,
+        `kyo-i18n`.wasm,
         `kyo-test-api`.wasm,
         `kyo-test-runner`.wasm,
         `kyo-test-prop`.wasm,
@@ -2625,6 +2629,18 @@ lazy val `kyo-markdown` =
             // downstream test link must match its module kind.
             scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
         )
+        .wasmSettings(`wasm-settings`)
+
+lazy val `kyo-i18n` =
+    crossProject(JSPlatform, JVMPlatform, NativePlatform, WasmPlatform)
+        .crossType(CrossType.Full)
+        .in(file("kyo-i18n"))
+        .dependsOn(`kyo-core`)
+        .withKyoTest
+        .settings(`kyo-settings`)
+        .jvmSettings(mimaCheck(false))
+        .nativeSettings(`native-settings`)
+        .jsSettings(`js-settings`)
         .wasmSettings(`wasm-settings`)
 
 lazy val `kyo-ui` =

--- a/kyo-i18n/README.md
+++ b/kyo-i18n/README.md
@@ -1,0 +1,186 @@
+# kyo-i18n
+
+Translate an application from `.ftl` bundles, with the active locale held as a `Signal` so a language switch re-renders exactly the affected text and nothing else. Bundles are parsed and formatted in pure Scala, so the module works across JVM, JavaScript, Scala Native, and WebAssembly and depends only on `kyo-core`. Translations read like plain calls: the resolved handle is provided once at the application root and read back ambiently, so no dependency is threaded through call sites.
+
+<!-- doctest:setup
+```scala
+val demoBundles = Dict(
+    Locale("en") -> "greet = Hello, { $name }!",
+    Locale("de") -> "greet = Hallo, { $name }!"
+)
+```
+-->
+
+```scala
+I18n.initInMemory(demoBundles, Locale("en")).map { i18n =>
+    I18n.let(i18n) {
+        val greeting: Signal[String] = I18n.t("greet", Dict("name" -> "Sam"))
+        greeting.current
+    }
+}
+// "Hello, Sam!"; set the locale to Locale("de") and every t leaf re-renders to German
+```
+
+`I18n.t` is the center: it returns a bare `Signal[String]` that a UI layer lifts into a reactive text node, so switching the locale patches the affected leaves in place. `I18n.now` and `I18n.at` are the point-in-time counterparts for values that must not re-translate. A handle built by `I18n.init` is made ambient with `I18n.let`; everything else reads it back.
+
+## Installation
+
+Add the dependency to your `build.sbt`:
+
+```scala doctest:expect=skipped
+libraryDependencies += "io.getkyo" %% "kyo-i18n" % "<latest version>"
+```
+
+All public types live in the `kyo` package:
+
+```scala
+import kyo.*
+```
+
+**Note:** the effectful methods take an implicit `kyo.Frame` used for source-location reporting. The signatures shown here omit `(using Frame)` for readability; the compiler synthesizes it at each call site.
+
+## Locales
+
+A `Locale` is a normalized primary language subtag. `apply` and `parse` lowercase the input and drop any region or script, so a value from a config file, a stored preference, and a browser `navigator.language` all compare equal:
+
+```scala doctest:scope=nested
+Locale.parse("de-DE") // Present(Locale("de"))
+Locale.parse("EN")    // Present(Locale("en"))
+Locale.parse("")      // Absent
+
+Locale("de").code // "de"
+```
+
+`Locale.default` reads the host environment: `navigator.language` in a browser, otherwise the `user.language` property or `LC_ALL`/`LANG`. It reports whatever the host prefers, which need not be a language the application has a bundle for, so `Locale.preferred` picks the host locale only when it is one of the supported set and falls back otherwise:
+
+```scala doctest:scope=nested
+val supported = Seq(Locale("en"), Locale("de"))
+
+Locale.preferred(supported, Locale("en"))
+// the host locale if it is en or de, otherwise en
+```
+
+When the host names no language at all, `Locale.default` is `Locale.Undetermined`, the BCP-47 `und` subtag.
+
+The module fixes no locale set. The consumer decides which locales exist by which bundles it loads and which start locale it passes to `init`.
+
+## Providing translations
+
+`initInMemory` builds a handle from bundle text you already hold:
+
+```scala doctest:scope=nested
+val bundles = Dict(
+    Locale("en") -> "hello = Hello",
+    Locale("de") -> "hello = Hallo"
+)
+
+I18n.initInMemory(bundles, Locale("en")).map { i18n =>
+    I18n.let(i18n)(I18n.now("hello"))
+}
+// "Hello"
+```
+
+`init` is the usual choice for an application: it loads each locale's text through a function you supply, so the source of the bundles stays in your code. On the client that loader is typically an HTTP fetch, on the server a classpath resource; its effects flow into the result:
+
+```scala doctest:scope=nested
+val supported = Seq(Locale("en"), Locale("de"))
+
+def loadBundle(locale: Locale): String < Async =
+    Async.defer(s"hello = Hello from ${locale.code}")
+
+I18n.init(supported, Locale("en"))(loadBundle).map { i18n =>
+    I18n.let(i18n)(I18n.now("hello"))
+}
+// "Hello from en"
+```
+
+Pair it with `Locale.preferred` to start in the reader's own language whenever a bundle exists for it:
+
+```scala doctest:expect=skipped
+for
+    start <- Locale.preferred(supported, Locale("en"))
+    i18n  <- I18n.init(supported, start)(loadBundle)
+yield i18n
+end for
+```
+
+On the JVM, Scala Native, and Node the bundles usually sit on disk, so `init` also takes a directory in place of the loader and reads `<locale>.ftl` from it:
+
+```scala doctest:expect=skipped
+for
+    start <- Locale.preferred(supported, Locale("en"))
+    i18n  <- I18n.init(supported, start)(Path("resources") / "i18n")
+yield i18n
+end for
+// reads resources/i18n/en.ftl and resources/i18n/de.ftl
+```
+
+That overload carries `Abort[FileReadException]` for the reads. A browser build never links it, since nothing there calls it.
+
+`let` provides the handle as the ambient source for its body. A `t` leaf built anywhere resolves against whichever handle is ambient when it is sampled; a leaf sampled outside any `let` renders miss markers.
+
+## Translating
+
+`t` is the reactive default. `now` reads the active locale once (for toasts, log lines, exception text). `at` reads an explicit locale, ignoring the active one:
+
+```scala doctest:scope=nested
+val bundles = Dict(
+    Locale("en") -> "hello = Hello",
+    Locale("de") -> "hello = Hallo"
+)
+
+I18n.initInMemory(bundles, Locale("en")).map { i18n =>
+    I18n.let(i18n) {
+        for
+            reactive <- I18n.t("hello").current        // "Hello"
+            german   <- I18n.at(Locale("de"), "hello") // "Hallo"
+            _        <- I18n.setLocale(Locale("de"))
+            switched <- I18n.now("hello")              // "Hallo"
+        yield (reactive, german, switched)
+    }
+}
+```
+
+Interpolate named arguments with `{ $name }` placeholders. An argument that is itself a `Signal[String]` (typically a nested `t`) keeps the composed message reactive to that argument as well as to the locale:
+
+```scala doctest:scope=nested
+val bundles = Dict(Locale("en") -> "greet = Hello, { $name }!")
+
+I18n.initInMemory(bundles, Locale("en")).map { i18n =>
+    I18n.let(i18n)(I18n.t("greet", Dict("name" -> "Sam")).current)
+}
+// "Hello, Sam!"
+```
+
+The `i18n"..."` interpolator composes literal text and arguments into one reactive `Signal[String]`:
+
+```scala doctest:scope=nested
+val bundles = Dict(Locale("en") -> "hello = Hello")
+
+I18n.initInMemory(bundles, Locale("en")).map { i18n =>
+    I18n.let(i18n) {
+        val hello = I18n.t("hello")
+        i18n"[$hello]".current
+    }
+}
+// "[Hello]"
+```
+
+## Missing keys
+
+A key that is absent, or present but value-less, renders as `‹key›` rather than falling back to another locale or an empty string, so a gap in a bundle is visible in the output:
+
+```scala doctest:scope=nested
+val bundles = Dict(Locale("en") -> "hello = Hello")
+
+I18n.initInMemory(bundles, Locale("en")).map { i18n =>
+    I18n.let(i18n)(I18n.now("missing"))
+}
+// "‹missing›"
+```
+
+## Bundle format
+
+Bundles are the interpolation-only subset of [Fluent](https://projectfluent.org/): `id = pattern` messages, indented continuation lines, `#` comments, and `{ $name }` placeholders. Select expressions, message attributes, and term references are not parsed; when a count-bearing string first needs plural selection it becomes a new pattern case handled in the parser, not a change to any message that already parses.
+
+A line outside that subset is ignored, but not silently: parsing reports the ignored lines through `kyo.Log` at warn level, so a bundle written against full Fluent shows up in the log rather than as mysteriously absent text. The two behaviors that are specified rather than accidental stay quiet: a value-less message is absent per Fluent semantics, and a brace that is not a `{ $name }` placeholder is literal by design.

--- a/kyo-i18n/js-wasm/src/main/scala/kyo/internal/LocalePlatformSpecific.scala
+++ b/kyo-i18n/js-wasm/src/main/scala/kyo/internal/LocalePlatformSpecific.scala
@@ -1,0 +1,20 @@
+package kyo.internal
+
+import kyo.AllowUnsafe
+import scala.scalajs.js
+
+/** Browser language detection for [[kyo.Locale.default]]: `navigator.language`, for example `"de-DE"`.
+  *
+  * Empty under Node, where there is no navigator and `kyo.System` supplies the environment instead.
+  */
+private[kyo] object LocalePlatformSpecific:
+
+    def browserLanguageTag()(using AllowUnsafe): String =
+        // The `typeof` guard must stay INLINE on the global selection: binding `js.Dynamic.global.navigator`
+        // to a val first emits a bare `navigator` read, which throws ReferenceError where it is undeclared.
+        if js.typeOf(js.Dynamic.global.navigator) == "undefined" then ""
+        else
+            val language = js.Dynamic.global.navigator.language
+            if js.isUndefined(language) || language == null then "" else language.asInstanceOf[String]
+
+end LocalePlatformSpecific

--- a/kyo-i18n/jvm-native/src/main/scala/kyo/internal/LocalePlatformSpecific.scala
+++ b/kyo-i18n/jvm-native/src/main/scala/kyo/internal/LocalePlatformSpecific.scala
@@ -1,0 +1,14 @@
+package kyo.internal
+
+import kyo.AllowUnsafe
+
+/** Browser language detection for [[kyo.Locale.default]].
+  *
+  * There is no browser on the JVM or Scala Native, so detection falls entirely to the `user.language` property
+  * and the environment, which `kyo.System` reads for every platform.
+  */
+private[kyo] object LocalePlatformSpecific:
+
+    def browserLanguageTag()(using AllowUnsafe): String = ""
+
+end LocalePlatformSpecific

--- a/kyo-i18n/jvm-native/src/test/scala/kyo/I18nPathTest.scala
+++ b/kyo-i18n/jvm-native/src/test/scala/kyo/I18nPathTest.scala
@@ -1,0 +1,27 @@
+package kyo
+
+/** Covers the directory overload of [[I18n.init]].
+  *
+  * It lives here rather than in the shared suite because reaching `Path` from the Scala.js test bundle would
+  * pull in the `node:fs` module import, and those tests link as `NoModule`. The overload itself is documented
+  * as the JVM, Scala Native, and Node path.
+  */
+class I18nPathTest extends kyo.test.Test[Any]:
+
+    private val en = Locale("en")
+    private val de = Locale("de")
+
+    "init from a directory" - {
+        "reads <locale>.ftl per locale" in {
+            for
+                dir <- Path.tempDir("kyo-i18n")
+                _   <- (dir / "en.ftl").write("hello = Hello")
+                _   <- (dir / "de.ftl").write("hello = Hallo")
+                h   <- I18n.init(Seq(en, de), en)(dir)
+                a   <- I18n.let(h)(I18n.at(en, "hello"))
+                b   <- I18n.let(h)(I18n.at(de, "hello"))
+                _   <- dir.removeAll
+            yield assert(a == "Hello" && b == "Hallo")
+        }
+    }
+end I18nPathTest

--- a/kyo-i18n/shared/src/main/scala/kyo/I18n.scala
+++ b/kyo-i18n/shared/src/main/scala/kyo/I18n.scala
@@ -1,0 +1,184 @@
+package kyo
+
+import kyo.internal.Bundle
+
+/** A resolved translation handle: parsed bundles plus the reactive current locale.
+  *
+  * An `I18n` is built once by [[I18n.init]] (or [[I18n.initInMemory]]) and provided ambiently for the scope of
+  * an application via [[I18n.let]]. Application code does not pass it around: the module-level [[I18n.t]],
+  * [[I18n.now]], [[I18n.setLocale]] and the `i18n"..."` interpolator read the ambient handle, so a translated
+  * value reads exactly like a plain call with no dependency threaded through every signature.
+  *
+  * The handle is held in a `Local`, whose default is an empty handle that renders every key as its miss marker
+  * `‹key›`. Reading a translation before `init` therefore produces a visible marker rather than throwing.
+  *
+  * @see
+  *   [[I18n.t]] for the reactive translation leaf, [[I18n.now]] for a point-in-time lookup
+  * @see
+  *   [[I18n.init]], [[I18n.initInMemory]] for building a handle, [[I18n.let]] for providing it
+  * @see
+  *   [[Locale]] for the locale identifier the handle is keyed on
+  */
+final class I18n private[kyo] (
+    private[kyo] val bundles: Dict[Locale, Bundle],
+    val locale: Signal[Locale],
+    private val setLocaleFn: Locale => Unit < Sync
+):
+
+    /** The active locale, read once (does not subscribe). Point-in-time counterpart to [[locale]]. */
+    def currentLocale(using Frame): Locale < Sync = locale.current
+
+    /** Sets the active locale, emitting on [[locale]] so every reactive leaf re-renders. */
+    def setLocale(target: Locale)(using Frame): Unit < Sync = setLocaleFn(target)
+
+    private[kyo] def lookup(loc: Locale, key: String, args: I18n.Args): String =
+        bundles.get(loc).flatMap(_.get(key))
+            .fold(s"${I18n.MissOpen}$key${I18n.MissClose}")(_.render(I18n.coerce(args)))
+
+    private[kyo] def leaf(key: String, args: I18n.Args)(using Frame): Signal[String] =
+        val sigArgs = args.toChunk.collect { case (name, sig: Signal[String] @unchecked) => name -> sig }
+        if sigArgs.isEmpty then locale.map(loc => lookup(loc, key, args))
+        else
+            locale.combineLatest(Signal.combineLatestAll(sigArgs.map(_._2))).map { case (loc, values) =>
+                lookup(loc, key, I18n.resolve(args, sigArgs, values))
+            }
+        end if
+    end leaf
+end I18n
+
+/** Internationalization facade over pure-Scala Fluent-subset bundles.
+  *
+  * Translations are parsed once into per-locale bundles and formatted synchronously; there is no dependency on
+  * a JavaScript Fluent runtime, so the module is cross-platform and adds nothing beyond `kyo-core`. The active
+  * locale is a `Signal`, so [[t]] can hand back a bare `Signal[String]` that a UI layer lifts into a reactive
+  * text node: switching the locale re-renders exactly the affected leaves.
+  *
+  * The handle built by [[init]] is provided ambiently through [[let]] and read back inside [[t]] at sample
+  * time, so call sites carry no `using` parameter and no pending effect. A key that is missing (or defined but
+  * empty) renders as `‹key›`, never as a silent fallback to another locale.
+  *
+  * @see
+  *   [[t]], [[now]], [[at]] for translation, [[setLocale]] for switching
+  * @see
+  *   [[init]], [[initInMemory]] for building a handle, [[let]] for providing it
+  * @see
+  *   [[Locale]] for the locale identifier, [[I18n.Arg]] for interpolation argument types
+  */
+object I18n:
+
+    /** An interpolation argument. A `Signal[String]` argument (typically a nested [[t]]) keeps the composed
+      * message reactive; other values are formatted once at build time.
+      */
+    type Arg = String | Int | Long | Double | Boolean | Signal[String]
+
+    /** Named interpolation arguments for a message. */
+    type Args = Dict[String, Arg]
+
+    private[kyo] val MissOpen  = '‹'
+    private[kyo] val MissClose = '›'
+
+    private val i18nLocal: Local[I18n] =
+        Local.init(new I18n(Dict.empty, Signal.initConst(Locale.Undetermined)(using Frame.internal), _ => ()))
+
+    /** The reactive translation leaf, and the default way to translate. Looks up `key` per locale emission,
+      * interpolating `{ $name }` placeholders from `args`; a `Signal[String]` argument keeps the result
+      * reactive to that argument too. A missing or empty key renders as `‹key›`.
+      */
+    def t(key: String, args: Args = Dict.empty)(using Frame): Signal[String] =
+        Signal.initRaw[String](
+            currentWith = [B, S] => (f: String => B < S) => i18nLocal.use(_.leaf(key, args).currentWith(f)),
+            nextWith = [B, S] => (f: String => B < S) => i18nLocal.use(_.leaf(key, args).nextWith(f))
+        )
+
+    /** Point-in-time lookup against the active locale, for values that must not re-translate after the fact
+      * (toast messages, exception messages, log lines).
+      */
+    def now(key: String, args: Args = Dict.empty)(using Frame): String < Sync =
+        i18nLocal.use(handle => handle.currentLocale.map(loc => handle.lookup(loc, key, args)))
+
+    /** Lookup at an explicit locale, ignoring the active one. The building block for hand-composed strings. */
+    def at(locale: Locale, key: String, args: Args = Dict.empty)(using Frame): String < Sync =
+        i18nLocal.use(handle => (handle.lookup(locale, key, args): String < Sync))
+
+    /** Sets the active locale on the ambient handle, re-rendering every reactive leaf. */
+    def setLocale(locale: Locale)(using Frame): Unit < Sync =
+        i18nLocal.use(_.setLocale(locale))
+
+    /** The active locale of the ambient handle, read once (does not subscribe). */
+    def currentLocale(using Frame): Locale < Sync =
+        i18nLocal.use(_.currentLocale)
+
+    /** Provides `handle` as the ambient translation source for `v`. Every [[t]] leaf built inside (whenever it
+      * is sampled) resolves against it; leaves sampled outside any `let` render miss markers.
+      */
+    def let[A, S](handle: I18n)(v: A < S)(using Frame): A < S =
+        i18nLocal.let(handle)(v)
+
+    /** Builds a handle from in-memory bundle text, keyed by locale, starting at `start`. The fetch-free
+      * counterpart to [[init]], for tests and for callers that already hold the bundle sources.
+      */
+    def initInMemory(bundles: Dict[Locale, String], start: Locale)(using Frame): I18n < Sync =
+        Kyo.foreach(bundles.toChunk)((loc, ftl) => Bundle.parse(ftl).map(loc -> _))
+            .map(parsed => handle(parsed, start))
+
+    /** Builds a handle by loading each locale's bundle text via `load`, starting at `start`. The `load`
+      * function supplies the platform-specific source (an HTTP fetch, a classpath resource); its effects flow
+      * into the result.
+      */
+    def init[S](locales: Seq[Locale], start: Locale)(load: Locale => String < (Async & S))(using Frame): I18n < (Async & S) =
+        Kyo.foreach(locales)(loc => load(loc).map(ftl => Bundle.parse(ftl).map(loc -> _)))
+            .map(parsed => handle(parsed, start))
+
+    /** Builds a handle by reading `<locale>.ftl` from `dir`, starting at `start`. The filesystem counterpart to
+      * the loader overload, for the JVM, Scala Native, and Node; a browser build simply never links it.
+      */
+    def init(locales: Seq[Locale], start: Locale)(dir: Path)(using Frame): I18n < (Sync & Abort[FileReadException]) =
+        Kyo.foreach(locales)(loc => (dir / s"${loc.code}.ftl").read.map(ftl => Bundle.parse(ftl).map(loc -> _)))
+            .map(parsed => handle(parsed, start))
+
+    private def handle(parsed: Seq[(Locale, Bundle)], start: Locale)(using Frame): I18n < Sync =
+        val bundles = parsed.foldLeft(Dict.empty[Locale, Bundle])((acc, pair) => acc.update(pair._1, pair._2))
+        Signal.initRef(start).map(ref => new I18n(bundles, ref, loc => ref.set(loc)))
+    end handle
+
+    private[kyo] def coerce(args: Args): Dict[String, String] =
+        args.collect {
+            case (name, v: String)  => name -> v
+            case (name, v: Int)     => name -> v.toString
+            case (name, v: Long)    => name -> v.toString
+            case (name, v: Double)  => name -> v.toString
+            case (name, v: Boolean) => name -> v.toString
+        }
+
+    /** Overlays the sampled values of the signal-valued arguments onto `args`, in the order they were sampled. */
+    private def resolve(args: Args, sigArgs: Chunk[(String, Signal[String])], values: Chunk[String]): Args =
+        sigArgs.iterator.map(_._1).zip(values.iterator).foldLeft(args)((acc, pair) => acc.update(pair._1, pair._2))
+
+    private[kyo] def interpolate(sc: StringContext, args: Seq[Arg])(using Frame): Signal[String] =
+        val sigs = Chunk.from(args).collect { case sig: Signal[String] @unchecked => sig }
+        def render(resolved: Iterator[String]): String =
+            val sb = new StringBuilder(StringContext.processEscapes(sc.parts.head))
+            args.iterator.zip(sc.parts.tail.iterator).foreach { (arg, part) =>
+                val value = arg match
+                    case _: Signal[String] @unchecked => resolved.next()
+                    case other                        => other.toString
+                sb.append(value).append(StringContext.processEscapes(part))
+            }
+            sb.toString
+        end render
+        if sigs.isEmpty then
+            Signal.initRaw[String](
+                currentWith = [B, S] => (f: String => B < S) => i18nLocal.use(_.locale.currentWith(_ => f(render(Iterator.empty)))),
+                nextWith = [B, S] => (f: String => B < S) => i18nLocal.use(_.locale.nextWith(_ => f(render(Iterator.empty))))
+            )
+        else Signal.combineLatestAll(sigs).map(chunk => render(chunk.iterator))
+        end if
+    end interpolate
+end I18n
+
+/** The `i18n"..."` interpolator: composes literal text and arguments into one reactive `Signal[String]`. A
+  * `Signal[String]` argument (typically a [[I18n.t]] leaf) re-renders the composed string on every emission;
+  * other arguments are formatted once. With no signal argument the result still re-derives on locale change.
+  */
+extension (sc: StringContext)
+    def i18n(args: I18n.Arg*)(using Frame): Signal[String] = I18n.interpolate(sc, args)

--- a/kyo-i18n/shared/src/main/scala/kyo/Locale.scala
+++ b/kyo-i18n/shared/src/main/scala/kyo/Locale.scala
@@ -1,0 +1,77 @@
+package kyo
+
+import kyo.internal.LocalePlatformSpecific
+
+/** A language identifier, held as a normalized primary language subtag (for example `en`, `de`).
+  *
+  * `Locale` is a zero-cost wrapper over the code string. It carries only the primary subtag: [[Locale.apply]]
+  * and [[Locale.parse]] lowercase the input and drop any region or script (`de-DE` and `DE` both become `de`),
+  * so a locale used as a bundle key, a persisted value, and a `navigator.language` prefix all compare equal.
+  *
+  * The module is not tied to a fixed set of locales: the consumer decides which locales exist by which bundles
+  * it loads and which start locale it passes to [[I18n.init]]. `derives`-style `CanEqual` is provided because a
+  * `Signal[Locale]` needs `CanEqual[Locale, Locale]` to detect changes.
+  *
+  * @see
+  *   [[Locale.parse]] for turning a code or BCP-47 tag into a `Locale`
+  * @see
+  *   [[Locale.default]] for the host environment's language, [[Locale.preferred]] for picking a supported one
+  * @see
+  *   [[I18n]] for the translation facade keyed on `Locale`
+  */
+opaque type Locale = String
+
+object Locale:
+
+    given CanEqual[Locale, Locale] = CanEqual.derived
+
+    /** The `und` subtag, registered in the IANA Language Subtag Registry with a scope of `special` for content
+      * whose language is undetermined. It is a valid language tag rather than a placeholder string, which is
+      * why it can stand wherever a `Locale` is structurally required but none has been established.
+      *
+      * That is the ambient handle installed before any [[I18n.let]]. The handle carries no bundles, so every
+      * key renders its miss marker whatever its locale is; [[default]] is the one to reach for when an actual
+      * language is wanted.
+      */
+    val Undetermined: Locale = "und"
+
+    /** Wraps a language code, normalized to its lowercase primary subtag. */
+    def apply(code: String): Locale = normalize(code)
+
+    extension (locale: Locale)
+        /** The normalized language code, for use as a bundle id or persisted value. */
+        def code: String = locale
+
+    /** Parses a code or BCP-47 tag (`de`, `de-DE`, `DE`) into a `Locale`. Input with no language subtag (empty
+      * or punctuation-only) is [[Absent]] so the caller can apply its own fallback.
+      */
+    def parse(raw: String): Maybe[Locale] =
+        val code = normalize(raw)
+        if code.isEmpty then Absent else Present(code)
+
+    /** The host environment's language, from the first source that names one: the browser's
+      * `navigator.language`, the `user.language` property, then the `LC_ALL` and `LANG` environment
+      * variables. [[Undetermined]] when none of them does.
+      *
+      * This is the raw host preference and need not be a locale the application has a bundle for; see
+      * [[preferred]] for choosing among the ones it does have.
+      */
+    def default(using Frame): Locale < Sync =
+        for
+            browser  <- Sync.Unsafe.defer(LocalePlatformSpecific.browserLanguageTag())
+            property <- System.property[String]("user.language", "")
+            lcAll    <- System.env[String]("LC_ALL", "")
+            lang     <- System.env[String]("LANG", "")
+        yield Seq(browser, property, lcAll, lang)
+            .foldLeft(Absent: Maybe[Locale])((found, raw) => found.orElse(parse(raw)))
+            .getOrElse(Undetermined)
+
+    /** The host locale when `available` contains it, otherwise `fallback`. The usual way to pick a start locale:
+      * it honors the reader's environment without ever selecting one that has no bundle behind it.
+      */
+    def preferred(available: Seq[Locale], fallback: Locale)(using Frame): Locale < Sync =
+        default.map(host => if available.contains(host) then host else fallback)
+
+    private def normalize(raw: String): String =
+        raw.trim.toLowerCase.takeWhile(c => c != '-' && c != '_')
+end Locale

--- a/kyo-i18n/shared/src/main/scala/kyo/internal/Ftl.scala
+++ b/kyo-i18n/shared/src/main/scala/kyo/internal/Ftl.scala
@@ -1,0 +1,115 @@
+package kyo.internal
+
+import kyo.*
+import scala.annotation.tailrec
+
+/** One segment of a parsed message pattern.
+  *
+  * A message value is a flat sequence of parts: literal text interleaved with variable references. This is
+  * the interpolation-only subset of Fluent the parser supports. A `Select` case (plural / gender branching)
+  * is intentionally absent: when a count-bearing string first needs it, it becomes a new `Part` case handled
+  * here, not a change to any message that already parses.
+  */
+private[kyo] enum Part derives CanEqual:
+    case Literal(text: String)
+    case VarRef(name: String)
+
+/** A single parsed message: its pattern as a sequence of [[Part]]s.
+  *
+  * [[render]] resolves variable references against already-stringified arguments. A reference with no matching
+  * argument renders as `{$name}` so a missing interpolation is visible rather than silently blank.
+  */
+final private[kyo] case class Message(parts: Chunk[Part]):
+    def render(args: Dict[String, String]): String =
+        val sb = new StringBuilder
+        parts.foreach {
+            case Part.Literal(text) => sb.append(text)
+            case Part.VarRef(name)  => sb.append(args.get(name).getOrElse(s"{$$$name}"))
+        }
+        sb.toString
+    end render
+end Message
+
+/** A parsed translation bundle: message id to [[Message]]. One bundle holds one locale's translations. */
+final private[kyo] case class Bundle(messages: Dict[String, Message]):
+    def get(key: String): Maybe[Message] = messages.get(key)
+
+private[kyo] object Bundle:
+    def parse(ftl: String)(using Frame): Bundle < Sync = FtlParser.parse(ftl).map(Bundle(_))
+
+/** Parser for the flat, interpolation-only subset of Fluent (`.ftl`) this module supports.
+  *
+  * It reads `id = pattern` messages, joins indented continuation lines, and skips comments (`#`) and blank
+  * lines. Constructs outside the subset (col-0 `-term` definitions, `.attribute` lines) end the current
+  * message and are reported through [[kyo.Log]] rather than dropped silently. Within a pattern only
+  * `{ $name }` placeholders are recognized; any other `{...}` is kept as literal text, so an unparseable brace
+  * degrades to visible output rather than an error.
+  *
+  * Two behaviors are specified rather than accidental and therefore stay quiet: a value-less message (blank
+  * after `=`) is absent per Fluent semantics, and a non-placeholder brace is literal by design.
+  */
+private[kyo] object FtlParser:
+
+    private val KeyLine = "^([A-Za-z][A-Za-z0-9_-]*)[ \\t]*=[ \\t]*(.*)$".r
+
+    /** How many ignored lines a single warning quotes before summarizing the rest by count. */
+    private val MaxReported = 5
+
+    final private case class St(key: Maybe[String], buf: String, done: Dict[String, String], ignored: Chunk[String])
+
+    def parse(ftl: String)(using Frame): Dict[String, Message] < Sync =
+        def flush(st: St): Dict[String, String] =
+            st.key match
+                case Present(k) if st.buf.trim.nonEmpty => st.done.update(k, st.buf)
+                case _                                  => st.done
+        val end = ftl.linesIterator.zipWithIndex.foldLeft(St(Absent, "", Dict.empty, Chunk.empty)) { case (st, (line, index)) =>
+            if line.isBlank || line.trim.startsWith("#") then st.copy(key = Absent, buf = "", done = flush(st))
+            else
+                line match
+                    case KeyLine(key, value) => st.copy(key = Present(key), buf = value, done = flush(st))
+                    case _ =>
+                        st.key match
+                            case Present(_) if line.startsWith(" ") || line.startsWith("\t") =>
+                                st.copy(buf = s"${st.buf} ${line.trim}")
+                            case _ =>
+                                st.copy(key = Absent, buf = "", done = flush(st), ignored = st.ignored :+ s"${index + 1}: ${line.trim}")
+        }
+        warnIgnored(end.ignored).andThen {
+            flush(end).foldLeft(Dict.empty[String, Message])((acc, key, value) => acc.update(key, Message(parsePattern(value))))
+        }
+    end parse
+
+    private def warnIgnored(ignored: Chunk[String])(using Frame): Unit < Sync =
+        if ignored.isEmpty then ()
+        else
+            val quoted = ignored.take(MaxReported).mkString("; ")
+            val rest   = ignored.size - MaxReported
+            val suffix = if rest > 0 then s" (and $rest more)" else ""
+            Log.warn(s"kyo-i18n: ignored ${ignored.size} line(s) outside the supported Fluent subset: $quoted$suffix")
+
+    private def parsePattern(raw: String): Chunk[Part] =
+        @tailrec
+        def loop(i: Int, acc: Vector[Part]): Vector[Part] =
+            if i >= raw.length then acc
+            else
+                val open = raw.indexOf('{', i)
+                if open < 0 then acc :+ Part.Literal(raw.substring(i))
+                else
+                    val close = raw.indexOf('}', open)
+                    if close < 0 then acc :+ Part.Literal(raw.substring(i))
+                    else
+                        val inner = raw.substring(open + 1, close).trim
+                        if inner.startsWith("$") && isIdent(inner.drop(1)) then
+                            val lit = if open > i then Vector(Part.Literal(raw.substring(i, open))) else Vector.empty
+                            loop(close + 1, (acc ++ lit) :+ Part.VarRef(inner.drop(1)))
+                        else
+                            loop(open + 1, acc :+ Part.Literal(raw.substring(i, open + 1)))
+                        end if
+                    end if
+                end if
+        Chunk.from(loop(0, Vector.empty))
+    end parsePattern
+
+    private def isIdent(s: String): Boolean =
+        s.nonEmpty && s.head.isLetter && s.forall(c => c.isLetterOrDigit || c == '_' || c == '-')
+end FtlParser

--- a/kyo-i18n/shared/src/test/scala/kyo/I18nTest.scala
+++ b/kyo-i18n/shared/src/test/scala/kyo/I18nTest.scala
@@ -1,0 +1,213 @@
+package kyo
+
+import kyo.internal.Bundle
+
+class I18nTest extends kyo.test.Test[Any]:
+
+    private val en = Locale("en")
+    private val de = Locale("de")
+
+    private val enFtl =
+        """|# greetings
+           |hello = Hello
+           |greet = Hello, { $name }!
+           |count = { $count } players
+           |empty =
+           |""".stripMargin
+
+    private val deFtl =
+        """|hello = Hallo
+           |greet = Hallo, { $name }!
+           |count = { $count } Spieler
+           |""".stripMargin
+
+    private val bundles = Dict(en -> enFtl, de -> deFtl)
+
+    private val withUnsupported =
+        """|hello = Hello
+           |-brand = Kyo
+           |.attribute = nope
+           |bye = Bye
+           |""".stripMargin
+
+    /** A handle over a locale ref the caller owns, so a switch can be sequenced against the leaf's subscription
+      * (`ref.waiters`) rather than a sleep. Mirrors what [[I18n.initInMemory]] builds internally.
+      */
+    private def handleOver(ref: SignalRef[Locale])(using Frame): I18n < Sync =
+        Kyo.foreach(bundles.toChunk)((loc, ftl) => Bundle.parse(ftl).map(loc -> _)).map { parsed =>
+            new I18n(parsed.foldLeft(Dict.empty[Locale, Bundle])((acc, p) => acc.update(p._1, p._2)), ref, loc => ref.set(loc))
+        }
+
+    "Locale" - {
+        "parse normalizes code and tag" in {
+            assert(Locale.parse("de-DE") == Present(de))
+            assert(Locale.parse("EN") == Present(en))
+            assert(Locale.parse("  de  ") == Present(de))
+        }
+        "parse rejects empty input" in {
+            assert(Locale.parse("") == Absent)
+            assert(Locale.parse("-x") == Absent)
+        }
+        "code round-trips" in {
+            assert(en.code == "en" && de.code == "de")
+        }
+        "Undetermined is the BCP-47 und subtag" in {
+            assert(Locale.Undetermined.code == "und")
+        }
+        "default reports a normalized subtag" in {
+            // The host language varies per machine, so assert the shape the module guarantees: a
+            // normalized primary subtag, falling back to Undetermined when the host names none.
+            for host <- Locale.default
+            yield assert(host.code.nonEmpty && host.code == host.code.toLowerCase && !host.code.contains("-"))
+        }
+        "preferred picks the host locale when it is available" in {
+            for
+                host   <- Locale.default
+                picked <- Locale.preferred(Seq(host), en)
+            yield assert(picked == host)
+        }
+        "preferred falls back when the host locale has no bundle" in {
+            for picked <- Locale.preferred(Seq.empty, en)
+            yield assert(picked == en)
+        }
+    }
+
+    "init" - {
+        "loads each locale through the supplied function" in {
+            for
+                h <- I18n.init(Seq(en, de), en)(loc => Sync.defer(s"hello = from ${loc.code}"))
+                a <- I18n.let(h)(I18n.at(en, "hello"))
+                b <- I18n.let(h)(I18n.at(de, "hello"))
+            yield assert(a == "from en" && b == "from de")
+        }
+        // The directory overload is covered by I18nPathTest, which is jvm-native: reaching Path from the
+        // JS test bundle would require the node:fs module import, and these tests link as NoModule.
+    }
+
+    "at (explicit locale)" - {
+        "resolves per locale" in {
+            for
+                h <- I18n.initInMemory(bundles, en)
+                a <- I18n.let(h)(I18n.at(en, "hello"))
+                b <- I18n.let(h)(I18n.at(de, "hello"))
+            yield assert(a == "Hello" && b == "Hallo")
+        }
+        "interpolates a named argument" in {
+            for
+                h <- I18n.initInMemory(bundles, en)
+                v <- I18n.let(h)(I18n.at(en, "greet", Dict("name" -> "Sam")))
+            yield assert(v == "Hello, Sam!")
+        }
+        "missing key renders the miss marker" in {
+            for
+                h <- I18n.initInMemory(bundles, en)
+                v <- I18n.let(h)(I18n.at(en, "nope"))
+            yield assert(v == "‹nope›")
+        }
+        "empty-valued key renders the miss marker" in {
+            for
+                h <- I18n.initInMemory(bundles, en)
+                v <- I18n.let(h)(I18n.at(en, "empty"))
+            yield assert(v == "‹empty›")
+        }
+    }
+
+    "now (active locale, point-in-time)" - {
+        "follows the active locale" in {
+            for
+                h <- I18n.initInMemory(bundles, en)
+                result <- I18n.let(h) {
+                    for
+                        before <- I18n.now("hello")
+                        _      <- I18n.setLocale(de)
+                        after  <- I18n.now("hello")
+                    yield (before, after)
+                }
+            yield assert(result == ("Hello", "Hallo"))
+        }
+    }
+
+    "t (reactive leaf)" - {
+        "current reflects the active locale, before and after a switch" in {
+            for
+                h <- I18n.initInMemory(bundles, en)
+                result <- I18n.let(h) {
+                    for
+                        v1 <- I18n.t("hello").current
+                        _  <- I18n.setLocale(de)
+                        v2 <- I18n.t("hello").current
+                    yield (v1, v2)
+                }
+            yield assert(result == ("Hello", "Hallo"))
+        }
+        "a forked next wakes on a locale switch" in {
+            for
+                ref <- Signal.initRef(en)
+                h   <- handleOver(ref)
+                f   <- Fiber.initUnscoped(I18n.let(h)(I18n.t("hello").next))
+                // Wait for the leaf to arm its waiter on the locale ref; setting before that would
+                // race the subscription and the fiber would never wake.
+                _ <- assertEventually(ref.waiters.map(_ == 1))
+                _ <- ref.set(de)
+                v <- f.get
+            yield assert(v == "Hallo")
+        }
+        "outside any let, renders the miss marker" in {
+            for v <- I18n.t("hello").current
+            yield assert(v == "‹hello›")
+        }
+        "a Signal[String] argument is interpolated" in {
+            for
+                h <- I18n.initInMemory(bundles, en)
+                v <- I18n.let(h) {
+                    for
+                        nameRef <- Signal.initRef("Sam")
+                        out     <- I18n.t("greet", Dict("name" -> nameRef)).current
+                    yield out
+                }
+            yield assert(v == "Hello, Sam!")
+        }
+    }
+
+    "i18n\"...\" interpolator" - {
+        "composes literal text with a reactive leaf" in {
+            for
+                h <- I18n.initInMemory(bundles, en)
+                v <- I18n.let(h) {
+                    val hello = I18n.t("hello")
+                    i18n"[$hello]".current
+                }
+            yield assert(v == "[Hello]")
+        }
+    }
+
+    "parsing outside the supported subset" - {
+        "keeps the messages it understands" in {
+            for
+                h <- I18n.initInMemory(Dict(en -> withUnsupported), en)
+                a <- I18n.let(h)(I18n.at(en, "hello"))
+                b <- I18n.let(h)(I18n.at(en, "bye"))
+            yield assert(a == "Hello" && b == "Bye")
+        }
+
+        "warns rather than dropping them silently" in {
+            // Unsafe: an AtomicRef observes the warn emitted from the parser's Log side-effect.
+            val warned = AtomicRef.Unsafe.init(Maybe.empty[String])(using AllowUnsafe.embrace.danger)
+
+            // Override emit, not warn: the async drain dispatches through event.sink.emit.
+            class CapturingLog extends Log.Unsafe.ConsoleLogger("test", Log.Level.warn):
+                override def emit(event: Log.Event)(using allow: AllowUnsafe): Unit =
+                    if event.level == Log.Level.warn then warned.set(Present(event.message))(using allow)
+
+            Log.let(Log(new CapturingLog)) {
+                for
+                    _   <- I18n.initInMemory(Dict(en -> withUnsupported), en)
+                    _   <- Log.flush
+                    saw <- Sync.Unsafe.defer(warned.get())
+                yield
+                    assert(saw.isDefined, "an ignored line must be reported")
+                    assert(saw.get.contains("-brand") && saw.get.contains(".attribute"))
+            }
+        }
+    }
+end I18nTest


### PR DESCRIPTION
## Problem

kyo has no shared way to translate an application. A module that needs localized text has to reach for a third-party i18n runtime, which pins it to one platform (the common Fluent runtime is JavaScript-only) and threads a translator dependency through every call site that renders a string. Nothing ties the active locale to kyo-ui's reactivity, so a language switch means re-rendering by hand.

## Solution

Add `kyo-i18n`, a cross-platform module that parses and formats [Fluent](https://projectfluent.org/) (`.ftl`) bundles in pure Scala and depends only on `kyo-core`. It builds on JVM, JS, Native, and Wasm, with no third-party Fluent runtime.

The active locale is a `Signal`, and `I18n.t(key, args)` returns a bare `Signal[String]` that a UI layer lifts into a reactive text node: switching the locale re-renders exactly the affected leaves and nothing else. `I18n.now` and `I18n.at` are the `< Sync` point-in-time counterparts for values that must not re-translate (toasts, log lines, exception text). Interpolation covers `{ $name }` placeholders; an argument that is itself a `Signal[String]` (typically a nested `t`) keeps the composed message reactive to that argument too, and the `i18n"..."` interpolator composes literals and arguments into one reactive signal.

A handle is built once by `I18n.init` or `I18n.initInMemory`, then made ambient with `I18n.let`. `init` loads each locale's text through a caller-supplied function, so a platform-specific source (an HTTP fetch, a classpath resource) stays in the caller; passing a directory in place of that function reads `<locale>.ftl` from it instead, for the JVM, Native, and Node. Everything else reads the handle back through a `Local`, so a translated value reads like a plain call: no `using` parameter, no pending effect on the reactive path, no global mutable state. The `Local`'s default is an empty handle, so a translation read before `init` renders a visible miss marker rather than throwing.

A `Locale` is a normalized primary language subtag (`de-DE` and `DE` both become `de`), so a config value, a stored preference, and a `navigator.language` prefix all compare equal. `Locale.default` reads the host environment (`navigator.language` in a browser, otherwise `user.language` or `LC_ALL`/`LANG`) and `Locale.preferred` narrows that to the locales an application actually has bundles for, so a start locale can honor the reader without ever naming one that would render nothing. A host that names no language yields `Locale.Undetermined`, the BCP-47 `und` subtag. The module fixes no locale set: the consumer decides which locales exist by which bundles it loads.

## Notes

The directory overload is covered by a `jvm-native` test rather than the shared suite: reaching `Path` from the Scala.js test bundle would pull in the `node:fs` module import, and those tests link as `NoModule`.

A key that is missing, or present but value-less, renders as `‹key›` rather than falling back to another locale or an empty string, so a gap in a bundle is visible in the output. The parser accepts the flat, interpolation-only subset of Fluent (`id = pattern` messages, indented continuation lines, `#` comments); select expressions, message attributes, and term references are not parsed. A line outside the subset is ignored but reported through `kyo.Log` at warn level, so a bundle written against full Fluent shows up in the log rather than as mysteriously absent text; the two specified behaviors stay quiet, namely a value-less message being absent and a non-placeholder brace staying literal. A `Select` AST node is reserved so plural selection, when first needed, is an internal parser addition rather than a change to any message that already parses.
