### PR TITLE
[kyo-ui] add UI.tbody: explicit table row group

### DIFF
--- a/kyo-ui/shared/src/main/scala/kyo/UI.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/UI.scala
@@ -116,6 +116,7 @@ object UI:
     def blockquote(using Frame): Blockquote       = Blockquote()
     def code(using Frame): Code                   = Code()
     def table(using Frame): Table                 = Table()
+    def tbody(using Frame): Tbody                 = Tbody()
     def tr(using Frame): Tr                       = Tr()
     def td(using Frame): Td                       = Td()
     def th(using Frame): Th                       = Th()
@@ -1083,6 +1084,18 @@ object UI:
             def withAttrs(a: Attrs): Table      = copy(attrs = a)
             def apply(cs: HtmlChildVal*): Table = copy(children = children ++ Chunk.from(cs.map(_.value)))
         end Table
+
+        /** Explicit table row group. The HTML parser only synthesizes an implicit `<tbody>` while PARSING row
+          * content; rows patched into a live table programmatically (a reactive region between comment markers)
+          * become direct `<table>` children, which renders fine but breaks `tbody`-scoped selectors and
+          * semantics. Wrap a row region in `UI.tbody` to get a real row group.
+          */
+        final case class Tbody(attrs: Attrs = Attrs(), children: Chunk[UI] = Chunk.empty)(using val frame: Frame) extends Block
+            with Interactive:
+            type Self = Tbody
+            def withAttrs(a: Attrs): Tbody      = copy(attrs = a)
+            def apply(cs: HtmlChildVal*): Tbody = copy(children = children ++ Chunk.from(cs.map(_.value)))
+        end Tbody
 
         // ====== Headings (Block) ======
 

--- a/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
+++ b/kyo-ui/shared/src/main/scala/kyo/internal/HtmlRenderer.scala
@@ -308,6 +308,7 @@ private[kyo] object HtmlRenderer:
         case _: Ul             => "ul"
         case _: Ol             => "ol"
         case _: Table          => "table"
+        case _: Tbody          => "tbody"
         case _: H1             => "h1"
         case _: H2             => "h2"
         case _: H3             => "h3"

--- a/kyo-ui/shared/src/test/scala/kyo/TableTest.scala
+++ b/kyo-ui/shared/src/test/scala/kyo/TableTest.scala
@@ -183,4 +183,13 @@ class TableTest extends UITest:
         }
     }
 
+    "explicit tbody renders as a real row group" in {
+        withUI(UI.div(UI.table(UI.tbody(UI.tr(UI.td("B").id("tb-cell")))).id("tb-table"))) {
+            for
+                _ <- Browser.assertText(Selector.css("#tb-table tbody td"), "B")
+                _ <- Browser.assertText(Selector.id("tb-cell"), "B")
+            yield ()
+        }
+    }
+
 end TableTest


### PR DESCRIPTION
## Problem

kyo-ui has `UI.table`, `UI.tr`, `UI.td`/`UI.th`, but no table section elements. That matters for reactive tables: the HTML parser only synthesizes an implicit `<tbody>` while PARSING row content, so rows inserted into a live table programmatically (a reactive region's patch) become direct `<table>` children. That renders fine (anonymous table objects), but breaks `tbody`-scoped selectors, any tooling that queries `tbody tr` (the js-framework-benchmark harness does, which is how we hit this), and the expected document structure.

## Solution

Add `UI.tbody` (a `Block` element rendering `<tbody>`), so tables can host rows and row regions in a real row group. A browser test pins that an explicit `UI.tbody` renders as an addressable row group. SSR golden HTML is untouched (new element, no existing output changes).

## Notes

`thead`/`tfoot`/`caption`/`colgroup` are left for a future pass; `tbody` is the one required for reactive row regions.