### PR TITLE
[kyo-ffi] GraalVM native-image support out of the box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,10 @@ test-output
 .jvmopts
 node_modules
 
+# GraalVM native-image manifests are checked into module resources and ship in the jar; the
+# global *.json ignore above would otherwise drop them. Plugin-generated manifests live under
+# target/ (resourceManaged) and stay ignored via the target rule.
+!**/src/main/resources/META-INF/native-image/**/*.json
+
 # Local analysis notes, never committed
 analysis-*.md

--- a/kyo-core/jvm/src/main/resources/META-INF/native-image/io.getkyo/kyo-core/reachability-metadata.json
+++ b/kyo-core/jvm/src/main/resources/META-INF/native-image/io.getkyo/kyo-core/reachability-metadata.json
@@ -1,0 +1,13 @@
+{
+  "reflection": [
+    {
+      "type": "sun.misc.Signal",
+      "methods": [
+        { "name": "<init>", "parameterTypes": ["java.lang.String"] },
+        { "name": "handle", "parameterTypes": ["sun.misc.Signal", "sun.misc.SignalHandler"] }
+      ]
+    },
+    { "type": "sun.misc.SignalHandler" },
+    { "type": { "proxy": ["sun.misc.SignalHandler"] } }
+  ]
+}

--- a/kyo-ffi/codegen/src/main/scala/kyo/ffi/codegen/FfiGenerator.scala
+++ b/kyo-ffi/codegen/src/main/scala/kyo/ffi/codegen/FfiGenerator.scala
@@ -78,7 +78,8 @@ object FfiGenerator:
     final case class Result(
         files: Seq[Path],
         warnings: Seq[String],
-        traits: Seq[TraitSpec]
+        traits: Seq[TraitSpec],
+        reachabilityMetadata: String = ""
     )
 
     /** Entry point.
@@ -118,7 +119,13 @@ object FfiGenerator:
         }
         val warnings = collectWarnings(specs, config)
         val files    = specs.map(spec => writeSpec(spec, outputDir, platform, config.includeDirs))
-        Result(files = files, warnings = warnings, traits = specs)
+        // GraalVM native-image reachability metadata is a JVM-only concern (native-image runs JVM bytecode). One merged
+        // manifest per module carries the FFM downcalls/upcalls and the generated impls' reflective instantiation; the plugin
+        // writes it into the module's managed resources.
+        val reachabilityMetadata =
+            if platform == Platform.JVM && specs.nonEmpty then ReachabilityMetadataEmitter.emitModule(specs)
+            else ""
+        Result(files = files, warnings = warnings, traits = specs, reachabilityMetadata = reachabilityMetadata)
     end generate
 
     private[codegen] def writeSpec(spec: TraitSpec, outputDir: Path, platform: Platform, includeDirs: Seq[String] = Nil): Path =

--- a/kyo-ffi/codegen/src/main/scala/kyo/ffi/codegen/emitters/ReachabilityMetadataEmitter.scala
+++ b/kyo-ffi/codegen/src/main/scala/kyo/ffi/codegen/emitters/ReachabilityMetadataEmitter.scala
@@ -1,0 +1,129 @@
+package kyo.ffi.codegen.emitters
+
+import kyo.ffi.codegen.model.*
+
+/** Emits the GraalVM native-image `reachability-metadata.json` for one `Ffi` trait's generated JVM impl.
+  *
+  * The FFM downcall and upcall descriptors are taken verbatim from [[JvmEmitter.emitFunctionDescriptor]] and
+  * [[JvmEmitter.callbackFunctionDescriptor]], the same `FunctionDescriptor`s the generated impl builds at class-construction
+  * time, then each Panama `ValueLayout` name is re-spelled as the native-image foreign token (`JAVA_INT` becomes `jint`,
+  * `ADDRESS` becomes `void*`). Reusing the emitter's descriptors is what keeps this metadata from drifting away from the
+  * generated code: a new binding, a changed signature, or a new option flows through the shared descriptor logic into both
+  * the impl and this manifest.
+  *
+  * The generated `<simpleName>Impl` is registered for reflective instantiation because `FfiReflect` loads it on the JVM via
+  * `Class.forName(...).getDeclaredConstructor().newInstance()`. The remaining reflection a native-image build needs (the kyo
+  * scheduler, `Tag`, `Log`, and so on) is auto-derived by native-image's own analysis and is not emitted here.
+  */
+object ReachabilityMetadataEmitter:
+
+    /** Panama `ValueLayout` name (as emitted by [[JvmEmitter]]) to its native-image foreign type token. Downcall and callback
+      * signatures only ever use these primitive layouts and `ADDRESS` (structs are always passed by pointer), so no struct
+      * layout token is needed here.
+      */
+    private val layoutToken: Map[String, String] = Map(
+        "JAVA_BOOLEAN" -> "jboolean",
+        "JAVA_BYTE"    -> "jbyte",
+        "JAVA_CHAR"    -> "jchar",
+        "JAVA_SHORT"   -> "jshort",
+        "JAVA_INT"     -> "jint",
+        "JAVA_LONG"    -> "jlong",
+        "JAVA_FLOAT"   -> "jfloat",
+        "JAVA_DOUBLE"  -> "jdouble",
+        "ADDRESS"      -> "void*"
+    )
+
+    private def token(layout: String): String =
+        layoutToken.getOrElse(
+            layout.trim,
+            throw new IllegalStateException(
+                s"ReachabilityMetadataEmitter: no native-image foreign token for Panama layout '$layout'"
+            )
+        )
+
+    /** Split a `FunctionDescriptor.of(R, P...)` or `FunctionDescriptor.ofVoid(P...)` expression into its return token and
+      * parameter tokens.
+      */
+    private def parse(descriptor: String): (String, List[String]) =
+        val ofVoid = descriptor.startsWith("FunctionDescriptor.ofVoid")
+        val inner  = descriptor.substring(descriptor.indexOf('(') + 1, descriptor.lastIndexOf(')')).trim
+        val parts  = if inner.isEmpty then List.empty[String] else inner.split(",").iterator.map(_.trim).filter(_.nonEmpty).toList
+        if ofVoid then ("void", parts.map(token))
+        else (token(parts.head), parts.tail.map(token))
+    end parse
+
+    private def str(s: String): String = "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
+    private def arr(items: Seq[String]): String = items.mkString("[", ", ", "]")
+
+    private def downcall(method: MethodSpec, structsByName: Map[String, StructSpec]): String =
+        val (ret, params) = parse(JvmEmitter.emitFunctionDescriptor(method, structsByName))
+        // errno capture is always on (mirrors JvmEmitter's `capture` option); critical(true) only for a non-blocking method
+        // with an array parameter, which pins the array off-heap for a zero-copy call.
+        val options =
+            if !method.blocking && method.hasArrayParam then
+                """{ "captureCallState": true, "critical": { "allowHeapAccess": true } }"""
+            else
+                """{ "captureCallState": true }"""
+        s"""      { "returnType": ${str(ret)}, "parameterTypes": ${arr(params.map(str))}, "options": $options }"""
+    end downcall
+
+    /** Distinct callback C signatures reachable from the trait: top-level function-pointer parameters and function-pointer
+      * struct fields. Each becomes a general (descriptor-only) upcall registration.
+      */
+    private def callbackSignatures(spec: TraitSpec, structsByName: Map[String, StructSpec]): List[(List[TypeRef], TypeRef)] =
+        val fromParams =
+            spec.methods.flatMap(_.params).collect { case ParamSpec(_, TypeRef.FnPtrT(ps, r)) => (ps, r) }
+        val fromStructFields =
+            structsByName.values.toList.flatMap(_.fields).collect { case StructField(_, TypeRef.FnPtrT(ps, r)) => (ps, r) }
+        (fromParams ++ fromStructFields).distinct
+    end callbackSignatures
+
+    private def upcall(sig: (List[TypeRef], TypeRef)): String =
+        val (params, ret) = sig
+        val (r, ps)       = parse(JvmEmitter.callbackFunctionDescriptor(params, ret))
+        s"""      { "returnType": ${str(r)}, "parameterTypes": ${arr(ps.map(str))} }"""
+    end upcall
+
+    /** The `reachability-metadata.json` content for one trait's generated JVM impl. */
+    def emit(spec: TraitSpec): String = emitModule(Seq(spec))
+
+    /** The merged `reachability-metadata.json` for all of a module's generated JVM impls: the union of every trait's reflection
+      * entry, downcall, and (deduplicated) upcall. One file per module, so a jar carries a single manifest that native-image
+      * auto-discovers. Callers pass only the traits emitted for the JVM platform and only when the list is non-empty.
+      */
+    def emitModule(specs: Seq[TraitSpec]): String =
+        val reflectionEntries =
+            specs.map { spec =>
+                val implFqcn = s"${spec.packageName}.${spec.simpleName}Impl"
+                s"""    { "type": ${str(implFqcn)}, "methods": [ { "name": "<init>", "parameterTypes": [] } ] }"""
+            }
+        val downcalls =
+            specs.flatMap { spec =>
+                val structsByName = spec.structs.map(s => s.simpleName -> s).toMap
+                spec.methods.map(m => downcall(m, structsByName))
+            }
+        val upcalls =
+            specs.flatMap { spec =>
+                val structsByName = spec.structs.map(s => s.simpleName -> s).toMap
+                callbackSignatures(spec, structsByName)
+            }.distinct.map(upcall)
+
+        val foreignBody =
+            val dc = s"""    "downcalls": [\n${downcalls.mkString(",\n")}\n    ]"""
+            if upcalls.isEmpty then dc
+            else dc + s""",\n    "upcalls": [\n${upcalls.mkString(",\n")}\n    ]"""
+        end foreignBody
+
+        s"""{
+           |  "reflection": [
+           |${reflectionEntries.mkString(",\n")}
+           |  ],
+           |  "foreign": {
+           |$foreignBody
+           |  }
+           |}
+           |""".stripMargin
+    end emitModule
+
+end ReachabilityMetadataEmitter

--- a/kyo-ffi/codegen/src/test/scala/kyo/ffi/codegen/emitters/ReachabilityMetadataEmitterTest.scala
+++ b/kyo-ffi/codegen/src/test/scala/kyo/ffi/codegen/emitters/ReachabilityMetadataEmitterTest.scala
@@ -1,0 +1,72 @@
+package kyo.ffi.codegen.emitters
+
+import EmitterFixtures.*
+import kyo.ffi.codegen.model.*
+
+class ReachabilityMetadataEmitterTest extends kyo.test.Test[Any]:
+
+    "registers the generated impl for reflective instantiation" in {
+        val spec = mkTrait("Sockets", "kyo_net", List(mkMethod("noop", "noop", Nil, ReturnShape.Void)))
+        val json = ReachabilityMetadataEmitter.emit(spec)
+        assert(json.contains(""""type": "kyo.example.SocketsImpl""""))
+        assert(json.contains(""""name": "<init>""""))
+        assert(json.contains(""""reflection""""))
+    }
+
+    "maps primitive and pointer parameters to foreign tokens with errno capture" in {
+        val spec = mkTrait(
+            "Sockets",
+            "kyo_net",
+            List(
+                mkMethod(
+                    "recv",
+                    "recv",
+                    List(
+                        ParamSpec("fd", TypeRef.IntT),
+                        ParamSpec("buf", TypeRef.BufferT(TypeRef.ByteT)),
+                        ParamSpec("len", TypeRef.IntT)
+                    ),
+                    ReturnShape.Primitive(TypeRef.LongT)
+                )
+            )
+        )
+        val json = ReachabilityMetadataEmitter.emit(spec)
+        assert(json.contains(""""returnType": "jlong""""))
+        assert(json.contains(""""parameterTypes": ["jint", "void*", "jint"]"""))
+        assert(json.contains(""""captureCallState": true"""))
+    }
+
+    "emits the void token for a void return" in {
+        val spec =
+            mkTrait("Sockets", "kyo_net", List(mkMethod("close", "close", List(ParamSpec("fd", TypeRef.IntT)), ReturnShape.Void)))
+        val json = ReachabilityMetadataEmitter.emit(spec)
+        assert(json.contains(""""returnType": "void""""))
+        assert(json.contains(""""parameterTypes": ["jint"]"""))
+    }
+
+    "a non-blocking array method adds the critical option" in {
+        val spec = mkTrait(
+            "Sockets",
+            "kyo_net",
+            List(
+                mkMethod(
+                    "writeAll",
+                    "write_all",
+                    List(ParamSpec("buf", TypeRef.ArrayT(TypeRef.ByteT))),
+                    ReturnShape.Primitive(TypeRef.IntT)
+                )
+            )
+        )
+        val json = ReachabilityMetadataEmitter.emit(spec)
+        assert(json.contains(""""critical": { "allowHeapAccess": true }"""))
+    }
+
+    "a zero-parameter primitive method emits an empty parameter list and both sections" in {
+        val spec = mkTrait("Sockets", "kyo_net", List(mkMethod("getpid", "getpid", Nil, ReturnShape.Primitive(TypeRef.IntT))))
+        val json = ReachabilityMetadataEmitter.emit(spec)
+        assert(json.contains(""""foreign""""))
+        assert(json.contains(""""downcalls""""))
+        assert(json.contains(""""returnType": "jint", "parameterTypes": []"""))
+    }
+
+end ReachabilityMetadataEmitterTest

--- a/kyo-ffi/jvm/src/main/resources/META-INF/native-image/io.getkyo/kyo-ffi/native-image.properties
+++ b/kyo-ffi/jvm/src/main/resources/META-INF/native-image/io.getkyo/kyo-ffi/native-image.properties
@@ -1,0 +1,16 @@
+# GraalVM native-image build arguments required by kyo-ffi's Panama FFM layer.
+#
+# SharedArenaSupport: kyo-data's UnsafeBufferPlatform.alloc uses Arena.ofShared() for
+# I/O buffers that cross scheduler carriers (submission and reaping run on different
+# carriers), and native-image gates shared arenas behind this experimental flag. Without
+# it, closing such an arena raises UnsupportedFeatureError at runtime.
+#
+# enable-native-access marks the FFM downcalls as permitted native access so the binary
+# does not warn (and, on future releases, does not block) on the restricted Linker calls.
+#
+# Verified against GraalVM 25 native-image: a kyo-http server+client native binary using
+# the FFM transport fails at Arena.ofShared close without SharedArenaSupport and runs
+# cleanly with it.
+Args = -H:+UnlockExperimentalVMOptions \
+       -H:+SharedArenaSupport \
+       --enable-native-access=ALL-UNNAMED

--- a/kyo-ffi/jvm/src/main/resources/META-INF/native-image/io.getkyo/kyo-ffi/reachability-metadata.json
+++ b/kyo-ffi/jvm/src/main/resources/META-INF/native-image/io.getkyo/kyo-ffi/reachability-metadata.json
@@ -1,0 +1,21 @@
+{
+  "reflection": [
+    { "type": "java.lang.invoke.VarHandleSegmentAsBytes", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsShortsAligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsShortsUnaligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsCharsAligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsCharsUnaligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsIntsAligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsIntsUnaligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsLongsAligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsLongsUnaligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsFloatsAligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsFloatsUnaligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsDoublesAligned", "allDeclaredMethods": true },
+    { "type": "java.lang.invoke.VarHandleSegmentAsDoublesUnaligned", "allDeclaredMethods": true }
+  ],
+  "resources": [
+    { "glob": "META-INF/kyo-ffi/**" },
+    { "glob": "META-INF/native/**" }
+  ]
+}

--- a/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/CodegenBridge.scala
+++ b/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/CodegenBridge.scala
@@ -36,7 +36,7 @@ private[sbt] object CodegenBridge {
       *                  Used by the plugin to validate library ids (#10) and to
       *                  detect stale generated impls when a trait is deleted (#34).
       */
-    final case class Generated(files: Seq[Path], traits: Seq[TraitInfo])
+    final case class Generated(files: Seq[Path], traits: Seq[TraitInfo], reachabilityMetadata: String = "")
     final case class TraitInfo(fqcn: String, simpleName: String, packageName: String, library: String)
 
     def generate(
@@ -125,6 +125,8 @@ private[sbt] object CodegenBridge {
         val files     = resultCls.getMethod("files").invoke(result)
         val warnings  = resultCls.getMethod("warnings").invoke(result)
         val traits    = resultCls.getMethod("traits").invoke(result)
+        val reachabilityMetadata =
+            resultCls.getMethod("reachabilityMetadata").invoke(result).asInstanceOf[String]
 
         val warningList = scalaSeqToJava(warnings)
         warningList.foreach(w => log.warn(w.toString))
@@ -140,7 +142,7 @@ private[sbt] object CodegenBridge {
                 library = cls.getMethod("library").invoke(c).asInstanceOf[String]
             )
         }
-        Generated(filesList, traitList)
+        Generated(filesList, traitList, reachabilityMetadata)
     }
 
     /** Build (and cache) a URLClassLoader containing the codegen JAR PLUS the codegen's

--- a/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/KyoFfiPlugin.scala
+++ b/kyo-ffi/plugin/src/main/scala/kyo/ffi/sbt/KyoFfiPlugin.scala
@@ -449,6 +449,10 @@ object KyoFfiPlugin extends AutoPlugin {
                         // resource generator runs as a separate task and cannot re-derive it, so it is written to a
                         // stable file under `target` that survives cache hits (rewritten only on a codegen miss).
                         writeTraitLibraryIndex(genTarget, generated.traits.map(t => t.fqcn -> t.library))
+                        // GraalVM native-image reachability metadata for this module's JVM impls (empty for JS/Native),
+                        // persisted to a stable file under target that survives cache hits exactly like the index above; the
+                        // reachability-metadata resource generator copies it into managed resources.
+                        writeReachabilityMetadata(genTarget, generated.reachabilityMetadata)
                         generated.files.map(_.toFile).toSet
                     } catch {
                         case t: Throwable =>
@@ -608,6 +612,10 @@ object KyoFfiPlugin extends AutoPlugin {
         // per library id its bundled `<os>-<arch>` platforms, version and minRuntime, plus a reflection-free
         // binding-trait -> library-id index. See `ffiNativeManifestGenerator`.
         Compile / resourceGenerators += ffiNativeManifestGenerator.taskValue,
+
+        // GraalVM native-image: ship the codegen-emitted reachability-metadata.json (JVM only) so a downstream
+        // native-image build discovers the FFM downcalls/upcalls and the generated impls' reflection with no agent.
+        Compile / resourceGenerators += ffiReachabilityMetadataGenerator.taskValue,
 
         // Native only: copy each library's C sources into `resourceManaged/scala-native/`.
         // sbt's `copyResources` then folds managed resources into the compile `classDirectory`,
@@ -1065,12 +1073,57 @@ object KyoFfiPlugin extends AutoPlugin {
         }
     }
 
+    /** Ship the GraalVM native-image reachability metadata that `ffiGenerate` emitted for this module's JVM impls (FFM
+      * downcalls/upcalls plus the generated `*Impl` reflective instantiation), under
+      * `META-INF/native-image/io.getkyo/<module>/reachability-metadata.json` so native-image auto-discovers it with no
+      * tracing agent. JVM only: JS and Native modules persist no content, so this generates nothing.
+      */
+    private def ffiReachabilityMetadataGenerator: Def.Initialize[Task[Seq[File]]] = Def.task {
+        // Force the codegen so the persisted reachability metadata is fresh, then copy it into managed resources.
+        val _          = ffiGenerate.value
+        val projTarget = target.value
+        val resManaged = (Compile / resourceManaged).value
+        val moduleName = name.value
+        val src        = ffiReachabilityMetadataFile(projTarget)
+        if (!src.exists()) Seq.empty[File]
+        else {
+            val content = IO.read(src)
+            if (content.trim.isEmpty) Seq.empty[File]
+            else {
+                val dest =
+                    resManaged / "META-INF" / "native-image" / "io.getkyo" / moduleName / "reachability-metadata.json"
+                IO.createDirectory(dest.getParentFile)
+                if (!dest.exists() || IO.read(dest) != content) IO.write(dest, content)
+                Seq(dest)
+            }
+        }
+    }
+
     /** File under `target` where `ffiGenerate` persists the binding-trait -> library-id pairs the native manifest
       * generator reads (one `<fqcn>=<library>` per line). Kept out of the resource tree so it is never itself
       * packaged; it is a cross-task hand-off, not a shipped artifact.
       */
     private def ffiTraitLibraryIndexFile(projTarget: File): File =
         projTarget / "kyo-ffi" / "trait-library-index.txt"
+
+    /** File under `target` where `ffiGenerate` persists the JVM reachability-metadata.json content the native-image
+      * resource generator ships. Kept out of the resource tree so it is never itself packaged; a cross-task hand-off.
+      */
+    private def ffiReachabilityMetadataFile(projTarget: File): File =
+        projTarget / "kyo-ffi" / "reachability-metadata.json"
+
+    /** Persist the GraalVM native-image reachability metadata for the resource generator, content-skipped. Empty content
+      * removes a stale file (a JS/Native module, or a module whose bindings were all deleted).
+      */
+    private def writeReachabilityMetadata(projTarget: File, content: String): Unit = {
+        val dest = ffiReachabilityMetadataFile(projTarget)
+        if (content.isEmpty) {
+            if (dest.exists()) IO.delete(dest): Unit
+        } else {
+            IO.createDirectory(dest.getParentFile)
+            if (!dest.exists() || IO.read(dest) != content) IO.write(dest, content)
+        }
+    }
 
     /** Persist `pairs` (`<fqcn> -> <library>`) for the native manifest generator, content-skipped. An empty list
       * removes a stale index so a module whose bindings were all deleted stops indexing traits that are gone.

--- a/kyo-ffi/plugin/src/sbt-test/kyo-ffi/end-to-end/build.sbt
+++ b/kyo-ffi/plugin/src/sbt-test/kyo-ffi/end-to-end/build.sbt
@@ -12,5 +12,27 @@ lazy val root = (project in file("."))
         run / javaOptions ++= Seq("--enable-native-access=ALL-UNNAMED"),
         run / fork := true,
         Test / javaOptions ++= Seq("--enable-native-access=ALL-UNNAMED"),
-        Test / fork := true
+        Test / fork := true,
+        // Regression guard for the GraalVM native-image reachability-metadata generation (emitter + plugin wiring):
+        // force managed resources and assert the per-module manifest is produced with the expected downcalls,
+        // reflection entry, and foreign tokens for this binding (2 Int methods -> jint, 1 Long method -> jlong).
+        TaskKey[Unit]("checkReachabilityMetadata") := {
+            val _ = (Compile / managedResources).value
+            val f =
+                (Compile / resourceManaged).value / "META-INF" / "native-image" / "io.getkyo" / name.value / "reachability-metadata.json"
+            if (!f.exists) sys.error(s"[reachability] expected generated manifest at $f")
+            val json         = IO.read(f)
+            def need(s: String): Unit = if (!json.contains(s)) sys.error(s"[reachability] manifest missing '$s':\n$json")
+            need("\"reflection\"")
+            need("\"foreign\"")
+            need("\"downcalls\"")
+            need("e2e.E2eBindingsImpl")
+            need("\"jint\"")
+            need("\"jlong\"")
+            need("\"captureCallState\": true")
+            val downcalls = json.split("\"returnType\"").length - 1
+            if (downcalls != 3)
+                sys.error(s"[reachability] expected 3 downcalls (E2eBindings has 3 methods), got $downcalls:\n$json")
+            streams.value.log.info(s"[reachability] OK: $downcalls downcalls, impl + tokens present in $f")
+        }
     )

--- a/kyo-ffi/plugin/src/sbt-test/kyo-ffi/end-to-end/test
+++ b/kyo-ffi/plugin/src/sbt-test/kyo-ffi/end-to-end/test
@@ -6,3 +6,5 @@
 > ffiPackage
 > compile
 > run
+# GraalVM native-image reachability metadata is generated into managed resources.
+> checkReachabilityMetadata


### PR DESCRIPTION
## Problem

Any app that reaches kyo's FFM layer (kyo-ffi's JVM Panama backend, behind kyo-http's native transport, kyo-net, or a user's own binding) cannot be built with GraalVM native-image as-is. native-image needs metadata the JVM otherwise resolves dynamically:

- every FFM downcall and upcall descriptor, registered in `reachability-metadata.json`'s `foreign` section;
- the generated `<Trait>Impl` classes (loaded reflectively) and the FFM `VarHandleSegmentAs*` accessors;
- `-H:+SharedArenaSupport`: kyo-data allocates cross-carrier I/O buffers with `Arena.ofShared()`, which native-image gates behind that flag and otherwise fails at arena close.

Missing any of it, the build fails or the binary dies at runtime. Hand-authoring it per binding is toil that silently rots the moment a signature changes.

## Solution

The codegen already builds each binding's `FunctionDescriptor`; it now emits the `foreign` metadata from those same descriptors. `ReachabilityMetadataEmitter` reuses `JvmEmitter`'s downcall and upcall descriptors verbatim and re-spells each Panama layout as its native-image token (`JAVA_INT` becomes `jint`, `ADDRESS` becomes `void*`), so a new binding, a changed signature, or a new option reaches both the generated impl and its manifest from one source and cannot drift apart. The sbt plugin writes one merged `reachability-metadata.json` per module and folds it into resources (JVM only), so a downstream native-image build discovers the downcalls, upcalls, and impl reflection with no tracing agent.

Alongside the generated per-module metadata, this ships the static pieces codegen cannot derive: kyo-ffi's `native-image.properties` (the `SharedArenaSupport` and `enable-native-access` build args) and the `VarHandleSegmentAs*` reflection its runtime uses, plus kyo-core's `sun.misc.Signal` registration for OS-signal handling. A plugin scripted test guards that the manifest is generated end to end.

## Notes

- Verified on GraalVM 25 native-image: a kyo-http server and client over the FFM transport fails at `Arena.ofShared` close without the shipped flags and runs cleanly with them.
- JS and Native do not use FFM, so the foreign-metadata generator is a no-op on those platforms.
- native-image's own analysis still auto-derives the ordinary reflection (scheduler, `Tag`, `Log`); only the FFM-specific and signal registrations need shipping.
