### PR TITLE
[kyo-ui] focus restore skips reactive wrapper spans (follow-up: #1781)

### DIFF
--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -61,6 +61,7 @@ Every `Element` carries an `Attrs` record. The chainable setters are:
 - `.hidden(v: Boolean)`: hide the element. The `Signal[Boolean]` overload exists but lives under "Reactivity" below because it changes the return type.
 - `.style(v: Style)` / `.style(f: Style.type => Style)`: attach styling, see [Styles](#styles).
 - `.tabIndex(v)`, `.focusTrap(v)`, `.focusGroup(id)`: focus order and grouping for keyboard navigation.
+- `.focusAuto(v: Boolean)`, `.focusRestore(v: Boolean)`: declarative focus management. `focusAuto` calls `.focus()` once when a re-render newly inserts the element (like native `autofocus`, but re-render-aware — an echo re-render of an already-visible element never re-steals focus); `focusRestore` returns focus to the element focused before seeding when the seeded element leaves the document (the modal-returns-focus-to-its-trigger pattern). Pair with `tabIndex(-1)` for elements that are not natively focusable.
 
 ```scala
 import UI.*

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -8,6 +8,12 @@ import scala.scalajs.js
 /** Scala.js UI backend. Mounts a UI into the browser DOM. */
 private[kyo] object DomBackend:
 
+    /** Focus seeding/restore stack for `data-kyo-focus-auto`/`data-kyo-focus-restore` (seeded path, prior-focus path,
+      * restore flag). Mirrors `__frs` in HtmlRenderer.clientJs. Module-level mutable state is safe: all mutation runs
+      * inside `Sync.defer` on the single-threaded JS runtime.
+      */
+    private var focusReturnStack: List[(String, Maybe[String], Boolean)] = Nil
+
     /** Mount a UI into the page body. */
     def mount(ui: UI)(using Frame): Unit < (Async & Scope) =
         mountInto(ui, document.body)
@@ -41,7 +47,9 @@ private[kyo] object DomBackend:
             html <- HtmlRenderer.render(ui, Seq.empty)
             _    <- Sync.defer(container.innerHTML = html)
             _    <- applyJsProps(container)
-            _    <- Sync.defer(beginAnimationsSync(container))
+            // Initial mount: everything is new, so pass an empty old-path set (mirrors clientJs startup faSeed).
+            _ <- Sync.defer(seedFocusAuto(container, Set.empty))
+            _ <- Sync.defer(beginAnimationsSync(container))
             exchange = LocalExchange(root)
             dispatch <- ReactiveUI.subscribe(root, exchange)
             // Single-consumer drain owned by the ambient page Scope: every JS event effect is run by a
@@ -110,6 +118,9 @@ private[kyo] object DomBackend:
                                 else pathAttr
                             else null
                         val (selStart, selEnd) = if insideRegion then readSelection(ae) else (Absent, Absent)
+                        // Focus-auto paths present BEFORE the replace, so seeding fires only for newly-appeared
+                        // elements (a re-render of an already-open overlay must not steal focus).
+                        val oldFocusAuto = focusAutoPaths(el)
                         el.outerHTML = finalHtml
                         val updated = document.querySelector(s"""[data-kyo-path="$pathAttr"]""")
                         if updated != null then
@@ -117,6 +128,10 @@ private[kyo] object DomBackend:
                             beginAnimationsSync(updated)
                         if activePath != null then
                             restoreFocus(activePath, selStart, selEnd)
+                        // Seed AFTER restoreFocus so a newly-appeared focus-auto element wins over restore-to-trigger.
+                        if updated != null then
+                            seedFocusAuto(updated, oldFocusAuto)
+                        sweepFocusAuto()
                     end if
                 }
             }
@@ -157,6 +172,64 @@ private[kyo] object DomBackend:
             end match
         end if
     end restoreFocus
+
+    /** The set of `data-kyo-path` values of every `data-kyo-focus-auto` element inside `root`, `root` itself included. */
+    private def focusAutoPaths(root: dom.Element): Set[String] =
+        val els = root.querySelectorAll("[data-kyo-focus-auto]")
+        val descendants = (0 until els.length).flatMap { i =>
+            Maybe(els(i).asInstanceOf[dom.Element].getAttribute("data-kyo-path")).toList
+        }.toSet
+        if root.hasAttribute("data-kyo-focus-auto") && root.hasAttribute("data-kyo-path") then
+            descendants + root.getAttribute("data-kyo-path")
+        else descendants
+    end focusAutoPaths
+
+    /** Seed the FIRST `data-kyo-focus-auto` element under `newRoot` whose path is not in `oldSet` (i.e. it newly
+      * appeared): record the previously focused element's path plus the focus-restore flag on the stack, then call
+      * `.focus()` on it. Mirrors `faSeed` in HtmlRenderer.clientJs.
+      */
+    private def seedFocusAuto(newRoot: dom.Element, oldSet: Set[String]): Unit =
+        val els = newRoot.querySelectorAll("[data-kyo-focus-auto]")
+        val candidates =
+            (if newRoot.hasAttribute("data-kyo-focus-auto") then Seq(newRoot) else Seq.empty) ++
+                (0 until els.length).map(els(_).asInstanceOf[dom.Element])
+        candidates.find { el =>
+            val p = el.getAttribute("data-kyo-path")
+            p != null && !oldSet.contains(p)
+        }.foreach { el =>
+            val ae = document.activeElement
+            val ret =
+                if ae != null && (ae ne document.body) then Maybe(ae.getAttribute("data-kyo-path"))
+                else Absent
+            focusReturnStack =
+                (el.getAttribute("data-kyo-path"), ret, el.hasAttribute("data-kyo-focus-restore")) :: focusReturnStack
+            val _ = el.asInstanceOf[scalajs.js.Dynamic].focus()
+        }
+    end seedFocusAuto
+
+    /** Pop stack entries whose seeded focus-auto element left the document; when the entry carried
+      * `data-kyo-focus-restore`, focus the recorded previous element (skip silently if it is gone too).
+      * Mirrors `frSweep` in HtmlRenderer.clientJs.
+      */
+    private def sweepFocusAuto(): Unit =
+        var continue = true
+        while continue do
+            focusReturnStack match
+                case (faPath, ret, restore) :: rest =>
+                    if document.querySelector(s"""[data-kyo-path="$faPath"][data-kyo-focus-auto]""") != null then
+                        continue = false
+                    else
+                        focusReturnStack = rest
+                        if restore then
+                            ret.foreach { retPath =>
+                                val re = document.querySelector(s"""[data-kyo-path="$retPath"]""")
+                                if re != null then
+                                    val _ = re.asInstanceOf[scalajs.js.Dynamic].focus()
+                            }
+                        end if
+                case Nil => continue = false
+        end while
+    end sweepFocusAuto
 
     // Bridge a Kyo Async computation from a JS callback boundary by offering it to the page-scoped drain
     // channel. The single AllowUnsafe site narrows to the offer crossing (the JS callback has no Kyo

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -145,7 +145,8 @@ private[kyo] object DomBackend:
     end readSelection
 
     private def restoreFocus(capturedPath: String, selStart: Maybe[Int], selEnd: Maybe[Int]): Unit =
-        val located = document.querySelector(s"""[data-kyo-path="$capturedPath"]""")
+        // Prefer the real element over the reactive wrapper span that shares its path (the wrapper is unfocusable).
+        val located = locateByPath(capturedPath)
         if located != null then
             val focusTarget =
                 if located.hasAttribute("data-kyo-reactive") then
@@ -172,6 +173,14 @@ private[kyo] object DomBackend:
             end match
         end if
     end restoreFocus
+
+    /** The element at `path`, preferring a non-wrapper match: reactive wrapper spans share their
+      * `data-kyo-path` with the first element they wrap, so a plain first-match query can return
+      * the transparent (unfocusable) wrapper instead of the real element.
+      */
+    private def locateByPath(path: String): dom.Element =
+        val direct = document.querySelector(s"""[data-kyo-path="$path"]:not([data-kyo-reactive])""")
+        if direct != null then direct else document.querySelector(s"""[data-kyo-path="$path"]""")
 
     /** The set of `data-kyo-path` values of every `data-kyo-focus-auto` element inside `root`, `root` itself included. */
     private def focusAutoPaths(root: dom.Element): Set[String] =
@@ -222,7 +231,7 @@ private[kyo] object DomBackend:
                         focusReturnStack = rest
                         if restore then
                             ret.foreach { retPath =>
-                                val re = document.querySelector(s"""[data-kyo-path="$retPath"]""")
+                                val re = locateByPath(retPath)
                                 if re != null then
                                     val _ = re.asInstanceOf[scalajs.js.Dynamic].focus()
                             }

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -682,6 +682,21 @@ object UI:
             def focusTrap(v: Boolean): Self  = withAttrs(attrs.copy(focusTrap = Present(v)))
             def focusGroup(id: String): Self = withAttrs(attrs.copy(focusGroup = Present(id)))
 
+            /** Declarative focus seeding: when a re-render inserts this element newly into the DOM (its `data-kyo-path` was
+              * not present before), the client calls `.focus()` on it once; re-rendering an already-visible element (same
+              * path) does not re-seed. Seeding runs after focus/caret restore, so opening a panel wins over
+              * restore-to-trigger; on initial load any focus-auto element is seeded (like native autofocus). Does not make
+              * the element focusable, pair with `tabIndex(-1)` for non-natively-focusable elements. The previously focused
+              * element is recorded for [[focusRestore]].
+              */
+            def focusAuto(v: Boolean): Self = withAttrs(attrs.copy(focusAuto = Present(v)))
+
+            /** Declarative focus return: when this focus-seeded element (see [[focusAuto]]) leaves the document, the client
+              * focuses whatever was focused just before seeding (located by `data-kyo-path`, skipped silently if gone). Only
+              * meaningful with `focusAuto(true)`; typical use is a modal that returns focus to its trigger on close.
+              */
+            def focusRestore(v: Boolean): Self = withAttrs(attrs.copy(focusRestore = Present(v)))
+
             /** Runs `action` on click, ignoring the event payload. */
             def onClick(action: => Any < Async): Self = withAttrs(attrs.copy(onClick = Present(Sync.defer(action)(using frame))))
 
@@ -922,6 +937,8 @@ object UI:
             tabIndex: Maybe[Int] = Absent,
             focusTrap: Maybe[Boolean] = Absent,
             focusGroup: Maybe[String] = Absent,
+            focusAuto: Maybe[Boolean] = Absent,
+            focusRestore: Maybe[Boolean] = Absent,
             uiStyle: Style = Style.empty,
             onClick: Maybe[Any < Async] = Absent,
             onClickEvt: Maybe[MouseEvent => Any < Async] = Absent,

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -388,6 +388,8 @@ private[kyo] object HtmlRenderer:
         attrs.tabIndex.foreach(n => w(sb, s""" tabindex="$n""""))
         attrs.focusTrap.foreach(v => if v then w(sb, """ data-kyo-focus-trap="1""""))
         attrs.focusGroup.foreach(id => w(sb, s""" data-kyo-focus-group="${esc(id)}""""))
+        attrs.focusAuto.foreach(v => if v then w(sb, """ data-kyo-focus-auto="1""""))
+        attrs.focusRestore.foreach(v => if v then w(sb, """ data-kyo-focus-restore="1""""))
         // A generated pseudoClass already carries the base props in its own rule (see
         // registerPseudoClass); rendering them inline too would shadow the pseudo-state override.
         if pseudoClass.isEmpty then
@@ -771,14 +773,19 @@ private[kyo] object HtmlRenderer:
            |      var ap=ae&&ae!==document.body&&ae.getAttribute?ae.getAttribute("data-kyo-path"):null;
            |      var ss=(ae&&typeof ae.selectionStart==='number')?ae.selectionStart:null;
            |      var se=(ae&&typeof ae.selectionEnd==='number')?ae.selectionEnd:null;
+           |      var __fa=faPaths(el);
            |      el.outerHTML=op.Replace.html;
            |      var nel=document.querySelector('[data-kyo-path="'+p+'"]');if(nel){applyJsProps(nel);ba(nel);}
            |      if(ap){var rf=document.querySelector('[data-kyo-path="'+ap+'"]');if(rf&&rf.hasAttribute&&rf.hasAttribute('data-kyo-reactive')){var inner=rf.querySelector('input,textarea,select,[contenteditable]');if(inner)rf=inner;}if(rf){rf.focus();if(ss!==null&&typeof rf.setSelectionRange==='function'){try{rf.setSelectionRange(ss,se);}catch(e){if(e.name!=='InvalidStateError')throw e;}}}}
+           |      // Seed AFTER focus/caret restore so a newly-appeared focus-auto element wins restore-to-trigger (the morph path never seeds).
+           |      if(nel)faSeed(nel,__fa);
            |    }
+           |    frSweep();
            |  }else if(op.Remove){
            |    var p=op.Remove.path.join(".");
            |    var el=document.querySelector('[data-kyo-path="'+p+'"]');
            |    if(el)el.remove();
+           |    frSweep();
            |  }else if(op.InjectCss){
            |    var s=document.createElement("style");
            |    s.textContent=op.InjectCss.css;
@@ -854,7 +861,48 @@ private[kyo] object HtmlRenderer:
            |  if(!an.length)return;
            |  requestAnimationFrame(function(){for(var i=0;i<an.length;i++){try{an[i].beginElement();}catch(e){}}});
            |}
+           |// Focus seeding/restore for [data-kyo-focus-auto]/[data-kyo-focus-restore]; __frs stacks {fa, ret|null, restore}.
+           |// Mirrors DomBackend.focusReturnStack for the SPA transport.
+           |var __frs=[];
+           |// Object-set (keyed by path) of every [data-kyo-focus-auto] path inside root, root included.
+           |function faPaths(root){
+           |  var s={};
+           |  if(!root||!root.querySelectorAll)return s;
+           |  if(root.hasAttribute&&root.hasAttribute("data-kyo-focus-auto")){var rp=root.getAttribute("data-kyo-path");if(rp!==null)s[rp]=true;}
+           |  var els=root.querySelectorAll("[data-kyo-focus-auto]");
+           |  for(var i=0;i<els.length;i++){var ep=els[i].getAttribute("data-kyo-path");if(ep!==null)s[ep]=true;}
+           |  return s;
+           |}
+           |// Seed the FIRST newly-appeared focus-auto element under newRoot (path not in oldSet); record prior focus for frSweep.
+           |function faSeed(newRoot,oldSet){
+           |  if(!newRoot||!newRoot.querySelectorAll)return;
+           |  var cand=[];
+           |  if(newRoot.hasAttribute&&newRoot.hasAttribute("data-kyo-focus-auto"))cand.push(newRoot);
+           |  var els=newRoot.querySelectorAll("[data-kyo-focus-auto]");
+           |  for(var i=0;i<els.length;i++)cand.push(els[i]);
+           |  for(var j=0;j<cand.length;j++){
+           |    var fa=cand[j].getAttribute("data-kyo-path");
+           |    if(fa!==null&&!oldSet[fa]){
+           |      var ae=document.activeElement;
+           |      var ret=(ae&&ae!==document.body&&ae.getAttribute)?ae.getAttribute("data-kyo-path"):null;
+           |      __frs.push({fa:fa,ret:ret,restore:cand[j].hasAttribute("data-kyo-focus-restore")});
+           |      if(typeof cand[j].focus==='function')cand[j].focus();
+           |      return;
+           |    }
+           |  }
+           |}
+           |// Pop stack entries whose seeded element left the document; if it carried focus-restore, focus the recorded prior element.
+           |function frSweep(){
+           |  while(__frs.length>0){
+           |    var top=__frs[__frs.length-1];
+           |    if(document.querySelector('[data-kyo-path="'+top.fa+'"][data-kyo-focus-auto]'))return;
+           |    __frs.pop();
+           |    if(top.restore&&top.ret){var re=document.querySelector('[data-kyo-path="'+top.ret+'"]');if(re&&typeof re.focus==='function')re.focus();}
+           |  }
+           |}
            |applyJsProps(document.body);ba(document.body);
+           |// Initial mount: everything server-rendered is new (empty old set), like native autofocus.
+           |faSeed(document.body,{});
            |// Dropdown helpers: close all dropdowns except the given id
            |function kyoCloseDropdown(exceptId){
            |  var all=document.querySelectorAll('[data-kyo-dropdown-options]');

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -776,7 +776,7 @@ private[kyo] object HtmlRenderer:
            |      var __fa=faPaths(el);
            |      el.outerHTML=op.Replace.html;
            |      var nel=document.querySelector('[data-kyo-path="'+p+'"]');if(nel){applyJsProps(nel);ba(nel);}
-           |      if(ap){var rf=document.querySelector('[data-kyo-path="'+ap+'"]');if(rf&&rf.hasAttribute&&rf.hasAttribute('data-kyo-reactive')){var inner=rf.querySelector('input,textarea,select,[contenteditable]');if(inner)rf=inner;}if(rf){rf.focus();if(ss!==null&&typeof rf.setSelectionRange==='function'){try{rf.setSelectionRange(ss,se);}catch(e){if(e.name!=='InvalidStateError')throw e;}}}}
+           |      if(ap){var rf=lbp(ap);if(rf&&rf.hasAttribute&&rf.hasAttribute('data-kyo-reactive')){var inner=rf.querySelector('input,textarea,select,[contenteditable]');if(inner)rf=inner;}if(rf){rf.focus();if(ss!==null&&typeof rf.setSelectionRange==='function'){try{rf.setSelectionRange(ss,se);}catch(e){if(e.name!=='InvalidStateError')throw e;}}}}
            |      // Seed AFTER focus/caret restore so a newly-appeared focus-auto element wins restore-to-trigger (the morph path never seeds).
            |      if(nel)faSeed(nel,__fa);
            |    }
@@ -891,13 +891,15 @@ private[kyo] object HtmlRenderer:
            |    }
            |  }
            |}
+           |// Prefer the non-wrapper match: a reactive wrapper span shares its data-kyo-path with the element it wraps and is transparent/unfocusable.
+           |function lbp(p){return document.querySelector('[data-kyo-path="'+p+'"]:not([data-kyo-reactive])')||document.querySelector('[data-kyo-path="'+p+'"]');}
            |// Pop stack entries whose seeded element left the document; if it carried focus-restore, focus the recorded prior element.
            |function frSweep(){
            |  while(__frs.length>0){
            |    var top=__frs[__frs.length-1];
            |    if(document.querySelector('[data-kyo-path="'+top.fa+'"][data-kyo-focus-auto]'))return;
            |    __frs.pop();
-           |    if(top.restore&&top.ret){var re=document.querySelector('[data-kyo-path="'+top.ret+'"]');if(re&&typeof re.focus==='function')re.focus();}
+           |    if(top.restore&&top.ret){var re=lbp(top.ret);if(re&&typeof re.focus==='function')re.focus();}
            |  }
            |}
            |applyJsProps(document.body);ba(document.body);

--- a/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
@@ -607,4 +607,30 @@ class FocusableTest extends UITest:
         }
     }
 
+    "closing a focus-restore panel returns focus to a reactive-wrapped trigger (skips the wrapper span)" in {
+        // The reactive-wrapped trigger sits in a <span data-kyo-reactive> that shares its data-kyo-path and is
+        // unfocusable, so restore must prefer the :not([data-kyo-reactive]) match to reach the real button.
+        val app: UI < Async =
+            for
+                showPanel <- Signal.initRef(false)
+                tick      <- Signal.initRef(0)
+            yield UI.div(
+                tick.map(_ => UI.button("Open").id("trigger").onClick(showPanel.set(true))),
+                UI.when(showPanel)(
+                    UI.div(
+                        UI.button("Close").id("close").onClick(showPanel.set(false))
+                    ).id("panel").tabIndex(-1).focusAuto(true).focusRestore(true)
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.click(Selector.id("trigger"))
+                _ <- Browser.assertFocused(Selector.id("panel"))
+                _ <- Browser.click(Selector.id("close"))
+                _ <- Browser.assertNotExists(Selector.id("panel"))
+                _ <- Browser.assertFocused(Selector.id("trigger"))
+            yield ()
+        }
+    }
+
 end FocusableTest

--- a/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
@@ -515,4 +515,96 @@ class FocusableTest extends UITest:
         }
     }
 
+    // focusAuto/focusRestore over the server-push transport in real Chrome. The DomBackend SPA mirror has
+    // no browser harness (Node test env has no DOM); it is kept in sync by construction.
+    "focusAuto and focusRestore emit their data attributes; absent by default" in {
+        val app: UI < Async = UI.div(
+            UI.div("seed").tabIndex(-1).focusAuto(true).focusRestore(true).id("seeded"),
+            UI.div("plain").id("plain")
+        )
+        withUI(app) {
+            for
+                _ <- Browser.assertAttribute(Selector.id("seeded"), "data-kyo-focus-auto", "1")
+                _ <- Browser.assertAttribute(Selector.id("seeded"), "data-kyo-focus-restore", "1")
+                _ <- Browser.assertNoAttribute(Selector.id("plain"), "data-kyo-focus-auto")
+                _ <- Browser.assertNoAttribute(Selector.id("plain"), "data-kyo-focus-restore")
+            yield ()
+        }
+    }
+
+    "opening a panel seeds focus into the focus-auto element (winning over restore-to-trigger)" in {
+        val app: UI < Async =
+            for showPanel <- Signal.initRef(false)
+            yield UI.div(
+                UI.button("Open").id("trigger").onClick(showPanel.set(true)),
+                UI.when(showPanel)(
+                    UI.div(
+                        UI.button("Inside").id("inside")
+                    ).id("panel").tabIndex(-1).focusAuto(true)
+                )
+            )
+        withUI(app) {
+            for
+                // The trigger is focused when the panel appears; without seeding, focus restore would keep it there.
+                _ <- Browser.click(Selector.id("trigger"))
+                _ <- Browser.assertVisible(Selector.id("panel"))
+                _ <- Browser.assertFocused(Selector.id("panel"))
+            yield ()
+        }
+    }
+
+    "a re-render of an already-open focus-auto element does not steal the user's focus" in {
+        // The focus-auto panel is seeded on initial load. Bumping re-renders the whole region with
+        // identical paths: the panel must NOT re-seed, and focus restore must keep focus on the inner button.
+        val app: UI < Async =
+            for n <- Signal.initRef(0)
+            yield UI.div(
+                n.map(i =>
+                    UI.div(
+                        UI.button(s"Inner").id("inner"),
+                        UI.div("seed").tabIndex(-1).focusAuto(true).id("panel"),
+                        UI.span(s"n=$i").id("status")
+                    )
+                ),
+                UI.button("Bump").id("bump").onClick(n.getAndUpdate(_ + 1).unit)
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertFocused(Selector.id("panel"))
+                _ <- Browser.click(Selector.id("inner"))
+                _ <- Browser.assertFocused(Selector.id("inner"))
+                // Synthetic JS click so the click itself does not move focus; the region re-renders with the same paths.
+                _ <- Browser.evalDiscard("document.getElementById('bump').click()")
+                _ <- Browser.assertText(Selector.id("status"), "n=1")
+                // No re-seed: focus stays on the inner button.
+                _ <- Browser.assertFocused(Selector.id("inner"))
+                _ <- Browser.assertNotFocused(Selector.id("panel"))
+            yield ()
+        }
+    }
+
+    "closing a focus-restore panel returns focus to the previously focused element" in {
+        val app: UI < Async =
+            for showPanel <- Signal.initRef(false)
+            yield UI.div(
+                UI.button("Open").id("trigger").onClick(showPanel.set(true)),
+                UI.when(showPanel)(
+                    UI.div(
+                        UI.button("Close").id("close").onClick(showPanel.set(false))
+                    ).id("panel").tabIndex(-1).focusAuto(true).focusRestore(true)
+                )
+            )
+        withUI(app) {
+            for
+                // Opening seeds focus into the panel and records the trigger as the return target.
+                _ <- Browser.click(Selector.id("trigger"))
+                _ <- Browser.assertFocused(Selector.id("panel"))
+                // Closing removes the seeded element, so the sweep restores focus to the trigger.
+                _ <- Browser.click(Selector.id("close"))
+                _ <- Browser.assertNotExists(Selector.id("panel"))
+                _ <- Browser.assertFocused(Selector.id("trigger"))
+            yield ()
+        }
+    }
+
 end FocusableTest


### PR DESCRIPTION
> **⚠ Depends on #1781 (declarative focus seeding / return) — please merge that first.** This refines the focus-restore path introduced by #1781 (`data-kyo-focus-auto` / `-restore`, `restoreFocus`, the focus-return sweep), so it builds on it. The diff shows #1781's commit until it lands.

## Problem

A reactive child — an element whose content or attributes are driven by a signal, e.g. a trigger whose label updates live, `state.map(s => UI.button(s.title))` — renders inside a `<span data-kyo-reactive>` wrapper. That wrapper is styled `display: contents` (layout-transparent) and shares its `data-kyo-path` with the first element it wraps. So when focus restore looks an element up by path with a plain first-match query, it can hit that transparent, unfocusable wrapper instead of the real element — and `.focus()` on the wrapper goes nowhere.

This bites focus restore to a trigger that happens to be a reactive child: opening a `focusRestore` panel records the trigger's path as the return target, and on close the sweep queries that path, lands on the wrapper span, and the trigger never regains focus.

## Solution

Both transports now prefer a `:not([data-kyo-reactive])` match when locating an element by path for focus, falling back to the plain query when there is no non-wrapper match:

- browser mount (`DomBackend`): a `locateByPath` helper, used by the caret/focus restore after a reactive region replace and by the focus-return sweep;
- server-push client (`HtmlRenderer.clientJs`): the same as an `lbp(p)` helper, used in the replace handler's focus/caret restore and in `frSweep`.

## Notes

`FocusableTest` gains a scenario where the trigger is a reactive-wrapped button: open the `focusRestore` panel, close it, and assert focus returns to the button. Without the wrapper skip the restore lands on the `data-kyo-reactive` span and the button never regains focus (verified: the test fails on the base branch and passes here).
