### PR TITLE
[kyo-core] fix Meter deadlock when an interrupt races a permit

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Meter.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Meter.scala
@@ -127,8 +127,7 @@ object Meter:
       *   A Meter effect that represents a mutex.
       */
     def useMutex[A, S](f: Meter => A < S)(using Frame): A < (Sync & S) =
-        initMutexUnscoped.map: meter =>
-            Sync.ensure(meter.close)(f(meter))
+        Sync.acquireReleaseWith(initMutexUnscoped)(_.close)(f)
 
     /** Use a **reentrant** Meter that acts as a mutex (binary semaphore). Meter is closed automatically after usage.
       *
@@ -136,8 +135,7 @@ object Meter:
       *   A Meter effect that represents a mutex.
       */
     def useMutex(reentrant: Boolean)[A, S](f: Meter => A < S)(using Frame): A < (Sync & S) =
-        initMutexUnscoped(reentrant).map: meter =>
-            Sync.ensure(meter.close)(f(meter))
+        Sync.acquireReleaseWith(initMutexUnscoped(reentrant))(_.close)(f)
 
     /** Creates a **reentrant** Meter that acts as a mutex (binary semaphore). Does not ensure meter is cleaned up.
       *
@@ -179,8 +177,7 @@ object Meter:
       *   A Meter effect that represents a semaphore.
       */
     def useSemaphore(concurrency: Int, reentrant: Boolean = true)[A, S](f: Meter => A < S)(using Frame): A < (Sync & S) =
-        initSemaphoreUnscoped(concurrency, reentrant).map: meter =>
-            Sync.ensure(meter.close)(f(meter))
+        Sync.acquireReleaseWith(initSemaphoreUnscoped(concurrency, reentrant))(_.close)(f)
 
     /** Creates a Meter that acts as a semaphore with the specified concurrency. Does not ensure meter is cleaned up.
       *
@@ -194,13 +191,10 @@ object Meter:
     def initSemaphoreUnscoped(concurrency: Int, reentrant: Boolean = true)(using Frame): Meter < Sync =
         Sync.Unsafe.defer {
             new Base(concurrency, reentrant):
-                def dispatch[A, S](v: => A < S) =
-                    // Release the permit right after the computation
-                    Sync.ensure(discard(release()))(v)
-                def settleWait(acquired: Boolean): Unit =
-                    // Abandoning returns only the registration: nothing was freed, so no handoff.
-                    if acquired then discard(release()) else returnRegistration()
-                def onClose(): Unit = ()
+                // The permit is returned when the body ends; `settle` runs this from the one ensure
+                // installed before the take, so an interrupt in the step after the take still releases.
+                def settleAcquired(): Unit = discard(release())
+                def onClose(): Unit        = ()
         }
 
     /** Creates a Meter that acts as a rate limiter. Does not ensure meter is cleaned up.
@@ -231,8 +225,7 @@ object Meter:
     def useRateLimiter(rate: Int, period: Duration, reentrant: Boolean = true)[A, S](f: Meter => A < S)(using
         initFrame: Frame
     ): A < (Sync & S) =
-        initRateLimiterUnscoped(rate, period, reentrant).map: meter =>
-            Sync.ensure(meter.close)(f(meter))
+        Sync.acquireReleaseWith(initRateLimiterUnscoped(rate, period, reentrant))(_.close)(f)
 
     /** Creates a Meter that acts as a rate limiter. Does not ensure meter is cleaned up.
       *
@@ -252,13 +245,8 @@ object Meter:
                     // Schedule periodic task to replenish permits
                     Sync.Unsafe.evalOrThrow(Clock.repeatAtInterval(period, period)(replenish()))
 
-                def dispatch[A, S](v: => A < S) =
-                    // Don't release a permit since it's managed by the timer task
-                    v
-
-                // Rate belongs to the clock: `replenish` restores it each period regardless of who
-                // consumed it, so neither finishing nor abandoning returns it early.
-                def settleWait(acquired: Boolean): Unit = ()
+                // A consumed permit is not returned on completion; the timer task replenishes it.
+                def settleAcquired(): Unit = ()
 
                 @tailrec def replenish(i: Int = 0): Unit =
                     if i < rate && release() then
@@ -369,26 +357,63 @@ object Meter:
 
     private val acquiredMeters = Local.initNoninheritable(Set.empty[Meter])
 
+    /** Packed ledger for [[Base]], a single AtomicLong holding both halves of the state.
+      *
+      *   - bit 63: closed flag (a snapshot is closed iff it is negative)
+      *   - bits 62-32: free permits (31 bits, capped at the meter's `permits`)
+      *   - bits 31-0: registered waiters (32 bits)
+      *
+      * Free permits and waiters are separate fields, not the two signs of one counter, so a snapshot
+      * can hold a free permit AND a registered waiter at once. That is what lets a registration
+      * give-back touch only the waiter field (never a permit), and lets a released permit always land
+      * in the free field visible to the next claimant. Mirrors the `Gate` `State` convention.
+      */
+    private type State = State.Impl
+
+    private object State:
+
+        opaque type Impl = AtomicLong.Unsafe
+
+        opaque type Snapshot = Long
+
+        private inline def pack(free: Int, waiters: Int): Long =
+            (free.toLong << 32) | (waiters.toLong & 0xffffffffL)
+
+        def init(free: Int)(using AllowUnsafe): State =
+            AtomicLong.Unsafe.init(pack(free, 0))
+
+        extension (self: State)
+            def get()(using AllowUnsafe): Snapshot = AtomicLong.Unsafe.get(self)()
+            def cas(expected: Snapshot, update: Snapshot)(using AllowUnsafe): Boolean =
+                AtomicLong.Unsafe.compareAndSet(self)(expected, update)
+            def getAndClose()(using AllowUnsafe): Snapshot =
+                AtomicLong.Unsafe.getAndSet(self)(Long.MinValue)
+        end extension
+
+        extension (self: Snapshot)
+            inline def free: Int              = ((self & 0x7fffffff00000000L) >>> 32).toInt
+            inline def waiters: Int           = (self & 0xffffffffL).toInt
+            inline def isClosed: Boolean      = self < 0
+            inline def addPermit: Snapshot    = self + (1L << 32)
+            inline def takePermit: Snapshot   = self - (1L << 32)
+            inline def addWaiter: Snapshot    = self + 1L
+            inline def removeWaiter: Snapshot = self - 1L
+        end extension
+    end State
+
     sealed abstract private class Base(permits: Int, reentrant: Boolean)(using initFrame: Frame, allow: AllowUnsafe) extends Meter:
 
-        // MinValue => closed
-        // >= 0     => # of permits
-        // < 0      => # of waiters
-        val state   = AtomicInt.Unsafe.init(permits)
+        val state   = State.init(permits)
         val waiters = new MpmcUnboundedUnsafeQueue[Promise.Unsafe[Unit, Abort[Closed]]](8)
         val closed  = Promise.Unsafe.init[Nothing, Abort[Closed]]()
 
-        protected def dispatch[A, S](v: => A < S): A < (S & Sync)
+        // The two per-kind hooks: settleAcquired returns a claimed permit (semaphore) or does nothing
+        // (rate limiter, whose timer replenishes instead); onClose releases kind-specific resources.
+        protected def settleAcquired(): Unit
         protected def onClose(): Unit
 
-        /** Settles what a caller owes when its wait ends, having acquired a permit or not.
-          *
-          * Per-kind for the same reason [[dispatch]] is: a semaphore's permits are owned by callers, so
-          * both outcomes owe something back, while a rate limiter's are owned by the clock and are
-          * restored by its timer either way.
-          */
-        protected def settleWait(acquired: Boolean): Unit
-
+        // Reentrancy: if this fiber already holds this meter (tracked in the acquiredMeters fiber-local),
+        // a nested call reenters the body WITHOUT taking a second permit, so it cannot self-deadlock.
         private inline def withReentry[A, S](inline reenter: => A < S)(acquire: AllowUnsafe ?=> A < S): A < (Sync & S) =
             if reentrant then
                 Sync.withLocal(acquiredMeters) { meters =>
@@ -398,6 +423,8 @@ object Meter:
             else
                 acquire
 
+        // Marks this meter as held in the fiber-local set for the duration of the body, so a nested
+        // acquire (via withReentry) sees it and reenters instead of taking another permit.
         private inline def withAcquiredMeter[A, S](inline v: => A < S) =
             if reentrant then
                 acquiredMeters.update(_ + this)(v)
@@ -406,91 +433,102 @@ object Meter:
 
         final def run[A, S](v: => A < S)(using Frame) =
             withReentry(v) {
-                def loop(): A < (S & Async & Abort[Closed]) =
-                    val st = state.get()
-                    if st == Int.MinValue then
-                        // Meter is closed
-                        closed.safe.get
-                    else if st > 0 then
-                        // Permit available, dispatch immediately
-                        if state.compareAndSet(st, st - 1) then dispatch(withAcquiredMeter(v))
-                        else loop()
-                    else
-                        // No permit available. The teardown is installed before the promise is queued and
-                        // the reservation is taken, and those two run in one step: an interrupt landing
-                        // between the reservation and its teardown installation would otherwise leak the
-                        // registration and leave the queued promise pending, and a later handoff would hand
-                        // a real permit to the interrupted caller. Queueing still precedes reserving within
-                        // the step, so a reservation visible in `state` always has its promise queued;
-                        // `close` and `handoff` rely on that.
-                        val p = Promise.Unsafe.init[Unit, Abort[Closed]]()
-                        // Written in the same step as the reservation CAS and read only by `settle`, which
-                        // runs on this fiber strictly after that step: the fiber's own scheduling orders it.
-                        var reserved = false
-                        Sync.ensure(settle(p, reserved)) {
-                            Sync.Unsafe.defer {
-                                discard(waiters.offer(p))
-                                if state.compareAndSet(st, st - 1) then
-                                    reserved = true
-                                    p.safe.use(_ => withAcquiredMeter(v))
-                                else
-                                    // Reservation lost, so this promise stands for nothing. Retiring it is
-                                    // what keeps `handoff` and `close` from granting to it, and losing that
-                                    // race means a permit was already handed to a promise no reservation
-                                    // stands behind. The handoff has to be made again or the waiter it was
-                                    // owed to never wakes.
-                                    if !p.complete(Result.fail(Closed("Meter", initFrame))) && p.poll().exists(_.isSuccess) then
-                                        handoff()
+                // Permits are claimed from `free` by CAS; a completed promise means only "re-check the
+                // ledger", never "here is a permit", so a woken waiter re-competes as a fresh caller (one
+                // park shape). `waiterPromise`/`registered`/`taken` are this run's private, single-fiber
+                // state, so plain vars are safe: they record what this acquisition owes the ledger, and
+                // `settle` (installed before any take) reconciles them on every exit, so an interrupt at
+                // any suspension still settles correctly.
+                var waiterPromise: Maybe[Promise.Unsafe[Unit, Abort[Closed]]] = Maybe.Absent
+                var registered                                                = false
+                var taken                                                     = false
+                Sync.ensure(settle(waiterPromise, registered, taken)) {
+                    def loop(): A < (S & Async & Abort[Closed]) =
+                        val s = state.get()
+                        if s.isClosed then
+                            closed.safe.get
+                        else if s.free > 0 then
+                            // Fast path: claim a free permit. `taken` is set in the same step as the take
+                            // CAS, so the pre-installed `settle` owns the release from here on.
+                            if state.cas(s, s.takePermit) then
+                                taken = true
+                                withAcquiredMeter(v)
+                            else loop()
+                        else
+                            // No free permit: register as a waiter and park.
+                            val p = Promise.Unsafe.init[Unit, Abort[Closed]]()
+                            waiterPromise = Maybe.Present(p)
+                            // Queue-before-register: a releaser that witnesses `waiters > 0` finds the
+                            // entry. The register CAS is on the whole word, so it re-validates `free == 0`
+                            // in the same step; if a permit appeared, the CAS fails and the loop claims it.
+                            discard(waiters.offer(p))
+                            if state.cas(s, s.addWaiter) then
+                                registered = true
+                                p.safe.use { _ =>
+                                    // Woken. The `use` above is the park; the re-entry IS the re-check.
+                                    // Give the registration back and re-enter as a fresh caller: a release
+                                    // never consumes registrations, so a permit freed in the eject window
+                                    // stays visible in `free` for the re-entry to claim.
+                                    registered = false
+                                    giveBack()
                                     loop()
-                                end if
-                            }
-                        }
-                    end if
-                end loop
-                loop()
+                                }
+                            else
+                                retire(p)
+                                loop()
+                            end if
+                        end if
+                    end loop
+                    loop()
+                }
             }
         end run
 
         final def tryRun[A, S](v: => A < S)(using Frame): Maybe[A] < (S & Async & Abort[Closed]) =
             withReentry(v.map(Maybe(_))) {
-                @tailrec def loop(): Maybe[A] < (S & Async & Abort[Closed]) =
-                    val st = state.get()
-                    if st == Int.MinValue then
-                        // Meter is closed
-                        closed.safe.get
-                    else if st <= 0 then
-                        // No permit available, return empty
-                        Maybe.empty
-                    else if state.compareAndSet(st, st - 1) then
-                        // Permit available, dispatch
-                        dispatch(withAcquiredMeter(v.map(Maybe(_))))
-                    else
-                        // CAS failed, retry
-                        loop()
-                    end if
-                end loop
-                loop()
+                var taken = false
+                // The teardown is installed before the take CAS, so a claimed permit is owned even if an
+                // interrupt lands in the step after the CAS. No wait path here (Absent promise, never
+                // registered), so `settle` only ever runs its taken branch.
+                Sync.ensure(settle(Maybe.Absent, false, taken)) {
+                    @tailrec def loop(): Maybe[A] < (S & Async & Abort[Closed]) =
+                        val s = state.get()
+                        if s.isClosed then
+                            // Meter is closed
+                            closed.safe.get
+                        else if s.free <= 0 then
+                            // No permit available, return empty
+                            Maybe.empty
+                        else if state.cas(s, s.takePermit) then
+                            // Permit available, claim it; `settle` returns it after the body.
+                            taken = true
+                            withAcquiredMeter(v.map(Maybe(_)))
+                        else
+                            // CAS failed, retry
+                            loop()
+                        end if
+                    end loop
+                    loop()
+                }
             }
         end tryRun
 
         final def availablePermits(using Frame) =
             Sync.Unsafe.defer {
-                state.get() match
-                    case Int.MinValue => closed.safe.get
-                    case st           => Math.max(0, st)
+                val s = state.get()
+                if s.isClosed then closed.safe.get else s.free
             }
 
         final def pendingWaiters(using Frame) =
             Sync.Unsafe.defer {
-                state.get() match
-                    case Int.MinValue => closed.safe.get
-                    case st           => Math.min(0, st).abs
+                val s = state.get()
+                if s.isClosed then closed.safe.get else s.waiters
             }
 
         final def close(using frame: Frame): Boolean < Sync =
             Sync.Unsafe.defer {
-                val st = state.getAndSet(Int.MinValue)
-                val ok = st != Int.MinValue // The meter wasn't already closed
+                val s  = state.getAndClose()
+                val ok = !s.isClosed // The meter wasn't already closed
                 if ok then
                     val fail = Result.fail(Closed("Meter", initFrame))
                     // Complete the closed promise to fail new operations
@@ -512,62 +550,69 @@ object Meter:
             }
         end close
 
-        final def closed(using Frame) = Sync.defer(state.get() == Int.MinValue)
+        final def closed(using Frame) = Sync.defer(state.get().isClosed)
 
+        /** Releases a permit into the free pool, then nudges one waiter to re-check.
+          *
+          * The permit lands in `free` unconditionally; the wake is best-effort. If every queued entry is
+          * dead, nobody is woken but the permit stays visible in `free`, so any claimant (a fresh arrival,
+          * a woken waiter, a re-parking waiter) takes it by CAS. Capped at `permits`.
+          */
         @tailrec final protected def release(): Boolean =
-            val st = state.get()
-            if st >= permits || st == Int.MinValue then
+            val s = state.get()
+            if s.isClosed || s.free >= permits then
                 // No more permits to release or meter is closed
                 false
-            else if !state.compareAndSet(st, st + 1) then
+            else if !state.cas(s, s.addPermit) then
                 // CAS failed, retry
                 release()
             else
-                // st < 0 means every permit was held and a registration is queued, so this permit is
-                // owed to a waiter rather than to the free pool.
-                if st < 0 then handoff()
+                if s.waiters > 0 then wake()
                 // Permit released
                 true
             end if
         end release
 
-        /** Hands the just-returned permit to the first waiter that can still take it.
-          *
-          * A promise whose owner withdrew after being interrupted is skipped without touching `state`:
-          * that owner's own withdrawal already returned its registration, so returning it here as well
-          * would inflate the ledger and admit more callers than there are permits. An empty queue means
-          * no live waiter remains, and the permit stays in the ledger for the next caller.
+        /** Wakes the first still-pending waiter so it re-checks the ledger. A completed promise means
+          * "re-check", never "here is a permit"; already-completed entries are skipped, an empty queue is
+          * benign (the permit is already visible in `free`).
           */
-        @tailrec final private def handoff(): Unit =
+        @tailrec final private def wake(): Unit =
             waiters.poll() match
-                case Maybe.Present(waiter) => if !waiter.completeUnit() then handoff()
+                case Maybe.Present(waiter) => if !waiter.completeUnit() then wake()
                 case Maybe.Absent          => ()
-        end handoff
+        end wake
 
-        /** Returns a registration that never became an acquisition, without handing a permit to anyone.
-          *
-          * A caller interrupted while parked reserved a slot but never held a permit, so nothing was
-          * freed for a waiter to take. This is the counterpart of [[release]] for the wait phase, and
-          * the difference between them is exactly the handoff.
+        /** Retires a promise its owner is abandoning. If it had already been woken (completed with
+          * success) but that wake was not converted into a claim, re-issue the wake to the next pending
+          * waiter so a nudge is never lost. A spurious re-wake is absorbed by the claim CAS.
           */
-        @tailrec final protected def returnRegistration(): Unit =
-            val st = state.get()
-            if st != Int.MinValue && !state.compareAndSet(st, st + 1) then returnRegistration()
+        final protected def retire(p: Promise.Unsafe[Unit, Abort[Closed]])(using AllowUnsafe): Unit =
+            if !p.complete(Result.fail(Closed("Meter", initFrame))) && p.poll().exists(_.isSuccess) then
+                wake()
 
-        /** Settles the wait's promise and ledger once the wait ends, however it ends.
-          *
-          * Retires the promise first: completion has a single winner, so either this retirement wins (the
-          * wait never acquired, and no later `handoff` can grant to it) or a completion already decided the
-          * outcome and is read from the promise. Without the retirement, a wait interrupted between reserving
-          * and parking leaves a pending promise queued, and a later `handoff` hands a real permit to a caller
-          * that already settled. `reserved` is false when the wait ended before the reservation CAS: nothing
-          * was taken, so nothing is owed and the promise, if it was ever queued, is retired harmlessly.
+        /** Gives back a registration that never became an acquisition. Touches ONLY the waiter field, so
+          * it can never consume a permit; that field-locality is what deletes the lost-wakeup class.
           */
-        private def settle(p: Promise.Unsafe[Unit, Abort[Closed]], reserved: Boolean)(using AllowUnsafe): Unit =
-            if p.complete(Result.fail(Closed("Meter", initFrame))) then
-                if reserved then settleWait(false)
-            else if reserved then
-                settleWait(p.poll().exists(_.isSuccess))
+        @tailrec final protected def giveBack(): Unit =
+            val s = state.get()
+            if !s.isClosed && !state.cas(s, s.removeWaiter) then giveBack()
+
+        /** Settles an attempt once it ends, however it ends. A claim (`taken`) hands the permit's
+          * lifecycle to [[settleAcquired]] (release for a semaphore, nothing for a rate limiter); the
+          * promise, present only when the claim came off the wait path, is retired without re-issuing a
+          * wake (it was consumed by the claim). A non-claiming exit retires the current promise (re-issuing
+          * a consumed-but-unused wake) and gives back a still-held registration.
+          */
+        private def settle(waiterPromise: Maybe[Promise.Unsafe[Unit, Abort[Closed]]], registered: Boolean, taken: Boolean)(using
+            AllowUnsafe
+        ): Unit =
+            if taken then
+                waiterPromise.foreach(p => discard(p.complete(Result.fail(Closed("Meter", initFrame)))))
+                settleAcquired()
+            else
+                waiterPromise.foreach(retire)
+                if registered then giveBack()
     end Base
 
 end Meter

--- a/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/MeterTest.scala
@@ -198,7 +198,7 @@ class MeterTest extends kyo.test.Test[Any]:
             // to a promise no reservation stands behind, so the waiter it was owed to keeps waiting and the
             // meter runs one permit short from then on. The last release then sees free permits in the
             // ledger, skips the handoff, and leaves that waiter parked for good.
-            "sustained contention never strands a queued waiter".onlyJvm in {
+            "sustained contention never strands a queued waiter".notJs.notWasm in {
                 val permits    = 2
                 val callers    = 8
                 val iterations = 10000
@@ -222,7 +222,7 @@ class MeterTest extends kyo.test.Test[Any]:
                     .unit
             }
 
-            "with interruptions".onlyJvm in {
+            "with interruptions".notJs.notWasm in {
                 (for
                     size    <- Choice.eval(1, 2, 3, 50)
                     meter   <- Meter.initSemaphore(size)
@@ -253,31 +253,44 @@ class MeterTest extends kyo.test.Test[Any]:
         // A permit is held for the whole body, so no more bodies may run concurrently than the
         // meter has permits. The case under test is a waiter interrupted while parked: it never
         // acquired a permit, so withdrawing it must not admit anyone.
-        "concurrency never exceeds permits while parked waiters are interrupted".onlyJvm in {
+        "concurrency never exceeds permits while parked waiters are interrupted".notJs.notWasm in {
             val permits = 1
             val waiters = 32
             (for
                 meter      <- Meter.initSemaphore(permits)
+                entered    <- AtomicInt.init(0)
                 live       <- AtomicInt.init(0)
                 violations <- AtomicInt.init(0)
                 gate       <- Latch.init(1)
                 body =
                     for
+                        _ <- entered.incrementAndGet
                         n <- live.incrementAndGet
                         _ <- if n > permits then violations.incrementAndGet.map(_ => ()) else Sync.defer(())
-                        _ <- Async.sleep(1.millis)
                         _ <- live.decrementAndGet
                     yield ()
                 holder <- Fiber.initUnscoped(meter.run(gate.await.andThen(body)))
-                _      <- Async.sleep(20.millis)
+                // The holder owns the permit before anything else moves (counter, not a sleep).
+                _      <- assertEventually(Abort.run(meter.availablePermits).map(_ == Result.succeed(0)))
                 parked <- Kyo.foreach(1 to waiters)(_ => Fiber.initUnscoped(meter.run(body)))
-                _      <- Async.sleep(20.millis)
-                _      <- Async.foreach(parked.take(waiters / 2), waiters / 2)(_.interrupt(panic))
-                _      <- gate.release
-                _      <- holder.getResult
-                _      <- Kyo.foreach(parked)(_.getResult)
-                bad    <- violations.get
-            yield assert(bad == 0, s"observed $bad moments with more than $permits concurrent holders"))
+                // Every waiter is parked before any interrupt (counter, not a sleep).
+                _ <- assertEventually(Abort.run(meter.pendingWaiters).map(_ == Result.succeed(waiters)))
+                _ <- Async.foreach(parked.take(waiters / 2), waiters / 2)(_.interrupt(panic))
+                // The interrupted waiters' give-backs have landed: the exact window in which a handoff
+                // through a dead entry would admit a live waiter while the permit is still held.
+                _ <- assertEventually(Abort.run(meter.pendingWaiters).map(_ == Result.succeed(waiters - waiters / 2)))
+                // Deterministic arbiter: no waiter body may have run while the holder holds the only
+                // permit. Read before releasing the gate. (`violations` stays a best-effort ceiling
+                // for the drain phase, its dwell removed.)
+                held <- entered.get
+                _    <- gate.release
+                _    <- holder.getResult
+                _    <- Kyo.foreach(parked)(_.getResult)
+                bad  <- violations.get
+            yield assert(
+                held == 0 && bad == 0,
+                s"held-phase admissions=$held (must be 0); over-$permits concurrency moments=$bad"
+            ))
                 .handle(Loop.repeat(20))
                 .unit
         }
@@ -285,32 +298,40 @@ class MeterTest extends kyo.test.Test[Any]:
         // Closing must complete EVERY parked waiter, including ones queued behind a waiter that was
         // interrupted first. A close that drains a count derived from `state` stops on the retired
         // promise the interrupted waiter left behind and strands the live ones, which hangs here.
-        "close completes waiters queued behind an interrupted waiter".onlyJvm in {
+        "close completes waiters queued behind an interrupted waiter".notJs.notWasm in {
             val permits = 1
             val waiters = 8
             (for
                 meter  <- Meter.initSemaphore(permits)
                 gate   <- Latch.init(1)
                 holder <- Fiber.initUnscoped(meter.run(gate.await))
-                _      <- Async.sleep(20.millis)
-                parked <- Kyo.foreach(1 to waiters)(_ => Fiber.initUnscoped(meter.run(Async.sleep(1.millis))))
-                _      <- Async.sleep(20.millis)
-                // Interrupt the FIRST waiter, so its retired promise sits at the head of the queue
-                // ahead of every still-parked waiter behind it.
-                _       <- parked.head.interrupt(panic)
-                _       <- Async.sleep(10.millis)
+                _      <- assertEventually(Abort.run(meter.availablePermits).map(_ == Result.succeed(0)))
+                parked <- Kyo.foreach(1 to waiters)(_ => Fiber.initUnscoped(meter.run(())))
+                _      <- assertEventually(Abort.run(meter.pendingWaiters).map(_ == Result.succeed(waiters)))
+                // Interrupt the FIRST waiter (verified parked) so its retired promise sits at the head
+                // of the queue ahead of every still-parked waiter behind it.
+                _ <- assertEventually(parked.head.waiters.map(_ == 1))
+                _ <- parked.head.interrupt(panic)
+                // Its give-back has landed: the queue now holds a retired head plus waiters-1 live
+                // entries, the exact state a count-derived drain (waiters-1 counted vs waiters entries)
+                // stops short on, stranding a live waiter.
+                _       <- assertEventually(Abort.run(meter.pendingWaiters).map(_ == Result.succeed(waiters - 1)))
                 _       <- meter.close
                 _       <- gate.release
                 _       <- holder.getResult
                 settled <- Kyo.foreach(parked)(_.getResult)
-            yield assert(settled.size == waiters, s"expected all $waiters waiters to settle, got ${settled.size}"))
+                closed  <- Abort.run(meter.availablePermits)
+            yield assert(
+                settled.size == waiters && settled.drop(1).forall(_.isFailure) && closed.isFailure,
+                s"expected all $waiters waiters to settle behind the interrupted head, got ${settled.size}"
+            ))
                 .handle(Loop.repeat(20))
                 .unit
         }
 
         // After every fiber has settled, the permit ledger must be back to full. An interrupted
         // waiter that over-returns would show up here as more free permits than the meter has.
-        "permits return to full after parked waiters are interrupted".onlyJvm in {
+        "permits return to full after parked waiters are interrupted".notJs.notWasm in {
             val permits = 2
             val waiters = 16
             (for
@@ -328,7 +349,9 @@ class MeterTest extends kyo.test.Test[Any]:
                 _      <- Kyo.foreach(parked)(_.getResult)
                 // A settled fiber does not mean a settled ledger: the teardown that returns a permit
                 // runs as the fiber unwinds, so read until it comes to rest instead of once.
-                _ <- assertEventually(Abort.run(meter.availablePermits).map(_ == Result.succeed(permits)))
+                _ <- assertEventually(
+                    Abort.run(Kyo.zip(meter.availablePermits, meter.pendingWaiters)).map(_ == Result.succeed((permits, 0)))
+                )
             yield ())
                 .handle(Loop.repeat(20))
                 .unit
@@ -339,7 +362,7 @@ class MeterTest extends kyo.test.Test[Any]:
         // live waiter behind it was never woken. Many contenders are interrupted mid-approach (racing
         // the reserve-before-park window), then settled; the victim queued behind them must always be
         // granted the permit the holder frees.
-        "interrupt racing the acquisition never strands a later waiter".onlyJvm in {
+        "interrupt racing the acquisition never strands a later waiter".notJs.notWasm in {
             val contenders = 30
             (for
                 meter   <- Meter.initSemaphore(1)
@@ -353,9 +376,109 @@ class MeterTest extends kyo.test.Test[Any]:
                 _       <- assertEventually(Abort.run(meter.pendingWaiters).map(_.exists(_ >= 1)))
                 _       <- gate.release
                 _       <- holder.getResult
-                granted <- Abort.run[Timeout](Async.timeout(5.seconds)(victim.getResult))
+                granted <- Abort.run[Timeout](Async.timeout(10.seconds)(victim.getResult))
+                // If the victim was granted, the storm must also have left the ledger at rest: a
+                // mid-acquisition regression that leaks or doubles a registration without stranding
+                // the victim shows here. Skipped on a strand so it never hangs on the buggy build.
+                _ <- if granted.isSuccess then
+                    assertEventually(
+                        Abort.run(Kyo.zip(meter.availablePermits, meter.pendingWaiters)).map(_ == Result.succeed((1, 0)))
+                    )
+                else Sync.defer(())
             yield assert(granted.isSuccess, "the waiter behind interrupted callers was never handed the permit"))
                 .handle(Loop.repeat(200))
+                .unit
+        }
+
+        // A permit released while an interrupted waiter's ledger give-back is still pending must
+        // reach the next waiter. This forces (via a finalizer gate, no sleeps) the one ordering the
+        // public API cannot: the interrupted waiter's give-back runs AFTER the holder's release AND
+        // after a fresh victim has registered. On the current impl the release drops the permit into
+        // the dead entry and the victim strands forever; a correct impl hands it to the victim.
+        "a permit released while an interrupted waiter's teardown is pending reaches the next waiter".notJs.notWasm in {
+            (for
+                meter      <- Meter.initSemaphore(1)
+                gateOpen   <- AtomicInt.init(0)
+                holderGate <- Latch.init(1)
+                holder     <- Fiber.initUnscoped(meter.run(holderGate.await))
+                _          <- assertEventually(Abort.run(meter.availablePermits).map(_ == Result.succeed(0)))
+                // The waiter's own finalizer spins on the gate. Finalizers run FIFO, so this outer
+                // ensure runs strictly before Meter's internal settle, holding the give-back open.
+                w <- Fiber.initUnscoped(Sync.ensure(spinUntilOpen(gateOpen))(meter.run(())))
+                // Reserved (pendingWaiters) AND parked (the fiber registered a join), so the interrupt
+                // kills a queued promise rather than a not-yet-parked one.
+                _ <- assertEventually(Abort.run(meter.pendingWaiters).map(_ == Result.succeed(1)))
+                _ <- assertEventually(w.waiters.map(_ == 1))
+                _ <- w.interrupt(panic)
+                // Safety net: however the window exits, open the gate so w can settle and the leaf
+                // fails on its real assertion instead of wedging on the spin.
+                granted <- Sync.ensure(gateOpen.set(1)) {
+                    for
+                        _      <- holderGate.release
+                        _      <- holder.getResult
+                        victim <- Fiber.initUnscoped(meter.run(()))
+                        // The victim engaged the meter before the gate opens: parked (pendingWaiters
+                        // == 1) on the current impl, or already done if a future fix lets it fast-path.
+                        // Either way it registered first, and this never hangs on a correct fix.
+                        _ <- assertEventually(
+                            for
+                                pw <- Abort.run(meter.pendingWaiters)
+                                d  <- victim.done
+                            yield pw == Result.succeed(1) || d
+                        )
+                        _ <- gateOpen.set(1)
+                        g <- Abort.run[Timeout](Async.timeout(10.seconds)(victim.getResult))
+                    yield g
+                }
+            yield assert(granted.isSuccess, "the waiter behind an interrupted caller was never handed the released permit"))
+                .handle(Loop.repeat(3))
+                .unit
+        }
+
+        // The take-then-install class. run's fast path and its woken claim (and tryRun) take a permit
+        // by a single CAS, but the finalizer that returns it installs one effect-step later; an
+        // interrupt, or a preemption whose queue-wait an interrupt then lands in, hitting that gap
+        // strands the permit. At permits=1 the meter then dies: no later acquire ever completes. A
+        // storm of interrupts over a ring of fibers churning acquire/release on one permit samples
+        // every such gap at uniform phase (paced by a channel take per strike, no sleeps), so the
+        // ledger must always return to full. Reliably red on any build that leaves a window open.
+        "an interrupt storm over churning acquisitions never leaks a permit".notJs.notWasm in {
+            val loopers = 4
+            val strikes = 10000
+            (for
+                meter <- Meter.initSemaphore(1)
+                ch    <- Channel.initUnscoped[Unit](64)
+                count <- AtomicInt.init(0)
+                slots <- Kyo.foreach(0 until loopers)(_ => Fiber.initUnscoped(churn(meter, ch, count)))
+                ring0 = (0 until loopers).map(i => i -> slots(i)).toMap
+                // Bound the whole scenario: a leaked permit either stalls the storm's next take or
+                // leaves the ledger short of full, and the timeout turns either into a red Timeout
+                // instead of a framework-length hang. A correct build finishes in a few seconds.
+                outcome <- Abort.run[Timeout](Async.timeout(30.seconds) {
+                    for
+                        finalRing <- Loop.indexed(ring0) { (i, ring) =>
+                            if i >= strikes then Loop.done(ring)
+                            else
+                                val slot = i % loopers
+                                // One completed body (a take) means the ring is live; then strike a slot
+                                // and fork its replacement so the ring keeps cycling under one permit.
+                                for
+                                    _ <- ch.take
+                                    _ <- ring(slot).interrupt(panic)
+                                    f <- Fiber.initUnscoped(churn(meter, ch, count))
+                                yield Loop.continue(ring.updated(slot, f))
+                                end for
+                        }
+                        _ <- Async.foreach(finalRing.values.toSeq, loopers)(_.interrupt(panic))
+                        _ <- Kyo.foreach(finalRing.values.toSeq)(_.getResult)
+                        _ <- assertEventually(
+                            Abort.run(Kyo.zip(meter.availablePermits, meter.pendingWaiters)).map(_ == Result.succeed((1, 0)))
+                        )
+                    yield ()
+                })
+                n <- count.get
+            yield assert(outcome.isSuccess && n > 0, s"permit leaked: storm stalled or ledger never returned to full (bodies=$n)"))
+                .handle(Loop.repeat(2))
                 .unit
         }
     }
@@ -363,13 +486,54 @@ class MeterTest extends kyo.test.Test[Any]:
     def loop(meter: Meter, ch: Channel[Unit]): Unit < (Async & Abort[Closed]) =
         meter.run(ch.put(())).andThen(loop(meter, ch))
 
+    // A fiber that churns the meter: acquire, run a body that puts one token (so a storm can pace on
+    // it) and bumps a completed-body counter, release, repeat. Used by the take-then-install storm leaf.
+    def churn(meter: Meter, ch: Channel[Unit], count: AtomicInt): Unit < (Async & Abort[Closed]) =
+        meter.run(ch.put(()).andThen(count.incrementAndGet.unit)).andThen(churn(meter, ch, count))
+
     val panic = Result.Panic(new Exception)
+
+    // Test-only synchronous gate: holds a fiber's finalizer open until `flag` flips to 1, so a test
+    // can force the interrupted waiter's ledger give-back to run after a release. JVM-only: it spins
+    // a scheduler worker and needs a second worker to make progress.
+    def spinUntilOpen(flag: AtomicInt)(using Frame): Unit < Sync =
+        flag.get.map(v => if v == 1 then () else spinUntilOpen(flag))
 
     "rate limiter" - {
         "init" in {
             Scope.run(Meter.initRateLimiter(2, 1.milli)).map: meter =>
                 meter.closed.map: isClosed =>
                     assert(isClosed)
+        }
+
+        // A rate-limiter waiter interrupted while parked must return NOTHING to the rate: it never
+        // held a permit, so its teardown must not mint one early. A regression that returned the
+        // registration (semaphore-style) would leave a phantom permit or drop the pending count here.
+        // Red is near-certain rather than forced: the buggy give-back runs in the waiter's wrap-up
+        // slice with no edge to gate strictly after it, so Loop.repeat samples the post-give-back
+        // state; green is sound (on correct code the asserted values are the stable initial state).
+        "interrupting a parked waiter returns nothing to the rate".notJs.notWasm in {
+            (for
+                meter <- Meter.initRateLimiter(1, 1.hour)
+                _     <- meter.run(())
+                _     <- assertEventually(Abort.run(meter.availablePermits).map(_ == Result.succeed(0)))
+                w     <- Fiber.initUnscoped(meter.run(()))
+                _     <- assertEventually(Abort.run(meter.pendingWaiters).map(_ == Result.succeed(1)))
+                _     <- assertEventually(w.waiters.map(_ == 1))
+                _     <- w.interrupt(panic)
+                _     <- w.getResult
+                // The registration give-back runs in the interrupted waiter's finalizer slice; wait for
+                // it to settle to 0. Crucially no rate is minted: availablePermits and tryRun below stay
+                // at their initial values (the give-back touches only the waiter field, never a permit).
+                _  <- assertEventually(Abort.run(meter.pendingWaiters).map(_ == Result.succeed(0)))
+                ap <- Abort.run(meter.availablePermits)
+                tr <- meter.tryRun(())
+            yield assert(
+                ap == Result.succeed(0) && tr.isEmpty,
+                s"interrupted rate waiter minted rate: availablePermits=$ap tryRun=$tr"
+            ))
+                .handle(Loop.repeat(20))
+                .unit
         }
 
         "use" in {


### PR DESCRIPTION
## Problem

Meter (mutex, semaphore, rate limiter) could permanently lose a permit under interruption: a release handed to an already-interrupted waiter, or an interrupt landing in the window between claiming a permit and arming the finalizer that returns it. At one permit that is a hard deadlock, every later acquire blocks forever. Meter guards real contended paths, mutexes in kyo-ai, the compiler's compile cap, HTTP rate limiting, the test runner's leaf pool, so this is reachable under ordinary interruption rather than a corner case.

## Solution

The core is reworked so these races are closed by construction rather than by careful ordering. Free permits and the waiter count live in separate fields of one atomic word, so returning a permit and withdrawing a waiter can no longer collide; a release only nudges a waiter to re-check the ledger, with the permit always taken from the shared count by CAS instead of being routed to one specific, possibly dead, waiter; and the teardown that returns a permit is installed before the claim, so an interrupt any time after a successful claim still releases it. The result is also simpler: a woken waiter re-competes as an ordinary fresh caller, collapsing what were two acquire paths into one.

## Notes

Ships with a deterministic reproduction of the original deadlock and an interrupt-storm test that reliably catches the whole "claim, then arm the teardown" bug class, both run on the JVM and Native schedulers where these races actually occur.

A few incidental cleanups ride along: the use* combinators go through Sync.acquireReleaseWith, a redundant suspension in the acquire path is dropped, and the acquire path's load-bearing invariants are now documented.
