### PR TITLE
[kyo-ui] add an opt-in session handler-error policy (onHandlerError) (follow-up: #1780)

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -121,6 +121,12 @@ object Fiber:
 
     /** Runs an asynchronous computation in a new Fiber guaranteeing eventual interruption via the [[Scope]] effect.
       *
+      * If a [[Fiber.Supervisor]] is installed in the current context (see [[Supervisor.let]]), the spawned fiber is additionally
+      * SUPERVISED: any non-interrupt terminal failure (an `Abort` failure or a panic that is not an [[Interrupted]]) is reported to the
+      * supervisor exactly once. Interruptions — including the scope-close interrupt this very method registers — are never reported.
+      * With no supervisor installed (the default), behavior is unchanged. [[initUnscoped]] and [[use]] never supervise — they are the
+      * escape hatches for fire-and-forget fibers and for fibers whose failure the caller observes itself.
+      *
       * @param v
       *   The computation to run
       * @return
@@ -135,7 +141,56 @@ object Fiber:
         reduce: Reducible[Abort[E]],
         frame: Frame
     ): Fiber[A, reduce.SReduced & S2] < (Sync & S & Scope) =
-        Scope.acquireRelease(initUnscoped[E, A, S, S2](v))(_.interrupt)
+        Supervisor.local.use {
+            case Absent => Scope.acquireRelease(initUnscoped[E, A, S, S2](v))(_.interrupt)
+            case Present(sup) =>
+                Scope.acquireRelease(initUnscoped[E, A, S, S2](v))(_.interrupt).map { fiber =>
+                    Sync.defer {
+                        Supervisor.watch(fiber, sup)
+                        fiber
+                    }
+                }
+        }
+
+    /** Observes non-interrupt failures of fibers spawned via the scoped [[init]].
+      *
+      * A supervisor is carried in an inheritable [[Local]] ([[Supervisor.let]]), so it reaches every scoped `Fiber.init` in the
+      * wrapped computation AND in fibers it forks (context capture at spawn). This is the primitive behind kyo-ui's node-scope
+      * supervision: the UI engine installs a supervisor around a mounted node's effect so a background data feed failing AFTER the
+      * node published its UI can still flip the node into its error state.
+      *
+      * The callback runs on the completing fiber's thread with no effect context: it must be fast, non-blocking, and must not throw
+      * (typically it completes a promise or sets an atomic).
+      */
+    abstract private[kyo] class Supervisor:
+        /** Invoked at most once per supervised fiber, on any non-interrupt terminal failure. */
+        def onFailure(error: Result.Error[Any])(using AllowUnsafe): Unit
+
+    private[kyo] object Supervisor:
+        /** The ambient supervisor. Inheritable so supervised code's own forks stay supervised. */
+        private[kyo] val local: Local[Maybe[Supervisor]] = Local.init(Maybe.empty[Supervisor])
+
+        /** Runs `v` with `sup` installed as the ambient supervisor. */
+        private[kyo] def let[A, S](sup: Supervisor)(v: A < S)(using Frame): A < S =
+            local.let(Present(sup))(v)
+
+        /** Runs `v` with NO ambient supervisor — the subtree opt-out. */
+        private[kyo] def none[A, S](v: A < S)(using Frame): A < S =
+            local.let(Absent)(v)
+
+        /** Registers the failure watch on a just-spawned fiber. Safe to call after completion: `IOPromise.onComplete` on a settled
+          * promise invokes the callback immediately, so an instantly-failing fiber still reports.
+          */
+        private[kyo] def watch(fiber: IOPromiseBase[?, ?], sup: Supervisor): Unit =
+            fiber.asInstanceOf[IOPromise[Any, Any]].onComplete {
+                case Result.Panic(_: Interrupted)   => ()
+                case Result.Failure(_: Interrupted) => ()
+                case error: Result.Error[Any] =>
+                    import AllowUnsafe.embrace.danger
+                    sup.onFailure(error)
+                case _ => ()
+            }
+    end Supervisor
 
     /** Use an asynchronous computation running in a new Fiber, interrupting the fiber after usage.
       *

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -1,6 +1,7 @@
 package kyo
 
 import Fiber.Promise
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger as JAtomicInteger
 
 class FiberTest extends kyo.test.Test[Any]:
@@ -1240,6 +1241,167 @@ class FiberTest extends kyo.test.Test[Any]:
             yield
                 assert(!res)
                 assert(value == 42)
+        }
+    }
+
+    "supervisor" - {
+        final class Recorder extends Fiber.Supervisor:
+            val errors = new CopyOnWriteArrayList[Result.Error[Any]]()
+            def onFailure(error: Result.Error[Any])(using AllowUnsafe): Unit =
+                discard(errors.add(error))
+            def failures: List[Result.Error[Any]] =
+                import scala.jdk.CollectionConverters.*
+                errors.asScala.toList
+        end Recorder
+
+        val boom = new RuntimeException("boom")
+
+        "supervised" - {
+            "observes a scoped fiber's Abort failure" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        for
+                            fiber <- Fiber.init(Abort.fail(boom))
+                            _     <- fiber.getResult
+                        yield ()
+                    }
+                }.map { _ =>
+                    assert(sup.failures == List(Result.Failure(boom)))
+                }
+            }
+
+            "observes a panic" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        for
+                            // Sync.defer: the throw must happen INSIDE the running fiber (an eager
+                            // by-name throw would panic the spawning fiber instead).
+                            fiber <- Fiber.init(Sync.defer((throw boom): Unit))
+                            _     <- fiber.getResult
+                        yield ()
+                    }
+                }.map { _ =>
+                    assert(sup.failures == List(Result.Panic(boom)))
+                }
+            }
+
+            "interrupt does not notify" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        for
+                            fiber <- Fiber.init(Async.never)
+                            _     <- fiber.interrupt
+                            _     <- fiber.getResult.map(_ => ()).handle(Abort.run[Throwable](_))
+                        yield ()
+                    }
+                }.map { _ =>
+                    assert(sup.failures.isEmpty)
+                }
+            }
+
+            "scope-close interrupt does not notify" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        Fiber.init(Async.never).unit
+                    }
+                }.map { _ =>
+                    assert(sup.failures.isEmpty)
+                }
+            }
+
+            "an instantly-failed fiber still notifies (post-completion registration)" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        for
+                            fiber <- Fiber.init(Abort.fail(boom))
+                            _     <- fiber.getResult
+                        yield ()
+                    }
+                }.map { _ =>
+                    assert(sup.failures == List(Result.Failure(boom)))
+                }
+            }
+
+            "a nested scoped fork inherits the supervisor (grandchild failure notifies)" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        for
+                            outer <- Fiber.init {
+                                Scope.run {
+                                    Fiber.init(Abort.fail(boom)).map(_.getResult.unit)
+                                }
+                            }
+                            _ <- outer.getResult
+                        yield ()
+                    }
+                }.map { _ =>
+                    assert(sup.failures == List(Result.Failure(boom)))
+                }
+            }
+
+            "a successful fiber does not notify" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        Fiber.init(42).map(_.get).map(r => assert(r == 42))
+                    }
+                }.map { _ =>
+                    assert(sup.failures.isEmpty)
+                }
+            }
+
+            "a non-Throwable typed failure reaches the supervisor as Result.Failure" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        Fiber.init(Abort.fail("domain error")).map(_.getResult.unit)
+                    }
+                }.map { _ =>
+                    assert(sup.failures == List(Result.Failure("domain error")))
+                }
+            }
+        }
+
+        "opt-out" - {
+            "initUnscoped is not supervised" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    for
+                        fiber <- Fiber.initUnscoped(Abort.fail(boom))
+                        _     <- fiber.getResult
+                    yield ()
+                }.map { _ =>
+                    assert(sup.failures.isEmpty)
+                }
+            }
+
+            "Supervisor.none opts a subtree out" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Fiber.Supervisor.none {
+                        Scope.run {
+                            Fiber.init(Abort.fail(boom)).map(_.getResult.unit)
+                        }
+                    }
+                }.map { _ =>
+                    assert(sup.failures.isEmpty)
+                }
+            }
+        }
+
+        "no supervisor installed: init behaves identically (failure stays unobserved)" in {
+            Scope.run {
+                for
+                    fiber  <- Fiber.init(Abort.fail(boom))
+                    result <- fiber.getResult
+                yield assert(result == Result.Failure(boom))
+            }
         }
     }
 

--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -341,6 +341,43 @@ If you need both a signal-driven attribute AND a chainable element method, set t
 
 When you pass either a constant `String` or a `SignalRef[String]` to `.value`, the framework wraps it in `UI.Bound[String]`: `Const(v)` or `Ref(ref)`. You normally never name this type; it surfaces in AST pattern matching (see [Pattern-matching on UI](#pattern-matching-on-ui-ast-access)).
 
+## Effectful component mounts
+
+The reactive boundaries above re-render pure `UI` values as signals change. A component that must run an *effect* to produce its UI — load data, open a subscription, read an ambient service — needs more: a node that runs `UI < (Async & Scope)`, shows something while it is pending, and gives a failure somewhere to land. `UI.mounted` is that node.
+
+`UI.mounted(effect)` lifts an effectful component into the tree as an ordinary child. The effect runs when the node attaches, inside a `Scope` tied to the node's lifetime (torn down on detach), so resources it acquires are released when the node goes away; an `Abort[Throwable]` failure is caught into the node's error state instead of propagating. The builder tunes the surrounding behavior:
+
+| Modifier | Effect |
+| --- | --- |
+| `.keyed(k)` | Continuity anchor: the live instance (its `Scope`, resources, published content) is kept across re-renders of the enclosing reactive region while an equal key is re-emitted, and torn down when the key changes or disappears. Any `CanEqual` value works; the idiomatic key is the component's singleton object, tupled with the non-`Signal` inputs the effect closed over. |
+| `.placeholder(ui)` | Content painted while the effect is pending on first mount. Defaults to an empty node. |
+| `.onError(f)` | Renders a failed mount (an `Abort` failure or a panic); the failure is also logged. The enclosing region stays alive, and a later key change re-mounts cleanly. |
+| `.pending(KeepLatest \| Placeholder)` | Re-mount policy for a keyed node: `KeepLatest` (the default) keeps the last rendered content visible as an inert frozen snapshot — its nested regions and handlers are already torn down — until the new instance publishes; `Placeholder` drops back to the placeholder, the honest choice for interactive content where a frozen-but-visible form would swallow input. |
+
+```scala
+import UI.*
+import kyo.*
+
+def profileCard(userId: Int): UI < (Async & Scope) =
+    for name <- Signal.initRef("...")
+    yield div(h2(name), p(s"user #$userId"))
+
+val card: UI =
+    UI.mounted(profileCard(42))
+        .keyed(42)
+        .placeholder(div("loading..."))
+        .onError(e => div(s"failed: ${e.getMessage}"))
+        .pending(PendingPolicy.KeepLatest)
+```
+
+A value input that should UPDATE a live instance belongs in a `Signal` parameter, not the key; a non-`Signal` value the effect captures belongs IN the key, or it is silently frozen at mount time. A duplicate key under one region renders an inline error node in the second slot rather than silently sharing one instance.
+
+### Failure after the first paint
+
+A mount can also fail *after* it has already published its UI — a background fiber it forked (a data feed, a subscription) terminates with an error. Node-scope supervision covers that window: the engine installs a failure observer around the mounted effect, so a non-interrupt failure of any fiber it forked via the scoped `Fiber.init` flips the already-published node into the same error routing as an up-front failure — its `.onError`, then the enclosing `UI.boundary` chain, then a default error node. At most one flip happens per instance (first failure wins), and the flip *replaces* the node's content; a component that would rather keep its content and surface the error elsewhere routes that failure to a value or side channel (a toast) instead of letting the fiber fail, and an `.onError` render can offer a retry by swapping the node's key. A clean interrupt — including the one that tears the node down on a key change — is never a failure, and `Fiber.initUnscoped` opts a fire-and-forget fiber out of supervision entirely.
+
+`UI.boundary.fallback(spinner).onError { case e: DataError => card(e) }(subtree*)` (experimental) aggregates the pending state of the mounted descendants beneath it and supplies a shared error branch for any that carry no node-local `.onError`.
+
 ## Inputs and forms
 
 > **Note:** All input element factories (`UI.input`, `UI.textarea`, `UI.passwordInput`, `UI.emailInput`, `UI.telInput`, `UI.urlInput`, `UI.searchInput`, `UI.numberInput`, `UI.dateInput`, `UI.timeInput`, `UI.colorInput`, `UI.rangeInput`, `UI.fileInput`, `UI.hiddenInput`, `UI.checkbox`, `UI.radio`, `UI.dropdown`) are `Void` elements. They do not accept children; calling `.apply(children*)` on them is a compile error. Configure them through their setter methods only.

--- a/kyo-ui/js-wasm/src/main/scala/kyo/UIMount.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/UIMount.scala
@@ -12,6 +12,20 @@ extension (ui: UI.type)
     def runMount(u: UI, selector: String)(using Frame): Unit < (Async & Scope) =
         DomBackend.mount(u, selector)
 
+    /** Mount into the page body with a session HANDLER-ERROR POLICY: the app's one central decision what
+      * happens with an event-handler failure/panic nothing below consumed (e.g. surface it as a toast).
+      * The engine logs the error out-of-band either way and never stops the bubble chain. Handlers keep
+      * their local options: consume early (`Abort.recover`) or observe-and-bubble (`Abort.tap`).
+      */
+    def runMount(u: UI, onHandlerError: Throwable => Unit < Async)(using Frame): Unit < (Async & Scope) =
+        DomBackend.mount(u, onHandlerError)
+
+    /** [[runMount]] into a CSS selector with a session handler-error policy — see the overload above. */
+    def runMount(u: UI, selector: String, onHandlerError: Throwable => Unit < Async)(using
+        Frame
+    ): Unit < (Async & Scope) =
+        DomBackend.mount(u, selector, Present(onHandlerError))
+
     /** Injects a [[kyo.Stylesheet]] into the live document (`<head>` `<style>`), client-side.
       * JS-only. Idempotent: a second call with the same rendered CSS text is a no-op and does
       * not append duplicate rules. Reuses the existing kyo-ui document stylesheet (the same

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -10,14 +10,22 @@ private[kyo] object DomBackend:
 
     /** Mount a UI into the page body. */
     def mount(ui: UI)(using Frame): Unit < (Async & Scope) =
-        mountInto(ui, document.body)
+        mountInto(ui, document.body, Absent)
+
+    def mount(ui: UI, onHandlerError: Throwable => Unit < Async)(using Frame): Unit < (Async & Scope) =
+        mountInto(ui, document.body, Present(onHandlerError))
 
     /** Mount a UI into a specific DOM element selected by CSS selector. */
     def mount(ui: UI, selector: String)(using Frame): Unit < (Async & Scope) =
+        mount(ui, selector, Absent)
+
+    def mount(ui: UI, selector: String, onHandlerError: Maybe[Throwable => Unit < Async])(using
+        Frame
+    ): Unit < (Async & Scope) =
         Sync.defer {
             val target = document.querySelector(selector)
             if target == null then Abort.panic(UIException(s"Element not found: $selector"))
-            else mountInto(ui, target.asInstanceOf[dom.Element])
+            else mountInto(ui, target.asInstanceOf[dom.Element], onHandlerError)
         }
     end mount
 
@@ -34,10 +42,14 @@ private[kyo] object DomBackend:
     private[kyo] def injectStylesheet(sheet: Stylesheet)(using Frame): Unit < Sync =
         DomStyleSheet.injectBase().andThen(Sync.defer(DomStyleSheet.injectStylesheet(sheet.render)))
 
-    private def mountInto(ui: UI, container: dom.Element)(using Frame): Unit < (Async & Scope) =
+    private def mountInto(
+        ui: UI,
+        container: dom.Element,
+        onHandlerError: Maybe[Throwable => Unit < Async]
+    )(using Frame): Unit < (Async & Scope) =
         for
             _    <- DomStyleSheet.injectBase()
-            root <- ReactiveUI.normalize(ui, Seq.empty)
+            root <- ReactiveUI.normalize(ui, Seq.empty, onHandlerError = onHandlerError)
             html <- HtmlRenderer.render(ui, Seq.empty)
             _    <- Sync.defer(container.innerHTML = html)
             _    <- applyJsProps(container)

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -239,6 +239,115 @@ object UI:
     def when[C <: UI](condition: Signal[Boolean])(body: => C)(using Frame): Reactive[C] =
         Reactive[C](condition.map(v => if v then body else UI.empty))
 
+    /** What an already-rendered mounted node shows while it re-mounts (key change): keep the last rendered content visible as a
+      * frozen snapshot until the new effect publishes (`KeepLatest`, the default — note the snapshot is inert: its nested regions
+      * and handlers are torn down with the old Scope), or drop back to the placeholder (`Placeholder` — the honest loading window,
+      * right for interactive content where a frozen-but-visible form would swallow input).
+      */
+    enum PendingPolicy derives CanEqual:
+        case KeepLatest, Placeholder
+
+    /** Embeds an effectful component mount in a pure render tree: `effect` runs when the node attaches, inside a node-lifetime
+      * `Scope` (torn down on detach), with `Abort[Throwable]` caught into the node's error state. See [[kyo.UI.Ast.Mounted]] for
+      * the lifecycle/identity contract and the [[kyo.UI.MountedOps]] extensions (`keyed`, `placeholder`, `onError`, `pending`).
+      *
+      * '''Node-scope supervision.''' The node's error state is not limited to the mount phase: every fiber the effect forks via
+      * the scoped `Fiber.init` (directly or transitively — a data feed forked by a library the effect calls) is SUPERVISED. A
+      * non-interrupt terminal failure of such a fiber retroactively flips the ALREADY-PUBLISHED node into the same error routing
+      * a failed mount takes: node-local `.onError` render, else the enclosing [[UI.boundary]] chain (typed selection), else the
+      * default inline error. First failure wins (at most one flip per instance, shared with the effect-failure path); teardown
+      * interrupts are exempt; the node `Scope` stays open on a flip (sibling fibers keep running, exactly like a pending-phase
+      * failure). The flip REPLACES the node's content — an app that wants "keep the content, surface the error elsewhere" routes
+      * that failure to a value/side channel (e.g. a toast) instead of failing the fiber; an `.onError` render may offer retry by
+      * swapping the node's key (a key change mounts a fresh instance). Escape hatches: `Fiber.initUnscoped` for fire-and-forget
+      * fibers whose failure must NOT flip the node — and note the sharp edge: a fiber whose failure the effect observes and
+      * handles itself (`Abort.run(f.getResult)`) still reports to supervision if forked with the scoped `Fiber.init`; use
+      * `Fiber.use`/`initUnscoped` for those.
+      *
+      * Effect typing: `S` must be dischargeable across a fork boundary — the same `Isolate[S, Sync, S]` gate `Fiber.init` uses.
+      * Context effects (`Env`, `Local`) derive silently and resolve at run time from the renderer fiber's inherited context
+      * (all renderer fibers descend from the `runMount`/`serveSession` caller, so an `Env.runAll` at the root reaches every
+      * mount); stateful effects (`Var`, `Emit`) do not derive and must be handled before the node is constructed. The node
+      * stores the effect with `S` erased: the `Isolate` evidence is the compile-time gate, not a runtime strategy — an
+      * explicitly provided stateful isolate is NOT applied, and such an effect fails loudly at run time (missing handler).
+      */
+    def mounted[S](effect: UI < (Abort[Throwable] & Async & Scope & S))(using
+        frame: Frame,
+        isolate: Isolate[S, Sync, S]
+    ): Mounted =
+        discard(isolate)
+        Mounted(
+            effect.asInstanceOf[UI < (Abort[Throwable] & Async & Scope)],
+            key = Absent,
+            placeholderUI = Absent,
+            errorRender = Absent,
+            pendingPolicy = PendingPolicy.KeepLatest
+        )
+    end mounted
+
+    /** Entry point for [[kyo.UI.Ast.Boundary]] (EXPERIMENTAL): `UI.boundary.fallback(spinner).onError { case e: DataError =>
+      * card(e) }(subtree...)`. See the Boundary scaladoc for aggregation/reveal/error semantics.
+      */
+    def boundary: BoundaryBuilder = BoundaryBuilder(Absent, Absent)
+
+    final case class BoundaryBuilder private[kyo] (
+        fallbackUI: Maybe[UI],
+        errorPf: Maybe[PartialFunction[Throwable, UI]]
+    ):
+        /** Painted while mounted descendants that started under this boundary are pending. Default: empty. */
+        def fallback(ui: UI): BoundaryBuilder = copy(fallbackUI = Present(ui))
+
+        /** Typed error selection: renders the first matching error of a mounted descendant that has no
+          * node-local `.onError`; non-matching errors bubble to the next enclosing boundary, then to the
+          * node-local default.
+          */
+        def onError(pf: PartialFunction[Throwable, UI]): BoundaryBuilder = copy(errorPf = Present(pf))
+
+        def apply(children: Ast.HtmlChildVal*)(using Frame): Ast.Boundary =
+            val child = children.toList match
+                case single :: Nil => single.value
+                case many          => Ast.Fragment[UI](Chunk.from(many.map(_.value)))
+            Ast.Boundary(child, fallbackUI, errorPf)
+        end apply
+    end BoundaryBuilder
+
+    /** Builder-style modifiers for [[kyo.UI.Ast.Mounted]], following the attrs-API idiom. */
+    object MountedOps:
+        extension (m: Mounted)
+            /** Continuity anchor: a mounted node with a key keeps its live instance (Scope, resources, published content)
+              * across re-renders of its immediately enclosing reactive region while an equal key is re-emitted; the instance
+              * is torn down (closed and awaited) when the key changes or disappears. Any `CanEqual`-comparable value works —
+              * the idiomatic key is the component's singleton object (`.keyed(ScoreboardView)`), tupled with value inputs the
+              * effect closed over when identity depends on them (`.keyed(EraPanel -> era)`): changing inputs that should
+              * UPDATE the live instance belong in `Signal` parameters, not the key; non-Signal inputs the effect captures
+              * belong IN the key, or they are silently frozen at mount time.
+              */
+            def keyed(key: Any): Mounted =
+                given Frame = m.frame
+                m.copy(key = Present(key))
+
+            /** Content rendered while the effect is pending on FIRST mount (and on re-mount under `PendingPolicy.Placeholder`).
+              * Defaults to an empty node.
+              */
+            def placeholder(ui: UI): Mounted =
+                given Frame = m.frame
+                m.copy(placeholderUI = Present(ui))
+
+            /** Renders a failed mount (`Abort` failure or panic of the effect). Defaults to a minimal inline error node; the
+              * failure is additionally logged. The enclosing region stays alive; a subsequent key change re-mounts cleanly.
+              */
+            def onError(f: Throwable => UI): Mounted =
+                given Frame = m.frame
+                m.copy(errorRender = Present(f))
+
+            /** Re-mount pending policy — see [[kyo.UI.PendingPolicy]]. Default: `KeepLatest`. */
+            def pending(p: PendingPolicy): Mounted =
+                given Frame = m.frame
+                m.copy(pendingPolicy = p)
+        end extension
+    end MountedOps
+    export MountedOps.*
+
     /** Server-push: returns HTTP handlers (SSR page GET and a WebSocket route) for this UI at the given path. Compose with other handlers
       * via HttpServer.init.
       *
@@ -676,49 +785,85 @@ object UI:
 
         // ---- Interactive trait (event handlers + tabIndex) ----
 
-        /** Capability trait for elements that accept event handlers (`onClick`, `onKeyDown`, ...) and `tabIndex`/focus-group settings. */
+        /** Handler storage erasure: the setter's `Isolate[S, Sync, S]` gate proved `S` fork-safe (context effects
+          * only, in practice); storage drops `S` because the Attrs slots are `Any < Async` and the run-time context
+          * comes from the event-drain fiber's inherited Context, not from the type. Mirrors [[kyo.UI.mounted]]'s
+          * erased storage.
+          */
+        private def eraseHandler[S](v: Any < (Abort[Throwable] & Async & S)): Any < Async =
+            v.asInstanceOf[Any < Async]
+
+        private def eraseHandlerFn[A, S](f: A => Any < (Abort[Throwable] & Async & S)): A => Any < Async =
+            f.asInstanceOf[A => Any < Async]
+
+        /** Capability trait for elements that accept event handlers (`onClick`, `onKeyDown`, ...) and `tabIndex`/focus-group settings.
+          *
+          * Handler effect typing: every setter is effect-polymorphic in `S` behind the same `Isolate[S, Sync, S]` gate as
+          * [[kyo.UI.mounted]] — context effects (`Env`, `Local`) derive silently, stateful effects get the curated compile
+          * error. Handlers are stored with `S` erased and resolve their context at run time from the fiber that drains
+          * events (the browser backend's event-drain fiber descends from the `runMount` caller, so a root `Env.runAll`
+          * reaches every handler). Pure `Any < Async` handlers infer `S = Any` — fully source-compatible. NOTE: in the
+          * server-push transport (`runHandlers`), event dispatch runs on kyo-http session fibers, which do not currently
+          * inherit the `runHandlers` caller's context — the same known gap as mounted effects there.
+          */
         sealed trait Interactive extends Element:
             def tabIndex(v: Int): Self       = withAttrs(attrs.copy(tabIndex = Present(v)))
             def focusTrap(v: Boolean): Self  = withAttrs(attrs.copy(focusTrap = Present(v)))
             def focusGroup(id: String): Self = withAttrs(attrs.copy(focusGroup = Present(id)))
 
             /** Runs `action` on click, ignoring the event payload. */
-            def onClick(action: => Any < Async): Self = withAttrs(attrs.copy(onClick = Present(Sync.defer(action)(using frame))))
+            def onClick[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onClick = Present(eraseHandler(Sync.defer(action)(using frame)))))
 
             /** Runs `f` on click, receiving the [[kyo.UI.MouseEvent]] payload (target id, modifier chord). */
-            def onClick(f: MouseEvent => Any < Async): Self = withAttrs(attrs.copy(onClickEvt = Present(f)))
+            def onClick[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onClickEvt = Present(eraseHandlerFn(f))))
 
             /** Runs `action` only when the click lands on this element itself, not on a descendant; ignores the event payload. */
-            def onClickSelf(action: => Any < Async): Self = withAttrs(attrs.copy(onClickSelf = Present(Sync.defer(action)(using frame))))
+            def onClickSelf[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onClickSelf = Present(eraseHandler(Sync.defer(action)(using frame)))))
 
             /** Runs `f` only when the click lands on this element itself, not on a descendant; receives the [[kyo.UI.MouseEvent]] payload. */
-            def onClickSelf(f: MouseEvent => Any < Async): Self = withAttrs(attrs.copy(onClickSelfEvt = Present(f)))
+            def onClickSelf[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onClickSelfEvt = Present(eraseHandlerFn(f))))
 
             /** Runs `f` on key-down, receiving the [[kyo.UI.KeyboardEvent]] payload (typed key, modifier chord, target id). */
-            def onKeyDown(f: KeyboardEvent => Any < Async): Self = withAttrs(attrs.copy(onKeyDown = Present(f)))
-            def onKeyUp(f: KeyboardEvent => Any < Async): Self   = withAttrs(attrs.copy(onKeyUp = Present(f)))
-            def onFocus(action: => Any < Async): Self            = withAttrs(attrs.copy(onFocus = Present(Sync.defer(action)(using frame))))
-            def onFocus(f: MouseEvent => Any < Async): Self      = withAttrs(attrs.copy(onFocusEvt = Present(f)))
-            def onBlur(action: => Any < Async): Self             = withAttrs(attrs.copy(onBlur = Present(Sync.defer(action)(using frame))))
-            def onBlur(f: MouseEvent => Any < Async): Self       = withAttrs(attrs.copy(onBlurEvt = Present(f)))
+            def onKeyDown[S](f: KeyboardEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onKeyDown = Present(eraseHandlerFn(f))))
+            def onKeyUp[S](f: KeyboardEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onKeyUp = Present(eraseHandlerFn(f))))
+            def onFocus[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onFocus = Present(eraseHandler(Sync.defer(action)(using frame)))))
+            def onFocus[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onFocusEvt = Present(eraseHandlerFn(f))))
+            def onBlur[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onBlur = Present(eraseHandler(Sync.defer(action)(using frame)))))
+            def onBlur[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onBlurEvt = Present(eraseHandlerFn(f))))
 
             /** Runs `action` when the pointer enters this element. */
-            def onHover(action: => Any < Async): Self = withAttrs(attrs.copy(onHover = Present(Sync.defer(action)(using frame))))
+            def onHover[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onHover = Present(eraseHandler(Sync.defer(action)(using frame)))))
 
             /** Runs `f` when the pointer enters this element, receiving the [[kyo.UI.MouseEvent]] payload. */
-            def onHover(f: MouseEvent => Any < Async): Self = withAttrs(attrs.copy(onHoverEvt = Present(f)))
+            def onHover[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onHoverEvt = Present(eraseHandlerFn(f))))
 
             /** Runs `action` when the pointer leaves this element. */
-            def onUnhover(action: => Any < Async): Self = withAttrs(attrs.copy(onUnhover = Present(Sync.defer(action)(using frame))))
+            def onUnhover[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onUnhover = Present(eraseHandler(Sync.defer(action)(using frame)))))
 
             /** Runs `f` when the pointer leaves this element, receiving the [[kyo.UI.MouseEvent]] payload. */
-            def onUnhover(f: MouseEvent => Any < Async): Self = withAttrs(attrs.copy(onUnhoverEvt = Present(f)))
+            def onUnhover[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onUnhoverEvt = Present(eraseHandlerFn(f))))
 
             /** Runs `action` when the mouse wheel is used over this element. */
-            def onScroll(action: => Any < Async): Self = withAttrs(attrs.copy(onScroll = Present(Sync.defer(action)(using frame))))
+            def onScroll[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onScroll = Present(eraseHandler(Sync.defer(action)(using frame)))))
 
             /** Runs `f` when the mouse wheel is used over this element, receiving the [[kyo.UI.WheelEvent]] payload. */
-            def onScroll(f: WheelEvent => Any < Async): Self = withAttrs(attrs.copy(onScrollEvt = Present(f)))
+            def onScroll[S](f: WheelEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onScrollEvt = Present(eraseHandlerFn(f))))
         end Interactive
 
         // ---- Layout traits ----
@@ -989,6 +1134,47 @@ object UI:
 
         private[kyo] case class KeyedChild[C <: UI](key: String, child: UI)(using val frame: Frame) extends UI
 
+        /** An effectful component mount: a first-class AST node whose content is produced by an effect.
+          *
+          * The renderer runs `effect` when the node attaches, inside a node-lifetime `Scope` that is torn down when the node
+          * detaches; `placeholderUI` renders while the effect is pending (first mount), and a `Failure`/`Panic` of the effect
+          * renders through `errorRender` while the enclosing region stays alive. The effect must follow the same prompt-return
+          * contract as reactive regions: allocate and fork, never park — the node's Scope owns anything long-lived it forks.
+          *
+          * Identity is explicit: a node without a key is remounted (Scope closed and awaited, effect re-run) whenever its
+          * enclosing reactive region re-renders; a node with [[kyo.UI.MountedOps.keyed]] keeps its live instance (Scope,
+          * resources, published content) across re-renders of the immediately enclosing region for as long as a re-render
+          * emits a mounted node with an equal key, and is torn down when the key disappears or changes. Extends `HtmlContent`
+          * so it is accepted anywhere an HTML child is (the content-model of the effect's RESULT is the caller's contract).
+          *
+          * Stored effect: `S` from [[kyo.UI.mounted]] is erased here after the `Isolate` gate — see the constructor's note.
+          */
+        case class Mounted(
+            effect: UI < (Abort[Throwable] & Async & Scope),
+            key: Maybe[Any],
+            placeholderUI: Maybe[UI],
+            errorRender: Maybe[Throwable => UI],
+            pendingPolicy: UI.PendingPolicy
+        )(using val frame: Frame) extends UI with HtmlContent
+
+        /** A pending/error boundary over a subtree (EXPERIMENTAL): while any mounted descendant that started
+          * under this boundary is still pending, the boundary paints `fallbackUI` instead of `child` — the
+          * subtree is subscribed EAGERLY behind the fallback (all mount effects start immediately, in
+          * parallel; no waterfalls), and the child content is painted from current signal values once the
+          * pending count reaches zero. Reveal is once-only (Suspense semantics for first load): mounts that
+          * start after the reveal use their node-local placeholders.
+          *
+          * `errorPf` is the boundary's typed error selection: a mounted descendant's failure WITHOUT a
+          * node-local `.onError` is offered to the nearest enclosing boundary chain; the first boundary whose
+          * partial function is defined at the error renders it (replacing the boundary's whole content). An
+          * unmatched error falls back to the node-local default rendering and counts as settled.
+          */
+        case class Boundary(
+            child: UI,
+            fallbackUI: Maybe[UI],
+            errorPf: Maybe[PartialFunction[Throwable, UI]]
+        )(using val frame: Frame) extends UI with HtmlContent
+
         // ====== Block containers ======
 
         final case class Div(attrs: Attrs = Attrs(), children: Chunk[UI] = Chunk.empty)(using val frame: Frame) extends Block
@@ -1162,10 +1348,12 @@ object UI:
             def apply(cs: HtmlChildVal*): Form = copy(children = children ++ Chunk.from(cs.map(_.value)))
 
             /** Runs `action` on form submit, ignoring the event payload. */
-            def onSubmit(action: => Any < Async): Form = copy(onSubmit = Present(Sync.defer(action)(using frame)))
+            def onSubmit[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Form =
+                copy(onSubmit = Present(eraseHandler(Sync.defer(action)(using frame))))
 
             /** Runs `f` on form submit, receiving the [[kyo.UI.MouseEvent]] payload. */
-            def onSubmit(f: MouseEvent => Any < Async): Form = copy(onSubmitEvt = Present(f))
+            def onSubmit[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Form =
+                copy(onSubmitEvt = Present(eraseHandlerFn(f)))
         end Form
 
         final case class Textarea(

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -358,6 +358,15 @@ object UI:
     def runHandlers(basePath: String)(ui: => UI < Async)(using Frame): Seq[HttpHandler[?, ?, ?]] < Sync =
         UIServer.handlers(basePath)(ui)
 
+    /** [[runHandlers]] with a per-session handler-error policy: the server-push counterpart of the `runMount`
+      * overload. One central decision for an event-handler failure/panic nothing below consumed; logged
+      * out-of-band either way, and the bubble chain never stops.
+      */
+    def runHandlers(basePath: String, onHandlerError: Throwable => Unit < Async)(ui: => UI < Async)(using
+        Frame
+    ): Seq[HttpHandler[?, ?, ?]] < Sync =
+        UIServer.handlers(basePath, Present(onHandlerError))(ui)
+
     /** Scrolls the element with `id` into the client viewport, from inside an event handler.
       *
       * The command rides the session the handler runs in: under [[runHandlers]] it travels the same

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -209,6 +209,22 @@ private[kyo] object HtmlRenderer:
                             }.andThen(w(sb, s"</$tag>"))
                             end for
                 }
+
+            case m: Mounted =>
+                // Static/SSG projection of a mount is its placeholder; live, ReactiveUI.subscribeMounted patches
+                // the region when the node's cell publishes (synchronously, before paint, for an adopted keyed instance).
+                val tag = if svg then "g" else "span"
+                w(sb, s"""<$tag data-kyo-path="${pathAttr(path)}" data-kyo-reactive>""")
+                renderTo(sb, m.placeholderUI.getOrElse(UI.empty(using m.frame)), path, svg)
+                    .andThen(w(sb, s"</$tag>"))
+
+            case b: Boundary =>
+                // Static/SSG projection of a boundary is its fallback; live, ReactiveUI.subscribeBoundary repaints
+                // with the child on reveal (same task chain, when the eager child walk started nothing pending).
+                val tag = if svg then "g" else "span"
+                w(sb, s"""<$tag data-kyo-path="${pathAttr(path)}" data-kyo-reactive>""")
+                renderTo(sb, b.fallbackUI.getOrElse(UI.empty(using b.frame)), path, svg)
+                    .andThen(w(sb, s"</$tag>"))
     end renderTo
 
     private def renderTextareaValue(sb: StringBuilder, ta: Textarea)(using Frame): Unit < Sync =

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
@@ -89,7 +89,15 @@ end BoundaryCtx
   * observe's closed-and-awaited ordering makes unregister-then-reregister safe across region rebuilds), and read by
   * the dispatch-time handler of whatever fresh Mounted node value occupies the same path.
   */
-final private[kyo] class MountDispatch(cells: AtomicRef[Map[Seq[String], Signal[UI]]]):
+final private[kyo] class MountDispatch(
+    cells: AtomicRef[Map[Seq[String], Signal[UI]]],
+    /** The session's handler-error policy (installed at the transport entry, see [[ReactiveUI.normalize]]):
+      * invoked by `safeDispatch` for every handler failure/panic, AFTER the out-of-band log and WITHOUT
+      * stopping the bubble chain. Carried here because this table is the one session-level object every
+      * dispatch closure the normalization tree builds already closes over.
+      */
+    val onHandlerError: Maybe[Throwable => Unit < Async]
+):
     def register(path: Seq[String], cell: Signal[UI])(using Frame): Unit < Sync =
         cells.getAndUpdate(_.updated(path, cell)).unit
 
@@ -106,8 +114,8 @@ final private[kyo] class MountDispatch(cells: AtomicRef[Map[Seq[String], Signal[
 end MountDispatch
 
 private[kyo] object MountDispatch:
-    def init(using Frame): MountDispatch < Sync =
-        AtomicRef.init(Map.empty[Seq[String], Signal[UI]]).map(new MountDispatch(_))
+    def init(onHandlerError: Maybe[Throwable => Unit < Async] = Absent)(using Frame): MountDispatch < Sync =
+        AtomicRef.init(Map.empty[Seq[String], Signal[UI]]).map(new MountDispatch(_, onHandlerError))
 
 /** Normalization-time companion of a [[kyo.UI.Ast.Mounted]] node: the node plus its rendering defaults. */
 final private[kyo] case class MountedSpec(node: UI.Ast.Mounted):
@@ -150,10 +158,15 @@ private[kyo] object ReactiveUI:
       * (subscribe picks it up from there). All recursion goes through normalizeWith so every handler closure
       * shares the one table.
       */
-    def normalize(ui: UI, path: Seq[String], svg: Boolean = false): ReactiveUI < Sync =
+    def normalize(
+        ui: UI,
+        path: Seq[String],
+        svg: Boolean = false,
+        onHandlerError: Maybe[Throwable => Unit < Async] = Absent
+    ): ReactiveUI < Sync =
         given Frame = ui.frame
         for
-            mountDispatch <- MountDispatch.init
+            mountDispatch <- MountDispatch.init(onHandlerError)
             root          <- normalizeWith(ui, path, svg, mountDispatch)
         yield root.copy(mountDispatch = Present(mountDispatch))
         end for
@@ -315,7 +328,7 @@ private[kyo] object ReactiveUI:
                     val reactiveChildren = childWalks.flatMap(_._1)
                     val staticHandlers   = childWalks.flatMap(_._2)
                     val handle: Handler = (targetPath, event) =>
-                        dispatch(elem, basePath, targetPath, event, reactiveChildren, staticHandlers)
+                        dispatch(elem, basePath, targetPath, event, reactiveChildren, staticHandlers, mountDispatch.onHandlerError)
                     (reactiveChildren, handle)
                 end for
 
@@ -356,14 +369,17 @@ private[kyo] object ReactiveUI:
                 val noHandle: Handler = (_, _) => true
                 (Seq.empty[ReactiveUI], noHandle)
 
-    /** Dispatch an event through an element. */
+    /** Dispatch an event through an element. `onHandlerError` is the session's handler-error policy
+      * (threaded from the normalize root's [[MountDispatch]]), handed to [[safeDispatch]].
+      */
     private def dispatch(
         elem: Element,
         myPath: Seq[String],
         targetPath: Seq[String],
         event: UIEvent,
         reactiveChildren: Seq[ReactiveUI],
-        staticHandlers: Seq[(Int, Handler)]
+        staticHandlers: Seq[(Int, Handler)],
+        onHandlerError: Maybe[Throwable => Unit < Async]
     )(using Frame): Boolean < Async =
         if targetPath == myPath then
             dispatchToElement(elem, event, isTarget = true)
@@ -405,11 +421,13 @@ private[kyo] object ReactiveUI:
                 )
                 result <- Maybe.fromOption(staticChild) match
                     case Present(childHandle) =>
-                        safeDispatch(childHandle, targetPath, event).map(keep => if keep then bubble else false)
+                        safeDispatch(childHandle, targetPath, event, onHandlerError).map(keep => if keep then bubble else false)
                     case Absent =>
                         Maybe.fromOption(reactiveChild)
                             .fold(bubble)(child =>
-                                safeDispatch(child.handle, targetPath, event).map(keep => if keep then bubble else false)
+                                safeDispatch(child.handle, targetPath, event, onHandlerError).map(keep =>
+                                    if keep then bubble else false
+                                )
                             )
             yield result
             end for
@@ -424,18 +442,31 @@ private[kyo] object ReactiveUI:
     private def invokeWith[A](handler: Maybe[A => Any < Async], value: A)(using Frame): Unit < Async =
         if handler.isEmpty then () else handler.get(value).unit
 
-    /** Dispatch an event safely, logging and recovering from handler errors without stopping the bubble chain. */
-    private def safeDispatch(handle: (Seq[String], UIEvent) => Boolean < Async, path: Seq[String], event: UIEvent)(using
-        Frame
-    ): Boolean < Async =
+    /** Dispatch an event safely: handler errors are logged out-of-band, offered to the session's
+      * handler-error policy (`onHandlerError` — the app's central "what happens with action errors"
+      * decision, e.g. a toast), and never stop the bubble chain. A handler that wants a different
+      * fate for a failure consumes it itself (`Abort.recover`) before it reaches this seam; a
+      * handler that only wants to observe uses `Abort.tap` and lets it bubble here.
+      */
+    private def safeDispatch(
+        handle: (Seq[String], UIEvent) => Boolean < Async,
+        path: Seq[String],
+        event: UIEvent,
+        onHandlerError: Maybe[Throwable => Unit < Async]
+    )(using Frame): Boolean < Async =
+        def surface(err: Throwable): Unit < Async =
+            onHandlerError match
+                case Present(f) => f(err)
+                case Absent     => ()
         Abort.recover[Throwable](
             onFail = err =>
                 Log.error(s"Handler error during ${event.getClass.getSimpleName} at ${path.mkString(".")}: ${err.getMessage}")
-                    .andThen(true), // continue bubbling
+                    .andThen(surface(err)).andThen(true), // continue bubbling
             onPanic = thr =>
                 Log.error(s"Handler panic during ${event.getClass.getSimpleName} at ${path.mkString(".")}: ${thr.getMessage}")
-                    .andThen(true) // continue bubbling
+                    .andThen(surface(thr)).andThen(true) // continue bubbling
         )(handle(path, event))
+    end safeDispatch
 
     /** Read current checked value from Maybe[Bound[Boolean]]. */
     private def readChecked(checked: Maybe[Bound[Boolean]])(using Frame): Boolean < Sync =
@@ -762,7 +793,7 @@ private[kyo] object ReactiveUI:
             // Absent only for hand-built ReactiveUIs in tests; a normalize-produced root always carries the table.
             mountDispatch <- rui.mountDispatch match
                 case Present(d) => Kyo.lift(d)
-                case Absent     => MountDispatch.init
+                case Absent     => MountDispatch.init()
             _ <- subscribeScoped(rui, exchange, signalChangeTime, rootMounts, mountDispatch, Absent)
         yield Subscription(rui.handle, signalChangeTime)
 

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
@@ -11,8 +11,115 @@ private[kyo] case class ReactiveUI(
     isConst: Boolean,
     children: Seq[ReactiveUI],
     handle: (Seq[String], UIEvent) => Boolean < Async,
-    svgContext: Boolean = false
+    svgContext: Boolean = false,
+    mountedSpec: Maybe[MountedSpec] = Absent,
+    boundarySpec: Maybe[BoundarySpec] = Absent,
+    mountDispatch: Maybe[MountDispatch] = Absent // set on the ROOT normalize product only; see subscribe
 )
+
+/** Normalization-time companion of a [[kyo.UI.Ast.Boundary]] node. */
+final private[kyo] case class BoundarySpec(node: UI.Ast.Boundary):
+    def fallbackUI(using Frame): UI = node.fallbackUI.getOrElse(UI.empty)
+
+/** Live pending/error aggregation of one subscribed Boundary (see [[kyo.UI.Ast.Boundary]]).
+  *
+  * `enter` counts a mount that starts while the boundary is unrevealed; `exit` (on settle) reveals — paints
+  * the child from current signal values over the fallback — when the count reaches zero. Reveal is once-only
+  * and idempotent (settles racing the initial zero-check both funnel through the same getAndSet). Boundaries
+  * chain via `parentCtx`: `tryHandle` offers an unhandled mounted failure to the nearest boundary whose error
+  * partial function matches; a match paints the error at THAT boundary (and freezes its counting).
+  */
+final private[kyo] class BoundaryCtx(
+    path: Seq[String],
+    child: UI,
+    node: UI.Ast.Boundary,
+    exchange: UIExchange,
+    mountDispatch: MountDispatch,
+    pending: AtomicInt,
+    revealed: AtomicRef[Boolean],
+    parentCtx: Maybe[BoundaryCtx]
+):
+    /** Count a newly starting mount if this boundary has not revealed yet; returns whether it was counted. */
+    def enter(using Frame): Boolean < Sync =
+        revealed.get.map(r => if r then false else pending.incrementAndGet.andThen(true))
+
+    /** A counted mount settled; reveal when the count reaches zero. */
+    def exit(using Frame): Unit < Async =
+        pending.decrementAndGet.map(n => if n <= 0 then reveal else ())
+
+    /** Paint the child over the fallback, then re-push every live mount cell under this boundary (shallowest
+      * first): the static child render emits mounted nodes as PLACEHOLDER wrappers (the renderer cannot see
+      * subscribe-time cells), and the mounts' own regions already emitted their content while the fallback was
+      * up — against DOM that did not exist. The re-push replays each cell's current value into the freshly
+      * painted wrappers.
+      */
+    def reveal(using Frame): Unit < Async =
+        revealed.getAndSet(true).map { was =>
+            if was then ()
+            else
+                exchange.onChange(path, child).andThen {
+                    mountDispatch.snapshotUnder(path).map { entries =>
+                        Kyo.foreachDiscard(entries) { (p, cell) =>
+                            cell.current.map(ui => exchange.onChange(p, ui))
+                        }
+                    }
+                }
+        }
+
+    /** Offer an unhandled mounted failure to this boundary chain; a matching boundary paints the error over
+      * its whole content and stops counting. Returns whether some boundary handled it.
+      */
+    def tryHandle(t: Throwable)(using Frame): Boolean < Async =
+        node.errorPf match
+            case Present(pf) if pf.isDefinedAt(t) =>
+                revealed.getAndSet(true).map(_ => exchange.onChange(path, pf(t)).andThen(true))
+            case _ =>
+                parentCtx match
+                    case Present(p) => p.tryHandle(t)
+                    case Absent     => Kyo.lift(false)
+end BoundaryCtx
+
+/** Session-level dispatch table for mounted nodes: path → live content cell.
+  *
+  * Event dispatch re-derives handler chains from `signal.current` on every event, re-running any `Signal.map`
+  * lambdas on the way — so the Mounted node value (and any state carried on it or its normalize product) is FRESH
+  * per dispatch and cannot hold the subscribe-time wiring. The table is the stable meeting point: created once per
+  * normalize root (one per mount session), closed over by every handler the normalization tree builds, written by
+  * subscribeMounted (registration is Scope-bound: the per-value scope that subscribed a node unregisters it, and
+  * observe's closed-and-awaited ordering makes unregister-then-reregister safe across region rebuilds), and read by
+  * the dispatch-time handler of whatever fresh Mounted node value occupies the same path.
+  */
+final private[kyo] class MountDispatch(cells: AtomicRef[Map[Seq[String], Signal[UI]]]):
+    def register(path: Seq[String], cell: Signal[UI])(using Frame): Unit < Sync =
+        cells.getAndUpdate(_.updated(path, cell)).unit
+
+    /** Unregister only if `cell` is still the registered one — a successor that already re-registered wins. */
+    def unregister(path: Seq[String], cell: Signal[UI])(using Frame): Unit < Sync =
+        cells.getAndUpdate(m => if m.get(path).exists(_ eq cell) then m.removed(path) else m).unit
+
+    def lookup(path: Seq[String])(using Frame): Maybe[Signal[UI]] < Sync =
+        cells.get.map(m => Maybe.fromOption(m.get(path)))
+
+    /** All live mount cells at or under `prefix`, shallowest path first — the boundary reveal's re-push set. */
+    def snapshotUnder(prefix: Seq[String])(using Frame): Seq[(Seq[String], Signal[UI])] < Sync =
+        cells.get.map(_.toSeq.filter((p, _) => p.startsWith(prefix)).sortBy(_._1.length))
+end MountDispatch
+
+private[kyo] object MountDispatch:
+    def init(using Frame): MountDispatch < Sync =
+        AtomicRef.init(Map.empty[Seq[String], Signal[UI]]).map(new MountDispatch(_))
+
+/** Normalization-time companion of a [[kyo.UI.Ast.Mounted]] node: the node plus its rendering defaults. */
+final private[kyo] case class MountedSpec(node: UI.Ast.Mounted):
+    def placeholderUI(using Frame): UI = node.placeholderUI.getOrElse(UI.empty)
+
+    def errorUI(t: Throwable)(using Frame): UI =
+        node.errorRender match
+            case Present(f) => f(t)
+            case Absent =>
+                given Frame = node.frame
+                UI.span(UI.Ast.Text(Option(t.getMessage).getOrElse(t.toString))).cssClass("kyo-mount-error")
+end MountedSpec
 
 private[kyo] object ReactiveUI:
 
@@ -39,18 +146,31 @@ private[kyo] object ReactiveUI:
                 if acc.nonEmpty then acc else findNode(child, path)
             }
 
+    /** Root entry point: creates the session's MountDispatch table and stamps it on the returned root node
+      * (subscribe picks it up from there). All recursion goes through normalizeWith so every handler closure
+      * shares the one table.
+      */
     def normalize(ui: UI, path: Seq[String], svg: Boolean = false): ReactiveUI < Sync =
+        given Frame = ui.frame
+        for
+            mountDispatch <- MountDispatch.init
+            root          <- normalizeWith(ui, path, svg, mountDispatch)
+        yield root.copy(mountDispatch = Present(mountDispatch))
+        end for
+    end normalize
+
+    private def normalizeWith(ui: UI, path: Seq[String], svg: Boolean, mountDispatch: MountDispatch): ReactiveUI < Sync =
         given Frame = ui.frame
         ui match
             case ui: Reactive[?] =>
                 for
                     current   <- ui.signal.current
-                    (kids, _) <- walkStatic(current, path, svg)
+                    (kids, _) <- walkStatic(current, path, svg, mountDispatch)
                 yield init(path, ui.signal, isConst = false, kids, svgContext = svg) {
                     (targetPath, event) =>
                         for
                             currentUI     <- ui.signal.current
-                            (_, freshHdl) <- walkStatic(currentUI, path, svg)
+                            (_, freshHdl) <- walkStatic(currentUI, path, svg, mountDispatch)
                             result        <- freshHdl(targetPath, event)
                         yield result
                 }
@@ -67,12 +187,12 @@ private[kyo] object ReactiveUI:
                     }
                 for
                     current   <- sig.current
-                    (kids, _) <- walkStatic(current, path, svg)
+                    (kids, _) <- walkStatic(current, path, svg, mountDispatch)
                 yield init(path, sig, isConst = false, kids, svgContext = svg) {
                     (targetPath, event) =>
                         for
                             currentUI     <- sig.current
-                            (_, freshHdl) <- walkStatic(currentUI, path, svg)
+                            (_, freshHdl) <- walkStatic(currentUI, path, svg, mountDispatch)
                             result        <- freshHdl(targetPath, event)
                         yield result
                 }
@@ -90,18 +210,59 @@ private[kyo] object ReactiveUI:
                 // re-renders without the value-dedup ever suppressing a real edit. An element with no bound ref is const.
                 val (elementSignal, isConstNode) =
                     collectSignalRef(ui).fold((Signal.initConst(ui: UI), true))(ref => (ref.map(_ => ui: UI), false))
-                for (kids, hdl) <- walkStatic(ui, path, svg)
+                for (kids, hdl) <- walkStatic(ui, path, svg, mountDispatch)
                 yield ReactiveUI(path, elementSignal, isConst = isConstNode, kids, hdl, svgContext = svg)
+
+            case ui: Mounted =>
+                // The handler resolves through the MountDispatch TABLE (by path), not the node: dispatch re-normalizes
+                // a fresh node value per event, so no live wiring can ride the node. The stored signal is a placeholder
+                // constant the subscribe path never observes (subscribeScoped branches on mountedSpec first).
+                val spec = MountedSpec(ui)
+                val handle: Handler = (targetPath, event) =>
+                    mountDispatch.lookup(path).map {
+                        case Present(cell) =>
+                            for
+                                currentUI     <- cell.current
+                                (_, freshHdl) <- walkStatic(currentUI, path, svg, mountDispatch)
+                                result        <- freshHdl(targetPath, event)
+                            yield result
+                        case Absent => (true: Boolean) // not (or no longer) wired: bubble
+                    }
+                ReactiveUI(
+                    path,
+                    Signal.initConst(spec.placeholderUI),
+                    isConst = false,
+                    Seq.empty,
+                    handle,
+                    svgContext = svg,
+                    mountedSpec = Present(spec)
+                )
+
+            case ui: Boundary =>
+                // The reactive children are the CHILD's (they subscribe eagerly behind the fallback); the stored
+                // signal is a constant and reveal is driven by BoundaryCtx, not by it. Dispatch resolves through the
+                // child value (events can only originate from painted DOM, so pre-reveal there is nothing to hit).
+                val spec = BoundarySpec(ui)
+                for (kids, hdl) <- walkStatic(ui.child, path, svg, mountDispatch)
+                yield ReactiveUI(
+                    path,
+                    Signal.initConst(ui.child),
+                    isConst = false,
+                    kids,
+                    hdl,
+                    svgContext = svg,
+                    boundarySpec = Present(spec)
+                )
 
             case ui =>
                 // Catch-all for static leaf nodes: Text, Fragment, KeyedChild.
                 // All interactive types extend Element (handled above) and all reactive types are
-                // Reactive or Foreach (also handled above). If a new UI subtype is added, the
-                // exhaustiveness checker will NOT warn here; any new type that is interactive must
+                // Reactive, Foreach, Mounted, or Boundary (also handled above). If a new UI subtype is added,
+                // the exhaustiveness checker will NOT warn here; any new type that is interactive must
                 // be added as an explicit case above before this catch-all.
                 ReactiveUI(path, Signal.initConst(ui), isConst = true, Seq.empty, (_, _) => true, svgContext = svg)
         end match
-    end normalize
+    end normalizeWith
 
     /** Returns the element's single SignalRef-bound attribute (its `.value` or `.checked`), if any, so the element can be made reactive over
       * it (its HTML re-renders when that signal changes). An element binds at most one such ref.
@@ -123,7 +284,9 @@ private[kyo] object ReactiveUI:
     private type Handler = (Seq[String], UIEvent) => Boolean < Async
 
     /** Walk a static UI tree. Collect reactive children, build handle. */
-    private def walkStatic(ui: UI, basePath: Seq[String], svg: Boolean = false)(using Frame): (Seq[ReactiveUI], Handler) < Sync =
+    private def walkStatic(ui: UI, basePath: Seq[String], svg: Boolean, mountDispatch: MountDispatch)(using
+        Frame
+    ): (Seq[ReactiveUI], Handler) < Sync =
         ui match
             case elem: Element =>
                 // ForeignObject bridges back to HTML, so reset svg context to false. It MUST be matched
@@ -135,16 +298,16 @@ private[kyo] object ReactiveUI:
                 for childWalks <- Kyo.foreach(elem.children.toSeq.zipWithIndex) { (child, i) =>
                         val childPath = basePath :+ i.toString
                         child match
-                            case _: Reactive[?] | _: Foreach[?, ?] =>
-                                for rui <- normalize(child, childPath, childSvg)
+                            case _: Reactive[?] | _: Foreach[?, ?] | _: Mounted | _: Boundary =>
+                                for rui <- normalizeWith(child, childPath, childSvg, mountDispatch)
                                 yield (Seq(rui), Seq.empty[(Int, Handler)])
                             case childElem: Element if collectSignalRef(childElem).nonEmpty =>
                                 // Element with SignalRef-bound attributes is reactive over those signals;
                                 // normalize it so subscribeNode wires updates.
-                                for rui <- normalize(childElem, childPath, childSvg)
+                                for rui <- normalizeWith(childElem, childPath, childSvg, mountDispatch)
                                 yield (Seq(rui), Seq.empty[(Int, Handler)])
                             case _ =>
-                                for (innerKids, innerHandle) <- walkStatic(child, childPath, childSvg)
+                                for (innerKids, innerHandle) <- walkStatic(child, childPath, childSvg, mountDispatch)
                                 yield (innerKids, Seq((i, innerHandle)))
                         end match
                     }
@@ -164,7 +327,7 @@ private[kyo] object ReactiveUI:
                         val inner = child match
                             case kc: KeyedChild[?] => kc.child
                             case _                 => child
-                        walkStatic(inner, childPath, svg)
+                        walkStatic(inner, childPath, svg, mountDispatch)
                     }
                 yield
                     val allKids    = childWalks.flatMap(_._1)
@@ -181,12 +344,12 @@ private[kyo] object ReactiveUI:
                         else true
                     (allKids, handle)
 
-            case _: Reactive[?] | _: Foreach[?, ?] =>
-                // When walkStatic is called with a Reactive or Foreach as the top-level node
+            case _: Reactive[?] | _: Foreach[?, ?] | _: Mounted | _: Boundary =>
+                // When walkStatic is called with a Reactive, Foreach, or Mounted as the top-level node
                 // (not as a child of an Element), normalize it at basePath so subscribeNode
                 // sets up a subscription for it. This handles the case where an outer reactive's
                 // signal value is itself a Reactive or Foreach (e.g. outer.map { _ => inner.map(UI.span(_)) }).
-                for rui <- normalize(ui, basePath, svg)
+                for rui <- normalizeWith(ui, basePath, svg, mountDispatch)
                 yield (Seq(rui), rui.handle)
 
             case _ =>
@@ -213,6 +376,11 @@ private[kyo] object ReactiveUI:
             // multiple levels deep; their last segment may collide with a sibling's index at the
             // current level. Using prefix-match correctly routes only when the target lies inside.
             val reactiveChild = reactiveChildren.find(rc => targetPath.startsWith(rc.path))
+            // STATIC descent takes precedence: route through the static child's handler chain so intermediate bubble
+            // handlers run. Jumping straight to a DEEP reactive child would skip them — a click on a reactive label
+            // inside a button (`button(labelSignal)`) would bypass the button's own onClick. Only a DIRECT reactive
+            // child (no staticHandlers entry at its index) takes the reactive jump.
+            val staticChild = childIdx.flatMap(i => staticHandlers.find(_._1 == i).map(_._2))
 
             for
                 // Disabled-target (Form submit suppression), Button-target (only Button clicks submit
@@ -235,13 +403,13 @@ private[kyo] object ReactiveUI:
                     submitOrigin = targetIsButton,
                     selectTarget = targetIsSelect
                 )
-                result <- Maybe.fromOption(reactiveChild) match
-                    case Present(child) =>
-                        safeDispatch(child.handle, targetPath, event).map(keep => if keep then bubble else false)
+                result <- Maybe.fromOption(staticChild) match
+                    case Present(childHandle) =>
+                        safeDispatch(childHandle, targetPath, event).map(keep => if keep then bubble else false)
                     case Absent =>
-                        Maybe.fromOption(childIdx).flatMap(i => Maybe.fromOption(staticHandlers.find(_._1 == i)).map(_._2))
-                            .fold(bubble)(childHandle =>
-                                safeDispatch(childHandle, targetPath, event).map(keep => if keep then bubble else false)
+                        Maybe.fromOption(reactiveChild)
+                            .fold(bubble)(child =>
+                                safeDispatch(child.handle, targetPath, event).map(keep => if keep then bubble else false)
                             )
             yield result
             end for
@@ -379,6 +547,13 @@ private[kyo] object ReactiveUI:
             // Text and RawHtml are leaf content with no kyo-addressable Element children, so no event
             // target can resolve through them: neither can satisfy an Element predicate.
             case _: Text | _: RawHtml => false
+            // Predicates do not resolve THROUGH a mount boundary — the content lives behind a subscribe-time cell this
+            // static resolver cannot reach (v1 limitation: a Button in a mounted subtree does not trigger an OUTER
+            // Form's submit-on-bubble refinement). Event dispatch still resolves via the node's handler indirection.
+            case _: Mounted => false
+            // A Boundary's child occupies the boundary's own path (like a Reactive's content).
+            case b: Boundary =>
+                targetSatisfies(b.child, nodePath, targetPath, predicate)
 
     private def isTargetDisabled(elem: Element, myPath: Seq[String], targetPath: Seq[String])(using Frame): Boolean < Sync =
         targetSatisfies(elem, myPath, targetPath, isDisabled)
@@ -582,7 +757,13 @@ private[kyo] object ReactiveUI:
     def subscribe(rui: ReactiveUI, exchange: UIExchange)(using Frame): Subscription < (Async & Scope) =
         for
             signalChangeTime <- AtomicRef.init(Instant.Epoch)
-            _                <- subscribeScoped(rui, exchange, signalChangeTime)
+            rootMounts       <- MountRegistry.init
+            _                <- Scope.ensure(rootMounts.evictAll)
+            // Absent only for hand-built ReactiveUIs in tests; a normalize-produced root always carries the table.
+            mountDispatch <- rui.mountDispatch match
+                case Present(d) => Kyo.lift(d)
+                case Absent     => MountDispatch.init
+            _ <- subscribeScoped(rui, exchange, signalChangeTime, rootMounts, mountDispatch, Absent)
         yield Subscription(rui.handle, signalChangeTime)
 
     // Each reactive region forks a Fiber.init (scoped to the enclosing Scope) running observe. Each
@@ -592,42 +773,500 @@ private[kyo] object ReactiveUI:
     // interrupt-old bookkeeping (a ref of live child fibers, interrupted one level per change) is gone; the
     // per-value Scope does interrupt-old transitively (every descendant), fixing the climbing-waiters leak the
     // one-level interrupt left.
-    private def subscribeScoped(rui: ReactiveUI, exchange: UIExchange, signalChangeTime: AtomicRef[Instant])(using
+    //
+    // `mounts` is the MountRegistry of the nearest enclosing region (or the subscribe root): keyed Mounted instances
+    // escape the per-value cascade by living on fibers the registry owns, so keyed continuity spans re-renders of the
+    // immediately enclosing region and ends with that region.
+    private def subscribeScoped(
+        rui: ReactiveUI,
+        exchange: UIExchange,
+        signalChangeTime: AtomicRef[Instant],
+        mounts: MountRegistry,
+        mountDispatch: MountDispatch,
+        boundary: Maybe[BoundaryCtx]
+    )(using
         Frame
     ): Unit < (Async & Scope) =
-        if rui.isConst then
-            Kyo.foreachDiscard(rui.children)(subscribeScoped(_, exchange, signalChangeTime))
-        else
-            // Per-value setup, run inside each value's fresh Scope: render the region and fork its children into
-            // that scope, so the next value (or an interrupt) tears them down by cascade.
-            def renderValue(current: UI): Unit < (Async & Scope) =
-                for
-                    now          <- Clock.now
-                    _            <- signalChangeTime.set(now)
-                    _            <- exchange.onChange(rui.path, current)
-                    (newKids, _) <- walkStatic(current, rui.path, rui.svgContext)
-                    _            <- Kyo.foreachDiscard(newKids)(subscribeScoped(_, exchange, signalChangeTime))
-                yield ()
-            // Every region observes with observe: each value owns a fresh per-value Scope (renderValue forks its
-            // children into it), held open until the next change, then closed by cascade. SignalRef-bound element
-            // regions (normalize maps the bound leaf to the constant `ui`) ride the SignalRef's exact register-before-
-            // read observe: each ref edit is a distinct ref value that re-renders the region, with no deferred
-            // next-capture, no repair timer, and no idle re-render churn (an unchanged input never re-emits).
-            Fiber.init {
+        rui.mountedSpec match
+            case Present(spec) =>
+                subscribeMounted(rui, spec, exchange, signalChangeTime, mounts, mountDispatch, boundary)
+            case Absent =>
+                rui.boundarySpec match
+                    case Present(spec) =>
+                        subscribeBoundary(rui, spec, exchange, signalChangeTime, mounts, mountDispatch, boundary)
+                    case Absent =>
+                        if rui.isConst then
+                            Kyo.foreachDiscard(rui.children)(
+                                subscribeScoped(_, exchange, signalChangeTime, mounts, mountDispatch, boundary)
+                            )
+                        else
+                            subscribeRegion(
+                                rui.path,
+                                rui.signal,
+                                rui.svgContext,
+                                exchange,
+                                signalChangeTime,
+                                Absent,
+                                mountDispatch,
+                                boundary
+                            )
+
+    /** Subscribe one Boundary node: create its live context (chained to any enclosing boundary), subscribe the
+      * child's reactive kids EAGERLY into the current scope — all mount effects below start immediately, in
+      * parallel, while the painted DOM still shows the fallback (their region patches no-op against absent DOM
+      * until the reveal repaints the boundary from current signal values). If the eager walk started nothing
+      * pending, reveal right away — still within the same task chain as the enclosing paint, so a boundary
+      * without async mounts never flashes its fallback.
+      */
+    private def subscribeBoundary(
+        rui: ReactiveUI,
+        spec: BoundarySpec,
+        exchange: UIExchange,
+        signalChangeTime: AtomicRef[Instant],
+        mounts: MountRegistry,
+        mountDispatch: MountDispatch,
+        parent: Maybe[BoundaryCtx]
+    )(using Frame): Unit < (Async & Scope) =
+        for
+            pending  <- AtomicInt.init(0)
+            revealed <- AtomicRef.init(false)
+            ctx = new BoundaryCtx(rui.path, spec.node.child, spec.node, exchange, mountDispatch, pending, revealed, parent)
+            _ <- Kyo.foreachDiscard(rui.children)(
+                subscribeScoped(_, exchange, signalChangeTime, mounts, mountDispatch, Present(ctx))
+            )
+            n <- pending.get
+            _ <- if n == 0 then ctx.reveal else Kyo.unit
+        yield ()
+
+    /** Fork one region fiber observing `signal`, with a per-value Scope per emission (see subscribeScoped's
+      * contract note). `presetMounts` supplies the region's MountRegistry when the caller owns it already (the
+      * content region of a KEYED mounted instance reuses the instance's registry so nested keyed mounts survive
+      * re-subscription); `Absent` creates a fresh registry owned by the current scope — the same scope that owns
+      * the region fiber, so registry and region die together.
+      *
+      * renderValue ordering is walk → evict → paint → subscribe: mount keys of the new value are known after the
+      * walk, so instances whose key vanished (or was swapped) are closed AND awaited BEFORE the new HTML paints
+      * and before any successor effect runs — the region-level closed-and-awaited guarantee, extended to the
+      * keyed instances that deliberately escape the per-value cascade.
+      */
+    private def subscribeRegion(
+        path: Seq[String],
+        signal: Signal[UI],
+        svg: Boolean,
+        exchange: UIExchange,
+        signalChangeTime: AtomicRef[Instant],
+        presetMounts: Maybe[MountRegistry],
+        mountDispatch: MountDispatch,
+        boundary: Maybe[BoundaryCtx]
+    )(using Frame): Unit < (Async & Scope) =
+        for
+            regionMounts <- presetMounts match
+                case Present(r) => Kyo.lift(r)
+                case Absent     => MountRegistry.init.map(r => Scope.ensure(r.evictAll).andThen(r))
+            _ <- Fiber.init {
+                def renderValue(current: UI): Unit < (Async & Scope) =
+                    for
+                        now          <- Clock.now
+                        _            <- signalChangeTime.set(now)
+                        (newKids, _) <- walkStatic(current, path, svg, mountDispatch)
+                        _            <- regionMounts.evictExcept(collectMountKeys(newKids))
+                        _            <- exchange.onChange(path, current)
+                        _ <- Kyo.foreachDiscard(newKids)(
+                            subscribeScoped(_, exchange, signalChangeTime, regionMounts, mountDispatch, boundary)
+                        )
+                    yield ()
                 Abort.run[Throwable] {
-                    rui.signal.observe(renderValue)
+                    signal.observe(renderValue)
                 }.map { result =>
                     result.fold(
                         _ => (),
-                        err => Log.error(s"Reactive subscription fiber failed at path=${rui.path.mkString(".")}", err),
+                        err => Log.error(s"Reactive subscription fiber failed at path=${path.mkString(".")}", err),
                         panic =>
                             if panic.isInstanceOf[Interrupted] then ()
-                            else Log.error(s"Reactive subscription fiber failed at path=${rui.path.mkString(".")}", panic)
+                            else Log.error(s"Reactive subscription fiber failed at path=${path.mkString(".")}", panic)
                     )
                 }
+            }
+        yield ()
+
+    /** The keys of the Mounted nodes among a walk's reactive children — the claims of the upcoming subscribe
+      * pass, computed up front so evictExcept can run before paint. Recurses through Boundary nodes: their
+      * mounted descendants claim on the SAME enclosing region registry (a boundary is a paint gate, not a
+      * region), so their keys must count as kept.
+      */
+    private def collectMountKeys(kids: Seq[ReactiveUI]): Set[Any] =
+        kids.flatMap { k =>
+            k.mountedSpec.flatMap(_.node.key).toList
+                ++ (if k.boundarySpec.nonEmpty then collectMountKeys(k.children) else Nil)
+        }.toSet
+
+    /** Subscribe one Mounted node.
+      *
+      * KEYED: claim (or adopt) the live instance from the enclosing region's registry — the instance runner is an
+      * UNSCOPED fiber (it survives the per-value cascade; the registry's owner scope ends it) holding the node
+      * Scope open; then push one synchronous paint of the cell's current content (so an adopted instance's content
+      * replaces the placeholder the parent's wholesale re-render just painted, within the same task — no visible
+      * placeholder blink), and finally subscribe the content region over the cell, reusing the instance's child
+      * registry so keyed mounts NESTED in the content survive as long as this instance does.
+      *
+      * KEYLESS: the instance lifetime IS the current scope (the enclosing region's per-value scope, or the
+      * session scope for a static position): the effect runs on a normally-scoped fiber and the next parent
+      * emission tears it down by cascade — remount semantics. A thrash note counts remounts per path and logs a
+      * dev hint when a keyless node keeps remounting inside a hot region.
+      */
+    private def subscribeMounted(
+        rui: ReactiveUI,
+        spec: MountedSpec,
+        exchange: UIExchange,
+        signalChangeTime: AtomicRef[Instant],
+        mounts: MountRegistry,
+        mountDispatch: MountDispatch,
+        boundary: Maybe[BoundaryCtx]
+    )(using Frame): Unit < (Async & Scope) =
+        spec.node.key match
+            case Present(key) =>
+                mounts.claim(key, rui.path, spec, boundary).map {
+                    case Present(inst) =>
+                        for
+                            _       <- mountDispatch.register(rui.path, inst.cell)
+                            _       <- Scope.ensure(mountDispatch.unregister(rui.path, inst.cell))
+                            current <- inst.cell.current
+                            _       <- exchange.onChange(rui.path, current)
+                            _ <- subscribeRegion(
+                                rui.path,
+                                inst.cell,
+                                rui.svgContext,
+                                exchange,
+                                signalChangeTime,
+                                Present(inst.childMounts),
+                                mountDispatch,
+                                boundary
+                            )
+                        yield ()
+                    case Absent =>
+                        // Duplicate key this render pass (claim already warned): paint a loud inline error instead of
+                        // silently sharing the first slot's instance. No cell/dispatch/boundary entry — a dead slot
+                        // (boundary counting happens only at instance creation) until the caller gives distinct keys.
+                        given Frame = spec.node.frame
+                        exchange
+                            .onChange(
+                                rui.path,
+                                UI.span(UI.Ast.Text(s"kyo-ui: duplicate mounted key '$key'")).cssClass("kyo-mount-error")
+                            )
+                            .unit
+                }
+            case Absent =>
+                for
+                    _          <- mounts.noteKeylessRemount(rui.path)
+                    seed       <- mounts.keepLatestSeed(rui.path, spec)
+                    cell       <- Signal.initRef[UI](seed)
+                    _          <- mountDispatch.register(rui.path, cell)
+                    _          <- Scope.ensure(mountDispatch.unregister(rui.path, cell))
+                    settleOnce <- boundarySettle(boundary)
+                    // If the per-value scope tears this instance down before its effect publishes, the ensure
+                    // still balances the boundary count (the boundary would otherwise wait forever).
+                    _           <- Scope.ensure(settleOnce.run)
+                    supervision <- MountSupervision.init
+                    _ <- Fiber.init(runMountEffect(
+                        spec,
+                        cell,
+                        ui => mounts.recordContent(rui.path, ui),
+                        boundary,
+                        settleOnce.run,
+                        supervision
+                    ))
+                    _ <- subscribeRegion(rui.path, cell, rui.svgContext, exchange, signalChangeTime, Absent, mountDispatch, boundary)
+                yield ()
+
+    /** Once-only settle of a counted boundary entry — invocable from both the publish path and a teardown
+      * ensure without double-exit (kyo's auto-flattening map cannot carry an effect as a VALUE, hence the
+      * wrapper class; `run` builds a fresh effect per call, all funneling through the same once-guard).
+      */
+    final private[kyo] class SettleOnce(action: Maybe[(BoundaryCtx, AtomicRef[Boolean])]):
+        def run(using Frame): Unit < Async =
+            action match
+                case Present((ctx, settled)) =>
+                    settled.getAndSet(true).map(was => if was then () else ctx.exit)
+                case Absent => ()
+    end SettleOnce
+
+    /** Enter the enclosing boundary (if any) for a starting mount and return its once-only settle handle. */
+    private def boundarySettle(boundary: Maybe[BoundaryCtx])(using Frame): SettleOnce < Sync =
+        boundary match
+            case Absent => Kyo.lift(new SettleOnce(Absent))
+            case Present(ctx) =>
+                ctx.enter.map { counted =>
+                    if !counted then new SettleOnce(Absent)
+                    else AtomicRef.init(false).map(ref => new SettleOnce(Present((ctx, ref))))
+                }
+
+    /** A supervised background fiber of a mounted node failed with a non-Throwable `Abort` value; the node's
+      * error rendering needs a Throwable, so the value is carried in this wrapper.
+      */
+    final private[kyo] case class MountFiberFailure(value: Any)(using Frame)
+        extends KyoException(s"Mounted background fiber failed: $value")
+
+    /** The node-scope supervision seam of one mount instance: collects the FIRST non-interrupt failure of any
+      * supervised background fiber (see [[Fiber.Supervisor]]) and lets the node runner park on it AFTER the
+      * effect outcome — flipping an already-published node into its error rendering retroactively.
+      *
+      * Publish→flip is serialized on the node's own fiber (the park runs after [[runMountEffect]]'s outcome
+      * handling), so a supervised failure can never be overwritten by a late `cell.set(ui)` of the success
+      * path. The `routed` once-guard is shared between the effect-failure path and the park, so an effect
+      * failure racing a supervised failure routes exactly once.
+      */
+    final private[kyo] class MountSupervision(
+        firstFailure: Fiber.Promise.Unsafe[Throwable, Any],
+        routed: AtomicRef[Boolean]
+    ):
+        /** Installed around the USER effect only (engine fibers never see it): maps the fiber error to a
+          * Throwable and completes the once-only failure promise; later failures are dropped by the promise.
+          */
+        val supervisor: Fiber.Supervisor = new Fiber.Supervisor:
+            def onFailure(error: Result.Error[Any])(using AllowUnsafe): Unit =
+                val t = error match
+                    case failure: Result.Failure[Any] =>
+                        failure.failure match
+                            case t: Throwable => t
+                            case other        => MountFiberFailure(other)(using Frame.internal)
+                    case panic: Result.Panic => panic.exception
+                discard(firstFailure.complete(Result.succeed(t)))
+            end onFailure
+
+        /** Route a failure through `route` at most once across effect-fail and supervised-fail paths. */
+        def routeOnce(t: Throwable)(route: Throwable => Unit < Async)(using Frame): Unit < Async =
+            routed.getAndSet(true).map(was => if was then () else route(t))
+
+        /** Park the node fiber until a supervised failure arrives, then log + route it. Never returns — the
+          * park (interrupted on teardown) is what holds the node Scope open for the instance's lifetime.
+          */
+        def park(spec: MountedSpec, route: Throwable => Unit < Async)(using Frame): Nothing < Async =
+            firstFailure.safe.get.map { t =>
+                Log.error(s"Mounted background fiber failed (frame=${spec.node.frame.position.show})", t)
+                    .andThen(routeOnce(t)(route))
+            }.andThen(Async.never)
+    end MountSupervision
+
+    private[kyo] object MountSupervision:
+        def init(using Frame): MountSupervision < Sync =
+            AtomicRef.init(false).map { routed =>
+                Sync.Unsafe.defer {
+                    new MountSupervision(Fiber.Promise.Unsafe.init[Throwable, Any](), routed)
+                }
+            }
+    end MountSupervision
+
+    /** Run a Mounted node's effect and publish the outcome into its content cell, then settle the enclosing
+      * boundary — and then PARK on `supervision` for the instance's lifetime (this method never returns; the
+      * park is interrupted by the node's teardown). Failure routing — shared by the effect outcome and a later
+      * supervised background-fiber failure, at most once per instance: a node-local `.onError` wins; otherwise
+      * the failure is offered to the boundary chain (typed selection); otherwise the node's default error
+      * rendering applies. The enclosing region stays alive either way (a flip keeps the node Scope open, like
+      * a pending-phase failure always has); failures are additionally logged out-of-band.
+      */
+    private def runMountEffect(
+        spec: MountedSpec,
+        cell: SignalRef[UI],
+        record: UI => Unit < Sync,
+        boundary: Maybe[BoundaryCtx],
+        onSettled: Unit < Async,
+        supervision: MountSupervision
+    )(using Frame): Nothing < (Async & Scope) =
+        def failed(t: Throwable): Unit < Async =
+            spec.node.errorRender match
+                case Present(_) => cell.set(spec.errorUI(t)).unit
+                case Absent =>
+                    boundary match
+                        case Present(ctx) =>
+                            ctx.tryHandle(t).map(handled => if handled then () else cell.set(spec.errorUI(t)).unit)
+                        case Absent => cell.set(spec.errorUI(t)).unit
+        Abort.run[Throwable](Fiber.Supervisor.let(supervision.supervisor)(spec.node.effect)).map {
+            case Result.Success(ui) => cell.set(ui).andThen(record(ui)).andThen(onSettled)
+            case Result.Failure(t) =>
+                Log.error(s"Mounted effect failed (frame=${spec.node.frame.position.show})", t)
+                    .andThen(supervision.routeOnce(t)(failed)).andThen(onSettled)
+            case Result.Panic(t) =>
+                if t.isInstanceOf[Interrupted] then ()
+                else
+                    Log.error(s"Mounted effect panicked (frame=${spec.node.frame.position.show})", t)
+                        .andThen(supervision.routeOnce(t)(failed)).andThen(onSettled)
+        }.map(_ => supervision.park(spec, failed))
+    end runMountEffect
+
+    /** A live keyed mount: the content cell, the unscoped runner fiber that owns the node Scope, and the child
+      * registry that carries keyed mounts nested in this instance's content across re-subscriptions.
+      */
+    final private[kyo] class MountInstance(
+        val key: Any,
+        val cell: SignalRef[UI],
+        val fiber: Fiber[Nothing, Any],
+        val childMounts: MountRegistry
+    )
+
+    /** Per-region ownership of keyed mount instances (plus keep-latest seeds and the keyless thrash counter).
+      * All mutation happens from the owning region's sequential observe loop (or once, at static subscribe), so
+      * the AtomicRefs guard memory visibility across fiber steps, not concurrent writers.
+      */
+    final private[kyo] class MountRegistry(
+        instances: AtomicRef[Map[Any, MountInstance]],
+        lastContent: AtomicRef[Map[Seq[String], UI]],
+        keylessRemounts: AtomicRef[Map[Seq[String], Int]],
+        claimedThisWalk: AtomicRef[Set[Any]],
+        lastKeyByPath: AtomicRef[Map[Seq[String], (Any, Int)]]
+    ):
+
+        /** Content last published at a path — the KeepLatest seed: a re-mounting node at this slot starts from the
+          * previous content instead of the placeholder (frozen snapshot; its regions re-attach when the new effect
+          * publishes). Placeholder policy, or a slot that never published, starts from the placeholder.
+          */
+        def keepLatestSeed(path: Seq[String], spec: MountedSpec)(using Frame): UI < Sync =
+            spec.node.pendingPolicy match
+                case UI.PendingPolicy.Placeholder => spec.placeholderUI
+                case UI.PendingPolicy.KeepLatest =>
+                    lastContent.get.map(_.getOrElse(path, spec.placeholderUI))
+
+        def recordContent(path: Seq[String], ui: UI)(using Frame): Unit < Sync =
+            lastContent.getAndUpdate(_.updated(path, ui)).unit
+
+        /** Reuse the live instance under `key`, or create one: seed the cell (keep-latest by slot), fork the
+          * UNSCOPED runner (it must survive the caller's per-value scope; this registry's owner ends it), which
+          * holds the node Scope open until interrupted and evicts nested keyed mounts on the way out. Two claims
+          * of one key within a single walk (evictExcept resets the claim set per walk) are a caller bug: the
+          * duplicate claim returns `Absent` — the caller paints a loud inline error card in that slot instead of
+          * silently sharing the first slot's instance — and the warning names key and path (Laminar's
+          * duplicate-split-key discipline, made visible in the page).
+          */
+        def claim(key: Any, path: Seq[String], spec: MountedSpec, boundary: Maybe[BoundaryCtx])(using
+            Frame
+        ): Maybe[MountInstance] < (Async & Scope) =
+            claimedThisWalk.getAndUpdate(_ + key).map(_.contains(key)).map {
+                case true =>
+                    Log.warn(
+                        s"kyo-ui: duplicate mounted key '$key' claimed at ${path.mkString(".")} within one render pass — " +
+                            "the duplicate slot renders an inline error card; use distinct keys (e.g. .keyed(Component -> id))"
+                    ).andThen(Absent: Maybe[MountInstance])
+                case false =>
+                    for
+                        _ <- noteKeyAt(path, key)
+                        m <- instances.get
+                        inst <- m.get(key) match
+                            case Some(inst) => Kyo.lift(inst)
+                            case None =>
+                                for
+                                    seed        <- keepLatestSeed(path, spec)
+                                    cell        <- Signal.initRef[UI](seed)
+                                    childMounts <- MountRegistry.init
+                                    settleOnce  <- boundarySettle(boundary)
+                                    supervision <- MountSupervision.init
+                                    fiber <- Fiber.initUnscoped {
+                                        Scope.run {
+                                            // The ensure balances the boundary count even if the instance is evicted
+                                            // before its effect publishes (interrupt skips the publish path). runMountEffect
+                                            // never returns (parks on `supervision`), which holds this node Scope open until teardown.
+                                            Scope.ensure(childMounts.evictAll)
+                                                .andThen(Scope.ensure(settleOnce.run))
+                                                .andThen(runMountEffect(
+                                                    spec,
+                                                    cell,
+                                                    ui => recordContent(path, ui),
+                                                    boundary,
+                                                    settleOnce.run,
+                                                    supervision
+                                                ))
+                                        }
+                                    }
+                                    inst = new MountInstance(key, cell, fiber, childMounts)
+                                    _ <- instances.getAndUpdate(_.updated(key, inst))
+                                yield inst
+                    yield Present(inst)
+            }
+
+        /** Dev hint against the unstable-key anti-pattern: a key that is REBUILT per render (a fresh tuple or
+          * object identity, an inline-derived `Signal` inside the key) evicts and re-creates the instance on
+          * every enclosing re-render — keyed continuity silently degrades to remount semantics. A key that
+          * changes ONCE (`.keyed(EraPanel -> era)` on an era switch) is the intended re-creation and resets the
+          * streak; only consecutive-change streaks of COMPOSITE keys are flagged — simple value keys
+          * (String/primitive) are exempt, since a location-driven region (route node keyed by path) re-renders
+          * exclusively on key changes and would otherwise be flagged after three navigations.
+          */
+        private def noteKeyAt(path: Seq[String], key: Any)(using Frame): Unit < Sync =
+            if simpleValueKey(key) then lastKeyByPath.getAndUpdate(_ - path).unit
+            else noteCompositeKeyAt(path, key)
+
+        /** String / primitive / boxed-primitive keys — value equality, no identity risk. */
+        private def simpleValueKey(key: Any): Boolean = key match
+            case _: String | _: Int | _: Long | _: Boolean | _: Double | _: Float | _: Short |
+                _: Byte | _: Char =>
+                true
+            case _ => false
+
+        private def noteCompositeKeyAt(path: Seq[String], key: Any)(using Frame): Unit < Sync =
+            lastKeyByPath.getAndUpdate { m =>
+                m.get(path) match
+                    case Some((prev, streak)) if !prev.equals(key) => m.updated(path, (key, streak + 1))
+                    case _                                         => m.updated(path, (key, 0))
+            }.map { prev =>
+                prev.get(path) match
+                    case Some((prevKey, streak)) if !prevKey.equals(key) =>
+                        val n = streak + 1
+                        if n == 3 || n == 10 || n == 100 then
+                            Log.warn(
+                                s"kyo-ui: mounted key at ${path.mkString(".")} changed in $n consecutive render passes " +
+                                    s"(now '$key') — the key value is likely rebuilt per render (unstable tuple/object/" +
+                                    "Signal identity), so the instance is evicted and re-created every pass. Derive keys " +
+                                    "from stable data if the instance should live across re-renders."
+                            )
+                        else Kyo.unit
+                        end if
+                    case _ => Kyo.unit
             }.unit
-        end if
-    end subscribeScoped
+
+        /** Close-and-await every instance whose key is not in `keep` — run BEFORE the new value paints, so a
+          * vanished or swapped key's resources are fully released while the OLD content is still on screen
+          * (break-before-make; under KeepLatest the successor then seeds from the recorded content). Also opens
+          * the next claim generation for duplicate detection.
+          */
+        def evictExcept(keep: Set[Any])(using Frame): Unit < Async =
+            for
+                _   <- claimedThisWalk.set(Set.empty)
+                old <- instances.getAndUpdate(_.filter((k, _) => keep.contains(k)))
+                evicted = old.collect { case (k, inst) if !keep.contains(k) => inst }
+                _ <- Kyo.foreachDiscard(evicted)(teardown)
+            yield ()
+
+        def evictAll(using Frame): Unit < Async =
+            evictExcept(Set.empty)
+
+        private def teardown(inst: MountInstance)(using Frame): Unit < Async =
+            inst.fiber.interrupt.andThen(inst.fiber.getResult.unit)
+
+        /** Dev hint against the keyless-node-in-hot-region anti-pattern: a keyless Mounted re-runs its effect on
+          * every enclosing region re-render; keys are the opt-in continuity mechanism.
+          */
+        def noteKeylessRemount(path: Seq[String])(using Frame): Unit < Sync =
+            keylessRemounts.getAndUpdate(m => m.updated(path, m.getOrElse(path, 0) + 1)).map { prev =>
+                val n = prev.getOrElse(path, 0) + 1
+                if n == 10 || n == 100 || n == 1000 then
+                    Log.warn(
+                        s"kyo-ui: keyless UI.mounted at ${path.mkString(".")} remounted $n times — its effect re-runs on " +
+                            "every enclosing region re-render. Give it a stable identity with .keyed(...) if the instance " +
+                            "should live across re-renders, or move it out of the hot region."
+                    )
+                else Kyo.unit
+                end if
+            }
+    end MountRegistry
+
+    private[kyo] object MountRegistry:
+        def init(using Frame): MountRegistry < Sync =
+            for
+                instances       <- AtomicRef.init(Map.empty[Any, MountInstance])
+                lastContent     <- AtomicRef.init(Map.empty[Seq[String], UI])
+                keylessRemounts <- AtomicRef.init(Map.empty[Seq[String], Int])
+                claimedThisWalk <- AtomicRef.init(Set.empty[Any])
+                lastKeyByPath   <- AtomicRef.init(Map.empty[Seq[String], (Any, Int)])
+            yield new MountRegistry(instances, lastContent, keylessRemounts, claimedThisWalk, lastKeyByPath)
+    end MountRegistry
 
     // ---- Shared UI tree utilities (used by both backends) ----
 
@@ -665,6 +1304,12 @@ private[kyo] object ReactiveUI:
                 Kyo.foreach(children.toSeq)(resolveReactives).map(r => Fragment[UI](Chunk.from(r)))
             case KeyedChild(key, child) =>
                 resolveReactives(child).map(r => KeyedChild[UI](key, r))
+            case m: Mounted =>
+                // A static snapshot cannot run the mount effect; the node's static projection is its placeholder.
+                m.placeholderUI.getOrElse(UI.empty(using m.frame))
+            case b: Boundary =>
+                // Static projection of a boundary is its fallback (its mounted descendants cannot have run).
+                b.fallbackUI.getOrElse(UI.empty(using b.frame))
             case _ => ui
 
     private[kyo] def rebuildElement(elem: Element, newChildren: Chunk[UI]): UI =

--- a/kyo-ui/shared/src/main/scala/kyo/internal/UIServer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/UIServer.scala
@@ -8,10 +8,15 @@ private[kyo] object UIServer:
         if basePath.endsWith("/") then basePath.dropRight(1) else basePath
 
     def handlers(basePath: String)(ui: => UI < Async)(using Frame): Seq[HttpHandler[?, ?, ?]] < Sync =
+        handlers(basePath, Absent)(ui)
+
+    def handlers(basePath: String, onHandlerError: Maybe[Throwable => Unit < Async])(ui: => UI < Async)(using
+        Frame
+    ): Seq[HttpHandler[?, ?, ?]] < Sync =
         val base = normalizePath(basePath)
         Sync.defer(Seq(
             getPage(base, basePath, Sync.defer(ui)),
-            wsRoute(base, Sync.defer(ui))
+            wsRoute(base, Sync.defer(ui), onHandlerError)
         ))
     end handlers
 
@@ -30,11 +35,15 @@ private[kyo] object UIServer:
                 .addHeader("Content-Type", "text/html; charset=utf-8")
         }
 
-    private[kyo] def serveSession(ws: HttpWebSocket, ui: => UI < Async)(using Frame): Unit < (Async & Abort[Closed]) =
+    private[kyo] def serveSession(
+        ws: HttpWebSocket,
+        ui: => UI < Async,
+        onHandlerError: Maybe[Throwable => Unit < Async] = Absent
+    )(using Frame): Unit < (Async & Abort[Closed]) =
         Scope.run {
             for
                 uiTree <- ui
-                root   <- ReactiveUI.normalize(uiTree, Seq.empty)
+                root   <- ReactiveUI.normalize(uiTree, Seq.empty, onHandlerError = onHandlerError)
                 // Pre-seed the connection's sent-class tracking with every pseudo-state class the
                 // initial SSR page already carries (rendered once more here, discarding the HTML), so
                 // the first reactive update touching an unchanged pseudo-styled element does not
@@ -56,9 +65,13 @@ private[kyo] object UIServer:
             yield ()
         }
 
-    private def wsRoute(base: String, ui: => UI < Async)(using Frame): HttpHandler[?, ?, ?] =
+    private def wsRoute(
+        base: String,
+        ui: => UI < Async,
+        onHandlerError: Maybe[Throwable => Unit < Async] = Absent
+    )(using Frame): HttpHandler[?, ?, ?] =
         HttpHandler.webSocket(s"$base/_kyo/ws") { (_, ws) =>
-            serveSession(ws, ui)
+            serveSession(ws, ui, onHandlerError)
         }
 
     private def wsExchange(root: ReactiveUI, ws: HttpWebSocket, seenClasses: Set[String])(using Frame): UIExchange =

--- a/kyo-ui/shared/src/test/scala/kyo/BoundaryTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/BoundaryTest.scala
@@ -1,0 +1,156 @@
+package kyo
+
+import kyo.Browser.*
+
+/** Behavior tests for [[kyo.UI.boundary]] (EXPERIMENTAL) — pending aggregation, eager-behind-fallback,
+  * once-only reveal, and typed error selection over mounted descendants.
+  */
+class BoundaryTest extends UITest:
+
+    final class DataError(msg: String) extends RuntimeException(msg)
+
+    "boundary shows one fallback while ANY mounted child is pending, then reveals the whole area" in {
+        val setup =
+            for
+                gateA <- Promise.init[Unit, Any]
+                gateB <- Promise.init[Unit, Any]
+            yield (
+                gateA,
+                gateB,
+                UI.div(
+                    UI.boundary.fallback(UI.span("area-loading").id("fb"))(
+                        UI.div(
+                            UI.mounted(gateA.get.andThen(Kyo.lift(UI.span("a-ready").id("a")))),
+                            UI.mounted(gateB.get.andThen(Kyo.lift(UI.span("b-ready").id("b"))))
+                        )
+                    )
+                )
+            )
+        setup.map { (gateA, gateB, ui) =>
+            withUI(Kyo.lift(ui)) {
+                for
+                    _ <- Browser.assertText(Selector.id("fb"), "area-loading")
+                    _ <- gateA.completeUnitDiscard
+                    // one of two still pending: the fallback must still be up
+                    _ <- Browser.assertText(Selector.id("fb"), "area-loading")
+                    _ <- gateB.completeUnitDiscard
+                    _ <- Browser.assertText(Selector.id("a"), "a-ready")
+                    _ <- Browser.assertText(Selector.id("b"), "b-ready")
+                yield ()
+            }
+        }
+    }
+
+    "mount effects start EAGERLY behind the fallback (no waterfall)" in {
+        val setup =
+            for
+                started <- AtomicInt.init(0)
+                gate    <- Promise.init[Unit, Any]
+            yield (
+                started,
+                gate,
+                UI.div(
+                    UI.boundary.fallback(UI.span("loading").id("fb"))(
+                        UI.div(
+                            UI.mounted(started.incrementAndGet.andThen(gate.get).andThen(Kyo.lift(UI.span("x").id("x")))),
+                            UI.mounted(started.incrementAndGet.andThen(gate.get).andThen(Kyo.lift(UI.span("y").id("y"))))
+                        )
+                    )
+                )
+            )
+        setup.map { (started, gate, ui) =>
+            withUI(Kyo.lift(ui)) {
+                for
+                    _ <- Browser.assertText(Selector.id("fb"), "loading")
+                    n <- started.get
+                    _ <- gate.completeUnitDiscard
+                    _ <- Browser.assertText(Selector.id("x"), "x")
+                yield assert(n == 2) // both effects were already running while the fallback showed
+            }
+        }
+    }
+
+    "boundary without pending mounts reveals immediately (no fallback flash for sync content)" in {
+        val app: UI < Async =
+            Kyo.lift(UI.div(
+                UI.boundary.fallback(UI.span("never-shown").id("fb"))(
+                    UI.div(UI.span("sync-content").id("content"))
+                )
+            ))
+        withUI(app) {
+            Browser.assertText(Selector.id("content"), "sync-content")
+        }
+    }
+
+    "typed error selection: matching error renders at the boundary" in {
+        val app: UI < Async =
+            Kyo.lift(UI.div(
+                UI.boundary
+                    .fallback(UI.span("loading").id("fb"))
+                    .onError { case e: DataError => UI.span(s"boundary-caught:${e.getMessage}").id("berr") }(
+                        UI.div(
+                            UI.span("sibling-in-area").id("sib"),
+                            UI.mounted(Abort.fail(new DataError("nope")))
+                        )
+                    )
+            ))
+        withUI(app) {
+            Browser.assertText(Selector.id("berr"), "boundary-caught:nope")
+        }
+    }
+
+    "non-matching error falls back to node-local default and the boundary reveals normally" in {
+        val app: UI < Async =
+            Kyo.lift(UI.div(
+                UI.boundary
+                    .fallback(UI.span("loading").id("fb"))
+                    .onError { case e: DataError => UI.span("boundary-caught").id("berr") }(
+                        UI.div(
+                            UI.span("alive").id("sib"),
+                            UI.mounted(Abort.fail(new RuntimeException("other-error")))
+                                .onError(t => UI.span(s"node-error:${t.getMessage}").id("nerr"))
+                        )
+                    )
+            ))
+        withUI(app) {
+            for
+                // node-local .onError wins; the failure still settles the boundary count, so the area reveals (sibling intact)
+                _ <- Browser.assertText(Selector.id("sib"), "alive")
+                _ <- Browser.assertText(Selector.id("nerr"), "node-error:other-error")
+            yield ()
+        }
+    }
+
+    "a supervised tail failure routes to the boundary post-reveal and replaces the revealed content" in {
+        val setup =
+            for gate <- Promise.init[Unit, Any]
+            yield (
+                gate,
+                UI.div(
+                    UI.boundary
+                        .fallback(UI.span("loading").id("fb"))
+                        .onError { case e: DataError => UI.span(s"boundary-caught:${e.getMessage}").id("berr") }(
+                            UI.div(
+                                UI.span("revealed-sibling").id("sib"),
+                                UI.mounted(
+                                    Fiber.init(gate.get.andThen(Abort.fail(new DataError("tail-nope"))))
+                                        .map(_ => UI.span("live").id("content"))
+                                ).keyed("feed")
+                            )
+                        )
+                )
+            )
+        setup.map { (gate, ui) =>
+            withUI(Kyo.lift(ui)) {
+                for
+                    _ <- Browser.assertText(Selector.id("sib"), "revealed-sibling")
+                    _ <- Browser.assertText(Selector.id("content"), "live")
+                    // feed dies AFTER reveal: no node-local .onError, so the tail failure still walks to the boundary
+                    _ <- gate.completeUnitDiscard
+                    _ <- Browser.assertText(Selector.id("berr"), "boundary-caught:tail-nope")
+                yield ()
+            }
+        }
+    }
+
+end BoundaryTest

--- a/kyo-ui/shared/src/test/scala/kyo/HandlerEnvTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/HandlerEnvTest.scala
@@ -1,0 +1,54 @@
+package kyo
+
+import kyo.internal.MouseEventData
+import kyo.internal.UIEvent
+
+/** Effect-typed event handlers: `onClick[S](...)(using Isolate[S, Sync, S])` — context effects ride the
+  * handler erased and resolve from the dispatching fiber's inherited context at run time.
+  *
+  * Direct engine tests (no browser): the dispatch handle is invoked from THIS computation, mirroring the
+  * browser backend's event-drain fiber, which descends from the `runMount` caller — so `Env.run` around the
+  * dispatch is exactly the production ancestry. (LiveView-transport dispatch runs on kyo-http session fibers
+  * and does not inherit the caller context — same documented gap as mounted effects there.)
+  */
+class HandlerEnvTest extends UITest:
+
+    "onClick handler with erased Env resolves against the dispatching fiber's context" in {
+        Env.run("clicked-with-env") {
+            Scope.run {
+                for
+                    seen <- Promise.init[String, Any]
+                    ui = UI.div(
+                        UI.button("Go").id("btn").onClick(
+                            Env.get[String].map(v => seen.completeDiscard(Result.succeed(v)))
+                        )
+                    )
+                    exchange = new kyo.internal.UIExchange:
+                        def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async = ()
+                    root <- kyo.internal.ReactiveUI.normalize(ui, Seq.empty)
+                    sub  <- kyo.internal.ReactiveUI.subscribe(root, exchange)
+                    _    <- sub.handle(Seq("0"), UIEvent.Click(Seq("0"), MouseEventData(UI.Modifiers.none, Absent)))
+                    v    <- seen.get
+                yield assert(v == "clicked-with-env")
+            }
+        }
+    }
+
+    "pure handlers still infer S = Any (source compatibility)" in {
+        // Compile-level assertion: the pre-existing handler shapes typecheck unchanged against the
+        // effect-polymorphic setters.
+        Scope.run {
+            for
+                ref <- Signal.initRef(0)
+                ui = UI.div(
+                    UI.button("A").onClick(ref.set(1)),
+                    UI.button("B").onClick((_: UI.MouseEvent) => ref.set(2)),
+                    UI.form(UI.button("S")).onSubmit(ref.set(3)),
+                    UI.button("H").onHover(ref.set(4)).onBlur(ref.set(5))
+                )
+                root <- kyo.internal.ReactiveUI.normalize(ui, Seq.empty)
+            yield assert(root.path.isEmpty)
+        }
+    }
+
+end HandlerEnvTest

--- a/kyo-ui/shared/src/test/scala/kyo/MountedTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/MountedTest.scala
@@ -1,0 +1,508 @@
+package kyo
+
+import kyo.Browser.*
+
+/** Behavior tests for [[kyo.UI.mounted]] — the effectful component mount node.
+  *
+  * Runs against the LiveView transport (UITest.withUI = runHandlers + real Chrome over the WebSocket
+  * exchange), i.e. the shared ReactiveUI engine: mount effects execute server-side on fibers descending
+  * from the session, which is also what makes the Env test meaningful (context flows through the
+  * HttpServer.init ancestry into the mount effect at run time, with no Env in any UI-facing type).
+  */
+class MountedTest extends UITest:
+
+    "mounted effect renders its content" in {
+        val app: UI < Async =
+            Kyo.lift(UI.div(
+                UI.mounted(Kyo.lift(UI.span("hello-from-mount").id("content")))
+                    .placeholder(UI.span("loading...").id("ph"))
+            ))
+        withUI(app) {
+            Browser.assertText(Selector.id("content"), "hello-from-mount")
+        }
+    }
+
+    "placeholder shows while the effect is pending, content after it publishes" in {
+        val app: (Promise[Unit, Any], UI < Async) < Sync =
+            for gate <- Promise.init[Unit, Any]
+            yield (
+                gate,
+                Kyo.lift(UI.div(
+                    UI.mounted(gate.get.andThen(Kyo.lift(UI.span("ready").id("content"))))
+                        .placeholder(UI.span("loading...").id("ph"))
+                ))
+            )
+        app.map { (gate, ui) =>
+            withUI(ui) {
+                for
+                    _ <- Browser.assertText(Selector.id("ph"), "loading...")
+                    _ <- gate.completeUnitDiscard
+                    _ <- Browser.assertText(Selector.id("content"), "ready")
+                yield ()
+            }
+        }
+    }
+
+    "Env provided at the mount root flows into the mount effect (runMount-style fiber ancestry)" in {
+        // Direct engine test: subscribe is invoked from THIS fiber, so the mount runner descends from it (like the
+        // browser runMount path) and the erased Env[String] resolves at run time. Deliberately NOT via withUI: in the
+        // LiveView transport session fibers descend from kyo-http internals, so root Env does not reach mount effects
+        // there today (documented follow-up).
+        val greetEffect: UI < (Async & Scope & Env[String]) =
+            Env.get[String].map(greeting => UI.span(greeting).id("content"))
+        val ui: UI = UI.div(UI.mounted(greetEffect))
+        Env.run("hello-env") {
+            Scope.run {
+                for
+                    seen <- Promise.init[String, Any]
+                    exchange = new kyo.internal.UIExchange:
+                        def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async =
+                            kyo.internal.HtmlRenderer.render(changed, path).map { html =>
+                                if html.contains("hello-env") then seen.completeDiscard(Result.succeed(html))
+                                else ()
+                            }
+                    root <- kyo.internal.ReactiveUI.normalize(ui, Seq.empty)
+                    _    <- kyo.internal.ReactiveUI.subscribe(root, exchange)
+                    html <- seen.get
+                yield assert(html.contains("hello-env"))
+            }
+        }
+    }
+
+    "keyless mounted remounts (effect re-runs) when the enclosing region re-renders" in {
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(_ => UI.div(UI.mounted(runs.incrementAndGet.map(n => UI.span(s"runs:$n").id("content")))))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("content"), "runs:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("content"), "runs:2")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("content"), "runs:3")
+            yield ()
+        }
+    }
+
+    "keyed mounted keeps its live instance across region re-renders" in {
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(n =>
+                    UI.div(
+                        UI.span(s"tick:$n").id("tickview"),
+                        UI.mounted(runs.incrementAndGet.map(r => UI.span(s"runs:$r").id("content"))).keyed("box")
+                    )
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("content"), "runs:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("tickview"), "tick:1")
+                _ <- Browser.assertText(Selector.id("content"), "runs:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("tickview"), "tick:2")
+                _ <- Browser.assertText(Selector.id("content"), "runs:1")
+            yield ()
+        }
+    }
+
+    "keyed mounted keeps component-local signal state across region re-renders" in {
+        def counterComponent(runs: AtomicInt): UI < (Async & Scope) =
+            for
+                _     <- runs.incrementAndGet
+                count <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                count.map(c => UI.span(s"count:$c").id("count"))
+            )
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(_ => UI.div(UI.mounted(counterComponent(runs)).keyed("counter")))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:2")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("count"), "count:2")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:3")
+            yield ()
+        }
+    }
+
+    "key change tears down the old instance (Scope closed) and mounts a fresh one" in {
+        def component(key: Int, runs: AtomicInt, released: AtomicInt): UI < (Async & Scope) =
+            for
+                _ <- runs.incrementAndGet
+                _ <- Scope.ensure(released.incrementAndGet.unit)
+            yield UI.span(s"instance:$key").id("content")
+        val app: (AtomicInt, AtomicInt, UI < Async) < Sync =
+            for
+                runs     <- AtomicInt.init(0)
+                released <- AtomicInt.init(0)
+                sel      <- Signal.initRef(1)
+            yield (
+                runs,
+                released,
+                Kyo.lift(UI.div(
+                    UI.button("Next").id("next").onClick(sel.getAndUpdate(_ + 1).unit),
+                    sel.map(k => UI.div(UI.mounted(component(k, runs, released)).keyed(k)))
+                ))
+            )
+        app.map { (runs, released, ui) =>
+            withUI(ui) {
+                for
+                    _ <- Browser.assertText(Selector.id("content"), "instance:1")
+                    _ <- Browser.click(Selector.id("next"))
+                    _ <- Browser.assertText(Selector.id("content"), "instance:2")
+                    r <- released.get
+                    n <- runs.get
+                yield
+                    assert(r == 1) // old instance's Scope was closed on key change
+                    assert(n == 2) // and the effect ran exactly once per key
+            }
+        }
+    }
+
+    "failed mount renders the error state while the enclosing region stays alive" in {
+        val app: UI < Async =
+            for other <- Signal.initRef("sibling-0")
+            yield UI.div(
+                UI.button("Bump").id("bump").onClick(other.set("sibling-1")),
+                other.map(v => UI.span(v).id("sibling")),
+                UI.mounted(Abort.fail(new RuntimeException("boom-mount")))
+                    .onError(t => UI.span(s"error:${t.getMessage}").id("content"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("content"), "error:boom-mount")
+                _ <- Browser.click(Selector.id("bump"))
+                _ <- Browser.assertText(Selector.id("sibling"), "sibling-1")
+            yield ()
+        }
+    }
+
+    "handler inside a nested region INSIDE mounted content dispatches (region -> mounted -> region -> button)" in {
+        def component(): UI < (Async & Scope) =
+            for
+                gate  <- Signal.initRef(true)
+                count <- Signal.initRef(0)
+            yield UI.div(
+                gate.map(g =>
+                    if g then
+                        UI.div(
+                            UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                            count.map(c => UI.span(s"count:$c").id("count"))
+                        )
+                    else UI.span("off")
+                )
+            )
+        val app: UI < Async =
+            for
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(_ => UI.div(UI.mounted(component()).keyed("nested")))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:2")
+            yield ()
+        }
+    }
+
+    "handler under TWO nested regions inside mounted content dispatches (mounted -> region -> region -> button)" in {
+        def component(): UI < (Async & Scope) =
+            for
+                outer <- Signal.initRef(0)
+                inner <- Signal.initRef(0)
+                count <- Signal.initRef(0)
+            yield UI.div(
+                outer.map(_ =>
+                    UI.div(
+                        inner.map(_ =>
+                            UI.div(
+                                UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                                count.map(c => UI.span(s"count:$c").id("count"))
+                            )
+                        )
+                    )
+                )
+            )
+        val app: UI < Async =
+            Kyo.lift(UI.div(UI.mounted(component()).keyed("deep")))
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+            yield ()
+        }
+    }
+
+    "mount content whose ROOT is a region stays live (region-at-cell-root: patches AND dispatch)" in {
+        def component(): UI < (Async & Scope) =
+            for
+                idSig <- Signal.initRef(0)
+                count <- Signal.initRef(0)
+            yield (idSig.map { _ =>
+                UI.div(
+                    UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                    count.map(c => UI.span(s"count:$c").id("count"))
+                )
+            }: UI)
+        val app: UI < Async =
+            Kyo.lift(UI.div(UI.mounted(component()).keyed("rootregion")))
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+            yield ()
+        }
+    }
+
+    "mounted node as the direct ROOT of a region's content stays live (route shape: region content = Mounted)" in {
+        def component(runs: AtomicInt): UI < (Async & Scope) =
+            for
+                _     <- runs.incrementAndGet
+                count <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                count.map(c => UI.span(s"count:$c").id("count"))
+            )
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(n => (UI.mounted(component(runs)).keyed(("box", n)): UI))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+            yield ()
+        }
+    }
+
+    "nested route shape end-to-end: region -> Mounted(root) -> region(content root) -> element -> region -> button" in {
+        def page(count: Signal.SignalRef[Int]): UI < (Async & Scope) =
+            for
+                identity <- Signal.initRef("me")
+                query    <- Signal.initRef("loaded")
+            yield (identity.map { _ =>
+                UI.main(
+                    (query.map { _ =>
+                        UI.div(
+                            UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                            count.map(c => UI.span(s"count:$c").id("count"))
+                        )
+                    }: UI)
+                )
+            }: UI)
+        val app: (Signal.SignalRef[String], UI < Async) < Sync =
+            for
+                count    <- Signal.initRef(0)
+                location <- Signal.initRef("/a")
+            yield (
+                location,
+                Kyo.lift(UI.div(
+                    UI.span("header").id("hdr"),
+                    UI.div((location.map(path => (UI.mounted(page(count)).keyed(path): UI)): UI))
+                ))
+            )
+        app.map { (location, ui) =>
+            withUI(ui) {
+                for
+                    _ <- Browser.assertText(Selector.id("count"), "count:0")
+                    _ <- Browser.click(Selector.id("inc"))
+                    _ <- Browser.assertText(Selector.id("count"), "count:1")
+                    _ <- location.set("/b")
+                    // count survives navigation: the count signal is shared across pages
+                    _ <- Browser.assertText(Selector.id("count"), "count:1")
+                    _ <- Browser.click(Selector.id("inc"))
+                    _ <- Browser.assertText(Selector.id("count"), "count:2")
+                yield ()
+            }
+        }
+    }
+
+    "click on a REACTIVE child of a button inside mounted content bubbles to the button handler" in {
+        def component(): UI < (Async & Scope) =
+            for
+                label <- Signal.initRef("Leave")
+                count <- Signal.initRef(0)
+            yield UI.div(
+                UI.button((label.map(s => (UI.Ast.Text(s): UI)): UI)).id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                count.map(c => UI.span(s"count:$c").id("count"))
+            )
+        val app: UI < Async =
+            Kyo.lift(UI.div(UI.mounted(component()).keyed("i18nbtn")))
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc")) // centre click hits the inner reactive span
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+            yield ()
+        }
+    }
+
+    "ENGINE: dispatch targeting a reactive label INSIDE a button (below intermediate static elements) runs the button handler" in {
+        Scope.run {
+            for
+                label   <- Signal.initRef("Leave")
+                clicked <- AtomicInt.init(0)
+                ui = UI.div(
+                    UI.div(UI.span("cards")),
+                    UI.div( // button-bar (static intermediate)
+                        UI.button((label.map(s => (UI.Ast.Text(s): UI)): UI))
+                            .id("leave")
+                            .onClick(clicked.incrementAndGet.unit)
+                    )
+                )
+                exchange = new kyo.internal.UIExchange:
+                    def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async = ()
+                root     <- kyo.internal.ReactiveUI.normalize(ui, Seq.empty)
+                dispatch <- kyo.internal.ReactiveUI.subscribe(root, exchange)
+                // Target = the LABEL region's path: div(0)=cards-div... button-bar=child 1, button=child 0, label=child 0.
+                labelPath = Seq("1", "0", "0")
+                handled <- dispatch.handle(
+                    labelPath,
+                    kyo.internal.UIEvent.Click(labelPath, kyo.internal.MouseEventData(UI.Modifiers.none, Absent))
+                )
+                n <- clicked.get
+            yield assert(handled && n == 1, s"handled=$handled clicks=$n (expected the BUTTON handler to run)")
+        }
+    }
+
+    "duplicate mounted key: the first slot mounts, the duplicate slot renders an inline error card" in {
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+            yield UI.div(
+                UI.mounted(runs.incrementAndGet.map(r => UI.span(s"runs:$r").id("first"))).keyed("dup"),
+                UI.mounted(runs.incrementAndGet.map(r => UI.span(s"runs:$r").id("second"))).keyed("dup")
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("first"), "runs:1")
+                // duplicate slot never runs its effect: it paints the error card rather than silently sharing the first instance
+                _ <- Browser.assertText(Selector.css(".kyo-mount-error"), "kyo-ui: duplicate mounted key 'dup'")
+            yield ()
+        }
+    }
+
+    "unstable key (fresh per re-render) re-creates the instance each pass (the churn-hint path)" in {
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(n =>
+                    UI.div(
+                        UI.mounted(runs.incrementAndGet.map(r => UI.span(s"runs:$r").id("content"))).keyed(("box", n))
+                    )
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("content"), "runs:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("content"), "runs:2")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("content"), "runs:3")
+                // Third consecutive key change — the unstable-key dev hint logs on this pass.
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("content"), "runs:4")
+            yield ()
+        }
+    }
+
+    "background fiber failure after publish flips the mounted node to its error render (node-scope supervision)" in {
+        val setup =
+            for gate <- Promise.init[Unit, Any]
+            yield (
+                gate,
+                UI.div(
+                    UI.span("sibling").id("sibling"),
+                    UI.mounted(
+                        Fiber.init(gate.get.andThen(Abort.fail(new RuntimeException("feed-died"))))
+                            .map(_ => UI.span("live").id("content"))
+                    ).keyed("game")
+                        .onError(t => UI.span(s"error:${t.getMessage}").id("content"))
+                )
+            )
+        setup.map { (gate, ui) =>
+            withUI(Kyo.lift(ui)) {
+                for
+                    _ <- Browser.assertText(Selector.id("content"), "live")
+                    _ <- gate.completeUnitDiscard // feed dies AFTER publish
+                    _ <- Browser.assertText(Selector.id("content"), "error:feed-died")
+                    _ <- Browser.assertText(Selector.id("sibling"), "sibling")
+                yield ()
+            }
+        }
+    }
+
+    "keyed instance kept across region re-renders still flips on a later feed failure (supervision survives adoption)" in {
+        val app: UI < Async =
+            for
+                gate <- Promise.init[Unit, Any]
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                UI.button("Kill").id("kill").onClick(gate.completeUnitDiscard),
+                tick.map(n =>
+                    UI.div(
+                        UI.span(s"tick:$n").id("tick-val"),
+                        UI.mounted(
+                            Fiber.init(gate.get.andThen(Abort.fail(new RuntimeException("late-fail"))))
+                                .map(_ => UI.span("live").id("content"))
+                        ).keyed("stable")
+                            .onError(t => UI.span(s"error:${t.getMessage}").id("content"))
+                    )
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("content"), "live")
+                _ <- Browser.click(Selector.id("tick")) // instance is ADOPTED across the re-render, not re-created
+                _ <- Browser.assertText(Selector.id("tick-val"), "tick:1")
+                _ <- Browser.assertText(Selector.id("content"), "live")
+                _ <- Browser.click(Selector.id("kill"))
+                _ <- Browser.assertText(Selector.id("content"), "error:late-fail")
+            yield ()
+        }
+    }
+
+end MountedTest

--- a/kyo-ui/shared/src/test/scala/kyo/UIEventWiringTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIEventWiringTest.scala
@@ -33,6 +33,22 @@ class UIEventWiringTest extends kyo.test.Test[Any]:
             yield subscription.handle
         }
 
+    /** Like [[makeDispatch]] but installs a session handler-error policy at the normalize root. */
+    private def makeDispatch(ui: UI, onHandlerError: Throwable => Unit < Async)(using
+        Frame
+    ): ((Seq[String], UIEvent) => Boolean < Async) < Async =
+        Scope.run {
+            for
+                root         <- ReactiveUI.normalize(ui, Seq.empty, onHandlerError = Present(onHandlerError))
+                subscription <- ReactiveUI.subscribe(root, new NoopExchange)
+            yield subscription.handle
+        }
+
+    private val boom = new RuntimeException("action failed")
+
+    private def click(path: Seq[String]): UIEvent =
+        UIEvent.Click(path, MouseEventData(UI.Modifiers.none, Absent))
+
     // ---- onHover action fires (HTML) ----
 
     "onHover(action) fires on Hover dispatch (HTML div)" in {
@@ -234,6 +250,91 @@ class UIEventWiringTest extends kyo.test.Test[Any]:
         yield
             assert(action)
             assert(evt == Present("foo"))
+    }
+
+    // ---- session handler-error policy (normalize onHandlerError -> safeDispatch) ----
+    // These pin the opt-in policy: an unconsumed handler failure/panic is offered to onHandlerError, after the log, without stopping the bubble.
+
+    "a handler Abort reaches the policy and the event still dispatches (bubbling continues)" in {
+        Scope.run {
+            for
+                seen <- AtomicRef.init(Maybe.empty[Throwable])
+                ui = UI.div(
+                    UI.button("go").id("go").onClick(Abort.fail(boom))
+                )
+                dispatch <- makeDispatch(ui, err => seen.set(Present(err)))
+                handled  <- dispatch(Seq("0"), click(Seq("0")))
+                s        <- seen.get
+            yield
+                assert(handled)
+                assert(s == Present(boom))
+        }
+    }
+
+    "a handler panic reaches the policy too" in {
+        Scope.run {
+            for
+                seen <- AtomicRef.init(Maybe.empty[Throwable])
+                ui = UI.div(
+                    UI.button("go").id("go").onClick(Sync.defer((throw boom): Unit))
+                )
+                dispatch <- makeDispatch(ui, err => seen.set(Present(err)))
+                handled  <- dispatch(Seq("0"), click(Seq("0")))
+                s        <- seen.get
+            yield
+                assert(handled)
+                assert(s == Present(boom))
+        }
+    }
+
+    "a successful handler never invokes the policy" in {
+        Scope.run {
+            for
+                seen    <- AtomicRef.init(false)
+                clicked <- AtomicInt.init(0)
+                ui = UI.div(
+                    UI.button("go").id("go").onClick(clicked.incrementAndGet.unit)
+                )
+                dispatch <- makeDispatch(ui, _ => seen.set(true))
+                _        <- dispatch(Seq("0"), click(Seq("0")))
+                n        <- clicked.get
+                s        <- seen.get
+            yield
+                assert(n == 1)
+                assert(!s)
+        }
+    }
+
+    "a handler that consumes its own failure keeps it from the policy; observe-and-reraise lets it bubble" in {
+        Scope.run {
+            for
+                policySaw <- AtomicRef.init(List.empty[String])
+                tapSaw    <- AtomicRef.init(false)
+                ui = UI.div(
+                    // consumed locally: never reaches the policy
+                    UI.button("a").id("a").onClick(Abort.recover[Throwable](_ => ())(Abort.fail(boom): Unit < Abort[Throwable])),
+                    // observed then re-raised (what Abort.tap does): bubbles on to the policy
+                    UI.button("b").id("b").onClick(
+                        Abort.recover[Throwable](e => tapSaw.set(true).andThen(Abort.fail(e)))(Abort.fail(boom): Unit < Abort[Throwable])
+                    )
+                )
+                dispatch <- makeDispatch(ui, err => policySaw.getAndUpdate(err.getMessage :: _).unit)
+                _        <- dispatch(Seq("0"), click(Seq("0")))
+                _        <- dispatch(Seq("1"), click(Seq("1")))
+                p        <- policySaw.get
+                t        <- tapSaw.get
+            yield
+                assert(p == List("action failed")) // only button b's failure arrived
+                assert(t)                          // and the observer saw it on the way
+        }
+    }
+
+    "no policy installed: dispatch behaves as before (log-only, bubbling continues)" in {
+        for
+            ui       <- Kyo.lift(UI.div(UI.button("go").id("go").onClick(Abort.fail(boom))))
+            dispatch <- makeDispatch(ui)
+            handled  <- dispatch(Seq("0"), click(Seq("0")))
+        yield assert(handled)
     }
 
 end UIEventWiringTest

--- a/kyo-ui/shared/src/test/scala/kyo/internal/MountSupervisionTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/internal/MountSupervisionTest.scala
@@ -1,0 +1,195 @@
+package kyo.internal
+
+import java.util.concurrent.CopyOnWriteArrayList
+import kyo.*
+
+/** Direct-engine tests for node-scope supervision (no browser): a mounted node's background fiber failing
+  * AFTER publication flips the node into its error routing (node `.onError` → boundary chain → default error
+  * UI), first-failure-wins, teardown interrupts never flip, `initUnscoped` opts out. The engine is driven via
+  * `ReactiveUI.normalize`/`subscribe` with a recording `UIExchange` (the MountedTest direct-test idiom).
+  */
+class MountSupervisionTest extends kyo.test.Test[Any]:
+
+    /** Records every emission's rendered HTML and completes marker promises on first match. */
+    final private class Recording(markers: Map[String, Fiber.Promise.Unsafe[String, Any]]):
+        val emissions = new CopyOnWriteArrayList[String]()
+        val exchange = new UIExchange:
+            def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async =
+                HtmlRenderer.render(changed, path).map { html =>
+                    discard(emissions.add(html))
+                    markers.foreach { (marker, p) =>
+                        if html.contains(marker) then
+                            import AllowUnsafe.embrace.danger
+                            discard(p.complete(Result.succeed(html)))
+                    }
+                }
+        def count(marker: String): Int =
+            import scala.jdk.CollectionConverters.*
+            emissions.asScala.count(_.contains(marker))
+        def indexOf(marker: String): Int =
+            import scala.jdk.CollectionConverters.*
+            emissions.asScala.indexWhere(_.contains(marker))
+    end Recording
+
+    private def recording(markers: String*)(using Frame): (Recording, Map[String, Fiber[String, Any]]) < Sync =
+        Sync.Unsafe.defer {
+            val ps  = markers.map(m => m -> Fiber.Promise.Unsafe.init[String, Any]()).toMap
+            val rec = new Recording(ps)
+            (rec, ps.view.mapValues(_.safe: Fiber[String, Any]).toMap)
+        }
+
+    private def run(ui: UI, rec: Recording)(using Frame): Unit < (Async & Scope) =
+        ReactiveUI.normalize(ui, Seq.empty).map(root => ReactiveUI.subscribe(root, rec.exchange).unit)
+
+    private def boom = new RuntimeException("feed died")
+
+    "a published keyed mount flips to its default error render when a background fiber fails" in {
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready", "feed died")
+                effect = Fiber.init(gate.get.andThen(Abort.fail(boom)))
+                    .map(_ => UI.span("ready").id("content"))
+                _ <- run(UI.div(UI.mounted(effect).keyed("k")), rec)
+                _ <- marks("ready").get
+                _ <- gate.completeUnitDiscard
+                _ <- marks("feed died").get
+            yield assert(rec.indexOf("ready") < rec.indexOf("feed died"))
+        }
+    }
+
+    "a keyless mount flips too" in {
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready", "feed died")
+                effect = Fiber.init(gate.get.andThen(Abort.fail(boom)))
+                    .map(_ => UI.span("ready").id("content"))
+                _ <- run(UI.div(UI.mounted(effect)), rec)
+                _ <- marks("ready").get
+                _ <- gate.completeUnitDiscard
+                _ <- marks("feed died").get
+            yield assert(rec.count("feed died") >= 1)
+        }
+    }
+
+    "a node-local .onError wins for a supervised failure" in {
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready", "custom:feed died")
+                effect = Fiber.init(gate.get.andThen(Abort.fail(boom)))
+                    .map(_ => UI.span("ready").id("content"))
+                node = UI.mounted(effect).keyed("k").onError(t => UI.span(s"custom:${t.getMessage}"))
+                _ <- run(UI.div(node), rec)
+                _ <- marks("ready").get
+                _ <- gate.completeUnitDiscard
+                _ <- marks("custom:feed died").get
+            yield assert(rec.count("custom:feed died") == 1)
+        }
+    }
+
+    "an unhandled supervised failure walks the boundary chain post-reveal" in {
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready", "boundary:feed died")
+                effect = Fiber.init(gate.get.andThen(Abort.fail(boom)))
+                    .map(_ => UI.span("ready").id("content"))
+                ui = UI.div(
+                    UI.boundary.onError { case t: RuntimeException => UI.span(s"boundary:${t.getMessage}") }(
+                        UI.mounted(effect).keyed("k")
+                    )
+                )
+                _ <- run(ui, rec)
+                _ <- marks("ready").get
+                _ <- gate.completeUnitDiscard
+                _ <- marks("boundary:feed died").get
+            yield assert(rec.count("boundary:feed died") == 1)
+        }
+    }
+
+    "first failure wins — two failing feeds, exactly one error paint" in {
+        Scope.run {
+            for
+                gate1        <- Promise.init[Unit, Any]
+                gate2        <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready", "kyo-mount-error")
+                effect =
+                    for
+                        _ <- Fiber.init(gate1.get.andThen(Abort.fail(new RuntimeException("first"))))
+                        _ <- Fiber.init(gate2.get.andThen(Abort.fail(new RuntimeException("second"))))
+                    yield UI.span("ready").id("content")
+                _ <- run(UI.div(UI.mounted(effect).keyed("k")), rec)
+                _ <- marks("ready").get
+                _ <- gate1.completeUnitDiscard
+                _ <- marks("kyo-mount-error").get
+                _ <- gate2.completeUnitDiscard
+                _ <- Async.sleep(100L.millis)
+            yield assert(rec.count("kyo-mount-error") == 1)
+        }
+    }
+
+    "a supervised failure during pending is deferred until the effect settles, then flips" in {
+        // The flip is serialized after publish, but the intermediate "ready" paint is not observable through the
+        // coalescing content signal (observe keeps only the latest) — so we assert: no error while pending, error after settle.
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("feed died")
+                effect = Fiber.init(Abort.fail(boom)) // fails while the effect is still pending
+                    .map(_ => gate.get)
+                    .map(_ => UI.span("ready").id("content"))
+                _ <- run(UI.div(UI.mounted(effect).keyed("k")), rec)
+                _ <- Async.sleep(100L.millis) // failure has long landed…
+                noneYet = rec.count("kyo-mount-error") == 0 // …but nothing flipped while pending
+                _ <- gate.completeUnitDiscard
+                _ <- marks("feed died").get // flip arrives once the effect settled
+            yield assert(noneYet)
+        }
+    }
+
+    "an effect failure racing a supervised failure routes once (shared once-guard)" in {
+        Scope.run {
+            for
+                (rec, _) <- recording()
+                effect = Fiber.init(Abort.fail(new RuntimeException("from fiber")))
+                    .andThen(Abort.fail(new RuntimeException("from effect")))
+                _ <- run(UI.div(UI.mounted(effect).keyed("k")), rec)
+                _ <- Async.sleep(150L.millis)
+            yield assert(rec.count("kyo-mount-error") == 1)
+        }
+    }
+
+    "eviction: a key swap interrupts feeds without any error paint" in {
+        Scope.run {
+            for
+                sel          <- Signal.initRef("a")
+                (rec, marks) <- recording("inst:a", "inst:b")
+                effect = (k: String) =>
+                    Fiber.init(Async.never).map(_ => UI.span(s"inst:$k").id("content"))
+                ui = UI.div(sel.map(k => UI.div(UI.mounted(effect(k)).keyed(k))))
+                _ <- run(ui, rec)
+                _ <- marks("inst:a").get
+                _ <- sel.set("b")
+                _ <- marks("inst:b").get
+                _ <- Async.sleep(100L.millis)
+            yield assert(rec.count("kyo-mount-error") == 0)
+        }
+    }
+
+    "initUnscoped feed failure does NOT flip the node" in {
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready")
+                effect = Fiber.initUnscoped(gate.get.andThen(Abort.fail(boom)))
+                    .map(_ => UI.span("ready").id("content"))
+                _ <- run(UI.div(UI.mounted(effect).keyed("k")), rec)
+                _ <- marks("ready").get
+                _ <- gate.completeUnitDiscard
+                _ <- Async.sleep(100L.millis)
+            yield assert(rec.count("kyo-mount-error") == 0)
+        }
+    }
+end MountSupervisionTest


### PR DESCRIPTION
> **⚠ Depends on #1780 (`UI.mounted`) — please merge that first.** The policy threads through the mount/normalize/`MountDispatch`/`safeDispatch` dispatch machinery introduced by #1780, so it builds on it. The diff shows #1780's commit until it lands.

## Problem

When an event handler fails or panics and nothing below it consumed the error, the engine logs it out-of-band and keeps the event bubbling — but an app has no way to react to those escaped errors in one place. For example: a dozen buttons whose `onClick` handlers each call a backend, and the app wants any one of them failing to pop the same error toast. Today that means wrapping every single handler; there is no one place to say "any unhandled handler error becomes a toast."

## Solution

Add an opt-in `onHandlerError` policy: `UI.runMount` and `UI.runHandlers` gain overloads taking `Throwable => Unit < Async`, the app's single central decision for any event-handler failure or panic that nothing below consumed.

It is threaded structurally from the transport entry point through `normalize` → `MountDispatch` → `safeDispatch`, deliberately **not** a `Local`: root-only is the truth, and it works identically on the server-push transport (where the browser drives server-side session fibers over a WebSocket), on which a `Local` installed at the mount site does not reach those per-session fibers.

`safeDispatch` still logs out-of-band and never stops the bubble chain; the policy is simply offered the error after the log. Handlers keep their local options:

- a handler that wants a different fate **consumes** the error itself (`Abort.recover`) before it reaches this seam, so the policy never sees it;
- a handler that only wants to **observe** re-raises after its side effect and lets the error bubble on to the policy.

With no policy installed the behavior is unchanged (log-only).

## Notes

Tested in `UIEventWiringTest` (direct-engine dispatch, no browser), alongside the existing `safeDispatch` recover test: the policy sees an Abort and a panic, a successful handler never invokes it, a locally-consumed failure is kept from it while an observed-and-re-raised one reaches it, and with no policy the log-only status quo holds.
