### PR TITLE
[build] drop the whole Scala Native work directory in CI, not just generated/

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -82,7 +82,19 @@ runs:
     - name: Install podman (Linux)
       if: ${{ contains(inputs.os, 'linux') }}
       shell: bash
-      run: bash scripts/apt-install.sh podman uidmap runc
+      run: |
+        bash scripts/apt-install.sh podman uidmap
+        # Install runc separately, and only when the runner has none. Ubuntu's runc package Conflicts
+        # with Docker's containerd.io, so `apt-get install runc` resolves the conflict by REMOVING
+        # containerd.io and docker-ce. That leaves no Docker daemon, which fails the `docker version`
+        # probe below and costs the kyo-pod suite the half of its container cases that run against
+        # docker. The runners already carry a runc binary alongside containerd.io, so this normally
+        # installs nothing.
+        if command -v runc >/dev/null 2>&1; then
+          echo "runc already present at $(command -v runc)"
+        else
+          bash scripts/apt-install.sh runc
+        fi
 
     - name: Start podman (Linux)
       if: ${{ contains(inputs.os, 'linux') }}
@@ -129,7 +141,18 @@ runs:
         echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"
         podman info | grep -iE 'cgroup|rootless' || true
         podman version
-        docker version
+        # Which OCI runtime podman resolved. Printed rather than asserted on: containers.conf above
+        # pins runc, and a silent fall back to crun shows up downstream as "crun: unknown version
+        # specified" on every kyo-pod container test, which this line attributes.
+        podman info | grep -iE 'ociRuntime|runc|crun' || true
+        # docker is load-bearing too, and it has been removed out from under this step before, so name
+        # what broke rather than letting `set -e` end the step on a bare exit code.
+        if ! docker version; then
+          echo "docker daemon unreachable. The kyo-pod suite runs its container cases against docker as" >&2
+          echo "well as podman, so this is fatal. Check the apt output in the podman install step: the" >&2
+          echo "ubuntu runc package Conflicts with containerd.io, and installing it removes docker-ce." >&2
+          exit 1
+        fi
 
     - uses: coursier/setup-action@v3.0.0
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,17 @@ jobs:
       # platform's user cache dir; the setup action restores it. The action also installs Node, the native
       # libraries, and podman conditionally on the target and os, and provisions corretto:25 + sbt.
 
+      # Guards issue #1821. The `native-settings` hook drops each module's Scala Native work directory
+      # right after its test binary links, to keep the row's ~40 modules inside the runner's disk; a
+      # drop that leaves state describing the deleted IR makes the next link hand clang object paths
+      # for files nobody wrote, and the row dies an hour in on a missing .ll.o with no diagnostic.
+      # kyo-data is the cheapest module with a Native test binary, and the row reuses the binary linked
+      # here, so the guard costs the row a couple of minutes and fails fast when it trips.
+      - name: native relink guard (${{ inputs.os }})
+        if: ${{ matrix.target == 'Native' }}
+        shell: bash
+        run: ./scripts/native-relink-selftest.sh
+
       - name: ${{ inputs.mode }} ${{ matrix.target }} (${{ inputs.os }})
         shell: bash
         run: |

--- a/build.sbt
+++ b/build.sbt
@@ -2942,16 +2942,29 @@ lazy val `native-settings-base` = Seq(
 )
 
 lazy val `native-settings` = `native-settings-base` ++ Seq(
-    // Drop this module's LLVM intermediates the moment its test binary links. Scala Native keeps
-    // <target>/native-test/generated (IR plus objects: 526MB of kyo-core's 665MB workspace) so a LATER
-    // invocation can relink incrementally. CI links each module exactly once, and the ~13GB the ~40
-    // modules of a Native row accumulate is what carries the row's peak past the free disk of a runner
-    // image that started small, killing the runner mid-link with no log at all. Deleting them forces no
-    // relink: sbt caches the nativeLink result and the binary itself is untouched. Reads the environment
-    // rather than insideCI because a value transform sees no other settings; a local build keeps its
-    // intermediates for the next incremental link.
+    // Drop this module's Scala Native work directory the moment its test binary links. Scala Native
+    // keeps <target>/native-test (IR, objects, unpacked native libraries: 526MB of kyo-core's 665MB
+    // workspace) so a LATER invocation can relink incrementally, and the ~13GB the ~40 modules of a
+    // Native row accumulate is what carries the row's peak past the free disk of a runner image that
+    // started small, killing the runner mid-link with no log at all.
+    //
+    // Everything except `build-checksum` goes. That file and the linked binary (which sits one level
+    // up, outside the work directory) are the entire input to Scala Native's "Build skipped" check, so
+    // a repeat link still short-circuits; dropping the rest wholesale is what keeps the directory
+    // self-consistent. Deleting only `generated/` did not: it left `package2hash`, the incremental
+    // codegen state naming those IR files, behind. A later link that missed the checksum (CI relinks a
+    // module whenever the test phase recompiles one of its dependencies) then trusted that state,
+    // skipped regenerating every unit whose NIR was unchanged, and handed clang object paths for files
+    // nobody had written. Codegen and compilation both reported success and the link died on missing
+    // .ll.o with no diagnostic. See issue #1821.
+    //
+    // Reads the environment rather than insideCI because a value transform sees no other settings; a
+    // local build keeps its intermediates for the next incremental link.
     Test / nativeLink ~= { binary =>
-        if (sys.env.contains("CI")) IO.delete(binary.getParentFile / "native-test" / "generated")
+        if (sys.env.contains("CI")) {
+            val workDir = binary.getParentFile / "native-test"
+            IO.listFiles(workDir).filterNot(_.getName == "build-checksum").foreach(IO.delete)
+        }
         binary
     }
 )

--- a/scripts/native-relink-selftest.sh
+++ b/scripts/native-relink-selftest.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -uo pipefail
+#
+# Regression guard for issue #1821: a Native test binary must still relink after CI has dropped the
+# module's Scala Native work directory.
+#
+# Usage:
+#   native-relink-selftest.sh [module]
+#   native-relink-selftest.sh --self-test
+#
+# [module]  cross-project base name, default kyo-data (the cheapest module with a Native test binary).
+#
+# What it proves, in three steps against the real build:
+#
+#   1. CI=1 <module>Native/Test/nativeLink succeeds, and the `native-settings` hook leaves the work
+#      directory holding nothing but `build-checksum`.
+#   2. The mtime of one .nir on the module's classpath is bumped. That is the whole trigger: Scala
+#      Native's build-skip checksum covers classpath mtimes, so the next link rebuilds, while every
+#      compilation unit's NIR is byte-identical so incremental codegen considers all of them unchanged.
+#   3. The relink succeeds and emits no missing-object diagnostics.
+#
+# Step 3 is what regressed. When the hook deleted `<workdir>/generated` but left `package2hash`, the
+# incremental-codegen state naming those IR files, codegen skipped regenerating every unchanged unit
+# and handed clang object paths for files nobody had written. Codegen and compilation both logged
+# success; the link died on `clang: error: no such file or directory: .../<hash>.ll.o`.
+#
+# Reads SBT_CMD (the sbt binary, default `sbt`) from the environment; mutates nothing outside the
+# module's own target directory, and touches no tracked file.
+
+MISSING_OBJECT_RE='no such file or directory.*\.ll\.o'
+
+# -- self-test mode (must precede argument handling) --
+# Exercises this harness against a faked sbt and a faked module target tree, so each case asserts the
+# verdict this script reaches for a known build outcome rather than just its own exit code: the happy
+# path, a failing first link, the #1821 relink failure, a hook that stopped pruning, a relink that was
+# skipped rather than rebuilt, and a missing .nir.
+if [ "${1:-}" = "--self-test" ]; then
+    # Absolute: the fixture symlinks this script into a temp directory, and a relative target would
+    # dangle there.
+    SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+    PASS=0; FAIL=0; TOTAL=0
+    SELFDIR=$(mktemp -d)
+    trap 'rm -rf "$SELFDIR"' EXIT
+
+    WORKDIR_REL="kyo-data/native/target/scala-3.8.4/native-test"
+    CLASSES_REL="kyo-data/native/target/scala-3.8.4/classes"
+
+    # Build a fake repo whose layout matches what the real script discovers, plus a stub sbt whose
+    # behaviour per invocation is read from a scenario file. The stub emulates the build AND the
+    # `native-settings` hook, so a case can model the hook regressing as well as the link failing.
+    make_fixture() {
+        rm -rf "$SELFDIR/repo"
+        mkdir -p "$SELFDIR/repo/scripts" "$SELFDIR/repo/$CLASSES_REL/kyo" "$SELFDIR/repo/$WORKDIR_REL"
+        ln -s "$SELF" "$SELFDIR/repo/scripts/native-relink-selftest.sh"
+        : > "$SELFDIR/repo/$CLASSES_REL/kyo/Sample.nir"
+        : > "$SELFDIR/repo/$WORKDIR_REL/build-checksum"
+        : > "$SELFDIR/repo/calls.log"
+    }
+
+    # <exit-1> <exit-2> <mode>
+    #   mode=clean      both links rebuild and prune
+    #   mode=stale      relink prints the #1821 missing-object errors
+    #   mode=unpruned   links succeed but the hook leaves the work directory populated
+    #   mode=skipped    relink short-circuits instead of rebuilding
+    make_sbt_stub() {
+        {
+            printf '#!/usr/bin/env bash\n'
+            printf 'n=$(( $(cat "%s/n" 2>/dev/null || echo 0) + 1 )); echo "$n" > "%s/n"\n' "$SELFDIR" "$SELFDIR"
+            printf 'printf "%%s\\n" "$*" >> "%s/repo/calls.log"\n' "$SELFDIR"
+            printf 'wd="%s/repo/%s"\n' "$SELFDIR" "$WORKDIR_REL"
+            printf 'if [ "$n" = 1 ]; then code=%s; else code=%s; fi\n' "$1" "$2"
+            printf 'mode=%s\n' "$3"
+            printf 'if [ "$n" = 2 ] && [ "$mode" = skipped ]; then\n'
+            printf '  echo "[info] Build skipped: No changes detected in build configuration and class path contents since last build."\n'
+            printf '  exit "$code"\n'
+            printf 'fi\n'
+            printf 'echo "[info] Produced 141 LLVM IR files"\n'
+            printf 'if [ "$n" = 2 ] && [ "$mode" = stale ]; then\n'
+            printf '  echo "[error] clang: error: no such file or directory: $wd/generated/373c1303.ll.o"\n'
+            printf 'fi\n'
+            printf 'mkdir -p "$wd/generated"; : > "$wd/generated/373c1303.ll"; : > "$wd/build-checksum"\n'
+            printf 'if [ "$mode" != unpruned ]; then rm -rf "$wd/generated"; fi\n'
+            printf 'exit "$code"\n'
+        } > "$SELFDIR/sbt"
+        chmod +x "$SELFDIR/sbt"
+    }
+
+    # Run the real script against the fixture. Sets NR_EXIT.
+    run_harness() {
+        rm -f "$SELFDIR/n"
+        ( cd "$SELFDIR/repo" && PATH="$SELFDIR:$PATH" "$SELFDIR/repo/scripts/native-relink-selftest.sh" kyo-data ) \
+            >"$SELFDIR/out.log" 2>&1
+        NR_EXIT=$?
+    }
+
+    exit_is()    { [ "$NR_EXIT" = "$1" ]; }
+    links_run()  { [ "$(wc -l < "$SELFDIR/repo/calls.log" | tr -d ' ')" = "$1" ]; }
+    out_has()    { grep -qF -- "$1" "$SELFDIR/out.log"; }
+
+    record() {
+        TOTAL=$((TOTAL+1))
+        if [ "$1" = "ok" ]; then echo "  PASS: $2"; PASS=$((PASS+1))
+        else echo "  FAIL: $2"; FAIL=$((FAIL+1)); fi
+    }
+
+    echo "Running native-relink-selftest.sh self-tests..."
+
+    # 1. Both links rebuild, prune, and stay clean.
+    make_fixture; make_sbt_stub 0 0 clean; run_harness
+    if exit_is 0 && links_run 2; then record ok "clean relink after the intermediates drop passes"
+    else record no "clean relink after the intermediates drop passes"; fi
+
+    # 2. A failing first link aborts before the relink.
+    make_fixture; make_sbt_stub 1 0 clean; run_harness
+    if exit_is 1 && links_run 1; then record ok "first link failure aborts before the relink"
+    else record no "first link failure aborts before the relink"; fi
+
+    # 3. The #1821 regression: relink reports missing .ll.o objects.
+    make_fixture; make_sbt_stub 0 1 stale; run_harness
+    if exit_is 1 && out_has "1821"; then record ok "relink on missing .ll.o objects fails and cites #1821"
+    else record no "relink on missing .ll.o objects fails and cites #1821"; fi
+
+    # 3b. Same missing objects, but the link process still exits 0: the log alone must condemn it.
+    make_fixture; make_sbt_stub 0 0 stale; run_harness
+    if exit_is 1 && out_has "1821"; then record ok "missing .ll.o in the log fails even on a zero exit"
+    else record no "missing .ll.o in the log fails even on a zero exit"; fi
+
+    # 4. A hook that stopped pruning is a regression of the disk fix, not of the link.
+    make_fixture; make_sbt_stub 0 0 unpruned; run_harness
+    if exit_is 1 && out_has "not pruned"; then record ok "an unpruned work directory fails"
+    else record no "an unpruned work directory fails"; fi
+
+    # 5. A relink that short-circuits proves nothing, so it must not pass.
+    make_fixture; make_sbt_stub 0 0 skipped; run_harness
+    if exit_is 1 && out_has "did not rebuild"; then record ok "a skipped relink fails as vacuous"
+    else record no "a skipped relink fails as vacuous"; fi
+
+    # 6. No .nir on the classpath is a setup error, distinct from a build failure.
+    make_fixture; make_sbt_stub 0 0 clean; rm -f "$SELFDIR/repo/$CLASSES_REL/kyo/Sample.nir"; run_harness
+    if exit_is 2 && links_run 1; then record ok "a classpath with no .nir exits 2"
+    else record no "a classpath with no .nir exits 2"; fi
+
+    # Negative control: a deliberately wrong expectation MUST flip FAIL, proving the harness is not
+    # vacuous. Not counted in the scenario total.
+    make_fixture; make_sbt_stub 0 0 clean; run_harness
+    if exit_is 1; then echo "  SELFTEST-BUG: negative control passed"; FAIL=$((FAIL+1)); fi
+
+    echo ""
+    echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+    [ "$FAIL" -eq 0 ] && [ "$TOTAL" -eq 7 ]
+    exit $?
+fi
+
+MODULE="${1:-kyo-data}"
+PROJECT="${MODULE}Native"
+SBT_CMD="${SBT_CMD:-sbt}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOG=$(mktemp)
+trap 'rm -f "$LOG"' EXIT
+
+log()  { echo "=== [native-relink] $* ==="; }
+fail() { echo "=== [native-relink] FAILED: $* ===" >&2; exit "${2:-1}"; }
+
+# The single sbt invocation shape under test. CI=1 is what arms the `native-settings` drop hook, which
+# reads the environment rather than a setting.
+link() {
+    log "$1: CI=1 $SBT_CMD $PROJECT/Test/nativeLink"
+    ( cd "$ROOT" && CI=1 "$SBT_CMD" "$PROJECT/Test/nativeLink" ) 2>&1 | tee "$LOG"
+    return "${PIPESTATUS[0]}"
+}
+
+# Newest <module>/native/target/scala-*/<name>, so a repo carrying more than one Scala version resolves
+# to the one the link just wrote.
+resolve() {
+    local name="$1" newest="" candidate
+    for candidate in "$ROOT/$MODULE"/native/target/scala-*/"$name"; do
+        [ -e "$candidate" ] || continue
+        [ -z "$newest" ] && newest="$candidate"
+        [ "$candidate" -nt "$newest" ] && newest="$candidate"
+    done
+    printf '%s' "$newest"
+}
+
+# The hook keeps build-checksum (Scala Native's build-skip state, which needs no other work directory
+# file) and drops everything else. Anything left over is either the disk fix regressing or a new state
+# file that outlives the IR it describes, which is how #1821 happened.
+assert_pruned() {
+    local workdir="$1" stage="$2" entry name saved
+    local leftovers=()
+    saved=$(shopt -p nullglob dotglob)
+    shopt -s nullglob dotglob
+    for entry in "$workdir"/*; do
+        name=$(basename "$entry")
+        [ "$name" = "build-checksum" ] && continue
+        leftovers+=("$name")
+    done
+    eval "$saved"
+    if [ "${#leftovers[@]}" -gt 0 ]; then
+        printf '  %s\n' "${leftovers[@]}" >&2
+        fail "$stage: work directory not pruned to build-checksum ($workdir)"
+    fi
+    log "$stage: work directory pruned to build-checksum"
+}
+
+log "module $MODULE"
+
+link "first link" || fail "first link of $PROJECT/Test/nativeLink"
+
+WORKDIR="$(resolve native-test)"
+[ -n "$WORKDIR" ] || fail "no native-test work directory under $MODULE/native/target/scala-*"
+assert_pruned "$WORKDIR" "first link"
+
+CLASSES="$(resolve classes)"
+[ -n "$CLASSES" ] || fail "no classes directory under $MODULE/native/target/scala-*" 2
+NIR="$(find "$CLASSES" -name '*.nir' -type f 2>/dev/null | head -n1)"
+[ -n "$NIR" ] || fail "no .nir on $MODULE's Native classpath, nothing to invalidate" 2
+
+# Bump one classpath mtime and nothing else. Scala Native's build-skip checksum covers classpath
+# mtimes, so this forces a real rebuild; the NIR bytes are untouched, so every compilation unit looks
+# unchanged to incremental codegen. That combination is what a CI relink hits and what #1821 broke.
+log "invalidating the build-skip checksum: touch ${NIR#"$ROOT"/}"
+touch "$NIR"
+
+link "relink" || fail "relink of $PROJECT/Test/nativeLink after the intermediates drop (see issue #1821)"
+
+if grep -qE "$MISSING_OBJECT_RE" "$LOG"; then
+    grep -E "$MISSING_OBJECT_RE" "$LOG" | sed 's/^/  /' >&2
+    fail "relink referenced object files that codegen never wrote (see issue #1821)"
+fi
+if ! grep -q "LLVM IR files" "$LOG"; then
+    fail "relink did not rebuild, so it proves nothing: the checksum invalidation stopped working"
+fi
+assert_pruned "$WORKDIR" "relink"
+
+log "PASSED: $PROJECT relinks cleanly after the CI intermediates drop"


### PR DESCRIPTION
Fixes #1821.

## What was happening

The Native rows failed at link with a run of

```
clang: error: no such file or directory: .../generated/<hash>.ll.o
```

and no diagnostic from any earlier phase. Deterministic: the same nine hashes on both arches, shared across `kyo-aeron` (#1818) and `kyo-actor` (#1809), because those are the compilation units whose NIR nothing in the build perturbs.

The issue guessed that clang was failing and its stderr was being discarded. It is not: clang is never started for those units.

## Cause

`Test / nativeLink` deleted `<module>/native/target/scala-*/native-test/generated` after each link, to keep ~40 modules inside the runner's disk. It left `package2hash`, Scala Native's incremental-codegen state naming those IR files, as a sibling of the directory it deleted.

Scala Native's build-skip checksum covers classpath mtimes, so a module whose dependency the test phase recompiled relinks rather than short-circuiting. Then:

1. `CodeGen.separateIncrementally` reads `package2hash`, sees the unit unchanged, and returns the `.ll` path without checking the file exists. Its only guard is `assert(ownerDirectory.toFile.exists())` on the parent directory, which `emit` recreated a few lines earlier.
2. `LLVM.needsCompiling` compares two absent files, `0 > 0`, skips clang, and returns the object path anyway.
3. Both phases log success. The link is the first thing to touch the disk.

## Fix

Prune the whole work directory except `build-checksum`. That file plus the linked binary (one level up, outside the work directory) is the entire input to Scala Native's "Build skipped" check, so a repeat link still short-circuits. Dropping the rest wholesale is what keeps the directory self-consistent, and it reclaims more disk than before.

## Guard

`scripts/native-relink-selftest.sh`: link, assert the work directory holds only `build-checksum`, bump one classpath mtime so the checksum misses without recompiling anything, relink, assert it succeeds and referenced no object codegen never wrote. `--self-test` covers the harness against a faked sbt, negative control included. The Native rows run it before the suite, on `kyo-data`, and reuse the binary it links.

## Verification

Reproduced locally on macOS with `kyo-dataNative`, hitting the same nine hashes as CI.

| Check | Result |
| --- | --- |
| `native-relink-selftest.sh --self-test` | 7/7 |
| guard against the fixed build | pass |
| guard against the old hook | fails on `work directory not pruned` |
| old hook plus a checksum miss | exit 1, nine missing `.ll.o` |
| no-change relink after the prune | `Build skipped`, fast path intact |
| `actionlint`, `shellcheck`, `scalafmtSbt` | clean |

## Upstream

The underlying defect is in Scala Native 0.5.12 and reproduces without kyo: https://github.com/DamianReeves/scala-native-bug-reporting

Not yet filed against `scala-native`.