### PR TITLE
[kyo-prelude] add Abort.tap / Abort.tapError

### DIFF
--- a/kyo-prelude/README.md
+++ b/kyo-prelude/README.md
@@ -114,6 +114,24 @@ assert(Abort.run(partial).eval == Result.succeed(Result.succeed(1)))
 
 When you want recovery only for declared domain errors and want unexpected panics to escape, use `recover` (leaves `Abort[Nothing]`) or `recoverOrThrow` (throws). When you want to consume the whole result including unexpected exceptions, use `recover(onFail, onPanic)` or `fold(onSuccess, onFail, onPanic)`. The single-handler variants always leave panic in some form; the multi-handler variants consume it. `Abort.recoverError` recovers from any `Error[E]` (both `Failure` and `Panic`) with a single handler. `Abort.foldError` folds over an `Error[E]` alongside a success branch. `Abort.foldOrThrow` folds success and typed failures while rethrowing panics as exceptions.
 
+### Observing a failure without consuming it
+
+`Abort.tap` runs a side effect when a computation fails with an `E` and then re-raises the same failure, so the error stays in the row for a downstream handler to decide its fate; success values and panics pass through without evaluating the observer. `Abort.tapError` additionally observes panics, receiving the full `Error[E]`. They are the non-consuming siblings of `recover` / `recoverError` — use them for intermediate observation such as logging or metrics.
+
+```scala
+import kyo.*
+
+// `tap` runs an observer on a Failure (recorded here via Var) and re-raises it unchanged,
+// so a downstream handler still sees the same failure; `tapError` also observes panics.
+val (seen, result) =
+    Var.runTuple(Maybe.empty[String]) {
+        Abort.run[String](Abort.tap[String](e => Var.set(Present(e): Maybe[String]))(Abort.fail("boom")))
+    }.eval
+
+assert(result == Result.fail("boom"))
+assert(seen == Present("boom"))
+```
+
 ### Singleton-typed errors
 
 `Abort.literal.fail("not_found")` preserves the singleton type `"not_found"` instead of widening to `String`, useful when you want the type system to track exactly which symbolic errors a function can produce.

--- a/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
+++ b/kyo-prelude/shared/src/main/scala/kyo/Abort.scala
@@ -427,6 +427,47 @@ object Abort:
     ): (A | B) < (S & reduce.SReduced & Abort[Nothing]) =
         runWith[E](v)(_.foldError(identity, onError))
 
+    /** Observes an Abort failure with a side effect, then re-raises it unchanged.
+      *
+      * This is the non-consuming sibling of [[recover]]: `onFail` runs when the computation fails with an E, and the failure is
+      * re-raised afterwards so enclosing handlers still see it. Success values and panics pass through without evaluating `onFail`
+      * (see [[tapError]] to observe panics too). Use it for intermediate observation such as logging or metrics, where the failure's
+      * fate is decided elsewhere.
+      *
+      * @param onFail
+      *   A function invoked with the failure value of type E; its result is discarded
+      * @param v
+      *   The original computation that may fail
+      * @return
+      *   The original computation, with `onFail` run on an E failure and that failure re-raised unchanged
+      */
+    def tap[E](
+        using Frame
+    )[A, S, S2, ER](onFail: E => Any < S2)(v: => A < (Abort[E | ER] & S))(
+        using ConcreteTag[E]
+    ): A < (Abort[E | ER] & S & S2) =
+        recover[E](e => onFail(e).andThen(Abort.fail(e)))(v)
+
+    /** Observes an Abort failure or panic with a side effect, then re-raises it unchanged.
+      *
+      * This is the non-consuming sibling of [[recoverError]]: `onError` receives the full [[Result.Error]] (`Failure(e)` or
+      * `Panic(t)`) and then the error is re-raised so enclosing handlers still see it. Success values pass through without
+      * evaluating `onError`.
+      *
+      * @param onError
+      *   A function invoked with the Error value (either Failure[E] or Panic); its result is discarded
+      * @param v
+      *   The original computation that may fail or panic
+      * @return
+      *   The original computation, with `onError` run on an error and that error re-raised unchanged
+      */
+    def tapError[E](
+        using Frame
+    )[A, S, S2, ER](onError: Error[E] => Any < S2)(v: => A < (Abort[E | ER] & S))(
+        using ConcreteTag[E]
+    ): A < (Abort[E | ER] & S & S2) =
+        recoverError[E](err => onError(err).andThen(Abort.error(err)))(v)
+
     /** Recovers from an Abort failure by applying the provided function.
       *
       * This method allows you to handle failures in an Abort effect and potentially continue the computation with a new value. It only

--- a/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
+++ b/kyo-prelude/shared/src/test/scala/kyo/AbortTest.scala
@@ -1376,6 +1376,69 @@ class AbortTest extends kyo.test.Test[Any]:
         }
     }
 
+    "tap" - {
+        val boom = new RuntimeException("boom")
+
+        "fires on failure and re-raises the same failure" in {
+            val (seen, result) =
+                Var.runTuple(Maybe.empty[Throwable]) {
+                    Abort.run[Throwable](
+                        Abort.tap[Throwable](e => Var.set(Present(e): Maybe[Throwable]))(Abort.fail(boom): Int < Abort[Throwable])
+                    )
+                }.eval
+            assert(result == Result.Failure(boom))
+            assert(seen == Present(boom))
+        }
+
+        "does not fire on success" in {
+            val (seen, result) =
+                Var.runTuple(false) {
+                    Abort.run[Throwable](Abort.tap[Throwable](_ => Var.set(true))(42: Int < Abort[Throwable]))
+                }.eval
+            assert(result == Result.Success(42))
+            assert(!seen)
+        }
+
+        "an enclosing recover still sees the tapped failure (does not consume)" in {
+            val (order, result) =
+                Var.runTuple(List.empty[String]) {
+                    Abort.run[Nothing] {
+                        Abort.recover[Throwable](_ => Var.update[List[String]]("recover" :: _).andThen(-1)) {
+                            Abort.tap[Throwable](_ => Var.update[List[String]]("tap" :: _).unit)(Abort.fail(boom): Int < Abort[Throwable])
+                        }
+                    }
+                }.eval
+            assert(result == Result.Success(-1))
+            assert(order.reverse == List("tap", "recover"))
+        }
+    }
+
+    "tapError" - {
+        val boom = new RuntimeException("boom")
+
+        "fires on a panic too, and re-raises it" in {
+            val (seen, result) =
+                Var.runTuple(Maybe.empty[Result.Error[Throwable]]) {
+                    Abort.run[Throwable](Abort.tapError[Throwable](err => Var.set(Present(err): Maybe[Result.Error[Throwable]]))(
+                        Abort.panic(boom): Int < Abort[Throwable]
+                    ))
+                }.eval
+            assert(result == Result.Panic(boom))
+            assert(seen == Present(Result.Panic(boom)))
+        }
+
+        "fires on a typed failure with the full Error" in {
+            val (seen, result) =
+                Var.runTuple(Maybe.empty[Result.Error[String]]) {
+                    Abort.run[String](Abort.tapError[String](err => Var.set(Present(err): Maybe[Result.Error[String]]))(
+                        Abort.fail("domain"): Int < Abort[String]
+                    ))
+                }.eval
+            assert(result == Result.Failure("domain"))
+            assert(seen == Present(Result.Failure("domain")))
+        }
+    }
+
     "foldError" - {
         case class CustomError(message: String) derives CanEqual
 


### PR DESCRIPTION
## Problem

`Abort` has a consuming recovery family (`recover`, `recoverError`, `recoverOrThrow`, `fold`) and a success-side `tap` (`Stream.tap`, `Pipe.tap`, `KyoCombinators.tap`), but no way to observe a failure and let it keep propagating. Code that wants to log or record a failure on its way out has to `recover` and re-raise it by hand, which reads as handling the error even when it is only being observed.

## Solution

Add `Abort.tap` and `Abort.tapError` on the `Abort` companion, next to `recover`/`recoverError`.

`tap` runs a side effect when the computation fails with an `E`, then re-raises the same failure; success values and panics pass through without evaluating the observer. `tapError` additionally observes panics, receiving the full `Result.Error` (`Failure(e)` or `Panic(t)`). Both leave the error in the effect row, so an enclosing handler still decides its fate. The callback returns `Any < S`, matching the existing success-side `tap`, and its result is discarded.

## Notes

Each combinator delegates to its consuming sibling with a re-raise (`recover(e => onFail(e).andThen(Abort.fail(e)))` / `recoverError(err => onError(err).andThen(Abort.error(err)))`), so it shares the exact handler semantics of the pair: `E` is matched via `ConcreteTag`, and for `tap` the panic channel is preserved untouched. The tests thread the observed value through `Var` so the side effect stays inside the effect row.
