### PR TITLE
[kyo-ui] declarative input filtering and masking (inputFilter / inputMask)

### DIFF
--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -356,6 +356,8 @@ Input elements share three capability traits.
 
 `BooleanInput`: boolean-shaped fields with `.checked`, disabled, and a `Boolean => Unit < Async` Change handler. Implementations: `UI.checkbox`, `UI.radio`.
 
+`ConstrainedInput`: the `TextInput` variants that accept typing constraints, adding `.inputFilter(v: InputFilter)` and `.inputMask(v: String)`. Implementations: every `TextInput` except `UI.numberInput`, which constrains its content through `type="number"` plus `.min` / `.max` / `.step` instead. See [Typing constraints](#typing-constraints).
+
 ### Two-way binding via `SignalRef`
 
 The most useful API on every input is `.value(ref: SignalRef[String])` (text and picker) or `.checked(ref: SignalRef[Boolean])` (boolean). Passing a `SignalRef` activates two-way binding: the framework writes `ref.set(newValue)` BEFORE invoking any user-supplied `onInput` or `onChange`. By the time your handler runs, the ref already reflects the new value.
@@ -515,6 +517,39 @@ val sortByCustom: UI < Async =
 
 Use `Select` when you want native browser controls (keyboard navigation, screen-reader semantics) and the default chrome. Use `Dropdown` when you want to style the overlay yourself with `.style(...)`.
 
+### Typing constraints
+
+`ConstrainedInput` fields accept two declarative constraints, both enforced in the browser as the reader types, pastes or drops.
+
+`.inputFilter(v: InputFilter)` restricts which characters the field admits. The rejected character never enters the field, so there is no flicker and the caret does not jump.
+
+```scala
+import UI.*
+import kyo.*
+
+val pin: UI < Async =
+    for code <- Signal.initRef("")
+    yield input.id("pin").inputFilter(InputFilter.Digits).value(code)
+```
+
+`.inputMask(v: String)` formats the field progressively against a fixed pattern. `9` is a digit, `a` an ASCII letter, `*` either; every other character is a literal the mask inserts on its own. A backslash escapes the next character, so a literal `9` stays literal.
+
+```scala
+import UI.*
+import kyo.*
+
+val phone: UI < Async =
+    for number <- Signal.initRef("")
+    yield div(
+        input.id("phone").inputMask("(999) 999-9999").value(number),
+        input.id("intl").inputMask("+4\\9 999 999")
+    )
+```
+
+Three things are worth knowing. The mask governs display and not only typing: the initial value and a value bound to a `SignalRef` are formatted as they render, so a masked field never shows an unformatted value whoever set it, and a value the mask cannot hold is truncated at its capacity. A composition (IME, dead key, mobile autocorrect) is let through and corrected once it finishes, rather than being cancelled mid-composition. And both constraints are typing conveniences, not validation boundaries: any client can submit any value, so server-side checks still apply.
+
+`UI.numberInput` deliberately does not implement `ConstrainedInput`; calling either setter on it is a compile error. Its content is already constrained by `type="number"` plus `.min` / `.max` / `.step`, its `value` reads empty while the content is not a valid number, and a mask's own literals are never valid there.
+
 ### Domain enums for attributes
 
 Several attributes accept typed enums rather than raw strings.
@@ -556,6 +591,16 @@ val dataUri: UI = img(ImgSrc.Data("image/svg+xml", "<svg ... />"), "inline")
 `ImageExt`: `Png`, `Jpeg`, `Webp`, `Gif`, `Svg`, `Avif`. Used inside `FileAccept.Image(ext)`.
 
 `FileAccept`: `AnyImage`, `AnyVideo`, `AnyAudio`, `Pdf`, `Image(ext)`, plus string escape hatches `Extension(ext: String)` and `MediaType(mime: String)` for arbitrary extensions / MIME types.
+
+`InputFilter` for `ConstrainedInput.inputFilter`: `Digits`, `Decimal` (digits plus at most one `.` or `,`), and the escape hatch `Allowed(chars: String)` for an arbitrary character set. The escape hatch is explicit so a set can never be read as a keyword: `Allowed("int")` admits `i`, `n` and `t`, which a stringly-typed attribute could not express. See [Typing constraints](#typing-constraints).
+
+```scala
+import UI.*
+import kyo.*
+
+val amount: UI = input.id("amount").inputFilter(InputFilter.Decimal)
+val hex: UI    = input.id("hex").inputFilter(InputFilter.Allowed("0123456789abcdef"))
+```
 
 `Keyboard` and `KeyboardEvent`: the value handed to `onKeyDown` / `onKeyUp`. `Keyboard` is an enum of named keys (`Enter`, `Tab`, `Escape`, `Space`, arrow keys, function keys) plus `Char(c: scala.Char)` for printable characters and `Unknown(raw: String)` for everything else.
 

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -61,6 +61,7 @@ private[kyo] object DomBackend:
             _    <- Sync.defer(seedEnter(container, Set.empty))
             _    <- Sync.defer(seedFocusAuto(container, Set.empty))
             _    <- Sync.defer(beginAnimationsSync(container))
+            _    <- setupInputMasking()
             exchange = LocalExchange(root)
             dispatch <- ReactiveUI.subscribe(root, exchange)
             // Single-consumer drain owned by the ambient page Scope: every JS event effect is run by a
@@ -168,22 +169,8 @@ private[kyo] object DomBackend:
                 else located
             val _ = focusTarget.asInstanceOf[scalajs.js.Dynamic].focus()
             (selStart, selEnd) match
-                case (Present(s), Present(e)) =>
-                    val dyn = focusTarget.asInstanceOf[scalajs.js.Dynamic]
-                    if scalajs.js.typeOf(dyn.setSelectionRange) == "function" then
-                        try
-                            val _ = dyn.setSelectionRange(s, e)
-                        catch
-                            // setSelectionRange throws InvalidStateError on input types that do not
-                            // support text selection (e.g. email, number). Mirrors HtmlRenderer.clientJs:583:
-                            // `catch(e){if(e.name!=='InvalidStateError')throw e;}`. Re-throw any other
-                            // JS exception so genuine failures are not silently dropped.
-                            case ex: scalajs.js.JavaScriptException
-                                if ex.exception.asInstanceOf[scalajs.js.Dynamic].name.asInstanceOf[String] == "InvalidStateError" =>
-                                ()
-                    end if
-                case _ => ()
-            end match
+                case (Present(s), Present(e)) => setSelection(focusTarget, s, e)
+                case _                        => ()
         end if
     end restoreFocus
 
@@ -256,6 +243,25 @@ private[kyo] object DomBackend:
             true
         end if
     end focusIfPresent
+
+    /** Moves the caret on `el`, tolerating the two documented ways that is a no-op.
+      *
+      * Elements outside input and textarea (select, contenteditable) have no `setSelectionRange` at all, and on
+      * input types without a text selection (email, number, both of which kyo-ui offers as text inputs) it throws
+      * `InvalidStateError`. In either case the value is already set and only the caret stays put. Any other
+      * JavaScript exception is a real failure and propagates rather than being swallowed. Mirrored by
+      * `kyoSetCaret` in `HtmlRenderer.clientJs`.
+      */
+    private def setSelection(el: dom.Element, start: Int, end: Int): Unit =
+        val dyn = el.asInstanceOf[scalajs.js.Dynamic]
+        if scalajs.js.typeOf(dyn.setSelectionRange) == "function" then
+            try discard(dyn.setSelectionRange(start, end))
+            catch
+                case ex: scalajs.js.JavaScriptException
+                    if ex.exception.asInstanceOf[scalajs.js.Dynamic].name.asInstanceOf[String] == "InvalidStateError" =>
+                    ()
+        end if
+    end setSelection
 
     // Bridge a Kyo Async computation from a JS callback boundary by offering it to the page-scoped drain
     // channel. The single AllowUnsafe site narrows to the offer crossing (the JS callback has no Kyo
@@ -618,5 +624,133 @@ private[kyo] object DomBackend:
             discard(dom.window.setTimeout(to, 1000.0))
         }
     end spawnGhosts
+
+    // ---- input filter/mask (SPA transport) ----
+    // The character-level decisions live in the shared InputMasking so they are testable without a DOM;
+    // what stays here is the DOM wiring.
+
+    private def dispatchInput(t: dom.EventTarget): Unit =
+        val ctor = scalajs.js.Dynamic.global.Event
+        val ev   = scalajs.js.Dynamic.newInstance(ctor)("input", scalajs.js.Dynamic.literal(bubbles = true))
+        discard(t.asInstanceOf[scalajs.js.Dynamic].dispatchEvent(ev))
+    end dispatchInput
+
+    private def setValue(t: dom.html.Input, v: String): Unit =
+        t.value = v
+        setSelection(t, v.length, v.length)
+        dispatchInput(t)
+    end setValue
+
+    private def setFilteredAt(t: dom.html.Input, txt: String, s: Int, e: Int): Unit =
+        val v = t.value
+        t.value = v.substring(0, s) + txt + v.substring(e)
+        val np = s + txt.length
+        setSelection(t, np, np)
+        dispatchInput(t)
+    end setFilteredAt
+
+    private def setupInputMasking()(using Frame): Unit < Sync = Sync.defer {
+        val handler: scalajs.js.Function1[dom.Event, Unit] = (e: dom.Event) =>
+            val tRaw = e.target
+            if tRaw != null then
+                val el = tRaw.asInstanceOf[dom.Element]
+                // Interactive.data lets any element carry data-kyo-filter, and everything below assumes a value
+                // property and a text selection. Throwing from a beforeinput capture listener would break typing
+                // for the whole page, so anything but a text field is left alone.
+                val isTextField = el.tagName == "INPUT" || el.tagName == "TEXTAREA"
+                val filt        = if isTextField then el.getAttribute("data-kyo-filter") else null
+                val mask        = if isTextField then el.getAttribute("data-kyo-mask") else null
+                if filt != null || mask != null then
+                    val t   = tRaw.asInstanceOf[dom.html.Input]
+                    val dyn = e.asInstanceOf[scalajs.js.Dynamic]
+                    val it  = if scalajs.js.typeOf(dyn.inputType) == "string" then dyn.inputType.asInstanceOf[String] else ""
+                    def selStart: Int =
+                        val d = t.asInstanceOf[scalajs.js.Dynamic]
+                        if scalajs.js.typeOf(d.selectionStart) == "number" then d.selectionStart.asInstanceOf[Int] else t.value.length
+                    def selEnd: Int =
+                        val d = t.asInstanceOf[scalajs.js.Dynamic]
+                        if scalajs.js.typeOf(d.selectionEnd) == "number" then d.selectionEnd.asInstanceOf[Int] else selStart
+                    def transferText: String =
+                        val dt = dyn.dataTransfer
+                        if dt != null && scalajs.js.typeOf(dt) == "object" then dt.getData("text").asInstanceOf[String]
+                        else if scalajs.js.typeOf(dyn.data) == "string" then dyn.data.asInstanceOf[String]
+                        else ""
+                    end transferText
+                    // insertCompositionText is deliberately absent below: preventDefault on it does not filter the
+                    // input, it aborts the composition, which breaks CJK input, dead keys and mobile autocorrect.
+                    // Composition is let through and the finished text is corrected by the compositionend listener.
+                    if filt != null then
+                        if it.startsWith("delete") then ()
+                        else if it == "insertText" || it == "insertReplacementText" then
+                            if scalajs.js.typeOf(dyn.data) == "string" then
+                                val ds = dyn.data.asInstanceOf[String]
+                                val f1 = InputMasking.filterStr(filt, ds, t.value)
+                                if f1 != ds then
+                                    e.preventDefault()
+                                    if f1.nonEmpty then setFilteredAt(t, f1, selStart, selEnd)
+                        else if it == "insertFromPaste" || it == "insertFromDrop" then
+                            e.preventDefault()
+                            val f2 = InputMasking.filterStr(filt, transferText, t.value)
+                            if f2.nonEmpty then setFilteredAt(t, f2, selStart, selEnd)
+                        end if
+                    else if mask != null then
+                        val tokens = InputMasking.parseMask(mask)
+                        if it.startsWith("delete") then
+                            e.preventDefault()
+                            val raw = InputMasking.maskRaw(tokens, t.value)
+                            val nr  = if raw.nonEmpty then raw.substring(0, raw.length - 1) else raw
+                            setValue(t, InputMasking.maskFormat(tokens, nr))
+                        else if it == "insertText" || it == "insertReplacementText" ||
+                            it == "insertFromPaste" || it == "insertFromDrop"
+                        then
+                            e.preventDefault()
+                            val ins = if it == "insertFromPaste" || it == "insertFromDrop" then transferText
+                            else if scalajs.js.typeOf(dyn.data) == "string" then dyn.data.asInstanceOf[String]
+                            else ""
+                            var raw2 = InputMasking.maskRaw(tokens, t.value)
+                            var ci   = 0
+                            var full = false
+                            while ci < ins.length && !full do
+                                InputMasking.maskClassAt(tokens, raw2.length) match
+                                    case Present(cls) =>
+                                        val ch = ins.charAt(ci)
+                                        if InputMasking.maskOk(cls, ch) then raw2 = raw2 + ch
+                                    case Absent => full = true
+                                end match
+                                ci += 1
+                            end while
+                            setValue(t, InputMasking.maskFormat(tokens, raw2))
+                        end if
+                    end if
+                end if
+            end if
+        document.body.addEventListener("beforeinput", handler, true)
+        document.body.addEventListener("compositionend", compositionEndHandler, true)
+    }
+    end setupInputMasking
+
+    /** Corrects the whole value once a composition finishes.
+      *
+      * An IME, a dead key or mobile autocorrect produces its text only when the composition ends, so there is no
+      * per-character event to constrain; the finished value is filtered or formatted here instead. Writing back only
+      * on a change keeps a composition that already conforms free of a caret jump and of a spurious input event.
+      * Mirrored by `kyoCompositionEnd` in `HtmlRenderer.clientJs`.
+      */
+    private val compositionEndHandler: scalajs.js.Function1[dom.Event, Unit] = (e: dom.Event) =>
+        val tRaw = e.target
+        if tRaw != null then
+            val el = tRaw.asInstanceOf[dom.Element]
+            if el.tagName == "INPUT" || el.tagName == "TEXTAREA" then
+                val t    = tRaw.asInstanceOf[dom.html.Input]
+                val filt = el.getAttribute("data-kyo-filter")
+                val mask = el.getAttribute("data-kyo-mask")
+                val v    = t.value
+                val nv =
+                    if filt != null then InputMasking.filterStr(filt, v, "")
+                    else if mask != null then InputMasking.maskNormalize(mask, v)
+                    else v
+                if nv != v then setValue(t, nv)
+            end if
+        end if
 
 end DomBackend

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -507,6 +507,24 @@ object UI:
         case MediaType(mime: String) // "application/foo", explicit escape for arbitrary MIME types
     end FileAccept
 
+    /** A typed set of characters a text input accepts, replacing a stringly-typed pattern.
+      *
+      * `Digits` and `Decimal` name the two numeric constraints, and `Allowed` is the explicit escape for an arbitrary
+      * character set. A stringly-typed pattern could not express both: a set spelled `"int"` was indistinguishable
+      * from the digits-only keyword, and a typo like `"integer"` silently degraded to "allow i, n, t, e, g and r".
+      *
+      * The filter is applied in the browser as the reader types, so it is a typing convenience rather than a
+      * validation boundary: any client can submit any value, and server-side checks still apply.
+      *
+      * @see
+      *   [[kyo.UI.ConstrainedInput.inputFilter]] for the setter
+      */
+    enum InputFilter derives CanEqual:
+        case Digits                 // "digits"
+        case Decimal                // "decimal", digits plus at most one `.` or `,`
+        case Allowed(chars: String) // "chars:" ++ chars, explicit escape for an arbitrary set
+    end InputFilter
+
     /** The ctrl/alt/shift/meta chord held down when a mouse or keyboard event fired.
       *
       * Carried by [[kyo.UI.MouseEvent]] and [[kyo.UI.KeyboardEvent]] so handlers can branch on modified clicks/keystrokes (for example
@@ -926,6 +944,54 @@ object UI:
             def value(v: SignalRef[String]): Self
         end TextInput
 
+        /** Capability trait for text inputs that accept declarative client-local typing constraints.
+          *
+          * Every free-text input mixes this in except `NumberInput`. A `number` field constrains its content through
+          * `type`, `min`, `max` and `step` instead, its `value` reads as the empty string while the content is not a
+          * valid number, and a mask's own literals (`(`, `)`, `-`, space) are never valid there. Leaving the trait off
+          * that one element keeps the combination from compiling rather than failing at runtime.
+          *
+          * Both constraints are enforced in the browser as the reader types, so they are typing conveniences rather
+          * than validation boundaries: any client can submit any value, and server-side checks still apply.
+          *
+          * A composition (an IME, a dead key, mobile autocorrect) is let through and its finished text corrected on
+          * `compositionend`, rather than being cancelled mid-composition, which is what cancelling the composition
+          * event would do.
+          */
+        sealed trait ConstrainedInput extends TextInput:
+            def inputFilter: Maybe[InputFilter]
+            def inputMask: Maybe[String]
+
+            /** Restricts the characters the field accepts, rejecting the rest as they are typed, pasted or dropped.
+              *
+              * The rejected character never enters the field, so the reader sees no flicker and the caret does not
+              * jump, and the server only observes filtered text through the normal input and change events. Emits
+              * `data-kyo-filter`, read by a document-level `beforeinput` capture listener.
+              *
+              * @see
+              *   [[kyo.UI.InputFilter]] for the available character sets
+              */
+            def inputFilter(v: InputFilter): Self
+
+            /** Formats the field progressively against a fixed pattern as the reader types.
+              *
+              * Tokens are `9` for a digit, `a` for an ASCII letter and `*` for either; every other character is a
+              * literal the mask inserts on its own, as in `"(999) 999-9999"`. A backslash escapes the next character,
+              * so `"+4\\9 999"` keeps a literal `9` in the country code rather than opening an input position there.
+              * Each position accepts only its own character class, backspace steps back over literals, and the caret
+              * follows the insertion. Formatting stops at the first position the value cannot fill, so a partial entry
+              * renders without trailing literals.
+              *
+              * The classes are ASCII only: `a` and `*` reject accented and non-Latin letters. The server receives the
+              * formatted value through the normal input and change events. Emits `data-kyo-mask`.
+              *
+              * The mask governs display, not only typing: the initial value and a value bound to a [[kyo.SignalRef]]
+              * are formatted as they render, so a masked field never shows an unformatted value whoever set it. A
+              * value the mask cannot hold is truncated at its capacity.
+              */
+            def inputMask(v: String): Self
+        end ConstrainedInput
+
         /** Capability trait for picker inputs that carry a `String` `value` and an `onChange` but no free-text typing (`select`, date/time/color, ...). */
         sealed trait PickerInput extends Focusable with HasDisabled:
             def value: Maybe[Bound[String]]
@@ -1229,7 +1295,7 @@ object UI:
         final case class Textarea(
             attrs: Attrs = Attrs(),
             textInputAttrs: TextInputAttrs = TextInputAttrs()
-        )(using val frame: Frame) extends Block with Interactive with TextInput with Void:
+        )(using val frame: Frame) extends Block with Interactive with ConstrainedInput with Void:
             type Self = Textarea
             def withAttrs(a: Attrs): Textarea = copy(attrs = a)
 
@@ -1239,6 +1305,8 @@ object UI:
             def disabled: Maybe[Boolean]               = textInputAttrs.disabled
             def onInput: Maybe[String => Any < Async]  = textInputAttrs.onInput
             def onChange: Maybe[String => Any < Async] = textInputAttrs.onChange
+            def inputFilter: Maybe[InputFilter]        = textInputAttrs.inputFilter
+            def inputMask: Maybe[String]               = textInputAttrs.inputMask
 
             def value(v: String): Textarea                   = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Const(v))))
             def value(v: SignalRef[String]): Textarea        = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Ref(v))))
@@ -1247,6 +1315,8 @@ object UI:
             def disabled(v: Boolean): Textarea               = copy(textInputAttrs = textInputAttrs.copy(disabled = Present(v)))
             def onInput(f: String => Any < Async): Textarea  = copy(textInputAttrs = textInputAttrs.copy(onInput = Present(f)))
             def onChange(f: String => Any < Async): Textarea = copy(textInputAttrs = textInputAttrs.copy(onChange = Present(f)))
+            def inputFilter(v: InputFilter): Textarea        = copy(textInputAttrs = textInputAttrs.copy(inputFilter = Present(v)))
+            def inputMask(v: String): Textarea               = copy(textInputAttrs = textInputAttrs.copy(inputMask = Present(v)))
         end Textarea
 
         final case class Select(
@@ -1394,13 +1464,15 @@ object UI:
             readOnly: Maybe[Boolean] = Absent,
             disabled: Maybe[Boolean] = Absent,
             onInput: Maybe[String => Any < Async] = Absent,
-            onChange: Maybe[String => Any < Async] = Absent
+            onChange: Maybe[String => Any < Async] = Absent,
+            inputFilter: Maybe[InputFilter] = Absent,
+            inputMask: Maybe[String] = Absent
         )
 
         final case class Input(
             attrs: Attrs = Attrs(),
             textInputAttrs: TextInputAttrs = TextInputAttrs()
-        )(using val frame: Frame) extends Inline with Interactive with TextInput with Void:
+        )(using val frame: Frame) extends Inline with Interactive with ConstrainedInput with Void:
             type Self = Input
             def withAttrs(a: Attrs): Input = copy(attrs = a)
 
@@ -1410,6 +1482,8 @@ object UI:
             def disabled: Maybe[Boolean]               = textInputAttrs.disabled
             def onInput: Maybe[String => Any < Async]  = textInputAttrs.onInput
             def onChange: Maybe[String => Any < Async] = textInputAttrs.onChange
+            def inputFilter: Maybe[InputFilter]        = textInputAttrs.inputFilter
+            def inputMask: Maybe[String]               = textInputAttrs.inputMask
 
             def value(v: String): Input                   = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Const(v))))
             def value(v: SignalRef[String]): Input        = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Ref(v))))
@@ -1418,12 +1492,14 @@ object UI:
             def disabled(v: Boolean): Input               = copy(textInputAttrs = textInputAttrs.copy(disabled = Present(v)))
             def onInput(f: String => Any < Async): Input  = copy(textInputAttrs = textInputAttrs.copy(onInput = Present(f)))
             def onChange(f: String => Any < Async): Input = copy(textInputAttrs = textInputAttrs.copy(onChange = Present(f)))
+            def inputFilter(v: InputFilter): Input        = copy(textInputAttrs = textInputAttrs.copy(inputFilter = Present(v)))
+            def inputMask(v: String): Input               = copy(textInputAttrs = textInputAttrs.copy(inputMask = Present(v)))
         end Input
 
         final case class PasswordInput(
             attrs: Attrs = Attrs(),
             textInputAttrs: TextInputAttrs = TextInputAttrs()
-        )(using val frame: Frame) extends Inline with Interactive with TextInput with Void:
+        )(using val frame: Frame) extends Inline with Interactive with ConstrainedInput with Void:
             type Self = PasswordInput
             def withAttrs(a: Attrs): PasswordInput = copy(attrs = a)
 
@@ -1433,6 +1509,8 @@ object UI:
             def disabled: Maybe[Boolean]               = textInputAttrs.disabled
             def onInput: Maybe[String => Any < Async]  = textInputAttrs.onInput
             def onChange: Maybe[String => Any < Async] = textInputAttrs.onChange
+            def inputFilter: Maybe[InputFilter]        = textInputAttrs.inputFilter
+            def inputMask: Maybe[String]               = textInputAttrs.inputMask
 
             def value(v: String): PasswordInput            = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Const(v))))
             def value(v: SignalRef[String]): PasswordInput = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Ref(v))))
@@ -1441,12 +1519,14 @@ object UI:
             def disabled(v: Boolean): PasswordInput        = copy(textInputAttrs = textInputAttrs.copy(disabled = Present(v)))
             def onInput(f: String => Any < Async): PasswordInput  = copy(textInputAttrs = textInputAttrs.copy(onInput = Present(f)))
             def onChange(f: String => Any < Async): PasswordInput = copy(textInputAttrs = textInputAttrs.copy(onChange = Present(f)))
+            def inputFilter(v: InputFilter): PasswordInput        = copy(textInputAttrs = textInputAttrs.copy(inputFilter = Present(v)))
+            def inputMask(v: String): PasswordInput               = copy(textInputAttrs = textInputAttrs.copy(inputMask = Present(v)))
         end PasswordInput
 
         final case class EmailInput(
             attrs: Attrs = Attrs(),
             textInputAttrs: TextInputAttrs = TextInputAttrs()
-        )(using val frame: Frame) extends Inline with Interactive with TextInput with Void:
+        )(using val frame: Frame) extends Inline with Interactive with ConstrainedInput with Void:
             type Self = EmailInput
             def withAttrs(a: Attrs): EmailInput = copy(attrs = a)
 
@@ -1456,6 +1536,8 @@ object UI:
             def disabled: Maybe[Boolean]               = textInputAttrs.disabled
             def onInput: Maybe[String => Any < Async]  = textInputAttrs.onInput
             def onChange: Maybe[String => Any < Async] = textInputAttrs.onChange
+            def inputFilter: Maybe[InputFilter]        = textInputAttrs.inputFilter
+            def inputMask: Maybe[String]               = textInputAttrs.inputMask
 
             def value(v: String): EmailInput                   = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Const(v))))
             def value(v: SignalRef[String]): EmailInput        = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Ref(v))))
@@ -1464,12 +1546,14 @@ object UI:
             def disabled(v: Boolean): EmailInput               = copy(textInputAttrs = textInputAttrs.copy(disabled = Present(v)))
             def onInput(f: String => Any < Async): EmailInput  = copy(textInputAttrs = textInputAttrs.copy(onInput = Present(f)))
             def onChange(f: String => Any < Async): EmailInput = copy(textInputAttrs = textInputAttrs.copy(onChange = Present(f)))
+            def inputFilter(v: InputFilter): EmailInput        = copy(textInputAttrs = textInputAttrs.copy(inputFilter = Present(v)))
+            def inputMask(v: String): EmailInput               = copy(textInputAttrs = textInputAttrs.copy(inputMask = Present(v)))
         end EmailInput
 
         final case class TelInput(
             attrs: Attrs = Attrs(),
             textInputAttrs: TextInputAttrs = TextInputAttrs()
-        )(using val frame: Frame) extends Inline with Interactive with TextInput with Void:
+        )(using val frame: Frame) extends Inline with Interactive with ConstrainedInput with Void:
             type Self = TelInput
             def withAttrs(a: Attrs): TelInput = copy(attrs = a)
 
@@ -1479,6 +1563,8 @@ object UI:
             def disabled: Maybe[Boolean]               = textInputAttrs.disabled
             def onInput: Maybe[String => Any < Async]  = textInputAttrs.onInput
             def onChange: Maybe[String => Any < Async] = textInputAttrs.onChange
+            def inputFilter: Maybe[InputFilter]        = textInputAttrs.inputFilter
+            def inputMask: Maybe[String]               = textInputAttrs.inputMask
 
             def value(v: String): TelInput                   = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Const(v))))
             def value(v: SignalRef[String]): TelInput        = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Ref(v))))
@@ -1487,12 +1573,14 @@ object UI:
             def disabled(v: Boolean): TelInput               = copy(textInputAttrs = textInputAttrs.copy(disabled = Present(v)))
             def onInput(f: String => Any < Async): TelInput  = copy(textInputAttrs = textInputAttrs.copy(onInput = Present(f)))
             def onChange(f: String => Any < Async): TelInput = copy(textInputAttrs = textInputAttrs.copy(onChange = Present(f)))
+            def inputFilter(v: InputFilter): TelInput        = copy(textInputAttrs = textInputAttrs.copy(inputFilter = Present(v)))
+            def inputMask(v: String): TelInput               = copy(textInputAttrs = textInputAttrs.copy(inputMask = Present(v)))
         end TelInput
 
         final case class UrlInput(
             attrs: Attrs = Attrs(),
             textInputAttrs: TextInputAttrs = TextInputAttrs()
-        )(using val frame: Frame) extends Inline with Interactive with TextInput with Void:
+        )(using val frame: Frame) extends Inline with Interactive with ConstrainedInput with Void:
             type Self = UrlInput
             def withAttrs(a: Attrs): UrlInput = copy(attrs = a)
 
@@ -1502,6 +1590,8 @@ object UI:
             def disabled: Maybe[Boolean]               = textInputAttrs.disabled
             def onInput: Maybe[String => Any < Async]  = textInputAttrs.onInput
             def onChange: Maybe[String => Any < Async] = textInputAttrs.onChange
+            def inputFilter: Maybe[InputFilter]        = textInputAttrs.inputFilter
+            def inputMask: Maybe[String]               = textInputAttrs.inputMask
 
             def value(v: String): UrlInput                   = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Const(v))))
             def value(v: SignalRef[String]): UrlInput        = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Ref(v))))
@@ -1510,12 +1600,14 @@ object UI:
             def disabled(v: Boolean): UrlInput               = copy(textInputAttrs = textInputAttrs.copy(disabled = Present(v)))
             def onInput(f: String => Any < Async): UrlInput  = copy(textInputAttrs = textInputAttrs.copy(onInput = Present(f)))
             def onChange(f: String => Any < Async): UrlInput = copy(textInputAttrs = textInputAttrs.copy(onChange = Present(f)))
+            def inputFilter(v: InputFilter): UrlInput        = copy(textInputAttrs = textInputAttrs.copy(inputFilter = Present(v)))
+            def inputMask(v: String): UrlInput               = copy(textInputAttrs = textInputAttrs.copy(inputMask = Present(v)))
         end UrlInput
 
         final case class SearchInput(
             attrs: Attrs = Attrs(),
             textInputAttrs: TextInputAttrs = TextInputAttrs()
-        )(using val frame: Frame) extends Inline with Interactive with TextInput with Void:
+        )(using val frame: Frame) extends Inline with Interactive with ConstrainedInput with Void:
             type Self = SearchInput
             def withAttrs(a: Attrs): SearchInput = copy(attrs = a)
 
@@ -1525,6 +1617,8 @@ object UI:
             def disabled: Maybe[Boolean]               = textInputAttrs.disabled
             def onInput: Maybe[String => Any < Async]  = textInputAttrs.onInput
             def onChange: Maybe[String => Any < Async] = textInputAttrs.onChange
+            def inputFilter: Maybe[InputFilter]        = textInputAttrs.inputFilter
+            def inputMask: Maybe[String]               = textInputAttrs.inputMask
 
             def value(v: String): SearchInput                  = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Const(v))))
             def value(v: SignalRef[String]): SearchInput       = copy(textInputAttrs = textInputAttrs.copy(value = Present(Bound.Ref(v))))
@@ -1533,6 +1627,8 @@ object UI:
             def disabled(v: Boolean): SearchInput              = copy(textInputAttrs = textInputAttrs.copy(disabled = Present(v)))
             def onInput(f: String => Any < Async): SearchInput = copy(textInputAttrs = textInputAttrs.copy(onInput = Present(f)))
             def onChange(f: String => Any < Async): SearchInput = copy(textInputAttrs = textInputAttrs.copy(onChange = Present(f)))
+            def inputFilter(v: InputFilter): SearchInput        = copy(textInputAttrs = textInputAttrs.copy(inputFilter = Present(v)))
+            def inputMask(v: String): SearchInput               = copy(textInputAttrs = textInputAttrs.copy(inputMask = Present(v)))
         end SearchInput
 
         final case class NumberInput(

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -213,10 +213,10 @@ private[kyo] object HtmlRenderer:
 
     private def renderTextareaValue(sb: StringBuilder, ta: Textarea)(using Frame): Unit < Sync =
         ta.value match
-            case Present(Bound.Const(s)) => w(sb, esc(s))
+            case Present(Bound.Const(s)) => w(sb, esc(masked(ta.inputMask, s)))
             case Present(Bound.Ref(ref)) =>
                 for str <- ref.get
-                yield w(sb, esc(str))
+                yield w(sb, esc(masked(ta.inputMask, str)))
             case _ => ()
 
     // ---- Dropdown (custom div-based overlay) ----
@@ -415,7 +415,20 @@ private[kyo] object HtmlRenderer:
 
     // ---- Element-specific attributes ----
 
+    /** The typing constraints, read client-side by the `beforeinput` capture listener.
+      *
+      * Only [[kyo.UI.Ast.ConstrainedInput]] carries these, so they are emitted here rather than with the universal
+      * attributes: a `div` or a chart datum has no use for them.
+      */
+    private def renderInputConstraints(sb: StringBuilder, ci: ConstrainedInput): Unit =
+        ci.inputFilter.foreach(f => w(sb, s""" data-kyo-filter="${esc(InputMasking.filterWire(f))}""""))
+        ci.inputMask.foreach(m => w(sb, s""" data-kyo-mask="${esc(m)}""""))
+    end renderInputConstraints
+
     private def renderElementAttrs(sb: StringBuilder, elem: Element)(using Frame): Unit < Sync =
+        elem match
+            case ci: ConstrainedInput => renderInputConstraints(sb, ci)
+            case _                    => ()
         elem match
             case b: Button =>
                 w(sb, " type=\"submit\"")
@@ -432,42 +445,42 @@ private[kyo] object HtmlRenderer:
                 }
             case i: Input =>
                 w(sb, " type=\"text\"");
-                renderValueAttr(sb, i.value)
+                renderValueAttr(sb, i.value, i.inputMask)
                     .andThen {
                         boolAttr(sb, "disabled", i.disabled); boolAttr(sb, "readonly", i.readOnly);
                         i.placeholder.foreach(p => w(sb, s""" placeholder="${esc(p)}""""))
                     }
             case p: PasswordInput =>
                 w(sb, " type=\"password\"");
-                renderValueAttr(sb, p.value)
+                renderValueAttr(sb, p.value, p.inputMask)
                     .andThen {
                         boolAttr(sb, "disabled", p.disabled); boolAttr(sb, "readonly", p.readOnly);
                         p.placeholder.foreach(p2 => w(sb, s""" placeholder="${esc(p2)}""""))
                     }
             case e: EmailInput =>
                 w(sb, " type=\"email\"");
-                renderValueAttr(sb, e.value)
+                renderValueAttr(sb, e.value, e.inputMask)
                     .andThen {
                         boolAttr(sb, "disabled", e.disabled); boolAttr(sb, "readonly", e.readOnly);
                         e.placeholder.foreach(p => w(sb, s""" placeholder="${esc(p)}""""))
                     }
             case t: TelInput =>
                 w(sb, " type=\"tel\"");
-                renderValueAttr(sb, t.value)
+                renderValueAttr(sb, t.value, t.inputMask)
                     .andThen {
                         boolAttr(sb, "disabled", t.disabled); boolAttr(sb, "readonly", t.readOnly);
                         t.placeholder.foreach(p => w(sb, s""" placeholder="${esc(p)}""""))
                     }
             case u: UrlInput =>
                 w(sb, " type=\"url\"");
-                renderValueAttr(sb, u.value)
+                renderValueAttr(sb, u.value, u.inputMask)
                     .andThen {
                         boolAttr(sb, "disabled", u.disabled); boolAttr(sb, "readonly", u.readOnly);
                         u.placeholder.foreach(p => w(sb, s""" placeholder="${esc(p)}""""))
                     }
             case s: SearchInput =>
                 w(sb, " type=\"search\"");
-                renderValueAttr(sb, s.value)
+                renderValueAttr(sb, s.value, s.inputMask)
                     .andThen {
                         boolAttr(sb, "disabled", s.disabled); boolAttr(sb, "readonly", s.readOnly);
                         s.placeholder.foreach(p => w(sb, s""" placeholder="${esc(p)}""""))
@@ -584,6 +597,8 @@ private[kyo] object HtmlRenderer:
                 lbl.forId.foreach(f => w(sb, s""" for="${esc(f)}""""))
             case e: Svg.SvgElement => renderSvgAttrs(sb, e)
             case _                 => ()
+        end match
+    end renderElementAttrs
 
     private def boolAttr(sb: StringBuilder, name: String, value: Maybe[Boolean]): Unit =
         value.foreach(v => if v then w(sb, s" $name"))
@@ -597,12 +612,28 @@ private[kyo] object HtmlRenderer:
             case _ => ()
 
     /** Render a value attribute, reading SignalRef if needed. */
-    private def renderValueAttr(sb: StringBuilder, value: Maybe[Bound[String]])(using Frame): Unit < Sync =
+    /** Formats a value about to be displayed through the element's mask, if it carries one.
+      *
+      * A mask is a display format, so a masked field has to show a masked value whoever set it. Client-side
+      * enforcement only ever sees typing: a value bound to a [[SignalRef]], a server-side transform of what was
+      * typed, and the initial render all reach the field without a `beforeinput` event. Formatting here covers
+      * every one of them at once, in both transports and on both the morph and the replace path, which no amount
+      * of client-side patching would.
+      *
+      * A value the mask already formatted comes back unchanged, so the keystroke echo of a two-way binding still
+      * compares equal and leaves the caret where it is.
+      */
+    private def masked(mask: Maybe[String], value: String): String =
+        mask.fold(value)(InputMasking.maskNormalize(_, value))
+
+    private def renderValueAttr(sb: StringBuilder, value: Maybe[Bound[String]], mask: Maybe[String] = Absent)(using
+        Frame
+    ): Unit < Sync =
         value match
-            case Present(Bound.Const(s)) => w(sb, s""" value="${esc(s)}"""")
+            case Present(Bound.Const(s)) => w(sb, s""" value="${esc(masked(mask, s))}"""")
             case Present(Bound.Ref(ref)) =>
                 for s <- ref.get
-                yield w(sb, s""" value="${esc(s)}"""")
+                yield w(sb, s""" value="${esc(masked(mask, s))}"""")
             case _ => ()
 
     private def renderPickerAttrs(sb: StringBuilder, pi: PickerInput)(using Frame): Unit < Sync =
@@ -698,7 +729,7 @@ private[kyo] object HtmlRenderer:
     // U+2028 -> U+2028  (LINE SEPARATOR, JS line terminator)
     // U+2029 -> U+2029  (PARAGRAPH SEPARATOR, JS line terminator)
     //  </  -> <\/  (prevents </script> from closing the element; < alone is harmless in JS)
-    private def jsStr(s: String): String =
+    private[kyo] def jsStr(s: String): String =
         val sb = new StringBuilder(s.length)
         @scala.annotation.tailrec
         def loop(i: Int): Unit =
@@ -737,10 +768,60 @@ private[kyo] object HtmlRenderer:
 
     // ---- Client JS ----
 
+    /** The pure half of the client-side input filter and mask: the JavaScript mirror of [[InputMasking]].
+      *
+      * Kept out of [[clientJs]] as a named fragment for two reasons. It is the part that has an exact Scala
+      * counterpart, so having it standalone lets `InputMaskingJsParityTest` load it into a page and drive the same
+      * case table through both implementations, which is what keeps the two from drifting. And unlike [[clientJs]]
+      * this is not an interpolated string, so a backslash written here is the backslash the browser sees; inlined,
+      * the mask parser's escape had to be doubled, and getting that wrong produced an unterminated JavaScript
+      * literal that took down the whole client script.
+      *
+      * Only DOM-free functions belong here. Everything that touches an element stays in [[clientJs]].
+      */
+    private[kyo] val inputMaskJs: String =
+        """// Mirrors kyo.internal.InputMasking.filterStr: keep the two in step.
+          |// An unrecognized wire value admits everything, so a page cached from an older build stays usable.
+          |function kyoFilterStr(pat,str,cur){
+          |  var isChars=pat.indexOf("chars:")===0;var allowed=isChars?pat.slice(6):"";
+          |  if(!isChars&&pat!=="digits"&&pat!=="decimal")return str;
+          |  var out="";var hasSep=(pat==="decimal")&&(cur.indexOf(".")>=0||cur.indexOf(",")>=0);
+          |  for(var i=0;i<str.length;i++){var ch=str.charAt(i);
+          |    if(isChars){if(allowed.indexOf(ch)>=0)out+=ch;}
+          |    else if(pat==="digits"){if(ch>="0"&&ch<="9")out+=ch;}
+          |    else if(ch>="0"&&ch<="9")out+=ch;
+          |    else if((ch==="."||ch===",")&&!hasSep){out+=ch;hasSep=true;}}
+          |  return out;
+          |}
+          |// Mirrors kyo.internal.InputMasking.parseMask: the mask is parsed once into positions, {k:class} or
+          |// {l:literal}, so the backslash escape is handled in one place rather than in every function.
+          |function kyoMaskParse(mask){var ts=[];for(var i=0;i<mask.length;){var c=mask.charAt(i);
+          |  if(c==="\\"&&i+1<mask.length){ts.push({l:mask.charAt(i+1)});i+=2;}
+          |  else{if(c==="9"||c==="a"||c==="*")ts.push({k:c});else ts.push({l:c});i++;}}
+          |  return ts;}
+          |function kyoMaskClassAt(ts,idx){var c=0;for(var i=0;i<ts.length;i++){if(ts[i].k!==undefined){if(c===idx)return ts[i].k;c++;}}return null;}
+          |function kyoMaskOk(cls,ch){if(cls==="9")return ch>="0"&&ch<="9";if(cls==="a")return (ch>="a"&&ch<="z")||(ch>="A"&&ch<="Z");return (ch>="0"&&ch<="9")||(ch>="a"&&ch<="z")||(ch>="A"&&ch<="Z");}
+          |function kyoMaskFormat(ts,raw){var out="";var ri=0;for(var i=0;i<ts.length;i++){
+          |  if(ts[i].k!==undefined){if(ri<raw.length){out+=raw.charAt(ri);ri++;}else break;}
+          |  else{if(ri<raw.length)out+=ts[i].l;else break;}}
+          |  return out;}
+          |function kyoMaskRaw(ts,val){var raw="";var vi=0;for(var i=0;i<ts.length&&vi<val.length;i++){
+          |  if(ts[i].k!==undefined){raw+=val.charAt(vi);vi++;}
+          |  else{if(val.charAt(vi)===ts[i].l)vi++;else{raw+=val.charAt(vi);vi++;}}}
+          |  return raw;}
+          |// Mirrors kyo.internal.InputMasking.maskNormalize.
+          |function kyoMaskNormalize(mask,val){var ts=kyoMaskParse(mask);return kyoMaskFormat(ts,kyoMaskRaw(ts,val));}""".stripMargin
+
     private def clientJs(basePath: String): String =
         s"""(function(){
            |var base="$basePath";
            |var __q=[];
+           |// Mirrors DomBackend.setSelection: the one place that knows the two ways a caret move can be a no-op.
+           |// Elements outside input and textarea (select, contenteditable) have no setSelectionRange at all, and
+           |// on input types without a text selection (email, number) it throws InvalidStateError; in both cases
+           |// the value is set and only the caret stays put. Every other exception is a real failure and propagates.
+           |function kyoSetCaret(t,s,e){if(typeof t.setSelectionRange!=="function")return;
+           |  try{t.setSelectionRange(s,e);}catch(er){if(er.name!=="InvalidStateError")throw er;}}
            |var ws=new WebSocket((location.protocol===\"https:\"?\"wss:\":\"ws:\")+"//"+location.host+base+"/_kyo/ws");
            |ws.onopen=function(){__q.forEach(function(m){ws.send(m);});__q=[];};
            |ws.onmessage=function(e){
@@ -784,7 +865,7 @@ private[kyo] object HtmlRenderer:
            |      var __fa=focusAutoPaths(el);
            |      el.outerHTML=op.Replace.html;
            |      var nel=document.querySelector('[data-kyo-path="'+p+'"]');if(nel){applyJsProps(nel);ba(nel);}
-           |      if(ap){var rf=document.querySelector('[data-kyo-path="'+ap+'"]');if(rf&&rf.hasAttribute&&rf.hasAttribute('data-kyo-reactive')){var inner=rf.querySelector('input,textarea,select,[contenteditable]');if(inner)rf=inner;}if(rf){rf.focus();if(ss!==null&&typeof rf.setSelectionRange==='function'){try{rf.setSelectionRange(ss,se);}catch(e){if(e.name!=='InvalidStateError')throw e;}}}}
+           |      if(ap){var rf=document.querySelector('[data-kyo-path="'+ap+'"]');if(rf&&rf.hasAttribute&&rf.hasAttribute('data-kyo-reactive')){var inner=rf.querySelector('input,textarea,select,[contenteditable]');if(inner)rf=inner;}if(rf){rf.focus();if(ss!==null)kyoSetCaret(rf,ss,se);}}
            |      // Seed AFTER focus/caret restore so a newly-appeared focus-auto element wins restore-to-trigger (the morph path never seeds).
            |      if(nel){kyoEnterSeed(nel,__en);seedFocusAuto(nel,__fa);}
            |      kyoSpawnGhosts(__gh);
@@ -1196,10 +1277,64 @@ private[kyo] object HtmlRenderer:
            |  // Do NOT auto-call preventDefault: leave native-scroll suppression to the handler, matching DomBackend. Server-side rendering cannot synchronously decline the event, so the default is to NOT prevent.
            |  else if(t==="wheel"&&he(el,"wheel")){var whtid=e.target&&e.target.id?e.target.id:null;var sc={path:p,deltaX:e.deltaX,deltaY:e.deltaY,modifiers:{ctrl:e.ctrlKey,alt:e.altKey,shift:e.shiftKey,meta:e.metaKey}};if(whtid)sc.targetId=whtid;post({Scroll:sc});}
            |}
+           |// ---- client-local input filter/mask (document-level beforeinput capture listener) ----
+           |$inputMaskJs
+           |function kyoSetVal(t,v){t.value=v;kyoSetCaret(t,v.length,v.length);t.dispatchEvent(new Event("input",{bubbles:true}));}
+           |function kyoSetValAt(t,txt,s,en){var v=t.value;t.value=v.slice(0,s)+txt+v.slice(en);var np=s+txt.length;kyoSetCaret(t,np,np);t.dispatchEvent(new Event("input",{bubbles:true}));}
+           |function kyoBeforeInput(e){
+           |  var t=e.target;if(!t||!t.getAttribute)return;
+           |  // Interactive.data lets any element carry data-kyo-filter, and everything below assumes a value
+           |  // property and a text selection. Throwing from a beforeinput capture listener would break typing
+           |  // for the whole page, so anything but a text field is left alone.
+           |  if(t.tagName!=="INPUT"&&t.tagName!=="TEXTAREA")return;
+           |  var filt=t.getAttribute("data-kyo-filter");var mask=t.getAttribute("data-kyo-mask");
+           |  if(!filt&&!mask)return;
+           |  var it=e.inputType||"";
+           |  // insertCompositionText is deliberately absent below: preventDefault on it does not filter the input,
+           |  // it aborts the composition, which breaks CJK input, dead keys and mobile autocorrect. Composition is
+           |  // let through and the finished text is corrected in kyoCompositionEnd instead.
+           |  if(filt){
+           |    if(it.indexOf("delete")===0)return;
+           |    if(it==="insertText"||it==="insertReplacementText"){
+           |      var data=e.data;if(data==null)return;
+           |      var f1=kyoFilterStr(filt,data,t.value);
+           |      if(f1!==data){e.preventDefault();if(f1){var s=(typeof t.selectionStart==="number")?t.selectionStart:t.value.length;var en=(typeof t.selectionEnd==="number")?t.selectionEnd:s;kyoSetValAt(t,f1,s,en);}}
+           |    }else if(it==="insertFromPaste"||it==="insertFromDrop"){
+           |      e.preventDefault();var pasted=e.dataTransfer?e.dataTransfer.getData("text"):(e.data||"");
+           |      var f2=kyoFilterStr(filt,pasted,t.value);if(f2){var s2=(typeof t.selectionStart==="number")?t.selectionStart:t.value.length;var e2=(typeof t.selectionEnd==="number")?t.selectionEnd:s2;kyoSetValAt(t,f2,s2,e2);}
+           |    }
+           |    return;
+           |  }
+           |  if(mask){
+           |    var mts=kyoMaskParse(mask);
+           |    if(it.indexOf("delete")===0){e.preventDefault();var raw=kyoMaskRaw(mts,t.value);raw=raw.slice(0,raw.length-1);kyoSetVal(t,kyoMaskFormat(mts,raw));return;}
+           |    if(it==="insertText"||it==="insertReplacementText"||it==="insertFromPaste"||it==="insertFromDrop"){
+           |      e.preventDefault();var ins=e.data;if((it==="insertFromPaste"||it==="insertFromDrop")&&e.dataTransfer)ins=e.dataTransfer.getData("text");if(ins==null)ins="";
+           |      var raw2=kyoMaskRaw(mts,t.value);
+           |      for(var ci=0;ci<ins.length;ci++){var cls=kyoMaskClassAt(mts,raw2.length);if(cls===null)break;var ch=ins.charAt(ci);if(kyoMaskOk(cls,ch))raw2+=ch;}
+           |      kyoSetVal(t,kyoMaskFormat(mts,raw2));return;
+           |    }
+           |  }
+           |}
+           |// Corrects the whole value once a composition finishes. Mirrors DomBackend's compositionend listener:
+           |// the composed text is only known when it ends, so it is filtered or formatted here rather than
+           |// per keystroke. Writing back only on a change keeps a conforming composition free of a caret jump.
+           |function kyoCompositionEnd(e){
+           |  var t=e.target;if(!t||!t.getAttribute)return;
+           |  if(t.tagName!=="INPUT"&&t.tagName!=="TEXTAREA")return;
+           |  var filt=t.getAttribute("data-kyo-filter");var mask=t.getAttribute("data-kyo-mask");
+           |  var v=t.value;var nv;
+           |  if(filt)nv=kyoFilterStr(filt,v,"");
+           |  else if(mask)nv=kyoMaskNormalize(mask,v);
+           |  else return;
+           |  if(nv!==v)kyoSetVal(t,nv);
+           |}
            |["click","input","change","submit","keydown","keyup","focus","blur","mouseover","mouseout"].forEach(function(t){
            |  document.body.addEventListener(t,handle,true);
            |});
            |document.body.addEventListener("wheel",handle,{capture:true,passive:false});
+           |document.body.addEventListener("beforeinput",kyoBeforeInput,true);
+           |document.body.addEventListener("compositionend",kyoCompositionEnd,true);
            |})();""".stripMargin
 
     // ---- SVG tag and attribute rendering ----

--- a/kyo-ui/shared/src/main/scala/kyo/internal/InputMasking.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/InputMasking.scala
@@ -1,0 +1,166 @@
+package kyo.internal
+
+import kyo.*
+
+/** The pure character-level logic behind `inputFilter` and `inputMask`.
+  *
+  * Both transports enforce the constraints client-side, and both need the same decisions: which characters a filter
+  * admits, which class a mask position expects, how a raw value formats into a mask, and how a formatted value reduces
+  * back to raw. That logic lives here, free of any DOM dependency, so it can be tested directly on every platform.
+  *
+  * The SPA transport calls these methods from `DomBackend`; the server-push transport carries a hand-written JavaScript
+  * mirror in `HtmlRenderer.inputMaskJs`. The two must agree, so a change here needs the matching change there;
+  * `kyo.InputMaskingJsParityTest` holds both to the case table in `InputMaskingTest`, so adding a row there covers
+  * both transports.
+  *
+  * @see
+  *   [[kyo.UI.ConstrainedInput.inputFilter]] and [[kyo.UI.ConstrainedInput.inputMask]] for the declarative API
+  */
+private[kyo] object InputMasking:
+
+    /** The `chars:` prefix marking an explicit character set, so a set can never collide with a keyword. */
+    private val CharsPrefix = "chars:"
+
+    /** Encodes a filter for the `data-kyo-filter` attribute. */
+    def filterWire(filter: UI.InputFilter): String =
+        filter match
+            case UI.InputFilter.Digits         => "digits"
+            case UI.InputFilter.Decimal        => "decimal"
+            case UI.InputFilter.Allowed(chars) => CharsPrefix + chars
+
+    /** Keeps only the characters `pat` admits, dropping the rest.
+      *
+      * `curVal` is the field's current text, consulted only by `decimal` to decide whether a separator is still
+      * available. A wire value this build does not recognize admits everything: a page cached from an older build
+      * must stay usable rather than become impossible to type into.
+      */
+    def filterStr(pat: String, str: String, curVal: String): String =
+        val isChars = pat.startsWith(CharsPrefix)
+        val allowed = if isChars then pat.drop(CharsPrefix.length) else ""
+        if !isChars && pat != "digits" && pat != "decimal" then str
+        else
+            val sb     = new StringBuilder
+            var hasSep = pat == "decimal" && (curVal.contains(".") || curVal.contains(","))
+            str.foreach { ch =>
+                if isChars then
+                    if allowed.contains(ch) then sb.append(ch)
+                else if pat == "digits" then
+                    if ch >= '0' && ch <= '9' then sb.append(ch)
+                else if ch >= '0' && ch <= '9' then sb.append(ch)
+                else if (ch == '.' || ch == ',') && !hasSep then
+                    sb.append(ch); hasSep = true
+            }
+            sb.toString
+        end if
+    end filterStr
+
+    /** One position of a parsed mask: a character class the reader fills in, or a literal the mask inserts itself. */
+    enum MaskToken derives CanEqual:
+        case Class(cls: Char)
+        case Literal(ch: Char)
+    end MaskToken
+
+    /** Parses a mask pattern into its positions.
+      *
+      * `9`, `a` and `*` are the digit, letter and alphanumeric classes; every other character is a literal. A
+      * backslash escapes the next character, so `"+4\\9 999"` keeps a literal `9` where the pattern would otherwise
+      * open an input position. A trailing lone backslash is itself a literal.
+      */
+    def parseMask(mask: String): Chunk[MaskToken] =
+        val b = Chunk.newBuilder[MaskToken]
+        var i = 0
+        while i < mask.length do
+            val c = mask.charAt(i)
+            if c == '\\' && i + 1 < mask.length then
+                b += MaskToken.Literal(mask.charAt(i + 1))
+                i += 2
+            else
+                if c == '9' || c == 'a' || c == '*' then b += MaskToken.Class(c)
+                else b += MaskToken.Literal(c)
+                i += 1
+            end if
+        end while
+        b.result()
+    end parseMask
+
+    /** The class governing the `idx`-th input position, or [[Absent]] past the mask's capacity. */
+    def maskClassAt(tokens: Chunk[MaskToken], idx: Int): Maybe[Char] =
+        var c   = 0
+        var i   = 0
+        var res = Maybe.empty[Char]
+        while i < tokens.length && res.isEmpty do
+            tokens(i) match
+                case MaskToken.Class(cls) =>
+                    if c == idx then res = Present(cls)
+                    c += 1
+                case MaskToken.Literal(_) => ()
+            end match
+            i += 1
+        end while
+        res
+    end maskClassAt
+
+    /** Whether `ch` satisfies the class token `cls`. ASCII only: no locale letters, no digits beyond `0-9`. */
+    def maskOk(cls: Char, ch: Char): Boolean =
+        if cls == '9' then ch >= '0' && ch <= '9'
+        else if cls == 'a' then (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+        else (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+
+    /** Formats `raw` into the mask, inserting literals ahead of the characters that follow them.
+      *
+      * Formatting stops at the first position `raw` cannot fill, so a partial value renders without trailing literals.
+      */
+    def maskFormat(tokens: Chunk[MaskToken], raw: String): String =
+        val sb   = new StringBuilder
+        var ri   = 0
+        var i    = 0
+        var stop = false
+        while i < tokens.length && !stop do
+            tokens(i) match
+                case MaskToken.Class(_) =>
+                    if ri < raw.length then
+                        sb.append(raw.charAt(ri)); ri += 1
+                    else stop = true
+                case MaskToken.Literal(ch) =>
+                    if ri < raw.length then sb.append(ch)
+                    else stop = true
+            end match
+            i += 1
+        end while
+        sb.toString
+    end maskFormat
+
+    /** Reduces a formatted value back to the raw characters the reader supplied, dropping the mask's own literals.
+      *
+      * A character sitting at a literal position without matching it is kept: the value is then out of step with the
+      * mask, and treating it as content preserves what the reader typed rather than silently deleting it.
+      */
+    def maskRaw(tokens: Chunk[MaskToken], value: String): String =
+        val sb = new StringBuilder
+        var vi = 0
+        var i  = 0
+        while i < tokens.length && vi < value.length do
+            tokens(i) match
+                case MaskToken.Class(_) =>
+                    sb.append(value.charAt(vi)); vi += 1
+                case MaskToken.Literal(ch) =>
+                    if value.charAt(vi) == ch then vi += 1
+                    else
+                        sb.append(value.charAt(vi)); vi += 1
+            end match
+            i += 1
+        end while
+        sb.toString
+    end maskRaw
+
+    /** Formats a complete value through `mask`, dropping whatever the pattern cannot hold.
+      *
+      * Both callers need to correct a value they did not watch being typed: the renderer formats a value the
+      * application supplied, and the `compositionend` handler formats text an IME produced without per-character
+      * events. Idempotent, so a value the mask already formatted comes back unchanged.
+      */
+    def maskNormalize(mask: String, value: String): String =
+        val tokens = parseMask(mask)
+        maskFormat(tokens, maskRaw(tokens, value))
+
+end InputMasking

--- a/kyo-ui/shared/src/test/scala/kyo/HtmlRendererTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/HtmlRendererTest.scala
@@ -823,6 +823,15 @@ class HtmlRendererTest extends UITest:
 
     "clientJs transport" - {
 
+        "the mask parser emits a well-formed backslash literal" in {
+            // The mask escape is the one place the client script needs a backslash, and getting it wrong yields an
+            // unterminated string literal that stops the entire blob from parsing, disabling every client behavior
+            // at once rather than just the escape. `inputMaskJs` is kept uninterpolated so the source reads as the
+            // browser sees it; this pins the emitted form against anyone folding it back into the interpolated blob.
+            val page = kyo.internal.HtmlRenderer.renderPage("t", "<div></div>", "", "/app")
+            assert(page.contains("""if(c==="\\"&&i+1<mask.length)"""))
+        }
+
         "rendered page opens a WebSocket and carries no EventSource or fetch-POST queue" in {
             val page = kyo.internal.HtmlRenderer.renderPage("t", "<div></div>", "", "/app")
             assert(page.contains("new WebSocket("))

--- a/kyo-ui/shared/src/test/scala/kyo/InputMaskingJsParityTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/InputMaskingJsParityTest.scala
@@ -1,0 +1,43 @@
+package kyo
+
+import kyo.internal.HtmlRenderer
+import kyo.internal.InputMaskingTest
+
+/** Holds the JavaScript half of the input filter and mask logic to the same case table as the Scala half.
+  *
+  * The feature ships twice: `kyo.internal.InputMasking` drives the SPA transport, and a hand-written JavaScript
+  * mirror inside `HtmlRenderer.inputMaskJs` drives the server-push transport. Nothing but this suite makes the two
+  * agree. It loads the mirror into a real page, runs `InputMaskingTest.parityCases` through it, and compares against
+  * the expectations that `InputMaskingTest` holds the Scala implementation to. A row added there covers both.
+  *
+  * The whole table runs in a single evaluation: one round trip keeps a browser-backed suite cheap, and a mismatch
+  * names the calls that disagreed rather than failing on the first one.
+  */
+class InputMaskingJsParityTest extends UITest:
+
+    /** The mirror is emitted inside an IIFE, so its functions are not reachable from an evaluated expression. Load a
+      * second copy and publish it explicitly instead of reaching into the page's own copy.
+      */
+    private val loadMirror =
+        val names =
+            Seq("kyoFilterStr", "kyoMaskParse", "kyoMaskClassAt", "kyoMaskOk", "kyoMaskFormat", "kyoMaskRaw", "kyoMaskNormalize")
+        HtmlRenderer.inputMaskJs + ";" + names.map(n => s"window.$n=$n;").mkString
+    end loadMirror
+
+    "the JavaScript mirror agrees with the Scala implementation" in {
+        val cases = InputMaskingTest.parityCases
+        val table = cases.map(c => InputMaskingTest.runJs(c.call)).mkString("[", ",", "]")
+        withUI(UI.div("parity")) {
+            for
+                _   <- Browser.evalDiscard(loadMirror)
+                got <- Browser.evalJson[Seq[String]](table)
+                _ = assert(got.length == cases.length, s"expected ${cases.length} results, got ${got.length}")
+                mismatches = cases.zip(got).collect {
+                    case (c, actual) if actual != c.expected =>
+                        s"${c.call}: js=$actual expected=${c.expected}"
+                }
+            yield assert(mismatches.isEmpty, mismatches.mkString("; "))
+        }
+    }
+
+end InputMaskingJsParityTest

--- a/kyo-ui/shared/src/test/scala/kyo/InputMaskingScenarioItTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/InputMaskingScenarioItTest.scala
@@ -1,0 +1,267 @@
+package kyo
+
+import kyo.Browser.*
+
+/** Declarative client-local input filtering (`inputFilter`) and masking (`inputMask`) in a real browser.
+  *
+  * Drives the server-push transport (withUI -> runHandlers -> HtmlRenderer.clientJs) in real Chrome. Each field
+  * reflects its constrained value into a span through `onInput` or a bound `SignalRef`, so the assertions read what
+  * the SERVER received, which is the point of the feature. The DomBackend SPA mirror has no browser harness; the
+  * character-level logic it shares is covered by `kyo.internal.InputMaskingTest`, and the JavaScript mirror driven
+  * here is held to the same case table by `InputMaskingJsParityTest`.
+  *
+  * What only a browser can show, and is therefore covered here rather than in the unit suites: paste and drop,
+  * typing over a selection, caret placement, mask capacity, the compositionend correction, and a `type=email` field,
+  * whose caret cannot be moved at all.
+  */
+class InputMaskingScenarioItTest extends UITest:
+
+    "inputFilter emits data-kyo-filter" in {
+        withUI(UI.div(UI.input.id("i").inputFilter(UI.InputFilter.Digits))) {
+            Browser.assertAttribute(Selector.id("i"), "data-kyo-filter", "digits").unit
+        }
+    }
+
+    "inputMask emits data-kyo-mask" in {
+        withUI(UI.div(UI.input.id("i").inputMask("(999) 999-9999"))) {
+            Browser.assertAttribute(Selector.id("i"), "data-kyo-mask", "(999) 999-9999").unit
+        }
+    }
+
+    "filter=digits drops non-digits as they are typed" in {
+        val app: UI < Async =
+            for got <- Signal.initRef("")
+            yield UI.div(
+                UI.input.id("i").inputFilter(UI.InputFilter.Digits).onInput(v => got.set(v)),
+                got.map(v => UI.span(v).id("out"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.press(Selector.id("i"), Key('a'))
+                _ <- Browser.press(Selector.id("i"), Key('1'))
+                _ <- Browser.press(Selector.id("i"), Key('b'))
+                _ <- Browser.press(Selector.id("i"), Key('2'))
+                _ <- Browser.assertText(Selector.id("out"), "12")
+            yield ()
+        }
+    }
+
+    "mask auto-inserts literals as digits are typed" in {
+        val app: UI < Async =
+            for got <- Signal.initRef("")
+            yield UI.div(
+                UI.input.id("i").inputMask("(999) 999").onInput(v => got.set(v)),
+                got.map(v => UI.span(v).id("out"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.press(Selector.id("i"), Key('1'))
+                _ <- Browser.press(Selector.id("i"), Key('2'))
+                _ <- Browser.press(Selector.id("i"), Key('3'))
+                _ <- Browser.press(Selector.id("i"), Key('4'))
+                _ <- Browser.press(Selector.id("i"), Key('5'))
+                _ <- Browser.press(Selector.id("i"), Key('6'))
+                _ <- Browser.assertText(Selector.id("out"), "(123) 456")
+            yield ()
+        }
+    }
+
+    "mask backspace deletes the digit before the literal and collapses trailing literals" in {
+        val app: UI < Async =
+            for got <- Signal.initRef("")
+            yield UI.div(
+                UI.input.id("i").inputMask("(999) 999").onInput(v => got.set(v)),
+                got.map(v => UI.span(v).id("out"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.press(Selector.id("i"), Key('1'))
+                _ <- Browser.press(Selector.id("i"), Key('2'))
+                _ <- Browser.press(Selector.id("i"), Key('3'))
+                _ <- Browser.press(Selector.id("i"), Key('4'))
+                _ <- Browser.assertText(Selector.id("out"), "(123) 4")
+                _ <- Browser.press(Selector.id("i"), Key.Backspace)
+                _ <- Browser.assertText(Selector.id("out"), "(123")
+            yield ()
+        }
+    }
+
+    "a value the server sets reaches the field masked" in {
+        // The gap a client-side beforeinput listener cannot close: nobody typed, so no event fires and the field
+        // would otherwise show the raw value. The mirror span is asserted first because it retries, which
+        // synchronizes on the update having arrived before the value is read.
+        val app: UI < Async =
+            for ref <- Signal.initRef("")
+            yield UI.div(
+                UI.input.id("i").inputMask("(999) 999").value(ref),
+                UI.button("set").id("b").onClick(ref.set("1234567890")),
+                ref.map(v => UI.span(s"sig:$v").id("out"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.click(Selector.id("b"))
+                _ <- Browser.assertText(Selector.id("out"), "sig:1234567890")
+                v <- Browser.value(Selector.id("i"))
+            yield assert(v == "(123) 456")
+        }
+    }
+
+    // A composition (IME, dead key, mobile autocorrect) is let through rather than cancelled, because
+    // preventDefault on insertCompositionText aborts the composition instead of filtering it. The finished text is
+    // corrected on compositionend. CDP cannot drive a real IME, so these set the composed text and fire the event
+    // directly; what they pin is the handler's contract, that the field and the server end up constrained.
+    private def composeInto(id: String, text: String)(using Frame) =
+        Browser.evalDiscard(
+            s"""(function(){var t=document.getElementById("$id");t.value="$text";
+               |t.dispatchEvent(new CompositionEvent("compositionend",{bubbles:true}));})()""".stripMargin
+        )
+
+    "a finished composition is filtered" in {
+        val app: UI < Async =
+            for got <- Signal.initRef("")
+            yield UI.div(
+                UI.input.id("i").inputFilter(UI.InputFilter.Digits).onInput(v => got.set(v)),
+                got.map(v => UI.span(s"sig:$v").id("out"))
+            )
+        withUI(app) {
+            for
+                _ <- composeInto("i", "a1b2")
+                _ <- Browser.assertText(Selector.id("out"), "sig:12")
+                v <- Browser.value(Selector.id("i"))
+            yield assert(v == "12")
+        }
+    }
+
+    "a finished composition is formatted against the mask" in {
+        val app: UI < Async =
+            for got <- Signal.initRef("")
+            yield UI.div(
+                UI.input.id("i").inputMask("(999) 999").onInput(v => got.set(v)),
+                got.map(v => UI.span(s"sig:$v").id("out"))
+            )
+        withUI(app) {
+            for
+                _ <- composeInto("i", "123456")
+                _ <- Browser.assertText(Selector.id("out"), "sig:(123) 456")
+                v <- Browser.value(Selector.id("i"))
+            yield assert(v == "(123) 456")
+        }
+    }
+
+    // Paste, drop and typing over a selection reach the handler as beforeinput events CDP cannot synthesize from
+    // key presses, so they are dispatched directly. The value and caret they leave behind are what is asserted.
+    private def pasteInto(id: String, text: String)(using Frame) =
+        Browser.evalDiscard(
+            s"""(function(){var t=document.getElementById("$id");t.focus();
+               |var dt=new DataTransfer();dt.setData("text","$text");
+               |t.dispatchEvent(new InputEvent("beforeinput",
+               |  {bubbles:true,cancelable:true,inputType:"insertFromPaste",dataTransfer:dt}));})()""".stripMargin
+        )
+
+    private def typeOverSelection(id: String, current: String, start: Int, end: Int, text: String)(using Frame) =
+        Browser.evalDiscard(
+            s"""(function(){var t=document.getElementById("$id");t.focus();
+               |t.value="$current";t.setSelectionRange($start,$end);
+               |t.dispatchEvent(new InputEvent("beforeinput",
+               |  {bubbles:true,cancelable:true,inputType:"insertText",data:"$text"}));})()""".stripMargin
+        )
+
+    private def caretAt(id: String)(using Frame) =
+        Browser.evalInt(s"""document.getElementById("$id").selectionStart""")
+
+    "pasted text is filtered and the caret lands after the insertion" in {
+        val app: UI < Async =
+            for got <- Signal.initRef("")
+            yield UI.div(
+                UI.input.id("i").inputFilter(UI.InputFilter.Digits).onInput(v => got.set(v)),
+                got.map(v => UI.span(s"sig:$v").id("out"))
+            )
+        withUI(app) {
+            for
+                _ <- pasteInto("i", "a1b2c3")
+                _ <- Browser.assertText(Selector.id("out"), "sig:123")
+                v <- Browser.value(Selector.id("i"))
+                c <- caretAt("i")
+            yield
+                assert(v == "123")
+                assert(c == 3)
+        }
+    }
+
+    "typing over a selection replaces it with the filtered text and places the caret after it" in {
+        val app: UI < Async =
+            for got <- Signal.initRef("")
+            yield UI.div(
+                UI.input.id("i").inputFilter(UI.InputFilter.Digits).onInput(v => got.set(v)),
+                got.map(v => UI.span(s"sig:$v").id("out"))
+            )
+        withUI(app) {
+            for
+                // "12345" with "23" selected, typing "a9": the letter is dropped and the digit replaces the selection.
+                _ <- typeOverSelection("i", "12345", 1, 3, "a9")
+                _ <- Browser.assertText(Selector.id("out"), "sig:1945")
+                v <- Browser.value(Selector.id("i"))
+                c <- caretAt("i")
+            yield
+                assert(v == "1945")
+                assert(c == 2)
+        }
+    }
+
+    "a keystroke past the mask capacity is dropped" in {
+        val app: UI < Async =
+            for got <- Signal.initRef("")
+            yield UI.div(
+                UI.input.id("i").inputMask("(999) 999").onInput(v => got.set(v)),
+                got.map(v => UI.span(v).id("out"))
+            )
+        withUI(app) {
+            for
+                _ <- Kyo.foreachDiscard("123456".toList)(c => Browser.press(Selector.id("i"), Key(c)))
+                _ <- Browser.assertText(Selector.id("out"), "(123) 456")
+                _ <- Browser.press(Selector.id("i"), Key('7'))
+                _ <- Browser.assertText(Selector.id("out"), "(123) 456")
+                v <- Browser.value(Selector.id("i"))
+            yield assert(v == "(123) 456")
+        }
+    }
+
+    "a filter drives a two-way binding, so the ref only ever sees filtered text" in {
+        val app: UI < Async =
+            for ref <- Signal.initRef("")
+            yield UI.div(
+                UI.input.id("i").inputFilter(UI.InputFilter.Decimal).value(ref),
+                ref.map(v => UI.span(s"sig:$v").id("out"))
+            )
+        withUI(app) {
+            for
+                _ <- Kyo.foreachDiscard("1a.5b.2".toList)(c => Browser.press(Selector.id("i"), Key(c)))
+                _ <- Browser.assertText(Selector.id("out"), "sig:1.52")
+                v <- Browser.value(Selector.id("i"))
+            yield assert(v == "1.52")
+        }
+    }
+
+    "a filter works on an email input, whose caret cannot be moved" in {
+        // type=email has no text selection: reading selectionStart yields null and setSelectionRange throws
+        // InvalidStateError. Both are tolerated deliberately, and the second keystroke proves the client script
+        // survived the first, which is what an unhandled throw out of a beforeinput listener would have ended.
+        val app: UI < Async =
+            for got <- Signal.initRef("")
+            yield UI.div(
+                UI.emailInput.id("i").inputFilter(UI.InputFilter.Digits).onInput(v => got.set(v)),
+                got.map(v => UI.span(s"sig:$v").id("out"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.press(Selector.id("i"), Key('a'))
+                _ <- Browser.press(Selector.id("i"), Key('1'))
+                _ <- Browser.assertText(Selector.id("out"), "sig:1")
+                _ <- Browser.press(Selector.id("i"), Key('2'))
+                _ <- Browser.assertText(Selector.id("out"), "sig:12")
+                v <- Browser.value(Selector.id("i"))
+            yield assert(v == "12")
+        }
+    }
+
+end InputMaskingScenarioItTest

--- a/kyo-ui/shared/src/test/scala/kyo/internal/InputMaskingTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/internal/InputMaskingTest.scala
@@ -1,0 +1,427 @@
+package kyo.internal
+
+import kyo.*
+
+/** Covers the pure filter and mask logic on every platform.
+  *
+  * What is deliberately NOT covered here: the DOM wiring in `DomBackend` (`setupInputMasking`, `setValue`,
+  * `setFilteredAt`, `dispatchInput`, the `compositionend` listener). The browser harness serves the server-push
+  * transport, so no test in this repo loads the Scala.js backend; those methods are thin shims over the logic below,
+  * and the parts that can be observed from a browser are covered by `InputMaskingScenarioItTest` against the
+  * JavaScript mirror, which `kyo.InputMaskingJsParityTest` holds to the same case table.
+  */
+class InputMaskingTest extends kyo.test.Test[Any]:
+
+    private def m(mask: String) = InputMasking.parseMask(mask)
+
+    "filterStr" - {
+
+        "digits" - {
+            "keeps digits" in {
+                assert(InputMasking.filterStr("digits", "123", "") == "123")
+            }
+            "drops letters and symbols" in {
+                assert(InputMasking.filterStr("digits", "a1b2-3", "") == "123")
+            }
+            "empty input yields empty" in {
+                assert(InputMasking.filterStr("digits", "", "") == "")
+            }
+            "drops a separator" in {
+                assert(InputMasking.filterStr("digits", "1.5", "") == "15")
+            }
+        }
+
+        "decimal" - {
+            "keeps digits" in {
+                assert(InputMasking.filterStr("decimal", "123", "") == "123")
+            }
+            "keeps the first dot" in {
+                assert(InputMasking.filterStr("decimal", "1.5", "") == "1.5")
+            }
+            "keeps the first comma" in {
+                assert(InputMasking.filterStr("decimal", "1,5", "") == "1,5")
+            }
+            "drops a second separator within the same input" in {
+                assert(InputMasking.filterStr("decimal", "1.5.2", "") == "1.52")
+            }
+            "drops a separator when the field already holds one" in {
+                assert(InputMasking.filterStr("decimal", ".5", "1.0") == "5")
+            }
+            "treats a comma in the field as the separator too" in {
+                assert(InputMasking.filterStr("decimal", ".5", "1,0") == "5")
+            }
+            "drops a leading sign, so negatives are not expressible" in {
+                assert(InputMasking.filterStr("decimal", "-1.5", "") == "1.5")
+            }
+            "drops letters" in {
+                assert(InputMasking.filterStr("decimal", "1a.5b", "") == "1.5")
+            }
+        }
+
+        "explicit character set" - {
+            "keeps characters in the set" in {
+                assert(InputMasking.filterStr("chars:abc", "cab", "") == "cab")
+            }
+            "drops characters outside the set" in {
+                assert(InputMasking.filterStr("chars:abc", "axbycz", "") == "abc")
+            }
+            "an empty set drops everything" in {
+                assert(InputMasking.filterStr("chars:", "abc", "") == "")
+            }
+            "an unrecognized wire value admits everything" in {
+                // Fail open: a page cached from an older build must stay usable, not become impossible to type into.
+                assert(InputMasking.filterStr("int", "a1.", "") == "a1.")
+                assert(InputMasking.filterStr("nonsense", "a1.", "") == "a1.")
+            }
+            "a set spelling a keyword is reachable through the prefix" in {
+                // The regression the typed InputFilter fixes: the old wire format read "int" as the
+                // digits-only keyword, so an allowed set of i, n and t could not be expressed at all.
+                assert(InputMasking.filterStr("chars:int", "int", "") == "int")
+                assert(InputMasking.filterStr("chars:int", "1", "") == "")
+            }
+        }
+    }
+
+    "filterWire round-trips through filterStr" - {
+        "Digits" in {
+            assert(InputMasking.filterWire(UI.InputFilter.Digits) == "digits")
+            assert(InputMasking.filterStr(InputMasking.filterWire(UI.InputFilter.Digits), "a1", "") == "1")
+        }
+        "Decimal" in {
+            assert(InputMasking.filterWire(UI.InputFilter.Decimal) == "decimal")
+            assert(InputMasking.filterStr(InputMasking.filterWire(UI.InputFilter.Decimal), "a1.5", "") == "1.5")
+        }
+        "Allowed carries an arbitrary set, keywords included" in {
+            val wire = InputMasking.filterWire(UI.InputFilter.Allowed("int"))
+            assert(wire == "chars:int")
+            assert(InputMasking.filterStr(wire, "int1", "") == "int")
+        }
+        "Allowed carries a set that itself looks like the prefix" in {
+            val wire = InputMasking.filterWire(UI.InputFilter.Allowed("chars:"))
+            assert(InputMasking.filterStr(wire, "chars:x", "") == "chars:")
+        }
+        "Allowed with an empty set drops everything" in {
+            assert(InputMasking.filterStr(InputMasking.filterWire(UI.InputFilter.Allowed("")), "abc", "") == "")
+        }
+    }
+
+    "maskClassAt" - {
+        "index zero skips a leading literal" in {
+            assert(InputMasking.maskClassAt(m("(999) 999"), 0) == Present('9'))
+        }
+        "counts only input positions, not literals" in {
+            assert(InputMasking.maskClassAt(m("(999) 999"), 3) == Present('9'))
+        }
+        "reports the class of a mixed mask" in {
+            assert(InputMasking.maskClassAt(m("9a*"), 0) == Present('9'))
+            assert(InputMasking.maskClassAt(m("9a*"), 1) == Present('a'))
+            assert(InputMasking.maskClassAt(m("9a*"), 2) == Present('*'))
+        }
+        "past capacity is Absent" in {
+            assert(InputMasking.maskClassAt(m("999"), 3) == Absent)
+        }
+        "a mask of only literals has no input position" in {
+            assert(InputMasking.maskClassAt(m("()-"), 0) == Absent)
+        }
+        "an empty mask has no input position" in {
+            assert(InputMasking.maskClassAt(m(""), 0) == Absent)
+        }
+    }
+
+    "parseMask" - {
+        "class tokens and literals" in {
+            assert(m("(9a*)") == Chunk(
+                InputMasking.MaskToken.Literal('('),
+                InputMasking.MaskToken.Class('9'),
+                InputMasking.MaskToken.Class('a'),
+                InputMasking.MaskToken.Class('*'),
+                InputMasking.MaskToken.Literal(')')
+            ))
+        }
+        "a backslash escapes a class character into a literal" in {
+            assert(m("\\9") == Chunk(InputMasking.MaskToken.Literal('9')))
+            assert(m("\\a") == Chunk(InputMasking.MaskToken.Literal('a')))
+            assert(m("\\*") == Chunk(InputMasking.MaskToken.Literal('*')))
+        }
+        "a backslash escapes itself" in {
+            assert(m("\\\\") == Chunk(InputMasking.MaskToken.Literal('\\')))
+        }
+        "a trailing lone backslash is a literal" in {
+            assert(m("9\\") == Chunk(InputMasking.MaskToken.Class('9'), InputMasking.MaskToken.Literal('\\')))
+        }
+        "an empty pattern has no positions" in {
+            assert(m("") == Chunk.empty)
+        }
+        "an escaped class character is not an input position" in {
+            // The regression the escape fixes: "+49 999" used to open input positions inside the country code.
+            assert(InputMasking.maskClassAt(m("+4\\9 999"), 0) == Present('9'))
+            assert(InputMasking.maskFormat(m("+4\\9 999"), "123") == "+49 123")
+        }
+    }
+
+    "maskOk" - {
+        "digit class" in {
+            assert(InputMasking.maskOk('9', '0'))
+            assert(InputMasking.maskOk('9', '9'))
+            assert(!InputMasking.maskOk('9', 'a'))
+            assert(!InputMasking.maskOk('9', ' '))
+        }
+        "letter class" in {
+            assert(InputMasking.maskOk('a', 'a'))
+            assert(InputMasking.maskOk('a', 'Z'))
+            assert(!InputMasking.maskOk('a', '0'))
+            assert(!InputMasking.maskOk('a', '_'))
+        }
+        "letter class is ASCII only" in {
+            // Pins the current behavior: accented and non-Latin letters are rejected.
+            assert(!InputMasking.maskOk('a', 'ü'))
+            assert(!InputMasking.maskOk('*', 'ü'))
+        }
+        "alphanumeric class" in {
+            assert(InputMasking.maskOk('*', '0'))
+            assert(InputMasking.maskOk('*', 'a'))
+            assert(InputMasking.maskOk('*', 'Z'))
+            assert(!InputMasking.maskOk('*', '-'))
+        }
+    }
+
+    "maskFormat" - {
+        "empty raw yields empty" in {
+            assert(InputMasking.maskFormat(m("(999) 999"), "") == "")
+        }
+        "a leading literal appears with the first raw character" in {
+            assert(InputMasking.maskFormat(m("(999) 999"), "1") == "(1")
+        }
+        "partial raw stops without trailing literals" in {
+            assert(InputMasking.maskFormat(m("(999) 999"), "123") == "(123")
+        }
+        "literals between positions are inserted" in {
+            assert(InputMasking.maskFormat(m("(999) 999"), "1234") == "(123) 4")
+        }
+        "raw filling every position omits a closing literal" in {
+            assert(InputMasking.maskFormat(m("999-"), "123") == "123")
+        }
+        "raw beyond capacity is ignored" in {
+            assert(InputMasking.maskFormat(m("999"), "123456") == "123")
+        }
+        "an empty mask yields empty" in {
+            assert(InputMasking.maskFormat(m(""), "123") == "")
+        }
+    }
+
+    "maskRaw" - {
+        "literals are dropped" in {
+            assert(InputMasking.maskRaw(m("(999) 999"), "(123) 456") == "123456")
+        }
+        "a partial value reduces to what was entered" in {
+            assert(InputMasking.maskRaw(m("(999) 999"), "(12") == "12")
+        }
+        "a character not matching a literal position is kept as content" in {
+            // The value is out of step with the mask; keeping the character preserves what the user typed.
+            assert(InputMasking.maskRaw(m("(999"), "1234") == "1234")
+        }
+        "a value longer than the mask is truncated" in {
+            assert(InputMasking.maskRaw(m("999"), "123456") == "123")
+        }
+        "an empty value yields empty" in {
+            assert(InputMasking.maskRaw(m("(999) 999"), "") == "")
+        }
+    }
+
+    "typing constraints are offered only where they work" - {
+        "a text input accepts them" in {
+            val e = UI.input.inputFilter(UI.InputFilter.Digits).inputMask("(999) 999")
+            assert(e.inputFilter == Present(UI.InputFilter.Digits))
+            assert(e.inputMask == Present("(999) 999"))
+        }
+        "a number input does not accept a filter" in {
+            // NumberInput deliberately omits ConstrainedInput: it constrains its content through type,
+            // min, max and step, its value reads empty while the content is not a valid number, and a
+            // mask's own literals are never valid there.
+            typeCheckFailure("""
+                import kyo.*
+                UI.numberInput.inputFilter(UI.InputFilter.Digits)
+            """)
+        }
+        "a number input does not accept a mask" in {
+            typeCheckFailure("""
+                import kyo.*
+                UI.numberInput.inputMask("(999) 999")
+            """)
+        }
+    }
+
+    "a rendered value carries the mask" - {
+        // A mask is a display format, so it has to hold for values the client never sees typed: a bound SignalRef,
+        // a server-side transform, the initial render. Formatting at render time is what makes that true in both
+        // transports and on both the morph and the replace path.
+        def render(ui: UI)(using Frame) = HtmlRenderer.render(ui, Seq.empty)
+
+        "an unformatted value is formatted" in {
+            render(UI.input.value("1234567890").inputMask("(999) 999-9999")).map { s =>
+                assert(s.contains("""value="(123) 456-7890""""))
+            }
+        }
+        "an already formatted value is unchanged, so a keystroke echo compares equal" in {
+            render(UI.input.value("(123) 456").inputMask("(999) 999")).map { s =>
+                assert(s.contains("""value="(123) 456""""))
+            }
+        }
+        "a partial value renders without trailing literals" in {
+            render(UI.input.value("12").inputMask("(999) 999")).map { s =>
+                assert(s.contains("""value="(12""""))
+            }
+        }
+        "characters the mask cannot hold are dropped" in {
+            render(UI.input.value("12345678901234").inputMask("(999) 999")).map { s =>
+                assert(s.contains("""value="(123) 456""""))
+            }
+        }
+        "an escaped literal is not filled from the value" in {
+            render(UI.telInput.value("123").inputMask("+4\\9 999")).map { s =>
+                assert(s.contains("""value="+49 123""""))
+            }
+        }
+        "a field without a mask keeps its value verbatim" in {
+            render(UI.input.value("1234567890")).map { s =>
+                assert(s.contains("""value="1234567890""""))
+            }
+        }
+        "a textarea formats its content, which is not an attribute" in {
+            render(UI.textarea.value("123456").inputMask("999-999")).map { s =>
+                assert(s.contains(">123-456<"))
+            }
+        }
+    }
+
+    "the parity table agrees with the Scala implementation" in {
+        // The table is shared with InputMaskingJsParityTest, which drives it against the JavaScript mirror.
+        // Checking it here too is what makes a parity failure readable: if only the JavaScript suite fails,
+        // the mirror has drifted; if both fail, the expectation itself is wrong.
+        val wrong = InputMaskingTest.parityCases.filter(c => InputMaskingTest.runScala(c.call) != c.expected)
+        assert(wrong.isEmpty, wrong.map(c => s"${c.call} yielded ${InputMaskingTest.runScala(c.call)}").mkString("; "))
+    }
+
+    "maskRaw inverts maskFormat for class-valid input" in {
+        val cases = Seq(
+            "(999) 999-9999" -> "1234567890",
+            "999-999"        -> "123456",
+            "aa-99"          -> "ab12",
+            "***"            -> "a1Z",
+            "99"             -> "",
+            "99"             -> "4"
+        )
+        cases.foreach { (mask, raw) =>
+            val tokens    = m(mask)
+            val formatted = InputMasking.maskFormat(tokens, raw)
+            assert(
+                InputMasking.maskRaw(tokens, formatted) == raw,
+                s"mask=$mask raw=$raw formatted=$formatted"
+            )
+        }
+        succeed
+    }
+end InputMaskingTest
+
+/** The case table both implementations of the filter and mask logic are held to.
+  *
+  * `InputMaskingTest` runs it against [[InputMasking]], `kyo.InputMaskingJsParityTest` against the JavaScript mirror
+  * in `HtmlRenderer.inputMaskJs`. Adding a row therefore covers both transports at once, which is the coupling the
+  * two hand-written implementations otherwise lack.
+  */
+object InputMaskingTest:
+
+    /** A call into the logic, in the one form both implementations understand. */
+    enum Call derives CanEqual:
+        case Filter(pat: String, str: String, cur: String)
+        case ClassAt(mask: String, idx: Int)
+        case Ok(cls: Char, ch: Char)
+        case Format(mask: String, raw: String)
+        case Raw(mask: String, value: String)
+        case Normalize(mask: String, value: String)
+    end Call
+
+    /** A call and the single result both implementations must produce.
+      *
+      * Results are compared as strings because that is the only shape the browser bridge returns: an absent mask
+      * position is the empty string, and `maskOk` reports `"true"` or `"false"`.
+      */
+    final case class Case(call: Call, expected: String) derives CanEqual
+
+    val parityCases: Chunk[Case] = Chunk(
+        Case(Call.Filter("digits", "a1b2-3", ""), "123"),
+        Case(Call.Filter("digits", "1.5", ""), "15"),
+        Case(Call.Filter("digits", "", ""), ""),
+        Case(Call.Filter("decimal", "1.5", ""), "1.5"),
+        Case(Call.Filter("decimal", "1,5", ""), "1,5"),
+        Case(Call.Filter("decimal", "1.5.2", ""), "1.52"),
+        Case(Call.Filter("decimal", ".5", "1.0"), "5"),
+        Case(Call.Filter("decimal", ".5", "1,0"), "5"),
+        Case(Call.Filter("decimal", "-1.5", ""), "1.5"),
+        Case(Call.Filter("decimal", "1a.5b", ""), "1.5"),
+        Case(Call.Filter("chars:abc", "axbycz", ""), "abc"),
+        Case(Call.Filter("chars:", "abc", ""), ""),
+        Case(Call.Filter("chars:int", "int1", ""), "int"),
+        Case(Call.Filter("chars:chars:", "chars:x", ""), "chars:"),
+        Case(Call.Filter("int", "a1.", ""), "a1."),
+        Case(Call.Filter("nonsense", "a1.", ""), "a1."),
+        Case(Call.ClassAt("(999) 999", 0), "9"),
+        Case(Call.ClassAt("(999) 999", 3), "9"),
+        Case(Call.ClassAt("9a*", 1), "a"),
+        Case(Call.ClassAt("9a*", 2), "*"),
+        Case(Call.ClassAt("999", 3), ""),
+        Case(Call.ClassAt("()-", 0), ""),
+        Case(Call.ClassAt("", 0), ""),
+        Case(Call.ClassAt("+4\\9 999", 0), "9"),
+        Case(Call.Ok('9', '0'), "true"),
+        Case(Call.Ok('9', 'a'), "false"),
+        Case(Call.Ok('9', ' '), "false"),
+        Case(Call.Ok('a', 'Z'), "true"),
+        Case(Call.Ok('a', '0'), "false"),
+        Case(Call.Ok('a', 'ü'), "false"),
+        Case(Call.Ok('*', 'a'), "true"),
+        Case(Call.Ok('*', '-'), "false"),
+        Case(Call.Format("(999) 999", ""), ""),
+        Case(Call.Format("(999) 999", "1"), "(1"),
+        Case(Call.Format("(999) 999", "1234"), "(123) 4"),
+        Case(Call.Format("999-", "123"), "123"),
+        Case(Call.Format("999", "123456"), "123"),
+        Case(Call.Format("", "123"), ""),
+        Case(Call.Format("+4\\9 999", "123"), "+49 123"),
+        Case(Call.Raw("(999) 999", "(123) 456"), "123456"),
+        Case(Call.Raw("(999) 999", "(12"), "12"),
+        Case(Call.Raw("(999", "1234"), "1234"),
+        Case(Call.Raw("999", "123456"), "123"),
+        Case(Call.Raw("(999) 999", ""), ""),
+        Case(Call.Normalize("(999) 999", "123456"), "(123) 456"),
+        Case(Call.Normalize("(999) 999", "(123) 456"), "(123) 456"),
+        Case(Call.Normalize("(999) 999", "12"), "(12"),
+        Case(Call.Normalize("(999) 999", "1234567890"), "(123) 456"),
+        Case(Call.Normalize("+4\\9 999", "123"), "+49 123"),
+        Case(Call.Normalize("(999) 999", ""), "")
+    )
+
+    /** Runs a call against the Scala implementation. */
+    def runScala(call: Call): String =
+        call match
+            case Call.Filter(pat, str, cur)  => InputMasking.filterStr(pat, str, cur)
+            case Call.ClassAt(mask, idx)     => InputMasking.maskClassAt(InputMasking.parseMask(mask), idx).fold("")(_.toString)
+            case Call.Ok(cls, ch)            => InputMasking.maskOk(cls, ch).toString
+            case Call.Format(mask, raw)      => InputMasking.maskFormat(InputMasking.parseMask(mask), raw)
+            case Call.Raw(mask, value)       => InputMasking.maskRaw(InputMasking.parseMask(mask), value)
+            case Call.Normalize(mask, value) => InputMasking.maskNormalize(mask, value)
+
+    /** The JavaScript expression running the same call against the mirror, yielding the same string. */
+    def runJs(call: Call): String =
+        def q(s: String) = "\"" + HtmlRenderer.jsStr(s) + "\""
+        call match
+            case Call.Filter(pat, str, cur)  => s"kyoFilterStr(${q(pat)},${q(str)},${q(cur)})"
+            case Call.ClassAt(mask, idx)     => s"(kyoMaskClassAt(kyoMaskParse(${q(mask)}),$idx)||\"\")"
+            case Call.Ok(cls, ch)            => s"String(kyoMaskOk(${q(cls.toString)},${q(ch.toString)}))"
+            case Call.Format(mask, raw)      => s"kyoMaskFormat(kyoMaskParse(${q(mask)}),${q(raw)})"
+            case Call.Raw(mask, value)       => s"kyoMaskRaw(kyoMaskParse(${q(mask)}),${q(value)})"
+            case Call.Normalize(mask, value) => s"kyoMaskNormalize(${q(mask)},${q(value)})"
+        end match
+    end runJs
+
+end InputMaskingTest


### PR DESCRIPTION
## Problem

kyo-ui text inputs accept any typed or pasted character; there is no declarative way to constrain input to digits, a decimal number, or a fixed format, so an app has to post-validate and correct the field after the fact (the rejected character is briefly visible, and the caret jumps).

## Solution

Add `inputFilter` and `inputMask`, enforced client-side by a document-level `beforeinput` capture listener wired in both transports (the server-push clientJs and the SPA `DomBackend`), keyed off `data-kyo-filter` / `data-kyo-mask` markers.

- `inputFilter(pattern)`: `"int"`, `"decimal"`, or a literal allowed-character set. A disallowed character is rejected before it enters the field, and filtered out of pasted or dropped text — so the value never shows a character it would reject.
- `inputMask(mask)`: Prime-style tokens (`9` = digit, `a` = letter, `*` = alphanumeric, any other character is a literal, e.g. `"(999) 999-9999"`). The field formats progressively — literals auto-insert, each position restricts its character class, backspace steps over literals, and the caret stays correct. The server sees the masked value through the normal `input`/`change` events.

## Notes

Test: `InputMaskScenarioItTest` (real-Chrome integration test, server-push transport).
