### PR TITLE
kyo-ai: declare the Anthropic system-slot encoding as a config

### DIFF
--- a/kyo-ai/shared/src/main/scala/kyo/ai/Config.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/Config.scala
@@ -80,12 +80,20 @@ final case class Config private (
     // default applies, so an untouched config states nothing and never warns; a warning fires only on a
     // STATED amount the encoding cannot express. Held rather than dropped where it cannot ride, since
     // one config re-aims across providers, and held while reasoning is off.
-    reasoningAmount: Maybe[Config.Amount] = Absent
+    reasoningAmount: Maybe[Config.Amount] = Absent,
+    // Untyped on the wire (`string | Array<TextBlockParam>` on at least one endpoint); the entry
+    // declares which form it accepts. Defaulted so a positional construction elsewhere is unaffected.
+    systemEncoding: Config.SystemEncoding = Config.SystemEncoding.Text
 ):
-    def apiUrl(url: String): Config              = copy(apiUrl = url)
-    def apiKey(key: String): Config              = copy(apiKey = Present(key))
-    def apiOrg(org: String): Config              = copy(apiOrg = Present(org))
-    def temperature(temperature: Double): Config = copy(temperature = Present(temperature.max(0).min(2)))
+    def apiUrl(url: String): Config = copy(apiUrl = url)
+
+    /** Declares which system-slot encoding this endpoint accepts (see [[Config.SystemEncoding]]). Set it
+      * when `apiUrl` points at an endpoint whose contract differs from the provider's own.
+      */
+    def systemEncoding(encoding: Config.SystemEncoding): Config = copy(systemEncoding = encoding)
+    def apiKey(key: String): Config                             = copy(apiKey = Present(key))
+    def apiOrg(org: String): Config                             = copy(apiOrg = Present(org))
+    def temperature(temperature: Double): Config                = copy(temperature = Present(temperature.max(0).min(2)))
 
     /** The output-token ceiling this request asks for, clamped to the model's declared maximum.
       *
@@ -301,7 +309,8 @@ final case class Config private (
         reasoningOff: Maybe[Config.ReasoningOff] = Absent,
         forcedToolChoice: Maybe[Config.ForcedToolChoice] = Absent,
         systemInstructions: Maybe[Config.SystemMessages] = Absent,
-        invalidToolCalls: Maybe[Config.InvalidToolCalls] = Absent
+        invalidToolCalls: Maybe[Config.InvalidToolCalls] = Absent,
+        systemEncoding: Maybe[Config.SystemEncoding] = Absent
     ): Config =
         copy(
             provider = provider,
@@ -316,6 +325,7 @@ final case class Config private (
             reasoningOff = reasoningOff.getOrElse(provider.reasoningOff),
             forcedToolChoice = forcedToolChoice.getOrElse(provider.forcedToolChoice),
             systemInstructions = systemInstructions.getOrElse(provider.systemInstructions),
+            systemEncoding = systemEncoding.getOrElse(provider.systemEncoding),
             invalidToolCalls = invalidToolCalls.getOrElse(provider.invalidToolCalls)
         )
 
@@ -424,7 +434,8 @@ object Config:
         reasoningOff: Maybe[ReasoningOff] = Absent,
         forcedToolChoice: Maybe[ForcedToolChoice] = Absent,
         systemInstructions: Maybe[SystemMessages] = Absent,
-        invalidToolCalls: Maybe[InvalidToolCalls] = Absent
+        invalidToolCalls: Maybe[InvalidToolCalls] = Absent,
+        systemEncoding: Maybe[SystemEncoding] = Absent
     ): Config =
         Config(
             provider.baseUrl,
@@ -441,7 +452,8 @@ object Config:
             reasoningOff.getOrElse(provider.reasoningOff),
             forcedToolChoice.getOrElse(provider.forcedToolChoice),
             systemInstructions.getOrElse(provider.systemInstructions),
-            invalidToolCalls.getOrElse(provider.invalidToolCalls)
+            invalidToolCalls.getOrElse(provider.invalidToolCalls),
+            systemEncoding = systemEncoding.getOrElse(provider.systemEncoding)
         )
 
     /** A model's maximum output tokens, and whether that number is known or stood in for.
@@ -578,6 +590,26 @@ object Config:
         case FirstOnly
     end SystemMessages
 
+    /** How the out-of-band system slot is encoded on the wire, declared per provider.
+      *
+      * Two endpoints that both accept a system prompt can disagree about its SHAPE: one takes a bare
+      * string, another a list of content blocks. The block form is what carries per-block metadata (a
+      * prompt-cache breakpoint, for instance); the string form cannot express it at all.
+      *
+      * Declared here for the same reason as [[SystemMessages]]: only the provider knows, and the
+      * completion impls must not read a provider name to shape a request. An endpoint reached through
+      * `apiUrl` that accepts the string form only says so on its entry.
+      */
+    enum SystemEncoding derives CanEqual:
+        /** The system prompt rides as a bare string. */
+        case Text
+
+        /** The system prompt rides as a list of content blocks, which is what can carry per-block
+          * metadata such as a cache breakpoint.
+          */
+        case Blocks
+    end SystemEncoding
+
     /** How an endpoint says "do not reason", declared per provider.
       *
       * A wire that reasons by default has to be told to stop, and endpoints disagree about how: one
@@ -662,7 +694,8 @@ object Config:
         val systemInstructions: SystemMessages = SystemMessages.AllDelivered,
         val invalidToolCalls: InvalidToolCalls = InvalidToolCalls.Returned,
         val forcedToolChoice: ForcedToolChoice = ForcedToolChoice.Honored,
-        val usesApiKey: Boolean = true
+        val usesApiKey: Boolean = true,
+        val systemEncoding: SystemEncoding = SystemEncoding.Text
     ):
         val orgKey: String = keyName + "_ORG"
         def default: Config
@@ -716,7 +749,11 @@ object Config:
             forcedToolChoice = ForcedToolChoice.RefusedWhileReasoning,
             // One out-of-band system slot: the leading system run merges into it and later system
             // messages arrive as user turns, the shared transform's job, not this impl's.
-            systemInstructions = SystemMessages.FirstOnly
+            systemInstructions = SystemMessages.FirstOnly,
+            // This wire documents `system` as `string | Array<TextBlockParam>`, and only the block
+            // form can carry a per-block cache breakpoint. An endpoint reached through `apiUrl` that
+            // accepts the string form only overrides this on its entry.
+            systemEncoding = SystemEncoding.Blocks
         ):
         // Declared facts, with provenance. maxOutputTokens comes from the provider's own limit
         // response (a request above it is refused and names the maximum). The thinking kind and

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
@@ -12,7 +12,7 @@ import kyo.ai.Context.{Message as ContextMessage, *}
 /** The Anthropic completion backend (the `/messages` API).
   *
   * Serializes the conversation to the Anthropic request shape via typed `Content` DTOs that `Json.encode`
-  * emits directly: the first context message is lifted into the top-level `system` field, the rest map to
+  * emits directly: the first context message is lifted into the top-level `system` block array, the rest map to
   * user/assistant `Message`s, a tool result becomes a USER-role message with a `tool_result` block, and a
   * user image serializes as a multi-part text-then-image content list. A reply's `tool_use.input` is an
   * arbitrary object, carried as a `Structure.Value` and re-encoded to the raw argument JSON the `Call`
@@ -202,8 +202,13 @@ private[completion] object AnthropicCompletion extends Completion:
             // Extended-thinking reply blocks ({"type":"thinking","thinking":...,"signature":...}); decoded so
             // the reply parses, then ignored by `read` (the reasoning is not surfaced as a transcript message).
             thinking: Maybe[String] = Absent,
-            signature: Maybe[String] = Absent
+            signature: Maybe[String] = Absent,
+            // Prompt-cache breakpoint. Anthropic caches a prefix only against an explicit marker on a
+            // block, so this is the only place it can be expressed. Absent everywhere today; the field
+            // exists so the marker HAS a home on the wire.
+            cache_control: Maybe[CacheControl] = Absent
         ) derives Schema
+        case class CacheControl(`type`: String) derives Schema
         case class Source(`type`: String, media_type: String, data: String) derives Schema
         case class Message(role: String, content: List[Content]) derives Schema
         // strict = true enables Anthropic structured outputs: token-level constrained decoding against the
@@ -221,7 +226,10 @@ private[completion] object AnthropicCompletion extends Completion:
         case class Request(
             model: String,
             messages: List[Message],
-            system: Maybe[String],
+            // `string | Array<TextBlockParam>` on the wire, so the field is untyped here and the entry's
+            // declared Config.SystemEncoding decides which of the two is emitted. Only the block form can
+            // carry a per-block `cache_control` breakpoint; the string form cannot express it at all.
+            system: Maybe[Structure.Value],
             max_tokens: Int,
             temperature: Maybe[Double],
             tools: Maybe[List[ToolDefinition]] = Absent,
@@ -289,9 +297,17 @@ private[completion] object AnthropicCompletion extends Completion:
                         ctx.messages,
                         content => UserMessage(systemReminder(content), Absent)
                     )
+                // The encoding is the entry's declared fact, never a provider name read here: an endpoint
+                // that accepts the string form only says so on its config (Config.SystemEncoding).
+                def encodeSystem(content: String): Structure.Value =
+                    config.systemEncoding match
+                        case Config.SystemEncoding.Text =>
+                            Structure.encode(content)
+                        case Config.SystemEncoding.Blocks =>
+                            Structure.encode(List(Content("text", text = Present(content))))
                 val (system, body) =
                     fitted.headMaybe match
-                        case Present(SystemMessage(c)) => (Present(c), fitted.drop(1))
+                        case Present(SystemMessage(c)) => (Present(encodeSystem(c)), fitted.drop(1))
                         case _                         => (Absent, fitted)
                 val mapped =
                     body.map {

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/AnthropicCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/AnthropicCompletionTest.scala
@@ -113,6 +113,69 @@ class AnthropicCompletionTest extends kyo.test.Test[Any]:
         }
     }
 
+    "the system field is emitted as a block array, so a cache breakpoint has a place to live" in {
+        TestCompletionServer.run { server =>
+            val config = keyedConfig(server.baseUrl)
+            val ctx = Context.empty
+                .systemMessage("instruction one")
+                .systemMessage("instruction two")
+                .userMessage("hello from user")
+            server.enqueueBody(minimalAnthropicBody("ok")).andThen {
+                LLM.run(config) {
+                    Abort.run[HttpException] {
+                        Abort.run[AIException] {
+                            AnthropicCompletion(config, ctx, Chunk.empty)
+                        }
+                    }
+                }.andThen {
+                    server.captured.map { caps =>
+                        val body = caps.head.body
+                        // `string | Array<TextBlockParam>`: the block form is what can carry cache_control.
+                        assert(
+                            body.contains("\"system\":[") || body.contains("\"system\": ["),
+                            s"system should be a block array, not a bare string: $body"
+                        )
+                        assert(
+                            body.contains("\"type\":\"text\"") || body.contains("\"type\": \"text\""),
+                            s"the system block should be a text block: $body"
+                        )
+                        // Merging of the leading run is unchanged: both instructions still travel, together.
+                        assert(body.contains("instruction one"), s"first instruction lost: $body")
+                        assert(body.contains("instruction two"), s"second instruction lost: $body")
+                        assert(body.contains("hello from user"), s"user message lost: $body")
+                    }
+                }
+            }
+        }
+    }
+
+    "an entry declaring the string encoding sends system as a bare string" in {
+        TestCompletionServer.run { server =>
+            val config = keyedConfig(server.baseUrl).systemEncoding(Config.SystemEncoding.Text)
+            val ctx = Context.empty
+                .systemMessage("you are X")
+                .userMessage("hello from user")
+            server.enqueueBody(minimalAnthropicBody("ok")).andThen {
+                LLM.run(config) {
+                    Abort.run[HttpException] {
+                        Abort.run[AIException] {
+                            AnthropicCompletion(config, ctx, Chunk.empty)
+                        }
+                    }
+                }.andThen {
+                    server.captured.map { caps =>
+                        val body = caps.head.body
+                        assert(
+                            body.contains("\"system\":\"you are X\"") || body.contains("\"system\": \"you are X\""),
+                            s"an entry declaring Text should send a bare string: $body"
+                        )
+                        assert(body.contains("hello from user"), s"user message lost: $body")
+                    }
+                }
+            }
+        }
+    }
+
     "a conversation with no leading system message keeps the opening user turn (regression: head was dropped)" in {
         TestCompletionServer.run { server =>
             val config = keyedConfig(server.baseUrl)


### PR DESCRIPTION
### Problem

The Anthropic Messages API accepts `system` as `string | Array<TextBlockParam>`.
kyo-ai sends the string form, which works, but a bare string has nowhere to carry a
`cache_control` breakpoint, so prompt caching cannot be expressed on this wire.
Context: #1802.

### Solution

`Config.SystemEncoding` declares which form an endpoint accepts, defaulted per
provider (Anthropic declares `Blocks`) and overridable per model entry, with a
`systemEncoding` setter for a config re-aimed at another endpoint via `apiUrl`. The
Anthropic backend reads the declared fact; it does not decide the shape itself.
`Content` gains an optional `cache_control`, absent everywhere, so the marker has a
place to live.

`Request.system` becomes `Maybe[Structure.Value]` because the two encodings are
different JSON types in one field, the same approach `Content.input` already uses.

### Notes

- Merging is unchanged: `Completion.fitSystemMessages` still merges the leading run,
  and this only changes how the merged content is encoded.
- No caching behaviour is introduced. Placement of a marker, thresholds, and TTL
  remain open for the transparent design in #1802, which would populate this same
  field.
- Both encodings are covered by tests. Full `kyo-aiJVM/test` is green.
- One observation while validating: `LLMStreamIntegrationTest` failed once in a
  full-suite run and did not reproduce. It passes on the base commit, in isolation,
  and in a repeated full-suite run. That test drives an external CLI and this change
  does not touch the ClaudeCode path.