### PR TITLE
[kyo-core] Signal: exact lossless observe on SignalRef via version-validated register/validate/await

### DIFF
--- a/kyo-core/shared/src/main/scala/kyo/Signal.scala
+++ b/kyo-core/shared/src/main/scala/kyo/Signal.scala
@@ -89,13 +89,16 @@ sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
       * closed before the next `f` runs, at most one value's children are alive at a time and no waiter or fiber accumulates across changes.
       *
       * It is designed never to permanently miss the latest value, even under a write that races the observation, and never to tear a
-      * still-current value's `Scope` down on an idle timer. Every signal uses the same repairing loop: it reads `current`, runs `f`, then
-      * re-arms a `nextWith`/`Async.sleep(repairInterval)` race that holds the value's `Scope` open until the next change. A write that lands
-      * in the narrow window between reading `current` and registering `nextWith` is missed by the immediate wakeup and reconciled when the
-      * repair timer next fires and re-reads `current` (the hold re-waits on a still-current value, so a repair timer never closes its `Scope`).
-      * So the final value is always delivered: immediately in the common case, and within `repairInterval` in the worst case when a write
-      * races that window. Correctness never depends on `repairInterval` ; only the worst-case reconciliation latency does. This variant uses
-      * [[Signal.defaultRepairInterval]].
+      * still-current value's `Scope` down on an idle timer. Delivery comes in two tiers. A [[SignalRef]] (and a `map` chain rooted in one)
+      * observes exactly: a version-validated register/validate/await protocol makes every change wake the observer immediately, with no
+      * repair timer armed at all (see the `SignalRef.observe` override). Combinator-derived signals (`zip`, `combineLatest`, `switchMap`,
+      * `zipAll`, `combineLatestAll`, custom `initRaw`) use the repairing loop: it reads `current`, runs `f`, then re-arms a
+      * `nextWith`/`Async.sleep(repairInterval)` race that holds the value's `Scope` open until the next change. A write that lands in the
+      * window between reading `current` and registering `nextWith` is missed by the immediate wakeup and reconciled when the repair timer
+      * next fires and re-reads `current` (the hold re-waits on a still-current value, so a repair timer never closes its `Scope`). So the
+      * final value is always delivered: immediately in the common case, and within `repairInterval` in the worst case when a write races
+      * that window on a derived signal. Correctness never depends on `repairInterval` ; only the worst-case reconciliation latency does.
+      * This variant uses [[Signal.defaultRepairInterval]].
       *
       * @param f
       *   The per-value setup, run inside a fresh `Scope`; it may fork scoped children (`Fiber.init`) and should return once setup is done,
@@ -114,11 +117,31 @@ sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
       * keeps the per-value `Scope` open.
       *
       * @param repairInterval
+      *   How often a parked observation re-reads `current` to reconcile a missed wakeup on the repair path; ignored by exact observers
+      *   (`SignalRef` and `map` chains rooted in one), which never miss a wakeup
+      * @param f
+      *   The per-value setup, run inside a fresh `Scope`
+      */
+    final def observe[S](repairInterval: Duration)(f: A => Unit < (S & Async & Scope))(using Frame): Unit < (S & Async) =
+        observe(Absent, repairInterval)(f)
+
+    /** Like [[observe]] but seeded: `f` is skipped while the current value still equals `baseline`.
+      *
+      * With `Absent` this is exactly [[observe]]. With `Present(v)` the loop treats `v` as the last observed value: the initial emission is
+      * skipped when the current value still equals it, and the first differing value is delivered as usual. This is the primitive behind
+      * [[observeChanges]] and behind callers that already processed the current value (e.g. painted it) and only want what changed since.
+      *
+      * This is the overridable observation primitive: [[SignalRef]] replaces the repairing loop with an exact register/validate/await
+      * protocol (see there), and `map` delegates to its source's loop.
+      *
+      * @param baseline
+      *   The value already processed by the caller: `f` is not run while `current` still equals it
+      * @param repairInterval
       *   How often a parked observation re-reads `current` to reconcile a missed wakeup on the repair path
       * @param f
       *   The per-value setup, run inside a fresh `Scope`
       */
-    def observe[S](repairInterval: Duration)(f: A => Unit < (S & Async & Scope))(using Frame): Unit < (S & Async) =
+    def observe[S](baseline: Maybe[A], repairInterval: Duration)(f: A => Unit < (S & Async & Scope))(using Frame): Unit < (S & Async) =
         // Repairing default. Each value runs inside a fresh `Scope.run`; the inner `holdUntilChanged` loops until `current`
         // differs from the value `f` set up, so an idle repair timer NEVER closes a still-current value's scope. The scope
         // closes (releasing what `f` forked) only when the value actually changes; then the outer loop re-reads `current`.
@@ -133,8 +156,21 @@ sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
                 else
                     Scope.run(f(cur).andThen(holdUntilChanged(cur))).andThen(loop(Present(cur)))
             }
-        loop(Absent)
+        loop(baseline)
     end observe
+
+    /** Runs `f` for every change AFTER subscription, skipping the initial current value.
+      *
+      * Identical to [[observe]] except that the value current at subscription time is not delivered: the first emission is the first value
+      * that differs from it. Same per-value [[Scope]] semantics and the same delivery tiers. This variant uses
+      * [[Signal.defaultRepairInterval]].
+      */
+    final def observeChanges[S](f: A => Unit < (S & Async & Scope))(using Frame): Unit < (S & Async) =
+        observeChanges(Signal.defaultRepairInterval)(f)
+
+    /** Like [[observeChanges]] but with an explicit reconciliation interval. */
+    final def observeChanges[S](repairInterval: Duration)(f: A => Unit < (S & Async & Scope))(using Frame): Unit < (S & Async) =
+        currentWith(c => observe(Present(c), repairInterval)(f))
 
     /** Creates a new signal by applying a transformation function to this signal's values.
       *
@@ -151,7 +187,19 @@ sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
         Signal._initRawF(
             [C, S] => g => self.currentWith(a => g(f(a))),
             [C, S] => g => self.nextWith(a => g(f(a))),
-            [S] => (ri, g) => self.observe[S](ri)(a => g(f(a)))
+            [S] =>
+                (baseline, ri, g) =>
+                    baseline match
+                        case Present(b0) =>
+                            // Translate the B-space baseline into an A-space seed by sampling the source: skip
+                            // while the source still holds a value whose image equals the baseline. A source
+                            // change whose image happens to equal the baseline re-emits it, consistent with a
+                            // mapped observe already re-emitting equal images for distinct source values.
+                            self.currentWith { a0 =>
+                                if f(a0) == b0 then self.observe[S](Present(a0), ri)(a => g(f(a)))
+                                else self.observe[S](Absent, ri)(a => g(f(a)))
+                            }
+                        case _ => self.observe[S](Absent, ri)(a => g(f(a)))
         )
 
     /** Dynamically switches to an inner signal based on the current value.
@@ -160,8 +208,9 @@ sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
       * that change. This is switchMap semantics (no monad laws): the previous inner is implicitly dropped on outer change. The caller
       * re-arms via `nextWith` in a loop matching the `streamChanges` driver pattern.
       *
-      * Note: like `streamChanges`, may skip intermediate values if changes occur faster than they can be processed. The read/arm race
-      * window in `SignalRef` propagates here.
+      * Note: like `streamChanges`, may skip intermediate values if changes occur faster than they can be processed. The combinator's own
+      * await/re-read window applies here (a write landing between the wakeup and the re-read is coalesced); observation over it is
+      * reconciled within the repair interval.
       *
       * @param f
       *   The function that produces an inner signal from the current value
@@ -228,27 +277,20 @@ sealed abstract class Signal[A](using CanEqual[A, A]) extends Serializable:
 
     /** Creates a stream that emits only when the signal's value changes.
       *
-      * This method produces a stream that emits values only when they differ from the previous value. Note that rapid changes may result in
-      * some intermediate values being skipped if they occur faster than they can be processed.
+      * The value current at subscription time is NOT emitted: the first element is the first value that differs from it. Built on
+      * [[observeChanges]], so it inherits its delivery tiers: exact on a [[SignalRef]] (and `map` chains rooted in one), reconciled within
+      * `repairInterval` on combinator-derived signals. Rapid changes may still coalesce (the stream is level-based, not a queue). This
+      * variant uses [[Signal.defaultRepairInterval]].
       *
       * @return
-      *   A stream that emits only when values change
+      *   A stream that emits only when the value changes, skipping the subscription-time value
       */
     final def streamChanges(using Frame, Tag[Emit[Chunk[A]]]): Stream[A, Async] =
-        Stream(
-            Loop(Maybe.empty[A]) { last =>
-                currentWith { curr =>
-                    if last.forall(_ != curr) then
-                        Emit.valueWith(Chunk(curr))(Loop.continue(Present(curr)))
-                    else
-                        nextWith { a =>
-                            Emit.valueWith(Chunk(a))(Loop.continue(Present(a)))
-                        }
-                }
+        streamChanges(Signal.defaultRepairInterval)
 
-            }
-        )
-    end streamChanges
+    /** Like [[streamChanges]] but with an explicit reconciliation interval. */
+    final def streamChanges(repairInterval: Duration)(using Frame, Tag[Emit[Chunk[A]]]): Stream[A, Async] =
+        Stream(observeChanges[Emit[Chunk[A]]](repairInterval)(a => Emit.value(Chunk(a))))
 
 end Signal
 
@@ -260,7 +302,8 @@ object Signal:
       *
       * It bounds how soon a missed wakeup is reconciled by re-reading `current`: a write that races the observation's
       * read/register window is delivered within this interval. Real changes are otherwise immediate, so this can be
-      * generous; it exists to bound that rare race, not to drive normal updates.
+      * generous; it exists to bound that rare race, not to drive normal updates. Exact observers ([[SignalRef]] and
+      * `map` chains rooted in one) never miss a wakeup and ignore it entirely, arming no timer at all.
       */
     val defaultRepairInterval: Duration = 1.second
 
@@ -500,7 +543,7 @@ object Signal:
     private inline def _initRawF[A](
         inline _currentWith: [B, S] => (A => B < S) => B < (S & Sync),
         inline _nextWith: [B, S] => (A => B < S) => B < (S & Async),
-        inline _observe: [S] => (Duration, A => Unit < (S & Async & Scope)) => Unit < (S & Async)
+        inline _observe: [S] => (Maybe[A], Duration, A => Unit < (S & Async & Scope)) => Unit < (S & Async)
     )(
         using
         frame: Frame,
@@ -511,8 +554,10 @@ object Signal:
                 _currentWith(f)
             def nextWith[B, S](f: A => B < S)(using frame: Frame): B < (S & Async) =
                 _nextWith(f)
-            override def observe[S](repairInterval: Duration)(f: A => Unit < (S & Async & Scope))(using frame: Frame): Unit < (S & Async) =
-                _observe(repairInterval, f)
+            override def observe[S](baseline: Maybe[A], repairInterval: Duration)(f: A => Unit < (S & Async & Scope))(using
+                frame: Frame
+            ): Unit < (S & Async) =
+                _observe(baseline, repairInterval, f)
         end new
     end _initRawF
 
@@ -530,16 +575,67 @@ object Signal:
 
         def nextWith[B, S](f: A => B < S)(using Frame) = Sync.Unsafe.defer(unsafe.next().safe.use(f))
 
-        // `observe` is intentionally NOT overridden here: `SignalRef` uses the trait's repairing `observe`.
+        // Exact, lossless observation via a version-validated register/validate/await protocol.
         //
-        // An earlier exact, register-before-read override captured the next-change promise before reading `current` and
-        // held it live across the per-value `Scope.run`/`Async` suspension. That pattern miscompiles on Scala Native
-        // 0.5.10: although it runs correctly in isolation (kyo-core's own native suite passes), its mere presence in a
-        // downstream native binary perturbs whole-program codegen and corrupts the heap, surfacing as an unrecoverable
-        // SIGSEGV/SIGABRT under concurrent load (reproduced in the kyo-browser native suite). The repairing loop never
-        // holds a promise across the suspension, emits no such pattern, and is lossless: a write that races the
-        // read/register window is reconciled within `repairInterval`, never dropped. Do not reintroduce an exact
-        // override without re-validating the full kyo-browser native suite.
+        // Writer order (see Unsafe.onUpdate): value write, version increment, promise swap+complete. The observer
+        // reads the version BEFORE the value, runs `f`, and re-arms through `nextSince(v0)`: capture the
+        // next-change promise, re-check the version, and only park when it is unchanged.
+        //   - If the validate step sees a newer version, `nextSince` returns immediately and the re-read observes
+        //     the new value (the value write happens before the increment).
+        //   - Otherwise the capture happened before that write's promise swap, and the swap completes exactly the
+        //     captured promise. Either way no change is stranded, with no repair timer armed at all (so an idle
+        //     parked observer costs nothing and holds exactly one waiter).
+        //   - Version-before-value is load-bearing: reading the value first could pair a fresh value with a stale
+        //     version and validate cleanly against a completion nobody held.
+        // Coalescing stays allowed (observation is level-based): a change-and-revert during `f` wakes the
+        // observer, re-reads an unchanged value, and re-arms.
+        //
+        // Scala Native note: earlier revisions of this override were blamed for kyo-browser native suite
+        // SIGSEGVs ("miscompiles", "heap corruption"). Root-caused 2026-07-31: the crashes never involved
+        // Signal at all (the class is unreachable from that binary; zero Signal symbols in the linked
+        // artifact). The real fault is a Scala Native 0.5.12 libunwind null read (CFI_Parser::decodeFDE
+        // during Throwable.fillInStackTrace) on certain deep continuation stacks, triggered whenever an
+        // exception is constructed there, and layout-sensitive enough that unrelated source changes (like
+        // adding a method here) flipped it on and off. The trigger on kyo's side was an exception thrown
+        // per non-numeric token in SchemaSerializer.DiscriminatorReader.matchField, since made
+        // exception-free. If the kyo-browser native suite segfaults after touching this file, suspect
+        // exception construction on deep stacks (si_addr=(nil), libunwind frames in the core), not this
+        // code.
+        override def observe[S](baseline: Maybe[A], repairInterval: Duration)(f: A => Unit < (S & Async & Scope))(using
+            Frame
+        ): Unit < (S & Async) =
+            // The repair interval is unused here: delivery is exact. The parameter exists for signals that can
+            // miss wakeups (combinator-derived ones run the trait's repairing loop).
+            discard(repairInterval)
+            def nextSince(v0: Long): Unit < Async =
+                Sync.Unsafe.defer {
+                    if _unsafe.version() != v0 then ()
+                    else
+                        // Race wrapper: the next-promise is masked, and a fiber parked directly on a masked
+                        // promise is not resumed by its own interrupt; racing behind a fresh result promise
+                        // restores interruptibility.
+                        Async.race(Seq(
+                            Sync.Unsafe.defer {
+                                val waiter = _unsafe.next().safe
+                                if _unsafe.version() != v0 then (): Unit < Async
+                                else waiter.use(_ => ())
+                            }
+                        ))
+                }
+            def hold(v0: Long, cur: A): Unit < Async =
+                nextSince(v0).andThen(Sync.Unsafe.defer {
+                    val v1 = _unsafe.version()
+                    if _unsafe.get() == cur then hold(v1, cur) else (): Unit < Async
+                })
+            def loop(last: Maybe[A]): Unit < (S & Async) =
+                Sync.Unsafe.defer {
+                    val v0  = _unsafe.version()
+                    val cur = _unsafe.get()
+                    if last.exists(_ == cur) then nextSince(v0).andThen(loop(last))
+                    else Scope.run(f(cur).andThen(hold(v0, cur))).andThen(loop(Present(cur)))
+                }
+            loop(baseline)
+        end observe
 
         /** Retrieves the current value of the reference.
           *
@@ -637,10 +733,16 @@ object Signal:
           */
         final class Unsafe[A] private (
             currentRef: AtomicRef.Unsafe[A],
-            nextPromise: AtomicRef.Unsafe[Promise.Unsafe[A, Any]]
+            nextPromise: AtomicRef.Unsafe[Promise.Unsafe[A, Any]],
+            versionRef: AtomicLong.Unsafe
         )(using CanEqual[A, A]):
 
             def get()(using AllowUnsafe): A = currentRef.get()
+
+            /** Monotonic change counter, incremented once per distinct-value update. `SignalRef.observe` uses it
+              * to validate that no write landed between reading `current` and capturing the next-change promise.
+              */
+            def version()(using AllowUnsafe): Long = versionRef.get()
 
             def set(value: A)(using AllowUnsafe): Unit =
                 discard(getAndSet(value))
@@ -695,8 +797,13 @@ object Signal:
                 nextPromise.get()
 
             private def onUpdate(value: A)(using AllowUnsafe): Unit =
+                // The version MUST be bumped before the promise swap. Writer order is: value write (in the
+                // caller), version increment, promise swap+complete. `SignalRef.observe`'s register/validate
+                // protocol relies on exactly this order for losslessness (see the override).
+                discard(versionRef.incrementAndGet())
                 nextPromise.getAndSet(Promise.Unsafe.initMasked())
                     .completeDiscard(Result.succeed(value))
+            end onUpdate
 
             def waiters()(using AllowUnsafe): Int = nextPromise.get().waiters()
 
@@ -715,7 +822,8 @@ object Signal:
                     // signal's next-promise and accidentally interrupt other subscribers waiting on the
                     // same signal. All subsequent promises (created in onUpdate) are already masked for
                     // the same reason; the initial promise must be consistent.
-                    AtomicRef.Unsafe.init(Promise.Unsafe.initMasked())
+                    AtomicRef.Unsafe.init(Promise.Unsafe.initMasked()),
+                    AtomicLong.Unsafe.init(0L)
                 )
         end Unsafe
 

--- a/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
+++ b/kyo-core/shared/src/test/scala/kyo/SignalTest.scala
@@ -218,6 +218,7 @@ class SignalTest extends kyo.test.Test[Any]:
         }
 
         "streamChanges" in {
+            // Changes only: the subscription-time value (1) is NOT emitted.
             for
                 ref    <- Signal.initRef(1)
                 f      <- Fiber.initUnscoped(ref.streamChanges.take(3).run)
@@ -228,8 +229,24 @@ class SignalTest extends kyo.test.Test[Any]:
                 _      <- Async.sleep(100.millis)
                 _      <- ref.set(3)
                 _      <- Async.sleep(100.millis)
+                _      <- ref.set(4)
+                _      <- Async.sleep(100.millis)
                 values <- f.get
-            yield assert(values == Chunk(1, 2, 3))
+            yield assert(values == Chunk(2, 3, 4))
+        }
+
+        "streamChanges delivers changes with NO repair timer on a leaf" in {
+            // Exact delivery on a SignalRef: with an infinite reconciliation interval nothing would heal a
+            // missed wakeup, so this pins that the exact protocol never misses one.
+            for
+                ref    <- Signal.initRef(0)
+                f      <- Fiber.initUnscoped(ref.streamChanges(Duration.Infinity).take(2).run)
+                _      <- Async.sleep(100.millis)
+                _      <- ref.set(1)
+                _      <- Async.sleep(100.millis)
+                _      <- ref.set(2)
+                values <- f.get
+            yield assert(values == Chunk(1, 2))
         }
     }
 
@@ -352,6 +369,7 @@ class SignalTest extends kyo.test.Test[Any]:
         }
 
         "inside streamChanges produces expected sequence" in {
+            // Changes only: the subscription-time value (10) is NOT emitted.
             for
                 outer <- Signal.initRef(0)
                 inner <- Signal.initRef(10)
@@ -361,8 +379,10 @@ class SignalTest extends kyo.test.Test[Any]:
                 _  <- inner.set(11)
                 _  <- Async.sleep(100.millis)
                 _  <- inner.set(12)
+                _  <- Async.sleep(100.millis)
+                _  <- inner.set(13)
                 vs <- f.get
-            yield assert(vs == Chunk(10, 11, 12))
+            yield assert(vs == Chunk(11, 12, 13))
         }
 
         "switchMap f called once when only inner changes" in {
@@ -508,11 +528,12 @@ class SignalTest extends kyo.test.Test[Any]:
         }
 
         "interleaved self,other,self,other produces four emits" in {
+            // Changes only: the subscription-time pair (0, 0) is NOT emitted.
             for
                 refA <- Signal.initRef(0)
                 refB <- Signal.initRef(0)
                 cl = refA.combineLatest(refB)
-                f  <- Fiber.initUnscoped(cl.streamChanges.take(5).run)
+                f  <- Fiber.initUnscoped(cl.streamChanges.take(4).run)
                 _  <- Async.sleep(50.millis)
                 _  <- refA.set(1)
                 _  <- Async.sleep(50.millis)
@@ -522,7 +543,7 @@ class SignalTest extends kyo.test.Test[Any]:
                 _  <- Async.sleep(50.millis)
                 _  <- refB.set(2)
                 vs <- f.get
-            yield assert(vs.size >= 4 && vs.last == (2, 2))
+            yield assert(vs.size == 4 && vs.last == (2, 2))
         }
 
         "source remains usable after concurrent waiters complete" in {
@@ -747,14 +768,16 @@ class SignalTest extends kyo.test.Test[Any]:
         }
 
         "rapid bursts coalesce" in {
+            // Changes only: the subscription-time Chunk(0) is NOT emitted, and the burst may collapse into a
+            // single coalesced emission, so only the first change emission is awaited.
             for
                 ref <- Signal.initRef(0)
                 z = Signal.combineLatestAll(Seq(ref))
-                f  <- Fiber.initUnscoped(z.streamChanges.take(2).run)
+                f  <- Fiber.initUnscoped(z.streamChanges.take(1).run)
                 _  <- Async.sleep(50.millis)
                 _  <- Kyo.foreachDiscard(Seq.range(1, 11))(ref.set)
                 vs <- f.get
-            yield assert(vs.size == 2 && vs.head == Chunk(0) && vs.last.head >= 1)
+            yield assert(vs.size == 1 && vs.head.head >= 1)
         }
 
     }
@@ -774,6 +797,7 @@ class SignalTest extends kyo.test.Test[Any]:
         }
 
         "switchMap inside streamChanges with mutation" in {
+            // Changes only: the subscription-time value (10) is NOT emitted.
             for
                 outer <- Signal.initRef(0)
                 inner <- Signal.initRef(10)
@@ -784,16 +808,19 @@ class SignalTest extends kyo.test.Test[Any]:
                 _  <- inner.set(11)
                 _  <- Async.sleep(100.millis)
                 _  <- inner.set(12)
+                _  <- Async.sleep(100.millis)
+                _  <- inner.set(13)
                 vs <- f.get
-            yield assert(vs == Chunk(10, 11, 12))
+            yield assert(vs == Chunk(11, 12, 13))
         }
 
         "combineLatest feeding streamChanges produces interleaved emit sequence" in {
+            // Changes only: the subscription-time pair (0, 0) is NOT emitted.
             for
                 refA <- Signal.initRef(0)
                 refB <- Signal.initRef(0)
                 cl = refA.combineLatest(refB)
-                f  <- Fiber.initUnscoped(cl.streamChanges.take(5).run)
+                f  <- Fiber.initUnscoped(cl.streamChanges.take(4).run)
                 _  <- Async.sleep(50.millis)
                 _  <- refA.set(1)
                 _  <- Async.sleep(50.millis)
@@ -803,7 +830,7 @@ class SignalTest extends kyo.test.Test[Any]:
                 _  <- Async.sleep(50.millis)
                 _  <- refB.set(2)
                 vs <- f.get
-            yield assert(vs.size >= 4 && vs.last == (2, 2))
+            yield assert(vs.size == 4 && vs.last == (2, 2))
         }
 
     }
@@ -828,19 +855,24 @@ class SignalTest extends kyo.test.Test[Any]:
     // never lost: a write that lands in the read/register window is reconciled within `repairInterval`. Drive
     // back-to-back set(a);set(b) under an explicit short repairInterval (50ms) and require the final value to arrive
     // within a generous multiple of it (1s); a returned count > 0 means a value was actually lost, not merely late.
-    private def observeNeverLosesFinalValue(useMap: Boolean, iterations: Int)(using Frame): Int < Async =
+    private def observeNeverLosesFinalValue(
+        useMap: Boolean,
+        iterations: Int,
+        repairInterval: Duration = 50.millis,
+        maxTries: Int = 1000
+    )(using Frame): Int < Async =
         for
             ref <- Signal.initRef("")
             sig = if useMap then ref.map(v => v) else ref
             lastSeen <- AtomicRef.init("")
-            fiber    <- Fiber.initUnscoped(sig.observe(50.millis)(lastSeen.set(_)))
+            fiber    <- Fiber.initUnscoped(sig.observe(repairInterval)(lastSeen.set(_)))
             misses <- Kyo.foreach(Chunk.from(1 to iterations)) { i =>
                 val a = s"a$i"
                 val b = s"b$i"
                 for
                     _   <- ref.set(a)
                     _   <- ref.set(b)
-                    got <- awaitValue(lastSeen, b, 1000)
+                    got <- awaitValue(lastSeen, b, maxTries)
                 yield if got then 0 else 1
                 end for
             }
@@ -908,6 +940,91 @@ class SignalTest extends kyo.test.Test[Any]:
 
         "never loses the final value under back-to-back writes (map delegates to leaf)" in {
             observeNeverLosesFinalValue(useMap = true, iterations = 5000).map(lost => assert(lost == 0, s"map lost $lost / 5000"))
+        }
+
+        "never loses the final value with NO repair timer (SignalRef leaf, exact protocol)" in {
+            // With an infinite repair interval nothing heals a missed wakeup: this only passes because the
+            // version-validated register/validate/await protocol never misses one in the first place.
+            observeNeverLosesFinalValue(useMap = false, iterations = 5000, repairInterval = Duration.Infinity, maxTries = 500)
+                .map(lost => assert(lost == 0, s"SignalRef lost $lost / 5000 without repair"))
+        }
+
+        "never loses the final value with NO repair timer (map delegates to leaf)" in {
+            observeNeverLosesFinalValue(useMap = true, iterations = 5000, repairInterval = Duration.Infinity, maxTries = 500)
+                .map(lost => assert(lost == 0, s"map lost $lost / 5000 without repair"))
+        }
+
+        "delivers a write landing while f runs, without repair (SignalRef leaf)" in {
+            // The historical loss window: f(0) is still running when the write lands, so the promise captured
+            // by the swap completes with nobody parked on it. The exact protocol validates the version when it
+            // re-arms and must deliver immediately; the old repairing loop with an infinite interval would
+            // strand the value forever.
+            for
+                ref     <- Signal.initRef(0)
+                gate    <- Latch.init(1)
+                started <- Latch.init(1)
+                seen    <- AtomicRef.init(Chunk.empty[Int])
+                fiber <- Fiber.initUnscoped(ref.observe(Duration.Infinity) { v =>
+                    recordValue(seen, v).andThen {
+                        if v == 0 then started.release.andThen(gate.await) else (): Unit < Async
+                    }
+                })
+                _  <- started.await
+                _  <- ref.set(1) // lands while f(0) is blocked on the gate
+                _  <- gate.release
+                ok <- pollUntil(seen.get.map(_.contains(1)))
+                _  <- fiber.interrupt
+            yield assert(ok)
+        }
+
+        "delivers a write landing while f runs, without repair (map over leaf)" in {
+            for
+                ref     <- Signal.initRef(0)
+                gate    <- Latch.init(1)
+                started <- Latch.init(1)
+                seen    <- AtomicRef.init(Chunk.empty[Int])
+                sig = ref.map(_ + 10)
+                fiber <- Fiber.initUnscoped(sig.observe(Duration.Infinity) { v =>
+                    recordValue(seen, v).andThen {
+                        if v == 10 then started.release.andThen(gate.await) else (): Unit < Async
+                    }
+                })
+                _  <- started.await
+                _  <- ref.set(1)
+                _  <- gate.release
+                ok <- pollUntil(seen.get.map(_.contains(11)))
+                _  <- fiber.interrupt
+            yield assert(ok)
+        }
+
+        "an idle parked observer holds exactly one waiter (no repair ticks on a leaf)" in {
+            // The old repairing loop armed a nextWith/sleep race per interval; each tick cancelled a waiter
+            // parked on the masked promise, leaving a ghost until the next set. The exact protocol arms no
+            // timer, so the waiter count stays at exactly one across several would-be intervals.
+            for
+                ref   <- Signal.initRef(0)
+                seen  <- AtomicRef.init(Chunk.empty[Int])
+                fiber <- Fiber.initUnscoped(ref.observe(50.millis)(recordValue(seen, _)))
+                _     <- pollUntil(seen.get.map(_.nonEmpty))
+                _     <- Async.sleep(200.millis)
+                w     <- ref.waiters
+                _     <- fiber.interrupt
+            yield assert(w == 1)
+        }
+
+        "version increments only on distinct-value writes" in {
+            import AllowUnsafe.embrace.danger
+            for
+                ref <- Signal.initRef(0)
+                v0  <- Sync.defer(ref.unsafe.version())
+                _   <- ref.set(0) // same value: no notification, no version bump
+                v1  <- Sync.defer(ref.unsafe.version())
+                _   <- ref.set(1)
+                v2  <- Sync.defer(ref.unsafe.version())
+                _   <- ref.getAndUpdate(_ + 1)
+                v3  <- Sync.defer(ref.unsafe.version())
+            yield assert(v1 == v0 && v2 == v0 + 1 && v3 == v0 + 2)
+            end for
         }
 
         "reconciles a missed wakeup within repairInterval on a non-exact signal" in {
@@ -1120,6 +1237,93 @@ class SignalTest extends kyo.test.Test[Any]:
                 _      <- ref.set(1)
                 result <- seen.get
             yield assert(result == Chunk(0)) // the post-interrupt change is not observed
+        }
+    }
+
+    "observeChanges" - {
+        "does not emit the subscription-time value" in {
+            for
+                ref    <- Signal.initRef(0)
+                seen   <- AtomicRef.init(Chunk.empty[Int])
+                fiber  <- Fiber.initUnscoped(ref.observeChanges(recordValue(seen, _)))
+                _      <- Async.sleep(50.millis)
+                silent <- seen.get
+                _      <- ref.set(1)
+                _      <- pollUntil(seen.get.map(_.contains(1)))
+                result <- seen.get
+                _      <- fiber.interrupt
+            yield assert(silent.isEmpty && result == Chunk(1))
+        }
+
+        "delivers subsequent distinct changes in order" in {
+            for
+                ref    <- Signal.initRef(0)
+                seen   <- AtomicRef.init(Chunk.empty[Int])
+                fiber  <- Fiber.initUnscoped(ref.observeChanges(recordValue(seen, _)))
+                _      <- Async.sleep(30.millis)
+                _      <- ref.set(1)
+                _      <- pollUntil(seen.get.map(_.contains(1)))
+                _      <- ref.set(2)
+                _      <- pollUntil(seen.get.map(_.contains(2)))
+                result <- seen.get
+                _      <- fiber.interrupt
+            yield assert(result == Chunk(1, 2))
+        }
+
+        "a write racing subscription folds into the baseline or is delivered, never stranded" in {
+            // The baseline is sampled when the observation starts running: a write landing before that sample
+            // folds into the baseline (correctly not emitted), one landing after it is emitted. Either way,
+            // once the observer is parked every subsequent change must be delivered.
+            for
+                ref    <- Signal.initRef(0)
+                seen   <- AtomicRef.init(Chunk.empty[Int])
+                fiber  <- Fiber.initUnscoped(ref.observeChanges(recordValue(seen, _)))
+                _      <- ref.set(1)                                // may land before or after the baseline sample
+                _      <- assertEventually(ref.waiters.map(_ >= 1)) // observer parked: baseline settled
+                _      <- ref.set(2)
+                ok     <- pollUntil(seen.get.map(_.contains(2)))
+                result <- seen.get
+                _      <- fiber.interrupt
+            yield assert(ok && (result == Chunk(2) || result == Chunk(1, 2)))
+        }
+
+        "stops after interruption" in {
+            for
+                ref    <- Signal.initRef(0)
+                seen   <- AtomicRef.init(Chunk.empty[Int])
+                fiber  <- Fiber.initUnscoped(ref.observeChanges(recordValue(seen, _)))
+                _      <- Async.sleep(30.millis)
+                _      <- fiber.interrupt
+                _      <- fiber.getResult
+                _      <- ref.set(1)
+                _      <- Async.sleep(30.millis)
+                result <- seen.get
+            yield assert(result.isEmpty)
+        }
+
+        "seeded observe with a stale baseline emits the current value immediately" in {
+            for
+                ref   <- Signal.initRef(5)
+                seen  <- AtomicRef.init(Chunk.empty[Int])
+                fiber <- Fiber.initUnscoped(ref.observe(Present(4), Signal.defaultRepairInterval)(recordValue(seen, _)))
+                ok    <- pollUntil(seen.get.map(_.contains(5)))
+                _     <- fiber.interrupt
+            yield assert(ok)
+        }
+
+        "map chain skips while the source image equals the baseline" in {
+            for
+                ref <- Signal.initRef(1)
+                sig = ref.map(_ * 2)
+                seen   <- AtomicRef.init(Chunk.empty[Int])
+                fiber  <- Fiber.initUnscoped(sig.observeChanges(recordValue(seen, _)))
+                _      <- Async.sleep(50.millis)
+                silent <- seen.get
+                _      <- ref.set(2)
+                _      <- pollUntil(seen.get.map(_.contains(4)))
+                result <- seen.get
+                _      <- fiber.interrupt
+            yield assert(silent.isEmpty && result == Chunk(4))
         }
     }
 

--- a/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/internal/SchemaSerializer.scala
@@ -1608,9 +1608,14 @@ private[kyo] object SchemaSerializer:
                     // Wire-format-agnostic fallback: when the underlying inner reader is wire-format-tagged
                     // (e.g. Protobuf, which reports fields by their numeric tag id), the buffered "name" is a
                     // numeric string. Match it against CodecMacro.fieldId(expected) to align with the way
-                    // the macro-generated case-class read body matches fields downstream.
-                    try parsed.toInt == CodecMacro.fieldId(expected)
-                    catch case _: NumberFormatException => false
+                    // the macro-generated case-class read body matches fields downstream. wireFieldId
+                    // classifies without throwing: the common token here is a plain field NAME, and paying
+                    // a NumberFormatException per non-id token is not merely slow on Scala Native, it is
+                    // fatal on some stacks: collecting the exception's stack trace walks the frames via
+                    // libunwind, which can segfault on deep continuation stacks (kyo-browser native suite,
+                    // SN 0.5.12: null read in CFI_Parser::decodeFDE during fillInStackTrace). fieldId is
+                    // always positive, so wireFieldId's -1 non-id sentinel never matches.
+                    wireFieldId(parsed) == CodecMacro.fieldId(expected)
                 end if
         end matchField
 


### PR DESCRIPTION
> **⚠ Depends on #1827: please merge it first.** The kyo-browser native suite is only reliably green with the exception-free discriminator classification from #1827 (see the Scala Native paragraph below); the branch is stacked accordingly and the diff shows its commit until it lands.

## Problem

`Signal.observe` can miss a change for up to `repairInterval` (1s by default). The observe loop reads `current`, runs the observer body `f`, and only then registers on the next-change promise. A write that lands while `f` runs completes the previous promise with nobody parked on it: the observer then parks on the fresh promise and the change is stranded until either the next write or the periodic repair tick re-reads `current`.

The window is not narrow: it spans the entire execution of `f`. With many observers re-subscribing after a burst (a UI re-rendering a large list, for example), a measurable share of follow-up signal writes land inside it, and every one of them costs up to a second of latency. The repair timer that heals this also has a standing cost: every parked observer wakes once per interval, and each tick's cancelled race arm leaves a ghost waiter on the masked promise until the next write.

## Solution

Make `SignalRef` observation exact with a version-validated register/validate/await protocol, so no wakeup can be missed and no repair timer needs to be armed at all.

`SignalRef.Unsafe` gains a monotonic version counter, incremented once per distinct-value update, before the promise swap. Writer order is: value write, version increment, promise swap+complete. The observer reads the version before the value, runs `f`, and re-arms by capturing the next-change promise and re-checking the version:

- If the validate step sees a newer version, it returns immediately and the re-read observes the value (the value write happens before the increment).
- Otherwise the capture happened before that write's promise swap, and the swap completes exactly the captured promise.

Either way no change is stranded. An idle parked observer holds exactly one waiter and wakes only on a real change. Coalescing stays allowed: observation is level-based, not a queue.

The Scala Native "miscompile" warning at the previous comment block turned out to be a misdiagnosis, and this PR rewrites it with the actual finding. The historical kyo-browser native suite SIGSEGVs never involved `Signal`: the class is unreachable from that test binary (zero `Signal` symbols in the linked artifact), and core dumps show the real fault is a Scala Native 0.5.12 libunwind null read (`CFI_Parser::decodeFDE` inside `Throwable.fillInStackTrace`) on certain deep continuation stacks, layout-sensitive enough that unrelated source changes flipped it on and off. The kyo-side trigger was an exception thrown per non-numeric token in `SchemaSerializer.DiscriminatorReader.matchField`; with that classification made exception-free (using the adjacent `wireFieldId` helper), the full kyo-browser native suite is green on this change. Only a `Long` crosses `f` in this override; the promise handle is captured inside the race arm after `f` returned and dies with the re-arm call.

Delivery now comes in two documented tiers:

| Signal | Delivery |
|---|---|
| `SignalRef`, `map` chains rooted in one | exact, no repair timer armed |
| combinator-derived (`zip`, `combineLatest`, `switchMap`, `zipAll`, `combineLatestAll`, custom `initRaw`) | repairing loop, reconciled within `repairInterval` |

## API additions

- `observe(baseline: Maybe[A], repairInterval)(f)`: the (overridable) seeded primitive. `f` is skipped while `current` still equals `baseline`; existing `observe` overloads delegate with `Absent` and keep their exact semantics, including the initial emission.
- `observeChanges([repairInterval])(f)`: observes every change after subscription, skipping the value current at subscription time. This is the common "I already processed the current value" subscription, previously hand-rolled with a mutable first-emission flag.
- `streamChanges` is rebuilt on `observeChanges` and now matches its name and scaladoc: the subscription-time value is not emitted (previously it was), and a change can no longer strand until the next write (it had no repair path at all). `streamChanges(repairInterval)` overload added. No production call sites existed; tests are updated.

## Tests

New: a write landing while `f` runs is delivered with `repairInterval = Duration.Infinity` (hangs forever on the old loop), for the leaf and through `map`; the back-to-back loss harness re-run with `Infinity` and a tight await budget; `waiters == 1` across several would-be repair intervals; version increments only on distinct writes; `observeChanges` semantics (no initial emission, in-order changes, subscribe-race safety, interrupt); seeded-baseline semantics; `streamChanges` changes-only and no-repair delivery. All existing per-value `Scope` invariants (single live scope, interrupt cascade, no idle teardown) are unchanged and pass.
