### PR TITLE
[kyo-ui] leave-ghost pins its size against inherited %-based min/max (follow-up: #1788)

### DIFF
--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -41,6 +41,7 @@ private[kyo] object DomBackend:
             html <- HtmlRenderer.render(ui, Seq.empty)
             _    <- Sync.defer(container.innerHTML = html)
             _    <- applyJsProps(container)
+            _    <- Sync.defer(seedEnter(container, Set.empty))
             _    <- Sync.defer(beginAnimationsSync(container))
             exchange = LocalExchange(root)
             dispatch <- ReactiveUI.subscribe(root, exchange)
@@ -110,6 +111,8 @@ private[kyo] object DomBackend:
                                 else pathAttr
                             else null
                         val (selStart, selEnd) = if insideRegion then readSelection(ae) else (Absent, Absent)
+                        val oldEnter           = enterPaths(el)
+                        val ghosts             = prepareLeaveGhosts(el, leaveSurvSet(finalHtml))
                         el.outerHTML = finalHtml
                         val updated = document.querySelector(s"""[data-kyo-path="$pathAttr"]""")
                         if updated != null then
@@ -117,6 +120,9 @@ private[kyo] object DomBackend:
                             beginAnimationsSync(updated)
                         if activePath != null then
                             restoreFocus(activePath, selStart, selEnd)
+                        if updated != null then
+                            seedEnter(updated, oldEnter)
+                        spawnGhosts(ghosts)
                     end if
                 }
             }
@@ -373,5 +379,118 @@ private[kyo] object DomBackend:
     private def parsePath(p: String): Seq[String] =
         if p == null || p.isEmpty then Seq.empty
         else p.split("\\.").toSeq
+
+    // ---- enter/leave transition mirror (SPA transport) ----
+
+    /** The set of `data-kyo-path` values of every `data-kyo-enter` element inside `root`, `root` itself included. */
+    private def enterPaths(root: dom.Element): Set[String] =
+        val els = root.querySelectorAll("[data-kyo-enter]")
+        val ds = (0 until els.length).flatMap { i =>
+            Maybe(els(i).asInstanceOf[dom.Element].getAttribute("data-kyo-path")).toList
+        }.toSet
+        if root.hasAttribute("data-kyo-enter") && root.hasAttribute("data-kyo-path") then
+            ds + root.getAttribute("data-kyo-path")
+        else ds
+    end enterPaths
+
+    /** Animate every `data-kyo-enter` element under `newRoot` (root included) whose path is not in `oldSet`: add the enter
+      * classes, force a reflow, then remove them next frame so the CSS transition runs from the enter-from state.
+      */
+    private def seedEnter(newRoot: dom.Element, oldSet: Set[String]): Unit =
+        val els = newRoot.querySelectorAll("[data-kyo-enter]")
+        val cand =
+            (if newRoot.hasAttribute("data-kyo-enter") then Seq(newRoot) else Seq.empty) ++
+                (0 until els.length).map(els(_).asInstanceOf[dom.Element])
+        cand.foreach { el =>
+            val p = el.getAttribute("data-kyo-path")
+            if p != null && !oldSet.contains(p) then
+                val cls     = el.getAttribute("data-kyo-enter").split("\\s+").filter(_.nonEmpty)
+                val clsList = el.asInstanceOf[scalajs.js.Dynamic].classList
+                cls.foreach(c => clsList.add(c))
+                val _ = el.asInstanceOf[scalajs.js.Dynamic].offsetWidth // force reflow
+                discard(dom.window.requestAnimationFrame { (_: Double) =>
+                    cls.foreach(c => clsList.remove(c))
+                })
+            end if
+        }
+    end seedEnter
+
+    /** The set of paths of `data-kyo-leave` elements in an HTML fragment (which leave-elements survive a region
+      * replace). Keyed on leave-carrying elements, NOT all `data-kyo-path`: a reactive wrapper span shares its path
+      * with the (leaving) element it wraps, so an all-path set would wrongly report the element as surviving.
+      */
+    private def leaveSurvSet(html: String): Set[String] =
+        val tpl = document.createElement("template").asInstanceOf[scalajs.js.Dynamic]
+        tpl.innerHTML = html
+        val content = tpl.content.asInstanceOf[dom.DocumentFragment]
+        val els     = content.querySelectorAll("[data-kyo-leave]")
+        (0 until els.length).flatMap { i =>
+            Maybe(els(i).asInstanceOf[dom.Element].getAttribute("data-kyo-path")).toList
+        }.toSet
+    end leaveSurvSet
+
+    /** Strip `data-kyo-*` and `id` from a subtree so a ghost clone is inert (no selector collisions). */
+    private def stripKyo(el: dom.Element): Unit =
+        def strip(e: dom.Element): Unit =
+            val dyn = e.asInstanceOf[scalajs.js.Dynamic]
+            if scalajs.js.typeOf(dyn.getAttributeNames) == "function" then
+                val names = dyn.getAttributeNames().asInstanceOf[scalajs.js.Array[String]]
+                names.foreach(n => if n.startsWith("data-kyo-") || n == "id" then e.removeAttribute(n))
+        end strip
+        strip(el)
+        val ds = el.querySelectorAll("*")
+        (0 until ds.length).foreach(i => strip(ds(i).asInstanceOf[dom.Element]))
+    end stripKyo
+
+    /** Prepare leave ghosts for the OUTERMOST `data-kyo-leave` elements under `root` being removed (path not in `surv`).
+      * Captures rect + clone WHILE the node is still in the DOM; returns (ghostNode, leaveClasses) descriptors.
+      */
+    private def prepareLeaveGhosts(root: dom.Element, surv: Set[String]): Seq[(dom.Element, String)] =
+        val els = root.querySelectorAll("[data-kyo-leave]")
+        val cand =
+            (if root.getAttribute("data-kyo-leave") != null then Seq(root) else Seq.empty) ++
+                (0 until els.length).map(els(_).asInstanceOf[dom.Element])
+        val removed = cand.filter { e =>
+            val p = e.getAttribute("data-kyo-path")
+            p == null || !surv.contains(p)
+        }
+        val outer = removed.filterNot(e => removed.exists(o => (o ne e) && o.contains(e)))
+        outer.map { node =>
+            val rect  = node.asInstanceOf[scalajs.js.Dynamic].getBoundingClientRect()
+            val leave = node.getAttribute("data-kyo-leave")
+            val g     = node.cloneNode(true).asInstanceOf[dom.Element]
+            stripKyo(g)
+            val st = g.asInstanceOf[scalajs.js.Dynamic].style
+            st.position = "fixed"
+            st.left = rect.left.asInstanceOf[Double].toString + "px"
+            st.top = rect.top.asInstanceOf[Double].toString + "px"
+            st.width = rect.width.asInstanceOf[Double].toString + "px"
+            st.height = rect.height.asInstanceOf[Double].toString + "px"
+            st.margin = "0"
+            st.pointerEvents = "none"
+            g.setAttribute("data-kyo-ghost", "1")
+            (g, if leave == null then "" else leave)
+        }
+    end prepareLeaveGhosts
+
+    /** Append prepared ghosts to `<body>`, add their leave classes next frame, remove on transitionend/animationend or a 1s safety. */
+    private def spawnGhosts(ghosts: Seq[(dom.Element, String)]): Unit =
+        ghosts.foreach { case (g, leave) =>
+            discard(document.body.appendChild(g))
+            val cls     = leave.split("\\s+").filter(_.nonEmpty)
+            val clsList = g.asInstanceOf[scalajs.js.Dynamic].classList
+            discard(dom.window.requestAnimationFrame((_: Double) => cls.foreach(c => clsList.add(c))))
+            var done = false
+            def cleanup(): Unit =
+                if !done then
+                    done = true
+                    if g.parentNode != null then discard(g.parentNode.removeChild(g))
+            val listener: scalajs.js.Function1[dom.Event, Unit] = (_: dom.Event) => cleanup()
+            g.addEventListener("transitionend", listener)
+            g.addEventListener("animationend", listener)
+            val to: scalajs.js.Function0[Unit] = () => cleanup()
+            discard(dom.window.setTimeout(to, 1000.0))
+        }
+    end spawnGhosts
 
 end DomBackend

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -466,6 +466,12 @@ private[kyo] object DomBackend:
             st.top = rect.top.asInstanceOf[Double].toString + "px"
             st.width = rect.width.asInstanceOf[Double].toString + "px"
             st.height = rect.height.asInstanceOf[Double].toString + "px"
+            // The clone keeps the source classes; a %-based min/max (e.g. an overlay's `min-width:100%`)
+            // resolves against <body> and would override the pinned width, so neutralize it to hold the rect pin.
+            st.minWidth = "0"
+            st.maxWidth = "none"
+            st.minHeight = "0"
+            st.maxHeight = "none"
             st.margin = "0"
             st.pointerEvents = "none"
             g.setAttribute("data-kyo-ghost", "1")

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -669,6 +669,23 @@ object UI:
               */
             def cssClass(name: String): Self = withAttrs(attrs.copy(cssClasses = attrs.cssClasses :+ name))
 
+            /** Declarative ENTER transition (client-local): when a patch inserts this element newly into the DOM (its
+              * `data-kyo-path` was not present before, or at initial mount), the client adds the space-separated `classes`
+              * after insertion, forces a reflow, then removes them next frame, so a CSS transition runs from the enter-from
+              * state the classes describe. An echo re-render of an already-present element does not replay. Emits
+              * `data-kyo-enter="..."`.
+              */
+            def enterTransition(classes: String): Self = withAttrs(attrs.copy(enterTransition = Present(classes)))
+
+            /** Declarative LEAVE transition (client-local): when a Replace/Remove removes this element, the client captures
+              * its `getBoundingClientRect` before applying the patch (nothing crosses the wire), then appends a visual GHOST
+              * (deep clone, `position:fixed` at the captured rect, `pointer-events:none`) to `document.body` with these
+              * classes added next frame; the ghost is removed on `transitionend`/`animationend` or a 1s safety timeout. Only
+              * the outermost removed leave-element per patch spawns a ghost. The ghost is visual-only: its identifying
+              * `data-kyo-*`/`id` attributes are stripped from the clone. Emits `data-kyo-leave="..."`.
+              */
+            def leaveTransition(classes: String): Self = withAttrs(attrs.copy(leaveTransition = Present(classes)))
+
             // Internal JS property setter (used by Checkbox.indeterminate, etc.)
             private[kyo] def jsProp(name: String, value: String): Self =
                 withAttrs(attrs.copy(jsProps = attrs.jsProps.updated(name, value)))
@@ -922,6 +939,8 @@ object UI:
             tabIndex: Maybe[Int] = Absent,
             focusTrap: Maybe[Boolean] = Absent,
             focusGroup: Maybe[String] = Absent,
+            enterTransition: Maybe[String] = Absent,
+            leaveTransition: Maybe[String] = Absent,
             uiStyle: Style = Style.empty,
             onClick: Maybe[Any < Async] = Absent,
             onClickEvt: Maybe[MouseEvent => Any < Async] = Absent,

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -388,6 +388,9 @@ private[kyo] object HtmlRenderer:
         attrs.tabIndex.foreach(n => w(sb, s""" tabindex="$n""""))
         attrs.focusTrap.foreach(v => if v then w(sb, """ data-kyo-focus-trap="1""""))
         attrs.focusGroup.foreach(id => w(sb, s""" data-kyo-focus-group="${esc(id)}""""))
+        // enter/leave transition class lists (read client-side by the patch-application code).
+        attrs.enterTransition.foreach(c => w(sb, s""" data-kyo-enter="${esc(c)}""""))
+        attrs.leaveTransition.foreach(c => w(sb, s""" data-kyo-leave="${esc(c)}""""))
         // A generated pseudoClass already carries the base props in its own rule (see
         // registerPseudoClass); rendering them inline too would shadow the pseudo-state override.
         if pseudoClass.isEmpty then
@@ -771,14 +774,20 @@ private[kyo] object HtmlRenderer:
            |      var ap=ae&&ae!==document.body&&ae.getAttribute?ae.getAttribute("data-kyo-path"):null;
            |      var ss=(ae&&typeof ae.selectionStart==='number')?ae.selectionStart:null;
            |      var se=(ae&&typeof ae.selectionEnd==='number')?ae.selectionEnd:null;
+           |      var __en=faEnterPaths(el);
+           |      var __gh=kyoLeavePrepare(el,kyoLeaveSurv(op.Replace.html));
            |      el.outerHTML=op.Replace.html;
            |      var nel=document.querySelector('[data-kyo-path="'+p+'"]');if(nel){applyJsProps(nel);ba(nel);}
            |      if(ap){var rf=document.querySelector('[data-kyo-path="'+ap+'"]');if(rf&&rf.hasAttribute&&rf.hasAttribute('data-kyo-reactive')){var inner=rf.querySelector('input,textarea,select,[contenteditable]');if(inner)rf=inner;}if(rf){rf.focus();if(ss!==null&&typeof rf.setSelectionRange==='function'){try{rf.setSelectionRange(ss,se);}catch(e){if(e.name!=='InvalidStateError')throw e;}}}}
+           |      if(nel)kyoEnterSeed(nel,__en);
+           |      kyoSpawnGhosts(__gh);
            |    }
            |  }else if(op.Remove){
            |    var p=op.Remove.path.join(".");
            |    var el=document.querySelector('[data-kyo-path="'+p+'"]');
+           |    var __rgh=el?kyoLeavePrepare(el,{}):[];
            |    if(el)el.remove();
+           |    kyoSpawnGhosts(__rgh);
            |  }else if(op.InjectCss){
            |    var s=document.createElement("style");
            |    s.textContent=op.InjectCss.css;
@@ -854,7 +863,87 @@ private[kyo] object HtmlRenderer:
            |  if(!an.length)return;
            |  requestAnimationFrame(function(){for(var i=0;i<an.length;i++){try{an[i].beginElement();}catch(e){}}});
            |}
+           |// ---- enter/leave transition helpers (client-local; nothing crosses the wire) ----
+           |// Set of data-kyo-enter paths under root (root included): the enter elements present BEFORE a patch.
+           |function faEnterPaths(root){
+           |  var s={};if(!root)return s;
+           |  if(root.hasAttribute&&root.hasAttribute("data-kyo-enter")){var rp=root.getAttribute("data-kyo-path");if(rp!==null)s[rp]=true;}
+           |  var els=root.querySelectorAll?root.querySelectorAll("[data-kyo-enter]"):[];
+           |  for(var i=0;i<els.length;i++){var ep=els[i].getAttribute("data-kyo-path");if(ep!==null)s[ep]=true;}
+           |  return s;
+           |}
+           |// For each data-kyo-enter element under newRoot (root included) whose path is NOT in oldSet (newly appeared):
+           |// add its enter classes, force a reflow (offsetWidth), then remove them next frame so the CSS transition runs.
+           |function kyoEnterSeed(newRoot,oldSet){
+           |  if(!newRoot)return;
+           |  var cand=[];
+           |  if(newRoot.hasAttribute&&newRoot.hasAttribute("data-kyo-enter"))cand.push(newRoot);
+           |  var els=newRoot.querySelectorAll?newRoot.querySelectorAll("[data-kyo-enter]"):[];
+           |  for(var i=0;i<els.length;i++)cand.push(els[i]);
+           |  for(var j=0;j<cand.length;j++){
+           |    var el=cand[j];var pth=el.getAttribute("data-kyo-path");
+           |    if(pth===null||oldSet[pth])continue;
+           |    var cls=el.getAttribute("data-kyo-enter").split(/\\s+/);
+           |    for(var k=0;k<cls.length;k++){if(cls[k])el.classList.add(cls[k]);}
+           |    void el.offsetWidth;
+           |    (function(e2,cs){requestAnimationFrame(function(){for(var m=0;m<cs.length;m++){if(cs[m])e2.classList.remove(cs[m]);}});})(el,cls);
+           |  }
+           |}
+           |// Set of paths of data-kyo-LEAVE elements in an HTML fragment (which leave-elements SURVIVE a Replace).
+           |// Keyed on leave-carrying elements, NOT all data-kyo-path: a reactive wrapper span shares its path with
+           |// the (leaving) element it wraps, so an all-path set would wrongly report the element as surviving.
+           |function kyoLeaveSurv(html){
+           |  var s={};var t=document.createElement("template");t.innerHTML=html;
+           |  var els=t.content.querySelectorAll("[data-kyo-leave]");
+           |  for(var i=0;i<els.length;i++){var pp=els[i].getAttribute("data-kyo-path");if(pp!==null)s[pp]=true;}
+           |  return s;
+           |}
+           |// Strip data-kyo-* and id from a subtree so a ghost clone is inert (no data-kyo-path/focus-auto selector collisions).
+           |function kyoStrip(el){
+           |  var all=[el];if(el.querySelectorAll){var ds=el.querySelectorAll("*");for(var i=0;i<ds.length;i++)all.push(ds[i]);}
+           |  for(var j=0;j<all.length;j++){var e2=all[j];if(!e2.getAttributeNames)continue;var ns=e2.getAttributeNames();
+           |    for(var k=0;k<ns.length;k++){if(ns[k].indexOf("data-kyo-")===0||ns[k]==="id")e2.removeAttribute(ns[k]);}}
+           |}
+           |// Prepare leave ghosts for the OUTERMOST data-kyo-leave elements under root being removed (path not in survSet).
+           |// Captures rect+clone WHILE the node is still in the DOM (getBoundingClientRect on a detached node is zero).
+           |function kyoLeavePrepare(root,survSet){
+           |  if(!root)return [];
+           |  var cand=[];
+           |  if(root.getAttribute&&root.getAttribute("data-kyo-leave")!==null)cand.push(root);
+           |  var els=root.querySelectorAll?root.querySelectorAll("[data-kyo-leave]"):[];
+           |  for(var i=0;i<els.length;i++)cand.push(els[i]);
+           |  var removed=[];
+           |  for(var j=0;j<cand.length;j++){var pp=cand[j].getAttribute("data-kyo-path");if(pp===null||!survSet[pp])removed.push(cand[j]);}
+           |  var out=[];
+           |  for(var k=0;k<removed.length;k++){var inside=false;
+           |    for(var m=0;m<removed.length;m++){if(m!==k&&removed[m].contains(removed[k])){inside=true;break;}}
+           |    if(!inside)out.push(removed[k]);}
+           |  var ghosts=[];
+           |  for(var n=0;n<out.length;n++){
+           |    var node=out[n];var rect=node.getBoundingClientRect();var leave=node.getAttribute("data-kyo-leave");
+           |    var g=node.cloneNode(true);kyoStrip(g);
+           |    g.style.position="fixed";g.style.left=rect.left+"px";g.style.top=rect.top+"px";
+           |    g.style.width=rect.width+"px";g.style.height=rect.height+"px";g.style.margin="0";g.style.pointerEvents="none";
+           |    g.setAttribute("data-kyo-ghost","1");
+           |    ghosts.push({node:g,leave:leave});
+           |  }
+           |  return ghosts;
+           |}
+           |// Append prepared ghosts to <body>, add their leave classes next frame, remove on transitionend/animationend or a 1s safety.
+           |function kyoSpawnGhosts(ghosts){
+           |  if(!ghosts)return;
+           |  for(var i=0;i<ghosts.length;i++){(function(gh){
+           |    var g=gh.node;document.body.appendChild(g);
+           |    var cls=(gh.leave||"").split(/\\s+/);
+           |    requestAnimationFrame(function(){for(var c=0;c<cls.length;c++){if(cls[c])g.classList.add(cls[c]);}});
+           |    var done=false;
+           |    function cleanup(){if(done)return;done=true;if(g.parentNode)g.parentNode.removeChild(g);}
+           |    g.addEventListener("transitionend",cleanup);g.addEventListener("animationend",cleanup);
+           |    setTimeout(cleanup,1000);
+           |  })(ghosts[i]);}
+           |}
            |applyJsProps(document.body);ba(document.body);
+           |kyoEnterSeed(document.body,{});
            |// Dropdown helpers: close all dropdowns except the given id
            |function kyoCloseDropdown(exceptId){
            |  var all=document.querySelectorAll('[data-kyo-dropdown-options]');

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -923,7 +923,11 @@ private[kyo] object HtmlRenderer:
            |    var node=out[n];var rect=node.getBoundingClientRect();var leave=node.getAttribute("data-kyo-leave");
            |    var g=node.cloneNode(true);kyoStrip(g);
            |    g.style.position="fixed";g.style.left=rect.left+"px";g.style.top=rect.top+"px";
-           |    g.style.width=rect.width+"px";g.style.height=rect.height+"px";g.style.margin="0";g.style.pointerEvents="none";
+           |    g.style.width=rect.width+"px";g.style.height=rect.height+"px";
+           |    // The clone keeps the source classes; a %-based min/max (e.g. `min-width:100%`) resolves
+           |    // against <body> and would override the pinned width, so neutralize it to hold the rect pin.
+           |    g.style.minWidth="0";g.style.maxWidth="none";g.style.minHeight="0";g.style.maxHeight="none";
+           |    g.style.margin="0";g.style.pointerEvents="none";
            |    g.setAttribute("data-kyo-ghost","1");
            |    ghosts.push({node:g,leave:leave});
            |  }

--- a/kyo-ui/shared/src/test/scala/kyo/EnterLeaveTransitionScenarioItTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/EnterLeaveTransitionScenarioItTest.scala
@@ -1,0 +1,79 @@
+package kyo
+
+import kyo.Browser.*
+
+/** Declarative enter/leave CSS transition lifecycle over the server-push transport in real Chrome. The DomBackend
+  * SPA mirror has no browser harness (same convention as FocusAutoScenarioItTest) and is kept in sync by construction.
+  *
+  * The transition is on a plain CSS class ("boxbase"), not the element id, because the leave ghost is a clone with
+  * all `data-kyo-*`/`id` attributes stripped; a regular class survives the strip so the ghost actually transitions.
+  */
+class EnterLeaveTransitionScenarioItTest extends UITest:
+
+    private val styleTag: String =
+        """<style>.boxbase{opacity:1;transition:opacity 0.15s linear;} .efrom{opacity:0;} .lto{opacity:0;}</style>"""
+
+    "enterTransition emits data-kyo-enter" in {
+        withUI(UI.div(UI.div("hi").id("box").enterTransition("efrom"))) {
+            Browser.assertAttribute(Selector.id("box"), "data-kyo-enter", "efrom").unit
+        }
+    }
+
+    "leaveTransition emits data-kyo-leave" in {
+        withUI(UI.div(UI.div("bye").id("box").leaveTransition("lto"))) {
+            Browser.assertAttribute(Selector.id("box"), "data-kyo-leave", "lto").unit
+        }
+    }
+
+    "toggling an enter element visible runs its enter transition then clears the enter class" in {
+        val app: UI < Async =
+            for visible <- Signal.initRef(false)
+            yield UI.div(
+                UI.rawHtml(styleTag),
+                UI.button("show").id("show").onClick(visible.set(true)),
+                UI.when(visible)(
+                    UI.div("hi").id("box").cssClass("boxbase").enterTransition("efrom")
+                )
+            )
+        withUI(app) {
+            for
+                // A transitionend on #box fires only if the enter class was applied (opacity 0) then removed
+                // (opacity 1), i.e. the enter lifecycle actually ran.
+                _ <- Browser.evalDiscard(
+                    "window.__enterDone=false;document.body.addEventListener('transitionend',function(e){if(e.target&&e.target.id==='box')window.__enterDone=true;},true);"
+                )
+                _ <- Browser.click(Selector.id("show"))
+                _ <- Browser.assertExists(Selector.id("box"))
+                _ <- Browser.waitFor("window.__enterDone")
+                _ <- Browser.waitFor("!document.getElementById('box').classList.contains('efrom')")
+            yield ()
+        }
+    }
+
+    "toggling a leave element hidden spawns a body-level ghost carrying the leave class, then removes it" in {
+        val app: UI < Async =
+            for visible <- Signal.initRef(true)
+            yield UI.div(
+                UI.rawHtml(styleTag),
+                UI.button("hide").id("hide").onClick(visible.set(false)),
+                UI.when(visible)(
+                    UI.div("bye").id("box").cssClass("boxbase").leaveTransition("lto")
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertExists(Selector.id("box"))
+                // Observe ghost insertion into <body> and whether it later carries the leave class.
+                _ <- Browser.evalDiscard(
+                    "window.__ghostSeen=false;window.__ghostHadClass=false;new MutationObserver(function(ms){ms.forEach(function(m){for(var i=0;i<m.addedNodes.length;i++){var n=m.addedNodes[i];if(n.getAttribute&&n.getAttribute('data-kyo-ghost')){window.__ghostSeen=true;(function(nd){requestAnimationFrame(function(){requestAnimationFrame(function(){if(nd.classList&&nd.classList.contains('lto'))window.__ghostHadClass=true;});});})(n);}}});}).observe(document.body,{childList:true});"
+                )
+                _ <- Browser.click(Selector.id("hide"))
+                _ <- Browser.assertNotExists(Selector.id("box"))
+                _ <- Browser.waitFor("window.__ghostSeen")
+                _ <- Browser.waitFor("window.__ghostHadClass")
+                _ <- Browser.waitFor("document.querySelectorAll('[data-kyo-ghost]').length===0")
+            yield ()
+        }
+    }
+
+end EnterLeaveTransitionScenarioItTest


### PR DESCRIPTION
> **⚠ Depends on #1788 (enter/leave CSS transition lifecycle) — please merge that first.** This refines the leave-ghost that #1788 introduced, so it builds on it. The diff shows #1788's commit until it lands.

## Problem

A leave transition clones the departing element into a `position: fixed` ghost re-parented to `<body>` and pins it to the element's last `getBoundingClientRect`, so it animates out from where it was. But the clone keeps the source's classes — and a percentage min/max size on those classes (e.g. an overlay panel's `min-width: 100%`) now resolves against the ghost's **new** parent, `<body>` (the viewport), overriding the pinned pixel width. The ghost balloons full-width for the duration of the transition.

## Solution

Right after pinning the rect, neutralize the four percentage-sensitive constraints on the ghost — `min-width`/`max-width`/`min-height`/`max-height` — in both transports (browser mount `DomBackend` and server-push `HtmlRenderer.clientJs`), so the pixel pin holds regardless of what the cloned classes declare.

## Notes

Covered by the existing enter/leave ghost scenario test (the ghost is still spawned and torn down correctly — no regression). The change is a layout-constraint neutralization on the already-tested ghost element.
