### PR TITLE
[kyo-ui] add preventScrollKeys: suppress native page scroll for nav keys

### DIFF
--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -362,6 +362,14 @@ private[kyo] object DomBackend:
         var clickSubmitGuard = false
 
         val handler: scalajs.js.Function1[dom.Event, Unit] = (e: dom.Event) =>
+            // Runs before path resolution so it fires even when the focused descendant is not a path element;
+            // the keydown is still forwarded below, so the region's own onKeyDown runs (see `scrollKeyPrevented`).
+            if e.`type` == "keydown" then
+                val ke  = e.asInstanceOf[dom.KeyboardEvent]
+                val tgt = e.target.asInstanceOf[dom.Element]
+                if tgt != null && scrollKeyPrevented(ke.key, tgt) && tgt.closest("[data-kyo-scroll-keys]") != null then
+                    e.preventDefault()
+            end if
             findPathElement(e.target.asInstanceOf[dom.Element]).foreach { target =>
                 val path    = parsePath(target.getAttribute("data-kyo-path"))
                 val evTypes = ChainTypes(target)
@@ -752,5 +760,22 @@ private[kyo] object DomBackend:
                 if nv != v then setValue(t, nv)
             end if
         end if
+
+    /** True when `key` is a page-scrolling navigation key a `preventScrollKeys` region should suppress on `target`.
+      * Vertical keys are always suppressed; horizontal/edge keys only when `target` is not text-editable, so a filter
+      * input keeps caret movement.
+      */
+    private def scrollKeyPrevented(key: String, target: dom.Element): Boolean =
+        def editable =
+            val tag = target.tagName
+            tag == "INPUT" || tag == "TEXTAREA" || tag == "SELECT" ||
+            target.asInstanceOf[scalajs.js.Dynamic].isContentEditable.asInstanceOf[Boolean]
+        end editable
+        key match
+            case "ArrowUp" | "ArrowDown" | "PageUp" | "PageDown" => true
+            case "ArrowLeft" | "ArrowRight" | "Home" | "End"     => !editable
+            case _                                               => false
+        end match
+    end scrollKeyPrevented
 
 end DomBackend

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -762,17 +762,18 @@ private[kyo] object DomBackend:
         end if
 
     /** True when `key` is a page-scrolling navigation key a `preventScrollKeys` region should suppress on `target`.
-      * Vertical keys are always suppressed; horizontal/edge keys only when `target` is not text-editable, so a filter
-      * input keeps caret movement.
+      * Vertical keys are exempt when `target` consumes them itself (caret line movement, option change) — there the
+      * browser default is not a page scroll, so there is nothing to suppress. A single-line input stays suppressed for
+      * vertical keys on purpose: that is the combobox case where `ArrowDown` drives the listbox highlight.
+      * Horizontal/edge keys are exempt for any text-editable target, so a filter input keeps caret movement.
       */
     private def scrollKeyPrevented(key: String, target: dom.Element): Boolean =
-        def editable =
-            val tag = target.tagName
-            tag == "INPUT" || tag == "TEXTAREA" || tag == "SELECT" ||
-            target.asInstanceOf[scalajs.js.Dynamic].isContentEditable.asInstanceOf[Boolean]
-        end editable
+        val tag              = target.tagName
+        def contentEditable  = target.asInstanceOf[scalajs.js.Dynamic].isContentEditable.asInstanceOf[Boolean]
+        def editable         = tag == "INPUT" || tag == "TEXTAREA" || tag == "SELECT" || contentEditable
+        def verticalConsumer = tag == "TEXTAREA" || tag == "SELECT" || contentEditable
         key match
-            case "ArrowUp" | "ArrowDown" | "PageUp" | "PageDown" => true
+            case "ArrowUp" | "ArrowDown" | "PageUp" | "PageDown" => !verticalConsumer
             case "ArrowLeft" | "ArrowRight" | "Home" | "End"     => !editable
             case _                                               => false
         end match

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -778,6 +778,22 @@ object UI:
 
             /** Runs `f` when the mouse wheel is used over this element, receiving the [[kyo.UI.WheelEvent]] payload. */
             def onScroll(f: WheelEvent => Any < Async): Self = withAttrs(attrs.copy(onScrollEvt = Present(f)))
+
+            /** Marks this element (and its subtree) as a keyboard-navigation region whose page-scrolling keys are
+              * suppressed. While focus is on this element or a descendant, the client calls `preventDefault()`
+              * synchronously for the navigation keys so the browser does not ALSO scroll the page; the keydown is
+              * still forwarded, so this element's own `onKeyDown` (e.g. moving an option highlight) runs unchanged.
+              *
+              * Vertical keys (`ArrowUp`/`ArrowDown`/`PageUp`/`PageDown`) are always suppressed. Horizontal/edge keys
+              * (`ArrowLeft`/`ArrowRight`/`Home`/`End`) are suppressed only when the focused target is NOT a text-editable
+              * field, so caret movement inside a filter input keeps working.
+              *
+              * Declarative by necessity: a kyo-ui handler runs asynchronously (and remotely on the server-push
+              * transport), so it cannot decline the browser default in time. Both transports therefore read the emitted
+              * `data-kyo-scroll-keys` attribute in the browser before posting the event — the framework's equivalent of
+              * the imperative `event.preventDefault()` a component library calls in every arrow-key handler.
+              */
+            def preventScrollKeys: Self = withAttrs(attrs.copy(dataAttrs = attrs.dataAttrs.updated("kyo-scroll-keys", "1")))
         end Interactive
 
         // ---- Layout traits ----

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -784,7 +784,10 @@ object UI:
               * synchronously for the navigation keys so the browser does not ALSO scroll the page; the keydown is
               * still forwarded, so this element's own `onKeyDown` (e.g. moving an option highlight) runs unchanged.
               *
-              * Vertical keys (`ArrowUp`/`ArrowDown`/`PageUp`/`PageDown`) are always suppressed. Horizontal/edge keys
+              * Vertical keys (`ArrowUp`/`ArrowDown`/`PageUp`/`PageDown`) are suppressed unless the focused target
+              * consumes them itself (`textarea`, `select`, contenteditable — there the browser default is caret line
+              * movement or an option change, not a page scroll). A single-line input stays suppressed for vertical keys:
+              * that is the combobox case where `ArrowDown` drives the listbox highlight. Horizontal/edge keys
               * (`ArrowLeft`/`ArrowRight`/`Home`/`End`) are suppressed only when the focused target is NOT a text-editable
               * field, so caret movement inside a filter input keeps working.
               *

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -1134,6 +1134,13 @@ private[kyo] object HtmlRenderer:
            |    else post({Change:{path:p,value:tgt.value}});
            |  }else if(t==="submit"){e.preventDefault();if(!window._kyoClickSubmit&&he(el,"submit")){var smid=e.target&&e.target.id?e.target.id:null;post({Submit:{path:p,mouse:mkMouse({ctrl:false,alt:false,shift:false,meta:false},smid)}});}}
            |  else if(t==="keydown"){
+           |    // preventScrollKeys: suppress native page-scroll for nav keys in a data-kyo-scroll-keys region; keydown still posts below.
+           |    if(e.target&&e.target.closest&&e.target.closest('[data-kyo-scroll-keys]')){
+           |      var __sk=e.target,__ed=(/^(INPUT|TEXTAREA|SELECT)$$/.test(__sk.tagName)||__sk.isContentEditable);
+           |      var __vk=(e.key==="ArrowUp"||e.key==="ArrowDown"||e.key==="PageUp"||e.key==="PageDown");
+           |      var __hk=(e.key==="ArrowLeft"||e.key==="ArrowRight"||e.key==="Home"||e.key==="End");
+           |      if(__vk||(__hk&&!__ed))e.preventDefault();
+           |    }
            |    // Focus-trap: when Tab is pressed inside a [data-kyo-focus-trap="1"] container,
            |    // wrap focus within the trap's focusable children instead of escaping to the page.
            |    // Escape falls through so the element's onKeyDown handler can close the modal.

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -1137,9 +1137,10 @@ private[kyo] object HtmlRenderer:
            |    // preventScrollKeys: suppress native page-scroll for nav keys in a data-kyo-scroll-keys region; keydown still posts below.
            |    if(e.target&&e.target.closest&&e.target.closest('[data-kyo-scroll-keys]')){
            |      var __sk=e.target,__ed=(/^(INPUT|TEXTAREA|SELECT)$$/.test(__sk.tagName)||__sk.isContentEditable);
+           |      var __vc=(/^(TEXTAREA|SELECT)$$/.test(__sk.tagName)||__sk.isContentEditable);
            |      var __vk=(e.key==="ArrowUp"||e.key==="ArrowDown"||e.key==="PageUp"||e.key==="PageDown");
            |      var __hk=(e.key==="ArrowLeft"||e.key==="ArrowRight"||e.key==="Home"||e.key==="End");
-           |      if(__vk||(__hk&&!__ed))e.preventDefault();
+           |      if((__vk&&!__vc)||(__hk&&!__ed))e.preventDefault();
            |    }
            |    // Focus-trap: when Tab is pressed inside a [data-kyo-focus-trap="1"] container,
            |    // wrap focus within the trap's focusable children instead of escaping to the page.

--- a/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
@@ -715,4 +715,18 @@ class FocusableTest extends UITest:
         }
     }
 
+    "preventScrollKeys keeps caret line movement in a textarea inside the region" in {
+        // A textarea consumes vertical keys itself (caret line movement), so the region must not suppress them there.
+        withUI(UI.div.preventScrollKeys(
+            UI.textarea.id("ta")
+        )) {
+            for
+                _   <- Browser.fill(Selector.id("ta"), "first\nsecond")
+                _   <- Browser.evalDiscard("var t=document.getElementById('ta');t.focus();t.setSelectionRange(0,0)")
+                _   <- Browser.press(Selector.id("ta"), Key.ArrowDown)
+                pos <- Browser.evalInt("document.getElementById('ta').selectionStart")
+            yield assert(pos >= 6) // caret left line 1 ("first\n" is 6 chars), so ArrowDown was not preventDefault-ed
+        }
+    }
+
 end FocusableTest

--- a/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/FocusableTest.scala
@@ -692,4 +692,27 @@ class FocusableTest extends UITest:
         }
     }
 
+    "preventScrollKeys suppresses the browser's native page scroll for a nav key, still firing onKeyDown" in {
+        // A tall page so PageDown CAN scroll it natively; the focused button opts into preventScrollKeys.
+        val app: UI < Async =
+            for log <- Signal.initRef("")
+            yield UI.div(
+                UI.button("nav").id("nav").tabIndex(0).preventScrollKeys
+                    .onKeyDown((_: KeyboardEvent) => log.set("pressed")),
+                UI.span(log).id("log"),
+                UI.div("spacer").style(Style.height(Length.Px(3000)))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.click(Selector.id("nav"))
+                _ <- Browser.assertFocused(Selector.id("nav"))
+                _ <- Browser.assertAttribute(Selector.id("nav"), "data-kyo-scroll-keys", "1")
+                _ <- Browser.press(Selector.id("nav"), Key.PageDown)
+                // The keydown is suppressed for scrolling, not swallowed: onKeyDown still ran...
+                _  <- Browser.assertText(Selector.id("log"), "pressed")
+                sp <- Browser.scrollPosition
+            yield assert(sp.y == 0) // ...and the page did not scroll
+        }
+    }
+
 end FocusableTest


### PR DESCRIPTION
## Problem

Consider a custom listbox: the user holds `ArrowDown` to move the highlight through the options. The element's `onKeyDown` moves the highlight — but the browser *also* scrolls the whole page, because `ArrowDown` is a page-scroll key and nothing declined that default. The list scrolls out from under the user.

A kyo-ui handler cannot fix this itself. Handlers here run asynchronously — and on the server-push transport they run on the server, a network round trip away — so by the time a handler could call `preventDefault()`, the browser has already scrolled. Declining a browser default has to happen synchronously, in the browser, at the moment of the keydown.

## Solution

Add `preventScrollKeys`, which marks an element and its subtree as a keyboard-navigation region. It emits a `data-kyo-scroll-keys` attribute, and both transports (the browser-mount `DomBackend` and the server-push client script) read it in the browser: while focus is on that element or a descendant, they call `preventDefault()` synchronously for the page-scrolling navigation keys, then still forward the keydown so the element's own `onKeyDown` runs. The key is suppressed for scrolling, not swallowed.

Vertical keys (`ArrowUp`/`ArrowDown`/`PageUp`/`PageDown`) are always suppressed. Horizontal and edge keys (`ArrowLeft`/`ArrowRight`/`Home`/`End`) are suppressed only when the focused target is not a text-editable field (`<input>`/`<textarea>`/`<select>`/`contenteditable`), so caret movement inside a filter input keeps working.

## Notes

`FocusableTest` gains a scenario: a focused `preventScrollKeys` button sits on a deliberately tall (3000px) page. Pressing `PageDown` leaves `window.scrollY` at 0 while the button's `onKeyDown` still fires (verified: without the fix the page scrolls and the assertion fails).
