### PR TITLE
[kyo-schema] derive sealed case classes as products, and add derivedVia for validating constructors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -162,7 +162,7 @@ lazy val `kyo-settings` = Seq(
         val deps    = (Compile / dependencyClasspath).value.map(_.data)
         // `products` rather than `classDirectory`: it carries the same directories but is a task, so
         // depending on it is what compiles this module before its TASTy is read.
-        val classes = (Compile / products).value
+        val classes     = (Compile / products).value
         val opts        = (Compile / doc / scalacOptions).value
         val toolVersion = scaladocToolVersion.value
         // This tool reads TASTy, which only the Scala 3 series emits, so the 2.13 and 2.12 modules

--- a/kyo-schema-tests/shared/src/test/scala/kyo/SchemaTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/SchemaTest.scala
@@ -3601,6 +3601,19 @@ class SchemaTest extends kyo.test.Test[Any]:
             end match
         }
 
+        "a generic case class derives through a constructor at a concrete type argument" in {
+            val schema = summon[Schema[DVNonEmpty[Int]]]
+            val value  = DVNonEmpty.make(Chunk(1, 2)).toMaybe.get
+            val json   = schema.encodeString[Json](value)
+            assert(json == """{"items":[1,2]}""", s"wire: $json")
+            assert(schema.decodeString[Json](json) == Result.succeed(value))
+            schema.decodeString[Json]("""{"items":[]}""") match
+                case Result.Failure(e: ConstructorRejectedException) =>
+                    assert(e.getMessage.contains("must not be empty"), s"message: ${e.getMessage}")
+                case other => fail(s"expected a ConstructorRejectedException, got $other")
+            end match
+        }
+
         "a constructor whose arity does not match the case fields is a compile error naming them" in {
             val errs = scala.compiletime.testing.typeCheckErrors(
                 "kyo.Schema.derivedVia((a: Int, b: Int) => kyo.DVEven(a)): kyo.Schema[kyo.DVEven]"
@@ -3635,6 +3648,15 @@ end DVPort
 case class DVPortTwin(value: Int) derives CanEqual
 
 case class DVListener(name: String, port: DVPort) derives CanEqual, Schema
+
+case class DVNonEmpty[A](items: Chunk[A]) derives CanEqual
+object DVNonEmpty:
+    def make[A](items: Chunk[A]): Result[String, DVNonEmpty[A]] =
+        if items.nonEmpty then Result.succeed(DVNonEmpty(items))
+        else Result.fail("must not be empty")
+
+    given nonEmptySchema[A](using Schema[A]): Schema[DVNonEmpty[A]] = Schema.derivedVia(make[A])
+end DVNonEmpty
 
 sealed abstract case class DVRange private (low: Int, high: Int) derives CanEqual
 object DVRange:

--- a/kyo-schema-tests/shared/src/test/scala/kyo/SchemaTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/SchemaTest.scala
@@ -3483,7 +3483,214 @@ class SchemaTest extends kyo.test.Test[Any]:
         }
     }
 
+    "derivedVia" - {
+
+        "a sealed abstract case class round-trips through its smart constructor" in {
+            val schema = summon[Schema[DVPort]]
+            val port   = DVPort.make(8080).toMaybe.get
+            val json   = schema.encodeString[Json](port)
+            assert(json == """{"value":8080}""", s"wire: $json")
+            assert(schema.decodeString[Json](json) == Result.succeed(port))
+        }
+
+        "the wire shape is the same as the plain case class with the same field" in {
+            val viaJson   = summon[Schema[DVPort]].encodeString[Json](DVPort.make(443).toMaybe.get)
+            val plainJson = Schema.derived[DVPortTwin].encodeString[Json](DVPortTwin(443))
+            assert(viaJson == plainJson, s"via=$viaJson plain=$plainJson")
+        }
+
+        "the derived structure is a Product over the case fields" in {
+            summon[Schema[DVPort]].structure match
+                case product: Structure.Type.Product =>
+                    assert(product.fields.map(_.name) == Chunk("value"), s"fields: ${product.fields}")
+                case other => fail(s"expected a Product structure, got $other")
+        }
+
+        "a rejected value decodes to a ConstructorRejectedException carrying the constructor's reason" in {
+            summon[Schema[DVPort]].decodeString[Json]("""{"value":0}""") match
+                case Result.Failure(e: ConstructorRejectedException) =>
+                    assert(e.typeName == "DVPort")
+                    assert(e.getMessage.contains("port out of range: 0"), s"message: ${e.getMessage}")
+                case other => fail(s"expected a ConstructorRejectedException, got $other")
+        }
+
+        "the invariant holds on every codec, not just Json" in {
+            val schema = summon[Schema[DVPort]]
+            val port   = DVPort.make(22).toMaybe.get
+            assert(schema.decode[Protobuf](schema.encode[Protobuf](port)) == Result.succeed(port))
+            assert(schema.decode[MsgPack](schema.encode[MsgPack](port)) == Result.succeed(port))
+            val rejected = schema.decode[Protobuf](Schema.derived[DVPortTwin].encode[Protobuf](DVPortTwin(-1)))
+            assert(rejected.isFailure, s"a negative port must not decode: $rejected")
+        }
+
+        "a two-argument constructor takes the case fields in declaration order" in {
+            val schema = summon[Schema[DVRange]]
+            val range  = DVRange.make(1, 9).toMaybe.get
+            val json   = schema.encodeString[Json](range)
+            assert(json == """{"low":1,"high":9}""", s"wire: $json")
+            assert(schema.decodeString[Json](json) == Result.succeed(range))
+            assert(schema.decodeString[Json]("""{"low":9,"high":1}""").isFailure)
+        }
+
+        "a total constructor applies on decode, so the decoded value is the constructed one" in {
+            val schema = summon[Schema[DVUpper]]
+            assert(schema.decodeString[Json]("""{"name":"ada"}""") == Result.succeed(DVUpper("ADA")))
+            assert(schema.encodeString[Json](DVUpper("ADA")) == """{"name":"ADA"}""")
+        }
+
+        "an Option constructor reports absence as a decode failure" in {
+            val schema = summon[Schema[DVEven]]
+            assert(schema.decodeString[Json]("""{"n":4}""") == Result.succeed(DVEven(4)))
+            schema.decodeString[Json]("""{"n":5}""") match
+                case Result.Failure(e: ConstructorRejectedException) =>
+                    assert(e.getMessage.contains("returned None"), s"message: ${e.getMessage}")
+                case other => fail(s"expected a ConstructorRejectedException, got $other")
+            end match
+        }
+
+        "a Maybe constructor reports absence as a decode failure" in {
+            val schema = summon[Schema[DVPositive]]
+            assert(schema.decodeString[Json]("""{"v":3}""") == Result.succeed(DVPositive(3L)))
+            schema.decodeString[Json]("""{"v":0}""") match
+                case Result.Failure(e: ConstructorRejectedException) =>
+                    assert(e.getMessage.contains("returned Absent"), s"message: ${e.getMessage}")
+                case other => fail(s"expected a ConstructorRejectedException, got $other")
+            end match
+        }
+
+        "an Either constructor carries its Left value into the decode failure" in {
+            val schema = summon[Schema[DVCode]]
+            assert(schema.decodeString[Json]("""{"code":"sku"}""") == Result.succeed(DVCode("sku")))
+            schema.decodeString[Json]("""{"code":""}""") match
+                case Result.Failure(e: ConstructorRejectedException) =>
+                    assert(e.getMessage.contains("empty code"), s"message: ${e.getMessage}")
+                case other => fail(s"expected a ConstructorRejectedException, got $other")
+            end match
+        }
+
+        "a Try constructor carries its exception into the decode failure as the cause" in {
+            val schema = summon[Schema[DVShort]]
+            assert(schema.decodeString[Json]("""{"raw":"abc"}""") == Result.succeed(DVShort("abc")))
+            schema.decodeString[Json]("""{"raw":"abcd"}""") match
+                case Result.Failure(e: ConstructorRejectedException) =>
+                    assert(e.getMessage.contains("too long"), s"message: ${e.getMessage}")
+                    assert(e.getCause.isInstanceOf[IllegalArgumentException], s"cause: ${e.getCause}")
+                case other => fail(s"expected a ConstructorRejectedException, got $other")
+            end match
+        }
+
+        "an Option field keeps its optional wire treatment when decoding through a constructor" in {
+            val schema = summon[Schema[DVTagged]]
+            assert(schema.decodeString[Json]("""{"id":1,"label":"x"}""") == Result.succeed(DVTagged(1, Some("x"))))
+            assert(schema.decodeString[Json]("""{"id":1}""") == Result.succeed(DVTagged(1, None)))
+        }
+
+        "the constructed type is inferred from the constructor with no expected type to pin it" in {
+            val schema: Schema[DVPort] = Schema.derivedVia(DVPort.make)
+            assert(schema.encodeString[Json](DVPort.make(80).toMaybe.get) == """{"value":80}""")
+        }
+
+        "a derivedVia type nested as a field decodes through its constructor, not around it" in {
+            val schema = Schema.derived[DVListener]
+            assert(schema.encodeString[Json](DVListener("api", DVPort.make(80).toMaybe.get)) == """{"name":"api","port":{"value":80}}""")
+            assert(schema.decodeString[Json]("""{"name":"api","port":{"value":80}}""").isSuccess)
+            schema.decodeString[Json]("""{"name":"api","port":{"value":-1}}""") match
+                case Result.Failure(e: ConstructorRejectedException) =>
+                    assert(e.typeName == "DVPort", s"typeName: ${e.typeName}")
+                case other => fail(s"a nested rejection must fail the outer decode, got $other")
+            end match
+        }
+
+        "a constructor whose arity does not match the case fields is a compile error naming them" in {
+            val errs = scala.compiletime.testing.typeCheckErrors(
+                "kyo.Schema.derivedVia((a: Int, b: Int) => kyo.DVEven(a)): kyo.Schema[kyo.DVEven]"
+            )
+            assert(errs.nonEmpty)
+            val msg = errs.map(_.message).mkString("\n")
+            assert(msg.contains("expects a constructor of 1 argument"), s"message: $msg")
+            assert(msg.contains("(n: scala.Int)"), s"message: $msg")
+        }
+
+        "a constructor argument that does not accept its case field is a compile error naming the field" in {
+            val errs = scala.compiletime.testing.typeCheckErrors(
+                "kyo.Schema.derivedVia((s: String) => kyo.DVEven(s.length)): kyo.Schema[kyo.DVEven]"
+            )
+            assert(errs.nonEmpty)
+            val msg = errs.map(_.message).mkString("\n")
+            assert(msg.contains("case field 'n'"), s"message: $msg")
+        }
+    }
+
 end SchemaTest
+
+sealed abstract case class DVPort private (value: Int) derives CanEqual
+object DVPort:
+    def make(value: Int): Result[String, DVPort] =
+        if value > 0 && value < 65536 then Result.succeed(new DVPort(value) {})
+        else Result.fail(s"port out of range: $value")
+
+    given Schema[DVPort] = Schema.derivedVia(make)
+end DVPort
+
+case class DVPortTwin(value: Int) derives CanEqual
+
+case class DVListener(name: String, port: DVPort) derives CanEqual, Schema
+
+sealed abstract case class DVRange private (low: Int, high: Int) derives CanEqual
+object DVRange:
+    def make(low: Int, high: Int): Result[String, DVRange] =
+        if low <= high then Result.succeed(new DVRange(low, high) {})
+        else Result.fail(s"low $low exceeds high $high")
+
+    given Schema[DVRange] = Schema.derivedVia(make)
+end DVRange
+
+case class DVUpper(name: String) derives CanEqual
+object DVUpper:
+    def make(name: String): DVUpper = DVUpper(name.toUpperCase)
+
+    given Schema[DVUpper] = Schema.derivedVia(make)
+end DVUpper
+
+case class DVEven(n: Int) derives CanEqual
+object DVEven:
+    def make(n: Int): Option[DVEven] = if n % 2 == 0 then Some(DVEven(n)) else None
+
+    given Schema[DVEven] = Schema.derivedVia(make)
+end DVEven
+
+case class DVPositive(v: Long) derives CanEqual
+object DVPositive:
+    def make(v: Long): Maybe[DVPositive] = if v > 0 then Present(DVPositive(v)) else Absent
+
+    given Schema[DVPositive] = Schema.derivedVia(make)
+end DVPositive
+
+case class DVCode(code: String) derives CanEqual
+object DVCode:
+    def make(code: String): Either[String, DVCode] =
+        if code.nonEmpty then Right(DVCode(code)) else Left("empty code")
+
+    given Schema[DVCode] = Schema.derivedVia(make)
+end DVCode
+
+case class DVShort(raw: String) derives CanEqual
+object DVShort:
+    def make(raw: String): scala.util.Try[DVShort] =
+        scala.util.Try:
+            require(raw.length <= 3, s"too long: $raw")
+            DVShort(raw)
+
+    given Schema[DVShort] = Schema.derivedVia(make)
+end DVShort
+
+case class DVTagged(id: Int, label: Option[String]) derives CanEqual
+object DVTagged:
+    def make(id: Int, label: Option[String]): Result[String, DVTagged] =
+        if id > 0 then Result.succeed(DVTagged(id, label)) else Result.fail("id must be positive")
+
+    given Schema[DVTagged] = Schema.derivedVia(make)
+end DVTagged
 
 sealed case class SCCSingle(x: Int) derives CanEqual
 sealed case class SCCMulti(name: String, age: Int) derives CanEqual

--- a/kyo-schema-tests/shared/src/test/scala/kyo/SchemaTest.scala
+++ b/kyo-schema-tests/shared/src/test/scala/kyo/SchemaTest.scala
@@ -3416,7 +3416,102 @@ class SchemaTest extends kyo.test.Test[Any]:
         }
     }
 
+    "sealed case class derivation" - {
+
+        "single-field sealed case class derives as a product, not a sum" in {
+            val schema = Schema.derived[SCCSingle]
+            assert(schema.structure.isInstanceOf[Structure.Type.Product], s"expected a Product structure, got ${schema.structure}")
+            val json = schema.encodeString[Json](SCCSingle(7))
+            assert(json == """{"x":7}""", s"wire: $json")
+            assert(schema.decodeString[Json](json) == Result.succeed(SCCSingle(7)))
+        }
+
+        "multi-field sealed case class round-trips" in {
+            val schema = Schema.derived[SCCMulti]
+            val value  = SCCMulti("ada", 36)
+            val json   = schema.encodeString[Json](value)
+            assert(json == """{"name":"ada","age":36}""", s"wire: $json")
+            assert(schema.decodeString[Json](json) == Result.succeed(value))
+        }
+
+        "sealed case class nested as a field of another product round-trips" in {
+            val schema = Schema.derived[SCCHolder]
+            val value  = SCCHolder(1, SCCSingle(2))
+            val json   = schema.encodeString[Json](value)
+            assert(json == """{"id":1,"inner":{"x":2}}""", s"wire: $json")
+            assert(schema.decodeString[Json](json) == Result.succeed(value))
+        }
+
+        "sealed case class wire shape matches the same class without sealed" in {
+            val sealedJson = Schema.derived[SCCSingle].encodeString[Json](SCCSingle(3))
+            val plainJson  = Schema.derived[SCCPlainTwin].encodeString[Json](SCCPlainTwin(3))
+            assert(sealedJson == plainJson, s"sealed=$sealedJson plain=$plainJson")
+        }
+
+        "a genuine sealed hierarchy still derives as a sum" in {
+            val schema = Schema.derived[SCCShape]
+            assert(schema.structure.isInstanceOf[Structure.Type.Sum], s"expected a Sum structure, got ${schema.structure}")
+            val value: SCCShape = SCCShape.Circle(2)
+            val json            = schema.encodeString[Json](value)
+            assert(json == """{"Circle":{"r":2}}""", s"wire: $json")
+            assert(schema.decodeString[Json](json) == Result.succeed(value))
+        }
+
+        "a sealed case class variant of a sealed trait round-trips as that variant's product" in {
+            val schema         = Schema.derived[SCCNode]
+            val value: SCCNode = SCCNode.Leaf(4)
+            val json           = schema.encodeString[Json](value)
+            assert(json == """{"Leaf":{"v":4}}""", s"wire: $json")
+            assert(schema.decodeString[Json](json) == Result.succeed(value))
+        }
+
+        "an intermediate sealed abstract class delegates to its own sum instead of a zero-field product" in {
+            val schema        = Schema.derived[SCCTop]
+            val value: SCCTop = SCCTop.Mid.Concrete(5)
+            val json          = schema.encodeString[Json](value)
+            assert(json == """{"Mid":{"Concrete":{"n":5}}}""", s"wire: $json")
+            assert(schema.decodeString[Json](json) == Result.succeed(value))
+        }
+
+        "an abstract case class reports its missing constructor, not a wrong shape" in {
+            val src  = "sealed abstract case class SCCAbstractProbe(v: Int) derives kyo.Schema"
+            val errs = scala.compiletime.testing.typeCheckErrors(src)
+            assert(errs.nonEmpty)
+            val msg = errs.head.message
+            assert(msg.contains("no accessible constructor"), s"message must name the obstacle: $msg")
+            assert(!msg.contains("sealed trait"), s"message must not misclassify the type: $msg")
+        }
+    }
+
 end SchemaTest
+
+sealed case class SCCSingle(x: Int) derives CanEqual
+sealed case class SCCMulti(name: String, age: Int) derives CanEqual
+case class SCCPlainTwin(x: Int) derives CanEqual
+case class SCCHolder(id: Int, inner: SCCSingle) derives CanEqual
+given Schema[SCCSingle] = Schema.derived
+
+sealed trait SCCShape derives CanEqual
+object SCCShape:
+    case class Circle(r: Int) extends SCCShape
+    case class Square(s: Int) extends SCCShape
+end SCCShape
+
+sealed trait SCCNode derives CanEqual
+object SCCNode:
+    sealed case class Leaf(v: Int) extends SCCNode
+    case class Label(name: String) extends SCCNode
+end SCCNode
+
+sealed trait SCCTop derives CanEqual
+object SCCTop:
+    sealed abstract class Mid extends SCCTop
+    object Mid:
+        case class Concrete(n: Int) extends Mid
+        case class Other(s: String) extends Mid
+    end Mid
+    case class Direct(flag: Boolean) extends SCCTop
+end SCCTop
 
 case class UnionCaseA(label: String, value: Int) derives CanEqual, Schema
 case class UnionCaseB(flag: Boolean) derives CanEqual, Schema

--- a/kyo-schema/README.md
+++ b/kyo-schema/README.md
@@ -865,6 +865,53 @@ object Username:
 end Username
 ```
 
+### Validating smart constructors
+
+`derives Schema` emits a decoder that calls the type's primary constructor. For a type whose invariant lives in a smart constructor that is the wrong route: decoding would construct a value the constructor would have rejected. `Schema.derivedVia` takes the constructor and routes decoding through it. Encoding is untouched, so the wire shape stays the one the same fields would have on a plain case class.
+
+The `sealed abstract case class` idiom is the clearest case, since `abstract` suppresses `apply` and `copy` so the companion's constructor is the only route to a value at all:
+
+```scala
+sealed abstract case class Port private (value: Int)
+
+object Port:
+    def make(value: Int): Result[String, Port] =
+        if value > 0 && value < 65536 then Result.succeed(new Port(value) {})
+        else Result.fail(s"port out of range: $value")
+
+    given Schema[Port] = Schema.derivedVia(make)
+end Port
+
+Port.make(8080).map(Json.encode(_))
+// Result.Success({"value":8080})
+
+Json.decode[Port]("""{"value":0}""")
+// Result.Failure(ConstructorRejectedException(Nil, "Port", "port out of range: 0"))
+```
+
+A rejection is a `ConstructorRejectedException`, which subtypes `DecodeException`, so it arrives as the same `Result.Failure` any other malformed input arrives as rather than as a thrown exception or a silently bypassed check.
+
+The constructor takes the case fields one for one in declaration order, up to eight of them; a mismatch in arity or in a field's type is a compile error naming the field. Its result may be the constructed type itself or any shape `Schema.Constructed` reads a value out of: `Result`, `Maybe`, `Option`, `Either`, or `Try`. Any other outcome type works once it has its own `given Schema.Constructed` instance.
+
+Nothing about this is specific to types with no usable constructor. A refined type, a newtype carrying an invariant, or a domain primitive that rejects bad input all have public constructors that decoding should not reach for:
+
+```scala
+case class Slug(value: String)
+
+object Slug:
+    def make(value: String): Option[Slug] =
+        Option.when(value.nonEmpty && value.forall(c => c.isLetterOrDigit || c == '-'))(Slug(value))
+
+    given Schema[Slug] = Schema.derivedVia(make)
+end Slug
+
+Json.decode[Slug]("""{"value":"hello-world"}""")
+// Result.Success(Slug("hello-world"))
+
+Json.decode[Slug]("""{"value":"hello world"}""")
+// Result.Failure(ConstructorRejectedException(Nil, "Slug", "the constructor returned None"))
+```
+
 ## Annotations
 
 Everything the serialization sections configure with builder calls (variant representations, field and variant renaming, decode aliases, conditional omission, custom field codecs) can also be declared inline on the type with annotations from `kyo.schema`. `derives Schema` reads them and desugars each onto the same programmatic configuration, so an annotated type and the equivalent builder chain produce identical schemas. Annotations are opt-in: a type with none derives a byte-identical schema, and when an annotation and a programmatic call configure the same field, the programmatic call wins.
@@ -1785,6 +1832,7 @@ Errors raised by the schema core and schema codecs extend the sealed `SchemaExce
 | `TrailingInputException` | decode finishes one complete value but the input still contains extra content |
 | `LimitExceededException` | `maxDepth` or `maxCollectionSize` is exceeded |
 | `RangeException` | a numeric value overflows the target type |
+| `ConstructorRejectedException` | a `Schema.derivedVia` decode reaches the smart constructor and the constructor refuses the decoded fields; carries the `typeName` and the constructor's own rejection |
 | `ValidationFailedException` | a `.check` / `checkMin` / ... predicate fails |
 | `TransformFailedException` | a schema transform cannot complete |
 | `PathNotFoundException` | a `Structure.Path` segment does not exist |

--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -4,6 +4,7 @@ import kyo.Codec.Reader
 import kyo.Codec.Writer
 import kyo.internal.StructureValueReader
 import kyo.internal.StructureValueWriter
+import scala.annotation.implicitNotFound
 import scala.annotation.nowarn
 import scala.annotation.publicInBinary
 import scala.annotation.tailrec
@@ -1975,7 +1976,149 @@ object Schema:
       */
     inline given derived[A]: Schema[A] = ${ internal.SchemaDerivedMacro.derivedImpl[A] }
 
+    /** Derives a Schema[A] that decodes through a validating smart constructor.
+      *
+      * The encode side is the one [[derived]] emits: the wire shape is A's case fields, so a type derived this way is byte-identical on the
+      * wire to the same fields on a plain case class. The decode side reads those fields and then hands them to `construct` instead of
+      * calling A's primary constructor, so the type's invariant is enforced on the way in. A rejected value surfaces as a
+      * `ConstructorRejectedException`, a `DecodeException` like any other malformed input, never as a bypassed check or a raw throw.
+      *
+      * This is the entry point for the `sealed abstract case class` idiom, where `abstract` deliberately suppresses `apply` and `copy` so the
+      * companion's constructor is the only route to a value and [[derived]] has no constructor to call:
+      *
+      * {{{
+      * sealed abstract case class Port private (value: Int)
+      * object Port:
+      *     def make(value: Int): Result[String, Port] =
+      *         if value > 0 && value < 65536 then Result.succeed(new Port(value) {})
+      *         else Result.fail("port out of range")
+      *
+      *     given Schema[Port] = Schema.derivedVia(make)
+      * }}}
+      *
+      * It applies just as well to a type with a perfectly usable public constructor that should not be used for decoding: a refined type, a
+      * newtype with an invariant, a domain primitive that rejects bad input.
+      *
+      * `construct`'s arguments must match the case fields one for one in declaration order; a mismatch in arity or type is a compile error
+      * naming the offending field. Its outcome may be A itself or any shape [[Constructed]] recognizes: `Result`, `Maybe`, `Option`,
+      * `Either`, or `Try`.
+      *
+      * @param construct
+      *   the smart constructor, taking the case fields in declaration order
+      */
+    inline def derivedVia[B1, R, A](construct: B1 => R)(using c: Constructed[R, A]): Schema[A] =
+        ${ internal.SchemaDerivedMacro.derivedViaImpl[A, R]('construct, 'c) }
+
+    /** Two-field overload of [[derivedVia]]. */
+    inline def derivedVia[B1, B2, R, A](construct: (B1, B2) => R)(using c: Constructed[R, A]): Schema[A] =
+        ${ internal.SchemaDerivedMacro.derivedViaImpl[A, R]('construct, 'c) }
+
+    /** Three-field overload of [[derivedVia]]. */
+    inline def derivedVia[B1, B2, B3, R, A](construct: (B1, B2, B3) => R)(using c: Constructed[R, A]): Schema[A] =
+        ${ internal.SchemaDerivedMacro.derivedViaImpl[A, R]('construct, 'c) }
+
+    /** Four-field overload of [[derivedVia]]. */
+    inline def derivedVia[B1, B2, B3, B4, R, A](construct: (B1, B2, B3, B4) => R)(using c: Constructed[R, A]): Schema[A] =
+        ${ internal.SchemaDerivedMacro.derivedViaImpl[A, R]('construct, 'c) }
+
+    /** Five-field overload of [[derivedVia]]. */
+    inline def derivedVia[B1, B2, B3, B4, B5, R, A](construct: (B1, B2, B3, B4, B5) => R)(using c: Constructed[R, A]): Schema[A] =
+        ${ internal.SchemaDerivedMacro.derivedViaImpl[A, R]('construct, 'c) }
+
+    /** Six-field overload of [[derivedVia]]. */
+    inline def derivedVia[B1, B2, B3, B4, B5, B6, R, A](construct: (B1, B2, B3, B4, B5, B6) => R)(using
+        c: Constructed[R, A]
+    ): Schema[A] =
+        ${ internal.SchemaDerivedMacro.derivedViaImpl[A, R]('construct, 'c) }
+
+    /** Seven-field overload of [[derivedVia]]. */
+    inline def derivedVia[B1, B2, B3, B4, B5, B6, B7, R, A](construct: (B1, B2, B3, B4, B5, B6, B7) => R)(using
+        c: Constructed[R, A]
+    ): Schema[A] =
+        ${ internal.SchemaDerivedMacro.derivedViaImpl[A, R]('construct, 'c) }
+
+    /** Eight-field overload of [[derivedVia]]. */
+    inline def derivedVia[B1, B2, B3, B4, B5, B6, B7, B8, R, A](construct: (B1, B2, B3, B4, B5, B6, B7, B8) => R)(using
+        c: Constructed[R, A]
+    ): Schema[A] =
+        ${ internal.SchemaDerivedMacro.derivedViaImpl[A, R]('construct, 'c) }
+
     // --- Public nested types ---
+
+    /** Reads the constructed value out of whatever shape a smart constructor reports its outcome in.
+      *
+      * [[derivedVia]] summons one of these for the constructor's return type so a rejection folds into a decode failure. Instances exist for
+      * a total constructor (`R = A`, nothing to unwrap) and for `Result`, `Maybe`, `Option`, `Either`, and `Try`. A constructor reporting its
+      * outcome some other way is supported by giving that type its own instance:
+      *
+      * {{{
+      * given Schema.Constructed[Validated[String, Port], Port] with
+      *     def asResult(outcome: Validated[String, Port]): Result[Any, Port] = outcome.fold(Result.fail, Result.succeed)
+      * }}}
+      *
+      * @tparam R
+      *   the constructor's return type
+      * @tparam A
+      *   the constructed type
+      */
+    @implicitNotFound(
+        "Schema.derivedVia cannot read a constructed ${A} out of '${R}'. Supported outcomes are ${A} itself, " +
+            "Result[E, ${A}], Maybe[${A}], Option[${A}], Either[E, ${A}], and Try[${A}]. " +
+            "For any other shape, provide a given Schema.Constructed[${R}, ${A}]."
+    )
+    trait Constructed[R, A]:
+        /** Reports the constructor's outcome as a Result: a success carries the value, a failure carries whatever the constructor rejected
+          * it with.
+          */
+        def asResult(outcome: R): Result[Any, A]
+    end Constructed
+
+    /** Lower-priority half of [[Constructed]]'s instances.
+      *
+      * `total` matches any R at all, including the wrapped shapes, so it sits below them. Without the split, a constructor returning
+      * `Result[String, Port]` would match both `total` (constructing a `Result`) and `fromResult` (constructing a `Port`), and the search
+      * would be ambiguous wherever A is not already pinned by an expected type.
+      */
+    sealed trait ConstructedFallback:
+        /** A total constructor reports the value itself, with nothing to unwrap and no way to reject. */
+        given total[A]: Constructed[A, A] with
+            def asResult(outcome: A): Result[Any, A] = Result.succeed(outcome)
+    end ConstructedFallback
+
+    object Constructed extends ConstructedFallback:
+
+        given fromResult[E, A]: Constructed[Result[E, A], A] with
+            def asResult(outcome: Result[E, A]): Result[Any, A] = outcome
+
+        given fromMaybe[A]: Constructed[Maybe[A], A] with
+            def asResult(outcome: Maybe[A]): Result[Any, A] =
+                outcome match
+                    case Present(value) => Result.succeed(value)
+                    case _              => Result.fail("the constructor returned Absent")
+        end fromMaybe
+
+        given fromOption[A]: Constructed[Option[A], A] with
+            def asResult(outcome: Option[A]): Result[Any, A] =
+                outcome match
+                    case Some(value) => Result.succeed(value)
+                    case None        => Result.fail("the constructor returned None")
+        end fromOption
+
+        given fromEither[E, A]: Constructed[Either[E, A], A] with
+            def asResult(outcome: Either[E, A]): Result[Any, A] =
+                outcome match
+                    case Right(value) => Result.succeed(value)
+                    case Left(error)  => Result.fail(error)
+        end fromEither
+
+        given fromTry[A]: Constructed[scala.util.Try[A], A] with
+            def asResult(outcome: scala.util.Try[A]): Result[Any, A] =
+                outcome match
+                    case scala.util.Success(value)     => Result.succeed(value)
+                    case scala.util.Failure(exception) => Result.fail(exception)
+        end fromTry
+
+    end Constructed
 
     /** Typed constraint for a field in a Schema.
       *

--- a/kyo-schema/shared/src/main/scala/kyo/Schema.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/Schema.scala
@@ -2066,7 +2066,7 @@ object Schema:
             "Result[E, ${A}], Maybe[${A}], Option[${A}], Either[E, ${A}], and Try[${A}]. " +
             "For any other shape, provide a given Schema.Constructed[${R}, ${A}]."
     )
-    trait Constructed[R, A]:
+    abstract class Constructed[R, A]:
         /** Reports the constructor's outcome as a Result: a success carries the value, a failure carries whatever the constructor rejected
           * it with.
           */
@@ -2090,33 +2090,21 @@ object Schema:
         given fromResult[E, A]: Constructed[Result[E, A], A] with
             def asResult(outcome: Result[E, A]): Result[Any, A] = outcome
 
+        // Absence carries no error value, so these two supply the description the message reports;
+        // the other shapes already carry one and convert through Result's own constructors.
         given fromMaybe[A]: Constructed[Maybe[A], A] with
             def asResult(outcome: Maybe[A]): Result[Any, A] =
-                outcome match
-                    case Present(value) => Result.succeed(value)
-                    case _              => Result.fail("the constructor returned Absent")
-        end fromMaybe
+                outcome.toResult(Result.fail("the constructor returned Absent"))
 
         given fromOption[A]: Constructed[Option[A], A] with
             def asResult(outcome: Option[A]): Result[Any, A] =
-                outcome match
-                    case Some(value) => Result.succeed(value)
-                    case None        => Result.fail("the constructor returned None")
-        end fromOption
+                Maybe.fromOption(outcome).toResult(Result.fail("the constructor returned None"))
 
         given fromEither[E, A]: Constructed[Either[E, A], A] with
-            def asResult(outcome: Either[E, A]): Result[Any, A] =
-                outcome match
-                    case Right(value) => Result.succeed(value)
-                    case Left(error)  => Result.fail(error)
-        end fromEither
+            def asResult(outcome: Either[E, A]): Result[Any, A] = Result.fromEither(outcome)
 
         given fromTry[A]: Constructed[scala.util.Try[A], A] with
-            def asResult(outcome: scala.util.Try[A]): Result[Any, A] =
-                outcome match
-                    case scala.util.Success(value)     => Result.succeed(value)
-                    case scala.util.Failure(exception) => Result.fail(exception)
-        end fromTry
+            def asResult(outcome: scala.util.Try[A]): Result[Any, A] = Result.fromTry(outcome)
 
     end Constructed
 

--- a/kyo-schema/shared/src/main/scala/kyo/SchemaException.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/SchemaException.scala
@@ -155,6 +155,26 @@ case class RangeException(value: Long, targetType: String, min: Long, max: Long)
     extends SchemaException(s"Value $value out of range for $targetType ($min to $max)")
     with DecodeException derives CanEqual
 
+/** Thrown when a smart constructor refuses the decoded fields.
+  *
+  * Raised only by schemas built with `Schema.derivedVia`, at the point a plain derived schema would
+  * have called the primary constructor. The fields themselves decoded successfully; the type's own
+  * invariant is what rejected them, so this is a decode failure and not a panic: it surfaces as the
+  * `Result.Failure` every other malformed-input outcome surfaces as.
+  *
+  * `rejection` carries whatever the constructor reported: the error value of a `Result` or `Either`
+  * failure, the exception of a `Try` failure, or a fixed description when the constructor reports
+  * absence with no detail (`Option` / `Maybe`).
+  */
+case class ConstructorRejectedException(path: Seq[String], typeName: String, rejection: String | Throwable)(using Frame)
+    extends SchemaException(
+        s"Constructor rejected the decoded value for '$typeName'" + SchemaException.pathSuffix(path) +
+            s": ${String.valueOf(rejection)}. The fields decoded successfully; the smart constructor refused them. " +
+            "Correct the input, or decode with a schema whose constructor accepts it.",
+        rejection
+    )
+    with DecodeException
+
 // --- Validation ---
 
 /** Thrown when a user-defined validation check fails on a field or root value. */

--- a/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
@@ -1279,6 +1279,91 @@ import scala.quoted.*
         end if
     end derivedImpl
 
+    /** Derives `Schema[A]` whose encode side is the plain product emission and whose decode side runs
+      * the decoded fields through `construct`, a smart constructor.
+      *
+      * The wire shape comes from `A`'s case fields, so a type derived this way encodes and decodes
+      * exactly like the same fields on a plain case class; the only difference is the last step of the
+      * read body, where [[emitProductSchemaStatic]]'s primary-constructor call is replaced by a call
+      * to `construct` folded through `Constructed` (see the `constructVia` hook). That is what makes
+      * the idiom reachable at all for a `sealed abstract case class`, whose suppressed `apply` leaves
+      * no constructor to call, and what keeps a validating constructor's invariant on the decode path
+      * for any other type: a rejection becomes a `ConstructorRejectedException` decode failure rather
+      * than a bypassed check.
+      *
+      * `construct`'s parameters must match the case fields one for one, in declaration order. The
+      * types are checked here rather than at the call site because the overloads in `Schema.derivedVia`
+      * infer their parameter types from the supplied function, not from `A`.
+      */
+    def derivedViaImpl[A: Type, R: Type](using
+        Quotes
+    )(
+        construct: Expr[Any],
+        constructed: Expr[Schema.Constructed[R, A]]
+    ): Expr[Schema[A]] =
+        import quotes.reflect.*
+
+        val tpe = TypeRepr.of[A].dealias
+        val sym = tpe.typeSymbol
+
+        if !sym.isClassDef || !sym.flags.is(Flags.Case) then
+            report.errorAndAbort(
+                s"Cannot derive Schema for ${tpe.show} via a constructor: the type is not a case class. " +
+                    "Schema.derivedVia reads the wire shape from the case fields, so it needs one. " +
+                    "Provide a given Schema built with Schema.init for a type with no case fields."
+            )
+        end if
+        rejectPrivateCaseFields(tpe, sym)
+        rejectSumOnlyAnnotations(tpe, sym)
+
+        val fields     = sym.caseFields
+        val fieldTypes = fields.map(f => tpe.memberType(f))
+        val fnTerm     = construct.asTerm
+        val paramTypes = fnTerm.tpe.widen.dealias match
+            case AppliedType(tycon, args) if tycon.typeSymbol.fullName.startsWith("scala.Function") => args.init
+            case other =>
+                report.errorAndAbort(
+                    s"Schema.derivedVia expects a function over ${tpe.show}'s case fields; got ${other.show}."
+                )
+        end paramTypes
+
+        def signature = fields.zip(fieldTypes).map((f, ft) => s"${f.name}: ${ft.show}").mkString(", ")
+
+        if paramTypes.length != fields.length then
+            report.errorAndAbort(
+                s"Schema.derivedVia for ${tpe.show} expects a constructor of ${fields.length} argument(s), " +
+                    s"one per case field ($signature); the supplied function takes ${paramTypes.length}."
+            )
+        end if
+
+        fields.zip(fieldTypes).zip(paramTypes).zipWithIndex.foreach { case (((field, fieldType), paramType), idx) =>
+            if !(fieldType <:< paramType) then
+                report.errorAndAbort(
+                    s"Schema.derivedVia for ${tpe.show}: case field '${field.name}' of type ${fieldType.show} cannot be " +
+                        s"passed to constructor argument ${idx + 1} of type ${paramType.show}. " +
+                        s"The constructor's arguments must match the case fields in declaration order ($signature)."
+                )
+        }
+
+        val typeNameExpr = Expr(sym.name)
+        val sourceFieldsExpr: Expr[Seq[kyo.Field[?, ?]]] = Expr.summon[kyo.Fields[A]] match
+            case Some(fieldsExpr) => '{ $fieldsExpr.fields }
+            case None             => '{ Seq.empty[kyo.Field[?, ?]] }
+
+        emitProductSchemaStatic[A](
+            tpe,
+            sym,
+            sourceFields = sourceFieldsExpr,
+            focusedType = tpe,
+            constructVia = Some { (args, reader) =>
+                val applied = Apply(Select.unique(fnTerm, "apply"), args).asExprOf[R]
+                '{
+                    kyo.internal.constructedOrThrow[A]($constructed.asResult($applied), $typeNameExpr)(using $reader.frame)
+                }.asTerm
+            }
+        )
+    end derivedViaImpl
+
     /** True iff `tpe` is a Scala type union (`A | B`). */
     private def isOrType(using Quotes)(tpe: quotes.reflect.TypeRepr): Boolean =
         import quotes.reflect.*
@@ -1482,6 +1567,7 @@ import scala.quoted.*
       * `abstract` deliberately suppresses `apply` and `copy` so the only way to a value is the
       * companion's constructor. Derived code can reach the fields for encoding but has no route to
       * construct one, which is a different obstacle from the type having the wrong shape.
+      * `Schema.derivedVia`, which takes that constructor, is the entry point for the idiom.
       */
     private[internal] def rejectAbstractCaseClass(using
         Quotes
@@ -1494,7 +1580,7 @@ import scala.quoted.*
             report.errorAndAbort(
                 s"Cannot derive Schema for ${tpe.show}: no accessible constructor (abstract case class). " +
                     "An abstract case class synthesizes no apply, so derived code cannot construct one. " +
-                    "Provide a given Schema explicitly, or derive through its smart constructor."
+                    "Derive through its smart constructor with Schema.derivedVia(make), or provide a given Schema explicitly."
             )
         end if
     end rejectAbstractCaseClass
@@ -1542,7 +1628,8 @@ import scala.quoted.*
         sym: quotes.reflect.Symbol,
         sourceFields: Expr[Seq[kyo.Field[?, ?]]],
         focusedType: quotes.reflect.TypeRepr,
-        parentSelf: Option[(quotes.reflect.TypeRepr, quotes.reflect.Term)] = None
+        parentSelf: Option[(quotes.reflect.TypeRepr, quotes.reflect.Term)] = None,
+        constructVia: Option[(List[quotes.reflect.Term], Expr[Reader]) => quotes.reflect.Term] = None
     ): Expr[Schema[A]] =
         import quotes.reflect.*
 
@@ -1837,13 +1924,19 @@ import scala.quoted.*
             tpe.asType match
                 case '[a] =>
                     val ctorArgs: List[Term] = localSyms.map(Ref(_))
-                    val ctor: Term           = Select(New(TypeTree.of[a]), sym.primaryConstructor)
-                    val typeArgsList = tpe match
-                        case AppliedType(_, targs) => targs
-                        case _                     => List.empty
-                    val construct: Term =
-                        if typeArgsList.isEmpty then Apply(ctor, ctorArgs)
-                        else TypeApply(ctor, typeArgsList.map(t => Inferred(t))).appliedToArgs(ctorArgs)
+                    // `constructVia` replaces the primary-constructor call with a caller-supplied
+                    // build step over the same decoded field locals, which is what Schema.derivedVia
+                    // routes decoding through a smart constructor with. Everything before this point
+                    // (field decoding, defaults, the required-field bitmap) is shared verbatim.
+                    val construct: Term = constructVia match
+                        case Some(build) => build(ctorArgs, r)
+                        case None =>
+                            val ctor: Term = Select(New(TypeTree.of[a]), sym.primaryConstructor)
+                            val typeArgsList = tpe match
+                                case AppliedType(_, targs) => targs
+                                case _                     => List.empty
+                            if typeArgsList.isEmpty then Apply(ctor, ctorArgs)
+                            else TypeApply(ctor, typeArgsList.map(t => Inferred(t))).appliedToArgs(ctorArgs)
 
                     val resultSym = Symbol.newVal(owner, "_result", tpe, Flags.EmptyFlags, Symbol.noSymbol)
                     val resultDef = ValDef(resultSym, Some(construct))

--- a/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/FocusMacro.scala
@@ -279,7 +279,9 @@ import scala.quoted.*
         val sym      = tpe.typeSymbol
         val expanded = ExpandMacro.expandType(TypeRepr.of[A])
 
-        val isCaseClass   = sym.isClassDef && sym.flags.is(Flags.Case)
+        rejectAbstractCaseClass(tpe, sym)
+
+        val isCaseClass   = isConstructibleCaseClass(sym)
         val isSealedTrait = sym.flags.is(Flags.Sealed)
 
         expanded.asType match
@@ -1241,6 +1243,12 @@ import scala.quoted.*
       * pattern-matches on container or primitive type symbols; recursive cycles are handled by the
       * by-name `Structure.Field` thunk plus the `lazy val structure` cycle break on the generated
       * Schema's `structure` member.
+      *
+      * The product test comes FIRST, before the sealed test. `sealed` and `case` are independent
+      * flags: `sealed` restricts where subclasses may be declared and does not change a type's shape,
+      * so a `sealed case class` is a product with a public constructor and derives exactly as the same
+      * class without `sealed`. Testing `Flags.Sealed` first sent every such class down the sum path,
+      * where its empty `children` list aborted derivation and reported the class as a sealed trait.
       */
     def derivedImpl[A: Type](using Quotes): Expr[Schema[A]] =
         import quotes.reflect.*
@@ -1248,15 +1256,17 @@ import scala.quoted.*
         val tpe = TypeRepr.of[A].dealias
         val sym = tpe.typeSymbol
 
-        if sym.isClassDef && sym.flags.is(Flags.Sealed) then
-            emitSealedSchemaStatic[A](tpe, sym, sourceFields = '{ Seq.empty[kyo.Field[?, ?]] }, focusedType = tpe)
-        else if sym.isClassDef && sym.flags.is(Flags.Case) then
+        rejectAbstractCaseClass(tpe, sym)
+
+        if isConstructibleCaseClass(sym) then
             rejectPrivateCaseFields(tpe, sym)
             rejectSumOnlyAnnotations(tpe, sym)
             val sourceFieldsExpr: Expr[Seq[kyo.Field[?, ?]]] = Expr.summon[kyo.Fields[A]] match
                 case Some(fieldsExpr) => '{ $fieldsExpr.fields }
                 case None             => '{ Seq.empty[kyo.Field[?, ?]] }
             emitProductSchemaStatic[A](tpe, sym, sourceFields = sourceFieldsExpr, focusedType = tpe)
+        else if sym.isClassDef && sym.flags.is(Flags.Sealed) then
+            emitSealedSchemaStatic[A](tpe, sym, sourceFields = '{ Seq.empty[kyo.Field[?, ?]] }, focusedType = tpe)
         else if isOrType(tpe) then
             // Reject sum-representation annotations placed on a union type alias.
             rejectSumOnlyAnnotations(TypeRepr.of[A], TypeRepr.of[A].typeSymbol)
@@ -1452,6 +1462,42 @@ import scala.quoted.*
 
         Block(nameBytesValDefs ++ (selfDef :: variantDefs), selfRef).asExprOf[Schema[A]]
     end emitUnionSchemaStatic
+
+    /** True iff `sym` is a case class whose primary constructor the generated decoder can call.
+      *
+      * `case` and `sealed` are independent: `sealed` restricts where subclasses may be declared and
+      * leaves the shape a product, so a `sealed case class` qualifies. `abstract` does change the
+      * shape: it suppresses `apply`/`copy` synthesis and leaves no constructor the emitted read body
+      * can invoke, so an abstract case class does not qualify and is reported by
+      * [[rejectAbstractCaseClass]].
+      */
+    private[internal] def isConstructibleCaseClass(using Quotes)(sym: quotes.reflect.Symbol): Boolean =
+        import quotes.reflect.*
+        sym.isClassDef && sym.flags.is(Flags.Case) && !sym.flags.is(Flags.Abstract)
+    end isConstructibleCaseClass
+
+    /** Rejects an abstract case class, naming the missing constructor rather than the type's shape.
+      *
+      * `sealed abstract case class R private (v: Int)` is the validating-smart-constructor idiom:
+      * `abstract` deliberately suppresses `apply` and `copy` so the only way to a value is the
+      * companion's constructor. Derived code can reach the fields for encoding but has no route to
+      * construct one, which is a different obstacle from the type having the wrong shape.
+      */
+    private[internal] def rejectAbstractCaseClass(using
+        Quotes
+    )(
+        tpe: quotes.reflect.TypeRepr,
+        sym: quotes.reflect.Symbol
+    ): Unit =
+        import quotes.reflect.*
+        if sym.isClassDef && sym.flags.is(Flags.Case) && sym.flags.is(Flags.Abstract) then
+            report.errorAndAbort(
+                s"Cannot derive Schema for ${tpe.show}: no accessible constructor (abstract case class). " +
+                    "An abstract case class synthesizes no apply, so derived code cannot construct one. " +
+                    "Provide a given Schema explicitly, or derive through its smart constructor."
+            )
+        end if
+    end rejectAbstractCaseClass
 
     /** Rejects case classes with private case-fields (would otherwise leak storage names on the wire). */
     private def rejectPrivateCaseFields(using
@@ -1940,10 +1986,14 @@ import scala.quoted.*
         val childName       = child.name.stripSuffix("$")
         val isSingletonCase = !child.isType || child.flags.is(Flags.Module)
 
-        // Sealed-trait child (an intermediate sealed trait in a multi-level hierarchy): derive its
-        // own Schema[T], which routes back through the static sealed emitter, so the parent sum
-        // delegates to it instead of mis-treating it as a zero-field product.
-        if childSym.flags.is(Flags.Sealed) && childSym.flags.is(Flags.Trait) && !child.flags.is(Flags.Module) then
+        // Sealed intermediate child in a multi-level hierarchy: derive its own Schema[T], which routes
+        // back through the static sealed emitter, so the parent sum delegates to it instead of
+        // mis-treating it as a zero-field product. The child qualifies when it is itself a sealed
+        // parent, whether written as a trait or as an abstract class; a `sealed case class` child is
+        // constructible and takes the product path below.
+        if childSym.flags.is(Flags.Sealed) && !child.flags.is(Flags.Module) && !isConstructibleCaseClass(childSym) &&
+            (childSym.flags.is(Flags.Trait) || childSym.flags.is(Flags.Abstract))
+        then
             '{ kyo.Schema.derived[T] }
         else if isSingletonCase && childSym.caseFields.isEmpty then
             // Case object variant: serialize as empty object

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaBridge.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaBridge.scala
@@ -2,8 +2,10 @@ package kyo.internal
 
 import kyo.Codec.Reader
 import kyo.Codec.Writer
+import kyo.ConstructorRejectedException
 import kyo.Frame
 import kyo.Present
+import kyo.Result
 import kyo.Schema
 import scala.compiletime.erasedValue
 
@@ -52,6 +54,25 @@ inline def readField[A](inline s: Schema[A], r: Reader): A =
         case _: Byte    => r.byte().asInstanceOf[A]
         case _: Char    => r.char().asInstanceOf[A]
         case _          => s.serializeRead(r)
+
+// Smart-constructor fold for `Schema.derivedVia`-generated decoders.
+//
+// The generated read body decodes every field exactly as a plain product does, then hands the
+// constructor's outcome here instead of calling the primary constructor. A rejection becomes a
+// `ConstructorRejectedException`, which is a `DecodeException`, so it surfaces through
+// `Schema.decode`'s `Result.catching[DecodeException]` as a `Result.Failure` like any other decode
+// failure instead of escaping as a raw throw. The error branch is matched before unwrapping, and the
+// success branch goes through `getOrThrow` so a success value that is itself a `Result.Error` (kyo
+// nests those as `SuccessError`) unnests correctly rather than being read as a rejection.
+def constructedOrThrow[A](outcome: Result[Any, A], typeName: String)(using Frame): A =
+    outcome match
+        case error: Result.Error[Any] @unchecked =>
+            val rejection: String | Throwable = error.failureOrPanic match
+                case throwable: Throwable => throwable
+                case other                => String.valueOf(other)
+            throw ConstructorRejectedException(Seq.empty, typeName, rejection)
+        case success =>
+            success.asInstanceOf[Result[Nothing, A]].getOrThrow
 
 inline def absentDefaultSeed[A](inline s: Schema[A]): A =
     s.absentDefaultValue match

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaDerivedMacro.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaDerivedMacro.scala
@@ -19,4 +19,12 @@ object SchemaDerivedMacro:
     def derivedImpl[A: Type](using Quotes): Expr[Schema[A]] =
         FocusMacro.derivedImpl[A]
 
+    def derivedViaImpl[A: Type, R: Type](using
+        Quotes
+    )(
+        construct: Expr[Any],
+        constructed: Expr[Schema.Constructed[R, A]]
+    ): Expr[Schema[A]] =
+        FocusMacro.derivedViaImpl[A, R](construct, constructed)
+
 end SchemaDerivedMacro


### PR DESCRIPTION
Fixes #1811, #1812

### Problem

Two separate gaps in `Schema` derivation, both surfacing as the same wrong message.

**#1811 (bug).** `Schema.derived` failed on any `sealed case class`, reporting it as a sealed trait:

```
Cannot derive Schema for sealed trait Sealed: no case class or object variants found.
```

`sealed` restricts where subclasses may be declared; it does not change a type's shape. A `sealed case class` is a product with a public constructor and should derive exactly as the same class without `sealed`. There is no sum reading to prefer either, because Scala prohibits case-to-case inheritance, so there could never have been variants to find. The message's premise was true but vacuous.

`derivedImpl` tested `Flags.Sealed` before `Flags.Case`, so a class carrying both took the sum path and aborted on an empty `children` list. Corroborating evidence sits in the same file: `metaApplyImpl` already tested Case first, so `Schema[Sealed]` worked while `Schema.derived[Sealed]` failed on the same type.

Found deriving schemas for [finos/morphir-scala](https://github.com/finos/morphir-scala), where every naming type (`Name`, `Path`, `FQName`, ...) is declared `sealed case class`, which blocked derivation for the whole IR.

**#1812 (missing capability).** A type whose construction is guarded by a validating smart constructor had no derivation route at all. The fields are readable, so encoding is derivable, but decoding has to go through the constructor, both to reach the type and to honour its invariant:

```scala
sealed abstract case class Refined private (value: Int)
object Refined:
    def make(v: Int): Result[String, Refined] =
        if v > 0 then Result.succeed(new Refined(v) {}) else Result.fail("must be positive")
```

`abstract` deliberately suppresses `apply` and `copy`, so derived code could not construct one by any route. This is not specific to that idiom: it applies to any refined type, newtype with an invariant, or domain primitive that rejects bad input. Deriving a Schema that bypasses the invariant would be worse than failing.

### Solution

**#1811.** The product test now comes first in `derivedImpl`, and it excludes abstract case classes via a new `isConstructibleCaseClass`. An abstract case class gets `rejectAbstractCaseClass`, which names the missing constructor and points at `derivedVia` instead of misclassifying the type. `metaApplyImpl` picks up the same guard, so both entry points agree.

**`Schema.derivedVia(make)`.** The encode side is the plain product emission, so the wire shape stays byte-identical to the same fields on a case class. The decode side reads those fields exactly as a product does and then applies `make` in place of the primary-constructor call, through a new `constructVia` hook in `emitProductSchemaStatic`. Everything before that point (field decoding, defaults, the required-field bitmap) is shared verbatim rather than reimplemented.

Arity 1 through 8, one argument per case field in declaration order. Arity and per-field types are checked in the macro, because the overloads infer their parameter types from the supplied function rather than from `A`; a mismatch is a compile error naming the offending field.

`Schema.Constructed[R, A]` reads the value out of whatever shape the constructor reports its outcome in: the type itself, `Result`, `Maybe`, `Option`, `Either`, or `Try`. Any other outcome type works with its own given. The total instance (`Constructed[A, A]`) sits in a lower-priority parent, so a `Result`-returning constructor is not ambiguous when no expected type pins the constructed type.

A refusal becomes `ConstructorRejectedException`, a `DecodeException`, so it arrives as the `Result.Failure` every other malformed input arrives as instead of a raw throw escaping `decode` or an invariant quietly bypassed. A `Try` failure keeps its exception as the cause.

Naming: `derivedVia`, not `derivedWith`. Per CONTRIBUTING, `fooWith(f)` in kyo means "do foo, then apply `f` to the result" (`initWith`, `runWith`, `initUnscopedWith`). Here `make` is an input to derivation, not a continuation over its output, so `With` would read backwards.

### Notes

- **A third bug fell out of the same dispatch logic.** The variant emitter tested `Sealed && Trait` to spot an intermediate sealed parent, so a `sealed abstract class` mid-hierarchy failed that test and was emitted as a zero-field product, which emits `New` on an abstract class and does not compile. It now routes any sealed intermediate back through the sum emitter, trait or abstract class. Covered by its own test.
- **Reproductions were written first.** Both issues' repros are in `SchemaTest.scala` and were confirmed failing with the issue's exact message before any implementation change.
- 24 new tests: 8 for the sealed-case-class shapes (product structure, multi-field, nesting, wire-shape parity with the unsealed twin, sum hierarchy unaffected, `sealed case class` as a sum variant, intermediate abstract class, the abstract-case-class message), 16 for `derivedVia` (all six outcome shapes, rejection paths, cross-codec invariant enforcement, `Option`-field wire treatment, nesting, inference with no expected type, and both compile-error paths).
- Full schema family green, 0 failures across all 8 modules. README doctest: 104 blocks, 0 failures, including the new "Validating smart constructors" section. JS and Native `Test/compile` pass; downstream consumers (`kyo-jsonrpc`, `kyo-tasty`, `kyo-examples`, `kyo-test-snapshot`, `kyo-doctest`) compile.
- `kyo-aeronJVM/Test/compile` could not be run locally: it fails in `ffiCompile` ("C compilation failed"). Confirmed to reproduce with this diff stashed, so it is a local C-toolchain issue and not from this change.
- `Schema[A]` and `Schema.derived[A]` still re-derive a plain schema for a *concrete* case class that has a `derivedVia` given, bypassing the invariant. That is `Schema[A]`'s documented behaviour (it never consults a user given) and is unchanged by this PR; nested field resolution goes through `summonInline`, so a `derivedVia` type used as a field does decode through its constructor. There is a test for that.
- `derivedVia` on a generic case class is covered: the case-field types resolve against the applied type, so a `Chunk[A]` field checks against the constructor's `Chunk[A]` parameter and the read body decodes through the summoned element schema.
- The `probe` / scaladoc breakage this PR originally tripped over (`MissingType: ... java.lang.foreign.type.MemorySegment` for `kyo-aeron`, `kyo-stats-machine`, `kyo-net`) was a `main` problem, not this branch's. I diagnosed and filed it as #1819; it is fixed on `main` by `3179315e4`, this branch is merged up to `06e1795c3`, and I verified both modules document cleanly here before closing the issue.
