### PR TITLE
[kyo-ui] SPA local mount fired form onSubmit twice on a submit-button click

### DIFF
--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -257,6 +257,11 @@ private[kyo] object DomBackend:
         final class ChainTypes(target: dom.Element):
             def contains(t: String): Boolean = declaredInChain(target, t)
 
+        // A submit button's click makes the browser fire a native `submit` right after, but the Click dispatch
+        // already emulates onSubmit; this flag (set on Click, cleared on a 0-timeout) suppresses that one
+        // following native submit so the form handler runs once. Mirrors clientJs's `_kyoClickSubmit` guard.
+        var clickSubmitGuard = false
+
         val handler: scalajs.js.Function1[dom.Event, Unit] = (e: dom.Event) =>
             findPathElement(e.target.asInstanceOf[dom.Element]).foreach { target =>
                 val path    = parsePath(target.getAttribute("data-kyo-path"))
@@ -277,6 +282,8 @@ private[kyo] object DomBackend:
                         // is handled by UILocation's interceptor. Prevent-defaulting every anchor here
                         // would also kill those.
                         if target.tagName.toLowerCase == "a" && evTypes.contains("click") then e.preventDefault()
+                        clickSubmitGuard = true
+                        discard(dom.window.setTimeout(() => clickSubmitGuard = false, 0))
                         Present(UIEvent.Click(path, mouse))
                     else if t == "input" && evTypes.contains("input") then
                         Present(UIEvent.Input(path, e.target.asInstanceOf[dom.html.Input].value))
@@ -303,12 +310,15 @@ private[kyo] object DomBackend:
                         end if
                     else if t == "submit" && evTypes.contains("submit") then
                         e.preventDefault()
-                        val submitTargetId = Maybe(e.target.asInstanceOf[dom.Element].id).filter(_.nonEmpty)
-                        val submitMouse = MouseEventData(
-                            modifiers = UI.Modifiers.none,
-                            targetId = submitTargetId
-                        )
-                        Present(UIEvent.Submit(path, submitMouse))
+                        if clickSubmitGuard then Absent
+                        else
+                            val submitTargetId = Maybe(e.target.asInstanceOf[dom.Element].id).filter(_.nonEmpty)
+                            val submitMouse = MouseEventData(
+                                modifiers = UI.Modifiers.none,
+                                targetId = submitTargetId
+                            )
+                            Present(UIEvent.Submit(path, submitMouse))
+                        end if
                     else if t == "keydown" && evTypes.contains("keydown") then
                         val ke         = e.asInstanceOf[dom.KeyboardEvent]
                         val kdTargetId = Maybe(ke.target.asInstanceOf[dom.Element].id).filter(_.nonEmpty)

--- a/kyo-ui/shared/src/test/scala/kyo/FormValidationScenarioItTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/FormValidationScenarioItTest.scala
@@ -286,4 +286,24 @@ class FormValidationScenarioItTest extends UITest:
         }
     }
 
+    "clicking a submit button runs onSubmit exactly once (no click+native-submit double dispatch)" in {
+        val app: UI < Async =
+            for
+                count <- Signal.initRef(0)
+            yield UI.div(
+                UI.form.id("f").onSubmit(count.updateAndGet(_ + 1).unit)(
+                    UI.input.id("name"),
+                    UI.button("Submit").id("sub")
+                ),
+                count.map(v => UI.span(s"count:$v").id("c"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.click(Selector.id("sub"))
+                // Regression guard for DomBackend's clickSubmitGuard: the click+native-submit pair fires onSubmit once.
+                _ <- Browser.assertText(Selector.id("c"), "count:1")
+            yield ()
+        }
+    }
+
 end FormValidationScenarioItTest


### PR DESCRIPTION
## Problem

A click on a submit button makes the browser fire a native `submit` event right after the `click`. The engine already emulates `onSubmit` from a click that bubbles to a `<form>` (matching browser behavior), so forwarding both the click and the native submit runs the form's `onSubmit` twice. The server-push transport (`HtmlRenderer.clientJs`) already guards this with a `_kyoClickSubmit` flag; the client-only SPA transport (`DomBackend`) does not, so a locally-mounted app double-fires.

## Solution

Mirror the server-push guard in `DomBackend`'s event delegation: set `clickSubmitGuard` on every dispatched Click and clear it on a 0-timeout; the synchronously-following native `submit` is dropped while the flag is set (its `preventDefault` still applies, so the browser never performs its own form navigation). A standalone submit (Enter in an input, a programmatic submit) has no preceding click, so it is unaffected.

## Notes

Adds a counting regression test to `FormValidationScenarioItTest` asserting a single button click runs `onSubmit` exactly once. As with the SPA transport itself, the browser test harness (`withUI`) drives the server-push transport — which already guards this — so the test pins the expected "once" behavior that this change aligns the SPA local-mount transport to, rather than failing without it. The client-only `DomBackend` path has no browser harness; it is kept in sync by construction with the clientJs guard it mirrors.
