### PR TITLE
kyo-ai: model Anthropic's system field as a content-block array

### DIFF
--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
@@ -12,7 +12,7 @@ import kyo.ai.Context.{Message as ContextMessage, *}
 /** The Anthropic completion backend (the `/messages` API).
   *
   * Serializes the conversation to the Anthropic request shape via typed `Content` DTOs that `Json.encode`
-  * emits directly: the first context message is lifted into the top-level `system` field, the rest map to
+  * emits directly: the first context message is lifted into the top-level `system` block array, the rest map to
   * user/assistant `Message`s, a tool result becomes a USER-role message with a `tool_result` block, and a
   * user image serializes as a multi-part text-then-image content list. A reply's `tool_use.input` is an
   * arbitrary object, carried as a `Structure.Value` and re-encoded to the raw argument JSON the `Call`
@@ -202,8 +202,13 @@ private[completion] object AnthropicCompletion extends Completion:
             // Extended-thinking reply blocks ({"type":"thinking","thinking":...,"signature":...}); decoded so
             // the reply parses, then ignored by `read` (the reasoning is not surfaced as a transcript message).
             thinking: Maybe[String] = Absent,
-            signature: Maybe[String] = Absent
+            signature: Maybe[String] = Absent,
+            // Prompt-cache breakpoint. Anthropic caches a prefix only against an explicit marker on a
+            // block, so this is the only place it can be expressed. Absent everywhere today; the field
+            // exists so the marker HAS a home on the wire.
+            cache_control: Maybe[CacheControl] = Absent
         ) derives Schema
+        case class CacheControl(`type`: String) derives Schema
         case class Source(`type`: String, media_type: String, data: String) derives Schema
         case class Message(role: String, content: List[Content]) derives Schema
         // strict = true enables Anthropic structured outputs: token-level constrained decoding against the
@@ -221,7 +226,10 @@ private[completion] object AnthropicCompletion extends Completion:
         case class Request(
             model: String,
             messages: List[Message],
-            system: Maybe[String],
+            // `string | Array<TextBlockParam>` on the wire. The block form is the only one that can carry
+            // a `cache_control` breakpoint, so it is the form emitted here; a single instruction produces a
+            // one-element array, which the API treats identically to the bare string.
+            system: Maybe[List[Content]],
             max_tokens: Int,
             temperature: Maybe[Double],
             tools: Maybe[List[ToolDefinition]] = Absent,
@@ -291,8 +299,9 @@ private[completion] object AnthropicCompletion extends Completion:
                     )
                 val (system, body) =
                     fitted.headMaybe match
-                        case Present(SystemMessage(c)) => (Present(c), fitted.drop(1))
-                        case _                         => (Absent, fitted)
+                        case Present(SystemMessage(c)) =>
+                            (Present(List(Content("text", text = Present(c)))), fitted.drop(1))
+                        case _ => (Absent, fitted)
                 val mapped =
                     body.map {
                         case UserMessage(content, Present(image)) =>

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/AnthropicCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/AnthropicCompletionTest.scala
@@ -113,6 +113,42 @@ class AnthropicCompletionTest extends kyo.test.Test[Any]:
         }
     }
 
+    "the system field is emitted as a block array, so a cache breakpoint has a place to live" in {
+        TestCompletionServer.run { server =>
+            val config = keyedConfig(server.baseUrl)
+            val ctx = Context.empty
+                .systemMessage("instruction one")
+                .systemMessage("instruction two")
+                .userMessage("hello from user")
+            server.enqueueBody(minimalAnthropicBody("ok")).andThen {
+                LLM.run(config) {
+                    Abort.run[HttpException] {
+                        Abort.run[AIException] {
+                            AnthropicCompletion(config, ctx, Chunk.empty)
+                        }
+                    }
+                }.andThen {
+                    server.captured.map { caps =>
+                        val body = caps.head.body
+                        // `string | Array<TextBlockParam>`: the block form is what can carry cache_control.
+                        assert(
+                            body.contains("\"system\":[") || body.contains("\"system\": ["),
+                            s"system should be a block array, not a bare string: $body"
+                        )
+                        assert(
+                            body.contains("\"type\":\"text\"") || body.contains("\"type\": \"text\""),
+                            s"the system block should be a text block: $body"
+                        )
+                        // Merging of the leading run is unchanged: both instructions still travel, together.
+                        assert(body.contains("instruction one"), s"first instruction lost: $body")
+                        assert(body.contains("instruction two"), s"second instruction lost: $body")
+                        assert(body.contains("hello from user"), s"user message lost: $body")
+                    }
+                }
+            }
+        }
+    }
+
     "a conversation with no leading system message keeps the opening user turn (regression: head was dropped)" in {
         TestCompletionServer.run { server =>
             val config = keyedConfig(server.baseUrl)


### PR DESCRIPTION
Anthropic's Messages API accepts `system` as `string | Array<TextBlockParam>`. kyo-ai
sends the string form, which works, but a plain string has nowhere to carry a
`cache_control` breakpoint — so prompt caching cannot be expressed on this wire at
all. Context: #1802.

This models `system` as a block array and adds an optional `cache_control` to
`Content`.

**Semantics are unchanged.** `Completion.fitSystemMessages` still merges the
contiguous leading run into one message; this changes only how that merged content
travels — one text block instead of a bare string. A single-instruction conversation
produces a one-element array, which the API treats identically.

**Nothing is hardcoded and no behaviour is introduced.** `cache_control` is `Absent`
everywhere; the change only gives the marker a home on the wire. It is also the field
an automatic layer would populate, so this doesn't constrain the transparent design
described in #1802 — a single marker, as you suggested, fits here without further
change.

**One judgement call worth flagging.** The array form is emitted unconditionally. It
is the documented shape for every current Anthropic model and the string form is
sugar over it, so there is no model variation to encode. The only scenario where it
could matter is a third-party endpoint pointed at via `apiUrl` that accepts the
string form only. I left it unconditional rather than add a config for a case that
may not exist — happy to gate it behind a provider config if you'd rather not carry
that risk.

**Scope deliberately excluded:**

- Any threshold or automatic-marking logic — that is the transparent design, and yours.
- Any change to non-leading system messages. The `<system-reminder>` path is correct
  as it stands.
- The cache usage counters from item (3) of #1802: on re-reading, `Usage` already
  carries both and `usageStats` already folds them into `AIStats`, with the same
  subset semantics as the OpenAI backend (`cachedInputTokens` as a subset of
  `inputTokens`). There was nothing to add.

**Tests:** a new case asserts the wire shape (`system` as an array of `text` blocks)
while checking that the leading-run merge still delivers every instruction. Full
`kyo-aiJVM/test` suite green locally.