### PR TITLE
kyo-ai: declare whether an endpoint accepts a mid-conversation system message

### DIFF
--- a/kyo-ai/shared/src/main/scala/kyo/ai/Config.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/Config.scala
@@ -80,9 +80,19 @@ final case class Config private (
     // default applies, so an untouched config states nothing and never warns; a warning fires only on a
     // STATED amount the encoding cannot express. Held rather than dropped where it cannot ride, since
     // one config re-aims across providers, and held while reasoning is off.
-    reasoningAmount: Maybe[Config.Amount] = Absent
+    reasoningAmount: Maybe[Config.Amount] = Absent,
+    // Whether a later instruction may ride with system authority (see
+    // [[Config.MidConversationSystem]]). Defaulted so a positional construction elsewhere is unaffected.
+    midConversationSystem: Config.MidConversationSystem = Config.MidConversationSystem.Unsupported
 ):
-    def apiUrl(url: String): Config              = copy(apiUrl = url)
+    def apiUrl(url: String): Config = copy(apiUrl = url)
+
+    /** Declares whether this endpoint accepts a system instruction after the conversation has started
+      * (see [[Config.MidConversationSystem]]). Set it when `apiUrl` points at an endpoint whose contract
+      * differs from the provider's own.
+      */
+    def midConversationSystem(mode: Config.MidConversationSystem): Config =
+        copy(midConversationSystem = mode)
     def apiKey(key: String): Config              = copy(apiKey = Present(key))
     def apiOrg(org: String): Config              = copy(apiOrg = Present(org))
     def temperature(temperature: Double): Config = copy(temperature = Present(temperature.max(0).min(2)))
@@ -301,7 +311,8 @@ final case class Config private (
         reasoningOff: Maybe[Config.ReasoningOff] = Absent,
         forcedToolChoice: Maybe[Config.ForcedToolChoice] = Absent,
         systemInstructions: Maybe[Config.SystemMessages] = Absent,
-        invalidToolCalls: Maybe[Config.InvalidToolCalls] = Absent
+        invalidToolCalls: Maybe[Config.InvalidToolCalls] = Absent,
+        midConversationSystem: Maybe[Config.MidConversationSystem] = Absent
     ): Config =
         copy(
             provider = provider,
@@ -316,7 +327,8 @@ final case class Config private (
             reasoningOff = reasoningOff.getOrElse(provider.reasoningOff),
             forcedToolChoice = forcedToolChoice.getOrElse(provider.forcedToolChoice),
             systemInstructions = systemInstructions.getOrElse(provider.systemInstructions),
-            invalidToolCalls = invalidToolCalls.getOrElse(provider.invalidToolCalls)
+            invalidToolCalls = invalidToolCalls.getOrElse(provider.invalidToolCalls),
+            midConversationSystem = midConversationSystem.getOrElse(provider.midConversationSystem)
         )
 
     /** Re-declares which request field this config's endpoint reads the output ceiling from.
@@ -424,7 +436,8 @@ object Config:
         reasoningOff: Maybe[ReasoningOff] = Absent,
         forcedToolChoice: Maybe[ForcedToolChoice] = Absent,
         systemInstructions: Maybe[SystemMessages] = Absent,
-        invalidToolCalls: Maybe[InvalidToolCalls] = Absent
+        invalidToolCalls: Maybe[InvalidToolCalls] = Absent,
+        midConversationSystem: Maybe[MidConversationSystem] = Absent
     ): Config =
         Config(
             provider.baseUrl,
@@ -441,7 +454,8 @@ object Config:
             reasoningOff.getOrElse(provider.reasoningOff),
             forcedToolChoice.getOrElse(provider.forcedToolChoice),
             systemInstructions.getOrElse(provider.systemInstructions),
-            invalidToolCalls.getOrElse(provider.invalidToolCalls)
+            invalidToolCalls.getOrElse(provider.invalidToolCalls),
+            midConversationSystem = midConversationSystem.getOrElse(provider.midConversationSystem)
         )
 
     /** A model's maximum output tokens, and whether that number is known or stood in for.
@@ -578,6 +592,34 @@ object Config:
         case FirstOnly
     end SystemMessages
 
+    /** Whether an entry accepts a system instruction that arrives after the conversation has started,
+      * declared per provider and overridable per entry.
+      *
+      * On a one-slot wire a later instruction cannot ride with system authority, so it is converted to a
+      * user turn (see [[SystemMessages]]). Some endpoints do accept one, appended to the message history
+      * with the same authority as the out-of-band slot and without invalidating a cached prefix before it.
+      *
+      * Declared rather than derived from the model name, because the capability belongs to the ENDPOINT
+      * and not to the model: one gateway can serve the same model name under a contract that refuses it.
+      * A completion impl that inferred this from a name would be wrong on one of them.
+      *
+      * The first entry in the history can never be a system message on such a wire, so a leading
+      * instruction keeps taking the out-of-band slot regardless of what this declares.
+      */
+    enum MidConversationSystem derives CanEqual:
+        /** A later instruction is converted to a user turn, since a turn that arrives with the wrong role
+          * still arrives and one that is dropped never does.
+          */
+        case Unsupported
+
+        /** A later instruction rides as a system-role message in the history, and only after the history
+          * has opened with another role: it can never be the first entry. The placement belongs to the
+          * declared fact rather than to the impl, so an endpoint with a different rule states its own
+          * case here instead of the impl growing a positional branch of its own.
+          */
+        case AcceptedAfterOpeningTurn
+    end MidConversationSystem
+
     /** How an endpoint says "do not reason", declared per provider.
       *
       * A wire that reasons by default has to be told to stop, and endpoints disagree about how: one
@@ -662,7 +704,8 @@ object Config:
         val systemInstructions: SystemMessages = SystemMessages.AllDelivered,
         val invalidToolCalls: InvalidToolCalls = InvalidToolCalls.Returned,
         val forcedToolChoice: ForcedToolChoice = ForcedToolChoice.Honored,
-        val usesApiKey: Boolean = true
+        val usesApiKey: Boolean = true,
+        val midConversationSystem: MidConversationSystem = MidConversationSystem.Unsupported
     ):
         val orgKey: String = keyName + "_ORG"
         def default: Config
@@ -721,6 +764,8 @@ object Config:
         // Declared facts, with provenance. maxOutputTokens comes from the provider's own limit
         // response (a request above it is refused and names the maximum). The thinking kind and
         // temperature acceptance are this provider's documented per-generation contract.
+        // Documented as accepting a system-role message after the conversation has started, with the
+        // same authority as the out-of-band slot and without invalidating a cached prefix before it.
         val opus_4_8: Config = catalog(
             this,
             "claude-opus-4-8",
@@ -728,7 +773,8 @@ object Config:
             outputMaximum = OutputMaximum.Verified(128000),
             ReasoningEncoding.Adaptive,
             acceptsTemperature = false,
-            acceptsImages = true
+            acceptsImages = true,
+            midConversationSystem = Present(MidConversationSystem.AcceptedAfterOpeningTurn)
         )
         val sonnet_4_6: Config = catalog(
             this,
@@ -748,6 +794,7 @@ object Config:
             acceptsTemperature = true,
             acceptsImages = true
         )
+        // Documented alongside opus_4_8 as accepting a mid-conversation system message.
         val fable_5: Config = catalog(
             this,
             "claude-fable-5",
@@ -755,7 +802,8 @@ object Config:
             outputMaximum = OutputMaximum.Verified(128000),
             ReasoningEncoding.Adaptive,
             acceptsTemperature = false,
-            acceptsImages = true
+            acceptsImages = true,
+            midConversationSystem = Present(MidConversationSystem.AcceptedAfterOpeningTurn)
         )
         val sonnet_5: Config = catalog(
             this,

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/AnthropicCompletion.scala
@@ -294,39 +294,53 @@ private[completion] object AnthropicCompletion extends Completion:
                         case Present(SystemMessage(c)) => (Present(c), fitted.drop(1))
                         case _                         => (Absent, fitted)
                 val mapped =
-                    body.map {
-                        case UserMessage(content, Present(image)) =>
-                            Message(
-                                Role.User.name,
-                                List(
-                                    Content("text", text = Present(content)),
-                                    Content("image", source = Present(Source("base64", "image/jpeg", image.base64)))
+                    body.zipWithIndex.map { (message, index) =>
+                        message match
+                            case UserMessage(content, Present(image)) =>
+                                Message(
+                                    Role.User.name,
+                                    List(
+                                        Content("text", text = Present(content)),
+                                        Content("image", source = Present(Source("base64", "image/jpeg", image.base64)))
+                                    )
                                 )
-                            )
-                        case UserMessage(content, _) =>
-                            Message(Role.User.name, List(Content("text", text = Present(content))))
-                        case AssistantMessage(content, calls) =>
-                            Message(
-                                Role.Assistant.name,
-                                List(Content("text", text = Present(content))).filter(_.text.exists(_.nonEmpty))
-                                    ++ calls.map(call =>
-                                        Content(
-                                            "tool_use",
-                                            id = Present(call.id.id),
-                                            name = Present(call.function),
-                                            input = Json.decode[Structure.Value](call.arguments).toMaybe
-                                        )
-                                    ).toList
-                            )
-                        case ToolMessage(callId, content) =>
-                            Message(
-                                Role.User.name,
-                                List(Content("tool_result", tool_use_id = Present(callId.id), content = Present(content)))
-                            )
-                        case SystemMessage(content) =>
-                            // Residual only: the transform converts every non-leading system message, so this
-                            // fires just for a system message not at the start (no leading system prompt to lift).
-                            Message(Role.User.name, List(Content("text", text = Present(systemReminder(content)))))
+                            case UserMessage(content, _) =>
+                                Message(Role.User.name, List(Content("text", text = Present(content))))
+                            case AssistantMessage(content, calls) =>
+                                Message(
+                                    Role.Assistant.name,
+                                    List(Content("text", text = Present(content))).filter(_.text.exists(_.nonEmpty))
+                                        ++ calls.map(call =>
+                                            Content(
+                                                "tool_use",
+                                                id = Present(call.id.id),
+                                                name = Present(call.function),
+                                                input = Json.decode[Structure.Value](call.arguments).toMaybe
+                                            )
+                                        ).toList
+                                )
+                            case ToolMessage(callId, content) =>
+                                Message(
+                                    Role.User.name,
+                                    List(Content("tool_result", tool_use_id = Present(callId.id), content = Present(content)))
+                                )
+                            case SystemMessage(content) =>
+                                // A system message that is not the lifted one. How it rides is the entry's
+                                // declared fact, applied here rather than decided here: the variant states
+                                // the placement it allows, so no combination of declared facts builds a
+                                // request the endpoint rejects, and an endpoint with a different rule adds
+                                // its own case instead of this impl growing a positional branch.
+                                val ridesAsSystem = config.midConversationSystem match
+                                    case Config.MidConversationSystem.Unsupported              => false
+                                    case Config.MidConversationSystem.AcceptedAfterOpeningTurn => index > 0
+                                if ridesAsSystem then
+                                    Message(Role.System.name, List(Content("text", text = Present(content))))
+                                else
+                                    Message(
+                                        Role.User.name,
+                                        List(Content("text", text = Present(systemReminder(content))))
+                                    )
+                                end if
                     }.toList
                 // Anthropic rejects consecutive same-role messages, so merge adjacent ones (e.g. the separate user
                 // messages from parallel tool results) by concatenating their content blocks into one message.

--- a/kyo-ai/shared/src/main/scala/kyo/ai/completion/Completion.scala
+++ b/kyo-ai/shared/src/main/scala/kyo/ai/completion/Completion.scala
@@ -99,8 +99,16 @@ object Completion:
                     else if index > firstSystem && index <= leadingEnd then Chunk.empty
                     else
                         message match
-                            case SystemMessage(content) => Chunk(convert(content))
-                            case other                  => Chunk(other)
+                            // Converted only where the entry cannot carry a later instruction with system
+                            // authority. Where it can, the message survives with its role and the impl
+                            // emits it as such; the decision is the declared fact, never a provider name.
+                            case SystemMessage(content) =>
+                                config.midConversationSystem match
+                                    case Config.MidConversationSystem.AcceptedAfterOpeningTurn =>
+                                        Chunk(SystemMessage(content))
+                                    case Config.MidConversationSystem.Unsupported =>
+                                        Chunk(convert(content))
+                            case other => Chunk(other)
                 }
             end if
     end fitSystemMessages

--- a/kyo-ai/shared/src/test/scala/kyo/ai/completion/AnthropicCompletionTest.scala
+++ b/kyo-ai/shared/src/test/scala/kyo/ai/completion/AnthropicCompletionTest.scala
@@ -113,6 +113,117 @@ class AnthropicCompletionTest extends kyo.test.Test[Any]:
         }
     }
 
+    "an entry accepting mid-conversation system messages sends a later instruction with its own role" in {
+        TestCompletionServer.run { server =>
+            val config = keyedConfig(server.baseUrl)
+                .midConversationSystem(Config.MidConversationSystem.AcceptedAfterOpeningTurn)
+            val ctx = Context.empty
+                .systemMessage("you are X")
+                .userMessage("hello from user")
+                .systemMessage("from now on, be brief")
+            server.enqueueBody(minimalAnthropicBody("ok")).andThen {
+                LLM.run(config) {
+                    Abort.run[HttpException] {
+                        Abort.run[AIException] {
+                            AnthropicCompletion(config, ctx, Chunk.empty)
+                        }
+                    }
+                }.andThen {
+                    server.captured.map { caps =>
+                        val body = caps.head.body
+                        assert(
+                            body.contains("\"role\":\"system\"") || body.contains("\"role\": \"system\""),
+                            s"the later instruction should ride with its own role: $body"
+                        )
+                        assert(
+                            !body.contains("<system-reminder>"),
+                            s"an accepting entry should not wrap the instruction as a user turn: $body"
+                        )
+                        // The leading instruction still takes the out-of-band slot: a system message can
+                        // never be the first entry in the history.
+                        assert(body.contains("\"system\""), s"top-level system field lost: $body")
+                        assert(body.contains("you are X"), s"leading instruction lost: $body")
+                        assert(body.contains("from now on, be brief"), s"later instruction lost: $body")
+                    }
+                }
+            }
+        }
+    }
+
+    "an entry that does not accept them keeps wrapping a later instruction as a user turn" in {
+        TestCompletionServer.run { server =>
+            val config = Config.Anthropic.sonnet_5.apiKey("test-key").apiUrl(server.baseUrl)
+            val ctx = Context.empty
+                .systemMessage("you are X")
+                .userMessage("hello from user")
+                .systemMessage("from now on, be brief")
+            server.enqueueBody(minimalAnthropicBody("ok")).andThen {
+                LLM.run(config) {
+                    Abort.run[HttpException] {
+                        Abort.run[AIException] {
+                            AnthropicCompletion(config, ctx, Chunk.empty)
+                        }
+                    }
+                }.andThen {
+                    server.captured.map { caps =>
+                        val body = caps.head.body
+                        assert(body.contains("<system-reminder>"), s"the wrapper is the fallback: $body")
+                        assert(
+                            !body.contains("\"role\":\"system\"") && !body.contains("\"role\": \"system\""),
+                            s"an entry that refuses the role must not send it: $body"
+                        )
+                        assert(body.contains("from now on, be brief"), s"later instruction lost: $body")
+                    }
+                }
+            }
+        }
+    }
+
+    "a system message is never the first entry in the history, whatever the entry declares" in {
+        TestCompletionServer.run { server =>
+            // AllDelivered keeps every leading instruction as its own message: the head is lifted into the
+            // out-of-band slot and the SECOND one would open `messages`, which the wire refuses.
+            val config = Config.Anthropic.default
+                .model(
+                    Config.Anthropic,
+                    "claude-opus-4-8",
+                    contextWindow = 1000000,
+                    outputMaximum = Config.OutputMaximum.Verified(128000),
+                    reasoning = Config.ReasoningEncoding.Adaptive,
+                    acceptsTemperature = false,
+                    acceptsImages = true,
+                    systemInstructions = Present(Config.SystemMessages.AllDelivered),
+                    midConversationSystem = Present(Config.MidConversationSystem.AcceptedAfterOpeningTurn)
+                )
+                .apiKey("test-key")
+                .apiUrl(server.baseUrl)
+            val ctx = Context.empty
+                .systemMessage("you are X")
+                .systemMessage("and you are brief")
+                .userMessage("hello from user")
+            server.enqueueBody(minimalAnthropicBody("ok")).andThen {
+                LLM.run(config) {
+                    Abort.run[HttpException] {
+                        Abort.run[AIException] {
+                            AnthropicCompletion(config, ctx, Chunk.empty)
+                        }
+                    }
+                }.andThen {
+                    server.captured.map { caps =>
+                        val body       = caps.head.body
+                        val messagesAt = body.indexOf("\"messages\":[")
+                        val firstRole  = body.indexOf("\"role\":", messagesAt)
+                        val opening    = body.substring(firstRole, firstRole + 20)
+                        assert(
+                            !opening.contains("system"),
+                            s"a system message must never open the history: $opening in $body"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     "a conversation with no leading system message keeps the opening user turn (regression: head was dropped)" in {
         TestCompletionServer.run { server =>
             val config = keyedConfig(server.baseUrl)
@@ -359,11 +470,14 @@ class AnthropicCompletionTest extends kyo.test.Test[Any]:
 
     "a non-head system message serializes as a system-reminder user message" in {
         TestCompletionServer.run { server =>
-            val config = keyedConfig(server.baseUrl)
+            // Pinned on an entry that does not declare Config.MidConversationSystem.Accepted. The wrapper
+            // is the behaviour wherever the endpoint cannot carry a later instruction with system
+            // authority, which is every entry except the two that document accepting one.
+            val config = Config.Anthropic.sonnet_5.apiKey("test-key").apiUrl(server.baseUrl)
             val ctx = Context.empty
                 .systemMessage("primary") // head -> top-level system
                 .userMessage("hi")
-                .systemMessage("a reminder") // non-head -> system-reminder user turn (Anthropic has no system tail)
+                .systemMessage("a reminder") // non-head -> system-reminder user turn on this entry
             server.enqueueBody(minimalAnthropicBody("ok")).andThen {
                 LLM.run(config) {
                     Abort.run[HttpException](Abort.run[AIException](AnthropicCompletion(config, ctx, Chunk.empty)))


### PR DESCRIPTION
### Problem

A system instruction that arrives after the conversation has started is converted by
`Completion.fitSystemMessages` into a user turn wrapped in `<system-reminder>`. That is
correct on a wire with one system slot, and it stays the right default.

Some endpoints accept a system-role message inside the history: it carries the same
authority as the out-of-band slot, and because it is appended after the prefix it does
not invalidate a cached one. Where a caller already pinned such an entry, the stronger
primitive goes unused, and the wrapper arrives through the same channel as the untrusted
input it is meant to govern. Fixes #1810.

### Solution

`Config.MidConversationSystem` declares whether an entry accepts one, defaulted per
provider and overridable per entry, with a setter for a config re-aimed via `apiUrl`.

The variant carries the placement it allows (`AcceptedAfterOpeningTurn`), so the
completion impl applies the declared fact rather than deciding a rule of its own. An
endpoint whose contract differs adds its own case instead of the impl growing a
positional branch. The shared transform decides whether to convert; the impl decides
only how a surviving message is serialized. Neither reads a provider name.

`claude-opus-4-8` and `claude-fable-5` declare the capability, with the documented
behaviour as provenance, in the same style as the other declared facts on those entries.

### Notes

- **This changes wire behaviour on two catalog entries**, one of which is the provider
  default. On `claude-opus-4-8` and `claude-fable-5`, an instruction that arrives after
  the conversation has started now rides as a system-role message rather than a
  reminder-wrapped user turn. Every other entry is byte-identical to before.
- Only entries whose capability is documented declare it. `claude-sonnet-4-6`,
  `claude-haiku-4-5` and `claude-sonnet-5` stay `Unsupported`. The catalog has no entry
  for the other two models the documentation lists.
- A system message can never open the history, and that holds for every combination of
  declared facts, including `SystemMessages.AllDelivered` on a declaring entry. Written
  as a reproducing test first, since that combination produced an invalid request before
  the fix.
- `"a non-head system message serializes as a system-reminder user message"` moved to
  `claude-sonnet-5`. Its premise, that this wire has no system tail, is still true for
  every entry that does not declare the capability, and that is where it now guards.
- The residual risk is the one this codebase already carries for every declared fact: a
  gateway serving the same model name under a different contract. The per-entry override
  is how a caller states it.
- Full `kyo-aiJVM/test` is green.