### PR TITLE
[kyo-net] degrade to NIO when the posix native is unavailable

### DIFF
--- a/kyo-net/jvm-native/src/main/scala/kyo/net/internal/backend/PosixBackends.scala
+++ b/kyo-net/jvm-native/src/main/scala/kyo/net/internal/backend/PosixBackends.scala
@@ -10,6 +10,7 @@ import kyo.net.internal.posix.KqueueBindings
 import kyo.net.internal.posix.PollerIoDriver
 import kyo.net.internal.posix.PosixConstants
 import kyo.net.internal.posix.PosixHandle
+import kyo.net.internal.posix.PosixShimBindings
 import kyo.net.internal.posix.PosixTransport
 import kyo.net.internal.posix.SocketBindings
 import kyo.net.internal.transport.IoDriver
@@ -34,6 +35,7 @@ private[net] object EpollBackend extends PosixIoBackend:
             val ep = Ffi.load[EpollBindings]
             val fd = ep.epoll_create1(0).value
             if fd >= 0 then
+                requirePosixShim(fd)
                 discard(Ffi.load[SocketBindings].close(fd))
                 true
             else false
@@ -51,6 +53,7 @@ private[net] object KqueueBackend extends PosixIoBackend:
             val kq = Ffi.load[KqueueBindings]
             val fd = kq.kqueue().value
             if fd >= 0 then
+                requirePosixShim(fd)
                 discard(Ffi.load[SocketBindings].close(fd))
                 true
             else false
@@ -83,6 +86,16 @@ end IoUringBackend
 private def probe(test: => Boolean): Boolean =
     try test
     catch case _: Throwable => false
+
+/** Exercise the bundled `kyonet_posix_uring` shim (a read-only `F_GETFL` on an already-open fd) as part of a backend probe. The epoll and
+  * kqueue probes otherwise touch only libc (`epoll_create1` / `kqueue`), which resolves on a host whose BUNDLED native is absent, so those
+  * backends would report available and then crash at the first socket op (`PosixTransport.prepareClientSocket` -> `kyo_posix_set_nonblocking`).
+  * Loading the shim here throws when the bundled native is missing for this platform; the enclosing `probe { ... }` catches it and demotes the
+  * backend, so selection falls to the NIO floor instead. Only that the shim LOADS matters, the returned flags are ignored. `IoUringBackend` needs
+  * no equivalent: its probe already loads the same bundled library.
+  */
+private def requirePosixShim(fd: Int)(using AllowUnsafe): Unit =
+    discard(Ffi.load[PosixShimBindings].kyo_posix_get_flags(fd))
 
 /** A selectable registry entry: the identity `IoBackend.select` reads (`name` / `priority` / `isAvailable`), plus a `build` thunk that
   * constructs and starts the entry's transport. `build` is invoked only once selection wins, so an unavailable entry never constructs a driver.

--- a/kyo-net/jvm/src/test/scala/kyo/net/internal/backend/JvmPosixBackendSelectionTest.scala
+++ b/kyo-net/jvm/src/test/scala/kyo/net/internal/backend/JvmPosixBackendSelectionTest.scala
@@ -114,4 +114,40 @@ class JvmPosixBackendSelectionTest extends Test:
         assert(nioEntries.head.isAvailable, "the nio floor must be unconditionally available")
     }
 
+    "a posix backend whose bundled shim cannot load demotes to the nio floor instead of crashing" in {
+        // A posix host whose bundled kyonet_posix_uring native is absent must demote its posix backend to the nio floor rather than select it
+        // and crash at the first socket op, where the data path calls the shim's kyo_posix_set_nonblocking. PosixShimBindings' load state is
+        // cached JVM-wide, so the missing-native case cannot be induced in-process; a fresh child JVM with the bundled lib pointed at a
+        // nonexistent path drives the probe to fail there. Runs on any posix host (kqueue on macOS/BSD, epoll on Linux).
+        if !PosixConstants.isMacOrBsd && !PosixConstants.isLinux then cancel("no posix backend on this host to demote")
+        else
+            val javaBin = java.nio.file.Paths.get(sys.props("java.home"), "bin", "java").toString
+            val cp      = sys.props("java.class.path")
+            val out = scala.sys.process.Process(Seq(
+                javaBin,
+                "-Dkyo.ffi.kyonet_posix_uring.path=/nonexistent-kyo-posix-shim",
+                "-cp",
+                cp,
+                "kyo.net.internal.backend.BackendSelectionProbeMain"
+            )).!!.trim
+            assert(
+                out.linesIterator.contains("SELECTED=nio"),
+                s"expected the posix backend to demote to nio when its bundled shim is unavailable, child output:\n$out"
+            )
+        end if
+    }
+
 end JvmPosixBackendSelectionTest
+
+/** Child-JVM entry point for the shim-missing degrade leaf above. Prints the selected backend so the parent can assert it fell to the nio
+  * floor. It runs in a fresh JVM (launched with the bundled `kyonet_posix_uring` pointed at a nonexistent path) because `PosixShimBindings`'
+  * load state is cached JVM-wide and cannot be re-failed in-process. It deliberately does not extend `kyo.net.Test`, so no `KYO_NET_ONLY`
+  * bridge runs here and selection walks the natural priority gradient.
+  */
+object BackendSelectionProbeMain:
+    def main(args: Array[String]): Unit =
+        import AllowUnsafe.embrace.danger
+        given Frame = Frame.internal
+        println("SELECTED=" + IoBackendPlatform.selected.name)
+    end main
+end BackendSelectionProbeMain


### PR DESCRIPTION
## Problem

On a host whose bundled `kyonet_posix_uring` native is missing (macOS, or any platform absent from the published jar's natives), the first client connection crashed with an opaque `NoSuchElementException: No value present` from `PosixShimBindingsImpl$.<clinit>`.

`EpollBackend` and `KqueueBackend` reported available from a libc-only probe (`epoll_create1` / `kqueue`), but the data path also needs the bundled shim (`kyo_posix_set_nonblocking`). So a posix backend won selection and then died at the first socket op, past the point the always-available NIO floor could take over.

## Solution

Both probes now also exercise the bundled shim: a read-only `kyo_posix_get_flags` on the probe fd. If the native is missing, loading it throws, the existing `probe { ... }` catch demotes the backend, and selection falls to the NIO floor, a working (if unaccelerated) transport instead of a crash. `IoUringBackend` already loaded the same library, so it was unaffected.

## Notes

- The exercise is read-only and its result ignored, so it demotes only on a genuine load failure, which matters on the shared jvm-native path where Native has no NIO floor.
- Reproduced by a fresh-JVM leaf in `JvmPosixBackendSelectionTest` (the shim's load state is cached process-wide): with the native pointed at a bad path, selection now returns `nio` where it previously selected, and crashed on, the posix backend.
- Graceful degradation only; follow-up work is tracked separately. Packaging: the published jar carries natives for one platform, so off it there is no fast path to select at all, so ship per-platform native artifacts. Errors: when a native is genuinely absent, `NativeLoader` should raise a clear `FfiLoadError` naming the platform instead of the opaque symbol-lookup crash.