### PR TITLE
[kyo-schema-json] add pure JSONL framing and codec support

### DIFF
--- a/kyo-schema-json/shared/src/main/scala/kyo/Json.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/Json.scala
@@ -26,6 +26,13 @@ object Json:
 
     given Json = Json()
 
+    /** Line-delimited JSON (JSONL, also called NDJSON) support: one JSON value per line.
+      *
+      * Alias for [[kyo.JsonLines]], whose body lives in its own file. Reach it as `Json.Lines.Framer`,
+      * `Json.Lines.Record`, and `Json.Lines.DefaultMaxLineBytes`.
+      */
+    export kyo.JsonLines as Lines
+
     /** Encodes a value of type A to a JSON string.
       *
       * @param value

--- a/kyo-schema-json/shared/src/main/scala/kyo/JsonLines.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/JsonLines.scala
@@ -1,0 +1,209 @@
+package kyo
+
+import java.nio.charset.StandardCharsets
+import scala.annotation.tailrec
+
+/** Line-delimited JSON (JSONL, also called NDJSON): one JSON value per line.
+  *
+  * The format is the interchange shape for append-only record logs, including AI agent session transcripts and structured application
+  * logs. This object holds the pure surface: framing a byte sequence into records.
+  *
+  * Framing is byte-level and splits on `'\n'`. That is a complete framer rather than an approximation, because JSON requires control
+  * characters inside strings to be escaped, so a valid record cannot contain an unescaped newline. Each complete record then goes to the
+  * ordinary whole-input JSON reader, which is why no incremental JSON parser is needed.
+  *
+  * Framing happens on bytes rather than on text because a UTF-8 multibyte character can straddle a chunk boundary. Splitting bytes first
+  * and decoding each complete record afterwards removes that hazard without an incremental text decoder.
+  *
+  * Reachable as `Json.Lines`, which aliases this object.
+  *
+  * @see
+  *   [[JsonLines.Framer]] for the resumable, chunk-oriented framing value
+  */
+object JsonLines:
+
+    /** Maximum bytes in a single record before framing aborts.
+      *
+      * A byte stream that contains no newline would otherwise grow the framer's residual without bound. The `maxDepth` and
+      * `maxCollectionSize` limits operate inside a single document and do not cover this.
+      */
+    val DefaultMaxLineBytes: Int = 16 * 1024 * 1024
+
+    private val LimitName: String = "JSONL record length"
+
+    private val Newline: Byte = '\n'.toByte
+    private val Return: Byte  = '\r'.toByte
+    private val Tab: Byte     = '\t'.toByte
+    private val Space: Byte   = ' '.toByte
+
+    private val Bom: Span[Byte] =
+        Span(0xef.toByte, 0xbb.toByte, 0xbf.toByte)
+
+    /** One framed record, with its position in the overall input.
+      *
+      * The bytes are the record's own UTF-8 encoding with the line terminator (`'\n'` and any preceding `'\r'`) already removed. They are
+      * carried as bytes rather than text so that framing never has to decode, which is what keeps a record identical no matter how the
+      * input was split into chunks.
+      *
+      * `index` counts only records that were emitted, so blank and whitespace-only lines do not consume an index. `byteOffset` counts
+      * every byte of the overall input, including skipped blank lines and a leading byte order mark, so it addresses the record in the
+      * original source.
+      *
+      * @param bytes
+      *   the record's UTF-8 bytes, with any line terminator removed
+      * @param index
+      *   zero-based position among non-blank records
+      * @param byteOffset
+      *   offset of the record's first byte within the overall input
+      */
+    final case class Record(bytes: Span[Byte], index: Long, byteOffset: Long):
+        /** The record decoded as UTF-8 text. */
+        def text: String = new String(bytes.toArray, StandardCharsets.UTF_8)
+    end Record
+
+    /** Immutable, resumable framer over arbitrary byte chunks.
+      *
+      * Holds the only stateful concern in JSONL handling, a record straddling a chunk boundary, as a value. Callers thread it through
+      * their own loop rather than the framer owning one, so the same framer serves a whole-input decode and a live stream without
+      * duplication. Feeding a framer never mutates it: [[feed]] returns the advanced framer, and the receiver stays usable.
+      *
+      * A byte order mark is recognized across chunk boundaries. While the bytes seen so far are still a proper prefix of the mark, the
+      * framer holds them and stays in its start state rather than guessing, so a one-byte-at-a-time feed strips the mark exactly as a
+      * whole-input feed does.
+      *
+      * @param residual
+      *   bytes seen since the last record terminator
+      * @param nextIndex
+      *   index the next emitted record will carry
+      * @param residualOffset
+      *   overall-input offset of `residual`'s first byte
+      * @param maxLineBytes
+      *   record size ceiling
+      * @param atStart
+      *   true until a byte that settles the byte order mark question is consumed
+      */
+    final case class Framer private[kyo] (
+        residual: Span[Byte],
+        nextIndex: Long,
+        residualOffset: Long,
+        maxLineBytes: Int,
+        atStart: Boolean
+    ):
+
+        /** Feeds a chunk, returning the advanced framer and every record the chunk completed.
+          *
+          * @param chunk
+          *   the next bytes of the input, of any size including empty
+          * @return
+          *   the advanced framer paired with the completed records, or a failure if a record or the pending residual exceeds
+          *   `maxLineBytes`
+          */
+        def feed(chunk: Span[Byte])(using Frame): Result[LimitExceededException, (Framer, Chunk[Record])] =
+            val combined = if residual.isEmpty then chunk else residual ++ chunk
+            if atStart && startsWithBomPrefix(combined) then
+                if combined.size < Bom.size then
+                    // Still undecided: the bytes so far are a proper prefix of the mark, and a proper
+                    // prefix holds no newline, so there is nothing to emit while waiting for the rest.
+                    Result.succeed[LimitExceededException, (Framer, Chunk[Record])](
+                        (Framer(combined, nextIndex, residualOffset, maxLineBytes, true), Chunk.empty)
+                    )
+                else
+                    scan(combined.slice(Bom.size, combined.size), residualOffset + Bom.size)
+            else scan(combined, residualOffset)
+            end if
+        end feed
+
+        /** Returns the unterminated trailing record, if the input ended without a newline.
+          *
+          * @return
+          *   the final record when the residual holds anything other than whitespace, `Absent` otherwise
+          */
+        def finish: Maybe[Record] =
+            val trimmed = stripReturn(residual)
+            if isBlank(trimmed) then Absent
+            else Present(Record(trimmed, nextIndex, residualOffset))
+        end finish
+
+        private def startsWithBomPrefix(buf: Span[Byte]): Boolean =
+            val n  = math.min(buf.size, Bom.size)
+            var i  = 0
+            var ok = true
+            while ok && i < n do
+                if buf(i) != Bom(i) then ok = false
+                i += 1
+            ok
+        end startsWithBomPrefix
+
+        private def scan(buf: Span[Byte], offset: Long)(using Frame): Result[LimitExceededException, (Framer, Chunk[Record])] =
+            emitFrom(buf, offset, nextIndex, Chunk.empty).flatMap { case (rest, restOffset, index, records) =>
+                if rest.size > maxLineBytes then
+                    Result.fail[LimitExceededException, (Framer, Chunk[Record])](
+                        LimitExceededException(LimitName, rest.size, maxLineBytes)
+                    )
+                else
+                    Result.succeed[LimitExceededException, (Framer, Chunk[Record])](
+                        (Framer(rest, index, restOffset, maxLineBytes, false), records)
+                    )
+            }
+        end scan
+
+        @tailrec
+        private def emitFrom(
+            buf: Span[Byte],
+            offset: Long,
+            index: Long,
+            acc: Chunk[Record]
+        )(using Frame): Result[LimitExceededException, (Span[Byte], Long, Long, Chunk[Record])] =
+            indexOfNewline(buf) match
+                case -1 => Result.succeed((buf, offset, index, acc))
+                case nl =>
+                    val line = stripReturn(buf.slice(0, nl))
+                    if line.size > maxLineBytes then
+                        Result.fail(LimitExceededException(LimitName, line.size, maxLineBytes))
+                    else
+                        val rest       = buf.slice(nl + 1, buf.size)
+                        val restOffset = offset + nl + 1
+                        if isBlank(line) then emitFrom(rest, restOffset, index, acc)
+                        else emitFrom(rest, restOffset, index + 1, acc :+ Record(line, index, offset))
+                    end if
+            end match
+        end emitFrom
+    end Framer
+
+    object Framer:
+        /** Creates a framer positioned at the start of an input.
+          *
+          * @param maxLineBytes
+          *   the largest record the framer will emit, in bytes
+          * @return
+          *   a framer holding no residual, at record index zero and byte offset zero
+          */
+        def init(maxLineBytes: Int = DefaultMaxLineBytes): Framer =
+            Framer(Span.empty[Byte], 0L, 0L, maxLineBytes, true)
+    end Framer
+
+    private def indexOfNewline(buf: Span[Byte]): Int =
+        var i     = 0
+        var found = -1
+        while found < 0 && i < buf.size do
+            if buf(i) == Newline then found = i
+            i += 1
+        found
+    end indexOfNewline
+
+    private def stripReturn(line: Span[Byte]): Span[Byte] =
+        if line.nonEmpty && line(line.size - 1) == Return then line.slice(0, line.size - 1)
+        else line
+
+    private def isBlank(line: Span[Byte]): Boolean =
+        var i     = 0
+        var blank = true
+        while blank && i < line.size do
+            val b = line(i)
+            if b != Space && b != Tab && b != Return then blank = false
+            i += 1
+        end while
+        blank
+    end isBlank
+
+end JsonLines

--- a/kyo-schema-json/shared/src/main/scala/kyo/JsonLines.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/JsonLines.scala
@@ -26,6 +26,11 @@ object JsonLines:
       *
       * A byte stream that contains no newline would otherwise grow the framer's residual without bound. The `maxDepth` and
       * `maxCollectionSize` limits operate inside a single document and do not cover this.
+      *
+      * The limit counts the record's own bytes, the ones a decoder will see, and never the line terminator: a `'\n'` and any `'\r'`
+      * immediately before it are excluded. A `\r\n`-terminated line therefore holds one more byte on the wire than the limit allows for
+      * its record. A pending residual is measured the same way, so a record is accepted or rejected identically whether its terminator
+      * arrived in the same chunk or a later one.
       */
     val DefaultMaxLineBytes: Int = 16 * 1024 * 1024
 
@@ -48,6 +53,9 @@ object JsonLines:
       * `index` counts only records that were emitted, so blank and whitespace-only lines do not consume an index. `byteOffset` counts
       * every byte of the overall input, including skipped blank lines and a leading byte order mark, so it addresses the record in the
       * original source.
+      *
+      * Do not compare two records with `==`. `Span` is an opaque array with no structural equality, so the derived `equals` compares
+      * `bytes` by reference and two records holding identical content never match. Compare [[text]] or `bytes.is(other.bytes)` instead.
       *
       * @param bytes
       *   the record's UTF-8 bytes, with any line terminator removed
@@ -120,7 +128,7 @@ object JsonLines:
           */
         def finish: Maybe[Record] =
             val trimmed = stripReturn(residual)
-            if isBlank(trimmed) then Absent
+            if isBlank(trimmed, 0, trimmed.size) then Absent
             else Present(Record(trimmed, nextIndex, residualOffset))
         end finish
 
@@ -135,36 +143,62 @@ object JsonLines:
         end startsWithBomPrefix
 
         private def scan(buf: Span[Byte], offset: Long)(using Frame): Result[LimitExceededException, (Framer, Chunk[Record])] =
-            emitFrom(buf, offset, nextIndex, Chunk.empty).flatMap { case (rest, restOffset, index, records) =>
-                if rest.size > maxLineBytes then
+            emitFrom(buf, 0, offset, nextIndex, Chunk.empty).flatMap { case (start, restOffset, index, records) =>
+                // The residual is measured by the same rule a completed record is: a trailing '\r' is the
+                // first half of a terminator that has not arrived yet, so it does not count toward the limit.
+                val restSize = buf.size - start
+                val restLine =
+                    if restSize > 0 && buf(buf.size - 1) == Return then restSize - 1
+                    else restSize
+                if restLine > maxLineBytes then
                     Result.fail[LimitExceededException, (Framer, Chunk[Record])](
-                        LimitExceededException(LimitName, rest.size, maxLineBytes)
+                        LimitExceededException(LimitName, restLine, maxLineBytes)
                     )
                 else
+                    val rest = if start == 0 then buf else buf.slice(start, buf.size)
                     Result.succeed[LimitExceededException, (Framer, Chunk[Record])](
                         (Framer(rest, index, restOffset, maxLineBytes, false), records)
                     )
+                end if
             }
         end scan
 
+        /** Walks `buf` from `start`, emitting one record per newline.
+          *
+          * Carries `start` as an index rather than re-slicing the tail after each record: `Span.slice` copies, so slicing per record
+          * would make framing a chunk of k records cost O(chunk size * k). Only an emitted record copies, which keeps the total cost
+          * linear in the chunk with allocation proportional to the output.
+          *
+          * `offset` is the overall-input offset of `buf(start)`, and the returned `Int` is the index where the unterminated residual
+          * begins.
+          */
         @tailrec
         private def emitFrom(
             buf: Span[Byte],
+            start: Int,
             offset: Long,
             index: Long,
             acc: Chunk[Record]
-        )(using Frame): Result[LimitExceededException, (Span[Byte], Long, Long, Chunk[Record])] =
-            indexOfNewline(buf) match
-                case -1 => Result.succeed((buf, offset, index, acc))
+        )(using Frame): Result[LimitExceededException, (Int, Long, Long, Chunk[Record])] =
+            indexOfNewline(buf, start) match
+                case -1 => Result.succeed((start, offset, index, acc))
                 case nl =>
-                    val line = stripReturn(buf.slice(0, nl))
-                    if line.size > maxLineBytes then
-                        Result.fail(LimitExceededException(LimitName, line.size, maxLineBytes))
+                    val lineEnd  = if nl > start && buf(nl - 1) == Return then nl - 1 else nl
+                    val lineSize = lineEnd - start
+                    if lineSize > maxLineBytes then
+                        Result.fail(LimitExceededException(LimitName, lineSize, maxLineBytes))
                     else
-                        val rest       = buf.slice(nl + 1, buf.size)
-                        val restOffset = offset + nl + 1
-                        if isBlank(line) then emitFrom(rest, restOffset, index, acc)
-                        else emitFrom(rest, restOffset, index + 1, acc :+ Record(line, index, offset))
+                        val restOffset = offset + (nl + 1 - start)
+                        if isBlank(buf, start, lineEnd) then emitFrom(buf, nl + 1, restOffset, index, acc)
+                        else
+                            emitFrom(
+                                buf,
+                                nl + 1,
+                                restOffset,
+                                index + 1,
+                                acc :+ Record(buf.slice(start, lineEnd), index, offset)
+                            )
+                        end if
                     end if
             end match
         end emitFrom
@@ -182,12 +216,13 @@ object JsonLines:
             Framer(Span.empty[Byte], 0L, 0L, maxLineBytes, true)
     end Framer
 
-    private def indexOfNewline(buf: Span[Byte]): Int =
-        var i     = 0
+    private def indexOfNewline(buf: Span[Byte], from: Int): Int =
+        var i     = from
         var found = -1
         while found < 0 && i < buf.size do
             if buf(i) == Newline then found = i
             i += 1
+        end while
         found
     end indexOfNewline
 
@@ -195,11 +230,11 @@ object JsonLines:
         if line.nonEmpty && line(line.size - 1) == Return then line.slice(0, line.size - 1)
         else line
 
-    private def isBlank(line: Span[Byte]): Boolean =
-        var i     = 0
+    private def isBlank(buf: Span[Byte], from: Int, until: Int): Boolean =
+        var i     = from
         var blank = true
-        while blank && i < line.size do
-            val b = line(i)
+        while blank && i < until do
+            val b = buf(i)
             if b != Space && b != Tab && b != Return then blank = false
             i += 1
         end while

--- a/kyo-schema-json/shared/src/main/scala/kyo/JsonLines.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/JsonLines.scala
@@ -69,6 +69,20 @@ object JsonLines:
         def text: String = new String(bytes.toArray, StandardCharsets.UTF_8)
     end Record
 
+    /** The outcome of feeding one chunk to a [[Framer]].
+      *
+      * `records` always holds every record framed from the fed chunk before any breach, whether or not `error` is present: a limit
+      * breach never discards records that were already complete. See [[Framer.feed]] for what `error` and `framer` mean together.
+      *
+      * @param framer
+      *   the advanced framer, safe to feed again only when `error` is `Absent`
+      * @param records
+      *   every record framed from this chunk, in order, up to the breach if there was one
+      * @param error
+      *   `Present` when no record boundary could be found for the current residual
+      */
+    final case class Framed(framer: Framer, records: Chunk[Record], error: Maybe[LimitExceededException])
+
     /** Immutable, resumable framer over arbitrary byte chunks.
       *
       * Holds the only stateful concern in JSONL handling, a record straddling a chunk boundary, as a value. Callers thread it through
@@ -98,23 +112,23 @@ object JsonLines:
         atStart: Boolean
     ):
 
-        /** Feeds a chunk, returning the advanced framer and every record the chunk completed.
+        /** Feeds a chunk, returning every record it completed along with the advanced framer.
           *
           * @param chunk
           *   the next bytes of the input, of any size including empty
           * @return
-          *   the advanced framer paired with the completed records, or a failure if a record or the pending residual exceeds
-          *   `maxLineBytes`
+          *   a [[Framed]] holding every record this chunk completed and, if a record or the pending residual exceeds `maxLineBytes`,
+          *   the breach as `error`. `records` is populated even when `error` is present: a breach ends framing but never discards a
+          *   record that was already complete. When `error` is `Present`, no record boundary could be found for the offending bytes,
+          *   so the returned `framer` must not be fed again. When `error` is `Absent`, `framer` is safe to feed with the next chunk.
           */
-        def feed(chunk: Span[Byte])(using Frame): Result[LimitExceededException, (Framer, Chunk[Record])] =
+        def feed(chunk: Span[Byte])(using Frame): Framed =
             val combined = if residual.isEmpty then chunk else residual ++ chunk
             if atStart && startsWithBomPrefix(combined) then
                 if combined.size < Bom.size then
                     // Still undecided: the bytes so far are a proper prefix of the mark, and a proper
                     // prefix holds no newline, so there is nothing to emit while waiting for the rest.
-                    Result.succeed[LimitExceededException, (Framer, Chunk[Record])](
-                        (Framer(combined, nextIndex, residualOffset, maxLineBytes, true), Chunk.empty)
-                    )
+                    Framed(Framer(combined, nextIndex, residualOffset, maxLineBytes, true), Chunk.empty, Absent)
                 else
                     scan(combined.slice(Bom.size, combined.size), residualOffset + Bom.size)
             else scan(combined, residualOffset)

--- a/kyo-schema-json/shared/src/main/scala/kyo/JsonLines.scala
+++ b/kyo-schema-json/shared/src/main/scala/kyo/JsonLines.scala
@@ -241,4 +241,172 @@ object JsonLines:
         blank
     end isBlank
 
+    /** Folds a chunk of per-record results into a single result, short-circuiting on the first
+      * failure or panic.
+      *
+      * `decodeAllBytes` reduces `decodeAllResults` through this. It is not a general-purpose
+      * combinator, so it stays private to this file rather than joining `Result` itself.
+      */
+    private def foldResults[E, A](results: Chunk[Result[E, A]]): Result[E, Chunk[A]] =
+        @tailrec
+        def loop(i: Int, acc: Chunk[A]): Result[E, Chunk[A]] =
+            if i >= results.size then Result.succeed(acc)
+            else
+                results(i) match
+                    case Result.Success(a) => loop(i + 1, acc :+ a)
+                    case Result.Failure(e) => Result.fail(e)
+                    case Result.Panic(ex)  => Result.panic(ex)
+        loop(0, Chunk.empty[A])
+    end foldResults
+
+    /** Decodes one framed record.
+      *
+      * Routes through `Codec.decodeFully`, so a record holding trailing content after a complete value is rejected rather than silently
+      * truncated. A failure is wrapped with the record's position so the caller can locate it in the original input.
+      *
+      * @param record
+      *   the framed record to decode
+      * @param maxDepth
+      *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
+      * @param maxCollectionSize
+      *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
+      * @return
+      *   the decoded value, or a `RecordDecodeException` carrying the record's position and text
+      */
+    def decodeRecord[A](
+        record: Record,
+        maxDepth: Int = Json.DefaultMaxDepth,
+        maxCollectionSize: Int = Json.DefaultMaxCollectionSize
+    )(using json: Json, schema: Schema[A], frame: Frame): Result[DecodeException, A] =
+        json.decodeFully[A](record.bytes, maxDepth, maxCollectionSize).mapFailure { cause =>
+            RecordDecodeException(record.index, record.byteOffset, record.text, cause)
+        }
+    end decodeRecord
+
+    /** Decodes every record in a JSONL string, failing on the first undecodable one.
+      *
+      * @param input
+      *   the JSONL text to decode
+      * @param maxDepth
+      *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
+      * @param maxCollectionSize
+      *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
+      * @param maxLineBytes
+      *   the largest record the framer will accept, in bytes (default `DefaultMaxLineBytes`)
+      * @return
+      *   every decoded value in order, or the first decode or framing failure encountered
+      */
+    def decodeAll[A](
+        input: String,
+        maxDepth: Int = Json.DefaultMaxDepth,
+        maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
+        maxLineBytes: Int = DefaultMaxLineBytes
+    )(using Json, Schema[A], Frame): Result[DecodeException, Chunk[A]] =
+        decodeAllBytes[A](
+            Span.from(input.getBytes(StandardCharsets.UTF_8)),
+            maxDepth,
+            maxCollectionSize,
+            maxLineBytes
+        )
+    end decodeAll
+
+    /** Decodes every record in raw JSONL bytes, failing on the first undecodable one.
+      *
+      * @param input
+      *   the raw UTF-8 JSONL bytes to decode
+      * @param maxDepth
+      *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
+      * @param maxCollectionSize
+      *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
+      * @param maxLineBytes
+      *   the largest record the framer will accept, in bytes (default `DefaultMaxLineBytes`)
+      * @return
+      *   every decoded value in order, or the first decode or framing failure encountered
+      */
+    def decodeAllBytes[A](
+        input: Span[Byte],
+        maxDepth: Int = Json.DefaultMaxDepth,
+        maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
+        maxLineBytes: Int = DefaultMaxLineBytes
+    )(using Json, Schema[A], Frame): Result[DecodeException, Chunk[A]] =
+        foldResults(decodeAllResults[A](input, maxDepth, maxCollectionSize, maxLineBytes))
+    end decodeAllBytes
+
+    /** Decodes every record, returning one `Result` per record instead of failing the whole input.
+      *
+      * The variant for heterogeneous or partially-written logs: a truncated tail or an unrecognized record type yields one failure rather
+      * than discarding the whole file.
+      *
+      * The one failure this cannot recover from is a record exceeding `maxLineBytes`: no record boundary was found, so there is nothing
+      * to skip to. That surfaces as a final failure element and ends the chunk.
+      *
+      * @param input
+      *   the raw UTF-8 JSONL bytes to decode
+      * @param maxDepth
+      *   maximum nesting depth for objects/arrays (default `Json.DefaultMaxDepth`)
+      * @param maxCollectionSize
+      *   maximum number of entries in maps, sets, or arrays (default `Json.DefaultMaxCollectionSize`)
+      * @param maxLineBytes
+      *   the largest record the framer will accept, in bytes (default `DefaultMaxLineBytes`)
+      * @return
+      *   one result per record; a framing failure that finds no record boundary yields a single-element chunk
+      */
+    def decodeAllResults[A](
+        input: Span[Byte],
+        maxDepth: Int = Json.DefaultMaxDepth,
+        maxCollectionSize: Int = Json.DefaultMaxCollectionSize,
+        maxLineBytes: Int = DefaultMaxLineBytes
+    )(using Json, Schema[A], Frame): Chunk[Result[DecodeException, A]] =
+        Framer.init(maxLineBytes).feed(input) match
+            case Result.Success((framer, records)) =>
+                val decoded = records.map(r => decodeRecord[A](r, maxDepth, maxCollectionSize))
+                framer.finish match
+                    case Absent       => decoded
+                    case Present(rec) => decoded :+ decodeRecord[A](rec, maxDepth, maxCollectionSize)
+            case Result.Failure(e) => Chunk(Result.fail(e))
+            case Result.Panic(ex)  => Chunk(Result.panic(ex))
+    end decodeAllResults
+
+    /** Encodes every value as one JSONL record per line, each terminated by a newline.
+      *
+      * @param values
+      *   the values to encode, in order
+      * @return
+      *   the JSONL text, or the empty string for an empty input
+      */
+    def encodeAll[A](values: Seq[A])(using schema: Schema[A], frame: Frame): String =
+        val json = summon[Json]
+        val sb   = new StringBuilder
+        values.foreach { v =>
+            val w = json.newWriter()
+            schema.writeTo(v, w)
+            discard(sb.append(new String(w.result().toArray, StandardCharsets.UTF_8)).append('\n'))
+        }
+        sb.toString
+    end encodeAll
+
+    /** Encodes every value as one JSONL record per line, returning raw UTF-8 bytes.
+      *
+      * @param values
+      *   the values to encode, in order
+      * @return
+      *   the JSONL bytes, or an empty span for an empty input
+      */
+    def encodeAllBytes[A](values: Seq[A])(using Schema[A], Frame): Span[Byte] =
+        Span.from(encodeAll(values).getBytes(StandardCharsets.UTF_8))
+    end encodeAllBytes
+
+    /** Encodes a single value as one JSONL record, terminated by a newline.
+      *
+      * @param value
+      *   the value to encode
+      * @return
+      *   the value's compact JSON encoding followed by a newline
+      */
+    def encodeLine[A](value: A)(using schema: Schema[A], frame: Frame): String =
+        val w = summon[Json].newWriter()
+        schema.writeTo(value, w)
+        new String(w.result().toArray, StandardCharsets.UTF_8) + "\n"
+    end encodeLine
+
 end JsonLines

--- a/kyo-schema-json/shared/src/test/scala/kyo/JsonLinesTest.scala
+++ b/kyo-schema-json/shared/src/test/scala/kyo/JsonLinesTest.scala
@@ -84,6 +84,39 @@ class JsonLinesTest extends kyo.test.Test[Any]:
             val r = frameAll("{\"name\":\"café\"}\n", 1024)
             assert(r.map(_.text) == Chunk("{\"name\":\"café\"}"))
         }
+
+        // Pins the start-index walk in emitFrom: every record after the first is read from an
+        // offset into the fed buffer rather than from a freshly sliced tail, so an off-by-one in
+        // that index shows up as wrong content or a wrong byteOffset somewhere in the middle.
+        // Record N is `{"i":N}`, so lines are 8 bytes for N < 10, 9 bytes for N < 100, 10 after.
+        "frames many records from a single chunk" in {
+            val count = 500
+            val input = (0 until count).map(i => s"{\"i\":$i}").mkString("", "\n", "\n")
+            val r     = frameAll(input, 1 << 20)
+            assert(r.size == count)
+
+            assert(r(0).text == "{\"i\":0}")
+            assert(r(0).index == 0L)
+            assert(r(0).byteOffset == 0L)
+
+            assert(r(250).text == "{\"i\":250}")
+            assert(r(250).index == 250L)
+            assert(r(250).byteOffset == 2390L)
+
+            assert(r(499).text == "{\"i\":499}")
+            assert(r(499).index == 499L)
+            assert(r(499).byteOffset == 4880L)
+        }
+
+        "frames many records identically when the chunk boundaries fall inside records" in {
+            val count = 500
+            val input = (0 until count).map(i => s"{\"i\":$i}").mkString("", "\n", "\n")
+            val whole = frameAll(input, 1 << 20)
+            val split = frameAll(input, 7)
+            assert(split.map(_.text) == whole.map(_.text))
+            assert(split.map(_.index) == whole.map(_.index))
+            assert(split.map(_.byteOffset) == whole.map(_.byteOffset))
+        }
     }
 
     "re-chunking produces identical records at every boundary" - {
@@ -126,6 +159,34 @@ class JsonLinesTest extends kyo.test.Test[Any]:
             val f            = Json.Lines.Framer.init(8)
             val (_, records) = f.feed(bytes("12345678\n")).getOrThrow
             assert(records.size == 1)
+        }
+
+        // The limit counts the record, not the line terminator, so a CRLF line carries one more
+        // byte on the wire than the limit allows for its record.
+        "accepts a CRLF record whose content is exactly maxLineBytes" in {
+            val f            = Json.Lines.Framer.init(8)
+            val (_, records) = f.feed(bytes("12345678\r\n")).getOrThrow
+            assert(records.map(_.text) == Chunk("12345678"))
+        }
+
+        "rejects a CRLF record whose content exceeds maxLineBytes" in {
+            val f = Json.Lines.Framer.init(8)
+            f.feed(bytes("123456789\r\n")) match
+                case Result.Failure(e: LimitExceededException) =>
+                    assert(e.actual == 9)
+                    assert(e.maximum == 8)
+                case other => fail(s"Expected LimitExceededException, got $other")
+            end match
+        }
+
+        // The residual path and the completed-record path must agree: whether the '\n' arrives in
+        // this chunk or the next one cannot change whether the record is accepted.
+        "measures a pending CRLF residual the same way as a completed record" in {
+            val f            = Json.Lines.Framer.init(8)
+            val (held, none) = f.feed(bytes("12345678\r")).getOrThrow
+            assert(none.isEmpty)
+            val (_, records) = held.feed(bytes("\n")).getOrThrow
+            assert(records.map(_.text) == Chunk("12345678"))
         }
     }
 end JsonLinesTest

--- a/kyo-schema-json/shared/src/test/scala/kyo/JsonLinesTest.scala
+++ b/kyo-schema-json/shared/src/test/scala/kyo/JsonLinesTest.scala
@@ -189,4 +189,93 @@ class JsonLinesTest extends kyo.test.Test[Any]:
             assert(records.map(_.text) == Chunk("12345678"))
         }
     }
+
+    case class Event(name: String, count: Int) derives Schema, CanEqual
+
+    "decodeAll" - {
+
+        "decodes every record" in {
+            val in = "{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}\n"
+            assert(Json.Lines.decodeAll[Event](in).getOrThrow == Chunk(Event("a", 1), Event("b", 2)))
+        }
+
+        "decodes an unterminated final record" in {
+            val in = "{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}"
+            assert(Json.Lines.decodeAll[Event](in).getOrThrow == Chunk(Event("a", 1), Event("b", 2)))
+        }
+
+        "returns an empty chunk for empty input" in {
+            assert(Json.Lines.decodeAll[Event]("").getOrThrow == Chunk.empty)
+        }
+
+        "fails on the first bad record with its position" in {
+            val in     = "{\"name\":\"a\",\"count\":1}\n{\"nope\":true}\n{\"name\":\"c\",\"count\":3}\n"
+            val result = Json.Lines.decodeAll[Event](in)
+            assert(result.isFailure)
+            result.foldError(
+                _ => fail("expected a failure"),
+                {
+                    case Result.Failure(e: RecordDecodeException) =>
+                        assert(e.recordIndex == 1L)
+                        assert(e.byteOffset == 23L)
+                        assert(e.record == "{\"nope\":true}")
+                    case other => fail(s"unexpected error $other")
+                }
+            )
+        }
+
+        "rejects trailing content after a complete value on one line" in {
+            assert(Json.Lines.decodeAll[Event]("{\"name\":\"a\",\"count\":1} {}\n").isFailure)
+        }
+    }
+
+    "decodeAllResults" - {
+
+        "keeps going past a bad record" in {
+            val in = "{\"name\":\"a\",\"count\":1}\n{\"nope\":true}\n{\"name\":\"c\",\"count\":3}\n"
+            val rs = Json.Lines.decodeAllResults[Event](Span.from(in.getBytes(StandardCharsets.UTF_8)))
+            assert(rs.size == 3)
+            assert(rs(0).getOrThrow == Event("a", 1))
+            assert(rs(1).isFailure)
+            assert(rs(2).getOrThrow == Event("c", 3))
+        }
+
+        "terminates after an oversized record because no boundary was found" in {
+            val in = "aaaaaaaaaaaaaaaaaaaaaaaa"
+            val rs = Json.Lines.decodeAllResults[Event](
+                Span.from(in.getBytes(StandardCharsets.UTF_8)),
+                maxLineBytes = 8
+            )
+            assert(rs.size == 1)
+            assert(rs(0).isFailure)
+        }
+    }
+
+    "encode" - {
+
+        "encodeLine appends a newline" in {
+            assert(Json.Lines.encodeLine(Event("a", 1)) == "{\"name\":\"a\",\"count\":1}\n")
+        }
+
+        "encodeAll writes one record per line" in {
+            val out = Json.Lines.encodeAll(Seq(Event("a", 1), Event("b", 2)))
+            assert(out == "{\"name\":\"a\",\"count\":1}\n{\"name\":\"b\",\"count\":2}\n")
+        }
+
+        "encodeAll of an empty sequence is empty" in {
+            assert(Json.Lines.encodeAll(Seq.empty[Event]) == "")
+        }
+
+        "round trips through decodeAll" in {
+            val values = Seq(Event("café", 1), Event("🎉", 2))
+            assert(Json.Lines.decodeAll[Event](Json.Lines.encodeAll(values)).getOrThrow == Chunk.from(values))
+        }
+
+        "encodeLine escapes an embedded newline rather than emitting it raw" in {
+            val line = Json.Lines.encodeLine(Event("a\nb", 1))
+            assert(line.count(_ == '\n') == 1)
+            assert(line.endsWith("\n"))
+            assert(Json.Lines.decodeAll[Event](line).getOrThrow == Chunk(Event("a\nb", 1)))
+        }
+    }
 end JsonLinesTest

--- a/kyo-schema-json/shared/src/test/scala/kyo/JsonLinesTest.scala
+++ b/kyo-schema-json/shared/src/test/scala/kyo/JsonLinesTest.scala
@@ -1,0 +1,131 @@
+package kyo
+
+import java.nio.charset.StandardCharsets
+
+class JsonLinesTest extends kyo.test.Test[Any]:
+
+    private def bytes(s: String): Span[Byte] =
+        Span.from(s.getBytes(StandardCharsets.UTF_8))
+
+    private def text(span: Span[Byte]): String =
+        new String(span.toArray, StandardCharsets.UTF_8)
+
+    /** Feed `input` through a fresh framer in fixed-size chunks, returning every record. */
+    private def frameAll(input: String, chunkSize: Int): Chunk[Json.Lines.Record] =
+        val all = bytes(input)
+        var f   = Json.Lines.Framer.init(Json.Lines.DefaultMaxLineBytes)
+        var out = Chunk.empty[Json.Lines.Record]
+        var i   = 0
+        while i < all.size do
+            val end             = math.min(i + chunkSize, all.size)
+            val (next, records) = f.feed(all.slice(i, end)).getOrThrow
+            f = next
+            out = out ++ records
+            i = end
+        end while
+        f.finish match
+            case Present(rec) => out :+ rec
+            case Absent       => out
+    end frameAll
+
+    "framing" - {
+
+        "splits records on newline" in {
+            val r = frameAll("{\"a\":1}\n{\"a\":2}\n", 1024)
+            assert(r.map(rec => text(rec.bytes)) == Chunk("{\"a\":1}", "{\"a\":2}"))
+        }
+
+        "strips a trailing carriage return" in {
+            val r = frameAll("{\"a\":1}\r\n{\"a\":2}\r\n", 1024)
+            assert(r.map(rec => text(rec.bytes)) == Chunk("{\"a\":1}", "{\"a\":2}"))
+        }
+
+        "skips a leading UTF-8 BOM" in {
+            val r = frameAll("﻿{\"a\":1}\n", 1024)
+            assert(r.map(rec => text(rec.bytes)) == Chunk("{\"a\":1}"))
+        }
+
+        "does not strip a BOM that is not at offset zero" in {
+            val r = frameAll("{\"a\":1}\n﻿{\"a\":2}\n", 1024)
+            assert(r.map(rec => text(rec.bytes)) == Chunk("{\"a\":1}", "﻿{\"a\":2}"))
+        }
+
+        "skips blank and whitespace-only lines without advancing the record index" in {
+            val r = frameAll("{\"a\":1}\n\n   \n{\"a\":2}\n", 1024)
+            assert(r.map(rec => text(rec.bytes)) == Chunk("{\"a\":1}", "{\"a\":2}"))
+            assert(r.map(_.index) == Chunk(0L, 1L))
+        }
+
+        "emits an unterminated final record" in {
+            val r = frameAll("{\"a\":1}\n{\"a\":2}", 1024)
+            assert(r.map(rec => text(rec.bytes)) == Chunk("{\"a\":1}", "{\"a\":2}"))
+        }
+
+        "produces no records for empty input" in {
+            assert(frameAll("", 1024).isEmpty)
+        }
+
+        "reports the byte offset of each record" in {
+            val r = frameAll("{\"a\":1}\n{\"bb\":2}\n{\"c\":3}\n", 1024)
+            assert(r.map(_.byteOffset) == Chunk(0L, 8L, 17L))
+        }
+
+        "reports byte offsets past a skipped blank line" in {
+            val r = frameAll("{\"a\":1}\n\n{\"b\":2}\n", 1024)
+            assert(r.map(_.byteOffset) == Chunk(0L, 9L))
+        }
+
+        "counts the BOM in subsequent byte offsets" in {
+            val r = frameAll("﻿{\"a\":1}\n{\"b\":2}\n", 1024)
+            assert(r.map(_.byteOffset) == Chunk(3L, 11L))
+        }
+
+        "exposes the record text as UTF-8" in {
+            val r = frameAll("{\"name\":\"café\"}\n", 1024)
+            assert(r.map(_.text) == Chunk("{\"name\":\"café\"}"))
+        }
+    }
+
+    "re-chunking produces identical records at every boundary" - {
+        val input = "﻿{\"name\":\"café\"}\n{\"emoji\":\"🎉\"}\r\n\n{\"last\":true}"
+        val whole = frameAll(input, 4096)
+
+        "whole-input framing produces three records" in {
+            assert(whole.size == 3)
+        }
+
+        for size <- Seq(1, 2, 3, 5, 7, 13, 64) do
+            s"chunk size $size" in {
+                val got = frameAll(input, size)
+                assert(got.map(rec => text(rec.bytes)) == whole.map(rec => text(rec.bytes)))
+                assert(got.map(_.index) == whole.map(_.index))
+                assert(got.map(_.byteOffset) == whole.map(_.byteOffset))
+            }
+        end for
+    }
+
+    "limits" - {
+
+        "rejects a complete record longer than maxLineBytes" in {
+            val f = Json.Lines.Framer.init(8)
+            val r = f.feed(bytes("{\"aaaaaaaaaaaa\":1}\n"))
+            assert(r.isFailure)
+            r match
+                case Result.Failure(e: LimitExceededException) =>
+                    assert(e.maximum == 8)
+                case other => fail(s"Expected LimitExceededException, got $other")
+            end match
+        }
+
+        "rejects a residual longer than maxLineBytes with no newline in sight" in {
+            val f = Json.Lines.Framer.init(8)
+            assert(f.feed(bytes("aaaaaaaaaaaaaaaaaaaa")).isFailure)
+        }
+
+        "accepts a record exactly at maxLineBytes" in {
+            val f            = Json.Lines.Framer.init(8)
+            val (_, records) = f.feed(bytes("12345678\n")).getOrThrow
+            assert(records.size == 1)
+        }
+    }
+end JsonLinesTest

--- a/kyo-schema/shared/src/main/scala/kyo/SchemaException.scala
+++ b/kyo-schema/shared/src/main/scala/kyo/SchemaException.scala
@@ -145,6 +145,39 @@ case class TrailingInputException(format: Codec, detail: String)(using Frame)
     extends SchemaException(s"Unexpected trailing content: $detail")
     with DecodeException
 
+/** Thrown when one record in a multi-record stream fails to decode.
+  *
+  * Line-delimited formats (JSONL, NDJSON) and multi-document formats decode a sequence of
+  * independent values, so a failure needs to say which one failed and where it sat in the
+  * input. Without that, a fault in a large transcript reports only the shape of the error
+  * and leaves the reader to find the offending record by hand.
+  *
+  * `byteOffset` is the offset of the record's first byte in the overall input, so a consumer
+  * that records it can resume from that point rather than replaying from the start.
+  *
+  * The name is format-agnostic because this type lives in the format-agnostic core.
+  *
+  * @param recordIndex
+  *   zero-based position of the record among the decodable records seen so far
+  * @param byteOffset
+  *   offset of the record's first byte within the overall input
+  * @param record
+  *   the raw record text, truncated in the rendered message but complete on the field
+  * @param cause
+  *   the underlying decode failure
+  */
+case class RecordDecodeException(
+    recordIndex: Long,
+    byteOffset: Long,
+    record: String,
+    cause: DecodeException
+)(using Frame)
+    extends SchemaException(
+        s"Failed to decode record $recordIndex at byte $byteOffset: " +
+            (if record.length > 50 then record.take(50) + "..." else record),
+        cause
+    ) with DecodeException
+
 /** Thrown when a configured safety limit is exceeded during decoding. */
 case class LimitExceededException(limit: String, actual: Int, maximum: Int)(using Frame)
     extends SchemaException(s"$limit $actual exceeds maximum $maximum")

--- a/kyo-schema/shared/src/test/scala/kyo/SchemaExceptionTest.scala
+++ b/kyo-schema/shared/src/test/scala/kyo/SchemaExceptionTest.scala
@@ -1,0 +1,34 @@
+package kyo
+
+class SchemaExceptionTest extends kyo.test.Test[Any]:
+
+    given CanEqual[Any, Any] = CanEqual.derived
+
+    // Minimal Codec stand-in for tests that only need a Codec value to construct a DecodeException.
+    // kyo-schema cannot see the real codecs (Json, Yaml, ...), which live in their own format
+    // modules, and no Codec instance is otherwise built in this module's test scope. The tests
+    // below never call newWriter/newReader, so both throw.
+    object TestCodec extends Codec:
+        def newWriter(): Codec.Writer                               = throw NotImplementedError()
+        def newReader(input: Span[Byte])(using Frame): Codec.Reader = throw NotImplementedError()
+
+    "RecordDecodeException carries position and renders a truncated record" in {
+        val long  = "x" * 80
+        val cause = TruncatedInputException(TestCodec, "unexpected end")
+        val e     = RecordDecodeException(41L, 2048L, long, cause)
+        assert(e.recordIndex == 41L)
+        assert(e.byteOffset == 2048L)
+        assert(e.record == long)
+        assert(e.getMessage.contains("record 41"))
+        assert(e.getMessage.contains("byte 2048"))
+        assert(e.getMessage.contains("x" * 50 + "..."))
+        assert(!e.getMessage.contains("x" * 51))
+    }
+
+    "RecordDecodeException is a DecodeException" in {
+        val cause              = TruncatedInputException(TestCodec, "unexpected end")
+        val e: DecodeException = RecordDecodeException(0L, 0L, "{}", cause)
+        assert(e.isInstanceOf[SchemaException])
+    }
+
+end SchemaExceptionTest


### PR DESCRIPTION
### Problem

Kyo lacked a pure API for processing newline-delimited JSON, including byte framing for records split across input chunks. Multi-record decoding also needed to preserve successfully framed records when a later record exceeded the configured size limit.

### Solution

- Add `Json.Lines` pure decode and encode entry points.
- Add `Json.Lines.Framer` for incremental JSONL byte framing.
- Carry the frame start index across chunks and align CRLF handling with the configured size limit.
- Preserve already-framed records when a subsequent record fails due to the size limit.
- Add `RecordDecodeException` for failures while decoding multiple records.
- Add comprehensive JSONL framing and codec tests.

### Notes

- The JSONL APIs support pure processing of newline-delimited records while retaining partial input between chunks.
- Framing handles LF and CRLF line endings and enforces record limits consistently.