### PR TITLE
[kyo-ui] SPA event delegation forwards ancestor-declared bubbling events

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,6 +19,14 @@ runs:
       with:
         node-version: '24'
 
+    # jsdom for the DOM-backed Scala.js unit tests (kyo-ui DomTestEnv); loaded lazily via require,
+    # so only suites that install the DOM need it. JS only: the helper lives in the js-only test tree.
+    # The repo ignores *.json, so the version is pinned here rather than in a package.json.
+    - name: Install Node.js test dependencies
+      if: ${{ inputs.target == 'JS' }}
+      shell: bash
+      run: npm install --no-save --no-fund --no-audit jsdom@^30
+
     - uses: actions/cache@v5
       env:
         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -227,11 +227,31 @@ private[kyo] object DomBackend:
     private def setupEventDelegation(dispatch: (Seq[String], UIEvent) => Boolean < Async, events: Channel[Unit < Async])(using
         Frame
     ): Unit < Sync = Sync.defer {
+        // ReactiveUI.dispatchToElement bubbles an event to every ancestor that declared a handler for its type, so
+        // this SPA forwarding gate must forward when ANY ancestor declared it, not just the target (checking only the
+        // target's own data-kyo-ev would drop e.g. a keydown meant for an ancestor panel before bubble dispatch runs).
+        def declaredInChain(start: dom.Element, t: String): Boolean =
+            var n: dom.Element = start
+            var found          = false
+            while !found && n != null && (n ne document.body) do
+                val ev = n.getAttribute("data-kyo-ev")
+                if ev != null && ev.split(",").contains(t) then found = true
+                else
+                    n = n.parentNode match
+                        case p: dom.Element => p
+                        case _              => null
+                end if
+            end while
+            found
+        end declaredInChain
+
+        final class ChainTypes(target: dom.Element):
+            def contains(t: String): Boolean = declaredInChain(target, t)
+
         val handler: scalajs.js.Function1[dom.Event, Unit] = (e: dom.Event) =>
             findPathElement(e.target.asInstanceOf[dom.Element]).foreach { target =>
                 val path    = parsePath(target.getAttribute("data-kyo-path"))
-                val evAttr  = target.getAttribute("data-kyo-ev")
-                val evTypes = if evAttr != null then evAttr.split(",").toSet else Set.empty[String]
+                val evTypes = ChainTypes(target)
                 val t       = e.`type`
 
                 val event: Maybe[UIEvent] =

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -223,28 +223,31 @@ private[kyo] object DomBackend:
         end if
     end beginAnimationsSync
 
+    /** True when `start` or any of its ancestors below `document.body` declares event type `t` in `data-kyo-ev`.
+      *
+      * ReactiveUI.dispatchToElement bubbles an event to every ancestor that declared a handler for its type, so the
+      * SPA forwarding gate must forward when ANY ancestor declared it, not just the target (checking only the
+      * target's own data-kyo-ev would drop e.g. a keydown meant for an ancestor panel before bubble dispatch runs).
+      */
+    private[kyo] def declaredInChain(start: dom.Element, t: String): Boolean =
+        var n: dom.Element = start
+        var found          = false
+        while !found && n != null && (n ne document.body) do
+            val ev = n.getAttribute("data-kyo-ev")
+            if ev != null && ev.split(",").contains(t) then found = true
+            else
+                n = n.parentNode match
+                    case p: dom.Element => p
+                    case _              => null
+            end if
+        end while
+        found
+    end declaredInChain
+
     /** Set up capture-phase event delegation on document.body. */
     private def setupEventDelegation(dispatch: (Seq[String], UIEvent) => Boolean < Async, events: Channel[Unit < Async])(using
         Frame
     ): Unit < Sync = Sync.defer {
-        // ReactiveUI.dispatchToElement bubbles an event to every ancestor that declared a handler for its type, so
-        // this SPA forwarding gate must forward when ANY ancestor declared it, not just the target (checking only the
-        // target's own data-kyo-ev would drop e.g. a keydown meant for an ancestor panel before bubble dispatch runs).
-        def declaredInChain(start: dom.Element, t: String): Boolean =
-            var n: dom.Element = start
-            var found          = false
-            while !found && n != null && (n ne document.body) do
-                val ev = n.getAttribute("data-kyo-ev")
-                if ev != null && ev.split(",").contains(t) then found = true
-                else
-                    n = n.parentNode match
-                        case p: dom.Element => p
-                        case _              => null
-                end if
-            end while
-            found
-        end declaredInChain
-
         final class ChainTypes(target: dom.Element):
             def contains(t: String): Boolean = declaredInChain(target, t)
 

--- a/kyo-ui/js/src/test/scala/kyo/DomBackendDelegationTest.scala
+++ b/kyo-ui/js/src/test/scala/kyo/DomBackendDelegationTest.scala
@@ -1,0 +1,67 @@
+package kyo
+
+import kyo.internal.DomBackend
+import org.scalajs.dom
+
+/** Isolated tests for [[DomBackend.declaredInChain]], the SPA event-delegation forwarding gate.
+  *
+  * These run against a real jsdom document (see [[DomTestEnv]]), so the traversal is exercised through the actual DOM
+  * API: `createElement`, attribute reads, `parentNode` links, and the `instanceof Element` check in the walk.
+  */
+class DomBackendDelegationTest extends kyo.test.Test[Any]:
+
+    DomTestEnv.install
+
+    private def el(parent: dom.Node, ev: String = null): dom.Element =
+        val e = dom.document.createElement("div")
+        if ev != null then e.setAttribute("data-kyo-ev", ev)
+        if parent != null then discard(parent.appendChild(e))
+        e
+    end el
+
+    "forwards when the target itself declares the type" in {
+        val target = el(dom.document.body, ev = "keydown")
+        assert(DomBackend.declaredInChain(target, "keydown"))
+    }
+
+    "forwards when only an ancestor declares the type" in {
+        // The regression this PR fixes: a keydown declared on an ancestor panel must be forwarded even
+        // though the event target carries no data-kyo-ev of its own.
+        val ancestor = el(dom.document.body, ev = "keydown")
+        val mid      = el(ancestor)
+        val target   = el(mid)
+        assert(DomBackend.declaredInChain(target, "keydown"))
+    }
+
+    "does not forward when no element in the chain declares the type" in {
+        val ancestor = el(dom.document.body, ev = "click")
+        val target   = el(ancestor)
+        assert(!DomBackend.declaredInChain(target, "keydown"))
+    }
+
+    "matches individual entries of a comma-separated declaration" in {
+        val target = el(dom.document.body, ev = "click,keydown")
+        assert(DomBackend.declaredInChain(target, "keydown"))
+        assert(DomBackend.declaredInChain(target, "click"))
+        assert(!DomBackend.declaredInChain(target, "key"))
+    }
+
+    "does not consult a declaration on document.body itself" in {
+        dom.document.body.setAttribute("data-kyo-ev", "click")
+        val target = el(dom.document.body)
+        val result = DomBackend.declaredInChain(target, "click")
+        dom.document.body.removeAttribute("data-kyo-ev")
+        assert(!result)
+    }
+
+    "stops at a non-element parent without crashing" in {
+        // documentElement's parent is the document node, which is not an Element, so the walk must end there.
+        assert(!DomBackend.declaredInChain(dom.document.documentElement, "click"))
+    }
+
+    "returns false for a detached element" in {
+        val target = el(null, ev = null)
+        assert(!DomBackend.declaredInChain(target, "click"))
+    }
+
+end DomBackendDelegationTest

--- a/kyo-ui/js/src/test/scala/kyo/DomTestEnv.scala
+++ b/kyo-ui/js/src/test/scala/kyo/DomTestEnv.scala
@@ -1,0 +1,37 @@
+package kyo
+
+import scala.scalajs.js
+
+/** Installs a real DOM into the Node.js test process via jsdom.
+  *
+  * The test environment is plain Node.js with no DOM globals. This helper loads jsdom lazily through the CommonJS
+  * `require` in scope for the test bundle and copies the window's DOM constructors and globals onto `globalThis`, so
+  * production code compiled against `org.scalajs.dom` (global `document`, `window`, and `instanceof Element` checks)
+  * runs unmodified. The load is lazy and idempotent: suites that never touch the DOM never require jsdom, and repeated
+  * calls reuse the first window.
+  *
+  * jsdom must be resolvable from the repo root: `npm install --no-save jsdom@^30` (CI does this in the setup action;
+  * the repo ignores *.json, so there is no package.json to install from).
+  */
+private[kyo] object DomTestEnv:
+
+    lazy val install: Unit =
+        if js.typeOf(js.Dynamic.global.document) == "undefined" then
+            val jsdom = js.Dynamic.global.require("jsdom")
+            // pretendToBeVisual enables requestAnimationFrame, which DomBackend uses to start SMIL animations.
+            // jsdom still performs no layout: getBoundingClientRect stays zeroed, so measurement behavior belongs
+            // in the real-Chrome suites, not here.
+            val dom = js.Dynamic.newInstance(jsdom.JSDOM)(
+                "<!doctype html><html><head></head><body></body></html>",
+                js.Dynamic.literal(pretendToBeVisual = true)
+            )
+            val window = dom.window
+            js.Dynamic.global.globalThis.window = window
+            js.Dynamic.global.globalThis.document = window.document
+            js.Dynamic.global.globalThis.Element = window.Element
+            js.Dynamic.global.globalThis.HTMLElement = window.HTMLElement
+            js.Dynamic.global.globalThis.Node = window.Node
+        end if
+    end install
+
+end DomTestEnv


### PR DESCRIPTION
## Problem

kyo-ui's reactive dispatch bubbles an event to every ancestor that declared a handler for its type (a keydown inside a panel reaches the panel's own `onKeyDown`). The SPA transport (`DomBackend`, the client-only mount) honors this only for a handler declared on the event's own target: its forwarding gate reads just the target element's `data-kyo-ev`, so an event whose handler sits on an ancestor is dropped at the JS boundary before the bubble dispatch can run. The server-push transport already ancestor-walks and is unaffected.

## Solution

Walk the ancestor chain in the SPA forwarding gate. A small `ChainTypes` wrapper replaces the target-only `data-kyo-ev` set; its `contains(type)` checks each ancestor up to `document.body` via `declaredInChain`, so the gate matches the dispatch's bubble semantics (the same ancestor-walk the server-push client already performs). Every use site of the old set was `contains(...)`, so the wrapper is a drop-in.

## Notes

Verified: `kyo-uiJS` compile; the event-delegation suite (`EventHandlerTest`, `TypedEventTest`, `UIEventWiringTest`, `UITestSpa*`) stays green: 103 tests, no regression. Full `kyo-uiJS` suite green with the new test infrastructure (2052 tests).

The `withUI` browser harness runs the server-push transport (through `UIServer`), whose ancestor-walk already handles this correctly, so it cannot reach this SPA code path. The forwarding gate is unit-tested in isolation instead: `declaredInChain` is hoisted to a `private[kyo]` method, and `DomBackendDelegationTest` exercises it against a real jsdom document. Since the Node.js test environment has no DOM globals (and the jsdom jsEnv cannot load the CommonJS test bundle), a small `DomTestEnv` helper requires jsdom lazily and installs the window's globals onto `globalThis`; suites that never touch the DOM never load it. The ancestor-declared case fails under the pre-fix target-only semantics, so the test is non-vacuous. jsdom is installed for the JS CI target in the setup action (version pinned there: the repo gitignores `*.json`, so there is no `package.json`).
