### PR TITLE
[kyo-ui] opt-in per-level event consumption (stopPropagation)

### DIFF
--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -101,6 +101,8 @@ div.onClickSelf(Console.printLine("background"))(
 )
 ```
 
+By default an event bubbles through the tree: every ancestor that declared a handler for the event's type fires, innermost first. `.stopPropagation(true)` makes an element *consume* the events it handles — when the dispatch walk reaches an element that both carries the flag and declared a handler for the arriving type, handlers on elements above it do not fire. It only consumes the types that element actually handles; other types pass through. Typical use is nested overlays, where an Escape should close just the innermost layer. Focus and blur never bubble, so the flag does not apply to them.
+
 > **Note:** `onClick`, `onClickSelf`, `onFocus`, `onBlur`, and `Form.onSubmit` each available as a by-name `=> Any < Async` action or as a typed handler receiving `MouseEvent` or `KeyboardEvent`. `onKeyDown` and `onKeyUp` take a `KeyboardEvent => Any < Async`; the function shape is required because the handler receives the key. Per-input change handlers take `String => Any < Async`, `Boolean => Any < Async`, or `Double => Any < Async`.
 
 ### Invalid states do not compile

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -682,6 +682,14 @@ object UI:
             def focusTrap(v: Boolean): Self  = withAttrs(attrs.copy(focusTrap = Present(v)))
             def focusGroup(id: String): Self = withAttrs(attrs.copy(focusGroup = Present(id)))
 
+            /** Opt-in per-level event consumption: when the dispatch walk (innermost target first, then ancestors) reaches
+              * this element AND it declared a handler for the event's type, the event stops here so handlers on elements
+              * above do not fire. Only consumes event types this element actually handles; others pass through, and the
+              * default (unset/`false`) keeps bubble-through. Applies to bubbling events (click, keydown, keyup, hover,
+              * unhover, scroll). Typical use: nested overlays where Escape closes only the innermost layer.
+              */
+            def stopPropagation(v: Boolean): Self = withAttrs(attrs.copy(stopPropagation = Present(v)))
+
             /** Runs `action` on click, ignoring the event payload. */
             def onClick(action: => Any < Async): Self = withAttrs(attrs.copy(onClick = Present(Sync.defer(action)(using frame))))
 
@@ -922,6 +930,7 @@ object UI:
             tabIndex: Maybe[Int] = Absent,
             focusTrap: Maybe[Boolean] = Absent,
             focusGroup: Maybe[String] = Absent,
+            stopPropagation: Maybe[Boolean] = Absent,
             uiStyle: Style = Style.empty,
             onClick: Maybe[Any < Async] = Absent,
             onClickEvt: Maybe[MouseEvent => Any < Async] = Absent,

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -388,6 +388,8 @@ private[kyo] object HtmlRenderer:
         attrs.tabIndex.foreach(n => w(sb, s""" tabindex="$n""""))
         attrs.focusTrap.foreach(v => if v then w(sb, """ data-kyo-focus-trap="1""""))
         attrs.focusGroup.foreach(id => w(sb, s""" data-kyo-focus-group="${esc(id)}""""))
+        // Marker only: stop-propagation is decided server-side in ReactiveUI.dispatchToElement; the client never reads this.
+        attrs.stopPropagation.foreach(v => if v then w(sb, """ data-kyo-stop="1""""))
         // A generated pseudoClass already carries the base props in its own rule (see
         // registerPseudoClass); rendering them inline too would shadow the pseudo-state override.
         if pseudoClass.isEmpty then

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
@@ -389,6 +389,13 @@ private[kyo] object ReactiveUI:
     private def isTargetSelect(elem: Element, myPath: Seq[String], targetPath: Seq[String])(using Frame): Boolean < Sync =
         targetSatisfies(elem, myPath, targetPath, _.isInstanceOf[Select])
 
+    /** Bubble-continue value after an element handled `event`: `false` (consume) only when the element set
+      * `stopPropagation(true)` AND actually declared a handler for this event's type (`declared`). The result flows up the
+      * dispatch recursion, so a `false` makes every element ABOVE this one skip its own handler.
+      */
+    private def keepBubbling(elem: Element, declared: Boolean): Boolean =
+        !(declared && elem.attrs.stopPropagation.getOrElse(false))
+
     /** Dispatch event to element. isTarget=true when element is the click target, false on bubble. disabledTarget=true when the original
       * click target was disabled (prevents Form onSubmit on bubble).
       */
@@ -423,12 +430,15 @@ private[kyo] object ReactiveUI:
                                 invoke(f.onSubmit).andThen(invokeWith(f.onSubmitEvt, mouse))
                             case _ => Kyo.lift(())
                     else Kyo.lift(())
+                    // Self handlers only count as "declared" when they actually fired (isTarget).
+                    val declared = attrs.onClick.nonEmpty || attrs.onClickEvt.nonEmpty ||
+                        (isTarget && (attrs.onClickSelf.nonEmpty || attrs.onClickSelfEvt.nonEmpty))
                     self
                         .andThen(invokeWith(attrs.onClickEvt, mouse))
                         .andThen(invoke(attrs.onClick))
                         .andThen(activateToggle)
                         .andThen(formSubmit)
-                        .andThen(true)
+                        .andThen(keepBubbling(elem, declared))
             case ev: UIEvent.Focus =>
                 val isFocusable = elem.isInstanceOf[Focusable] || elem.attrs.tabIndex.nonEmpty
                 if isTarget && isFocusable then
@@ -485,14 +495,15 @@ private[kyo] object ReactiveUI:
                             case f: Form => invoke(f.onSubmit)
                             case _       => Kyo.lift(())
                     else Kyo.lift(())
-                    keyHandler.andThen(activateClick).andThen(activateToggle).andThen(selectCycle).andThen(formSubmit).andThen(true)
+                    keyHandler.andThen(activateClick).andThen(activateToggle).andThen(selectCycle).andThen(formSubmit)
+                        .andThen(keepBubbling(elem, attrs.onKeyDown.nonEmpty))
             case e: UIEvent.KeyUp =>
                 val kbEvent = UI.KeyboardEvent(
                     key = Keyboard.fromString(e.keyboard.key),
                     modifiers = e.keyboard.modifiers,
                     targetId = e.keyboard.targetId
                 )
-                invokeWith(attrs.onKeyUp, kbEvent).andThen(true)
+                invokeWith(attrs.onKeyUp, kbEvent).andThen(keepBubbling(elem, attrs.onKeyUp.nonEmpty))
             case e: UIEvent.Input =>
                 if isTarget && (isDisabled(elem) || isReadOnly(elem)) then true
                 else
@@ -557,13 +568,16 @@ private[kyo] object ReactiveUI:
                     case _ => true
             case ev: UIEvent.Hover =>
                 val mouse = UI.MouseEvent(ev.mouse.targetId, ev.mouse.modifiers)
-                invoke(attrs.onHover).andThen(invokeWith(attrs.onHoverEvt, mouse)).andThen(true)
+                invoke(attrs.onHover).andThen(invokeWith(attrs.onHoverEvt, mouse))
+                    .andThen(keepBubbling(elem, attrs.onHover.nonEmpty || attrs.onHoverEvt.nonEmpty))
             case ev: UIEvent.Unhover =>
                 val mouse = UI.MouseEvent(ev.mouse.targetId, ev.mouse.modifiers)
-                invoke(attrs.onUnhover).andThen(invokeWith(attrs.onUnhoverEvt, mouse)).andThen(true)
+                invoke(attrs.onUnhover).andThen(invokeWith(attrs.onUnhoverEvt, mouse))
+                    .andThen(keepBubbling(elem, attrs.onUnhover.nonEmpty || attrs.onUnhoverEvt.nonEmpty))
             case ev: UIEvent.Scroll =>
                 val wheel = UI.WheelEvent(ev.deltaX, ev.deltaY, ev.targetId, ev.modifiers)
-                invoke(attrs.onScroll).andThen(invokeWith(attrs.onScrollEvt, wheel)).andThen(true)
+                invoke(attrs.onScroll).andThen(invokeWith(attrs.onScrollEvt, wheel))
+                    .andThen(keepBubbling(elem, attrs.onScroll.nonEmpty || attrs.onScrollEvt.nonEmpty))
             case _ => true
         end match
     end dispatchToElement

--- a/kyo-ui/shared/src/test/scala/kyo/EventHandlerTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/EventHandlerTest.scala
@@ -1236,4 +1236,140 @@ class EventHandlerTest extends UITest:
         }
     }
 
+    // Per-level event consumption via stopPropagation(true); decided server-side in ReactiveUI.dispatchToElement.
+    "stopPropagation emits its marker attribute; absent by default" in {
+        val app: UI < Async = UI.div(
+            UI.div("stopper").id("s").stopPropagation(true).onKeyDown(_ => ()),
+            UI.div("plain").id("plain").onKeyDown(_ => ())
+        )
+        withUI(app) {
+            for
+                _ <- Browser.assertAttribute(Selector.id("s"), "data-kyo-stop", "1")
+                _ <- Browser.assertNoAttribute(Selector.id("plain"), "data-kyo-stop")
+            yield ()
+        }
+    }
+
+    "without the flag both nested onKeyDown handlers fire (regression pin for bubble-through)" in {
+        val app: UI < Async =
+            for
+                aKey <- Signal.initRef("")
+                bKey <- Signal.initRef("")
+            yield UI.div(
+                UI.div.id("a").onKeyDown(ke => aKey.set(ke.key.toString))(
+                    UI.div.id("b").onKeyDown(ke => bKey.set(ke.key.toString))(
+                        UI.input.id("i")
+                    )
+                ),
+                aKey.map(v => UI.span(s"a:$v").id("av")),
+                bKey.map(v => UI.span(s"b:$v").id("bv"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.press(Selector.id("i"), Key.Escape)
+                _ <- Browser.assertText(Selector.id("bv"), "b:Escape")
+                _ <- Browser.assertText(Selector.id("av"), "a:Escape")
+            yield ()
+        }
+    }
+
+    "keydown stops at the consuming inner container: only B's handler fires" in {
+        val app: UI < Async =
+            for
+                aKey <- Signal.initRef("none")
+                bKey <- Signal.initRef("none")
+            yield UI.div(
+                UI.div.id("a").onKeyDown(ke => aKey.set(ke.key.toString))(
+                    UI.div.id("b").stopPropagation(true).onKeyDown(ke => bKey.set(ke.key.toString))(
+                        UI.input.id("i")
+                    )
+                ),
+                aKey.map(v => UI.span(s"a:$v").id("av")),
+                bKey.map(v => UI.span(s"b:$v").id("bv"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.press(Selector.id("i"), Key.Escape)
+                _ <- Browser.assertText(Selector.id("bv"), "b:Escape")
+                _ <- Browser.assertText(Selector.id("av"), "a:none")
+            yield ()
+        }
+    }
+
+    "the flag only consumes event types the element declared: click passes through a keydown-stopper" in {
+        val app: UI < Async =
+            for
+                aClicks <- Signal.initRef(0)
+                bKey    <- Signal.initRef("none")
+            yield UI.div(
+                UI.div.id("a").onClick(aClicks.getAndUpdate(_ + 1).unit)(
+                    UI.div.id("b").stopPropagation(true).onKeyDown(ke => bKey.set(ke.key.toString))(
+                        UI.button("Go").id("btn")
+                    )
+                ),
+                aClicks.map(n => UI.span(s"a:$n").id("av")),
+                bKey.map(v => UI.span(s"b:$v").id("bv"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.click(Selector.id("btn"))
+                _ <- Browser.assertText(Selector.id("av"), "a:1")
+            yield ()
+        }
+    }
+
+    "click consumption: a stopping inner handler keeps the outer onClick from firing" in {
+        val app: UI < Async =
+            for
+                inner <- Signal.initRef(0)
+                outer <- Signal.initRef(0)
+            yield UI.div(
+                UI.div.id("outer").onClick(outer.getAndUpdate(_ + 1).unit)(
+                    UI.button("Go").id("btn").stopPropagation(true).onClick(inner.getAndUpdate(_ + 1).unit)
+                ),
+                inner.map(n => UI.span(s"in:$n").id("iv")),
+                outer.map(n => UI.span(s"out:$n").id("ov"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.click(Selector.id("btn"))
+                _ <- Browser.assertText(Selector.id("iv"), "in:1")
+                _ <- Browser.assertText(Selector.id("ov"), "out:0")
+            yield ()
+        }
+    }
+
+    "nested overlays: Escape closes only the innermost layer" in {
+        val app: UI < Async =
+            for
+                showOuter <- Signal.initRef(true)
+                showInner <- Signal.initRef(true)
+            yield UI.div(
+                UI.when(showOuter)(
+                    UI.div.id("overlay-outer").onKeyDown { ke =>
+                        if ke.key == UI.Keyboard.Escape then showOuter.set(false)
+                        else ()
+                    }(
+                        UI.span("outer content").id("outer-content"),
+                        UI.when(showInner)(
+                            UI.div.id("overlay-inner").stopPropagation(true).onKeyDown { ke =>
+                                if ke.key == UI.Keyboard.Escape then showInner.set(false)
+                                else ()
+                            }(
+                                UI.input.id("inner-input")
+                            )
+                        )
+                    )
+                ),
+                UI.span("sentinel").id("sentinel")
+            )
+        withUI(app) {
+            for
+                _ <- Browser.press(Selector.id("inner-input"), Key.Escape)
+                _ <- Browser.assertNotExists(Selector.id("overlay-inner"))
+                _ <- Browser.assertVisible(Selector.id("outer-content"))
+            yield ()
+        }
+    }
+
 end EventHandlerTest


### PR DESCRIPTION
> **Merge before its stacked follow-ups.** #1783 (`onContextMenu`) and #1786 (`onFileSelect`) are based on this branch and opt their new events into the `keepBubbling` introduced here. Merge this PR first; their diffs narrow to just their own feature once this lands.

## Problem

kyo-ui dispatches a bubbling event to every element on the path from the innermost target outward, firing each ancestor that declared a handler for that event's type. There is no way for an element to say "I handled this; do not also run the handlers above me." Nested overlays are the common case: an Escape keydown inside an inner panel also reaches the outer panel's handler, so both close at once.

## Solution

Add `stopPropagation(v: Boolean)`. When the dispatch walk reaches an element that carries the flag AND declared a handler for the arriving event's type, the event stops there — the ancestors' handlers do not fire. It only consumes the types that element actually handles; other event types pass through unaffected. The default (unset or `false`) keeps the existing bubble-through semantics.

The stop lives server-side in `ReactiveUI.dispatchToElement` (`keepBubbling`), the single source of truth for both transports; `data-kyo-stop="1"` is emitted as an inspection marker only, and the clients never branch on it. It applies to the bubbling events (click, keydown, keyup, hover, unhover, scroll); focus and blur never bubble in kyo-ui.

## Notes

Tested as `stopPropagation` cases in `EventHandlerTest` (real-Chrome integration test, server-push transport).
