### PR TITLE
[kyo-schema] classify discriminator id tokens without throwing

### DIFF
--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
@@ -1608,9 +1608,14 @@ private[kyo] object SchemaSerializer:
                     // Wire-format-agnostic fallback: when the underlying inner reader is wire-format-tagged
                     // (e.g. Protobuf, which reports fields by their numeric tag id), the buffered "name" is a
                     // numeric string. Match it against CodecMacro.fieldId(expected) to align with the way
-                    // the macro-generated case-class read body matches fields downstream.
-                    try parsed.toInt == CodecMacro.fieldId(expected)
-                    catch case _: NumberFormatException => false
+                    // the macro-generated case-class read body matches fields downstream. wireFieldId
+                    // classifies without throwing: the common token here is a plain field NAME, and paying
+                    // a NumberFormatException per non-id token is not merely slow on Scala Native, it is
+                    // fatal on some stacks: collecting the exception's stack trace walks the frames via
+                    // libunwind, which can segfault on deep continuation stacks (kyo-browser native suite,
+                    // SN 0.5.12: null read in CFI_Parser::decodeFDE during fillInStackTrace). fieldId is
+                    // always positive, so wireFieldId's -1 non-id sentinel never matches.
+                    wireFieldId(parsed) == CodecMacro.fieldId(expected)
                 end if
         end matchField
 


### PR DESCRIPTION
## Problem

`SchemaSerializer.DiscriminatorReader.matchField` classifies a buffered wire token as a numeric field id via `parsed.toInt` inside a try/catch. The common token on that fallback path is a plain field NAME, so a `NumberFormatException` is constructed and discarded per non-numeric token as ordinary control flow on the decode hot path.

Beyond the avoidable allocation and fill-in cost, this is fatal on Scala Native in some real workloads: constructing the exception collects its stack trace, and `Throwable.fillInStackTrace` walks the frames via libunwind, which segfaults with a null read (`CFI_Parser::decodeFDE` -> `LocalAddressSpace::get32`, `si_addr=(nil)`, SN 0.5.12) on certain deep continuation stacks. The kyo-browser native suite hit exactly this: `kyo.internal.ResolverTest` crashed the whole test binary (`ScalaNative: Unhandled signal 11`) whenever this classification threw under its parallel CDP decode test, and the trigger was layout-sensitive enough that unrelated source changes elsewhere flipped the crash on and off.

## Solution

Classify with the adjacent `wireFieldId` helper, which the file already uses for the same purpose elsewhere: a strict ASCII digit scan returning `-1` for any non-id token, no exception, no allocation. `CodecMacro.fieldId` is always positive (`(hash & 0x1fffff) + 1`), so the `-1` sentinel can never match and the comparison is equivalent for every reachable token. The one intentional difference is documented on `wireFieldId` itself: a name made of unicode digits stays classified as a NAME (previously `toInt` would have parsed it), which is the stricter, documented-correct behavior since real ids are always ASCII decimal.

With this change the kyo-browser native suite runs green where it previously segfaulted deterministically; the underlying Scala Native libunwind issue remains and is worth an upstream report, but kyo's decode path no longer constructs exceptions as control flow to trigger it.

## Tests

No behavior change: the kyo-schema test aggregate passes unchanged on the JVM, including ProtobufTest (the protobuf reader is the wire-format-tagged case this fallback exists for). On Scala Native, the previously deterministic SIGSEGV reproducer (`kyo-browserNative` `BrowserEvalLocateCountTest` + `ResolverTest` in one process) and the full kyo-browser native suite now pass with zero unhandled signals.
