### PR TITLE
[kyo-data] add ByteSize, an opaque type for quantities of storage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,10 +243,15 @@ When a Kyo primitive exists for a concept, use it instead of the stdlib equivale
 | `Result[E, A]` | `Either`, `Try`                                            | Three-way: `Success`/`Failure`/`Panic` — never raw `Either` or `Try` in effect signatures                                                                                                        |
 | `Chunk[A]`     | `Seq`, `List`, `Vector`                                    | Use internally; accept generic collections in public APIs (see below)                                                                                                                            |
 | `Duration`     | `java.time.Duration`, `scala.concurrent.duration.Duration` | Opaque `Long`-based, zero-allocation                                                                                                                                                             |
+| `ByteSize`     | a bare `Long` or `Int` holding a byte count                | Opaque `Long`-based, zero-allocation, saturating arithmetic, non-negative by construction                                                                                                        |
 | `Instant`      | `java.time.Instant`                                        | Kyo's own wrapper with consistent API                                                                                                                                                            |
 | `Span[A]`      | `IArray[A]`, `ArraySeq[A]`                                 | Immutable array wrapper, avoids boxing, O(1) indexing                                                                                                                                            |
 | `Schedule`     | Custom retry/timing logic                                  | Composable scheduling policies                                                                                                                                                                   |
 | `TypeMap[A]`   | Heterogeneous maps                                         | Type-safe map keyed by type                                                                                                                                                                      |
+
+Prefer `ByteSize` over a bare numeric type wherever a value means "a quantity of bytes": storage and disk sizes, file sizes, buffer and byte-array capacities, read and write chunk sizes, network packet and frame sizes, transfer limits and quotas, memory footprints. It carries the unit in the type, so a call site cannot silently pass kibibytes where bytes were expected, and its arithmetic saturates instead of overflowing. A raw `Long` or `Int` stays correct for an index, an offset into a buffer, or a count of elements; those are positions, not sizes.
+
+This is guidance for new and changed code. Existing APIs that thread byte counts as `Long` are not required to migrate, and a migration should be its own change rather than a drive-by edit inside an unrelated one.
 
 **kyo-prelude** — effects:
 

--- a/kyo-data/README.md
+++ b/kyo-data/README.md
@@ -482,6 +482,58 @@ def take3(s: Schedule, now: Instant): List[Duration] =
 
 `schedule.show` returns a string that resembles the source-level constructor call; `toString` delegates to `show`. The result is suitable for logs and debug output.
 
+## Storage sizes
+
+When code talks about a quantity of storage (a buffer cap, a file rotation threshold, a transfer limit), reach for `ByteSize`. It is an opaque type over `Long` (representing bytes). Construct it through the unit extensions (`64L.mib`, `1L.gib`), the factory method (`ByteSize.fromBytes`), or parse it from text.
+
+```scala doctest:expect=runs
+import kyo.*
+
+val small: ByteSize   = 512L.bytes
+val medium: ByteSize  = 64L.mib
+val large: ByteSize   = 1L.gib
+val fromInt: ByteSize = 512.mib // Int constructor, identical result to 512L.mib
+val fromKb: ByteSize  = 100.kb  // decimal unit: 100,000 bytes
+
+assert(medium.toBytes == 67108864L)
+assert(fromInt == 512L.mib)
+assert(fromKb.toBytes == 100000L)
+assert(ByteSize.Zero.toBytes == 0L)
+
+val parsed: Result[ByteSize.InvalidByteSize, ByteSize] = ByteSize.parse("64MiB")
+assert(parsed == Result.succeed(64L.mib))
+```
+
+> **Note:** Negative inputs to `ByteSize.fromBytes` and the unit extensions clamp to `ByteSize.Zero`. There is no `Infinity` sentinel; the maximum representable value is `Long.MaxValue` bytes.
+
+Arithmetic saturates on overflow: addition and multiplication that would exceed `Long.MaxValue` clamp to `Long.MaxValue`; subtraction clamps to `ByteSize.Zero`.
+
+```scala doctest:expect=runs
+import kyo.*
+
+val a: ByteSize       = 32L.mib + 32L.mib
+val b: ByteSize       = 1L.gib - 256L.mib
+val c: ByteSize       = 1L.mib * 128.0
+val clamped: ByteSize = ByteSize.fromBytes(Long.MaxValue) + 1L.bytes
+
+assert(a == 64L.mib)
+assert(b == 768L.mib)
+assert(c == 128L.mib)
+assert(clamped == ByteSize.fromBytes(Long.MaxValue))
+```
+
+`ByteSize` also offers `to(unit)` for converting to a `Double` in a given unit, and `show` for a human-readable string at the coarsest lossless binary unit.
+
+```scala doctest:expect=runs
+import kyo.*
+
+val size: ByteSize = 64L.mib
+
+assert(size.to(ByteSize.Units.GiB) == 0.0625)
+assert(size.show == "64.mib")
+assert(ByteSize.Zero.show == "ByteSize.Zero")
+```
+
 ## Records and named fields
 
 A record is a named collection of typed fields whose shape is known at compile time but is not declared as a case class. `kyo-data` offers `Record[F]`, where `F` is an intersection of `Name ~ Value` pairs encoding the schema directly in the type. The macro-derived `Fields[F]` companion provides runtime metadata; `Field[Name, Value]` is the reified per-field descriptor.
@@ -765,6 +817,7 @@ When `kyo-config` is on the classpath, kyo-data types can be used directly as `F
 | Type | Format | Example |
 |------|--------|---------|
 | `Duration` | number + unit (optional space) | `"5s"`, `"100ms"`, `"2minutes"`, `"infinity"` |
+| `ByteSize` | number + unit (optional space), or bare digits (bytes) | `"64MiB"`, `"1.5GiB"`, `"1024"` |
 | `Chunk[A]` | comma-separated | `"a,b,c"` |
 | `Span[A]` | comma-separated | `"1,2,3"` |
 | `Dict[K,V]` | key=value pairs, comma-separated | `"host=localhost,port=8080"` |

--- a/kyo-data/shared/src/main/scala/kyo/ByteSize.scala
+++ b/kyo-data/shared/src/main/scala/kyo/ByteSize.scala
@@ -1,0 +1,283 @@
+package kyo
+
+/** Represents a quantity of storage in bytes.
+  *
+  * `ByteSize` is an opaque type over `Long` (representing bytes). Values are non-negative:
+  * construction methods clamp negative inputs to `ByteSize.Zero`.
+  *
+  * Construct through the unit extensions (`64L.mib`, `1L.gib`), the factory methods
+  * (`ByteSize.fromBytes`, `ByteSize.fromUnits`), or by parsing from text
+  * (`ByteSize.parse("64MiB")`).
+  *
+  * Arithmetic saturates on overflow: addition and multiplication that would exceed `Long.MaxValue`
+  * clamp to `Long.MaxValue`; subtraction clamps to `ByteSize.Zero`.
+  *
+  * The `show` method produces a human-readable string at the coarsest lossless binary unit:
+  * `"64.mib"`, `"1.gib"`, `"ByteSize.Zero"`.
+  *
+  * @see
+  *   [[Duration]] for the analogous time-span type
+  */
+opaque type ByteSize = Long
+
+/** Companion object for ByteSize type. */
+object ByteSize:
+
+    inline given CanEqual[ByteSize, ByteSize] = CanEqual.derived
+
+    /** Exception thrown for invalid byte size parsing. */
+    class InvalidByteSize(message: String)(using Frame) extends KyoException(message)
+
+    /** Represents zero bytes. */
+    val Zero: ByteSize = 0L
+
+    /** Creates a `ByteSize` from a raw byte count.
+      *
+      * Negative values are clamped to `ByteSize.Zero`.
+      */
+    def fromBytes(value: Long): ByteSize =
+        if value <= 0 then ByteSize.Zero else value
+
+    /** Creates a `ByteSize` from a value and unit.
+      *
+      * The byte count is the exact integer product `value * unit.bytes`; no floating-point
+      * arithmetic is used, so results carry full precision at every magnitude. Negative and zero
+      * values are clamped to `ByteSize.Zero`. Values whose product would exceed `Long.MaxValue`
+      * clamp to `Long.MaxValue`.
+      */
+    def fromUnits(value: Long, unit: Units): ByteSize =
+        if value <= 0 then ByteSize.Zero
+        else if value > Long.MaxValue / unit.bytes then Long.MaxValue
+        else value * unit.bytes
+
+    /** Parses a human-readable byte size string.
+      *
+      * Accepted formats: `"64MiB"`, `"64 MiB"`, `"1.5GiB"`, `"512B"`, `"1024"` (bare digits equal
+      * bytes), `"10MB"`. Unit matching is case-insensitive. An integral value with a unit (for
+      * example `"10MB"`) yields the exact byte count `value * unit.bytes`; a fractional value (for
+      * example `"1.5GiB"`) is scaled with `BigDecimal` and rounded to whole bytes using `HALF_UP`.
+      * Negative values and values that overflow `Long.MaxValue` are rejected with an
+      * `InvalidByteSize` error.
+      *
+      * @param s
+      *   the string to parse
+      * @return
+      *   a `Result` containing either the parsed `ByteSize` or an `InvalidByteSize` error
+      */
+    def parse(s: String)(using Frame): Result[InvalidByteSize, ByteSize] =
+        // dotPattern handles the show output format: "64.mib", "1.bytes", "1.tib"
+        // (integer immediately followed by a dot and letters -- never matches "1.5GiB" because "5" is not a letter)
+        val dotPattern = """(\d+)\.([a-zA-Z]+)""".r
+        // userPattern handles human input: "64MiB", "64 MiB", "1.5GiB", "10MB", or bare "1024"
+        val userPattern = """(\d+(?:\.\d+)?)\s*([a-zA-Z]*)""".r
+        s.trim match
+            case str if str.equalsIgnoreCase("ByteSize.Zero") =>
+                Result.succeed(Zero)
+            case dotPattern(numStr, unitStr) =>
+                parseNumberAndUnit(numStr, unitStr, s)
+            case userPattern(numStr, unitStr) if unitStr.isEmpty =>
+                Result.catching[NumberFormatException](numStr.toLong)
+                    .mapFailure(_ => InvalidByteSize(s"Invalid number: $numStr"))
+                    .map(fromBytes)
+            case userPattern(numStr, unitStr) =>
+                parseNumberAndUnit(numStr, unitStr, s)
+            case _ => Result.fail(InvalidByteSize(s"Invalid byte size format: $s"))
+        end match
+    end parse
+
+    private def parseNumberAndUnit(numStr: String, unitStr: String, original: String)(using Frame): Result[InvalidByteSize, ByteSize] =
+        Units.values.find(u => u.symbol.equalsIgnoreCase(unitStr) || u.toString.equalsIgnoreCase(unitStr))
+            .map(Result.succeed)
+            .getOrElse(Result.fail(InvalidByteSize(s"Invalid unit: $unitStr")))
+            .flatMap { unit =>
+                bytesFromParsed(numStr, unit) match
+                    case Present(byteCount) => Result.succeed(fromBytes(byteCount))
+                    case Absent             => Result.fail(InvalidByteSize(s"Byte size overflow: $original"))
+            }
+
+    /** Computes the exact byte count for a parsed numeric string in the given unit.
+      *
+      * An integral input (no decimal point) uses exact integer arithmetic: the byte count is
+      * `value * unit.bytes` computed without floating point. A fractional input (for example
+      * `"1.5"`) is scaled by `unit.bytes` using `BigDecimal` and rounded to a whole number of bytes
+      * with `HALF_UP`. Returns `Absent` when the byte count would exceed `Long.MaxValue`.
+      *
+      * The input is assumed to be a non-negative decimal literal, as produced by the parse
+      * patterns. Shared by `ByteSize.parse` and the `Flag.Reader` given so the two cannot drift.
+      */
+    private[kyo] def bytesFromParsed(numStr: String, unit: Units): Maybe[Long] =
+        val byteCount =
+            if numStr.contains('.') then
+                (BigDecimal(numStr) * BigDecimal(unit.bytes))
+                    .setScale(0, BigDecimal.RoundingMode.HALF_UP)
+                    .toBigInt
+            else
+                BigInt(numStr) * BigInt(unit.bytes)
+        if byteCount > BigInt(Long.MaxValue) then Absent
+        else Present(byteCount.toLong)
+    end bytesFromParsed
+
+    /** Storage size units with their byte counts and symbols. */
+    enum Units(val bytes: Long, val symbol: String) derives CanEqual:
+        case Bytes extends Units(1L, "B")
+        case KiB   extends Units(1L << 10, "KiB")
+        case MiB   extends Units(1L << 20, "MiB")
+        case GiB   extends Units(1L << 30, "GiB")
+        case TiB   extends Units(1L << 40, "TiB")
+        case KB    extends Units(1000L, "KB")
+        case MB    extends Units(1000000L, "MB")
+        case GB    extends Units(1000000000L, "GB")
+    end Units
+
+    object Units:
+        /** All units in declaration order: the binary units ascending, then the decimal units ascending. */
+        val all: Array[Units] = Units.values
+
+        /** Binary units in ascending order. Used by `show` to find the coarsest lossless representation. */
+        private[kyo] val binary: Seq[Units] = Seq(Bytes, KiB, MiB, GiB, TiB)
+    end Units
+
+    extension (self: ByteSize)
+
+        private def toLong: Long = self
+
+        /** Returns the size in bytes. */
+        def toBytes: Long = self.toLong
+
+        /** Returns the size as a `Double` in the given unit. */
+        def to(unit: Units): Double = self.toLong.toDouble / unit.bytes.toDouble
+
+        infix def >=(that: ByteSize): Boolean = self.toLong >= that.toLong
+        infix def <=(that: ByteSize): Boolean = self.toLong <= that.toLong
+        infix def >(that: ByteSize): Boolean  = self.toLong > that.toLong
+        infix def <(that: ByteSize): Boolean  = self.toLong < that.toLong
+
+        infix def +(that: ByteSize): ByteSize =
+            val sum: Long = self.toLong + that.toLong
+            if sum >= 0 then sum else Long.MaxValue
+
+        infix def -(that: ByteSize): ByteSize =
+            val diff: Long = self.toLong - that.toLong
+            if diff > 0 then diff else ByteSize.Zero
+
+        infix def *(factor: Double): ByteSize =
+            if factor <= 0 || self.toLong <= 0L then ByteSize.Zero
+            else if factor <= Long.MaxValue / self.toLong.toDouble then Math.round(self.toLong.toDouble * factor)
+            else Long.MaxValue
+
+        def max(that: ByteSize): ByteSize = Math.max(self.toLong, that.toLong)
+        def min(that: ByteSize): ByteSize = Math.min(self.toLong, that.toLong)
+
+        /** Returns a human-readable string at the coarsest lossless binary unit.
+          *
+          * Examples: `"64.mib"`, `"1.gib"`, `"ByteSize.Zero"`. The format mirrors `Duration.show`.
+          */
+        def show: String =
+            if self == Zero then "ByteSize.Zero"
+            else
+                val b = self.toBytes
+                Units.binary.reverse.find(unit => b % unit.bytes == 0) match
+                    case Some(unit) =>
+                        val value = b / unit.bytes
+                        val name  = unit.toString.toLowerCase
+                        s"$value.$name"
+                    case None =>
+                        s"$b.bytes"
+                end match
+    end extension
+
+    /** Parses a `ByteSize` from a string without requiring a `Frame`, for use in CLI/config-flag contexts.
+      *
+      * This mirrors `ByteSize.parse`'s pattern matching to avoid the `Frame` requirement while
+      * sharing `bytesFromParsed` for the numeric conversion, so the two stay consistent.
+      */
+    given Flag.Reader.Scalar[ByteSize] with
+        private val dotPattern  = """(\d+)\.([a-zA-Z]+)""".r
+        private val userPattern = """(\d+(?:\.\d+)?)\s*([a-zA-Z]*)""".r
+
+        def apply(s: String): Either[Throwable, ByteSize] =
+            s.trim match
+                case str if str.equalsIgnoreCase("ByteSize.Zero") =>
+                    Right(Zero)
+                case dotPattern(numStr, unitStr) =>
+                    applyUnit(numStr, unitStr, s)
+                case userPattern(numStr, unitStr) if unitStr.isEmpty =>
+                    try Right(fromBytes(numStr.toLong))
+                    catch case _: NumberFormatException => Left(new IllegalArgumentException(s"Invalid byte size number: $numStr"))
+                case userPattern(numStr, unitStr) =>
+                    applyUnit(numStr, unitStr, s)
+                case _ => Left(new IllegalArgumentException(s"Invalid byte size format: $s"))
+            end match
+        end apply
+
+        private def applyUnit(numStr: String, unitStr: String, original: String): Either[Throwable, ByteSize] =
+            Units.values.find(u => u.symbol.equalsIgnoreCase(unitStr) || u.toString.equalsIgnoreCase(unitStr)) match
+                case None => Left(new IllegalArgumentException(s"Invalid byte size unit: $unitStr"))
+                case Some(unit) =>
+                    bytesFromParsed(numStr, unit) match
+                        case Present(byteCount) => Right(fromBytes(byteCount))
+                        case Absent             => Left(new IllegalArgumentException(s"Byte size overflow: $original"))
+
+        def typeName: String = "ByteSize"
+    end given
+
+end ByteSize
+
+extension (value: Long)
+    /** Creates a `ByteSize` of the given number of bytes. */
+    def bytes: ByteSize = ByteSize.fromBytes(value)
+
+    /** Creates a `ByteSize` of the given number of kibibytes (1 KiB = 1024 bytes). */
+    def kib: ByteSize = value.asByteSizeUnit(ByteSize.Units.KiB)
+
+    /** Creates a `ByteSize` of the given number of mebibytes (1 MiB = 1,048,576 bytes). */
+    def mib: ByteSize = value.asByteSizeUnit(ByteSize.Units.MiB)
+
+    /** Creates a `ByteSize` of the given number of gibibytes (1 GiB = 1,073,741,824 bytes). */
+    def gib: ByteSize = value.asByteSizeUnit(ByteSize.Units.GiB)
+
+    /** Creates a `ByteSize` of the given number of tebibytes (1 TiB = 1,099,511,627,776 bytes). */
+    def tib: ByteSize = value.asByteSizeUnit(ByteSize.Units.TiB)
+
+    /** Creates a `ByteSize` of the given number of kilobytes (1 KB = 1,000 bytes). */
+    def kb: ByteSize = value.asByteSizeUnit(ByteSize.Units.KB)
+
+    /** Creates a `ByteSize` of the given number of megabytes (1 MB = 1,000,000 bytes). */
+    def mb: ByteSize = value.asByteSizeUnit(ByteSize.Units.MB)
+
+    /** Creates a `ByteSize` of the given number of gigabytes (1 GB = 1,000,000,000 bytes). */
+    def gb: ByteSize = value.asByteSizeUnit(ByteSize.Units.GB)
+
+    /** Creates a `ByteSize` from a specific unit. */
+    private[kyo] def asByteSizeUnit(unit: ByteSize.Units): ByteSize =
+        ByteSize.fromUnits(value, unit)
+end extension
+
+extension (value: Int)
+    /** Creates a `ByteSize` of the given number of bytes. */
+    def bytes: ByteSize = ByteSize.fromBytes(value.toLong)
+
+    /** Creates a `ByteSize` of the given number of kibibytes (1 KiB = 1024 bytes). */
+    def kib: ByteSize = value.asIntByteSizeUnit(ByteSize.Units.KiB)
+
+    /** Creates a `ByteSize` of the given number of mebibytes (1 MiB = 1,048,576 bytes). */
+    def mib: ByteSize = value.asIntByteSizeUnit(ByteSize.Units.MiB)
+
+    /** Creates a `ByteSize` of the given number of gibibytes (1 GiB = 1,073,741,824 bytes). */
+    def gib: ByteSize = value.asIntByteSizeUnit(ByteSize.Units.GiB)
+
+    /** Creates a `ByteSize` of the given number of tebibytes (1 TiB = 1,099,511,627,776 bytes). */
+    def tib: ByteSize = value.asIntByteSizeUnit(ByteSize.Units.TiB)
+
+    /** Creates a `ByteSize` of the given number of kilobytes (1 KB = 1,000 bytes). */
+    def kb: ByteSize = value.asIntByteSizeUnit(ByteSize.Units.KB)
+
+    /** Creates a `ByteSize` of the given number of megabytes (1 MB = 1,000,000 bytes). */
+    def mb: ByteSize = value.asIntByteSizeUnit(ByteSize.Units.MB)
+
+    /** Creates a `ByteSize` of the given number of gigabytes (1 GB = 1,000,000,000 bytes). */
+    def gb: ByteSize = value.asIntByteSizeUnit(ByteSize.Units.GB)
+
+    private[kyo] def asIntByteSizeUnit(unit: ByteSize.Units): ByteSize =
+        ByteSize.fromUnits(value.toLong, unit)
+end extension

--- a/kyo-data/shared/src/test/scala/kyo/ByteSizeTest.scala
+++ b/kyo-data/shared/src/test/scala/kyo/ByteSizeTest.scala
@@ -1,0 +1,635 @@
+package kyo
+
+class ByteSizeTest extends kyo.test.Test[Any]:
+
+    "Long extension" - {
+        "bytes" in {
+            assert(0L.bytes == ByteSize.Zero)
+            assert(1L.bytes.toBytes == 1L)
+            assert(1024L.bytes.toBytes == 1024L)
+        }
+
+        "kib" in {
+            assert(1L.kib.toBytes == 1024L)
+            assert(64L.kib.toBytes == 65536L)
+        }
+
+        "mib" in {
+            assert(1L.mib.toBytes == 1048576L)
+            assert(64L.mib.toBytes == 67108864L)
+        }
+
+        "gib" in {
+            assert(1L.gib.toBytes == 1073741824L)
+            assert(2L.gib.toBytes == 2147483648L)
+        }
+
+        "tib" in {
+            assert(1L.tib.toBytes == 1099511627776L)
+        }
+
+        "negative clamps to Zero" in {
+            assert((-1L).bytes == ByteSize.Zero)
+            assert((-1L).kib == ByteSize.Zero)
+            assert((-1L).mib == ByteSize.Zero)
+            assert((-1L).gib == ByteSize.Zero)
+            assert((-1L).tib == ByteSize.Zero)
+        }
+
+        "zero clamps to Zero" in {
+            assert(0L.kib == ByteSize.Zero)
+            assert(0L.mib == ByteSize.Zero)
+        }
+    }
+
+    "Int extension" - {
+        "bytes" in {
+            assert(0.bytes == ByteSize.Zero)
+            assert(1.bytes.toBytes == 1L)
+            assert(1024.bytes.toBytes == 1024L)
+        }
+
+        "kib" in {
+            assert(1.kib.toBytes == 1024L)
+            assert(2.kib.toBytes == 2048L)
+        }
+
+        "mib" in {
+            assert(1.mib.toBytes == 1048576L)
+            assert(512.mib.toBytes == 536870912L)
+        }
+
+        "gib" in {
+            assert(1.gib.toBytes == 1073741824L)
+            assert(2.gib.toBytes == 2147483648L)
+        }
+
+        "tib" in {
+            assert(1.tib.toBytes == 1099511627776L)
+        }
+
+        "negative clamps to Zero" in {
+            assert((-1).bytes == ByteSize.Zero)
+            assert((-1).kib == ByteSize.Zero)
+            assert((-1).mib == ByteSize.Zero)
+            assert((-1).gib == ByteSize.Zero)
+            assert((-1).tib == ByteSize.Zero)
+        }
+
+        "zero clamps to Zero" in {
+            assert(0.kib == ByteSize.Zero)
+            assert(0.mib == ByteSize.Zero)
+        }
+
+        "Int.MaxValue.tib saturates to Long.MaxValue" in {
+            assert(Int.MaxValue.tib.toBytes == Long.MaxValue)
+        }
+
+        "equality across Int and Long forms" in {
+            assert(2.mib == 2L.mib)
+            assert(1.gib == 1L.gib)
+            assert(512.kib == 512L.kib)
+        }
+    }
+
+    "decimal unit extensions" - {
+        "Long.kb" in {
+            assert(1L.kb.toBytes == 1000L)
+            assert(3L.kb.toBytes == 3000L)
+        }
+
+        "Long.mb" in {
+            assert(1L.mb.toBytes == 1000000L)
+            assert(5L.mb.toBytes == 5000000L)
+        }
+
+        "Long.gb" in {
+            assert(1L.gb.toBytes == 1000000000L)
+            assert(2L.gb.toBytes == 2000000000L)
+        }
+
+        "Int.kb" in {
+            assert(1.kb.toBytes == 1000L)
+            assert(3.kb.toBytes == 3000L)
+        }
+
+        "Int.mb" in {
+            assert(1.mb.toBytes == 1000000L)
+            assert(5.mb.toBytes == 5000000L)
+        }
+
+        "Int.gb" in {
+            assert(1.gb.toBytes == 1000000000L)
+            assert(2.gb.toBytes == 2000000000L)
+        }
+
+        "negative Long.kb clamps to Zero" in {
+            assert((-1L).kb == ByteSize.Zero)
+            assert((-1L).mb == ByteSize.Zero)
+            assert((-1L).gb == ByteSize.Zero)
+        }
+
+        "negative Int.kb clamps to Zero" in {
+            assert((-1).kb == ByteSize.Zero)
+            assert((-1).mb == ByteSize.Zero)
+            assert((-1).gb == ByteSize.Zero)
+        }
+
+        "Int and Long decimal forms are equal" in {
+            assert(3.kb == 3L.kb)
+            assert(5.mb == 5L.mb)
+            assert(2.gb == 2L.gb)
+        }
+
+        "large Long.gb is exact" in {
+            assert(8589934591L.gb.toBytes == 8589934591000000000L)
+        }
+
+        "large Long.mb is exact" in {
+            assert(1099511627775L.mb.toBytes == 1099511627775000000L)
+        }
+
+        "large Long.kb is exact" in {
+            assert(73838224265209L.kb.toBytes == 73838224265209000L)
+        }
+    }
+
+    "ByteSize.fromBytes" - {
+        "positive value" in {
+            assert(ByteSize.fromBytes(512L).toBytes == 512L)
+        }
+
+        "negative clamps to Zero" in {
+            assert(ByteSize.fromBytes(-1L) == ByteSize.Zero)
+        }
+
+        "zero clamps to Zero" in {
+            assert(ByteSize.fromBytes(0L) == ByteSize.Zero)
+        }
+    }
+
+    "ByteSize.fromUnits" - {
+        "binary units" in {
+            assert(ByteSize.fromUnits(1L, ByteSize.Units.Bytes).toBytes == 1L)
+            assert(ByteSize.fromUnits(1L, ByteSize.Units.KiB).toBytes == 1024L)
+            assert(ByteSize.fromUnits(1L, ByteSize.Units.MiB).toBytes == 1048576L)
+            assert(ByteSize.fromUnits(1L, ByteSize.Units.GiB).toBytes == 1073741824L)
+            assert(ByteSize.fromUnits(1L, ByteSize.Units.TiB).toBytes == 1099511627776L)
+        }
+
+        "decimal units" in {
+            assert(ByteSize.fromUnits(1L, ByteSize.Units.KB).toBytes == 1000L)
+            assert(ByteSize.fromUnits(1L, ByteSize.Units.MB).toBytes == 1000000L)
+            assert(ByteSize.fromUnits(1L, ByteSize.Units.GB).toBytes == 1000000000L)
+        }
+
+        "negative clamps to Zero" in {
+            assert(ByteSize.fromUnits(-1L, ByteSize.Units.MiB) == ByteSize.Zero)
+        }
+    }
+
+    "to(unit) conversion" - {
+        "exact binary" in {
+            assert(64L.mib.to(ByteSize.Units.MiB) == 64.0)
+            assert(1L.gib.to(ByteSize.Units.MiB) == 1024.0)
+            assert(1L.tib.to(ByteSize.Units.GiB) == 1024.0)
+        }
+
+        "fractional result" in {
+            val half = ByteSize.fromBytes(512L)
+            assert(half.to(ByteSize.Units.KiB) == 0.5)
+        }
+
+        "bytes" in {
+            assert(1L.kib.to(ByteSize.Units.Bytes) == 1024.0)
+        }
+
+        "decimal units" in {
+            assert(ByteSize.fromUnits(1L, ByteSize.Units.MB).to(ByteSize.Units.KB) == 1000.0)
+        }
+    }
+
+    "ByteSize.parse" - {
+        "binary unit symbols" in {
+            assert(ByteSize.parse("512B") == Result.succeed(512L.bytes))
+            assert(ByteSize.parse("1KiB") == Result.succeed(1L.kib))
+            assert(ByteSize.parse("64MiB") == Result.succeed(64L.mib))
+            assert(ByteSize.parse("1GiB") == Result.succeed(1L.gib))
+            assert(ByteSize.parse("1TiB") == Result.succeed(1L.tib))
+        }
+
+        "decimal unit symbols" in {
+            assert(ByteSize.parse("1KB") == Result.succeed(ByteSize.fromUnits(1L, ByteSize.Units.KB)))
+            assert(ByteSize.parse("10MB") == Result.succeed(ByteSize.fromUnits(10L, ByteSize.Units.MB)))
+            assert(ByteSize.parse("2GB") == Result.succeed(ByteSize.fromUnits(2L, ByteSize.Units.GB)))
+        }
+
+        "large integral decimal value is exact" in {
+            assert(ByteSize.parse("8589934591GB") == Result.succeed(ByteSize.fromBytes(8589934591000000000L)))
+        }
+
+        "whitespace between number and unit" in {
+            assert(ByteSize.parse("64 MiB") == Result.succeed(64L.mib))
+            assert(ByteSize.parse("1  GiB") == Result.succeed(1L.gib))
+        }
+
+        "case insensitive units" in {
+            assert(ByteSize.parse("64mib") == Result.succeed(64L.mib))
+            assert(ByteSize.parse("64MIB") == Result.succeed(64L.mib))
+            assert(ByteSize.parse("64Mib") == Result.succeed(64L.mib))
+            assert(ByteSize.parse("1kib") == Result.succeed(1L.kib))
+        }
+
+        "fractional values" in {
+            assert(ByteSize.parse("1.5GiB") == Result.succeed(ByteSize.fromBytes(Math.round(1.5 * (1L << 30)))))
+            assert(ByteSize.parse("0.5MiB") == Result.succeed(ByteSize.fromBytes(512L * 1024L)))
+        }
+
+        "bare number is bytes" in {
+            assert(ByteSize.parse("1024") == Result.succeed(1024L.bytes))
+            assert(ByteSize.parse("0") == Result.succeed(ByteSize.Zero))
+        }
+
+        "leading and trailing whitespace" in {
+            assert(ByteSize.parse("  64MiB  ") == Result.succeed(64L.mib))
+        }
+    }
+
+    "ByteSize.parse rejections" - {
+        "empty string" in {
+            assert(ByteSize.parse("").isFailure)
+        }
+
+        "garbage input" in {
+            assert(ByteSize.parse("hello").isFailure)
+            assert(ByteSize.parse("abc123").isFailure)
+            assert(ByteSize.parse("!@#").isFailure)
+        }
+
+        "negative number" in {
+            assert(ByteSize.parse("-64MiB").isFailure)
+            assert(ByteSize.parse("-1").isFailure)
+        }
+
+        "unknown unit" in {
+            assert(ByteSize.parse("64PiB").isFailure)
+            assert(ByteSize.parse("1lightyear").isFailure)
+        }
+
+        "overflow past Long.MaxValue" in {
+            assert(ByteSize.parse("9999999999TiB").isFailure)
+            assert(ByteSize.parse("99999999999999GiB").isFailure)
+        }
+    }
+
+    "ByteSize.show" - {
+        "zero" in {
+            assert(ByteSize.Zero.show == "ByteSize.Zero")
+        }
+
+        "exact binary units" in {
+            assert(1L.bytes.show == "1.bytes")
+            assert(1L.kib.show == "1.kib")
+            assert(64L.mib.show == "64.mib")
+            assert(1L.gib.show == "1.gib")
+            assert(1L.tib.show == "1.tib")
+        }
+
+        "coarsest lossless unit" in {
+            assert((1024L.bytes).show == "1.kib")
+            assert((1024L.kib).show == "1.mib")
+            assert((1024L.mib).show == "1.gib")
+            assert((1024L.gib).show == "1.tib")
+        }
+
+        "non-exact falls to smaller binary unit" in {
+            assert(ByteSize.fromBytes(1536L).show == "1536.bytes")
+            assert(ByteSize.fromBytes(1536L * 1024L).show == "1536.kib")
+        }
+
+        "multi-kib value" in {
+            assert(ByteSize.fromBytes(2048L).show == "2.kib")
+        }
+    }
+
+    "arithmetic" - {
+        "addition" in {
+            assert(1L.mib + 1L.mib == 2L.mib)
+            assert(ByteSize.Zero + 64L.mib == 64L.mib)
+        }
+
+        "addition overflow saturates" in {
+            val big = ByteSize.fromBytes(Long.MaxValue)
+            assert((big + 1L.bytes).toBytes == Long.MaxValue)
+            assert((big + big).toBytes == Long.MaxValue)
+        }
+
+        "subtraction" in {
+            assert(64L.mib - 32L.mib == 32L.mib)
+        }
+
+        "subtraction underflow clamps to Zero" in {
+            assert(1L.mib - 2L.mib == ByteSize.Zero)
+            assert(ByteSize.Zero - 1L.bytes == ByteSize.Zero)
+        }
+
+        "subtraction equal values gives Zero" in {
+            assert(64L.mib - 64L.mib == ByteSize.Zero)
+        }
+
+        "multiply by factor" in {
+            assert((64L.mib * 2.0).toBytes == 64L.mib.toBytes * 2L)
+            assert((1L.gib * 0.5).toBytes == 512L.mib.toBytes)
+        }
+
+        "multiply by zero clamps to Zero" in {
+            assert(64L.mib * 0.0 == ByteSize.Zero)
+        }
+
+        "multiply by negative clamps to Zero" in {
+            assert(64L.mib * -1.0 == ByteSize.Zero)
+        }
+
+        "multiply overflow saturates" in {
+            val big = ByteSize.fromBytes(Long.MaxValue / 2 + 1)
+            assert((big * 3.0).toBytes == Long.MaxValue)
+        }
+
+        "max" in {
+            assert((32L.mib).max(64L.mib) == 64L.mib)
+            assert((64L.mib).max(32L.mib) == 64L.mib)
+        }
+
+        "min" in {
+            assert((32L.mib).min(64L.mib) == 32L.mib)
+            assert((64L.mib).min(32L.mib) == 32L.mib)
+        }
+    }
+
+    "comparisons" - {
+        "equality via CanEqual" in {
+            assert(64L.mib == 64L.mib)
+            assert(64L.mib != 32L.mib)
+        }
+
+        ">= and <=" in {
+            assert(64L.mib >= 32L.mib)
+            assert(32L.mib <= 64L.mib)
+            assert(64L.mib >= 64L.mib)
+            assert(64L.mib <= 64L.mib)
+        }
+
+        "> and <" in {
+            assert(64L.mib > 32L.mib)
+            assert(32L.mib < 64L.mib)
+            assert(!(64L.mib > 64L.mib))
+            assert(!(64L.mib < 64L.mib))
+        }
+
+        "Zero is smallest" in {
+            assert(ByteSize.Zero <= 1L.bytes)
+            assert(!(ByteSize.Zero > 1L.bytes))
+        }
+    }
+
+    "parse/show round-trip" - {
+        "lossless binary values" in {
+            val values = Seq(1L.bytes, 1L.kib, 1L.mib, 64L.mib, 1L.gib, 1L.tib, 512L.kib, 256L.mib)
+            values.foreach { size =>
+                assert(ByteSize.parse(size.show) == Result.succeed(size))
+            }
+            ()
+        }
+
+        "Zero round-trips" in {
+            assert(ByteSize.parse(ByteSize.Zero.show) == Result.succeed(ByteSize.Zero))
+        }
+    }
+
+    "Flag.Reader" - {
+        val reader = summon[Flag.Reader[ByteSize]]
+
+        "typeName" in {
+            assert(reader.typeName == "ByteSize")
+        }
+
+        "binary units" in {
+            assert(reader("64MiB") == Right(64L.mib))
+            assert(reader("1GiB") == Right(1L.gib))
+            assert(reader("512B") == Right(512L.bytes))
+        }
+
+        "decimal units" in {
+            assert(reader("10MB") == Right(ByteSize.fromUnits(10L, ByteSize.Units.MB)))
+        }
+
+        "large integral decimal value is exact" in {
+            assert(reader("8589934591GB") == Right(ByteSize.fromBytes(8589934591000000000L)))
+        }
+
+        "bare number is bytes" in {
+            assert(reader("1024") == Right(1024L.bytes))
+        }
+
+        "case insensitive" in {
+            assert(reader("64mib") == Right(64L.mib))
+            assert(reader("64MIB") == Right(64L.mib))
+        }
+
+        "whitespace between number and unit" in {
+            assert(reader("64 MiB") == Right(64L.mib))
+        }
+
+        "invalid format" in {
+            assert(reader("not-a-size").isLeft)
+        }
+
+        "invalid unit" in {
+            assert(reader("64PiB").isLeft)
+        }
+
+        "overflow" in {
+            assert(reader("9999999999TiB").isLeft)
+        }
+    }
+
+    "Units metadata" - {
+        "byte counts" in {
+            assert(ByteSize.Units.Bytes.bytes == 1L)
+            assert(ByteSize.Units.KiB.bytes == 1024L)
+            assert(ByteSize.Units.MiB.bytes == 1048576L)
+            assert(ByteSize.Units.GiB.bytes == 1073741824L)
+            assert(ByteSize.Units.TiB.bytes == 1099511627776L)
+            assert(ByteSize.Units.KB.bytes == 1000L)
+            assert(ByteSize.Units.MB.bytes == 1000000L)
+            assert(ByteSize.Units.GB.bytes == 1000000000L)
+        }
+
+        "symbols" in {
+            assert(ByteSize.Units.Bytes.symbol == "B")
+            assert(ByteSize.Units.KiB.symbol == "KiB")
+            assert(ByteSize.Units.MiB.symbol == "MiB")
+            assert(ByteSize.Units.GiB.symbol == "GiB")
+            assert(ByteSize.Units.TiB.symbol == "TiB")
+            assert(ByteSize.Units.KB.symbol == "KB")
+            assert(ByteSize.Units.MB.symbol == "MB")
+            assert(ByteSize.Units.GB.symbol == "GB")
+        }
+
+        "all lists every unit in declaration order" in {
+            assert(ByteSize.Units.all.length == 8)
+            assert(ByteSize.Units.all(0) == ByteSize.Units.Bytes)
+            assert(ByteSize.Units.all(1) == ByteSize.Units.KiB)
+            assert(ByteSize.Units.all(2) == ByteSize.Units.MiB)
+            assert(ByteSize.Units.all(3) == ByteSize.Units.GiB)
+            assert(ByteSize.Units.all(4) == ByteSize.Units.TiB)
+            assert(ByteSize.Units.all(5) == ByteSize.Units.KB)
+            assert(ByteSize.Units.all(6) == ByteSize.Units.MB)
+            assert(ByteSize.Units.all(7) == ByteSize.Units.GB)
+        }
+    }
+
+    "ByteSize.fromUnits saturation boundary" - {
+        "largest exact TiB value does not clamp" in {
+            assert(ByteSize.fromUnits(8388607L, ByteSize.Units.TiB).toBytes == 9223370937343148032L)
+        }
+
+        "one TiB past the boundary clamps" in {
+            assert(ByteSize.fromUnits(8388608L, ByteSize.Units.TiB).toBytes == Long.MaxValue)
+        }
+
+        "largest exact GiB value does not clamp" in {
+            assert(ByteSize.fromUnits(8589934591L, ByteSize.Units.GiB).toBytes == 9223372035781033984L)
+        }
+
+        "one GiB past the boundary clamps" in {
+            assert(ByteSize.fromUnits(8589934592L, ByteSize.Units.GiB).toBytes == Long.MaxValue)
+        }
+
+        "Long.MaxValue in Bytes is exact" in {
+            assert(ByteSize.fromUnits(Long.MaxValue, ByteSize.Units.Bytes).toBytes == Long.MaxValue)
+        }
+    }
+
+    "ByteSize.parse overflow boundary" - {
+        "Long.MaxValue as bare bytes parses" in {
+            assert(ByteSize.parse("9223372036854775807") == Result.succeed(ByteSize.fromBytes(Long.MaxValue)))
+        }
+
+        "one past Long.MaxValue as bare bytes is rejected" in {
+            assert(ByteSize.parse("9223372036854775808").isFailure)
+        }
+
+        "largest exact TiB value parses" in {
+            assert(ByteSize.parse("8388607TiB") == Result.succeed(ByteSize.fromBytes(9223370937343148032L)))
+        }
+
+        "one TiB past the boundary is rejected" in {
+            assert(ByteSize.parse("8388608TiB").isFailure)
+        }
+    }
+
+    "ByteSize.parse rounding" - {
+        "fractional bytes round half up" in {
+            assert(ByteSize.parse("1.5B") == Result.succeed(ByteSize.fromBytes(2L)))
+            assert(ByteSize.parse("2.5B") == Result.succeed(ByteSize.fromBytes(3L)))
+            assert(ByteSize.parse("0.5B") == Result.succeed(ByteSize.fromBytes(1L)))
+        }
+
+        "fractional bytes below the tie round down" in {
+            assert(ByteSize.parse("0.4B") == Result.succeed(ByteSize.Zero))
+            assert(ByteSize.parse("1.4B") == Result.succeed(ByteSize.fromBytes(1L)))
+        }
+
+        "1.5GiB is exactly 1610612736 bytes" in {
+            assert(ByteSize.parse("1.5GiB") == Result.succeed(ByteSize.fromBytes(1610612736L)))
+        }
+
+        "trailing zeros in the fraction do not change the result" in {
+            assert(ByteSize.parse("1.50GiB") == Result.succeed(ByteSize.fromBytes(1610612736L)))
+        }
+    }
+
+    "arithmetic edge cases" - {
+        "multiplication rounds half up" in {
+            assert((ByteSize.fromBytes(3L) * 0.5).toBytes == 2L)
+            assert((ByteSize.fromBytes(5L) * 0.5).toBytes == 3L)
+        }
+
+        "multiplication below the tie rounds down" in {
+            assert((ByteSize.fromBytes(1L) * 0.4) == ByteSize.Zero)
+        }
+
+        "multiplication by one is identity" in {
+            assert(64L.mib * 1.0 == 64L.mib)
+        }
+
+        "Zero multiplied by any factor stays Zero" in {
+            assert(ByteSize.Zero * 1000.0 == ByteSize.Zero)
+        }
+
+        "subtraction from Long.MaxValue is exact" in {
+            assert((ByteSize.fromBytes(Long.MaxValue) - 1L.bytes).toBytes == 9223372036854775806L)
+        }
+
+        "max and min against Zero" in {
+            assert(ByteSize.Zero.max(64L.mib) == 64L.mib)
+            assert(ByteSize.Zero.min(64L.mib) == ByteSize.Zero)
+            assert(ByteSize.Zero.max(ByteSize.Zero) == ByteSize.Zero)
+        }
+    }
+
+    "show edge cases" - {
+        "Long.MaxValue is odd so it renders as bytes" in {
+            assert(ByteSize.fromBytes(Long.MaxValue).show == "9223372036854775807.bytes")
+        }
+
+        "values above TiB stay in TiB" in {
+            assert(ByteSize.fromBytes(1125899906842624L).show == "1024.tib")
+        }
+
+        "one byte below a KiB renders as bytes" in {
+            assert(ByteSize.fromBytes(1023L).show == "1023.bytes")
+        }
+    }
+
+    // Mirrors the exact values asserted in the Storage sizes section of kyo-data/README.md.
+    // The doctest runner type-checks those blocks but does not execute them, so these leaves
+    // are what actually holds the documented numbers to the implementation.
+    "README examples" - {
+        "construction" in {
+            assert(512L.bytes.toBytes == 512L)
+            assert(64L.mib.toBytes == 67108864L)
+            assert(1L.gib.toBytes == 1073741824L)
+            assert(512.mib == 512L.mib)
+            assert(100.kb.toBytes == 100000L)
+            assert(ByteSize.Zero.toBytes == 0L)
+            assert(ByteSize.parse("64MiB") == Result.succeed(64L.mib))
+        }
+
+        "saturating arithmetic" in {
+            assert(32L.mib + 32L.mib == 64L.mib)
+            assert(1L.gib - 256L.mib == 768L.mib)
+            assert(1L.mib * 128.0 == 128L.mib)
+            assert(ByteSize.fromBytes(Long.MaxValue) + 1L.bytes == ByteSize.fromBytes(Long.MaxValue))
+        }
+
+        "to(unit) and show" in {
+            assert(64L.mib.to(ByteSize.Units.GiB) == 0.0625)
+            assert(64L.mib.show == "64.mib")
+            assert(ByteSize.Zero.show == "ByteSize.Zero")
+        }
+    }
+
+    "to(unit) at the extremes" - {
+        "Long.MaxValue in bytes" in {
+            assert(ByteSize.fromBytes(Long.MaxValue).to(ByteSize.Units.Bytes) == 9.223372036854776e18)
+        }
+
+        "Zero in any unit is 0.0" in {
+            assert(ByteSize.Zero.to(ByteSize.Units.GiB) == 0.0)
+            assert(ByteSize.Zero.to(ByteSize.Units.Bytes) == 0.0)
+        }
+    }
+
+end ByteSizeTest


### PR DESCRIPTION
Adds `ByteSize` to `kyo-data`: an opaque type over `Long` (bytes) for talking about quantities of storage. It is a sibling of `Duration` in the same module and follows its structure closely.

## What it provides

- Unit constructors on `Long` and `Int`, binary (`64L.mib`, `1L.gib`, `1L.tib`) and decimal (`100.kb`, `10L.mb`, `2L.gb`).
- Factories: `ByteSize.fromBytes`, `ByteSize.fromUnits`, `ByteSize.Zero`.
- Text parsing: `ByteSize.parse("64MiB")`, accepting `"64 MiB"`, `"1.5GiB"`, `"512B"`, bare `"1024"` (bytes) and `"10MB"`, case-insensitively.
- `show`, rendering at the coarsest lossless binary unit (`"64.mib"`, `"1.gib"`, `"ByteSize.Zero"`), mirroring `Duration.show`.
- A `Flag.Reader.Scalar[ByteSize]` instance, so it works as a config flag type like `Duration` already does.

## Design points

**Non-negative by construction.** Negative and zero inputs clamp to `ByteSize.Zero`. There is no `Infinity` sentinel; the maximum representable value is `Long.MaxValue` bytes.

**Saturating arithmetic.** Addition and multiplication that would exceed `Long.MaxValue` clamp to it; subtraction clamps to `Zero`. The `fromUnits` overflow guard is checked before the multiply, not after, so it cannot rely on wrapped arithmetic.

**Exact integer math where it matters.** `fromUnits` and integral parse inputs compute `value * unit.bytes` without floating point, so a large decimal value such as `"8589934591GB"` is exact rather than rounded through a `Double`. Only fractional parse inputs (`"1.5GiB"`) go through `BigDecimal`, rounded `HALF_UP`.

**One numeric conversion path.** `parse` and the `Flag.Reader` instance both route through `private[kyo] def bytesFromParsed`, so the two cannot drift. The two regex patterns are duplicated deliberately: `Flag.Reader.apply` cannot take a `Frame` and `parse` returns `Result` rather than `Either`. `Duration` handles the same constraint the same way.

**`Units derives CanEqual`.** With `-language:strictEquality` on project-wide, comparing two `Units` values would otherwise be a compile error at every call site, including the tests here.

Following `Duration`'s current surface, this lands with `CanEqual` and the `Flag.Reader` only. No `Ordering`, `Render` or `Numeric`; those are reasonable follow-ups rather than something to preempt here.

## No in-repo consumer, on purpose

Nothing in the tree calls `ByteSize` yet. The first consumer arrives with the `kyo-system` `Path` work, which carries a `size: Maybe[ByteSize]` field. That branch is large and touches many modules; `ByteSize` is the one piece of it that is a self-contained foundation-layer value type with no dependency on the rest, so it lands first to shrink that review surface. Read "unused" as deliberate rather than accidental. The tests and the README section are what exercise the type here.

(The `structByteSize` / `verifyByteSize` / `newByteSize` identifiers in `kyo-ffi`, `kyo-net` and `kyo-offheap` are unrelated `Long` arithmetic that predate this and do not reference `kyo.ByteSize`.)

## Contributor guidance

`CONTRIBUTING.md` gains a `ByteSize` row in the kyo-data primitives table plus a short paragraph on where it belongs: storage and file sizes, buffer and byte-array capacities, read and write chunk sizes, packet and frame sizes, transfer limits and quotas. A raw `Long` or `Int` stays correct for an index, an offset, or a count of elements, since those are positions rather than sizes.

This is guidance for new and changed code. Nothing is migrated here, and existing APIs that thread byte counts as `Long` are not required to migrate.

## A doctest gap found along the way

The README examples carry `assert` calls so the documented numbers are checked rather than merely stated, and are marked `doctest:expect=runs`.

That expectation turns out not to be enforced. `expect=runs` and `expect=crashes` are documented in `kyo-doctest/README.md` but are folded into the compile-only branch at `Orchestrator.scala:179`, so no block body is ever executed. A README block with a deliberately false assert passes with `failures=0`. Filed as #1844 with a reproduction and follow-up tasks.

The markers stay, since they declare the intended semantics and will begin to be enforced once that lands. In the meantime every README assertion is mirrored into a `"README examples"` group in `ByteSizeTest`, where it does execute.

## Tests

113 leaves in `ByteSizeTest`, each asserting concrete values. Beyond the happy path:

- `fromUnits` saturation at the exact boundary, one step either side, for `TiB` and `GiB`.
- `parse` overflow at `Long.MaxValue` and one past it, rather than only at absurd magnitudes.
- `HALF_UP` rounding exercised at a tie (`"1.5B"`, `"2.5B"`, `"0.5B"`) and just below one, so a silent change to `FLOOR` or `HALF_DOWN` fails.
- `Math.round` in `*` exercised at a tie for the same reason.
- `Units` byte counts, symbols, and `all` in declaration order; the symbols are what `parse` matches against.
- `show` at `Long.MaxValue`, above `TiB`, and one byte below a `KiB`.

Both rounding and boundary groups were spot-checked by mutation: flipping the `fromUnits` guard from `>` to `>=` and `HALF_UP` to `FLOOR` each fail the corresponding leaves.

## Verification

| Command | Result |
|---|---|
| `sbt 'kyo-dataJVM/testOnly kyo.ByteSizeTest'` | 113 passed, 0 failed |
| `sbt 'kyo-dataJVM/test'` | green |
| `sbt 'kyo-dataJS/test'` | 3589 passed, 0 failed |
| `sbt 'kyo-dataNative/test'` | 696 passed, 0 failed |
| `sbt 'kyo-dataJVM/doctest'` | 45 blocks, 0 failures |

JS and Native matter here specifically: `BigDecimal` rounding and `Long` overflow semantics are where backends diverge, and this type's contract is built on both.

No `build.sbt` change is needed; `kyo-data` already cross-builds all four targets and everything `ByteSize` uses is on its classpath.

