### PR TITLE
[kyo-ui] add declarative focus seeding and return (focusAuto / focusRestore)

### DIFF
--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -61,6 +61,7 @@ Every `Element` carries an `Attrs` record. The chainable setters are:
 - `.hidden(v: Boolean)`: hide the element. The `Signal[Boolean]` overload exists but lives under "Reactivity" below because it changes the return type.
 - `.style(v: Style)` / `.style(f: Style.type => Style)`: attach styling, see [Styles](#styles).
 - `.tabIndex(v)`, `.focusTrap(v)`, `.focusGroup(id)`: focus order and grouping for keyboard navigation.
+- `.focusAuto(v: Boolean)`, `.focusRestore(v: Boolean)`: declarative focus management. `focusAuto` calls `.focus()` once when a re-render newly inserts the element (like native `autofocus`, but re-render-aware: an echo re-render of an already-visible element never re-steals focus); `focusRestore` returns focus to the element focused before seeding when the seeded element leaves the document (the modal-returns-focus-to-its-trigger pattern). Pair with `tabIndex(-1)` for elements that are not natively focusable.
 
 ```scala
 import UI.*

--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -61,6 +61,7 @@ Every `Element` carries an `Attrs` record. The chainable setters are:
 - `.hidden(v: Boolean)`: hide the element. The `Signal[Boolean]` overload exists but lives under "Reactivity" below because it changes the return type.
 - `.style(v: Style)` / `.style(f: Style.type => Style)`: attach styling, see [Styles](#styles).
 - `.tabIndex(v)`, `.focusTrap(v)`, `.focusGroup(id)`: focus order and grouping for keyboard navigation.
+- `.focusAuto(v: Boolean)`, `.focusRestore(v: Boolean)`: declarative focus management. `focusAuto` calls `.focus()` once when a re-render newly inserts the element (like native `autofocus`, but re-render-aware — an echo re-render of an already-visible element never re-steals focus); `focusRestore` returns focus to the element focused before seeding when the seeded element leaves the document (the modal-returns-focus-to-its-trigger pattern). Pair with `tabIndex(-1)` for elements that are not natively focusable.
 
 ```scala
 import UI.*

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -8,6 +8,12 @@ import scala.scalajs.js
 /** Scala.js UI backend. Mounts a UI into the browser DOM. */
 private[kyo] object DomBackend:
 
+    /** Focus seeding/restore stack for `data-kyo-focus-auto`/`data-kyo-focus-restore` (seeded path, prior-focus path,
+      * restore flag). Mirrors `__frs` in HtmlRenderer.clientJs. Module-level mutable state is safe: all mutation runs
+      * inside `Sync.defer` on the single-threaded JS runtime.
+      */
+    private var focusReturnStack: List[(String, Maybe[String], Boolean)] = Nil
+
     /** Mount a UI into the page body. */
     def mount(ui: UI)(using Frame): Unit < (Async & Scope) =
         mountInto(ui, document.body)
@@ -41,7 +47,9 @@ private[kyo] object DomBackend:
             html <- HtmlRenderer.render(ui, Seq.empty)
             _    <- Sync.defer(container.innerHTML = html)
             _    <- applyJsProps(container)
-            _    <- Sync.defer(beginAnimationsSync(container))
+            // Initial mount: everything is new, so pass an empty old-path set (mirrors clientJs startup faSeed).
+            _ <- Sync.defer(seedFocusAuto(container, Set.empty))
+            _ <- Sync.defer(beginAnimationsSync(container))
             exchange = LocalExchange(root)
             dispatch <- ReactiveUI.subscribe(root, exchange)
             // Single-consumer drain owned by the ambient page Scope: every JS event effect is run by a
@@ -110,6 +118,9 @@ private[kyo] object DomBackend:
                                 else pathAttr
                             else null
                         val (selStart, selEnd) = if insideRegion then readSelection(ae) else (Absent, Absent)
+                        // Focus-auto paths present BEFORE the replace, so seeding fires only for newly-appeared
+                        // elements (a re-render of an already-open overlay must not steal focus).
+                        val oldFocusAuto = focusAutoPaths(el)
                         el.outerHTML = finalHtml
                         val updated = document.querySelector(s"""[data-kyo-path="$pathAttr"]""")
                         if updated != null then
@@ -117,6 +128,10 @@ private[kyo] object DomBackend:
                             beginAnimationsSync(updated)
                         if activePath != null then
                             restoreFocus(activePath, selStart, selEnd)
+                        // Seed AFTER restoreFocus so a newly-appeared focus-auto element wins over restore-to-trigger.
+                        if updated != null then
+                            seedFocusAuto(updated, oldFocusAuto)
+                        sweepFocusAuto()
                     end if
                 }
             }
@@ -157,6 +172,64 @@ private[kyo] object DomBackend:
             end match
         end if
     end restoreFocus
+
+    /** The set of `data-kyo-path` values of every `data-kyo-focus-auto` element inside `root`, `root` itself included. */
+    private def focusAutoPaths(root: dom.Element): Set[String] =
+        val els = root.querySelectorAll("[data-kyo-focus-auto]")
+        val descendants = (0 until els.length).flatMap { i =>
+            Maybe(els(i).asInstanceOf[dom.Element].getAttribute("data-kyo-path")).toList
+        }.toSet
+        if root.hasAttribute("data-kyo-focus-auto") && root.hasAttribute("data-kyo-path") then
+            descendants + root.getAttribute("data-kyo-path")
+        else descendants
+    end focusAutoPaths
+
+    /** Seed the FIRST `data-kyo-focus-auto` element under `newRoot` whose path is not in `oldSet` (i.e. it newly
+      * appeared): record the previously focused element's path plus the focus-restore flag on the stack, then call
+      * `.focus()` on it. Mirrors `faSeed` in HtmlRenderer.clientJs.
+      */
+    private def seedFocusAuto(newRoot: dom.Element, oldSet: Set[String]): Unit =
+        val els = newRoot.querySelectorAll("[data-kyo-focus-auto]")
+        val candidates =
+            (if newRoot.hasAttribute("data-kyo-focus-auto") then Seq(newRoot) else Seq.empty) ++
+                (0 until els.length).map(els(_).asInstanceOf[dom.Element])
+        candidates.find { el =>
+            val p = el.getAttribute("data-kyo-path")
+            p != null && !oldSet.contains(p)
+        }.foreach { el =>
+            val ae = document.activeElement
+            val ret =
+                if ae != null && (ae ne document.body) then Maybe(ae.getAttribute("data-kyo-path"))
+                else Absent
+            focusReturnStack =
+                (el.getAttribute("data-kyo-path"), ret, el.hasAttribute("data-kyo-focus-restore")) :: focusReturnStack
+            val _ = el.asInstanceOf[scalajs.js.Dynamic].focus()
+        }
+    end seedFocusAuto
+
+    /** Pop stack entries whose seeded focus-auto element left the document; when the entry carried
+      * `data-kyo-focus-restore`, focus the recorded previous element (skip silently if it is gone too).
+      * Mirrors `frSweep` in HtmlRenderer.clientJs.
+      */
+    private def sweepFocusAuto(): Unit =
+        var continue = true
+        while continue do
+            focusReturnStack match
+                case (faPath, ret, restore) :: rest =>
+                    if document.querySelector(s"""[data-kyo-path="$faPath"][data-kyo-focus-auto]""") != null then
+                        continue = false
+                    else
+                        focusReturnStack = rest
+                        if restore then
+                            ret.foreach { retPath =>
+                                val re = document.querySelector(s"""[data-kyo-path="$retPath"]""")
+                                if re != null then
+                                    val _ = re.asInstanceOf[scalajs.js.Dynamic].focus()
+                            }
+                        end if
+                case Nil => continue = false
+        end while
+    end sweepFocusAuto
 
     // Bridge a Kyo Async computation from a JS callback boundary by offering it to the page-scoped drain
     // channel. The single AllowUnsafe site narrows to the offer crossing (the JS callback has no Kyo

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -3,10 +3,27 @@ package kyo.internal
 import kyo.*
 import org.scalajs.dom
 import org.scalajs.dom.document
+import scala.annotation.tailrec
 import scala.scalajs.js
 
 /** Scala.js UI backend. Mounts a UI into the browser DOM. */
 private[kyo] object DomBackend:
+
+    /** One seeded `data-kyo-focus-auto` element and where focus should go when it leaves the document.
+      *
+      * @param path
+      *   `data-kyo-path` of the seeded element
+      * @param returnTo
+      *   `data-kyo-path` of the element focused just before seeding, `Absent` when nothing was focused
+      * @param restore
+      *   whether the seeded element declared `data-kyo-focus-restore`
+      */
+    final private case class FocusSeed(path: String, returnTo: Maybe[String], restore: Boolean)
+
+    /** Seeded focus-auto elements, innermost last. Mirrors `__focusReturnStack` in HtmlRenderer.clientJs. Module-level
+      * mutable state is safe: all mutation runs inside `Sync.defer` on the single-threaded JS runtime.
+      */
+    private var focusReturnStack: Chunk[FocusSeed] = Chunk.empty
 
     /** Mount a UI into the page body. */
     def mount(ui: UI)(using Frame): Unit < (Async & Scope) =
@@ -42,6 +59,7 @@ private[kyo] object DomBackend:
             _    <- Sync.defer(container.innerHTML = html)
             _    <- applyJsProps(container)
             _    <- Sync.defer(seedEnter(container, Set.empty))
+            _    <- Sync.defer(seedFocusAuto(container, Set.empty))
             _    <- Sync.defer(beginAnimationsSync(container))
             exchange = LocalExchange(root)
             dispatch <- ReactiveUI.subscribe(root, exchange)
@@ -113,6 +131,7 @@ private[kyo] object DomBackend:
                         val (selStart, selEnd) = if insideRegion then readSelection(ae) else (Absent, Absent)
                         val oldEnter           = enterPaths(el)
                         val ghosts             = prepareLeaveGhosts(el, leaveSurvSet(finalHtml))
+                        val oldFocusAuto       = focusAutoPaths(el)
                         el.outerHTML = finalHtml
                         val updated = document.querySelector(s"""[data-kyo-path="$pathAttr"]""")
                         if updated != null then
@@ -122,7 +141,11 @@ private[kyo] object DomBackend:
                             restoreFocus(activePath, selStart, selEnd)
                         if updated != null then
                             seedEnter(updated, oldEnter)
+                            // Seed AFTER restoreFocus so a newly-appeared focus-auto element wins over restore-to-trigger.
+                            seedFocusAuto(updated, oldFocusAuto)
+                        end if
                         spawnGhosts(ghosts)
+                        sweepFocusAuto()
                     end if
                 }
             }
@@ -163,6 +186,76 @@ private[kyo] object DomBackend:
             end match
         end if
     end restoreFocus
+
+    /** The set of `data-kyo-path` values of every `data-kyo-focus-auto` element inside `root`, `root` itself included.
+      *
+      * Callers capture this BEFORE replacing a region so that [[seedFocusAuto]] can tell a newly appeared element from
+      * one that was already on screen: an echo re-render of an open overlay must not steal focus back from the user.
+      */
+    private def focusAutoPaths(root: dom.Element): Set[String] =
+        val els = root.querySelectorAll("[data-kyo-focus-auto]")
+        val descendants = (0 until els.length).flatMap { i =>
+            Maybe(els(i).asInstanceOf[dom.Element].getAttribute("data-kyo-path")).toList
+        }.toSet
+        if root.hasAttribute("data-kyo-focus-auto") && root.hasAttribute("data-kyo-path") then
+            descendants + root.getAttribute("data-kyo-path")
+        else descendants
+    end focusAutoPaths
+
+    /** Seed the FIRST `data-kyo-focus-auto` element under `newRoot` whose path is not in `oldSet` (i.e. it newly
+      * appeared): record the previously focused element's path plus the focus-restore flag on the stack, then call
+      * `.focus()` on it. On the initial mount `oldSet` is empty, so any focus-auto element is seeded, like native
+      * `autofocus`. Mirrors `seedFocusAuto` in HtmlRenderer.clientJs.
+      */
+    private def seedFocusAuto(newRoot: dom.Element, oldSet: Set[String]): Unit =
+        val els = newRoot.querySelectorAll("[data-kyo-focus-auto]")
+        val candidates =
+            (if newRoot.hasAttribute("data-kyo-focus-auto") then Seq(newRoot) else Seq.empty) ++
+                (0 until els.length).map(els(_).asInstanceOf[dom.Element])
+        candidates.find { el =>
+            val p = el.getAttribute("data-kyo-path")
+            p != null && !oldSet.contains(p)
+        }.foreach { el =>
+            val ae = document.activeElement
+            val ret =
+                if ae != null && (ae ne document.body) then Maybe(ae.getAttribute("data-kyo-path"))
+                else Absent
+            focusReturnStack =
+                focusReturnStack.append(
+                    FocusSeed(el.getAttribute("data-kyo-path"), ret, el.hasAttribute("data-kyo-focus-restore"))
+                )
+            discard(el.asInstanceOf[scalajs.js.Dynamic].focus())
+        }
+    end seedFocusAuto
+
+    /** Unwind stack entries whose seeded focus-auto element left the document, returning focus at most once.
+      *
+      * Stops at the first entry whose element is still in the document: that seed is still on screen, and
+      * restoring an entry below it would move focus out of it. Below that, exactly one restore may land: a
+      * deeper entry belongs to a seed that closed while a newer one stayed open, so its return target is stale
+      * and must not override the one just restored. Its entry is still dropped, so it cannot fire on a later
+      * sweep either. Mirrors `sweepFocusAuto` in HtmlRenderer.clientJs.
+      */
+    @tailrec
+    private def sweepFocusAuto(restored: Boolean = false): Unit =
+        focusReturnStack.lastMaybe match
+            case Present(seed)
+                if document.querySelector(s"""[data-kyo-path="${seed.path}"][data-kyo-focus-auto]""") == null =>
+                focusReturnStack = focusReturnStack.dropLeftAndRight(0, 1)
+                val landed = !restored && seed.restore && seed.returnTo.exists(retPath => focusIfPresent(retPath))
+                sweepFocusAuto(restored || landed)
+            case _ => ()
+    end sweepFocusAuto
+
+    /** Focus the element carrying `path`; `false` when it is no longer in the document (nothing focused). */
+    private def focusIfPresent(path: String): Boolean =
+        val el = document.querySelector(s"""[data-kyo-path="$path"]""")
+        if el == null then false
+        else
+            discard(el.asInstanceOf[scalajs.js.Dynamic].focus())
+            true
+        end if
+    end focusIfPresent
 
     // Bridge a Kyo Async computation from a JS callback boundary by offering it to the page-scoped drain
     // channel. The single AllowUnsafe site narrows to the offer crossing (the JS callback has no Kyo

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -700,6 +700,21 @@ object UI:
             def focusTrap(v: Boolean): Self  = withAttrs(attrs.copy(focusTrap = Present(v)))
             def focusGroup(id: String): Self = withAttrs(attrs.copy(focusGroup = Present(id)))
 
+            /** Declarative focus seeding: when a re-render inserts this element newly into the DOM (its `data-kyo-path` was
+              * not present before), the client calls `.focus()` on it once; re-rendering an already-visible element (same
+              * path) does not re-seed. Seeding runs after focus/caret restore, so opening a panel wins over
+              * restore-to-trigger; on initial load any focus-auto element is seeded (like native autofocus). Does not make
+              * the element focusable, pair with `tabIndex(-1)` for non-natively-focusable elements. The previously focused
+              * element is recorded for [[focusRestore]].
+              */
+            def focusAuto(v: Boolean): Self = withAttrs(attrs.copy(focusAuto = Present(v)))
+
+            /** Declarative focus return: when this focus-seeded element (see [[focusAuto]]) leaves the document, the client
+              * focuses whatever was focused just before seeding (located by `data-kyo-path`, skipped silently if gone). Only
+              * meaningful with `focusAuto(true)`; typical use is a modal that returns focus to its trigger on close.
+              */
+            def focusRestore(v: Boolean): Self = withAttrs(attrs.copy(focusRestore = Present(v)))
+
             /** Opt-in per-level event consumption: when the dispatch walk (innermost target first, then ancestors) reaches
               * this element AND it declared a handler for the event's type, the event stops here so handlers on elements
               * above do not fire. Only consumes event types this element actually handles; others pass through, and the
@@ -948,6 +963,8 @@ object UI:
             tabIndex: Maybe[Int] = Absent,
             focusTrap: Maybe[Boolean] = Absent,
             focusGroup: Maybe[String] = Absent,
+            focusAuto: Maybe[Boolean] = Absent,
+            focusRestore: Maybe[Boolean] = Absent,
             stopPropagation: Maybe[Boolean] = Absent,
             enterTransition: Maybe[String] = Absent,
             leaveTransition: Maybe[String] = Absent,

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -682,6 +682,21 @@ object UI:
             def focusTrap(v: Boolean): Self  = withAttrs(attrs.copy(focusTrap = Present(v)))
             def focusGroup(id: String): Self = withAttrs(attrs.copy(focusGroup = Present(id)))
 
+            /** Declarative focus seeding: when a re-render inserts this element newly into the DOM (its `data-kyo-path` was
+              * not present before), the client calls `.focus()` on it once; re-rendering an already-visible element (same
+              * path) does not re-seed. Seeding runs after focus/caret restore, so opening a panel wins over
+              * restore-to-trigger; on initial load any focus-auto element is seeded (like native autofocus). Does not make
+              * the element focusable, pair with `tabIndex(-1)` for non-natively-focusable elements. The previously focused
+              * element is recorded for [[focusRestore]].
+              */
+            def focusAuto(v: Boolean): Self = withAttrs(attrs.copy(focusAuto = Present(v)))
+
+            /** Declarative focus return: when this focus-seeded element (see [[focusAuto]]) leaves the document, the client
+              * focuses whatever was focused just before seeding (located by `data-kyo-path`, skipped silently if gone). Only
+              * meaningful with `focusAuto(true)`; typical use is a modal that returns focus to its trigger on close.
+              */
+            def focusRestore(v: Boolean): Self = withAttrs(attrs.copy(focusRestore = Present(v)))
+
             /** Runs `action` on click, ignoring the event payload. */
             def onClick(action: => Any < Async): Self = withAttrs(attrs.copy(onClick = Present(Sync.defer(action)(using frame))))
 
@@ -922,6 +937,8 @@ object UI:
             tabIndex: Maybe[Int] = Absent,
             focusTrap: Maybe[Boolean] = Absent,
             focusGroup: Maybe[String] = Absent,
+            focusAuto: Maybe[Boolean] = Absent,
+            focusRestore: Maybe[Boolean] = Absent,
             uiStyle: Style = Style.empty,
             onClick: Maybe[Any < Async] = Absent,
             onClickEvt: Maybe[MouseEvent => Any < Async] = Absent,

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -388,6 +388,8 @@ private[kyo] object HtmlRenderer:
         attrs.tabIndex.foreach(n => w(sb, s""" tabindex="$n""""))
         attrs.focusTrap.foreach(v => if v then w(sb, """ data-kyo-focus-trap="1""""))
         attrs.focusGroup.foreach(id => w(sb, s""" data-kyo-focus-group="${esc(id)}""""))
+        attrs.focusAuto.foreach(v => if v then w(sb, """ data-kyo-focus-auto="1""""))
+        attrs.focusRestore.foreach(v => if v then w(sb, """ data-kyo-focus-restore="1""""))
         // A generated pseudoClass already carries the base props in its own rule (see
         // registerPseudoClass); rendering them inline too would shadow the pseudo-state override.
         if pseudoClass.isEmpty then
@@ -771,14 +773,19 @@ private[kyo] object HtmlRenderer:
            |      var ap=ae&&ae!==document.body&&ae.getAttribute?ae.getAttribute("data-kyo-path"):null;
            |      var ss=(ae&&typeof ae.selectionStart==='number')?ae.selectionStart:null;
            |      var se=(ae&&typeof ae.selectionEnd==='number')?ae.selectionEnd:null;
+           |      var __fa=faPaths(el);
            |      el.outerHTML=op.Replace.html;
            |      var nel=document.querySelector('[data-kyo-path="'+p+'"]');if(nel){applyJsProps(nel);ba(nel);}
            |      if(ap){var rf=document.querySelector('[data-kyo-path="'+ap+'"]');if(rf&&rf.hasAttribute&&rf.hasAttribute('data-kyo-reactive')){var inner=rf.querySelector('input,textarea,select,[contenteditable]');if(inner)rf=inner;}if(rf){rf.focus();if(ss!==null&&typeof rf.setSelectionRange==='function'){try{rf.setSelectionRange(ss,se);}catch(e){if(e.name!=='InvalidStateError')throw e;}}}}
+           |      // Seed AFTER focus/caret restore so a newly-appeared focus-auto element wins restore-to-trigger (the morph path never seeds).
+           |      if(nel)faSeed(nel,__fa);
            |    }
+           |    frSweep();
            |  }else if(op.Remove){
            |    var p=op.Remove.path.join(".");
            |    var el=document.querySelector('[data-kyo-path="'+p+'"]');
            |    if(el)el.remove();
+           |    frSweep();
            |  }else if(op.InjectCss){
            |    var s=document.createElement("style");
            |    s.textContent=op.InjectCss.css;
@@ -854,7 +861,48 @@ private[kyo] object HtmlRenderer:
            |  if(!an.length)return;
            |  requestAnimationFrame(function(){for(var i=0;i<an.length;i++){try{an[i].beginElement();}catch(e){}}});
            |}
+           |// Focus seeding/restore for [data-kyo-focus-auto]/[data-kyo-focus-restore]; __frs stacks {fa, ret|null, restore}.
+           |// Mirrors DomBackend.focusReturnStack for the SPA transport.
+           |var __frs=[];
+           |// Object-set (keyed by path) of every [data-kyo-focus-auto] path inside root, root included.
+           |function faPaths(root){
+           |  var s={};
+           |  if(!root||!root.querySelectorAll)return s;
+           |  if(root.hasAttribute&&root.hasAttribute("data-kyo-focus-auto")){var rp=root.getAttribute("data-kyo-path");if(rp!==null)s[rp]=true;}
+           |  var els=root.querySelectorAll("[data-kyo-focus-auto]");
+           |  for(var i=0;i<els.length;i++){var ep=els[i].getAttribute("data-kyo-path");if(ep!==null)s[ep]=true;}
+           |  return s;
+           |}
+           |// Seed the FIRST newly-appeared focus-auto element under newRoot (path not in oldSet); record prior focus for frSweep.
+           |function faSeed(newRoot,oldSet){
+           |  if(!newRoot||!newRoot.querySelectorAll)return;
+           |  var cand=[];
+           |  if(newRoot.hasAttribute&&newRoot.hasAttribute("data-kyo-focus-auto"))cand.push(newRoot);
+           |  var els=newRoot.querySelectorAll("[data-kyo-focus-auto]");
+           |  for(var i=0;i<els.length;i++)cand.push(els[i]);
+           |  for(var j=0;j<cand.length;j++){
+           |    var fa=cand[j].getAttribute("data-kyo-path");
+           |    if(fa!==null&&!oldSet[fa]){
+           |      var ae=document.activeElement;
+           |      var ret=(ae&&ae!==document.body&&ae.getAttribute)?ae.getAttribute("data-kyo-path"):null;
+           |      __frs.push({fa:fa,ret:ret,restore:cand[j].hasAttribute("data-kyo-focus-restore")});
+           |      if(typeof cand[j].focus==='function')cand[j].focus();
+           |      return;
+           |    }
+           |  }
+           |}
+           |// Pop stack entries whose seeded element left the document; if it carried focus-restore, focus the recorded prior element.
+           |function frSweep(){
+           |  while(__frs.length>0){
+           |    var top=__frs[__frs.length-1];
+           |    if(document.querySelector('[data-kyo-path="'+top.fa+'"][data-kyo-focus-auto]'))return;
+           |    __frs.pop();
+           |    if(top.restore&&top.ret){var re=document.querySelector('[data-kyo-path="'+top.ret+'"]');if(re&&typeof re.focus==='function')re.focus();}
+           |  }
+           |}
            |applyJsProps(document.body);ba(document.body);
+           |// Initial mount: everything server-rendered is new (empty old set), like native autofocus.
+           |faSeed(document.body,{});
            |// Dropdown helpers: close all dropdowns except the given id
            |function kyoCloseDropdown(exceptId){
            |  var all=document.querySelectorAll('[data-kyo-dropdown-options]');

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -389,6 +389,8 @@ private[kyo] object HtmlRenderer:
         attrs.tabIndex.foreach(n => w(sb, s""" tabindex="$n""""))
         attrs.focusTrap.foreach(v => if v then w(sb, """ data-kyo-focus-trap="1""""))
         attrs.focusGroup.foreach(id => w(sb, s""" data-kyo-focus-group="${esc(id)}""""))
+        attrs.focusAuto.foreach(v => if v then w(sb, """ data-kyo-focus-auto="1""""))
+        attrs.focusRestore.foreach(v => if v then w(sb, """ data-kyo-focus-restore="1""""))
         // Marker only: stop-propagation is decided server-side in ReactiveUI.dispatchToElement; the client never reads this.
         attrs.stopPropagation.foreach(v => if v then w(sb, """ data-kyo-stop="1""""))
         // enter/leave transition class lists (read client-side by the patch-application code).
@@ -779,18 +781,22 @@ private[kyo] object HtmlRenderer:
            |      var se=(ae&&typeof ae.selectionEnd==='number')?ae.selectionEnd:null;
            |      var __en=faEnterPaths(el);
            |      var __gh=kyoLeavePrepare(el,kyoLeaveSurv(op.Replace.html));
+           |      var __fa=focusAutoPaths(el);
            |      el.outerHTML=op.Replace.html;
            |      var nel=document.querySelector('[data-kyo-path="'+p+'"]');if(nel){applyJsProps(nel);ba(nel);}
            |      if(ap){var rf=document.querySelector('[data-kyo-path="'+ap+'"]');if(rf&&rf.hasAttribute&&rf.hasAttribute('data-kyo-reactive')){var inner=rf.querySelector('input,textarea,select,[contenteditable]');if(inner)rf=inner;}if(rf){rf.focus();if(ss!==null&&typeof rf.setSelectionRange==='function'){try{rf.setSelectionRange(ss,se);}catch(e){if(e.name!=='InvalidStateError')throw e;}}}}
-           |      if(nel)kyoEnterSeed(nel,__en);
+           |      // Seed AFTER focus/caret restore so a newly-appeared focus-auto element wins restore-to-trigger (the morph path never seeds).
+           |      if(nel){kyoEnterSeed(nel,__en);seedFocusAuto(nel,__fa);}
            |      kyoSpawnGhosts(__gh);
            |    }
+           |    sweepFocusAuto();
            |  }else if(op.Remove){
            |    var p=op.Remove.path.join(".");
            |    var el=document.querySelector('[data-kyo-path="'+p+'"]');
            |    var __rgh=el?kyoLeavePrepare(el,{}):[];
            |    if(el)el.remove();
            |    kyoSpawnGhosts(__rgh);
+           |    sweepFocusAuto();
            |  }else if(op.InjectCss){
            |    var s=document.createElement("style");
            |    s.textContent=op.InjectCss.css;
@@ -945,8 +951,53 @@ private[kyo] object HtmlRenderer:
            |    setTimeout(cleanup,1000);
            |  })(ghosts[i]);}
            |}
+           |// Focus seeding/restore for [data-kyo-focus-auto]/[data-kyo-focus-restore]; __focusReturnStack stacks {fa, ret|null, restore}.
+           |// Mirrors DomBackend.focusReturnStack for the SPA transport.
+           |var __focusReturnStack=[];
+           |// Object-set (keyed by path) of every [data-kyo-focus-auto] path inside root, root included.
+           |function focusAutoPaths(root){
+           |  var s={};
+           |  if(!root||!root.querySelectorAll)return s;
+           |  if(root.hasAttribute&&root.hasAttribute("data-kyo-focus-auto")){var rp=root.getAttribute("data-kyo-path");if(rp!==null)s[rp]=true;}
+           |  var els=root.querySelectorAll("[data-kyo-focus-auto]");
+           |  for(var i=0;i<els.length;i++){var ep=els[i].getAttribute("data-kyo-path");if(ep!==null)s[ep]=true;}
+           |  return s;
+           |}
+           |// Seed the FIRST newly-appeared focus-auto element under newRoot (path not in oldSet); record prior focus for the sweep.
+           |function seedFocusAuto(newRoot,oldSet){
+           |  if(!newRoot||!newRoot.querySelectorAll)return;
+           |  var cand=[];
+           |  if(newRoot.hasAttribute&&newRoot.hasAttribute("data-kyo-focus-auto"))cand.push(newRoot);
+           |  var els=newRoot.querySelectorAll("[data-kyo-focus-auto]");
+           |  for(var i=0;i<els.length;i++)cand.push(els[i]);
+           |  for(var j=0;j<cand.length;j++){
+           |    var fa=cand[j].getAttribute("data-kyo-path");
+           |    if(fa!==null&&!oldSet[fa]){
+           |      var ae=document.activeElement;
+           |      var ret=(ae&&ae!==document.body&&ae.getAttribute)?ae.getAttribute("data-kyo-path"):null;
+           |      __focusReturnStack.push({fa:fa,ret:ret,restore:cand[j].hasAttribute("data-kyo-focus-restore")});
+           |      if(typeof cand[j].focus==='function')cand[j].focus();
+           |      return;
+           |    }
+           |  }
+           |}
+           |// Unwind entries whose seeded element left the document, returning focus at most once. Mirrors DomBackend.sweepFocusAuto.
+           |function sweepFocusAuto(){
+           |  var restored=false;
+           |  while(__focusReturnStack.length>0){
+           |    var top=__focusReturnStack[__focusReturnStack.length-1];
+           |    // Stop at the first seed still on screen: restoring an entry below it would move focus out of it.
+           |    if(document.querySelector('[data-kyo-path="'+top.fa+'"][data-kyo-focus-auto]'))return;
+           |    __focusReturnStack.pop();
+           |    // At most one restore per unwind: a deeper entry belongs to a seed that closed while a newer one stayed
+           |    // open, so its return target is stale and must not override the one just restored.
+           |    if(!restored&&top.restore&&top.ret){var re=document.querySelector('[data-kyo-path="'+top.ret+'"]');if(re&&typeof re.focus==='function'){re.focus();restored=true;}}
+           |  }
+           |}
            |applyJsProps(document.body);ba(document.body);
            |kyoEnterSeed(document.body,{});
+           |// Initial mount: everything server-rendered is new (empty old set), like native autofocus.
+           |seedFocusAuto(document.body,{});
            |// Dropdown helpers: close all dropdowns except the given id
            |function kyoCloseDropdown(exceptId){
            |  var all=document.querySelectorAll('[data-kyo-dropdown-options]');

--- a/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
@@ -515,4 +515,181 @@ class FocusableTest extends UITest:
         }
     }
 
+    // focusAuto/focusRestore over the server-push transport in real Chrome. The DomBackend SPA mirror has
+    // no browser harness (Node test env has no DOM); it is kept in sync by construction.
+    "focusAuto and focusRestore emit their data attributes; absent by default and when set to false" in {
+        val app: UI < Async = UI.div(
+            UI.div("seed").tabIndex(-1).focusAuto(true).focusRestore(true).id("seeded"),
+            UI.div("off").tabIndex(-1).focusAuto(false).focusRestore(false).id("off"),
+            UI.div("plain").id("plain")
+        )
+        withUI(app) {
+            for
+                _ <- Browser.assertAttribute(Selector.id("seeded"), "data-kyo-focus-auto", "1")
+                _ <- Browser.assertAttribute(Selector.id("seeded"), "data-kyo-focus-restore", "1")
+                // An explicit false emits nothing, so it cannot be seeded either.
+                _ <- Browser.assertNoAttribute(Selector.id("off"), "data-kyo-focus-auto")
+                _ <- Browser.assertNoAttribute(Selector.id("off"), "data-kyo-focus-restore")
+                _ <- Browser.assertNoAttribute(Selector.id("plain"), "data-kyo-focus-auto")
+                _ <- Browser.assertNoAttribute(Selector.id("plain"), "data-kyo-focus-restore")
+                _ <- Browser.assertFocused(Selector.id("seeded"))
+                _ <- Browser.assertNotFocused(Selector.id("off"))
+            yield ()
+        }
+    }
+
+    "opening a panel seeds focus into the focus-auto element (winning over restore-to-trigger)" in {
+        val app: UI < Async =
+            for showPanel <- Signal.initRef(false)
+            yield UI.div(
+                UI.button("Open").id("trigger").onClick(showPanel.set(true)),
+                UI.when(showPanel)(
+                    UI.div(
+                        UI.button("Inside").id("inside")
+                    ).id("panel").tabIndex(-1).focusAuto(true)
+                )
+            )
+        withUI(app) {
+            for
+                // The trigger is focused when the panel appears; without seeding, focus restore would keep it there.
+                _ <- Browser.click(Selector.id("trigger"))
+                _ <- Browser.assertVisible(Selector.id("panel"))
+                _ <- Browser.assertFocused(Selector.id("panel"))
+            yield ()
+        }
+    }
+
+    "a re-render of an already-open focus-auto element does not steal the user's focus" in {
+        // The focus-auto panel is seeded on initial load. Bumping re-renders the whole region with
+        // identical paths: the panel must NOT re-seed, and focus restore must keep focus on the inner button.
+        val app: UI < Async =
+            for n <- Signal.initRef(0)
+            yield UI.div(
+                n.map(i =>
+                    UI.div(
+                        UI.button(s"Inner").id("inner"),
+                        UI.div("seed").tabIndex(-1).focusAuto(true).id("panel"),
+                        UI.span(s"n=$i").id("status")
+                    )
+                ),
+                UI.button("Bump").id("bump").onClick(n.getAndUpdate(_ + 1).unit)
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertFocused(Selector.id("panel"))
+                _ <- Browser.click(Selector.id("inner"))
+                _ <- Browser.assertFocused(Selector.id("inner"))
+                // Synthetic JS click so the click itself does not move focus; the region re-renders with the same paths.
+                _ <- Browser.evalDiscard("document.getElementById('bump').click()")
+                _ <- Browser.assertText(Selector.id("status"), "n=1")
+                // No re-seed: focus stays on the inner button.
+                _ <- Browser.assertFocused(Selector.id("inner"))
+                _ <- Browser.assertNotFocused(Selector.id("panel"))
+            yield ()
+        }
+    }
+
+    "closing a focus-restore panel returns focus to the previously focused element" in {
+        val app: UI < Async =
+            for showPanel <- Signal.initRef(false)
+            yield UI.div(
+                UI.button("Open").id("trigger").onClick(showPanel.set(true)),
+                UI.when(showPanel)(
+                    UI.div(
+                        UI.button("Close").id("close").onClick(showPanel.set(false))
+                    ).id("panel").tabIndex(-1).focusAuto(true).focusRestore(true)
+                )
+            )
+        withUI(app) {
+            for
+                // Opening seeds focus into the panel and records the trigger as the return target.
+                _ <- Browser.click(Selector.id("trigger"))
+                _ <- Browser.assertFocused(Selector.id("panel"))
+                // Closing removes the seeded element, so the sweep restores focus to the trigger.
+                _ <- Browser.click(Selector.id("close"))
+                _ <- Browser.assertNotExists(Selector.id("panel"))
+                _ <- Browser.assertFocused(Selector.id("trigger"))
+            yield ()
+        }
+    }
+
+    "an older panel closing does not pull focus from a newer open one, nor override its return target" in {
+        // Two independent focus-restore panels. Closing the older one while the newer is still open must not
+        // return focus to the older trigger (that would yank focus out of the open panel), and its stale entry
+        // must not fire later and override the newer panel's own return.
+        val app: UI < Async =
+            for
+                showA <- Signal.initRef(false)
+                showB <- Signal.initRef(false)
+            yield UI.div(
+                UI.button("Open A").id("triggerA").onClick(showA.set(true)),
+                UI.button("Open B").id("triggerB").onClick(showB.set(true)),
+                UI.when(showA)(
+                    UI.div(
+                        UI.button("Close A").id("closeA").onClick(showA.set(false))
+                    ).id("panelA").tabIndex(-1).focusAuto(true).focusRestore(true)
+                ),
+                UI.when(showB)(
+                    UI.div(
+                        UI.button("Close B").id("closeB").onClick(showB.set(false))
+                    ).id("panelB").tabIndex(-1).focusAuto(true).focusRestore(true)
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.click(Selector.id("triggerA"))
+                _ <- Browser.assertFocused(Selector.id("panelA"))
+                _ <- Browser.click(Selector.id("triggerB"))
+                _ <- Browser.assertFocused(Selector.id("panelB"))
+                // Synthetic JS click so closing A does not move focus by itself.
+                _ <- Browser.evalDiscard("document.getElementById('closeA').click()")
+                _ <- Browser.assertNotExists(Selector.id("panelA"))
+                // A's entry is stale but B is still seeded: the sweep stops on B, focus stays inside it.
+                _ <- Browser.assertFocused(Selector.id("panelB"))
+                _ <- Browser.evalDiscard("document.getElementById('closeB').click()")
+                _ <- Browser.assertNotExists(Selector.id("panelB"))
+                // Exactly one return, and it is B's trigger: A's stale entry unwinds without restoring.
+                _ <- Browser.assertFocused(Selector.id("triggerB"))
+            yield ()
+        }
+    }
+
+    "a focus-restore panel whose return target left the document unwinds without focusing anything" in {
+        // The trigger is removed while the panel is open, so the recorded return path no longer resolves.
+        // The entry must be dropped silently: no focus move, and the session keeps processing events.
+        val app: UI < Async =
+            for
+                showPanel   <- Signal.initRef(false)
+                showTrigger <- Signal.initRef(true)
+                bumps       <- Signal.initRef(0)
+            yield UI.div(
+                UI.when(showTrigger)(UI.button("Open").id("trigger").onClick(showPanel.set(true))),
+                UI.button("Drop").id("drop").onClick(showTrigger.set(false)),
+                UI.button("Bump").id("bump").onClick(bumps.getAndUpdate(_ + 1).unit),
+                bumps.map(n => UI.span(s"bumps=$n").id("bumps")),
+                UI.when(showPanel)(
+                    UI.div(
+                        UI.button("Close").id("close").onClick(showPanel.set(false))
+                    ).id("panel").tabIndex(-1).focusAuto(true).focusRestore(true)
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.click(Selector.id("trigger"))
+                _ <- Browser.assertFocused(Selector.id("panel"))
+                // Synthetic clicks so neither removing the trigger nor closing moves focus by itself.
+                _ <- Browser.evalDiscard("document.getElementById('drop').click()")
+                _ <- Browser.assertNotExists(Selector.id("trigger"))
+                _ <- Browser.evalDiscard("document.getElementById('close').click()")
+                _ <- Browser.assertNotExists(Selector.id("panel"))
+                // Nothing was focused in place of the vanished trigger.
+                _ <- Browser.assertNotFocused(Selector.id("drop"))
+                _ <- Browser.assertNotFocused(Selector.id("bump"))
+                // The sweep did not throw: the client still applies patches.
+                _ <- Browser.evalDiscard("document.getElementById('bump').click()")
+                _ <- Browser.assertText(Selector.id("bumps"), "bumps=1")
+            yield ()
+        }
+    }
+
 end FocusableTest

--- a/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
@@ -515,4 +515,96 @@ class FocusableTest extends UITest:
         }
     }
 
+    // focusAuto/focusRestore over the server-push transport in real Chrome. The DomBackend SPA mirror has
+    // no browser harness (Node test env has no DOM); it is kept in sync by construction.
+    "focusAuto and focusRestore emit their data attributes; absent by default" in {
+        val app: UI < Async = UI.div(
+            UI.div("seed").tabIndex(-1).focusAuto(true).focusRestore(true).id("seeded"),
+            UI.div("plain").id("plain")
+        )
+        withUI(app) {
+            for
+                _ <- Browser.assertAttribute(Selector.id("seeded"), "data-kyo-focus-auto", "1")
+                _ <- Browser.assertAttribute(Selector.id("seeded"), "data-kyo-focus-restore", "1")
+                _ <- Browser.assertNoAttribute(Selector.id("plain"), "data-kyo-focus-auto")
+                _ <- Browser.assertNoAttribute(Selector.id("plain"), "data-kyo-focus-restore")
+            yield ()
+        }
+    }
+
+    "opening a panel seeds focus into the focus-auto element (winning over restore-to-trigger)" in {
+        val app: UI < Async =
+            for showPanel <- Signal.initRef(false)
+            yield UI.div(
+                UI.button("Open").id("trigger").onClick(showPanel.set(true)),
+                UI.when(showPanel)(
+                    UI.div(
+                        UI.button("Inside").id("inside")
+                    ).id("panel").tabIndex(-1).focusAuto(true)
+                )
+            )
+        withUI(app) {
+            for
+                // The trigger is focused when the panel appears; without seeding, focus restore would keep it there.
+                _ <- Browser.click(Selector.id("trigger"))
+                _ <- Browser.assertVisible(Selector.id("panel"))
+                _ <- Browser.assertFocused(Selector.id("panel"))
+            yield ()
+        }
+    }
+
+    "a re-render of an already-open focus-auto element does not steal the user's focus" in {
+        // The focus-auto panel is seeded on initial load. Bumping re-renders the whole region with
+        // identical paths: the panel must NOT re-seed, and focus restore must keep focus on the inner button.
+        val app: UI < Async =
+            for n <- Signal.initRef(0)
+            yield UI.div(
+                n.map(i =>
+                    UI.div(
+                        UI.button(s"Inner").id("inner"),
+                        UI.div("seed").tabIndex(-1).focusAuto(true).id("panel"),
+                        UI.span(s"n=$i").id("status")
+                    )
+                ),
+                UI.button("Bump").id("bump").onClick(n.getAndUpdate(_ + 1).unit)
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertFocused(Selector.id("panel"))
+                _ <- Browser.click(Selector.id("inner"))
+                _ <- Browser.assertFocused(Selector.id("inner"))
+                // Synthetic JS click so the click itself does not move focus; the region re-renders with the same paths.
+                _ <- Browser.evalDiscard("document.getElementById('bump').click()")
+                _ <- Browser.assertText(Selector.id("status"), "n=1")
+                // No re-seed: focus stays on the inner button.
+                _ <- Browser.assertFocused(Selector.id("inner"))
+                _ <- Browser.assertNotFocused(Selector.id("panel"))
+            yield ()
+        }
+    }
+
+    "closing a focus-restore panel returns focus to the previously focused element" in {
+        val app: UI < Async =
+            for showPanel <- Signal.initRef(false)
+            yield UI.div(
+                UI.button("Open").id("trigger").onClick(showPanel.set(true)),
+                UI.when(showPanel)(
+                    UI.div(
+                        UI.button("Close").id("close").onClick(showPanel.set(false))
+                    ).id("panel").tabIndex(-1).focusAuto(true).focusRestore(true)
+                )
+            )
+        withUI(app) {
+            for
+                // Opening seeds focus into the panel and records the trigger as the return target.
+                _ <- Browser.click(Selector.id("trigger"))
+                _ <- Browser.assertFocused(Selector.id("panel"))
+                // Closing removes the seeded element, so the sweep restores focus to the trigger.
+                _ <- Browser.click(Selector.id("close"))
+                _ <- Browser.assertNotExists(Selector.id("panel"))
+                _ <- Browser.assertFocused(Selector.id("trigger"))
+            yield ()
+        }
+    }
+
 end FocusableTest


### PR DESCRIPTION
## Problem

kyo-ui has attributes for keyboard focus *order* and *containment* (`tabIndex`, `focusTrap`, `focusGroup`), but nothing that moves focus in response to the tree changing. Two common patterns have no declarative form: focusing an element the moment it appears (a panel or field that opens), and returning focus to where it was when that element goes away (a modal closing). Doing it by hand means reaching for the DOM from an effect and tracking the previously focused element yourself, and it is easy to steal focus on an unrelated re-render.

## Solution

Add two attributes in the `data-kyo-focus-*` family, wired in both transports (`HtmlRenderer.clientJs` for server-push, `DomBackend` for the SPA):

- `focusAuto(true)`: when a re-render inserts the element NEWLY into the DOM (its `data-kyo-path` was not present in the replaced subtree before), the client calls `.focus()` on it once. A re-render of an already-visible element (same path) does not re-seed, so the user's focus is never stolen by an echo re-render. Seeding runs after the client's existing focus/caret restore, so opening a panel wins over restore-to-trigger. On initial page load a focus-auto element already present is seeded, consistent with native `autofocus`. The element is not made focusable automatically; pair with `tabIndex(-1)` for elements that are not natively focusable.
- `focusRestore(true)`: when the seeded element leaves the document, the client returns focus to the element focused just before seeding (located by `data-kyo-path`, skipped if it is gone) — the modal-returns-focus-to-its-trigger pattern.

Both are pure attribute setters returning `Self`; the behavior lives entirely in the two client transports, keyed off the emitted `data-kyo-focus-auto` / `data-kyo-focus-restore` markers, and composes with the existing `focusTrap` / `focusGroup` family.

## Notes

Seeding is edge-triggered on NEW insertion — compared against the set of focus-auto paths present before the patch — so it never fights the user for focus. Tested as `focusAuto`/`focusRestore` cases in `FocusableTest` (real-Chrome integration test, server-push transport).
