### PR TITLE
[kyo-ui] comment-marker region delimiters + in-place range morphing (both transports) (follow-up: #1780)

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Fiber.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Fiber.scala
@@ -121,6 +121,12 @@ object Fiber:
 
     /** Runs an asynchronous computation in a new Fiber guaranteeing eventual interruption via the [[Scope]] effect.
       *
+      * If a [[Fiber.Supervisor]] is installed in the current context (see [[Supervisor.let]]), the spawned fiber is additionally
+      * SUPERVISED: any non-interrupt terminal failure (an `Abort` failure or a panic that is not an [[Interrupted]]) is reported to the
+      * supervisor exactly once. Interruptions (including the scope-close interrupt this very method registers) are never reported.
+      * With no supervisor installed (the default), behavior is unchanged. [[initUnscoped]] and [[use]] never supervise: they are the
+      * escape hatches for fire-and-forget fibers and for fibers whose failure the caller observes itself.
+      *
       * @param v
       *   The computation to run
       * @return
@@ -135,7 +141,56 @@ object Fiber:
         reduce: Reducible[Abort[E]],
         frame: Frame
     ): Fiber[A, reduce.SReduced & S2] < (Sync & S & Scope) =
-        Scope.acquireRelease(initUnscoped[E, A, S, S2](v))(_.interrupt)
+        Supervisor.local.use {
+            case Absent => Scope.acquireRelease(initUnscoped[E, A, S, S2](v))(_.interrupt)
+            case Present(sup) =>
+                Scope.acquireRelease(initUnscoped[E, A, S, S2](v))(_.interrupt).map { fiber =>
+                    Sync.defer {
+                        Supervisor.watch(fiber, sup)
+                        fiber
+                    }
+                }
+        }
+
+    /** Observes non-interrupt failures of fibers spawned via the scoped [[init]].
+      *
+      * A supervisor is carried in an inheritable [[Local]] ([[Supervisor.let]]), so it reaches every scoped `Fiber.init` in the
+      * wrapped computation AND in fibers it forks (context capture at spawn). This is the primitive behind kyo-ui's node-scope
+      * supervision: the UI engine installs a supervisor around a mounted node's effect so a background data feed failing AFTER the
+      * node published its UI can still flip the node into its error state.
+      *
+      * The callback runs on the completing fiber's thread with no effect context: it must be fast, non-blocking, and must not throw
+      * (typically it completes a promise or sets an atomic).
+      */
+    abstract private[kyo] class Supervisor:
+        /** Invoked at most once per supervised fiber, on any non-interrupt terminal failure. */
+        def onFailure(error: Result.Error[Any])(using AllowUnsafe): Unit
+
+    private[kyo] object Supervisor:
+        /** The ambient supervisor. Inheritable so supervised code's own forks stay supervised. */
+        private[kyo] val local: Local[Maybe[Supervisor]] = Local.init(Maybe.empty[Supervisor])
+
+        /** Runs `v` with `sup` installed as the ambient supervisor. */
+        private[kyo] def let[A, S](sup: Supervisor)(v: A < S)(using Frame): A < S =
+            local.let(Present(sup))(v)
+
+        /** Runs `v` with NO ambient supervisor: the subtree opt-out. */
+        private[kyo] def none[A, S](v: A < S)(using Frame): A < S =
+            local.let(Absent)(v)
+
+        /** Registers the failure watch on a just-spawned fiber. Safe to call after completion: `IOPromise.onComplete` on a settled
+          * promise invokes the callback immediately, so an instantly-failing fiber still reports.
+          */
+        private[kyo] def watch(fiber: IOPromiseBase[?, ?], sup: Supervisor): Unit =
+            fiber.asInstanceOf[IOPromise[Any, Any]].onComplete {
+                case Result.Panic(_: Interrupted)   => ()
+                case Result.Failure(_: Interrupted) => ()
+                case error: Result.Error[Any] =>
+                    import AllowUnsafe.embrace.danger
+                    sup.onFailure(error)
+                case _ => ()
+            }
+    end Supervisor
 
     /** Use an asynchronous computation running in a new Fiber, interrupting the fiber after usage.
       *

--- a/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/FiberTest.scala
@@ -1,6 +1,7 @@
 package kyo
 
 import Fiber.Promise
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger as JAtomicInteger
 
 class FiberTest extends kyo.test.Test[Any]:
@@ -1240,6 +1241,167 @@ class FiberTest extends kyo.test.Test[Any]:
             yield
                 assert(!res)
                 assert(value == 42)
+        }
+    }
+
+    "supervisor" - {
+        final class Recorder extends Fiber.Supervisor:
+            val errors = new CopyOnWriteArrayList[Result.Error[Any]]()
+            def onFailure(error: Result.Error[Any])(using AllowUnsafe): Unit =
+                discard(errors.add(error))
+            def failures: List[Result.Error[Any]] =
+                import scala.jdk.CollectionConverters.*
+                errors.asScala.toList
+        end Recorder
+
+        val boom = new RuntimeException("boom")
+
+        "supervised" - {
+            "observes a scoped fiber's Abort failure" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        for
+                            fiber <- Fiber.init(Abort.fail(boom))
+                            _     <- fiber.getResult
+                        yield ()
+                    }
+                }.map { _ =>
+                    assert(sup.failures == List(Result.Failure(boom)))
+                }
+            }
+
+            "observes a panic" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        for
+                            // Sync.defer: the throw must happen INSIDE the running fiber (an eager
+                            // by-name throw would panic the spawning fiber instead).
+                            fiber <- Fiber.init(Sync.defer((throw boom): Unit))
+                            _     <- fiber.getResult
+                        yield ()
+                    }
+                }.map { _ =>
+                    assert(sup.failures == List(Result.Panic(boom)))
+                }
+            }
+
+            "interrupt does not notify" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        for
+                            fiber <- Fiber.init(Async.never)
+                            _     <- fiber.interrupt
+                            _     <- fiber.getResult.map(_ => ()).handle(Abort.run[Throwable](_))
+                        yield ()
+                    }
+                }.map { _ =>
+                    assert(sup.failures.isEmpty)
+                }
+            }
+
+            "scope-close interrupt does not notify" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        Fiber.init(Async.never).unit
+                    }
+                }.map { _ =>
+                    assert(sup.failures.isEmpty)
+                }
+            }
+
+            "an instantly-failed fiber still notifies (post-completion registration)" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        for
+                            fiber <- Fiber.init(Abort.fail(boom))
+                            _     <- fiber.getResult
+                        yield ()
+                    }
+                }.map { _ =>
+                    assert(sup.failures == List(Result.Failure(boom)))
+                }
+            }
+
+            "a nested scoped fork inherits the supervisor (grandchild failure notifies)" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        for
+                            outer <- Fiber.init {
+                                Scope.run {
+                                    Fiber.init(Abort.fail(boom)).map(_.getResult.unit)
+                                }
+                            }
+                            _ <- outer.getResult
+                        yield ()
+                    }
+                }.map { _ =>
+                    assert(sup.failures == List(Result.Failure(boom)))
+                }
+            }
+
+            "a successful fiber does not notify" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        Fiber.init(42).map(_.get).map(r => assert(r == 42))
+                    }
+                }.map { _ =>
+                    assert(sup.failures.isEmpty)
+                }
+            }
+
+            "a non-Throwable typed failure reaches the supervisor as Result.Failure" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Scope.run {
+                        Fiber.init(Abort.fail("domain error")).map(_.getResult.unit)
+                    }
+                }.map { _ =>
+                    assert(sup.failures == List(Result.Failure("domain error")))
+                }
+            }
+        }
+
+        "opt-out" - {
+            "initUnscoped is not supervised" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    for
+                        fiber <- Fiber.initUnscoped(Abort.fail(boom))
+                        _     <- fiber.getResult
+                    yield ()
+                }.map { _ =>
+                    assert(sup.failures.isEmpty)
+                }
+            }
+
+            "Supervisor.none opts a subtree out" in {
+                val sup = new Recorder
+                Fiber.Supervisor.let(sup) {
+                    Fiber.Supervisor.none {
+                        Scope.run {
+                            Fiber.init(Abort.fail(boom)).map(_.getResult.unit)
+                        }
+                    }
+                }.map { _ =>
+                    assert(sup.failures.isEmpty)
+                }
+            }
+        }
+
+        "no supervisor installed: init behaves identically (failure stays unobserved)" in {
+            Scope.run {
+                for
+                    fiber  <- Fiber.init(Abort.fail(boom))
+                    result <- fiber.getResult
+                yield assert(result == Result.Failure(boom))
+            }
         }
     }
 

--- a/kyo-ui/README.md
+++ b/kyo-ui/README.md
@@ -341,6 +341,43 @@ If you need both a signal-driven attribute AND a chainable element method, set t
 
 When you pass either a constant `String` or a `SignalRef[String]` to `.value`, the framework wraps it in `UI.Bound[String]`: `Const(v)` or `Ref(ref)`. You normally never name this type; it surfaces in AST pattern matching (see [Pattern-matching on UI](#pattern-matching-on-ui-ast-access)).
 
+## Effectful component mounts
+
+The reactive boundaries above re-render pure `UI` values as signals change. A component that must run an *effect* to produce its UI (load data, open a subscription, read an ambient service) needs more: a node that runs `UI < (Async & Scope)`, shows something while it is pending, and gives a failure somewhere to land. `UI.mounted` is that node.
+
+`UI.mounted(effect)` lifts an effectful component into the tree as an ordinary child. The effect runs when the node attaches, inside a `Scope` tied to the node's lifetime (torn down on detach), so resources it acquires are released when the node goes away; an `Abort[Throwable]` failure is caught into the node's error state instead of propagating. The builder tunes the surrounding behavior:
+
+| Modifier | Effect |
+| --- | --- |
+| `.keyed(k)` | Continuity anchor: the live instance (its `Scope`, resources, published content) is kept across re-renders of the enclosing reactive region while an equal key is re-emitted, and torn down when the key changes or disappears. Any `CanEqual` value works; the idiomatic key is the component's singleton object, tupled with the non-`Signal` inputs the effect closed over. |
+| `.placeholder(ui)` | Content painted while the effect is pending on first mount. Defaults to an empty node. |
+| `.onError(f)` | Renders a failed mount (an `Abort` failure or a panic); the failure is also logged. The enclosing region stays alive, and a later key change re-mounts cleanly. |
+| `.pending(KeepLatest \| Placeholder)` | Re-mount policy for a keyed node: `KeepLatest` (the default) keeps the last rendered content visible as an inert frozen snapshot (its nested regions and handlers are already torn down) until the new instance publishes; `Placeholder` drops back to the placeholder, the honest choice for interactive content where a frozen-but-visible form would swallow input. |
+
+```scala
+import UI.*
+import kyo.*
+
+def profileCard(userId: Int): UI < (Async & Scope) =
+    for name <- Signal.initRef("...")
+    yield div(h2(name), p(s"user #$userId"))
+
+val card: UI =
+    UI.mounted(profileCard(42))
+        .keyed(42)
+        .placeholder(div("loading..."))
+        .onError(e => div(s"failed: ${e.getMessage}"))
+        .pending(PendingPolicy.KeepLatest)
+```
+
+A value input that should UPDATE a live instance belongs in a `Signal` parameter, not the key; a non-`Signal` value the effect captures belongs IN the key, or it is silently frozen at mount time. A duplicate key under one region renders an inline error node in the second slot rather than silently sharing one instance.
+
+### Failure after the first paint
+
+A mount can also fail *after* it has already published its UI: a background fiber it forked (a data feed, a subscription) terminates with an error. Node-scope supervision covers that window: the engine installs a failure observer around the mounted effect, so a non-interrupt failure of any fiber it forked via the scoped `Fiber.init` flips the already-published node into the same error routing as an up-front failure: its `.onError`, then the enclosing `UI.boundary` chain, then a default error node. At most one flip happens per instance (first failure wins), and the flip *replaces* the node's content; a component that would rather keep its content and surface the error elsewhere routes that failure to a value or side channel (a toast) instead of letting the fiber fail, and an `.onError` render can offer a retry by swapping the node's key. A clean interrupt (including the one that tears the node down on a key change) is never a failure, and `Fiber.initUnscoped` opts a fire-and-forget fiber out of supervision entirely.
+
+`UI.boundary.fallback(spinner).onError { case e: DataError => card(e) }(subtree*)` (experimental) aggregates the pending state of the mounted descendants beneath it and supplies a shared error branch for any that carry no node-local `.onError`.
+
 ## Inputs and forms
 
 > **Note:** All input element factories (`UI.input`, `UI.textarea`, `UI.passwordInput`, `UI.emailInput`, `UI.telInput`, `UI.urlInput`, `UI.searchInput`, `UI.numberInput`, `UI.dateInput`, `UI.timeInput`, `UI.colorInput`, `UI.rangeInput`, `UI.fileInput`, `UI.hiddenInput`, `UI.checkbox`, `UI.radio`, `UI.dropdown`) are `Void` elements. They do not accept children; calling `.apply(children*)` on them is a compile error. Configure them through their setter methods only.

--- a/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
+++ b/kyo-ui/js-wasm/src/main/scala/kyo/internal/DomBackend.scala
@@ -40,8 +40,11 @@ private[kyo] object DomBackend:
             root <- ReactiveUI.normalize(ui, Seq.empty)
             html <- HtmlRenderer.render(ui, Seq.empty)
             _    <- Sync.defer(container.innerHTML = html)
-            _    <- applyJsProps(container)
-            _    <- Sync.defer(beginAnimationsSync(container))
+            // Comment markers produce no node handles from an innerHTML assignment; one full scan
+            // builds the path->range registry the patch path resolves against.
+            _ <- Sync.defer { scanRoot = container; rebuildRegions() }
+            _ <- applyJsProps(container)
+            _ <- Sync.defer(beginAnimationsSync(container))
             exchange = LocalExchange(root)
             dispatch <- ReactiveUI.subscribe(root, exchange)
             // Single-consumer drain owned by the ambient page Scope: every JS event effect is run by a
@@ -74,49 +77,86 @@ private[kyo] object DomBackend:
                 discard(el.asInstanceOf[js.Dynamic].scrollIntoView(js.Dynamic.literal(behavior = "smooth", block = "start")))
         }
 
+    // Keyed-list keys are user data and become path segments: escape the CSS attribute-selector
+    // metacharacters (backslash, double quote) so a key cannot break or redirect the query.
+    private def pathSelector(joined: String): String =
+        s"""[data-kyo-path="${joined.replace("\\", "\\\\").replace("\"", "\\\"")}"]"""
+
+    private def queryByPath(path: Seq[String]): dom.Element =
+        document.querySelector(pathSelector(path.mkString(".")))
+
     /** Exchange that renders UI to HTML and applies directly to the DOM. */
     private class LocalExchange(root: ReactiveUI) extends UIExchange:
-        private def svgContextAt(path: Seq[String]): Boolean =
-            ReactiveUI.findNode(root, path).map(_.svgContext).getOrElse(false)
 
-        def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async =
-            HtmlRenderer.render(ui, path).map { html =>
-                // Always wrap the rendered html in the reactive boundary element so the node carrying
-                // data-kyo-path=path survives subsequent replacements. A Fragment, Text, or RawHtml value
-                // renders without a path-carrying root, so an unwrapped replace would drop the marker and
-                // the next update could not locate the node. In SVG context the boundary is a <g> (a <span>
-                // is invalid inside <svg>); otherwise a <span> (CSS sets `display: contents` so it is layout-
-                // transparent).
-                val tag       = if svgContextAt(path) then "g" else "span"
-                val pathAttr  = path.mkString(".")
-                val finalHtml = s"""<$tag data-kyo-path="$pathAttr" data-kyo-reactive>$html</$tag>"""
+        def onChange(path: Seq[String], ui: UI, mount: Boolean)(using Frame): Unit < Async =
+            // Render content at its nested-reactive sub-path (contentPath) so a reactive-valued region paints a
+            // DISTINCT inner marker span matching SSR/walkStatic. mountSlot=true stamps the `s` flag on Mounted
+            // placeholders for the mount guards below. The payload is a bare fragment: the region's own live
+            // markers stay in the DOM and are never re-sent, so the path stays addressable across replacements
+            // regardless of what the content is (Fragment, Text, RawHtml: none carry a path-bearing root).
+            HtmlRenderer.render(ui, HtmlRenderer.contentPath(path, ui), mountSlot = true).map { html =>
                 Sync.defer {
-                    val el = document.querySelector(s"""[data-kyo-path="$pathAttr"]""")
-                    if el != null && el.outerHTML != finalHtml then
-                        // Capture focus and caret of the active element inside the replaced region,
-                        // keyed on data-kyo-path identity (mirrors HtmlRenderer.clientJs:576-583 on
-                        // the JS DOM API). Plain DOM inside the already-suspended Sync.defer; no new
-                        // AllowUnsafe crossing.
-                        val ae = document.activeElement
-                        val insideRegion = ae != null && (ae ne document.body) &&
-                            (ae.getAttribute("data-kyo-path") == pathAttr || el.contains(ae))
-                        // Use the active element's own data-kyo-path when it carries one (nested
-                        // reactive region), otherwise fall back to pathAttr so the region wrapper
-                        // itself is queried (common case: value-bound input inside the region has
-                        // no data-kyo-path of its own).
+                    val pathAttr = path.mkString(".")
+                    val r        = lookupRegion(pathAttr)
+                    if r == null then
+                        // No marker pair at this path: either an ELEMENT region (a signal-bound field like
+                        // `input.value(ref)`: the region root IS the live element carrying the path; no wrapper
+                        // of any kind exists) morphed 1:1 in place, or genuinely unpainted DOM (e.g. Boundary
+                        // pre-reveal), which stays a silent no-op.
+                        val el = queryByPath(path)
+                        if el != null && el.parentNode != null then
+                            val toContainer = parseToContainer(el.parentNode.asInstanceOf[dom.Element], html)
+                            val toRoot      = if toContainer != null then firstElementChildOf(toContainer) else null
+                            if toRoot != null then
+                                morphNode(el, toRoot)
+                                val live = queryByPath(path)
+                                if live != null then
+                                    applyJsPropsSync(live)
+                                    beginAnimationsSync(live)
+                            end if
+                        end if
+                    // Leave the live mount region untouched ONLY when the new content is itself a mount slot
+                    // (`s` = the SAME mount re-rendering, which owns its subtree). Different content or an empty
+                    // gate-closed repaint falls through so the morph reconciles/empties the region.
+                    else if !mount && r.mount && payloadRootIsMountSlot(html) then ()
+                    else
+                        val parent = r.start.parentNode.asInstanceOf[dom.Element]
+                        // Capture focus and caret of the active element inside the replaced region (mirrors the
+                        // clientJs Replace handler on the JS DOM API). Plain DOM inside the already-suspended
+                        // Sync.defer; no new AllowUnsafe crossing.
+                        val ae           = document.activeElement
+                        val insideRegion = ae != null && (ae ne document.body) && rangeContains(r, ae)
+                        // Use the active element's own data-kyo-path when it carries one (nested element),
+                        // otherwise fall back to the region path so restoreFocus searches the range (common
+                        // case: value-bound input inside the region has no data-kyo-path of its own).
                         val activePath =
                             if insideRegion then
                                 if ae.hasAttribute("data-kyo-path") then ae.getAttribute("data-kyo-path")
                                 else pathAttr
                             else null
                         val (selStart, selEnd) = if insideRegion then readSelection(ae) else (Absent, Absent)
-                        el.outerHTML = finalHtml
-                        val updated = document.querySelector(s"""[data-kyo-path="$pathAttr"]""")
-                        if updated != null then
-                            applyJsPropsSync(updated)
-                            beginAnimationsSync(updated)
-                        if activePath != null then
-                            restoreFocus(activePath, selStart, selEnd)
+                        val toContainer        = parseToContainer(parent, html)
+                        if toContainer != null then
+                            // Morph the marker-delimited range instead of replacing, so focus/caret/scroll/
+                            // transitions on reused nodes survive.
+                            morphRange(parent, r.start.nextSibling, r.end, toContainer.firstChild, null)
+                            if mount && !r.mount then
+                                // The mount's own first paint claims the region: the `m` flag rides the live
+                                // start marker (source of truth, survives registry rebuilds); the registry
+                                // entry is a cache. Client-only mutation, never in server-rendered HTML.
+                                r.mount = true
+                                r.start.data = RegionMarker.openData(pathAttr, mount = true)
+                            end if
+                            // A morph imports subtrees, which carries new nested-region markers with it:
+                            // refresh the registry for exactly this range.
+                            rescanRange(r)
+                            foreachRangeElement(r) { el =>
+                                applyJsPropsSync(el)
+                                beginAnimationsSync(el)
+                            }
+                            if activePath != null then
+                                restoreFocus(activePath, selStart, selEnd)
+                        end if
                     end if
                 }
             }
@@ -130,13 +170,27 @@ private[kyo] object DomBackend:
     end readSelection
 
     private def restoreFocus(capturedPath: String, selStart: Maybe[Int], selEnd: Maybe[Int]): Unit =
-        val located = document.querySelector(s"""[data-kyo-path="$capturedPath"]""")
-        if located != null then
-            val focusTarget =
-                if located.hasAttribute("data-kyo-reactive") then
-                    val inner = located.querySelector("input,textarea,select,[contenteditable]")
-                    if inner != null then inner else located
-                else located
+        val located = document.querySelector(pathSelector(capturedPath))
+        val focusTarget: dom.Element =
+            if located != null then located
+            else
+                // A region path has no element carrying it; resolve via the registry and take the first
+                // focus-capable element in the range (mirrors the old descend-into-wrapper behavior).
+                regions.get(capturedPath).orNull match
+                    case null => null
+                    case r =>
+                        var found: dom.Element = null
+                        foreachRangeElement(r) { el =>
+                            if found == null then
+                                val sel = "input,textarea,select,[contenteditable]"
+                                if el.matches(sel) then found = el
+                                else
+                                    val inner = el.querySelector(sel)
+                                    if inner != null then found = inner
+                                end if
+                        }
+                        found
+        if focusTarget != null then
             val _ = focusTarget.asInstanceOf[scalajs.js.Dynamic].focus()
             (selStart, selEnd) match
                 case (Present(s), Present(e)) =>
@@ -373,5 +427,414 @@ private[kyo] object DomBackend:
     private def parsePath(p: String): Seq[String] =
         if p == null || p.isEmpty then Seq.empty
         else p.split("\\.").toSeq
+
+    // ---- DOM morphing: patch a sibling range in place toward new HTML, preserving element identity ----
+    // Replacing wholesale discards DOM-local state (focus, caret, scroll, in-flight transitions, pointer
+    // capture) and node identity; morphing reuses nodes and patches only diffs. Reconciliation is
+    // SIBLING-SCOPED, keyed on `data-kyo-path` for elements (unique among siblings: Foreach items get
+    // `path :+ key`, element children `path :+ i`) and on the region path for marker-delimited spans, which
+    // move/insert/remove as ONE logical child. A region owns the sibling range between its two comment
+    // markers, so patches never touch out-of-range siblings of the same parent.
+    private val SvgNs = "http://www.w3.org/2000/svg"
+
+    // ---- region registry: joined path -> live comment-marker range ----
+
+    /** A live region's marker pair. `mount` mirrors the `m` flag on the start marker's data (cache only;
+      * the marker text is the source of truth and survives registry rebuilds).
+      */
+    final private class RegionRange(val start: dom.Comment, val end: dom.Comment, var mount: Boolean)
+
+    /** Path -> live range. Rebuilt by full scans (initial paint, stale-lookup fallback) and refreshed by
+      * range-scoped rescans after every patch (a morph imports subtrees via importNode, which brings new
+      * nested-region markers with them). Module-level mutable is safe on the single-threaded runtime.
+      */
+    private var regions: js.Dictionary[RegionRange] = js.Dictionary.empty
+    private var scanRoot: dom.Node                  = null
+
+    private def commentData(n: dom.Node): String = n.asInstanceOf[dom.Comment].data
+
+    /** Register a scanned pair, repairing parser separation first: the whole-page parser keeps an open
+      * marker that precedes a table's FIRST row as a `<table>` child while the rows and the close
+      * marker land inside the implied `<tbody>` it synthesizes. Adopting the open marker into that row
+      * group makes the pair share a parent again (the invariant every range walk relies on) and puts
+      * the rows inside the range. Twin of `__kyoRegPair` in clientJs.
+      */
+    private def registerPair(path: String, start: dom.Comment, end: dom.Comment, mount: Boolean): Unit =
+        if (start.parentNode ne end.parentNode) && end.parentNode != null && (end.parentNode.parentNode eq start.parentNode) then
+            discard(end.parentNode.insertBefore(start, end.parentNode.firstChild))
+        regions(path) = new RegionRange(start, end, mount)
+    end registerPair
+
+    /** Register every marker pair under `root` (whole-subtree TreeWalker) into `regions`. Paths are
+      * document-unique, so pairing open->close by path needs no stack; unbalanced markers are dropped.
+      */
+    private def scanRegionsInto(root: dom.Node): Unit =
+        val walker = document.createTreeWalker(root, dom.NodeFilter.SHOW_COMMENT, null, false)
+        val opens  = js.Dictionary.empty[(dom.Comment, Boolean)]
+        var n      = walker.nextNode()
+        while n != null do
+            RegionMarker.parse(commentData(n)) match
+                case Present(p) =>
+                    if p.isClose then
+                        opens.get(p.path) match
+                            case Some((start, mount)) =>
+                                registerPair(p.path, start, n.asInstanceOf[dom.Comment], mount)
+                                discard(opens.remove(p.path))
+                            case None => ()
+                    else opens(p.path) = (n.asInstanceOf[dom.Comment], p.mount)
+                case Absent => ()
+            end match
+            n = walker.nextNode()
+        end while
+    end scanRegionsInto
+
+    private def rebuildRegions(): Unit =
+        regions = js.Dictionary.empty
+        if scanRoot != null then scanRegionsInto(scanRoot)
+    end rebuildRegions
+
+    /** Re-register marker pairs inside `r` after a patch. A pair always shares one parent, so direct
+      * comment siblings pair at this level and everything deeper is contained in element siblings.
+      * Bounded by patch size, not page size.
+      */
+    private def rescanRange(r: RegionRange): Unit =
+        val opens = js.Dictionary.empty[(dom.Comment, Boolean)]
+        var n     = r.start.nextSibling
+        while n != null && (n ne r.end) do
+            if n.nodeType == 8 then
+                RegionMarker.parse(commentData(n)) match
+                    case Present(p) =>
+                        if p.isClose then
+                            opens.get(p.path) match
+                                case Some((start, mount)) =>
+                                    registerPair(p.path, start, n.asInstanceOf[dom.Comment], mount)
+                                    discard(opens.remove(p.path))
+                                case None => ()
+                        else opens(p.path) = (n.asInstanceOf[dom.Comment], p.mount)
+                    case Absent => ()
+            else if n.nodeType == 1 then scanRegionsInto(n)
+            end if
+            n = n.nextSibling
+        end while
+    end rescanRange
+
+    /** Locate a live region by joined path. Connectivity-validated; a stale or missing entry triggers
+      * ONE full rescan, then retries; still missing -> null. Callers no-op on null, preserving the old
+      * "querySelector returned null -> silently skip" contract Boundary pre-reveal patches rely on.
+      */
+    private def lookupRegion(pathAttr: String): RegionRange =
+        def connected(r: RegionRange): Boolean =
+            r != null && r.start.isConnected && r.end.isConnected
+        val direct = regions.get(pathAttr).orNull
+        if connected(direct) then direct
+        else
+            rebuildRegions()
+            val retried = regions.get(pathAttr).orNull
+            if connected(retried) then retried else null
+        end if
+    end lookupRegion
+
+    /** True when `node` is one of the range's direct children or a descendant of one. */
+    private def rangeContains(r: RegionRange, node: dom.Node): Boolean =
+        var n     = r.start.nextSibling
+        var found = false
+        while !found && n != null && (n ne r.end) do
+            if (n eq node) || (n.nodeType == 1 && n.contains(node)) then found = true
+            n = n.nextSibling
+        found
+    end rangeContains
+
+    private def foreachRangeElement(r: RegionRange)(f: dom.Element => Unit): Unit =
+        var n = r.start.nextSibling
+        while n != null && (n ne r.end) do
+            if n.nodeType == 1 then f(n.asInstanceOf[dom.Element])
+            n = n.nextSibling
+    end foreachRangeElement
+
+    // ---- logical children: a marker-delimited span is ONE keyed child ----
+
+    /** For an open marker, its matching close marker among following siblings; null when unbalanced (the
+      * caller then treats the comment as a plain positional node). Pairs never nest at one level (paths
+      * are unique among siblings), so a direct path match suffices.
+      */
+    private def spanClose(open: dom.Node, openPath: String): dom.Node =
+        var n                = open.nextSibling
+        var result: dom.Node = null
+        while result == null && n != null do
+            if n.nodeType == 8 then
+                RegionMarker.parse(commentData(n)) match
+                    case Present(p) if p.isClose && p.path == openPath => result = n
+                    case _                                             => ()
+            end if
+            n = n.nextSibling
+        end while
+        result
+    end spanClose
+
+    /** The reconciliation key of a logical child: an element's `data-kyo-path`, an open marker's region
+      * path, else null (text, plain comments, and unkeyed elements reconcile positionally). Markers are
+      * NEVER matched positionally: mispairing would rewrite marker text and corrupt region identity.
+      */
+    private def logicalKey(node: dom.Node): String =
+        if node.nodeType == 1 then
+            val el = node.asInstanceOf[dom.Element]
+            if el.hasAttribute("data-kyo-path") then el.getAttribute("data-kyo-path") else null
+        else if node.nodeType == 8 then
+            RegionMarker.parse(commentData(node)) match
+                case Present(p) if !p.isClose && spanClose(node, p.path) != null => p.path
+                case _                                                           => null
+        else null
+
+    /** Next logical sibling: past the whole span for an open marker, else nextSibling. */
+    private def logicalNext(node: dom.Node): dom.Node =
+        if node.nodeType == 8 then
+            RegionMarker.parse(commentData(node)) match
+                case Present(p) if !p.isClose =>
+                    val close = spanClose(node, p.path)
+                    if close != null then close.nextSibling else node.nextSibling
+                case _ => node.nextSibling
+        else node.nextSibling
+
+    private def eachSpanNode(first: dom.Node)(f: dom.Node => Unit): Unit =
+        val last =
+            if first.nodeType == 8 then
+                RegionMarker.parse(commentData(first)) match
+                    case Present(p) if !p.isClose =>
+                        val close = spanClose(first, p.path)
+                        if close != null then close else first
+                    case _ => first
+            else first
+        var n    = first
+        var stop = false
+        while !stop && n != null do
+            val next = n.nextSibling
+            stop = n eq last
+            f(n)
+            n = next
+        end while
+    end eachSpanNode
+
+    private def moveLogicalBefore(parent: dom.Element, node: dom.Node, ref: dom.Node): Unit =
+        eachSpanNode(node)(n => discard(parent.insertBefore(n, ref)))
+
+    private def removeLogical(parent: dom.Element, node: dom.Node): Unit =
+        eachSpanNode(node)(n => discard(parent.removeChild(n)))
+
+    private def insertLogicalClone(parent: dom.Element, toNode: dom.Node, ref: dom.Node): Unit =
+        eachSpanNode(toNode)(n => discard(parent.insertBefore(document.importNode(n, true), ref)))
+
+    /** Patch matched logical children (same key). Element vs element morphs in place; span vs span
+      * recurses on the two content ranges, unless the live span carries the `m` (mount root) flag and
+      * the incoming one the `s` (mount slot) flag: that is the SAME mount re-rendering, which owns and
+      * repaints its own subtree, so the span is opaque and its start marker is never touched (the `m`
+      * flag must survive). A kind mismatch at one key replaces wholesale.
+      */
+    private def patchLogical(parent: dom.Element, m: dom.Node, toNode: dom.Node): Unit =
+        val fromIsSpan = m.nodeType == 8
+        val toIsSpan   = toNode.nodeType == 8
+        if !fromIsSpan && !toIsSpan then morphNode(m, toNode)
+        else if fromIsSpan && toIsSpan then
+            (RegionMarker.parse(commentData(m)), RegionMarker.parse(commentData(toNode))) match
+                case (Present(f), Present(t)) =>
+                    val fClose = spanClose(m, f.path)
+                    val tClose = spanClose(toNode, t.path)
+                    if fClose == null || tClose == null then ()
+                    else if f.mount && t.slot then ()
+                    else morphRange(parent, m.nextSibling, fClose, toNode.nextSibling, tClose)
+                case _ => ()
+        else
+            insertLogicalClone(parent, toNode, m)
+            removeLogical(parent, m)
+        end if
+    end patchLogical
+
+    /** True when the payload's first node is an open marker carrying the `s` (mount slot) flag: the
+      * region's new content root IS a mount placeholder. Bounded to the leading comment so a descendant
+      * marker cannot false-match.
+      */
+    private def payloadRootIsMountSlot(html: String): Boolean =
+        if !html.startsWith("<!--") then false
+        else
+            val end = html.indexOf("-->")
+            end > 4 && (RegionMarker.parse(html.substring(4, end)) match
+                case Present(p) => !p.isClose && p.slot
+                case Absent     => false)
+
+    private def firstElementChildOf(parent: dom.Node): dom.Element =
+        var c = parent.firstChild
+        while c != null && c.nodeType != 1 do c = c.nextSibling
+        if c == null then null else c.asInstanceOf[dom.Element]
+    end firstElementChildOf
+
+    /** Parse a region payload (a bare content fragment, zero..n roots) in the parse context its live
+      * parent dictates, returning the detached node whose childNodes are the new content (kept inside
+      * the template; the morph imports nodes on insert). The context wrap keeps the fragment parser from
+      * foster-parenting or silently dropping context-sensitive content: a `<tr>` payload outside a table
+      * parse is discarded wholesale, an `<option>` outside select likewise, and bare SVG elements in an
+      * HTML template become unknown elements. Comment markers survive every one of these parse modes,
+      * which is what makes marker-delimited regions parseable at all. Twin of `__kyoParseCtx` in
+      * clientJs; keep in lockstep.
+      */
+    private def parseToContainer(parent: dom.Element, html: String): dom.Node =
+        val tpl = document.createElement("template").asInstanceOf[dom.HTMLTemplateElement]
+        val tag = parent.tagName
+        val (prefix, suffix, depth) =
+            if parent.namespaceURI == SvgNs && tag.toLowerCase != "foreignobject" then ("<svg>", "</svg>", 1)
+            else
+                tag match
+                    // Explicit <tbody> (not the parser's implied one) so the descent depth is fixed.
+                    case "TABLE" | "THEAD" | "TBODY" | "TFOOT" => ("<table><tbody>", "</tbody></table>", 2)
+                    case "TR"                                  => ("<table><tbody><tr>", "</tr></tbody></table>", 3)
+                    case "SELECT" | "OPTGROUP"                 => ("<select>", "</select>", 1)
+                    case _                                     => ("", "", 0)
+        tpl.innerHTML = prefix + html + suffix
+        var container: dom.Node = tpl.content
+        var d                   = depth
+        while d > 0 && container != null do
+            container = firstElementChildOf(container)
+            d -= 1
+        container
+    end parseToContainer
+
+    private def morphNode(fromNode: dom.Node, toNode: dom.Node): Unit =
+        if toNode.nodeType != 1 then
+            if fromNode.nodeValue != toNode.nodeValue then fromNode.nodeValue = toNode.nodeValue
+        else
+            val fromEl = fromNode.asInstanceOf[dom.Element]
+            val toEl   = toNode.asInstanceOf[dom.Element]
+            if fromEl.tagName != toEl.tagName then
+                discard(fromEl.parentNode.replaceChild(document.importNode(toEl, true), fromEl))
+            else morphEl(fromEl, toEl)
+    end morphNode
+
+    private def morphEl(fromEl: dom.Element, toEl: dom.Element): Unit =
+        morphAttrs(fromEl, toEl)
+        // A focused contenteditable would lose its caret if its children were rewritten mid-edit; leave its
+        // subtree alone (INPUT/TEXTAREA have no element children, so need no such guard).
+        val editing = (fromEl eq document.activeElement) && fromEl.hasAttribute("contenteditable")
+        if !editing then morphChildren(fromEl, toEl)
+    end morphEl
+
+    private def morphAttrs(fromEl: dom.Element, toEl: dom.Element): Unit =
+        val tag = fromEl.tagName
+        val activeInput =
+            (fromEl eq document.activeElement) && (tag == "INPUT" || tag == "TEXTAREA")
+        val toAttrs = toEl.attributes
+        var i       = 0
+        while i < toAttrs.length do
+            val a    = toAttrs(i)
+            val name = a.name
+            if fromEl.getAttribute(name) != a.value then fromEl.setAttribute(name, a.value)
+            i += 1
+        end while
+        // Remove attributes gone from `to`. Walk the live NamedNodeMap backward so a removal never shifts an
+        // index still to be visited (no intermediate collection allocated).
+        val fromAttrs = fromEl.attributes
+        var j         = fromAttrs.length - 1
+        while j >= 0 do
+            val name = fromAttrs(j).name
+            if !toEl.hasAttribute(name) then fromEl.removeAttribute(name)
+            j -= 1
+        end while
+        // Active-input preservation: two-way binding echoes each keystroke back as a re-render. Never overwrite the
+        // focused field's live `.value` (its caret) with its own echo (value already matches); assign only a genuine
+        // external change (submit-clear, programmatic update).
+        if activeInput then
+            val nv =
+                if tag == "TEXTAREA" then toEl.textContent
+                else
+                    val v = toEl.getAttribute("value")
+                    if v == null then "" else v
+            val dyn = fromEl.asInstanceOf[scalajs.js.Dynamic]
+            if nv != dyn.value.asInstanceOf[String] then dyn.value = nv
+        end if
+    end morphAttrs
+
+    private def morphChildren(fromParent: dom.Element, toParent: dom.Element): Unit =
+        morphRange(fromParent, fromParent.firstChild, null, toParent.firstChild, null)
+
+    /** Reconcile the live sibling range [fromStart, fromEnd) of `fromParent` toward the target range
+      * [toStart, toEnd) (nodes inside a detached template). Null bounds mean "to the end of the parent";
+      * a region's close marker serves as the from-side sentinel, so out-of-range siblings (including a
+      * region's own markers) are never visited and `insertBefore(node, sentinel)` appends at the range
+      * end. Keyed lookups are sibling-scoped over LOGICAL children (keys unique among siblings); `toKeyed`
+      * records which stale from-children are reused elsewhere so an unkeyed slot doesn't destroy them.
+      * Twin of `__kyoMorphRange` in clientJs; keep in lockstep.
+      */
+    private def morphRange(
+        fromParent: dom.Element,
+        fromStart: dom.Node,
+        fromEnd: dom.Node,
+        toStart: dom.Node,
+        toEnd: dom.Node
+    ): Unit =
+        var fromKeyed: js.Dictionary[dom.Node] = null
+        var toKeyed: js.Dictionary[Boolean]    = null
+        var scan                               = fromStart
+        while scan != null && (scan ne fromEnd) do
+            val k = logicalKey(scan)
+            if k != null then
+                if fromKeyed == null then fromKeyed = js.Dictionary.empty[dom.Node]
+                fromKeyed(k) = scan
+            scan = logicalNext(scan)
+        end while
+        scan = toStart
+        while scan != null && (scan ne toEnd) do
+            val k = logicalKey(scan)
+            if k != null then
+                if toKeyed == null then toKeyed = js.Dictionary.empty[Boolean]
+                toKeyed(k) = true
+            scan = logicalNext(scan)
+        end while
+        var curFrom = fromStart
+        var curTo   = toStart
+        while curTo != null && (curTo ne toEnd) do
+            val toNext = logicalNext(curTo)
+            val tKey   = logicalKey(curTo)
+            if tKey != null then
+                val m = if fromKeyed != null then fromKeyed.get(tKey).orNull else null
+                if m != null then
+                    if m ne curFrom then moveLogicalBefore(fromParent, m, curFrom)
+                    else curFrom = logicalNext(curFrom)
+                    patchLogical(fromParent, m, curTo)
+                else
+                    insertLogicalClone(fromParent, curTo, curFrom)
+                end if
+            else
+                var handled = false
+                var loop    = true
+                while loop && curFrom != null && (curFrom ne fromEnd) do
+                    val fNext = logicalNext(curFrom)
+                    val fKey  = logicalKey(curFrom)
+                    if fKey != null then
+                        // A keyed from-child at an unkeyed slot: keep it if `to` reuses it elsewhere (its own slot
+                        // moves it into place), else it's stale and removed. Null toKeyed = `to` has no keyed child.
+                        if toKeyed == null || !toKeyed.contains(fKey) then removeLogical(fromParent, curFrom)
+                        curFrom = fNext
+                    else if compatible(curFrom, curTo) then
+                        morphNode(curFrom, curTo)
+                        curFrom = fNext
+                        handled = true
+                        loop = false
+                    else
+                        removeLogical(fromParent, curFrom)
+                        curFrom = fNext
+                    end if
+                end while
+                if !handled then insertLogicalClone(fromParent, curTo, curFrom)
+            end if
+            curTo = toNext
+        end while
+        while curFrom != null && (curFrom ne fromEnd) do
+            val fNext = logicalNext(curFrom)
+            removeLogical(fromParent, curFrom)
+            curFrom = fNext
+        end while
+    end morphRange
+
+    /** Two nodes may be patched into each other positionally: same node kind, and for elements the same tag. */
+    private def compatible(a: dom.Node, b: dom.Node): Boolean =
+        a.nodeType == b.nodeType &&
+            (a.nodeType != 1 || a.asInstanceOf[dom.Element].tagName == b.asInstanceOf[dom.Element].tagName)
 
 end DomBackend

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -384,7 +384,7 @@ object UI:
                 Channel.use[Unit](256) { channel =>
                     val exchange =
                         new UIExchange:
-                            def onChange(path: Seq[String], changedUI: UI)(using Frame): Unit < Async =
+                            def onChange(path: Seq[String], changedUI: UI, mount: Boolean)(using Frame): Unit < Async =
                                 // runPartial drops only a Closed (the consumer stopped draining); a Panic propagates.
                                 Abort.runPartial[Closed](channel.put(())).unit
                     // Scope.run owns the root region Fiber.init: when the stream consumer stops draining,
@@ -412,8 +412,8 @@ object UI:
         }
 
     /** The base CSS reset kyo-ui relies on for correct layout: `box-sizing: border-box`, the
-      * flex-column / flex-row element defaults, `[data-kyo-reactive] { display: contents }`, the
-      * list/heading/anchor/table normalizations, and `[hidden] { display: none }`.
+      * flex-column / flex-row element defaults, the list/heading/anchor/table normalizations, and
+      * `[hidden] { display: none }`.
       *
       * Every kyo-ui runner injects this automatically (`runMount` via the DOM stylesheet,
       * `runHandlers` and the page runner via the document `<head>`), so a normal app never names

--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -239,6 +239,115 @@ object UI:
     def when[C <: UI](condition: Signal[Boolean])(body: => C)(using Frame): Reactive[C] =
         Reactive[C](condition.map(v => if v then body else UI.empty))
 
+    /** What an already-rendered mounted node shows while it re-mounts (key change): keep the last rendered content visible as a
+      * frozen snapshot until the new effect publishes (`KeepLatest`, the default. Note the snapshot is inert: its nested regions
+      * and handlers are torn down with the old Scope), or drop back to the placeholder (`Placeholder`: the honest loading window,
+      * right for interactive content where a frozen-but-visible form would swallow input).
+      */
+    enum PendingPolicy derives CanEqual:
+        case KeepLatest, Placeholder
+
+    /** Embeds an effectful component mount in a pure render tree: `effect` runs when the node attaches, inside a node-lifetime
+      * `Scope` (torn down on detach), with `Abort[Throwable]` caught into the node's error state. See [[kyo.UI.Ast.Mounted]] for
+      * the lifecycle/identity contract and the [[kyo.UI.MountedOps]] extensions (`keyed`, `placeholder`, `onError`, `pending`).
+      *
+      * '''Node-scope supervision.''' The node's error state is not limited to the mount phase: every fiber the effect forks via
+      * the scoped `Fiber.init` (directly or transitively: a data feed forked by a library the effect calls) is SUPERVISED. A
+      * non-interrupt terminal failure of such a fiber retroactively flips the ALREADY-PUBLISHED node into the same error routing
+      * a failed mount takes: node-local `.onError` render, else the enclosing [[UI.boundary]] chain (typed selection), else the
+      * default inline error. First failure wins (at most one flip per instance, shared with the effect-failure path); teardown
+      * interrupts are exempt; the node `Scope` stays open on a flip (sibling fibers keep running, exactly like a pending-phase
+      * failure). The flip REPLACES the node's content: an app that wants "keep the content, surface the error elsewhere" routes
+      * that failure to a value/side channel (e.g. a toast) instead of failing the fiber; an `.onError` render may offer retry by
+      * swapping the node's key (a key change mounts a fresh instance). Escape hatches: `Fiber.initUnscoped` for fire-and-forget
+      * fibers whose failure must NOT flip the node, and note the sharp edge: a fiber whose failure the effect observes and
+      * handles itself (`Abort.run(f.getResult)`) still reports to supervision if forked with the scoped `Fiber.init`; use
+      * `Fiber.use`/`initUnscoped` for those.
+      *
+      * Effect typing: `S` must be dischargeable across a fork boundary (the same `Isolate[S, Sync, S]` gate `Fiber.init` uses).
+      * Context effects (`Env`, `Local`) derive silently and resolve at run time from the renderer fiber's inherited context
+      * (all renderer fibers descend from the `runMount`/`serveSession` caller, so an `Env.runAll` at the root reaches every
+      * mount); stateful effects (`Var`, `Emit`) do not derive and must be handled before the node is constructed. The node
+      * stores the effect with `S` erased: the `Isolate` evidence is the compile-time gate, not a runtime strategy. An
+      * explicitly provided stateful isolate is NOT applied, and such an effect fails loudly at run time (missing handler).
+      */
+    def mounted[S](effect: UI < (Abort[Throwable] & Async & Scope & S))(using
+        frame: Frame,
+        isolate: Isolate[S, Sync, S]
+    ): Mounted =
+        discard(isolate)
+        Mounted(
+            effect.asInstanceOf[UI < (Abort[Throwable] & Async & Scope)],
+            key = Absent,
+            placeholderUI = Absent,
+            errorRender = Absent,
+            pendingPolicy = PendingPolicy.KeepLatest
+        )
+    end mounted
+
+    /** Entry point for [[kyo.UI.Ast.Boundary]] (EXPERIMENTAL): `UI.boundary.fallback(spinner).onError { case e: DataError =>
+      * card(e) }(subtree...)`. See the Boundary scaladoc for aggregation/reveal/error semantics.
+      */
+    def boundary: BoundaryBuilder = BoundaryBuilder(Absent, Absent)
+
+    final case class BoundaryBuilder private[kyo] (
+        fallbackUI: Maybe[UI],
+        errorPf: Maybe[PartialFunction[Throwable, UI]]
+    ):
+        /** Painted while mounted descendants that started under this boundary are pending. Default: empty. */
+        def fallback(ui: UI): BoundaryBuilder = copy(fallbackUI = Present(ui))
+
+        /** Typed error selection: renders the first matching error of a mounted descendant that has no
+          * node-local `.onError`; non-matching errors bubble to the next enclosing boundary, then to the
+          * node-local default.
+          */
+        def onError(pf: PartialFunction[Throwable, UI]): BoundaryBuilder = copy(errorPf = Present(pf))
+
+        def apply(children: Ast.HtmlChildVal*)(using Frame): Ast.Boundary =
+            val child = children.toList match
+                case single :: Nil => single.value
+                case many          => Ast.Fragment[UI](Chunk.from(many.map(_.value)))
+            Ast.Boundary(child, fallbackUI, errorPf)
+        end apply
+    end BoundaryBuilder
+
+    /** Builder-style modifiers for [[kyo.UI.Ast.Mounted]], following the attrs-API idiom. */
+    object MountedOps:
+        extension (m: Mounted)
+            /** Continuity anchor: a mounted node with a key keeps its live instance (Scope, resources, published content)
+              * across re-renders of its immediately enclosing reactive region while an equal key is re-emitted; the instance
+              * is torn down (closed and awaited) when the key changes or disappears. Any `CanEqual`-comparable value works:
+              * the idiomatic key is the component's singleton object (`.keyed(ScoreboardView)`), tupled with value inputs the
+              * effect closed over when identity depends on them (`.keyed(EraPanel -> era)`): changing inputs that should
+              * UPDATE the live instance belong in `Signal` parameters, not the key; non-Signal inputs the effect captures
+              * belong IN the key, or they are silently frozen at mount time.
+              */
+            def keyed(key: Any): Mounted =
+                given Frame = m.frame
+                m.copy(key = Present(key))
+
+            /** Content rendered while the effect is pending on FIRST mount (and on re-mount under `PendingPolicy.Placeholder`).
+              * Defaults to an empty node.
+              */
+            def placeholder(ui: UI): Mounted =
+                given Frame = m.frame
+                m.copy(placeholderUI = Present(ui))
+
+            /** Renders a failed mount (`Abort` failure or panic of the effect). Defaults to a minimal inline error node; the
+              * failure is additionally logged. The enclosing region stays alive; a subsequent key change re-mounts cleanly.
+              */
+            def onError(f: Throwable => UI): Mounted =
+                given Frame = m.frame
+                m.copy(errorRender = Present(f))
+
+            /** Re-mount pending policy: see [[kyo.UI.PendingPolicy]]. Default: `KeepLatest`. */
+            def pending(p: PendingPolicy): Mounted =
+                given Frame = m.frame
+                m.copy(pendingPolicy = p)
+        end extension
+    end MountedOps
+    export MountedOps.*
+
     /** Server-push: returns HTTP handlers (SSR page GET and a WebSocket route) for this UI at the given path. Compose with other handlers
       * via HttpServer.init.
       *
@@ -676,49 +785,85 @@ object UI:
 
         // ---- Interactive trait (event handlers + tabIndex) ----
 
-        /** Capability trait for elements that accept event handlers (`onClick`, `onKeyDown`, ...) and `tabIndex`/focus-group settings. */
+        /** Handler storage erasure: the setter's `Isolate[S, Sync, S]` gate proved `S` fork-safe (context effects
+          * only, in practice); storage drops `S` because the Attrs slots are `Any < Async` and the run-time context
+          * comes from the event-drain fiber's inherited Context, not from the type. Mirrors [[kyo.UI.mounted]]'s
+          * erased storage.
+          */
+        private def eraseHandler[S](v: Any < (Abort[Throwable] & Async & S)): Any < Async =
+            v.asInstanceOf[Any < Async]
+
+        private def eraseHandlerFn[A, S](f: A => Any < (Abort[Throwable] & Async & S)): A => Any < Async =
+            f.asInstanceOf[A => Any < Async]
+
+        /** Capability trait for elements that accept event handlers (`onClick`, `onKeyDown`, ...) and `tabIndex`/focus-group settings.
+          *
+          * Handler effect typing: every setter is effect-polymorphic in `S` behind the same `Isolate[S, Sync, S]` gate as
+          * [[kyo.UI.mounted]]. Context effects (`Env`, `Local`) derive silently, stateful effects get the curated compile
+          * error. Handlers are stored with `S` erased and resolve their context at run time from the fiber that drains
+          * events (the browser backend's event-drain fiber descends from the `runMount` caller, so a root `Env.runAll`
+          * reaches every handler). Pure `Any < Async` handlers infer `S = Any` (fully source-compatible). NOTE: in the
+          * server-push transport (`runHandlers`), event dispatch runs on kyo-http session fibers, which do not currently
+          * inherit the `runHandlers` caller's context (the same known gap as mounted effects there).
+          */
         sealed trait Interactive extends Element:
             def tabIndex(v: Int): Self       = withAttrs(attrs.copy(tabIndex = Present(v)))
             def focusTrap(v: Boolean): Self  = withAttrs(attrs.copy(focusTrap = Present(v)))
             def focusGroup(id: String): Self = withAttrs(attrs.copy(focusGroup = Present(id)))
 
             /** Runs `action` on click, ignoring the event payload. */
-            def onClick(action: => Any < Async): Self = withAttrs(attrs.copy(onClick = Present(Sync.defer(action)(using frame))))
+            def onClick[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onClick = Present(eraseHandler(Sync.defer(action)(using frame)))))
 
             /** Runs `f` on click, receiving the [[kyo.UI.MouseEvent]] payload (target id, modifier chord). */
-            def onClick(f: MouseEvent => Any < Async): Self = withAttrs(attrs.copy(onClickEvt = Present(f)))
+            def onClick[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onClickEvt = Present(eraseHandlerFn(f))))
 
             /** Runs `action` only when the click lands on this element itself, not on a descendant; ignores the event payload. */
-            def onClickSelf(action: => Any < Async): Self = withAttrs(attrs.copy(onClickSelf = Present(Sync.defer(action)(using frame))))
+            def onClickSelf[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onClickSelf = Present(eraseHandler(Sync.defer(action)(using frame)))))
 
             /** Runs `f` only when the click lands on this element itself, not on a descendant; receives the [[kyo.UI.MouseEvent]] payload. */
-            def onClickSelf(f: MouseEvent => Any < Async): Self = withAttrs(attrs.copy(onClickSelfEvt = Present(f)))
+            def onClickSelf[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onClickSelfEvt = Present(eraseHandlerFn(f))))
 
             /** Runs `f` on key-down, receiving the [[kyo.UI.KeyboardEvent]] payload (typed key, modifier chord, target id). */
-            def onKeyDown(f: KeyboardEvent => Any < Async): Self = withAttrs(attrs.copy(onKeyDown = Present(f)))
-            def onKeyUp(f: KeyboardEvent => Any < Async): Self   = withAttrs(attrs.copy(onKeyUp = Present(f)))
-            def onFocus(action: => Any < Async): Self            = withAttrs(attrs.copy(onFocus = Present(Sync.defer(action)(using frame))))
-            def onFocus(f: MouseEvent => Any < Async): Self      = withAttrs(attrs.copy(onFocusEvt = Present(f)))
-            def onBlur(action: => Any < Async): Self             = withAttrs(attrs.copy(onBlur = Present(Sync.defer(action)(using frame))))
-            def onBlur(f: MouseEvent => Any < Async): Self       = withAttrs(attrs.copy(onBlurEvt = Present(f)))
+            def onKeyDown[S](f: KeyboardEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onKeyDown = Present(eraseHandlerFn(f))))
+            def onKeyUp[S](f: KeyboardEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onKeyUp = Present(eraseHandlerFn(f))))
+            def onFocus[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onFocus = Present(eraseHandler(Sync.defer(action)(using frame)))))
+            def onFocus[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onFocusEvt = Present(eraseHandlerFn(f))))
+            def onBlur[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onBlur = Present(eraseHandler(Sync.defer(action)(using frame)))))
+            def onBlur[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onBlurEvt = Present(eraseHandlerFn(f))))
 
             /** Runs `action` when the pointer enters this element. */
-            def onHover(action: => Any < Async): Self = withAttrs(attrs.copy(onHover = Present(Sync.defer(action)(using frame))))
+            def onHover[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onHover = Present(eraseHandler(Sync.defer(action)(using frame)))))
 
             /** Runs `f` when the pointer enters this element, receiving the [[kyo.UI.MouseEvent]] payload. */
-            def onHover(f: MouseEvent => Any < Async): Self = withAttrs(attrs.copy(onHoverEvt = Present(f)))
+            def onHover[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onHoverEvt = Present(eraseHandlerFn(f))))
 
             /** Runs `action` when the pointer leaves this element. */
-            def onUnhover(action: => Any < Async): Self = withAttrs(attrs.copy(onUnhover = Present(Sync.defer(action)(using frame))))
+            def onUnhover[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onUnhover = Present(eraseHandler(Sync.defer(action)(using frame)))))
 
             /** Runs `f` when the pointer leaves this element, receiving the [[kyo.UI.MouseEvent]] payload. */
-            def onUnhover(f: MouseEvent => Any < Async): Self = withAttrs(attrs.copy(onUnhoverEvt = Present(f)))
+            def onUnhover[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onUnhoverEvt = Present(eraseHandlerFn(f))))
 
             /** Runs `action` when the mouse wheel is used over this element. */
-            def onScroll(action: => Any < Async): Self = withAttrs(attrs.copy(onScroll = Present(Sync.defer(action)(using frame))))
+            def onScroll[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onScroll = Present(eraseHandler(Sync.defer(action)(using frame)))))
 
             /** Runs `f` when the mouse wheel is used over this element, receiving the [[kyo.UI.WheelEvent]] payload. */
-            def onScroll(f: WheelEvent => Any < Async): Self = withAttrs(attrs.copy(onScrollEvt = Present(f)))
+            def onScroll[S](f: WheelEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Self =
+                withAttrs(attrs.copy(onScrollEvt = Present(eraseHandlerFn(f))))
         end Interactive
 
         // ---- Layout traits ----
@@ -989,6 +1134,47 @@ object UI:
 
         private[kyo] case class KeyedChild[C <: UI](key: String, child: UI)(using val frame: Frame) extends UI
 
+        /** An effectful component mount: a first-class AST node whose content is produced by an effect.
+          *
+          * The renderer runs `effect` when the node attaches, inside a node-lifetime `Scope` that is torn down when the node
+          * detaches; `placeholderUI` renders while the effect is pending (first mount), and a `Failure`/`Panic` of the effect
+          * renders through `errorRender` while the enclosing region stays alive. The effect must follow the same prompt-return
+          * contract as reactive regions: allocate and fork, never park (the node's Scope owns anything long-lived it forks).
+          *
+          * Identity is explicit: a node without a key is remounted (Scope closed and awaited, effect re-run) whenever its
+          * enclosing reactive region re-renders; a node with [[kyo.UI.MountedOps.keyed]] keeps its live instance (Scope,
+          * resources, published content) across re-renders of the immediately enclosing region for as long as a re-render
+          * emits a mounted node with an equal key, and is torn down when the key disappears or changes. Extends `HtmlContent`
+          * so it is accepted anywhere an HTML child is (the content-model of the effect's RESULT is the caller's contract).
+          *
+          * Stored effect: `S` from [[kyo.UI.mounted]] is erased here after the `Isolate` gate (see the constructor's note).
+          */
+        case class Mounted(
+            effect: UI < (Abort[Throwable] & Async & Scope),
+            key: Maybe[Any],
+            placeholderUI: Maybe[UI],
+            errorRender: Maybe[Throwable => UI],
+            pendingPolicy: UI.PendingPolicy
+        )(using val frame: Frame) extends UI with HtmlContent
+
+        /** A pending/error boundary over a subtree (EXPERIMENTAL): while any mounted descendant that started
+          * under this boundary is still pending, the boundary paints `fallbackUI` instead of `child`: the
+          * subtree is subscribed EAGERLY behind the fallback (all mount effects start immediately, in
+          * parallel; no waterfalls), and the child content is painted from current signal values once the
+          * pending count reaches zero. Reveal is once-only (Suspense semantics for first load): mounts that
+          * start after the reveal use their node-local placeholders.
+          *
+          * `errorPf` is the boundary's typed error selection: a mounted descendant's failure WITHOUT a
+          * node-local `.onError` is offered to the nearest enclosing boundary chain; the first boundary whose
+          * partial function is defined at the error renders it (replacing the boundary's whole content). An
+          * unmatched error falls back to the node-local default rendering and counts as settled.
+          */
+        case class Boundary(
+            child: UI,
+            fallbackUI: Maybe[UI],
+            errorPf: Maybe[PartialFunction[Throwable, UI]]
+        )(using val frame: Frame) extends UI with HtmlContent
+
         // ====== Block containers ======
 
         final case class Div(attrs: Attrs = Attrs(), children: Chunk[UI] = Chunk.empty)(using val frame: Frame) extends Block
@@ -1162,10 +1348,12 @@ object UI:
             def apply(cs: HtmlChildVal*): Form = copy(children = children ++ Chunk.from(cs.map(_.value)))
 
             /** Runs `action` on form submit, ignoring the event payload. */
-            def onSubmit(action: => Any < Async): Form = copy(onSubmit = Present(Sync.defer(action)(using frame)))
+            def onSubmit[S](action: => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Form =
+                copy(onSubmit = Present(eraseHandler(Sync.defer(action)(using frame))))
 
             /** Runs `f` on form submit, receiving the [[kyo.UI.MouseEvent]] payload. */
-            def onSubmit(f: MouseEvent => Any < Async): Form = copy(onSubmitEvt = Present(f))
+            def onSubmit[S](f: MouseEvent => Any < (Abort[Throwable] & Async & S))(using Isolate[S, Sync, S]): Form =
+                copy(onSubmitEvt = Present(eraseHandlerFn(f)))
         end Form
 
         final case class Textarea(

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlOp.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlOp.scala
@@ -6,8 +6,12 @@ import kyo.*
 sealed private[kyo] trait HtmlOp derives CanEqual
 
 private[kyo] object HtmlOp:
-    case class Replace(path: Seq[String], html: String) extends HtmlOp derives Schema
-    case class Remove(path: Seq[String])                extends HtmlOp derives Schema
-    case class InjectCss(css: String)                   extends HtmlOp derives Schema
-    case class ScrollIntoView(id: String)               extends HtmlOp derives Schema
+    // `html` is the region's bare content fragment (zero..n roots, no markers: the live comment
+    // markers stay in the DOM and are never re-sent). `mount = true` marks a keyless mount's own
+    // paint: the client stamps the `m` flag onto the live start marker so parent morphs treat the
+    // span as opaque.
+    case class Replace(path: Seq[String], html: String, mount: Boolean = false) extends HtmlOp derives Schema
+    case class Remove(path: Seq[String])                                        extends HtmlOp derives Schema
+    case class InjectCss(css: String)                                           extends HtmlOp derives Schema
+    case class ScrollIntoView(id: String)                                       extends HtmlOp derives Schema
 end HtmlOp

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -12,10 +12,16 @@ private[kyo] object HtmlRenderer:
     // costs nothing on the render(...) path (cssRules stays Absent there).
     private type CssCollector = scala.collection.mutable.LinkedHashMap[String, String]
 
-    /** Render a UI tree to HTML with data-kyo-path attributes. */
-    def render(ui: UI, path: Seq[String])(using Frame): String < Sync =
+    /** Render a UI tree to HTML with data-kyo-path attributes.
+      *
+      * `mountSlot` (CLIENT-ONLY, set by the region-morph exchanges `DomBackend`/`UIServer` `onChange`) stamps a
+      * `data-kyo-mount-slot` marker on every `Mounted` placeholder, so a morph can tell "this slot IS a mount"
+      * from content that merely collided on the positional data-kyo-path key. SSR/full-page keep the default
+      * `false`, so golden HTML stays byte-identical.
+      */
+    def render(ui: UI, path: Seq[String], mountSlot: Boolean = false)(using Frame): String < Sync =
         val sb = new StringBuilder
-        renderTo(sb, ui, path).andThen(sb.toString)
+        renderTo(sb, ui, path, mountSlot = mountSlot).andThen(sb.toString)
 
     /** Render a UI tree to HTML, additionally collecting the CSS rule(s) for every pseudo-state
       * (hover/focus/active/disabled) [[kyo.Style]] encountered along the way.
@@ -28,31 +34,13 @@ private[kyo] object HtmlRenderer:
       * [[kyo.internal.CssStyleRenderer.pseudoStateClass]]), so the result has one entry per distinct
       * rule, in first-encountered order.
       */
-    private[kyo] def renderWithCss(ui: UI, path: Seq[String])(using Frame): (String, Chunk[(String, String)]) < Sync =
+    private[kyo] def renderWithCss(ui: UI, path: Seq[String], mountSlot: Boolean = false)(using
+        Frame
+    ): (String, Chunk[(String, String)]) < Sync =
         val sb  = new StringBuilder
         val css = new CssCollector
-        renderTo(sb, ui, path, cssRules = Present(css)).andThen((sb.toString, Chunk.from(css)))
+        renderTo(sb, ui, path, cssRules = Present(css), mountSlot = mountSlot).andThen((sb.toString, Chunk.from(css)))
     end renderWithCss
-
-    /** Wrap a reactive region's inner HTML in the appropriate placeholder tag.
-      *
-      * Used by the server transport layer when pushing an updated reactive region to the client.
-      * Extracts the tag-choice logic (g in SVG context, span in HTML context) into a shared, testable
-      * function so tests can assert on the real production wrap rather than reconstructing the string
-      * themselves.
-      *
-      * @param path
-      *   the region's path segments (joined with "." for the data-kyo-path attribute)
-      * @param svgContext
-      *   true if the reactive region lives inside SVG (uses "g" tag), false for HTML (uses "span")
-      * @param innerHtml
-      *   the rendered inner content to wrap
-      * @return
-      *   the full placeholder HTML string with data-kyo-path and data-kyo-reactive attributes
-      */
-    private[kyo] def wrapReactiveRegion(path: Seq[String], svgContext: Boolean, innerHtml: String): String =
-        val tag = if svgContext then "g" else "span"
-        s"""<$tag data-kyo-path="${path.mkString(".")}" data-kyo-reactive>$innerHtml</$tag>"""
 
     /** Wrap body HTML in a full page with inline JS client. */
     def renderPage(title: String, body: String, css: String, basePath: String): String =
@@ -120,11 +108,20 @@ private[kyo] object HtmlRenderer:
 
     // ---- Core rendering ----
 
-    private def renderTo(sb: StringBuilder, ui: UI, path: Seq[String], svg: Boolean = false, cssRules: Maybe[CssCollector] = Absent)(using
+    private def renderTo(
+        sb: StringBuilder,
+        ui: UI,
+        path: Seq[String],
+        svg: Boolean = false,
+        cssRules: Maybe[CssCollector] = Absent,
+        // Client-only: when true, stamp `data-kyo-mount-slot` on Mounted placeholders reached here (forwarded recursively).
+        mountSlot: Boolean = false
+    )(using
         Frame
     ): Unit < Sync =
         ui match
             case dd: Dropdown =>
+                // Dropdown renders <select>/<option> only, never a Mounted node, so `mountSlot` need not thread through.
                 renderDropdown(sb, dd, path, cssRules)
             case elem: Element =>
                 val tag  = tagName(elem)
@@ -161,7 +158,7 @@ private[kyo] object HtmlRenderer:
                             case _            => Kyo.unit
                         textChild.andThen(
                             Kyo.foreachDiscard(elem.children.toSeq.zipWithIndex) { (child, i) =>
-                                renderTo(sb, child, path :+ i.toString, childSvg, cssRules)
+                                renderTo(sb, child, path :+ i.toString, childSvg, cssRules, mountSlot)
                             }.andThen(w(sb, s"</$tag>"))
                         )
                     end if
@@ -180,23 +177,22 @@ private[kyo] object HtmlRenderer:
                     val childPath = child match
                         case kc: KeyedChild[?] => path :+ kc.key
                         case _                 => path :+ i.toString
-                    renderTo(sb, child, childPath, svg, cssRules)
+                    renderTo(sb, child, childPath, svg, cssRules, mountSlot)
                 }
 
             case KeyedChild(_, child) =>
-                renderTo(sb, child, path, svg, cssRules)
+                renderTo(sb, child, path, svg, cssRules, mountSlot)
 
             case r: Reactive[?] =>
-                // In SVG context emit a <g> placeholder (a <span> is invalid inside <svg>); the
-                // closing tag matches the opening. Both carry the same data-kyo-reactive anchor.
-                val tag = if svg then "g" else "span"
-                w(sb, s"""<$tag data-kyo-path="${pathAttr(path)}" data-kyo-reactive>""")
+                // Regions are delimited by comment markers, not a wrapper element: comments are valid
+                // in every parse context (table, tr, select, svg), whereas the parser foster-parents a
+                // wrapper out of table contexts and drops it inside select.
+                w(sb, RegionMarker.open(path))
                 for current <- r.signal.current(using r.frame)
-                yield renderTo(sb, current, path, svg, cssRules).andThen(w(sb, s"</$tag>"))
+                yield renderTo(sb, current, contentPath(path, current), svg, cssRules, mountSlot).andThen(w(sb, RegionMarker.close(path)))
 
             case fe: Foreach[?, ?] @unchecked =>
-                val tag = if svg then "g" else "span"
-                w(sb, s"""<$tag data-kyo-path="${pathAttr(path)}" data-kyo-reactive>""")
+                w(sb, RegionMarker.open(path))
                 fe.applyTyped {
                     [T] =>
                         (signal, keyFn, renderFn) =>
@@ -205,26 +201,28 @@ private[kyo] object HtmlRenderer:
                                 val key = keyFn match
                                     case Present(f) => f(item)
                                     case Absent     => i.toString
-                                renderTo(sb, renderFn(i, item), path :+ key, svg, cssRules)
-                            }.andThen(w(sb, s"</$tag>"))
+                                renderTo(sb, renderFn(i, item), path :+ key, svg, cssRules, mountSlot)
+                            }.andThen(w(sb, RegionMarker.close(path)))
                             end for
                 }
 
             case m: Mounted =>
                 // Static/SSG projection of a mount is its placeholder; live, ReactiveUI.subscribeMounted patches
                 // the region when the node's cell publishes (synchronously, before paint, for an adopted keyed instance).
-                val tag = if svg then "g" else "span"
-                w(sb, s"""<$tag data-kyo-path="${pathAttr(path)}" data-kyo-reactive>""")
-                renderTo(sb, m.placeholderUI.getOrElse(UI.empty(using m.frame)), path, svg)
-                    .andThen(w(sb, s"</$tag>"))
+                // The `s` flag is client-only (see `render`): declares a mount belongs at this slot, so a parent morph
+                // preserves a live mount but reconciles away a stale one when the new content is NOT a mount. SSR keeps golden HTML.
+                w(sb, RegionMarker.open(path, slot = mountSlot))
+                val mph = m.placeholderUI.getOrElse(UI.empty(using m.frame))
+                renderTo(sb, mph, contentPath(path, mph), svg, cssRules, mountSlot)
+                    .andThen(w(sb, RegionMarker.close(path)))
 
             case b: Boundary =>
                 // Static/SSG projection of a boundary is its fallback; live, ReactiveUI.subscribeBoundary repaints
                 // with the child on reveal (same task chain, when the eager child walk started nothing pending).
-                val tag = if svg then "g" else "span"
-                w(sb, s"""<$tag data-kyo-path="${pathAttr(path)}" data-kyo-reactive>""")
-                renderTo(sb, b.fallbackUI.getOrElse(UI.empty(using b.frame)), path, svg)
-                    .andThen(w(sb, s"</$tag>"))
+                w(sb, RegionMarker.open(path))
+                val bfb = b.fallbackUI.getOrElse(UI.empty(using b.frame))
+                renderTo(sb, bfb, contentPath(path, bfb), svg, cssRules, mountSlot)
+                    .andThen(w(sb, RegionMarker.close(path)))
     end renderTo
 
     private def renderTextareaValue(sb: StringBuilder, ta: Textarea)(using Frame): Unit < Sync =
@@ -665,7 +663,6 @@ private[kyo] object HtmlRenderer:
           |body { font-family: system-ui, -apple-system, sans-serif; margin: 0; padding: 0; }
           |div, section, main, header, footer, form, article, aside, p, ul, ol, pre, code, h1, h2, h3, h4, h5, h6, label { display: flex; flex-direction: column; }
           |nav, li, span, button, a { display: flex; flex-direction: row; align-items: center; }
-          |[data-kyo-reactive] { display: contents; }
           |ul, ol { list-style: none; padding: 0; margin: 0; }
           |h1, h2, h3, h4, h5, h6, p { margin: 0; }
           |a { color: inherit; text-decoration: none; }
@@ -674,6 +671,25 @@ private[kyo] object HtmlRenderer:
           |""".stripMargin
 
     private def pathAttr(path: Seq[String]): String = path.mkString(".")
+
+    /** Reserved path segment for a reactive region whose current value is ITSELF a reactive region
+      * (`Reactive`/`Foreach`/`Mounted`/`Boundary`). Without it, nested reactive wrappers collapse onto one
+      * `data-kyo-path` and only the OUTERMOST is addressable; appending it gives each nesting level a distinct,
+      * stable wrapper path. Contains no '.' (path separator) and is not a decimal index, so it cannot collide with
+      * Element/Fragment child indices; it only appears as a reactive wrapper's sole content, so it cannot collide
+      * with Foreach/KeyedChild keys.
+      */
+    private[kyo] val reactiveContentSegment: String = "$r"
+
+    /** Path at which a reactive region renders its current value: a distinct sub-path when the value is itself a
+      * reactive region, else `path` unchanged (flat content stays byte-identical). SINGLE SOURCE OF TRUTH:
+      * `renderTo` (SSR), `ReactiveUI.walkStatic`, and both patch exchanges (`DomBackend`/`UIServer` `onChange`)
+      * MUST all route content through this, or SSR and client paths diverge.
+      */
+    private[kyo] def contentPath(path: Seq[String], current: UI): Seq[String] =
+        current match
+            case _: Reactive[?] | _: Foreach[?, ?] | _: Mounted | _: Boundary => path :+ reactiveContentSegment
+            case _                                                            => path
 
     private def fmtD(v: Double): String = NumberFormat.double(v)
 
@@ -755,46 +771,45 @@ private[kyo] object HtmlRenderer:
            |  var op=JSON.parse(e.data);
            |  if(op.Replace){
            |    var p=op.Replace.path.join(".");
-           |    var el=document.querySelector('[data-kyo-path="'+p+'"]');
-           |    // Two-way binding echoes each keystroke back as a Replace. An outerHTML replace of the focused field
-           |    // resets its caret (email/number inputs do not support selectionStart, so it cannot be restored),
-           |    // reversing typed text. So when the focused editable element is inside this Replace, MORPH it in place
-           |    // instead: sync attributes (the value attribute keeps mirroring the signal) but assign the live .value
-           |    // only on a genuine change. The user's own keystroke echo carries the value the field already holds, so
-           |    // .value is left alone and the caret is preserved; a submit-clear or external update carries a different
-           |    // value and is applied. The re-render is wrapped in <span data-kyo-reactive>, so the field is inside `el`.
-           |    // Only morph the field's OWN value echo: its data-kyo-path equals this Replace's path (the bound input
-           |    // and its wrapper span share the path). A larger subtree re-render (a foreach reorder, a `when` swap)
-           |    // has a shorter path and merely CONTAINS the focused field; that must fall through to the normal
-           |    // replace so focus-follows-item and structural changes still work.
-           |    var __ae=document.activeElement;
-           |    var __morphed=false;
-           |    if(el&&__ae&&(__ae.tagName==="INPUT"||__ae.tagName==="TEXTAREA")&&__ae.getAttribute("data-kyo-path")===p&&el.contains(__ae)){
-           |      var __t=document.createElement("template");__t.innerHTML=op.Replace.html.trim();
-           |      var __ni=__t.content.querySelector(__ae.tagName.toLowerCase());
-           |      if(__ni){
-           |        for(var __i=0;__i<__ni.attributes.length;__i++){var __a=__ni.attributes[__i];if(__ae.getAttribute(__a.name)!==__a.value)__ae.setAttribute(__a.name,__a.value);}
-           |        var __names=[];for(var __j=0;__j<__ae.attributes.length;__j++)__names.push(__ae.attributes[__j].name);
-           |        for(var __k=0;__k<__names.length;__k++){if(!__ni.hasAttribute(__names[__k]))__ae.removeAttribute(__names[__k]);}
-           |        var __nv=(__ae.tagName==="TEXTAREA")?__ni.textContent:(__ni.getAttribute("value")||"");
-           |        if(__nv!==__ae.value)__ae.value=__nv;
-           |        applyJsProps(__ae);
-           |        __morphed=true;
+           |    var r=__kyoRegion(p);
+           |    if(!r){
+           |      // ELEMENT region (a signal-bound field like input.value(ref)): the region root IS the live
+           |      // element carrying the path: morph it 1:1 in place. Genuinely unpainted DOM (e.g. Boundary
+           |      // pre-reveal) stays a silent no-op. Twin of DomBackend.onChange.
+           |      var eel=document.querySelector(__kyoPathSel(p));
+           |      if(eel&&eel.parentNode){
+           |        var etc=__kyoParseCtx(eel.parentNode,op.Replace.html);
+           |        var etr=etc?__kyoFirstEl(etc):null;
+           |        if(etr){__kyoMorphNode(eel,etr);var eln=document.querySelector(__kyoPathSel(p));if(eln){applyJsProps(eln);ba(eln);}}
            |      }
            |    }
-           |    if(el&&!__morphed&&el.outerHTML!==op.Replace.html){
+           |    // A live mount region ('m') is left untouched ONLY when the new content is itself a mount slot
+           |    // ('s' = the SAME mount re-rendering, which owns its subtree).
+           |    else if(!(!op.Replace.mount&&r.m&&__kyoPayloadSlot(op.Replace.html))){
+           |      var rp=r.s.parentNode;
+           |      // Capture focus/caret of the active element inside the patched range.
            |      var ae=document.activeElement;
-           |      var ap=ae&&ae!==document.body&&ae.getAttribute?ae.getAttribute("data-kyo-path"):null;
-           |      var ss=(ae&&typeof ae.selectionStart==='number')?ae.selectionStart:null;
-           |      var se=(ae&&typeof ae.selectionEnd==='number')?ae.selectionEnd:null;
-           |      el.outerHTML=op.Replace.html;
-           |      var nel=document.querySelector('[data-kyo-path="'+p+'"]');if(nel){applyJsProps(nel);ba(nel);}
-           |      if(ap){var rf=document.querySelector('[data-kyo-path="'+ap+'"]');if(rf&&rf.hasAttribute&&rf.hasAttribute('data-kyo-reactive')){var inner=rf.querySelector('input,textarea,select,[contenteditable]');if(inner)rf=inner;}if(rf){rf.focus();if(ss!==null&&typeof rf.setSelectionRange==='function'){try{rf.setSelectionRange(ss,se);}catch(e){if(e.name!=='InvalidStateError')throw e;}}}}
+           |      var inR=ae&&ae!==document.body&&__kyoRangeHas(r,ae);
+           |      var ap=inR?((ae.hasAttribute&&ae.hasAttribute("data-kyo-path"))?ae.getAttribute("data-kyo-path"):p):null;
+           |      var ss=(inR&&typeof ae.selectionStart==='number')?ae.selectionStart:null;
+           |      var se=(inR&&typeof ae.selectionEnd==='number')?ae.selectionEnd:null;
+           |      var tc=__kyoParseCtx(rp,op.Replace.html);
+           |      if(tc){
+           |        __kyoMorphRange(rp,r.s.nextSibling,r.e,tc.firstChild,null);
+           |        // The mount's own first paint claims the region: the 'm' flag rides the live start marker
+           |        // (source of truth, survives registry rebuilds); the registry entry is a cache.
+           |        if(op.Replace.mount&&!r.m){r.m=true;r.s.data="kyo:"+__kyoMEsc(p)+" m";}
+           |        // A morph imports subtrees (new nested-region markers ride along), so refresh this range.
+           |        __kyoRescanRange(r);
+           |        var rn=r.s.nextSibling;while(rn&&rn!==r.e){if(rn.nodeType===1){applyJsProps(rn);ba(rn);}rn=rn.nextSibling;}
+           |        if(ap)__kyoRestoreFocus(ap,ss,se);
+           |      }
            |    }
            |  }else if(op.Remove){
            |    var p=op.Remove.path.join(".");
-           |    var el=document.querySelector('[data-kyo-path="'+p+'"]');
+           |    var el=document.querySelector(__kyoPathSel(p));
            |    if(el)el.remove();
+           |    else{var rr=__kyoRegions[p];if(rr&&rr.s.isConnected){var n=rr.s.nextSibling;while(n&&n!==rr.e){var nx=n.nextSibling;rr.s.parentNode.removeChild(n);n=nx;}}}
            |  }else if(op.InjectCss){
            |    var s=document.createElement("style");
            |    s.textContent=op.InjectCss.css;
@@ -808,6 +823,198 @@ private[kyo] object HtmlRenderer:
            |    });
            |  }
            |};
+           |// ---- region markers + range morphing (twin of RegionMarker/DomBackend; keep in lockstep) ----
+           |// Regions are delimited by comment markers <!--kyo:PATH-->...<!--/kyo:PATH--> (flags: ' m' mount root,
+           |// ' s' mount slot). Patch a marker-delimited sibling range in place toward new HTML, so focus/caret/
+           |// scroll/transitions on reused nodes survive. Reconciliation is SIBLING-SCOPED over LOGICAL children:
+           |// an element keyed by data-kyo-path, a marker-delimited span keyed by its region path (never matched
+           |// positionally: mispairing would corrupt marker text). Objects use Object.create(null) so a path equal
+           |// to a prototype name (e.g. "constructor") can't false-match.
+           |// Marker byte-format contract lives in RegionMarker.scala: escape %->%25, '-'->%2D, ' '->%20.
+           |function __kyoMEsc(s){return s.replace(/%/g,"%25").replace(/-/g,"%2D").replace(/ /g,"%20");}
+           |function __kyoMUnesc(s){return s.replace(/%2D/g,"-").replace(/%20/g," ").replace(/%25/g,"%");}
+           |function __kyoMParse(d){
+           |  var close=false,s=d;
+           |  if(s.indexOf("/kyo:")===0){close=true;s=s.substring(5);}
+           |  else if(s.indexOf("kyo:")===0){s=s.substring(4);}
+           |  else return null;
+           |  var m=false,sl=false;
+           |  if(!close){var sp=s.indexOf(" ");if(sp>=0){var fl=s.substring(sp+1).split(" ");m=fl.indexOf("m")>=0;sl=fl.indexOf("s")>=0;s=s.substring(0,sp);}}
+           |  return {p:__kyoMUnesc(s),c:close,m:m,s:sl};
+           |}
+           |// True when the payload's first node is an open marker with the 's' flag (the region's new content
+           |// root IS a mount placeholder). Bounded to the leading comment.
+           |function __kyoPayloadSlot(html){
+           |  if(html.indexOf("<!--")!==0)return false;
+           |  var e=html.indexOf("-->");if(e<=4)return false;
+           |  var p=__kyoMParse(html.substring(4,e));
+           |  return !!(p&&!p.c&&p.s);
+           |}
+           |// Path -> {s:startComment,e:endComment,m:mountFlag}. Rebuilt by full scans (boot, stale lookup),
+           |// refreshed by range-scoped rescans after each patch. Marker pairs always share one parent.
+           |var __kyoRegions=Object.create(null);
+           |// Register a pair, repairing parser separation first (twin of DomBackend.registerPair): an open marker
+           |// that precedes a table's FIRST row stays a <table> child while rows + close marker land inside the
+           |// implied <tbody>: adopt the open marker into that row group so the pair shares a parent again.
+           |function __kyoRegPair(path,start,end,m){
+           |  if(start.parentNode!==end.parentNode&&end.parentNode&&end.parentNode.parentNode===start.parentNode)end.parentNode.insertBefore(start,end.parentNode.firstChild);
+           |  __kyoRegions[path]={s:start,e:end,m:m};
+           |}
+           |function __kyoScanInto(root){
+           |  var w=document.createTreeWalker(root,128,null);
+           |  var opens=Object.create(null),n=w.nextNode();
+           |  while(n){
+           |    var p=__kyoMParse(n.data);
+           |    if(p){if(p.c){var o=opens[p.p];if(o){__kyoRegPair(p.p,o.n,n,o.m);delete opens[p.p];}}else opens[p.p]={n:n,m:p.m};}
+           |    n=w.nextNode();
+           |  }
+           |}
+           |function __kyoRebuild(){__kyoRegions=Object.create(null);__kyoScanInto(document.body);}
+           |function __kyoRescanRange(r){
+           |  var opens=Object.create(null),n=r.s.nextSibling;
+           |  while(n&&n!==r.e){
+           |    if(n.nodeType===8){var p=__kyoMParse(n.data);if(p){if(p.c){var o=opens[p.p];if(o){__kyoRegPair(p.p,o.n,n,o.m);delete opens[p.p];}}else opens[p.p]={n:n,m:p.m};}}
+           |    else if(n.nodeType===1)__kyoScanInto(n);
+           |    n=n.nextSibling;
+           |  }
+           |}
+           |// Connectivity-validated lookup: stale/missing -> ONE full rescan -> retry -> null (silent no-op).
+           |function __kyoRegion(p){
+           |  var r=__kyoRegions[p];
+           |  if(r&&r.s.isConnected&&r.e.isConnected)return r;
+           |  __kyoRebuild();
+           |  r=__kyoRegions[p];
+           |  return (r&&r.s.isConnected&&r.e.isConnected)?r:null;
+           |}
+           |function __kyoRangeHas(r,node){var n=r.s.nextSibling;while(n&&n!==r.e){if(n===node||(n.nodeType===1&&n.contains(node)))return true;n=n.nextSibling;}return false;}
+           |// Keyed-list keys are user data and become path segments: escape the CSS attribute-selector
+           |// metacharacters (backslash, double quote) so a key cannot break or redirect the query. Built via
+           |// fromCharCode because this literal's escape processing must not touch the emitted JS.
+           |function __kyoPathSel(p){var bs=String.fromCharCode(92),q=String.fromCharCode(34);var s=String(p).split(bs).join(bs+bs).split(q).join(bs+q);return '[data-kyo-path='+q+s+q+']';}
+           |// Focus restore: an element path resolves directly; a region path searches its range for the first
+           |// focus-capable element (mirrors the old descend-into-wrapper behavior).
+           |function __kyoRestoreFocus(ap,ss,se){
+           |  var rf=document.querySelector(__kyoPathSel(ap));
+           |  if(!rf){var r=__kyoRegions[ap];if(r&&r.s.isConnected){var fs='input,textarea,select,[contenteditable]',n=r.s.nextSibling;while(!rf&&n&&n!==r.e){if(n.nodeType===1){rf=(n.matches&&n.matches(fs))?n:n.querySelector(fs);}n=n.nextSibling;}}}
+           |  if(rf){rf.focus();if(ss!==null&&typeof rf.setSelectionRange==='function'){try{rf.setSelectionRange(ss,se);}catch(e){if(e.name!=='InvalidStateError')throw e;}}}
+           |}
+           |function __kyoFirstEl(p){var c=p.firstChild;while(c&&c.nodeType!==1)c=c.nextSibling;return c;}
+           |// For an open marker, its matching close among following siblings (paths unique among siblings).
+           |function __kyoSpanClose(open,path){
+           |  var n=open.nextSibling;
+           |  while(n){if(n.nodeType===8){var p=__kyoMParse(n.data);if(p&&p.c&&p.p===path)return n;}n=n.nextSibling;}
+           |  return null;
+           |}
+           |// Logical-child key: element data-kyo-path, open marker's region path, else null (positional).
+           |function __kyoLKey(n){
+           |  if(n.nodeType===1)return n.hasAttribute("data-kyo-path")?n.getAttribute("data-kyo-path"):null;
+           |  if(n.nodeType===8){var p=__kyoMParse(n.data);if(p&&!p.c&&__kyoSpanClose(n,p.p))return p.p;}
+           |  return null;
+           |}
+           |// Next logical sibling: past the whole span for an open marker, else nextSibling.
+           |function __kyoLNext(n){
+           |  if(n.nodeType===8){var p=__kyoMParse(n.data);if(p&&!p.c){var c=__kyoSpanClose(n,p.p);if(c)return c.nextSibling;}}
+           |  return n.nextSibling;
+           |}
+           |function __kyoEachSpan(first,f){
+           |  var last=first;
+           |  if(first.nodeType===8){var p=__kyoMParse(first.data);if(p&&!p.c){var c=__kyoSpanClose(first,p.p);if(c)last=c;}}
+           |  var n=first,stop=false;
+           |  while(!stop&&n){var nx=n.nextSibling;stop=(n===last);f(n);n=nx;}
+           |}
+           |function __kyoMoveL(parent,node,ref){__kyoEachSpan(node,function(n){parent.insertBefore(n,ref);});}
+           |function __kyoRemoveL(parent,node){__kyoEachSpan(node,function(n){parent.removeChild(n);});}
+           |function __kyoInsertL(parent,toNode,ref){__kyoEachSpan(toNode,function(n){parent.insertBefore(document.importNode(n,true),ref);});}
+           |// Patch matched logical children. Span vs span recurses on the content ranges, unless the live span
+           |// carries 'm' and the incoming one 's' (the SAME mount re-rendering, which owns its subtree): opaque,
+           |// and the 'm' start marker is never touched. Kind mismatch replaces wholesale.
+           |function __kyoPatchL(parent,m,toNode){
+           |  var fs=m.nodeType===8,ts=toNode.nodeType===8;
+           |  if(!fs&&!ts){__kyoMorphNode(m,toNode);return;}
+           |  if(fs&&ts){
+           |    var f=__kyoMParse(m.data),t=__kyoMParse(toNode.data);
+           |    if(!f||!t)return;
+           |    var fc=__kyoSpanClose(m,f.p),tc=__kyoSpanClose(toNode,t.p);
+           |    if(!fc||!tc)return;
+           |    if(f.m&&t.s)return;
+           |    __kyoMorphRange(parent,m.nextSibling,fc,toNode.nextSibling,tc);
+           |    return;
+           |  }
+           |  __kyoInsertL(parent,toNode,m);__kyoRemoveL(parent,m);
+           |}
+           |// Parse a bare content fragment in the parse context the live parent dictates (twin of
+           |// DomBackend.parseToContainer): the wrap keeps the fragment parser from foster-parenting or dropping
+           |// context-sensitive content. Comments survive all these parse modes. Returns the node whose childNodes
+           |// are the new content, or null.
+           |function __kyoParseCtx(parent,html){
+           |  var t=document.createElement("template"),tag=parent.tagName,pre="",suf="",d=0;
+           |  if(parent.namespaceURI==="http://www.w3.org/2000/svg"&&tag.toLowerCase()!=="foreignobject"){pre="<svg>";suf="</svg>";d=1;}
+           |  else if(tag==="TABLE"||tag==="THEAD"||tag==="TBODY"||tag==="TFOOT"){pre="<table><tbody>";suf="</tbody></table>";d=2;}
+           |  else if(tag==="TR"){pre="<table><tbody><tr>";suf="</tr></tbody></table>";d=3;}
+           |  else if(tag==="SELECT"||tag==="OPTGROUP"){pre="<select>";suf="</select>";d=1;}
+           |  t.innerHTML=pre+html+suf;
+           |  var c=t.content;
+           |  while(d>0&&c){c=__kyoFirstEl(c);d--;}
+           |  return c;
+           |}
+           |function __kyoCompat(a,b){return a.nodeType===b.nodeType&&(a.nodeType!==1||a.tagName===b.tagName);}
+           |function __kyoMorphAttrs(fromEl,toEl){
+           |  var tag=fromEl.tagName;
+           |  var activeInput=(fromEl===document.activeElement)&&(tag==="INPUT"||tag==="TEXTAREA");
+           |  var ta=toEl.attributes,i;
+           |  for(i=0;i<ta.length;i++){var a=ta[i];if(fromEl.getAttribute(a.name)!==a.value)fromEl.setAttribute(a.name,a.value);}
+           |  var fa=fromEl.attributes,j;
+           |  for(j=fa.length-1;j>=0;j--){var fn=fa[j].name;if(!toEl.hasAttribute(fn))fromEl.removeAttribute(fn);}
+           |  // Never overwrite a focused field's live .value (its caret) with its own two-way-binding echo (value
+           |  // already matches); assign only a genuine external change (submit-clear, programmatic update).
+           |  if(activeInput){var nv=(tag==="TEXTAREA")?toEl.textContent:(toEl.getAttribute("value")||"");if(nv!==fromEl.value)fromEl.value=nv;}
+           |}
+           |// Reconcile the live sibling range [fromStart,fromEnd) toward [toStart,toEnd) (template nodes).
+           |// Null bounds = to the end of the parent; a region's close marker is the from-side sentinel, so
+           |// out-of-range siblings (incl. the region's own markers) are never visited and insertBefore(node,
+           |// sentinel) appends at the range end. Twin of DomBackend.morphRange; keep in lockstep.
+           |function __kyoMorphRange(fromParent,fromStart,fromEnd,toStart,toEnd){
+           |  var fromKeyed=null,toKeyed=null,scan=fromStart;
+           |  while(scan&&scan!==fromEnd){var k=__kyoLKey(scan);if(k!==null){if(!fromKeyed)fromKeyed=Object.create(null);fromKeyed[k]=scan;}scan=__kyoLNext(scan);}
+           |  scan=toStart;
+           |  while(scan&&scan!==toEnd){var k2=__kyoLKey(scan);if(k2!==null){if(!toKeyed)toKeyed=Object.create(null);toKeyed[k2]=true;}scan=__kyoLNext(scan);}
+           |  var curFrom=fromStart,curTo=toStart;
+           |  while(curTo&&curTo!==toEnd){
+           |    var toNext=__kyoLNext(curTo),tKey=__kyoLKey(curTo);
+           |    if(tKey!==null){
+           |      var m=(fromKeyed&&fromKeyed[tKey])?fromKeyed[tKey]:null;
+           |      if(m){
+           |        if(m!==curFrom)__kyoMoveL(fromParent,m,curFrom);else curFrom=__kyoLNext(curFrom);
+           |        __kyoPatchL(fromParent,m,curTo);
+           |      }else __kyoInsertL(fromParent,curTo,curFrom);
+           |    }else{
+           |      var handled=false,loop=true;
+           |      while(loop&&curFrom&&curFrom!==fromEnd){
+           |        var fNext=__kyoLNext(curFrom),fKey=__kyoLKey(curFrom);
+           |        if(fKey!==null){
+           |          // A keyed from-child at an unkeyed slot: keep it if `to` reuses it elsewhere, else stale.
+           |          if(!toKeyed||!toKeyed[fKey])__kyoRemoveL(fromParent,curFrom);
+           |          curFrom=fNext;
+           |        }else if(__kyoCompat(curFrom,curTo)){__kyoMorphNode(curFrom,curTo);curFrom=fNext;handled=true;loop=false;}
+           |        else{__kyoRemoveL(fromParent,curFrom);curFrom=fNext;}
+           |      }
+           |      if(!handled)__kyoInsertL(fromParent,curTo,curFrom);
+           |    }
+           |    curTo=toNext;
+           |  }
+           |  while(curFrom&&curFrom!==fromEnd){var fN=__kyoLNext(curFrom);__kyoRemoveL(fromParent,curFrom);curFrom=fN;}
+           |}
+           |function __kyoMorphChildren(fromParent,toParent){__kyoMorphRange(fromParent,fromParent.firstChild,null,toParent.firstChild,null);}
+           |function __kyoMorphEl(fromEl,toEl){
+           |  __kyoMorphAttrs(fromEl,toEl);
+           |  var editing=(fromEl===document.activeElement)&&fromEl.hasAttribute("contenteditable");
+           |  if(!editing)__kyoMorphChildren(fromEl,toEl);
+           |}
+           |function __kyoMorphNode(fromNode,toNode){
+           |  if(toNode.nodeType!==1){if(fromNode.nodeValue!==toNode.nodeValue)fromNode.nodeValue=toNode.nodeValue;}
+           |  else if(fromNode.tagName!==toNode.tagName)fromNode.parentNode.replaceChild(document.importNode(toNode,true),fromNode);
+           |  else __kyoMorphEl(fromNode,toNode);
+           |}
            |function fp(el){
            |  while(el&&el!==document.body){
            |    if(el.hasAttribute("data-kyo-path"))return el;
@@ -870,7 +1077,7 @@ private[kyo] object HtmlRenderer:
            |  if(!an.length)return;
            |  requestAnimationFrame(function(){for(var i=0;i<an.length;i++){try{an[i].beginElement();}catch(e){}}});
            |}
-           |applyJsProps(document.body);ba(document.body);
+           |__kyoRebuild();applyJsProps(document.body);ba(document.body);
            |// Dropdown helpers: close all dropdowns except the given id
            |function kyoCloseDropdown(exceptId){
            |  var all=document.querySelectorAll('[data-kyo-dropdown-options]');

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -209,6 +209,22 @@ private[kyo] object HtmlRenderer:
                             }.andThen(w(sb, s"</$tag>"))
                             end for
                 }
+
+            case m: Mounted =>
+                // Static/SSG projection of a mount is its placeholder; live, ReactiveUI.subscribeMounted patches
+                // the region when the node's cell publishes (synchronously, before paint, for an adopted keyed instance).
+                val tag = if svg then "g" else "span"
+                w(sb, s"""<$tag data-kyo-path="${pathAttr(path)}" data-kyo-reactive>""")
+                renderTo(sb, m.placeholderUI.getOrElse(UI.empty(using m.frame)), path, svg)
+                    .andThen(w(sb, s"</$tag>"))
+
+            case b: Boundary =>
+                // Static/SSG projection of a boundary is its fallback; live, ReactiveUI.subscribeBoundary repaints
+                // with the child on reveal (same task chain, when the eager child walk started nothing pending).
+                val tag = if svg then "g" else "span"
+                w(sb, s"""<$tag data-kyo-path="${pathAttr(path)}" data-kyo-reactive>""")
+                renderTo(sb, b.fallbackUI.getOrElse(UI.empty(using b.frame)), path, svg)
+                    .andThen(w(sb, s"</$tag>"))
     end renderTo
 
     private def renderTextareaValue(sb: StringBuilder, ta: Textarea)(using Frame): Unit < Sync =

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
@@ -327,7 +327,19 @@ private[kyo] object ReactiveUI:
                         val inner = child match
                             case kc: KeyedChild[?] => kc.child
                             case _                 => child
-                        walkStatic(inner, childPath, svg, mountDispatch)
+                        inner match
+                            case _: Reactive[?] | _: Foreach[?, ?] | _: Mounted | _: Boundary =>
+                                // Same contract as an Element's reactive child: the renderer paints the
+                                // node's own anchor at childPath (no content descent), so normalize there
+                                // directly. Recursing through walkStatic would hit the TOP-LEVEL branch,
+                                // which registers at childPath :+ "$r", so every patch would then target a
+                                // path the painted DOM does not have (mount stuck on its placeholder,
+                                // reactive updates silently dropped).
+                                for rui <- normalizeWith(inner, childPath, svg, mountDispatch)
+                                yield (Seq(rui), rui.handle)
+                            case _ =>
+                                walkStatic(inner, childPath, svg, mountDispatch)
+                        end match
                     }
                 yield
                     val allKids    = childWalks.flatMap(_._1)
@@ -345,11 +357,11 @@ private[kyo] object ReactiveUI:
                     (allKids, handle)
 
             case _: Reactive[?] | _: Foreach[?, ?] | _: Mounted | _: Boundary =>
-                // When walkStatic is called with a Reactive, Foreach, or Mounted as the top-level node
-                // (not as a child of an Element), normalize it at basePath so subscribeNode
-                // sets up a subscription for it. This handles the case where an outer reactive's
-                // signal value is itself a Reactive or Foreach (e.g. outer.map { _ => inner.map(UI.span(_)) }).
-                for rui <- normalizeWith(ui, basePath, svg, mountDispatch)
+                // walkStatic on a top-level Reactive/Foreach/Mounted (not a child of an Element): normalize it so
+                // subscribeNode subscribes it (handles an outer reactive whose value is itself reactive, e.g.
+                // outer.map { _ => inner.map(UI.span(_)) }). The inner region owns a DISTINCT sub-path
+                // (HtmlRenderer.contentPath) so it's addressable independently; MUST match the SSR/patch descents.
+                for rui <- normalizeWith(ui, HtmlRenderer.contentPath(basePath, ui), svg, mountDispatch)
                 yield (Seq(rui), rui.handle)
 
             case _ =>
@@ -857,7 +869,11 @@ private[kyo] object ReactiveUI:
         signalChangeTime: AtomicRef[Instant],
         presetMounts: Maybe[MountRegistry],
         mountDispatch: MountDispatch,
-        boundary: Maybe[BoundaryCtx]
+        boundary: Maybe[BoundaryCtx],
+        // True when this region IS a keyless mount's content cell: its paint flags the DOM node as a mount root so a
+        // parent's in-place update leaves the subtree alone (the mount repaints itself). Keyed mounts stay false;
+        // their reset relies on the parent painting the placeholder over the stale content.
+        mount: Boolean = false
     )(using Frame): Unit < (Async & Scope) =
         for
             regionMounts <- presetMounts match
@@ -870,7 +886,7 @@ private[kyo] object ReactiveUI:
                         _            <- signalChangeTime.set(now)
                         (newKids, _) <- walkStatic(current, path, svg, mountDispatch)
                         _            <- regionMounts.evictExcept(collectMountKeys(newKids))
-                        _            <- exchange.onChange(path, current)
+                        _            <- exchange.onChange(path, current, mount)
                         _ <- Kyo.foreachDiscard(newKids)(
                             subscribeScoped(_, exchange, signalChangeTime, regionMounts, mountDispatch, boundary)
                         )
@@ -975,7 +991,17 @@ private[kyo] object ReactiveUI:
                         settleOnce.run,
                         supervision
                     ))
-                    _ <- subscribeRegion(rui.path, cell, rui.svgContext, exchange, signalChangeTime, Absent, mountDispatch, boundary)
+                    _ <- subscribeRegion(
+                        rui.path,
+                        cell,
+                        rui.svgContext,
+                        exchange,
+                        signalChangeTime,
+                        Absent,
+                        mountDispatch,
+                        boundary,
+                        mount = true
+                    )
                 yield ()
 
     /** Once-only settle of a counted boundary entry: invocable from both the publish path and a teardown

--- a/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/ReactiveUI.scala
@@ -11,8 +11,115 @@ private[kyo] case class ReactiveUI(
     isConst: Boolean,
     children: Seq[ReactiveUI],
     handle: (Seq[String], UIEvent) => Boolean < Async,
-    svgContext: Boolean = false
+    svgContext: Boolean = false,
+    mountedSpec: Maybe[MountedSpec] = Absent,
+    boundarySpec: Maybe[BoundarySpec] = Absent,
+    mountDispatch: Maybe[MountDispatch] = Absent // set on the ROOT normalize product only; see subscribe
 )
+
+/** Normalization-time companion of a [[kyo.UI.Ast.Boundary]] node. */
+final private[kyo] case class BoundarySpec(node: UI.Ast.Boundary):
+    def fallbackUI(using Frame): UI = node.fallbackUI.getOrElse(UI.empty)
+
+/** Live pending/error aggregation of one subscribed Boundary (see [[kyo.UI.Ast.Boundary]]).
+  *
+  * `enter` counts a mount that starts while the boundary is unrevealed; `exit` (on settle) reveals (paints
+  * the child from current signal values over the fallback) when the count reaches zero. Reveal is once-only
+  * and idempotent (settles racing the initial zero-check both funnel through the same getAndSet). Boundaries
+  * chain via `parentCtx`: `tryHandle` offers an unhandled mounted failure to the nearest boundary whose error
+  * partial function matches; a match paints the error at THAT boundary (and freezes its counting).
+  */
+final private[kyo] class BoundaryCtx(
+    path: Seq[String],
+    child: UI,
+    node: UI.Ast.Boundary,
+    exchange: UIExchange,
+    mountDispatch: MountDispatch,
+    pending: AtomicInt,
+    revealed: AtomicRef[Boolean],
+    parentCtx: Maybe[BoundaryCtx]
+):
+    /** Count a newly starting mount if this boundary has not revealed yet; returns whether it was counted. */
+    def enter(using Frame): Boolean < Sync =
+        revealed.get.map(r => if r then false else pending.incrementAndGet.andThen(true))
+
+    /** A counted mount settled; reveal when the count reaches zero. */
+    def exit(using Frame): Unit < Async =
+        pending.decrementAndGet.map(n => if n <= 0 then reveal else ())
+
+    /** Paint the child over the fallback, then re-push every live mount cell under this boundary (shallowest
+      * first): the static child render emits mounted nodes as PLACEHOLDER wrappers (the renderer cannot see
+      * subscribe-time cells), and the mounts' own regions already emitted their content while the fallback was
+      * up, against DOM that did not exist. The re-push replays each cell's current value into the freshly
+      * painted wrappers.
+      */
+    def reveal(using Frame): Unit < Async =
+        revealed.getAndSet(true).map { was =>
+            if was then ()
+            else
+                exchange.onChange(path, child).andThen {
+                    mountDispatch.snapshotUnder(path).map { entries =>
+                        Kyo.foreachDiscard(entries) { (p, cell) =>
+                            cell.current.map(ui => exchange.onChange(p, ui))
+                        }
+                    }
+                }
+        }
+
+    /** Offer an unhandled mounted failure to this boundary chain; a matching boundary paints the error over
+      * its whole content and stops counting. Returns whether some boundary handled it.
+      */
+    def tryHandle(t: Throwable)(using Frame): Boolean < Async =
+        node.errorPf match
+            case Present(pf) if pf.isDefinedAt(t) =>
+                revealed.getAndSet(true).map(_ => exchange.onChange(path, pf(t)).andThen(true))
+            case _ =>
+                parentCtx match
+                    case Present(p) => p.tryHandle(t)
+                    case Absent     => Kyo.lift(false)
+end BoundaryCtx
+
+/** Session-level dispatch table for mounted nodes: path → live content cell.
+  *
+  * Event dispatch re-derives handler chains from `signal.current` on every event, re-running any `Signal.map`
+  * lambdas on the way, so the Mounted node value (and any state carried on it or its normalize product) is FRESH
+  * per dispatch and cannot hold the subscribe-time wiring. The table is the stable meeting point: created once per
+  * normalize root (one per mount session), closed over by every handler the normalization tree builds, written by
+  * subscribeMounted (registration is Scope-bound: the per-value scope that subscribed a node unregisters it, and
+  * observe's closed-and-awaited ordering makes unregister-then-reregister safe across region rebuilds), and read by
+  * the dispatch-time handler of whatever fresh Mounted node value occupies the same path.
+  */
+final private[kyo] class MountDispatch(cells: AtomicRef[Map[Seq[String], Signal[UI]]]):
+    def register(path: Seq[String], cell: Signal[UI])(using Frame): Unit < Sync =
+        cells.getAndUpdate(_.updated(path, cell)).unit
+
+    /** Unregister only if `cell` is still the registered one: a successor that already re-registered wins. */
+    def unregister(path: Seq[String], cell: Signal[UI])(using Frame): Unit < Sync =
+        cells.getAndUpdate(m => if m.get(path).exists(_ eq cell) then m.removed(path) else m).unit
+
+    def lookup(path: Seq[String])(using Frame): Maybe[Signal[UI]] < Sync =
+        cells.get.map(m => Maybe.fromOption(m.get(path)))
+
+    /** All live mount cells at or under `prefix`, shallowest path first: the boundary reveal's re-push set. */
+    def snapshotUnder(prefix: Seq[String])(using Frame): Seq[(Seq[String], Signal[UI])] < Sync =
+        cells.get.map(_.toSeq.filter((p, _) => p.startsWith(prefix)).sortBy(_._1.length))
+end MountDispatch
+
+private[kyo] object MountDispatch:
+    def init(using Frame): MountDispatch < Sync =
+        AtomicRef.init(Map.empty[Seq[String], Signal[UI]]).map(new MountDispatch(_))
+
+/** Normalization-time companion of a [[kyo.UI.Ast.Mounted]] node: the node plus its rendering defaults. */
+final private[kyo] case class MountedSpec(node: UI.Ast.Mounted):
+    def placeholderUI(using Frame): UI = node.placeholderUI.getOrElse(UI.empty)
+
+    def errorUI(t: Throwable)(using Frame): UI =
+        node.errorRender match
+            case Present(f) => f(t)
+            case Absent =>
+                given Frame = node.frame
+                UI.span(UI.Ast.Text(Option(t.getMessage).getOrElse(t.toString))).cssClass("kyo-mount-error")
+end MountedSpec
 
 private[kyo] object ReactiveUI:
 
@@ -39,18 +146,31 @@ private[kyo] object ReactiveUI:
                 if acc.nonEmpty then acc else findNode(child, path)
             }
 
+    /** Root entry point: creates the session's MountDispatch table and stamps it on the returned root node
+      * (subscribe picks it up from there). All recursion goes through normalizeWith so every handler closure
+      * shares the one table.
+      */
     def normalize(ui: UI, path: Seq[String], svg: Boolean = false): ReactiveUI < Sync =
+        given Frame = ui.frame
+        for
+            mountDispatch <- MountDispatch.init
+            root          <- normalizeWith(ui, path, svg, mountDispatch)
+        yield root.copy(mountDispatch = Present(mountDispatch))
+        end for
+    end normalize
+
+    private def normalizeWith(ui: UI, path: Seq[String], svg: Boolean, mountDispatch: MountDispatch): ReactiveUI < Sync =
         given Frame = ui.frame
         ui match
             case ui: Reactive[?] =>
                 for
                     current   <- ui.signal.current
-                    (kids, _) <- walkStatic(current, path, svg)
+                    (kids, _) <- walkStatic(current, path, svg, mountDispatch)
                 yield init(path, ui.signal, isConst = false, kids, svgContext = svg) {
                     (targetPath, event) =>
                         for
                             currentUI     <- ui.signal.current
-                            (_, freshHdl) <- walkStatic(currentUI, path, svg)
+                            (_, freshHdl) <- walkStatic(currentUI, path, svg, mountDispatch)
                             result        <- freshHdl(targetPath, event)
                         yield result
                 }
@@ -67,12 +187,12 @@ private[kyo] object ReactiveUI:
                     }
                 for
                     current   <- sig.current
-                    (kids, _) <- walkStatic(current, path, svg)
+                    (kids, _) <- walkStatic(current, path, svg, mountDispatch)
                 yield init(path, sig, isConst = false, kids, svgContext = svg) {
                     (targetPath, event) =>
                         for
                             currentUI     <- sig.current
-                            (_, freshHdl) <- walkStatic(currentUI, path, svg)
+                            (_, freshHdl) <- walkStatic(currentUI, path, svg, mountDispatch)
                             result        <- freshHdl(targetPath, event)
                         yield result
                 }
@@ -90,18 +210,59 @@ private[kyo] object ReactiveUI:
                 // re-renders without the value-dedup ever suppressing a real edit. An element with no bound ref is const.
                 val (elementSignal, isConstNode) =
                     collectSignalRef(ui).fold((Signal.initConst(ui: UI), true))(ref => (ref.map(_ => ui: UI), false))
-                for (kids, hdl) <- walkStatic(ui, path, svg)
+                for (kids, hdl) <- walkStatic(ui, path, svg, mountDispatch)
                 yield ReactiveUI(path, elementSignal, isConst = isConstNode, kids, hdl, svgContext = svg)
+
+            case ui: Mounted =>
+                // The handler resolves through the MountDispatch TABLE (by path), not the node: dispatch re-normalizes
+                // a fresh node value per event, so no live wiring can ride the node. The stored signal is a placeholder
+                // constant the subscribe path never observes (subscribeScoped branches on mountedSpec first).
+                val spec = MountedSpec(ui)
+                val handle: Handler = (targetPath, event) =>
+                    mountDispatch.lookup(path).map {
+                        case Present(cell) =>
+                            for
+                                currentUI     <- cell.current
+                                (_, freshHdl) <- walkStatic(currentUI, path, svg, mountDispatch)
+                                result        <- freshHdl(targetPath, event)
+                            yield result
+                        case Absent => (true: Boolean) // not (or no longer) wired: bubble
+                    }
+                ReactiveUI(
+                    path,
+                    Signal.initConst(spec.placeholderUI),
+                    isConst = false,
+                    Seq.empty,
+                    handle,
+                    svgContext = svg,
+                    mountedSpec = Present(spec)
+                )
+
+            case ui: Boundary =>
+                // The reactive children are the CHILD's (they subscribe eagerly behind the fallback); the stored
+                // signal is a constant and reveal is driven by BoundaryCtx, not by it. Dispatch resolves through the
+                // child value (events can only originate from painted DOM, so pre-reveal there is nothing to hit).
+                val spec = BoundarySpec(ui)
+                for (kids, hdl) <- walkStatic(ui.child, path, svg, mountDispatch)
+                yield ReactiveUI(
+                    path,
+                    Signal.initConst(ui.child),
+                    isConst = false,
+                    kids,
+                    hdl,
+                    svgContext = svg,
+                    boundarySpec = Present(spec)
+                )
 
             case ui =>
                 // Catch-all for static leaf nodes: Text, Fragment, KeyedChild.
                 // All interactive types extend Element (handled above) and all reactive types are
-                // Reactive or Foreach (also handled above). If a new UI subtype is added, the
-                // exhaustiveness checker will NOT warn here; any new type that is interactive must
+                // Reactive, Foreach, Mounted, or Boundary (also handled above). If a new UI subtype is added,
+                // the exhaustiveness checker will NOT warn here; any new type that is interactive must
                 // be added as an explicit case above before this catch-all.
                 ReactiveUI(path, Signal.initConst(ui), isConst = true, Seq.empty, (_, _) => true, svgContext = svg)
         end match
-    end normalize
+    end normalizeWith
 
     /** Returns the element's single SignalRef-bound attribute (its `.value` or `.checked`), if any, so the element can be made reactive over
       * it (its HTML re-renders when that signal changes). An element binds at most one such ref.
@@ -123,7 +284,9 @@ private[kyo] object ReactiveUI:
     private type Handler = (Seq[String], UIEvent) => Boolean < Async
 
     /** Walk a static UI tree. Collect reactive children, build handle. */
-    private def walkStatic(ui: UI, basePath: Seq[String], svg: Boolean = false)(using Frame): (Seq[ReactiveUI], Handler) < Sync =
+    private def walkStatic(ui: UI, basePath: Seq[String], svg: Boolean, mountDispatch: MountDispatch)(using
+        Frame
+    ): (Seq[ReactiveUI], Handler) < Sync =
         ui match
             case elem: Element =>
                 // ForeignObject bridges back to HTML, so reset svg context to false. It MUST be matched
@@ -135,16 +298,16 @@ private[kyo] object ReactiveUI:
                 for childWalks <- Kyo.foreach(elem.children.toSeq.zipWithIndex) { (child, i) =>
                         val childPath = basePath :+ i.toString
                         child match
-                            case _: Reactive[?] | _: Foreach[?, ?] =>
-                                for rui <- normalize(child, childPath, childSvg)
+                            case _: Reactive[?] | _: Foreach[?, ?] | _: Mounted | _: Boundary =>
+                                for rui <- normalizeWith(child, childPath, childSvg, mountDispatch)
                                 yield (Seq(rui), Seq.empty[(Int, Handler)])
                             case childElem: Element if collectSignalRef(childElem).nonEmpty =>
                                 // Element with SignalRef-bound attributes is reactive over those signals;
                                 // normalize it so subscribeNode wires updates.
-                                for rui <- normalize(childElem, childPath, childSvg)
+                                for rui <- normalizeWith(childElem, childPath, childSvg, mountDispatch)
                                 yield (Seq(rui), Seq.empty[(Int, Handler)])
                             case _ =>
-                                for (innerKids, innerHandle) <- walkStatic(child, childPath, childSvg)
+                                for (innerKids, innerHandle) <- walkStatic(child, childPath, childSvg, mountDispatch)
                                 yield (innerKids, Seq((i, innerHandle)))
                         end match
                     }
@@ -164,7 +327,7 @@ private[kyo] object ReactiveUI:
                         val inner = child match
                             case kc: KeyedChild[?] => kc.child
                             case _                 => child
-                        walkStatic(inner, childPath, svg)
+                        walkStatic(inner, childPath, svg, mountDispatch)
                     }
                 yield
                     val allKids    = childWalks.flatMap(_._1)
@@ -181,12 +344,12 @@ private[kyo] object ReactiveUI:
                         else true
                     (allKids, handle)
 
-            case _: Reactive[?] | _: Foreach[?, ?] =>
-                // When walkStatic is called with a Reactive or Foreach as the top-level node
+            case _: Reactive[?] | _: Foreach[?, ?] | _: Mounted | _: Boundary =>
+                // When walkStatic is called with a Reactive, Foreach, or Mounted as the top-level node
                 // (not as a child of an Element), normalize it at basePath so subscribeNode
                 // sets up a subscription for it. This handles the case where an outer reactive's
                 // signal value is itself a Reactive or Foreach (e.g. outer.map { _ => inner.map(UI.span(_)) }).
-                for rui <- normalize(ui, basePath, svg)
+                for rui <- normalizeWith(ui, basePath, svg, mountDispatch)
                 yield (Seq(rui), rui.handle)
 
             case _ =>
@@ -213,6 +376,11 @@ private[kyo] object ReactiveUI:
             // multiple levels deep; their last segment may collide with a sibling's index at the
             // current level. Using prefix-match correctly routes only when the target lies inside.
             val reactiveChild = reactiveChildren.find(rc => targetPath.startsWith(rc.path))
+            // STATIC descent takes precedence: route through the static child's handler chain so intermediate bubble
+            // handlers run. Jumping straight to a DEEP reactive child would skip them: a click on a reactive label
+            // inside a button (`button(labelSignal)`) would bypass the button's own onClick. Only a DIRECT reactive
+            // child (no staticHandlers entry at its index) takes the reactive jump.
+            val staticChild = childIdx.flatMap(i => staticHandlers.find(_._1 == i).map(_._2))
 
             for
                 // Disabled-target (Form submit suppression), Button-target (only Button clicks submit
@@ -235,13 +403,13 @@ private[kyo] object ReactiveUI:
                     submitOrigin = targetIsButton,
                     selectTarget = targetIsSelect
                 )
-                result <- Maybe.fromOption(reactiveChild) match
-                    case Present(child) =>
-                        safeDispatch(child.handle, targetPath, event).map(keep => if keep then bubble else false)
+                result <- Maybe.fromOption(staticChild) match
+                    case Present(childHandle) =>
+                        safeDispatch(childHandle, targetPath, event).map(keep => if keep then bubble else false)
                     case Absent =>
-                        Maybe.fromOption(childIdx).flatMap(i => Maybe.fromOption(staticHandlers.find(_._1 == i)).map(_._2))
-                            .fold(bubble)(childHandle =>
-                                safeDispatch(childHandle, targetPath, event).map(keep => if keep then bubble else false)
+                        Maybe.fromOption(reactiveChild)
+                            .fold(bubble)(child =>
+                                safeDispatch(child.handle, targetPath, event).map(keep => if keep then bubble else false)
                             )
             yield result
             end for
@@ -379,6 +547,13 @@ private[kyo] object ReactiveUI:
             // Text and RawHtml are leaf content with no kyo-addressable Element children, so no event
             // target can resolve through them: neither can satisfy an Element predicate.
             case _: Text | _: RawHtml => false
+            // Predicates do not resolve THROUGH a mount boundary: the content lives behind a subscribe-time cell this
+            // static resolver cannot reach (v1 limitation: a Button in a mounted subtree does not trigger an OUTER
+            // Form's submit-on-bubble refinement). Event dispatch still resolves via the node's handler indirection.
+            case _: Mounted => false
+            // A Boundary's child occupies the boundary's own path (like a Reactive's content).
+            case b: Boundary =>
+                targetSatisfies(b.child, nodePath, targetPath, predicate)
 
     private def isTargetDisabled(elem: Element, myPath: Seq[String], targetPath: Seq[String])(using Frame): Boolean < Sync =
         targetSatisfies(elem, myPath, targetPath, isDisabled)
@@ -582,7 +757,13 @@ private[kyo] object ReactiveUI:
     def subscribe(rui: ReactiveUI, exchange: UIExchange)(using Frame): Subscription < (Async & Scope) =
         for
             signalChangeTime <- AtomicRef.init(Instant.Epoch)
-            _                <- subscribeScoped(rui, exchange, signalChangeTime)
+            rootMounts       <- MountRegistry.init
+            _                <- Scope.ensure(rootMounts.evictAll)
+            // Absent only for hand-built ReactiveUIs in tests; a normalize-produced root always carries the table.
+            mountDispatch <- rui.mountDispatch match
+                case Present(d) => Kyo.lift(d)
+                case Absent     => MountDispatch.init
+            _ <- subscribeScoped(rui, exchange, signalChangeTime, rootMounts, mountDispatch, Absent)
         yield Subscription(rui.handle, signalChangeTime)
 
     // Each reactive region forks a Fiber.init (scoped to the enclosing Scope) running observe. Each
@@ -592,42 +773,500 @@ private[kyo] object ReactiveUI:
     // interrupt-old bookkeeping (a ref of live child fibers, interrupted one level per change) is gone; the
     // per-value Scope does interrupt-old transitively (every descendant), fixing the climbing-waiters leak the
     // one-level interrupt left.
-    private def subscribeScoped(rui: ReactiveUI, exchange: UIExchange, signalChangeTime: AtomicRef[Instant])(using
+    //
+    // `mounts` is the MountRegistry of the nearest enclosing region (or the subscribe root): keyed Mounted instances
+    // escape the per-value cascade by living on fibers the registry owns, so keyed continuity spans re-renders of the
+    // immediately enclosing region and ends with that region.
+    private def subscribeScoped(
+        rui: ReactiveUI,
+        exchange: UIExchange,
+        signalChangeTime: AtomicRef[Instant],
+        mounts: MountRegistry,
+        mountDispatch: MountDispatch,
+        boundary: Maybe[BoundaryCtx]
+    )(using
         Frame
     ): Unit < (Async & Scope) =
-        if rui.isConst then
-            Kyo.foreachDiscard(rui.children)(subscribeScoped(_, exchange, signalChangeTime))
-        else
-            // Per-value setup, run inside each value's fresh Scope: render the region and fork its children into
-            // that scope, so the next value (or an interrupt) tears them down by cascade.
-            def renderValue(current: UI): Unit < (Async & Scope) =
-                for
-                    now          <- Clock.now
-                    _            <- signalChangeTime.set(now)
-                    _            <- exchange.onChange(rui.path, current)
-                    (newKids, _) <- walkStatic(current, rui.path, rui.svgContext)
-                    _            <- Kyo.foreachDiscard(newKids)(subscribeScoped(_, exchange, signalChangeTime))
-                yield ()
-            // Every region observes with observe: each value owns a fresh per-value Scope (renderValue forks its
-            // children into it), held open until the next change, then closed by cascade. SignalRef-bound element
-            // regions (normalize maps the bound leaf to the constant `ui`) ride the SignalRef's exact register-before-
-            // read observe: each ref edit is a distinct ref value that re-renders the region, with no deferred
-            // next-capture, no repair timer, and no idle re-render churn (an unchanged input never re-emits).
-            Fiber.init {
+        rui.mountedSpec match
+            case Present(spec) =>
+                subscribeMounted(rui, spec, exchange, signalChangeTime, mounts, mountDispatch, boundary)
+            case Absent =>
+                rui.boundarySpec match
+                    case Present(spec) =>
+                        subscribeBoundary(rui, spec, exchange, signalChangeTime, mounts, mountDispatch, boundary)
+                    case Absent =>
+                        if rui.isConst then
+                            Kyo.foreachDiscard(rui.children)(
+                                subscribeScoped(_, exchange, signalChangeTime, mounts, mountDispatch, boundary)
+                            )
+                        else
+                            subscribeRegion(
+                                rui.path,
+                                rui.signal,
+                                rui.svgContext,
+                                exchange,
+                                signalChangeTime,
+                                Absent,
+                                mountDispatch,
+                                boundary
+                            )
+
+    /** Subscribe one Boundary node: create its live context (chained to any enclosing boundary), subscribe the
+      * child's reactive kids EAGERLY into the current scope: all mount effects below start immediately, in
+      * parallel, while the painted DOM still shows the fallback (their region patches no-op against absent DOM
+      * until the reveal repaints the boundary from current signal values). If the eager walk started nothing
+      * pending, reveal right away (still within the same task chain as the enclosing paint), so a boundary
+      * without async mounts never flashes its fallback.
+      */
+    private def subscribeBoundary(
+        rui: ReactiveUI,
+        spec: BoundarySpec,
+        exchange: UIExchange,
+        signalChangeTime: AtomicRef[Instant],
+        mounts: MountRegistry,
+        mountDispatch: MountDispatch,
+        parent: Maybe[BoundaryCtx]
+    )(using Frame): Unit < (Async & Scope) =
+        for
+            pending  <- AtomicInt.init(0)
+            revealed <- AtomicRef.init(false)
+            ctx = new BoundaryCtx(rui.path, spec.node.child, spec.node, exchange, mountDispatch, pending, revealed, parent)
+            _ <- Kyo.foreachDiscard(rui.children)(
+                subscribeScoped(_, exchange, signalChangeTime, mounts, mountDispatch, Present(ctx))
+            )
+            n <- pending.get
+            _ <- if n == 0 then ctx.reveal else Kyo.unit
+        yield ()
+
+    /** Fork one region fiber observing `signal`, with a per-value Scope per emission (see subscribeScoped's
+      * contract note). `presetMounts` supplies the region's MountRegistry when the caller owns it already (the
+      * content region of a KEYED mounted instance reuses the instance's registry so nested keyed mounts survive
+      * re-subscription); `Absent` creates a fresh registry owned by the current scope: the same scope that owns
+      * the region fiber, so registry and region die together.
+      *
+      * renderValue ordering is walk → evict → paint → subscribe: mount keys of the new value are known after the
+      * walk, so instances whose key vanished (or was swapped) are closed AND awaited BEFORE the new HTML paints
+      * and before any successor effect runs (the region-level closed-and-awaited guarantee, extended to the
+      * keyed instances that deliberately escape the per-value cascade).
+      */
+    private def subscribeRegion(
+        path: Seq[String],
+        signal: Signal[UI],
+        svg: Boolean,
+        exchange: UIExchange,
+        signalChangeTime: AtomicRef[Instant],
+        presetMounts: Maybe[MountRegistry],
+        mountDispatch: MountDispatch,
+        boundary: Maybe[BoundaryCtx]
+    )(using Frame): Unit < (Async & Scope) =
+        for
+            regionMounts <- presetMounts match
+                case Present(r) => Kyo.lift(r)
+                case Absent     => MountRegistry.init.map(r => Scope.ensure(r.evictAll).andThen(r))
+            _ <- Fiber.init {
+                def renderValue(current: UI): Unit < (Async & Scope) =
+                    for
+                        now          <- Clock.now
+                        _            <- signalChangeTime.set(now)
+                        (newKids, _) <- walkStatic(current, path, svg, mountDispatch)
+                        _            <- regionMounts.evictExcept(collectMountKeys(newKids))
+                        _            <- exchange.onChange(path, current)
+                        _ <- Kyo.foreachDiscard(newKids)(
+                            subscribeScoped(_, exchange, signalChangeTime, regionMounts, mountDispatch, boundary)
+                        )
+                    yield ()
                 Abort.run[Throwable] {
-                    rui.signal.observe(renderValue)
+                    signal.observe(renderValue)
                 }.map { result =>
                     result.fold(
                         _ => (),
-                        err => Log.error(s"Reactive subscription fiber failed at path=${rui.path.mkString(".")}", err),
+                        err => Log.error(s"Reactive subscription fiber failed at path=${path.mkString(".")}", err),
                         panic =>
                             if panic.isInstanceOf[Interrupted] then ()
-                            else Log.error(s"Reactive subscription fiber failed at path=${rui.path.mkString(".")}", panic)
+                            else Log.error(s"Reactive subscription fiber failed at path=${path.mkString(".")}", panic)
                     )
                 }
+            }
+        yield ()
+
+    /** The keys of the Mounted nodes among a walk's reactive children: the claims of the upcoming subscribe
+      * pass, computed up front so evictExcept can run before paint. Recurses through Boundary nodes: their
+      * mounted descendants claim on the SAME enclosing region registry (a boundary is a paint gate, not a
+      * region), so their keys must count as kept.
+      */
+    private def collectMountKeys(kids: Seq[ReactiveUI]): Set[Any] =
+        kids.flatMap { k =>
+            k.mountedSpec.flatMap(_.node.key).toList
+                ++ (if k.boundarySpec.nonEmpty then collectMountKeys(k.children) else Nil)
+        }.toSet
+
+    /** Subscribe one Mounted node.
+      *
+      * KEYED: claim (or adopt) the live instance from the enclosing region's registry. The instance runner is an
+      * UNSCOPED fiber (it survives the per-value cascade; the registry's owner scope ends it) holding the node
+      * Scope open; then push one synchronous paint of the cell's current content (so an adopted instance's content
+      * replaces the placeholder the parent's wholesale re-render just painted, within the same task, with no visible
+      * placeholder blink), and finally subscribe the content region over the cell, reusing the instance's child
+      * registry so keyed mounts NESTED in the content survive as long as this instance does.
+      *
+      * KEYLESS: the instance lifetime IS the current scope (the enclosing region's per-value scope, or the
+      * session scope for a static position): the effect runs on a normally-scoped fiber and the next parent
+      * emission tears it down by cascade (remount semantics). A thrash note counts remounts per path and logs a
+      * dev hint when a keyless node keeps remounting inside a hot region.
+      */
+    private def subscribeMounted(
+        rui: ReactiveUI,
+        spec: MountedSpec,
+        exchange: UIExchange,
+        signalChangeTime: AtomicRef[Instant],
+        mounts: MountRegistry,
+        mountDispatch: MountDispatch,
+        boundary: Maybe[BoundaryCtx]
+    )(using Frame): Unit < (Async & Scope) =
+        spec.node.key match
+            case Present(key) =>
+                mounts.claim(key, rui.path, spec, boundary).map {
+                    case Present(inst) =>
+                        for
+                            _       <- mountDispatch.register(rui.path, inst.cell)
+                            _       <- Scope.ensure(mountDispatch.unregister(rui.path, inst.cell))
+                            current <- inst.cell.current
+                            _       <- exchange.onChange(rui.path, current)
+                            _ <- subscribeRegion(
+                                rui.path,
+                                inst.cell,
+                                rui.svgContext,
+                                exchange,
+                                signalChangeTime,
+                                Present(inst.childMounts),
+                                mountDispatch,
+                                boundary
+                            )
+                        yield ()
+                    case Absent =>
+                        // Duplicate key this render pass (claim already warned): paint a loud inline error instead of
+                        // silently sharing the first slot's instance. No cell/dispatch/boundary entry: a dead slot
+                        // (boundary counting happens only at instance creation) until the caller gives distinct keys.
+                        given Frame = spec.node.frame
+                        exchange
+                            .onChange(
+                                rui.path,
+                                UI.span(UI.Ast.Text(s"kyo-ui: duplicate mounted key '$key'")).cssClass("kyo-mount-error")
+                            )
+                            .unit
+                }
+            case Absent =>
+                for
+                    _          <- mounts.noteKeylessRemount(rui.path)
+                    seed       <- mounts.keepLatestSeed(rui.path, spec)
+                    cell       <- Signal.initRef[UI](seed)
+                    _          <- mountDispatch.register(rui.path, cell)
+                    _          <- Scope.ensure(mountDispatch.unregister(rui.path, cell))
+                    settleOnce <- boundarySettle(boundary)
+                    // If the per-value scope tears this instance down before its effect publishes, the ensure
+                    // still balances the boundary count (the boundary would otherwise wait forever).
+                    _           <- Scope.ensure(settleOnce.run)
+                    supervision <- MountSupervision.init
+                    _ <- Fiber.init(runMountEffect(
+                        spec,
+                        cell,
+                        ui => mounts.recordContent(rui.path, ui),
+                        boundary,
+                        settleOnce.run,
+                        supervision
+                    ))
+                    _ <- subscribeRegion(rui.path, cell, rui.svgContext, exchange, signalChangeTime, Absent, mountDispatch, boundary)
+                yield ()
+
+    /** Once-only settle of a counted boundary entry: invocable from both the publish path and a teardown
+      * ensure without double-exit (kyo's auto-flattening map cannot carry an effect as a VALUE, hence the
+      * wrapper class; `run` builds a fresh effect per call, all funneling through the same once-guard).
+      */
+    final private[kyo] class SettleOnce(action: Maybe[(BoundaryCtx, AtomicRef[Boolean])]):
+        def run(using Frame): Unit < Async =
+            action match
+                case Present((ctx, settled)) =>
+                    settled.getAndSet(true).map(was => if was then () else ctx.exit)
+                case Absent => ()
+    end SettleOnce
+
+    /** Enter the enclosing boundary (if any) for a starting mount and return its once-only settle handle. */
+    private def boundarySettle(boundary: Maybe[BoundaryCtx])(using Frame): SettleOnce < Sync =
+        boundary match
+            case Absent => Kyo.lift(new SettleOnce(Absent))
+            case Present(ctx) =>
+                ctx.enter.map { counted =>
+                    if !counted then new SettleOnce(Absent)
+                    else AtomicRef.init(false).map(ref => new SettleOnce(Present((ctx, ref))))
+                }
+
+    /** A supervised background fiber of a mounted node failed with a non-Throwable `Abort` value; the node's
+      * error rendering needs a Throwable, so the value is carried in this wrapper.
+      */
+    final private[kyo] case class MountFiberFailure(value: Any)(using Frame)
+        extends KyoException(s"Mounted background fiber failed: $value")
+
+    /** The node-scope supervision seam of one mount instance: collects the FIRST non-interrupt failure of any
+      * supervised background fiber (see [[Fiber.Supervisor]]) and lets the node runner park on it AFTER the
+      * effect outcome, flipping an already-published node into its error rendering retroactively.
+      *
+      * Publish→flip is serialized on the node's own fiber (the park runs after [[runMountEffect]]'s outcome
+      * handling), so a supervised failure can never be overwritten by a late `cell.set(ui)` of the success
+      * path. The `routed` once-guard is shared between the effect-failure path and the park, so an effect
+      * failure racing a supervised failure routes exactly once.
+      */
+    final private[kyo] class MountSupervision(
+        firstFailure: Fiber.Promise.Unsafe[Throwable, Any],
+        routed: AtomicRef[Boolean]
+    ):
+        /** Installed around the USER effect only (engine fibers never see it): maps the fiber error to a
+          * Throwable and completes the once-only failure promise; later failures are dropped by the promise.
+          */
+        val supervisor: Fiber.Supervisor = new Fiber.Supervisor:
+            def onFailure(error: Result.Error[Any])(using AllowUnsafe): Unit =
+                val t = error match
+                    case failure: Result.Failure[Any] =>
+                        failure.failure match
+                            case t: Throwable => t
+                            case other        => MountFiberFailure(other)(using Frame.internal)
+                    case panic: Result.Panic => panic.exception
+                discard(firstFailure.complete(Result.succeed(t)))
+            end onFailure
+
+        /** Route a failure through `route` at most once across effect-fail and supervised-fail paths. */
+        def routeOnce(t: Throwable)(route: Throwable => Unit < Async)(using Frame): Unit < Async =
+            routed.getAndSet(true).map(was => if was then () else route(t))
+
+        /** Park the node fiber until a supervised failure arrives, then log + route it. Never returns: the
+          * park (interrupted on teardown) is what holds the node Scope open for the instance's lifetime.
+          */
+        def park(spec: MountedSpec, route: Throwable => Unit < Async)(using Frame): Nothing < Async =
+            firstFailure.safe.get.map { t =>
+                Log.error(s"Mounted background fiber failed (frame=${spec.node.frame.position.show})", t)
+                    .andThen(routeOnce(t)(route))
+            }.andThen(Async.never)
+    end MountSupervision
+
+    private[kyo] object MountSupervision:
+        def init(using Frame): MountSupervision < Sync =
+            AtomicRef.init(false).map { routed =>
+                Sync.Unsafe.defer {
+                    new MountSupervision(Fiber.Promise.Unsafe.init[Throwable, Any](), routed)
+                }
+            }
+    end MountSupervision
+
+    /** Run a Mounted node's effect and publish the outcome into its content cell, then settle the enclosing
+      * boundary, and then PARK on `supervision` for the instance's lifetime (this method never returns; the
+      * park is interrupted by the node's teardown). Failure routing (shared by the effect outcome and a later
+      * supervised background-fiber failure, at most once per instance): a node-local `.onError` wins; otherwise
+      * the failure is offered to the boundary chain (typed selection); otherwise the node's default error
+      * rendering applies. The enclosing region stays alive either way (a flip keeps the node Scope open, like
+      * a pending-phase failure always has); failures are additionally logged out-of-band.
+      */
+    private def runMountEffect(
+        spec: MountedSpec,
+        cell: SignalRef[UI],
+        record: UI => Unit < Sync,
+        boundary: Maybe[BoundaryCtx],
+        onSettled: Unit < Async,
+        supervision: MountSupervision
+    )(using Frame): Nothing < (Async & Scope) =
+        def failed(t: Throwable): Unit < Async =
+            spec.node.errorRender match
+                case Present(_) => cell.set(spec.errorUI(t)).unit
+                case Absent =>
+                    boundary match
+                        case Present(ctx) =>
+                            ctx.tryHandle(t).map(handled => if handled then () else cell.set(spec.errorUI(t)).unit)
+                        case Absent => cell.set(spec.errorUI(t)).unit
+        Abort.run[Throwable](Fiber.Supervisor.let(supervision.supervisor)(spec.node.effect)).map {
+            case Result.Success(ui) => cell.set(ui).andThen(record(ui)).andThen(onSettled)
+            case Result.Failure(t) =>
+                Log.error(s"Mounted effect failed (frame=${spec.node.frame.position.show})", t)
+                    .andThen(supervision.routeOnce(t)(failed)).andThen(onSettled)
+            case Result.Panic(t) =>
+                if t.isInstanceOf[Interrupted] then ()
+                else
+                    Log.error(s"Mounted effect panicked (frame=${spec.node.frame.position.show})", t)
+                        .andThen(supervision.routeOnce(t)(failed)).andThen(onSettled)
+        }.map(_ => supervision.park(spec, failed))
+    end runMountEffect
+
+    /** A live keyed mount: the content cell, the unscoped runner fiber that owns the node Scope, and the child
+      * registry that carries keyed mounts nested in this instance's content across re-subscriptions.
+      */
+    final private[kyo] class MountInstance(
+        val key: Any,
+        val cell: SignalRef[UI],
+        val fiber: Fiber[Nothing, Any],
+        val childMounts: MountRegistry
+    )
+
+    /** Per-region ownership of keyed mount instances (plus keep-latest seeds and the keyless thrash counter).
+      * All mutation happens from the owning region's sequential observe loop (or once, at static subscribe), so
+      * the AtomicRefs guard memory visibility across fiber steps, not concurrent writers.
+      */
+    final private[kyo] class MountRegistry(
+        instances: AtomicRef[Map[Any, MountInstance]],
+        lastContent: AtomicRef[Map[Seq[String], UI]],
+        keylessRemounts: AtomicRef[Map[Seq[String], Int]],
+        claimedThisWalk: AtomicRef[Set[Any]],
+        lastKeyByPath: AtomicRef[Map[Seq[String], (Any, Int)]]
+    ):
+
+        /** Content last published at a path, the KeepLatest seed: a re-mounting node at this slot starts from the
+          * previous content instead of the placeholder (frozen snapshot; its regions re-attach when the new effect
+          * publishes). Placeholder policy, or a slot that never published, starts from the placeholder.
+          */
+        def keepLatestSeed(path: Seq[String], spec: MountedSpec)(using Frame): UI < Sync =
+            spec.node.pendingPolicy match
+                case UI.PendingPolicy.Placeholder => spec.placeholderUI
+                case UI.PendingPolicy.KeepLatest =>
+                    lastContent.get.map(_.getOrElse(path, spec.placeholderUI))
+
+        def recordContent(path: Seq[String], ui: UI)(using Frame): Unit < Sync =
+            lastContent.getAndUpdate(_.updated(path, ui)).unit
+
+        /** Reuse the live instance under `key`, or create one: seed the cell (keep-latest by slot), fork the
+          * UNSCOPED runner (it must survive the caller's per-value scope; this registry's owner ends it), which
+          * holds the node Scope open until interrupted and evicts nested keyed mounts on the way out. Two claims
+          * of one key within a single walk (evictExcept resets the claim set per walk) are a caller bug: the
+          * duplicate claim returns `Absent` (the caller paints a loud inline error card in that slot instead of
+          * silently sharing the first slot's instance), and the warning names key and path (Laminar's
+          * duplicate-split-key discipline, made visible in the page).
+          */
+        def claim(key: Any, path: Seq[String], spec: MountedSpec, boundary: Maybe[BoundaryCtx])(using
+            Frame
+        ): Maybe[MountInstance] < (Async & Scope) =
+            claimedThisWalk.getAndUpdate(_ + key).map(_.contains(key)).map {
+                case true =>
+                    Log.warn(
+                        s"kyo-ui: duplicate mounted key '$key' claimed at ${path.mkString(".")} within one render pass: " +
+                            "the duplicate slot renders an inline error card; use distinct keys (e.g. .keyed(Component -> id))"
+                    ).andThen(Absent: Maybe[MountInstance])
+                case false =>
+                    for
+                        _ <- noteKeyAt(path, key)
+                        m <- instances.get
+                        inst <- m.get(key) match
+                            case Some(inst) => Kyo.lift(inst)
+                            case None =>
+                                for
+                                    seed        <- keepLatestSeed(path, spec)
+                                    cell        <- Signal.initRef[UI](seed)
+                                    childMounts <- MountRegistry.init
+                                    settleOnce  <- boundarySettle(boundary)
+                                    supervision <- MountSupervision.init
+                                    fiber <- Fiber.initUnscoped {
+                                        Scope.run {
+                                            // The ensure balances the boundary count even if the instance is evicted
+                                            // before its effect publishes (interrupt skips the publish path). runMountEffect
+                                            // never returns (parks on `supervision`), which holds this node Scope open until teardown.
+                                            Scope.ensure(childMounts.evictAll)
+                                                .andThen(Scope.ensure(settleOnce.run))
+                                                .andThen(runMountEffect(
+                                                    spec,
+                                                    cell,
+                                                    ui => recordContent(path, ui),
+                                                    boundary,
+                                                    settleOnce.run,
+                                                    supervision
+                                                ))
+                                        }
+                                    }
+                                    inst = new MountInstance(key, cell, fiber, childMounts)
+                                    _ <- instances.getAndUpdate(_.updated(key, inst))
+                                yield inst
+                    yield Present(inst)
+            }
+
+        /** Dev hint against the unstable-key anti-pattern: a key that is REBUILT per render (a fresh tuple or
+          * object identity, an inline-derived `Signal` inside the key) evicts and re-creates the instance on
+          * every enclosing re-render: keyed continuity silently degrades to remount semantics. A key that
+          * changes ONCE (`.keyed(EraPanel -> era)` on an era switch) is the intended re-creation and resets the
+          * streak; only consecutive-change streaks of COMPOSITE keys are flagged: simple value keys
+          * (String/primitive) are exempt, since a location-driven region (route node keyed by path) re-renders
+          * exclusively on key changes and would otherwise be flagged after three navigations.
+          */
+        private def noteKeyAt(path: Seq[String], key: Any)(using Frame): Unit < Sync =
+            if simpleValueKey(key) then lastKeyByPath.getAndUpdate(_ - path).unit
+            else noteCompositeKeyAt(path, key)
+
+        /** String / primitive / boxed-primitive keys: value equality, no identity risk. */
+        private def simpleValueKey(key: Any): Boolean = key match
+            case _: String | _: Int | _: Long | _: Boolean | _: Double | _: Float | _: Short |
+                _: Byte | _: Char =>
+                true
+            case _ => false
+
+        private def noteCompositeKeyAt(path: Seq[String], key: Any)(using Frame): Unit < Sync =
+            lastKeyByPath.getAndUpdate { m =>
+                m.get(path) match
+                    case Some((prev, streak)) if !prev.equals(key) => m.updated(path, (key, streak + 1))
+                    case _                                         => m.updated(path, (key, 0))
+            }.map { prev =>
+                prev.get(path) match
+                    case Some((prevKey, streak)) if !prevKey.equals(key) =>
+                        val n = streak + 1
+                        if n == 3 || n == 10 || n == 100 then
+                            Log.warn(
+                                s"kyo-ui: mounted key at ${path.mkString(".")} changed in $n consecutive render passes " +
+                                    s"(now '$key'): the key value is likely rebuilt per render (unstable tuple/object/" +
+                                    "Signal identity), so the instance is evicted and re-created every pass. Derive keys " +
+                                    "from stable data if the instance should live across re-renders."
+                            )
+                        else Kyo.unit
+                        end if
+                    case _ => Kyo.unit
             }.unit
-        end if
-    end subscribeScoped
+
+        /** Close-and-await every instance whose key is not in `keep`: run BEFORE the new value paints, so a
+          * vanished or swapped key's resources are fully released while the OLD content is still on screen
+          * (break-before-make; under KeepLatest the successor then seeds from the recorded content). Also opens
+          * the next claim generation for duplicate detection.
+          */
+        def evictExcept(keep: Set[Any])(using Frame): Unit < Async =
+            for
+                _   <- claimedThisWalk.set(Set.empty)
+                old <- instances.getAndUpdate(_.filter((k, _) => keep.contains(k)))
+                evicted = old.collect { case (k, inst) if !keep.contains(k) => inst }
+                _ <- Kyo.foreachDiscard(evicted)(teardown)
+            yield ()
+
+        def evictAll(using Frame): Unit < Async =
+            evictExcept(Set.empty)
+
+        private def teardown(inst: MountInstance)(using Frame): Unit < Async =
+            inst.fiber.interrupt.andThen(inst.fiber.getResult.unit)
+
+        /** Dev hint against the keyless-node-in-hot-region anti-pattern: a keyless Mounted re-runs its effect on
+          * every enclosing region re-render; keys are the opt-in continuity mechanism.
+          */
+        def noteKeylessRemount(path: Seq[String])(using Frame): Unit < Sync =
+            keylessRemounts.getAndUpdate(m => m.updated(path, m.getOrElse(path, 0) + 1)).map { prev =>
+                val n = prev.getOrElse(path, 0) + 1
+                if n == 10 || n == 100 || n == 1000 then
+                    Log.warn(
+                        s"kyo-ui: keyless UI.mounted at ${path.mkString(".")} remounted $n times: its effect re-runs on " +
+                            "every enclosing region re-render. Give it a stable identity with .keyed(...) if the instance " +
+                            "should live across re-renders, or move it out of the hot region."
+                    )
+                else Kyo.unit
+                end if
+            }
+    end MountRegistry
+
+    private[kyo] object MountRegistry:
+        def init(using Frame): MountRegistry < Sync =
+            for
+                instances       <- AtomicRef.init(Map.empty[Any, MountInstance])
+                lastContent     <- AtomicRef.init(Map.empty[Seq[String], UI])
+                keylessRemounts <- AtomicRef.init(Map.empty[Seq[String], Int])
+                claimedThisWalk <- AtomicRef.init(Set.empty[Any])
+                lastKeyByPath   <- AtomicRef.init(Map.empty[Seq[String], (Any, Int)])
+            yield new MountRegistry(instances, lastContent, keylessRemounts, claimedThisWalk, lastKeyByPath)
+    end MountRegistry
 
     // ---- Shared UI tree utilities (used by both backends) ----
 
@@ -665,6 +1304,12 @@ private[kyo] object ReactiveUI:
                 Kyo.foreach(children.toSeq)(resolveReactives).map(r => Fragment[UI](Chunk.from(r)))
             case KeyedChild(key, child) =>
                 resolveReactives(child).map(r => KeyedChild[UI](key, r))
+            case m: Mounted =>
+                // A static snapshot cannot run the mount effect; the node's static projection is its placeholder.
+                m.placeholderUI.getOrElse(UI.empty(using m.frame))
+            case b: Boundary =>
+                // Static projection of a boundary is its fallback (its mounted descendants cannot have run).
+                b.fallbackUI.getOrElse(UI.empty(using b.frame))
             case _ => ui
 
     private[kyo] def rebuildElement(elem: Element, newChildren: Chunk[UI]): UI =

--- a/kyo-ui/shared/src/main/scala/kyo/internal/RegionMarker.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/RegionMarker.scala
@@ -1,0 +1,99 @@
+package kyo.internal
+
+import kyo.*
+
+/** The comment-node markers that delimit a reactive region (`Reactive`/`Foreach`/`Mounted`/`Boundary`) in
+  * rendered HTML: `<!--kyo:PATH-->content<!--/kyo:PATH-->`.
+  *
+  * Comment nodes are valid in every HTML parse context (table, tr, select, svg), unlike the wrapper
+  * elements they replaced, which the parser foster-parented out of table contexts (span before table) or
+  * dropped entirely ("in select" insertion mode). The markers carry no layout, so no `display: contents`
+  * reset is needed and the region's content participates in its real parent's formatting context.
+  *
+  * BYTE-FORMAT CONTRACT: shared with the inline LiveView client in `HtmlRenderer.clientJs`; both
+  * implementations MUST stay in lockstep:
+  * {{{
+  *   open  comment data = "kyo:" + escape(path) [+ " m"] [+ " s"]
+  *   close comment data = "/kyo:" + escape(path)
+  *   escape: "%" -> "%25", "-" -> "%2D", " " -> "%20"   (decode in reverse; "%25" last)
+  * }}}
+  * Foreach keys are arbitrary user strings and land in the path, so escaping is load-bearing: with no raw
+  * '-' left, no comment-terminating "-->" / "--!>" can occur inside a marker; with no raw ' ', the first
+  * space unambiguously separates the path from the flags.
+  *
+  * Flags (client-paint only, never emitted by SSR/full-page renders, so golden HTML stays byte-identical):
+  *   - `m` (mount root): a keyless mount's live region; a parent morph treats the whole marker span as
+  *     opaque and never wipes the live subtree.
+  *   - `s` (mount slot): a `Mounted` placeholder painted by an exchange `onChange`, so a morph can tell
+  *     "this slot IS a mount" from content that merely collided on the positional path key.
+  */
+private[kyo] object RegionMarker:
+
+    /** A parsed marker comment's data. `path` is the unescaped dot-joined path (registry key). */
+    final case class Parsed(path: String, isClose: Boolean, mount: Boolean, slot: Boolean) derives CanEqual
+
+    def open(path: Seq[String], mount: Boolean = false, slot: Boolean = false): String =
+        s"<!--${openData(path.mkString("."), mount, slot)}-->"
+
+    def close(path: Seq[String]): String =
+        s"<!--${closeData(path.mkString("."))}-->"
+
+    /** Comment data (the text between `<!--` and `-->`) of an open marker for a dot-joined path. */
+    def openData(joinedPath: String, mount: Boolean = false, slot: Boolean = false): String =
+        val flags = (if mount then " m" else "") + (if slot then " s" else "")
+        s"kyo:${escape(joinedPath)}$flags"
+
+    /** Comment data of a close marker for a dot-joined path. */
+    def closeData(joinedPath: String): String =
+        s"/kyo:${escape(joinedPath)}"
+
+    /** Parse a comment node's data. `Absent` for comments that are not kyo markers. */
+    def parse(data: String): Maybe[Parsed] =
+        if data.startsWith("/kyo:") then Present(Parsed(unescape(data.substring(5)), isClose = true, mount = false, slot = false))
+        else if data.startsWith("kyo:") then
+            val rest = data.substring(4)
+            val sp   = rest.indexOf(' ')
+            if sp < 0 then Present(Parsed(unescape(rest), isClose = false, mount = false, slot = false))
+            else
+                val flags = rest.substring(sp + 1).split(' ')
+                Present(Parsed(
+                    unescape(rest.substring(0, sp)),
+                    isClose = false,
+                    mount = flags.contains("m"),
+                    slot = flags.contains("s")
+                ))
+            end if
+        else Absent
+
+    private[kyo] def escape(path: String): String =
+        if path.forall(c => c != '%' && c != '-' && c != ' ') then path
+        else
+            val sb = new StringBuilder(path.length + 4)
+            path.foreach {
+                case '%' => sb.append("%25")
+                case '-' => sb.append("%2D")
+                case ' ' => sb.append("%20")
+                case c   => sb.append(c)
+            }
+            sb.toString
+
+    private[kyo] def unescape(s: String): String =
+        if !s.contains('%') then s
+        else
+            val sb = new StringBuilder(s.length)
+            var i  = 0
+            while i < s.length do
+                val c = s.charAt(i)
+                if c == '%' && i + 2 < s.length then
+                    s.substring(i + 1, i + 3) match
+                        case "25" => sb.append('%'); i += 3
+                        case "2D" => sb.append('-'); i += 3
+                        case "20" => sb.append(' '); i += 3
+                        case _    => sb.append(c); i += 1
+                else
+                    sb.append(c)
+                    i += 1
+                end if
+            end while
+            sb.toString
+end RegionMarker

--- a/kyo-ui/shared/src/main/scala/kyo/internal/UIExchange.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/UIExchange.scala
@@ -2,7 +2,12 @@ package kyo.internal
 
 import kyo.*
 
-/** Reactive change notification. Transport-agnostic; each backend renders in its own format. */
+/** Reactive change notification. Transport-agnostic; each backend renders in its own format.
+  *
+  * `mount` marks the paint of a keyless mount's content root: the backend flags that DOM node so a parent's
+  * in-place update treats it as an opaque boundary (the mount owns and repaints its own subtree) rather than
+  * reconciling it against the placeholder a top-down re-render emits there.
+  */
 private[kyo] trait UIExchange:
-    def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async
+    def onChange(path: Seq[String], ui: UI, mount: Boolean = false)(using Frame): Unit < Async
 end UIExchange

--- a/kyo-ui/shared/src/main/scala/kyo/internal/UIServer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/UIServer.scala
@@ -63,9 +63,6 @@ private[kyo] object UIServer:
 
     private def wsExchange(root: ReactiveUI, ws: HttpWebSocket, seenClasses: Set[String])(using Frame): UIExchange =
         new UIExchange:
-            private def svgContextAt(path: Seq[String]): Boolean =
-                ReactiveUI.findNode(root, path).map(_.svgContext).getOrElse(false)
-
             // Pseudo-state CSS classes already carried by this connection's <style> (seeded from the
             // initial SSR page, then grown by every InjectCss this exchange sends), so a later
             // re-render reusing one of these classes never re-sends its rule. Connection-scoped: each
@@ -73,11 +70,14 @@ private[kyo] object UIServer:
             // already belongs to.
             private val sentClasses = scala.collection.mutable.Set.from(seenClasses)
 
-            def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async =
-                HtmlRenderer.renderWithCss(ui, path).map { (html, rules) =>
+            def onChange(path: Seq[String], ui: UI, mount: Boolean)(using Frame): Unit < Async =
+                // Content at its nested-reactive sub-path (matches SSR/walkStatic). The payload is the region's
+                // bare content fragment: the client patches between the region's live comment markers, which are
+                // never re-sent. `mountSlot = true` stamps the `s` flag on Mounted placeholders so the client
+                // morph tells the same mount from colliding content (twin of DomBackend.onChange).
+                HtmlRenderer.renderWithCss(ui, HtmlRenderer.contentPath(path, ui), mountSlot = true).map { (html, rules) =>
                     val newRules  = rules.filterNot(r => sentClasses.contains(r._1))
-                    val finalHtml = HtmlRenderer.wrapReactiveRegion(path, svgContextAt(path), html)
-                    val replaceOp = HtmlOp.Replace(path, finalHtml)
+                    val replaceOp = HtmlOp.Replace(path, html, mount)
                     // runPartial drops only a Closed (the socket closed mid-render -> the op is moot); a Panic
                     // propagates to the region fiber rather than being swallowed by the discard.
                     val sendReplace =

--- a/kyo-ui/shared/src/test/scala/kyo/BoundaryTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/BoundaryTest.scala
@@ -1,0 +1,156 @@
+package kyo
+
+import kyo.Browser.*
+
+/** Behavior tests for [[kyo.UI.boundary]] (EXPERIMENTAL): pending aggregation, eager-behind-fallback,
+  * once-only reveal, and typed error selection over mounted descendants.
+  */
+class BoundaryTest extends UITest:
+
+    final class DataError(msg: String) extends RuntimeException(msg)
+
+    "boundary shows one fallback while ANY mounted child is pending, then reveals the whole area" in {
+        val setup =
+            for
+                gateA <- Promise.init[Unit, Any]
+                gateB <- Promise.init[Unit, Any]
+            yield (
+                gateA,
+                gateB,
+                UI.div(
+                    UI.boundary.fallback(UI.span("area-loading").id("fb"))(
+                        UI.div(
+                            UI.mounted(gateA.get.andThen(Kyo.lift(UI.span("a-ready").id("a")))),
+                            UI.mounted(gateB.get.andThen(Kyo.lift(UI.span("b-ready").id("b"))))
+                        )
+                    )
+                )
+            )
+        setup.map { (gateA, gateB, ui) =>
+            withUI(Kyo.lift(ui)) {
+                for
+                    _ <- Browser.assertText(Selector.id("fb"), "area-loading")
+                    _ <- gateA.completeUnitDiscard
+                    // one of two still pending: the fallback must still be up
+                    _ <- Browser.assertText(Selector.id("fb"), "area-loading")
+                    _ <- gateB.completeUnitDiscard
+                    _ <- Browser.assertText(Selector.id("a"), "a-ready")
+                    _ <- Browser.assertText(Selector.id("b"), "b-ready")
+                yield ()
+            }
+        }
+    }
+
+    "mount effects start EAGERLY behind the fallback (no waterfall)" in {
+        val setup =
+            for
+                started <- AtomicInt.init(0)
+                gate    <- Promise.init[Unit, Any]
+            yield (
+                started,
+                gate,
+                UI.div(
+                    UI.boundary.fallback(UI.span("loading").id("fb"))(
+                        UI.div(
+                            UI.mounted(started.incrementAndGet.andThen(gate.get).andThen(Kyo.lift(UI.span("x").id("x")))),
+                            UI.mounted(started.incrementAndGet.andThen(gate.get).andThen(Kyo.lift(UI.span("y").id("y"))))
+                        )
+                    )
+                )
+            )
+        setup.map { (started, gate, ui) =>
+            withUI(Kyo.lift(ui)) {
+                for
+                    _ <- Browser.assertText(Selector.id("fb"), "loading")
+                    n <- started.get
+                    _ <- gate.completeUnitDiscard
+                    _ <- Browser.assertText(Selector.id("x"), "x")
+                yield assert(n == 2) // both effects were already running while the fallback showed
+            }
+        }
+    }
+
+    "boundary without pending mounts reveals immediately (no fallback flash for sync content)" in {
+        val app: UI < Async =
+            Kyo.lift(UI.div(
+                UI.boundary.fallback(UI.span("never-shown").id("fb"))(
+                    UI.div(UI.span("sync-content").id("content"))
+                )
+            ))
+        withUI(app) {
+            Browser.assertText(Selector.id("content"), "sync-content")
+        }
+    }
+
+    "typed error selection: matching error renders at the boundary" in {
+        val app: UI < Async =
+            Kyo.lift(UI.div(
+                UI.boundary
+                    .fallback(UI.span("loading").id("fb"))
+                    .onError { case e: DataError => UI.span(s"boundary-caught:${e.getMessage}").id("berr") }(
+                        UI.div(
+                            UI.span("sibling-in-area").id("sib"),
+                            UI.mounted(Abort.fail(new DataError("nope")))
+                        )
+                    )
+            ))
+        withUI(app) {
+            Browser.assertText(Selector.id("berr"), "boundary-caught:nope")
+        }
+    }
+
+    "non-matching error falls back to node-local default and the boundary reveals normally" in {
+        val app: UI < Async =
+            Kyo.lift(UI.div(
+                UI.boundary
+                    .fallback(UI.span("loading").id("fb"))
+                    .onError { case e: DataError => UI.span("boundary-caught").id("berr") }(
+                        UI.div(
+                            UI.span("alive").id("sib"),
+                            UI.mounted(Abort.fail(new RuntimeException("other-error")))
+                                .onError(t => UI.span(s"node-error:${t.getMessage}").id("nerr"))
+                        )
+                    )
+            ))
+        withUI(app) {
+            for
+                // node-local .onError wins; the failure still settles the boundary count, so the area reveals (sibling intact)
+                _ <- Browser.assertText(Selector.id("sib"), "alive")
+                _ <- Browser.assertText(Selector.id("nerr"), "node-error:other-error")
+            yield ()
+        }
+    }
+
+    "a supervised tail failure routes to the boundary post-reveal and replaces the revealed content" in {
+        val setup =
+            for gate <- Promise.init[Unit, Any]
+            yield (
+                gate,
+                UI.div(
+                    UI.boundary
+                        .fallback(UI.span("loading").id("fb"))
+                        .onError { case e: DataError => UI.span(s"boundary-caught:${e.getMessage}").id("berr") }(
+                            UI.div(
+                                UI.span("revealed-sibling").id("sib"),
+                                UI.mounted(
+                                    Fiber.init(gate.get.andThen(Abort.fail(new DataError("tail-nope"))))
+                                        .map(_ => UI.span("live").id("content"))
+                                ).keyed("feed")
+                            )
+                        )
+                )
+            )
+        setup.map { (gate, ui) =>
+            withUI(Kyo.lift(ui)) {
+                for
+                    _ <- Browser.assertText(Selector.id("sib"), "revealed-sibling")
+                    _ <- Browser.assertText(Selector.id("content"), "live")
+                    // feed dies AFTER reveal: no node-local .onError, so the tail failure still walks to the boundary
+                    _ <- gate.completeUnitDiscard
+                    _ <- Browser.assertText(Selector.id("berr"), "boundary-caught:tail-nope")
+                yield ()
+            }
+        }
+    }
+
+end BoundaryTest

--- a/kyo-ui/shared/src/test/scala/kyo/DomBackendTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/DomBackendTest.scala
@@ -134,4 +134,131 @@ class DomBackendTest extends UITest:
         }
     }
 
+    // The expando probe: a JS property no markup carries survives a sibling-driven re-render only if the node
+    // itself is reused (an outerHTML replace would recreate it and lose it).
+    "morph reuses an inner element (preserving its DOM-local state) across a re-render of its region" in {
+        val app: UI < Async =
+            for outer <- Signal.initRef[Int](0)
+            yield UI.div(
+                outer.map(o =>
+                    UI.div(
+                        UI.div("keep-me").id("inner"),
+                        UI.span(s"o=$o").id("status")
+                    )
+                ),
+                UI.button("bump").id("bump").onClick(outer.getAndUpdate(_ + 1).unit)
+            )
+        withUI(app) {
+            for
+                _      <- Browser.assertText(Selector.id("status"), "o=0")
+                _      <- Browser.evalDiscard("document.getElementById('inner').__kyoMark = 4242;")
+                before <- Browser.evalJson[Int]("document.getElementById('inner').__kyoMark || 0")
+                _      <- Browser.evalDiscard("document.getElementById('bump').click()")
+                _      <- Browser.assertText(Selector.id("status"), "o=1")
+                after  <- Browser.evalJson[Int]("document.getElementById('inner').__kyoMark || 0")
+            yield
+                assert(before == 4242)
+                assert(after == 4242) // node reused; an outerHTML replace would recreate it (mark gone)
+        }
+    }
+
+    "nested reactive directly inside a reactive patches independently (no path collision)" in {
+        // Regression for the same-data-kyo-path collision (a reactive whose value is ITSELF a reactive, e.g.
+        // `open.render(hi.render(...))`). The `: UI` ascription lifts the inner Signal into a Reactive so the outer value is itself reactive.
+        val app: UI < Async =
+            for
+                outer <- Signal.initRef("o0")
+                inner <- Signal.initRef("i0")
+            yield UI.div(
+                UI.button("set-inner").id("set-inner").onClick(inner.set("i1")),
+                UI.button("set-outer").id("set-outer").onClick(outer.set("o1")),
+                outer.map(o => (inner.map(i => UI.span(s"$o/$i").id("cell")): UI))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("cell"), "o0/i0")
+                // change ONLY inner: before the fix this stayed "o0/i0".
+                _ <- Browser.click(Selector.id("set-inner"))
+                _ <- Browser.assertText(Selector.id("cell"), "o0/i1")
+                _ <- Browser.click(Selector.id("set-outer"))
+                _ <- Browser.assertText(Selector.id("cell"), "o1/i1")
+            yield ()
+        }
+    }
+
+    // Mount-slot reconciliation: a keyless UI.mounted and a Reactive share the reactiveContentSegment key, so
+    // swapping one for the other collides on the same data-kyo-path. The live mount is preserved ONLY when the
+    // incoming top-down node is itself a mount slot (data-kyo-mount-slot); otherwise the stale mount is removed.
+
+    "a region swapping a keyless mount for colliding reactive content removes the stale mount DOM" in {
+        val app: UI < Async =
+            for
+                sel   <- Signal.initRef("a")
+                inner <- Signal.initRef("B-content")
+            yield UI.div(
+                UI.button("swap").id("swap").onClick(sel.set("b")),
+                sel.map {
+                    // both branches are reactive content -> they reconcile at the SAME positional key
+                    case "a" =>
+                        UI.mounted {
+                            Signal.initRef(0).map(_ => UI.span("A-content").id("mount-a"))
+                        }.placeholder(UI.empty): UI
+                    case _ =>
+                        inner.map(v => UI.span(v).id("plain-b")): UI
+                }
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("mount-a"), "A-content") // mount painted (data-kyo-mount)
+                _ <- Browser.click(Selector.id("swap"))
+                _ <- Browser.assertText(Selector.id("plain-b"), "B-content")
+                _ <- Browser.assertNotExists(Selector.id("mount-a"))         // stale mount DOM gone
+            yield ()
+        }
+    }
+
+    "a region closing a gate over a mount removes the mount DOM" in {
+        // Empty-slot path, keyed on the ABSENCE of a mount-slot marker: open -> false yields no mount, so the morph empties it.
+        val app: UI < Async =
+            for open <- Signal.initRef(true)
+            yield UI.div(
+                UI.button("gclose").id("gclose").onClick(open.set(false)),
+                open.map {
+                    case true  => UI.mounted { Signal.initRef(0).map(_ => UI.span("panel").id("gpanel")) }.placeholder(UI.empty): UI
+                    case false => UI.empty: UI
+                }
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("gpanel"), "panel")
+                _ <- Browser.click(Selector.id("gclose"))
+                _ <- Browser.assertNotExists(Selector.id("gpanel"))
+            yield ()
+        }
+    }
+
+    "a re-rendered region keeps a mount that is still present (no wipe)" in {
+        // Safety companion: the SAME mount stays across a region re-render. Its placeholder carries the mount-slot
+        // marker, so the guard preserves the live mount (the legitimate case the opaque-mount guard exists for).
+        val app: UI < Async =
+            for tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("ktick").id("ktick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map { t =>
+                    UI.div(
+                        UI.span(s"t:$t").id("ktxt"),
+                        UI.mounted { Signal.initRef(0).map(_ => UI.span("kept").id("kpanel")) }.placeholder(UI.empty)
+                    ): UI
+                }
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("kpanel"), "kept")
+                _ <- Browser.click(Selector.id("ktick"))
+                _ <- Browser.assertText(Selector.id("ktxt"), "t:1")
+                _ <- Browser.assertText(Selector.id("kpanel"), "kept") // mount preserved across the morph
+            yield ()
+        }
+    }
+
 end DomBackendTest

--- a/kyo-ui/shared/src/test/scala/kyo/HandlerEnvTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/HandlerEnvTest.scala
@@ -24,7 +24,7 @@ class HandlerEnvTest extends UITest:
                         )
                     )
                     exchange = new kyo.internal.UIExchange:
-                        def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async = ()
+                        def onChange(path: Seq[String], changed: UI, mount: Boolean)(using Frame): Unit < Async = ()
                     root <- kyo.internal.ReactiveUI.normalize(ui, Seq.empty)
                     sub  <- kyo.internal.ReactiveUI.subscribe(root, exchange)
                     _    <- sub.handle(Seq("0"), UIEvent.Click(Seq("0"), MouseEventData(UI.Modifiers.none, Absent)))

--- a/kyo-ui/shared/src/test/scala/kyo/HandlerEnvTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/HandlerEnvTest.scala
@@ -1,0 +1,54 @@
+package kyo
+
+import kyo.internal.MouseEventData
+import kyo.internal.UIEvent
+
+/** Effect-typed event handlers: `onClick[S](...)(using Isolate[S, Sync, S])`. Context effects ride the
+  * handler erased and resolve from the dispatching fiber's inherited context at run time.
+  *
+  * Direct engine tests (no browser): the dispatch handle is invoked from THIS computation, mirroring the
+  * browser backend's event-drain fiber, which descends from the `runMount` caller, so `Env.run` around the
+  * dispatch is exactly the production ancestry. (LiveView-transport dispatch runs on kyo-http session fibers
+  * and does not inherit the caller context, the same documented gap as mounted effects there.)
+  */
+class HandlerEnvTest extends UITest:
+
+    "onClick handler with erased Env resolves against the dispatching fiber's context" in {
+        Env.run("clicked-with-env") {
+            Scope.run {
+                for
+                    seen <- Promise.init[String, Any]
+                    ui = UI.div(
+                        UI.button("Go").id("btn").onClick(
+                            Env.get[String].map(v => seen.completeDiscard(Result.succeed(v)))
+                        )
+                    )
+                    exchange = new kyo.internal.UIExchange:
+                        def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async = ()
+                    root <- kyo.internal.ReactiveUI.normalize(ui, Seq.empty)
+                    sub  <- kyo.internal.ReactiveUI.subscribe(root, exchange)
+                    _    <- sub.handle(Seq("0"), UIEvent.Click(Seq("0"), MouseEventData(UI.Modifiers.none, Absent)))
+                    v    <- seen.get
+                yield assert(v == "clicked-with-env")
+            }
+        }
+    }
+
+    "pure handlers still infer S = Any (source compatibility)" in {
+        // Compile-level assertion: the pre-existing handler shapes typecheck unchanged against the
+        // effect-polymorphic setters.
+        Scope.run {
+            for
+                ref <- Signal.initRef(0)
+                ui = UI.div(
+                    UI.button("A").onClick(ref.set(1)),
+                    UI.button("B").onClick((_: UI.MouseEvent) => ref.set(2)),
+                    UI.form(UI.button("S")).onSubmit(ref.set(3)),
+                    UI.button("H").onHover(ref.set(4)).onBlur(ref.set(5))
+                )
+                root <- kyo.internal.ReactiveUI.normalize(ui, Seq.empty)
+            yield assert(root.path.isEmpty)
+        }
+    }
+
+end HandlerEnvTest

--- a/kyo-ui/shared/src/test/scala/kyo/MountedTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/MountedTest.scala
@@ -56,7 +56,7 @@ class MountedTest extends UITest:
                 for
                     seen <- Promise.init[String, Any]
                     exchange = new kyo.internal.UIExchange:
-                        def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async =
+                        def onChange(path: Seq[String], changed: UI, mount: Boolean)(using Frame): Unit < Async =
                             kyo.internal.HtmlRenderer.render(changed, path).map { html =>
                                 if html.contains("hello-env") then seen.completeDiscard(Result.succeed(html))
                                 else ()
@@ -390,7 +390,7 @@ class MountedTest extends UITest:
                     )
                 )
                 exchange = new kyo.internal.UIExchange:
-                    def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async = ()
+                    def onChange(path: Seq[String], changed: UI, mount: Boolean)(using Frame): Unit < Async = ()
                 root     <- kyo.internal.ReactiveUI.normalize(ui, Seq.empty)
                 dispatch <- kyo.internal.ReactiveUI.subscribe(root, exchange)
                 // Target = the LABEL region's path: div(0)=cards-div... button-bar=child 1, button=child 0, label=child 0.
@@ -501,6 +501,53 @@ class MountedTest extends UITest:
                 _ <- Browser.assertText(Selector.id("content"), "live")
                 _ <- Browser.click(Selector.id("kill"))
                 _ <- Browser.assertText(Selector.id("content"), "error:late-fail")
+            yield ()
+        }
+    }
+
+    "keyed mounted nodes inside a fragment splice paint their content" in {
+        // Regression: a Fragment child that is a Mounted node must be normalized at the
+        // fragment child's own path (where the renderer paints the slot anchor), not at the
+        // top-level content descent (path :+ "$r"): the mismatch left every publish patch
+        // targeting a nonexistent DOM node: placeholder forever, no error anywhere.
+        val app: UI < Async =
+            for tick <- Signal.initRef(0)
+            yield UI.div(
+                tick.map(_ =>
+                    UI.div(
+                        UI.fragment(
+                            UI.mounted(Kyo.lift(UI.span("card-a").id("card-a")))
+                                .keyed("a")
+                                .placeholder(UI.span("loading-a").id("ph-a")),
+                            UI.mounted(Kyo.lift(UI.span("card-b").id("card-b")))
+                                .keyed("b")
+                                .placeholder(UI.span("loading-b").id("ph-b"))
+                        )
+                    )
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("card-a"), "card-a")
+                _ <- Browser.assertText(Selector.id("card-b"), "card-b")
+            yield ()
+        }
+    }
+
+    "reactive child inside a fragment splice receives patches" in {
+        // Same path mismatch, quieter symptom: the initial SSR paints the reactive's current
+        // value inline (correct), but every LATER patch targeted the wrong path and was lost.
+        val app: UI < Async =
+            for cell <- Signal.initRef("v1")
+            yield UI.div(
+                UI.button("Bump").id("bump").onClick(cell.set("v2")),
+                UI.div(UI.fragment(cell.map(v => UI.span(v).id("val"))))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("val"), "v1")
+                _ <- Browser.click(Selector.id("bump"))
+                _ <- Browser.assertText(Selector.id("val"), "v2")
             yield ()
         }
     }

--- a/kyo-ui/shared/src/test/scala/kyo/MountedTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/MountedTest.scala
@@ -1,0 +1,508 @@
+package kyo
+
+import kyo.Browser.*
+
+/** Behavior tests for [[kyo.UI.mounted]]: the effectful component mount node.
+  *
+  * Runs against the LiveView transport (UITest.withUI = runHandlers + real Chrome over the WebSocket
+  * exchange), i.e. the shared ReactiveUI engine: mount effects execute server-side on fibers descending
+  * from the session, which is also what makes the Env test meaningful (context flows through the
+  * HttpServer.init ancestry into the mount effect at run time, with no Env in any UI-facing type).
+  */
+class MountedTest extends UITest:
+
+    "mounted effect renders its content" in {
+        val app: UI < Async =
+            Kyo.lift(UI.div(
+                UI.mounted(Kyo.lift(UI.span("hello-from-mount").id("content")))
+                    .placeholder(UI.span("loading...").id("ph"))
+            ))
+        withUI(app) {
+            Browser.assertText(Selector.id("content"), "hello-from-mount")
+        }
+    }
+
+    "placeholder shows while the effect is pending, content after it publishes" in {
+        val app: (Promise[Unit, Any], UI < Async) < Sync =
+            for gate <- Promise.init[Unit, Any]
+            yield (
+                gate,
+                Kyo.lift(UI.div(
+                    UI.mounted(gate.get.andThen(Kyo.lift(UI.span("ready").id("content"))))
+                        .placeholder(UI.span("loading...").id("ph"))
+                ))
+            )
+        app.map { (gate, ui) =>
+            withUI(ui) {
+                for
+                    _ <- Browser.assertText(Selector.id("ph"), "loading...")
+                    _ <- gate.completeUnitDiscard
+                    _ <- Browser.assertText(Selector.id("content"), "ready")
+                yield ()
+            }
+        }
+    }
+
+    "Env provided at the mount root flows into the mount effect (runMount-style fiber ancestry)" in {
+        // Direct engine test: subscribe is invoked from THIS fiber, so the mount runner descends from it (like the
+        // browser runMount path) and the erased Env[String] resolves at run time. Deliberately NOT via withUI: in the
+        // LiveView transport session fibers descend from kyo-http internals, so root Env does not reach mount effects
+        // there today (documented follow-up).
+        val greetEffect: UI < (Async & Scope & Env[String]) =
+            Env.get[String].map(greeting => UI.span(greeting).id("content"))
+        val ui: UI = UI.div(UI.mounted(greetEffect))
+        Env.run("hello-env") {
+            Scope.run {
+                for
+                    seen <- Promise.init[String, Any]
+                    exchange = new kyo.internal.UIExchange:
+                        def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async =
+                            kyo.internal.HtmlRenderer.render(changed, path).map { html =>
+                                if html.contains("hello-env") then seen.completeDiscard(Result.succeed(html))
+                                else ()
+                            }
+                    root <- kyo.internal.ReactiveUI.normalize(ui, Seq.empty)
+                    _    <- kyo.internal.ReactiveUI.subscribe(root, exchange)
+                    html <- seen.get
+                yield assert(html.contains("hello-env"))
+            }
+        }
+    }
+
+    "keyless mounted remounts (effect re-runs) when the enclosing region re-renders" in {
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(_ => UI.div(UI.mounted(runs.incrementAndGet.map(n => UI.span(s"runs:$n").id("content")))))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("content"), "runs:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("content"), "runs:2")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("content"), "runs:3")
+            yield ()
+        }
+    }
+
+    "keyed mounted keeps its live instance across region re-renders" in {
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(n =>
+                    UI.div(
+                        UI.span(s"tick:$n").id("tickview"),
+                        UI.mounted(runs.incrementAndGet.map(r => UI.span(s"runs:$r").id("content"))).keyed("box")
+                    )
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("content"), "runs:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("tickview"), "tick:1")
+                _ <- Browser.assertText(Selector.id("content"), "runs:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("tickview"), "tick:2")
+                _ <- Browser.assertText(Selector.id("content"), "runs:1")
+            yield ()
+        }
+    }
+
+    "keyed mounted keeps component-local signal state across region re-renders" in {
+        def counterComponent(runs: AtomicInt): UI < (Async & Scope) =
+            for
+                _     <- runs.incrementAndGet
+                count <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                count.map(c => UI.span(s"count:$c").id("count"))
+            )
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(_ => UI.div(UI.mounted(counterComponent(runs)).keyed("counter")))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:2")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("count"), "count:2")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:3")
+            yield ()
+        }
+    }
+
+    "key change tears down the old instance (Scope closed) and mounts a fresh one" in {
+        def component(key: Int, runs: AtomicInt, released: AtomicInt): UI < (Async & Scope) =
+            for
+                _ <- runs.incrementAndGet
+                _ <- Scope.ensure(released.incrementAndGet.unit)
+            yield UI.span(s"instance:$key").id("content")
+        val app: (AtomicInt, AtomicInt, UI < Async) < Sync =
+            for
+                runs     <- AtomicInt.init(0)
+                released <- AtomicInt.init(0)
+                sel      <- Signal.initRef(1)
+            yield (
+                runs,
+                released,
+                Kyo.lift(UI.div(
+                    UI.button("Next").id("next").onClick(sel.getAndUpdate(_ + 1).unit),
+                    sel.map(k => UI.div(UI.mounted(component(k, runs, released)).keyed(k)))
+                ))
+            )
+        app.map { (runs, released, ui) =>
+            withUI(ui) {
+                for
+                    _ <- Browser.assertText(Selector.id("content"), "instance:1")
+                    _ <- Browser.click(Selector.id("next"))
+                    _ <- Browser.assertText(Selector.id("content"), "instance:2")
+                    r <- released.get
+                    n <- runs.get
+                yield
+                    assert(r == 1) // old instance's Scope was closed on key change
+                    assert(n == 2) // and the effect ran exactly once per key
+            }
+        }
+    }
+
+    "failed mount renders the error state while the enclosing region stays alive" in {
+        val app: UI < Async =
+            for other <- Signal.initRef("sibling-0")
+            yield UI.div(
+                UI.button("Bump").id("bump").onClick(other.set("sibling-1")),
+                other.map(v => UI.span(v).id("sibling")),
+                UI.mounted(Abort.fail(new RuntimeException("boom-mount")))
+                    .onError(t => UI.span(s"error:${t.getMessage}").id("content"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("content"), "error:boom-mount")
+                _ <- Browser.click(Selector.id("bump"))
+                _ <- Browser.assertText(Selector.id("sibling"), "sibling-1")
+            yield ()
+        }
+    }
+
+    "handler inside a nested region INSIDE mounted content dispatches (region -> mounted -> region -> button)" in {
+        def component(): UI < (Async & Scope) =
+            for
+                gate  <- Signal.initRef(true)
+                count <- Signal.initRef(0)
+            yield UI.div(
+                gate.map(g =>
+                    if g then
+                        UI.div(
+                            UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                            count.map(c => UI.span(s"count:$c").id("count"))
+                        )
+                    else UI.span("off")
+                )
+            )
+        val app: UI < Async =
+            for
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(_ => UI.div(UI.mounted(component()).keyed("nested")))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:2")
+            yield ()
+        }
+    }
+
+    "handler under TWO nested regions inside mounted content dispatches (mounted -> region -> region -> button)" in {
+        def component(): UI < (Async & Scope) =
+            for
+                outer <- Signal.initRef(0)
+                inner <- Signal.initRef(0)
+                count <- Signal.initRef(0)
+            yield UI.div(
+                outer.map(_ =>
+                    UI.div(
+                        inner.map(_ =>
+                            UI.div(
+                                UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                                count.map(c => UI.span(s"count:$c").id("count"))
+                            )
+                        )
+                    )
+                )
+            )
+        val app: UI < Async =
+            Kyo.lift(UI.div(UI.mounted(component()).keyed("deep")))
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+            yield ()
+        }
+    }
+
+    "mount content whose ROOT is a region stays live (region-at-cell-root: patches AND dispatch)" in {
+        def component(): UI < (Async & Scope) =
+            for
+                idSig <- Signal.initRef(0)
+                count <- Signal.initRef(0)
+            yield (idSig.map { _ =>
+                UI.div(
+                    UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                    count.map(c => UI.span(s"count:$c").id("count"))
+                )
+            }: UI)
+        val app: UI < Async =
+            Kyo.lift(UI.div(UI.mounted(component()).keyed("rootregion")))
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+            yield ()
+        }
+    }
+
+    "mounted node as the direct ROOT of a region's content stays live (route shape: region content = Mounted)" in {
+        def component(runs: AtomicInt): UI < (Async & Scope) =
+            for
+                _     <- runs.incrementAndGet
+                count <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                count.map(c => UI.span(s"count:$c").id("count"))
+            )
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(n => (UI.mounted(component(runs)).keyed(("box", n)): UI))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc"))
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+            yield ()
+        }
+    }
+
+    "nested route shape end-to-end: region -> Mounted(root) -> region(content root) -> element -> region -> button" in {
+        def page(count: Signal.SignalRef[Int]): UI < (Async & Scope) =
+            for
+                identity <- Signal.initRef("me")
+                query    <- Signal.initRef("loaded")
+            yield (identity.map { _ =>
+                UI.main(
+                    (query.map { _ =>
+                        UI.div(
+                            UI.button("Inc").id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                            count.map(c => UI.span(s"count:$c").id("count"))
+                        )
+                    }: UI)
+                )
+            }: UI)
+        val app: (Signal.SignalRef[String], UI < Async) < Sync =
+            for
+                count    <- Signal.initRef(0)
+                location <- Signal.initRef("/a")
+            yield (
+                location,
+                Kyo.lift(UI.div(
+                    UI.span("header").id("hdr"),
+                    UI.div((location.map(path => (UI.mounted(page(count)).keyed(path): UI)): UI))
+                ))
+            )
+        app.map { (location, ui) =>
+            withUI(ui) {
+                for
+                    _ <- Browser.assertText(Selector.id("count"), "count:0")
+                    _ <- Browser.click(Selector.id("inc"))
+                    _ <- Browser.assertText(Selector.id("count"), "count:1")
+                    _ <- location.set("/b")
+                    // count survives navigation: the count signal is shared across pages
+                    _ <- Browser.assertText(Selector.id("count"), "count:1")
+                    _ <- Browser.click(Selector.id("inc"))
+                    _ <- Browser.assertText(Selector.id("count"), "count:2")
+                yield ()
+            }
+        }
+    }
+
+    "click on a REACTIVE child of a button inside mounted content bubbles to the button handler" in {
+        def component(): UI < (Async & Scope) =
+            for
+                label <- Signal.initRef("Leave")
+                count <- Signal.initRef(0)
+            yield UI.div(
+                UI.button((label.map(s => (UI.Ast.Text(s): UI)): UI)).id("inc").onClick(count.getAndUpdate(_ + 1).unit),
+                count.map(c => UI.span(s"count:$c").id("count"))
+            )
+        val app: UI < Async =
+            Kyo.lift(UI.div(UI.mounted(component()).keyed("i18nbtn")))
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("count"), "count:0")
+                _ <- Browser.click(Selector.id("inc")) // centre click hits the inner reactive span
+                _ <- Browser.assertText(Selector.id("count"), "count:1")
+            yield ()
+        }
+    }
+
+    "ENGINE: dispatch targeting a reactive label INSIDE a button (below intermediate static elements) runs the button handler" in {
+        Scope.run {
+            for
+                label   <- Signal.initRef("Leave")
+                clicked <- AtomicInt.init(0)
+                ui = UI.div(
+                    UI.div(UI.span("cards")),
+                    UI.div( // button-bar (static intermediate)
+                        UI.button((label.map(s => (UI.Ast.Text(s): UI)): UI))
+                            .id("leave")
+                            .onClick(clicked.incrementAndGet.unit)
+                    )
+                )
+                exchange = new kyo.internal.UIExchange:
+                    def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async = ()
+                root     <- kyo.internal.ReactiveUI.normalize(ui, Seq.empty)
+                dispatch <- kyo.internal.ReactiveUI.subscribe(root, exchange)
+                // Target = the LABEL region's path: div(0)=cards-div... button-bar=child 1, button=child 0, label=child 0.
+                labelPath = Seq("1", "0", "0")
+                handled <- dispatch.handle(
+                    labelPath,
+                    kyo.internal.UIEvent.Click(labelPath, kyo.internal.MouseEventData(UI.Modifiers.none, Absent))
+                )
+                n <- clicked.get
+            yield assert(handled && n == 1, s"handled=$handled clicks=$n (expected the BUTTON handler to run)")
+        }
+    }
+
+    "duplicate mounted key: the first slot mounts, the duplicate slot renders an inline error card" in {
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+            yield UI.div(
+                UI.mounted(runs.incrementAndGet.map(r => UI.span(s"runs:$r").id("first"))).keyed("dup"),
+                UI.mounted(runs.incrementAndGet.map(r => UI.span(s"runs:$r").id("second"))).keyed("dup")
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("first"), "runs:1")
+                // duplicate slot never runs its effect: it paints the error card rather than silently sharing the first instance
+                _ <- Browser.assertText(Selector.css(".kyo-mount-error"), "kyo-ui: duplicate mounted key 'dup'")
+            yield ()
+        }
+    }
+
+    "unstable key (fresh per re-render) re-creates the instance each pass (the churn-hint path)" in {
+        val app: UI < Async =
+            for
+                runs <- AtomicInt.init(0)
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                tick.map(n =>
+                    UI.div(
+                        UI.mounted(runs.incrementAndGet.map(r => UI.span(s"runs:$r").id("content"))).keyed(("box", n))
+                    )
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("content"), "runs:1")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("content"), "runs:2")
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("content"), "runs:3")
+                // Third consecutive key change: the unstable-key dev hint logs on this pass.
+                _ <- Browser.click(Selector.id("tick"))
+                _ <- Browser.assertText(Selector.id("content"), "runs:4")
+            yield ()
+        }
+    }
+
+    "background fiber failure after publish flips the mounted node to its error render (node-scope supervision)" in {
+        val setup =
+            for gate <- Promise.init[Unit, Any]
+            yield (
+                gate,
+                UI.div(
+                    UI.span("sibling").id("sibling"),
+                    UI.mounted(
+                        Fiber.init(gate.get.andThen(Abort.fail(new RuntimeException("feed-died"))))
+                            .map(_ => UI.span("live").id("content"))
+                    ).keyed("game")
+                        .onError(t => UI.span(s"error:${t.getMessage}").id("content"))
+                )
+            )
+        setup.map { (gate, ui) =>
+            withUI(Kyo.lift(ui)) {
+                for
+                    _ <- Browser.assertText(Selector.id("content"), "live")
+                    _ <- gate.completeUnitDiscard // feed dies AFTER publish
+                    _ <- Browser.assertText(Selector.id("content"), "error:feed-died")
+                    _ <- Browser.assertText(Selector.id("sibling"), "sibling")
+                yield ()
+            }
+        }
+    }
+
+    "keyed instance kept across region re-renders still flips on a later feed failure (supervision survives adoption)" in {
+        val app: UI < Async =
+            for
+                gate <- Promise.init[Unit, Any]
+                tick <- Signal.initRef(0)
+            yield UI.div(
+                UI.button("Tick").id("tick").onClick(tick.getAndUpdate(_ + 1).unit),
+                UI.button("Kill").id("kill").onClick(gate.completeUnitDiscard),
+                tick.map(n =>
+                    UI.div(
+                        UI.span(s"tick:$n").id("tick-val"),
+                        UI.mounted(
+                            Fiber.init(gate.get.andThen(Abort.fail(new RuntimeException("late-fail"))))
+                                .map(_ => UI.span("live").id("content"))
+                        ).keyed("stable")
+                            .onError(t => UI.span(s"error:${t.getMessage}").id("content"))
+                    )
+                )
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.id("content"), "live")
+                _ <- Browser.click(Selector.id("tick")) // instance is ADOPTED across the re-render, not re-created
+                _ <- Browser.assertText(Selector.id("tick-val"), "tick:1")
+                _ <- Browser.assertText(Selector.id("content"), "live")
+                _ <- Browser.click(Selector.id("kill"))
+                _ <- Browser.assertText(Selector.id("content"), "error:late-fail")
+            yield ()
+        }
+    }
+
+end MountedTest

--- a/kyo-ui/shared/src/test/scala/kyo/RegionMarkerTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/RegionMarkerTest.scala
@@ -1,0 +1,53 @@
+package kyo
+
+import kyo.internal.RegionMarker
+
+/** The comment-marker byte format is a cross-implementation contract (Scala + inline LiveView JS);
+  * these tests pin it. Escaping is load-bearing: Foreach keys are arbitrary user strings, and a raw
+  * "-->" inside a path would terminate the marker comment mid-path.
+  */
+class RegionMarkerTest extends kyo.test.Test[Any]:
+
+    "open/close format for a plain path" in {
+        assert(RegionMarker.open(Seq("0", "1", "a")) == "<!--kyo:0.1.a-->")
+        assert(RegionMarker.close(Seq("0", "1", "a")) == "<!--/kyo:0.1.a-->")
+    }
+
+    "flags ride the open marker only" in {
+        assert(RegionMarker.open(Seq("2"), mount = true) == "<!--kyo:2 m-->")
+        assert(RegionMarker.open(Seq("2"), slot = true) == "<!--kyo:2 s-->")
+        assert(RegionMarker.open(Seq("2"), mount = true, slot = true) == "<!--kyo:2 m s-->")
+    }
+
+    "hostile Foreach keys cannot terminate the comment" in {
+        val key  = "Track:abc-->def --!> g-h"
+        val open = RegionMarker.open(Seq("0", key))
+        // The only "-->" in the marker is its own terminator at the very end.
+        assert(open.indexOf("-->") == open.length - 3)
+        // Both comment terminators ("-->", "--!>") require "--", so the DATA must contain none.
+        val data = open.stripPrefix("<!--").stripSuffix("-->")
+        assert(!data.contains("--"))
+    }
+
+    "escape/unescape round-trips arbitrary keys" in {
+        val keys = List("plain", "a-b c%d", "-->", "%2D", "  --  ", "100% -done-", "$r")
+        assert(keys.forall(k => RegionMarker.unescape(RegionMarker.escape(k)) == k))
+    }
+
+    "parse reads back open markers with flags" in {
+        val data = RegionMarker.openData("0.a-b c", mount = true, slot = true)
+        assert(RegionMarker.parse(data) == Present(RegionMarker.Parsed("0.a-b c", isClose = false, mount = true, slot = true)))
+    }
+
+    "parse reads back close markers" in {
+        val parsed = RegionMarker.parse(RegionMarker.closeData("0.x y"))
+        assert(parsed == Present(RegionMarker.Parsed("0.x y", isClose = true, mount = false, slot = false)))
+    }
+
+    "parse ignores non-kyo comments" in {
+        assert(RegionMarker.parse("just a comment").isEmpty)
+        assert(RegionMarker.parse(" kyo:leading-space").isEmpty)
+        assert(RegionMarker.parse("").isEmpty)
+    }
+
+end RegionMarkerTest

--- a/kyo-ui/shared/src/test/scala/kyo/SvgReactiveTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/SvgReactiveTest.scala
@@ -7,8 +7,8 @@ import kyo.internal.HtmlRenderer
 import kyo.internal.ReactiveUI
 import scala.language.implicitConversions
 
-/** Tests SVG reactive resolution via the engine's rebuildSvgElement and resolveReactives, and the `<g>`-based
-  * reactive placeholders used for a reactive boundary in SVG context.
+/** Tests SVG reactive resolution via the engine's rebuildSvgElement and resolveReactives, and the comment-marker
+  * region delimiters (`<!--kyo:P-->…<!--/kyo:P-->`), which are uniform across SVG and HTML context.
   */
 class SvgReactiveTest extends kyo.test.Test[Any]:
 
@@ -32,66 +32,64 @@ class SvgReactiveTest extends kyo.test.Test[Any]:
         end for
     }
 
-    // An empty reactive boundary inside <svg> renders a <g> placeholder, not <span>.
-    "empty reactive in svg emits <g> placeholder" in {
+    // A reactive boundary inside <svg> renders comment markers (valid in SVG content), no wrapper element.
+    "empty reactive in svg emits comment markers" in {
         val emptySig = Signal.initConst(Chunk.empty[Int])
         val root     = Svg.svg(emptySig.foreach(i => Svg.rect.x(i.toDouble).y(0).width(1).height(1)))
         for html <- HtmlRenderer.render(root, Seq.empty)
         yield
-            assert(html.contains("<g data-kyo-path=\"0\" data-kyo-reactive>"))
-            assert(html.contains("</g>"))
-            // No <span> placeholder is emitted inside the svg.
-            assert(!html.contains("<span data-kyo-reactive"))
-            assert(!html.contains("data-kyo-reactive></span>"))
+            assert(html.contains("<!--kyo:0--><!--/kyo:0-->"))
+            // No wrapper element is emitted for the region.
+            assert(!html.contains("data-kyo-reactive"))
         end for
     }
 
-    // Once the SVG signal resolves to children, the SVG children appear under the <g> boundary.
+    // Once the SVG signal resolves to children, the SVG children appear between the markers.
     "reactive in svg renders children after signal resolves" in {
         val sig  = Signal.initConst(Chunk(1, 2))
         val root = Svg.svg(sig.foreach(i => Svg.rect.x(i.toDouble).y(0).width(1).height(1)))
         for html <- HtmlRenderer.render(root, Seq.empty)
         yield
-            assert(html.contains("<g data-kyo-path=\"0\" data-kyo-reactive>"))
+            assert(html.contains("<!--kyo:0-->"))
+            assert(html.contains("<!--/kyo:0-->"))
             assert(html.split("<rect").length - 1 == 2)
         end for
     }
 
-    // An empty reactive boundary in HTML context still renders a <span> placeholder.
-    "empty reactive in HTML emits <span> placeholder" in {
+    // An empty reactive boundary in HTML context renders the same comment markers: the format is
+    // context-uniform (the old <span>-vs-<g> distinction is gone).
+    "empty reactive in HTML emits comment markers" in {
         val emptySig = Signal.initConst(Chunk.empty[Int])
         val root     = UI.div(emptySig.foreach(i => UI.span(i.toString)))
         for html <- HtmlRenderer.render(root, Seq.empty)
         yield
-            assert(html.contains("<span data-kyo-path=\"0\" data-kyo-reactive>"))
-            assert(!html.contains("<g data-kyo-reactive"))
-            assert(!html.contains("data-kyo-reactive></g>"))
+            assert(html.contains("<!--kyo:0--><!--/kyo:0-->"))
+            assert(!html.contains("data-kyo-reactive"))
         end for
     }
 
-    // A reactive inside foreignObject (the HTML bridge) renders <span>, not <g>.
-    "reactive inside foreignObject resets to <span>" in {
+    // A reactive inside foreignObject (the HTML bridge) uses the same markers as everywhere else.
+    "reactive inside foreignObject emits comment markers" in {
         val emptySig = Signal.initConst(Chunk.empty[Int])
         val root     = Svg.svg(Svg.foreignObject(UI.div(emptySig.foreach(i => UI.span(i.toString)))))
         for html <- HtmlRenderer.render(root, Seq.empty)
         yield
-            // The reactive lives under foreignObject -> div, so HTML context applies: a <span> placeholder.
-            assert(html.contains("data-kyo-reactive></span>"))
-            assert(html.contains("<span data-kyo-path="))
-            // No <g> placeholder boundary carrying data-kyo-reactive is emitted for the bridged reactive.
-            assert(!html.contains("data-kyo-reactive></g>"))
+            // foreignObject -> div -> reactive: markers at the reactive's path, no wrapper element.
+            assert(html.contains("<!--kyo:0.0.0-->"))
+            assert(html.contains("<!--/kyo:0.0.0-->"))
+            assert(!html.contains("data-kyo-reactive"))
         end for
     }
 
-    // Nested svg/foreignObject/div/svg toggles the placeholder tag per boundary.
-    "nested svg/html/svg toggles placeholder tag" in {
+    // Nested svg/foreignObject/div/svg: markers appear at each boundary's own path.
+    "nested svg/html/svg markers carry per-boundary paths" in {
         val emptySig = Signal.initConst(Chunk.empty[Int])
         val inner    = Svg.svg(emptySig.foreach(i => Svg.rect.x(i.toDouble).y(0).width(1).height(1)))
         val root     = Svg.svg(Svg.foreignObject(UI.div(inner)))
         for html <- HtmlRenderer.render(root, Seq.empty)
         yield
-            // The innermost reactive is back in SVG context (inner svg) so it emits a <g> placeholder.
-            assert(html.contains("data-kyo-reactive>") && html.contains("</g>"))
+            // The innermost reactive sits at svg -> foreignObject(0) -> div(0.0) -> svg(0.0.0) -> region(0.0.0.0).
+            assert(html.contains("<!--kyo:0.0.0.0--><!--/kyo:0.0.0.0-->"))
             assert(html.contains("<foreignObject"))
             assert(html.contains("<div"))
         end for
@@ -121,11 +119,11 @@ class SvgReactiveTest extends kyo.test.Test[Any]:
         end for
     }
 
-    // The exchange wraps reactive updates in <g> for a reactive boundary in SVG context.
-    // Calls the real HtmlRenderer.wrapReactiveRegion production function; a bug in that
-    // function (wrong tag, missing attribute) makes the assertion fail. Also covers the
-    // non-svg branch: wrapReactiveRegion with svgContext=false must produce a <span>.
-    "reactive region wrapped in <g> in svg context" in {
+    // The exchange payload is the region's bare content fragment: no wrapper element in either
+    // context. The region stays addressable through its live comment markers, so the SSR string is the
+    // whole per-context contract (the parse-context wrap on the client side derives from the live
+    // parent at patch time).
+    "region payload carries no wrapper element" in {
         val sig  = Signal.initConst(Chunk.empty[Int])
         val root = Svg.svg(sig.foreach(i => Svg.rect.x(i.toDouble).y(0).width(1).height(1)))
         for
@@ -133,17 +131,10 @@ class SvgReactiveTest extends kyo.test.Test[Any]:
             node = ReactiveUI.findNode(rui, Seq("0"))
             innerHtml <- HtmlRenderer.render(UI.fragment(), Seq("0"))
         yield
-            // svg-context branch: node is recorded as svg, wrapReactiveRegion must pick "g"
+            // The node still records its svg context (normalize bookkeeping)...
             assert(node.isDefined && node.get.svgContext)
-            val svgWrapped = HtmlRenderer.wrapReactiveRegion(node.get.path, node.get.svgContext, innerHtml)
-            assert(svgWrapped.startsWith("<g data-kyo-path="))
-            assert(svgWrapped.contains("data-kyo-reactive"))
-            assert(svgWrapped.endsWith("</g>"))
-            // non-svg branch: wrapReactiveRegion with svgContext=false must pick "span"
-            val htmlWrapped = HtmlRenderer.wrapReactiveRegion(Seq("1", "2"), svgContext = false, innerHtml)
-            assert(htmlWrapped.startsWith("<span data-kyo-path=\"1.2\""))
-            assert(htmlWrapped.contains("data-kyo-reactive"))
-            assert(htmlWrapped.endsWith("</span>"))
+            // ...but the rendered content fragment is wrapper-free.
+            assert(!innerHtml.contains("data-kyo-reactive"))
         end for
     }
 
@@ -157,7 +148,7 @@ class SvgReactiveTest extends kyo.test.Test[Any]:
             b <- HtmlRenderer.render(root, Seq.empty)
         yield
             assert(a == b)
-            assert(a.contains("<g data-kyo-path=\"0\" data-kyo-reactive>"))
+            assert(a.contains("<!--kyo:0-->"))
         end for
     }
 

--- a/kyo-ui/shared/src/test/scala/kyo/TableRegionTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/TableRegionTest.scala
@@ -1,0 +1,152 @@
+package kyo
+
+import kyo.Browser.*
+import kyo.UI.foreach
+import kyo.UI.foreachKeyed
+import scala.language.implicitConversions
+
+/** Chrome-backed regressions for reactive regions in parser-hostile contexts (table, tr, select).
+  *
+  * These paint paths were structurally broken under element anchors: the HTML parser foster-parented a
+  * `<span>` anchor out of `<table>` at the initial paint, and the "in body" template fragment parse
+  * silently dropped `<tr>` payloads on the patch path. Comment markers plus context-aware payload
+  * parsing fix both. Every assert here is STRUCTURAL ("table tr", "select option"): a body-wide text
+  * assert passes even with foster-parented content, which is exactly how the old bug stayed invisible.
+  */
+class TableRegionTest extends UITest:
+
+    "reactive rows as direct table child paint inside the table and patch" in {
+        val app: UI < Async =
+            for rows <- Signal.initRef(Chunk("A", "B"))
+            yield UI.div(
+                UI.table(rows.foreach(r => UI.tr(UI.td(r).cssClass("cell")))),
+                UI.button("Grow").id("grow").onClick(rows.getAndUpdate(_ :+ "C").unit)
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertCount(Selector.css("table tr"), 2)
+                _ <- Browser.assertCount(Selector.css("table td.cell"), 2)
+                _ <- Browser.click(Selector.id("grow"))
+                // The patched row lands INSIDE the table (the payload parse must use a table context;
+                // the old "in body" parse dropped the <tr> wholesale).
+                _ <- Browser.assertCount(Selector.css("table tr"), 3)
+                _ <- Browser.assertText(Selector.css("table tr:last-child td"), "C")
+            yield ()
+        }
+    }
+
+    "reactive cell as direct tr child paints inside the row and patches" in {
+        val app: UI < Async =
+            for cell <- Signal.initRef("x")
+            yield UI.div(
+                UI.table(UI.tr(UI.th("head"), cell.map(v => UI.td(v).id("dyn-cell")))),
+                UI.button("Bump").id("bump").onClick(cell.set("y"))
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.css("table tr td#dyn-cell"), "x")
+                _ <- Browser.click(Selector.id("bump"))
+                _ <- Browser.assertText(Selector.css("table tr td#dyn-cell"), "y")
+            yield ()
+        }
+    }
+
+    "keyed row regions add, remove, and reorder inside the table" in {
+        val app: UI < Async =
+            for rows <- Signal.initRef(Chunk("a", "b", "c"))
+            yield UI.div(
+                UI.table(rows.foreachKeyed(identity)(r => UI.tr(UI.td(r).cssClass("cell")))),
+                UI.button("Rev").id("rev").onClick(rows.getAndUpdate(c => Chunk.from(c.toSeq.reverse)).unit),
+                UI.button("Drop").id("drop").onClick(rows.getAndUpdate(_.init).unit)
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertCount(Selector.css("table tr"), 3)
+                _ <- Browser.assertText(Selector.css("table tr:first-child td"), "a")
+                _ <- Browser.click(Selector.id("rev"))
+                _ <- Browser.assertText(Selector.css("table tr:first-child td"), "c")
+                _ <- Browser.assertText(Selector.css("table tr:last-child td"), "a")
+                _ <- Browser.click(Selector.id("drop"))
+                _ <- Browser.assertCount(Selector.css("table tr"), 2)
+            yield ()
+        }
+    }
+
+    "row-region patches leave sibling static rows untouched" in {
+        val app: UI < Async =
+            for rows <- Signal.initRef(Chunk("r1"))
+            yield UI.div(
+                UI.table(
+                    UI.tr(UI.th("H1").cssClass("head"), UI.th("H2").cssClass("head")),
+                    rows.foreach(r => UI.tr(UI.td(r).cssClass("cell")))
+                ),
+                UI.button("Grow").id("grow").onClick(rows.getAndUpdate(_ :+ "r2").unit)
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertCount(Selector.css("table th.head"), 2)
+                _ <- Browser.click(Selector.id("grow"))
+                // The range morph is bounded by the region's markers: the static header row is an
+                // out-of-range sibling and must survive exactly once.
+                _ <- Browser.assertCount(Selector.css("table th.head"), 2)
+                _ <- Browser.assertCount(Selector.css("table td.cell"), 2)
+                _ <- Browser.assertCount(Selector.css("table tr"), 3)
+            yield ()
+        }
+    }
+
+    "mounted rows inside a table paint inside it" in {
+        val mountedRows: UI < (Async & Scope) =
+            (UI.fragment(UI.tr(UI.td("M1").cssClass("mcell")), UI.tr(UI.td("M2").cssClass("mcell"))): UI)
+        val app: UI < Async =
+            UI.div(UI.table(UI.mounted(mountedRows).keyed("rows")))
+        withUI(app) {
+            for
+                _ <- Browser.assertCount(Selector.css("table td.mcell"), 2)
+                _ <- Browser.assertText(Selector.css("table tr:first-child td"), "M1")
+            yield ()
+        }
+    }
+
+    "nested region ($r) inside a table patches through both levels" in {
+        val app: UI < Async =
+            for
+                outer <- Signal.initRef(0)
+                inner <- Signal.initRef("v1")
+            yield UI.div(
+                UI.table(outer.map(o => (inner.map(v => UI.tr(UI.td(s"$o:$v").cssClass("cell"))): UI))),
+                UI.button("Inner").id("inner").onClick(inner.set("v2")),
+                UI.button("Outer").id("outer").onClick(outer.getAndUpdate(_ + 1).unit)
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertText(Selector.css("table td.cell"), "0:v1")
+                _ <- Browser.click(Selector.id("inner"))
+                _ <- Browser.assertText(Selector.css("table td.cell"), "0:v2")
+                _ <- Browser.click(Selector.id("outer"))
+                _ <- Browser.assertText(Selector.css("table td.cell"), "1:v2")
+                _ <- Browser.assertCount(Selector.css("table td.cell"), 1)
+            yield ()
+        }
+    }
+
+    "reactive options as direct select child paint and patch" in {
+        // Under element anchors the "in select" insertion mode dropped the <span> anchor wholesale,
+        // so signal-driven options never painted and updates were dead. Comments survive that mode.
+        val app: UI < Async =
+            for opts <- Signal.initRef(Chunk("one", "two"))
+            yield UI.div(
+                UI.select(opts.foreach(o => UI.option(o).value(o))).id("sel"),
+                UI.button("Grow").id("grow").onClick(opts.getAndUpdate(_ :+ "three").unit)
+            )
+        withUI(app) {
+            for
+                _ <- Browser.assertCount(Selector.css("select option"), 2)
+                _ <- Browser.click(Selector.id("grow"))
+                _ <- Browser.assertCount(Selector.css("select option"), 3)
+                _ <- Browser.assertText(Selector.css("select option:last-child"), "three")
+            yield ()
+        }
+    }
+
+end TableRegionTest

--- a/kyo-ui/shared/src/test/scala/kyo/TypedEventTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/TypedEventTest.scala
@@ -18,7 +18,7 @@ class TypedEventTest extends kyo.test.Test[Any]:
 
     /** Minimal UIExchange stub that discards onChange notifications. */
     private class NoopExchange extends UIExchange:
-        def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async = ()
+        def onChange(path: Seq[String], ui: UI, mount: Boolean)(using Frame): Unit < Async = ()
 
     /** Normalize a UI, subscribe it with a NoopExchange, and return the dispatch handle. The dispatch handle re-reads
       * the current signal state on each event, so it stays valid after the subscription's Scope closes; these tests

--- a/kyo-ui/shared/src/test/scala/kyo/UIBaseCssTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIBaseCssTest.scala
@@ -7,9 +7,8 @@ class UIBaseCssTest extends kyo.test.Test[Any]:
         assert(UI.baseCss.contains("box-sizing: border-box"))
     }
 
-    "UI.baseCss contains the data-kyo-reactive display:contents rule" in {
-        assert(UI.baseCss.contains("[data-kyo-reactive]"))
-        assert(UI.baseCss.contains("display: contents"))
+    "UI.baseCss carries no reactive-anchor rule (regions are comment markers)" in {
+        assert(!UI.baseCss.contains("data-kyo-reactive"))
     }
 
     "runRenderPage output contains UI.baseCss verbatim" in {

--- a/kyo-ui/shared/src/test/scala/kyo/UIEventWiringTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIEventWiringTest.scala
@@ -19,7 +19,7 @@ class UIEventWiringTest extends kyo.test.Test[Any]:
 
     /** Minimal UIExchange stub that discards onChange notifications. */
     private class NoopExchange extends UIExchange:
-        def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async = ()
+        def onChange(path: Seq[String], ui: UI, mount: Boolean)(using Frame): Unit < Async = ()
 
     /** Normalize a UI, subscribe it with a NoopExchange, and return the dispatch handle. The dispatch handle re-reads
       * the current signal state on each event, so it stays valid after the subscription's Scope closes; these tests

--- a/kyo-ui/shared/src/test/scala/kyo/UIServerWsTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/UIServerWsTest.scala
@@ -58,8 +58,8 @@ class UIServerWsTest extends kyo.test.Test[Any]:
         yield capturedData match
             case Present(data) =>
                 Json.decode[HtmlOp](data) match
-                    case Result.Success(HtmlOp.Replace(_, html)) => assert(html.contains("after"))
-                    case other                                   => fail(s"expected HtmlOp.Replace with 'after', got: $other")
+                    case Result.Success(HtmlOp.Replace(_, html, _)) => assert(html.contains("after"))
+                    case other                                      => fail(s"expected HtmlOp.Replace with 'after', got: $other")
             case Absent => fail("client did not receive a second frame after the click")
         end for
     }

--- a/kyo-ui/shared/src/test/scala/kyo/internal/MountSupervisionTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/internal/MountSupervisionTest.scala
@@ -14,7 +14,7 @@ class MountSupervisionTest extends kyo.test.Test[Any]:
     final private class Recording(markers: Map[String, Fiber.Promise.Unsafe[String, Any]]):
         val emissions = new CopyOnWriteArrayList[String]()
         val exchange = new UIExchange:
-            def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async =
+            def onChange(path: Seq[String], changed: UI, mount: Boolean)(using Frame): Unit < Async =
                 HtmlRenderer.render(changed, path).map { html =>
                     discard(emissions.add(html))
                     markers.foreach { (marker, p) =>

--- a/kyo-ui/shared/src/test/scala/kyo/internal/MountSupervisionTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/internal/MountSupervisionTest.scala
@@ -1,0 +1,195 @@
+package kyo.internal
+
+import java.util.concurrent.CopyOnWriteArrayList
+import kyo.*
+
+/** Direct-engine tests for node-scope supervision (no browser): a mounted node's background fiber failing
+  * AFTER publication flips the node into its error routing (node `.onError` → boundary chain → default error
+  * UI), first-failure-wins, teardown interrupts never flip, `initUnscoped` opts out. The engine is driven via
+  * `ReactiveUI.normalize`/`subscribe` with a recording `UIExchange` (the MountedTest direct-test idiom).
+  */
+class MountSupervisionTest extends kyo.test.Test[Any]:
+
+    /** Records every emission's rendered HTML and completes marker promises on first match. */
+    final private class Recording(markers: Map[String, Fiber.Promise.Unsafe[String, Any]]):
+        val emissions = new CopyOnWriteArrayList[String]()
+        val exchange = new UIExchange:
+            def onChange(path: Seq[String], changed: UI)(using Frame): Unit < Async =
+                HtmlRenderer.render(changed, path).map { html =>
+                    discard(emissions.add(html))
+                    markers.foreach { (marker, p) =>
+                        if html.contains(marker) then
+                            import AllowUnsafe.embrace.danger
+                            discard(p.complete(Result.succeed(html)))
+                    }
+                }
+        def count(marker: String): Int =
+            import scala.jdk.CollectionConverters.*
+            emissions.asScala.count(_.contains(marker))
+        def indexOf(marker: String): Int =
+            import scala.jdk.CollectionConverters.*
+            emissions.asScala.indexWhere(_.contains(marker))
+    end Recording
+
+    private def recording(markers: String*)(using Frame): (Recording, Map[String, Fiber[String, Any]]) < Sync =
+        Sync.Unsafe.defer {
+            val ps  = markers.map(m => m -> Fiber.Promise.Unsafe.init[String, Any]()).toMap
+            val rec = new Recording(ps)
+            (rec, ps.view.mapValues(_.safe: Fiber[String, Any]).toMap)
+        }
+
+    private def run(ui: UI, rec: Recording)(using Frame): Unit < (Async & Scope) =
+        ReactiveUI.normalize(ui, Seq.empty).map(root => ReactiveUI.subscribe(root, rec.exchange).unit)
+
+    private def boom = new RuntimeException("feed died")
+
+    "a published keyed mount flips to its default error render when a background fiber fails" in {
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready", "feed died")
+                effect = Fiber.init(gate.get.andThen(Abort.fail(boom)))
+                    .map(_ => UI.span("ready").id("content"))
+                _ <- run(UI.div(UI.mounted(effect).keyed("k")), rec)
+                _ <- marks("ready").get
+                _ <- gate.completeUnitDiscard
+                _ <- marks("feed died").get
+            yield assert(rec.indexOf("ready") < rec.indexOf("feed died"))
+        }
+    }
+
+    "a keyless mount flips too" in {
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready", "feed died")
+                effect = Fiber.init(gate.get.andThen(Abort.fail(boom)))
+                    .map(_ => UI.span("ready").id("content"))
+                _ <- run(UI.div(UI.mounted(effect)), rec)
+                _ <- marks("ready").get
+                _ <- gate.completeUnitDiscard
+                _ <- marks("feed died").get
+            yield assert(rec.count("feed died") >= 1)
+        }
+    }
+
+    "a node-local .onError wins for a supervised failure" in {
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready", "custom:feed died")
+                effect = Fiber.init(gate.get.andThen(Abort.fail(boom)))
+                    .map(_ => UI.span("ready").id("content"))
+                node = UI.mounted(effect).keyed("k").onError(t => UI.span(s"custom:${t.getMessage}"))
+                _ <- run(UI.div(node), rec)
+                _ <- marks("ready").get
+                _ <- gate.completeUnitDiscard
+                _ <- marks("custom:feed died").get
+            yield assert(rec.count("custom:feed died") == 1)
+        }
+    }
+
+    "an unhandled supervised failure walks the boundary chain post-reveal" in {
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready", "boundary:feed died")
+                effect = Fiber.init(gate.get.andThen(Abort.fail(boom)))
+                    .map(_ => UI.span("ready").id("content"))
+                ui = UI.div(
+                    UI.boundary.onError { case t: RuntimeException => UI.span(s"boundary:${t.getMessage}") }(
+                        UI.mounted(effect).keyed("k")
+                    )
+                )
+                _ <- run(ui, rec)
+                _ <- marks("ready").get
+                _ <- gate.completeUnitDiscard
+                _ <- marks("boundary:feed died").get
+            yield assert(rec.count("boundary:feed died") == 1)
+        }
+    }
+
+    "first failure wins: two failing feeds, exactly one error paint" in {
+        Scope.run {
+            for
+                gate1        <- Promise.init[Unit, Any]
+                gate2        <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready", "kyo-mount-error")
+                effect =
+                    for
+                        _ <- Fiber.init(gate1.get.andThen(Abort.fail(new RuntimeException("first"))))
+                        _ <- Fiber.init(gate2.get.andThen(Abort.fail(new RuntimeException("second"))))
+                    yield UI.span("ready").id("content")
+                _ <- run(UI.div(UI.mounted(effect).keyed("k")), rec)
+                _ <- marks("ready").get
+                _ <- gate1.completeUnitDiscard
+                _ <- marks("kyo-mount-error").get
+                _ <- gate2.completeUnitDiscard
+                _ <- Async.sleep(100L.millis)
+            yield assert(rec.count("kyo-mount-error") == 1)
+        }
+    }
+
+    "a supervised failure during pending is deferred until the effect settles, then flips" in {
+        // The flip is serialized after publish, but the intermediate "ready" paint is not observable through the
+        // coalescing content signal (observe keeps only the latest), so we assert: no error while pending, error after settle.
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("feed died")
+                effect = Fiber.init(Abort.fail(boom)) // fails while the effect is still pending
+                    .map(_ => gate.get)
+                    .map(_ => UI.span("ready").id("content"))
+                _ <- run(UI.div(UI.mounted(effect).keyed("k")), rec)
+                _ <- Async.sleep(100L.millis) // failure has long landed…
+                noneYet = rec.count("kyo-mount-error") == 0 // …but nothing flipped while pending
+                _ <- gate.completeUnitDiscard
+                _ <- marks("feed died").get // flip arrives once the effect settled
+            yield assert(noneYet)
+        }
+    }
+
+    "an effect failure racing a supervised failure routes once (shared once-guard)" in {
+        Scope.run {
+            for
+                (rec, _) <- recording()
+                effect = Fiber.init(Abort.fail(new RuntimeException("from fiber")))
+                    .andThen(Abort.fail(new RuntimeException("from effect")))
+                _ <- run(UI.div(UI.mounted(effect).keyed("k")), rec)
+                _ <- Async.sleep(150L.millis)
+            yield assert(rec.count("kyo-mount-error") == 1)
+        }
+    }
+
+    "eviction: a key swap interrupts feeds without any error paint" in {
+        Scope.run {
+            for
+                sel          <- Signal.initRef("a")
+                (rec, marks) <- recording("inst:a", "inst:b")
+                effect = (k: String) =>
+                    Fiber.init(Async.never).map(_ => UI.span(s"inst:$k").id("content"))
+                ui = UI.div(sel.map(k => UI.div(UI.mounted(effect(k)).keyed(k))))
+                _ <- run(ui, rec)
+                _ <- marks("inst:a").get
+                _ <- sel.set("b")
+                _ <- marks("inst:b").get
+                _ <- Async.sleep(100L.millis)
+            yield assert(rec.count("kyo-mount-error") == 0)
+        }
+    }
+
+    "initUnscoped feed failure does NOT flip the node" in {
+        Scope.run {
+            for
+                gate         <- Promise.init[Unit, Any]
+                (rec, marks) <- recording("ready")
+                effect = Fiber.initUnscoped(gate.get.andThen(Abort.fail(boom)))
+                    .map(_ => UI.span("ready").id("content"))
+                _ <- run(UI.div(UI.mounted(effect).keyed("k")), rec)
+                _ <- marks("ready").get
+                _ <- gate.completeUnitDiscard
+                _ <- Async.sleep(100L.millis)
+            yield assert(rec.count("kyo-mount-error") == 0)
+        }
+    }
+end MountSupervisionTest

--- a/kyo-ui/shared/src/test/scala/kyo/internal/ReactiveUITeardownTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/internal/ReactiveUITeardownTest.scala
@@ -25,7 +25,7 @@ class ReactiveUITeardownTest extends kyo.test.Test[Any]:
     // A no-op exchange: the teardown/cascade proof does not depend on rendered output, only on subscription liveness.
     private val stubExchange: UIExchange =
         new UIExchange:
-            def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async = ()
+            def onChange(path: Seq[String], ui: UI, mount: Boolean)(using Frame): Unit < Async = ()
 
     "bound input re-renders the latest value across back-to-back changes (convergence)".ignore(
         "interrupt-driven Scope finalizer teardown can stall before the result is observed; known finalizer-execution-on-interrupt issue, comprehensive fix pending"
@@ -43,7 +43,7 @@ class ReactiveUITeardownTest extends kyo.test.Test[Any]:
             // Exchange that renders each emitted input region to HTML and records it (the real onChange wire behavior).
             recordingExchange =
                 new UIExchange:
-                    def onChange(path: Seq[String], ui: UI)(using Frame): Unit < Async =
+                    def onChange(path: Seq[String], ui: UI, mount: Boolean)(using Frame): Unit < Async =
                         HtmlRenderer.render(ui, path).map(html => rendered.updateAndGet(_.append(html)).unit)
             tree = UI.input.id("i").value(ref)
             live <- AtomicInt.init(0)


### PR DESCRIPTION
> **⚠ Depends on #1780 (UI.mounted): please merge that first.** The diff shows #1780's commit until it lands.

## Problem

Reactive regions (`Reactive`/`Foreach`/`Mounted`/`Boundary`) paint as a wrapper element, `<span data-kyo-path=".." data-kyo-reactive>` (`<g>` in SVG), and updates replace that element's subtree. That representation is structurally broken in every parser-sensitive context, on `main` today:

1. **Tables, initial paint.** Both transports produce the page via an HTML string parse (`innerHTML` / full document). A `<span>` between `<table>` and its rows is invalid, so the parser *foster-parents* the wrapper out of the table: `table(rows.foreach(r => tr(td(r))))` paints its anchor before the table, subscribe-side paths and painted DOM disagree, and every subsequent patch targets a node outside the table. A body-wide text assert can't see this: the existing TableTest "foreach rows add remove" passed while the rows' updates landed outside the table.

2. **Tables, patch path.** Region updates re-parse from an HTML string via `<template>`. The fragment parser runs in "in body" mode, where a `<tr>` start tag is a parse error that is *silently dropped*: a row-region payload loses all its rows even when the anchor is found.

3. **Select.** The "in select" insertion mode drops unknown tags wholesale, so a reactive region as a direct `<select>` child never paints its wrapper and its updates are dead.

There is no wrapper tag that fixes this: in `<tr>` context a `<td>` anchor start tag *closes* the open cell ("in cell" mode), so no element can hold cell content through the parser.

## Solution

Regions render as **comment-node markers** (`<!--kyo:PATH-->content<!--/kyo:PATH-->`), the representation lit-html/Vue/Solid use for the same reason: comments are valid in every parse context (table, tr, select, svg: the `<g>` special case disappears too), and the region injects no element into user markup (`[data-kyo-reactive] { display: contents; }` leaves the base stylesheet).

- **Registry instead of querySelector.** Comments are not selectable; a `path -> (start, end)` registry is built by a `TreeWalker` scan after the initial paint, refreshed by range-scoped rescans after each patch, and connectivity-validated on lookup (stale → one full rescan → retry → silent no-op, preserving the pre-reveal Boundary contract).
- **Range morphing.** `morphChildren` generalizes to a sibling-range morph bounded by the markers; a nested region's marker span reconciles as ONE logical child keyed by its region path (never positionally: mispairing would corrupt marker text). Out-of-range siblings are never touched.
- **Context-aware payload parse.** Region payloads are bare content fragments parsed in the context the live parent dictates (`<table><tbody>`, `<table><tbody><tr>`, `<select>`, `<svg>` wraps), fixing (2) for good.
- **Mount flags ride the markers.** `data-kyo-mount`/`data-kyo-mount-slot` become ` m`/` s` flags on the open marker; `HtmlOp.Replace` carries `mount` explicitly (the payload no longer has a wrapper root to carry it).
- **Element regions stay wrapper-free.** A signal-bound field (`input.value(ref)`) is its own region root and is morphed 1:1 in place: the transparent wrapper `<span>` that used to appear around such fields on their first patch is gone entirely.
- **Parser-implied `<tbody>` repair.** The whole-page parser keeps an open marker that precedes a table's first row as a `<table>` child while the rows land in the implied `<tbody>`; scan-time pairing adopts the marker into the row group so the pair shares a parent again.
- **Marker escaping.** `%`→`%25`, `-`→`%2D`, space→`%20` per path: Foreach keys are arbitrary user strings and must not be able to terminate the comment (`-->`).

Both transports change in lockstep (SPA `DomBackend` + the server-push inline client), same as the base morphing work in this PR.

## Tests

- `TableRegionTest` (new, real Chrome, structural asserts: `table tr` / `select option`, not body-wide text): rows as direct table child paint inside the table and patch; reactive cell inside `tr`; keyed row add/remove/reorder; static sibling rows untouched by range patches; mounted rows in a table; nested (`$r`) region in a table; reactive options in `<select>`.
- `RegionMarkerTest` (new): the marker byte-format contract incl. hostile-key escaping.
- `MountedTest` gains two regressions for reactive-family children of `fragment(...)` splices (subscribe-side paths normalized at the child path, matching the painted markers).
- Full kyo-ui JVM suite green on this branch: 2091 tests, 0 failures (28 min, real Chrome).



### Path selectors escape user-provided keys

Keyed-list keys are user data and become `data-kyo-path` segments; both transports query elements with `[data-kyo-path="..."]` attribute selectors. A key containing a double quote or backslash broke (or redirected) the query. Both selector builders now escape those metacharacters: `pathSelector` on the SPA side and `__kyoPathSel` in the embedded client, kept in lockstep (the client helper is built via `fromCharCode` because the embedded script lives in an interpolated Scala literal whose escape processing must not touch the emitted JS).
