### PR TITLE
[kyo-compat] let backends be maintained outside the repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3262,7 +3262,38 @@ lazy val `kyo-compat-plugin` = (project in file("kyo-compat/plugin"))
                 Def.task(streams.value.log.info("scripted skipped on Windows (sbt#6777 boot-server named-pipe flake)"))
             else
                 Def.task((scripted.toTask("")).value)
-        }).value
+        }).value,
+        // Bundle the cross-binding conformance suite (kyo-compat/test + test-streams)
+        // into the plugin jar as resources, plus an INDEX, so an external binding can
+        // pull it in via `.compatConformance`. Copied verbatim from the canonical suite
+        // the in-repo bindings compile against, so the bundle stays byte-identical.
+        Compile / resourceGenerators += Def.task {
+            val outDir  = (Compile / resourceManaged).value / "kyo-compat-testkit"
+            val suites  = Seq("test" -> "test", "test-streams" -> "streams")
+            val buckets = Seq("shared", "jvm", "js", "native")
+            val base    = (ThisBuild / baseDirectory).value / "kyo-compat"
+            IO.delete(outDir)
+            val index     = scala.collection.mutable.ArrayBuffer.empty[String]
+            val generated = scala.collection.mutable.ArrayBuffer.empty[File]
+            for {
+                (suiteDir, suiteTag) <- suites
+                bucket               <- buckets
+                root = base / suiteDir / bucket / "src" / "test" / "scala"
+                if root.exists
+                src <- (root ** "*.scala").get
+            } {
+                val rel   = root.toPath.relativize(src.toPath).toString.replace('\\', '/')
+                val scope = s"$suiteTag-$bucket"
+                val dest  = outDir / scope / rel
+                IO.copyFile(src, dest)
+                index += s"$scope\t$rel"
+                generated += dest
+            }
+            val indexFile = outDir / "INDEX"
+            IO.write(indexFile, index.sorted.mkString("\n") + "\n")
+            generated += indexFile
+            generated.toSeq
+        }.taskValue
     )
 
 // ===========================================================================

--- a/kyo-compat/README.md
+++ b/kyo-compat/README.md
@@ -435,8 +435,8 @@ Constructors and terminals not in the surface compose from what is:
 ### Known divergences (kyo binding)
 
 Three tests in `CStreamTest` are marked `pending` because they expose limitations
-of `kyo.Stream` that the other five bindings (zio, ce, ox, twitter-future, future)
-don't have. They are kept in the suite as the cross-binding contract; removing the
+of `kyo.Stream` that the other backends (future, zio, ox, twitter-future) don't
+have. They are kept in the suite as the cross-binding contract; removing the
 `pending` markers once `kyo.Stream` is fixed will turn them green on every binding.
 
 - **Chunked-eager effectful map.** `kyo.Stream.map(f: A => B < S)` applies `f` eagerly
@@ -666,3 +666,79 @@ lazy val myLibAll = myLib.aggregate("my-lib-all")
 ```
 
 The aggregator sets `publish / skip := true`, so it never lands in maven local itself.
+
+## External bindings
+
+The five backends above live in this repo. A backend can also be maintained and published from a separate repository. Nothing here needs to change to consume it: a binding depends only on its target runtime (no other kyo module), and the plugin resolves each backend by its own Maven coordinates.
+
+The examples below use a fictitious library, `acme`, as a stand-in for the runtime you are integrating: substitute its name, coordinates, and dependency for the real ones.
+
+### Using an external binding
+
+Declare the backend with `CompatBackendAxis.external(...)`, giving its published coordinates, and pass it to `.compatLibrary(...)` alongside the built-in backends:
+
+```scala doctest:expect=skipped
+// build.sbt
+import sbt.VirtualAxis
+
+val AcmeLib = CompatBackendAxis.external(
+    name = "acme",
+    idSuffix = "Acme",
+    directorySuffix = "-acme",
+    supportedPlatforms = Set("jvm", "js"),
+    organization = "com.acme",
+    artifactName = "kyo-compat-acme",
+    version = "0.1.0"
+)
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .compatLibrary(KyoLib, ZioLib, AcmeLib)(VirtualAxis.jvm, VirtualAxis.js)(Seq("3.3.4"))
+```
+
+Each generated `acme` row pulls `com.acme:kyo-compat-acme:0.1.0` (with the platform suffix `%%%` adds) instead of an `io.getkyo` artifact; the built-in backends are unaffected. The backend `name` must not collide with a built-in (`future`, `kyo`, `zio`, `ox`, `twitter-future`): equality and matrix de-duplication are by `name`. External backends have no named accessor (`.kyo`, `.zio`, ...), so reach their rows with `myLib.get(AcmeLib)` (returns `Option[CompatBackendProjects]`) rather than a dotted accessor.
+
+### Vendoring a binding
+
+To keep the binding as a project in your own build instead of consuming a published artifact, declare it with `CompatBackendAxis.local(...)` (no coordinates) and route the backend to your project with `bindLocally`:
+
+```scala doctest:expect=skipped
+// A local binding module in your build (see "Setting up an external binding" for its shape).
+lazy val vendoredAcme = (crossProject(JVMPlatform) in file("kyo-compat-acme"))
+    .settings(libraryDependencies += "com.acme" %%% "acme-runtime" % "1.0.0")
+
+val AcmeLib = CompatBackendAxis.local("acme", "Acme", "-acme", Set("jvm"))
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .compatLibrary(KyoLib, AcmeLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+    .bindLocally(AcmeLib, vendoredAcme.jvm) // the acme row dependsOn vendoredAcme; nothing is resolved from Maven
+```
+
+A `local` backend carries no coordinates and must be bound; an unbound one fails at build load with a clear error. `bindLocally` also works on an `external` backend (it overrides the published coordinate with the local project), so you can move between vendoring and a published artifact without touching your library source.
+
+### Setting up an external binding
+
+A binding provides the whole `kyo.compat.*` surface for one runtime. To author one:
+
+1. **Implement the surface.** In `package kyo.compat`, define `CIO` as an `opaque type` aliasing the runtime's effect (see [Backends](#backends) for each built-in's carrier) and implement every `C*` handle (`CFiber`, `CPromise`, `CChannel`, `CStream`, the atomics, `CLatch`, `CMeter`, `CLocal`) plus the `CIO` combinators. Each operation is an `inline def` that lowers to the runtime's primitive. Depend only on the target runtime.
+2. **Cross-publish per platform.** Publish one artifact per platform in `supportedPlatforms`, with the suffixes `%%%` resolves (`_sjs1` for Scala.js, `_native0.5` for Native). The coordinates you publish are exactly what consumers pass to `CompatBackendAxis.external(...)`.
+3. **Validate against the shared contract.** `.compatConformance()` wires the cross-binding conformance suite (bundled inside `kyo-compat-plugin`) into every generated row's Test scope: the suite sources are extracted into `Test / sourceManaged` and scalatest plus `-Xmax-inlines` are added, so the suite compiles against your binding and runs. Point the backend at your in-development binding with `bindLocally` so the harness compiles against local sources rather than a published artifact. The harness declares the backend with `local` (not `external`) because the binding is not published yet; see [Vendoring a binding](#vendoring-a-binding):
+
+```scala doctest:expect=skipped
+// The binding artifact (implements kyo.compat.* for the target runtime), depending
+// only on that runtime.
+lazy val myBackend = (crossProject(JVMPlatform) in file("kyo-compat-acme"))
+    .settings(libraryDependencies += "com.acme" %%% "acme-runtime" % "1.0.0")
+
+val AcmeLib = CompatBackendAxis.local("acme", "Acme", "-acme", Set("jvm"))
+
+// Conformance harness: the acme backend bound to the local binding, suite wired in.
+lazy val acmeConformance = (projectMatrix in file(".conformance"))
+    .compatLibrary(AcmeLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+    .bindLocally(AcmeLib, myBackend.jvm)
+    .compatConformance()
+    .settings(publish / skip := true)
+
+// sbt acmeConformanceAcme/test  -> compiles the shared suite against the local binding and runs it
+```
+
+`.compatConformance(scalatestVersion)` takes the scalatest version to use (default matches the version the bundled suite is written against). The suite is the same one the built-in bindings pass; any test it exercises that a runtime genuinely cannot satisfy is the place to reconcile the binding with the surface's contract.

--- a/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatConformance.scala
+++ b/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatConformance.scala
@@ -1,0 +1,73 @@
+package io.getkyo.compat
+
+import java.io.File
+import sbt._
+
+/** Extracts the cross-binding conformance suite that [[CompatPlugin]] bundles into its own jar (see the `resourceGenerators` step in the
+  * plugin's build).
+  *
+  * The bundle is the canonical `kyo-compat/test` + `kyo-compat/test-streams` sources copied verbatim, plus an `INDEX`. Each INDEX line is
+  * `"<scope>\t<relpath>"`, where `<scope>` is `"<suite>-<bucket>"` (suite `test` / `streams`; bucket `shared` / `jvm` / `js` / `native`).
+  *
+  * [[extract]] writes the sources for one platform (the `shared` buckets always, plus the row's own platform bucket) into the row's
+  * `Test / sourceManaged`, so the suite compiles against whichever binding the row provides. `.compatConformance` wires this per row.
+  */
+private[compat] object CompatConformance {
+
+    private val ResourceRoot = "kyo-compat-testkit"
+
+    /** INDEX entries as `(scope, relpath)`, read from the plugin jar on the classpath. */
+    private def index(): Seq[(String, String)] = {
+        val stream = getClass.getClassLoader.getResourceAsStream(s"$ResourceRoot/INDEX")
+        if (stream == null)
+            sys.error(
+                s"kyo-compat: conformance sources are not on the plugin classpath (missing $ResourceRoot/INDEX). " +
+                    "This is a packaging bug in kyo-compat-plugin."
+            )
+        try
+            scala.io.Source.fromInputStream(stream, "UTF-8").getLines()
+                .filter(_.nonEmpty)
+                .map { line =>
+                    line.split("\t", 2) match {
+                        case Array(scope, rel) => (scope, rel)
+                        case _                 => sys.error(s"kyo-compat: malformed conformance INDEX line: '$line'")
+                    }
+                }
+                .toVector
+        finally stream.close()
+    }
+
+    /** A scope `"<suite>-<bucket>"` is in scope for `platform` when its bucket is `shared` or equals the platform. */
+    private def inScope(scope: String, platform: String): Boolean =
+        scope.split("-", 2) match {
+            case Array(_, bucket) => bucket == "shared" || bucket == platform
+            case _                => false
+        }
+
+    /** Writes the conformance sources for `platform` under `outDir` (scope prefix dropped, the `kyo/compat/...` path preserved) and returns
+      * the written files, for a `Test / sourceGenerators` entry.
+      */
+    def extract(outDir: File, platform: String): Seq[File] = {
+        val inScopeEntries = index().filter { case (scope, _) => inScope(scope, platform) }
+        // The scope prefix is dropped in the destination path, so two in-scope buckets
+        // contributing the same relpath would silently clobber. No collision exists today;
+        // fail loudly if one is ever introduced.
+        val collisions = inScopeEntries.groupBy(_._2).filter(_._2.size > 1)
+        if (collisions.nonEmpty)
+            sys.error(
+                "kyo-compat: conformance sources collide on " +
+                    collisions.map { case (rel, es) => s"'$rel' (scopes ${es.map(_._1).sorted.mkString(", ")})" }
+                        .mkString("; ")
+            )
+        inScopeEntries.map {
+            case (scope, rel) =>
+                val resourcePath = s"$ResourceRoot/$scope/$rel"
+                val stream       = getClass.getClassLoader.getResourceAsStream(resourcePath)
+                if (stream == null) sys.error(s"kyo-compat: missing bundled conformance resource '$resourcePath'")
+                val dest = outDir / rel
+                try IO.transfer(stream, dest)
+                finally stream.close()
+                dest
+        }
+    }
+}

--- a/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatLibrary.scala
+++ b/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatLibrary.scala
@@ -15,7 +15,7 @@ import sbtprojectmatrix.ReflectionUtil
   * carries its backend identity, then add a per-row `process` callback that injects:
   *
   *   - `moduleName := name.value + backend.directorySuffix`
-  *   - `libraryDependencies += "io.getkyo" %%% s"kyo-compat-<id>" % compatKyoVersion.value` (suppressed when the backend is locally bound)
+  *   - `libraryDependencies +=` the backend's artifact coordinates (`organization %%% artifactName % version`, defaulting to `io.getkyo %%% s"kyo-compat-<name>" % compatKyoVersion.value`; suppressed when the backend is locally bound)
   *   - shared/per-backend `unmanagedSourceDirectories`
   *
   * `dependsOn(other: ProjectMatrix)` between two compat libraries works out-of-the-box — `WeakAxis` semantics on [[CompatBackendAxis]]
@@ -40,7 +40,8 @@ private[compat] object CompatLibrary {
         bindings: Map[String, ProjectReference], // backend.name -> local project ref
         jvmExtras: Seq[Setting[?]] = Nil,
         jsExtras: Seq[Setting[?]] = Nil,
-        nativeExtras: Seq[Setting[?]] = Nil
+        nativeExtras: Seq[Setting[?]] = Nil,
+        conformance: Option[String] = None // Some(scalatestVersion) when .compatConformance is enabled
     )
 
     private val registry: scala.collection.mutable.Map[String, Meta] =
@@ -61,6 +62,15 @@ private[compat] object CompatLibrary {
                 sys.error(s"compatLibrary: matrix '$id' was not registered before bindLocally")
             )
             registry(id) = cur.copy(bindings = cur.bindings + (backend.name -> local))
+        }
+
+    def enableConformance(id: String, scalatestVersion: String): Unit =
+        registry.synchronized {
+            val cur = registry.getOrElse(
+                id,
+                sys.error(s"compatLibrary: matrix '$id' was not registered before compatConformance")
+            )
+            registry(id) = cur.copy(conformance = Some(scalatestVersion))
         }
 
     /** Append per-platform extra settings to the matrix's Meta entry. The extras are read at row-materialization time by `addRows`'s
@@ -169,6 +179,14 @@ private[compat] object CompatLibrary {
             }
 
             val process: Project => Project = (proj: Project) => {
+                // A backend declared with CompatBackendAxis.local carries no coordinates and must be
+                // bound to a vendored project. Fail clearly here (re-read at materialization, so a
+                // bindLocally placed after compatLibrary is seen) rather than later on a Maven miss.
+                if (backend.local && !metaOf(matrixId).exists(_.bindings.contains(backend.name)))
+                    sys.error(
+                        s"compatLibrary: backend '${backend.name}' was declared with CompatBackendAxis.local " +
+                            "but not bound; add .bindLocally(<axis>, <project>) for it."
+                    )
                 val withPlugin = enablePlatformPlugin(proj)
                 val withDeps = withPlugin.settings(
                     moduleName := name.value + backend.directorySuffix,
@@ -197,8 +215,8 @@ private[compat] object CompatLibrary {
                         val isBound = metaOf(matrixId).exists(_.bindings.contains(backend.name))
                         if (isBound) Seq.empty
                         else Seq(
-                            "io.getkyo" %%% s"kyo-compat-${backend.name}" %
-                                CompatPlugin.autoImport.compatKyoVersion.value
+                            backend.organization %%% backend.resolvedArtifactName %
+                                backend.version.getOrElse(CompatPlugin.autoImport.compatKyoVersion.value)
                         )
                     }
                 )
@@ -212,7 +230,8 @@ private[compat] object CompatLibrary {
                 // customRow process closures run). Re-read at materialization
                 // time so `.jvmSettings(...)` calls placed AFTER
                 // `.compatLibrary(...)` are picked up.
-                val platformExtras: Seq[Setting[?]] = metaOf(matrixId).map { meta =>
+                val currentMeta = metaOf(matrixId)
+                val platformExtras: Seq[Setting[?]] = currentMeta.map { meta =>
                     platform match {
                         case VirtualAxis.jvm    => meta.jvmExtras
                         case VirtualAxis.js     => meta.jsExtras
@@ -220,8 +239,17 @@ private[compat] object CompatLibrary {
                         case _                  => Nil
                     }
                 }.getOrElse(Nil)
-                if (platformExtras.isEmpty) withLocal
-                else withLocal.settings(platformExtras: _*)
+                // Conformance suite wiring, re-read at materialization time so a
+                // `.compatConformance(...)` call placed AFTER `.compatLibrary(...)` is
+                // picked up (same pattern as bindLocally and the per-platform extras).
+                val conformanceExtras: Seq[Setting[?]] =
+                    currentMeta.flatMap(_.conformance) match {
+                        case Some(scalatestVersion) => conformanceSettings(platform.value, scalatestVersion)
+                        case None                   => Nil
+                    }
+                val extras = platformExtras ++ conformanceExtras
+                if (extras.isEmpty) withLocal
+                else withLocal.settings(extras: _*)
             }
 
             // Add one row per scala version, tagging the row with a
@@ -237,6 +265,22 @@ private[compat] object CompatLibrary {
             }
         }
     }
+
+    /** Test-scope settings that wire the plugin-bundled conformance suite into one generated row: extract the suite for `platformValue`
+      * (the `shared` buckets plus this platform's bucket) into `Test / sourceManaged`, add scalatest, and set `-Xmax-inlines` (the suite
+      * relies on it). Applied per row by the `process` closure when `.compatConformance` is enabled.
+      */
+    private def conformanceSettings(platformValue: String, scalatestVersion: String): Seq[Setting[?]] =
+        Seq(
+            libraryDependencies += "org.scalatest" %%% "scalatest" % scalatestVersion % Test,
+            Test / scalacOptions += "-Xmax-inlines:1024",
+            Test / sourceGenerators += Def.task {
+                CompatConformance.extract(
+                    (Test / sourceManaged).value / "kyo-compat-testkit",
+                    platformValue
+                )
+            }.taskValue
+        )
 }
 
 /** A virtual axis representing one kyo-compat backend. Implements `VirtualAxis.WeakAxis` — at most one backend axis can be on a row, and
@@ -245,12 +289,22 @@ private[compat] object CompatLibrary {
   *
   * Suffix order is `40` so the backend lands BEFORE the platform (`80`) and scala (`100`) in generated project ids and source-set suffixes:
   * `myLibFuture`, `myLibFutureJS`, etc.
+  *
+  * The `organization`, `artifactName`, and `version` fields carry the Maven coordinates of the backend's runtime artifact. The five
+  * built-in backends leave them at their defaults (`io.getkyo` %%% `kyo-compat-<name>` % `compatKyoVersion.value`). A backend published
+  * OUTSIDE the kyo repo sets them to its own coordinates, so its generated rows pull that artifact
+  * instead of a nonexistent `io.getkyo:kyo-compat-<name>`. Prefer [[CompatBackendAxis.external]] to declare one. The backend `name` must
+  * not collide with a built-in, since equality (and matrix de-duplication) is by `name`.
   */
 final case class CompatBackendAxis(
-    name: String,                   // e.g. "future" — artifact name `kyo-compat-future`
-    idSuffix: String,               // e.g. "Future" — appended to project id
-    directorySuffix: String,        // e.g. "-future" — appended to moduleName + source dir
-    supportedPlatforms: Set[String] // values from PlatformAxis: "jvm" | "js" | "native"
+    name: String,                        // e.g. "future"; default artifact name `kyo-compat-future`
+    idSuffix: String,                    // e.g. "Future"; appended to project id
+    directorySuffix: String,             // e.g. "-future"; appended to moduleName + source dir
+    supportedPlatforms: Set[String],     // values from PlatformAxis: "jvm" | "js" | "native"
+    organization: String = "io.getkyo",  // Maven org of the backend artifact
+    artifactName: Option[String] = None, // artifact name; defaults to s"kyo-compat-$name"
+    version: Option[String] = None,      // artifact version; defaults to compatKyoVersion.value
+    local: Boolean = false               // declared via `local(...)`: vendored, must be bound with bindLocally
 ) extends VirtualAxis.WeakAxis {
     override val suffixOrder: Int = 40
     override def equals(obj: Any): Boolean = obj match {
@@ -258,6 +312,90 @@ final case class CompatBackendAxis(
         case _                       => false
     }
     override def hashCode(): Int = name.hashCode
+
+    /** Artifact name of the row dependency: `artifactName` when set, else `kyo-compat-<name>`. */
+    private[compat] def resolvedArtifactName: String = artifactName.getOrElse(s"kyo-compat-$name")
+}
+
+object CompatBackendAxis {
+
+    // Names of the five built-in backends (mirrors the axes in CompatPlugin.autoImport).
+    // An added backend must not reuse one, because equality and the named accessors
+    // (.future / .kyo / ...) match by name and would otherwise resolve to the added rows.
+    private[compat] val builtinNames: Set[String] =
+        Set("future", "kyo", "zio", "ox", "twitter-future")
+
+    private def requireDistinctName(name: String): Unit =
+        require(
+            !builtinNames.contains(name),
+            s"compatLibrary: backend name '$name' collides with a built-in backend " +
+                s"(${builtinNames.toSeq.sorted.mkString(", ")}); pick a distinct name, since equality and the " +
+                "named accessors match by name."
+        )
+
+    /** Declares a backend whose runtime artifact is published outside the kyo repo, with explicit Maven coordinates. The generated rows
+      * for this backend pull `organization %%% artifactName % version` instead of the default `io.getkyo:kyo-compat-<name>`. Use this when
+      * the binding is published as an artifact; use [[local]] to vendor the binding as a project in your own build instead.
+      *
+      * @param name
+      *   backend identity (also the source-dir segment `my-lib/<name>/...`); must not collide with a built-in backend
+      * @param idSuffix
+      *   appended to generated project ids (e.g. `Acme` yields `myLibAcme`)
+      * @param directorySuffix
+      *   appended to `moduleName` and the module source dir (e.g. `-acme`)
+      * @param supportedPlatforms
+      *   platform values the artifact is cross-published for (`"jvm"` / `"js"` / `"native"`)
+      * @param organization
+      *   Maven organization of the published artifact
+      * @param artifactName
+      *   Maven artifact name of the published artifact
+      * @param version
+      *   Maven version of the published artifact
+      */
+    def external(
+        name: String,
+        idSuffix: String,
+        directorySuffix: String,
+        supportedPlatforms: Set[String],
+        organization: String,
+        artifactName: String,
+        version: String
+    ): CompatBackendAxis = {
+        requireDistinctName(name)
+        CompatBackendAxis(
+            name,
+            idSuffix,
+            directorySuffix,
+            supportedPlatforms,
+            organization,
+            Some(artifactName),
+            Some(version)
+        )
+    }
+
+    /** Declares a backend whose binding is vendored as a project in the consumer's own build rather than resolved from Maven. The axis
+      * carries no coordinates; it MUST be paired with `bindLocally(axis, <project>)`, which routes each row to that project via
+      * `dependsOn`. A row for a `local` backend that was not bound fails at build load with a clear error. Use [[external]] instead when
+      * the binding is a published artifact.
+      *
+      * @param name
+      *   backend identity (also the source-dir segment `my-lib/<name>/...`); must not collide with a built-in backend
+      * @param idSuffix
+      *   appended to generated project ids (e.g. `Acme` yields `myLibAcme`)
+      * @param directorySuffix
+      *   appended to `moduleName` and the module source dir (e.g. `-acme`)
+      * @param supportedPlatforms
+      *   platform values the vendored binding supports (`"jvm"` / `"js"` / `"native"`)
+      */
+    def local(
+        name: String,
+        idSuffix: String,
+        directorySuffix: String,
+        supportedPlatforms: Set[String]
+    ): CompatBackendAxis = {
+        requireDistinctName(name)
+        CompatBackendAxis(name, idSuffix, directorySuffix, supportedPlatforms, local = true)
+    }
 }
 
 /** Raised by named accessors when the user accesses a backend that wasn't passed to `compatLibrary(...)`.

--- a/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatPlugin.scala
+++ b/kyo-compat/plugin/src/main/scala/io/getkyo/compat/CompatPlugin.scala
@@ -48,6 +48,11 @@ object CompatPlugin extends AutoPlugin {
         type CompatBackendAxis      = _root_.io.getkyo.compat.CompatBackendAxis
         type NoSuchBackendException = _root_.io.getkyo.compat.NoSuchBackendException
 
+        // Re-export the companion as a term too, so `CompatBackendAxis.external(...)`
+        // (and the bare `CompatBackendAxis(...)` apply) resolve in a build.sbt that
+        // declares an externally-published backend without a `_root_.io.getkyo.compat.*` import.
+        val CompatBackendAxis = _root_.io.getkyo.compat.CompatBackendAxis
+
         // Backend axis instances. The `Lib` suffix avoids collisions with
         // `scala.concurrent.Future` and the `kyo` package object.
         val FutureLib: CompatBackendAxis =
@@ -116,6 +121,22 @@ object CompatPlugin extends AutoPlugin {
             /** Convenience for binding multiple backends in one call. */
             def bindAllLocally(locals: Map[CompatBackendAxis, ProjectReference]): ProjectMatrix = {
                 locals.foreach { case (b, local) => CompatLibrary.updateBinding(m.id, b, local) }
+                m
+            }
+
+            /** Wire the kyo-compat cross-binding conformance suite into every generated row's Test scope. The suite (the same
+              * `kyo-compat/test` + `kyo-compat/test-streams` sources the built-in bindings pass) is bundled in this plugin's jar; each row
+              * extracts the sources for its platform into `Test / sourceManaged`, and scalatest plus `-Xmax-inlines` are added. This lets a
+              * binding, in particular one published outside the kyo repo, prove it satisfies the same contract as the built-in bindings.
+              *
+              * Must be called BEFORE first access to the matrix's `componentProjects` / `projectRefs` (like `bindLocally` and the
+              * per-platform settings, it is re-read at row-materialization time).
+              *
+              * @param scalatestVersion
+              *   scalatest version to add to each row's Test scope; defaults to the version the bundled suite is written against.
+              */
+            def compatConformance(scalatestVersion: String = "3.2.20"): ProjectMatrix = {
+                CompatLibrary.enableConformance(m.id, scalatestVersion)
                 m
             }
 

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/build.sbt
@@ -174,3 +174,87 @@ checkPartialKyoNoLocal := {
         )
     println(s"checkPartialKyoNoLocal OK; myPartialKyo has no local compat dependsOn (deps: $depIds).")
 }
+
+// --------------------------------------------------------------------
+// CompatBackendAxis.local: a vendored backend declared with no coordinates,
+// bound to a local project. The row must dependsOn the vendored project and
+// carry no maven kyo-compat-* dependency.
+// --------------------------------------------------------------------
+
+lazy val fakeLocalAcme = (project in file("fake-local-acme"))
+
+lazy val AcmeLib = CompatBackendAxis.local("acme", "Acme", "-acme", Set("jvm"))
+
+lazy val myLocal = (projectMatrix in file("my-local"))
+    .settings(
+        organization := "com.example",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary(AcmeLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+    .bindLocally(AcmeLib, fakeLocalAcme)
+
+val checkLocalAxisDep = taskKey[Unit](
+    "verify myLocalAcme (a CompatBackendAxis.local backend) dependsOn the vendored project"
+)
+val checkLocalAxisNoMaven = taskKey[Unit](
+    "verify myLocalAcme has no maven kyo-compat-* dependency when vendored"
+)
+
+checkLocalAxisDep := {
+    val s   = Keys.state.value
+    val ext = sbt.Project.extract(s)
+    val ref = ext.structure.allProjectRefs.find(_.project == "myLocalAcme").getOrElse(
+        sys.error(s"myLocalAcme project not found. Have: ${ext.structure.allProjectRefs.map(_.project)}")
+    )
+    val proj = ext.structure.allProjects(ref.build).find(_.id == ref.project).getOrElse(
+        sys.error(s"Project def for ${ref.project} not resolvable from structure")
+    )
+    val depIds = proj.dependencies.map(_.project.project).toSet
+    if (!depIds.contains("fakeLocalAcme"))
+        sys.error(s"myLocalAcme should dependsOn fakeLocalAcme (vendored). Actual dependencies: $depIds")
+    println(s"checkLocalAxisDep OK; myLocalAcme dependsOn $depIds (includes fakeLocalAcme).")
+}
+
+checkLocalAxisNoMaven := {
+    val ext  = sbt.Project.extract(Keys.state.value)
+    val deps = ext.get(
+        myLocal.get(AcmeLib).getOrElse(sys.error("Acme backend not opted in")).jvm / Keys.libraryDependencies
+    )
+    val leaked = deps.filter(_.name.startsWith("kyo-compat-"))
+    if (leaked.nonEmpty)
+        sys.error(s"myLocalAcme must have NO maven kyo-compat-* dependency when vendored. Leaked: $leaked")
+    println("checkLocalAxisNoMaven OK; vendored local axis has no maven compat dependency.")
+}
+
+// A CompatBackendAxis.local backend that is NOT bound must fail at row materialization
+// with a clear message. The matrix is built inside the task (not at build.sbt top level)
+// so evaluation succeeds and the guard is observed via try/catch, mirroring
+// empty-intersection-fail/checkErrorMessage.
+val checkUnboundLocalErrors = taskKey[Unit](
+    "an unbound CompatBackendAxis.local backend fails at materialization with a clear message"
+)
+
+checkUnboundLocalErrors := {
+    val caught: Option[Throwable] =
+        try {
+            val m = sbt.internal.ProjectMatrix("unboundLocalLib", file("unbound-local-lib"))
+                .compatLibrary(CompatBackendAxis.local("acme", "Acme", "-acme", Set("jvm")))(VirtualAxis.jvm)(Seq("3.3.4"))
+            val _ = m.componentProjects // force materialization so the guard fires
+            None
+        } catch {
+            case t: Throwable => Some(t)
+        }
+    caught match {
+        case None =>
+            sys.error("an unbound CompatBackendAxis.local backend should have failed at materialization but did not.")
+        case Some(t) =>
+            val msg = Option(t.getMessage).getOrElse(
+                sys.error(s"unbound-local error has null message (got: ${t.getClass.getName})")
+            )
+            val mustContain = Seq("acme", "CompatBackendAxis.local", "bindLocally")
+            val missing     = mustContain.filterNot(msg.contains)
+            if (missing.nonEmpty)
+                sys.error(s"unbound-local error message missing $missing. Actual: $msg")
+            println(s"checkUnboundLocalErrors OK; clear message: $msg")
+    }
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/bind-locally/test
@@ -6,3 +6,8 @@
 > checkPartialFutureNoMaven
 > checkPartialKyoMaven
 > checkPartialKyoNoLocal
+# CompatBackendAxis.local: a vendored backend bound to a local project.
+> checkLocalAxisDep
+> checkLocalAxisNoMaven
+# An unbound CompatBackendAxis.local backend fails with a clear message.
+> checkUnboundLocalErrors

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/conformance/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/conformance/build.sbt
@@ -1,0 +1,110 @@
+// Scripted test: .compatConformance wires the plugin-bundled conformance suite.
+//
+// The plugin bundles the cross-binding conformance suite (kyo-compat/test +
+// test-streams) in its jar. `.compatConformance()` makes each generated row
+// extract those sources into Test/sourceManaged and adds scalatest +
+// -Xmax-inlines. This test checks the wiring on a Future/JVM row: the expected
+// source files are extracted (shared bucket + the jvm-only bucket), scalatest is
+// on the Test classpath, -Xmax-inlines is set, and an extracted file is
+// byte-identical to its bundled resource. The scripted sandbox has no real
+// binding, so the suite is not compiled here; that is covered in the main build.
+//
+// A fake io.getkyo:kyo-compat-future stub is publishLocal'd first (same pattern
+// as publish/ and source-overrides/) so the auto-injected backend dependency
+// resolves when the checks read the row's settings.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-COMPAT-VERSION"
+
+// Pin ivy paths inside the test dir (ThisBuild / ivyPaths is shadowed by sbt's
+// per-project Defaults, so it is applied on every participating project).
+val rootBase: File = file(".").getCanonicalFile
+val pinnedIvyPaths: Setting[IvyPaths] =
+    ivyPaths := IvyPaths(rootBase, Some(rootBase / "ivy-cache"))
+
+// Fake empty io.getkyo:kyo-compat-future stub so the auto-injected dependency resolves.
+lazy val fakeFutureJVM = Project("fakeFutureJVM", file("fake-compat/future/jvm")).settings(
+    pinnedIvyPaths,
+    organization := "io.getkyo",
+    moduleName   := "kyo-compat-future",
+    version      := "STUB-COMPAT-VERSION",
+    scalaVersion := "3.3.4"
+)
+
+lazy val publishFakes = taskKey[Unit]("publishLocal the fake kyo-compat-future stub")
+publishFakes := (fakeFutureJVM / publishLocal).value
+
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        pinnedIvyPaths,
+        organization := "com.example",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary()(VirtualAxis.jvm)(Seq("3.3.4")) // Future backend (implicit), JVM only
+    .compatConformance()
+
+// --------------------------------------------------------------------
+// Assertion task keys
+// --------------------------------------------------------------------
+
+val checkConformanceSources = taskKey[Unit](
+    "verify the bundled conformance sources (shared + jvm buckets) are extracted into Test/sourceManaged"
+)
+val checkConformanceWiring = taskKey[Unit](
+    "verify scalatest and -Xmax-inlines are added to the row's Test scope"
+)
+val checkByteIdentity = taskKey[Unit](
+    "verify an extracted source is byte-identical to its bundled plugin resource"
+)
+
+// The 18 shared conformance files + the 1 streams-shared file all reach every
+// backend/platform; FromCompletionStageTest is jvm-only (test-jvm bucket).
+val expectedShared = Set(
+    "AsyncRegisterTest.scala", "AtomicNumTest.scala", "AtomicRefTest.scala",
+    "BlockingCedeTest.scala", "BracketEnsureTest.scala", "CChunkTest.scala",
+    "ChannelTest.scala", "CompatTest.scala", "ErrorsTest.scala", "FiberTest.scala",
+    "ForeachTest.scala", "LatchTest.scala", "LiftingTest.scala", "LocalTest.scala",
+    "MeterTest.scala", "PromiseTest.scala", "RaceZipTest.scala", "TimeTest.scala",
+    "CStreamTest.scala"
+)
+val expectedJvmOnly = Set("FromCompletionStageTest.scala")
+
+checkConformanceSources := {
+    val generated = (myLib.future.jvm / Test / managedSources).value
+    val names     = generated.map(_.getName).toSet
+    val missing   = (expectedShared ++ expectedJvmOnly) -- names
+    if (missing.nonEmpty)
+        sys.error(s"conformance sources not extracted: $missing (got: ${names.toSeq.sorted.mkString(", ")})")
+    if (!names.contains("FromCompletionStageTest.scala"))
+        sys.error("jvm-only bucket not extracted onto the JVM row (FromCompletionStageTest.scala missing)")
+    println(s"checkConformanceSources OK; extracted ${names.size} sources incl. jvm-only FromCompletionStageTest.scala")
+}
+
+checkConformanceWiring := {
+    val deps = (myLib.future.jvm / Keys.libraryDependencies).value
+    if (!deps.exists(m => m.organization == "org.scalatest" && m.name == "scalatest" && m.revision == "3.2.20"))
+        sys.error(s"scalatest 3.2.20 not added to the row. libraryDependencies: $deps")
+    val opts = (myLib.future.jvm / Test / scalacOptions).value
+    if (!opts.contains("-Xmax-inlines:1024"))
+        sys.error(s"-Xmax-inlines:1024 not in Test scalacOptions: $opts")
+    println("checkConformanceWiring OK; scalatest 3.2.20 + -Xmax-inlines:1024 present")
+}
+
+checkByteIdentity := {
+    val generated  = (myLib.future.jvm / Test / managedSources).value
+    val compatTest = generated.find(_.getName == "CompatTest.scala").getOrElse(
+        sys.error("CompatTest.scala was not extracted")
+    )
+    val extracted = IO.read(compatTest)
+    val resStream = getClass.getClassLoader.getResourceAsStream(
+        "kyo-compat-testkit/test-shared/kyo/compat/CompatTest.scala"
+    )
+    if (resStream == null)
+        sys.error("bundled CompatTest.scala resource not found on the plugin classpath")
+    val bundled =
+        try scala.io.Source.fromInputStream(resStream, "UTF-8").mkString
+        finally resStream.close()
+    if (extracted != bundled)
+        sys.error("extracted CompatTest.scala differs from the bundled plugin resource")
+    println("checkByteIdentity OK; extracted CompatTest.scala == bundled resource")
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/conformance/my-lib/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/conformance/my-lib/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,3 @@
+package example
+
+object Lib

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/conformance/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/conformance/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/conformance/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/conformance/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat-plugin" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/conformance/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/conformance/test
@@ -1,0 +1,5 @@
+# Scripted test - .compatConformance extracts the plugin-bundled conformance suite.
+> publishFakes
+> checkConformanceSources
+> checkConformanceWiring
+> checkByteIdentity

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/external-backend/build.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/external-backend/build.sbt
@@ -1,0 +1,85 @@
+// Scripted test: externally-published backend coordinates.
+//
+// A CompatBackendAxis can carry its own {organization, artifactName, version},
+// so a backend published OUTSIDE the kyo repo resolves to its own Maven
+// coordinates instead of io.getkyo:kyo-compat-<name>. Declared via
+// CompatBackendAxis.external(...). Built-in backends in the same matrix keep
+// pulling io.getkyo:kyo-compat-<name> % compatKyoVersion.
+
+ThisBuild / scalaVersion     := "3.3.4"
+ThisBuild / compatKyoVersion := "STUB-COMPAT-VERSION"
+
+// An externally-published backend: custom org, artifact, and version.
+lazy val AcmeLib = CompatBackendAxis.external(
+    name = "acme",
+    idSuffix = "Acme",
+    directorySuffix = "-acme",
+    supportedPlatforms = Set("jvm"),
+    organization = "com.acme",
+    artifactName = "kyo-compat-acme",
+    version = "9.9.9-EXTERNAL"
+)
+
+// Matrix with the external Acme backend plus the built-in Kyo backend.
+lazy val myLib = (projectMatrix in file("my-lib"))
+    .settings(
+        organization := "com.example",
+        version      := "0.1.0-TEST"
+    )
+    .compatLibrary(AcmeLib, KyoLib)(VirtualAxis.jvm)(Seq("3.3.4"))
+
+// --------------------------------------------------------------------
+// Assertion task keys
+// --------------------------------------------------------------------
+
+val checkExternalCoords = taskKey[Unit](
+    "verify myLibAcme pulls com.acme:kyo-compat-acme:9.9.9-EXTERNAL and NOT io.getkyo"
+)
+val checkBuiltinCoords = taskKey[Unit](
+    "verify myLibKyo still pulls io.getkyo:kyo-compat-kyo:<compatKyoVersion>"
+)
+
+checkExternalCoords := {
+    val ext = sbt.Project.extract(Keys.state.value)
+    val acmeProj = myLib.get(AcmeLib).getOrElse(
+        sys.error("Acme backend was not opted in to the matrix")
+    ).jvm
+    val deps = ext.get(acmeProj / Keys.libraryDependencies)
+    val external = deps.filter { mid =>
+        mid.organization == "com.acme" && mid.name == "kyo-compat-acme"
+    }
+    if (!external.exists(_.revision == "9.9.9-EXTERNAL"))
+        sys.error(
+            s"myLibAcme must pull com.acme:kyo-compat-acme:9.9.9-EXTERNAL. " +
+                s"Actual libraryDependencies: $deps"
+        )
+    val leaked = deps.filter { mid =>
+        mid.organization == "io.getkyo" && mid.name == "kyo-compat-acme"
+    }
+    if (leaked.nonEmpty)
+        sys.error(
+            s"myLibAcme must NOT pull io.getkyo:kyo-compat-acme (it is externally published). " +
+                s"Leaked entries: $leaked"
+        )
+    println(
+        "checkExternalCoords OK; myLibAcme -> " +
+            external.map(m => s"${m.organization}:${m.name}:${m.revision}").mkString(", ")
+    )
+}
+
+checkBuiltinCoords := {
+    val ext  = sbt.Project.extract(Keys.state.value)
+    val deps = ext.get(myLib.kyo.jvm / Keys.libraryDependencies)
+    val builtin = deps.filter { mid =>
+        mid.organization == "io.getkyo" && mid.name == "kyo-compat-kyo"
+    }
+    if (!builtin.exists(_.revision == "STUB-COMPAT-VERSION"))
+        sys.error(
+            s"myLibKyo MUST retain io.getkyo:kyo-compat-kyo:STUB-COMPAT-VERSION when Kyo is a " +
+                s"built-in backend. Actual io.getkyo deps: ${deps.filter(_.organization == "io.getkyo")}"
+        )
+    println(
+        "checkBuiltinCoords OK; myLibKyo -> " +
+            builtin.map(m => s"${m.organization}:${m.name}:${m.revision}").mkString(", ")
+    )
+}

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/external-backend/my-lib/shared/src/main/scala/example/Lib.scala
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/external-backend/my-lib/shared/src/main/scala/example/Lib.scala
@@ -1,0 +1,6 @@
+package example
+
+// Minimal placeholder so the matrix has a source root. The scripted checks
+// only inspect settings (libraryDependencies), so nothing here is compiled
+// against a backend artifact.
+object Lib

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/external-backend/project/build.properties
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/external-backend/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.12.5

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/external-backend/project/plugins.sbt
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/external-backend/project/plugins.sbt
@@ -1,0 +1,9 @@
+sys.props.get("plugin.version") match {
+    case Some(x) => addSbtPlugin("io.getkyo" % "kyo-compat-plugin" % x)
+    case _       => sys.error("plugin.version not set")
+}
+addSbtPlugin("com.eed3si9n"       % "sbt-projectmatrix"             % "0.10.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.20.2")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/kyo-compat/plugin/src/sbt-test/kyo-compat/external-backend/test
+++ b/kyo-compat/plugin/src/sbt-test/kyo-compat/external-backend/test
@@ -1,0 +1,5 @@
+# Scripted test - externally-published backend coordinates.
+# An external backend (declared via CompatBackendAxis.external) resolves to its
+# own org:artifact:version; built-in backends keep io.getkyo:kyo-compat-<name>.
+> checkExternalCoords
+> checkBuiltinCoords

--- a/kyo-compat/test/shared/src/test/scala/kyo/compat/FiberTest.scala
+++ b/kyo-compat/test/shared/src/test/scala/kyo/compat/FiberTest.scala
@@ -143,9 +143,9 @@ class FiberTest extends CompatTest:
     "onComplete callback failure does not crash the surrounding fiber" in run {
         // When a user-provided onComplete callback fails, the surrounding
         // chain MUST keep running. Each backend reports the unhandled
-        // failure through its native runtime mechanism (ZIO's logger,
-        // CE's IORuntime error reporter, etc.) — the surface only
-        // promises that the caller's program isn't taken down with it.
+        // failure through its native runtime mechanism (for example ZIO's
+        // logger). The surface only promises that the caller's program
+        // isn't taken down with it.
         val ctr = new java.util.concurrent.atomic.AtomicInteger(0)
         val c =
             CFiber.init(CIO.defer { 1 }).flatMap { fib =>


### PR DESCRIPTION
## Problem

#1779 removed kyo's cats-effect integrations, and #1778 invited the community to keep them alive in their own repositories. kyo-compat could not actually support that. It was built around a closed set of backends: every generated project hardcoded a dependency on `io.getkyo:kyo-compat-<name>`, and the cross-binding conformance suite that defines what it means to be a correct backend existed only as in-repo test wiring. An out-of-repo backend could not be declared, could not resolve to its own artifact, and could not be validated against the contract the built-in backends meet. So "maintain it elsewhere" was an invitation with no mechanism behind it; without this, the removed integrations have no path back.

## Solution

Decouple a backend's identity from who ships it, turning kyo-compat from a fixed set of five backends into an open surface. The built-in backends still live here; the plugin simply no longer assumes a backend is one of them, or that it comes from `io.getkyo`.

Three capabilities, each framed by what it unlocks:

- **External coordinates** are the load-bearing change. A backend can resolve to any `organization:artifact:version`. External and built-in coordinates go through a single resolution path, so this opens the door without changing how the five built-ins behave.

- **Vendoring** covers the consumer who would rather keep the binding as a project in their own build than depend on a published artifact. It mirrors the published path (the declaration has the same shape either way) and is guarded so a vendored backend that is never wired up fails loudly instead of silently resolving nothing.

- **The conformance suite becomes portable.** The plugin now carries the cross-binding suite and hands it to any binding on request, so an external binding is validated against the exact contract the built-ins pass rather than a private reimplementation. This is what makes a third-party binding trustworthy.

## Notes

- Built-ins are unchanged (coordinate defaults and a shared resolution path); a name-collision guard stops an external backend from shadowing a built-in.
- Covered by scripted tests (coordinate resolution, conformance extraction and wiring, vendoring and the unbound-guard error) and the README doctest.
