### PR TITLE
[ci] make a fork run CI cleanly out of the box

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 <!--
 PRs require an approval from any of the core contributors, other than the PR author.
+CI on pull requests may require maintainer approval before it runs. To run CI yourself in the
+meantime, see "Running CI in Your Fork" in CONTRIBUTING.md.
 
 Include this header if applicable:
 Fixes #issue1, #issue2, ...
@@ -21,4 +23,5 @@ Add any important additional information as bullet points, such as:
 - Implementation details reviewers should know about
 - Open questions and concerns
 - Limitations
+- A link to a passing CI run in your fork, if you ran one (see "Running CI in Your Fork" in CONTRIBUTING.md)
 -->

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'getkyo/kyo'
     runs-on: ubuntu-latest
     env:
       JAVA_OPTS: -Xms3G -Xmx4G -Xss10M -XX:MaxMetaspaceSize=512M
@@ -48,6 +49,7 @@ jobs:
           path: site
   deploy:
     needs: build
+    if: github.repository == 'getkyo/kyo'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/release-probe.yml
+++ b/.github/workflows/release-probe.yml
@@ -18,6 +18,8 @@ name: release-probe
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 permissions:
   contents: read
@@ -30,6 +32,11 @@ concurrency:
 
 jobs:
   probe:
+    # release.yml already builds the release artifacts on an upstream main push, so there the probe
+    # only needs to run for pull requests. In a fork release.yml is guarded off, so the probe also
+    # runs on pushes to the fork's main to keep publishability checked. On an upstream main push the
+    # guard skips the job, so no runner is used and the run entry is inert.
+    if: github.event_name == 'pull_request' || github.repository != 'getkyo/kyo'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,11 @@ jobs:
   # clang emit x86_64 code.
   natives-darwin:
     if: |
-      (github.event_name == 'push') ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       github.event.comment.body == '/release')
+      github.repository == 'getkyo/kyo' && (
+        (github.event_name == 'push') ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request &&
+         github.event.comment.body == '/release'))
     runs-on: macos-14
     env:
       JAVA_OPTS: -Xms4G -Xmx4G -XX:ReservedCodeCacheSize=256M
@@ -83,10 +84,11 @@ jobs:
   # run on the glibc host so they use the runner's Node; only the build runs in the container.
   natives-linux-x86_64:
     if: |
-      (github.event_name == 'push') ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       github.event.comment.body == '/release')
+      github.repository == 'getkyo/kyo' && (
+        (github.event_name == 'push') ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request &&
+         github.event.comment.body == '/release'))
     runs-on: ubuntu-latest
     env:
       JAVA_OPTS: -Xms4G -Xmx4G -XX:ReservedCodeCacheSize=256M
@@ -148,10 +150,11 @@ jobs:
   # the same Alpine step on the arm64 host (the temurin alpine image is multi-arch).
   natives-linux-aarch64:
     if: |
-      (github.event_name == 'push') ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       github.event.comment.body == '/release')
+      github.repository == 'getkyo/kyo' && (
+        (github.event_name == 'push') ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request &&
+         github.event.comment.body == '/release'))
     runs-on: ubuntu-24.04-arm
     env:
       JAVA_OPTS: -Xms4G -Xmx4G -XX:ReservedCodeCacheSize=256M
@@ -209,10 +212,11 @@ jobs:
   publish:
     needs: [natives-darwin, natives-linux-x86_64, natives-linux-aarch64]
     if: |
-      (github.event_name == 'push') ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       github.event.comment.body == '/release')
+      github.repository == 'getkyo/kyo' && (
+        (github.event_name == 'push') ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request &&
+         github.event.comment.body == '/release'))
     runs-on: ubuntu-latest
     env:
       JAVA_OPTS: -Xms4G -Xmx4G -XX:ReservedCodeCacheSize=256M

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for considering contributing to this project! We welcome all contribut
   - [Getting Started](#getting-started)
   - [Configuring Java Options](#configuring-java-options)
   - [How to Build Locally](#how-to-build-locally)
+  - [Running CI in Your Fork](#running-ci-in-your-fork)
   - [Adding a New API](#adding-a-new-api)
   - [LLM Use Guide](#llm-use-guide)
 - [Core Principles](#core-principles)
@@ -128,6 +129,20 @@ Check formatting before submitting:
 ```sh
 sbt "scalafmtCheckAll"
 ```
+
+### Running CI in Your Fork
+
+Pull requests to the main repository currently require maintainer approval before CI runs, so checks may not start right away. To get full CI signal on your own schedule, run the same workflows in your fork. They use only GitHub-hosted runners that are free for public repositories and read no repository secrets, so they run unmodified.
+
+1. **Enable Actions on your fork.** GitHub disables a fork's workflows by default. Open your fork's **Actions** tab (`https://github.com/<your-user>/<your-fork>/actions`) and enable them when prompted.
+
+2. **Run the `ci` workflow.** In the **Actions** tab, select **ci** and click **Run workflow**, then choose your branch. Set **oses** to `linux-x64 linux-arm64` to match what pull-request CI runs. Leave **mode** as `full` for a complete run, or set it to `diff` to test only the modules your branch changed. The Windows pole is not part of PR CI; add `windows-x64` to **oses** to include it.
+
+3. **Or open a fork-internal pull request.** A PR from your working branch against your fork's own `main` triggers the same diff-mode run an upstream PR would, on your runners, with no approval needed. It also runs `release-probe`, a no-secrets publishability check, for free.
+
+Diff mode compares against your fork's `main`, so sync your fork before a diff-mode run (the **Sync fork** button, or `git fetch upstream && git push origin main`) to match upstream. The first run is slower while the runner caches warm up.
+
+When you open your pull request, include a link to the fork CI run if you have one, so reviewers can see the result.
 
 ### Adding a New API
 


### PR DESCRIPTION
### Problem

The CI queue has been saturating often enough to block build-stabilization and release work, and kyo-sql pushed build times up further. As a stopgap we've made PRs require manual approval before CI runs, so a contributor no longer gets automatic CI feedback on a PR and instead waits for a maintainer to approve each run.

The natural way around that is for a contributor to run the full CI in their own fork, which is free on GitHub-hosted runners and needs no repository secrets. Today that does not work cleanly. Once a contributor enables Actions on their fork, `release.yml` fires on every push to the fork's `main`: its jobs are gated only on the event, with no check for which repository they run in, so they build the native artifacts and then fail at the credentialed publish step the fork has no secrets for. `deploy-site.yml` is unguarded the same way. The contributor gets failed, confusing runs and burned minutes, and there is nothing telling them how to run CI in a fork in the first place.

### Solution

Guard the workflows that only make sense on the canonical repo. `release.yml` (its four native and publish jobs) and `deploy-site.yml` now gate on `github.repository == 'getkyo/kyo'`, so in a fork they skip instead of running and failing. `ci`, `build`, `scalafmt`, `readme`, `actionlint`, and `release-probe` stay unguarded, since those are exactly what a contributor wants to run in a fork.

Guarding `release.yml` off in a fork removes the only thing that checked publishability on a fork's `main`, so `release-probe` (the no-secrets `publishLocal` build that already ran on PRs) now also triggers on a push to `main`, guarded so it runs there only in forks. On the canonical repo a `main` push still relies on `release.yml`, and the probe job skips with no runner used.

Document the fork workflow in `CONTRIBUTING.md` (enable Actions, run the `ci` workflow or open a fork-internal PR, sync for diff mode), and ask contributors to link their fork CI run in the PR template so a reviewer can see it passed before spending an approval on it.

### Notes

- This makes the manual-approval stopgap livable while the real fixes land separately: a kernel change to cut inlining and compile time, and broader build optimization. It is not the CI speedup itself, it is the escape hatch that lets contributors self-serve CI in the meantime.
- Verified on a real fork rather than by reasoning alone: with Actions enabled, a push to the fork's `main` skips `release` (all four jobs) and `deploy-site`, runs `release-probe`, and runs `ci`. The behavior matches what the `github.repository` guard predicts.
- The guards key on the repository name, not the fork's name, so any fork skips the guarded workflows no matter what it is called.
- `bench.yml` is left alone on purpose: it only runs on manual dispatch and targets a self-hosted runner a fork does not have, so it cannot fire in a fork anyway.
