### PR TITLE
[kyo-core/kyo-config] browser-safe env probes: inline typeof guard

### DIFF
--- a/kyo-core/js-wasm/src/main/scala/kyo/internal/SystemPlatformSpecific.scala
+++ b/kyo-core/js-wasm/src/main/scala/kyo/internal/SystemPlatformSpecific.scala
@@ -11,12 +11,17 @@ import scala.scalajs.js
   */
 private[kyo] object SystemPlatformSpecific:
     def env(name: String)(using AllowUnsafe): String =
-        val proc = js.Dynamic.global.process
-        if js.typeOf(proc) == "undefined" || js.typeOf(proc.env) == "undefined" then null
+        // The `typeof` guard must stay INLINE on the global selection: binding `js.Dynamic.global.process`
+        // to a val first emits a bare `process` read, which throws ReferenceError in browsers.
+        if js.typeOf(js.Dynamic.global.process) == "undefined" then null
         else
-            val value = proc.env.selectDynamic(name)
-            if js.isUndefined(value) || value == null then null
-            else value.asInstanceOf[String]
+            val proc = js.Dynamic.global.process
+            if js.typeOf(proc.env) == "undefined" then null
+            else
+                val value = proc.env.selectDynamic(name)
+                if js.isUndefined(value) || value == null then null
+                else value.asInstanceOf[String]
+            end if
         end if
     end env
 


### PR DESCRIPTION
## Problem

`System.env` (kyo-core) and `Flag`'s `env`/`envNames` (kyo-config) crash on Scala.js in browsers. `SystemPlatformSpecific.env` binds the `process` global to a `val` before its `typeof` guard runs:

```scala
val proc = js.Dynamic.global.process
if js.typeOf(proc) == "undefined" || ...
```

Scala.js compiles the first line to a bare `process` identifier read. In Node that yields the process object, but in a browser (no bundler shim) it throws `ReferenceError: process is not defined` before the guard on the next line ever executes. Any browser app that touches `System.env` during startup dies with that error.

## Solution

In both probes, keep the `typeof` guard inline on the global selection, which Scala.js compiles to a plain `typeof process` expression (safe on undeclared identifiers by JS semantics), and only bind the `val` after the guard passes. This is the same idiom `osName()` and `osArch()` in the same file already use.

## Notes

No behavior change on Node: the same values are returned for present, absent, and null variables.
